### PR TITLE
Asynchronous IngestJob and JobIoWrapper

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -56,6 +56,11 @@ module Hyrax
         true
       end
 
+      def ==(other)
+        return false unless other.is_a?(self.class)
+        file_set == other.file_set && relation == other.relation && user == other.user
+      end
+
       private
 
         # @return [Hydra::PCDM::File] the file referenced by relation

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -10,6 +10,40 @@ module Hyrax
         @user = user
       end
 
+      # @!group Asynchronous Operations
+
+      # Spawns asynchronous IngestJob
+      # Called from FileSetsController, AttachFilesToWorkJob, ImportURLJob, IngestLocalFileJob
+      # @param [Hyrax::UploadedFile, File, ActionDigest::HTTP::UploadedFile, Tempfile] file the file uploaded by the user
+      # @param [Symbol, #to_s] relation
+      # @return [IngestJob, FalseClass] false on failure, otherwise the queued job
+      def create_content(file, relation = :original_file)
+        # If the file set doesn't have a title or label assigned, set a default.
+        file_set.label ||= label_for(file)
+        file_set.title = [file_set.label] if file_set.title.blank?
+        return false unless file_set.save # Need to save to get an id
+        IngestJob.perform_later(wrapper!(file, relation))
+      end
+
+      # Spawns asynchronous IngestJob with user notification afterward
+      # @param [Hyrax::UploadedFile, File, ActionDigest::HTTP::UploadedFile, Tempfile] file the file uploaded by the user
+      # @param [Symbol, #to_s] relation
+      # @return [IngestJob] the queued job
+      def update_content(file, relation = :original_file)
+        IngestJob.perform_later(wrapper!(file, relation), notification: true)
+      end
+
+      # Spawns async ImportUrlJob to attach remote file to fileset
+      # @param [#to_s] url
+      # @return [IngestUrlJob] the queued job
+      def import_url(url)
+        file_set.update(import_url: url.to_s)
+        operation = Hyrax::Operation.create!(user: user, operation_type: "Attach File")
+        ImportUrlJob.perform_later(file_set, operation)
+      end
+
+      # @!endgroup
+
       # Adds the appropriate metadata, visibility and relationships to file_set
       # @note In past versions of Hyrax this method did not perform a save because it is mainly used in conjunction with
       #   create_content, which also performs a save.  However, due to the relationship between Hydra::PCDM objects,
@@ -29,29 +63,16 @@ module Hyrax
         yield(file_set) if block_given?
       end
 
-      # Called from FileSetsController, AttachFilesToWorkJob, ImportURLJob, IngestLocalFileJob
-      # @param [File, ActionDigest::HTTP::UploadedFile, Tempfile] file the file uploaded by the user.
-      # @param [Symbol, #to_sym] relation
-      # @return [Boolean] true on success, false otherwise
-      def create_content(file, relation = :original_file)
-        # If the file set doesn't have a title or label assigned, set a default.
-        file_set.label ||= label_for(file)
-        file_set.title = [file_set.label] if file_set.title.blank?
-        return false unless file_set.save # Need to save to get an id
-        build_file_actor(relation).ingest_file(io_decorator(file))
-        true
-      end
-
       # Adds a FileSet to the work using ore:Aggregations.
       # Locks to ensure that only one process is operating on the list at a time.
       def attach_to_work(work, file_set_params = {})
         acquire_lock_for(work.id) do
           # Ensure we have an up-to-date copy of the members association, so that we append to the end of the list.
           work.reload unless work.new_record?
-          copy_visibility(work, file_set) unless assign_visibility?(file_set_params)
+          file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
           work.ordered_members << file_set
-          set_representative(work, file_set)
-          set_thumbnail(work, file_set)
+          work.representative = file_set if work.representative_id.blank?
+          work.thumbnail = file_set if work.thumbnail_id.blank?
           # Save the work so the association between the work and the file_set is persisted (head_id)
           # NOTE: the work may not be valid, in which case this save doesn't do anything.
           work.save
@@ -70,15 +91,6 @@ module Hyrax
         true
       end
 
-      # @param [File, ActionDigest::HTTP::UploadedFile, Tempfile] file the file uploaded by the user.
-      # @param [Symbol, #to_sym] relation
-      # @return [Boolean] true on success, false otherwise
-      def update_content(file, relation = :original_file)
-        return false unless build_file_actor(relation).ingest_file(io_decorator(file))
-        Hyrax.config.callback.run(:after_update_content, file_set, user)
-        true
-      end
-
       def update_metadata(attributes)
         env = Actors::Environment.new(file_set, ability, attributes)
         CurationConcern.file_set_update_actor.update(env)
@@ -94,14 +106,6 @@ module Hyrax
         Hyrax::Actors::FileActor
       end
 
-      # Spawns async job to attach file to fileset
-      # @param [#to_s] url
-      def import_url(url)
-        file_set.update(import_url: url.to_s)
-        operation = Hyrax::Operation.create!(user: user, operation_type: "Attach File")
-        ImportUrlJob.perform_later(file_set, operation)
-      end
-
       private
 
         def ability
