### PR TITLE
Adds model for Collection Types

### DIFF
--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -1,0 +1,5 @@
+module Hyrax
+  class CollectionType < ActiveRecord::Base
+    self.table_name = 'hyrax_collection_types'
+  end
+end

--- a/db/migrate/20170808160431_create_collection_types.rb
+++ b/db/migrate/20170808160431_create_collection_types.rb
@@ -1,0 +1,17 @@
+class CreateCollectionTypes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :hyrax_collection_types do |t|
+      t.string :title
+      t.text :description
+      t.string :machine_id
+      t.boolean :nestable, null: false, default: true
+      t.boolean :discovery, null: false, default: true
+      t.boolean :sharing, null: false, default: true
+      t.boolean :multiple_membership, null: false, default: true
+      t.boolean :require_membership, null: false, default: false
+      t.boolean :workflow, null: false, default: false
+      t.boolean :visibility, null: false, default: false
+    end
+    add_index :hyrax_collection_types, :machine_id
+  end
+end

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :collection_type, class: Hyrax::CollectionType do
+    factory :user_collection_type do
+      title ['User Collection']
+      description ['A user oriented collection type']
+      machine_id ['user_collection']
+    end
+  end
+end

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Hyrax::CollectionType, type: :model do
+  let(:collection_type) { create(:user_collection_type) }
+
+  it "has basic metadata" do
+    expect(collection_type).to respond_to(:title)
+    expect(collection_type.title).not_to be_empty
+    expect(collection_type).to respond_to(:description)
+    expect(collection_type.description).not_to be_empty
+    expect(collection_type).to respond_to(:machine_id)
+    expect(collection_type.machine_id).not_to be_empty
+  end
+
+  it "has configuration properties with defaults" do
+    expect(collection_type.nestable).to be_truthy
+    expect(collection_type.discovery).to be_truthy
+    expect(collection_type.sharing).to be_truthy
+    expect(collection_type.multiple_membership).to be_truthy
+    expect(collection_type.require_membership).to be_falsey
+    expect(collection_type.workflow).to be_falsey
+    expect(collection_type.visibility).to be_falsey
+  end
+end


### PR DESCRIPTION
Fixes #1343

(collections extensions sprint)

Adds basic model, specs, and a factory for collection types.  The model in this initial iteration does not have validations on fields but can be added as the requirements for them are defined.  It also does not address the questions of participant assignment/permission templates raised in #1343 . 