### PR TITLE
Create non-english translations for embargoes and leases

### DIFF
--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -167,10 +167,10 @@ de:
             success: Das Aussehen wurde erfolgreich aktualisiert
       features:
         index:
-          header:           Charakteristik
-          feature:          Charakteristisch
-          description:      Beschreibung
-          action:           Aktion
+          action: Aktion
+          description: Beschreibung
+          feature: Charakteristisch
+          header: Charakteristik
       sidebar:
         activity: Aktivität
         admin_sets: Verwaltungssets
@@ -271,6 +271,14 @@ de:
         dropzone: Dateien hier ablegen.
         external_upload: Cloud-Provider
         local_upload: Lokale Dateien hinzufügen
+      form_permission_under_embargo:
+        help_html: "<strong>Diese Arbeit ist unter Embargo.</strong> Hier können Sie die Einstellungen des Embargos ändern, oder Sie können den %{edit_link} besuchen, um ihn zu deaktivieren."
+        legend_html: Sichtbarkeit <small>Wer sollte in der Lage sein, diesen Inhalt anzusehen oder herunterzuladen?</small>
+        management_page: Embargo Management Seite
+      form_permission_under_lease:
+        help_html: "<strong>Diese Arbeit ist vermietet.</strong> Hier können Sie die Einstellungen des Mietvertrages ändern oder den %{edit_link} besuchen, um ihn zu deaktivieren."
+        legend_html: Sichtbarkeit <small>Wer sollte in der Lage sein, diesen Inhalt anzusehen oder herunterzuladen?</small>
+        management_page: Leasing-Management-Seite
       form_progress:
         required_agreement: Kaution vereinbaren
         required_descriptions: Beschreiben Sie Ihre Arbeit
@@ -352,7 +360,7 @@ de:
         update: Update-Sammlung
     collections:
       edit:
-        header: "Sammlung Bearbeiten: %{title}"
+        header: 'Sammlung Bearbeiten: %{title}'
       form:
         tabs:
           description: Beschreibung
@@ -488,10 +496,38 @@ de:
       user_activity: Benutzeraktivität
       user_notifications: Benutzerbenachrichtigungen
       view_files: Dateien ansehen
-    directory:
-      suffix: "@ Example.org"
     document_language: En
     edit_profile: Profil bearbeiten
+    embargoes:
+      edit:
+        embargo_apply: Embargo anwenden
+        embargo_cancel: Alle Embargos abbrechen und verwalten
+        embargo_deactivate: Embargo deaktivieren
+        embargo_false_html: "<strong>Diese %{cc} ist derzeit nicht unter Embargo.</strong> Wenn Sie ein Embargo anwenden möchten, geben Sie hier die Informationen an."
+        embargo_return: Zurück zur Bearbeitung dieses %{cc}
+        embargo_true_html: "<strong>Dieser %{cc} ist unter Embargo.</strong>"
+        embargo_update: Embargo aktualisieren
+        header:
+          current: Aktuelles Embargo
+          past: Vergangene Embargos
+        history_empty: Diese %{cc} hat keine vorherigen Embargos angewendet.
+        manage_embargoes_html: Embargos für %{cc} <span class='human_readable_type'>(%{cc_type}) verwalten</span>
+      index:
+        active: Alle aktiven Embargos
+        deactivated: Deaktivierte Embargos
+        expired: Abgelaufene aktive Embargos
+        manage_embargoes: Embargos verwalten
+      list_expired_active_embargoes:
+        change_all: Ändern Sie alle Dateien in %{cc} zu
+        deactivate: Embargo deaktivieren
+        deactivate_selected: Embargos für Selected deaktivieren
+        missing: Es sind zu diesem Zeitpunkt keine abgelaufenen Embargos vorhanden.
+      table_headers:
+        release_date: Embargo Erscheinungsdatum
+        title: Titel
+        type: Art von Arbeit
+        viz_after: Sichtbarkeit wird geändert
+        viz_current: Aktuelle Sichtbarkeit
     featured_researchers: Ausgewählte Forscher
     file_manager:
       link_text: Dateimanager
@@ -534,9 +570,40 @@ de:
     icons:
       collection: Fa-cubes
       default: Fa fa-würfel
