### PR TITLE
Rename Technical page

### DIFF
--- a/app/views/hyrax/admin/features/index.html.erb
+++ b/app/views/hyrax/admin/features/index.html.erb
@@ -1,5 +1,5 @@
 <% provide :page_header do %>
-  <h1><span class="fa fa-cog"></span> Settings</h1>
+  <h1><span class="fa fa-wrench"></span> <%= t('.header') %></h1>
 <% end %>
 <div class="flip row">
   <div class="col-md-12">
@@ -10,9 +10,9 @@
             <thead>
               <tr>
                 <th></th>
-                <th class="name">Feature</th>
-                <th class="description">Description</th>
-                <th class="action">Action</th>
+                <th class="name"><%= t('.feature') %></th>
+                <th class="description"><%= t('.description') %></th>
+                <th class="action"><%= t('.action') %></th>
               </tr>
             </thead>
             <tbody>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -165,6 +165,12 @@ de:
         update:
           flash:
             success: Das Aussehen wurde erfolgreich aktualisiert
+      features:
+        index:
+          header:           Charakteristik
+          feature:          Charakteristisch
+          description:      Beschreibung
+          action:           Aktion
       sidebar:
         activity: Aktivität
         admin_sets: Verwaltungssets
@@ -179,7 +185,7 @@ de:
         settings: Einstellungen
         statistics: Berichte
         tasks: Aufgaben
-        technical: Technisch
+        technical: Charakteristik
         transfers: Transfers
         user_activity: Ihre Tätigkeit
         users: Benutzer verwalten

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -164,6 +164,12 @@ en:
         update:
           flash:
             success:        "The appearance was successfully updated"
+      features:
+        index:
+          header:           Features
+          feature:          Feature
+          description:      Description
+          action:           Action
       sidebar:
         activity:           "Activity"
         admin_sets:         "Administrative Sets"
@@ -178,7 +184,7 @@ en:
         settings:           "Settings"
         statistics:         "Reports"
         tasks:              "Tasks"
-        technical:          "Technical"
+        technical:          "Features"
         transfers:          "Transfers"
         users:              "Manage Users"
         user_activity:      "Your activity"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -165,6 +165,12 @@ es:
         update:
           flash:
             success: La apariencia se actualizó correctamente
+      features:
+        index:
+          header:           Caracteristicas
+          feature:          Característica
+          description:      Descripción
+          action:           Acción
       sidebar:
         activity: Actividad
         admin_sets: Conjuntos Administrativos
@@ -179,7 +185,7 @@ es:
         settings: Ajustes
         statistics: Informes
         tasks: Tareas
-        technical: Técnico
+        technical: Caracteristicas
         transfers: Transferencias
         user_activity: Su Actividad
         users: Usarios

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -165,6 +165,12 @@ fr:
         update:
           flash:
             success: L'apparence a été mise à jour avec succès
+      features:
+        index:
+          header:   Caractéristiques
+          feature:          Caractéristique
+          description:      Description
+          action:           Action
       sidebar:
         activity: Activité
         admin_sets: Ensembles administratifs
@@ -179,7 +185,7 @@ fr:
         settings: Paramètres
         statistics: Rapports
         tasks: les tâches
-        technical: Technique
+        technical: Caractéristiques
         transfers: Transferts
         user_activity: Votre activité
         users: gérer les utilisateurs

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -165,6 +165,12 @@ it:
         update:
           flash:
             success: L'aspetto è stato aggiornato con successo
+      features:
+        index:
+          header:           Caratteristiche
+          feature:          Caratteristica
+          description:      Descrizione
+          action:           Azione
       sidebar:
         activity: Attività
         admin_sets: Set amministrativi
@@ -179,7 +185,7 @@ it:
         settings: impostazioni
         statistics: Rapporti
         tasks: Compiti
-        technical: Tecnico
+        technical: Caratteristiche
         transfers: trasferimenti
         user_activity: La tua attività
         users: Gestisci utenti

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -165,6 +165,12 @@ pt-BR:
         update:
           flash:
             success: A aparência foi atualizada com sucesso
+      features:
+        index:
+          header:           Características
+          feature:          Característica
+          description:      Descrição
+          action:           Açao
       sidebar:
         activity: Atividade
         admin_sets: Conjuntos Administrativos
@@ -179,7 +185,7 @@ pt-BR:
         settings: Configurações
         statistics: Relatórios
         tasks: Tarefas
-        technical: Técnico
+        technical: Características
         transfers: Transferências
         user_activity: Sua atividade
         users: Gerenciar Usuários

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -167,6 +167,12 @@ zh:
         update:
           flash:
             success: 表面已更新
+      features:
+        index:
+          header:  特征
+          feature:          特征
+          description:      描述
+          action:           行动
       sidebar:
         activity: 活动
         admin_sets: 管理集
@@ -181,7 +187,7 @@ zh:
         settings: 设置
         statistics: 统计
         tasks: 任务
-        technical: 技术
+        technical: 特征
         transfers: 转让
         user_activity: 你的操作
         users: 管理用户

--- a/spec/controllers/hyrax/admin/features_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/features_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Hyrax::Admin::FeaturesController do
         expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
         expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path)
         expect(controller).to receive(:add_breadcrumb).with('Configuration', '#')
-        expect(controller).to receive(:add_breadcrumb).with('Technical', admin_features_path)
+        expect(controller).to receive(:add_breadcrumb).with('Features', admin_features_path)
         get :index
         expect(response).to be_success
       end


### PR DESCRIPTION
The flip-flop features page in the admin dashboard was called 'Technical', while the page itself was titled 'Settings'. Both were renamed to 'Features', the icon was changed to be consistent, and I18n capability was added for each of the headings (via google translate).

Resolves issue https://github.com/samvera/hyrax/issues/1100

@samvera/hyrax-code-reviewers
