### PR TITLE
[WIP] Deprecate Hyrax's Noid functionality

### DIFF
--- a/app/models/concerns/hyrax/admin_set_behavior.rb
+++ b/app/models/concerns/hyrax/admin_set_behavior.rb
@@ -21,7 +21,7 @@ module Hyrax
     extend ActiveSupport::Concern
 
     include Hydra::AccessControls::WithAccessRight
-    include Hyrax::Noid
+    include ActiveFedora::Noid::Model if Hyrax.config.enable_noids?
     include Hyrax::HumanReadableType
     include Hyrax::HasRepresentative
 

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -6,7 +6,7 @@ module Hyrax
     include Hydra::AccessControls::Permissions
     include Hyrax::CoreMetadata
     include Hydra::Works::CollectionBehavior
-    include Hyrax::Noid
+    include ActiveFedora::Noid::Model if Hyrax.config.enable_noids?
     include Hyrax::HumanReadableType
     include Hyrax::HasRepresentative
     include Hyrax::Permissions

--- a/app/models/concerns/hyrax/file_set_behavior.rb
+++ b/app/models/concerns/hyrax/file_set_behavior.rb
@@ -7,7 +7,7 @@ module Hyrax
     include Hyrax::FileSet::Characterization
     include Hydra::WithDepositor
     include Serializers
-    include Hyrax::Noid
+    include ActiveFedora::Noid::Model if Hyrax.config.enable_noids?
     include Hyrax::FileSet::Derivatives
     include Permissions
     include Hyrax::FileSet::Indexing

--- a/app/models/concerns/hyrax/work_behavior.rb
+++ b/app/models/concerns/hyrax/work_behavior.rb
@@ -3,7 +3,7 @@ module Hyrax
     extend ActiveSupport::Concern
     include Hydra::Works::WorkBehavior
     include HumanReadableType
-    include Noid
+    include ActiveFedora::Noid::Model if Hyrax.config.enable_noids?
     include Permissions
     include Serializers
     include Hydra::WithDepositor

--- a/app/services/hyrax/noid.rb
+++ b/app/services/hyrax/noid.rb
@@ -4,6 +4,11 @@ module Hyrax
   module Noid
     extend ActiveSupport::Concern
 
+    included do
+      Deprecation.warn(self, "Hyrax::Noid is deprecated and will be removed in Hyrax 3.0. " \
+        "Instead add 'include ActiveFedora::Noid::Model' to the classes that you want to use noids on.")
+    end
+
     ## This overrides the default behavior, which is to ask Fedora for an id
     # @see ActiveFedora::Persistence.assign_id
     def assign_id

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -59,7 +59,7 @@ EOF
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'rails_autolink', '~> 1.1'
-  spec.add_dependency 'active_fedora-noid', '~> 2.0', '>= 2.0.2'
+  spec.add_dependency 'active_fedora-noid', '~> 2.2' # Deprecated. Remove in Hyrax 3.0
   spec.add_dependency 'awesome_nested_set', '~> 3.1'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
   spec.add_dependency 'kaminari_route_prefix', '~> 0.1.1'

