### PR TITLE
Make collections add & edit consistent

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -59,6 +59,9 @@ module Hyrax
     end
 
     def new
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.collections.new.header'), hyrax.new_collection_path
       @collection.apply_depositor_metadata(current_user.user_key)
       form
     end

--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -3,7 +3,7 @@
       <div class="input-group">
         <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('hyrax.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
         <div class="input-group-btn">
-          <button type="submit" class="btn btn-primary" id="collection_submit"><i class="glyphicon glyphicon-search"></i> Go</button>
+          <button type="submit" class="btn btn-primary" id="collection_submit"><i class="glyphicon glyphicon-search"></i> <%= t('hyrax.collections.search_form.button_label') %></button>
         </div>
       </div>
       <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>

--- a/app/views/hyrax/collections/edit.html.erb
+++ b/app/views/hyrax/collections/edit.html.erb
@@ -1,7 +1,7 @@
-<% provide :page_title, construct_page_title("Edit Collection #{@form.title.first}") %>
+<% provide :page_title, construct_page_title( t('.header', title: @form.title.first) ) %>
 
 <%= provide :page_header do %>
-  <h1>Edit Collection: <%= @form.title.first %></h1>
+  <h1><span class="fa fa-edit"></span><%= t('.header', title: @form.title.first) %></h1>
 <% end %>
 
 <% unless has_collection_search_parameters? %>
@@ -10,7 +10,6 @@
       <%= render 'hyrax/collections/form' %>
     </div>
   </div>
-
 
   <div class="row">
     <div class="col-md-12">

--- a/app/views/hyrax/collections/new.html.erb
+++ b/app/views/hyrax/collections/new.html.erb
@@ -1,3 +1,11 @@
-<h1>Create New Collection</h1>
+<% provide :page_title, construct_page_title( t('.header') ) %>
 
-<%= render 'form' %>
+<% provide :page_header do %>
+  <h1><span class="fa fa-edit"></span> <%= t('.header') %></h1>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <%= render 'hyrax/collections/form' %>
+  </div>
+</div>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -351,12 +351,17 @@ de:
         title: Zur Sammlung hinzufügen
         update: Update-Sammlung
     collections:
+      edit:
+        header: "Sammlung Bearbeiten: %{title}"
       form:
         tabs:
           description: Beschreibung
           sharing: Teilen
           visibility: Sichtweite
+      new:
+        header: Neue Sammlung
       search_form:
+        button_label: Gehen
         label: Suche Sammlung %{title}
         placeholder: Suche Sammlung
       show:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -344,12 +344,17 @@ en:
         title: "Add to collection"
         update: "Update Collection"
     collections:
+      edit:
+        header: "Edit Collection: %{title}"
       form:
         tabs:
           description: "Description"
           sharing:     "Sharing"
           visibility:  "Visibility"
+      new:
+        header: Create New Collection
       search_form:
+        button_label: Go
         label: "Search Collection %{title}"
         placeholder: "Search Collection"
       show:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -346,12 +346,17 @@ es:
         title: Añadir a la colección
         update: Actualizar Colección
     collections:
+      edit:
+        header: "Editar Colección: %{title}"
       form:
         tabs:
           description: Descripción
           sharing: Compartir
           visibility: Visibilidad
+      new:
+        header: Nueva Colección
       search_form:
+        button_label: Ir
         label: Buscar Colección %{title}
         placeholder: Buscar Colección
       show:

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -351,12 +351,17 @@ fr:
         title: Ajouter à la collection
         update: Mise à jour de la collection
     collections:
+      edit:
+        header: "Modifier la Collection: %{title}"
       form:
         tabs:
           description: La description
           sharing: Partage
           visibility: Visibilité
+      new:
+        header: Nouvelle Collection
       search_form:
+        button_label: Aller
         label: Rechercher Collection %{title}
         placeholder: Rechercher Collection
       show:

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -351,12 +351,17 @@ it:
         title: Aggiungere alla collezione
         update: Aggiorna Collezione
     collections:
+      edit:
+        header: "Modifica Collezione: %{title}"
       form:
         tabs:
           description: Descrizione
           sharing: compartecipazione
           visibility: Visibilità
+      new:
+        header: Nuova Collezione
       search_form:
+        button_label: Partire
         label: Cerca la raccolta %{title}
         placeholder: Cerca raccolta
       show:

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -351,12 +351,17 @@ pt-BR:
         title: Adicionar a coleção
         update: Coleção de Atualizações
     collections:
+      edit:
+        header: "Editar Coleção: %{title}"
       form:
         tabs:
           description: Descrição
           sharing: Compartilhando
           visibility: Visibilidade
+      new:
+        header: Nova Coleção
       search_form:
+        button_label: Ir
         label: Pesquisar Collection %{title}
         placeholder: Pesquisar Coleção
       show:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -348,12 +348,17 @@ zh:
         title: 添加到新收藏集
         update: 更新收藏集
     collections:
+      edit:
+        header: "编辑收藏: %{title}"
       form:
         tabs:
           description: 描述
           sharing: 分享
           visibility: 能见度
+      new:
+        header: 新系列
       search_form:
+        button_label: 走
         label: 搜索收藏集 %{title}
         placeholder: 搜索收藏集
       show:


### PR DESCRIPTION
1. Add breadcrumbs which were missing
2. Handle i18n where missing on edit and new pages

Resolves https://github.com/samvera/hyrax/issues/1296

Note: the issue implied that the form being rendered was not the same, but in actuality it was... the only difference was that new rendered form without qualifying the path, while edit qualified the path to the form. For consistency purposes, I changed this in new.html.erb, but this does not affect behavior.

@samvera/hyrax-code-reviewers
