### PR TITLE
Match collection edit header with fa-edit icon

### DIFF
--- a/app/views/hyrax/base/edit.html.erb
+++ b/app/views/hyrax/base/edit.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, curation_concern_page_title(curation_concern) %>
 <% provide :page_header do %>
-  <h1><%= t("hyrax.works.update.header") %></h1>
+  <h1><span class="fa fa-edit"></span><%= t("hyrax.works.update.header") %></h1>
 <% end %>
 
 <%= render 'form' %>

--- a/spec/views/hyrax/base/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/base/edit.html.erb_spec.rb
@@ -21,6 +21,6 @@ RSpec.describe 'hyrax/base/edit.html.erb', type: :view do
     expect(view).to receive(:provide).with(:page_title, 'A nice work // Generic Work [456] // Hyrax')
     expect(view).to receive(:provide).with(:page_header).and_yield
     render
-    expect(rendered).to eq "  <h1>Edit Work</h1>\n\na form\n"
+    expect(rendered).to eq "  <h1><span class=\"fa fa-edit\"></span>Edit Work</h1>\n\na form\n"
   end
 end


### PR DESCRIPTION
Now looks like:
![screen shot 2017-08-09 at 3 17 00 pm](https://user-images.githubusercontent.com/109954/29146416-db0a5d50-7d15-11e7-9c6d-58c213ce8589.png)
