### PR TITLE
Adds validations to collection type model

### DIFF
--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -1,6 +1,8 @@
 module Hyrax
   class CollectionType < ActiveRecord::Base
     self.table_name = 'hyrax_collection_types'
+    validates :title, presence: true, uniqueness: true
+    validates :machine_id, presence: true, uniqueness: true
 
     # These are provided as a convenience method based on prior design discussions.
     # The deprecations are added to allow upstream developers to continue with what

--- a/db/migrate/20170810190549_update_collection_type_column_options.rb
+++ b/db/migrate/20170810190549_update_collection_type_column_options.rb
@@ -1,0 +1,9 @@
+class UpdateCollectionTypeColumnOptions < ActiveRecord::Migration[5.0]
+  def change
+    change_column :hyrax_collection_types, :title, :string, unique: true
+    change_column :hyrax_collection_types, :machine_id, :string, unique: true
+
+    remove_index :hyrax_collection_types, :machine_id
+    add_index :hyrax_collection_types, :machine_id, unique: true
+  end
+end

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -19,4 +19,18 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     expect(collection_type.assigns_workflow?).to be_falsey
     expect(collection_type.assigns_visibility?).to be_falsey
   end
+
+  describe "validations" do
+    it "ensures the required fields have values" do
+      collection_type.title = nil
+      collection_type.machine_id = nil
+      expect(collection_type).not_to be_valid
+      expect(collection_type.errors.messages[:title]).not_to be_empty
+      expect(collection_type.errors.messages[:machine_id]).not_to be_empty
+    end
+    it "ensures uniqueness" do
+      is_expected.to validate_uniqueness_of(:title)
+      is_expected.to validate_uniqueness_of(:machine_id)
+    end
+  end
 end


### PR DESCRIPTION
refs #1343 

Adds validations on collection type so that title and machine_id are required and unique.  Uniqueness is also enforced at the database level via a new migration.