### PR TITLE
Updating CollectionType attributes

### DIFF
--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -1,5 +1,20 @@
 module Hyrax
   class CollectionType < ActiveRecord::Base
     self.table_name = 'hyrax_collection_types'
+
+    # These are provided as a convenience method based on prior design discussions.
+    # The deprecations are added to allow upstream developers to continue with what
+    # they had already been doing. These can be removed as part of merging
+    # the collections-sprint branch into master (or before hand if coordinated)
+    alias_attribute :discovery, :discoverable
+    deprecation_deprecate discovery: "prefer #discoverable instead"
+    alias_attribute :sharing, :sharable
+    deprecation_deprecate sharing: "prefer #sharable instead"
+    alias_attribute :multiple_membership, :allow_multiple_membership
+    deprecation_deprecate multiple_membership: "prefer #allow_multiple_membership instead"
+    alias_attribute :workflow, :assigns_workflow
+    deprecation_deprecate workflow: "prefer #assigns_workflow instead"
+    alias_attribute :visibility, :assigns_visibility
+    deprecation_deprecate visibility: "prefer #assigns_visibility instead"
   end
 end

--- a/db/migrate/20170808160432_update_collection_type_column_names.rb
+++ b/db/migrate/20170808160432_update_collection_type_column_names.rb
@@ -1,0 +1,9 @@
+class UpdateCollectionTypeColumnNames < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :hyrax_collection_types, :discovery, :discoverable
+    rename_column :hyrax_collection_types, :sharing, :sharable
+    rename_column :hyrax_collection_types, :multiple_membership, :allow_multiple_membership
+    rename_column :hyrax_collection_types, :workflow, :assigns_workflow
+    rename_column :hyrax_collection_types, :visibility, :assigns_visibility
+  end
+end

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   it "has configuration properties with defaults" do
-    expect(collection_type.nestable).to be_truthy
-    expect(collection_type.discovery).to be_truthy
-    expect(collection_type.sharing).to be_truthy
-    expect(collection_type.multiple_membership).to be_truthy
-    expect(collection_type.require_membership).to be_falsey
-    expect(collection_type.workflow).to be_falsey
-    expect(collection_type.visibility).to be_falsey
+    expect(collection_type.nestable?).to be_truthy
+    expect(collection_type.discoverable?).to be_truthy
+    expect(collection_type.sharable?).to be_truthy
+    expect(collection_type.allow_multiple_membership?).to be_truthy
+    expect(collection_type.require_membership?).to be_falsey
+    expect(collection_type.assigns_workflow?).to be_falsey
+    expect(collection_type.assigns_visibility?).to be_falsey
   end
 end


### PR DESCRIPTION
These changes brings the column names inline with the helper methods
that were articulated in the associated Github issue. For short-term
backwards compatibility, I'm including alias_attributes so other
developers in the sprint will have an easier migration path.

Closes #1452
