### PR TITLE
Stop adding periods to end of citations

### DIFF
--- a/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
@@ -11,7 +11,6 @@ module Hyrax
           text << pub_date_text_for(work)
           text << add_title_text_for(work)
           text << add_publisher_text_for(work)
-          text << "." unless text.blank? || text =~ /\.$/
           text.html_safe
         end
 
@@ -65,7 +64,7 @@ module Hyrax
             if pub_info.nil?
               ''
             else
-              pub_info
+              pub_info + "."
             end
           end
 

--- a/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
@@ -17,7 +17,6 @@ module Hyrax
           # Get Pub Date
           pub_date = setup_pub_date(work)
           text << " #{pub_date}." unless pub_date.nil?
-          text << "." unless text.blank? || text =~ /\.$/
 
           text << format_title(work.to_s)
           pub_info = setup_pub_info(work, false)

--- a/app/helpers/hyrax/citations_behaviors/formatters/mla_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/mla_formatter.rb
@@ -18,8 +18,7 @@ module Hyrax
           # Publication
           pub_info = clean_end_punctuation(setup_pub_info(work, true))
 
-          text << pub_info if pub_info.present?
-          text << "." unless text.blank? || text =~ /\.$/
+          text << pub_info + "." if pub_info.present?
           text.html_safe
         end
 

--- a/spec/views/hyrax/citations/work.html.erb_spec.rb
+++ b/spec/views/hyrax/citations/work.html.erb_spec.rb
@@ -1,88 +1,174 @@
-
 RSpec.describe 'hyrax/citations/work.html.erb', type: :view do
-  let(:object_profile) { ["{\"id\":\"999\"}"] }
-  let(:contributor) { ['Gandalf Grey'] }
-  let(:creator)     { ['Bilbo Baggins', 'Baggins, Frodo'] }
-  let(:solr_document) do
-    SolrDocument.new(
-      id: '999',
-      object_profile_ssm: object_profile,
-      has_model_ssim: ['GenericWork'],
-      human_readable_type_tesim: ['Generic Work'],
-      contributor_tesim: contributor,
-      creator_tesim: creator,
-      license_tesim: ['http://creativecommons.org/licenses/by/3.0/us/'],
-      title_tesim: ['the Roared about the Langs'],
-      based_near_label_tesim: ['London'],
-      date_created_tesim: ['1969']
-    )
+  context "full work metadata" do
+    let(:object_profile) { ["{\"id\":\"999\"}"] }
+    let(:contributor) { ['Gandalf Grey'] }
+    let(:creator)     { ['Bilbo Baggins', 'Baggins, Frodo'] }
+    let(:solr_document) do
+      SolrDocument.new(
+        id: '999',
+        object_profile_ssm: object_profile,
+        has_model_ssim: ['GenericWork'],
+        human_readable_type_tesim: ['Generic Work'],
+        contributor_tesim: contributor,
+        creator_tesim: creator,
+        license_tesim: ['http://creativecommons.org/licenses/by/3.0/us/'],
+        title_tesim: ['the Roared about the Langs'],
+        based_near_label_tesim: ['London'],
+        date_created_tesim: ['1969']
+      )
+    end
+    let(:ability) { nil }
+    let(:presenter) do
+      Hyrax::WorkShowPresenter.new(solr_document, ability)
+    end
+
+    describe 'citations' do
+      let(:page) { Capybara::Node::Simple.new(rendered) }
+      let(:citation) { page.find(citation_selector) }
+      let(:title_selector) { "#{citation_selector} > i.citation-title" }
+      let(:author_selector) { "#{citation_selector} > .citation-author" }
+
+      before do
+        assign(:presenter, presenter)
+        render
+      end
+
+      context 'in APA style' do
+        let(:citation_selector) { 'span.apa-citation' }
+        let(:formatted_title) { 'the Roared about the Langs.' }
+        # entities will be unescaped
+        let(:authors) { 'Baggins, B., & Baggins, F.' }
+
+        it 'exports title' do
+          expect(page).to have_selector(title_selector, count: 1)
+          expect(page.find(title_selector)).to have_content(formatted_title)
+        end
+        it 'exports authors' do
+          expect(page).to have_selector(author_selector, count: 1)
+          expect(page.find(author_selector)).to have_content(authors)
+        end
+        it 'cites' do
+          expect(citation.text).to eql("#{authors} (1969). #{formatted_title} London.")
+        end
+      end
+      context 'in Chicago style' do
+        let(:citation_selector) { 'span.chicago-citation' }
+        let(:formatted_title) { 'The Roared about the Langs.' }
+        let(:authors) { 'Baggins, Bilbo, and Frodo Baggins.' }
+
+        it 'exports title' do
+          expect(page).to have_selector(title_selector, count: 1)
+          expect(page.find(title_selector)).to have_content(formatted_title)
+        end
+        it 'exports authors' do
+          expect(page).to have_selector(author_selector, count: 1)
+          expect(page.find(author_selector)).to have_content(authors)
+        end
+        it 'cites' do
+          expect(citation.text).to eql("#{authors} 1969. #{formatted_title} London.")
+        end
+      end
+      context 'in MLA style' do
+        let(:citation_selector) { 'span.mla-citation' }
+        let(:formatted_title) { 'the Roared About the Langs.' }
+        let(:authors) { 'Baggins, Bilbo, and Frodo Baggins.' }
+
+        it 'exports title' do
+          expect(page).to have_selector(title_selector, count: 1)
+          expect(page.find(title_selector)).to have_content(formatted_title)
+        end
+        it 'exports authors' do
+          expect(page).to have_selector(author_selector, count: 1)
+          expect(page.find(author_selector)).to have_content(authors)
+        end
+        it 'cites' do
+          expect(citation.text).to eql("#{authors} #{formatted_title} London, 1969.")
+        end
+      end
+    end
   end
