### PR TITLE
consolidating requires into app manifest

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -28,6 +28,14 @@
 //= require morris/raphael-min
 //= require morris/morris.min
 
+// Moved from app/assets/javascripts/hyrax/uploader.js
+//= require fileupload/tmpl
+//= require fileupload/jquery.iframe-transport
+//= require fileupload/jquery.fileupload.js
+//= require fileupload/jquery.fileupload-process.js
+//= require fileupload/jquery.fileupload-validate.js
+//= require fileupload/jquery.fileupload-ui.js
+
 //= require clipboard
 
 // I think this is primarily needed for testing with PhantomJS:

--- a/app/assets/javascripts/hyrax/uploader.js
+++ b/app/assets/javascripts/hyrax/uploader.js
@@ -1,10 +1,3 @@
-//= require fileupload/tmpl
-//= require fileupload/jquery.iframe-transport
-//= require fileupload/jquery.fileupload.js
-//= require fileupload/jquery.fileupload-process.js
-//= require fileupload/jquery.fileupload-validate.js
-//= require fileupload/jquery.fileupload-ui.js
-//
 /*
  * jQuery File Upload Plugin JS Example
  * https://github.com/blueimp/jQuery-File-Upload


### PR DESCRIPTION
We wanted to override some stuff in `uploader.js` but were running into issues with dependencies in our child app. I figured our dependencies should all be in the application manifest anyway (plus it allows us to override `uploader.js`successfully now) 

I didn't make this change for the master branch of hyrax since it looks like maxFileSize is going to be configurable in an initializer, but i can consolidate js dependencies in that branch too if you want.

@samvera/hyrax-code-reviewers
