### PR TITLE
Workflow notifications for pending reviews

### DIFF
--- a/app/services/hyrax/workflow/notification_service.rb
+++ b/app/services/hyrax/workflow/notification_service.rb
@@ -48,10 +48,18 @@ module Hyrax
       # @return [Hash<String, Array>] a hash with keys being the strategy (e.g. "to", "cc") and
       #                               the values are a list of users.
       def recipients(notification)
-        notification.recipients.each_with_object({}) do |r, h|
-          h[r.recipient_strategy] ||= []
-          h[r.recipient_strategy] += PermissionQuery.scope_users_for_entity_and_roles(entity: entity,
-                                                                                      roles: r.role)
+        case entity.workflow_state.name
+        when 'pending_review'
+          # notify the managers to review the deposit (CC depositors)
+          {
+            to: entity.workflow.permission_template.agent_ids_for(access: 'manage',  agent_type: 'user'),
+            cc: entity.workflow.permission_template.agent_ids_for(access: 'deposit', agent_type: 'user')
+          }
+        else
+          notification.recipients.each_with_object({}) do |r, h|
+            h[r.recipient_strategy] ||= []
+            h[r.recipient_strategy] += PermissionQuery.scope_users_for_entity_and_roles(entity: entity, roles: r.role)
+          end
         end
       end
 

--- a/spec/services/hyrax/workflow/notification_service_spec.rb
+++ b/spec/services/hyrax/workflow/notification_service_spec.rb
@@ -24,11 +24,43 @@ RSpec.describe Hyrax::Workflow::NotificationService do
   let(:entity) { Sipity::Entity.new }
   let(:user) { User.new }
 
+  let(:workflow) { Sipity::Workflow.new }
+  let(:workflow_state) { Sipity::WorkflowState.new }
+  let(:permission_template) { Hyrax::PermissionTemplate.new }
+
   let(:instance) do
     described_class.new(entity: entity,
                         action: action,
                         comment: "A pleasant read",
                         user: user)
+  end
+
+  describe '#recipients' do
+    context 'when an entity requires review' do
+      let(:creator) { [instance_double(User)] }
+      let(:managers) { [instance_double(User), instance_double(User)] }
+      let(:notification) { Sipity::Notification.new(name: 'pending review notification') }
+
+      before do
+        allow(instance).to receive(:send_notification) # mock it so it does nothing
+        allow(entity).to receive(:workflow_state).and_return(workflow_state)
+        allow(workflow_state).to receive(:name).and_return('pending_review')
+        allow(entity).to receive(:workflow).and_return(workflow)
+        # Mock the permission_template queries
+        allow(workflow).to receive(:permission_template).and_return(permission_template)
+        allow(permission_template).to receive(:agent_ids_for)
+          .with(access: 'manage', agent_type: 'user')
+          .and_return(managers)
+        allow(permission_template).to receive(:agent_ids_for)
+          .with(access: 'deposit', agent_type: 'user')
+          .and_return(creator)
+      end
+
+      it 'identifies the managers and depositor for notifications' do
+        recipients = instance.recipients(notification)
+        expect(recipients).to eq(to: managers, cc: creator)
+      end
+    end
   end
 
   describe "#call" do
@@ -49,6 +81,8 @@ RSpec.describe Hyrax::Workflow::NotificationService do
       let(:creator_rel) { double(ActiveRecord::Relation, to_ary: creator) }
 
       before do
+        allow(entity).to receive(:workflow_state).and_return(workflow_state)
+        allow(workflow_state).to receive(:name).and_return('not_pending_review')
         allow(Hyrax::Workflow::PermissionQuery).to receive(:scope_users_for_entity_and_roles)
           .with(entity: entity,
                 roles: advising)


### PR DESCRIPTION
Fixes #936 

This ensures that notifications to review/approve a new submission that belongs to an AdminSet are sent only to the managers associated with the AdminSet (cc to the depositor).

Changes proposed in this pull request:
* Use the entity workflow to query the AdminSet/PermissionTemplate associated with that workflow

@samvera/hyrax-code-reviewers
