### PR TITLE
Display tab outlines for dashboard works and collections pages.

### DIFF
--- a/app/views/hyrax/my/collections/_tabs.html.erb
+++ b/app/views/hyrax/my/collections/_tabs.html.erb
@@ -1,9 +1,9 @@
 <ul class="nav nav-tabs" id="my_nav" role="navigation">
   <span class="sr-only">You are currently listing your collections.  You have <%= @response.docs.count %> <%= 'collecction'.pluralize(@response.docs.count)%> </span>
-    <li<%= ' class="active"'.html_safe if current_page?(hyrax.dashboard_collections_path) %>>
+    <li<%= ' class="active"'.html_safe if current_page?(hyrax.dashboard_collections_path(locale: nil)) %>>
     <%= link_to t('hyrax.dashboard.all.collections'), hyrax.dashboard_collections_path %>
   </li>
-  <li<%= ' class="active"'.html_safe if current_page?(hyrax.my_collections_path) %>>
+  <li<%= ' class="active"'.html_safe if current_page?(hyrax.my_collections_path(locale: nil)) %>>
     <%= link_to t('hyrax.dashboard.my.collections'), hyrax.my_collections_path %>
   </li>
 </ul>

--- a/app/views/hyrax/my/works/_tabs.html.erb
+++ b/app/views/hyrax/my/works/_tabs.html.erb
@@ -1,9 +1,9 @@
 <ul class="nav nav-tabs" id="my_nav" role="navigation">
   <span class="sr-only">You are currently listing your works.  You have <%= @response.docs.count %> <%= 'work'.pluralize(@response.docs.count)%> </span>
-  <li<%= ' class="active"'.html_safe if current_page?(hyrax.dashboard_works_path) %>>
+  <li<%= ' class="active"'.html_safe if current_page?(hyrax.dashboard_works_path(locale: nil)) %>>
     <%= link_to t('hyrax.dashboard.all.works'), hyrax.dashboard_works_path %>
   </li>
-  <li<%= ' class="active"'.html_safe if current_page?(hyrax.my_works_path) %>>
+  <li<%= ' class="active"'.html_safe if current_page?(hyrax.my_works_path(locale: nil)) %>>
     <%= link_to t('hyrax.dashboard.my.works'), hyrax.my_works_path %>
   </li>
 </ul>


### PR DESCRIPTION
Fixes #1069 

When the all/my collections/works pages on the dashboard include additional query string parameters the URLs fail to match the `current_page?`. This prevents the `active` class from being added to the appropriate tab.

Changes proposed in this pull request:
* Pass `locale: nil` to path helpers.

@samvera/hyrax-code-reviewers
