### PR TITLE
Reducing redundant specs

### DIFF
--- a/app/presenters/hyrax/admin_stats_presenter.rb
+++ b/app/presenters/hyrax/admin_stats_presenter.rb
@@ -24,24 +24,29 @@ module Hyrax
 
     public
 
+    # @see Hyrax::Statistics::Depositors::Summary
     def depositors
-      @depositors ||= Hyrax::Statistics::Depositors::Summary.new(start_date, end_date).depositors
+      @depositors ||= Hyrax::Statistics::Depositors::Summary.depositors(start_date: start_date, end_date: end_date)
     end
 
+    # @see Hyrax::Statistics::SystemStats.recent_users
     def recent_users
-      @recent_users ||= stats.recent_users
+      @recent_users ||= Hyrax::Statistics::SystemStats.recent_users(limit: limit, start_date: start_date, end_date: end_date)
     end
 
+    # @see Hyrax::Statistics::Works::ByDepositor
     def active_users
-      @active_users ||= Hyrax::Statistics::Works::ByDepositor.new(limit).query
+      @active_users ||= Hyrax::Statistics::Works::ByDepositor.query(limit: limit)
     end
 
+    # @see Hyrax::Statistics::FileSets::ByFormat
     def top_formats
-      @top_formats ||= Hyrax::Statistics::FileSets::ByFormat.new(limit).query
+      @top_formats ||= Hyrax::Statistics::FileSets::ByFormat.query(limit: limit)
     end
 
+    # @see Hyrax::Statistics::Works::Count
     def works_count
-      @works_count ||= Hyrax::Statistics::Works::Count.new(start_date, end_date).by_permission
+      @works_count ||= Hyrax::Statistics::Works::Count.by_permission(start_date: start_date, end_date: end_date)
     end
 
     def date_filter_string
@@ -53,11 +58,5 @@ module Hyrax
         "#{start_date.to_date.to_formatted_s(:standard)} to #{end_date.to_date.to_formatted_s(:standard)}"
       end
     end
-
-    private
-
-      def stats
-        @stats ||= Hyrax::Statistics::SystemStats.new(limit, start_date, end_date)
-      end
   end
 end

--- a/app/services/hyrax/statistics/depositors/summary.rb
+++ b/app/services/hyrax/statistics/depositors/summary.rb
@@ -5,6 +5,14 @@ module Hyrax
       class Summary
         include Blacklight::SearchHelper
 
+        # @api public
+        # @param [Time] start_date optionally specify the start date to gather the stats from
+        # @param [Time] end_date optionally specify the end date to gather the stats from
+        # @return [Array<Hash>] With keys of: :key, :deposits, and :user
+        def self.depositors(start_date:, end_date:)
+          new(start_date, end_date).depositors
+        end
+
         # @param [Time] start_date optionally specify the start date to gather the stats from
         # @param [Time] end_date optionally specify the end date to gather the stats from
         def initialize(start_date, end_date)

--- a/app/services/hyrax/statistics/system_stats.rb
+++ b/app/services/hyrax/statistics/system_stats.rb
@@ -12,6 +12,15 @@ module Hyrax
     class SystemStats
       attr_reader :limit, :start_date, :end_date
 
+      # @api public
+      # @param [Fixnum] limit_records limits the results returned from top_depositors and top_formats. Maximum is 20, minimum is 5
+      # @param [Time] start_date Filters the statistics returned by the class to after this date. nil means no filter
+      # @param [Time] end_date Filters the statistics returned by the class to before this date. nil means today
+      # @return [Array<User>]
+      def self.recent_users(limit: 5, start_date: nil, end_date: nil)
+        new(limit, start_date, end_date).recent_users
+      end
+
       # @param [Fixnum] limit_records limits the results returned from top_depositors and top_formats. Maximum is 20, minimum is 5
       # @param [Time] start_date Filters the statistics returned by the class to after this date. nil means no filter
       # @param [Time] end_date Filters the statistics returned by the class to before this date. nil means today

--- a/app/services/hyrax/statistics/term_query.rb
+++ b/app/services/hyrax/statistics/term_query.rb
@@ -5,6 +5,13 @@ module Hyrax
     #
     # WARNING: you must use a term that isn't parsed (i.e. use _sim instead of _tesim)
     class TermQuery