@@ -112,26 +116,36 @@ module Hyrax
           file_actor_class.new(file_set, relation, user)
         end
 
-        def io_decorator(file)
-          Hydra::Derivatives::IoDecorator.new(file, mime_for(file), label_for(file))
+        # uses create! because object must be persisted to serialize for jobs
+        def wrapper!(file, relation)
+          JobIoWrapper.create!(wrapper_params(file, relation))
         end
 
-        # @return [String, nil] mime type explicitly set or sniffed
-        def mime_for(file)
-          if file.respond_to?(:content_type) # e.g. ActionDispatch::Http::UploadedFile, CarrierWave::SanitizedFile
-            file.content_type
-          elsif file.respond_to?(:mime_type) # e.g. Hydra::Derivatives::IoDecorator
-            file.mime_type
-          elsif file.respond_to?(:path) # e.g. File (note: will be meaningless for Tempfile)
-            MIME::Types.type_for(File.extname(file.path)).first.content_type
-          end # else nil
+        # helps testing
+        # @return [Hash] params for JobIoWrapper (new or create)
+        def wrapper_params(file, relation)
+          args = { user: user, relation: relation.to_s, file_set_id: file_set.id }
+          if file.is_a?(Hyrax::UploadedFile)
+            args[:uploaded_file] = file
+            args[:path] = file.uploader.path
+          elsif file.respond_to?(:path)
+            args[:path] = file.path
+            args[:original_name] = file.original_filename if file.respond_to?(:original_filename)
+            args[:original_name] ||= file.original_name if file.respond_to?(:original_name)
+          else
+            raise "Require Hyrax::UploadedFile or File-like object, received #{file.class} object: #{file}"
+          end
+          args
         end
 
         # For the label, use the original_filename or original_name if it's there.
         # If the file was imported via URL, parse the original filename.
         # If all else fails, use the basename of the file where it sits.
+        # @note This is only useful for labeling the file_set, because of the recourse to import_url
         def label_for(file)
-          if file.respond_to?(:original_filename) # e.g. ActionDispatch::Http::UploadedFile, CarrierWave::SanitizedFile
+          if file.is_a?(Hyrax::UploadedFile)
+            file.uploader.filename
+          elsif file.respond_to?(:original_filename) # e.g. ActionDispatch::Http::UploadedFile, CarrierWave::SanitizedFile
             file.original_filename
           elsif file.respond_to?(:original_name) # e.g. Hydra::Derivatives::IoDecorator
             file.original_name
@@ -143,34 +157,8 @@ module Hyrax
           end
         end
 
-        # Takes an optional block and executes the block if the save was successful.
-        # @return [Boolean] false if the save was unsuccessful
-        def save
-          on_retry = ->(exception, _, _, _) { ActiveFedora::Base.logger.warn "Hyrax::Actors::FileSetActor#save Caught RSOLR error #{exception.inspect}" }
-          Retriable.retriable on: RSolr::Error::Http, on_retry: on_retry, tries: 4, base_interval: 0.01 do
-            return false unless file_set.save
-          end
-          yield if block_given?
-          true
-        end
-
         def assign_visibility?(file_set_params = {})
           !((file_set_params || {}).keys.map(&:to_s) & %w[visibility embargo_release_date lease_expiration_date]).empty?
-        end
-
-        # copy visibility from source_concern to destination_concern
-        def copy_visibility(source_concern, destination_concern)
-          destination_concern.visibility =  source_concern.visibility
-        end
-
-        def set_representative(work, file_set)
-          return if work.representative_id.present?
-          work.representative = file_set
-        end
-
-        def set_thumbnail(work, file_set)
-          return if work.thumbnail_id.present?
-          work.thumbnail = file_set
         end
 
         def unlink_from_work

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -14,7 +14,7 @@ module Hyrax
 
       # Spawns asynchronous IngestJob
       # Called from FileSetsController, AttachFilesToWorkJob, ImportURLJob, IngestLocalFileJob
-      # @param [Hyrax::UploadedFile, File, ActionDigest::HTTP::UploadedFile, Tempfile] file the file uploaded by the user
+      # @param [Hyrax::UploadedFile, File, ActionDigest::HTTP::UploadedFile] file the file uploaded by the user
       # @param [Symbol, #to_s] relation
       # @return [IngestJob, FalseClass] false on failure, otherwise the queued job
       def create_content(file, relation = :original_file)
@@ -26,7 +26,7 @@ module Hyrax
       end
 
       # Spawns asynchronous IngestJob with user notification afterward
-      # @param [Hyrax::UploadedFile, File, ActionDigest::HTTP::UploadedFile, Tempfile] file the file uploaded by the user
+      # @param [Hyrax::UploadedFile, File, ActionDigest::HTTP::UploadedFile] file the file uploaded by the user
       # @param [Symbol, #to_s] relation
       # @return [IngestJob] the queued job
       def update_content(file, relation = :original_file)

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -2,6 +2,7 @@ class IngestJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
   after_perform do |job|
