### PR TITLE
Admins should be able to edit/read/etc. all identifiers

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -210,7 +210,7 @@ module Hyrax
         alias_action :show, to: :read
         alias_action :discover, to: :read
         can :update, :appearance
-        can :download, String # The identifier of a work or FileSet
+        can :manage, String # The identifier of a work or FileSet
         can :manage, curation_concerns_models
         can :manage, Sipity::WorkflowResponsibility
       end

--- a/spec/abilities/ability_spec.rb
+++ b/spec/abilities/ability_spec.rb
@@ -120,6 +120,8 @@ RSpec.describe 'Hyrax::Ability', type: :model do
     it { is_expected.to be_able_to(:read, ContentBlock) }
     it { is_expected.to be_able_to(:read, Hyrax::Statistics) }
     it { is_expected.to be_able_to(:download, 'abcd123') } # an id for a work/FileSet
+    it { is_expected.to be_able_to(:edit, 'abcd123') } # an id for a work/FileSet
+    it { is_expected.to be_able_to(:destroy, 'abcd123') } # an id for a work/FileSet
     it { is_expected.to be_able_to(:read, :admin_dashboard) }
     it { is_expected.to be_able_to(:manage, AdminSet) }
     it { is_expected.to be_able_to(:create, AdminSet) }


### PR DESCRIPTION
Refs #167

There are numerous spots in the code where we make ability checks against strings, such as:

* https://github.com/samvera/hyrax/blob/master/app/presenters/hyrax/file_set_presenter.rb#L50
* https://github.com/samvera/hyrax/blob/master/app/views/hyrax/file_sets/_actions.html.erb#L11 (see also lines 23, 31)

Expand administrative user abilities such that they can manage all Strings, which in this case are work and fileset identifiers. Prior to this, administrative users would see the file actions dropdown in the work show page without the links to edit and destroy file sets

@samvera/hyrax-code-reviewers
