### PR TITLE
Restore embedded metadata to work show page

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -48,6 +48,12 @@ module Hyrax
       @inspect_workflow ||= InspectWorkPresenter.new(solr_document, current_ability)
     end
 
+    # @return [String] a download URL, if work has representative media, or a blank string
+    def download_url
+      return '' if representative_presenter.nil?
+      Hyrax::Engine.routes.url_helpers.download_url(representative_presenter, host: request.host)
+    end
+
     # @return FileSetPresenter presenter for the representative FileSets
     def representative_presenter
       return nil if representative_id.blank?

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,4 +1,7 @@
 <% provide :page_title, @presenter.page_title %>
+
+<%= render 'shared/citations' %>
+
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">
   <div class="col-xs-12">
     <header>
@@ -12,7 +15,8 @@
   </div>
   <div class="col-sm-4">
     <%= render "show_actions", presenter: @presenter %>
-    <%= t('.last_modified', value: @presenter.date_modified) %>
+    <%# Use the fully qualified path to avoid RSpec error: translation missing: en.hyrax.base.show.html.erb.last_modified %>
+    <%= t('hyrax.base.show.last_modified', value: @presenter.date_modified) %>
     <%= render 'representative_media', presenter: @presenter %>
     <%= render 'social_media' %>
     <%= render 'citations', presenter: @presenter %>

--- a/app/views/hyrax/citations/work.html.erb
+++ b/app/views/hyrax/citations/work.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/citations' %>
-
 <h4>Citation Formats</h4>
 
 <h4>MLA</h4>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/citations' %>
-
 <div class="container-fluid">
   <div class="row">
     <div class="col-xs-12 col-sm-4">

--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -6,12 +6,12 @@
   <meta property="og:type" content="object"/>
   <meta property="og:title" content="<%= @presenter.title.first %>"/>
   <meta property="og:description" content="<%= @presenter.description.first.truncate(200) rescue @presenter.title.first %>"/>
-  <meta property="og:image" content="<%= hyrax.download_url(@presenter, file: 'thumbnail') %>"/>
-  <meta property="og:url" content="<%= polymorphic_path([main_app, @presenter]) %>"/>
+  <meta property="og:image" content="<%= @presenter.download_url %>"/>
+  <meta property="og:url" content="<%= polymorphic_url([main_app, @presenter]) %>"/>
   <meta name="twitter:data1" content="<%= @presenter.keyword.join(', ') %>"/>
   <meta name="twitter:label1" content="Keywords"/>
-  <meta name="twitter:data2" content="<%= @presenter.license %>"/>
-  <meta name="twitter:label2" content="License"/>
+  <meta name="twitter:data2" content="<%= @presenter.rights_statement.first %>"/>
+  <meta name="twitter:label2" content="Rights Statement"/>
 <% end %>
 
 <% content_for(:gscholar_meta) do %>
@@ -20,7 +20,7 @@
   <meta name="citation_author" content="<%= creator %>"/>
   <% end %>
   <meta name="citation_publication_date" content="<%= @presenter.date_created.first %>"/>
-  <meta name="citation_pdf_url" content="<%= hyrax.download_url(@presenter) %>"/>
+  <meta name="citation_pdf_url" content="<%= @presenter.download_url %>"/>
   <!-- Hyrax does not yet support these metadata -->
   <!--
     <meta name="citation_journal_title" content=""/>

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Hyrax::WorkShowPresenter do
   let(:solr_document) { SolrDocument.new(attributes) }
-  let(:request) { double }
+  let(:request) { double(host: 'example.org') }
   let(:user_key) { 'a_user_key' }
 
   let(:attributes) do
@@ -197,6 +197,24 @@ RSpec.describe Hyrax::WorkShowPresenter do
               presenter_args: [ability, request])
         .and_return ["abc"]
       expect(presenter.representative_presenter).to eq("abc")
+    end
+  end
+
+  describe "#download_url" do
+    subject { presenter.download_url }
+
+    let(:solr_document) { SolrDocument.new(work.to_solr) }
+
+    context "with a representative" do
+      let(:work) { create(:work_with_representative_file) }
+
+      it { is_expected.to eq "http://#{request.host}/downloads/#{work.representative_id}" }
+    end
+
+    context "without a representative" do
+      let(:work) { create(:work) }
+
+      it { is_expected.to eq '' }
     end
   end
 

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -1,21 +1,55 @@
 RSpec.describe 'hyrax/base/show.html.erb', type: :view do
-  let(:solr_document) do
+  let(:work_solr_document) do
     SolrDocument.new(id: '999',
-                     title_tesim: ['Title of the Work'],
+                     title_tesim: ['My Title'],
+                     creator_tesim: ['Doe, John', 'Doe, Jane'],
                      date_modified_dtsi: '2011-04-01',
-                     has_model_ssim: ['GenericWork'])
+                     has_model_ssim: ['GenericWork'],
+                     depositor_tesim: depositor.user_key,
+                     description_tesim: ['Lorem ipsum lorem ipsum.'],
+                     keyword_tesim: ['bacon', 'sausage', 'eggs'],
+                     rights_statement_tesim: ['http://example.org/rs/1'],
+                     date_created_tesim: ['1984-01-02'])
   end
+
+  let(:file_set_solr_document) do
+    SolrDocument.new(id: '123',
+                     title_tesim: ['My FileSet'],
+                     depositor_tesim: depositor.user_key)
+  end
+
   let(:ability) { double }
