### PR TITLE
Create metadata and settings partials for collection types

### DIFF
--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -97,6 +97,37 @@ form {
   }
 }
 
+.collection-types-settings {
+
+  .form-inline {
+    label {
+      font-weight: bold;
+
+      input {
+        margin-right: 0.25em;
+      }
+    }
+
+    .control-label,
+    label {
+      display: inline;
+      padding-left: 0;
+
+      &::after {
+        content: ' ';
+      }
+    }
+
+    .help-block {
+      display: inline;
+
+      &::before {
+        content: ' ';
+      }
+    }
+  }
+}
+
 .control-label.required {
   abbr {
     font-weight: bold;

--- a/app/controllers/hyrax/admin/collection_types_controller.rb
+++ b/app/controllers/hyrax/admin/collection_types_controller.rb
@@ -7,6 +7,7 @@ module Hyrax
     layout 'dashboard'
     class_attribute :form_class
     self.form_class = Hyrax::Forms::Admin::CollectionTypeForm
+    load_resource class: Hyrax::CollectionType, except: [:index, :show, :create], instance_name: :collection_type
 
     def index
       add_breadcrumb t(:'hyrax.controls.home'), root_path
@@ -25,7 +26,7 @@ module Hyrax
       add_breadcrumb t(:'hyrax.admin.sidebar.configuration'), '#'
       add_breadcrumb t(:'hyrax.admin.collection_types.index.breadcrumb'), hyrax.admin_collection_types_path
       add_breadcrumb t(:'hyrax.admin.collection_types.new.header'), hyrax.new_admin_collection_type_path
-      @form = form_class.new
+      @form = form_class.new(collection_type: @collection_type)
     end
 
     def create; end
@@ -36,7 +37,7 @@ module Hyrax
       add_breadcrumb t(:'hyrax.admin.sidebar.configuration'), '#'
       add_breadcrumb t(:'hyrax.admin.collection_types.index.breadcrumb'), hyrax.admin_collection_types_path
       add_breadcrumb t(:'hyrax.admin.collection_types.edit.header'), hyrax.edit_admin_collection_type_path
-      @form = form_class.new
+      @form = form_class.new(collection_type: @collection_type)
     end
 
     def update; end

--- a/app/forms/hyrax/forms/admin/collection_type_form.rb
+++ b/app/forms/hyrax/forms/admin/collection_type_form.rb
@@ -3,11 +3,12 @@ module Hyrax
     module Admin
       class CollectionTypeForm
         include ActiveModel::Model
+        attr_accessor :collection_type
+        validates :title, presence: true
 
-        # create enough of the form to make the views happy for now
-        def title
-          'placeholder'
-        end
+        delegate :title, :description, :discoverable, :nestable, :sharable,
+                 :require_membership, :allow_multiple_membership, :assigns_workflow,
+                 :assigns_visibility, :id, :persisted?, to: :collection_type
       end
     end
   end

--- a/app/views/hyrax/admin/collection_types/_form.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form.html.erb
@@ -12,7 +12,7 @@
         </li>
     <% end %>
   </ul>
-  <%= simple_form_for @form, url: hyrax.admin_collection_types_path do |f| %>
+  <%= simple_form_for @form, url: hyrax.admin_collection_types_path, as: :collection_type do |f| %>
   <div class="tab-content">
       <div id="metadata" class="tab-pane active">
         <div class="panel panel-default labels">

--- a/app/views/hyrax/admin/collection_types/_form_metadata.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_metadata.html.erb
@@ -1,0 +1,2 @@
+<%= f.input :title %>
+<%= f.input :description, as: :text %>

--- a/app/views/hyrax/admin/collection_types/_form_settings.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_settings.html.erb
@@ -1,0 +1,16 @@
+<p><%= t('.instructions') %></p>
+
+<p><strong><%= t('.warning') %></strong></p>
+
+<%# TODO: make these settings READ ONLY if at least one collection of this collection type already exists %>
+<div class="collection-types-settings">
+  <div class="form-inline">
+    <p><%= f.input :nestable, as: :boolean %></p>
+    <p><%= f.input :discoverable, as: :boolean %></p>
+    <p><%= f.input :sharable, as: :boolean %></p>
+    <p><%= f.input :require_membership, as: :boolean, disabled: true %></p>
+    <p><%= f.input :allow_multiple_membership, as: :boolean %></p>
+    <p><%= f.input :assigns_workflow, as: :boolean, disabled: true %></p>
+    <p><%= f.input :assigns_visibility, as: :boolean, disabled: true %></p>
+  </div>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -173,38 +173,9 @@ en:
             metadata:        "Description"
             settings:        "Settings"
             participants:    "Participants"
-          metadata:
-            name:
-              label:         "Type name"
-              description:   ""
-            description:
-              label:         "Type description"
-              description:   "A brief statement of the general purpose of this collection type.  Users will see this if they have more than one collection type to choose from when creating a new collection."
-          settings:
-            instructions:    "These settings determine how collections of this type can be managed and discovered."
-            warning:         "Warning: These settings cannot be changed after a collection of this type has been created."
-            nestable:
-              label:         "NESTABLE"
-              description:   "Allow collections of this type to be nested (a collection can contain other collections)"
-            discovery:
-              label:         "DISCOVERY"
-              description:   "Allow collections of this type to be discoverable"
-            sharing:
-              label:         "SHARING"
-              description:   "Allow users to assign collection managers, depositors, and viewers for collections they manage"
-            multi-membership:
-              label:         "MULTIPLE MEMBERSHIP"
-              description:   "Allow works to belong to multiple collections of this type"
-            require-membership:
-              label:         "REQUIRE MEMBERSHIP"
-              description:   "A work must belong to at least one collection of this type"
-            workflow:
-              label:         "WORKFLOW"
-              description:   "Allow collections of this type to assign workflow to a new work"
-            visibility:
-              label:         "VISIBILITY"
-              description:   "Allow collections of this type to assign initial visibility settings to a new work"
-          participants:
+        form_settings:
+          instructions:    "These settings determine how collections of this type can be managed and discovered."
+          warning:         "Warning: These settings cannot be changed after a collection of this type has been created."
         index:
           breadcrumb:       "Collection Types"
           create_new_button: "Create new collection type"
@@ -893,6 +864,16 @@ en:
         license: "Licensing and distribution information governing access to the collection. Select from the provided drop-down list."
         subject: "Headings or index terms describing what the collection is about; these do need to conform to an existing vocabulary."
         title: "A name to aid in identifying a collection."
+      collection_type:
+        allow_multiple_membership: "Allow works to belong to multiple collections of this type"
+        assigns_workflow:   "Allow collections of this type to assign workflow to a new work"
+        assigns_visibility:   "Allow collections of this type to assign initial visibility settings to a new work"
+        title: ""
+        description: "A brief statement of the general purpose of this collection type.  Users will see this if they have more than one collection type to choose from when creating a new collection."
+        discoverable: "Allow collections of this type to be discoverable"
+        nestable: "Allow collections of this type to be nested (a collection can contain other collections)"
+        require_membership: "A work must belong to at least one collection of this type"
+        sharable: "Allow users to assign collection managers, depositors, and viewers for collections they manage"
       defaults:
         based_near: "A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>."
         contributor: "A person or group you want to recognize for playing a role in the creation of the work, but not the primary role."
@@ -912,6 +893,16 @@ en:
       collection:
         size:                      "Size"
         total_items:               "Total works"
+      collection_type:
+        allow_multiple_membership: "MULTIPLE MEMBERSHIP"
+        assigns_workflow: "WORKFLOW"
+        assigns_visibility: "VISIBILITY"
+        description: "Type description"
+        discoverable: "DISCOVERY"
+        nestable: "NESTABLE"
+        require_membership: "REQUIRE MEMBERSHIP"
+        sharable: "SHARING"
+        title: "Type name"
       defaults:
         admin_set_id:              "Add as member of administrative set"
         based_near:                "Location"

--- a/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
 
   context "authorized user" do
     let(:user) { create(:user) }
+    let(:collection_type) { create(:user_collection_type) }
 
     before do
       allow(controller.current_ability).to receive(:can?).with(any_args).and_return(true)
@@ -142,21 +143,21 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
 
     describe "#edit" do
       it "returns http success" do
-        get :edit, params: { id: :id }
+        get :edit, params: { id: collection_type.id }
         expect(response).to have_http_status(:success)
       end
     end
 
     describe "#update" do
       it "returns http success" do
-        put :update, params: { id: :id }
+        put :update, params: { id: collection_type.id }
         expect(response).to have_http_status(:success)
       end
     end
 
     describe "#destroy" do
       it "returns success" do
-        delete :destroy, params: { id: :id }
+        delete :destroy, params: { id: collection_type.id }
         expect(response).to have_http_status(:success)
       end
 
@@ -165,14 +166,14 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.breadcrumbs.admin'), dashboard_path)
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.sidebar.configuration'), '#')
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.index.breadcrumb'), admin_collection_types_path)
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.edit.header'), edit_admin_collection_type_path(1))
-        get :edit, params: { id: 1 }
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.edit.header'), edit_admin_collection_type_path(collection_type.id))
+        get :edit, params: { id: collection_type.id }
         expect(response).to be_success
         expect(response).to render_template "layouts/dashboard"
       end
 
       it 'defines a form' do
-        get :edit, params: { id: 1 }
+        get :edit, params: { id: collection_type.id }
         expect(response).to be_success
         expect(assigns[:form]).to be_kind_of Hyrax::Forms::Admin::CollectionTypeForm
       end

--- a/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
+++ b/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
@@ -1,11 +1,17 @@
 RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
+  let(:collection_type) { build(:collection_type) }
   let(:form) { described_class.new }
 
-  describe ".title" do
-    subject { form.title }
+  subject { form }
 
-    it {
-      is_expected.to eq 'placeholder'
-    }
-  end
+  it { is_expected.to delegate_method(:title).to(:collection_type) }
+  it { is_expected.to delegate_method(:description).to(:collection_type) }
+  it { is_expected.to delegate_method(:nestable).to(:collection_type) }
+  it { is_expected.to delegate_method(:sharable).to(:collection_type) }
+  it { is_expected.to delegate_method(:require_membership).to(:collection_type) }
+  it { is_expected.to delegate_method(:allow_multiple_membership).to(:collection_type) }
+  it { is_expected.to delegate_method(:assigns_workflow).to(:collection_type) }
+  it { is_expected.to delegate_method(:assigns_visibility).to(:collection_type) }
+  it { is_expected.to delegate_method(:id).to(:collection_type) }
+  it { is_expected.to delegate_method(:persisted?).to(:collection_type) }
 end

--- a/spec/views/hyrax/admin/collection_types/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form.html.erb_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe 'hyrax/admin/collection_types/_form.html.erb', type: :view do
-  let(:form) { Hyrax::Forms::Admin::CollectionTypeForm.new }
+  let(:collection_type) { build(:collection_type) }
+  let(:form) { Hyrax::Forms::Admin::CollectionTypeForm.new(collection_type: collection_type) }
 
   before do
     assign(:form, form)

--- a/spec/views/hyrax/admin/collection_types/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_metadata.html.erb_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe 'hyrax/admin/collection_types/_form_metadata.html.erb', type: :view do
+  let(:collection_type) { Hyrax::CollectionType.new }
+  let(:collection_type_form) { Hyrax::Forms::Admin::CollectionTypeForm.new }
+
+  let(:form) do
+    view.simple_form_for(collection_type, url: '/update') do |fs_form|
+      return fs_form
+    end
+  end
+
+  before do
+    assign(:form, collection_type_form)
+    allow(view).to receive(:f).and_return(form)
+    render
+  end
+
+  it "renders the name field" do
+    expect(rendered).to have_content(I18n.t("simple_form.labels.collection_type.title"))
+    expect(rendered).to have_selector("input#collection_type_title")
+  end
+
+  it "renders the description field" do
+    expect(rendered).to have_content(I18n.t("simple_form.labels.collection_type.description"))
+    expect(rendered).to have_selector("textarea#collection_type_description")
+  end
+end

--- a/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :view do
+  let(:collection_type) { Hyrax::CollectionType.new }
+  let(:collection_type_form) { Hyrax::Forms::Admin::CollectionTypeForm.new }
+
+  let(:form) do
+    view.simple_form_for(collection_type, url: '/update') do |fs_form|
+      return fs_form
+    end
+  end
+
+  before do
+    assign(:form, collection_type_form)
+    allow(view).to receive(:f).and_return(form)
+    render
+  end
+
+  it "renders the intructions and warning" do
+    expect(rendered).to have_content(I18n.t("hyrax.admin.collection_types.form_settings.instructions"))
+    expect(rendered).to have_content(I18n.t("hyrax.admin.collection_types.form_settings.warning"))
+  end
+
+  it "renders the checkboxes" do
+    expect(rendered).to have_selector("input#collection_type_nestable")
+    expect(rendered).to have_selector("input#collection_type_discoverable")
+    expect(rendered).to have_selector("input#collection_type_sharable")
+    expect(rendered).to have_selector("input#collection_type_require_membership")
+    expect(rendered).to have_selector("input#collection_type_allow_multiple_membership")
+    expect(rendered).to have_selector("input#collection_type_assigns_workflow")
+    expect(rendered).to have_selector("input#collection_type_assigns_visibility")
+  end
+end


### PR DESCRIPTION
Fixes #1344 
Fixes #1346 

(collection sprint)

This finishes the partials for the collection type "metadata" and "settings" tabs.  The partials match the mockups.  

I added the needed logic to the form class, but I left the controller pretty minimal since there's another issue for that (#1341).  The edit view loads in content from existing collection types, but the #create and #update methods are still needed in the controller.  