+    leases:
+      edit:
+        header:
+          current: Aktuelle Leasing
+          past: Vergangene Mietverträge
+        history_empty: Diese %{cc} hat keine vorherigen Mietverträge angewendet.
+        lease_apply: Bewerben Lease
+        lease_cancel: Abbrechen und verwalten alle Leasingverhältnisse
+        lease_deactivate: Lease deaktivieren
+        lease_false_html: "<strong>Diese %{cc} ist derzeit nicht unter Leasing.</strong> Wenn Sie einen Mietvertrag anwenden möchten, geben Sie hier die Informationen an."
+        lease_return: Zurück zur Bearbeitung dieses %{cc}
+        lease_true_html: "<strong>Dieser %{cc} ist unter Leasing.</strong>"
+        lease_update: Update Lease
+        manage_leases_html: Lease für %{cc} <span class='human_readable_type'>(%{cc_type})</span>
+      index:
+        active: Alle aktiven Leasingverhältnisse
+        deactivated: Deaktivierte Leasingverhältnisse
+        expired: Abgelaufene aktive Leasingverhältnisse
+        manage_leases: Leasing verwalten
+      list_expired_active_leases:
+        change_all: Ändern Sie alle Dateien in %{cc} zu
+        deactivate: Lease deaktivieren
+        deactivate_selected: Deaktivieren Sie Leases für Selected
+        missing: Es sind zu diesem Zeitpunkt keine abgelaufenen Leasingverhältnisse vorhanden.
+      table_headers:
+        release_date: Lease Release Datum
+        title: Titel
+        type: Art von Arbeit
+        viz_after: Sichtbarkeit wird geändert
+        viz_current: Aktuelle Sichtbarkeit
     mailbox:
       date: Datum
       delete: Nachricht löschen
+      empty: Keine Benachrichtigungen gefunden
       message: Nachricht
       notifications_deleted: Benachrichtigungen wurden gelöscht
       subject: Fach

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -167,10 +167,10 @@ es:
             success: La apariencia se actualizó correctamente
       features:
         index:
-          header:           Caracteristicas
-          feature:          Característica
-          description:      Descripción
-          action:           Acción
+          action: Acción
+          description: Descripción
+          feature: Característica
+          header: Caracteristicas
       sidebar:
         activity: Actividad
         admin_sets: Conjuntos Administrativos
@@ -266,6 +266,14 @@ es:
         dropzone: Soltar archivos aquí.
         external_upload: Proveedores en la Nube
         local_upload: Añadir Archivos locales
+      form_permission_under_embargo:
+        help_html: "<strong>Esta obra está bajo embargo.</strong> Puede cambiar la configuración del embargo aquí, o puede visitar el %{edit_link} para desactivarlo."
+        legend_html: Visibilidad <small>¿Quién debería ser capaz de ver o descargar este contenido?</small>
+        management_page: Página de Administración de Embargo
+      form_permission_under_lease:
+        help_html: "<strong>Este trabajo está en arrendamiento.</strong> Puede cambiar los ajustes del contrato de arrendamiento aquí, o puede visitar el %{edit_link} para desactivarlo."
+        legend_html: Visibilidad <small>¿Quién debería ser capaz de ver o descargar este contenido?</small>
+        management_page: Página de Gestión de Arrendamiento
       form_progress:
         required_agreement: Comprobar el acuerdo de depósito
         required_descriptions: Describa su trabajo
@@ -347,7 +355,7 @@ es:
         update: Actualizar Colección
     collections:
       edit:
-        header: "Editar Colección: %{title}"
+        header: 'Editar Colección: %{title}'
       form:
         tabs:
           description: Descripción
@@ -483,10 +491,38 @@ es:
       user_activity: Actividad de usuario
       user_notifications: Notificaciones de Usuario
       view_files: Ver Archivos
-    directory:
-      suffix: "@ejemplo.org"
     document_language: es
     edit_profile: Editar Perfil