+      # @api public
+      # @param [Integer] limit - Limit the number of responses
+      # @return [Array<Hyrax::Statistics::TermQuery::Result>]
+      def self.query(limit: 5)
+        new(limit).query
+      end
+
       def initialize(limit = 5)
         @limit = limit
       end

--- a/app/services/hyrax/statistics/works/count.rb
+++ b/app/services/hyrax/statistics/works/count.rb
@@ -4,6 +4,17 @@ module Hyrax
       class Count
         attr_reader :start_date, :end_date
 
+        # @api public
+        # Retrieves the count of works in the system filtered by the start_date and end_date if present
+        #
+        # @param [Time] start_date Filters the statistics returned by the class to after this date. nil means no filter
+        # @param [Time] end_date Filters the statistics returned by the class to before this date. nil means today
+        # @return [Hash] A hash with the total files by permission for the system
+        # @see #by_permission
+        def self.by_permission(start_date: nil, end_date: nil)
+          new(start_date, end_date).by_permission
+        end
+
         # @param [Time] start_date Filters the statistics returned by the class to after this date. nil means no filter
         # @param [Time] end_date Filters the statistics returned by the class to before this date. nil means today
         def initialize(start_date = nil, end_date = nil)

--- a/spec/features/embargo_spec.rb
+++ b/spec/features/embargo_spec.rb
@@ -32,13 +32,4 @@ RSpec.feature 'embargo' do
       expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard))
     end
   end
-
-  describe 'managing embargoes' do
-    let(:user) { create(:user, groups: ['admin']) }
-
-    it 'shows lists of objects under lease' do
-      visit '/embargoes'
-      expect(page).to have_content 'Manage Embargoes'
-    end
-  end
 end

--- a/spec/presenters/hyrax/admin_stats_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_stats_presenter_spec.rb
@@ -11,138 +11,38 @@ RSpec.describe Hyrax::AdminStatsPresenter do
   let(:limit) { 5 }
   let(:service) { described_class.new(filters, limit) }
 
-  describe '#active_users', :clean_repo do
-    let!(:old_work) { create(:work, user: user1) }
-    let!(:work1) { create(:work, user: user1) }
-    let!(:work2) { create(:work, user: user2) }
-    let!(:collection1) { create(:public_collection, user: user1) }
-
-    before do
-      allow(old_work).to receive(:create_date).and_return(two_days_ago_date.to_datetime)
-      old_work.update_index
-      # Force optimize so the terms component is caught up.
-      ActiveFedora::SolrService.instance.conn.optimize
-    end
-
-    subject { service.active_users }
-
-    it "returns statistics" do
-      expect(subject).to eq [{ label: user1.user_key, data: 3 }, { label: user2.user_key, data: 1 }]
+  describe '#active_users' do
+    it 'delegates to Hyrax::Statistics::Works::ByDepositor.query' do
+      expect(Hyrax::Statistics::Works::ByDepositor).to receive(:query).with(limit: limit).and_return(:query_response)
+      expect(service.active_users).to eq(:query_response)
     end
   end
 
-  describe "#top_formats", :clean_repo do
-    let!(:file_set1) { create(:file_set, user: user1) }
-    let!(:file_set2) { create(:file_set, user: user1) }
-    let!(:file_set3) { create(:file_set, user: user2) }
-
-    before do
-      allow(file_set1).to receive(:create).and_return(two_days_ago_date)
-      allow(file_set1).to receive(:mime_type).and_return('image/png')
-      allow(file_set2).to receive(:mime_type).and_return('image/png')
-      allow(file_set3).to receive(:mime_type).and_return('image/jpeg')
-      file_set1.update_index
-      file_set2.update_index
-      file_set3.update_index
-    end
-
-    subject { service.top_formats }
-
-    it "gathers formats" do
-      expect(subject).to eq [{ label: "png", data: 2 }, { label: "jpeg", data: 1 }]
+  describe "#top_formats" do
+    it 'delegates to Hyrax::Statistics::FileSets::ByFormat.query' do
+      expect(Hyrax::Statistics::FileSets::ByFormat).to receive(:query).with(limit: limit).and_return(:query_response)
+      expect(service.top_formats).to eq(:query_response)
     end
   end
 
