### PR TITLE
Injecting progressive sleep into find elements

### DIFF
--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -25,30 +25,40 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
       # Reload the form and verify
       visit '/dashboard/my/works'
       check 'check_all'
-      click_on 'batch-edit'
+      find('#batch-edit').click
       expect(page).to have_content('Batch Edit Descriptions')
-      batch_edit_expand("creator")
-      expect(page).to have_css "input#generic_work_creator[value*='NEW creator']"
-      batch_edit_expand("contributor")
-      expect(page).to have_css "input#generic_work_contributor[value*='NEW contributor']"
-      batch_edit_expand("description")
-      expect(page).to have_css "textarea#generic_work_description", text: 'NEW description'
-      batch_edit_expand("keyword")
-      expect(page).to have_css "input#generic_work_keyword[value*='NEW keyword']"
-      batch_edit_expand("publisher")
-      expect(page).to have_css "input#generic_work_publisher[value*='NEW publisher']"
-      batch_edit_expand("date_created")
-      expect(page).to have_css "input#generic_work_date_created[value*='NEW date_created']"
-      batch_edit_expand("subject")
-      expect(page).to have_css "input#generic_work_subject[value*='NEW subject']"
-      batch_edit_expand("language")
-      expect(page).to have_css "input#generic_work_language[value*='NEW language']"
-      batch_edit_expand("identifier")
-      expect(page).to have_css "input#generic_work_identifier[value*='NEW identifier']"
+      batch_edit_expand("creator") do
+        page.find("input#generic_work_creator[value='NEW creator']")
+      end
+      batch_edit_expand("contributor") do
+        page.find("input#generic_work_contributor[value='NEW contributor']")
+      end
+      batch_edit_expand("description") do
+        page.find("textarea#generic_work_description", text: 'NEW description')
+      end
+      batch_edit_expand("keyword") do
+        page.find("input#generic_work_keyword[value='NEW keyword']")
+      end
+      batch_edit_expand("publisher") do
+        page.find "input#generic_work_publisher[value='NEW publisher']"
+      end
+      batch_edit_expand("date_created") do
+        page.find("input#generic_work_date_created[value='NEW date_created']")
+      end
+      batch_edit_expand("subject") do
+        page.find("input#generic_work_subject[value='NEW subject']")
+      end
+      batch_edit_expand("language") do
+        page.find("input#generic_work_language[value='NEW language']")
+      end
+      batch_edit_expand("identifier") do
+        page.find("input#generic_work_identifier[value='NEW identifier']")
+      end
       # batch_edit_expand("based_near")
       # expect(page).to have_css "input#generic_work_based_near[value*='NEW based_near']"
-      batch_edit_expand("related_url")
-      expect(page).to have_css "input#generic_work_related_url[value*='NEW related_url']"
+      batch_edit_expand("related_url") do
+        page.find("input#generic_work_related_url[value='NEW related_url']")
+      end
     end
   end
 

--- a/spec/support/features/batch_edit_actions.rb
+++ b/spec/support/features/batch_edit_actions.rb
@@ -18,5 +18,24 @@ def fill_in_batch_edit_fields_and_verify!
 end
 
 def batch_edit_expand(field)
-  find("#expand_link_#{field}").click
+  with_sleep_injector do
+    find("#expand_link_#{field}").click
+    yield if block_given?
+  end
+end
+
+# Cribbed from Notre Dame's experience with extensive Capybara testing in our QA_Tests environment.
+# https://github.com/ndlib/QA_tests/blob/4e52fa69d5c3fd774febb2bd85134a78d21cbe97/spec/spec_support/inject_sleep.rb#L8-L24
+# Capybara makes claims that it's wait will in fact wait for elements to appear. In our experience, this is
+# mostly true.
+def with_sleep_injector
+  yield
+rescue Capybara::ElementNotFound
+  sleep 3
+  begin
+    yield
+  rescue Capybara::ElementNotFound
+    sleep 10
+    yield
+  end
 end


### PR DESCRIPTION
In Notre Dame's extensive Capybara usage for our [QA_tests][1]
ecosystem, we have discovered intermittent failures of Capybara
expectations even when we have very large
`Capybara.max_default_wait_time` values.

Our solution has been to auto-inject sleep behavior into each of the
Capybara matchers ([see examples][2]). We have found that this behavior
eliminates most all of our unresponsive javascript element not found
errors.

In doing this, I've moved from `expect(page).to have_css` to the
simplified `page.find`. Note the outward behavior is still somewhat
similar (instead of an RSpec failure message we would instead get an
RSpec exception message).

If desired, I can refactor to auto-inject all of the sleep injectors
that we have included.

[1]:https://github.com/ndlib/qa_tests
[2]:https://github.com/ndlib/qa_tests

@samvera/hyrax-code-reviewers
