### PR TITLE
Fix various translation errors on Works list

### DIFF
--- a/app/helpers/hyrax/trophy_helper.rb
+++ b/app/helpers/hyrax/trophy_helper.rb
@@ -6,8 +6,8 @@ module Hyrax
       trophy = user.trophies.where(work_id: id).exists?
       trophyclass = trophy ? "trophy-on" : "trophy-off"
 
-      args[:add_text] ||= "Highlight Work on Profile"
-      args[:remove_text] ||= "Unhighlight Work"
+      args[:add_text] ||= t("hyrax.dashboard.my.action.highlight")
+      args[:remove_text] ||= t("hyrax.dashboard.my.action.unhighlight")
       text = trophy ? args[:remove_text] : args[:add_text]
       args[:class] = [args[:class], "trophy-class #{trophyclass}"].compact.join(' ')
       args[:data] ||= {}

--- a/app/presenters/hyrax/permission_badge.rb
+++ b/app/presenters/hyrax/permission_badge.rb
@@ -2,6 +2,14 @@ module Hyrax
   class PermissionBadge
     include ActionView::Helpers::TagHelper
 
+    VISIBILITY_LABEL_CLASS = {
+      authenticated: "label-info",
+      embargo: "label-warning",
+      lease: "label-warning",
+      open: "label-success",
+      restricted: "label-danger"
+    }.freeze
+
     # @param visibility [String] the current visibility
     def initialize(visibility)
       @visibility = visibility
@@ -15,7 +23,7 @@ module Hyrax
     private
 
       def dom_label_class
-        I18n.t("hyrax.visibility.#{@visibility}.class")
+        VISIBILITY_LABEL_CLASS.fetch(@visibility.to_sym)
       end
 
       def text

--- a/app/views/hyrax/my/works/_default_group.html.erb
+++ b/app/views/hyrax/my/works/_default_group.html.erb
@@ -6,7 +6,7 @@
       <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
       <th><%= t("hyrax.dashboard.my.heading.title") %></th>
       <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
-      <th>Highlighted</th>
+      <th><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
       <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
       <th><%= t("hyrax.dashboard.my.heading.action") %></th>
     </tr>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -430,10 +430,12 @@ de:
           delete_work: Arbeit löschen
           edit_collection: Sammlung bearbeiten
           edit_work: Arbeit bearbeiten
+          highlight: Markieren Sie die Arbeit am Profil
           select: Wählen
           select_all: Wählen Sie Aktuelle Seite aus
           select_none: Nichts ausgewählt
           transfer: Übertragung des Besitzes der Arbeit
+          unhighlight: Hervorhebung von der Arbeit entfernen
           work_confirmation: Das Löschen einer Arbeit aus %{application_name} ist dauerhaft. Klicken Sie auf OK, um diese Arbeit aus %{application_name} zu löschen, oder auf Abbrechen, um diesen Vorgang abzubrechen
         collection_list:
           description: 'Beschreibung:'
@@ -449,6 +451,7 @@ de:
         heading:
           action: Aktionen
           date_uploaded: Datum hinzugefügt
+          highlighted: Hervorgehoben
           title: Titel
           visibility: Sichtweite
         highlighted: Meine Highlights
@@ -654,7 +657,6 @@ de:
           placeholder: Suchbegriffe eingeben
     select_type:
       description: Allzweckarbeitstyp
-      icon_class: Fa-Datei-Text-o
       name: Arbeit
     share_button: Teilen Sie Ihre Arbeit
     single_use_links:
@@ -736,17 +738,13 @@ de:
         unlinked: Link mit Zotero
     visibility:
       authenticated:
-        class: Etiketten-Info
         note_html: Beschränkung des Zugriffs auf Benutzer und / oder Gruppen von %{institution}
         text: "%{institution}"
       embargo:
-        class: Etikettenwarnung
         text: Embargo
       lease:
-        class: Etikettenwarnung
         text: Mieten
       open:
