### PR TITLE
Work form should display selected collections based on params

### DIFF
--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -70,7 +70,7 @@ module Hyrax
         @result_set_size = @response.response["numFound"]
         @empty_batch = batch.empty?
         @all_checked = (count_on_page == @document_list.count)
-        @add_files_to_collection = params.fetch(:add_files_to_collection, '')
+        @add_works_to_collection = params.fetch(:add_works_to_collection, '')
       end
 
       def query_solr

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 module Hyrax
   module Forms
     # @abstract
@@ -103,6 +104,12 @@ module Hyrax
         CollectionOptionsPresenter.new(service).select_options(:edit)
       end
 
+      # Select collection(s) based on passed-in params
+      # @return [Array] a list of collection identifiers
+      def member_of_collections(collection_ids)
+        Array.wrap(collection_ids)
+      end
+
       # Sanitize the parameters coming from the form. This ensures that the client
       # doesn't send us any more parameters than we expect.
       # In particular we are discarding any access grant parameters for works that
@@ -122,6 +129,7 @@ module Hyrax
         super + [
           :on_behalf_of,
           :version,
+          :add_works_to_collection,
           {
             work_members_attributes: [:id, :_destroy],
             based_near_attributes: [:id, :_destroy]
@@ -155,3 +163,4 @@ module Hyrax
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/presenters/hyrax/collection_options_presenter.rb
+++ b/app/presenters/hyrax/collection_options_presenter.rb
@@ -6,7 +6,7 @@ module Hyrax
       @service = service
     end
 
-    # Return AdminSet selectbox options based on access type
+    # Return Collection selectbox options based on access type
     # @param [Symbol] access :read or :edit
     def select_options(access = :edit)
       option_values = results(access).map do |solr_doc|

--- a/app/presenters/hyrax/select_type_presenter.rb
+++ b/app/presenters/hyrax/select_type_presenter.rb
@@ -18,6 +18,22 @@ module Hyrax
       translate('name')
     end
 
+    def switch_to_new_work_path(route_set:, params:)
+      if params.key?(:add_works_to_collection)
+        route_set.new_polymorphic_path(concern, add_works_to_collection: params[:add_works_to_collection])
+      else
+        route_set.new_polymorphic_path(concern)
+      end
+    end
+
+    def switch_to_batch_upload_path(route_set:, params:)
+      if params.key?(:add_works_to_collection)
+        route_set.new_batch_upload_path(payload_concern: concern, add_works_to_collection: params[:add_works_to_collection])
+      else
+        route_set.new_batch_upload_path(payload_concern: concern)
+      end
+    end
+
     private
 
       def object_name

--- a/app/views/hyrax/base/_form_member_of_collections.html.erb
+++ b/app/views/hyrax/base/_form_member_of_collections.html.erb
@@ -3,5 +3,6 @@
   <%= f.input :member_of_collection_ids,
               as: :select,
               collection: f.object.collections_for_select,
+              selected: f.object.member_of_collections(params[:add_works_to_collection]),
               input_html: { class: 'form-control', multiple: true } %>
 </div>

--- a/app/views/hyrax/dashboard/collections/_edit_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_edit_actions.html.erb
@@ -1,7 +1,7 @@
 <h2 class="sr-only"><%= t('hyrax.collection.actions.header') %></h2>
 <div class="actions-controls-collections">
   <%= link_to t('hyrax.collection.actions.add_works.label'),
-              hyrax.my_works_path(add_files_to_collection: @form.id),
+              hyrax.my_works_path(add_works_to_collection: @form.id),
               title: t('hyrax.collection.actions.add_works.desc'),
               class: 'btn btn-default' %>
 </div>

--- a/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
@@ -15,7 +15,7 @@
               <ul>
                 <% user_collections.sort { |c1,c2| c2[CatalogController.uploaded_field] <=> c1[CatalogController.uploaded_field] }.each_with_index do |collection,index|  %>
                   <li>
-                    <% selected = (collection.id == @add_files_to_collection) || (@add_files_to_collection.blank? && index == 0) %>
+                    <% selected = (collection.id == @add_works_to_collection) || (@add_works_to_collection.blank? && index == 0) %>
                     <%= radio_button_tag(:id, collection.id, selected, class: "collection-selector") %>
                     <%= label_tag(:collection, collection.title_or_label, for: "id_#{collection.id}") %>
                   </li>

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -6,7 +6,7 @@
                   title: t('hyrax.collection.actions.edit.desc'),
                   class: 'btn btn-default' %>
       <%= link_to t('hyrax.collection.actions.add_works.label'),
-                  hyrax.my_works_path(add_files_to_collection: presenter.id),
+                  hyrax.my_works_path(add_works_to_collection: presenter.id),
                   title: t('hyrax.collection.actions.add_works.desc'),
                   class: 'btn btn-default' %>
     <%end %>

--- a/app/views/shared/_select_work_type_modal.html.erb
+++ b/app/views/shared/_select_work_type_modal.html.erb
@@ -11,8 +11,8 @@
             <div class="select-worktype">
               <label>
                 <input type="radio" name="payload_concern" value="<%= row_presenter.concern %>"
-                                                             data-single="<%= new_polymorphic_path([main_app, row_presenter.concern]) %>"
-                                                             data-batch="<%= hyrax.new_batch_upload_path(payload_concern: row_presenter.concern) %>">
+                                                             data-single="<%= row_presenter.switch_to_new_work_path(route_set: main_app, params: params) %>"
+                                                             data-batch="<%= row_presenter.switch_to_batch_upload_path(route_set: hyrax, params: params) %>">
                 <div class="select-work-icon">
                   <span class="<%= row_presenter.icon_class %>"></span>
                 </div>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -829,7 +829,6 @@ de:
       defaults:
         admin_set_id: Als Mitglied des Verwaltungssatzes hinzufügen
         based_near: Ort
-        collection_ids: Als Mitglied der Sammlung hinzufügen
         creator: Schöpfer
         date_created: Datum erstellt
         description: Zusammenfassung oder Zusammenfassung
@@ -838,6 +837,7 @@ de:
         keyword: Stichwort
         lease_expiration_date: bis
         license: Lizenz
+        member_of_collection_ids: Als Mitglied der Sammlung hinzufügen
         related_url: Zugehörige URL
         title: Titel
         visibility_after_embargo: Dann öffnen sie es bis zu

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -840,7 +840,6 @@ en:
       defaults:
         admin_set_id:              "Add as member of administrative set"
         based_near:                "Location"
-        collection_ids:            "Add as member of collection"
         creator:                   "Creator"
         date_created:              "Date Created"
         description:               "Abstract or Summary"
@@ -848,8 +847,9 @@ en:
         files:                     'Upload a file'
         keyword:                   "Keyword"
         lease_expiration_date:     'until'
-        related_url:               "Related URL"
         license:                   "License"
+        member_of_collection_ids:  "Add as member of collection"
+        related_url:               "Related URL"
         title:                     "Title"
         visibility_after_embargo:  'then open it up to'
         visibility_after_lease:    'then restrict it to'

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -826,7 +826,6 @@ es:
       defaults:
         admin_set_id: Añadir como miembro del conjunto administrativo
         based_near: Ubicación
-        collection_ids: Añadir como miembro de la colección
         creator: Creador
         date_created: Fecha de creación
         description: Resumen o Sumario
@@ -835,6 +834,7 @@ es:
         keyword: Palabra Clave
         lease_expiration_date: hasta
         license: Licencia
+        member_of_collection_ids: Añadir como miembro de la colección
         related_url: URL relacionada
         title: Título
         visibility_after_embargo: luego abrirlo a

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -829,7 +829,6 @@ fr:
       defaults:
         admin_set_id: Ajouter en tant que membre de l'ensemble administratif
         based_near: Emplacement
-        collection_ids: Ajouter en tant que membre de la collection
         creator: Créateur
         date_created: date créée
         description: Résumé ou résumé
@@ -838,6 +837,7 @@ fr:
         keyword: Mot-clé
         lease_expiration_date: jusqu'à
         license: Licence
+        member_of_collection_ids: Ajouter en tant que membre de la collection
         related_url: URL associée
         title: Titre
         visibility_after_embargo: Puis ouvrez-le jusqu'à

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -829,7 +829,6 @@ it:
       defaults:
         admin_set_id: Aggiungi come membro del set amministrativo
         based_near: luogo
-        collection_ids: Aggiungi come membro della collezione
         creator: Creatore
         date_created: data di creazione
         description: Riepilogo o Riepilogo
@@ -838,6 +837,7 @@ it:
         keyword: Parola chiave
         lease_expiration_date: fino a
         license: Licenza
+        member_of_collection_ids: Aggiungi come membro della collezione
         related_url: URL correlato
         title: Titolo
         visibility_after_embargo: Poi aprila fino a

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -829,7 +829,6 @@ pt-BR:
       defaults:
         admin_set_id: Adicionar como membro do conjunto administrativo
         based_near: Localização
-        collection_ids: Adicionar como membro da coleção
         creator: O Criador
         date_created: Data Criada
         description: Resumo ou Resumo
@@ -838,6 +837,7 @@ pt-BR:
         keyword: Palavra-chave
         lease_expiration_date: até
         license: Licença
+        member_of_collection_ids: Adicionar como membro da coleção
         related_url: URL associada
         title: Título
         visibility_after_embargo: Então abra-o até

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -832,7 +832,6 @@ zh:
       defaults:
         admin_set_id: 添加管理集成员
         based_near: 地点
-        collection_ids: 添加收藏集成员
         creator: 创建者
         date_created: 创建日期
         description: 摘要
@@ -841,6 +840,7 @@ zh:
         keyword: 关键词
         lease_expiration_date: until
         license: 许可
+        member_of_collection_ids: 添加收藏集成员
         related_url: 相关链接
         title: 标题
         visibility_after_embargo: 开放

--- a/spec/controllers/hyrax/my/works_controller_spec.rb
+++ b/spec/controllers/hyrax/my/works_controller_spec.rb
@@ -1,4 +1,3 @@
-
 RSpec.describe Hyrax::My::WorksController, type: :controller do
   let(:user) { create(:user) }
 
@@ -37,10 +36,10 @@ RSpec.describe Hyrax::My::WorksController, type: :controller do
     it { is_expected.to be_an_instance_of Hyrax::CollectionsService }
   end
 
-  context "when add_files_to_collection is provided" do
-    it "sets add_files_to_collection ivar" do
-      get :index, params: { add_files_to_collection: '12345' }
-      expect(assigns(:add_files_to_collection)).to eql('12345')
+  context "when add_works_to_collection is provided" do
+    it "sets add_works_to_collection ivar" do
+      get :index, params: { add_works_to_collection: '12345' }
+      expect(assigns(:add_works_to_collection)).to eql('12345')
     end
   end
 

--- a/spec/forms/hyrax/forms/batch_edit_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_edit_form_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe Hyrax::Forms::BatchEditForm do
                          { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
                          :on_behalf_of,
                          :version,
+                         :add_works_to_collection,
                          :visibility_during_embargo,
                          :embargo_release_date,
                          :visibility_after_embargo,

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe Hyrax::Forms::WorkForm do
     it { is_expected.to eq(title => file_id) }
   end
 
+  describe '#member_of_collections' do
+    subject { form.member_of_collections(args) }
+
+    context 'when passed nil' do
+      let(:args) { nil }
+
+      it { is_expected.to be_empty }
+    end
+    context 'when passed a string' do
+      let(:args) { 'foobar' }
+
+      it { is_expected.to match_array([args]) }
+    end
+  end
+
   describe "#[]" do
     it 'has one element' do
       expect(form['description']).to eq ['']
@@ -52,7 +67,10 @@ RSpec.describe Hyrax::Forms::WorkForm do
 
     context "without mediated deposit" do
       it {
-        is_expected.to include({ permissions_attributes: [:type, :name, :access, :id, :_destroy] },
+        is_expected.to include(:add_works_to_collection,
+                               :version,
+                               :on_behalf_of,
+                               { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
                                work_members_attributes: [:id, :_destroy],
                                based_near_attributes: [:id, :_destroy])
       }

--- a/spec/presenters/hyrax/select_type_presenter_spec.rb
+++ b/spec/presenters/hyrax/select_type_presenter_spec.rb
@@ -19,4 +19,44 @@ RSpec.describe Hyrax::SelectTypePresenter do
 
     it { is_expected.to eq 'Generic Work' }
   end
+
+  describe '#switch_to_new_work_path' do
+    subject { instance.switch_to_new_work_path(route_set: routes, params: params) }
+
+    let(:collection_id) { 'xyz123abc' }
+    let(:routes) do
+      Rails.application.routes.url_helpers.extend(ActionDispatch::Routing::PolymorphicRoutes)
+    end
+
+    context 'with add_works_to_collection param' do
+      let(:params) { { add_works_to_collection: collection_id } }
+
+      it { is_expected.to eq "/concern/#{model.to_s.tableize}/new?add_works_to_collection=#{collection_id}" }
+    end
+
+    context 'with no params' do
+      let(:params) { {} }
+
+      it { is_expected.to eq "/concern/#{model.to_s.tableize}/new" }
+    end
+  end
+
+  describe '#switch_to_batch_upload_path' do
+    subject { instance.switch_to_batch_upload_path(route_set: routes, params: params) }
+
+    let(:collection_id) { 'xyz123abc' }
+    let(:routes) { Hyrax::Engine.routes.url_helpers }
+
+    context 'with add_works_to_collection param' do
+      let(:params) { { add_works_to_collection: collection_id } }
+
+      it { is_expected.to eq "/batch_uploads/new?add_works_to_collection=#{collection_id}&payload_concern=#{model}" }
+    end
+
+    context 'with no params' do
+      let(:params) { {} }
+
+      it { is_expected.to eq "/batch_uploads/new?payload_concern=#{model}" }
+    end
+  end
 end

--- a/spec/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'hyrax/dashboard/collections/_form_for_select_collection.html.erb
   end
 
   it "selects the right collection when instructed to do so" do
-    assign(:add_files_to_collection, collections[2][:id])
+    assign(:add_works_to_collection, collections[2][:id])
     render
     expect(rendered).not_to have_selector "#id_#{collections[0][:id]}[checked='checked']"
     expect(rendered).not_to have_selector "#id_#{collections[1][:id]}[checked='checked']"

--- a/spec/views/shared/select_work_type_modal.html.erb_spec.rb
+++ b/spec/views/shared/select_work_type_modal.html.erb_spec.rb
@@ -1,24 +1,17 @@
 RSpec.describe 'shared/_select_work_type_modal.html.erb', type: :view do
   let(:presenter) { instance_double Hyrax::SelectTypeListPresenter }
   let(:row1) do
-    instance_double(Hyrax::SelectTypePresenter,
-                    icon_class: 'icon',
-                    name: 'Generic Work',
-                    description: 'Workhorse',
-                    concern: GenericWork)
+    Hyrax::SelectTypePresenter.new(GenericWork)
   end
   let(:row2) do
-    instance_double(Hyrax::SelectTypePresenter,
-                    icon_class: 'icon',
-                    name: 'Atlas',
-                    description: 'Atlas of places',
-                    concern: RareBooks::Atlas)
+    Hyrax::SelectTypePresenter.new(RareBooks::Atlas)
   end
-  let(:results) { [GenericWork, RareBooks::Atlas] }
 
   before do
     allow(presenter).to receive(:each).and_yield(row1).and_yield(row2)
     allow(view).to receive(:create_work_presenter).and_return(presenter)
+    # Because there is no i18n set up for this work type
+    allow(row2).to receive(:name).and_return('Atlas')
     render
   end
 


### PR DESCRIPTION
Fixes samvera-labs/hyku#1374

Users should be able to browse to a collection they created, click "Add Works," and create a new work that belongs to the collection. The current implementation uses a param `add_files_to_collection` (renamed to `add_works_to_collection` in this PR) that is passed to the `/dashboard/my/works` view but is lost when the select work type modal pops up and submits, creating the new work form.

The work on this PR passes on the `add_works_to_collection` param value to the "my" controller. To accomplish this, it adds a new method to the work form that selects one or more collections (based on the IDs passed in params) automatically in the Relationships tab of the rendered form. (Note that this does allow arbitrary collection IDs to be passed in, but the `CollectionOptionsPresenter` ensures the user only sees collections to which they have edit access so this should not introduce security or authorization issues.)

The implementation in this PR is working for both single works and batches of works.

@samvera/hyrax-code-reviewers
