### PR TITLE
Add collection_type to model

### DIFF
--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -14,7 +14,14 @@ module Hyrax
     included do
       validates_with HasOneTitleValidator
       self.indexer = Hyrax::CollectionIndexer
+
+      property :collection_type_gid, predicate: ::RDF::Vocab::SCHEMA.additionalType, multiple: false do |index|
+        index.as :symbol, :stored_searchable
+      end
     end
+
+    attr_accessor :collection_type
+    delegate :nestable?, :discoverable?, :sharable?, :allow_multiple_membership?, :require_membership?, :assigns_workflow?, :assigns_visibility?, to: :collection_type
 
     # Add members using the members association.
     def add_members(new_member_ids)

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -16,5 +16,9 @@ module Hyrax
     deprecation_deprecate workflow: "prefer #assigns_workflow instead"
     alias_attribute :visibility, :assigns_visibility
     deprecation_deprecate visibility: "prefer #assigns_visibility instead"
+
+    def gid
+      URI::GID.build app: GlobalID.app, model_name: model_name.name.parameterize.to_sym, model_id: id unless id.nil?
+    end
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Collection do
-  let(:collection) { create(:public_collection) }
+  let(:collection) { build(:public_collection) }
 
   it "has open visibility" do
     expect(collection.read_groups).to eq ['public']
@@ -114,6 +114,107 @@ RSpec.describe Collection do
     it "have members that know about the collection" do
       member.reload
       expect(member.member_of_collections).to eq [collection]
+    end
+  end
+
+  describe '#collection_type_gid' do
+    it 'has a collection_type_gid' do
+      subject.title = ['title']
+      subject.collection_type_gid = 'gid://internal/CollectionType/5'
+      subject.save!
+      expect(subject.reload.collection_type_gid).to eq 'gid://internal/CollectionType/5'
+    end
+  end
+
+  describe 'collection type delegated methods' do
+    let(:collection_type) { build(:collection_type) }
+
+    before do
+      allow(collection).to receive(:collection_type).and_return(collection_type)
+    end
+
+    describe '#nestable' do
+      it "returns false if collection_type's nestable property is false" do
+        collection_type.nestable = false
+        expect(collection.nestable?).to be_falsey
+      end
+
+      it "returns true if collection_type's nestable property is true" do
+        collection_type.nestable = true
+        expect(collection.nestable?).to be_truthy
+      end
+    end
+
+    describe '#discoverable' do
+      it "returns false if collection_type's discoverable property is false" do
+        collection_type.discoverable = false
+        expect(collection.discoverable?).to be_falsey
+      end
+
+      it "returns true if collection_type's discoverable property is true" do
+        collection_type.discoverable = true
+        expect(collection.discoverable?).to be_truthy
+      end
+    end
+
+    describe '#sharable' do
+      it "returns false if collection_type's sharable property is false" do
+        collection_type.sharable = false
+        expect(collection.sharable?).to be_falsey
+      end
+
+      it "returns true if collection_type's sharable property is true" do
+        collection_type.sharable = true
+        expect(collection.sharable?).to be_truthy
+      end
+    end
+
+    describe '#allow_multiple_membership' do
+      it "returns false if collection_type's allow_multiple_membership property is false" do
+        collection_type.allow_multiple_membership = false
+        expect(collection.allow_multiple_membership?).to be_falsey
+      end
+
+      it "returns true if collection_type's allow_multiple_membership property is true" do
+        collection_type.allow_multiple_membership = true
+        expect(collection.allow_multiple_membership?).to be_truthy
+      end
+    end
+
+    describe '#require_membership' do
+      it "returns false if collection_type's require_membership property is false" do
+        collection_type.require_membership = false
+        expect(collection.require_membership?).to be_falsey
+      end
+
+      it "returns true if collection_type's require_membership property is true" do
+        collection_type.require_membership = true
+        expect(collection.require_membership?).to be_truthy
+      end
+    end
+
+    describe '#assigns_workflow' do
+      it "returns false if collection_type's assigns_workflow property is false" do
+        collection_type.assigns_workflow = false
+        expect(collection.assigns_workflow?).to be_falsey
+      end
+
+      it "returns true if collection_type's assigns_workflow property is true" do
+        collection_type.assigns_workflow = true
+        expect(collection.assigns_workflow?).to be_truthy
+      end
+    end
+
+    describe '#assigns_visibility' do
+      it "returns false if collection_type's assigns_visibility property is false" do
+        collection_type.assigns_visibility = false
+        expect(collection.assigns_visibility?).to be_falsey
+      end
+
+      it "returns true if collection_type's assigns_visibility property is true" do
+        collection_type.assigns_visibility = true
+        expect(collection.assigns_visibility?).to be_truthy
+      end
     end
   end
 end

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -19,4 +19,16 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     expect(collection_type.assigns_workflow?).to be_falsey
     expect(collection_type.assigns_visibility?).to be_falsey
   end
+
+  describe '#gid' do
+    it 'returns the gid when id is not nil' do
+      collection_type.id = 5
+      expect(collection_type.gid.to_s).to eq 'gid://internal/hyrax-collectiontype/5'
+    end
+
+    it 'returns the gid when id is nil' do
+      collection_type.id = nil
+      expect(collection_type.gid).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Partially Fixes #1383

Changes proposed in this pull request:
* Adds collection_type_gid as a property that will be stored in Fedora and identify the collection_type of a specific collection.
* Adds collection_type instance and delegates settings methods to the instance.

Remaining work:
* Still needs collection type processing in controller to convert between controller_type instance and gid, and vice versa. I have some of that work done, but don’t want to include it in this PR.
* Admin set work - see Issue #1383 for more information