-        class: Etiketten-Erfolg
         note_html: Jeder. Schauen Sie sich <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> für die Urheberrechtsrichtlinien des Publishers an, wenn Sie planen, Ihr %{type} in einer Zeitschrift zu patentieren und / oder zu veröffentlichen.
         text: Öffentlichkeit
         warning_html: '<p> <strong>Bitte beachten Sie</strong> , dass etwas, das für die Welt sichtbar ist (dh das Markieren dieses als %{label}), als Publikation angesehen werden kann, die Ihre Fähigkeit beeinflussen könnte: </p><ul><li> Patent Ihre Arbeit </li><li> Veröffentlichen Sie Ihre Arbeit in einer Zeitschrift </li></ul><p> Überprüfen Sie <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> für weitere Informationen über Urheberrechtsrichtlinien des Publishers. </p>'
@@ -756,7 +754,6 @@ de:
         text: Privatgelände
       private_title_attr: Ändern Sie die Sichtbarkeit dieser Ressource
       restricted:
-        class: Etikett-Gefahr
         note_html: Nur Benutzer und / oder Gruppen, denen im Abschnitt "Freigeben" einen bestimmten Zugriff gewährt wurde.
         text: Privatgelände
       restricted_title_attr: Ändern Sie die Sichtbarkeit dieser Ressource

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -423,10 +423,12 @@ en:
           delete_work:             "Delete Work"
           edit_collection:         "Edit Collection"
           edit_work:               "Edit Work"
+          highlight:               "Highlight Work on Profile"
           select:                  "Select"
           select_all:              "Select Current Page"
           select_none:             "Select None"
           transfer:                "Transfer Ownership of Work"
+          unhighlight:             "Unhighlight Work"
           work_confirmation:       "Deleting a work from %{application_name} is permanent. Click OK to delete this work from %{application_name}, or Cancel to cancel this operation"
         collection_list:
           description:    "Description:"
@@ -442,6 +444,7 @@ en:
         heading:
           action:         "Actions"
           date_uploaded:  "Date Added"
+          highlighted:    "Highlighted"
           title:          "Title"
           visibility:     "Visibility"
         highlighted:  "My Highlights"
@@ -652,7 +655,6 @@ en:
           placeholder:    "Enter search terms"
     select_type:
       description: "General purpose worktype"
-      icon_class : 'fa fa-file-text-o'
       name:        "Work"
     share_button:       "Share Your Work"
     single_use_links:
@@ -734,17 +736,13 @@ en:
         unlinked: "Link with Zotero"
     visibility:
       authenticated:
-        class: "label-info"
         note_html: "Restrict access to only users and/or groups from %{institution}"
         text: "%{institution}"
       embargo:
-        class: "label-warning"
         text: "Embargo"
       lease:
-        class: "label-warning"
         text: "Lease"
       open:
-        class: "label-success"
         note_html: Everyone. Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for specific publishers' copyright policies if you plan to patent and/or publish your %{type} in a journal.
         text: Public
         warning_html: "<p>
@@ -764,7 +762,6 @@ en:
       restricted:
         note_html: Only users and/or groups that have been given specific access in the "Share With" section.
         text: "Private"
-        class: "label-danger"
       restricted_title_attr: "Change the visibility of this resource"
     workflow:
       default:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -425,10 +425,12 @@ es:
           delete_work: Borrar Trabajo
           edit_collection: Editar Colección
           edit_work: Editar Trabajo
+          highlight: Resalte Trabajo en Perfil
           select: Seleccionar
           select_all: Seleccionar la página actual
           select_none: Seleccionar ninguno
           transfer: Cambiar el Propietario del Trabajo
+          unhighlight: Retire Resalte del Trabajo
           work_confirmation: El borrado de un trabajo de %{application_name} es permanente. Presione OK para borrar este trabajo de %{application_name}, o Cancelar para cancelar esta operación
         collection_list:
           description: 'Descripción:'
@@ -444,6 +446,7 @@ es:
         heading:
           action: Acciones
           date_uploaded: Fecha añadida
+          highlighted: Destacado
           title: Título
           visibility: Visibilidad
         highlighted: Mis aspectos destacados
@@ -651,7 +654,6 @@ es:
           placeholder: Introduce términos de búsqueda
     select_type:
       description: Tipo de trabajo de propósito general.
-      icon_class: fa fa-file-text-o
       name: Trabajo
     share_button: Comparte tu Trabajo
     single_use_links:
@@ -733,17 +735,13 @@ es:
         unlinked: Vincular con Zotero
     visibility:
       authenticated:
