### PR TITLE
Adds ability in CollectionType to create the default user_collection

### DIFF
--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -4,6 +4,9 @@ module Hyrax
     validates :title, presence: true, uniqueness: true
     validates :machine_id, presence: true, uniqueness: true
 
+    DEFAULT_ID = 'user_collection'.freeze
+    DEFAULT_TITLE = 'User Collection'.freeze
+
     # These are provided as a convenience method based on prior design discussions.
     # The deprecations are added to allow upstream developers to continue with what
     # they had already been doing. These can be removed as part of merging
@@ -29,6 +32,24 @@ module Hyrax
       # For testing, return 'true' to display the "Cannot delete" modal.
       # And return 'false' to display the delete confirmation modal.
       true
+    end
+
+    def self.find_or_create_default_collection_type
+      return find_by(machine_id: DEFAULT_ID) if exists?(machine_id: DEFAULT_ID)
+      create_default_collection_type(machine_id: DEFAULT_ID, title: DEFAULT_TITLE)
+    end
+
+    def self.create_default_collection_type(machine_id:, title:)
+      create(machine_id: machine_id, title: title) do |c|
+        c.description = 'A User Collection can be created by any user to organize their works.'
+        c.nestable = false
+        c.discoverable = true
+        c.sharable = true
+        c.allow_multiple_membership = true
+        c.require_membership = false
+        c.assigns_workflow = false
+        c.assigns_visibility = false
+      end
     end
   end
 end

--- a/lib/tasks/default_collection_type.rake
+++ b/lib/tasks/default_collection_type.rake
@@ -1,0 +1,13 @@
+namespace :hyrax do
+  namespace :default_collection_type do
+    desc "Create the Default Collection Type"
+    task create: :environment do
+      ct = Hyrax::CollectionType.find_or_create_default_collection_type
+      if Hyrax::CollectionType.exists?(machine_id: ct.machine_id)
+        puts "Default collection type is #{ct.machine_id}"
+      else
+        $stderr.puts "ERROR: A default collection type did not get created."
+      end
+    end
+  end
+end

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     end
   end
 
+  describe ".find_or_create_default_collection_type" do
+    subject { described_class.find_or_create_default_collection_type }
+
+    it 'creates a default collection type' do
+      subject
+      expect(described_class.exists?(machine_id: described_class::DEFAULT_ID)).to be_truthy
+    end
+  end
+
   describe "validations" do
     it "ensures the required fields have values" do
       collection_type.title = nil

--- a/template.rb
+++ b/template.rb
@@ -6,3 +6,4 @@ generate 'hyrax:install', '-f'
 
 rails_command 'db:migrate'
 rails_command 'hyrax:workflow:load'
+rails_command 'hyrax:default_collection_type:create'


### PR DESCRIPTION
Partially fixes #1485

This adds ability to the CollectionType model to create a default collection type called 'User Collection' in the database.  This is accomplished by 'find or create' logic that can be called from a task, generator, or could even be used on the fly to ensure the existence of a default collection type if it is found to be missing.  

This also adds a simple rake task to accomplish default collection type creation, as well as invocation of that rake task from the Hyrax template.rb so that the collection type will be created when using the template method of installation.  

Regarding initialization of the default collection type in the generated test app: this is currently a problem because the creation method described cannot be invoked until the database table exists.  However, database migrations do not occur within the flow of the main Hyrax install generator (migration files are simply staged by various sub-generators.)  It seems that the Engine Cart gem is currently responsible for the actual database migration (see https://github.com/cbeer/engine_cart/blob/master/lib/engine_cart/tasks/engine_cart.rake#L102 ). The end result is that you can't run database dependent tasks before the migration, and there's no place to tuck additional tasks in after it. 

Note that this is mostly a problem for developers who like to use the generated test app in their development workflow - actual tests can always invoke the `find_or_create_default_collection_type` method as needed.  This timing problem isn't unique to this PR and presents the same problem for other database dependent use cases. The possible solutions are:

1. Hyrax could redefine the EC `:generate` task in a way that would allow post processing
2. Make a contribution to EC to allow for post processing options or optional placement of migrations
3. The `find_or_create_default_collection_type` method can be invoked by any code (from test suite or application) that requires the default collection type to exist
4. Rely on documentation and knowing to run the `hyrax:default_collection_type:create` rake task
