### PR TITLE
Embargoes and Leases from CurationConcerns

### DIFF
--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -1,0 +1,38 @@
+module Hyrax
+  module EmbargoesControllerBehavior
+    extend ActiveSupport::Concern
+    include Hyrax::ManagesEmbargoes
+    include Hyrax::Collections::AcceptsBatches
+
+    def index
+      authorize! :index, Hydra::AccessControls::Embargo
+    end
+
+    # Removes a single embargo
+    def destroy
+      Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
+      flash[:notice] = curation_concern.embargo_history.last
+      if curation_concern.work? && curation_concern.file_sets.present?
+        redirect_to confirm_permission_path
+      else
+        redirect_to edit_embargo_path
+      end
+    end
+
+    # Updates a batch of embargos
+    def update
+      filter_docs_with_edit_access!
+      copy_visibility = params[:embargoes].values.map { |h| h[:copy_visibility] }
+      ActiveFedora::Base.find(batch).each do |curation_concern|
+        Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
+        curation_concern.copy_visibility_to_files if copy_visibility.include?(curation_concern.id)
+      end
+      redirect_to embargoes_path
+    end
+
+    # This allows us to use the unauthorized template in curation_concerns/base
+    def self.local_prefixes
+      ['hyrax/base']
+    end
+  end
+end

--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -1,0 +1,37 @@
+module Hyrax
+  module LeasesControllerBehavior
+    extend ActiveSupport::Concern
+    include Hyrax::ManagesEmbargoes
+    include Hyrax::Collections::AcceptsBatches
+
+    def index
+      authorize! :index, Hydra::AccessControls::Lease
+    end
+
+    # Removes a single lease
+    def destroy
+      Hyrax::Actors::LeaseActor.new(curation_concern).destroy
+      flash[:notice] = curation_concern.lease_history.last
+      if curation_concern.work? && curation_concern.file_sets.present?
+        redirect_to confirm_permission_path
+      else
+        redirect_to edit_lease_path
+      end
+    end
+
+    def update
+      filter_docs_with_edit_access!
+      copy_visibility = params[:leases].values.map { |h| h[:copy_visibility] }
+      ActiveFedora::Base.find(batch).each do |curation_concern|
+        Hyrax::Actors::LeaseActor.new(curation_concern).destroy
+        curation_concern.copy_visibility_to_files if copy_visibility.include?(curation_concern.id)
+      end
+      redirect_to leases_path
+    end
+
+    # This allows us to use the unauthorized template in curation_concerns/base
+    def self.local_prefixes
+      ['hyrax/base']
+    end
+  end
+end

--- a/app/controllers/concerns/hyrax/manages_embargoes.rb
+++ b/app/controllers/concerns/hyrax/manages_embargoes.rb
@@ -1,0 +1,18 @@
+module Hyrax
+  module ManagesEmbargoes
+    extend ActiveSupport::Concern
+
+    included do
+      attr_accessor :curation_concern
+      helper_method :curation_concern
+      load_and_authorize_resource class: ActiveFedora::Base, instance_name: :curation_concern
+    end
+
+    # This is an override of Hyrax::ApplicationController
+    def deny_access(exception)
+      redirect_to root_path, alert: exception.message
+    end
+
+    def edit; end
+  end
+end

--- a/app/controllers/hyrax/embargoes_controller.rb
+++ b/app/controllers/hyrax/embargoes_controller.rb
@@ -1,0 +1,5 @@
+module Hyrax
+  class EmbargoesController < ApplicationController
+    include Hyrax::EmbargoesControllerBehavior
+  end
+end

--- a/app/controllers/hyrax/leases_controller.rb
+++ b/app/controllers/hyrax/leases_controller.rb
@@ -1,0 +1,5 @@
+module Hyrax
+  class LeasesController < ApplicationController
+    include Hyrax::LeasesControllerBehavior
+  end
+end

