### PR TITLE
Do not run AttachFilesToWorkJob when there are no files.

### DIFF
--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -38,7 +38,7 @@ module Hyrax
 
         # @return [TrueClass]
         def attach_files(files, env)
-          return true unless files
+          return true if files.blank?
           AttachFilesToWorkJob.perform_later(env.curation_concern, files, env.attributes.to_h.symbolize_keys)
           true
         end

--- a/spec/actors/hyrax/actors/create_with_files_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_files_actor_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Hyrax::Actors::CreateWithFilesActor do
 
       context "when no uploaded_file" do
         let(:attributes) { {} }
+
         it "doesn't invoke job" do
           expect(AttachFilesToWorkJob).not_to receive(:perform_later)
           expect(middleware.public_send(mode, env)).to be true

--- a/spec/actors/hyrax/actors/create_with_files_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_files_actor_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe Hyrax::Actors::CreateWithFilesActor do
           expect(middleware.public_send(mode, env)).to be false
         end
       end
+
+      context "when no uploaded_file" do
+        let(:attributes) { {} }
+        it "doesn't invoke job" do
+          expect(AttachFilesToWorkJob).not_to receive(:perform_later)
+          expect(middleware.public_send(mode, env)).to be true
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #1339 

@samvera/hyrax-code-reviewers
