### PR TITLE
Fix label of open access

### DIFF
--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -72,6 +72,8 @@ de:
           header: Verwaltungssatz bearbeiten
         form:
           cancel: Stornieren
+          permission_destroy_errors:
+            admin_group: Die Gruppe der Repository-Administratoren kann nicht entfernt werden
           permission_update_errors:
             error: Ungültige Update-Option für Berechtigungsvorlage.
             no_date: Für die gewählte Release-Option ist ein Datum erforderlich.
@@ -90,6 +92,7 @@ de:
             visibility: Freigabe und Sichtbarkeit
             workflow: Arbeitsablauf
         form_participant_table:
+          admin_users: Repository-Administratoren
           allow_all_registered: Erlauben Sie allen registrierten Benutzern, sich einzuladen
           depositors:
             action: Aktion
@@ -340,6 +343,11 @@ de:
         title: Zur Sammlung hinzufügen
         update: Update-Sammlung
     collections:
+      form:
+        tabs:
+          description: Beschreibung
+          sharing: Teilen
+          visibility: Sichtweite
       search_form:
         label: Suche Sammlung %{title}
         placeholder: Suche Sammlung
@@ -655,7 +663,7 @@ de:
       open:
         class: Etiketten-Erfolg
         note_html: Jeder. Schauen Sie sich <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> für die Urheberrechtsrichtlinien des Publishers an, wenn Sie planen, Ihr %{type} in einer Zeitschrift zu patentieren und / oder zu veröffentlichen.
-        text: Offener Zugang
+        text: Öffentlichkeit
         warning_html: '<p> <strong>Bitte beachten Sie</strong> , dass etwas, das für die Welt sichtbar ist (dh das Markieren dieses als %{label}), als Publikation angesehen werden kann, die Ihre Fähigkeit beeinflussen könnte: </p><ul><li> Patent Ihre Arbeit </li><li> Veröffentlichen Sie Ihre Arbeit in einer Zeitschrift </li></ul><p> Überprüfen Sie <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> für weitere Informationen über Urheberrechtsrichtlinien des Publishers. </p>'
       open_title_attr: Ändern Sie die Sichtbarkeit dieser Ressource
       private:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -660,7 +660,7 @@ en:
       open:
         class: "label-success"
         note_html:  Everyone. Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for specific publishers' copyright policies if you plan to patent and/or publish your %{type} in a journal.
-        text: "Open Access"
+        text: Public
         warning_html: "<p>
                         <strong>Please note</strong>, making something visible to the world (i.e.
                         marking this as %{label}) may be

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1,268 +1,269 @@
+---
 es:
   activefedora:
     models:
-      batch_upload_item: 'Trabajos por Lote'
+      batch_upload_item: Trabajos por Lote
   activemodel:
     errors:
       messages:
-        conflict: "No se pueden guardar los cambios porque otro usuario (o tarea en segundo plano) actualizó este %{model} después de que comenzase su edición. Asegúrese de que todos los archivos se hayan adjuntado correctamente y vuelva a intentarlo. Este formulario se actualizó con la copia guardada más reciente del %{model}."
+        conflict: No se pueden guardar los cambios porque otro usuario (o tarea en segundo plano) actualizó este %{model} después de que comenzase su edición. Asegúrese de que todos los archivos se hayan adjuntado correctamente y vuelva a intentarlo. Este formulario se actualizó con la copia guardada más reciente del %{model}.
   blacklight:
     search:
       fields:
-        show:
-          admin_set: "En Conjunto Administrativo:"
-          based_near_label: "Ubicación"
-          contributor: "Colaboradores"
-          keyword: "Palabra Clave"
         facet:
-          admin_set_sim: "Colección"
-          suppressed_bsi: "Estado"
-          resource_type_sim: "Tipo de recurso"
+          admin_set_sim: Colección
+          resource_type_sim: Tipo de recurso
+          suppressed_bsi: Estado
+        show:
+          admin_set: 'En Conjunto Administrativo:'
+          based_near_label: Ubicación
+          contributor: Colaboradores
+          keyword: Palabra Clave
       filters:
-        title:    "Filtrado por:"
+        title: 'Filtrado por:'
       start_over: Borrar filtros
   errors:
     messages:
-      carrierwave_download_error: "No se pudo descargar la imagen."
-      carrierwave_integrity_error: "No es una imagen."
-      carrierwave_processing_error: "No se puede cambiar el tamaño de la imagen."
-      extension_blacklist_error: "La subida de archivos %{extension} no está permitida, tipos prohibidos: %{prohibited_types}"
-      extension_whitelist_error: "La subida de archivos %{extension} no está permitida, tipos permitidos: %{allowed_types}"
+      carrierwave_download_error: No se pudo descargar la imagen.
+      carrierwave_integrity_error: No es una imagen.
+      carrierwave_processing_error: No se puede cambiar el tamaño de la imagen.
+      extension_blacklist_error: 'La subida de archivos %{extension} no está permitida, tipos prohibidos: %{prohibited_types}'
+      extension_whitelist_error: 'La subida de archivos %{extension} no está permitida, tipos permitidos: %{allowed_types}'
   helpers:
     action:
       admin_set:
-        new: "Crear un nuevo conjunto administrativo"
+        new: Crear un nuevo conjunto administrativo
       batch:
-        new: "Crear un lote de trabajos"
-      cancel: "Cancelar"
+        new: Crear un lote de trabajos
+      cancel: Cancelar
       collection:
-        new: "Nueva Colección"
-      delete: "Borrar"
-      edit: "Editar"
+        new: Nueva Colección
+      delete: Borrar
+      edit: Editar
       work:
-        new: "Crear un nuevo trabajo"
+        new: Crear un nuevo trabajo
     submit:
       admin_set:
-        create: 'Guardar'
-        update: 'Guardar'
-      create: 'Guardar'
+        create: Guardar
+        update: Guardar
+      create: Guardar
       hyrax_permission_template:
-        create: 'Guardar'
-        update: 'Guardar'
+        create: Guardar
+        update: Guardar
       hyrax_permission_template_access:
-        create: 'Añadir'
+        create: Añadir
       proxy_deposit_request:
-        create: 'Transferir'
-      update: 'Guardar'
+        create: Transferir
+      update: Guardar
   hyrax:
-    account_label:      "Usuario"
-    active_consent_to_agreement:  "He leído y estoy de acuerdo con"
+    account_label: Usuario
+    active_consent_to_agreement: He leído y estoy de acuerdo con
     admin:
       admin_sets:
-        document_list:
-          edit: "Editar"
-          no_works: "El conjunto administrativo está vacío."
-          title: "Lista de elementos de este conjunto administrativo"
         delete:
-          error_default_set: "El conjunto administrativo no se puede eliminar ya que es el conjunto predeterminado"
-          error_not_empty:   "El conjunto administrativo no se puede eliminar ya que no está vacío"
-          notification:      "Conjunto administrativo eliminado correctamente"
+          error_default_set: El conjunto administrativo no se puede eliminar ya que es el conjunto predeterminado
+          error_not_empty: El conjunto administrativo no se puede eliminar ya que no está vacío
+          notification: Conjunto administrativo eliminado correctamente
+        document_list:
+          edit: Editar
+          no_works: El conjunto administrativo está vacío.
+          title: Lista de elementos de este conjunto administrativo
         edit:
-          header:         "Editar Conjunto Administrativo"
+          header: Editar Conjunto Administrativo
         form:
-          cancel:               "Cancelar"
+          cancel: Cancelar
           permission_destroy_errors:
-            admin_group:        "No se puede eliminar el grupo de administradores del repositorio"
-          permission_update_notices:
-            new_admin_set:      "Se ha creado el conjunto administrativo '%{name}'. Utilice las pestañas adicionales para definir otros aspectos del conjunto administrativo."
-            updated_admin_set:  "El conjunto administrativo '%{name}' se ha actualizado."
-            participants:       "Se han actualizado los derechos de participante del conjunto administrativo"
-            visibility:         "La configuración de visibilidad y lanzamiento del conjunto administrativo se ha actualizado."
-            workflow:           "El flujo de trabajo del conjunto administrativo se ha actualizado."
+            admin_group: No se puede eliminar el grupo de administradores del repositorio
           permission_update_errors:
-            varies:             "La opción de lanzamiento 'Varía' requiere una fecha o período de embargo."
-            no_date:            "Se requiere una fecha para la opción de lanzamiento seleccionada."
-            no_embargo:         "Se requiere un período de embargo para la opción seleccionada."
-            nothing:            "Seleccione opciones de lanzamiento antes de guardar."
-            error:              "Opción de actualización no válida para la plantilla de permiso."
+            error: Opción de actualización no válida para la plantilla de permiso.
+            no_date: Se requiere una fecha para la opción de lanzamiento seleccionada.
+            no_embargo: Se requiere un período de embargo para la opción seleccionada.
+            nothing: Seleccione opciones de lanzamiento antes de guardar.
+            varies: La opción de lanzamiento 'Varía' requiere una fecha o período de embargo.
+          permission_update_notices:
+            new_admin_set: Se ha creado el conjunto administrativo '%{name}'. Utilice las pestañas adicionales para definir otros aspectos del conjunto administrativo.
+            participants: Se han actualizado los derechos de participante del conjunto administrativo
+            updated_admin_set: El conjunto administrativo '%{name}' se ha actualizado.
+            visibility: La configuración de visibilidad y lanzamiento del conjunto administrativo se ha actualizado.
+            workflow: El flujo de trabajo del conjunto administrativo se ha actualizado.
           tabs:
-            description:        "Descripción"
-            participants:       "Participantes"
-            visibility:         "Lanzamiento y Visibilidad"
-            workflow:           "Flujo de trabajo"
+            description: Descripción
+            participants: Participantes
+            visibility: Lanzamiento y Visibilidad
+            workflow: Flujo de trabajo
         form_participant_table:
-          admin_users:          "Administradores del Repositorio"
-          allow_all_registered: "Permitir depositar a todos los usuarios registrados"
+          admin_users: Administradores del Repositorio
+          allow_all_registered: Permitir depositar a todos los usuarios registrados
           depositors:
-            action:             "Acción"
-            agent_name:         "Depositantes de este Conjunto"
-            empty:              "No se han agregado depositantes a este conjunto administrativo."
-            help:               "Los depositantes pueden agregar nuevas obras a este conjunto administrativo."
-            remove:             "Quitar"
-            title:              "Depositantes"
-            type:               "Tipo"
+            action: Acción
+            agent_name: Depositantes de este Conjunto
+            empty: No se han agregado depositantes a este conjunto administrativo.
+            help: Los depositantes pueden agregar nuevas obras a este conjunto administrativo.
+            remove: Quitar
+            title: Depositantes
+            type: Tipo
           managers:
-            action:             "Acción"
-            agent_name:         "Administradores de este Conjunto"
-            empty:              "No se han agregado administradores a este conjunto administrativo."
-            help:               "Los administradores de este conjunto administrativo pueden editar los metadatos establecidos, los participantes y los valores de liberación y visibilidad. Los administradores también pueden editar metadatos de un trabajo, agregar o quitar archivos de un trabajo y agregar nuevos trabajos al conjunto."
-            remove:             "Quitar"
-            title:              "Administradores"
-            type:               "Tipo"
-          registered_users:     "Usuarios Registrados"
+            action: Acción
+            agent_name: Administradores de este Conjunto
+            empty: No se han agregado administradores a este conjunto administrativo.
+            help: Los administradores de este conjunto administrativo pueden editar los metadatos establecidos, los participantes y los valores de liberación y visibilidad. Los administradores también pueden editar metadatos de un trabajo, agregar o quitar archivos de un trabajo y agregar nuevos trabajos al conjunto.
+            remove: Quitar
+            title: Administradores
+            type: Tipo
+          registered_users: Usuarios Registrados
           viewers:
-            action:             "Acción"
-            agent_name:         "Espectadores de este Conjunto"
-            empty:              "No se han agregado espectadores a este conjunto administrativo."
-            help:               "Los espectadores de este conjunto administrativo pueden ver los trabajos en el conjunto independientemente de la configuración de visibilidad aplicada a la obra. Por ejemplo, los espectadores pueden ver obras en este conjunto incluso si las obras están actualmente embargadas o restringidas."
-            remove:             "Quitar"
-            title:              "Espectadores"
-            type:               "Tipo"
+            action: Acción
+            agent_name: Espectadores de este Conjunto
+            empty: No se han agregado espectadores a este conjunto administrativo.
+            help: Los espectadores de este conjunto administrativo pueden ver los trabajos en el conjunto independientemente de la configuración de visibilidad aplicada a la obra. Por ejemplo, los espectadores pueden ver obras en este conjunto incluso si las obras están actualmente embargadas o restringidas.
+            remove: Quitar
+            title: Espectadores
+            type: Tipo
         form_participants:
-          add_group:            "Añadir grupo:"
-          add_participants:     "Añadir participantes"
-          add_user:             "Añadir usuario:"
-          current_participants: "Participantes actuales"
+          add_group: 'Añadir grupo:'
+          add_participants: Añadir participantes
+          add_user: 'Añadir usuario:'
+          current_participants: Participantes actuales
         form_visibility:
-          cancel:               "Cancelar"
-          page_description:     "Las opciones de liberación y visibilidad controlan cuándo y quiénes pueden descubrir y descargar los trabajos añadidos a este conjunto."
+          cancel: Cancelar
+          page_description: Las opciones de liberación y visibilidad controlan cuándo y quiénes pueden descubrir y descargar los trabajos añadidos a este conjunto.
           release:
-            description:        "Puede imponer un retraso (embargo) antes de que los trabajos de este conjunto administrativo se liberen para su descubrimiento y descarga."
-            fixed:              "Fijo -- retrasar la liberación de todos los trabajos hasta"
-            no_delay:           "Sin demora -- liberar todas los trabajos tan pronto como se depositen"
-            title:              "Lanzamiento"
+            description: Puede imponer un retraso (embargo) antes de que los trabajos de este conjunto administrativo se liberen para su descubrimiento y descarga.
+            fixed: Fijo -- retrasar la liberación de todos los trabajos hasta
+            no_delay: Sin demora -- liberar todas los trabajos tan pronto como se depositen
+            title: Lanzamiento
             varies:
-              between:          "Entre \"ahora\" y"
-              description:      "Varía -- los depositantes pueden fijar la fecha de lanzamiento para un trabajo individual:"
+              between: Entre "ahora" y
+              description: 'Varía -- los depositantes pueden fijar la fecha de lanzamiento para un trabajo individual:'
               embargo:
-                1yr:            "Un año después del depósito"
-                2yrs:           "Dos años después del depósito"
-                3yrs:           "Tres años después del depósito"
-                6mos:           "Seis meses después del depósito"
-                select:         "Seleccione el período de embargo..."
+                1yr: Un año después del depósito
+                2yrs: Dos años después del depósito
+                3yrs: Tres años después del depósito
+                6mos: Seis meses después del depósito
+                select: Seleccione el período de embargo...
           visibility:
-            description:        "Después de su fecha de lanzamiento, los trabajos de este conjunto pueden ser descubiertos y descargados por:"
-            everyone:           "Todos -- todos los trabajos de este conjunto serán públicos."
-            institution:        "Institución -- todos los trabajos serán visibles sólo para los usuarios autenticados de esta institución"
-            restricted:         "Restringido -- todos los trabajos serán visibles sólo para los administradores y gestores de repositorios y los revisores de este conjunto administrativo"
-            title:              "Visibilidad"
-            varies:             "Varía -- por defecto es público, pero los depositantes pueden restringir la visibilidad de los trabajos individuales"
+            description: 'Después de su fecha de lanzamiento, los trabajos de este conjunto pueden ser descubiertos y descargados por:'
+            everyone: Todos -- todos los trabajos de este conjunto serán públicos.
+            institution: Institución -- todos los trabajos serán visibles sólo para los usuarios autenticados de esta institución
+            restricted: Restringido -- todos los trabajos serán visibles sólo para los administradores y gestores de repositorios y los revisores de este conjunto administrativo
+            title: Visibilidad
+            varies: Varía -- por defecto es público, pero los depositantes pueden restringir la visibilidad de los trabajos individuales
         form_workflow:
