### PR TITLE
Send workflow notifications only to roles associated with specific workflow

### DIFF
--- a/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
+++ b/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
@@ -6,7 +6,7 @@ module Hyrax
       def destroy
         ActiveRecord::Base.transaction do
           @permission_template_access.destroy
-          update_management if @permission_template_access.manage?
+          remove_access!
         end
 
         if @permission_template_access.destroyed?
@@ -28,8 +28,9 @@ module Hyrax
           @admin_set_id ||= @permission_template_access.permission_template.admin_set_id
         end
 
-        def update_management
-          Forms::PermissionTemplateForm.new(@permission_template_access.permission_template).update_management
+        def remove_access!
+          Forms::PermissionTemplateForm.new(@permission_template_access.permission_template)
+                                       .remove_access!(@permission_template_access)
         end
     end
   end

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -20,6 +20,9 @@ module Hyrax
       # Stores the selected
       attr_writer :workflow_id
 
+      # Adding attributes hash to state to avoid having to pass it around
+      attr_accessor :attributes
+
       def workflow_id
         @workflow_id || active_workflow.try(:id)
       end
@@ -41,54 +44,114 @@ module Hyrax
       # @return [Hash{Symbol => String, Boolean}] { :content_tab (for confirmation message),
       #                                             :updated (true/false),
       #                                               :error_code (for flash error lookup) }
+      # rubocop:disable Metrics/MethodLength
       def update(attributes)
-        return_info = { content_tab: tab_to_update(attributes) }
+        @attributes = attributes
+        return_info = { content_tab: tab_to_update }
         error_code = nil
         case return_info[:content_tab]
         when "participants"
-          update_participants_options(attributes)
+          update_participants_options
         when "visibility"
-          error_code = update_visibility_options(attributes)
+          error_code = update_visibility_options
         when "workflow"
-          grant_workflow_roles(attributes)
+          grant_workflow_roles
         end
         return_info[:error_code] = error_code if error_code
         return_info[:updated] = error_code ? false : true
         return_info
       end
+      # rubocop:enable Metrics/MethodLength
 
-      # If management roles have been granted or removed, then copy this access
-      # to the edit permissions of the AdminSet and to the WorkflowResponsibilities
-      # of the active workflow
       def update_management
         admin_set.update_access_controls!
-        update_workflow_approving_responsibilities
+        update_workflow_responsibilities
+      end
+
+      # This method is used to revoke access to an Admin Set and its workflows
+      #
+      # @return [Void]
+      def remove_access!(permission_template_access)
+        construct_attributes_from_template_access!(permission_template_access)
+        admin_set.update_access_controls!
+        update_workflow_responsibilities(remove_agent: true)
       end
 
       private
 
         # @return [String]
-        def tab_to_update(attributes)
+        def tab_to_update
           return "participants" if attributes[:access_grants_attributes].present?
           return "workflow" if attributes[:workflow_id].present?
           return "visibility" if attributes.key?(:visibility)
         end
 
+        # This method is used to build the attributes that this class
+        # relies on using the passed-in PermissionTemplateAccess
+        # instance. This allows the class to use the same methods for
+        # granting access (when a new Admin Set manager is added, for
+        # instance), when called via #update, for revoking access as
+        # well when called via #remove_access!
+        #
         # @return [Void]
-        def update_participants_options(attributes)
-          update_permission_template(attributes)
-          # if managers were added, recalculate update the access controls on the AdminSet
-          return unless managers_updated?(attributes)
-          update_management
+        def construct_attributes_from_template_access!(permission_template_access)
+          @attributes = {
+            access_grants_attributes: {
+              "0" => {
+                access: permission_template_access.access,
+                agent_type: permission_template_access.agent_type,
+                agent_id: permission_template_access.agent_id
+              }
+            }
+          }
         end
 
