### PR TITLE
Speeding up tests

### DIFF
--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -97,17 +97,28 @@ RSpec.describe AdminSet, type: :model do
     end
   end
 
-  it "has a title" do
-    subject.title = ["title"]
-    subject.save
-    expect(subject.reload.title).to eq ["title"]
+  it "has a title that is an ActiveTriples::Relation" do
+    subject.title = ['Hello World']
+    expect(subject.title).to eq(['Hello World'])
+    expect(subject.title).to be_a(ActiveTriples::Relation)
   end
 
-  it "has a description" do
-    subject.title = ["title"]
-    subject.description = ["description"]
-    subject.save
-    expect(subject.reload.description).to eq ["description"]
+  it "has a description that is an ActiveTriples::Relation" do
+    subject.description = ['My description']
+    expect(subject.description).to eq(['My description'])
+    expect(subject.description).to be_a(ActiveTriples::Relation)
+  end
+
+  describe '#title=' do
+    it 'raises an error if set with a String' do
+      expect { subject.title = 'New Title' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#description=' do
+    it 'raises an error if set with a String' do
+      expect { subject.description = 'New Description' }.to raise_error(ArgumentError)
+    end
   end
 
   describe ".default_set?" do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Collection do
-  let(:collection) { create(:public_collection) }
+  let(:collection) { build(:public_collection) }
 
   it "has open visibility" do
     expect(collection.read_groups).to eq ['public']

--- a/spec/models/content_block_spec.rb
+++ b/spec/models/content_block_spec.rb
@@ -1,23 +1,4 @@
 RSpec.describe ContentBlock, type: :model do
-  let!(:bilbo) do
-    create(:content_block,
-           name: ContentBlock::NAME_REGISTRY[:researcher],
-           value: '<h1>Bilbo Baggins</h1>',
-           created_at: Time.zone.now)
-  end
-
-  let!(:marketing) do
-    create(:content_block,
-           name: ContentBlock::NAME_REGISTRY[:marketing],
-           value: '<h1>Marketing Text</h1>')
-  end
-
-  let!(:announcement) do
-    create(:content_block,
-           name: ContentBlock::NAME_REGISTRY[:announcement],
-           value: '<h1>Announcement Text</h1>')
-  end
-
   describe '.for' do
     context 'with a nil' do
       it 'raises an ArgumentError' do
@@ -50,6 +31,12 @@ RSpec.describe ContentBlock, type: :model do
   end
 
   describe '.announcement_text' do
+    let!(:announcement) do
+      create(:content_block,
+             name: ContentBlock::NAME_REGISTRY[:announcement],
+             value: '<h1>Announcement Text</h1>')
+    end
+
     subject { described_class.for(:announcement).value }
 
     it { is_expected.to eq '<h1>Announcement Text</h1>' }
@@ -65,6 +52,12 @@ RSpec.describe ContentBlock, type: :model do
   end
 
   describe '.marketing_text' do
+    let!(:marketing) do
+      create(:content_block,
+             name: ContentBlock::NAME_REGISTRY[:marketing],
+             value: '<h1>Marketing Text</h1>')
+    end
+
     subject { described_class.for(:marketing).value }
 
     it { is_expected.to eq '<h1>Marketing Text</h1>' }
@@ -80,6 +73,13 @@ RSpec.describe ContentBlock, type: :model do
   end
 
   describe '.featured_researcher' do
+    let!(:bilbo) do
+      create(:content_block,
+             name: ContentBlock::NAME_REGISTRY[:researcher],
+             value: '<h1>Bilbo Baggins</h1>',
+             created_at: Time.zone.now)
+    end
+
     subject { described_class.for(:researcher) }
 
     it 'returns entry for featured_researcher' do

--- a/spec/models/featured_work_list_spec.rb
+++ b/spec/models/featured_work_list_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe FeaturedWorkList, type: :model do
   end
 
   describe '#featured_works_attributes=' do
-    let(:featured_work) { create(:featured_work, work_id: work1.id) }
+    # We don't need to persist the given work. This saves a few LDP calls.
+    let(:work_id) { 'no-need-to-persist' }
+    let(:featured_work) { create(:featured_work, work_id: work_id) }
 
     let(:attributes) do
       ActionController::Parameters.new(

--- a/spec/models/file_download_stat_spec.rb
+++ b/spec/models/file_download_stat_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe FileDownloadStat, type: :model do
   let(:file_id) { file.id }
   let(:date) { Time.current }
-  let(:file_stat) { described_class.create(downloads: "2", date: date, file_id: file_id) }
+  let(:file_stat) { described_class.new(downloads: "2", date: date, file_id: file_id) }
   let(:file) { mock_model(FileSet, id: 99) }
 
   it "has attributes" do

--- a/spec/models/file_download_stat_spec.rb
+++ b/spec/models/file_download_stat_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe FileDownloadStat, type: :model do
     # results from the Legato gem.
     let(:sample_download_statistics) do
       [
-        OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[0], totalEvents: "1"),
-        OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[1], totalEvents: "1"),
-        OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[2], totalEvents: "2"),
-        OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[3], totalEvents: "3")
+        SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[0], totalEvents: "1"),
+        SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[1], totalEvents: "1"),
+        SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[2], totalEvents: "2"),
+        SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[3], totalEvents: "3")
       ]
     end
 