-        class: label-info
         note_html: Restringir el acceso sólo a usuarios y/o grupos de %{institution}
         text: "%{institution}"
       embargo:
-        class: label-warning
         text: Embargo
       lease:
-        class: label-warning
         text: Arrendamiento
       open:
-        class: label-success
         note_html: Todo el mundo. Consulte <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> para conocer las políticas de derechos de autor de editores específicos si planea patentar y/o publicar su %{type} en un diario
         text: Público
         warning_html: '<p> <strong>Tenga en cuenta</strong>, hacer algo visible para el mundo (es decir, marcar esto como %{label}) puede ser visto como una publicación, lo que podría afectar su capacidad de: </p> <ul> <li>Patentar su trabajo</li> <li>Publicar su trabajo en una revista</li> </ul> <p> Eche un vistazo a <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> para más información sobre las políticas de copyright del editor. </p>'
@@ -753,7 +751,6 @@ es:
         text: Privado
       private_title_attr: Cambiar la visibilidad de este recurso
       restricted:
-        class: label-danger
         note_html: Sólo los usuarios y / o grupos a los que se les ha dado acceso específico en la sección "Compartir con".
         text: Privado
       restricted_title_attr: Cambiar la visibilidad de este recurso

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -430,10 +430,12 @@ fr:
           delete_work: Supprimer le travail
           edit_collection: Modifier la collection
           edit_work: Modifier le travail
+          highlight: Surligner le travail sur le profil
           select: Sélectionner
           select_all: Sélectionnez la page actuelle
           select_none: Ne rien sélectionner
           transfer: Transfert de propriété du travail
+          unhighlight: Supprimer la mise en évidence du travail
           work_confirmation: Supprimer un travail de %{application_name} est permanent. Cliquez sur OK pour supprimer ce travail de %{application_name} ou sur Annuler pour annuler cette opération
         collection_list:
           description: 'La description:'
@@ -447,8 +449,9 @@ fr:
           shared: 'Filtrer les actions:'
           works: 'Le filtre fonctionne:'
         heading:
-          action: actes
-          date_uploaded: date ajoutée
+          action: Actes
+          date_uploaded: Date Ajoutée
+          highlighted: Souligné
           title: Titre
           visibility: Visibilité
         highlighted: Mes faits saillants
@@ -654,7 +657,6 @@ fr:
           placeholder: Entrez les termes de recherche
     select_type:
       description: Type de travail à usage général
-      icon_class: Fa fa-file-text-o
       name: Travail
     share_button: Partagez votre travail
     single_use_links:
@@ -736,17 +738,13 @@ fr:
         unlinked: Lien avec Zotero
     visibility:
       authenticated:
-        class: Info-étiquette
         note_html: Limiter l'accès aux utilisateurs et / ou groupes exclus de %{institution}
         text: "%{institution}"
       embargo:
-        class: Étiquette-avertissement
         text: Embargo
       lease:
-        class: Étiquette-avertissement
         text: Bail
       open:
-        class: Label-succès
         note_html: Toutes les personnes. Consultez <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> pour les politiques de copyright des éditeurs spécifiques si vous prévoyez de breveter et / ou de publier votre %{type} dans un journal.
         text: Public
         warning_html: '<p> <strong>Notez</strong> que faire apparaître une chose visible dans le monde (c.-à-d. Marquer cela comme %{label}) peut être considérée comme une publication qui pourrait avoir une incidence sur votre capacité à: </p><ul><li> Prenez connaissance de votre travail </li><li> Publiez votre travail dans un journal </li></ul><p> Consultez <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> pour plus d''informations sur les politiques de copyright des éditeurs. </p>'
@@ -756,7 +754,6 @@ fr:
         text: Privé
       private_title_attr: Changez la visibilité de cette ressource
       restricted:
-        class: Label-danger
         note_html: Seuls les utilisateurs et / ou les groupes ayant reçu un accès spécifique dans la section "Partager avec".
         text: Privé
       restricted_title_attr: Modifier la visibilité de cette ressource

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -430,10 +430,12 @@ it:
           delete_work: Elimina lavoro
           edit_collection: Modifica raccolta
           edit_work: Modifica lavoro
+          highlight: Evidenziare il Savoro sul Profilo
           select: Selezionare
           select_all: Seleziona pagina corrente
           select_none: Non selezionare niente
           transfer: Trasferimento di proprietà del lavoro
