### PR TITLE
AdminSet - include GlobalID::Identification

### DIFF
--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -16,6 +16,7 @@
 # @see Hyrax::DefaultAdminSetActor
 # @see Hyrax::ApplyPermissionTemplateActor
 class AdminSet < ActiveFedora::Base
+  include GlobalID::Identification
   include Hydra::AccessControls::WithAccessRight
   include Hyrax::Noid
   include Hyrax::HumanReadableType

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe AdminSet, type: :model do
     end
   end
 
+  describe '#to_global_id' do
+    it 'returns a GlobalID URI' do
+      as = create(:admin_set)
+      expect(as.to_global_id).to be_an GlobalID
+    end
+
+    it 'fails unless the AdminSet is saved' do
+      as = build(:admin_set)
+      expect { as.to_global_id }.to raise_error URI::GID::MissingModelIdError
+    end
+  end
+
   describe "#to_solr" do
     let(:admin_set) do
       build(:admin_set, title: ['A good title'],


### PR DESCRIPTION
Fixes #1411 

This adds a global-id to the AdminSet (as suggested by @mjgiarlo in slack commentary on Aug 1, 2017)

@samvera/hyrax-code-reviewers
