### PR TITLE
Rename no-empty-label to no-label

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -58,7 +58,7 @@ rules:
   no-case-declarations: 2
   no-div-regex: 2
   no-else-return: 0
-  no-empty-label: 2
+  no-labels: 2
   no-empty-pattern: 2
   no-eq-null: 2
   no-eval: 2


### PR DESCRIPTION
This rule was removed and replaced in eslint 2.0
See http://eslint.org/docs/rules/no-empty-label
