### PR TITLE
Use current Redis instance for LockManager, ref #1443

### DIFF
--- a/app/services/hyrax/lock_manager.rb
+++ b/app/services/hyrax/lock_manager.rb
@@ -10,7 +10,7 @@ module Hyrax
     # @param [Fixnum] retry_delay Maximum wait time in milliseconds before retrying. Wait time is a random value between 0 and retry_delay.
     def initialize(time_to_live, retry_count, retry_delay)
       @ttl = time_to_live
-      @client = Redlock::Client.new([uri], retry_count: retry_count, retry_delay: retry_delay)
+      @client = Redlock::Client.new([Redis.current], retry_count: retry_count, retry_delay: retry_delay)
     end
 
     # Blocks until lock is acquired or timeout.
@@ -22,18 +22,5 @@ module Hyrax
       end
       returned_from_block
     end
-
-    private
-
-      def uri
-        @uri ||= begin
-          opts = options
-          URI("#{opts[:scheme]}://#{opts[:host]}:#{opts[:port]}").to_s
-        end
-      end
-
-      def options
-        ::Redis.current.client.options
-      end
   end
 end


### PR DESCRIPTION
The lock manager was creating a new instance of Redis using the existing
configuration options; however, these options did not include a
password.

The lock manager can create a new client using the current Redis
instance, which will already have all the parameters, including the
password.

Fixes #1443 

@samvera/hyrax-code-reviewers