-        # Grant workflow approve roles for any admin set managers
-        # and revoke the approving role for non-managers
-        def update_workflow_approving_responsibilities
-          return unless active_workflow
-          approving_role = Sipity::Role.find_by_name('approving')
-          return unless approving_role
-          active_workflow.update_responsibilities(role: approving_role, agents: manager_agents)
+        # @return [Void]
+        def update_participants_options
+          update_permission_template
+          update_workflow_responsibilities
+          # if managers were added or removed, recalculate update the access controls on the AdminSet
+          admin_set.update_access_controls! if managers_updated?
+        end
+
+        # Grant appropriate workflow roles based on access specified
+        def update_workflow_responsibilities(remove_agent: false)
+          return unless available_workflows
+          roles = roles_for_agent
+          return if roles.none?
+          agents = remove_agent ? manager_agents - agents_from_attributes : manager_agents + agents_from_attributes
+          available_workflows.each do |workflow|
+            roles.each do |role|
+              workflow.update_responsibilities(role: role, agents: agents)
+            end
+          end
+        end
+
+        def roles_for_agent
+          roles = []
+          grants_as_collection.each do |grant|
+            case grant[:access]
+            when Hyrax::PermissionTemplateAccess::DEPOSIT
+              roles << Sipity::Role.find_by(name: Hyrax::RoleRegistry::DEPOSITING)
+            when Hyrax::PermissionTemplateAccess::MANAGE
+              roles += Sipity::Role.where(name: Hyrax::RoleRegistry.new.role_names)
+              # TODO: Figure out what to do here
+              # when Hyrax::PermissionTemplateAccess::VIEW
+            end
+          end
+          roles.uniq
+        end
+
+        # @return [Array<Sipity::Agent>] a list sipity agents extracted from attrs
+        def agents_from_attributes
+          grants_as_collection.map do |grant|
+            agent = if grant[:agent_type] == 'user'
+                      ::User.find_by_user_key(grant[:agent_id])
+                    else
+                      Hyrax::Group.new(grant[:agent_id])
+                    end
+            PowerConverter.convert_to_sipity_agent(agent)
+          end
         end
 
         # @return [Array<Sipity::Agent>] a list of sipity agents corresponding to the manager role of the permission_template
@@ -107,17 +170,17 @@ module Hyrax
 
         # @return [Array<PermissionTemplateAccess>] a list of grants corresponding to the manager role of the permission_template
         def manager_grants
-          model.access_grants.where(access: 'manage'.freeze)
+          model.access_grants.where(access: Hyrax::PermissionTemplateAccess::MANAGE)
         end
 
         # @return [String, Nil] error_code if validation fails, nil otherwise
-        def update_visibility_options(attributes)
-          error_code = validate_visibility_combinations(attributes)
+        def update_visibility_options
+          error_code = validate_visibility_combinations
           return error_code if error_code
-          update_permission_template(attributes)
+          update_permission_template
         end
 
-        def activate_workflow_from(attributes)
+        def activate_workflow_from_attributes
           new_active_workflow_id = attributes[:workflow_id] || attributes['workflow_id']
           if active_workflow
             return active_workflow if new_active_workflow_id.to_s == active_workflow.id.to_s
@@ -131,28 +194,29 @@ module Hyrax
         # have all the roles for the new workflow
         # @return [Void]
         # @todo Instead of granting the manage users all of the roles (which means lots of emails), can we agree on a Managing role that all workflows should have?
-        def grant_workflow_roles(attributes)
-          new_active_workflow = activate_workflow_from(attributes)
+        def grant_workflow_roles
+          new_active_workflow = activate_workflow_from_attributes
           return unless new_active_workflow
           manager_agents.each do |agent|
-            active_workflow.workflow_roles.each do |role|
-              Sipity::WorkflowResponsibility.find_or_create_by!(workflow_role: role, agent: agent)
+            active_workflow.workflow_roles.each do |workflow_role|
+              new_workflow_role = Sipity::WorkflowRole.find_or_create_by!(workflow: new_active_workflow, role: workflow_role.role)
+              Sipity::WorkflowResponsibility.find_or_create_by!(workflow_role: new_workflow_role, agent: agent)
             end
           end
         end
 
         # @return [Nil]
-        def update_permission_template(attributes)
-          model.update(permission_template_update_params(attributes))
+        def update_permission_template
+          model.update(permission_template_update_params)
           nil
         end
 
-        def managers_updated?(attributes)
-          grants_as_collection(attributes).any? { |x| x[:access] == 'manage' }
+        def managers_updated?
+          grants_as_collection.any? { |x| x[:access] == Hyrax::PermissionTemplateAccess::MANAGE }
         end
 
         # This allows the attributes
-        def grants_as_collection(attributes)
+        def grants_as_collection
           return [] unless attributes[:access_grants_attributes]
           attributes_collection = attributes[:access_grants_attributes]
           if attributes_collection.respond_to?(:permitted?)
