### PR TITLE
Partially Resolves #1341: Create controller for collection types

### DIFF
--- a/app/controllers/hyrax/admin/collection_types_controller.rb
+++ b/app/controllers/hyrax/admin/collection_types_controller.rb
@@ -8,6 +8,12 @@ module Hyrax
 
     def new; end
 
+    def create; end
+
     def edit; end
+
+    def update; end
+
+    def destroy; end
   end
 end

--- a/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
@@ -1,54 +1,146 @@
-RSpec.describe Hyrax::Admin::CollectionTypesController do
-  routes { Hyrax::Engine.routes }
-  let(:user) { create(:user) }
-
-  context "a non admin" do
+RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
+  context "anonymous user" do
     describe "#index" do
-      it 'is unauthorized' do
+      it "returns http redirect" do
         get :index
-        expect(response).to be_redirect
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    describe "#create" do
+      it "returns http redirect" do
+        post :create
+        expect(response).to have_http_status(:redirect)
       end
     end
 
     describe "#new" do
-      it 'is unauthorized' do
+      it "returns http redirect" do
         get :new
-        expect(response).to be_redirect
+        expect(response).to have_http_status(:redirect)
       end
     end
 
     describe "#edit" do
-      it 'is unauthorized' do
-        get :edit, params: { id: 1 }
-        expect(response).to be_redirect
+      it "returns http redirect" do
+        get :edit, params: { id: :id }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    describe "#update" do
+      it "returns http redirect" do
+        put :update, params: { id: :id }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    describe "#destroy" do
+      it "returns http redirect" do
+        delete :destroy, params: { id: :id }
+        expect(response).to have_http_status(:redirect)
       end
     end
   end
 
-  context "as an admin" do
+  context "unauthorized user" do
+    let(:user) { create(:user) }
+
     before do
+      allow(controller.current_ability).to receive(:can?).with(any_args).and_return(false)
       sign_in user
-      allow(controller).to receive(:authorize!).and_return(true)
     end
 
     describe "#index" do
-      it 'allows an authorized user' do
+      it "returns http redirect" do
         get :index
-        expect(response).to be_success
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    describe "#create" do
+      it "returns http redirect" do
+        post :create
+        expect(response).to have_http_status(:redirect)
       end
     end
 
     describe "#new" do
-      it 'allows an authorized user' do
+      it "returns http redirect" do
         get :new
-        expect(response).to be_success
+        expect(response).to have_http_status(:redirect)
       end
     end
 
     describe "#edit" do
-      it 'allows an authorized user' do
-        get :edit, params: { id: 1 }
-        expect(response).to be_success
+      it "returns http redirect" do
+        get :edit, params: { id: :id }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    describe "#update" do
+      it "returns http redirect" do
+        put :update, params: { id: :id }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    describe "#destroy" do
+      it "returns http redirect" do
+        delete :destroy, params: { id: :id }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+
+  context "authorized user" do
+    let(:user) { create(:user) }
+
+    before do
+      allow(controller.current_ability).to receive(:can?).with(any_args).and_return(true)
+      sign_in user
+    end
+
+    describe "#index" do
+      it "returns http success" do
+        get :index
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    describe "#create" do
+      it "returns http success" do
+        post :create
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    describe "#new" do
+      it "returns http success" do
+        get :new
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    describe "#edit" do
+      it "returns http success" do
+        get :edit, params: { id: :id }
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    describe "#update" do
+      it "returns http success" do
+        put :update, params: { id: :id }
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    describe "#destroy" do
+      it "returns success" do
+        delete :destroy, params: { id: :id }
+        expect(response).to have_http_status(:success)
       end
     end
   end


### PR DESCRIPTION
Partially Resolves #1341 

CollectionTypesController skeleton

before_action: authorize! :manage, :collection_types
actions: [:index, :new, :create, :edit, :update, :destroy]