--- a/app/views/hyrax/base/_form_permission_under_embargo.html.erb
+++ b/app/views/hyrax/base/_form_permission_under_embargo.html.erb
@@ -6,7 +6,9 @@
 
   <section class="help-block">
     <p>
-      <strong>This work is under embargo.</strong>  You can change the settings of the embargo here, or you can visit the <%= link_to 'Embargo Management Page', main_app.edit_embargo_path(f.object) %> to deactivate it.
+      <strong>This work is under embargo.</strong>
+      You can change the settings of the embargo here, or you can
+      visit the <%= link_to 'Embargo Management Page', edit_embargo_path(f.object) %> to deactivate it.
     </p>
   </section>
 

--- a/app/views/hyrax/base/_form_permission_under_lease.html.erb
+++ b/app/views/hyrax/base/_form_permission_under_lease.html.erb
@@ -6,7 +6,9 @@
 
   <section class="help-block">
     <p>
-      <strong>This work is under lease.</strong>  You can change the settings of the lease here, or you can visit the <%= link_to 'Lease Management Page', main_app.edit_lease_path(f.object) %> to deactivate it.
+      <strong>This work is under lease.</strong>
+      You can change the settings of the lease here, or you can
+      visit the <%= link_to 'Lease Management Page', edit_lease_path(f.object) %> to deactivate it.
     </p>
   </section>
 

--- a/app/views/hyrax/embargoes/_embargo_history.html.erb
+++ b/app/views/hyrax/embargoes/_embargo_history.html.erb
@@ -1,0 +1,7 @@
+<ul>
+  <% curation_concern.embargo_history.each do |entry| %>
+    <% unless entry.empty? %>
+      <li><%= entry %></li>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/hyrax/embargoes/_list_active_embargoes.html.erb
+++ b/app/views/hyrax/embargoes/_list_active_embargoes.html.erb
@@ -1,0 +1,16 @@
+<table class="embargoes table">
+  <tbody>
+  <tr>
+    <th>Type of Work</th><th>Title</th><th>Current Visibility</th><th>Embargo Release Date</th><th>Visibility will Change to</th>
+  </tr>
+  <% assets_under_embargo.each do |curation_concern| %>
+    <tr>
+      <td class="human-readable-type"><%= curation_concern.human_readable_type %></td>
+      <td class="title"><%= link_to curation_concern, edit_embargo_path(curation_concern) %></td>
+      <td class="current-visibility"><%= visibility_badge(curation_concern.visibility) %></td>
+      <td class="embargo-release-date"><%= curation_concern.embargo_release_date %></td>
+      <td class="visibility-after-embargo"><%= visibility_badge(curation_concern.visibility_after_embargo) %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/hyrax/embargoes/_list_deactivated_embargoes.html.erb
+++ b/app/views/hyrax/embargoes/_list_deactivated_embargoes.html.erb
@@ -1,0 +1,10 @@
+<% assets_with_deactivated_embargoes.each do |curation_concern| %>
+  <%= link_to curation_concern, edit_embargo_path(curation_concern) %> <%= visibility_badge(curation_concern.visibility) %>
+  <ul>
+    <% curation_concern.embargo_history.each do |entry| %>
+      <% unless entry.empty? %>
+        <li><%= entry %></li>
+      <% end %>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
+++ b/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
@@ -1,0 +1,44 @@
+<% if assets_with_expired_embargoes.empty? %>
+  <table  class="embargoes table">
+    <tbody>
+    <tr>
+      <th>Type of Work</th><th>Title</th><th>Current Visibility</th><th>Embargo Release Date</th><th>Visibility will Change to</th>
+    </tr>
+    <tr>
+      <td colspan="5" class="text-center"><p>There are no expired embargoes in effect at this time.</p> </td>
+    </tr>
+    </tbody>
+  </table>
+
+<% else %>
+
+  <%= form_tag embargoes_path, method: :patch do %>
+    <%= submit_tag 'Deactivate Embargoes for Selected', class: 'btn btn-primary' %>
+    <table class="embargoes table">
+      <thead>
+        <tr>
+          <th></th><th>Type of Work</th><th>Title</th><th>Current Visibility</th><th>Embargo Release Date</th><th>Visibility will Change to</th><th></th>
+        </tr>
+      </thead>
+      <tbody>
+      <% assets_with_expired_embargoes.each_with_index do |curation_concern, i| %>
+        <tr>
+          <td><%= render 'hyrax/batch_select/add_button', document: curation_concern %></td>
+          <td class="human-readable-type"><%= curation_concern.human_readable_type %></td>
+          <td class="title"><%= link_to curation_concern, edit_embargo_path(curation_concern)  %></td>
+          <td class="current-visibility"><%= visibility_badge(curation_concern.visibility) %></td>
+          <td class="embargo-release-date"><%= curation_concern.embargo_release_date %></td>
+          <td class="visibility-after-embargo"><%= visibility_badge(curation_concern.visibility_after_embargo) %></td>
+          <td class="actions"><%= link_to 'Deactivate Embargo', embargo_path(curation_concern), method: :delete, class: 'btn btn-primary' %></td>
+        </tr>
+        <tr data-behavior="extra" data-id="<%= curation_concern.id %>" class="extra-embargo-info">
+          <td></td>
+          <td colspan=5>
+            <%= check_box_tag "embargoes[#{i}][copy_visibility]", curation_concern.id, true %> Change all files within <%= curation_concern %> to <%= visibility_badge(curation_concern.visibility_after_embargo) %>?</td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+<% end %>