+    embargoes:
+      edit:
+        embargo_apply: Aplicar Embargo
+        embargo_cancel: Cancelar y gestionar todos los embargos
+        embargo_deactivate: Desactivar Embargo
+        embargo_false_html: "<strong>Este %{cc} no está actualmente bajo embargo.</strong> Si desea aplicar un embargo, proporcione la información aquí."
+        embargo_return: Volver a la edición de este %{cc}
+        embargo_true_html: "<strong>Este %{cc} está bajo embargo.</strong>"
+        embargo_update: Actualizar Embargo
+        header:
+          current: Embargo actual
+          past: Embargos pasados
+        history_empty: Este %{cc} no tiene embargos previos aplicados a él.
+        manage_embargoes_html: Administrar embargos para %{cc} <span class='human_readable_type'>(%{cc_type})</span>
+      index:
+        active: Todos los embargos activos
+        deactivated: Desactivado Embargoes
+        expired: Embargos activos caducados
+        manage_embargoes: Gestionar embargos
+      list_expired_active_embargoes:
+        change_all: Cambiar todos los archivos de %{cc} a
+        deactivate: Desactivar Embargo
+        deactivate_selected: Desactivar Embargos para Seleccionados
+        missing: No hay embargos caducados en vigencia en este momento.
+      table_headers:
+        release_date: Embargo Fecha de lanzamiento
+        title: Título
+        type: Tipo de trabajo
+        viz_after: La visibilidad cambiará a
+        viz_current: Visibilidad actual
     featured_researchers: Investigadores Destacados
     file_manager:
       link_text: Administrador de archivos
@@ -531,9 +567,40 @@ es:
     icons:
       collection: fa fa-cubes
       default: fa fa-cube
+    leases:
+      edit:
+        header:
+          current: Arrendamiento actual
+          past: Alquileres pasados
+        history_empty: Este %{cc} no tiene ningún arrendamiento anterior aplicado a él.
+        lease_apply: Solicitar arrendamiento
+        lease_cancel: Cancelar y administrar todos los contratos de arrendamiento
+        lease_deactivate: Desactivar Arrendamiento
+        lease_false_html: "<strong>Este %{cc} no está actualmente bajo contrato de arrendamiento.</strong> Si desea aplicar un contrato de arrendamiento, proporcione la información aquí."
+        lease_return: Volver a la edición de este %{cc}
+        lease_true_html: "<strong>Este %{cc} está bajo contrato de arrendamiento.</strong>"
+        lease_update: Actualizar arrendamiento
+        manage_leases_html: Administrar concesiones para %{cc} <span class='human_readable_type'>(%{cc_type})</span>
+      index:
+        active: Todos los arrendamientos activos
+        deactivated: Desactivado Arrendamientos
+        expired: Arrendamientos activos caducados
+        manage_leases: Gestionar Arrendamientos
+      list_expired_active_leases:
+        change_all: Cambiar todos los archivos de %{cc} a
+        deactivate: Desactivar Arrendamiento
+        deactivate_selected: Desactivar Arrendamientos para Seleccionados
+        missing: No existen contratos de arrendamiento vencidos vigentes en este momento.
+      table_headers:
+        release_date: Fecha de lanzamiento del arrendamiento
+        title: Título
+        type: Tipo de trabajo
+        viz_after: La visibilidad cambiará a
+        viz_current: Visibilidad actual
     mailbox:
       date: Fecha
       delete: Borrar Mensaje
+      empty: No se han encontrado notificaciones
       message: Mensaje
       notifications_deleted: Las notificaciones han sido borradas
       subject: Asunto

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -167,10 +167,10 @@ fr:
             success: L'apparence a été mise à jour avec succès
       features:
         index:
-          header:   Caractéristiques
-          feature:          Caractéristique
-          description:      Description
-          action:           Action
+          action: Action
+          description: Description
+          feature: Caractéristique
+          header: Caractéristiques
       sidebar:
         activity: Activité
         admin_sets: Ensembles administratifs
@@ -271,6 +271,14 @@ fr:
         dropzone: Déposez les fichiers ici.
         external_upload: Cloud Providers
         local_upload: Ajouter des fichiers locaux
+      form_permission_under_embargo:
+        help_html: "<strong>Ce travail est sous embargo.</strong> Vous pouvez modifier les paramètres de l'embargo ici, ou vous pouvez visiter le %{edit_link} pour le désactiver."
+        legend_html: Visibilité <small>Qui devrait pouvoir afficher ou télécharger ce contenu?</small>
+        management_page: Page de gestion de l'embargo
+      form_permission_under_lease:
+        help_html: "<strong>Ce travail est en location.</strong> Vous pouvez modifier les paramètres du bail ici, ou vous pouvez visiter le %{edit_link} pour le désactiver."
+        legend_html: Visibilité <small>Qui devrait pouvoir afficher ou télécharger ce contenu?</small>
+        management_page: Page de gestion du bail
       form_progress:
         required_agreement: Contrôler l'accord de dépôt
         required_descriptions: Décrivez votre travail
