### PR TITLE
remove enforce_viewing_context_for_show_requests

### DIFF
--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -23,7 +23,6 @@ module Hyrax
 
     before_action :authenticate_user!
     before_action :enforce_show_permissions, only: :show
-    before_action :enforce_viewing_context_for_show_requests, only: :show
 
     # include the render_check_all view helper method
     helper Hyrax::BatchEditsHelper


### PR DESCRIPTION
Fixes #1494

Changes:
* Remove `before_action :enforce_viewing_context_for_show_requests, only: :show` from Hyrax::MyController.

See issue for rationale.

@samvera/hyrax-code-reviewers