-          cancel:         "Cancelar"
-          no_workflows:   "No hay flujos de trabajo que seleccionar."
-          page_description:     "Cada conjunto administrativo tiene un flujo de trabajo asociado con él. Este flujo de trabajo se aplica a todos los trabajos agregados al conjunto administrativo. Seleccione el flujo de trabajo que se utilizará para este conjunto de administración a continuación."
+          cancel: Cancelar
+          no_workflows: No hay flujos de trabajo que seleccionar.
+          page_description: Cada conjunto administrativo tiene un flujo de trabajo asociado con él. Este flujo de trabajo se aplica a todos los trabajos agregados al conjunto administrativo. Seleccione el flujo de trabajo que se utilizará para este conjunto de administración a continuación.
         new:
-          header:         "Crear Nuevo Conjunto Administrativo"
+          header: Crear Nuevo Conjunto Administrativo
         show:
-          breadcrumb:       "Ver Conjunto"
-          confirm_delete:   "¿Está seguro de que desea eliminar este conjunto administrativo? Esta acción no se puede deshacer."
-          header:           "Conjunto Administrativo"
-          item_list_header: "Trabajos en este conjunto"
+          breadcrumb: Ver Conjunto
+          confirm_delete: "¿Está seguro de que desea eliminar este conjunto administrativo? Esta acción no se puede deshacer."
+          header: Conjunto Administrativo
+          item_list_header: Trabajos en este conjunto
       appearances:
         show:
-          header:           "Apariencia"
+          header: Apariencia
         update:
           flash:
-            success:        "La apariencia se actualizó correctamente"
+            success: La apariencia se actualizó correctamente
       sidebar:
-        activity:           "Actividad"
-        admin_sets:         "Conjuntos Administrativos"
-        appearance:         "Apariencia"
-        collections:        "Colecciones"
-        configuration:      "Configuración"
-        content_blocks:     "Bloques de Contenido"
-        notifications:      "Notificaciones"
-        pages:              "Páginas"
-        profile:            "Perfil"
-        repository_objects: "Contenido del Repositorio"
-        settings:           "Ajustes"
-        statistics:         "Informes"
-        tasks:              "Tareas"
-        technical:          "Técnico"
-        transfers:          "Transferencias"
-        users:              "Usarios"
-        user_activity:      "Su Actividad"
-        workflow_review:    "Revisar Envíos"
-        workflow_roles:     "Roles del Flujo de trabajo"
-        works:              "Trabajos"
+        activity: Actividad
+        admin_sets: Conjuntos Administrativos
+        appearance: Apariencia
+        collections: Colecciones
+        configuration: Configuración
+        content_blocks: Bloques de Contenido
+        notifications: Notificaciones
+        pages: Páginas
+        profile: Perfil
+        repository_objects: Contenido del Repositorio
+        settings: Ajustes
+        statistics: Informes
+        tasks: Tareas
+        technical: Técnico
+        transfers: Transferencias
+        user_activity: Su Actividad
+        users: Usarios
+        workflow_review: Revisar Envíos
+        workflow_roles: Roles del Flujo de trabajo
+        works: Trabajos
       stats:
         deposited_form:
-          end_label: "Finalizando [el momento actual es el valor predeterminado]"
-          heading: "Ver Archivos Depositados:"
-          start_label: "Comenzando"
-        registered: "Registrado"
+          end_label: Finalizando [el momento actual es el valor predeterminado]
+          heading: 'Ver Archivos Depositados:'
+          start_label: Comenzando
+        registered: Registrado
         repository_objects:
           series:
-            published:   'Publicado'
-            unknown:     'Desconocido'
-            unpublished: 'Sin publicar'
+            published: Publicado
+            unknown: Desconocido
+            unpublished: Sin publicar
         user_deposits:
-          end_label: "Finalizando [el momento actual es el valor predeterminado]"
-          heading: "Ver archivos depositados por los usuarios"
-          start_label: "Comenzando"
+          end_label: Finalizando [el momento actual es el valor predeterminado]
+          heading: Ver archivos depositados por los usuarios
+          start_label: Comenzando
       users:
         index:
-          access_label: "Último acceso"
+          access_label: Último acceso
           describe_users_html:
-            one: "Hay <b>%{count} usario</b> en este repositorio."
-            other: "Hay <b>%{count} usarios</b> en este repositorio."
-          id_label:   "Nombre de usuario"
-          role_label: "Roles"
-          title: "Administrar usuarios"
+            one: Hay <b>%{count} usario</b> en este repositorio.
+            other: Hay <b>%{count} usarios</b> en este repositorio.
+          id_label: Nombre de usuario
+          role_label: Roles
+          title: Administrar usuarios
       workflow_roles:
-        header:     "Roles del Flujo de Trabajo"
+        header: Roles del Flujo de Trabajo
         index:
+          current_roles: Roles actuales
           delete:
             confirm: "¿Estás seguro?"
           header:
-            roles: "Roles"
-            user: "Usuario"
-          new_role: "Asignar Rol"
-          no_roles: "Sin roles"
-          current_roles: "Roles actuales"
+            roles: Roles
+            user: Usuario
+          new_role: Asignar Rol
+          no_roles: Sin roles
       workflows:
         index:
-          header: "Revise Envíos"
+          header: Revise Envíos
           tabs:
-            published: "Publicados"
-            under_review: "En Revisión"
+            published: Publicados
+            under_review: En Revisión
     api:
       accepted:
-        default: "Su solicitud se ha aceptado para su procesamiento, pero el procesamiento no está completo. Ver tarea para más información."
+        default: Su solicitud se ha aceptado para su procesamiento, pero el procesamiento no está completo. Ver tarea para más información.
       bad_request:
-        default: "No se puede procesar su solicitud. Ver errores para más información."
+        default: No se puede procesar su solicitud. Ver errores para más información.
       deleted:
-        default: "Eliminado el recurso"
+        default: Eliminado el recurso
       forbidden:
-        default: "No está autorizado para acceder a este contenido."
+        default: No está autorizado para acceder a este contenido.
       internal_error:
-        default: "El servidor encontró un error."
+        default: El servidor encontró un error.
       not_found:
-        default: "No se pudo encontrar un recurso que coincida con tu solicitud."
+        default: No se pudo encontrar un recurso que coincida con tu solicitud.
       success:
-        default: "Su solicitud se procesó correctamente."
+        default: Su solicitud se procesó correctamente.
       unauthorized:
         default: "¡Debe iniciar sesión para hacer eso!"
       unprocessable_entity:
-        default: "El recurso que intentó modificar no se puede modificar de acuerdo a su solicitud."
-        empty_file: "El archivo que subió no tiene contenido."
-    background_attribution_html: "Imagen de fondo CC by-nc-sa por <a href=\"https://flic.kr/p/eirxaf\" class=\"navbar-link\">f2b1610</a>"
+        default: El recurso que intentó modificar no se puede modificar de acuerdo a su solicitud.
+        empty_file: El archivo que subió no tiene contenido.
+    background_attribution_html: Imagen de fondo CC by-nc-sa por <a href="https://flic.kr/p/eirxaf" class="navbar-link">f2b1610</a>
     base:
       citations:
         header: 'Citaciones:'
       form_files:
-        dropzone: "Soltar archivos aquí."
+        dropzone: Soltar archivos aquí.
         external_upload: Proveedores en la Nube
         local_upload: Añadir Archivos locales
       form_progress:
+        required_agreement: Comprobar el acuerdo de depósito
         required_descriptions: Describa su trabajo
-        required_files:        Añadir archivos
-        required_agreement:    Comprobar el acuerdo de depósito
-        requirements:          Requisitos
+        required_files: Añadir archivos
+        requirements: Requisitos
       items:
         actions: Acciones
-        date_uploaded: "Fecha de subida"
-        empty:  "Este %{type} no tiene archivos asociados. Presione \"editar\" para añadir más archivos."
+        date_uploaded: Fecha de subida
+        empty: Este %{type} no tiene archivos asociados. Presione "editar" para añadir más archivos.
         header: Elementos
         thumbnail: Miniatura
         title: Título
@@ -272,30 +273,30 @@ es:
         attribute_values_label: Valores
         header: Descripciones
       relationships:
-        empty: "Este %{type} no está actualmente disponible en ninguna colección."
+        empty: Este %{type} no está actualmente disponible en ninguna colección.
         header: Relaciones
       relationships_parent_row:
-        label: "En %{type}:"
+        label: 'En %{type}:'
       relationships_parent_row_empty:
-        empty: "No hay relaciones %{type}."
-        label: "En %{type}:"
+        empty: No hay relaciones %{type}.
+        label: 'En %{type}:'
       show:
-        last_modified: "Última modificación: %{value}"
+        last_modified: 'Última modificación: %{value}'
       social_media:
-        facebook: 'Facebook'
-        google: 'Google+'
-        tumblr: 'Tumblr'
-        twitter: 'Twitter'
+        facebook: Facebook
+        google: Google+
+        tumblr: Tumblr
+        twitter: Twitter
     batch:
       help:
-        resource_type: "Puede seleccionar múltiples tipos a aplicar a todos los archivos"
-        title: "El nombre de archivo será el título predeterminado. Por favor, introduzca un título con más significado y los archivos aún serán preservados en el sistema."
+        resource_type: Puede seleccionar múltiples tipos a aplicar a todos los archivos
+        title: El nombre de archivo será el título predeterminado. Por favor, introduzca un título con más significado y los archivos aún serán preservados en el sistema.
     batch_uploads:
       disabled: Función desactivada por el administrador
       files:
+        button_label: Añadir Nuevo Trabajo
         instructions: Cada archivo será cargado en un nuevo trabajo separado, resultando en un trabajo por archivo cargado.
         upload_type_instructions: Para crear un único trabajo para todos los archivos, vaya a
-        button_label: Añadir Nuevo Trabajo
       new:
         header: Crear Nuevos Trabajos en Lote
         in_collections: Estos Trabajos en Colecciones
@@ -304,283 +305,287 @@ es:
       progress:
         header: Guardar Trabajos
     bread_crumb:
-      search_results: "Regresar a los resultados de búsqueda"
+      search_results: Regresar a los resultados de búsqueda
     collection:
       actions:
         add_works:
-          desc: "Añadir trabajos a esta Colección"
-          label: "Añadir trabajos"
+          desc: Añadir trabajos a esta Colección
+          label: Añadir trabajos
         delete:
           confirmation: "¿Borrar esta colección?"
-          desc: "Borrar esta colección"
-          label: "Borrar"
+          desc: Borrar esta colección
+          label: Borrar
         edit:
-          desc: "Editar esta colección"
-          label: "Editar"
-        header: "Acciones"
-      browse_view: "Vista Navegación"
+          desc: Editar esta colección
+          label: Editar
+        header: Acciones
+      browse_view: Vista Navegación
       document_list:
-        edit: "Editar"
-        no_visible_works: "La colección está vacía o no contiene elementos a los que tenga acceso."
+        edit: Editar
+        no_visible_works: La colección está vacía o no contiene elementos a los que tenga acceso.
       edit:
-        manage_items: "Administrar Elementos en esta Colección"
+        manage_items: Administrar Elementos en esta Colección
       form:
-        additional_fields: "Campos adicionales"
-        description: "Descripciones"
-      is_part_of: "Es parte de"
+        additional_fields: Campos adicionales
+        description: Descripciones
+      is_part_of: Es parte de
       select_form:
-        close: "Cerrar"
-        create: "Crear Colección"
-        create_new: "Añadir a una nueva Colección"
-        no_collections: "No tiene acceso a ninguna colección existente. Puede crear una nueva colección."
-        select_heading: "Seleccionar la colección a la que añadir tus archivos:"
-        title: "Añadir a la colección"
-        update: "Actualizar Colección"
+        close: Cerrar
+        create: Crear Colección
+        create_new: Añadir a una nueva Colección
+        no_collections: No tiene acceso a ninguna colección existente. Puede crear una nueva colección.
+        select_heading: 'Seleccionar la colección a la que añadir tus archivos:'
+        title: Añadir a la colección
+        update: Actualizar Colección
     collections:
+      form:
+        tabs:
+          description: Descripción
+          sharing: Compartir
+          visibility: Visibilidad
       search_form:
-        label: "Buscar Colección %{title}"
-        placeholder: "Buscar Colección"
+        label: Buscar Colección %{title}
+        placeholder: Buscar Colección
       show:
-        works_in_collection: "Trabajos en esta colección"
+        works_in_collection: Trabajos en esta colección
     contact_form:
-      button_label: "Enviar"
-      email_label: "Tu Correo Electrónico"
-      header: "Formulario de Contacto"
+      button_label: Enviar
+      email_label: Tu Correo Electrónico
+      header: Formulario de Contacto
       issue_types:
-        browsing: "Navegación y búsqueda"
-        changing: "Hacer cambios en mi contenido"
-        depositing: "Depositando contenido"
-        general: "Consulta general o solicitud"
-        reporting: "Informar de un problema"
-      message_label: "Mensaje"
-      name_label: "Tu Nombre"
-      notice: "Por favor, utilice el formulario de contacto para enviar preguntas sobre este sistema; para reportar un problema que está experimentando con el sistema; solicitar ayuda usando el sistema; o para comentarios generales. Consulte la página de ayuda para obtener información adicional acerca de este sistema."
-      select_type: "Seleccionar el Tipo de Problema"
-      subject_label: "Tema"
-      type_label: "Tipo de Problema"
+        browsing: Navegación y búsqueda
+        changing: Hacer cambios en mi contenido
+        depositing: Depositando contenido
+        general: Consulta general o solicitud
+        reporting: Informar de un problema
+      message_label: Mensaje
+      name_label: Tu Nombre
+      notice: Por favor, utilice el formulario de contacto para enviar preguntas sobre este sistema; para reportar un problema que está experimentando con el sistema; solicitar ayuda usando el sistema; o para comentarios generales. Consulte la página de ayuda para obtener información adicional acerca de este sistema.
+      select_type: Seleccionar el Tipo de Problema
+      subject_label: Tema
+      type_label: Tipo de Problema
     content_blocks:
-      cancel:       "Cancelar"
+      cancel: Cancelar
       tabs:
-        announcement_text: "Texto del Anuncio"
-        featured_researcher: "Investigador Destacado"
-        marketing_text: "Texto de Marketing"
-      updated: "Bloques de contenido actualizados."
+        announcement_text: Texto del Anuncio
+        featured_researcher: Investigador Destacado
+        marketing_text: Texto de Marketing
+      updated: Bloques de contenido actualizados.
     controls:
-      about:            "Acerca de"
-      contact:          "Contacto"
-      help:             "Ayuda"
-      home:             "Inicio"
+      about: Acerca de
+      contact: Contacto
+      help: Ayuda
+      home: Inicio
     dashboard:
-      additional_notifications: "ver todas las notificaciones"
+      additional_notifications: ver todas las notificaciones
       admin_sets:
-        admin_set:              "Conjunto administrativo"
-        files:                  "Archivos"
-        subtitle:               "Actividad reciente"
-        title:                  "Conjuntos administrativos"
-        works:                  "Trabajos"
+        admin_set: Conjunto administrativo
+        files: Archivos
+        subtitle: Actividad reciente
+        title: Conjuntos administrativos
+        works: Trabajos
       all:
-        collections:            "Todas los Colecciones"
-        works:                  "Todos los Trabajos"
-      authorize_proxies:        "Autorizar Proxies"
+        collections: Todas los Colecciones
+        works: Todos los Trabajos
+      authorize_proxies: Autorizar Proxies
       breadcrumbs:
-        admin:                  "Administración"
-      create_work:              "Crear Trabajo"
-      current_proxies:          "Proxies actuales"
+        admin: Administración
+      create_work: Crear Trabajo
+      current_proxies: Proxies actuales
       heading_actions:
-        close:                  "Cerrar"
-        create_work:            "Crear trabajo"
-        select_type_of_work:    "Seleccionar el tipo de trabajo"
-      manage_proxies:           "Administrar Proxies"
+        close: Cerrar
+        create_work: Crear trabajo
+        select_type_of_work: Seleccionar el tipo de trabajo
+      manage_proxies: Administrar Proxies
       my:
         action:
-          collection_confirmation: "El borrado de una colección de %{application_name} es permanente. Presione OK para borrar esta colección de %{application_name}, o Cancelar para cancelar esta operación"
-          delete_collection:       "Borrar Colección"
-          delete_work:             "Borrar Trabajo"
-          edit_collection:         "Editar Colección"
-          edit_work:               "Editar Trabajo"
-          select:                  "Seleccionar"
-          select_all:              "Seleccionar la página actual"
-          select_none:             "Seleccionar ninguno"
-          transfer:                "Cambiar el Propietario del Trabajo"
-          work_confirmation:       "El borrado de un trabajo de %{application_name} es permanente. Presione OK para borrar este trabajo de %{application_name}, o Cancelar para cancelar esta operación"
+          collection_confirmation: El borrado de una colección de %{application_name} es permanente. Presione OK para borrar esta colección de %{application_name}, o Cancelar para cancelar esta operación
+          delete_collection: Borrar Colección
+          delete_work: Borrar Trabajo
+          edit_collection: Editar Colección
+          edit_work: Editar Trabajo
+          select: Seleccionar
+          select_all: Seleccionar la página actual
+          select_none: Seleccionar ninguno
+          transfer: Cambiar el Propietario del Trabajo
+          work_confirmation: El borrado de un trabajo de %{application_name} es permanente. Presione OK para borrar este trabajo de %{application_name}, o Cancelar para cancelar esta operación
         collection_list:
-          description:    "Descripción:"
-          edit_access:    "Editar Acceso:"
-          groups:         "Grupos:"
-          users:          "Usuarios:"
-        collections:  "Mis Colecciones"
+          description: 'Descripción:'
+          edit_access: 'Editar Acceso:'
+          groups: 'Grupos:'
+          users: 'Usuarios:'
+        collections: Mis Colecciones
         facet_label:
-          collections: "Filtrar colecciones:"
-          highlighted: "Filtrar aspectos destacados:"
-          shared:      "Filtrar archivos compartidos:"
-          works:       "Filtrar trabajos:"
+          collections: 'Filtrar colecciones:'
+          highlighted: 'Filtrar aspectos destacados:'
+          shared: 'Filtrar archivos compartidos:'
+          works: 'Filtrar trabajos:'
         heading:
-          action:         "Acciones"
-          date_uploaded:  "Fecha añadida"
-          title:          "Título"
-          visibility:     "Visibilidad"
-        highlighted:  "Mis aspectos destacados"
-        shared:       "Trabajos compartidos conmigo"
+          action: Acciones
+          date_uploaded: Fecha añadida
+          title: Título
+          visibility: Visibilidad
+        highlighted: Mis aspectos destacados
+        shared: Trabajos compartidos conmigo
         sr:
-          batch_checkbox:   "Marque para agregar a una colección o editar la lista"
-          check_all_label:  "Seleccione todos los archivos a ser editados o agregados a una colección"
-          detail_label:     "Ver el resumen de"
-          listing:          "Enlistar los items que has depositado"
-          press_to:         "Presionar para"
-          show_label:       "Ver todos los detalles de"
-        works:        "Mis Trabajos"
-      no_activity:              "El usuario no tiene actividad reciente"
-      no_notifications:         "El usuario no tiene notificaciones"
-      no_transfer_requests:     "No ha recibido ninguna petición de transferencia"
-      no_transfers:             "No ha transferido ningún trabajo"
-      proxy_activity:           "Actividad de Proxy"
-      proxy_user:               "Usuario de Proxy"
+          batch_checkbox: Marque para agregar a una colección o editar la lista
+          check_all_label: Seleccione todos los archivos a ser editados o agregados a una colección
+          detail_label: Ver el resumen de
+          listing: Enlistar los items que has depositado
+          press_to: Presionar para
+          show_label: Ver todos los detalles de
+        works: Mis Trabajos
+      no_activity: El usuario no tiene actividad reciente
+      no_notifications: El usuario no tiene notificaciones
+      no_transfer_requests: No ha recibido ninguna petición de transferencia
+      no_transfers: No ha transferido ningún trabajo
+      proxy_activity: Actividad de Proxy
+      proxy_user: Usuario de Proxy
       show_admin:
-        new_visitors:       "Visitantes Nuevos"
-        registered_users:   "Usuarios registrados"
+        new_visitors: Visitantes Nuevos
+        registered_users: Usuarios registrados
         repository_growth:
-          title:            Crecimiento del Repositorio
-          subtitle:         Pasados 90 días
+          subtitle: Pasados 90 días
+          title: Crecimiento del Repositorio
         repository_objects:
-          title:            Objetos del Repositorio
-          subtitle:         Estado Actual
-        returning_visitors: "Visitantes Recurrentes"
-        total_visitors:     "Visitantes Totales"
+          subtitle: Estado Actual
+          title: Objetos del Repositorio
+        returning_visitors: Visitantes Recurrentes
+        total_visitors: Visitantes Totales
         user_activity:
-          title:            Actividad de Usuario
-          subtitle:         Nuevas inscripciones de usuarios
+          subtitle: Nuevas inscripciones de usuarios
+          title: Actividad de Usuario
       stats:
-        collections:        "Colecciones creadas"
-        file_downloads:     "Descargar"
-        file_views:         "Ver"
-        files:              "Archivos depositados"
-        heading:            "Mis Estadísticas"
-        works:              "Trabajos creados"
-      title:                    "Mi Panel de Control"
-      transfer_of_ownership:    "Transferencias de propiedad"
-      transfer_works_link:      "Seleccionar los trabajos a transferir"
-      transfers_received:       "Transferencias Recibidas"
-      transfers_sent:           "Transferencias Enviadas"
-      user_activity:            "Actividad de usuario"
-      user_notifications:       "Notificaciones de Usuario"
-      view_files:               "Ver Archivos"
+        collections: Colecciones creadas
+        file_downloads: Descargar
+        file_views: Ver
+        files: Archivos depositados
+        heading: Mis Estadísticas
+        works: Trabajos creados
+      title: Mi Panel de Control
+      transfer_of_ownership: Transferencias de propiedad
+      transfer_works_link: Seleccionar los trabajos a transferir
+      transfers_received: Transferencias Recibidas
+      transfers_sent: Transferencias Enviadas
+      user_activity: Actividad de usuario
+      user_notifications: Notificaciones de Usuario
+      view_files: Ver Archivos
     directory:
-      suffix:           "@ejemplo.org"
-    document_language:  "es"
-    edit_profile:       "Editar Perfil"
-    featured_researchers: "Investigadores Destacados"
+      suffix: "@ejemplo.org"
+    document_language: es
+    edit_profile: Editar Perfil
+    featured_researchers: Investigadores Destacados
     file_manager:
-      link_text: 'Administrador de archivos'
+      link_text: Administrador de archivos
     file_set:
-      browse_view: "Vista de Navegación"
+      browse_view: Vista de Navegación
       show:
-        download: "Descargar el archivo"
+        download: Descargar el archivo
         downloadable_content:
-          default_link: 'Descargar archivo'
-          heading: 'Contenido Descargable'
-          image_link: 'Descargar imagen'
-          office_link: 'Descargar archivo'
-          pdf_link: 'Descargar PDF'
+          default_link: Descargar archivo
+          heading: Contenido Descargable
+          image_link: Descargar imagen
+          office_link: Descargar archivo
+          pdf_link: Descargar PDF
     file_sets:
       groups_description:
-        description_html: >
-          La lista de grupos del listado "Seleccionar un grupo" es una lista de Grupos Administrados por el Usuario de la que
-          que es miembro. Puede seleccionar un grupo específico y asignar un nivel de acceso por archivo
-          dentro de %{application_name}, y del mismo modo puede agregar niveles de acceso de usuarios.
+        description_html: 'La lista de grupos del listado "Seleccionar un grupo" es una lista de Grupos Administrados por el Usuario de la que que es miembro. Puede seleccionar un grupo específico y asignar un nivel de acceso por archivo dentro de %{application_name}, y del mismo modo puede agregar niveles de acceso de usuarios.
+
+'
     help:
-      header: "Soporte al Usuario"
-      override_text: "Utilice app/views/static/help.html.erb para anular este archivo"
+      header: Soporte al Usuario
+      override_text: Utilice app/views/static/help.html.erb para anular este archivo
     homepage:
       admin_sets:
-        link:               'Ver todas las colecciones'
-        tab_label:          'Explorar Colecciones'
-        title:              'Explorar Colecciones'
+        link: Ver todas las colecciones
+        tab_label: Explorar Colecciones
+        title: Explorar Colecciones
       featured_researcher:
-        missing:            'No hay investigadores destacados'
-        tab_label:          'Investigador destacado'
-        title:              'Investigador destacado'
+        missing: No hay investigadores destacados
+        tab_label: Investigador destacado
+        title: Investigador destacado
       featured_works:
-        drag:               'Arrastrar'
-        no_works:           'No hay trabajos destacados'
-        tab_label:          'Trabajos destacados'
-        title:              'Trabajos destacados'
+        drag: Arrastrar
+        no_works: No hay trabajos destacados
+        tab_label: Trabajos destacados
+        title: Trabajos destacados
       recently_uploaded:
-        depositor:          'Depositante'
-        details:            'Detalles'
-        no_public:          'No hay trabajos públicos.'
-        tab_label:          'Subidos recientemente'
-        title:              'Subidos recientemente'
+        depositor: Depositante
+        details: Detalles
+        no_public: No hay trabajos públicos.
+        tab_label: Subidos recientemente
+        title: Subidos recientemente
     icons:
-      collection:       'fa fa-cubes'
-      default:          'fa fa-cube'
+      collection: fa fa-cubes
+      default: fa fa-cube
     mailbox:
-      date:     'Fecha'
-      delete:   'Borrar Mensaje'
-      message:  'Mensaje'
-      notifications_deleted: "Las notificaciones han sido borradas"
-      subject:  'Asunto'
+      date: Fecha
+      delete: Borrar Mensaje
+      message: Mensaje
+      notifications_deleted: Las notificaciones han sido borradas
+      subject: Asunto
     messages:
       failure:
         multiple:
-          keyword: "no pudieron ser actualizados. No tiene suficientes privilegios para editarlos."
-          link: "Estos archivos"
-        single: "no pudo ser actualizada. No tienes suficientes privilegios para editar."
-        subject: "Permiso denegado para la subida en lote"
-        title:  "Archivos fallidos"
+          keyword: no pudieron ser actualizados. No tiene suficientes privilegios para editarlos.
+          link: Estos archivos
+        single: no pudo ser actualizada. No tienes suficientes privilegios para editar.
+        subject: Permiso denegado para la subida en lote
+        title: Archivos fallidos
       success:
         multiple:
-          keyword: "han sido guardados."
-          link: "Estos archivos"
-        single: "ha sido guardado."
-        subject: "Subida en lote completa"
-        title:  "Archivos cargados satisfactoriamente"
+          keyword: han sido guardados.
+          link: Estos archivos
+        single: ha sido guardado.
+        subject: Subida en lote completa
+        title: Archivos cargados satisfactoriamente
     pages:
-      cancel:       "Cancelar"
+      cancel: Cancelar
       tabs:
-        about_page: "Página Acerca de nosotros"
-        help_page:  "Página de Ayuda"
-        agreement_page:  "Acuerdo de Depósito"
-        terms_page:  "Términos de Uso"
-      updated: "Páginas actualizadas."
-    passive_consent_to_agreement: "Al guardar este trabajo acepto a"
+        about_page: Página Acerca de nosotros
+        agreement_page: Acuerdo de Depósito
+        help_page: Página de Ayuda
+        terms_page: Términos de Uso
+      updated: Páginas actualizadas.
+    passive_consent_to_agreement: Al guardar este trabajo acepto a
     search:
       button:
-        html: '<span class="glyphicon glyphicon-search"></span> Ir'
-        text: "Buscar"
+        html: <span class="glyphicon glyphicon-search"></span> Ir
+        text: Buscar
       form:
         option:
           all:
-            label_long:   "Todos los %{application_name}"
-            label_short:  "Todo"
+            label_long: Todos los %{application_name}
+            label_short: Todo
           my_collections:
-            label_long:   "Mis Colecciones"
-            label_short:  "Mis Colecciones"
+            label_long: Mis Colecciones
+            label_short: Mis Colecciones
           my_shares:
-            label_long:   "Lo que he compartido"
-            label_short:  "Lo que he compartido"
+            label_long: Lo que he compartido
+            label_short: Lo que he compartido
           my_works:
-            label_long:   "Mis trabajos"
-            label_short:  "Mis trabajos"
+            label_long: Mis trabajos
+            label_short: Mis trabajos
         q:
-          label:          "Buscar en %{application_name}"
-          placeholder:    "Introduce términos de búsqueda"
+          label: Buscar en %{application_name}
+          placeholder: Introduce términos de búsqueda
     select_type:
-      description: "Tipo de trabajo de propósito general."
-      icon_class : 'fa fa-file-text-o'
-      name:        "Trabajo"
-    share_button:       "Comparte tu Trabajo"
+      description: Tipo de trabajo de propósito general.
+      icon_class: fa fa-file-text-o
+      name: Trabajo
+    share_button: Comparte tu Trabajo
     single_use_links:
-      button: "Enlace de un sólo uso al archivo"
+      button: Enlace de un sólo uso al archivo
       copy:
         button: Copiar
-        tooltip: ¡Copiado!
+        tooltip: "¡Copiado!"
       delete: Borrar
       download:
         type: Descargar
       expiration:
         lesser_time: en menos de una hora.
-        time: "en %{value} horas"
-      expiration_message: "El enlace %{link} expira en %{time}"
+        time: en %{value} horas
+      expiration_message: El enlace %{link} expira en %{time}
       show:
         type: Mostrar
       table:
@@ -590,117 +595,105 @@ es:
         link: Enlace
         no_links: No se han generado enlaces.
       title: Vínculos de uso único
-    sort_label: "Ordenar el listado de elementos"
+    sort_label: Ordenar el listado de elementos
     toolbar:
       dashboard:
-        menu: "Panel de Control"
-      language_switch: "Cambiar idioma"
-      notifications: "No hay notificaciones sin leer."
+        menu: Panel de Control
+      language_switch: Cambiar idioma
+      notifications: No hay notificaciones sin leer.
       profile:
-        login: "Iniciar sesión"
-        logout: "Cerrar sesión"
-        sr_action: "Ver"
-        sr_target: "perfil"
+        login: Iniciar sesión
+        logout: Cerrar sesión
+        sr_action: Ver
+        sr_target: perfil
     transfers:
       new:
         confirm: "¿Está seguro de que desea transferir la propiedad de este trabajo a otro usuario? Haga clic en Aceptar para transferir o Cancelar para volver a la pantalla de transferencia"
     upload:
       alert:
-        contact_href_text: "formulario de contacto"
-        fail_html: "Hubo un problema durante la subida, ninguno de sus archivos se ha cargado de forma correcta. Por favor %{reload_href}. Utilice la %{contact_href} para informar del error si persiste."
-        fail_restart_href_text: "comenzar de nuevo"
-        partial_fail_html: "Uno o más archivos no se han subido de forma correcta. Para continuar utilizando los archivos cargados %{metadata_href}. <br /> Utilizce la %{contact_href} para informar del error si persiste."
-        partial_fail_metadata_href_text: "editar los metadatos"
+        contact_href_text: formulario de contacto
+        fail_html: Hubo un problema durante la subida, ninguno de sus archivos se ha cargado de forma correcta. Por favor %{reload_href}. Utilice la %{contact_href} para informar del error si persiste.
+        fail_restart_href_text: comenzar de nuevo
+        partial_fail_html: Uno o más archivos no se han subido de forma correcta. Para continuar utilizando los archivos cargados %{metadata_href}. <br /> Utilizce la %{contact_href} para informar del error si persiste.
+        partial_fail_metadata_href_text: editar los metadatos
       browse_everything:
-        browse_files_button: "Navegar archivos en la nube"
-        files_selected: "archivos seleccionados"
-        sr_tab_label: "Acceder a los archivos desde"
-        tab_label: "Proveedores en la Nube"
-      change_access_flash_message: "Actualizando los niveles de acceso. Esto puede tomar unos minutos. Quizás quiera actualizar su navegador o regresar a este registro posteriormente para ver los niveles de acceso."
+        browse_files_button: Navegar archivos en la nube
+        files_selected: archivos seleccionados
+        sr_tab_label: Acceder a los archivos desde
+        tab_label: Proveedores en la Nube
+      change_access_flash_message: Actualizando los niveles de acceso. Esto puede tomar unos minutos. Quizás quiera actualizar su navegador o regresar a este registro posteriormente para ver los niveles de acceso.
       change_access_message_html: "<p>Ha cambiado los permisos de acceso en el trabajo <i>%{curation_concern}</i>, haciéndolo accesible a otros usuarios o grupos para ver o editar.</p><p>¿Le gustaría también cambiar todos los archivos dentro del mismo trabajo para que tengan los mismos usuarios de acceso, grupos y visibilidad?</p>"
-      change_access_no_message: "No. Los actualizaré automáticamente."
-      change_access_yes_message: "Sí, por favor."
+      change_access_no_message: No. Los actualizaré automáticamente.
+      change_access_yes_message: Sí, por favor.
       change_permissions_message_html: "<p>Ha cambiado los permisos en %{curation_concern_human_readable_type}, <i>%{curation_concern}</i>, haciéndolo visible para <b>%{visibility_badge}</b>.</p><p>¿Le gustaría también cambiar todos los archivos dentro de %{curation_concern_human_readable_type} a <b>%{visibility_badge}</b> también?</p>"
-      cloud_timeout_message_html: "En caso de subir una gran cantidad de archivos en un corto periodo de tiempo, el proveedor en la nube podría no ser capaz de resolver la petición. Si se experimentan errores durante la carga, por favor, comuníquese con nosotros a través de %{contact_href}."
+      cloud_timeout_message_html: En caso de subir una gran cantidad de archivos en un corto periodo de tiempo, el proveedor en la nube podría no ser capaz de resolver la petición. Si se experimentan errores durante la carga, por favor, comuníquese con nosotros a través de %{contact_href}.
       local_ingest:
-        tab_label: "Ubicación en Red/Servidor"
+        tab_label: Ubicación en Red/Servidor
       my_computer:
-        sr_instructions: "Acepto los términos de depósito y seleccionar los archivos a continuación. Presiona el botón de subir una vez que todos los archivos se hayan seleccionado."
-        sr_tab_label: "Acceder a archivos desde"
-        tab_label: "Mi ordenador"
-      permissions_message: "Actualizando permisos de archivo. Esto puede tardar unos minutos. Quizás quiera actualizar su navegador o regresar a este registro posteriormente para ver los permisos actualizados."
-      processing: "El archivo se está procesando; se puede editar en cuanto termine el procesamiento"
+        sr_instructions: Acepto los términos de depósito y seleccionar los archivos a continuación. Presiona el botón de subir una vez que todos los archivos se hayan seleccionado.
+        sr_tab_label: Acceder a archivos desde
+        tab_label: Mi ordenador
+      permissions_message: Actualizando permisos de archivo. Esto puede tardar unos minutos. Quizás quiera actualizar su navegador o regresar a este registro posteriormente para ver los permisos actualizados.
+      processing: El archivo se está procesando; se puede editar en cuanto termine el procesamiento
     user_profile:
       orcid:
-        alt: "Icono ORCID"
-        label: "Perfil ORCID"
-      tab_activity: "Actividad"
-      tab_highlighted: "Destacado"
-      tab_profile: "Perfil"
+        alt: Icono ORCID
+        label: Perfil ORCID
+      tab_activity: Actividad
+      tab_highlighted: Destacado
+      tab_profile: Perfil
       zotero:
-        alt: "Icono de Zotero"
+        alt: Icono de Zotero
         connected: "¡Conectado!"
-        label: "Perfil de Zotero"
-        unlinked: "Vincular con Zotero"
+        label: Perfil de Zotero
+        unlinked: Vincular con Zotero
     visibility:
       authenticated:
-        class: "label-info"
+        class: label-info
         note_html: Restringir el acceso sólo a usuarios y/o grupos de %{institution}
       embargo:
-        class: "label-warning"
-        text: "Embargo"
+        class: label-warning
+        text: Embargo
       lease:
-        class: "label-warning"
-        text: "Arrendamiento"
+        class: label-warning
+        text: Arrendamiento
       open:
-        class: "label-success"
+        class: label-success
         note_html: Todo el mundo. Consulte <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> para conocer las políticas de derechos de autor de editores específicos si planea patentar y/o publicar su %{type} en un diario
-        text: "Acceso abierto"
-        warning_html: "<p>
-                        <strong>Tenga en cuenta</strong>, hacer algo visible para el mundo (es decir,
- marcar esto como %{label}) puede ser
- visto como una publicación, lo que podría afectar su capacidad de:
-                      </p>
-                      <ul>
-                        <li>Patentar su trabajo</li>
-                        <li>Publicar su trabajo en una revista</li>
-                      </ul>
-                      <p>
-                        Eche un vistazo a <a href=\"http://www.sherpa.ac.uk/romeo/\">SHERPA/RoMEO</a> para más
-                        información sobre las políticas de copyright del editor.
-                      </p>"
-      open_title_attr: "Cambiar la visibilidad de este recurso"
+        text: Público
+        warning_html: '<p> <strong>Tenga en cuenta</strong>, hacer algo visible para el mundo (es decir, marcar esto como %{label}) puede ser visto como una publicación, lo que podría afectar su capacidad de: </p> <ul> <li>Patentar su trabajo</li> <li>Publicar su trabajo en una revista</li> </ul> <p> Eche un vistazo a <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> para más información sobre las políticas de copyright del editor. </p>'
+      open_title_attr: Cambiar la visibilidad de este recurso
       private:
-        note_html:  Sólo los usuarios y/o grupos a los que se les ha dado acceso específico en la sección "Compartir con".
+        note_html: Sólo los usuarios y/o grupos a los que se les ha dado acceso específico en la sección "Compartir con".
         text: Privado
-      private_title_attr: "Cambiar la visibilidad de este recurso"
+      private_title_attr: Cambiar la visibilidad de este recurso
       restricted:
-        class: "label-danger"
-        text: "Privado"
+        class: label-danger
+        text: Privado
     workflow:
       default:
-        deposit: "Depositar"
+        deposit: Depositar
       load:
-        state_error: "El flujo de trabajo %{workflow_name} no se ha actualizado. Está eliminando un estado, %{state_name}, con %{entity_count} entidad/es. ¡Un estado no puede ser borrado mientras tiene enidades activas!"
-      unauthorized: "El trabajo no está disponible en este momento porque aún no se ha completado el proceso de aprobación"
+        state_error: El flujo de trabajo %{workflow_name} no se ha actualizado. Está eliminando un estado, %{state_name}, con %{entity_count} entidad/es. ¡Un estado no puede ser borrado mientras tiene enidades activas!
+      unauthorized: El trabajo no está disponible en este momento porque aún no se ha completado el proceso de aprobación
     works:
       create:
-        after_create_html: "Tus archivos están siendo procesados por %{application_name} de forma paralela. Los metadatos y controles de acceso que ha especificado han sido aplicados. Quizás deba recargar la página para ver las actualizaciones."
-        breadcrumb: 'Añadir nuevo trabajo'
+        after_create_html: Tus archivos están siendo procesados por %{application_name} de forma paralela. Los metadatos y controles de acceso que ha especificado han sido aplicados. Quizás deba recargar la página para ver las actualizaciones.
+        breadcrumb: Añadir nuevo trabajo
         header: Añadir nuevo trabajo
       edit:
         breadcrumb: Editar
       form:
-        additional_fields: "Campos adicionales"
+        additional_fields: Campos adicionales
         in_collections: Este Trabajo en Colecciones
         in_other_works: Este Trabajo en otros Trabajos
         in_this_work: Otros Trabaos en este Trabajo
-        visibility_until: 'hasta'
         tab:
-          files:         "Archivos"
-          metadata:      "Descripciones"
-          relationships: "Relaciones"
-          share:         "Compartir"
+          files: Archivos
+          metadata: Descripciones
+          relationships: Relaciones
+          share: Compartir
+        visibility_until: hasta
       progress:
         header: Guardar Trabajo
       show:
@@ -710,62 +703,62 @@ es:
   simple_form:
     hints:
       admin_set:
-        description: 'Una breve descripción general que se aplica a todas los trabajos recogidos en este conjunto. Por ejemplo, "Tesis y archivos suplementarios creados por los estudiantes graduados de la Escuela de Ciencias de la Tierra".'
-        title: "Un nombre para ayudar a identificar el conjunto administrativo y distinguirlo de otros conjuntos administrativos en el repositorio."
+        description: Una breve descripción general que se aplica a todas los trabajos recogidos en este conjunto. Por ejemplo, "Tesis y archivos suplementarios creados por los estudiantes graduados de la Escuela de Ciencias de la Tierra".
+        title: Un nombre para ayudar a identificar el conjunto administrativo y distinguirlo de otros conjuntos administrativos en el repositorio.
       collection:
-        based_near: "Nombre de un lugar relacionado con la colección, tal como el sitio de publicación, ciudad, estado, o país, que esté relacionado con los contenidos de la colección. Obtenidos a través del servicio de <a href='http://www.geonames.org'>GeoNames</a>."
-        contributor: "Una persona o grupo que se quiera reconocer por tener un rol en la creación de la colección, pero no el rol principal."
-        creator: "La persona o grupo responsable de la colección. Generalmente es el autor del contenido. Los nombres personales deben llevar los apellidos al principio, ej. &quot;Smith, John.&quot;."
-        date_created: "La fecha en la que se creó la colección."
-        description: "Notas de texto libre acerca de la colección. Algunos ejemplos incluyen resúmenes de una publicación o información de citación de un artículo."
-        identifier: "Un identificador único de la colección. Un ejemplo podría ser el DOI para un artículo de revista, o un ISBN o número OCLC para un libro."
-        keyword: "Palabras o frases seleccionadas para describir de qué trata la colección. Serán usadas para buscar contenido."
-        language: "El idioma del contenido de la colección."
-        publisher: "La persona o grupo que facilitó la colección. Generalmente se trata de una institución."
-        related_url: "Un enlace a una página web u otro contenido específico (audio, vídeo, un documento PDF) relacionado a la colección. Un ejemplo es la URL de un proyecto de investigación de la cual proviene la colección"
-        resource_type: "Categorías predefinidas que describen el tipo de contenido que se ha subido, tal como &quot;artículo&quot; o &quot;conjunto de datos&quot;. Se puede seleccionar más de un tipo."
-        license: "Licencias e información de distribución sobre la colección. Seleccionar uno de la lista."
-        subject: "Cabeceras o términos de indexación que describen de qué trata la colección; no tienen por qué pertenecer a un vocabulario existente."
-        title: "Un nombre para ayudar a la identificación de una colección."
+        based_near: Nombre de un lugar relacionado con la colección, tal como el sitio de publicación, ciudad, estado, o país, que esté relacionado con los contenidos de la colección. Obtenidos a través del servicio de <a href='http://www.geonames.org'>GeoNames</a>.
+        contributor: Una persona o grupo que se quiera reconocer por tener un rol en la creación de la colección, pero no el rol principal.
+        creator: La persona o grupo responsable de la colección. Generalmente es el autor del contenido. Los nombres personales deben llevar los apellidos al principio, ej. &quot;Smith, John.&quot;.
+        date_created: La fecha en la que se creó la colección.
+        description: Notas de texto libre acerca de la colección. Algunos ejemplos incluyen resúmenes de una publicación o información de citación de un artículo.
+        identifier: Un identificador único de la colección. Un ejemplo podría ser el DOI para un artículo de revista, o un ISBN o número OCLC para un libro.
+        keyword: Palabras o frases seleccionadas para describir de qué trata la colección. Serán usadas para buscar contenido.
+        language: El idioma del contenido de la colección.
+        license: Licencias e información de distribución sobre la colección. Seleccionar uno de la lista.
+        publisher: La persona o grupo que facilitó la colección. Generalmente se trata de una institución.
+        related_url: Un enlace a una página web u otro contenido específico (audio, vídeo, un documento PDF) relacionado a la colección. Un ejemplo es la URL de un proyecto de investigación de la cual proviene la colección
+        resource_type: Categorías predefinidas que describen el tipo de contenido que se ha subido, tal como &quot;artículo&quot; o &quot;conjunto de datos&quot;. Se puede seleccionar más de un tipo.
+        subject: Cabeceras o términos de indexación que describen de qué trata la colección; no tienen por qué pertenecer a un vocabulario existente.
+        title: Un nombre para ayudar a la identificación de una colección.
       defaults:
-        based_near: "Nombre de un lugar relacionado con el trabajo, tal como el sitio de publicación, ciudad, estado, o país, que esté relacionado con los contenidos de el trabajo. Obtenidos a través del servicio de <a href='http://www.geonames.org'>GeoNames</a>."
-        contributor: "Una persona o grupo que se quiera reconocer por tener un rol en la creación del trabajo, pero no el rol principal."
-        creator: "La persona o grupo responsable del trabajo. Generalmente es el autor del contenido. Los nombres personales deben llevar los apellidos al principio, ej. &quot;Smith, John&quot;."
-        date_created: "La fecha en la que se creó el trabajo."
-        description: "Notas de texto libre acerca de el trabajo. Algunos ejemplos incluyen resúmenes de una publicación o información de citación de un artículo."
-        identifier: "Un identificador único de el trabajo. Un ejemplo podría ser el DOI para un artículo de revista, o un ISBN o número OCLC para un libro."
-        keyword: "Palabras o frases seleccionadas para describir de qué trata el trabajo. Éstas son usadas para buscar contenido."
-        language: "El idioma del contenido de el trabajo."
-        publisher: "La persona o grupo que facilitó el trabajo. Generalmente se trata de una institución."
-        related_url: "Un enlace a una página web u otro contenido específico (audio, vídeo, un documento PDF) relacionado con el trabajo. Un ejemplo es la URL de un proyecto de investigación de la cual proviene el trabajo"
-        resource_type: "Categorías predefinidas que describen el tipo de contenido que se ha subido, tal como &quot;artículo&quot; o &quot;conjunto de datos&quot;. Se puede seleccionar más de un tipo."
-        license: "Licencias e información de distribución sobre el trabajo. Seleccionar uno de la lista."
-        subject: "Cabeceras o términos de indexación que describen de qué trata el trabajo; no tienen por qué pertenecer a un vocabulario existente."
-        title: "Un nombre para ayudar a la identificación de un trabajo."
+        based_near: Nombre de un lugar relacionado con el trabajo, tal como el sitio de publicación, ciudad, estado, o país, que esté relacionado con los contenidos de el trabajo. Obtenidos a través del servicio de <a href='http://www.geonames.org'>GeoNames</a>.
+        contributor: Una persona o grupo que se quiera reconocer por tener un rol en la creación del trabajo, pero no el rol principal.
+        creator: La persona o grupo responsable del trabajo. Generalmente es el autor del contenido. Los nombres personales deben llevar los apellidos al principio, ej. &quot;Smith, John&quot;.
+        date_created: La fecha en la que se creó el trabajo.
+        description: Notas de texto libre acerca de el trabajo. Algunos ejemplos incluyen resúmenes de una publicación o información de citación de un artículo.
+        identifier: Un identificador único de el trabajo. Un ejemplo podría ser el DOI para un artículo de revista, o un ISBN o número OCLC para un libro.
+        keyword: Palabras o frases seleccionadas para describir de qué trata el trabajo. Éstas son usadas para buscar contenido.
+        language: El idioma del contenido de el trabajo.
+        license: Licencias e información de distribución sobre el trabajo. Seleccionar uno de la lista.
+        publisher: La persona o grupo que facilitó el trabajo. Generalmente se trata de una institución.
+        related_url: Un enlace a una página web u otro contenido específico (audio, vídeo, un documento PDF) relacionado con el trabajo. Un ejemplo es la URL de un proyecto de investigación de la cual proviene el trabajo
+        resource_type: Categorías predefinidas que describen el tipo de contenido que se ha subido, tal como &quot;artículo&quot; o &quot;conjunto de datos&quot;. Se puede seleccionar más de un tipo.
+        subject: Cabeceras o términos de indexación que describen de qué trata el trabajo; no tienen por qué pertenecer a un vocabulario existente.
+        title: Un nombre para ayudar a la identificación de un trabajo.
     labels:
       collection:
-        size:             "Tamaño"
-        total_items:      "Trabajos totales"
+        size: Tamaño
+        total_items: Trabajos totales
       defaults:
-        admin_set_id:     "Añadir como miembro del conjunto administrativo"
-        based_near:       "Ubicación"
-        collection_ids:   "Añadir como miembro de la colección"
-        creator:          "Creador"
-        date_created:     "Fecha de creación"
-        description:      "Resumen o Sumario"
-        embargo_release_date:      'hasta'
-        files:            "Subir una nueva versión de este archivo desde su ordenador"
-        keyword:          "Palabra Clave"
-        lease_expiration_date:     'hasta'
-        related_url:      "URL relacionada"
-        license:          "Licencia"
-        title:            "Título"
-        visibility_after_embargo:  'luego abrirlo a'
-        visibility_after_lease:    'luego restringirlo a'
-        visibility_during_embargo: 'Restringido a'
-        visibility_during_lease:   'Disponible para'
+        admin_set_id: Añadir como miembro del conjunto administrativo
+        based_near: Ubicación
+        collection_ids: Añadir como miembro de la colección
+        creator: Creador
+        date_created: Fecha de creación
+        description: Resumen o Sumario
+        embargo_release_date: hasta
+        files: Subir una nueva versión de este archivo desde su ordenador
+        keyword: Palabra Clave
+        lease_expiration_date: hasta
+        license: Licencia
+        related_url: URL relacionada
+        title: Título
+        visibility_after_embargo: luego abrirlo a
+        visibility_after_lease: luego restringirlo a
+        visibility_during_embargo: Restringido a
+        visibility_during_lease: Disponible para
       proxy_deposit_request:
-        transfer_to:               "Usuario"
-        sender_comment:            "Comentarios"
+        sender_comment: Comentarios
+        transfer_to: Usuario
     required:
-      html: '<span class="label label-info required-tag">obligatorio</span>'
+      html: <span class="label label-info required-tag">obligatorio</span>

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -72,6 +72,8 @@ fr:
           header: Modifier l'ensemble administratif
         form:
           cancel: Annuler
+          permission_destroy_errors:
+            admin_group: Le groupe des administrateurs du référentiel ne peut pas être supprimé
           permission_update_errors:
             error: Option de mise à jour non valide pour le modèle d'autorisation.
             no_date: Une date est requise pour l'option de publication sélectionnée.
@@ -90,6 +92,7 @@ fr:
             visibility: Libération et visibilité
             workflow: Workflow
         form_participant_table:
+          admin_users: Administrateurs de référentiel
           allow_all_registered: Permettre à tous les utilisateurs enregistrés de déposer
           depositors:
             action: action
@@ -340,6 +343,11 @@ fr:
         title: Ajouter à la collection
         update: Mise à jour de la collection
     collections:
+      form:
+        tabs:
+          description: La description
+          sharing: Partage
+          visibility: Visibilité
       search_form:
         label: Rechercher Collection %{title}
         placeholder: Rechercher Collection
@@ -655,7 +663,7 @@ fr:
       open:
         class: Label-succès
         note_html: Toutes les personnes. Consultez <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> pour les politiques de copyright des éditeurs spécifiques si vous prévoyez de breveter et / ou de publier votre %{type} dans un journal.
-        text: Accès ouvert
+        text: Public
         warning_html: '<p> <strong>Notez</strong> que faire apparaître une chose visible dans le monde (c.-à-d. Marquer cela comme %{label}) peut être considérée comme une publication qui pourrait avoir une incidence sur votre capacité à: </p><ul><li> Prenez connaissance de votre travail </li><li> Publiez votre travail dans un journal </li></ul><p> Consultez <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> pour plus d''informations sur les politiques de copyright des éditeurs. </p>'
       open_title_attr: Changez la visibilité de cette ressource
       private:

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -72,6 +72,8 @@ it:
           header: Modifica impostazione amministrativa
         form:
           cancel: Annulla
+          permission_destroy_errors:
+            admin_group: Impossibile rimuovere il gruppo amministratori di repository
           permission_update_errors:
             error: Opzione di aggiornamento non valida per il modello di autorizzazione.
             no_date: È necessaria una data per l'opzione di rilascio selezionata.
@@ -90,6 +92,7 @@ it:
             visibility: Rilascio e visibilità
             workflow: Flusso di lavoro
         form_participant_table:
+          admin_users: Amministratori Repository
           allow_all_registered: Consenti a tutti gli utenti registrati di depositare
           depositors:
             action: Azione
@@ -340,6 +343,11 @@ it:
         title: Aggiungere alla collezione
         update: Aggiorna Collezione
     collections:
+      form:
+        tabs:
+          description: Descrizione
+          sharing: compartecipazione
+          visibility: Visibilità
       search_form:
         label: Cerca la raccolta %{title}
         placeholder: Cerca raccolta
@@ -655,7 +663,7 @@ it:
       open:
         class: etichetta-successo
         note_html: Tutti. <a href="http://www.sherpa.ac.uk/romeo/">Controlla SHERPA / RoMEO</a> per <a href="http://www.sherpa.ac.uk/romeo/">specifiche politiche</a> di copyright dei publisher se intendi brevettare e / o pubblicare il tuo %{type} in un diario.
-        text: Accesso libero
+        text: Pubblico
         warning_html: '<p> <strong>Si prega di notare</strong> che facendo qualcosa di visibile al mondo (vale a dire marcatura come %{label}) può essere considerata come pubblicazione che potrebbe influenzare la tua capacità di: </p><ul><li> Brevetti il ​​tuo lavoro </li><li> Pubblica il tuo lavoro in un diario </li></ul><p> <a href="http://www.sherpa.ac.uk/romeo/">Controlla SHERPA / RoMEO</a> per ulteriori informazioni sulle norme del copyright dei publisher. </p>'
       open_title_attr: Modificare la visibilità di questa risorsa
       private:

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -72,6 +72,8 @@ pt-BR:
           header: Editar Conjunto Administrativo
         form:
           cancel: Cancelar
+          permission_destroy_errors:
+            admin_group: O grupo de administradores do repositório não pode ser removido
           permission_update_errors:
             error: Opção de atualização inválida para o modelo de permissão.
             no_date: É necessária uma data para a opção de lançamento selecionada.
@@ -90,6 +92,7 @@ pt-BR:
             visibility: Liberação e Visibilidade
             workflow: Fluxo de trabalho
         form_participant_table:
+          admin_users: Administradores do Repositório
           allow_all_registered: Permitir que todos os usuários cadastrados depositem
           depositors:
             action: Açao
@@ -340,6 +343,11 @@ pt-BR:
         title: Adicionar a coleção
         update: Coleção de Atualizações
     collections:
+      form:
+        tabs:
+          description: Descrição
+          sharing: Compartilhando
+          visibility: Visibilidade
       search_form:
         label: Pesquisar Collection %{title}
         placeholder: Pesquisar Coleção
@@ -655,7 +663,7 @@ pt-BR:
       open:
         class: Sucesso de etiqueta
         note_html: Todos. Confira <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> para políticas de direitos autorais de editoras específicas se você planeja patinar e / ou publicar seu %{type} em um diário.
-        text: Acesso livre
+        text: Público
         warning_html: '<p> <strong>Por favor</strong> , <strong>note que</strong> fazer algo visível para o mundo (ou seja, marcar isso como %{label}) pode ser visto como uma publicação que pode afetar sua capacidade de: </p><ul><li> Patente seu trabalho </li><li> Publique seu trabalho em um diário </li></ul><p> Confira <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> para obter mais informações sobre políticas de direitos autorais do editor. </p>'
       open_title_attr: Mude a visibilidade desse recurso
       private:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -1,270 +1,271 @@
+---
 zh:
   activefedora:
     models:
-      batch_upload_item: '批量上传的作品'
+      batch_upload_item: 批量上传的作品
   activemodel:
     errors:
       messages:
-        conflict: "您的更改无法保存，因为另一用户(或后台作业）在您开始编辑后更新了%{model}。 请确保所有文件附件已成功完成之后再试一次。这已经是最新刷新后保存的副本%{model}"
+        conflict: 您的更改无法保存，因为另一用户(或后台作业）在您开始编辑后更新了%{model}。 请确保所有文件附件已成功完成之后再试一次。这已经是最新刷新后保存的副本%{model}
   blacklight:
     search:
       facets:
-        more_html: '更多 <span class="sr-only">%{field_name}</span> »'
+        more_html: 更多 <span class="sr-only">%{field_name}</span> »
       fields:
-        show:
-          admin_set: "管理集内:"
-          based_near_label: "地点"
-          contributor: "贡献者"
-          keyword: "关键词"
         facet:
-          admin_set_sim: "集"
-          suppressed_bsi: "状况"
-          resource_type_sim: "资源类型"
+          admin_set_sim: 集
+          resource_type_sim: 资源类型
+          suppressed_bsi: 状况
+        show:
+          admin_set: '管理集内:'
+          based_near_label: 地点
+          contributor: 贡献者
+          keyword: 关键词
       filters:
-        title:    "过滤:"
-      start_over: "清除过滤"
+        title: '过滤:'
+      start_over: 清除过滤
   errors:
     messages:
-      carrierwave_download_error: "图片不能下载。"
-      carrierwave_integrity_error: "不是图片。"
-      carrierwave_processing_error: "图片大小不能调整。"
+      carrierwave_download_error: 图片不能下载。
+      carrierwave_integrity_error: 不是图片。
+      carrierwave_processing_error: 图片大小不能调整。
       extension_blacklist_error: "%{extension} 的文件不能上传, 禁止上传的扩展类型: %{prohibited_types}"
       extension_whitelist_error: "%{extension} 的文件不能上传, 可上传的扩展类型: %{allowed_types}"
   helpers:
     action:
       admin_set:
-        new: "创建新管理集"
+        new: 创建新管理集
       batch:
-        new: "创建批量作品"
-      cancel: "取消"
+        new: 创建批量作品
+      cancel: 取消
       collection:
-        new: "新收藏集"
-      delete: "删除"
-      edit: "编辑"
+        new: 新收藏集
+      delete: 删除
+      edit: 编辑
       work:
-        new: "添加新作品"
+        new: 添加新作品
     submit:
       admin_set:
-        create: '保存'
-        update: '保存'
-      create: '保存'
+        create: 保存
+        update: 保存
+      create: 保存
       hyrax_permission_template:
-        create: '保存'
-        update: '保存'
+        create: 保存
+        update: 保存
       hyrax_permission_template_access:
-        create: '添加'
+        create: 添加
       proxy_deposit_request:
-        create: '转让'
-      update: '保存'
+        create: 转让
+      update: 保存
   hyrax:
-    account_label:  "用户"
-    active_consent_to_agreement:  "我已经阅读并同意"
+    account_label: 用户
+    active_consent_to_agreement: 我已经阅读并同意
     admin:
       admin_sets:
-        document_list:
-          edit:     "编辑"
-          no_works: "管理集中不包含任何作品。"
-          title:    "管理集中的项目列表"
         delete:
-          error_default_set: "管理集是默认集，不能被删除"
-          error_not_empty:   "管理集不是空集，不能被删除"
-          notification:      "管理集删除成功"
+          error_default_set: 管理集是默认集，不能被删除
+          error_not_empty: 管理集不是空集，不能被删除
+          notification: 管理集删除成功
+        document_list:
+          edit: 编辑
+          no_works: 管理集中不包含任何作品。
+          title: 管理集中的项目列表
         edit:
-          header:         "编辑管理集"
+          header: 编辑管理集
         form:
-          cancel:               "取消"
+          cancel: 取消
           permission_destroy_errors:
-            admin_group:        "无法删除存储库管理员组"
-          permission_update_notices:
-            new_admin_set:      "管理集 '%{name}' 已建立。 请用附加标签定义管理集中的其他方面。"
-            updated_admin_set:  "管理集 '%{name}' 已更新。"
-            participants:       "管理集的参与者权限已更新"
-            visibility:         "管理集的发布与公开度的设置已更新。"
-            workflow:           "管理集的工作流程已更新。"
+            admin_group: 无法删除存储库管理员组
           permission_update_errors:
-            varies:             "发布选项 '变动' 需要选择一个日期或时滞期限。"
-            no_date:            "所选发布项需要一个日期。"
-            no_embargo:         "所选项需要一个时滞期限。"
-            nothing:            "保存之前请选择发布选项。"
-            error:              "权限模板的更新选项无效。"
+            error: 权限模板的更新选项无效。
+            no_date: 所选发布项需要一个日期。
+            no_embargo: 所选项需要一个时滞期限。
+            nothing: 保存之前请选择发布选项。
+            varies: 发布选项 '变动' 需要选择一个日期或时滞期限。
+          permission_update_notices:
+            new_admin_set: 管理集 '%{name}' 已建立。 请用附加标签定义管理集中的其他方面。
+            participants: 管理集的参与者权限已更新
+            updated_admin_set: 管理集 '%{name}' 已更新。
+            visibility: 管理集的发布与公开度的设置已更新。
+            workflow: 管理集的工作流程已更新。
           tabs:
-            description:        "描述"
-            participants:       "参与者"
-            visibility:         "发布与公开度"
-            workflow:           "工作流程"
+            description: 描述
+            participants: 参与者
+            visibility: 发布与公开度
+            workflow: 工作流程
         form_participant_table:
-          admin_users:          "存储库管理员"
-          allow_all_registered: "允许所有注册用户存款"
+          admin_users: 存储库管理员
+          allow_all_registered: 允许所有注册用户存款
           depositors:
-            action:             "行动"
-            agent_name:         "管理集的存储者"
-            empty:              "存储者尚未加入此管理集。"
-            help:               "存储者可以向此管理集添加新作品。"
-            remove:             "移除"
-            title:              "存储者"
-            type:               "类型"
+            action: 行动
+            agent_name: 管理集的存储者
+            empty: 存储者尚未加入此管理集。
+            help: 存储者可以向此管理集添加新作品。
+            remove: 移除
+            title: 存储者
+            type: 类型
           managers:
-            action:             "行动"
-            agent_name:         "管理集的管理者"
-            empty:              "此管理集尚未加入管理者。"
-            help:               "管理者可以编辑管理集的原数据、参与者、及发布与公开度的设置。 管理者还可以编辑作品的元数据, 从一件作品中添加或移除文件，以及向管理集添加新作品。"
-            remove:             "移除"
-            title:              "管理者"
-            type:               "类型"
-          registered_users:     "注册用户"
+            action: 行动
+            agent_name: 管理集的管理者
+            empty: 此管理集尚未加入管理者。
+            help: 管理者可以编辑管理集的原数据、参与者、及发布与公开度的设置。 管理者还可以编辑作品的元数据, 从一件作品中添加或移除文件，以及向管理集添加新作品。
+            remove: 移除
+            title: 管理者
+            type: 类型
+          registered_users: 注册用户
           viewers:
-            action:             "行动"
-            agent_name:         "管理集的观众"
-            empty:              "此管理集尚未加入观众。"
-            help:               "此管理集的观众可以看见集中的作品，无论该作品公开度的设置如何。 例如观众可以看见管理集中目前有时滞限或限制的作品。"
-            remove:             "移除"
-            title:              "观众"
-            type:               "类型"
+            action: 行动
+            agent_name: 管理集的观众
+            empty: 此管理集尚未加入观众。
+            help: 此管理集的观众可以看见集中的作品，无论该作品公开度的设置如何。 例如观众可以看见管理集中目前有时滞限或限制的作品。
+            remove: 移除
+            title: 观众
+            type: 类型
         form_participants:
-          add_group:            "添加小组:"
-          add_participants:     "添加参与者"
-          add_user:             "添加用户:"
-          current_participants: "目前参与者"
+          add_group: '添加小组:'
+          add_participants: 添加参与者
+          add_user: '添加用户:'
+          current_participants: 目前参与者
         form_visibility:
-          cancel:               "取消"
-          page_description:     "当作品加入收藏集，发布和公开度设置可以控制谁和何时可以观看和下载这些作品。"
+          cancel: 取消
+          page_description: 当作品加入收藏集，发布和公开度设置可以控制谁和何时可以观看和下载这些作品。
           release:
-            description:        "你可以在管理集内作品发布之前设置延迟被发现和下载的时期。"
-            fixed:              "既定的 -- 延迟发布所有作品"
-            no_delay:           "没有延迟 -- 所有作品一旦存储即可发布"
-            title:              "发布"
+            description: 你可以在管理集内作品发布之前设置延迟被发现和下载的时期。
+            fixed: 既定的 -- 延迟发布所有作品
+            no_delay: 没有延迟 -- 所有作品一旦存储即可发布
+            title: 发布
             varies:
-              between:          "在'现在'之间"
-              description:      "可变的 -- 存储者可以设置一件作品的发布日期:"
+              between: 在'现在'之间
+              description: '可变的 -- 存储者可以设置一件作品的发布日期:'
               embargo:
-                1yr:            "存储一年之后"
-                2yrs:           "存储两年之后"
-                3yrs:           "存储三年之后"
-                6mos:           "存储六个月之后"
-                select:         "选择时滞期限.."
+                1yr: 存储一年之后
+                2yrs: 存储两年之后
+                3yrs: 存储三年之后
+                6mos: 存储六个月之后
+                select: 选择时滞期限..
           visibility:
-            description:        "发布日期之后, 管理集内的作品可以被发现和下载:"
-            everyone:           "每个人 -- 管理集内的所有作品会公开"
-            institution:        "机构 -- 所有作品只对机构内的认证用户公开"
-            restricted:         "有限制的 -- 所有作品只会对存储库的管理者和此管理集的管理者与评审者公开"
-            title:              "公开度"
-            varies:             "可变的 -- 默认值是公开, 但是存储者可以限制个别作品的公开度"
+            description: '发布日期之后, 管理集内的作品可以被发现和下载:'
+            everyone: 每个人 -- 管理集内的所有作品会公开
+            institution: 机构 -- 所有作品只对机构内的认证用户公开
+            restricted: 有限制的 -- 所有作品只会对存储库的管理者和此管理集的管理者与评审者公开
+            title: 公开度
+            varies: 可变的 -- 默认值是公开, 但是存储者可以限制个别作品的公开度
         form_workflow:
-          cancel:               "取消"
-          no_workflows:         "没有工作流程可选。"
-          page_description:     "每个管理集都有一个与之相关的工作流程。 此工作流程可以应用于添加入管理集的所有作品。 选择用于以下管理集的工作流程。"
+          cancel: 取消
+          no_workflows: 没有工作流程可选。
+          page_description: 每个管理集都有一个与之相关的工作流程。 此工作流程可以应用于添加入管理集的所有作品。 选择用于以下管理集的工作流程。
         new:
-          header:         "创建新的管理集"
+          header: 创建新的管理集
         show:
-          breadcrumb:       "观看集"
-          confirm_delete:   "确定要删除吗？删除后不可复原。"
-          header:           "管理集"
-          item_list_header: "集内作品"
+          breadcrumb: 观看集
+          confirm_delete: 确定要删除吗？删除后不可复原。
+          header: 管理集
+          item_list_header: 集内作品
       appearances:
         show:
-          header:           "表面"
+          header: 表面
         update:
           flash:
-            success:        "表面已更新"
+            success: 表面已更新
       sidebar:
-        activity:           "活动"
-        admin_sets:         "管理集"
-        appearance:         "表面"
-        collections:        "收藏"
-        configuration:      "配置"
-        content_blocks:     "内容块"
-        notifications:      "通知"
-        pages:              "网页"
-        profile:            "个人资料"
-        repository_objects: "储存库内容"
-        settings:           "设置"
-        statistics:         "统计"
-        tasks:              "任务"
-        technical:          "技术"
-        transfers:          "转让"
-        users:              "管理用户"
-        user_activity:      "你的操作"
-        workflow_review:    "评审提交"
-        workflow_roles:     "工作流程角色"
-        works:              "作品"
+        activity: 活动
+        admin_sets: 管理集
+        appearance: 表面
+        collections: 收藏
+        configuration: 配置
+        content_blocks: 内容块
+        notifications: 通知
+        pages: 网页
+        profile: 个人资料
+        repository_objects: 储存库内容
+        settings: 设置
+        statistics: 统计
+        tasks: 任务
+        technical: 技术
+        transfers: 转让
+        user_activity: 你的操作
+        users: 管理用户
+        workflow_review: 评审提交
+        workflow_roles: 工作流程角色
+        works: 作品
       stats:
         deposited_form:
-          end_label: "结束 [默认到此刻]"
-          heading: "展示存储的文件:"
-          start_label: "开始"
-        registered: "已注册"
+          end_label: 结束 [默认到此刻]
+          heading: '展示存储的文件:'
+          start_label: 开始
+        registered: 已注册
         repository_objects:
           series:
-            published:   '出版品'
-            unknown:     '状况不明'
-            unpublished: '非出版品'
+            published: 出版品
+            unknown: 状况不明
+            unpublished: 非出版品
         user_deposits:
-          end_label: "结束 [默认到此刻]"
-          heading: "展示用户存储的文件"
-          start_label: "开始"
+          end_label: 结束 [默认到此刻]
+          heading: 展示用户存储的文件
+          start_label: 开始
       users:
         index:
-          access_label: "上次访问"
+          access_label: 上次访问
           describe_users_html:
-            one: "存储库内有<b>%{count} 用户</b>。"
-            other: "存储库内有<b>%{count} 用户</b>。"
-          id_label:   "用户名"
-          role_label: "角色"
-          title: "管理用户"
+            one: 存储库内有<b>%{count} 用户</b>。
+            other: 存储库内有<b>%{count} 用户</b>。
+          id_label: 用户名
+          role_label: 角色
+          title: 管理用户
       workflow_roles:
-        header:     "工作流程角色"
+        header: 工作流程角色
         index:
+          current_roles: 当前角色
           delete:
-            confirm: "您肯定要删除?"
+            confirm: 您肯定要删除?
           header:
-            roles:  "角色"
-            user:   "用户"
-          new_role: "授予角色:"
-          no_roles: "没有角色"
-          current_roles: "当前角色"
+            roles: 角色
+            user: 用户
+          new_role: '授予角色:'
+          no_roles: 没有角色
       workflows:
         index:
-          header: "审查提交"
+          header: 审查提交
           tabs:
-            published: "已出版"
-            under_review: "在审查中"
+            published: 已出版
+            under_review: 在审查中
     api:
       accepted:
-        default: "您的请求已被接受，正在处理中。参见？？See job for more info。"
+        default: 您的请求已被接受，正在处理中。参见？？See job for more info。
       bad_request:
-        default: "不能处理您的请求，参见错误信息。"
+        default: 不能处理您的请求，参见错误信息。
       deleted:
-        default: "已被删除"
+        default: 已被删除
       forbidden:
-        default: "您无权访问此内容。"
+        default: 您无权访问此内容。
       internal_error:
-        default: "服务器遇到错误。"
+        default: 服务器遇到错误。
       not_found:
-        default: "找不到您要求的文件"
+        default: 找不到您要求的文件
       success:
-        default: "您的请求已被成功处理。"
+        default: 您的请求已被成功处理。
       unauthorized:
-        default: "您必须要先登录才可以做这一点!"
+        default: 您必须要先登录才可以做这一点!
       unprocessable_entity:
-        default: "您试着要修改的资源按照您的请求是不能被修改。"
-        empty_file: "您上传的文件无内容。"
-    background_attribution_html: "背景图片的CC by-nc-sa 来自 <a href=\"https://flic.kr/p/eirxaf\">f2b1610</a>"
+        default: 您试着要修改的资源按照您的请求是不能被修改。
+        empty_file: 您上传的文件无内容。
+    background_attribution_html: 背景图片的CC by-nc-sa 来自 <a href="https://flic.kr/p/eirxaf">f2b1610</a>
     base:
       citations:
         header: '引文:'
       form_files:
-        dropzone: "请将文件拖放此处。"
+        dropzone: 请将文件拖放此处。
         external_upload: 云供应商
         local_upload: 添加本地文件
       form_progress:
+        required_agreement: 核对存储协议
         required_descriptions: 描述您的作品
-        required_files:        添加文件
-        required_agreement:    核对存储协议
-        requirements:          必要条件
+        required_files: 添加文件
+        requirements: 必要条件
       items:
         actions: 行动
-        date_uploaded: "上传日期"
-        empty:  "该 %{type} 没有相关文件。 请点击'编辑'添加更多文件。"
+        date_uploaded: 上传日期
+        empty: 该 %{type} 没有相关文件。 请点击'编辑'添加更多文件。
         header: 单件
         thumbnail: 缩略图
         title: 标题
@@ -274,30 +275,30 @@ zh:
         attribute_values_label: 属性值
         header: 描述
       relationships:
-        empty: "该 %{type} 目前未纳入任何收藏集内。"
+        empty: 该 %{type} 目前未纳入任何收藏集内。
         header: 关联
       relationships_parent_row:
-        label: "属于 %{type}:"
+        label: '属于 %{type}:'
       relationships_parent_row_empty:
-        empty: "和 %{type} 没有关联。"
-        label: "属于 %{type}:"
+        empty: 和 %{type} 没有关联。
+        label: '属于 %{type}:'
       show:
-        last_modified: "最新修改: %{value}"
+        last_modified: '最新修改: %{value}'
       social_media:
-        facebook: 'Facebook'
-        google: 'Google+'
-        tumblr: 'Tumblr'
-        twitter: 'Twitter'
+        facebook: Facebook
+        google: Google+
+        tumblr: Tumblr
+        twitter: Twitter
     batch:
       help:
-        resource_type: "您可以选择适用于所有文件的多种类型"
-        title: "文件名将作为默认标题。请提供更有意义的标题，文件名将会在系统内保留。"
+        resource_type: 您可以选择适用于所有文件的多种类型
+        title: 文件名将作为默认标题。请提供更有意义的标题，文件名将会在系统内保留。
     batch_uploads:
       disabled: 功能由管理员禁用
       files:
+        button_label: 添加新作品
         instructions: 上传的每份文件都会分别按新作品生成。
         upload_type_instructions: 如果建立一件作品包括所有文件，请去
-        button_label: 添加新作品
       new:
         header: 批量建立新作品
         in_collections: 这些作品包括在收藏集中
@@ -306,271 +307,277 @@ zh:
       progress:
         header: 保存作品
     bread_crumb:
-      search_results: "回到检索结果"
+      search_results: 回到检索结果
     collection:
       actions:
         add_works:
-          desc: "向收藏集添加作品"
-          label: "添加作品"
+          desc: 向收藏集添加作品
+          label: 添加作品
         delete:
-          confirmation: "删除此收藏集？"
-          desc: "删除此收藏集？"
-          label: "删除"
+          confirmation: 删除此收藏集？
+          desc: 删除此收藏集？
+          label: 删除
         edit:
-          desc: "编辑收藏集"
-          label: "编辑"
-        header: "行动"
-      browse_view: "浏览页面"
+          desc: 编辑收藏集
+          label: 编辑
+        header: 行动
+      browse_view: 浏览页面
       document_list:
-        edit: "编辑"
-        no_visible_works: "您访问的收藏集是空集"
+        edit: 编辑
+        no_visible_works: 您访问的收藏集是空集
       edit:
-        manage_items: "管理收藏集的单件"
+        manage_items: 管理收藏集的单件
       form:
-        additional_fields: "额外字段"
-        description: "描述"
-      is_part_of: "是一部分"
+        additional_fields: 额外字段
+        description: 描述
+      is_part_of: 是一部分
       select_form:
-        close: "关闭"
-        create: "创建收藏集"
-        create_new: "添加到新收藏集"
-        no_collections: "您没有访问现有收藏集的权限。您可以建立新收藏集。"
-        select_heading: "选择要添加文件的收藏集："
-        title: "添加到新收藏集"
-        update: "更新收藏集"
+        close: 关闭
+        create: 创建收藏集
+        create_new: 添加到新收藏集
+        no_collections: 您没有访问现有收藏集的权限。您可以建立新收藏集。
+        select_heading: 选择要添加文件的收藏集：
+        title: 添加到新收藏集
+        update: 更新收藏集
     collections:
+      form:
+        tabs:
+          description: 描述
+          sharing: 分享
+          visibility: 能见度
       search_form:
-        label: "搜索收藏集 %{title}"
-        placeholder: "搜索收藏集"
+        label: 搜索收藏集 %{title}
+        placeholder: 搜索收藏集
       show:
-        works_in_collection: "作品在此集合"
+        works_in_collection: 作品在此集合
     contact_form:
-      button_label: "发送"
-      email_label: "您的邮件"
-      header: "联系表格"
+      button_label: 发送
+      email_label: 您的邮件
+      header: 联系表格
       issue_types:
-        browsing: "浏览和搜索"
-        changing: "修改内容"
-        depositing: "存储内容"
-        general: "一般查询或请求"
-        reporting: "报告问题"
-      message_label: "通知"
-      name_label: "您的名字"
-      notice: "请用联系表格提交查询, 报告问题, 请求帮助, 或提供反馈。有关使用此系统的更多信息，请参见帮助页面。"
-      select_type: "选择问题类型"
-      subject_label: "主题"
-      type_label: "问题类型"
+        browsing: 浏览和搜索
+        changing: 修改内容
+        depositing: 存储内容
+        general: 一般查询或请求
+        reporting: 报告问题
+      message_label: 通知
+      name_label: 您的名字
+      notice: 请用联系表格提交查询, 报告问题, 请求帮助, 或提供反馈。有关使用此系统的更多信息，请参见帮助页面。
+      select_type: 选择问题类型
+      subject_label: 主题
+      type_label: 问题类型
     content_blocks:
-      cancel: "取消"
+      cancel: 取消
       tabs:
-        announcement_text: "公告文字"
-        featured_researcher: "特色研究员"
-        marketing_text: "营销文字"
-      updated: "内容块已更新。"
+        announcement_text: 公告文字
+        featured_researcher: 特色研究员
+        marketing_text: 营销文字
+      updated: 内容块已更新。
     controls:
-      about:            "关于"
-      contact:          "联系"
-      help:             "帮助"
-      home:             "首页"
+      about: 关于
+      contact: 联系
+      help: 帮助
+      home: 首页
     dashboard:
-      additional_notifications: "见所有通知"
+      additional_notifications: 见所有通知
       admin_sets:
-        admin_set:              "管理集"
-        files:                  "文件"
-        subtitle:               "近期活动"
-        title:                  "管理集"
-        works:                  "作品"
+        admin_set: 管理集
+        files: 文件
+        subtitle: 近期活动
+        title: 管理集
+        works: 作品
       all:
-        collections:            "所有收藏集"
-        works:                  "所有作品"
-      authorize_proxies:        "授权代理"
+        collections: 所有收藏集
+        works: 所有作品
+      authorize_proxies: 授权代理
       breadcrumbs:
-        admin:                  "管理"
-      create_work:              "创建作品"
-      current_proxies:          "目前代理"
+        admin: 管理
+      create_work: 创建作品
+      current_proxies: 目前代理
       heading_actions:
-        close:                  "关闭"
-        create_work:            "创建作品"
-        select_type_of_work:    "选择作品类型"
-      manage_proxies:           "管理代理"
+        close: 关闭
+        create_work: 创建作品
+        select_type_of_work: 选择作品类型
+      manage_proxies: 管理代理
       my:
         action:
-          collection_confirmation: "从%{application_name}删除是永久性的。点击 OK 从%{application_name}删除此收藏集，或取消删除。"
-          delete_collection:       "删除收藏集"
-          delete_work:             "删除作品"
-          edit_collection:         "编辑收藏集"
-          edit_work:               "编辑作品"
-          select:                  "选择行动"
-          select_all:              "选择当前页面"
-          select_none:             "选择无"
-          transfer:                "转让作品所有权"
-          work_confirmation:       "从%{application_name}删除作品是永久性的。点击 OK 从%{application_name}删除此作品，或取消删除。"
+          collection_confirmation: 从%{application_name}删除是永久性的。点击 OK 从%{application_name}删除此收藏集，或取消删除。
+          delete_collection: 删除收藏集
+          delete_work: 删除作品
+          edit_collection: 编辑收藏集
+          edit_work: 编辑作品
+          select: 选择行动
+          select_all: 选择当前页面
+          select_none: 选择无
+          transfer: 转让作品所有权
+          work_confirmation: 从%{application_name}删除作品是永久性的。点击 OK 从%{application_name}删除此作品，或取消删除。
         collection_list:
-          description:    "描述："
-          edit_access:    "编辑访问："
-          groups:         "群:"
-          users:          "用户:"
-        collections:  "你的收藏集"
+          description: 描述：
+          edit_access: 编辑访问：
+          groups: '群:'
+          users: '用户:'
+        collections: 你的收藏集
         facet_label:
-          collections: "过滤您的收藏集:"
-          highlighted: "过滤您的收藏精品:"
-          shared:      "过滤您分享:"
-          works:       "过滤作品:"
+          collections: '过滤您的收藏集:'
+          highlighted: '过滤您的收藏精品:'
+          shared: '过滤您分享:'
+          works: '过滤作品:'
         heading:
-          action:         "行动"
-          date_uploaded:  "上传日期"
-          title:          "标题"
-          visibility:     "公开度"
-        highlighted:  "我的重点"
-        shared:       "与我分享的作品"
+          action: 行动
+          date_uploaded: 上传日期
+          title: 标题
+          visibility: 公开度
+        highlighted: 我的重点
+        shared: 与我分享的作品
         sr:
-          batch_checkbox:   "点击向收藏集添加或者编辑列表"
-          check_all_label:  "选择添加或编辑所有文件"
-          detail_label:     "展示概括细节"
-          listing:          "您存储细项列单"
-          press_to:         "按击"
-          show_label:       "展示所有细节"
-        works:        "您的作品"
-      no_activity:              "用户最近没有活动"
-      no_notifications:         "用户没有收到通知"
-      no_transfer_requests:     "您没有收到任何在作品转让请求"
-      no_transfers:             "您没有转让任何作品"
-      proxy_activity:           "代理活动"
-      proxy_user:               "代理用户"
+          batch_checkbox: 点击向收藏集添加或者编辑列表
+          check_all_label: 选择添加或编辑所有文件
+          detail_label: 展示概括细节
+          listing: 您存储细项列单
+          press_to: 按击
+          show_label: 展示所有细节
+        works: 您的作品
+      no_activity: 用户最近没有活动
+      no_notifications: 用户没有收到通知
+      no_transfer_requests: 您没有收到任何在作品转让请求
+      no_transfers: 您没有转让任何作品
+      proxy_activity: 代理活动
+      proxy_user: 代理用户
       show_admin:
-        new_visitors:       "新访问者"
-        registered_users:   "注册用户"
+        new_visitors: 新访问者
+        registered_users: 注册用户
         repository_growth:
-          title:            储存库增长
-          subtitle:         过去90天
+          subtitle: 过去90天
+          title: 储存库增长
         repository_objects:
-          title:            储存库物件
-          subtitle:         现状
-        returning_visitors: "老访问者"
-        total_visitors:     "所有访问者"
+          subtitle: 现状
+          title: 储存库物件
+        returning_visitors: 老访问者
+        total_visitors: 所有访问者
         user_activity:
-          title:            用户活动
-          subtitle:         新用户注册
+          subtitle: 新用户注册
+          title: 用户活动
       stats:
-        collections:        "已建立的收藏集"
-        file_downloads:     "下载"
-        file_views:         "阅览"
-        files:              "文件已存储"
-        heading:            "您的【下载？】统计"
-        works:              "已建立的作品"
-      title:                    "我的控件板"
-      transfer_of_ownership:    "转让所有权"
-      transfer_works_link:      "选择作品转让"
-      transfers_received:       "收到转让"
-      transfers_sent:           "转让已发出"
-      user_activity:            "用户活动"
-      user_notifications:       "用户通知"
-      view_files:               "阅览文件"
+        collections: 已建立的收藏集
+        file_downloads: 下载
+        file_views: 阅览
+        files: 文件已存储
+        heading: 您的【下载？】统计
+        works: 已建立的作品
+      title: 我的控件板
+      transfer_of_ownership: 转让所有权
+      transfer_works_link: 选择作品转让
+      transfers_received: 收到转让
+      transfers_sent: 转让已发出
+      user_activity: 用户活动
+      user_notifications: 用户通知
+      view_files: 阅览文件
     directory:
-      suffix:           "@example.org"
-    document_language:  "en"
-    edit_profile:       "编辑个人资料"
-    featured_researchers: "特色研究者"
+      suffix: "@example.org"
+    document_language: en
+    edit_profile: 编辑个人资料
+    featured_researchers: 特色研究者
     file_manager:
-      link_text: '文件管理员'
+      link_text: 文件管理员
     file_set:
-      browse_view: "浏览"
+      browse_view: 浏览
       show:
-        download: "下载文件"
+        download: 下载文件
         downloadable_content:
-          default_link: '下载文件'
-          heading: '可下载的内容'
-          image_link: '下载图片'
-          office_link: '下载文件'
-          pdf_link: '下载PDF文件'
+          default_link: 下载文件
+          heading: 可下载的内容
+          image_link: 下载图片
+          office_link: 下载文件
+          pdf_link: 下载PDF文件
     file_sets:
       groups_description:
-        description_html: >
-          "标有‘选择一个群’的下拉框内是您所属的一组用户管理群的列表。您可以选择一个特定的群，指定对%{application_name}中文件的访问级别，类似于添加用户访问级别。"
+        description_html: '"标有‘选择一个群’的下拉框内是您所属的一组用户管理群的列表。您可以选择一个特定的群，指定对%{application_name}中文件的访问级别，类似于添加用户访问级别。"
+
+'
     help:
-      header: "User Support"
-      override_text: "用 app/views/static/help.html.erb 覆盖此文件。"
+      header: User Support
+      override_text: 用 app/views/static/help.html.erb 覆盖此文件。
     homepage:
       admin_sets:
-        link:               '查看所有收藏'
-        tab_label:          '探索收藏集'
-        title:              '探索收藏集'
+        link: 查看所有收藏
+        tab_label: 探索收藏集
+        title: 探索收藏集
       featured_researcher:
-        missing:            '没有研究人员被特色。'
-        tab_label:          '特色研究者'
-        title:              '特色研究者'
+        missing: 没有研究人员被特色。
+        tab_label: 特色研究者
+        title: 特色研究者
       featured_works:
-        drag:               '拖'
-        no_works:           '没有特色作品'
-        tab_label:          '特色作品'
-        title:              '特色作品'
+        drag: 拖
+        no_works: 没有特色作品
+        tab_label: 特色作品
+        title: 特色作品
       recently_uploaded:
-        depositor:          '存储者'
-        details:            '细节'
-        no_public:          '没有贡献公开的作品。'
-        tab_label:          '最近上传的'
-        title:              '最近上传的'
+        depositor: 存储者
+        details: 细节
+        no_public: 没有贡献公开的作品。
+        tab_label: 最近上传的
+        title: 最近上传的
     icons:
-      collection:       'fa fa-cubes'
-      default:          'fa fa-cube'
+      collection: fa fa-cubes
+      default: fa fa-cube
     mailbox:
-      date:     '日期'
-      delete:   '删除讯息'
-      message:  '讯息'
-      notifications_deleted: "通知已被删除"
-      subject:  '主题'
+      date: 日期
+      delete: 删除讯息
+      message: 讯息
+      notifications_deleted: 通知已被删除
+      subject: 主题
     messages:
       failure:
         multiple:
-          keyword: "不能被更新。 您没有足够的权限进行编辑。"
-          link: "这些文件"
-        single: "不能被更新。 您没有足够的权限进行编辑。"
-        subject: "批量上传许可被拒"
-        title:  "文件上传失败"
+          keyword: 不能被更新。 您没有足够的权限进行编辑。
+          link: 这些文件
+        single: 不能被更新。 您没有足够的权限进行编辑。
+        subject: 批量上传许可被拒
+        title: 文件上传失败
       success:
         multiple:
-          keyword: "已保存。"
-          link: "这些文件"
-        single: "已保存。"
-        subject: "批量上传完成"
-        title:  "文件上传成功"
+          keyword: 已保存。
+          link: 这些文件
+        single: 已保存。
+        subject: 批量上传完成
+        title: 文件上传成功
     pages:
-      cancel: "取消"
+      cancel: 取消
       tabs:
-        about_page: "关于页面"
-        help_page:  "帮助页面"
-        agreement_page: "存储协议"
-        terms_page: "使用条款"
-      updated: "页面更新。"
-    passive_consent_to_agreement: "保存这件作品表明我同意"
+        about_page: 关于页面
+        agreement_page: 存储协议
+        help_page: 帮助页面
+        terms_page: 使用条款
+      updated: 页面更新。
+    passive_consent_to_agreement: 保存这件作品表明我同意
     search:
       button:
-        html: '<span class="glyphicon glyphicon-search"></span> 转到'
-        text: "搜索"
+        html: <span class="glyphicon glyphicon-search"></span> 转到
+        text: 搜索
       form:
         option:
           all:
-            label_long:   "%{application_name}的全部"
-            label_short:  "全部"
+            label_long: "%{application_name}的全部"
+            label_short: 全部
           my_collections:
-            label_long:   "我的收藏集"
-            label_short:  "我的收藏集"
+            label_long: 我的收藏集
+            label_short: 我的收藏集
           my_shares:
-            label_long:   "我的共享"
-            label_short:  "我的共享"
+            label_long: 我的共享
+            label_short: 我的共享
           my_works:
-            label_long:   "我的作品"
-            label_short:  "我的作品"
+            label_long: 我的作品
+            label_short: 我的作品
         q:
-          label:          "搜索 %{application_name}"
-          placeholder:    "输入搜索词"
+          label: 搜索 %{application_name}
+          placeholder: 输入搜索词
     select_type:
-      description: "普通目的作品类型"
-      icon_class : 'fa fa-file-text-o'
-      name:        "作品"
-    share_button:       "分享您的作品"
+      description: 普通目的作品类型
+      icon_class: fa fa-file-text-o
+      name: 作品
+    share_button: 分享您的作品
     single_use_links:
-      button: "文件的单次使用链接"
+      button: 文件的单次使用链接
       copy:
         button: 复制
         tooltip: 已复制!
@@ -579,8 +586,8 @@ zh:
         type: 下载
       expiration:
         lesser_time: 在不到一小时之内
-        time: "在%{value}小时"
-      expiration_message: "链接%{link}到期%{time}"
+        time: 在%{value}小时
+      expiration_message: 链接%{link}到期%{time}
       show:
         type: 显示
       table:
@@ -590,107 +597,107 @@ zh:
         link: 链接
         no_links: 链接未生成
       title: 单次使用链接
-    sort_label: "对列表中单件排序"
+    sort_label: 对列表中单件排序
     toolbar:
       dashboard:
-        menu: "控件板"
-      language_switch: "转换语言"
-      notifications: "您没有未曾阅读的通知"
+        menu: 控件板
+      language_switch: 转换语言
+      notifications: 您没有未曾阅读的通知
       profile:
-        login: "登录"
-        logout: "退出登录"
-        sr_action: "阅览"
-        sr_target: "个人资料"
+        login: 登录
+        logout: 退出登录
+        sr_action: 阅览
+        sr_target: 个人资料
     transfers:
       new:
-        confirm: "您确定要将此作品的所有权转让给其他使用者吗？ 单击确定转移或取消返回到传输屏幕"
+        confirm: 您确定要将此作品的所有权转让给其他使用者吗？ 单击确定转移或取消返回到传输屏幕
     upload:
       alert:
-        contact_href_text: "联系表格"
-        fail_html: "上传时遇到问题, 没有文件上传正确。 请%{reload_href}。 如果问题继续出现，请用%{contact_href}报告。"
-        fail_restart_href_text: "重新开始"
-        partial_fail_html: "一件或多件文件上传不成功。 请继续用%{metadata_href}上传文件。 如果问题继续出现，请用%{contact_href}报告。"
-        partial_fail_metadata_href_text: "编辑元数据"
+        contact_href_text: 联系表格
+        fail_html: 上传时遇到问题, 没有文件上传正确。 请%{reload_href}。 如果问题继续出现，请用%{contact_href}报告。
+        fail_restart_href_text: 重新开始
+        partial_fail_html: 一件或多件文件上传不成功。 请继续用%{metadata_href}上传文件。 如果问题继续出现，请用%{contact_href}报告。
+        partial_fail_metadata_href_text: 编辑元数据
       browse_everything:
-        browse_files_button: "浏览云文件"
-        files_selected: "已选文件"
-        sr_tab_label: "从此处访问文件"
-        tab_label: "云提供商"
-      change_access_flash_message: "更新文件访问级别。 稍等片刻。 您可能需要刷新浏览器或稍后回访查询该文件访问级别是否更新。"
+        browse_files_button: 浏览云文件
+        files_selected: 已选文件
+        sr_tab_label: 从此处访问文件
+        tab_label: 云提供商
+      change_access_flash_message: 更新文件访问级别。 稍等片刻。 您可能需要刷新浏览器或稍后回访查询该文件访问级别是否更新。
       change_access_message_html: "<p>您改变了其他用户或群组对作品阅览或编辑的访问级别 <i>%{curation_concern}</i> </p><p>您需要对作品内所有文件的用户或群组的访问级别和公开度做同样的改变吗</p>"
-      change_access_no_message: "不用。 我会手动更新。"
-      change_access_yes_message: "是的, 请做同样的更新。"
+      change_access_no_message: 不用。 我会手动更新。
+      change_access_yes_message: 是的, 请做同样的更新。
       change_permissions_message_html: "<p>您改变了对%{curation_concern_human_readable_type}, <i>%{curation_concern}</i>的权限，使它对<b>%{visibility_badge}</b>公开。</p><p> 您需要对%{curation_concern_human_readable_type}中所有文件对<b>%{visibility_badge}</b>的权限做同样的改变吗？</p>"
-      cloud_timeout_message_html: "请注意如果您在短时间内上传了大量文件, 云提供商可能不能满足您的请求。 如果您上传中遇到问题，请用%{contact_href}报告。"
+      cloud_timeout_message_html: 请注意如果您在短时间内上传了大量文件, 云提供商可能不能满足您的请求。 如果您上传中遇到问题，请用%{contact_href}报告。
       local_ingest:
-        tab_label: "网络/服务器地点"
+        tab_label: 网络/服务器地点
       my_computer:
-        sr_instructions: "同意存储协议，选择文件。 文件选好之后点击开始上传键"
-        sr_tab_label: "访问文件"
-        tab_label: "我的电脑"
-      permissions_message: "文件许可正在更新中。稍等片刻。您可能需要刷新浏览器或稍后回访查询该文件访问许可是否更新"
-      processing: "文件正在处理。 等处理完毕，您可以开始编辑。"
+        sr_instructions: 同意存储协议，选择文件。 文件选好之后点击开始上传键
+        sr_tab_label: 访问文件
+        tab_label: 我的电脑
+      permissions_message: 文件许可正在更新中。稍等片刻。您可能需要刷新浏览器或稍后回访查询该文件访问许可是否更新
+      processing: 文件正在处理。 等处理完毕，您可以开始编辑。
     user_profile:
       orcid:
-        alt: "ORCID 图标"
-        label: "ORCID 资料"
-      tab_activity: "活动"
-      tab_highlighted: "Highlighted"
-      tab_profile: "个人资料"
+        alt: ORCID 图标
+        label: ORCID 资料
+      tab_activity: 活动
+      tab_highlighted: Highlighted
+      tab_profile: 个人资料
       zotero:
-        alt: "Zotero 图标"
-        connected: "已连接!"
-        label: "Zotero 个人资料"
-        unlinked: "与Zotero链接"
+        alt: Zotero 图标
+        connected: 已连接!
+        label: Zotero 个人资料
+        unlinked: 与Zotero链接
     visibility:
       authenticated:
-        class: "信息标签 "
-        note_html: "访问仅限于%{institution} 的用户"
+        class: '信息标签 '
+        note_html: 访问仅限于%{institution} 的用户
       embargo:
-        class: "警告提示标签"
-        text: "时滞期限"
+        class: 警告提示标签
+        text: 时滞期限
       lease:
-        class: "警告提示标签"
-        text: "租约"
+        class: 警告提示标签
+        text: 租约
       open:
-        class: "成功标签"
-        note_html:  "各位请注意， 如果您计划申请专利或在期刊上发表您的%{type}，请在<a href='http://www.sherpa.ac.uk/romeo/'>SHERPA/RoMEO</a> 查看相关出版社的版权政策"
-        text: "Open Access"
-        warning_html: "<p><strong>请注意</strong>, 在此公开(例如，加上%{label}标记)会被视作已出版，从而影响:</p><ul><li>为您的作品申请专利</li><li>在期刊上发表您的作品</li></ul><p>请在<a href=\"http://www.sherpa.ac.uk/romeo/\">SHERPA/RoMEO</a>查看相关出版社的版权政策。</p>"
-      open_title_attr: "修改此资源的公开度"
+        class: 成功标签
+        note_html: 各位请注意， 如果您计划申请专利或在期刊上发表您的%{type}，请在<a href='http://www.sherpa.ac.uk/romeo/'>SHERPA/RoMEO</a> 查看相关出版社的版权政策
+        text: 上市
+        warning_html: <p><strong>请注意</strong>, 在此公开(例如，加上%{label}标记)会被视作已出版，从而影响:</p><ul><li>为您的作品申请专利</li><li>在期刊上发表您的作品</li></ul><p>请在<a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a>查看相关出版社的版权政策。</p>
+      open_title_attr: 修改此资源的公开度
       private:
         note_html: 只有指定用户有权访问"共享"内容。
-        text: "私人的"
-      private_title_attr: "修改此资源的公开度"
+        text: 私人的
+      private_title_attr: 修改此资源的公开度
       restricted:
-        class: "危险标签"
-        text: "非公开"
+        class: 危险标签
+        text: 非公开
     workflow:
       default:
-        deposit: "存储"
+        deposit: 存储
       load:
-        state_error: "工作流程：%{workflow_name}尚未更新。 您在移除%{entity_count}条目的状况: %{state_name}。 在包含有效条目时，状况不能被移除!"
-      unauthorized: "该作品目前还在审批中，目前不可用"
+        state_error: '工作流程：%{workflow_name}尚未更新。 您在移除%{entity_count}条目的状况: %{state_name}。 在包含有效条目时，状况不能被移除!'
+      unauthorized: 该作品目前还在审批中，目前不可用
     works:
       create:
-        after_create_html: "您的文件正在后台被%{application_name}处理。 您所指定的元数据和访问权限已添加。请刷新后查看更新。"
-        breadcrumb: '添加新作品'
-        header: "添加新 %{type}"
+        after_create_html: 您的文件正在后台被%{application_name}处理。 您所指定的元数据和访问权限已添加。请刷新后查看更新。
+        breadcrumb: 添加新作品
+        header: 添加新 %{type}
       edit:
-        breadcrumb: '编辑'
+        breadcrumb: 编辑
       form:
-        additional_fields: "附加字段"
+        additional_fields: 附加字段
         in_collections: 在收藏集中的这件作品
         in_other_works: 在其它作品中包括的这件作品
         in_this_work: 这件作品包括的其它作品
-        visibility_until: 直到
         tab:
-          files:         "文件"
-          metadata:      "描述"
-          relationships: "关联"
-          share:         "分享"
+          files: 文件
+          metadata: 描述
+          relationships: 关联
+          share: 分享
+        visibility_until: 直到
       progress:
-        header: "保存作品"
+        header: 保存作品
       show:
         no_preview: 不可预览
       update:
@@ -698,62 +705,62 @@ zh:
   simple_form:
     hints:
       admin_set:
-        description: '涵盖管理集内所有作品的简短综述。 例如 "地球科学系研究生创建的论文以及论文辅助文件。"'
-        title: "用于帮助识别管理集的名称并有别于储存库内其它的管理集。"
+        description: 涵盖管理集内所有作品的简短综述。 例如 "地球科学系研究生创建的论文以及论文辅助文件。"
+        title: 用于帮助识别管理集的名称并有别于储存库内其它的管理集。
       collection:
-        based_near: "与收藏集相关的地名，例如出版品的地点，或者是收藏集内涉及的城市，州、或国家。 参见<a href='http://www.geonames.org'>GeoNames web service</a>。"
-        contributor: "个人与团体，虽未担任主要职责，却对收藏集的创建做出贡献"
-        creator: "对收藏集负责的个人与团体。通常指收藏集内容的作者。 个人姓名应该先输入姓氏，例如 &quot;Smith, John.&quot;。"
-        date_created: "收藏集创建的日期。"
-        description: "关于收藏集的自由体文字注释。例如一篇文章的概要或一篇文章的引文信息。"
-        identifier: "一个独特的句柄用于标识收藏集。 例如用于标识期刊文章的DOI，或者标识一本书的ISBN或者OCLC系统编号。"
-        keyword: "用于描述和检索收藏集内容的的词或词组。"
-        language: "收藏集内容使用的语言。"
-        publisher: "出版收藏集的个人或团体。 一般来说是机构单位。"
-        related_url: "相关链接，用于链接与收藏集相关的网页或其它具体内容(音频、视频、PDF文件)。例如一个研究项目的网址，收藏集是此研究项目的成果"
-        resource_type: "预定类型用于描述上传内容类型，例如&quot;文章&quot; or &quot;数据集。&quot; 可以选择多项类型。"
-        license: "用于管理收藏集访问权限的许可与发布信息。 可从下拉列表中选择。"
-        subject: "用于描述收藏集的主题词或索引词,需要选自现存的词汇表。"
-        title: "用于帮助识别收藏集的名称。"
+        based_near: 与收藏集相关的地名，例如出版品的地点，或者是收藏集内涉及的城市，州、或国家。 参见<a href='http://www.geonames.org'>GeoNames web service</a>。
+        contributor: 个人与团体，虽未担任主要职责，却对收藏集的创建做出贡献
+        creator: 对收藏集负责的个人与团体。通常指收藏集内容的作者。 个人姓名应该先输入姓氏，例如 &quot;Smith, John.&quot;。
+        date_created: 收藏集创建的日期。
+        description: 关于收藏集的自由体文字注释。例如一篇文章的概要或一篇文章的引文信息。
+        identifier: 一个独特的句柄用于标识收藏集。 例如用于标识期刊文章的DOI，或者标识一本书的ISBN或者OCLC系统编号。
+        keyword: 用于描述和检索收藏集内容的的词或词组。
+        language: 收藏集内容使用的语言。
+        license: 用于管理收藏集访问权限的许可与发布信息。 可从下拉列表中选择。
+        publisher: 出版收藏集的个人或团体。 一般来说是机构单位。
+        related_url: 相关链接，用于链接与收藏集相关的网页或其它具体内容(音频、视频、PDF文件)。例如一个研究项目的网址，收藏集是此研究项目的成果
+        resource_type: 预定类型用于描述上传内容类型，例如&quot;文章&quot; or &quot;数据集。&quot; 可以选择多项类型。
+        subject: 用于描述收藏集的主题词或索引词,需要选自现存的词汇表。
+        title: 用于帮助识别收藏集的名称。
       defaults:
-        based_near: "与作品相关的地名，例如出版品的地点，或者是作品中涉及的城市，州、或国家。 参见<a href='http://www.geonames.org'>GeoNames web service</a>。"
-        contributor: "个人与团体，虽未担任主要职责，却对作品创建做出贡献。"
-        creator: "对作品负责的个人与团体。通常指作品内容的作者。 个人姓名应该先输入姓氏，例如 &quot;Smith, John.&quot;。"
-        date_created: "作品创建的日期。"
-        description: "关于作品的自由体文字注释。例如一篇文章的概要或一篇文章的引文信息。"
-        identifier: "一个独特的句柄用于标识作品。 例如用于标识期刊文章的DOI，或者标识一本书的ISBN或者OCLC系统编号。"
-        keyword: "用于描述和搜索作品内容的的词或词组。"
-        language: "作品内容使用的语言。"
-        publisher: "出版作品的个人或团体，一般来说是机构单位。"
-        related_url: "相关链接，用于链接与作品相关的网页或其它具体内容(音频、视频、PDF文件)。例如一个研究项目的网址，作品是此研究项目的成果。"
-        resource_type: "预定类型用于描述上传内容类型，例如&quot;文章&quot; or &quot;数据集。&quot; 可以选择多项类型。"
-        license: "用于管理作品访问权限的许可与发布信息。 可从下拉列表中选择。"
-        subject: "用于描述作品的主题词或索引词,需要选自现存的词汇表。"
-        title: "用于帮助识别作品的名称。"
+        based_near: 与作品相关的地名，例如出版品的地点，或者是作品中涉及的城市，州、或国家。 参见<a href='http://www.geonames.org'>GeoNames web service</a>。
+        contributor: 个人与团体，虽未担任主要职责，却对作品创建做出贡献。
+        creator: 对作品负责的个人与团体。通常指作品内容的作者。 个人姓名应该先输入姓氏，例如 &quot;Smith, John.&quot;。
+        date_created: 作品创建的日期。
+        description: 关于作品的自由体文字注释。例如一篇文章的概要或一篇文章的引文信息。
+        identifier: 一个独特的句柄用于标识作品。 例如用于标识期刊文章的DOI，或者标识一本书的ISBN或者OCLC系统编号。
+        keyword: 用于描述和搜索作品内容的的词或词组。
+        language: 作品内容使用的语言。
+        license: 用于管理作品访问权限的许可与发布信息。 可从下拉列表中选择。
+        publisher: 出版作品的个人或团体，一般来说是机构单位。
+        related_url: 相关链接，用于链接与作品相关的网页或其它具体内容(音频、视频、PDF文件)。例如一个研究项目的网址，作品是此研究项目的成果。
+        resource_type: 预定类型用于描述上传内容类型，例如&quot;文章&quot; or &quot;数据集。&quot; 可以选择多项类型。
+        subject: 用于描述作品的主题词或索引词,需要选自现存的词汇表。
+        title: 用于帮助识别作品的名称。
     labels:
       collection:
-        size:                      "大小"
-        total_items:               "总作品"
+        size: 大小
+        total_items: 总作品
       defaults:
-        admin_set_id:              "添加管理集成员"
-        based_near:                "地点"
-        collection_ids:            "添加收藏集成员"
-        creator:                   "创建者"
-        date_created:              "创建日期"
-        description:               "摘要"
-        embargo_release_date:      'until'
-        files:                     '上传文件'
-        keyword:                   "关键词"
-        lease_expiration_date:     'until'
-        related_url:               "相关链接"
-        license:                   "许可"
-        title:                     "标题"
-        visibility_after_embargo:  '开放'
-        visibility_after_lease:    '仅限'
-        visibility_during_embargo: '仅限'
-        visibility_during_lease:   '可使用'
+        admin_set_id: 添加管理集成员
+        based_near: 地点
+        collection_ids: 添加收藏集成员
+        creator: 创建者
+        date_created: 创建日期
+        description: 摘要
+        embargo_release_date: until
+        files: 上传文件
+        keyword: 关键词
+        lease_expiration_date: until
+        license: 许可
+        related_url: 相关链接
+        title: 标题
+        visibility_after_embargo: 开放
+        visibility_after_lease: 仅限
+        visibility_during_embargo: 仅限
+        visibility_during_lease: 可使用
       proxy_deposit_request:
-        transfer_to:               "用户"
-        sender_comment:            "注释"
+        sender_comment: 注释
+        transfer_to: 用户
     required:
-      html: '<span class="label label-info required-tag">需要的</span>'
+      html: <span class="label label-info required-tag">需要的</span>

--- a/spec/features/embargo_spec.rb
+++ b/spec/features/embargo_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'embargo' do
       choose 'Embargo'
       fill_in 'generic_work_embargo_release_date', with: future_date
       select 'Private', from: 'Restricted to'
-      select 'Open Access', from: 'then open it up to'
+      select 'Public', from: 'then open it up to'
       click_button 'Save'
 
       # chosen embargo date is on the show page

--- a/spec/features/lease_spec.rb
+++ b/spec/features/lease_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'leases' do
       fill_in 'Title', with: 'Lease test'
       choose 'Lease'
       fill_in 'generic_work_lease_expiration_date', with: future_date
-      select 'Open Access', from: 'Is available for'
+      select 'Public', from: 'Is available for'
       select 'Private', from: 'then restrict it to'
       click_button 'Save'
 

--- a/spec/helpers/hyrax/ability_helper_spec.rb
+++ b/spec/helpers/hyrax/ability_helper_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Hyrax::AbilityHelper do
     subject { helper.visibility_badge visibility }
     {
       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC =>
-        "<span class=\"label label-success\">Open Access</span>",
+        "<span class=\"label label-success\">Public</span>",
       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED =>
         "<span class=\"label label-info\">%s</span>",
       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE =>
@@ -20,7 +20,7 @@ RSpec.describe Hyrax::AbilityHelper do
     end
   end
   describe "#visibility_options" do
-    let(:public_opt) { ['Open Access', Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC] }
+    let(:public_opt) { ['Public', Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC] }
     let(:authenticated_opt) { [t('hyrax.institution_name'), Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED] }
     let(:private_opt) { ['Private', Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE] }
     subject { helper.visibility_options(option) }

--- a/spec/presenters/hyrax/permission_badge_spec.rb
+++ b/spec/presenters/hyrax/permission_badge_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::PermissionBadge do
 
       context "when open-access" do
         let(:attributes) { { read_access_group_ssim: ['public'] } }
-        it { is_expected.to eq "<span class=\"label label-success\">Open Access</span>" }
+        it { is_expected.to eq "<span class=\"label label-success\">Public</span>" }
       end
 
       context "when registered" do
@@ -50,7 +50,7 @@ RSpec.describe Hyrax::PermissionBadge do
 
       context "when open-access" do
         let(:value) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
-        it { is_expected.to eq "<span class=\"label label-success\">Open Access</span>" }
+        it { is_expected.to eq "<span class=\"label label-success\">Public</span>" }
       end
 
       context "when registered" do


### PR DESCRIPTION
CurationConcerns provided the ability to differentiate between labels and text for visibility layers: https://github.com/samvera/curation_concerns/blob/master/config/locales/curation_concerns.en.yml#L145-L147 and used the term "Open Access" (which we now understand is problematic).

You can see how these are used in CC:

* https://github.com/samvera/curation_concerns/blob/master/app/helpers/curation_concerns/ability_helper.rb#L37
* https://github.com/samvera/curation_concerns/blob/b1d34b15f233da1df1ed07421fffc5a8959eb18f/app/views/curation_concerns/base/_form_permission.html.erb#L16

Sufia overrode this behavior from CC, but only overrode *part* of it (the label). But, as far as I can tell, Sufia failed to override the text because this i18n key:

* https://github.com/samvera/sufia/blob/master/config/locales/sufia.en.yml#L222

Which is used here:

* https://github.com/samvera/sufia/blob/master/app/helpers/sufia/sufia_helper_behavior.rb#L255

is overridden by an identically named key here: https://github.com/samvera/sufia/blob/master/config/locales/sufia.en.yml#L495

Since, as we have learned that the term "Open Access" is problematic because it has baggage, I propose that we change this label back to "Public".