@@ -352,7 +360,7 @@ fr:
         update: Mise à jour de la collection
     collections:
       edit:
-        header: "Modifier la Collection: %{title}"
+        header: 'Modifier la Collection: %{title}'
       form:
         tabs:
           description: La description
@@ -488,10 +496,38 @@ fr:
       user_activity: Activité de l'utilisateur
       user_notifications: Notifications de l'utilisateur
       view_files: Afficher les fichiers
-    directory:
-      suffix: "@ Example.org"
     document_language: En
     edit_profile: Editer le profil
+    embargoes:
+      edit:
+        embargo_apply: Embargo d'application
+        embargo_cancel: Annuler et gérer tous les embargos
+        embargo_deactivate: Désactiver Embargo
+        embargo_false_html: "<strong>Ce %{cc} n'est actuellement pas sous embargo.</strong> Si vous souhaitez appliquer un embargo, fournissez les informations ici."
+        embargo_return: Retourner à l'édition de ce %{cc}
+        embargo_true_html: "<strong>Ce %{cc} est sous embargo.</strong>"
+        embargo_update: Mise à jour Embargo
+        header:
+          current: Embargement actuel
+          past: Embargos passés
+        history_empty: Ce %{cc} n'a pas d'embargos antérieurs.
+        manage_embargoes_html: Gérer les embargos pour %{cc} <span class='human_readable_type'>(%{cc_type})</span>
+      index:
+        active: Tous les embargos actifs
+        deactivated: Embargés désactivés
+        expired: Embargos actifs périmés
+        manage_embargoes: Gérer les embargos
+      list_expired_active_embargoes:
+        change_all: Changer tous les fichiers dans %{cc} à
+        deactivate: Désactiver Embargo
+        deactivate_selected: Désactiver les embargos pour la sélection
+        missing: Il n'y a pas d'embargos expirés en vigueur en ce moment.
+      table_headers:
+        release_date: Date de sortie de l'embargo
+        title: Titre
+        type: Type de travail
+        viz_after: La visibilité changera en
+        viz_current: Visibilité actuelle
     featured_researchers: Les chercheurs en vedette
     file_manager:
       link_text: Gestionnaire de fichiers
@@ -534,9 +570,40 @@ fr:
     icons:
       collection: Fa fa-cubes
       default: Fa fa-cube
+    leases:
+      edit:
+        header:
+          current: Bail actuel
+          past: Baux passés
+        history_empty: Ce %{cc} n'a pas de bail antérieur.
+        lease_apply: Appliquer le bail
+        lease_cancel: Annuler et gérer tous les baux
+        lease_deactivate: Désactiver le bail
+        lease_false_html: "<strong>Ce %{cc} n'est actuellement pas sous bail.</strong> Si vous souhaitez déposer un bail, fournissez les informations ici."
+        lease_return: Retourner à l'édition de ce %{cc}
+        lease_true_html: "<strong>Ce %{cc} est en location.</strong>"
+        lease_update: Mise à jour du bail
+        manage_leases_html: Gérer les baux pour %{cc} <span class='human_readable_type'>(%{cc_type})</span>
+      index:
+        active: Tous les baux actifs
+        deactivated: Bailleurs désactivés
+        expired: Baux actifs expirés
+        manage_leases: Gérer les baux
+      list_expired_active_leases:
+        change_all: Changer tous les fichiers dans %{cc} à
+        deactivate: Désactiver le bail
+        deactivate_selected: Désactiver les baux pour la sélection
+        missing: Il n'y a pas de location à bail en ce moment.
+      table_headers:
+        release_date: Date de sortie du bail
+        title: Titre
+        type: Type de travail
+        viz_after: La visibilité changera en
+        viz_current: Visibilité actuelle
     mailbox:
       date: Rendez-vous amoureux
       delete: Supprimer le message
+      empty: Aucune notification trouvée
       message: Message
       notifications_deleted: Les notifications ont été supprimées
       subject: Assujettir

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -167,10 +167,10 @@ it:
             success: L'aspetto è stato aggiornato con successo
       features:
         index:
-          header:           Caratteristiche
-          feature:          Caratteristica
-          description:      Descrizione
-          action:           Azione
+          action: Azione
+          description: Descrizione
+          feature: Caratteristica
+          header: Caratteristiche
       sidebar:
         activity: Attività
         admin_sets: Set amministrativi
