### PR TITLE
Make indentation consistent in user_util_links partial

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,8 +1,8 @@
 <ul id="user_utility_links" class="nav navbar-nav navbar-right">
-    <%= render 'shared/locale_picker' if available_translations.size > 1 %>
-    <% if user_signed_in? %>
+  <%= render 'shared/locale_picker' if available_translations.size > 1 %>
+  <% if user_signed_in? %>
     <li>
-        <%= render 'hyrax/users/notify_number' %>
+      <%= render 'hyrax/users/notify_number' %>
     </li>
     <li class="dropdown">
       <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false} do %>

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -22,7 +22,7 @@
   <% else %>
     <li>
       <%= link_to main_app.new_user_session_path do %>
-        <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span > <%= t("hyrax.toolbar.profile.login") %>
+        <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> <%= t("hyrax.toolbar.profile.login") %>
       <% end %>
     </li>
   <% end %>


### PR DESCRIPTION
@jcoyne found this in Hyku when I overrode this view: https://github.com/samvera-labs/hyku/pull/1233/files/11f0d1d78b3040234fe1c5841c7bc0bff62eae4c#diff-83b496719ae1e0e43b9c5564724570de