-  describe "#works_count", :clean_repo do
-    before do
-      build(:generic_work, user: user1, id: "abc1223").update_index
-      build(:public_generic_work, user: user1, id: "bbb1223").update_index
-      build(:registered_generic_work, user: user1, id: "ccc1223").update_index
-      create(:public_collection, user: user1)
-    end
-
-    let(:one_day_ago)  { one_day_ago_date.strftime("%Y-%m-%d") }
-    let(:two_days_ago) { two_days_ago_date.strftime("%Y-%m-%d") }
-
-    subject { service.works_count }
-
-    it "includes files but not collections" do
-      expect(subject[:total]).to eq(3)
-      expect(subject[:public]).to eq(1)
-      expect(subject[:registered]).to eq(1)
-      expect(subject[:private]).to eq(1)
-    end
-
-    context "when there is uncommitted work" do
-      let(:original_works_count) do
-        work = create(:generic_work, user: user1)
-        original_files_count = GenericWork.count
-        ActiveFedora::SolrService.instance.conn.delete_by_id(work.id)
-        original_files_count
-      end
-
-      it "provides accurate count, ensuring that solr deletes have been expunged first" do
-        expect(subject[:total]).to eq(original_works_count - 1)
-      end
-    end
-
-    context "when start date is provided" do
-      let(:start_date) { one_day_ago }
-      let(:system_stats) { double(by_permission: {}) }
-
-      it "queries by start date" do
-        expect(Hyrax::Statistics::Works::Count).to receive(:new)
-          .with(one_day_ago_date.beginning_of_day,
-                nil)
-          .and_return(system_stats)
-        subject
-      end
-    end
-
-    context "when start and end date is provided" do
-      let(:start_date) { two_days_ago }
-      let(:end_date) { one_day_ago }
-      let(:system_stats) { double(by_permission: {}) }
-
-      it "queries by start and date" do
-        expect(Hyrax::Statistics::Works::Count).to receive(:new)
-          .with(two_days_ago_date.beginning_of_day,
-                one_day_ago_date.end_of_day)
-          .and_return(system_stats)
-        subject
-      end
+  describe "#works_count" do
+    it 'delegates to Hyrax::Statistics::Works::Count.by_permission' do
+      expect(Hyrax::Statistics::Works::Count).to receive(:by_permission).with(start_date: service.start_date, end_date: service.end_date).and_return(:query_response)
+      expect(service.works_count).to eq(:query_response)
     end
   end
 
-  describe "recent_users" do
-    let(:one_day_ago)  { one_day_ago_date.strftime("%Y-%m-%d") }
-    let(:two_days_ago) { two_days_ago_date.strftime("%Y-%m-%d") }
-
-    subject { service.recent_users }
-
-    context "default range" do
-      it "defaults to latest 5 users" do
-        expect(subject).to eq(User.order('created_at DESC').limit(5))
-      end
+  describe "#depositors" do
+    it 'delegates to Hyrax::Statistics::Depositors::Summary.depositors' do
+      expect(Hyrax::Statistics::Depositors::Summary).to receive(:depositors).with(start_date: service.start_date, end_date: service.end_date).and_return(:query_response)
+      expect(service.depositors).to eq(:query_response)
     end
+  end
 
-    context "with a start and no end date" do
-      let(:start_date) { one_day_ago }
-
-      it "allows queries against stats_filters" do
-        expect(User).to receive(:recent_users).with(one_day_ago_date.beginning_of_day, nil).and_return([user2])
-        expect(subject).to eq [user2]
-      end
-    end
-
-    context 'with start and end dates' do
-      let(:start_date) { two_days_ago }
-      let(:end_date) { one_day_ago }
-
-      it "queries" do
-        expect(User).to receive(:recent_users).with(two_days_ago_date.beginning_of_day, one_day_ago_date.end_of_day).and_return([user2])
-        expect(subject).to eq [user2]
-      end
+  describe "#recent_users" do
+    it 'delegates to Hyrax::Statistics::SystemStats.recent_users' do
+      expect(Hyrax::Statistics::SystemStats).to receive(:recent_users).with(limit: limit, start_date: service.start_date, end_date: service.end_date).and_return(:query_response)
+      expect(service.recent_users).to eq(:query_response)
     end
   end
 

