### PR TITLE
Adding ability to profile slow specs

### DIFF
--- a/spec/support/logging_formatter.rb
+++ b/spec/support/logging_formatter.rb
@@ -34,14 +34,31 @@ class LoggingFormatter < RSpec::Core::Formatters::ProgressFormatter
                                'PATCH' => 0 }
   end
 
-  def dump_profile(_prof)
-    output.puts "Examples with the most LDP requests"
-    top = @profile.sort_by { |hash| hash[:count] }.last(10)
-    top.each do |hash|
-      result = hash[:count_by_name].select { |_, v| v > 0 }
-      next if result.empty?
-      output.puts "  #{hash[:description]}"
-      output.puts "    Total LDP: #{hash[:count]} #{result}"
-    end
+  def dump_profile(profile)
+    dump_most_ldp_exampes(profile)
+    output.puts ""
+    dump_slowest_examples(profile)
   end
+
+  private
+
+    def dump_most_ldp_exampes(_prof)
+      output.puts "Examples with the most LDP requests"
+      top = @profile.sort_by { |hash| hash[:count] }.last(10)
+      top.each do |hash|
+        result = hash[:count_by_name].select { |_, v| v > 0 }
+        next if result.empty?
+        output.puts "  #{hash[:description]}"
+        output.puts "    Total LDP: #{hash[:count]} #{result}"
+      end
+    end
+
+    def dump_slowest_examples(profile)
+      output.puts "Slowest examples"
+      profile.slowest_examples.each do |slowest_example|
+        output.puts "  #{slowest_example.full_description}"
+        output.puts "    #{slowest_example.location}"
+        output.puts "    #{slowest_example.execution_result.run_time} seconds"
+      end
+    end
 end


### PR DESCRIPTION
LDP connections are not the only things that we may want to profile.
Add profiling for the slowest specs as well.

With the changes to the default profiler, we've lost the ability to see the slowest specs. This has been restored.