@@ -271,6 +271,14 @@ it:
         dropzone: Drop file qui.
         external_upload: Fornitori di nubi
         local_upload: Aggiungere file locali
+      form_permission_under_embargo:
+        help_html: "<strong>Questo lavoro è sotto embargo.</strong> È possibile modificare le impostazioni dell'embargo qui oppure è possibile visitare lo %{edit_link} per disattivarlo."
+        legend_html: Visibilità <small>Chi dovrebbe essere in grado di visualizzare o scaricare questo contenuto?</small>
+        management_page: Gestione embargo
+      form_permission_under_lease:
+        help_html: "<strong>Questo lavoro è in affitto.</strong> È possibile modificare le impostazioni del contratto di locazione qui, oppure è possibile visitare lo %{edit_link} per disattivarlo."
+        legend_html: Visibilità <small>Chi dovrebbe essere in grado di visualizzare o scaricare questo contenuto?</small>
+        management_page: Gestione delle locazioni
       form_progress:
         required_agreement: Controllare l'accordo di deposito
         required_descriptions: Descrivi il tuo lavoro
@@ -352,7 +360,7 @@ it:
         update: Aggiorna Collezione
     collections:
       edit:
-        header: "Modifica Collezione: %{title}"
+        header: 'Modifica Collezione: %{title}'
       form:
         tabs:
           description: Descrizione
@@ -488,10 +496,38 @@ it:
       user_activity: Attività utente
       user_notifications: Notifiche utente
       view_files: Vedi files
-    directory:
-      suffix: "@ example.org"
     document_language: it
     edit_profile: Modifica Profilo
+    embargoes:
+      edit:
+        embargo_apply: Applicare Embargo
+        embargo_cancel: Annullare e gestire tutti gli embarghi
+        embargo_deactivate: Disattiva Embargo
+        embargo_false_html: "<strong>Questo %{cc} non è attualmente sotto embargo.</strong> Se desideri applicare un embargo, fornisci le informazioni qui."
+        embargo_return: Ritorna alla modifica di questo %{cc}
+        embargo_true_html: "<strong>Questo %{cc} è sotto embargo.</strong>"
+        embargo_update: Aggiorna Embargo
+        header:
+          current: Embargo attuale
+          past: Ultimi embarghi
+        history_empty: Questo %{cc} non ha applicato embarghi precedenti.
+        manage_embargoes_html: Gestisci embarghi per %{cc} <span class='human_readable_type'>(%{cc_type})</span>
+      index:
+        active: Tutti gli embarghi attivi
+        deactivated: Disattivato Embargoes
+        expired: Embargo attivo scaduto
+        manage_embargoes: Gestisci embarghi
+      list_expired_active_embargoes:
+        change_all: Cambiare tutti i file all'interno di %{cc}
+        deactivate: Disattiva Embargo
+        deactivate_selected: Disattiva gli embarghi per la selezione
+        missing: Attualmente non esistono embarghi scaduti.
+      table_headers:
+        release_date: Data di rilascio embargo
+        title: Titolo
+        type: Tipo di lavoro
+        viz_after: La visibilità cambierà
+        viz_current: Visibilità attuale
     featured_researchers: Ricercatori in primo piano
     file_manager:
       link_text: File Manager
@@ -534,9 +570,40 @@ it:
     icons:
       collection: Fa fa-cubetti
       default: Fa fa-cubo
+    leases:
+      edit:
+        header:
+          current: Leasing corrente
+          past: Leasing precedenti
+        history_empty: Questo %{cc} non dispone di locazioni precedenti.
+        lease_apply: Applica locazione
+        lease_cancel: Annulla e gestisci tutti i contratti di locazione
+        lease_deactivate: Disattiva leasing
+        lease_false_html: "<strong>Questo %{cc} non è attualmente in locazione.</strong> Se vuoi applicare un contratto di locazione, fornisci le informazioni qui."
+        lease_return: Ritorna alla modifica di questo %{cc}
+        lease_true_html: "<strong>Questo %{cc} è in affitto.</strong>"
+        lease_update: Aggiorna leasing
+        manage_leases_html: Gestione dei contratti di locazione per %{cc} <span class='human_readable_type'>(%{cc_type})</span>
+      index:
+        active: Tutti gli affitti attivi
+        deactivated: Disattivato Leases
+        expired: Leasing attivi scaduti
+        manage_leases: Gestione dei contratti di locazione
+      list_expired_active_leases:
+        change_all: Cambiare tutti i file all'interno di %{cc}
+        deactivate: Disattiva leasing
+        deactivate_selected: Disattiva i contratti di locazione selezionati
+        missing: In questo momento non sono in vigore leasing scadute.
+      table_headers:
+        release_date: Data di rilascio del leasing
+        title: Titolo
+        type: Tipo di lavoro
+        viz_after: La visibilità cambierà
+        viz_current: Visibilità attuale
     mailbox:
       date: Data
       delete: Elimina messaggio