-  let(:ability) { nil }
-  let(:presenter) do
-    Hyrax::WorkShowPresenter.new(solr_document, ability)
-  end
 
-  describe 'citations' do
-    let(:page) { Capybara::Node::Simple.new(rendered) }
-    let(:citation) { page.find(citation_selector) }
-    let(:title_selector) { "#{citation_selector} > i.citation-title" }
-    let(:author_selector) { "#{citation_selector} > .citation-author" }
-
-    before do
-      assign(:presenter, presenter)
-      render
+  context "minimal work metatdata" do
+    let(:object_profile) { ["{\"id\":\"999\"}"] }
+    let(:creator) { ['Bilbo Baggins', 'Baggins, Frodo'] }
+    let(:solr_document) do
+      SolrDocument.new(
+        id: '999',
+        object_profile_ssm: object_profile,
+        has_model_ssim: ['GenericWork'],
+        human_readable_type_tesim: ['Generic Work'],
+        creator_tesim: creator,
+        license_tesim: ['http://creativecommons.org/licenses/by/3.0/us/'],
+        title_tesim: ['the Roared about the Langs']
+      )
+    end
+    let(:ability) { nil }
+    let(:presenter) do
+      Hyrax::WorkShowPresenter.new(solr_document, ability)
     end
 
-    context 'in APA style' do
-      let(:citation_selector) { 'span.apa-citation' }
-      let(:formatted_title) { 'the Roared about the Langs.' }
-      # entities will be unescaped
-      let(:authors) { 'Baggins, B., & Baggins, F.' }
+    describe 'citations' do
+      let(:page) { Capybara::Node::Simple.new(rendered) }
+      let(:citation) { page.find(citation_selector) }
+      let(:title_selector) { "#{citation_selector} > i.citation-title" }
+      let(:author_selector) { "#{citation_selector} > .citation-author" }
 
-      it 'exports title' do
-        expect(page).to have_selector(title_selector, count: 1)
-        expect(page.find(title_selector)).to have_content(formatted_title)
+      before do
+        assign(:presenter, presenter)
+        render
       end
