### PR TITLE
increase the number of AdminSets rendered on #index

### DIFF
--- a/app/services/hyrax/admin_set_service.rb
+++ b/app/services/hyrax/admin_set_service.rb
@@ -46,7 +46,7 @@ module Hyrax
 
       # @param [Symbol] access :read or :edit
       def builder(access)
-        search_builder.new(context, access)
+        search_builder.new(context, access).rows(100)
       end
 
       # Count number of files from admin set works

--- a/spec/services/hyrax/admin_set_service_spec.rb
+++ b/spec/services/hyrax/admin_set_service_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Hyrax::AdminSetService do
     let(:search_builder_instance) { double }
 
     it "calls the injected search builder" do
+      expect(search_builder_instance).to receive(:rows).and_return(search_builder_instance)
       expect(search_builder_instance).to receive(:reverse_merge).and_return({})
       subject
     end


### PR DESCRIPTION
by default, when visiting the AdminSet #index view, the number of rows rendered is limited to 10. The select list for adjusting viewable rows in the table is not intending on making a request of the server for more/less rows, it just adjusts the visible rows and pagination on the page. 

This patch increased the default number of rows to be rendered so that the table is capable of rendering and paginating up to 100 AdminSets.

I don't think this is the best long term solution for this issue, however it does somewhat fall in line with how this is done in the CollectionSearchBuilder. https://github.com/samvera/hyrax/blob/master/app/search_builders/hyrax/collection_search_builder.rb