+    # We want the lastmost Hash, if any.
     opts = job.arguments.reverse.detect { |x| x.is_a? Hash } || {}
     wrapper = job.arguments.first
     ContentNewVersionEventJob.perform_later(wrapper.file_set, wrapper.user) if opts[:notification]

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -1,0 +1,17 @@
+class IngestJob < Hyrax::ApplicationJob
+  queue_as Hyrax.config.ingest_queue_name
+
+  after_perform do |job|
+    opts = job.arguments.reverse.detect { |x| x.is_a? Hash } || {}
+    wrapper = job.arguments.first
+    ContentNewVersionEventJob.perform_later(wrapper.file_set, wrapper.user) if opts[:notification]
+  end
+
+  # @param [JobIoWrapper] wrapper
+  # @param [Boolean] notification send the user a notification, used in after_perform callback
+  # @see 'config/initializers/hyrax_callbacks.rb'
+  # rubocop:disable Lint/UnusedMethodArgument
+  def perform(wrapper, notification: false)
+    wrapper.ingest_file
+  end
+end

--- a/app/models/concerns/hyrax/user.rb
+++ b/app/models/concerns/hyrax/user.rb
@@ -22,6 +22,8 @@ module Hyrax::User
     has_many :deposit_rights_received, foreign_key: 'grantee_id', class_name: 'ProxyDepositRights', dependent: :destroy
     has_many :can_make_deposits_for, through: :deposit_rights_received, source: :grantor
 
+    has_many :job_io_wrappers, inverse_of: 'user'
+
     scope :guests, ->() { where(guest: true) }
     scope :registered, ->() { where(guest: false) }
     scope :without_system_accounts, -> { where("#{Hydra.config.user_key_field} not in (?)", [::User.batch_user_key, ::User.audit_user_key]) }

--- a/app/models/hyrax/uploaded_file.rb
+++ b/app/models/hyrax/uploaded_file.rb
@@ -4,6 +4,8 @@ module Hyrax
   class UploadedFile < ActiveRecord::Base
     self.table_name = 'uploaded_files'
     mount_uploader :file, UploadedFileUploader
+    alias uploader file
+    has_many :job_io_wrappers, inverse_of: 'uploaded_file', class_name: 'JobIoWrapper'
     belongs_to :user, class_name: '::User'
 
     before_destroy :remove_file!

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -16,7 +16,7 @@
 #  however, the uploaded_file is used preferentially for default original_name and mime_type,
 #  because it already has that information.
 class JobIoWrapper < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: false
   belongs_to :uploaded_file, optional: true, class_name: 'Hyrax::UploadedFile'
   validates :uploaded_file, presence: true, if: proc { |x| x.path.blank? }
   validates :file_set_id, presence: true

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -1,0 +1,71 @@
+# Primarily for jobs like IngestJob to revivify an equivalent FileActor to one that existed on
+# the caller's side of an asynchronous Job invocation.  This involves providing slots
+# for the metadata that might travel w/ the actor's various supported types of @file.
+# For example, we cannot just do:
+#
+#   SomeJob.perform_later(arg1, arg2, File.new('/path/to/file'))
+#
+# Because we'll get:
+#
+#   ActiveJob::SerializationError: Unsupported argument type: File
+#
+# This also applies to Hydra::Derivatives::IoDecorator, Tempfile, etc., pretty much any IO.
+#
+# @note Along with user and file_set_id, path or uploaded_file are required.
+#  If both are provided: path is used preferentially for access IF it exists;
+#  however, the uploaded_file is used preferentially for default original_name and mime_type,
+#  because it already has that information.
+class JobIoWrapper < ApplicationRecord
+  belongs_to :user
+  belongs_to :uploaded_file, optional: true, class_name: 'Hyrax::UploadedFile'
+  validates :uploaded_file, presence: true, if: Proc.new { |x| x.path.blank? }
+  validates :file_set_id, presence: true
+
+  after_initialize :static_defaults
+  delegate :read, to: :file
+
+  def original_name
+    super || extracted_original_name
+  end
+
+  def mime_type
+    super || extracted_mime_type
+  end
+
+  def file_set
+    FileSet.find(file_set_id)
+  end
+
+  def file_actor
+    Hyrax::Actors::FileActor.new(file_set, relation.to_sym, user)
+  end
+
+  private
+
+    def extracted_original_name
+      uploaded_file ? uploaded_file.uploader.filename : File.basename(path)
+    end
+
+    def extracted_mime_type
+      uploaded_file ? uploaded_file.uploader.content_type : Hydra::PCDM::GetMimeTypeForFile.call(original_name)
+    end
+
+    # @raise when uploaded_file *becomes* required but is missing
+    def uploaded_file!
+      uploaded_file || raise("path '#{path}' was unusable and uploaded_file empty")
+    end
+
+    # The magic that switches between local filepath and CarrierWave file
+    def file
+      @file ||= (file_from_path || uploaded_file!.uploader.file.to_file)
+    end
+
+    # @return [File, nil] nil if the path doesn't exist on this (worker) system
+    def file_from_path
+      File.open(path, 'rb') if File.exist?(path) && File.readable?(path)
+    end
+
+    def static_defaults
+      self.relation ||= 'original_file'
+    end
+end