--- a/spec/services/hyrax/statistics/depositors/summary_spec.rb
+++ b/spec/services/hyrax/statistics/depositors/summary_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe Hyrax::Statistics::Depositors::Summary, :clean_repo do
     old_work.update_index
   end
 
+  describe '.depositors' do
+    it 'is a convenience method' do
+      summary_object = double(depositors: :the_depositors)
+      expect(described_class).to receive(:new).with('a_start_date', 'an_end_date').and_return(summary_object)
+      expect(described_class.depositors(start_date: 'a_start_date', end_date: 'an_end_date')).to eq(:the_depositors)
+    end
+  end
+
   describe "#depositors" do
     subject { service.depositors }
 

--- a/spec/services/hyrax/statistics/file_sets/by_format_spec.rb
+++ b/spec/services/hyrax/statistics/file_sets/by_format_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe Hyrax::Statistics::FileSets::ByFormat, :clean_repo do
-  let(:service) { described_class.new }
-
-  describe "#query" do
+  describe ".query" do
     let(:fs1) { build(:file_set, id: '1234567') }
     let(:fs2) { build(:file_set, id: '2345678') }
     let(:fs3) { build(:file_set, id: '3456789') }
@@ -18,7 +16,7 @@ RSpec.describe Hyrax::Statistics::FileSets::ByFormat, :clean_repo do
       fs4.update_index
     end
 
