### PR TITLE
Use layer 0 when making image derivatives

### DIFF
--- a/app/services/hyrax/file_set_derivatives_service.rb
+++ b/app/services/hyrax/file_set_derivatives_service.rb
@@ -74,8 +74,13 @@ module Hyrax
       end
 
       def create_image_derivatives(filename)
+        # We're asking for layer 0, becauase otherwise pyramidal tiffs flatten all the layers together into the thumbnail
         Hydra::Derivatives::ImageDerivatives.create(filename,
-                                                    outputs: [{ label: :thumbnail, format: 'jpg', size: '200x150>', url: derivative_url('thumbnail') }])
+                                                    outputs: [{ label: :thumbnail,
+                                                                format: 'jpg',
+                                                                size: '200x150>',
+                                                                url: derivative_url('thumbnail'),
+                                                                layer: 0 }])
       end
 
       def derivative_path_factory


### PR DESCRIPTION
Fixes problem where pyramidal tiffs get flattend into the thumbnail.
Thanks to @hackmastera for the fix:
https://github.com/chemheritage/chf-sufia/blob/b8d3d8747cb2a77e141febdac2f7d80ca5704a45/app/models/file_set.rb#L14


@samvera/hyrax-code-reviewers
