### PR TITLE
Refactoring FileSetActor

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -4,7 +4,6 @@ Security/MarshalLoad:
 
 Metrics/ClassLength:
   Exclude:
-    - 'app/actors/hyrax/actors/file_set_actor.rb'
     - 'app/controllers/hyrax/file_sets_controller.rb'
     - 'app/forms/hyrax/forms/permission_template_form.rb'
     - 'app/presenters/hyrax/work_show_presenter.rb'


### PR DESCRIPTION
* Moving logic to create JobIoWrapper into a factory-like method in the
  JobIoWrapper class. The clue for this refactor was that there were
  several specs for a private method. Also, the private method in
  FileSetactor had intimate knowledge of files and the attributes of
  JobIoWrapper.
* Marking #import_url as deprecated, as it does not appear to be called
  in any tests in Hyrax.
* Adding a class attribute for .file_actor_class; I believe this creates
  a clearer definition of external collaborators.

The original impetus was to remove a Rubocop violation regarding class
length.

@samvera/hyrax-code-reviewers