-      it 'exports authors' do
-        expect(page).to have_selector(author_selector, count: 1)
-        expect(page.find(author_selector)).to have_content(authors)
-      end
-      it 'cites' do
-        expect(citation.text).to eql("#{authors} (1969). #{formatted_title} London.")
-      end
-    end
-    context 'in Chicago style' do
-      let(:citation_selector) { 'span.chicago-citation' }
-      let(:formatted_title) { 'The Roared about the Langs.' }
-      let(:authors) { 'Baggins, Bilbo, and Frodo Baggins.' }
 
-      it 'exports title' do
-        expect(page).to have_selector(title_selector, count: 1)
-        expect(page.find(title_selector)).to have_content(formatted_title)
-      end
-      it 'exports authors' do
-        expect(page).to have_selector(author_selector, count: 1)
-        expect(page.find(author_selector)).to have_content(authors)
-      end
-      it 'cites' do
-        expect(citation.text).to eql("#{authors} 1969. #{formatted_title} London.")
-      end
-    end
-    context 'in MLA style' do
-      let(:citation_selector) { 'span.mla-citation' }
-      let(:formatted_title) { 'the Roared About the Langs.' }
-      let(:authors) { 'Baggins, Bilbo, and Frodo Baggins.' }
+      context 'in APA style' do
+        let(:citation_selector) { 'span.apa-citation' }
+        let(:formatted_title) { 'the Roared about the Langs.' }
+        # entities will be unescaped
+        let(:authors) { 'Baggins, B., & Baggins, F.' }
 
-      it 'exports title' do
-        expect(page).to have_selector(title_selector, count: 1)
-        expect(page.find(title_selector)).to have_content(formatted_title)
+        it 'exports title' do
+          expect(page).to have_selector(title_selector, count: 1)
+          expect(page.find(title_selector)).to have_content(formatted_title)
+        end
+        it 'exports authors' do
+          expect(page).to have_selector(author_selector, count: 1)
+          expect(page.find(author_selector)).to have_content(authors)
+        end
+        it 'cites' do
+          expect(citation.text).to eql("#{authors} #{formatted_title} ")
+        end
       end
-      it 'exports authors' do
-        expect(page).to have_selector(author_selector, count: 1)
-        expect(page.find(author_selector)).to have_content(authors)
+      context 'in Chicago style' do
+        let(:citation_selector) { 'span.chicago-citation' }
+        let(:formatted_title) { 'The Roared about the Langs.' }
+        let(:authors) { 'Baggins, Bilbo, and Frodo Baggins.' }
+
+        it 'exports title' do
+          expect(page).to have_selector(title_selector, count: 1)
+          expect(page.find(title_selector)).to have_content(formatted_title)
+        end
+        it 'exports authors' do
+          expect(page).to have_selector(author_selector, count: 1)
+          expect(page.find(author_selector)).to have_content(authors)
+        end
+        it 'cites' do
+          expect(citation.text).to eql("#{authors} #{formatted_title}")
+        end
       end
-      it 'cites' do
-        expect(citation.text).to eql("#{authors} #{formatted_title} London, 1969.")
+      context 'in MLA style' do
+        let(:citation_selector) { 'span.mla-citation' }
+        let(:formatted_title) { 'the Roared About the Langs.' }
+        let(:authors) { 'Baggins, Bilbo, and Frodo Baggins.' }
+
+        it 'exports title' do
+          expect(page).to have_selector(title_selector, count: 1)
+          expect(page.find(title_selector)).to have_content(formatted_title)
+        end
+        it 'exports authors' do
+          expect(page).to have_selector(author_selector, count: 1)
+          expect(page.find(author_selector)).to have_content(authors)
+        end
+        it 'cites' do
+          expect(citation.text).to eql("#{authors} #{formatted_title} ")
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #1333 

Citation helpers append periods to citations based on conditional presence of period at end of string. The regex to check for period fails to account for possible html tags in the output, resulting in duplicate periods for minimal citations (presence and location of html markup can vary based on metadata elements included in work metadata). In MLA and APA, the final component of the citation is publication info. This PR removes the conditional terminating periods and groups the period with the publication info of the citation.

Changes proposed in this pull request:
* APA and MLA formatters - move terminal period to publication info
* Chicago formatter - terminal period unnecessary

@samvera/hyrax-code-reviewers