+
   let(:presenter) do
-    Hyrax::WorkShowPresenter.new(solr_document, ability)
+    Hyrax::WorkShowPresenter.new(work_solr_document, ability, request)
   end
+
   let(:workflow_presenter) do
     double('workflow_presenter', badge: 'Foobar')
   end
+
+  let(:representative_presenter) do
+    Hyrax::FileSetPresenter.new(file_set_solr_document, ability)
+  end
+
   let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  let(:request) { double('request', host: 'test.host') }
+
+  let(:depositor) do
+    stub_model(User,
+               user_key: 'bob',
+               twitter_handle: 'bot4lib')
+  end
 
   before do
     allow(presenter).to receive(:workflow).and_return(workflow_presenter)
+    allow(presenter).to receive(:representative_presenter).and_return(representative_presenter)
+    allow(presenter).to receive(:tweeter).and_return("@#{depositor.twitter_handle}")
+    allow(controller).to receive(:current_user).and_return(depositor)
+    allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
+    allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+    allow(view).to receive(:on_the_dashboard?).and_return(false)
     stub_template 'hyrax/base/_metadata.html.erb' => ''
     stub_template 'hyrax/base/_relationships.html.erb' => ''
     stub_template 'hyrax/base/_show_actions.html.erb' => ''
@@ -24,8 +58,9 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
     stub_template 'hyrax/base/_citations.html.erb' => ''
     stub_template 'hyrax/base/_items.html.erb' => ''
     stub_template 'hyrax/base/_workflow_actions_widget.html.erb' => ''
+    stub_template '_masthead.html.erb' => ''
     assign(:presenter, presenter)
-    render
+    render template: 'hyrax/base/show.html.erb', layout: 'layouts/hyrax/1_column'
   end
 
   it 'shows last saved' do
@@ -34,5 +69,105 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
 
   it 'shows workflow badge' do
     expect(page).to have_content 'Foobar'
+  end
+
+  describe 'google scholar' do
+    it 'appears in meta tags' do
+      gscholar_meta_tags = Nokogiri::HTML(rendered).xpath("//meta[contains(@name, 'citation_')]")
+      expect(gscholar_meta_tags.count).to eq(5)
+    end
+
+    it 'displays title' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_title']")
+      expect(tag.attribute('content').value).to eq('My Title')
+    end
+
+    it 'displays authors' do
+      tags = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_author']")
+      expect(tags.first.attribute('content').value).to eq('Doe, John')
+      expect(tags.last.attribute('content').value).to eq('Doe, Jane')
+    end
+
+    it 'displays publication date' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_publication_date']")
+      expect(tag.attribute('content').value).to eq('1984-01-02')
+    end
+
+    it 'displays download URL' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_pdf_url']")
+      expect(tag.attribute('content').value).to eq('http://test.host/downloads/123')
+    end
+  end
+
+  describe 'twitter cards' do
+    it 'appears in meta tags' do
+      twitter_meta_tags = Nokogiri::HTML(rendered).xpath("//meta[contains(@name, 'twitter:') or contains(@property, 'og:')]")
+      expect(twitter_meta_tags.count).to eq(13)
+    end
+
+    it 'displays twitter:card' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:card']")
+      expect(tag.attribute('content').value).to eq('product')
+    end
+
+    it 'displays twitter:site' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:site']")
+      expect(tag.attribute('content').value).to eq('@HydraSphere')
+    end
+
+    it 'displays twitter:creator' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:creator']")
+      expect(tag.attribute('content').value).to eq('@bot4lib')
+    end
+
+    it 'displays og:site_name' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:site_name']")
+      expect(tag.attribute('content').value).to eq('Hyrax')
+    end
+
+    it 'displays og:type' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:type']")
+      expect(tag.attribute('content').value).to eq('object')
+    end
+
+    it 'displays og:title' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:title']")
+      expect(tag.attribute('content').value).to eq('My Title')
+    end
+
+    it 'displays og:description' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:description']")
+      expect(tag.attribute('content').value).to eq('Lorem ipsum lorem ipsum.')
+    end
+
+    it 'displays og:image' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:image']")
+      expect(tag.attribute('content').value).to eq('http://test.host/downloads/123')
+    end
+
+    it 'displays og:url' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:url']")
+      expect(tag.attribute('content').value).to eq('http://test.host/concern/generic_works/999')
+    end
+
+    it 'displays twitter:data1' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:data1']")
+      expect(tag.attribute('content').value).to eq('bacon, sausage, eggs')
+    end
+
+    it 'displays twitter:label1' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:label1']")
+      expect(tag.attribute('content').value).to eq('Keywords')
+    end
+
+    it 'displays twitter:data2' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:data2']")
+      expect(tag.attribute('content').value).to eq('http://example.org/rs/1')
+    end
+
+    it 'displays twitter:label2' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:label2']")
+      expect(tag.attribute('content').value).to eq('Rights Statement')
+    end
   end
 end


### PR DESCRIPTION
Pulls Facebook/opengraph, Twitter card, and Google Scholar meta tag information into the work show page from the fileset show page.

Removes same from the fileset show page because much of the metadata that drives this feature will not be present for FileSets, which will result in broken integration. (Is this OK, @crowesn @newmanld?)

Fixes #109, #1323

@samvera/hyrax-code-reviewers
