### PR TITLE
Add configuration option to disable full text extract

### DIFF
--- a/app/services/hyrax/file_set_derivatives_service.rb
+++ b/app/services/hyrax/file_set_derivatives_service.rb
@@ -49,8 +49,7 @@ module Hyrax
       def create_pdf_derivatives(filename)
         Hydra::Derivatives::PdfDerivatives.create(filename,
                                                   outputs: [{ label: :thumbnail, format: 'jpg', size: '338x493', url: derivative_url('thumbnail') }])
-        Hydra::Derivatives::FullTextExtract.create(filename,
-                                                   outputs: [{ url: uri, container: "extracted_text" }])
+        extract_full_text(filename, uri)
       end
 
       def create_office_document_derivatives(filename)
@@ -58,8 +57,7 @@ module Hyrax
                                                        outputs: [{ label: :thumbnail, format: 'jpg',
                                                                    size: '200x150>',
                                                                    url: derivative_url('thumbnail') }])
-        Hydra::Derivatives::FullTextExtract.create(filename,
-                                                   outputs: [{ url: uri, container: "extracted_text" }])
+        extract_full_text(filename, uri)
       end
 
       def create_audio_derivatives(filename)
@@ -82,6 +80,16 @@ module Hyrax
 
       def derivative_path_factory
         Hyrax::DerivativePath
+      end
+
+      # Calls the Hydra::Derivates::FulltextExtraction unless the extract_full_text
+      # configuration option is set to false
+      # @param [String] filename of the object to be used for full text extraction
+      # @param [String] uri to the file set (deligated to file_set)
+      def extract_full_text(filename, uri)
+        return unless Hyrax.config.extract_full_text?
+        Hydra::Derivatives::FullTextExtract.create(filename,
+                                                   outputs: [{ url: uri, container: "extracted_text" }])
       end
   end
 end

--- a/lib/generators/hyrax/templates/config/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/hyrax.rb
@@ -74,6 +74,10 @@ Hyrax.config do |config|
   # Path to the file derivatives creation tool
   # config.libreoffice_path = "soffice"
 
+  # Option to enable/disable full text extraction from PDFs
+  # Default is true, set to false to disable full text extraction
+  # config.extract_full_text = true
+
   # How many seconds back from the current time that we should show by default of the user's activity on the user's dashboard
   # config.activity_to_show_default_seconds_since_now = 24*60*60
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -373,6 +373,12 @@ module Hyrax
       @subject_prefix ||= "Contact form:"
     end
 
+    attr_writer :extract_full_text
+    def extract_full_text?
+      return @extract_full_text unless @extract_full_text.nil?
+      @extract_full_text = true
+    end
+
     private
 
       # @param [Symbol, #to_s] model_name - symbol representing the model

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -55,4 +55,5 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:translate_uri_to_id) }
   it { is_expected.to respond_to(:upload_path) }
   it { is_expected.to respond_to(:work_requires_files?) }
+  it { is_expected.to respond_to(:extract_full_text?) }
 end


### PR DESCRIPTION
This is related to issue #1089.

This provides an option that can be set to allow the skipping of full text generation when desired.

Note: This does not address issue #1089, but provides a work around for instances where full text extraction is causing encoding issues and full text is not required.