--- a/app/views/hyrax/embargoes/edit.html.erb
+++ b/app/views/hyrax/embargoes/edit.html.erb
@@ -1,0 +1,43 @@
+<% provide :page_header do %>
+  <h1>Manage Embargoes for  <%= curation_concern %><span class="human_readable_type">(<%= curation_concern.human_readable_type %>)</span></h1>
+<% end %>
+
+<h2>Current Embargo</h2>
+<%= simple_form_for [main_app, curation_concern] do |f| %>
+  <fieldset class="set-access-controls">
+    <section class="help-block">
+      <p>
+        <% if curation_concern.embargo_release_date %>
+          <strong>This work is under embargo.</strong>
+        <% else %>
+          <strong>This work is not currently under embargo.</strong> If you would like to apply and embargo, provide the information here.
+        <% end %>
+      </p>
+    </section>
+
+    <div class="form-group">
+      <input type="hidden" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>" />
+      <%= render "hyrax/base/form_permission_embargo", curation_concern: curation_concern, f: f  %>
+    </div>
+  </fieldset>
+
+  <div class="row">
+    <div class="col-md-12 form-actions">
+      <% if curation_concern.embargo_release_date %>
+        <%= f.submit "Update Embargo", class: 'btn btn-primary' %>
+        <%= link_to "Deactivate Embargo", embargo_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
+      <% else %>
+        <%= f.submit "Apply Embargo", class: 'btn btn-primary' %>
+      <% end %>
+      <%= link_to 'Cancel and manage all embargoes', embargoes_path, class: 'btn btn-default' %>
+      <%= link_to "Return to editing this #{curation_concern.human_readable_type}", edit_polymorphic_path([main_app, curation_concern]), class: 'btn btn-default' %>
+    </div>
+  </div>
+<% end %>
+
+<h2>Past Embargoes</h2>
+<% if curation_concern.embargo_history.empty? %>
+  This <%= curation_concern.human_readable_type %> has never had embargoes applied to it.
+<% else %>
+  <%= render partial: "embargo_history" %>
+<% end %>

