### PR TITLE
GraphExporter: fix replacer methods for nested objects

### DIFF
--- a/spec/controllers/hyrax/batch_uploads_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_uploads_controller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Hyrax::BatchUploadsController do
     context "when submitting works on behalf of other user" do
       let(:batch_upload_item) do
         {
-          payload_concern: RareBooks::Atlas,
+          payload_concern: NamespacedWorks::NestedWork,
           permissions_attributes: [
             { type: "group", name: "public", access: "read" }
           ],

--- a/spec/forms/hyrax/forms/batch_edit_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_edit_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::Forms::BatchEditForm do
   # Using a different work type in order to show that the form supports
   # batches containing multiple types of works
   let(:work2) do
-    RareBooks::Atlas.create!(
+    NamespacedWorks::NestedWork.create!(
       title: ["title 2"],
       keyword: ["123"],
       creator: ["Fred"],

--- a/spec/views/shared/select_work_type_modal.html.erb_spec.rb
+++ b/spec/views/shared/select_work_type_modal.html.erb_spec.rb
@@ -4,22 +4,22 @@ RSpec.describe 'shared/_select_work_type_modal.html.erb', type: :view do
     Hyrax::SelectTypePresenter.new(GenericWork)
   end
   let(:row2) do
-    Hyrax::SelectTypePresenter.new(RareBooks::Atlas)
+    Hyrax::SelectTypePresenter.new(NamespacedWorks::NestedWork)
   end
 
   before do
     allow(presenter).to receive(:each).and_yield(row1).and_yield(row2)
     allow(view).to receive(:create_work_presenter).and_return(presenter)
     # Because there is no i18n set up for this work type
-    allow(row2).to receive(:name).and_return('Atlas')
+    allow(row2).to receive(:name).and_return('Nested Work')
     render
   end
 
   it 'draws the modal' do
     expect(rendered).to have_selector '#worktypes-to-create.modal'
     expect(rendered).to have_content 'Generic Work'
-    expect(rendered).to have_content 'Atlas'
+    expect(rendered).to have_content 'Nested Work'
     expect(rendered).to have_selector 'input[type="radio"][data-single="/concern/generic_works/new"][data-batch="/batch_uploads/new?payload_concern=GenericWork"]'
-    expect(rendered).to have_selector 'input[type="radio"][data-single="/concern/rare_books/atlases/new"][data-batch="/batch_uploads/new?payload_concern=RareBooks%3A%3AAtlas"]'
+    expect(rendered).to have_selector 'input[type="radio"][data-single="/concern/namespaced_works/nested_works/new"][data-batch="/batch_uploads/new?payload_concern=NamespacedWorks%3A%3ANestedWork"]'
   end
 end


### PR DESCRIPTION
Hopefully unblocks #1071.

From that ticket (https://github.com/samvera/hyrax/pull/1071#issuecomment-305680630):
> Looks like the problem is that subresource_replacer is called when result is falsy (https://github.com/samvera-labs/hyrax/blob/master/app/services/hyrax/graph_exporter.rb#L45), but subresource_replacer itself calls subject_replacer with result as one of the arguments: https://github.com/samvera-labs/hyrax/blob/master/app/services/hyrax/graph_exporter.rb#L59

Since `subject_replacer` only needs `result` in order to compute the class of the object model, just pass that directly as a parameter.

@samvera/hyrax-code-reviewers 