### PR TITLE
Build out basic controller

### DIFF
--- a/app/controllers/hyrax/admin/collection_types_controller.rb
+++ b/app/controllers/hyrax/admin/collection_types_controller.rb
@@ -3,6 +3,7 @@ module Hyrax
     before_action do
       authorize! :manage, :collection_types
     end
+    before_action :set_collection_type, only: [:edit, :update, :destroy]
 
     layout 'dashboard'
     class_attribute :form_class
@@ -10,38 +11,78 @@ module Hyrax
     load_resource class: Hyrax::CollectionType, except: [:index, :show, :create], instance_name: :collection_type
 
     def index
-      add_breadcrumb t(:'hyrax.controls.home'), root_path
-      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb t(:'hyrax.admin.sidebar.configuration'), '#'
-      add_breadcrumb t(:'hyrax.admin.sidebar.collection_types'), request.path
-
       # TODO: How do we know if a collection_type has existing collections?
       # Will that be a property on @collection_types here?
       @collection_types = Hyrax::CollectionType.all
+      add_common_breadcrumbs
     end
 
     def new
-      add_breadcrumb t(:'hyrax.controls.home'), root_path
-      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb t(:'hyrax.admin.sidebar.configuration'), '#'
-      add_breadcrumb t(:'hyrax.admin.collection_types.index.breadcrumb'), hyrax.admin_collection_types_path
+      setup_form
+      add_common_breadcrumbs
       add_breadcrumb t(:'hyrax.admin.collection_types.new.header'), hyrax.new_admin_collection_type_path
-      @form = form_class.new(collection_type: @collection_type)
     end
 
-    def create; end
+    def create
+      @collection_type = Hyrax::CollectionType.new(collection_type_params)
+      @collection_type.machine_id = @collection_type.title.parameterize.underscore.to_sym
+      if @collection_type.save
+        redirect_to hyrax.edit_admin_collection_type_path(@collection_type), notice: t(:'hyrax.admin.collection_types.create.notification', name: @collection_type.title)
+      else
+        setup_form
+        add_common_breadcrumbs
+        add_breadcrumb t(:'hyrax.admin.collection_types.new.header'), hyrax.new_admin_collection_type_path
+        render :new
+      end
+    end
 
     def edit
-      add_breadcrumb t(:'hyrax.controls.home'), root_path
-      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb t(:'hyrax.admin.sidebar.configuration'), '#'
-      add_breadcrumb t(:'hyrax.admin.collection_types.index.breadcrumb'), hyrax.admin_collection_types_path
+      setup_form
+      add_common_breadcrumbs
       add_breadcrumb t(:'hyrax.admin.collection_types.edit.header'), hyrax.edit_admin_collection_type_path
-      @form = form_class.new(collection_type: @collection_type)
     end
 
-    def update; end
+    def update
+      if @collection_type.update(collection_type_params)
+        redirect_to hyrax.edit_admin_collection_type_path(@collection_type), notice: t(:'hyrax.admin.collection_types.update.notification', name: @collection_type.title)
+      else
+        setup_form
+        add_common_breadcrumbs
+        add_breadcrumb t(:'hyrax.admin.collection_types.edit.header'), hyrax.edit_admin_collection_type_path
+        render :edit
+      end
+    end
 
-    def destroy; end
+    def destroy
+      if @collection_type.destroy
+        redirect_to hyrax.admin_collection_types_path, notice: t(:'hyrax.admin.collection_types.delete.notification', name: @collection_type.title)
+      else
+        redirect_to hyrax.admin_collection_types_path, alert: @collection_type.errors.full_messages.to_sentence
+      end
+    end
+
+    private
+
+      def add_common_breadcrumbs
+        add_breadcrumb t(:'hyrax.controls.home'), root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        add_breadcrumb t(:'hyrax.admin.sidebar.configuration'), '#'
+        add_breadcrumb t(:'hyrax.admin.collection_types.index.breadcrumb'), hyrax.admin_collection_types_path
+      end
+
+      # initialize the form object
+      def form
+        @form ||= form_class.new(collection_type: @collection_type)
+      end
+      alias setup_form form
+
+      def set_collection_type
+        @collection_type = Hyrax::CollectionType.find(params[:id])
+      end
+
+      def collection_type_params
+        params.require(:collection_type).permit(:title, :machine_id, :description, :nestable, :discoverable, :sharable,
+                                                :allow_multiple_membership, :require_membership, :assigns_workflow, :assigns_visibility)
+      end
   end
 end

--- a/app/views/hyrax/admin/collection_types/_form.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form.html.erb
@@ -12,7 +12,8 @@
         </li>
     <% end %>
   </ul>
