### PR TITLE
Clean up work visibility text and styling

### DIFF
--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -72,6 +72,10 @@ form {
     }
   }
 
+  #collapseLease .form-group {
+    padding: 0;
+  }
+
   #collapseEmbargo .form-group {
     padding: 0;
 

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -10,6 +10,7 @@
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' }  %>
             <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
+            <br>
             <%= t('hyrax.visibility.open.note_html', type: f.object.human_readable_type) %>
             <div class="collapse" id="collapsePublic">
               <%= t('hyrax.visibility.open.warning_html', label: visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)) %>
@@ -20,6 +21,7 @@
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
             <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) %>
+            <br>
             <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
           </label>
         </li>
@@ -27,6 +29,8 @@
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
             <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) %>
+            <br>
+            <%= t('hyrax.visibility.embargo.note_html') %>
             <div class="collapse" id="collapseEmbargo">
               <div class="form-inline">
                 <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
@@ -41,9 +45,12 @@
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
             <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE) %>
+            <br>
+            <%= t('hyrax.visibility.lease.note_html') %>
             <div class="collapse" id="collapseLease">
               <div class="form-inline">
                 <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+                <%= t('hyrax.works.form.visibility_until') %>
                 <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker form-control' %>
                 <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
               </div>
@@ -54,6 +61,7 @@
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
             <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
+            <br>
             <%= t('hyrax.visibility.restricted.note_html') %>
           </label>
         </li>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -736,14 +736,16 @@ en:
         unlinked: "Link with Zotero"
     visibility:
       authenticated:
-        note_html: "Restrict access to only users and/or groups from %{institution}"
+        note_html: "Restrict access to %{institution}."
         text: "%{institution}"
       embargo:
+        note_html: "Set date for future release."
         text: "Embargo"
       lease:
+        note_html: "Set date for future reduced access."
         text: "Lease"
       open:
-        note_html: Everyone. Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for specific publishers' copyright policies if you plan to patent and/or publish your %{type} in a journal.
+        note_html: "Make available to all."
         text: Public
         warning_html: "<p>
                         <strong>Please note</strong>, making something visible to the world (i.e.
@@ -760,7 +762,7 @@ en:
                       </p>"
       open_title_attr: "Change the visibility of this resource"
       restricted:
-        note_html: Only users and/or groups that have been given specific access in the "Share With" section.
+        note_html: "Keep to myself with option to share."
         text: "Private"
       restricted_title_attr: "Change the visibility of this resource"
     workflow:
@@ -849,7 +851,7 @@ en:
         visibility_after_embargo:  'then open it up to'
         visibility_after_lease:    'then restrict it to'
         visibility_during_embargo: 'Restricted to'
-        visibility_during_lease:   'Is available for'
+        visibility_during_lease:   'Is available to'
       proxy_deposit_request:
         transfer_to:              "User"
         sender_comment:           "Comments"

--- a/spec/features/lease_spec.rb
+++ b/spec/features/lease_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'leases' do
       fill_in 'Title', with: 'Lease test'
       choose 'Lease'
       fill_in 'generic_work_lease_expiration_date', with: future_date
-      select 'Public', from: 'Is available for'
+      select 'Public', from: 'Is available to'
       select 'Private', from: 'then restrict it to'
       click_button 'Save'
 


### PR DESCRIPTION
Fixes #1030 

This does not reduce the duplication and divergence of our various visibility selectors, but at least it makes the styling internally consistent for this one.

Note: no "read more" link, since the `note_html` contains all the additional information (not a separate page).  The end user can link to a separate page in their i18n `note_html`.