@@ -188,36 +252,36 @@ module Hyrax
         # @return [Hash] attributes used to update the model
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity
-        def permission_template_update_params(raw_attributes)
-          attributes = raw_attributes.except(:release_varies, :release_embargo)
+        def permission_template_update_params
+          filtered_attributes = attributes.except(:release_varies, :release_embargo)
           # If 'varies' before date option selected, then set release_period='before' and save release_date as-is
-          if raw_attributes[:release_varies] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE
-            attributes[:release_period] = Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE
+          if attributes[:release_varies] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE
+            filtered_attributes[:release_period] = Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE
           # Else if 'varies' + embargo selected, save embargo as the release_period
-          elsif raw_attributes[:release_varies] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_EMBARGO &&
-                raw_attributes[:release_embargo]
-            attributes[:release_period] = raw_attributes[:release_embargo]
+          elsif attributes[:release_varies] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_EMBARGO &&
+                attributes[:release_embargo]
+            filtered_attributes[:release_period] = attributes[:release_embargo]
             # In an embargo, the release_date should be unspecified as it is based on deposit date
-            attributes[:release_date] = nil
+            filtered_attributes[:release_date] = nil
           end
 
-          if attributes[:release_period] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY || (attributes[:release_period].blank? && raw_attributes[:release_varies].blank?)
+          if filtered_attributes[:release_period] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY || (filtered_attributes[:release_period].blank? && attributes[:release_varies].blank?)
             # If release is "no delay" or is "varies" and "allow depositor to decide",
             # then a release_date should never be allowed/specified
-            attributes[:release_date] = nil
+            filtered_attributes[:release_date] = nil
           end
 
-          attributes
+          filtered_attributes
         end
         # rubocop:enable Metrics/CyclomaticComplexity
         # rubocop:enable Metrics/PerceivedComplexity
 
         # validate the hash of attributes used to update the visibility tab of the model
-        # @param [Hash] attributes
         # @return [String, Nil] the error code if invalid, nil if valid
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity
-        def validate_visibility_combinations(attributes)
+        # rubocop:disable Metrics/AbcSize
+        def validate_visibility_combinations
           return unless attributes.key?(:visibility) # only the visibility tab has validations
 
           # if "save" without any selections - none of the attributes are present
