### PR TITLE
Use javascript to calculate the relative time

### DIFF
--- a/app/views/hyrax/notifications/_notifications.html.erb
+++ b/app/views/hyrax/notifications/_notifications.html.erb
@@ -12,7 +12,11 @@
       <tbody>
         <% messages.each do |msg| %>
           <tr>
-            <td><%= (time_ago_in_words(msg.last_message.created_at) + " ago") %></td>
+            <td>
+              <relative-time datetime="<%= msg.last_message.created_at.getutc.iso8601 %>" title="<%= msg.last_message.created_at.to_formatted_s(:standard) %>">
+                <%= msg.last_message.created_at.to_formatted_s(:long_ordinal) %>
+              </relative-time>
+            </td>
             <td><%= msg.last_message.subject.html_safe %></td>
             <td><%= msg.last_message.body.html_safe %></td>
             <td>

--- a/app/views/hyrax/transfers/_received.html.erb
+++ b/app/views/hyrax/transfers/_received.html.erb
@@ -14,11 +14,9 @@
     <tr>
       <td> <%= show_transfer_request_title(req) %> </td>
       <td>
-        <% if req.created_at > Time.current.beginning_of_day %>
-          <%= "#{time_ago_in_words(req.created_at)} ago"%>
-        <% else %>
-          <%= req.created_at.strftime("%b %d %Y") %>
-        <% end %>
+        <relative-time datetime="<%= req.created_at.getutc.iso8601 %>" title="<%= req.created_at.to_formatted_s(:standard) %>">
+          <%= req.created_at.to_formatted_s(:long_ordinal) %>
+        </relative-time>
       </td>
       <td><%= link_to req.sending_user.name, hyrax.user_path(req.sending_user)  %></td>
       <td>

--- a/app/views/hyrax/transfers/_sent.html.erb
+++ b/app/views/hyrax/transfers/_sent.html.erb
@@ -14,11 +14,9 @@
         <tr>
           <td> <%= show_transfer_request_title(req) %> </td>
           <td>
-            <% if req.created_at > Time.current.beginning_of_day %>
-              <%= "#{time_ago_in_words(req.created_at)} ago"%>
-            <% else %>
-              <%= req.created_at.strftime("%b %d %Y") %>
-            <% end %>
+            <relative-time datetime="<%= req.created_at.getutc.iso8601 %>" title="<%= req.created_at.to_formatted_s(:standard) %>">
+              <%= req.created_at.to_formatted_s(:long_ordinal) %>
+            </relative-time>
           </td>
 
           <td><%= link_to req.receiving_user.name, hyrax.user_path(req.receiving_user)  %></td>

--- a/app/views/hyrax/users/_activity_log.html.erb
+++ b/app/views/hyrax/users/_activity_log.html.erb
@@ -10,7 +10,12 @@
     <% next if event[:action].blank? or event[:timestamp].blank? %>
     <tr>
       <td><%= event[:action].html_safe %></td>
-      <td><%= time_ago_in_words(Time.zone.at(event[:timestamp].to_i)) %> ago</td>
+      <td>
+        <% time = Time.zone.at(event[:timestamp].to_i) %>
+        <relative-time datetime="<%= time.getutc.iso8601 %>" title="<%= time.to_formatted_s(:standard) %>">
+          <%= time.to_formatted_s(:long_ordinal) %>
+        </relative-time>
+      </td>
     </tr>
   <% end %>
   </tbody>


### PR DESCRIPTION
Using `time_ago_in_words` means that pages can't be cached. This also fixes sorting by date

<img width="445" alt="screen shot 2017-08-02 at 9 48 58 pm" src="https://user-images.githubusercontent.com/92044/28906453-8379d69a-77cc-11e7-9cca-85610cb15aea.png">



Fixes #1403