### PR TITLE
set old licenses to inactive and add refs to new licenses

### DIFF
--- a/lib/generators/hyrax/templates/config/authorities/licenses.yml
+++ b/lib/generators/hyrax/templates/config/authorities/licenses.yml
@@ -39,7 +39,7 @@ terms:
       term: Creative Commons BY-NC-SA NonCommercial-ShareAlike 4.0 International
       active: true
     - id: http://creativecommons.org/publicdomain/zero/1.0/
-      term: Creative Commons CC0 1.0 Universal
+      term: CC0 1.0 Universal
       active: true
     - id: http://creativecommons.org/publicdomain/mark/1.0/
       term: Public Domain Mark 1.0

--- a/lib/generators/hyrax/templates/config/authorities/licenses.yml
+++ b/lib/generators/hyrax/templates/config/authorities/licenses.yml
@@ -39,7 +39,7 @@ terms:
       term: Creative Commons BY-NC-SA NonCommercial-ShareAlike 4.0 International
       active: true
     - id: http://creativecommons.org/publicdomain/zero/1.0/
-      term: Creative Common CC0 1.0 Universal
+      term: Creative Commons CC0 1.0 Universal
       active: true
     - id: http://creativecommons.org/publicdomain/mark/1.0/
       term: Public Domain Mark 1.0

--- a/lib/generators/hyrax/templates/config/authorities/licenses.yml
+++ b/lib/generators/hyrax/templates/config/authorities/licenses.yml
@@ -1,28 +1,55 @@
 terms:
     - id: http://creativecommons.org/licenses/by/3.0/us/
       term: Attribution 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-sa/3.0/us/
       term: Attribution-ShareAlike 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nc/3.0/us/
       term: Attribution-NonCommercial 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nd/3.0/us/
       term: Attribution-NoDerivs 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nc-nd/3.0/us/
       term: Attribution-NonCommercial-NoDerivs 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nc-sa/3.0/us/
       term: Attribution-NonCommercial-ShareAlike 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/publicdomain/mark/1.0/
       term: Public Domain Mark 1.0
+      active: false
+    - id: http://creativecommons.org/publicdomain/zero/1.0/
+      term: CC0 1.0 Universal
+      active: false
+    - id: http://www.europeana.eu/portal/rights/rr-r.html
+      term: All rights reserved
+      active: true
+    - id: http://rightsstatements.org/vocab/InC/1.0/
+      term: In Copyright
+      active: true
+    - id: https://creativecommons.org/licenses/by/4.0/
+      term: CC BY Attribution 4.0 International
+      active: true
+    - id: https://creativecommons.org/licenses/by-sa/4.0/
+      term: CC SA ShareAlike 4.0 International
+      active: true
+    - id: https://creativecommons.org/licenses/by-nd/4.0/
+      term: CC ND NoDerivatives 4.0 International
+      active: true
+    - id: https://creativecommons.org/licenses/by-nc/4.0/
+      term: CC NC NonCommercial 4.0 International
+      active: true
+    - id: https://creativecommons.org/licenses/by-nc-nd/4.0/
+      term: CC BY NC ND NonCommercial-NoDerivs 4.0 International
+      active: true
+    - id: https://creativecommons.org/licenses/by-nc-sa/4.0/
+      term: CC BY NC SA NonCommercial-ShareAlike 4.0 International
       active: true
     - id: http://creativecommons.org/publicdomain/zero/1.0/
       term: CC0 1.0 Universal
       active: true
-    - id: http://www.europeana.eu/portal/rights/rr-r.html
-      term: All rights reserved
+    - id: http://creativecommons.org/publicdomain/mark/1.0/
+      term: Public Domain Mark 1.0
       active: true

--- a/lib/generators/hyrax/templates/config/authorities/licenses.yml
+++ b/lib/generators/hyrax/templates/config/authorities/licenses.yml
@@ -17,38 +17,29 @@ terms:
     - id: http://creativecommons.org/licenses/by-nc-sa/3.0/us/
       term: Attribution-NonCommercial-ShareAlike 3.0 United States
       active: false
-    - id: http://creativecommons.org/publicdomain/mark/1.0/
-      term: Public Domain Mark 1.0
-      active: false
-    - id: http://creativecommons.org/publicdomain/zero/1.0/
-      term: CC0 1.0 Universal
-      active: false
     - id: http://www.europeana.eu/portal/rights/rr-r.html
       term: All rights reserved
-      active: true
-    - id: http://rightsstatements.org/vocab/InC/1.0/
-      term: In Copyright
-      active: true
+      active: false
     - id: https://creativecommons.org/licenses/by/4.0/
-      term: CC BY Attribution 4.0 International
+      term: Creative Commons BY Attribution 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-sa/4.0/
-      term: CC SA ShareAlike 4.0 International
+      term: Creative Commons SA ShareAlike 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-nd/4.0/
-      term: CC ND NoDerivatives 4.0 International
+      term: Creative Commons ND NoDerivatives 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-nc/4.0/
-      term: CC NC NonCommercial 4.0 International
+      term: Creative Commons NC NonCommercial 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-nc-nd/4.0/
-      term: CC BY NC ND NonCommercial-NoDerivs 4.0 International
+      term: Creative Commons BY-NC-ND NonCommercial-NoDerivs 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-nc-sa/4.0/
-      term: CC BY NC SA NonCommercial-ShareAlike 4.0 International
+      term: Creative Commons BY-NC-SA NonCommercial-ShareAlike 4.0 International
       active: true
     - id: http://creativecommons.org/publicdomain/zero/1.0/