+      empty: Nessuna notifica trovata
       message: Messaggio
       notifications_deleted: Le notifiche sono state eliminate
       subject: Soggetto

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -167,10 +167,10 @@ pt-BR:
             success: A aparência foi atualizada com sucesso
       features:
         index:
-          header:           Características
-          feature:          Característica
-          description:      Descrição
-          action:           Açao
+          action: Açao
+          description: Descrição
+          feature: Característica
+          header: Características
       sidebar:
         activity: Atividade
         admin_sets: Conjuntos Administrativos
@@ -271,6 +271,14 @@ pt-BR:
         dropzone: Largue os arquivos aqui.
         external_upload: Provedores de nuvem
         local_upload: Adicionar arquivos locais
+      form_permission_under_embargo:
+        help_html: "<strong>Este trabalho está sob embargo.</strong> Você pode alterar as configurações do embargo aqui, ou você pode visitar o %{edit_link} para desativá-lo."
+        legend_html: Visibilidade <small>Quem deve poder visualizar ou fazer o download desse conteúdo?</small>
+        management_page: Página de Gerenciamento de Embargo
+      form_permission_under_lease:
+        help_html: "<strong>Este trabalho está sob contrato de arrendamento.</strong> Você pode alterar as configurações da locação aqui, ou você pode visitar o %{edit_link} para desativá-lo."
+        legend_html: Visibilidade <small>Quem deve poder visualizar ou fazer o download desse conteúdo?</small>
+        management_page: Página de Gerenciamento de Arrendamento
       form_progress:
         required_agreement: Contrato de depósito de cheques
         required_descriptions: Descreva seu trabalho
@@ -352,7 +360,7 @@ pt-BR:
         update: Coleção de Atualizações
     collections:
       edit:
-        header: "Editar Coleção: %{title}"
+        header: 'Editar Coleção: %{title}'
       form:
         tabs:
           description: Descrição
@@ -488,10 +496,38 @@ pt-BR:
       user_activity: Atividade do usuário
       user_notifications: Notificações do usuário
       view_files: Ver arquivos
-    directory:
-      suffix: "@ Example.org"
     document_language: En
     edit_profile: Editar Perfil
+    embargoes:
+      edit:
+        embargo_apply: Aplicar Embargo
+        embargo_cancel: Cancelar e gerenciar todos os embargos
+        embargo_deactivate: Desativar Embargo
+        embargo_false_html: "<strong>Este %{cc} não está atualmente sob embargo.</strong> Se você quiser aplicar um embargo, forneça as informações aqui."
+        embargo_return: Retorne para editar este %{cc}
+        embargo_true_html: "<strong>Este %{cc} está sob embargo.</strong>"
+        embargo_update: Update Embargo
+        header:
+          current: Embargo atual
+          past: Embargos passados
+        history_empty: Este %{cc} não tem nenhum embargado anterior aplicado a ele.
+        manage_embargoes_html: Gerenciar Embargos para %{cc} <span class='human_readable_type'>(%{cc_type})</span>
+      index:
+        active: Todos os Embargos Ativos
+        deactivated: Embargos Desativados
+        expired: Embargos ativos expirados
+        manage_embargoes: Gerenciar Embargo
+      list_expired_active_embargoes:
+        change_all: Altere todos os arquivos no %{cc} para
+        deactivate: Desativar Embargo
+        deactivate_selected: Desativar Embargos para Selecionados
+        missing: Não há embargos expirados vigentes neste momento.
+      table_headers:
+        release_date: Data de lançamento do embargo
+        title: Título
+        type: Tipo de trabalho
+        viz_after: A visibilidade mudará para
+        viz_current: Visibilidade atual
     featured_researchers: Pesquisadores em destaque
     file_manager:
       link_text: Gerenciador de arquivos