+          unhighlight: Rimuovi l'evidenziazione dal lavoro
           work_confirmation: La cancellazione di un lavoro da %{application_name} è permanente. Fare clic su OK per eliminare questo lavoro da %{application_name} oppure Annulla per annullare questa operazione
         collection_list:
           description: 'Descrizione:'
@@ -449,6 +451,7 @@ it:
         heading:
           action: Azioni
           date_uploaded: Data aggiunta
+          highlighted: Evidenziato
           title: Titolo
           visibility: Visibilità
         highlighted: I miei punti salienti
@@ -654,7 +657,6 @@ it:
           placeholder: Inserisci i termini di ricerca
     select_type:
       description: Tipo di lavoro generale
-      icon_class: Fa fa-file-testo-o
       name: Lavoro
     share_button: Condividi il tuo lavoro
     single_use_links:
@@ -736,17 +738,13 @@ it:
         unlinked: Link con Zotero
     visibility:
       authenticated:
-        class: Etichetta-info
         note_html: Limitare l'accesso a soli utenti e / o gruppi da %{institution}
         text: "%{institution}"
       embargo:
-        class: label-warning
         text: Embargo
       lease:
-        class: label-warning
         text: Contratto di locazione
       open:
-        class: etichetta-successo
         note_html: Tutti. <a href="http://www.sherpa.ac.uk/romeo/">Controlla SHERPA / RoMEO</a> per <a href="http://www.sherpa.ac.uk/romeo/">specifiche politiche</a> di copyright dei publisher se intendi brevettare e / o pubblicare il tuo %{type} in un diario.
         text: Pubblico
         warning_html: '<p> <strong>Si prega di notare</strong> che facendo qualcosa di visibile al mondo (vale a dire marcatura come %{label}) può essere considerata come pubblicazione che potrebbe influenzare la tua capacità di: </p><ul><li> Brevetti il ​​tuo lavoro </li><li> Pubblica il tuo lavoro in un diario </li></ul><p> <a href="http://www.sherpa.ac.uk/romeo/">Controlla SHERPA / RoMEO</a> per ulteriori informazioni sulle norme del copyright dei publisher. </p>'
@@ -756,7 +754,6 @@ it:
         text: Privato
       private_title_attr: Modificare la visibilità di questa risorsa
       restricted:
-        class: label-pericolo
         note_html: Solo utenti e / o gruppi che hanno ricevuto l'accesso specifico nella sezione "Condividi con".
         text: Privato
       restricted_title_attr: Cambiare la visibilità di questa risorsa

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -430,10 +430,12 @@ pt-BR:
           delete_work: Excluir o trabalho
           edit_collection: Editar coleção
           edit_work: Editar trabalho
+          highlight: Destaque trabalho em perfil
           select: Selecione
           select_all: Selecione a página atual
           select_none: Selecione nenhum
           transfer: Transferência de propriedade do trabalho
+          unhighlight: Remova o destaque do trabalho
           work_confirmation: Excluir um trabalho do %{application_name} é permanente. Clique em OK para excluir este trabalho de %{application_name} ou Cancelar para cancelar esta operação
         collection_list:
           description: 'Descrição:'
@@ -449,6 +451,7 @@ pt-BR:
         heading:
           action: Ações
           date_uploaded: data adicionada
+          highlighted: Meus destaques
           title: Título
           visibility: Visibilidade
         highlighted: Meus destaques
@@ -654,7 +657,6 @@ pt-BR:
           placeholder: Digite os termos de pesquisa
     select_type:
       description: Tipo de trabalho de propósito geral
-      icon_class: Fa fa-file-text-o
       name: Trabalhos
     share_button: Compartilhe seu trabalho
     single_use_links:
@@ -736,17 +738,13 @@ pt-BR:
         unlinked: Link com Zotero
     visibility:
       authenticated:
-        class: Etiqueta-info
         note_html: Restringir acesso a apenas usuários e / ou grupos de %{institution}
         text: "%{institution}"
       embargo:
-        class: Rotulagem
         text: Embargo
       lease:
-        class: Rotulagem
         text: De concessão
       open:
-        class: Sucesso de etiqueta
         note_html: Todos. Confira <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> para políticas de direitos autorais de editoras específicas se você planeja patinar e / ou publicar seu %{type} em um diário.
         text: Público
         warning_html: '<p> <strong>Por favor</strong> , <strong>note que</strong> fazer algo visível para o mundo (ou seja, marcar isso como %{label}) pode ser visto como uma publicação que pode afetar sua capacidade de: </p><ul><li> Patente seu trabalho </li><li> Publique seu trabalho em um diário </li></ul><p> Confira <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> para obter mais informações sobre políticas de direitos autorais do editor. </p>'
@@ -756,7 +754,6 @@ pt-BR:
         text: Privado
       private_title_attr: Mude a visibilidade desse recurso
       restricted:
-        class: Label-danger
         note_html: Apenas usuários e / ou grupos que receberam acesso específico na seção "Compartilhar com".
         text: Privado
       restricted_title_attr: Altere a visibilidade deste recurso

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -8,8 +8,12 @@ zh:
       messages:
         conflict: 您的更改无法保存，因为另一用户(或后台作业）在您开始编辑后更新了%{model}。 请确保所有文件附件已成功完成之后再试一次。这已经是最新刷新后保存的副本%{model}
   blacklight:
+    application_name: Blacklight # needed until blacklight adds chinese translation
     search:
+      rss_feed: RSS Feed # needed until blacklight adds chinese translation
+      atom_feed: Atom Feed # needed until blacklight adds chinese translation
       facets:
+        count: Count
         more_html: 更多 <span class="sr-only">%{field_name}</span> »
       fields:
         facet:
@@ -427,10 +431,12 @@ zh:
           delete_work: 删除作品
           edit_collection: 编辑收藏集
           edit_work: 编辑作品
+          highlight: 突出工作在配置文件
           select: 选择行动
           select_all: 选择当前页面
           select_none: 选择无
           transfer: 转让作品所有权
+          unhighlight: 从工作中删除高亮
           work_confirmation: 从%{application_name}删除作品是永久性的。点击 OK 从%{application_name}删除此作品，或取消删除。
         collection_list:
           description: 描述：
@@ -446,6 +452,7 @@ zh:
         heading:
           action: 行动
           date_uploaded: 上传日期
+          highlighted: 突出
           title: 标题
           visibility: 公开度
         highlighted: 我的重点
@@ -653,7 +660,6 @@ zh:
           placeholder: 输入搜索词
     select_type:
       description: 普通目的作品类型
-      icon_class: fa fa-file-text-o
       name: 作品
     share_button: 分享您的作品
     single_use_links:
@@ -735,17 +741,13 @@ zh:
         unlinked: 与Zotero链接
     visibility:
       authenticated:
-        class: '信息标签 '
         note_html: 访问仅限于%{institution} 的用户
         text: "%{institution}"
       embargo:
-        class: 警告提示标签
         text: 时滞期限
       lease:
-        class: 警告提示标签
         text: 租约
       open:
-        class: 成功标签
         note_html: 各位请注意， 如果您计划申请专利或在期刊上发表您的%{type}，请在<a href='http://www.sherpa.ac.uk/romeo/'>SHERPA/RoMEO</a> 查看相关出版社的版权政策
         text: 上市
         warning_html: <p><strong>请注意</strong>, 在此公开(例如，加上%{label}标记)会被视作已出版，从而影响:</p><ul><li>为您的作品申请专利</li><li>在期刊上发表您的作品</li></ul><p>请在<a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a>查看相关出版社的版权政策。</p>
@@ -755,7 +757,6 @@ zh:
         text: 私人的
       private_title_attr: 修改此资源的公开度
       restricted:
-        class: 危险标签
         note_html: 只有在“分享到”部分中被赋予特定访问权限的用户和/或组。
         text: 非公开
       restricted_title_attr: 更改此资源的可见性


### PR DESCRIPTION
## 1. Add translation options for "Highighted" and "Highlight work on profile".

## 2. Move class names out of I18n files. 
They were getting translated into various languages, causing them to not work.

## 3. Add missing Chinese Blacklight translations. 
Blacklight does not include Chinese translation, so any terms used in Hyrax need to be included in the Hyrax I18n files until Blacklight gets updated.

Fixes https://github.com/samvera/hyrax/issues/1401

@samvera/hyrax-code-reviewers
