### PR TITLE
Refactoring to more compact methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,7 +47,7 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
 
 Metrics/MethodLength:
-  Max: 14
+  Max: 13
 
 Style/AsciiComments:
   Enabled: false

--- a/app/controllers/hyrax/workflow_actions_controller.rb
+++ b/app/controllers/hyrax/workflow_actions_controller.rb
@@ -3,23 +3,29 @@ module Hyrax
     before_action :authenticate_user!
 
     def update
-      @curation_concern = ActiveFedora::Base.find(params[:id])
-      workflow_action_form = Hyrax::Forms::WorkflowActionForm.new(
-        current_ability: current_ability,
-        work: @curation_concern,
-        attributes: workflow_action_params
-      )
       if workflow_action_form.save
         after_update_response
       else
         respond_to do |wants|
           wants.html { render 'hyrax/base/unauthorized', status: :unauthorized }
-          wants.json { render_json_response(response_type: :unprocessable_entity, options: { errors: @curation_concern.errors }) }
+          wants.json { render_json_response(response_type: :unprocessable_entity, options: { errors: curation_concern.errors }) }
         end
       end
     end
 
     private
+
+      def curation_concern
+        @curation_concern ||= ActiveFedora::Base.find(params[:id])
+      end
+
+      def workflow_action_form
+        @workflow_action_form ||= Hyrax::Forms::WorkflowActionForm.new(
+          current_ability: current_ability,
+          work: curation_concern,
+          attributes: workflow_action_params
+        )
+      end
 
       def workflow_action_params
         params.require(:workflow_action).permit(:name, :comment)
@@ -27,8 +33,8 @@ module Hyrax
 
       def after_update_response
         respond_to do |wants|
-          wants.html { redirect_to [main_app, @curation_concern], notice: "The #{@curation_concern.human_readable_type} has been updated." }
-          wants.json { render 'hyrax/base/show', status: :ok, location: polymorphic_path([main_app, @curation_concern]) }
+          wants.html { redirect_to [main_app, curation_concern], notice: "The #{curation_concern.human_readable_type} has been updated." }
+          wants.json { render 'hyrax/base/show', status: :ok, location: polymorphic_path([main_app, curation_concern]) }
         end
       end
   end

--- a/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
@@ -5,6 +5,7 @@ module Hyrax
         include Hyrax::CitationsBehaviors::PublicationBehavior
         include Hyrax::CitationsBehaviors::TitleBehavior
 
+        # rubocop:disable Metrics/MethodLength
         def format(work)
           text = ""
 
@@ -41,6 +42,7 @@ module Hyrax
           text << "." unless text =~ /\.$/
           text
         end
+        # rubocop:enable Metrics/MethodLength
 
         def format_date(pub_date); end
 

--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -15,6 +15,7 @@ module Hyrax::FileSetHelper
            locals.merge(file_set: presenter)
   end
 
+  # rubocop:disable Metrics/MethodLength
   def media_display_partial(file_set)
     'hyrax/file_sets/media_display/' +
       if file_set.image?
@@ -31,4 +32,5 @@ module Hyrax::FileSetHelper
         'default'
       end
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -233,6 +233,7 @@ module Hyrax
         request.user_agent || ''
       end
 
+      # rubocop:disable Metrics/MethodLength
       def search_action_for_dashboard
         case params[:controller]
         when "hyrax/my/collections"
@@ -250,6 +251,7 @@ module Hyrax
           hyrax.my_works_path
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       # @param [ActionController::Parameters] params first argument for Blacklight::SearchState.new
       # @param [Hash] facet

--- a/app/helpers/hyrax/trophy_helper.rb
+++ b/app/helpers/hyrax/trophy_helper.rb
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 module Hyrax
   module TrophyHelper
+    # rubocop:disable Metrics/MethodLength
     def display_trophy_link(user, id, args = {}, &_block)
       return unless user
       trophy = user.trophies.where(work_id: id).exists?
@@ -19,5 +20,6 @@ module Hyrax
         yield(text)
       end
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/generators/hyrax/models_generator.rb
+++ b/lib/generators/hyrax/models_generator.rb
@@ -17,6 +17,7 @@ This generator makes the following changes to your application:
   end
 
   # Add behaviors to the user model
+  # rubocop:disable Metrics/MethodLength
   def inject_user_behavior
     file_path = "app/models/#{model_name.underscore}.rb"
     if File.exist?(file_path)
@@ -33,6 +34,7 @@ This generator makes the following changes to your application:
            "argument. Such as \b  rails -g hyrax:models client"
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def create_collection
     copy_file 'app/models/collection.rb', 'app/models/collection.rb'


### PR DESCRIPTION
## Refactoring to more compact methods

@90eab8d604c981f839e3fe3028b94602c36a9b9d

Rubocop has a 14 line method length enforcer. These two files exceeded
that method length. By refactoring the methods they are below the 14
line method length.

In the case of the `batch_uploads_controller.rb` the refactoring
introduces a seam in the code that allows Hyrax implementors to more
easily change the response behavior when batches are disabled.

I believe we should aspire to a 10 line method length as the general
rule, with exceptions for data mapping of attributes and other similar
methods.

## Reducing Rubocop allowed method length to 13

@9f2019363a679d347c7cfcd842ea234cc2e16439

Following the advice of Sandi Metz, aiming for fewer lines per method.