--- a/app/services/hyrax/working_directory.rb
+++ b/app/services/hyrax/working_directory.rb
@@ -1,4 +1,5 @@
 module Hyrax
+  # @deprecated Use JobIoWrapper instead
   class WorkingDirectory
     class << self
       # Returns the file passed as filepath if that file exists. Otherwise it grabs the file from repository,

--- a/config/initializers/hyrax_callbacks.rb
+++ b/config/initializers/hyrax_callbacks.rb
@@ -11,9 +11,7 @@ Hyrax.config.callback.set(:after_revert_content) do |file_set, user, revision|
   ContentRestoredVersionEventJob.perform_later(file_set, user, revision)
 end
 
-Hyrax.config.callback.set(:after_update_content) do |file_set, user|
-  ContentNewVersionEventJob.perform_later(file_set, user)
-end
+# :after_update_content callback replaced by after_perform block in IngestJob
 
 Hyrax.config.callback.set(:after_update_metadata) do |curation_concern, user|
   ContentUpdateEventJob.perform_later(curation_concern, user)

--- a/db/migrate/20170621201939_create_job_io_wrappers.rb
+++ b/db/migrate/20170621201939_create_job_io_wrappers.rb
@@ -1,0 +1,15 @@
+class CreateJobIoWrappers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :job_io_wrappers do |t|
+      t.references :user
+      t.references :uploaded_file
+      t.string :file_set_id
+      t.string :mime_type
+      t.string :original_name
+      t.string :path
+      t.string :relation
+
+      t.timestamps
+    end
+  end
+end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -69,7 +69,6 @@ EOF
   spec.add_dependency 'dry-equalizer', '~> 0.2'
   spec.add_dependency 'dry-struct', '~> 0.1'
   spec.add_dependency 'redlock', '>= 0.1.2'
-  spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'active-fedora', '>= 11.3.1'
   spec.add_dependency 'linkeddata' # Required for getting values from geonames
 

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::Actors::FileActor do
     end
     it 'uses the relation from the actor' do
       expect(CharacterizeJob).to receive(:perform_later).with(file_set, String, io.tempfile.path)
-      expect(actor.ingest_file(io)).to be_truthy
+      actor.ingest_file(io)
       expect(file_set.reload.remastered.mime_type).to eq 'image/png'
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe Hyrax::Actors::FileActor do
 
     it 'uses the provided mime_type' do
       expect(CharacterizeJob).to receive(:perform_later).with(file_set, String, io.tempfile.path)
-      expect(actor.ingest_file(io)).to be_truthy
+      actor.ingest_file(io)
       expect(file_set.reload.original_file.mime_type).to eq 'image/gif'
     end
   end
@@ -60,7 +60,7 @@ RSpec.describe Hyrax::Actors::FileActor do
         versioning: false
       ).and_call_original
       expect(CharacterizeJob).to receive(:perform_later).with(file_set, String, io.tempfile.path)
-      expect(actor.ingest_file(io)).to be_truthy
+      actor.ingest_file(io)
     end
   end
 
@@ -99,7 +99,7 @@ RSpec.describe Hyrax::Actors::FileActor do
       allow(file_set).to receive(:save).and_return(true)
       allow(file_set).to receive(:original_file).and_return(pcdmfile)
       expect(CharacterizeJob).to receive(:perform_later).with(file_set, pcdmfile.id, io.tempfile.path)
-      expect(actor.ingest_file(io)).to be_truthy
+      actor.ingest_file(io)
     end
     it 'returns false when save fails' do
       allow(file_set).to receive(:save).and_return(false)
@@ -120,7 +120,7 @@ RSpec.describe Hyrax::Actors::FileActor do
     it 'reverts to a previous version of a file' do
       expect(file_set).not_to receive(:remastered)
       expect(actor.relation).to eq(:original_file)
-      expect(actor.revert_to(revision_id)).to be_truthy
+      actor.revert_to(revision_id)
     end
 
     describe 'for a different relation' do
@@ -128,7 +128,7 @@ RSpec.describe Hyrax::Actors::FileActor do
 
       it 'reverts to a previous version of a file' do
         expect(actor.relation).to eq(:remastered)
-        expect(actor.revert_to(revision_id)).to be_truthy
+        actor.revert_to(revision_id)
       end
       it 'does not rely on the default relation' do
         pending "Hydra::Works::VirusCheck must support other relations: https://github.com/samvera/hyrax/issues/1187"

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -3,17 +3,60 @@ require 'redlock'
 RSpec.describe Hyrax::Actors::FileSetActor do
   include ActionDispatch::TestProcess
 