--- a/app/views/hyrax/embargoes/index.html.erb
+++ b/app/views/hyrax/embargoes/index.html.erb
@@ -1,0 +1,25 @@
+<% provide :page_header do %>
+    <h1><span class="fa fa-sitemap"></span> Manage Embargoes</h1>
+<% end %>
+
+<div class="panel panel-default">
+  <div class="panel-body">
+    <ul class="nav nav-tabs">
+      <li class="active"><a href="#active" data-toggle="tab">All Active Embargoes</a></li>
+      <li><a href="#expired" data-toggle="tab">Expired Active Embargoes</a></li>
+      <li><a href="#deactivated" data-toggle="tab">Deactivated Embargoes</a></li>
+    </ul>
+    <div class="tab-content">
+      <div class="tab-pane active" id="active">
+        <%= render "list_active_embargoes" %>
+      </div>
+      <div class="tab-pane" id="expired">
+        <%= render "list_expired_active_embargoes" %>
+      </div>
+      <div class="tab-pane" id="deactivated">
+        <%= render "list_deactivated_embargoes" %>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/views/hyrax/leases/_lease_history.html.erb
+++ b/app/views/hyrax/leases/_lease_history.html.erb
@@ -1,0 +1,7 @@
+<ul>
+  <% curation_concern.lease_history.each do |entry| %>
+    <% unless entry.empty? %>
+      <li><%= entry %></li>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/hyrax/leases/_list_active_leases.html.erb
+++ b/app/views/hyrax/leases/_list_active_leases.html.erb
@@ -1,0 +1,16 @@
+<table class="leases table">
+  <tbody>
+  <tr>
+    <th>Type of Work</th><th>Title</th><th>Current Visibility</th><th>Lease Release Date</th><th>Visibility will Change to</th>
+  </tr>
+  <% assets_under_lease.each do |curation_concern| %>
+    <tr>
+      <td class="human-readable-type"><%= curation_concern.human_readable_type %></td>
+      <td class="title"><%= link_to curation_concern, edit_lease_path(curation_concern) %></td>
+      <td class="current-visibility"><%= visibility_badge(curation_concern.visibility) %></td>
+      <td class="lease-expiration-date"><%= curation_concern.lease_expiration_date %></td>
+      <td class="visibility-after-lease"><%= visibility_badge(curation_concern.visibility_after_lease) %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/hyrax/leases/_list_deactivated_leases.html.erb
+++ b/app/views/hyrax/leases/_list_deactivated_leases.html.erb
@@ -1,0 +1,4 @@
+<% assets_with_deactivated_leases.each do |curation_concern| %>
+  <%= link_to curation_concern, edit_lease_path(curation_concern) %> <%= visibility_badge(curation_concern.visibility) %>
+  <%= render "lease_history", curation_concern: curation_concern %>
+<% end %>

--- a/app/views/hyrax/leases/_list_expired_active_leases.html.erb
+++ b/app/views/hyrax/leases/_list_expired_active_leases.html.erb
@@ -1,0 +1,43 @@
+<% if assets_with_expired_leases.empty? %>
+  <table  class="leases table">
+    <tbody>
+    <tr>
+      <th>Type of Work</th><th>Title</th><th>Current Visibility</th><th>Lease Release Date</th><th>Visibility will Change to</th>
+    </tr>
+    <tr>
+      <td colspan="5"><p>There are no expired leases in effect at this time.</p> </td>
+    </tr>
+    </tbody>
+  </table>
+
+<% else %>
+
+  <%= form_tag leases_path, method: :patch do %>
+    <%= submit_tag 'Deactivate Leases for Selected', class: 'btn btn-primary' %>
+    <table  class="leases table">
+      <thead>
+        <tr>
+          <th></th><th>Type of Work</th><th>Title</th><th>Current Visibility</th><th>Lease Release Date</th><th>Visibility will Change to</th><th></th>
+        </tr>
+      </thead>
+      <tbody>
+      <% assets_with_expired_leases.each_with_index do |curation_concern, i| %>
+        <tr>
+          <td><%= render 'hyrax/batch_select/add_button', document: curation_concern %></td>
+          <td class="human-readable-type"><%= curation_concern.human_readable_type %></td>
+          <td class="title"><%= link_to curation_concern, edit_lease_path(curation_concern)  %></td>
+          <td class="current-visibility"><%= visibility_badge(curation_concern.visibility) %></td>
+          <td class="lease-release-date"><%= curation_concern.lease_expiration_date %></td>
+          <td class="visibility-after-lease"><%= visibility_badge(curation_concern.visibility_after_lease) %></td>
+          <td class="actions"><%= link_to 'Deactivate Lease', embargo_path(curation_concern), method: :delete, class: 'btn btn-primary' %></td>
+        </tr>
+        <tr data-behavior="extra" data-id="<%= curation_concern.id %>" class="extra-lease-info">
+          <td></td>
+          <td colspan=5>
+            <%= check_box_tag "leases[#{i}][copy_visibility]", curation_concern.id, true %> Change all files within <%= curation_concern %> to <%= visibility_badge(curation_concern.visibility_after_lease) %>?</td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% end %>
+<% end %>

