### PR TITLE
Handle resource_type # => nil case in SolrDocumentBehavior#itemtype

### DIFF
--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -11,7 +11,8 @@ module Hyrax
 
     # Add a schema.org itemtype
     def itemtype
-      ResourceTypesService.microdata_type(resource_type.first)
+      types = resource_type || []
+      ResourceTypesService.microdata_type(types.first)
     end
 
     def title_or_label

--- a/app/services/hyrax/resource_types_service.rb
+++ b/app/services/hyrax/resource_types_service.rb
@@ -13,7 +13,10 @@ module Hyrax
       authority.find(id).fetch('term')
     end
 
-    # @param [String] id identifier of the resource type
+    ##
+    # @param [String, nil] id identifier of the resource type
+    #
+    # @return [String] a schema.org type. Gives the default type if `id` is nil.
     def self.microdata_type(id)
       return Hyrax.config.microdata_default_type if id.nil?
       Microdata.fetch("resource_type.#{id}", default: Hyrax.config.microdata_default_type)

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe ::SolrDocument, type: :model do
     subject { document.itemtype }
 
     it { is_expected.to eq 'http://schema.org/Article' }
+
+    context 'with no resource_type' do
+      let(:attributes) { {} }
+
+      it { is_expected.to eq 'http://schema.org/CreativeWork' }
+    end
   end
 
   describe "date_uploaded" do


### PR DESCRIPTION
`SolrDocumentBehavior#itemtype` tries to access `resource_type`. By default, this is fine, but `resource_type` is allowed to return `nil` in client apps. This handles this case by using an empty array as the default resource_type value within the method.

`ResourceTypesService#microdata_type` handles the `nil` case, so `[].first` is an acceptable parameter. The `#microdata_type` behavior is tested, and this PR adds documentation making it more clear to clients.

Changes proposed in this pull request:
* Make `SolrDocumentBehavior#itemtype` more resilient to return values of the (non-core) `resource_type`.

@samvera/hyrax-code-reviewers
