### PR TITLE
Tell hound to use our .eslintrc file

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -3,3 +3,7 @@ ruby:
 
 scss:
   config_file: .scss-lint.yml
+
+eslint:
+  enabled: true
+  config_file: .eslintrc


### PR DESCRIPTION
Otherwise it uses its own defaults.