### PR TITLE
Default Admin Set not getting all access grants and workflow responsibilities created

### DIFF
--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -6,6 +6,10 @@ namespace :hyrax do
     end
 
     task add_admin_group_to_admin_sets: :environment do
+      # Force creation of registered MANAGING role if it doesn't exist
+      # This code must be invoked before calling `Sipity::Role.all` or the managing role won't be there
+      Sipity::Role[Hyrax::RoleRegistry::MANAGING]
+
       AdminSet.all.each do |admin_set|
         permission_template = admin_set.permission_template
         if permission_template.access_grants.where(agent_type: 'group', agent_id: ::Ability.admin_group_name).none?


### PR DESCRIPTION
This brings the Default Admin Set in line with other Admin Sets. In particular, works deposited by other users to the Default Admin Set with mediation turned on would not appear in the Review Submissions view for repository administrators.

Refs #167

@samvera/hyrax-code-reviewers
