### PR TITLE
Refactoring FixityCheckJob

### DIFF
--- a/spec/jobs/fixity_check_job_spec.rb
+++ b/spec/jobs/fixity_check_job_spec.rb
@@ -32,6 +32,9 @@ RSpec.describe FixityCheckJob do
       it 'passes' do
         expect(log_record).to be_passed
       end
+      it "returns a ChecksumAuditLog" do
+        expect(log_record).to be_kind_of ChecksumAuditLog
+      end
     end
 
     describe 'fixity check an invalid version of the content' do
@@ -40,26 +43,9 @@ RSpec.describe FixityCheckJob do
       it 'fails' do
         expect(log_record).to be_failed
       end
-    end
-  end
-
-  describe '#run_fixity_check' do
-    let(:uri) { Hyrax::VersioningService.latest_version_of(file_set.original_file).uri }
-    let!(:old) { ChecksumAuditLog.create(file_set_id: file_set.id, file_id: file_id, checked_uri: uri, passed: true, created_at: 2.minutes.ago) }
-    let!(:new) { ChecksumAuditLog.create(file_set_id: file_set.id, file_id: file_id, checked_uri: uri, passed: false) }
-    let(:mock_service) { double('mock fixity check service') }
-    let(:job) do
-      described_class.new
-    end
-
-    before do
-      allow(ActiveFedora::FixityService).to receive(:new).and_return(mock_service)
-      allow(mock_service).to receive(:check).and_return(true, false, false, true, false)
-    end
-
-    it 'does not prune failed fixity checks' do
-      5.times { job.send(:run_check, file_set.id, file_id, uri) }
-      expect(ChecksumAuditLog.logs_for(file_set.id, checked_uri: uri).map(&:passed)).to eq [false, true, false, false, true, false, true]
+      it "returns a ChecksumAuditLog" do
+        expect(log_record).to be_kind_of ChecksumAuditLog
+      end
     end
   end
 end

--- a/spec/models/checksum_audit_log_spec.rb
+++ b/spec/models/checksum_audit_log_spec.rb
@@ -24,7 +24,33 @@ RSpec.describe ChecksumAuditLog do
     end
   end
 
-  describe "prune_history" do
+  describe ".create_and_prune!" do
+    let(:file_set_id) { 'file_set_id' }
+    let(:checked_uri) { "file_id/fcr:versions/version1" }
+
+    subject { described_class.create_and_prune!(passed: passed, file_set_id: 'file_set_id', file_id: 'file_id', checked_uri: checked_uri, expected_result: '1234') }
+
+    describe 'when check passed' do
+      let(:passed) { true }
+
+      it { is_expected.to be_a(described_class) }
+      it 'will prune history' do
+        expect(described_class).to receive(:prune_history).with(file_set_id, checked_uri: checked_uri)
+        subject
+      end
+    end
+    describe 'when check failed' do
+      let(:passed) { false }
+
+      it { is_expected.to be_a(described_class) }
+      it 'will not prune history' do
+        expect(described_class).not_to receive(:prune_history).with(file_set_id, checked_uri: checked_uri)
+        subject
+      end
+    end
+  end
+
+  describe ".prune_history" do
     let(:file_set_id) { "file_set_id" }
     let(:file_id) { "file_id" }
     let(:version_uri) { "#{file_id}/fcr:versions/version1" }


### PR DESCRIPTION
Prior to this refactor, the FixityCheckJob had knowledge of when to
short-circuit the prune ChecksumAuditLog history. By moving the create
and prune directives to ChecksumAuditLog the specs for FixityCheckJob
become much more focused on the FixityCheckJob behavior instead of
the behavioral interactions with the ChecksumAuditLog.

Looking at methods that are at the limit of the Rubocop method length.

@samvera/hyrax-code-reviewers
