### PR TITLE
Check the :download ability to determine if user can download file

### DIFF
--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -7,7 +7,6 @@
   </button>
 
   <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= file_set.id %>">
-
   <% if can?(:edit, file_set.id) %>
     <li role="menuitem" tabindex="-1">
       <%= link_to 'Edit', edit_polymorphic_path([main_app, file_set]),
@@ -28,7 +27,7 @@
     </li>
   <% end %>
 
-  <% if can?(:read, file_set.id) %>
+  <% if can?(:download, file_set.id) %>
     <li role="menuitem" tabindex="-1">
       <%= link_to 'Download', hyrax.download_path(file_set),
         title: "Download #{file_set.to_s.inspect}", target: "_blank" %>

--- a/spec/views/hyrax/base/_member.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_member.html.erb_spec.rb
@@ -17,13 +17,17 @@ RSpec.describe 'hyrax/base/_member.html.erb' do
     allow(view).to receive(:current_search_session).and_return nil
     allow(view).to receive(:search_session).and_return({})
     # abilities called in _actions.html.erb
-    allow(view).to receive(:can?).with(:read, kind_of(String)).and_return(true)
+    allow(view).to receive(:can?).with(:download, kind_of(String)).and_return(true)
     allow(view).to receive(:can?).with(:edit, kind_of(String)).and_return(true)
     allow(view).to receive(:can?).with(:destroy, String).and_return(true)
     allow(view).to receive(:contextual_path).with(anything, anything) do |x, y|
       Hyrax::ContextualPath.new(x, y).show
     end
     render 'hyrax/base/member.html.erb', member: presenter
+  end
+
+  it 'checks the :download ability' do
+    expect(view).to have_received(:can?).with(:download, kind_of(String)).once
   end
 
   it 'renders the view' do


### PR DESCRIPTION
Refs #1163
Follows #1232
Refs #167

This fixes a bug where, when an admin user views a work deposited into an admin set created by another user, the file actions dropdowns do not contain the "Download" link.

@samvera/hyrax-code-reviewers
