### PR TITLE
Port and adapt batch edit spec changes from ScholarSphere

### DIFF
--- a/app/views/hyrax/my/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/my/_sort_and_per_page.html.erb
@@ -1,7 +1,5 @@
-
-
   <div class="sort-toggle">
-    <% if @response.response['numFound'] > 1 && !sort_fields.empty? %>
+    <% if @response.response['numFound'] > 1 %>
       <%= form_tag search_action_for_dashboard, method: :get, class: 'per_page form-inline' do %>
             <div class="form-group">
               <fieldset class="col-xs-12">

--- a/app/views/hyrax/uploads/_js_templates.html.erb
+++ b/app/views/hyrax/uploads/_js_templates.html.erb
@@ -1,7 +1,8 @@
 <!-- The template to display files available for upload -->
+<% fade_class_if_not_test = Rails.env.test? ? '' : 'fade' %>
 <script id="template-upload" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
-    <tr class="template-upload fade">
+    <tr class="template-upload <%= fade_class_if_not_test %>">
         <td>
             <span class="preview"></span>
         </td>
@@ -53,7 +54,7 @@
 <!-- The template to display files available for download -->
 <script id="batch-template-download" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
-    <tr class="template-download fade">
+    <tr class="template-download <%= fade_class_if_not_test %>">
         <td>
           <div class="row">
             <div class="col-sm-6 name">
@@ -97,7 +98,7 @@
 <!-- TODO: further consolidate with template-download above -->
 <script id="template-download" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