--- a/app/views/hyrax/leases/edit.html.erb
+++ b/app/views/hyrax/leases/edit.html.erb
@@ -1,0 +1,43 @@
+<% provide :page_header do %>
+  <h1>Manage Leases for  <%= curation_concern %><span class="human_readable_type">(<%= curation_concern.human_readable_type %>)</span></h1>
+<% end %>
+
+<h2>Current Lease</h2>
+<%= simple_form_for [main_app, curation_concern] do |f| %>
+  <fieldset class="set-access-controls">
+    <section class="help-block">
+      <p>
+        <% if curation_concern.lease_expiration_date %>
+          <strong>This work is under lease.</strong>
+        <% else %>
+          <strong>This work is not currently under lease.</strong> If you would like to apply a lease, provide the information here.
+        <% end %>
+      </p>
+    </section>
+
+    <div class="form-group">
+      <input type="hidden" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE %>" />
+      <%= render "hyrax/base/form_permission_lease", curation_concern: curation_concern, f: f  %>
+    </div>
+  </fieldset>
+
+  <div class="row">
+    <div class="col-md-12 form-actions">
+      <% if curation_concern.lease_expiration_date %>
+        <%= f.submit "Update Lease", class: 'btn btn-primary' %>
+        <%= link_to "Deactivate Lease", lease_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
+      <% else %>
+        <%= f.submit "Apply Lease", class: 'btn btn-primary' %>
+      <% end %>
+      <%= link_to 'Cancel and manage all leases', leases_path, class: 'btn btn-default' %>
+      <%= link_to "Return to editing this #{curation_concern.human_readable_type}", edit_polymorphic_path([main_app, curation_concern]), class: 'btn btn-default' %>
+    </div>
+  </div>
+<% end %>
+
+<h2>Past Leases</h2>
+<% if curation_concern.lease_history.empty? %>
+  This <%= curation_concern.human_readable_type %> has never had embargoes applied to it.
+<% else %>
+  <%= render "lease_history" %>
+<% end %>

--- a/app/views/hyrax/leases/index.html.erb
+++ b/app/views/hyrax/leases/index.html.erb
@@ -1,0 +1,24 @@
+<% provide :page_header do %>
+    <h1><span class="fa fa-sitemap"></span> Manage Leases</h1>
+<% end %>
+
+<div class="panel panel-default">
+  <div class="panel-body">
+    <ul class="nav nav-tabs">
+        <li class="active"><a href="#active" data-toggle="tab">All Active Leases</a></li>
+        <li><a href="#expired" data-toggle="tab">Expired Active Leases</a></li>
+        <li><a href="#deactivated" data-toggle="tab">Deactivated Leases</a></li>
+    </ul>
+    <div class="tab-content">
+      <div class="tab-pane active" id="active">
+        <%= render "list_active_leases" %>
+      </div>
+      <div class="tab-pane" id="expired">
+        <%= render "list_expired_active_leases" %>
+      </div>
+      <div class="tab-pane" id="deactivated">
+        <%= render "list_deactivated_leases" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,18 @@ Hyrax::Engine.routes.draw do
   get 'single_use_link/generated/:id' => 'single_use_links#index', as: :generated_single_use_links
   delete 'single_use_link/:id/delete/:link_id' => 'single_use_links#destroy', as: :delete_single_use_link
 