@@ -534,9 +570,40 @@ pt-BR:
     icons:
       collection: Fa faucos
       default: Fa fa-cube
+    leases:
+      edit:
+        header:
+          current: Locação atual
+          past: Locações passadas
+        history_empty: Este %{cc} não possui concessões anteriores aplicadas a ele.
+        lease_apply: Aplicar arrendamento
+        lease_cancel: Cancelar e gerenciar todos os contratos de arrendamento
+        lease_deactivate: Desativar Arrendamento
+        lease_false_html: "<strong>Este %{cc} não está atualmente em locação.</strong> Se você deseja aplicar um contrato de arrendamento, forneça as informações aqui."
+        lease_return: Retorne para editar este %{cc}
+        lease_true_html: "<strong>Este %{cc} está em locação.</strong>"
+        lease_update: Atualização de locação
+        manage_leases_html: Gerenciar Arrendamentos para %{cc} <span class='human_readable_type'>(%{cc_type})</span>
+      index:
+        active: Todos os arrendamentos ativos
+        deactivated: Arrendamentos desativados
+        expired: Locações ativas expiradas
+        manage_leases: Gerenciar Locações
+      list_expired_active_leases:
+        change_all: Altere todos os arquivos no %{cc} para
+        deactivate: Desativar Arrendamento
+        deactivate_selected: Desativar aluguéis para seleção
+        missing: Não há contratos de arrendamento vencidos vigentes neste momento.
+      table_headers:
+        release_date: Data de lançamento da locação
+        title: Título
+        type: Tipo de trabalho
+        viz_after: A visibilidade mudará para
+        viz_current: Visibilidade atual
     mailbox:
       date: Encontro
       delete: Apagar mensagem
+      empty: Nenhuma notificação encontrada
       message: mensagem
       notifications_deleted: As notificações foram excluídas
       subject: Sujeito

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -169,10 +169,10 @@ zh:
             success: 表面已更新
       features:
         index:
-          header:  特征
-          feature:          特征
-          description:      描述
-          action:           行动
+          action: 行动
+          description: 描述
+          feature: 特征
+          header: 特征
       sidebar:
         activity: 活动
         admin_sets: 管理集
@@ -268,6 +268,14 @@ zh:
         dropzone: 请将文件拖放此处。
         external_upload: 云供应商
         local_upload: 添加本地文件
+      form_permission_under_embargo:
+        help_html: "<strong>这项工作受到禁运。</strong>您可以在此更改禁令的设置，也可以访问%{edit_link}以停用它。"
+        legend_html: 可见性<small>谁可以查看或下载此内容？</small>
+        management_page: 禁运管理页面
+      form_permission_under_lease:
+        help_html: "<strong>这项工作正在进行中。</strong>您可以在此处更改租约的设置，也可以访问%{edit_link}以停用该租约。"
+        legend_html: 可见性<small>谁可以查看或下载此内容？</small>
+        management_page: 租赁管理页面
       form_progress:
         required_agreement: 核对存储协议
         required_descriptions: 描述您的作品
@@ -349,7 +357,7 @@ zh:
         update: 更新收藏集
     collections:
       edit:
-        header: "编辑收藏: %{title}"
+        header: '编辑收藏: %{title}'
       form:
         tabs:
           description: 描述
@@ -485,10 +493,38 @@ zh:
       user_activity: 用户活动
       user_notifications: 用户通知
       view_files: 阅览文件
-    directory:
-      suffix: "@example.org"
     document_language: en
     edit_profile: 编辑个人资料
+    embargoes:
+      edit:
+        embargo_apply: 申请禁运
+        embargo_cancel: 取消并管理所有禁运
+        embargo_deactivate: 停用禁运
+        embargo_false_html: "<strong>这个%{cc}目前没有受到禁运。</strong>如果您想申请禁运，请在此处提供信息。"
+        embargo_return: 返回编辑这个%{cc}
+        embargo_true_html: "<strong>这个%{cc}受到禁运。</strong>"
+        embargo_update: 更新禁运
+        header:
+          current: 当前禁运
+          past: 过去的禁运
+        history_empty: 这个%{cc}没有应用先前的禁运。
+        manage_embargoes_html: 管理%{cc} <span class='human_readable_type'>（%{cc_type}）的</span>禁运
+      index:
+        active: 所有主动禁运
+        deactivated: 停用的禁运
+        expired: 过期主动禁运
+        manage_embargoes: 管理禁运
+      list_expired_active_embargoes:
+        change_all: 将%{cc}中的所有文件更改为
+        deactivate: 停用禁运
+        deactivate_selected: 停用选定的禁运
+        missing: 目前没有有效的禁运。
+      table_headers:
+        release_date: 禁运发布日期
+        title: 标题
+        type: 什么样的工作
+        viz_after: 可见度将更改为
+        viz_current: 当前可见度
     featured_researchers: 特色研究者
     file_manager:
       link_text: 文件管理员