-  let(:user)           { create(:user) }
-  let(:uploaded_file)  { fixture_file_upload('/world.png', 'image/png') }
-  let(:local_file)     { File.open(File.join(fixture_path, 'world.png')) }
-  let(:file_set)       { create(:file_set, content: local_file) }
-  let(:actor)          { described_class.new(file_set, user) }
-  let(:relation)       { :original_file }
-  let(:file_actor)     { Hyrax::Actors::FileActor.new(file_set, relation, user) }
-  let(:io)             { Hydra::Derivatives::IoDecorator.new(uploaded_file, uploaded_file.content_type, uploaded_file.original_filename) }
+  let(:user)          { create(:user) }
+  let(:file_path)     { File.join(fixture_path, 'world.png') }
+  let(:file)          { fixture_file_upload(file_path, 'image/png') } # we will override for the different types of File objects
+  let(:wrapper_path)  { file.path }                                   # override to match
+  let(:local_file)    { File.open(file_path) }
+  let(:file_set)      { create(:file_set, content: local_file) }
+  let(:actor)         { described_class.new(file_set, user) }
+  let(:relation)      { :original_file }
+  let(:file_actor)    { Hyrax::Actors::FileActor.new(file_set, relation, user) }
 
-  before do
-    allow(actor).to receive(:build_file_actor).with(relation).and_return(file_actor)
+  before { allow(CharacterizeJob).to receive(:perform_later) } # not testing that
+
+  describe 'private' do
+    let(:file_set) { build(:file_set) } # avoid 130+ LDP requests
+
+    describe '#wrapper_params' do
+      let(:baseline_args) { { user: user, file_set_id: file_set.id, relation: relation.to_s } }
+      let(:wrapper_args)  { baseline_args.merge(path: wrapper_path, original_name: actor.send(:label_for, file)) }
+
+      subject { actor.send(:wrapper_params, file, relation) }
+
+      it 'with Rack::Test::UploadedFile returns expected hash' do
+        expect(subject).to eq(wrapper_args)
+        expect(actor.send(:wrapper_params, file, :remastered)).to eq(wrapper_args.merge(relation: 'remastered'))
+      end
+
+      context 'with ::File' do
+        let(:file) { local_file }
+        it 'returns expected hash' do
+          wrapper_args.delete(:original_name)
+          expect(subject).to eq(wrapper_args)
+        end
+      end
+
+      context 'with Hyrax::UploadedFile' do
+        let(:file) { Hyrax::UploadedFile.new(user: user, file_set_uri: file_set.uri, file: local_file) }
+        let(:wrapper_path) { file.uploader.path }
+        it 'returns expected hash' do
+          wrapper_args.delete(:original_name)
+          expect(subject).to eq(wrapper_args.merge(uploaded_file: file))
+        end
+      end
+    end
+
+    describe '#assign_visibility?' do
+      let(:viz) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+      it 'without params, returns false' do
+        expect(actor.send(:assign_visibility?)).to eq false
+      end
+      it 'with string-keyed or symbol-keyed visibility, returns true' do
+        expect(actor.send(:assign_visibility?, visibility: viz)).to eq true
+        expect(actor.send(:assign_visibility?, 'visibility' => viz)).to eq true
+      end
+    end
   end
 
   describe 'creating metadata, content and attaching to a work' do
@@ -25,17 +68,9 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     before do
       allow(DateTime).to receive(:current).and_return(date_today)
       allow(actor).to receive(:acquire_lock_for).and_yield
-      # NOTE: we have to use this unweidly block instead of `.with(io)`
-      # because Hydra::Derivatives::IoDecorator objects cannot be compared
-      # https://github.com/samvera/hydra-derivatives/issues/165
-      # We reuse this pattern throughout this file.
-      # TODO: replace IoDecorator with a regular Hyrax::Io class
-      expect(file_actor).to receive(:ingest_file) do |input|
-        expect(input.mime_type).to eq(uploaded_file.content_type)
-        expect(input.original_name).to eq(uploaded_file.original_filename)
-      end
+      # expect(actor).to receive(:wrapper).with(file, relation)
       actor.create_metadata
-      actor.create_content(uploaded_file)
+      actor.create_content(file)
       actor.attach_to_work(work)
     end
 
@@ -69,31 +104,28 @@ RSpec.describe Hyrax::Actors::FileSetActor do
   end
 
   describe '#create_content' do
-    it 'calls ingest_file' do
-      expect(file_actor).to receive(:ingest_file) do |input|
-        expect(input.mime_type).to eq(uploaded_file.content_type)
-        expect(input.original_name).to eq(uploaded_file.original_filename)
+    before do
+      expect(JobIoWrapper).to receive(:create!).with(any_args) do |args|
+        JobIoWrapper.new(args) # skip persistence
       end
-      actor.create_content(uploaded_file)
+      expect(IngestJob).to receive(:perform_later).with(JobIoWrapper)
+    end
+
+    it 'calls ingest_file' do
+      actor.create_content(file)
     end
 
     context 'when an alternative relationship is specified' do
       let(:relation) { :remastered }
 
       it 'calls ingest_file' do
-        expect(file_actor).to receive(:ingest_file) do |input|
-          expect(input.mime_type).to eq(uploaded_file.content_type)
-          expect(input.original_name).to eq(uploaded_file.original_filename)
-        end
-        actor.create_content(uploaded_file, :remastered)
+        actor.create_content(file, :remastered)
       end
     end
 
     context 'using ::File' do
