### PR TITLE
AWSFile/S3 integrations

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -143,8 +143,8 @@ module Hyrax
         # If all else fails, use the basename of the file where it sits.
         # @note This is only useful for labeling the file_set, because of the recourse to import_url
         def label_for(file)
-          if file.is_a?(Hyrax::UploadedFile)
-            file.uploader.filename
+          if file.is_a?(Hyrax::UploadedFile) # filename not present for uncached remote file!
+            file.uploader.filename.present? ? file.uploader.filename : File.basename(Addressable::URI.parse(file.file_url).path)
           elsif file.respond_to?(:original_filename) # e.g. ActionDispatch::Http::UploadedFile, CarrierWave::SanitizedFile
             file.original_filename
           elsif file.respond_to?(:original_name) # e.g. Hydra::Derivatives::IoDecorator

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -5,40 +5,34 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
   # @param [ActiveFedora::Base] work - the work object
   # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
   def perform(work, uploaded_files, **work_attributes)
-    user = User.find_by_user_key(work.depositor)
+    validate_files!(uploaded_files)
+    user = User.find_by_user_key(work.depositor) # BUG? file depositor ignored
     work_permissions = work.permissions.map(&:to_hash)
+    metadata = visibility_attributes(work_attributes)
     uploaded_files.each do |uploaded_file|
-      file_set = FileSet.new
-      actor = Hyrax::Actors::FileSetActor.new(file_set, user)
-      actor.create_metadata(visibility_attributes(work_attributes))
-      attach_content(actor, uploaded_file)
+      actor = Hyrax::Actors::FileSetActor.new(FileSet.new, user)
+      actor.create_metadata(metadata)
+      actor.create_content(uploaded_file)
       actor.attach_to_work(work)
       actor.file_set.permissions_attributes = work_permissions
-      uploaded_file.update(file_set_uri: file_set.uri)
+      uploaded_file.update(file_set_uri: actor.file_set.uri)
     end
   end
 
   private
 
-    # @param [Hyrax::Actors::FileSetActor] actor
-    # @param [Hyrax::UploadedFile] uploaded_file .uploader.file must be a CarrierWave::SanitizedFile or .uploader.url must be present
-    def attach_content(actor, uploaded_file)
-      file_uploader = uploaded_file.uploader
-      if file_uploader.file.is_a? CarrierWave::SanitizedFile
-        actor.create_content(file_uploader.file.to_file)
-      elsif file_uploader.url.present?
-        actor.import_url(file_uploader.url)
-      else
-        raise ArgumentError, "#{file_uploader.class} received with #{file_uploader.file.class} object and no URL"
-      end
-    end
-
-    # The attributes used for visibility - used to send as initial params to
-    # created FileSets.
+    # The attributes used for visibility - sent as initial params to created FileSets.
     def visibility_attributes(attributes)
       attributes.slice(:visibility, :visibility_during_lease,
                        :visibility_after_lease, :lease_expiration_date,
                        :embargo_release_date, :visibility_during_embargo,
                        :visibility_after_embargo)
+    end
+
+    def validate_files!(uploaded_files)
+      uploaded_files.each do |uploaded_file|
+        next if uploaded_file.is_a? Hyrax::UploadedFile
+        raise ArgumentError, "Hyrax::UploadedFile required, but #{uploaded_file.class} received: #{uploaded_file.inspect}"
+      end
     end
 end

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -10,7 +10,7 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
     work_permissions = work.permissions.map(&:to_hash)
     metadata = visibility_attributes(work_attributes)
     uploaded_files.each do |uploaded_file|
-      actor = Hyrax::Actors::FileSetActor.new(FileSet.new, user)
+      actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
       actor.create_metadata(metadata)
       actor.create_content(uploaded_file)
       actor.attach_to_work(work)

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -6,19 +6,27 @@ RSpec.describe AttachFilesToWorkJob do
     let(:uploaded_file2) { build(:uploaded_file, file: file2) }
     let(:generic_work) { create(:public_generic_work) }
 
-    context "with uploaded files on the filesystem" do
-      before do
-        generic_work.permissions.build(name: 'userz@bbb.ddd', type: 'person', access: 'edit')
-        generic_work.save
-      end
-      it "attaches files, copies visibility and permissions and updates the uploaded files" do
+    shared_examples 'a file attacher' do
+      it 'attaches files, copies visibility and permissions and updates the uploaded files' do
+        expect(ImportUrlJob).not_to receive(:perform_later)
         expect(CharacterizeJob).to receive(:perform_later).twice
         described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
         generic_work.reload
         expect(generic_work.file_sets.count).to eq 2
         expect(generic_work.file_sets.map(&:visibility)).to all(eq 'open')
-        expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor, 'userz@bbb.ddd']))
         expect(uploaded_file1.reload.file_set_uri).not_to be_nil
+      end
+    end
+
+    context "with uploaded files on the filesystem" do
+      before do
+        generic_work.permissions.build(name: 'userz@bbb.ddd', type: 'person', access: 'edit')
+        generic_work.save
+      end
+      it_behaves_like 'a file attacher' do
+        it 'records the depositor(s) in edit_users' do
+          expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor, 'userz@bbb.ddd']))
+        end
       end
     end
 
@@ -33,14 +41,7 @@ RSpec.describe AttachFilesToWorkJob do
         allow(uploaded_file2.file).to receive(:file).and_return(fog_file2)
       end
 
-      it 'creates ImportUrlJobs' do
-        expect(ImportUrlJob).to receive(:perform_later).twice
-        described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
-        generic_work.reload
-        expect(generic_work.file_sets.count).to eq 2
-        expect(generic_work.file_sets.map(&:visibility)).to all(eq 'open')
-        expect(uploaded_file1.reload.file_set_uri).not_to be_nil
-      end
+      it_behaves_like 'a file attacher'
     end
   end
 end


### PR DESCRIPTION
- Use shared_examples in test
- Cut out unnecessary recourse to `ImportUrlJob` for Carrierwave-AWS (S3) objects since the OO API still does what we want
- Validate all files in job *before* beginning, to avoid dying mid-job.
- Failover for `filename` of uncached remote file, since that is `nil` until fetched (and we don't want to fetch just to learn the filename)

See https://github.com/samvera-labs/hyku/issues/1371

