### PR TITLE
Move #present_terms to the CollectionsHelper

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -14,8 +14,6 @@ module Hyrax
       helper Hyrax::BatchEditsHelper
       # include the display_trophy_link view helper method
       helper Hyrax::TrophyHelper
-      # include the present_terms view helper method
-      helper ::FileSetHelper
 
       # This is needed as of BL 3.7
       copy_blacklight_config_from(::CatalogController)

--- a/app/helpers/file_set_helper.rb
+++ b/app/helpers/file_set_helper.rb
@@ -1,7 +1,0 @@
-# -*- coding: utf-8 -*-
-module FileSetHelper
-  def present_terms(presenter, terms = :all, &block)
-    terms = presenter.terms if terms == :all
-    Hyrax::PresenterRenderer.new(presenter, self).fields(terms, &block)
-  end
-end

--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -1,5 +1,13 @@
 module Hyrax
   module CollectionsHelper
+    # TODO: we could move this to CollectionPresenter if it had a view_context
+    # @param presenter [Hyrax::CollectionPresenter]
+    # @param terms [Array<Symbol>,:all] the list of terms to draw
+    def present_terms(presenter, terms = :all, &block)
+      terms = presenter.terms if terms == :all
+      Hyrax::PresenterRenderer.new(presenter, self).fields(terms, &block)
+    end
+
     def render_collection_links(solr_doc)
       collection_list = Hyrax::CollectionMemberService.run(solr_doc)
       return if collection_list.empty?

--- a/spec/views/hyrax/collections/_show_descriptions.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_descriptions.html.erb_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'hyrax/collections/_show_descriptions.html.erb', type: :view do
     let(:presenter) { Hyrax::CollectionPresenter.new(solr_document, ability) }
 
     before do
-      view.extend FileSetHelper
       allow(presenter).to receive(:total_items).and_return(2)
       allow(presenter).to receive(:size).and_return("118 MB")
       assign(:presenter, presenter)

--- a/spec/views/hyrax/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/show.html.erb_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'hyrax/collections/show.html.erb', type: :view do
   let(:presenter) { Hyrax::CollectionPresenter.new(document, ability) }
 
   before do
-    view.extend FileSetHelper
     allow(document).to receive(:hydra_model).and_return(::Collection)
     allow(controller).to receive(:current_user).and_return(stub_model(User))
     allow(view).to receive(:can?).with(:edit, document).and_return(true)


### PR DESCRIPTION
This method is only used in the collections show action.