-  <%= simple_form_for @form, url: hyrax.admin_collection_types_path, as: :collection_type do |f| %>
+  <% form_url = @form.id.nil? ? hyrax.admin_collection_types_path : hyrax.admin_collection_type_path(@form.id) %>
+  <%= simple_form_for @form, url: form_url, as: :collection_type do |f| %>
   <div class="tab-content">
       <div id="metadata" class="tab-pane active">
         <div class="panel panel-default labels">
@@ -44,7 +45,7 @@
         <% else %>
           <%= f.submit t(:'hyrax.admin.collection_types.form.submit'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "update_submit", name: "update_collection_type" %>
         <% end %>
-        <%= link_to t(:'helpers.action.cancel'), main_app.root_path, class: 'btn btn-link' %>
+        <%= link_to t(:'helpers.action.cancel'), hyrax.admin_collection_types_path, class: 'btn btn-link' %>
       </div>
 
   <% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -201,6 +201,12 @@ en:
             actions:        "Actions"
         new:
           header:           "Create New Collection Type"
+        create:
+          notification:     "The collection type %{name} has been created."
+        update:
+          notification:     "The collection type %{name} has been updated."
+        destroy:
+          notification:     "The collection type %{name} has been deleted."
       features:
         index:
           header:           Features

--- a/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
@@ -95,8 +95,24 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
   end
 
   context "authorized user" do
+    let(:valid_attributes) do
+      {
+        title: 'Collection type title',
+        description: 'Description of collection type',
+        machine_id: 'collection_type_title',
+        nestable: true,
+        discoverable: true,
+        sharable: true,
+        allow_multiple_membership: true,
+        require_membership: true,
+        assigns_workflow: true,
+        assigns_visibility: true
+      }
+    end
+
+    let(:valid_session) { {} }
+    let(:collection_type) { create(:collection_type) }
     let(:user) { create(:user) }
-    let(:collection_type) { create(:user_collection_type) }
 
     before do
       allow(controller.current_ability).to receive(:can?).with(any_args).and_return(true)
@@ -108,12 +124,59 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
         get :index
         expect(response).to have_http_status(:success)
       end
+
+      it 'adds breadcrumbs' do
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.controls.home'), root_path)
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.breadcrumbs.admin'), dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.sidebar.configuration'), '#')
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.index.breadcrumb'), admin_collection_types_path)
+        get :index
+        expect(response).to be_success
+        expect(response).to render_template "layouts/dashboard"
+      end
     end
 
     describe "#create" do
-      it "returns http success" do
-        post :create
-        expect(response).to have_http_status(:success)
+      context "with valid params" do
+        it "creates a new CollectionType" do
+          expect do
+            post :create, params: { collection_type: valid_attributes }, session: valid_session
+          end.to change(Hyrax::CollectionType, :count).by(1)
+        end
+
+        it "redirects to the created collection_type" do
+          post :create, params: { collection_type: valid_attributes }, session: valid_session
+          expect(response).to redirect_to(edit_admin_collection_type_path(Hyrax::CollectionType.last))
+        end
+
+        it "assigns all attributes" do
+          post :create, params: { collection_type: valid_attributes }, session: valid_session
+          expect(assigns[:collection_type].attributes.symbolize_keys).to include(valid_attributes)
+        end
+      end
+
+      context "with invalid params" do
+        it "returns a success response (i.e. to display the 'new' template)" do
+          post :create, params: { collection_type: { title: collection_type.title } }, session: valid_session
+          expect(response).to be_success
+        end
+
+        it 'adds breadcrumbs' do
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.controls.home'), root_path)
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.breadcrumbs.admin'), dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.sidebar.configuration'), '#')
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.index.breadcrumb'), admin_collection_types_path)
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.new.header'), new_admin_collection_type_path)
+          post :create, params: { collection_type: { title: collection_type.title } }, session: valid_session
+          expect(response).to be_success
+          expect(response).to render_template "layouts/dashboard"
+        end
+
+        it 'defines a form' do
+          post :create, params: { collection_type: { title: collection_type.title } }, session: valid_session
+          expect(response).to be_success
+          expect(assigns[:form]).to be_kind_of Hyrax::Forms::Admin::CollectionTypeForm
+        end
       end
     end
 
@@ -143,21 +206,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
 
     describe "#edit" do
       it "returns http success" do
-        get :edit, params: { id: collection_type.id }
-        expect(response).to have_http_status(:success)
-      end
-    end
-
-    describe "#update" do
-      it "returns http success" do
-        put :update, params: { id: collection_type.id }
-        expect(response).to have_http_status(:success)
-      end
-    end
-
-    describe "#destroy" do
-      it "returns success" do
-        delete :destroy, params: { id: collection_type.id }
+        get :edit, params: { id: collection_type.to_param }
         expect(response).to have_http_status(:success)
       end
 