-      before do
-        allow(file_actor).to receive(:ingest_file).with(any_args)
-        actor.create_content(local_file)
-      end
+      let(:file) { local_file }
+      before { actor.create_content(local_file) }
 
       it 'sets the label and title' do
         expect(file_set.label).to eq(File.basename(local_file))
@@ -107,18 +139,14 @@ RSpec.describe Hyrax::Actors::FileSetActor do
 
     context 'when file_set.title is empty and file_set.label is not' do
       let(:long_name) do
-        'an absurdly long title that goes on way to long and ' \
-                         'messes up the display of the page which should not need ' \
-                         'to be this big in order to show this impossibly long, ' \
-                         'long, long, oh so long string'
+        'an absurdly long title that goes on way to long and messes up the display of the page which should not need ' \
+          'to be this big in order to show this impossibly long, long, long, oh so long string'
       end
       let(:short_name) { 'Nice Short Name' }
-      let(:actor)      { described_class.new(file_set, user) }
 
       before do
-        allow(file_actor).to receive(:ingest_file).with(any_args)
         allow(file_set).to receive(:label).and_return(short_name)
-        actor.create_content(uploaded_file)
+        actor.create_content(file)
       end
 
       subject { file_set.title }
@@ -128,21 +156,21 @@ RSpec.describe Hyrax::Actors::FileSetActor do
 
     context 'when a label is already specified' do
       let(:label) { 'test_file.png' }
-      let(:file_set_with_label) do
+      let(:file_set) do
         FileSet.new do |f|
           f.apply_depositor_metadata(user.user_key)
           f.label = label
         end
       end
-      let(:actor) { described_class.new(file_set_with_label, user) }
+      let(:actor) { described_class.new(file_set, user) }
 
       before do
-        allow(file_actor).to receive(:ingest_file).with(any_args)
-        actor.create_content(uploaded_file)
+        allow(IngestJob).to receive(:perform_later).with(JobIoWrapper)
+        actor.create_content(file)
       end
 
       it "retains the object's original label" do
-        expect(file_set_with_label.label).to eql(label)
+        expect(file_set.label).to eql(label)
       end
     end
   end
@@ -155,19 +183,14 @@ RSpec.describe Hyrax::Actors::FileSetActor do
   end
 
   describe "#update_content" do
-    let(:io) { Hydra::Derivatives::IoDecorator.new(local_file, uploaded_file.content_type, uploaded_file.original_filename) }
-
-    it 'calls ingest_file and returns true' do
-      expect(file_actor).to receive(:ingest_file) do |input|
-        expect(input.mime_type).to eq(uploaded_file.content_type)
-        expect(input.original_name).to eq(uploaded_file.original_filename)
-      end.and_return(true)
-      expect(actor.update_content(local_file)).to be true
+    it 'calls ingest_file and returns queued job' do
+      expect(IngestJob).to receive(:perform_later).with(any_args).and_return(IngestJob.new)
+      expect(actor.update_content(local_file)).to be_a(IngestJob)
     end
     it 'runs callbacks' do
-      # Do not bother ingesting the file -- test only that the callback is run
-      allow(file_actor).to receive(:ingest_file).with(any_args).and_return(true)
-      expect(Hyrax.config.callback).to receive(:run).with(:after_update_content, file_set, user)
+      # Do not bother ingesting the file -- test only the result of callback
+      allow(file_actor).to receive(:ingest_file).with(any_args).and_return(double)
+      expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
       actor.update_content(local_file)
     end
   end
@@ -227,80 +250,6 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     end
   end
 
-  describe "#assign_visibility?" do
-    context "when no params are specified" do
-      it "does not need to assign visibility" do
-        expect(actor.send(:assign_visibility?)).to eq false
-      end
-    end
-
-    context "when file set params with visibility are specified with symbols as keys" do
-      let(:file_set_params) { { visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC } }
-
-      it "does need to assign visibility" do
-        expect(actor.send(:assign_visibility?, file_set_params)).to eq true
-      end
-    end
-
-    context "when file set params with visibility are specified with strings as keys" do
-      let(:file_set_params) { { "visibility" => Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC } }
-
-      it "does need to assign visibility" do
-        expect(actor.send(:assign_visibility?, file_set_params)).to eq true
-      end
-    end
-  end
-
-  describe "#set_representative" do
-    let(:work) { build(:generic_work, representative: rep) }
-    let(:file_set) { build(:file_set) }
-
-    before do
-      actor.send(:set_representative, work, file_set)
-    end
-
-    context "when the representative isn't set" do
-      let(:rep) { nil }
-
-      it 'sets the representative' do
-        expect(work.representative).to eq file_set
-      end
-    end
-
-    context 'when the representative is already set' do
-      let(:rep) { build(:file_set, id: '123') }
-
-      it 'keeps the existing representative' do
-        expect(work.representative).to eq rep
-      end
-    end
-  end
-
-  describe "#set_thumbnail" do
-    let(:work) { build(:generic_work, thumbnail: thumb) }
-    let(:file_set) { build(:file_set) }
-
-    before do
-      actor.send(:set_thumbnail, work, file_set)
-    end
-
-    context "when the thumbnail isn't set" do
-      let(:thumb) { nil }
-
-      it 'sets the thumbnail' do
-        expect(work.thumbnail).to eq file_set
-      end
-    end
-
-    context 'when the thumbnail is already set' do
-      let(:thumb) { build(:file_set, id: '123') }
-
-      it 'keeps the existing thumbnail' do
-        expect(work.thumbnail).to eq thumb
-      end
-    end
-  end
-
   describe "#file_actor_class" do
     subject { actor.file_actor_class }
 