--- a/spec/models/file_view_stat_spec.rb
+++ b/spec/models/file_view_stat_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe FileViewStat, type: :model do
     # results from the Legato gem.
     let(:sample_pageview_statistics) do
       [
-        OpenStruct.new(date: date_strs[0], pageviews: 4),
-        OpenStruct.new(date: date_strs[1], pageviews: 8),
-        OpenStruct.new(date: date_strs[2], pageviews: 6),
-        OpenStruct.new(date: date_strs[3], pageviews: 10)
+        SpecStatistic.new(date: date_strs[0], pageviews: 4),
+        SpecStatistic.new(date: date_strs[1], pageviews: 8),
+        SpecStatistic.new(date: date_strs[2], pageviews: 6),
+        SpecStatistic.new(date: date_strs[3], pageviews: 10)
       ]
     end
 

--- a/spec/models/work_view_stat_spec.rb
+++ b/spec/models/work_view_stat_spec.rb
@@ -62,10 +62,10 @@ RSpec.describe WorkViewStat, type: :model do
     # results from the Legato gem.
     let(:sample_work_pageview_statistics) do
       [
-        OpenStruct.new(date: date_strs[0], pageviews: 4),
-        OpenStruct.new(date: date_strs[1], pageviews: 8),
-        OpenStruct.new(date: date_strs[2], pageviews: 6),
-        OpenStruct.new(date: date_strs[3], pageviews: 10)
+        SpecStatistic.new(date: date_strs[0], pageviews: 4),
+        SpecStatistic.new(date: date_strs[1], pageviews: 8),
+        SpecStatistic.new(date: date_strs[2], pageviews: 6),
+        SpecStatistic.new(date: date_strs[3], pageviews: 10)
       ]
     end
 

--- a/spec/presenters/hyrax/file_usage_spec.rb
+++ b/spec/presenters/hyrax/file_usage_spec.rb
@@ -32,21 +32,21 @@ RSpec.describe Hyrax::FileUsage, type: :model do
 
   let(:sample_download_statistics) do
     [
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[0], totalEvents: "1"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[1], totalEvents: "1"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[2], totalEvents: "2"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[3], totalEvents: "3"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[4], totalEvents: "5")
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[0], totalEvents: "1"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[1], totalEvents: "1"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[2], totalEvents: "2"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[3], totalEvents: "3"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "hyrax:x920fw85p", date: date_strs[4], totalEvents: "5")
     ]
   end
 
   let(:sample_pageview_statistics) do
     [
-      OpenStruct.new(date: date_strs[0], pageviews: 4),
-      OpenStruct.new(date: date_strs[1], pageviews: 8),
-      OpenStruct.new(date: date_strs[2], pageviews: 6),
-      OpenStruct.new(date: date_strs[3], pageviews: 10),
-      OpenStruct.new(date: date_strs[4], pageviews: 2)
+      SpecStatistic.new(date: date_strs[0], pageviews: 4),
+      SpecStatistic.new(date: date_strs[1], pageviews: 8),
+      SpecStatistic.new(date: date_strs[2], pageviews: 6),
+      SpecStatistic.new(date: date_strs[3], pageviews: 10),
+      SpecStatistic.new(date: date_strs[4], pageviews: 2)
     ]
   end
 

