### PR TITLE
Reworking view specs to be faster

### DIFF
--- a/spec/views/hyrax/admin/admin_sets/_show_document_list.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_show_document_list.html.erb_spec.rb
@@ -1,27 +1,13 @@
 
 RSpec.describe 'hyrax/admin/admin_sets/_show_document_list.html.erb', type: :view do
-  let(:user) { create(:user, groups: 'admin') }
-
-  let(:work) do
-    GenericWork.create(creator: ["ggm"], title: ['One Hundred Years of Solitude']) do |gw|
-      gw.apply_depositor_metadata(user)
-    end
-  end
-
-  let(:documents) { [work] }
+  let(:documents) { ["Hello", "World"] }
 
   before do
-    view.blacklight_config = Blacklight::Configuration.new
-    allow(view).to receive(:current_user).and_return(user)
-    allow(work).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
-    allow(work).to receive(:edit_groups).and_return([user])
-    allow(work).to receive(:edit_people).and_return([user])
-    allow(work).to receive(:workflow_state).and_return('deposited')
-    stub_template '_show_document_list_menu.erb' => ''
+    stub_template('hyrax/admin/admin_sets/_show_document_list_row.html.erb' => "<%= show_document_list_row %>")
   end
 
   it "renders rows of works" do
     render('hyrax/admin/admin_sets/show_document_list.html.erb', documents: documents)
-    expect(rendered).to have_content 'One Hundred Years of Solitude'
+    expect(rendered).to have_css('tbody', text: documents.join)
   end
 end

--- a/spec/views/hyrax/base/show.json.jbuilder_spec.rb
+++ b/spec/views/hyrax/base/show.json.jbuilder_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'hyrax/base/show.json.jbuilder' do
-  let(:curation_concern) { create(:generic_work) }
+  let(:curation_concern) { build(:generic_work) }
 
   before do
     allow(curation_concern).to receive(:etag).and_return('W/"87f79d2244ded4239ad1f0e822c8429b1e72b66c"')

--- a/spec/views/hyrax/collections/_show_document_list.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_document_list.html.erb_spec.rb
@@ -1,28 +1,25 @@
 
 RSpec.describe 'hyrax/collections/_show_document_list.html.erb', type: :view do
-  let(:user) { create(:user) }
-  let(:collection) { mock_model(Collection) }
+  let(:documents) { ["Hello", "World"] }
 
-  let(:file) do
-    FileSet.create(creator: ["ggm"], title: ['One Hundred Years of Solitude']) do |fs|
-      fs.apply_depositor_metadata(user)
+  before do
+    stub_template('hyrax/collections/_show_document_list_row.html.erb' => "<%= document %>")
+  end
+  context 'when not logged in' do
+    it "renders the documents without an Action section" do
+      allow(view).to receive(:current_user).and_return(nil)
+      render('hyrax/collections/show_document_list.html.erb', documents: documents)
+      expect(rendered).to have_css('tbody', text: documents.join)
+      expect(rendered).not_to have_css('th', text: 'Action')
     end
   end
 
-  let(:documents) { [file] }
-
-  context 'when not logged in' do
-    before do
-      view.blacklight_config = Blacklight::Configuration.new
-      allow(view).to receive(:current_user).and_return(nil)
-      allow(file).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
-      allow(file).to receive(:edit_people).and_return([])
-    end
-
-    it "renders collection" do
+  context 'when logged in' do
+    it "renders the documents with an Action section" do
+      allow(view).to receive(:current_user).and_return(true)
       render('hyrax/collections/show_document_list.html.erb', documents: documents)
-      expect(rendered).to have_content 'One Hundred Years of Solitude'
-      expect(rendered).not_to have_content 'Action'
+      expect(rendered).to have_css('tbody', text: documents.join)
+      expect(rendered).to have_css('th', text: 'Action')
     end
   end
 end


### PR DESCRIPTION
Do you want specs to run 10 seconds or so faster each time? I bet Travis will appreciate a few less cycles.

## Reworking view specs to not test called partials

@be56884d79888071793ed58b1704cfcc2cae7b7a

The spec was testing the implementation details of the subsequently
called (and tested) partial.

See `./spec/views/hyrax/collections/_show_document_list_row.html.erb_spec.rb`
for details of the spec.

With this change the individual tests go from:

* Before - Finished in 3.02 seconds (files took 6.82 seconds to load)
* After - Finished in 0.41196 seconds (files took 6.5 seconds to load)

Dropping 15 LDP requests

## Reworking view specs to not test called partials

@c036eb078dfae843942c13ac1b10d08ca8b759d0

The spec was testing the implementation details of the subsequently
called (and tested) partial.

See `./spec/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb.erb_spec.rb`
for details of the spec.

With this change the individual tests go from:

* Before - Finished in 3.16 seconds (files took 6.85 seconds to load)
* After - Finished in 0.38931 seconds (files took 6.41 seconds to load)

Dropping 15 LDP requests

## Switching from create to build :generic_work

@aa8267ce1b160beab1b6041b74fc522922e3d86f

Before this change there are 15 LDP hits. After the change there are 3.
The single goes from 2.61 second to 0.7597.

## Reworking view specs to not test called partials

@7e955218e0a2e4757993632f90ed3ea53701ee8c

The spec was testing the implementation details of the subsequently
called (and tested) partial.

See `./spec/views/hyrax/base/_member.html.erb.erb_spec.rb`
for details of the spec.

With this change the individual tests go from:

* Before - Finished in 3.1 seconds (files took 6.73 seconds to load)
* After - Finished in 0.49883 seconds (files took 7.04 seconds to load)

Dropping 13 LDP requests
