### PR TITLE
Move translation key collection_type to collection_types

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -157,8 +157,16 @@ en:
           breadcrumb:       "View Set"
           confirm_delete:   "Are you sure you wish to delete this Administrative Set? This action cannot be undone."
           header:           "Administrative Set"
-          item_list_header: "Works in This Set"
-      collection_type:
+          item_list_header: "Works in This Set"  
+      appearances:
+        show:
+          header:           "Appearance"
+        update:
+          flash:
+            success:        "The appearance was successfully updated"
+      collection_types:
+        edit:
+          header:           "Edit Collection Type"
         form:
           tab:
             metadata:        "Description"
@@ -196,15 +204,6 @@ en:
               label:         "VISIBILITY"
               description:   "Allow collections of this type to assign initial visibility settings to a new work"
           participants:
-      appearances:
-        show:
-          header:           "Appearance"
-        update:
-          flash:
-            success:        "The appearance was successfully updated"
-      collection_types:
-        edit:
-          header:           "Edit Collection Type"
         index:
           breadcrumb:       "Collection Types"
         new:


### PR DESCRIPTION
Fixes #1457 

Replaces the singular `collection_type` translation key with plural `collection_types`