### PR TITLE
Generate machine_id from title; Check for collections before save/destroy

### DIFF
--- a/app/controllers/hyrax/admin/collection_types_controller.rb
+++ b/app/controllers/hyrax/admin/collection_types_controller.rb
@@ -25,7 +25,6 @@ module Hyrax
 
     def create
       @collection_type = Hyrax::CollectionType.new(collection_type_params)
-      @collection_type.machine_id = @collection_type.title.parameterize.underscore.to_sym
       if @collection_type.save
         redirect_to hyrax.edit_admin_collection_type_path(@collection_type), notice: t(:'hyrax.admin.collection_types.create.notification', name: @collection_type.title)
       else
@@ -81,7 +80,7 @@ module Hyrax
       end
 
       def collection_type_params
-        params.require(:collection_type).permit(:title, :machine_id, :description, :nestable, :discoverable, :sharable,
+        params.require(:collection_type).permit(:title, :description, :nestable, :discoverable, :sharable,
                                                 :allow_multiple_membership, :require_membership, :assigns_workflow, :assigns_visibility)
       end
   end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -207,6 +207,7 @@ en:
           notification:     "The collection type %{name} has been updated."
         destroy:
           notification:     "The collection type %{name} has been deleted."
+        error_not_empty:    "Collection type cannot be altered as it has collections"
       features:
         index:
           header:           Features

--- a/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
@@ -99,7 +99,6 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
       {
         title: 'Collection type title',
         description: 'Description of collection type',
-        machine_id: 'collection_type_title',
         nestable: true,
         discoverable: true,
         sharable: true,
@@ -136,7 +135,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
       end
     end
 
-    describe "#create" do
+    describe "#create", :clean_repo do
       context "with valid params" do
         it "creates a new CollectionType" do
           expect do
@@ -215,7 +214,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.breadcrumbs.admin'), dashboard_path)
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.sidebar.configuration'), '#')
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.index.breadcrumb'), admin_collection_types_path)
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.edit.header'), edit_admin_collection_type_path(1))
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.edit.header'), edit_admin_collection_type_path(collection_type.to_param))
         get :edit, params: { id: collection_type.to_param }
         expect(response).to be_success
         expect(response).to render_template "layouts/dashboard"
@@ -228,11 +227,10 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
       end
     end
 
-    describe "#update" do
+    describe "#update", :clean_repo do
       let(:new_attributes) do
         {
           title: 'Improved title',
-          machine_id: 'improved-title',
           nestable: false,
           discoverable: false,
           sharable: false,
@@ -257,7 +255,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
       end
 
       context "with invalid params" do
-        let(:existing_collection_type) { create(:collection_type, title: 'Existing', machine_id: 'existing') }
+        let(:existing_collection_type) { create(:collection_type) }
         let(:invalid_attributes) { { title: existing_collection_type.title } }
 
         it "returns a success response (i.e. to display the 'edit' template)" do
@@ -270,7 +268,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller do
           expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.breadcrumbs.admin'), dashboard_path)
           expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.sidebar.configuration'), '#')
           expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.index.breadcrumb'), admin_collection_types_path)
-          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.edit.header'), edit_admin_collection_type_path(1))
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.collection_types.edit.header'), edit_admin_collection_type_path(collection_type.to_param))
           put :update, params: { id: collection_type.to_param, collection_type: invalid_attributes }, session: valid_session
           expect(response).to be_success
           expect(response).to render_template "layouts/dashboard"

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :collection_type, class: Hyrax::CollectionType do
+    sequence(:id) { |n| n }
     sequence(:title) { |n| "Title #{n}" }
     description 'Collection type with all options'
-    sequence(:machine_id) { |n| "title-#{n}" }
     nestable true
     discoverable true
     sharable true
@@ -13,7 +13,6 @@ FactoryGirl.define do
 
     factory :user_collection_type do
       title 'User Collection'
-      machine_id 'user_collection'
       description 'A user oriented collection type'
     end
   end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -146,17 +146,13 @@ RSpec.describe Collection do
     end
 
     context 'when gid in collection object is nil' do
-      let(:collection) { described_class.new(title: ['title']) }
+      let(:collection) { create(:collection, title: ['title']) }
 
-      before do
-        allow(collection).to receive(:collection_type_gid).and_return(nil)
-      end
+      subject { described_class.find(collection.id) }
 
       it 'loads default collection type' do
-        collection.save!
-        col = described_class.find(collection.id)
-        expect(col.collection_type).to be_a Hyrax::CollectionType
-        expect(col.collection_type.machine_id).to eq Hyrax::CollectionType::DEFAULT_ID
+        expect(subject.collection_type).to be_a Hyrax::CollectionType
+        expect(subject.collection_type.machine_id).to eq Hyrax::CollectionType::DEFAULT_ID
       end
     end
   end

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Hyrax::CollectionType, type: :model do
-  let(:collection_type) { create(:user_collection_type) }
+  let(:collection_type) { build(:collection_type) }
 
   it "has basic metadata" do
     expect(collection_type).to respond_to(:title)
@@ -7,7 +7,6 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     expect(collection_type).to respond_to(:description)
     expect(collection_type.description).not_to be_empty
     expect(collection_type).to respond_to(:machine_id)
-    expect(collection_type.machine_id).not_to be_empty
   end
 
   it "has configuration properties with defaults" do
@@ -41,7 +40,9 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     end
   end
 
-  describe "validations" do
+  describe "validations", :clean_repo do
+    let(:collection_type) { create(:collection_type) }
+
     it "ensures the required fields have values" do
       collection_type.title = nil
       collection_type.machine_id = nil
@@ -56,28 +57,86 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   describe '.find_by_gid' do
+    let(:collection_type) { create(:collection_type) }
+    let(:nonexistent_gid) { 'gid://internal/hyrax-collectiontype/NO_EXIST' }
+
     it 'returns instance of collection type when one with the gid exists' do
-      machine_id = collection_type.machine_id
-      requested_collection_type = Hyrax::CollectionType.find_by_gid('gid://internal/hyrax-collectiontype/1')
-      expect(requested_collection_type.machine_id).to eq machine_id
+      expect(Hyrax::CollectionType.find_by_gid(collection_type.gid)).to eq collection_type
     end
 
     it 'returns false if collection type with gid does NOT exist' do
-      requested_collection_type = Hyrax::CollectionType.find_by_gid('gid://internal/hyrax-collectiontype/NO_EXIST')
-      expect(requested_collection_type).to be_falsey
+      expect(Hyrax::CollectionType.find_by_gid(nonexistent_gid)).to be_falsey
     end
   end
 
   describe '.find_by_gid!' do
+    let(:collection_type) { create(:collection_type) }
+    let(:nonexistent_gid) { 'gid://internal/hyrax-collectiontype/NO_EXIST' }
+
     it 'returns instance of collection type when one with the gid exists' do
-      machine_id = collection_type.machine_id
-      requested_collection_type = Hyrax::CollectionType.find_by_gid!('gid://internal/hyrax-collectiontype/1')
-      expect(requested_collection_type.machine_id).to eq machine_id
+      expect(Hyrax::CollectionType.find_by_gid(collection_type.gid)).to eq collection_type
     end
 
     it 'raises error if collection type with gid does NOT exist' do
-      gid = 'gid://internal/hyrax-collectiontype/NO_EXIST'
-      expect { Hyrax::CollectionType.find_by_gid!(gid) }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID '#{gid}'")
+      expect { Hyrax::CollectionType.find_by_gid!(nonexistent_gid) }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID '#{nonexistent_gid}'")
+    end
+  end
+
+  describe "collections" do
+    let!(:collection) { create(:collection, collection_type_gid: collection_type.gid.to_s) }
+    let(:collection_type) { create(:collection_type) }
+
+    it 'returns collections of this collection type' do
+      expect(collection_type.collections.to_a).to include collection
+    end
+
+    it 'returns empty array if gid is nil' do
+      expect(Collection.count > 0).to be_truthy
+      expect(build(:collection_type).collections).to eq []
+    end
+  end
+
+  describe "collections?" do
+    let(:collection_type) { create(:collection_type) }
+
+    it 'returns true if there are any collections of this collection type' do
+      create(:collection, collection_type_gid: collection_type.gid.to_s)
+      expect(collection_type.collections?).to be_truthy
+    end
+    it 'returns false if there are not any collections of this collection type' do
+      expect(collection_type.collections?).to be_falsey
+    end
+  end
+
+  describe "machine_id" do
+    let(:collection_type) { described_class.new }
+
+    it 'assigns machine_id on title=' do
+      expect(collection_type.machine_id).to be_blank
+      collection_type.title = "New Collection Type"
+      expect(collection_type.machine_id).not_to be_blank
+    end
+  end
+
+  describe "destroy" do
+    before do
+      allow(collection_type).to receive(:collections?).and_return(true)
+    end
+
+    it "fails if collections exist of this type" do
+      expect(collection_type.destroy).to be_falsey
+      expect(collection_type.errors).not_to be_empty
+    end
+  end
+
+  describe "save" do
+    before do
+      allow(collection_type).to receive(:collections?).and_return(true)
+    end
+
+    it "fails if collections exist of this type" do
+      expect(collection_type.save).to be_falsey
+      expect(collection_type.errors).not_to be_empty
     end
   end
 end

--- a/spec/views/hyrax/admin/collection_types/index.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/index.html.erb_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-RSpec.describe 'hyrax/admin/collection_types/index.html.erb', type: :view do
+RSpec.describe 'hyrax/admin/collection_types/index.html.erb', type: :view, clean_repo: true do
   before do
     assign(:collection_types, [
-             FactoryGirl.create(:collection_type, title: 'Test Title 1', machine_id: 'test_title_1'),
-             FactoryGirl.create(:collection_type, title: 'Test Title 2', machine_id: 'test_title_2')
+             FactoryGirl.create(:collection_type, title: 'Test Title 1'),
+             FactoryGirl.create(:collection_type, title: 'Test Title 2')
            ])
     render
   end


### PR DESCRIPTION
Relates to #1341.

Handles the rest of #1341 except the following:
- #1345 anything dealing with participants
- #1547 - for Admin Sets, don't allow any changes EXCEPT for participants and description.
- #1547 - Saving a collection type should allow some changes even when collections exist