-      term: CC0 1.0 Universal
+      term: Creative Commons0 1.0 Universal
       active: true
     - id: http://creativecommons.org/publicdomain/mark/1.0/
       term: Public Domain Mark 1.0

--- a/lib/generators/hyrax/templates/config/authorities/licenses.yml
+++ b/lib/generators/hyrax/templates/config/authorities/licenses.yml
@@ -24,23 +24,23 @@ terms:
       term: Creative Commons BY Attribution 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-sa/4.0/
-      term: Creative Commons BY-SA ShareAlike 4.0 International
+      term: Creative Commons BY-SA Attribution-ShareAlike 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-nd/4.0/
-      term: Creative Commons BY-ND NoDerivatives 4.0 International
+      term: Creative Commons BY-ND Attribution-NoDerivatives 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-nc/4.0/
-      term: Creative Commons BY-NC NonCommercial 4.0 International
+      term: Creative Commons BY-NC Attribution-NonCommercial 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-nc-nd/4.0/
-      term: Creative Commons BY-NC-ND NonCommercial-NoDerivs 4.0 International
+      term: Creative Commons BY-NC-ND Attribution-NonCommercial-NoDerivs 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-nc-sa/4.0/
-      term: Creative Commons BY-NC-SA NonCommercial-ShareAlike 4.0 International
+      term: Creative Commons BY-NC-SA Attribution-NonCommercial-ShareAlike 4.0 International
       active: true
     - id: http://creativecommons.org/publicdomain/zero/1.0/
-      term: CC0 1.0 Universal
+      term: Creative Commons CC0 1.0 Universal
       active: true
     - id: http://creativecommons.org/publicdomain/mark/1.0/
-      term: Public Domain Mark 1.0
+      term: Creative Commons Public Domain Mark 1.0
       active: true

--- a/lib/generators/hyrax/templates/config/authorities/licenses.yml
+++ b/lib/generators/hyrax/templates/config/authorities/licenses.yml
@@ -24,13 +24,13 @@ terms:
       term: Creative Commons BY Attribution 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-sa/4.0/
-      term: Creative Commons SA ShareAlike 4.0 International
+      term: Creative Commons BY-SA ShareAlike 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-nd/4.0/
-      term: Creative Commons ND NoDerivatives 4.0 International
+      term: Creative Commons BY-ND NoDerivatives 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-nc/4.0/
-      term: Creative Commons NC NonCommercial 4.0 International
+      term: Creative Commons BY-NC NonCommercial 4.0 International
       active: true
     - id: https://creativecommons.org/licenses/by-nc-nd/4.0/
       term: Creative Commons BY-NC-ND NonCommercial-NoDerivs 4.0 International
@@ -39,7 +39,7 @@ terms:
       term: Creative Commons BY-NC-SA NonCommercial-ShareAlike 4.0 International
       active: true
     - id: http://creativecommons.org/publicdomain/zero/1.0/
-      term: Creative Commons0 1.0 Universal
+      term: Creative Common CC0 1.0 Universal
       active: true
     - id: http://creativecommons.org/publicdomain/mark/1.0/
       term: Public Domain Mark 1.0

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 RSpec.describe BlacklightHelper, type: :helper do
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:attributes) do

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 RSpec.describe BlacklightHelper, type: :helper do
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:attributes) do
@@ -49,8 +50,8 @@ RSpec.describe BlacklightHelper, type: :helper do
       let(:field_name) { 'rights_tesim' }
 
       it do
-        is_expected.to eq "<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">CC0 1.0 Universal</a>, " \
-                             "<a href=\"http://creativecommons.org/publicdomain/mark/1.0/\">Public Domain Mark 1.0</a>, " \
+        is_expected.to eq "<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">Creative Commons CC0 1.0 Universal</a>, " \
+                             "<a href=\"http://creativecommons.org/publicdomain/mark/1.0/\">Creative Commons Public Domain Mark 1.0</a>, " \
                              "and <a href=\"http://www.europeana.eu/portal/rights/rr-r.html\">All rights reserved</a>"
       end
     end

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -321,16 +321,16 @@ RSpec.describe HyraxHelper, type: :helper do
     it "maps the url to a link with a label" do
       expect(helper.license_links(
                value: ["http://creativecommons.org/publicdomain/zero/1.0/"]
-      )).to eq("<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">CC0 1.0 Universal</a>")
+      )).to eq("<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">Creative Commons CC0 1.0 Universal</a>")
     end
 
-    it "converts multiple rights statements to a sentence" do
+    it "converts multiple licenses to a sentence" do
       expect(helper.license_links(
                value: ["http://creativecommons.org/publicdomain/zero/1.0/",
                        "http://creativecommons.org/publicdomain/mark/1.0/",
                        "http://www.europeana.eu/portal/rights/rr-r.html"]
-      )).to eq("<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">CC0 1.0 Universal</a>, " \
-               "<a href=\"http://creativecommons.org/publicdomain/mark/1.0/\">Public Domain Mark 1.0</a>, " \
+      )).to eq("<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">Creative Commons CC0 1.0 Universal</a>, " \
+               "<a href=\"http://creativecommons.org/publicdomain/mark/1.0/\">Creative Commons Public Domain Mark 1.0</a>, " \
                "and <a href=\"http://www.europeana.eu/portal/rights/rr-r.html\">All rights reserved</a>")
     end
   end


### PR DESCRIPTION
Fixes #1135  

We set the old licenses to inactive so you can still pull up works that use an old license, but they aren't selectable for new works.  

@samvera/hyrax-code-reviewers