+  resources :embargoes, controller: 'embargoes', only: [:index, :edit, :destroy] do
+    collection do
+      patch :update
+    end
+  end
+
+  resources :leases, controller: 'leases', only: [:index, :edit, :destroy] do
+    collection do
+      patch :update
+    end
+  end
+
   # Permissions routes
   scope :concern do
     resources :permissions, only: [] do

--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -57,7 +57,6 @@ module Hyrax
         "  resources :welcome, only: 'index'\n"\
         "  root 'hyrax/homepage#index'\n"\
         "  curation_concerns_basic_routes\n"\
-        "  curation_concerns_embargo_management\n"\
       end
     end
 

--- a/lib/hyrax/rails/routes.rb
+++ b/lib/hyrax/rails/routes.rb
@@ -46,18 +46,9 @@ module ActionDispatch::Routing
       end
     end
 
-    # kmr added :show to make tests pass
     def curation_concerns_embargo_management
-      resources :embargoes, only: [:index, :edit, :destroy] do
-        collection do
-          patch :update
-        end
-      end
-      resources :leases, only: [:index, :edit, :destroy] do
-        collection do
-          patch :update
-        end
-      end
+      # routes moved to config/routes.rb
+      Deprecation.warn(self, '#curation_concerns_embargo_management is deprecated and has no effect. It will be removed in Hyrax 3.0')
     end
 
     private

