### PR TITLE
FeaturedWorkList handles AC::Parameters

### DIFF
--- a/app/models/featured_work_list.rb
+++ b/app/models/featured_work_list.rb
@@ -1,7 +1,11 @@
 class FeaturedWorkList
   include ActiveModel::Model
 
+  # @param [ActionController::Parameters] a collection of nested perameters
   def featured_works_attributes=(attributes_collection)
+    if attributes_collection.respond_to?(:permitted?)
+      attributes_collection = attributes_collection.to_h
+    end
     attributes_collection = attributes_collection.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes } if attributes_collection.is_a? Hash
     attributes_collection.each do |attributes|
       raise "Missing id" if attributes['id'].blank?

--- a/spec/models/featured_work_list_spec.rb
+++ b/spec/models/featured_work_list_spec.rb
@@ -14,20 +14,39 @@ RSpec.describe FeaturedWorkList, type: :model do
       expect(presenter).to be_kind_of Hyrax::WorkShowPresenter
       expect(presenter.id).to eq work1.id
     end
+
+    context 'when one of the files is deleted' do
+      before do
+        work1.destroy
+      end
+
+      it 'is a list of the remaining featured work objects, each with the generic_work\'s solr_doc' do
+        expect(subject.featured_works.size).to eq 1
+        presenter = subject.featured_works.first.presenter
+        expect(presenter).to be_kind_of Hyrax::WorkShowPresenter
+        expect(presenter.id).to eq work2.id
+      end
+    end
   end
 
-  describe 'file deleted' do
-    before do
-      create(:featured_work, work_id: work1.id)
-      create(:featured_work, work_id: work2.id)
-      work1.destroy
-    end
+  describe '#featured_works_attributes=' do
+    let(:featured_work) { create(:featured_work, work_id: work1.id) }
 
-    it 'is a list of the remaining featured work objects, each with the generic_work\'s solr_doc' do
-      expect(subject.featured_works.size).to eq 1
-      presenter = subject.featured_works.first.presenter
-      expect(presenter).to be_kind_of Hyrax::WorkShowPresenter
-      expect(presenter.id).to eq work2.id
+    let(:attributes) do
+      ActionController::Parameters.new(
+        "0" => {
+          "id" => featured_work.id,
+          "order" => "5"
+        }
+      ).permit!
+    end
+    let(:instance) { described_class.new }
+
+    subject { instance.featured_works_attributes = attributes }
+
+    it "sets order" do
+      subject
+      expect(featured_work.order).to eq 5
     end
   end
 


### PR DESCRIPTION
Previously it wasn't casting to a hash causing a: `Missing id` error.

Fixes https://github.com/samvera-labs/hyku/issues/1300
Fixes https://github.com/samvera-labs/hyku/issues/1278
Fixes https://github.com/samvera-labs/hyku/issues/1259


@samvera/hyrax-code-reviewers