@@ -332,7 +281,6 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     before do
       original_adapter = ActiveJob::Base.queue_adapter
       ActiveJob::Base.queue_adapter = :inline
-      allow(CharacterizeJob).to receive(:perform_later)
       actor.create_content(fixture_file_upload(file1))
       actor.create_content(fixture_file_upload('hyrax_generic_stub.txt'))
       ActiveJob::Base.queue_adapter = original_adapter

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
 
       context 'with ::File' do
         let(:file) { local_file }
+
         it 'returns expected hash' do
           wrapper_args.delete(:original_name)
           expect(subject).to eq(wrapper_args)
@@ -40,6 +41,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       context 'with Hyrax::UploadedFile' do
         let(:file) { Hyrax::UploadedFile.new(user: user, file_set_uri: file_set.uri, file: local_file) }
         let(:wrapper_path) { file.uploader.path }
+
         it 'returns expected hash' do
           wrapper_args.delete(:original_name)
           expect(subject).to eq(wrapper_args.merge(uploaded_file: file))
@@ -49,6 +51,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
 
     describe '#assign_visibility?' do
       let(:viz) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+
       it 'without params, returns false' do
         expect(actor.send(:assign_visibility?)).to eq false
       end
@@ -125,6 +128,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
 
     context 'using ::File' do
       let(:file) { local_file }
+
       before { actor.create_content(local_file) }
 
       it 'sets the label and title' do

--- a/spec/config/hyrax_events_spec.rb
+++ b/spec/config/hyrax_events_spec.rb
@@ -26,13 +26,6 @@ RSpec.describe "hyrax_events using Hyrax callbacks" do
     end
   end
 
-  describe "after_update_content" do
-    it "queues a ContentNewVersionEventJob" do
-      expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
-      Hyrax.config.callback.run(:after_update_content, file_set, user)
-    end
-  end
-
   describe "after_update_metadata" do
     it "queues a ContentUpdateEventJob" do
       expect(ContentUpdateEventJob).to receive(:perform_later).with(curation_concern, user)

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Hyrax::FileSetsController do
                                              terms_of_service: '1' }
           expect(response.status).to eq 400
           msg = JSON.parse(response.body)['message']
-          expect(msg).to match(/no file for upload/i)
+          expect(msg).to match(/No file uploaded/i)
         end
       end
 

--- a/spec/models/job_io_wrapper_spec.rb
+++ b/spec/models/job_io_wrapper_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe JobIoWrapper, type: :model do
+  let(:user) { build(:user) }
+  let(:path) { fixture_path + '/world.png' }
+  let(:file_set_id) { 'bn999672v' }
+  let(:file_set) { instance_double(FileSet, id: file_set_id, uri: 'http://127.0.0.1/rest/fake/bn/99/96/72/bn999672v') }
+  let(:uploaded_file) { Hyrax::UploadedFile.new(user: user, file_set_uri: file_set.uri, file: File.open(path)) }
+  let(:args) {  { file_set_id: file_set_id, user: user, path: path } }
+  subject { described_class.new(args) }
+
+  it 'requires attributes' do
+    expect { described_class.create! }.to raise_error ActiveRecord::RecordInvalid
+    expect { described_class.create!(file_set_id: file_set_id, path: path) }.to raise_error ActiveRecord::RecordInvalid
+    expect { described_class.create!(file_set_id: file_set_id, user: user) }.to raise_error ActiveRecord::RecordInvalid
+    expect { subject.save! }.not_to raise_error
+  end
+
+  context 'with uploaded_file' do
+    let(:args) { { file_set_id: file_set_id, user: user, uploaded_file: uploaded_file } }
+    it 'accepted in leiu of path' do
+      expect { subject.save! }.not_to raise_error
+    end
+    it 'accepted along with path' do
+      expect { described_class.create!(args.merge(path: path)) }.not_to raise_error
+    end
+  end
+
+  it 'has a #user' do
+    expect(subject.user).to eq(user)
+    expect(subject.user_id).to eq(user.id)
+  end
+
+  describe '#relation' do
+    it 'has default value' do
+      expect(subject.relation).to eq('original_file')
+    end
+    it 'accepts new value' do
+      subject.relation = 'remastered'
+      expect(subject.relation).to eq('remastered')
+    end
+  end
+
+  describe '#original_name' do
+    it 'extracts default value' do
+      expect(subject.original_name).to eq('world.png')
+    end
+    it 'accepts new value' do
+      subject.original_name = 'foobar'
+      expect(subject.original_name).to eq('foobar')
+    end
+  end
+
+  describe '#mime_type' do
+    it 'extracts default value' do
+      expect(subject.mime_type).to eq('image/png')
+    end
+    it 'accepts new value' do
+      subject.mime_type = 'text/plain'
+      expect(subject.mime_type).to eq('text/plain')
+    end
+    it 'uses original_name if set' do
+      subject.original_name = '汉字.jpg'
+      expect(subject.mime_type).to eq('image/jpeg')
+      subject.original_name = 'no_suffix'
+      expect(subject.mime_type).to eq('application/octet-stream')
+    end
+  end
+
+  describe '#file_actor' do
+    let(:file_actor) { Hyrax::Actors::FileActor.new(file_set, subject.relation, user) }
+    it 'produces an appropriate FileActor' do
+      allow(subject).to receive(:file_set).and_return(file_set)
+      expect(subject.file_actor).to eq(file_actor)
+    end
+  end
+
+  describe '#read' do
+    it 'delivers contents' do
+      expect(subject.read).to eq(File.open(path, 'rb').read)
+    end
+    context 'text file' do
+      let(:path) { fixture_path + '/png_fits.xml' }
+      it 'delivers contents' do
+        expect(subject.read).to eq(File.open(path, 'rb').read)
+      end
+    end
+  end
+end