--- a/spec/presenters/hyrax/work_usage_spec.rb
+++ b/spec/presenters/hyrax/work_usage_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe Hyrax::WorkUsage, type: :model do
 
   let(:sample_pageview_statistics) do
     [
-      OpenStruct.new(date: date_strs[0], pageviews: 4),
-      OpenStruct.new(date: date_strs[1], pageviews: 8),
-      OpenStruct.new(date: date_strs[2], pageviews: 6),
-      OpenStruct.new(date: date_strs[3], pageviews: 10),
-      OpenStruct.new(date: date_strs[4], pageviews: 2)
+      SpecStatistic.new(date: date_strs[0], pageviews: 4),
+      SpecStatistic.new(date: date_strs[1], pageviews: 8),
+      SpecStatistic.new(date: date_strs[2], pageviews: 6),
+      SpecStatistic.new(date: date_strs[3], pageviews: 10),
+      SpecStatistic.new(date: date_strs[4], pageviews: 2)
     ]
   end
 

--- a/spec/services/hyrax/user_stat_importer_spec.rb
+++ b/spec/services/hyrax/user_stat_importer_spec.rb
@@ -80,92 +80,92 @@ RSpec.describe Hyrax::UserStatImporter do
   # This is what the data looks like that's returned from Google Analytics via the Legato gem.
   let(:bilbo_file_1_pageview_stats) do
     [
-      OpenStruct.new(date: date_strs[0], pageviews: 1),
-      OpenStruct.new(date: date_strs[1], pageviews: 2),
-      OpenStruct.new(date: date_strs[2], pageviews: 3),
-      OpenStruct.new(date: date_strs[3], pageviews: 4),
-      OpenStruct.new(date: date_strs[4], pageviews: 5)
+      SpecStatistic.new(date: date_strs[0], pageviews: 1),
+      SpecStatistic.new(date: date_strs[1], pageviews: 2),
+      SpecStatistic.new(date: date_strs[2], pageviews: 3),
+      SpecStatistic.new(date: date_strs[3], pageviews: 4),
+      SpecStatistic.new(date: date_strs[4], pageviews: 5)
     ]
   end
 
   let(:bilbo_file_2_pageview_stats) do
     [
-      OpenStruct.new(date: date_strs[0], pageviews: 11),
-      OpenStruct.new(date: date_strs[1], pageviews: 12),
-      OpenStruct.new(date: date_strs[2], pageviews: 13),
-      OpenStruct.new(date: date_strs[3], pageviews: 14),
-      OpenStruct.new(date: date_strs[4], pageviews: 15)
+      SpecStatistic.new(date: date_strs[0], pageviews: 11),
+      SpecStatistic.new(date: date_strs[1], pageviews: 12),
+      SpecStatistic.new(date: date_strs[2], pageviews: 13),
+      SpecStatistic.new(date: date_strs[3], pageviews: 14),
+      SpecStatistic.new(date: date_strs[4], pageviews: 15)
     ]
   end
 
   let(:frodo_file_1_pageview_stats) do
     [
-      OpenStruct.new(date: date_strs[0], pageviews: 2),
-      OpenStruct.new(date: date_strs[1], pageviews: 4),
-      OpenStruct.new(date: date_strs[2], pageviews: 1),
-      OpenStruct.new(date: date_strs[3], pageviews: 1),
-      OpenStruct.new(date: date_strs[4], pageviews: 9)
+      SpecStatistic.new(date: date_strs[0], pageviews: 2),
+      SpecStatistic.new(date: date_strs[1], pageviews: 4),
+      SpecStatistic.new(date: date_strs[2], pageviews: 1),
+      SpecStatistic.new(date: date_strs[3], pageviews: 1),
+      SpecStatistic.new(date: date_strs[4], pageviews: 9)
     ]
   end
 
   # work
   let(:bilbo_work_1_pageview_stats) do
     [
-      OpenStruct.new(date: date_strs[0], pageviews: 1),
-      OpenStruct.new(date: date_strs[1], pageviews: 2),
-      OpenStruct.new(date: date_strs[2], pageviews: 3),
-      OpenStruct.new(date: date_strs[3], pageviews: 4),
-      OpenStruct.new(date: date_strs[4], pageviews: 5)
+      SpecStatistic.new(date: date_strs[0], pageviews: 1),
+      SpecStatistic.new(date: date_strs[1], pageviews: 2),
+      SpecStatistic.new(date: date_strs[2], pageviews: 3),
+      SpecStatistic.new(date: date_strs[3], pageviews: 4),
+      SpecStatistic.new(date: date_strs[4], pageviews: 5)
     ]
   end
 
   let(:bilbo_work_2_pageview_stats) do
     [
-      OpenStruct.new(date: date_strs[0], pageviews: 11),
-      OpenStruct.new(date: date_strs[1], pageviews: 12),
-      OpenStruct.new(date: date_strs[2], pageviews: 13),
-      OpenStruct.new(date: date_strs[3], pageviews: 14),
-      OpenStruct.new(date: date_strs[4], pageviews: 15)
+      SpecStatistic.new(date: date_strs[0], pageviews: 11),
+      SpecStatistic.new(date: date_strs[1], pageviews: 12),
+      SpecStatistic.new(date: date_strs[2], pageviews: 13),
+      SpecStatistic.new(date: date_strs[3], pageviews: 14),
+      SpecStatistic.new(date: date_strs[4], pageviews: 15)
     ]
   end
 
   let(:frodo_work_1_pageview_stats) do
     [
-      OpenStruct.new(date: date_strs[0], pageviews: 2),
-      OpenStruct.new(date: date_strs[1], pageviews: 4),
-      OpenStruct.new(date: date_strs[2], pageviews: 1),
-      OpenStruct.new(date: date_strs[3], pageviews: 1),
-      OpenStruct.new(date: date_strs[4], pageviews: 9)
+      SpecStatistic.new(date: date_strs[0], pageviews: 2),
+      SpecStatistic.new(date: date_strs[1], pageviews: 4),
+      SpecStatistic.new(date: date_strs[2], pageviews: 1),
+      SpecStatistic.new(date: date_strs[3], pageviews: 1),
+      SpecStatistic.new(date: date_strs[4], pageviews: 9)
     ]
   end
 
   let(:bilbo_file_1_download_stats) do
     [
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[0], totalEvents: "2"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[1], totalEvents: "3"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[2], totalEvents: "5"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[3], totalEvents: "3"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[4], totalEvents: "7")
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[0], totalEvents: "2"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[1], totalEvents: "3"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[2], totalEvents: "5"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[3], totalEvents: "3"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[4], totalEvents: "7")
     ]
   end
 
   let(:bilbo_file_2_download_stats) do
     [
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo2", date: date_strs[0], totalEvents: "1"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo2", date: date_strs[1], totalEvents: "4"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo2", date: date_strs[2], totalEvents: "3"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo2", date: date_strs[3], totalEvents: "2"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo2", date: date_strs[4], totalEvents: "3")
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo2", date: date_strs[0], totalEvents: "1"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo2", date: date_strs[1], totalEvents: "4"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo2", date: date_strs[2], totalEvents: "3"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo2", date: date_strs[3], totalEvents: "2"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo2", date: date_strs[4], totalEvents: "3")
     ]
   end
 
   let(:frodo_file_1_download_stats) do
     [
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "frodo1", date: date_strs[0], totalEvents: "5"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "frodo1", date: date_strs[1], totalEvents: "4"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "frodo1", date: date_strs[2], totalEvents: "2"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "frodo1", date: date_strs[3], totalEvents: "1"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "frodo1", date: date_strs[4], totalEvents: "6")
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "frodo1", date: date_strs[0], totalEvents: "5"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "frodo1", date: date_strs[1], totalEvents: "4"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "frodo1", date: date_strs[2], totalEvents: "2"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "frodo1", date: date_strs[3], totalEvents: "1"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "frodo1", date: date_strs[4], totalEvents: "6")
     ]
   end
 