--- a/spec/controllers/hyrax/embargoes_controller_spec.rb
+++ b/spec/controllers/hyrax/embargoes_controller_spec.rb
@@ -1,0 +1,103 @@
+RSpec.describe Hyrax::EmbargoesController do
+  let(:user) { create(:user) }
+  let(:a_work) { create(:generic_work, user: user) }
+  let(:not_my_work) { create(:generic_work) }
+
+  before { sign_in user }
+
+  describe '#index' do
+    context 'when I am NOT a repository manager' do
+      it 'redirects' do
+        get :index
+        expect(response).to redirect_to root_path
+      end
+    end
+    context 'when I am a repository manager' do
+      let(:user) { create(:user, groups: ['admin']) }
+      it 'shows me the page' do
+        get :index
+        expect(response).to be_success
+      end
+    end
+  end
+
+  describe '#edit' do
+    context 'when I do not have edit permissions for the object' do
+      it 'redirects' do
+        get :edit, params: { id: not_my_work }
+        expect(response.status).to eq 302
+        expect(flash[:alert]).to eq 'You are not authorized to access this page.'
+      end
+    end
+    context 'when I have permission to edit the object' do
+      it 'shows me the page' do
+        get :edit, params: { id: a_work }
+        expect(response).to be_success
+      end
+    end
+  end
+
+  describe '#destroy' do
+    context 'when I do not have edit permissions for the object' do
+      it 'denies access' do
+        get :destroy, params: { id: not_my_work }
+        expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
+      end
+    end
+
+    context 'when I have permission to edit the object' do
+      before do
+        expect(Hyrax::Actors::EmbargoActor).to receive(:new).with(a_work).and_return(actor)
+      end
+
+      let(:actor) { double }
+
+      context 'that has no files' do
+        it 'deactivates embargo and redirects' do
+          expect(actor).to receive(:destroy)
+          get :destroy, params: { id: a_work }
+          expect(response).to redirect_to edit_embargo_path(a_work)
+        end
+      end
+
+      context 'that has files' do
+        before do
+          a_work.members << create(:file_set)
+          a_work.save!
+        end
+
+        it 'deactivates embargo and checks to see if we want to copy the visibility to files' do
+          expect(actor).to receive(:destroy)
+          get :destroy, params: { id: a_work }
+          expect(response).to redirect_to confirm_permission_path(a_work)
+        end
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'when I have permission to edit the object' do
+      let(:file_set) { create(:file_set, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+      let(:release_date) { Time.zone.today + 2 }
+      before do
+        a_work.members << file_set
+        a_work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+        a_work.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+        a_work.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        a_work.embargo_release_date = release_date.to_s
+        a_work.embargo.save(validate: false)
+        a_work.save(validate: false)
+      end
+
+      context 'with an expired embargo' do
+        let(:release_date) { Time.zone.today - 2 }
+        it 'deactivates embargo, update the visibility and redirect' do
+          patch :update, params: { batch_document_ids: [a_work.id], embargoes: { '0' => { copy_visibility: a_work.id } } }
+          expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          expect(response).to redirect_to embargoes_path
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/leases_controller_spec.rb
+++ b/spec/controllers/hyrax/leases_controller_spec.rb
@@ -1,0 +1,103 @@
+RSpec.describe Hyrax::LeasesController do
+  let(:user) { create(:user) }
+  let(:a_work) { create(:generic_work, user: user) }
+  let(:not_my_work) { create(:generic_work) }
+
+  before { sign_in user }
+
+  describe '#index' do
+    context 'when I am NOT a repository manager' do
+      it 'redirects' do
+        get :index
+        expect(response).to redirect_to root_path
+      end
+    end
+    context 'when I am a repository manager' do
+      let(:user) { create(:user, groups: ['admin']) }
+      it 'shows me the page' do
+        get :index
+        expect(response).to be_success
+      end
+    end
+  end
+
+  describe '#edit' do
+    context 'when I do not have edit permissions for the object' do
+      it 'redirects' do
+        get :edit, params: { id: not_my_work }
+        expect(response.status).to eq 302
+        expect(flash[:alert]).to eq 'You are not authorized to access this page.'
+      end
+    end
+    context 'when I have permission to edit the object' do
+      it 'shows me the page' do
+        get :edit, params: { id: a_work }
+        expect(response).to be_success
+      end
+    end
+  end
+
+  describe '#destroy' do
+    context 'when I do not have edit permissions for the object' do
+      it 'denies access' do
+        get :destroy, params: { id: not_my_work }
+        expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
+      end
+    end
+
+    context 'when I have permission to edit the object' do
+      let(:actor) { double('lease actor') }
+      before do
+        allow(Hyrax::Actors::LeaseActor).to receive(:new).with(a_work).and_return(actor)
+      end
+
+      context 'that has no files' do
+        it 'deactivates the lease and redirects' do
+          expect(actor).to receive(:destroy)
+          get :destroy, params: { id: a_work }
+          expect(response).to redirect_to edit_lease_path(a_work)
+        end
+      end
+
+      context 'with files' do
+        before do
+          a_work.members << create(:file_set)
+          a_work.save!
+        end
+
+        it 'deactivates the lease and redirects' do
+          expect(actor).to receive(:destroy)
+          get :destroy, params: { id: a_work }
+          expect(response).to redirect_to confirm_permission_path(a_work)
+        end
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'when I have permission to edit the object' do
+      let(:file_set) { create(:file_set, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+      let(:expiration_date) { Time.zone.today + 2 }
+
+      before do
+        a_work.members << file_set
+        a_work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+        a_work.visibility_during_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        a_work.visibility_after_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+        a_work.lease_expiration_date = expiration_date.to_s
+        a_work.lease.save(validate: false)
+        a_work.save(validate: false)
+      end
+
+      context 'with an expired lease' do
+        let(:expiration_date) { Time.zone.today - 2 }
+        it 'deactivates lease, update the visibility and redirect' do
+          patch :update, params: { batch_document_ids: [a_work.id], leases: { '0' => { copy_visibility: a_work.id } } }
+          expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          expect(response).to redirect_to leases_path
+        end
+      end
+    end
+  end
+end

--- a/spec/features/embargo_spec.rb
+++ b/spec/features/embargo_spec.rb
@@ -1,0 +1,43 @@
+RSpec.feature 'embargo' do
+  let(:user) { create(:user) }
+  before do
+    sign_in user
+  end
+  describe 'creating an embargoed object' do
+    let(:future_date) { 5.days.from_now }
+    let(:later_future_date) { 10.days.from_now }
+
+    it 'can be created, displayed and updated', :clean_repo, :workflow do
+      visit '/concern/generic_works/new'
+      fill_in 'Title', with: 'Embargo test'
+      choose 'Embargo'
+      fill_in 'generic_work_embargo_release_date', with: future_date
+      select 'Private', from: 'Restricted to'
+      select 'Open Access', from: 'then open it up to'
+      click_button 'Save'
+
+      # chosen embargo date is on the show page
+      expect(page).to have_content(future_date.to_date.to_formatted_s(:standard))
+
+      click_link 'Edit'
+      click_link 'Embargo Management Page'
+
+      expect(page).to have_content('This work is under embargo.')
+      expect(page).to have_xpath("//input[@name='generic_work[embargo_release_date]' and @value='#{future_date.to_datetime.iso8601}']") # current embargo date is pre-populated in edit field
+
+      fill_in 'until', with: later_future_date.to_s
+
+      click_button 'Update Embargo'
+      expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard))
+    end
+  end
+
+  describe 'managing embargoes' do
+    let(:user) { create(:user, groups: ['admin']) }
+
+    it 'shows lists of objects under lease' do
+      visit '/embargoes'
+      expect(page).to have_content 'Manage Embargoes'
+    end
+  end
+end

--- a/spec/features/lease_spec.rb
+++ b/spec/features/lease_spec.rb
@@ -1,0 +1,43 @@
+RSpec.feature 'leases' do
+  let(:user) { create(:user) }
+  before do
+    sign_in user
+  end
+  describe 'create a new leased object' do
+    let(:future_date) { 5.days.from_now }
+    let(:later_future_date) { 10.days.from_now }
+
+    it 'can be created, displayed and updated', :clean_repo, :workflow do
+      visit '/concern/generic_works/new'
+      fill_in 'Title', with: 'Lease test'
+      choose 'Lease'
+      fill_in 'generic_work_lease_expiration_date', with: future_date
+      select 'Open Access', from: 'Is available for'
+      select 'Private', from: 'then restrict it to'
+      click_button 'Save'
+
+      # chosen lease date is on the show page
+      expect(page).to have_content(future_date.to_date.to_formatted_s(:standard))
+
+      click_link 'Edit'
+      click_link 'Lease Management Page'
+
+      expect(page).to have_content('This work is under lease.')
+      expect(page).to have_xpath("//input[@name='generic_work[lease_expiration_date]' and @value='#{future_date.to_datetime.iso8601}']") # current lease date is pre-populated in edit field
+
+      fill_in 'until', with: later_future_date.to_s
+
+      click_button 'Update Lease'
+      expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard)) # new lease date is displayed in message
+    end
+  end
+
+  describe 'managing leases' do
+    let(:user) { create(:user, groups: ['admin']) }
+
+    it 'shows lists of objects under lease' do
+      visit '/leases'
+      expect(page).to have_content 'Manage Leases'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #792 and related to https://github.com/samvera-labs/hyku/issues/1184

Changes proposed in this pull request:
* copy everything for embargoes and leases from CurationConcerns
  * adapt everything to the `Hyrax` namespace
  * some of the required content is already in hyrax

TODO:
- [x] hook up routes
- [x] find and copy over any additional helpers, views, etc.
- [x] find and copy over all the specs and get them working
- [x] get the feature specs working
- [x] cleanup commits

@samvera-labs/hyrax-code-reviewers 

