### PR TITLE
Skipping authorize for file download for admins that can already read parent file_set

### DIFF
--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -41,6 +41,7 @@ module Hyrax
       # Hydra::Ability#download_permissions can't be used in this case because it assumes
       # that files are in a LDP basic container, and thus, included in the asset's uri.
       def authorize_download!
+        return if current_ability.admin?
         authorize! :read, params[asset_param_key]
       rescue CanCan::AccessDenied
         redirect_to default_image


### PR DESCRIPTION
Fixes #1163 

Bypasses the `authorize!` check for admin user in the downloads controller so that the file(s) in the direct container can be downloaded/viewed (i.e. thumbnails, etc.)

There's a problem I can't figure out where the admin user has already passed an ability check to read a private file_set, but then when the downloads controller authorizes that user for that same file_set, in order to allow its file content to be viewed, it fails.  For now recommending bypassing the check when `user_ability.admin?` to get this issue unstuck so that #790 is not affected by this problem.

@samvera/hyrax-code-reviewers