@@ -533,9 +569,40 @@ zh:
     icons:
       collection: fa fa-cubes
       default: fa fa-cube
+    leases:
+      edit:
+        header:
+          current: 目前租赁
+          past: 过去租赁
+        history_empty: 这个%{cc}没有应用之前的租约。
+        lease_apply: 申请租赁
+        lease_cancel: 取消并管理所有租赁
+        lease_deactivate: 停用租赁
+        lease_false_html: "<strong>这个%{cc}目前不在租赁中。</strong>如果您想申请租赁，请在此处提供信息。"
+        lease_return: 返回编辑这个%{cc}
+        lease_true_html: "<strong>这个%{cc}是租赁的。</strong>"
+        lease_update: 更新租赁
+        manage_leases_html: 管理%{cc} <span class='human_readable_type'>（%{cc_type}）的</span>租赁
+      index:
+        active: 所有活跃租赁
+        deactivated: 停用租赁
+        expired: 过期活跃租赁
+        manage_leases: 管理租赁
+      list_expired_active_leases:
+        change_all: 将%{cc}中的所有文件更改为
+        deactivate: 停用租赁
+        deactivate_selected: 停用选定的租赁
+        missing: 目前没有到期的租赁期限。
+      table_headers:
+        release_date: 租赁发布日期
+        title: 标题
+        type: 什么样的工作
+        viz_after: 可见度将更改为
+        viz_current: 当前可见度
     mailbox:
       date: 日期
       delete: 删除讯息
+      empty: 找不到通知
       message: 讯息
       notifications_deleted: 通知已被删除
       subject: 主题

--- a/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
@@ -1,3 +1,4 @@
+---
 es:
   blacklight:
     search:
@@ -43,13 +44,13 @@ es:
           subject_tesim: Tema
           title_tesim: Título
   hyrax:
-    product_name:           "Hyrax"
-    product_twitter_handle: "@HydraSphere"
-    institution_name:       "institución"
-    institution_name_full:  "El nombre de la institución"
-    account_name:           "Mi identificador de cuenta institucional"
+    account_name: Mi identificador de cuenta institucional
     directory:
-      suffix:               "@example.org"
+      suffix: "@example.org"
     footer:
       copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> bajo licencia de Apache, Version 2.0"
       service_html: Un servicio de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera/a>.
+    institution_name: institución
+    institution_name_full: El nombre de la institución
+    product_name: Hyrax
+    product_twitter_handle: "@HydraSphere"

--- a/lib/generators/hyrax/templates/config/locales/hyrax.zh.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.zh.yml
@@ -1,3 +1,4 @@
+---
 zh:
   blacklight:
     search:
@@ -43,13 +44,13 @@ zh:
           subject_tesim: 学科
           title_tesim: 标题
   hyrax:
-    product_name:           "蹄兔"
-    product_twitter_handle: "@HydraSphere"
-    institution_name:       "机构"
-    institution_name_full:  "机构名称"
-    account_name:           "我的机构帐户标识符"
+    account_name: 我的机构帐户标识符
     directory:
-      suffix:               "@example.org"
+      suffix: "@example.org"
     footer:
       copyright_html: "<strong>版权所有 &copy; 2017 Samvera</strong> 根据Apache许可证2.0版许可"
       service_html: 的服务<a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
+    institution_name: 机构
+    institution_name_full: 机构名称
+    product_name: 蹄兔
+    product_twitter_handle: "@HydraSphere"


### PR DESCRIPTION
Also, re-sort some of the translations in lib/generators to be in alphabetical order.

This work also includes documentation for running i18n-tasks which
will be copied to the Hyrax wiki.

Fixes #1276
