### PR TITLE
Change service `working_directory` to not slurp file into memory

### DIFF
--- a/app/services/hyrax/working_directory.rb
+++ b/app/services/hyrax/working_directory.rb
@@ -37,6 +37,23 @@ module Hyrax
 
       private
 
+        # @param [#read] stream The stream to copy from
+        # @param  [String] filename The file name to copy to
+        # @param  [Number] chunk_size How many bytes to copy at once
+        def copy_stream_to_file(stream, filename, chunk_size = 4096)
+          File.open(filename, 'wb') do |outfile|
+            loop do
+              begin
+                outfile.write(
+                  stream.readpartial(chunk_size) # throws EOFError when done
+                )
+              rescue EOFError
+                # all done. I hate using error handling for flow control
+              end
+            end
+          end
+        end
+
         # @param [String] id the identifier
         # @param [String] name the file name
         # @param [#read] stream the stream to copy to the working directory
@@ -45,7 +62,7 @@ module Hyrax
           working_path = full_filename(id, name)
           Rails.logger.debug "Writing #{name} to the working directory at #{working_path}"
           FileUtils.mkdir_p(File.dirname(working_path))
-          IO.copy_stream(stream, working_path)
+          copy_stream_to_file(stream, working_path)
           working_path
         end
 


### PR DESCRIPTION
Fixes #1128

Method `#copy_stream_to_working_directory` previously used ruby's
`copy_stream`, which reads the whole source stream into memory.

New `#copy_stream_to_file` uses `IO#readpartial` to ferry it around in
4k chunks.

`IO#readpartial` is preferred to `#read` because it doesn't assume the stream
is complete when first referenced. 4k is a common heap page size and
should be fairly efficient.

@samvera/hyrax-code-reviewers