--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -24,7 +24,6 @@ module Hyrax
   14. Updates simple_form to use browser validations
   15. Installs Blacklight gallery (and removes it's scss)
   16. Install jquery-datatables
-  17. Initializes the active-fedora_noid database-backed minter
          """
 
     def run_required_generators
@@ -159,10 +158,6 @@ module Hyrax
       insert_into_file 'app/assets/stylesheets/application.css', before: ' *= require_self' do
         " *= require dataTables/bootstrap/3/jquery.dataTables.bootstrap\n"
       end
-    end
-
-    def af_noid_database_minter_initialize
-      generate 'active_fedora:noid:install'
     end
   end
 end

--- a/lib/generators/hyrax/templates/config/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/hyrax.rb
@@ -52,19 +52,6 @@ Hyrax.config do |config|
   # If you have ffmpeg installed and want to transcode audio and video set to true
   # config.enable_ffmpeg = false
 
-  # Hyrax uses NOIDs for files and collections instead of Fedora UUIDs
-  # where NOID = 10-character string and UUID = 32-character string w/ hyphens
-  # config.enable_noids = true
-
-  # Template for your repository's NOID IDs
-  # config.noid_template = ".reeddeeddk"
-
-  # Use the database-backed minter class
-  # config.noid_minter_class = ActiveFedora::Noid::Minter::Db
-
-  # Store identifier minter's state in a file for later replayability
-  # config.minter_statefile = '/tmp/minter-state'
-
   # Prefix for Redis keys
   # config.redis_namespace = "hyrax"
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -103,22 +103,30 @@ module Hyrax
     deprecation_deprecate :max_days_between_audits= => "use max_days_between_fixity_checks= instead"
 
     attr_writer :enable_noids
+    deprecation_deprecate :enable_noids= => "Hyrax's noid integration will be removed in 3.0. Instead " \
+      "add 'include ActiveFedora::Noid::Model' to those models that you want to use NOIDs"
     def enable_noids?
       return @enable_noids unless @enable_noids.nil?
-      @enable_noids = true
+      @enable_noids = false
     end
 
     attr_writer :noid_template
+    deprecation_deprecate :noid_template= => "Hyrax's noid integration will be removed in 3.0. Instead " \
+      "set 'ActiveFedora::Noid.config.template=' directly"
     def noid_template
       @noid_template ||= '.reeddeeddk'
     end
 
     attr_writer :noid_minter_class
+    deprecation_deprecate :noid_minter_class= => "Hyrax's noid integration will be removed in 3.0. Instead " \
+      "set 'ActiveFedora::Noid.config.minter_class=' directly"
     def noid_minter_class
       @noid_minter_class ||= ActiveFedora::Noid::Minter::Db
     end
 
     attr_writer :minter_statefile
+    deprecation_deprecate :minter_statefile= => "Hyrax's noid integration will be removed in 3.0. Instead " \
+      "set 'ActiveFedora::Noid.config.statefile=' directly"
     def minter_statefile
       @minter_statefile ||= '/tmp/minter-state'
     end

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -70,9 +70,11 @@ module Hyrax
         ActiveFedora::Base.translate_uri_to_id = c.translate_uri_to_id
         ActiveFedora::Base.translate_id_to_uri = c.translate_id_to_uri
 
-        ActiveFedora::Noid.config.template = c.noid_template
-        ActiveFedora::Noid.config.minter_class = c.noid_minter_class
-        ActiveFedora::Noid.config.statefile = c.minter_statefile
+        if c.enable_noids?
+          ActiveFedora::Noid.config.template = c.noid_template
+          ActiveFedora::Noid.config.minter_class = c.noid_minter_class
+          ActiveFedora::Noid.config.statefile = c.minter_statefile
+        end
       end
     end
 

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -222,6 +222,7 @@ RSpec.describe FileSet do
   describe 'noid integration', :clean_repo do
     let(:service) { instance_double(ActiveFedora::Noid::Service, mint: noid) }
     before do
+      Hyrax.config.enable_noids = true
       allow(ActiveFedora::Noid::Service).to receive(:new).and_return(service)
     end
 
@@ -496,29 +497,6 @@ RSpec.describe FileSet do
       end
       specify 'title is set' do
         expect(terms[title_key]).to eql(title)
-      end
-    end
-  end
-
-  describe 'assign_id' do
-    let(:service) { instance_double(ActiveFedora::Noid::Service) }
-    before do
-      allow(ActiveFedora::Noid::Service).to receive(:new).and_return(service)
-    end
-    context 'with noids enabled (by default)' do
-      it 'uses the noid service' do
-        expect(service).to receive(:mint).once
-        subject.assign_id
-      end
-    end
-
-    context 'with noids disabled' do
-      before { Hyrax.config.enable_noids = false }
-      after { Hyrax.config.enable_noids = true }
-
-      it 'does not use the noid service' do
-        expect(service).not_to receive(:mint)
-        subject.assign_id
       end
     end
   end

--- a/spec/models/hyrax/work_behavior_spec.rb
+++ b/spec/models/hyrax/work_behavior_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyrax::WorkBehavior do
   it 'mixes together all the goodness' do
     expect(subject.class.ancestors).to include(::Hyrax::WithFileSets,
                                                ::Hyrax::HumanReadableType,
-                                               Hyrax::Noid,
+                                               ActiveFedora::Noid::Model,
                                                Hyrax::Serializers,
                                                Hydra::WithDepositor,
                                                Hydra::AccessControls::Embargoable,

--- a/spec/services/hyrax/noid_spec.rb
+++ b/spec/services/hyrax/noid_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Hyrax::Noid do
       end
     end
   end
+
+  before do
+    allow(Deprecation).to receive(:warn)
+  end
+
   let(:object) { class_with_noids.new(id: 1234) }
 
   describe 'when noids are not enabled' do

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -67,4 +67,14 @@ class TestAppGenerator < Rails::Generators::Base
   def relax_routing_constraint
     gsub_file 'config/initializers/arkivo_constraint.rb', 'false', 'true'
   end
+
+  # We've turned off noid by default, but show we can turn it on if we want to.
+  def enable_noids
+    generate 'active_fedora:noid:install'
+    config = 'config/initializers/hyrax.rb'
+    anchor = "Hyrax.config do |config|\n"
+    inject_into_file config, after: anchor do
+      "  config.enable_noids = true\n"
+    end
+  end
 end


### PR DESCRIPTION
NOID has been the favored ID generator since Sufia's early days.  But there are some issues with NOID:

1. It may be faster and less error prone to use the default Fedora UUIDs.
1. Some institutions may favor their own service for generating identifiers.  
1. Adding another mandatory dependency slows the build.

Deprecating NOID integration will enable us to address these issues.


*NOTE* If you were using noids, you must now explicitly turn them on: `config.enable_noids = true`. Previously this was the default.