### PR TITLE
Sometimes WorkBehavior objects inherit Noid instead of Hyrax::Noid. F…

### DIFF
--- a/app/models/concerns/hyrax/work_behavior.rb
+++ b/app/models/concerns/hyrax/work_behavior.rb
@@ -3,7 +3,7 @@ module Hyrax
     extend ActiveSupport::Concern
     include Hydra::Works::WorkBehavior
     include HumanReadableType
-    include Noid
+    include Hyrax::Noid
     include Permissions
     include Serializers
     include Hydra::WithDepositor


### PR DESCRIPTION
…ixing it here fixes that problem.

Fixes #1287

I cannot figure out how to write an rspec test for this. In rspec, all seems to be working as expected. But in rails console, and in some places when I'm actually invoking a Hyrax::WorkBehavior object, it is not including Hyrax::Noid, just plain old Noid:
```
2.3.3 :007 > e.class
 => Etd
2.3.3 :008 > e.class.ancestors.include?(Hyrax::Noid)
 => false
2.3.3 :009 > e.class.ancestors.include?(Noid)
 => true
2.3.3 :010 > e.id
 => "e0b61595-b1fc-47dc-9f73-183cc6244bc1"
```

This prevents newly created objects from getting noid identifiers, and they instead get fedora style ids. This change fixes that behavior.

@samvera/hyrax-code-reviewers