--- a/spec/models/job_io_wrapper_spec.rb
+++ b/spec/models/job_io_wrapper_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe JobIoWrapper, type: :model do
   let(:file_set_id) { 'bn999672v' }
   let(:file_set) { instance_double(FileSet, id: file_set_id, uri: 'http://127.0.0.1/rest/fake/bn/99/96/72/bn999672v') }
   let(:args) { { file_set_id: file_set_id, user: user, path: path } }
+
   subject(:wrapper) { described_class.new(args) }
 
   it 'requires attributes' do
@@ -112,6 +113,7 @@ RSpec.describe JobIoWrapper, type: :model do
 
   describe '#file_actor' do
     let(:file_actor) { Hyrax::Actors::FileActor.new(file_set, subject.relation, user) }
+
     it 'produces an appropriate FileActor' do
       allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
       expect(subject.file_actor).to eq(file_actor)
@@ -124,6 +126,7 @@ RSpec.describe JobIoWrapper, type: :model do
     end
     context 'text file' do
       let(:path) { fixture_path + '/png_fits.xml' }
+
       it 'delivers contents' do
         expect(subject.read).to eq(File.open(path, 'rb').read)
       end

--- a/spec/models/job_io_wrapper_spec.rb
+++ b/spec/models/job_io_wrapper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe JobIoWrapper, type: :model do
   let(:file_set_id) { 'bn999672v' }
   let(:file_set) { instance_double(FileSet, id: file_set_id, uri: 'http://127.0.0.1/rest/fake/bn/99/96/72/bn999672v') }
   let(:uploaded_file) { Hyrax::UploadedFile.new(user: user, file_set_uri: file_set.uri, file: File.open(path)) }
-  let(:args) {  { file_set_id: file_set_id, user: user, path: path } }
+  let(:args) { { file_set_id: file_set_id, user: user, path: path } }
   subject { described_class.new(args) }
 
   it 'requires attributes' do
@@ -68,7 +68,7 @@ RSpec.describe JobIoWrapper, type: :model do
   describe '#file_actor' do
     let(:file_actor) { Hyrax::Actors::FileActor.new(file_set, subject.relation, user) }
     it 'produces an appropriate FileActor' do
-      allow(subject).to receive(:file_set).and_return(file_set)
+      allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
       expect(subject.file_actor).to eq(file_actor)
     end
   end


### PR DESCRIPTION
Fixes #1239 
Follows #1206 

`IngestJob` replaces the removed `IngestFileJob`, and is wired in for asynchronous use as before.

`JobIoWrapper` is persistence-backed, allowing it to be passed to asynchronous jobs.

In actors, where async job is spawned, return it (instead of `true`), in case caller wants to wait for completion or otherwise track/reference it. This also signifies the difference between "action successfully completed" like from `.save` and "a deferred thing will determine success/failure".

Replace one-off `after_update_content` callback with `after_perform` block.  Otherwise, the callback can happen **before** the async event.

In general, I propose that the rails framework callbacks (especially on ActiveJob) are a universally better approach than our bespoke magic in `config/initializers/hyrax_callbacks.rb`, giving us:
- `before` callbacks, symmetric to each `after` callback
- `around` callbacks, combining `before` and `after` actions
- a complete range of other callbacks
- the ability to use asynchronicity without breaking timing logic

If the problem is that some job callers want the callback to be optional while others do not, see the implementation of `:notification` in `IngestJob`'s `after_perform` block for an example that handles that.

TODO:
- update downstream jobs to accept `JobIoWrapper` for completeness
- update last two jobs using `Hyrax::WorkingDirectory` and remove it