--- a/spec/support/spec_statistic.rb
+++ b/spec/support/spec_statistic.rb
@@ -1,0 +1,23 @@
+# This is a replacement for the OpenStruct usage. The idea is to expose
+# an object with a common interface.
+class SpecStatistic
+  def initialize(**kargs)
+    @attributes = kargs.symbolize_keys
+  end
+
+  def [](key)
+    @attributes[key.to_sym]
+  end
+
+  def method_missing(method_name, *arguments, &block)
+    if @attributes.key?(method_name.to_sym)
+      @attributes[method_name]
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    @attributes.key?(method_name.to_sym) || super
+  end
+end


### PR DESCRIPTION
## Aligning spec description with spec body

@e55e9a25a7b7fe12d1c7ad86752cd1d82d7badad

I don't believe that testing the existence of a title and description
should require saving AdminSet.

## Reducing LDP requests in spec/collections_spec.rb

@404ee271a8a61bce049ad02a2784e097101f6942

After:

```console
Collection#validates_with ensures the collection has a title
  Total LDP: 3 {"GET"=>2, "POST"=>1}
...
Finished in 8.98 seconds (files took 6.93 seconds to load)
```

Before:

```console
Collection#validates_with ensures the collection has a title
  Total LDP: 16 {"HEAD"=>2, "GET"=>10, "POST"=>4}
...
Finished in 10.18 seconds (files took 7.07 seconds to load)
```

