### PR TITLE
Remove data.user when instantiating a "Work" object

### DIFF
--- a/app/assets/javascripts/hyrax/autocomplete.es6
+++ b/app/assets/javascripts/hyrax/autocomplete.es6
@@ -11,8 +11,7 @@ export default class Autocomplete {
         new Work(
           element,
           data.autocompleteUrl,
-          data.user,
-          element.data('exclude-work')
+          data.id
         )
         break
       default:
@@ -21,4 +20,3 @@ export default class Autocomplete {
     }
   }
 }
-

--- a/app/assets/javascripts/hyrax/autocomplete.es6
+++ b/app/assets/javascripts/hyrax/autocomplete.es6
@@ -11,7 +11,7 @@ export default class Autocomplete {
         new Work(
           element,
           data.autocompleteUrl,
-          data.id
+          element.data('exclude-work')
         )
         break
       default:


### PR DESCRIPTION
Fixes #1429 


Present tense short summary (50 characters or less)

Removes data.user param from Work instantiation in AutoComplete class.
https://github.com/samvera/hyrax/blob/1-0-stable/app/assets/javascripts/hyrax/autocomplete.es6 

The Work constructor is only expecting 3 params, not 4.
https://github.com/samvera/hyrax/blob/1-0-stable/app/assets/javascripts/hyrax/autocomplete/work.es6


@samvera/hyrax-code-reviewers
