### PR TITLE
Don't constantize a nil value

### DIFF
--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -68,7 +68,8 @@ module Hyrax
 
     # Method to return the ActiveFedora model
     def hydra_model
-      first(Solrizer.solr_name('has_model', :symbol)).constantize
+      value = first(Solrizer.solr_name('has_model', :symbol))
+      return value.constantize if value
     end
 
     def depositor(default = '')

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -2,6 +2,18 @@ RSpec.describe ::SolrDocument, type: :model do
   let(:document) { described_class.new(attributes) }
   let(:attributes) { {} }
 
+  describe "#hydra_model" do
+    subject { document.hydra_model }
+    context "when no has_model_ssim exists" do
+      it { is_expected.to be nil }
+    end
+
+    context "when has_model_ssim exists" do
+      let(:attributes) { { "has_model_ssim" => ['GenericWork'] } }
+      it { is_expected.to be GenericWork }
+    end
+  end
+
   describe "#itemtype" do
     let(:attributes) { { resource_type_tesim: ['Article'] } }
     it "delegates to the Hyrax::ResourceTypesService" do


### PR DESCRIPTION
Fixes issue where we attempt to route to a SolrDocument that doesn't have the `has_model_ssim` field set.