### PR TITLE
Collections #1349 index views

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -82,6 +82,7 @@
 //= require hyrax/relationships
 //= require hyrax/select_work_type
 //= require hyrax/collections
+//= require hyrax/collection_types
 //= require hydra-editor/hydra-editor
 //= require nestable
 //= require hyrax/file_manager/sorting

--- a/app/assets/javascripts/hyrax/app.js
+++ b/app/assets/javascripts/hyrax/app.js
@@ -12,6 +12,7 @@ Hyrax = {
         this.datatable();
         this.adminSetEditor();
         this.collectionEditor();
+        this.collectionTypes();
         this.adminStatisticsGraphs();
         this.tinyMCE();
         this.perPage();
@@ -40,6 +41,11 @@ Hyrax = {
       var controls = new CollectionControls($('#collection-controls'));
     },
 
+    // Collection types
+    collectionTypes: function() {
+      var CollectionTypes = require('hyrax/collection_types');
+      var collection_types = new CollectionTypes($('.collection-types-wrapper'))
+    },
 
     // Pretty graphs on the dashboard page
     adminStatisticsGraphs: function() {

--- a/app/assets/javascripts/hyrax/collection_types.es6
+++ b/app/assets/javascripts/hyrax/collection_types.es6
@@ -1,0 +1,47 @@
+export default class CollectionTypes {
+
+  constructor(element) {
+    if (element.length > 0) {
+      this.handleCollapseToggle()
+      this.handleDelete()
+    }
+  }
+
+  handleCollapseToggle() {
+    let $collapseHeader = $('a.collapse-header')
+    let $collapseHeaderSpan = $('a.collapse-header').find('span')
+
+    // Toggle show/hide of collapsible content on bootstrap toggle events
+    $('#collapseAbout').on('show.bs.collapse', () => {
+      $collapseHeader.addClass('open')
+      $collapseHeaderSpan.html('Less')
+    })
+    $('#collapseAbout').on('hide.bs.collapse', () => {
+      $collapseHeader.removeClass('open')
+      $collapseHeaderSpan.html('More')
+    })
+  }
+
+  handleDelete() {
+    let trData = null
+
+    // Click delete collections type button in the table row
+    $('.delete-collection-type').on('click', (event) => {
+      let dataset = event.target.dataset
+      let collectionType = JSON.parse(dataset.collectionType) || null
+      let hasCollections = dataset.hasCollections === 'true'
+
+      if (hasCollections === true) {
+        $('#deleteDenyModal').modal()
+      } else {
+        $('#deleteModal').modal()
+      }
+    })
+
+    // Confirm delete collection type
+    $('.confirm-delete-collection-type').on('click', (event) => {
+      // TODO: Handle the delete functionality here
+    })
+  }
+
+}

--- a/app/assets/stylesheets/hyrax/_collection_types.scss
+++ b/app/assets/stylesheets/hyrax/_collection_types.scss
@@ -1,0 +1,49 @@
+@mixin toggle-arrow($content) {
+  content: $content;
+  display: inline-block;
+  font-family: 'FontAwesome';
+  margin-left: 5px;
+  text-decoration: none;
+}
+
+.collection-types-wrapper {
+  @media (min-width: 900px) {
+    .collection-types-table {
+      th:last-child,
+      td:last-child {
+        width: 20%;
+      }
+    }
+  }
+
+  .screen-hidden {
+    height: 1px;
+    left: -10000px;
+    overflow: hidden;
+    position: absolute;
+    top: auto;
+    width: 1px;
+  }
+
+  .panel-heading {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .collapse-header {
+    &:focus {
+      text-decoration: none;
+    }
+
+    &::after {
+      @include toggle-arrow('\f0da');
+    }
+
+    &.open {
+      &::after {
+        @include toggle-arrow('\f0d7');
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/hyrax/_hyrax.scss
+++ b/app/assets/stylesheets/hyrax/_hyrax.scss
@@ -1,7 +1,7 @@
 @import 'hydra-editor/multi_value_fields';
 @import 'hyrax/variables', 'hyrax/file_sets', 'hyrax/settings', 'hyrax/header',
         'hyrax/styles', 'hyrax/file-listing', 'hyrax/browse_everything_overrides',
-        'hyrax/nestable', 'hyrax/collections', 'hyrax/batch-edit',
+        'hyrax/nestable', 'hyrax/collections', 'hyrax/collection_types', 'hyrax/batch-edit',
         'hyrax/home-page', 'hyrax/featured', 'hyrax/usage-stats', 'hyrax/catalog',
         'hyrax/buttons', 'hyrax/tinymce', 'hyrax/proxy-rights', 'hyrax/file-show',
         'hyrax/work-show', 'hyrax/modal', 'hyrax/forms', 'hyrax/form',

--- a/app/controllers/hyrax/admin/collection_types_controller.rb
+++ b/app/controllers/hyrax/admin/collection_types_controller.rb
@@ -8,7 +8,16 @@ module Hyrax
     class_attribute :form_class
     self.form_class = Hyrax::Forms::Admin::CollectionTypeForm
 
-    def index; end
+    def index
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.admin.sidebar.configuration'), '#'
+      add_breadcrumb t(:'hyrax.admin.sidebar.collection_types'), request.path
+
+      # TODO: How do we know if a collection_type has existing collections?
+      # Will that be a property on @collection_types here?
+      @collection_types = Hyrax::CollectionType.all
+    end
 
     def new
       add_breadcrumb t(:'hyrax.controls.home'), root_path

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -22,5 +22,13 @@ module Hyrax
     def gid
       URI::GID.build app: GlobalID.app, model_name: model_name.name.parameterize.to_sym, model_id: id unless id.nil?
     end
+
+    def collections?
+      # TODO: this is a stub method to check whether there are any collections with this
+      # collection type.  We should think about best way to retrieve this information.
+      # For testing, return 'true' to display the "Cannot delete" modal.
+      # And return 'false' to display the delete confirmation modal.
+      true
+    end
   end
 end

--- a/app/views/hyrax/admin/collection_types/index.html.erb
+++ b/app/views/hyrax/admin/collection_types/index.html.erb
@@ -1,0 +1,82 @@
+<div class="collection-types-wrapper">
+  <% provide :page_header do %>
+    <h1><span class="fa fa-folder-open"></span> <%= t('.header') %></h1>
+  <% end %>
+
+  <div class="panel panel-default">
+    <div class="panel-heading adam">
+      <span class="panel-heading-message">
+        <strong><%= pluralize(@collection_types.size, 'collection type') %> </strong> in this repository
+      </span>
+      <%= link_to hyrax.new_admin_collection_type_path, class: 'btn btn-primary' do %>
+        <%= t('.create_new_button') %>
+      <% end %>
+    </div>
+    <div class="panel-body">
+      <p><%= t('.description') %></p>
+
+      <p><a class="collapse-header" data-toggle="collapse" href="#collapseAbout" aria-expanded="false" aria-controls="collapseAbout"><%= t('.more_toggle_header_html') %></a></p>
+      <div id="collapseAbout" class="collapse">
+        <%= t('.more_toggle_content_html') %>
+      </div>
+
+      <h3>Current Collection Types</h3>
+      <table class="table collection-types-table">
+         <thead>
+           <tr>
+             <th><%= t('.table.name') %></th>
+             <th><%= t('.table.actions') %></th>
+           </tr>
+         </thead>
+         <tbody>
+           <% @collection_types.each do |collection_type| %>
+             <tr>
+               <td><%= collection_type.title %></td>
+               <td>
+                 <%= link_to hyrax.edit_admin_collection_type_path(collection_type), class: 'btn btn-primary btn-sm' do %>
+                  <%= t('helpers.action.edit') %>
+                 <% end %>
+                 <% if collection_type.machine_id != 'admin_set' %>
+                  <button class="btn btn-danger btn-sm delete-collection-type" data-collection-type="<%= collection_type.to_json %>" data-has-collections="<%= collection_type.collections? %>"><%= t('helpers.action.delete') %></button>
+                  <% end %>
+               </td>
+             </tr>
+           <% end %>
+         </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- Modal window: Delete collection type confirmation -->
+  <div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-body">
+          <h4 class="screen-hidden" id="deleteModalLabel"><%= t('.modal.header_can_delete') %></h4>
+          <%= t('.modal.can_delete_body_html') %>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
+          <button type="button" class="btn btn-danger confirm-delete-collection-type"><%= t('helpers.action.delete') %></button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal window: Can't delete the collection type -->
+  <div class="modal fade" id="deleteDenyModal" tabindex="-1" role="dialog" aria-labelledby="deleteDenyModalLabel">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-body">
+          <h4 class="screen-hidden" id="deleteDenyModalLabel"><%= t('.modal.header_cannot_delete') %></h4>
+          <%= t('.modal.cannot_delete_body_html') %>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
+          <button type="button" class="btn btn-primary"><%= t('.modal.view_collections') %></button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -207,6 +207,27 @@ en:
           participants:
         index:
           breadcrumb:       "Collection Types"
+          create_new_button: "Create new collection type"
+          description:      "Collection types enable you to define settings that govern collections that serve different purposes in your repository.  You can define as many collection types as you need."
+          header:           "Collection Types"
+          modal:
+            can_delete_body_html: "<p>Deleting this collection type will permanently remove the type and its settings from the repository.  Are you sure you want to delete this collection type?</p>"
+            cannot_delete_body_html: "<p>You cannot delete this collection type because one or more collections of this type have already been created.</p>
+            <p>To delete this collection type, first ensure that all collections of this type have been deleted.</p>"
+            header_can_delete:  "Delete Collection Type?"
+            header_cannot_delete:  "Cannot Delete Collection Type"
+            view_collections: "View collections of this type"
+          more_toggle_content_html: "<p>Typical scenarios for collection types include:</p>
+          <ul>
+            <li><strong>User Collections</strong> that any registered user can create to organize items they deposit.</li>
+            <li><strong>Exhibits</strong> that staff create and curate for public display, where items can be included in any number of exhibits.</li>
+            <li><strong>Controlled Collections</strong> created and managed by staff and not intended for public display, such as collections associated with organizational units or departments.</li>
+            <li><strong>Community Collections</strong> that are intended for public display, similar to how DSpace communities and collections are sometimes used.</li>
+          </ul>"
+          more_toggle_header_html: "<span>More</span> about collection types"
+          table:
+            name:           "Name"
+            actions:        "Actions"
         new:
           header:           "Create New Collection Type"
       features:
@@ -221,6 +242,7 @@ en:
         appearance:         "Appearance"
         collection_types:   "Collection types"
         collections:        "Collections"
+        collection_types:   "Collection Types"
         configuration:      "Configuration"
         content_blocks:     "Content Blocks"
         notifications:      "Notifications"

--- a/spec/views/hyrax/admin/collection_types/index.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/index.html.erb_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe 'hyrax/admin/collection_types/index.html.erb', type: :view do
+  before do
+    assign(:collection_types, [
+             FactoryGirl.create(:collection_type, title: 'Test Title 1', machine_id: 'test_title_1'),
+             FactoryGirl.create(:collection_type, title: 'Test Title 2', machine_id: 'test_title_2')
+           ])
+    render
+  end
+
+  it 'lists all the collection_types' do
+    expect(rendered).to have_content('Test Title 1')
+    expect(rendered).to have_content('Test Title 2')
+  end
+
+  it 'displays the collection type count correctly' do
+    expect(rendered).to have_content '2 collection types in this repository'
+  end
+end


### PR DESCRIPTION
Moves forward issue #1349 ; 

The initial Collection Types index page, markup, and basic UI wired up.  Still needs completion of other stories to be fully functional.

@samvera/hyrax-code-reviewers

Issues remaining:
 -  We added a `collections?` method to the CollectionsType model so that we could simulate different modals for empty vs full collection types. This will need to be changed when we have implemented a way to find collections that belong to a collection type.
 - Added `collection_type.machine_id != 'admin_set'` as a placeholder to check if the collection type was admin set. Not sure what the final check will be yet.
 - Actual delete functionality not wired up yet
 - Button to take you to 'View collections of this type' (if unable to delete because collection type has collections) not wired up yet