### PR TITLE
Add search action for dashboard collections path.

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -237,6 +237,8 @@ module Hyrax
           hyrax.dashboard_highlights_path
         when "hyrax/dashboard/works"
           hyrax.dashboard_works_path
+        when "hyrax/dashboard/collections"
+          hyrax.dashboard_collections_path
         else
           hyrax.my_works_path
         end

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -227,8 +227,6 @@ module Hyrax
 
       def search_action_for_dashboard
         case params[:controller]
-        when "hyrax/my/works"
-          hyrax.my_works_path
         when "hyrax/my/collections"
           hyrax.my_collections_path
         when "hyrax/my/shares"
@@ -240,6 +238,7 @@ module Hyrax
         when "hyrax/dashboard/collections"
           hyrax.dashboard_collections_path
         else
+          # hyrax/my/works controller and default cases.
           hyrax.my_works_path
         end
       end

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -207,6 +207,13 @@ RSpec.describe HyraxHelper, type: :helper do
       end
     end
 
+    context "when the user is on the all collections page" do
+      it "returns the all dashboard collections path" do
+        allow(helper).to receive(:params).and_return(controller: "hyrax/dashboard/collections")
+        expect(helper.search_form_action).to eq(hyrax.dashboard_collections_path)
+      end
+    end
+
     context "when the user is on the my highlights page" do
       it "returns the my dashboard highlights path" do
         allow(helper).to receive(:params).and_return(controller: "hyrax/my/highlights")


### PR DESCRIPTION
Fixes #1196 

When selecting an option from the per page drop-down menu for the "All Collections" page, the use is redirected to the "My Works" page.

Changes proposed in this pull request:
* Add case for `dashboard_collections_path` to `hyrax_helper_behavior.search_action_for_dashboard`

@samvera/hyrax-code-reviewers
