### PR TITLE
Update hyrax to use standardized license naming

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -24,7 +24,7 @@ EOF
   spec.name          = "hyrax"
   spec.require_paths = ["lib"]
   spec.version       = Hyrax::VERSION
-  spec.license       = 'Apache2'
+  spec.license       = 'Apache-2.0'
 
   # Note: rails does not follow sem-ver conventions, it's
   # minor version releases can include breaking changes; see


### PR DESCRIPTION
Because controlled vocabularies are the thing to do right.

Also fixes discussion raised on Slack

http://guides.rubygems.org/specification-reference/#license=
https://opensource.org/licenses/alphabetical

@samvera/hyrax-code-reviewers