@@ -166,16 +215,86 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.breadcrumbs.admin'), dashboard_path)
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.sidebar.configuration'), '#')
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.index.breadcrumb'), admin_collection_types_path)
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.edit.header'), edit_admin_collection_type_path(collection_type.id))
-        get :edit, params: { id: collection_type.id }
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.edit.header'), edit_admin_collection_type_path(1))
+        get :edit, params: { id: collection_type.to_param }
         expect(response).to be_success
         expect(response).to render_template "layouts/dashboard"
       end
 
       it 'defines a form' do
-        get :edit, params: { id: collection_type.id }
+        get :edit, params: { id: collection_type.to_param }
         expect(response).to be_success
         expect(assigns[:form]).to be_kind_of Hyrax::Forms::Admin::CollectionTypeForm
+      end
+    end
+
+    describe "#update" do
+      let(:new_attributes) do
+        {
+          title: 'Improved title',
+          machine_id: 'improved-title',
+          nestable: false,
+          discoverable: false,
+          sharable: false,
+          allow_multiple_membership: false,
+          require_membership: true,
+          assigns_workflow: true,
+          assigns_visibility: true
+        }
+      end
+
+      context "with valid params" do
+        it 'updates a record' do
+          put :update, params: { id: collection_type.to_param, collection_type: new_attributes }, session: valid_session
+          collection_type.reload
+          expect(assigns[:collection_type].attributes.symbolize_keys).to include(new_attributes)
+        end
+
+        it "redirects to the collection_type" do
+          put :update, params: { id: collection_type.to_param, collection_type: valid_attributes }, session: valid_session
+          expect(response).to redirect_to(edit_admin_collection_type_path(collection_type))
+        end
+      end
+
+      context "with invalid params" do
+        let(:existing_collection_type) { create(:collection_type, title: 'Existing', machine_id: 'existing') }
+        let(:invalid_attributes) { { title: existing_collection_type.title } }
+
+        it "returns a success response (i.e. to display the 'edit' template)" do
+          put :update, params: { id: collection_type.to_param, collection_type: invalid_attributes }, session: valid_session
+          expect(response).to have_http_status(:success)
+        end
+
+        it 'adds breadcrumbs' do
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.controls.home'), root_path)
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.breadcrumbs.admin'), dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.sidebar.configuration'), '#')
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.index.breadcrumb'), admin_collection_types_path)
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.edit.header'), edit_admin_collection_type_path(1))
+          put :update, params: { id: collection_type.to_param, collection_type: invalid_attributes }, session: valid_session
+          expect(response).to be_success
+          expect(response).to render_template "layouts/dashboard"
+        end
+
+        it 'defines a form' do
+          put :update, params: { id: collection_type.to_param, collection_type: invalid_attributes }, session: valid_session
+          expect(response).to be_success
+          expect(assigns[:form]).to be_kind_of Hyrax::Forms::Admin::CollectionTypeForm
+        end
+      end
+    end
+
+    describe "#destroy" do
+      it "destroys the requested collection_type" do
+        expect(collection_type).to be_persisted
+        expect do
+          delete :destroy, params: { id: collection_type.to_param }, session: valid_session
+        end.to change(Hyrax::CollectionType, :count).by(-1)
+      end
+
+      it "redirects to the collection_types list" do
+        delete :destroy, params: { id: collection_type.to_param }, session: valid_session
+        expect(response).to redirect_to(admin_collection_types_path)
       end
     end
   end

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -1,9 +1,20 @@
 FactoryGirl.define do
   factory :collection_type, class: Hyrax::CollectionType do
+    sequence(:title) { |n| "Title #{n}" }
+    description 'Collection type with all options'
+    sequence(:machine_id) { |n| "title-#{n}" }
+    nestable true
+    discoverable true
+    sharable true
+    allow_multiple_membership true
+    require_membership false
+    assigns_workflow false
+    assigns_visibility false
+
     factory :user_collection_type do
-      title ['User Collection']
-      description ['A user oriented collection type']
-      machine_id ['user_collection']
+      title 'User Collection'
+      machine_id 'user_collection'
+      description 'A user oriented collection type'
     end
   end
 end


### PR DESCRIPTION
refs #1341

Builds out the basic CrUD functionality of the collection type controller as well as some refactoring to DRY things up along with more testing based upon the rspec controller template.  This leaves the notes about special handling still to be handled in another PR.

```
General Notes

- participants will be handled using permission templates (I think - need more info - see Admin Sets implementation)

Notes on #create

- automatically assign the machine_id property using -
- new_collection_type.title.parameterize.underscore.to_sym

Notes on #update action

- disallow changes to settings IF a collection of this type already exists
- for Admin Sets, don't allow any changes EXCEPT for participants and description.

Notes on #destroy action

- FAIL if collections of this type exist
- delete this collection type from the database
```