### PR TITLE
consolidating requires into app manifest

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -37,6 +37,14 @@
 //= require webcomponentsjs/0.5.4/CustomElements.min
 //= require time-elements
 
+// Moved from app/assets/javascripts/hyrax/uploader.js
+//= require fileupload/tmpl
+//= require fileupload/jquery.iframe-transport
+//= require fileupload/jquery.fileupload.js
+//= require fileupload/jquery.fileupload-process.js
+//= require fileupload/jquery.fileupload-validate.js
+//= require fileupload/jquery.fileupload-ui.js
+
 //= require hyrax/monkey_patch_turbolinks
 //= require hyrax/app
 //= require hyrax/config

--- a/app/assets/javascripts/hyrax/uploader.js
+++ b/app/assets/javascripts/hyrax/uploader.js
@@ -1,10 +1,3 @@
-//= require fileupload/tmpl
-//= require fileupload/jquery.iframe-transport
-//= require fileupload/jquery.fileupload.js
-//= require fileupload/jquery.fileupload-process.js
-//= require fileupload/jquery.fileupload-validate.js
-//= require fileupload/jquery.fileupload-ui.js
-//
 /*
  * jQuery File Upload Plugin JS Example
  * https://github.com/blueimp/jQuery-File-Upload


### PR DESCRIPTION
refs #1414 

Let's put this change into `master` first!

We wanted to override some stuff in uploader.js but were running into issues with dependencies in our child app. I figured our dependencies should all be in the application manifest anyway (plus it allows us to override uploader.jssuccessfully now)

I didn't make this change for the master branch of hyrax since it looks like maxFileSize is going to be configurable in an initializer, but i can consolidate js dependencies in that branch too if you want.

@samvera/hyrax-code-reviewers