-    subject { service.query }
+    subject { described_class.query }
 
     it "is a list of categories" do
       expect(subject).to eq [{ label: 'jpg (JPEG image)', data: 2 },

--- a/spec/services/hyrax/statistics/system_stats_spec.rb
+++ b/spec/services/hyrax/statistics/system_stats_spec.rb
@@ -2,9 +2,8 @@ RSpec.describe Hyrax::Statistics::SystemStats do
   let(:user1) { create(:user) }
   let(:start_date) { nil }
   let(:end_date) { nil }
-  let(:stats) { described_class.new(depositor_count, start_date, end_date) }
 
-  describe "#recent_users" do
+  describe ".recent_users" do
     let!(:user2) { create(:user) }
 
     let(:two_days_ago_date) { 2.days.ago.beginning_of_day }
@@ -12,7 +11,7 @@ RSpec.describe Hyrax::Statistics::SystemStats do
 
     let(:depositor_count) { nil }
 
-    subject { stats.recent_users }
+    subject { described_class.recent_users(limit: depositor_count, start_date: start_date, end_date: end_date) }
 
     context "without dates" do
       let(:mock_order) { double }

--- a/spec/services/hyrax/statistics/works/by_depositor_spec.rb
+++ b/spec/services/hyrax/statistics/works/by_depositor_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe Hyrax::Statistics::Works::ByDepositor do
-  let(:service) { described_class.new }
-
-  describe "#query", :clean_repo do
+  describe ".query", :clean_repo do
     let(:user1) { create(:user) }
     let(:user2) { create(:user) }
 
@@ -16,7 +14,7 @@ RSpec.describe Hyrax::Statistics::Works::ByDepositor do
       gf.update_index
     end
 
-    subject { service.query }
+    subject { described_class.query }
 
     it "is a list of categories" do
       expect(subject).to eq [{ label: user1.user_key, data: 3 },

--- a/spec/services/hyrax/statistics/works/count_spec.rb
+++ b/spec/services/hyrax/statistics/works/count_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Hyrax::Statistics::Works::Count do
-  describe "#by_permission", :clean_repo do
+  describe ".by_permission", :clean_repo do
     let(:user1) { build(:user, id: 1) }
     let(:yesterday) { 1.day.ago }
 
@@ -17,17 +17,17 @@ RSpec.describe Hyrax::Statistics::Works::Count do
 
     # Consolidated these tests as they are rather slow when run in sequence
     it "retrieves by no date given, a start date given, and an end date given" do
-      no_date_range_given = described_class.new(nil, nil)
-      expect(no_date_range_given.by_permission).to include(public: 3, private: 1, registered: 1, total: 5)
+      no_date_range_given = described_class.by_permission(start_date: nil, end_date: nil)
+      expect(no_date_range_given).to include(public: 3, private: 1, registered: 1, total: 5)
 
       start_date = yesterday.beginning_of_day
-      start_date_given = described_class.new(start_date, nil)
-      expect(start_date_given.by_permission).to include(public: 2, private: 1, registered: 1, total: 4)
+      start_date_given = described_class.by_permission(start_date: start_date, end_date: nil)
+      expect(start_date_given).to include(public: 2, private: 1, registered: 1, total: 4)
 
       start_date = 2.days.ago.beginning_of_day
       end_date = yesterday.end_of_day
-      start_date_and_end_date_given = described_class.new(start_date, end_date)
-      expect(start_date_and_end_date_given.by_permission).to include(public: 1, private: 0, registered: 0, total: 1)
+      start_date_and_end_date_given = described_class.by_permission(start_date: start_date, end_date: end_date)
+      expect(start_date_and_end_date_given).to include(public: 1, private: 0, registered: 0, total: 1)
     end
   end
 end

--- a/spec/views/hyrax/embargoes/index.html.erb_spec.rb
+++ b/spec/views/hyrax/embargoes/index.html.erb_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe "hyrax/embargoes/index.html.erb", type: :view do
+  before do
+    stub_template 'hyrax/embargoes/_list_deactivated_embargoes' => 'rendered list_deactivated_embargoes'
+    stub_template 'hyrax/embargoes/_list_expired_active_embargoes' => 'rendered list_expired_active_embargoes'
+    stub_template 'hyrax/embargoes/_list_active_embargoes' => 'rendered list_active_embargoes'
+  end
+
+  it "displays the page and renderes deactivated, expired, and active embargoes" do
+    render template: 'hyrax/embargoes/index'
+    expect(rendered).to have_css('.tab-pane#active', text: 'rendered list_active_embargoes')
+    expect(rendered).to have_css('.tab-pane#expired', text: 'rendered list_expired_active_embargoes')
+    expect(rendered).to have_css('.tab-pane#deactivated', text: 'rendered list_deactivated_embargoes')
+  end
+end


### PR DESCRIPTION
## Reducing redundant specs

@3704b1853fef4fe12a61d037315bb934ff2aa0c8

Prior to this commit, the query logic was tested both in the presenter
and in the underlying query service object.

This commit now verifies that the presenter calls the query service
but does not re-test (and re-build the test conditions) of the details
of the query service implementation.

The refactor drops all of LDP requests on the presenter and speeds up
the isolated tests by about 6 seconds. See below for more details:

Before:

```console
Examples with the most LDP requests
  Hyrax::AdminStatsPresenter#works_count when start date is provided queries by start date
    Total LDP: 35 {"HEAD"=>3, "GET"=>22, "POST"=>7, "DELETE"=>2, "PUT"=>1}
  Hyrax::AdminStatsPresenter#works_count when start and end date is provided queries by start and date
    Total LDP: 35 {"HEAD"=>3, "GET"=>22, "POST"=>7, "DELETE"=>2, "PUT"=>1}
  Hyrax::AdminStatsPresenter#works_count includes files but not collections
    Total LDP: 35 {"HEAD"=>3, "GET"=>22, "POST"=>7, "DELETE"=>2, "PUT"=>1}
  Hyrax::AdminStatsPresenter#top_formats gathers formats
    Total LDP: 46 {"HEAD"=>7, "GET"=>27, "POST"=>9, "DELETE"=>2, "PUT"=>1}
  Hyrax::AdminStatsPresenter#works_count when there is uncommitted work provides accurate count, ensuring that solr deletes have been expunged first
    Total LDP: 49 {"HEAD"=>5, "GET"=>31, "POST"=>10, "DELETE"=>2, "PUT"=>1}
  Hyrax::AdminStatsPresenter#active_users returns statistics
    Total LDP: 63 {"HEAD"=>10, "GET"=>37, "POST"=>13, "DELETE"=>2, "PUT"=>1}
Finished in 6.88 seconds (files took 6.87 seconds to load)
```

After:

```console
Examples with the most LDP requests
  [NONE]
Finished in 0.30383 seconds (files took 6.38 seconds to load)
```

## Removing a redundant spec that intermittently fails

@e400383ece56dd5a6a4f034e06795feda5f31b3f

This does not address the underlying issue of related to a `nil`
visibility that could be passed to `Hyrax::PermissionBadge.new`

Analogue to changes made in 5270ee277b8352c8636a32e77cb691401eba8c9b2a4a5
