### PR TITLE
Travis cache solr/fedora downloads

### DIFF
--- a/.fcrepo_wrapper
+++ b/.fcrepo_wrapper
@@ -1,0 +1,8 @@
+# Place any default configuration for solr_wrapper here
+port: 8984
+enable_jms: false
+
+download_dir: tmp/fcrepo_wrapper
+
+version: 4.7.3-RC-1
+

--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,0 +1,7 @@
+# Place any default configuration for solr_wrapper here
+# port: 8983
+
+instance_dir: tmp/solr-development
+
+download_dir: tmp/solr_wrapper
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
   bundler: true
   directories:
     - "travis_phantomjs"
+    - tmp/solr_wrapper
+    - tmp/fcrepo_wrapper
 
 before_install:
   - gem update --system


### PR DESCRIPTION
Fixes slack requests for travis to cache the solr/fedora downloads, to avoid download throttling.

Changes proposed in this pull request:
* add .solr_wrapper
  * specify a download directory
* add .fcrepo_wrapper
  * specify a download directory
  * specify a version of Fedora to download

@projecthydra-labs/hyrax-code-reviewers