## Moving `let!` directives closer to their uses

@0e8cbb4c671e28215b9f4dd4ca6e6af1b3aca96e

This is a minor speed increase, as the three `let!` statements are not
fired before each and every `it` block in this spec file.

Before:

```console
Finished in 0.71341 seconds (files took 7.8 seconds to load)
```

After:

```console
Finished in 0.52115 seconds (files took 7.16 seconds to load)
```

## Removing an ActiveFedora create in spec

@16ac4e53685b156a009fddde5ece7fbafa13279f

We can instead rely on the identifier. This drops 14 LDP requests and
shaves 0.5 seconds from the specs.

Before:

```console
Examples with the most LDP requests
  FeaturedWorkList#featured_works_attributes= sets order
    Total LDP: 14 {"HEAD"=>2, "GET"=>9, "POST"=>3}
  FeaturedWorkList featured_works is a list of the featured work objects, each with the generic_work's solr_doc
    Total LDP: 29 {"HEAD"=>5, "GET"=>18, "POST"=>6}
  FeaturedWorkList featured_works when one of the files is deleted is a list of the remaining featured work objects, each with the generic_work's solr_doc
    Total LDP: 32 {"HEAD"=>4, "GET"=>19, "POST"=>6, "DELETE"=>3}

Finished in 5.21 seconds (files took 7.4 seconds to load)
```

After:

```console
Examples with the most LDP requests
  FeaturedWorkList featured_works is a list of the featured work objects, each with the generic_work's solr_doc
    Total LDP: 29 {"HEAD"=>5, "GET"=>18, "POST"=>6}
  FeaturedWorkList featured_works when one of the files is deleted is a list of the remaining featured work objects, each with the generic_work's solr_doc
    Total LDP: 32 {"HEAD"=>4, "GET"=>19, "POST"=>6, "DELETE"=>3}

Finished in 4.71 seconds (files took 6.88 seconds to load)
```

## Favoring `new` instead of `create` for spec

@44ea573d9f175d8546be163866a0bc6f0f84866e

This is a minor tweak, reducing DB calls. It's a small time saving:

Before:

```console
Finished in 0.41809 seconds (files took 7.86 seconds to load)
```

After:

```console
Finished in 0.46715 seconds (files took 9 seconds to load)
```

## Switching from OpenStruct to SpecStatistic

@7ba94fba1a5044124515538fc63e89e8c3d648d4

OpenStruct invalidates the method cache, favor instead a custom object
(that behaves kind of like an OpenStruct).

Before:

```console
Finished in 15 minutes 17 seconds (files took 22.12 seconds to load)
```

```console
Finished in 13 minutes 44 seconds (files took 18.03 seconds to load)
```

For more on the method cache see the following:

* https://mensfeld.pl/2015/04/ruby-global-method-cache-invalidation-impact-on-a-single-and-multithreaded-applications/