@@ -234,6 +298,7 @@ module Hyrax
         end
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/app/services/hyrax/workflow/abstract_notification.rb
+++ b/app/services/hyrax/workflow/abstract_notification.rb
@@ -41,7 +41,8 @@ module Hyrax
         @work_id = entity.proxy_for_global_id.sub(/.*\//, '')
         @title = entity.proxy_for.title.first
         @comment = comment.respond_to?(:comment) ? comment.comment.to_s : ''
-        @recipients = recipients
+        # Convert to hash with indifferent access to allow both string and symbol keys
+        @recipients = recipients.with_indifferent_access
         @user = user
         @entity = entity
       end
@@ -73,7 +74,7 @@ module Hyrax
         end
 
         def users_to_notify
-          recipients.fetch('to', []) + recipients.fetch('cc', [])
+          recipients.fetch(:to, []) + recipients.fetch(:cc, [])
         end
     end
   end

--- a/app/services/hyrax/workflow/notification_service.rb
+++ b/app/services/hyrax/workflow/notification_service.rb
@@ -48,18 +48,9 @@ module Hyrax
       # @return [Hash<String, Array>] a hash with keys being the strategy (e.g. "to", "cc") and
       #                               the values are a list of users.
       def recipients(notification)
-        case entity.workflow_state.name
-        when 'pending_review'
-          # notify the managers to review the deposit (CC depositors)
-          {
-            to: entity.workflow.permission_template.agent_ids_for(access: 'manage',  agent_type: 'user'),
-            cc: entity.workflow.permission_template.agent_ids_for(access: 'deposit', agent_type: 'user')
-          }
-        else
-          notification.recipients.each_with_object({}) do |r, h|
-            h[r.recipient_strategy] ||= []
-            h[r.recipient_strategy] += PermissionQuery.scope_users_for_entity_and_roles(entity: entity, roles: r.role)
-          end
+        notification.recipients.each_with_object({}) do |r, h|
+          h[r.recipient_strategy] ||= []
+          h[r.recipient_strategy] += PermissionQuery.scope_users_for_entity_and_roles(entity: entity, roles: r.role)
         end
       end
 

--- a/app/services/hyrax/workflow/permission_query.rb
+++ b/app/services/hyrax/workflow/permission_query.rb
@@ -231,8 +231,8 @@ module Hyrax
       #
       # An ActiveRecord::Relation scope that meets the following criteria:
       #
-      # * Users that are directly associated with the given entity through on or
-      #   more of the given roles
+      # * Users that are directly associated with the given entity through one or
+      #   more of the given roles within the entity's workflow
       # * Users that are indirectly associated with the given entity by group
       #   and role.
       #
@@ -248,7 +248,7 @@ module Hyrax
         agent_table = Sipity::Agent.arel_table
 
         workflow_role_id_subquery = workflow_roles.project(workflow_roles[:id]).where(
-          workflow_roles[:role_id].in(role_ids)
+          workflow_roles[:workflow_id].eq(entity.workflow_id).and(workflow_roles[:role_id].in(role_ids))
         )
 
         workflow_agent_id_subquery = workflow_responsibilities.project(workflow_responsibilities[:agent_id]).where(

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -17,6 +17,111 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     expect(form.workflow_id).to eq(workflow.id)
   end
 
+  describe 'integration tests' do
+    let(:permission_template) { create(:permission_template, with_admin_set: true, with_workflows: true) }
+
+    subject do
+      form.update(
+        ActionController::Parameters.new(
+          access_grants_attributes: [
+            ActionController::Parameters.new(agent_type: "user",
+                                             agent_id: user.user_key,
+                                             access: access_level).permit!
+          ]
+        ).permit!
+      )
+    end
+
+    before do
+      # Create MANAGING role manually
+      Sipity::Role[Hyrax::RoleRegistry::MANAGING]
+    end
+
+    def count_template_accesses_for(user, access_level)
+      Hyrax::PermissionTemplateAccess.where(
+        agent_id: user.user_key,
+        access: access_level
+      ).count
+    end
+
+    def count_workflow_responsibilities_for(user)
+      Sipity::WorkflowResponsibility.where(agent: user.to_sipity_agent).count
+    end
+
+    it 'starts with no PTAs' do
+      expect(permission_template.access_grants).to be_empty
+    end
+
+    context 'with manager users' do
+      let(:user) { create(:user) }
+      let(:access_level) { 'manage' }
+
+      it 'adds the expected permission template accesses and workflow responsibilities' do
+        expect { subject }.to change {
+          count_template_accesses_for(user, access_level)
+        }.from(0).to(1).and change {
+          count_workflow_responsibilities_for(user)
+        }.from(0).to(6)
+      end
+
+      it 'removes workflow responsibilities' do
+        subject
+        expect do
+          form.remove_access!(
+            permission_template.access_grants.find_by(agent_id: user.user_key, access: access_level)
+          )
+        end.to change { count_workflow_responsibilities_for(user) }
+          .from(6).to(0)
+      end
+    end
+
+    context 'with depositor users' do
+      let(:user) { create(:user) }
+      let(:access_level) { 'deposit' }
+
+      it 'adds the expected permission template accesses and workflow responsibilities' do
+        expect { subject }.to change {
+          count_template_accesses_for(user, access_level)
+        }.from(0).to(1).and change {
+          count_workflow_responsibilities_for(user)
+        }.from(0).to(2)
+      end
+
+      it 'removes workflow responsibilities' do
+        subject
+        expect do
+          form.remove_access!(
+            permission_template.access_grants.find_by(agent_id: user.user_key, access: access_level)
+          )
+        end.to change { count_workflow_responsibilities_for(user) }
+          .from(2).to(0)
+      end
+    end
+
+    context 'with viewer users' do
+      let(:user) { create(:user) }
+      let(:access_level) { 'view' }
+
+      it 'adds the expected permission template accesses and workflow responsibilities' do
+        expect { subject }.to change {
+          count_template_accesses_for(user, access_level)
+        }.from(0).to(1).and change {
+          count_workflow_responsibilities_for(user)
+        }.by(0)
+      end
+
+      it 'does nothing (yet)' do
+        subject
+        expect do
+          form.remove_access!(
+            permission_template.access_grants.find_by(agent_id: user.user_key, access: access_level)
+          )
+        end.to change { count_workflow_responsibilities_for(user) }
+          .by(0)
+      end
+    end
+  end
+
   describe "#update" do
     subject { form.update(input_params) }
 
@@ -234,7 +339,10 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
   end
 
   describe "#grant_workflow_roles" do
-    subject { form.send(:grant_workflow_roles, attributes) }
+    subject do
+      form.attributes = attributes
+      form.send(:grant_workflow_roles)
+    end
 
     let(:attributes) { { workflow_id: workflow.id } }
     let(:workflow) { create(:workflow, permission_template: permission_template, active: true) }
@@ -428,7 +536,10 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
   describe "#permission_template_update_params" do
     let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
 
-    subject { form.send(:permission_template_update_params, input_params) }
+    subject do
+      form.attributes = input_params
+      form.send(:permission_template_update_params)
+    end
 
     context "with release varies by date selected" do
       let(:input_params) do

--- a/spec/services/hyrax/workflow/notification_service_spec.rb
+++ b/spec/services/hyrax/workflow/notification_service_spec.rb
@@ -23,44 +23,11 @@ RSpec.describe Hyrax::Workflow::NotificationService do
   let(:action) { Sipity::WorkflowAction.new(notifiable_contexts: [notifiable_context]) }
   let(:entity) { Sipity::Entity.new }
   let(:user) { User.new }
-
-  let(:workflow) { Sipity::Workflow.new }
-  let(:workflow_state) { Sipity::WorkflowState.new }
-  let(:permission_template) { Hyrax::PermissionTemplate.new }
-
   let(:instance) do
     described_class.new(entity: entity,
                         action: action,
                         comment: "A pleasant read",
                         user: user)
-  end
-
-  describe '#recipients' do
-    context 'when an entity requires review' do
-      let(:creator) { [instance_double(User)] }
-      let(:managers) { [instance_double(User), instance_double(User)] }
-      let(:notification) { Sipity::Notification.new(name: 'pending review notification') }
-
-      before do
-        allow(instance).to receive(:send_notification) # mock it so it does nothing
-        allow(entity).to receive(:workflow_state).and_return(workflow_state)
-        allow(workflow_state).to receive(:name).and_return('pending_review')
-        allow(entity).to receive(:workflow).and_return(workflow)
-        # Mock the permission_template queries
-        allow(workflow).to receive(:permission_template).and_return(permission_template)
-        allow(permission_template).to receive(:agent_ids_for)
-          .with(access: 'manage', agent_type: 'user')
-          .and_return(managers)
-        allow(permission_template).to receive(:agent_ids_for)
-          .with(access: 'deposit', agent_type: 'user')
-          .and_return(creator)
-      end
-
-      it 'identifies the managers and depositor for notifications' do
-        recipients = instance.recipients(notification)
-        expect(recipients).to eq(to: managers, cc: creator)
-      end
-    end
   end
 
   describe "#call" do
@@ -81,8 +48,6 @@ RSpec.describe Hyrax::Workflow::NotificationService do
       let(:creator_rel) { double(ActiveRecord::Relation, to_ary: creator) }
 
       before do
-        allow(entity).to receive(:workflow_state).and_return(workflow_state)
-        allow(workflow_state).to receive(:name).and_return('not_pending_review')
         allow(Hyrax::Workflow::PermissionQuery).to receive(:scope_users_for_entity_and_roles)
           .with(entity: entity,
                 roles: advising)


### PR DESCRIPTION
Fixes #1455

This was super gnarly to untangle, partly because the root problem wasn't about notifications but about how workflow roles were being handled. We also had some prior work that brought us closer to a solution but that added new machinery instead of using the (substantial) Sipity machinery already in place, and this PR backs that work out. Here are the different components contained within this pull request.

* Admin Set Managers should be granted *all* registered roles on all available workflows for an Admin Set, not just the approving role on the active workflow
* Fix bug with `#grant_workflow_roles` that prevents creating a new corresponding workflow role when switching workflows
* Scope `PermissionQuery#scope_users_for_entity_and_roles` to the entity's workflow roles, not all roles (this method is only used in the context of this PR, so I'm not concerned about side effects)
* Disentangle `PermissionTemplateForm#update_management`, which was doing too much/being used in one more context than it needed to be
* Stop caring about hash keys in workflow notifications. (This has caused a small handful of workflow notification bugs over the past few months, and I don't think we need to care much about symbol vs. string keys since we can use indifferently accessed hashes).

This isn't perfect, but it leaves the code better than I found it and gets us closer to a more rational solution.

@samvera/hyrax-code-reviewers
