### PR TITLE
Removing a redundant spec that intermittently fails

### DIFF
--- a/spec/features/lease_spec.rb
+++ b/spec/features/lease_spec.rb
@@ -32,13 +32,4 @@ RSpec.feature 'leases' do
       expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard)) # new lease date is displayed in message
     end
   end
-
-  describe 'managing leases' do
-    let(:user) { create(:user, groups: ['admin']) }
-
-    it 'shows lists of objects under lease' do
-      visit '/leases'
-      expect(page).to have_content 'Manage Leases'
-    end
-  end
 end

--- a/spec/views/hyrax/leases/index.html.erb_spec.rb
+++ b/spec/views/hyrax/leases/index.html.erb_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe "hyrax/leases/index", type: :view do
+  before do
+    stub_template 'hyrax/leases/_list_deactivated_leases' => 'rendered list_deactivated_leases'
+    stub_template 'hyrax/leases/_list_expired_active_leases' => 'rendered list_expired_active_leases'
+    stub_template 'hyrax/leases/_list_active_leases' => 'rendered list_active_leases'
+  end
+
+  it "displays the page and renderes deactivated, expired, and active leases" do
+    render template: 'hyrax/leases/index'
+    expect(rendered).to have_css('.tab-pane#active', text: 'rendered list_active_leases')
+    expect(rendered).to have_css('.tab-pane#expired', text: 'rendered list_expired_active_leases')
+    expect(rendered).to have_css('.tab-pane#deactivated', text: 'rendered list_deactivated_leases')
+  end
+end


### PR DESCRIPTION
The removed feature spec is a duplicate of the following spec:

* https://github.com/samvera/hyrax/blob/bf78f7ed3d03864f22c1c26504862a915b016c08/spec/controllers/hyrax/leases_controller_spec.rb#L15-L22

Addresses the intermittent failing of the following build:

* https://travis-ci.org/samvera/hyrax/jobs/263066487

This does not address the underlying issue of related to a `nil`
visibility that could be passed to `Hyrax::PermissionBadge.new`

@samvera/hyrax-code-reviewers