-    <tr class="template-download fade">
+    <tr class="template-download <%= fade_class_if_not_test %>">
         <td>
             <span class="preview">
                 {% if (file.thumbnailUrl) { %}

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -1,28 +1,28 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Batch management of works', type: :feature do
+RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
   let(:current_user) { create(:user) }
   let!(:work1)       { create(:public_work, user: current_user) }
   let!(:work2)       { create(:public_work, user: current_user) }
 
   before do
-    sign_in(current_user)
+    sign_in current_user
     visit '/dashboard/my/works'
+    check 'check_all'
   end
 
-  describe 'editing and viewing multiple works' do
-    it 'edits each field and displays the changes', clean_repo: true, js: true do
-      check 'check_all'
+  describe 'editing' do
+    it 'changes the value of each field for all selected works' do
       click_on 'batch-edit'
-      fields.each do |f|
+      batch_edit_fields.each do |f|
         if f == "resource_type"
-          select_field(f, 'Book')
+          select_batch_edit_field(f, 'Book')
         else
-          fill_in_field_fill(f)
+          fill_in_batch_edit_field(f)
         end
       end
-      fields.each do |f|
-        fill_in_field_save_and_verify(f)
+      batch_edit_fields.each do |f|
+        fill_in_batch_edit_field_and_verify(f)
       end
       work1.reload
       work2.reload
@@ -56,81 +56,37 @@ RSpec.describe 'Batch management of works', type: :feature do
       check 'check_all'
       click_on 'batch-edit'
       expect(page).to have_content('Batch Edit Descriptions')
-      expand("creator")
+      batch_edit_expand("creator")
       expect(page).to have_css "input#generic_work_creator[value*='NEW creator']"
-      expand("contributor")
+      batch_edit_expand("contributor")
       expect(page).to have_css "input#generic_work_contributor[value*='NEW contributor']"
-      expand("description")
+      batch_edit_expand("description")
       expect(page).to have_css "textarea#generic_work_description", text: 'NEW description'
-      expand("keyword")
+      batch_edit_expand("keyword")
       expect(page).to have_css "input#generic_work_keyword[value*='NEW keyword']"
-      expand("publisher")
+      batch_edit_expand("publisher")
       expect(page).to have_css "input#generic_work_publisher[value*='NEW publisher']"
-      expand("date_created")
+      batch_edit_expand("date_created")
       expect(page).to have_css "input#generic_work_date_created[value*='NEW date_created']"
-      expand("subject")
+      batch_edit_expand("subject")
       expect(page).to have_css "input#generic_work_subject[value*='NEW subject']"
-      expand("language")
+      batch_edit_expand("language")
       expect(page).to have_css "input#generic_work_language[value*='NEW language']"
-      expand("identifier")
+      batch_edit_expand("identifier")
       expect(page).to have_css "input#generic_work_identifier[value*='NEW identifier']"
-      # expand("based_near")
+      # batch_edit_expand("based_near")
       # expect(page).to have_css "input#generic_work_based_near[value*='NEW based_near']"
-      expand("related_url")
+      batch_edit_expand("related_url")
       expect(page).to have_css "input#generic_work_related_url[value*='NEW related_url']"
-      expand("resource_type")
+      batch_edit_expand("resource_type")
       expect(page).to have_select "generic_work_resource_type", selected: 'Book'
     end
   end
 
-  describe 'Deleting multiple works', :clean_repo, js: true do
-    context 'Selecting all my works to delete' do
-      before do
-        visit '/dashboard/my/works'
-        check 'check_all'
-        accept_confirm { click_button 'Delete Selected' }
-      end
-      it 'Removes the works from the system' do
-        expect(GenericWork.count).to be_zero
-      end
+  describe 'deleting' do
+    it 'destroys the selected works' do
+      accept_confirm { click_button 'Delete Selected' }
+      expect(GenericWork.count).to be_zero
     end
-  end
-
-  def fields
-    # skipping based_near because it's a select2 field, which is hard to test via capybara
-    [
-      "creator", "contributor", "description", "keyword", "publisher", "date_created",
-      "subject", "language", "identifier", "related_url", "resource_type"
-    ]
-  end
-
-  def fill_in_field_fill(id)
-    expand(id)
-    within "#form_#{id}" do
-      fill_in "generic_work_#{id}", with: "NEW #{id}"
-    end
-  end
-
-  def fill_in_field_save_and_verify(id)
-    within "#form_#{id}" do
-      click_button "#{id}_save"
-      # Incrementing from 5 to 15 to see if we can prevent erratic failures in Travis. These
-      # failures result in a broken build and require a restart of the specs. This restart
-      # and waiting for feedback slows the overall trajectory of iterating on Hyrax.
-      expect(page).to have_content 'Changes Saved', wait: Capybara.default_max_wait_time * 15
-    end
-  end
-
-  def expand(field)
-    link = find("#expand_link_#{field}")
-    while link["class"].include?("collapsed")
-      sleep 0.1
-      link.click if link["class"].include?("collapsed")
-    end
-  end
-
-  def select_field(id, option)
-    expand(id)
-    select(option, from: "generic_work_#{id}")
   end
 end

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -14,42 +14,13 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
   describe 'editing' do
     it 'changes the value of each field for all selected works' do
       click_on 'batch-edit'
-      batch_edit_fields.each do |f|
-        if f == "resource_type"
-          select_batch_edit_field(f, 'Book')
-        else
-          fill_in_batch_edit_field(f)
-        end
-      end
-      batch_edit_fields.each do |f|
-        fill_in_batch_edit_field_and_verify(f)
-      end
+      fill_in_batch_edit_fields_and_verify!
       work1.reload
       work2.reload
-      expect(work1.creator).to eq ['NEW creator']
-      expect(work1.contributor).to eq ['NEW contributor']
-      expect(work1.description).to eq ['NEW description']
-      expect(work1.keyword).to eq ['NEW keyword']
-      expect(work1.publisher).to eq ['NEW publisher']
-      expect(work1.date_created).to eq ['NEW date_created']
-      expect(work1.subject).to eq ['NEW subject']
-      expect(work1.language).to eq ['NEW language']
-      expect(work1.identifier).to eq ['NEW identifier']
-      # expect(work1.based_near).to eq ['NEW based_near']
-      expect(work1.related_url).to eq ['NEW related_url']
-      expect(work1.resource_type).to eq ['Book']
-      expect(work2.creator).to eq ['NEW creator']
-      expect(work2.contributor).to eq ['NEW contributor']
-      expect(work2.description).to eq ['NEW description']
-      expect(work2.keyword).to eq ['NEW keyword']
-      expect(work2.publisher).to eq ['NEW publisher']
-      expect(work2.date_created).to eq ['NEW date_created']
-      expect(work2.subject).to eq ['NEW subject']
-      expect(work2.language).to eq ['NEW language']
-      expect(work2.identifier).to eq ['NEW identifier']
-      # expect(work2.based_near).to eq ['NEW based_near']
-      expect(work2.related_url).to eq ['NEW related_url']
-      expect(work2.resource_type).to eq ['Book']
+      batch_edit_fields.each do |field|
+        expect(work1.send(field)).to match_array("NEW #{field}")
+        expect(work2.send(field)).to match_array("NEW #{field}")
+      end
 
       # Reload the form and verify
       visit '/dashboard/my/works'
@@ -78,8 +49,6 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
       # expect(page).to have_css "input#generic_work_based_near[value*='NEW based_near']"
       batch_edit_expand("related_url")
       expect(page).to have_css "input#generic_work_related_url[value*='NEW related_url']"
-      batch_edit_expand("resource_type")
-      expect(page).to have_select "generic_work_resource_type", selected: 'Book'
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,20 +59,6 @@ ActiveJob::Base.queue_adapter = :inline
 # HttpLogger.ignore = [/localhost:8983\/solr/]
 # HttpLogger.colorize = false
 
-if ENV['TRAVIS']
-  # Monkey-patches the FITS runner to return the PDF FITS fixture
-  module Hydra::Works
-    class CharacterizationService
-      def self.run(_, _)
-        raise "FITS!!!"
-        # return unless file_set.original_file.has_content?
-        # filename = ::File.expand_path("../fixtures/pdf_fits.xml", __FILE__)
-        # file_set.characterization.ng_xml = ::File.read(filename)
-      end
-    end
-  end
-end
-
 if defined?(ClamAV)
   ClamAV.instance.loaddb
 else

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,7 +1,7 @@
 # spec/support/features.rb
 require File.expand_path('../features/session_helpers', __FILE__)
 require File.expand_path('../features/workflow', __FILE__)
-
+require File.expand_path('../features/batch_edit_actions', __FILE__)
 require File.expand_path('../selectors', __FILE__)
 require File.expand_path('../proxies', __FILE__)
 require File.expand_path('../statistic_helper', __FILE__)

--- a/spec/support/features/batch_edit_actions.rb
+++ b/spec/support/features/batch_edit_actions.rb
@@ -2,36 +2,21 @@ def batch_edit_fields
   # skipping based_near because it's a select2 field, which is hard to test via capybara
   [
     "creator", "contributor", "description", "keyword", "publisher", "date_created",
-    "subject", "language", "identifier", "related_url", "resource_type"
+    "subject", "language", "identifier", "related_url"
   ]
 end
 
-def fill_in_batch_edit_field(id)
-  batch_edit_expand(id)
-  within "#form_#{id}" do
-    fill_in "generic_work_#{id}", with: "NEW #{id}"
-  end
-end
-
-def fill_in_batch_edit_field_and_verify(id)
-  within "#form_#{id}" do
-    click_button "#{id}_save"
-    # Incrementing from 5 to 15 to see if we can prevent erratic failures in Travis. These
-    # failures result in a broken build and require a restart of the specs. This restart
-    # and waiting for feedback slows the overall trajectory of iterating on Hyrax.
-    expect(page).to have_content 'Changes Saved', wait: Capybara.default_max_wait_time * 15
+def fill_in_batch_edit_fields_and_verify!
+  batch_edit_fields.each do |field_id|
+    within "#form_#{field_id}" do
+      batch_edit_expand(field_id)
+      fill_in "generic_work_#{field_id}", with: "NEW #{field_id}"
+      click_button "#{field_id}_save"
+      expect(page).to have_content 'Changes Saved'
+    end
   end
 end
 
 def batch_edit_expand(field)
-  link = find("#expand_link_#{field}")
-  while link["class"].include?("collapsed")
-    sleep 0.1
-    link.click if link["class"].include?("collapsed")
-  end
-end
-
-def select_batch_edit_field(id, option)
-  batch_edit_expand(id)
-  select(option, from: "generic_work_#{id}")
+  find("#expand_link_#{field}").click
 end

--- a/spec/support/features/batch_edit_actions.rb
+++ b/spec/support/features/batch_edit_actions.rb
@@ -1,0 +1,37 @@
+def batch_edit_fields
+  # skipping based_near because it's a select2 field, which is hard to test via capybara
+  [
+    "creator", "contributor", "description", "keyword", "publisher", "date_created",
+    "subject", "language", "identifier", "related_url", "resource_type"
+  ]
+end
+
+def fill_in_batch_edit_field(id)
+  batch_edit_expand(id)
+  within "#form_#{id}" do
+    fill_in "generic_work_#{id}", with: "NEW #{id}"
+  end
+end
+
+def fill_in_batch_edit_field_and_verify(id)
+  within "#form_#{id}" do
+    click_button "#{id}_save"
+    # Incrementing from 5 to 15 to see if we can prevent erratic failures in Travis. These
+    # failures result in a broken build and require a restart of the specs. This restart
+    # and waiting for feedback slows the overall trajectory of iterating on Hyrax.
+    expect(page).to have_content 'Changes Saved', wait: Capybara.default_max_wait_time * 15
+  end
+end
+
+def batch_edit_expand(field)
+  link = find("#expand_link_#{field}")
+  while link["class"].include?("collapsed")
+    sleep 0.1
+    link.click if link["class"].include?("collapsed")
+  end
+end
+
+def select_batch_edit_field(id, option)
+  batch_edit_expand(id)
+  select(option, from: "generic_work_#{id}")
+end

--- a/spec/test_app_templates/disable_animations_in_test_environment.rb
+++ b/spec/test_app_templates/disable_animations_in_test_environment.rb
@@ -1,0 +1,54 @@
+# disable CSS3 and jQuery animations in test mode for speed, consistency and avoiding timing issues.
+# HT: https://gist.github.com/keithtom/8763169
+class DisableAnimationsInTestEnvironment
+  def initialize(app, _options = {})
+    @app = app
+  end
+
+  def call(env)
+    @status, @headers, @body = @app.call(env)
+    return [@status, @headers, @body] unless html?
+    response = Rack::Response.new([], @status, @headers)
+
+    @body.each { |fragment| response.write inject(fragment) }
+    @body.close if @body.respond_to?(:close)
+
+    response.finish
+  end
+
+  private
+
+    def html?
+      @headers["Content-Type"] =~ /html/
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Layout/IndentHeredoc
+    def inject(fragment)
+      disable_animations = <<-EOF
+<script type="text/javascript">(typeof jQuery !== 'undefined') && (jQuery.fx.off = true);</script>
+<style>
+  * {
+     -o-transition: none !important;
+     -moz-transition: none !important;
+     -ms-transition: none !important;
+     -webkit-transition: none !important;
+     transition: none !important;
+     -o-transform: none !important;
+     -moz-transform: none !important;
+     -ms-transform: none !important;
+     -webkit-transform: none !important;
+     transform: none !important;
+     -webkit-animation: none !important;
+     -moz-animation: none !important;
+     -o-animation: none !important;
+     -ms-animation: none !important;
+     animation: none !important;
+  }
+</style>
+      EOF
+      fragment.gsub(%r{</head>}, disable_animations + "</head>")
+    end
+  # rubocop:enable Layout/IndentHeredoc
+  # rubocop:enable Metrics/MethodLength
+end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -1,7 +1,9 @@
 require 'rails/generators'
 
 class TestAppGenerator < Rails::Generators::Base
-  source_root "./spec/test_app_templates"
+  # Generator is executed from /path/to/hyrax/.internal_test_app/lib/generators/test_app_generator/
+  # so the following path gets us to /path/to/hyrax/spec/test_app_templates/
+  source_root File.expand_path('../../../../spec/test_app_templates/', __FILE__)
 
   def install_engine
     generate 'hyrax:install', '-f'
@@ -66,5 +68,12 @@ class TestAppGenerator < Rails::Generators::Base
 
   def relax_routing_constraint
     gsub_file 'config/initializers/arkivo_constraint.rb', 'false', 'true'
+  end
+
+  def disable_animations_for_more_reliable_feature_specs
+    inject_into_file 'config/environments/test.rb', after: "Rails.application.configure do\n" do
+      "  config.middleware.use DisableAnimationsInTestEnvironment\n"
+    end
+    copy_file 'disable_animations_in_test_environment.rb', 'app/middleware/disable_animations_in_test_environment.rb'
   end
 end


### PR DESCRIPTION
The following changes are included, in order to eliminate dead code and to make the test suite more reliable:

* Remove dead code around monkey-patching FITS in `spec_helper.rb`
* Remove Blacklight `#sort_fields` deprecation warning
* Isolate batch edit-related actions into their own module
* Port changes from ScholarSphere's batch_edit_spec and then adapt them
* Use Rack middleware to disable CSS/jQuery animations in test environment
* Disable transitions in jquery file uploader in `RAILS_ENV=test`

Supersedes #989
Fixes #815
Fixes #1116 

Thanks to @awead for getting the ball rolling on these changes by doing the work in ScholarSphere!