### PR TITLE
Adds Collection Type Participants functionality (1345)

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -66,6 +66,8 @@
 //= require hyrax/admin/admin_set/registered_users
 //= require hyrax/admin/admin_set/participants
 //= require hyrax/admin/admin_set/visibility
+//= require hyrax/admin/collection_type_controls
+//= require hyrax/admin/collection_type/participants
 //= require hyrax/collections/editor
 //= require hyrax/editor
 //= require hyrax/editor/admin_set_widget

--- a/app/assets/javascripts/hyrax/admin/collection_type/participants.es6
+++ b/app/assets/javascripts/hyrax/admin/collection_type/participants.es6
@@ -1,0 +1,13 @@
+
+
+export default class {
+  // Adds autocomplete to the user search function and enables the
+  // "Allow all registered users" button.
+  constructor(elem) {
+    this.userField = elem.find('#user-participants-form input[type=text]')
+  }
+
+  setup() {
+    this.userField.userSearch()
+  }
+}

--- a/app/assets/javascripts/hyrax/admin/collection_type_controls.es6
+++ b/app/assets/javascripts/hyrax/admin/collection_type_controls.es6
@@ -1,0 +1,10 @@
+// The editor for the CollectionTypeParticipant
+// Add search for user/group to the edit an admin set's participants page
+import Participants from 'hyrax/admin/collection_type/participants'
+
+export default class {
+    constructor(elem) {
+        let participants = new Participants(elem.find('#participants'))
+        participants.setup();
+    }
+}

--- a/app/assets/javascripts/hyrax/app.js
+++ b/app/assets/javascripts/hyrax/app.js
@@ -13,6 +13,7 @@ Hyrax = {
         this.adminSetEditor();
         this.collectionEditor();
         this.collectionTypes();
+        this.collectionTypeEditor();
         this.adminStatisticsGraphs();
         this.tinyMCE();
         this.perPage();
@@ -33,6 +34,12 @@ Hyrax = {
     adminSetEditor: function() {
       var AdminSetControls = require('hyrax/admin/admin_set_controls');
       var controls = new AdminSetControls($('#admin-set-controls'));
+    },
+
+    // The collectionType edit page
+    collectionTypeEditor: function() {
+      var CollectionTypeControls = require('hyrax/admin/collection_type_controls');
+      var controls = new CollectionTypeControls($('#collection-types-controls'));
     },
 
     // The Collection edit page

--- a/app/controllers/hyrax/admin/collection_type_participants_controller.rb
+++ b/app/controllers/hyrax/admin/collection_type_participants_controller.rb
@@ -1,0 +1,44 @@
+module Hyrax
+  class Admin::CollectionTypeParticipantsController < ApplicationController
+    before_action do
+      authorize! :manage, :collection_types
+    end
+
+    class_attribute :form_class
+    self.form_class = Hyrax::Forms::Admin::CollectionTypeParticipantForm
+
+    def create
+      @collection_type_participant = Hyrax::CollectionTypeParticipant.new(collection_type_participant_params)
+      if @collection_type_participant.save
+        redirect_to(
+          edit_admin_collection_type_path(@collection_type_participant.hyrax_collection_type_id, anchor: 'participants'),
+          notice: I18n.t('update_notice', scope: 'hyrax.admin.collection_types.form_participants')
+        )
+      else
+        redirect_to(
+          edit_admin_collection_type_path(@collection_type_participant.hyrax_collection_type_id, anchor: 'participants'),
+          alert: @collection_type_participant.errors.full_messages.to_sentence
+        )
+      end
+    end
+
+    def destroy
+      @collection_type_participant = Hyrax::CollectionTypeParticipant.find(params[:id])
+      if @collection_type_participant.destroy
+        redirect_to(
+          edit_admin_collection_type_path(@collection_type_participant.hyrax_collection_type_id, anchor: 'participants'),
+          notice: I18n.t('remove_success', scope: 'hyrax.admin.collection_types.form_participants')
+        )
+      else
+        redirect_to(
+          edit_admin_collection_type_path(@collection_type_participant.hyrax_collection_type_id, anchor: 'participants'),
+          alert: @collection_type_participant.errors.full_messages.to_sentence
+        )
+      end
+    end
+
+    def collection_type_participant_params
+      params.require(:collection_type_participant).permit(:access, :agent_id, :agent_type, :hyrax_collection_type_id)
+    end
+  end
+end

--- a/app/controllers/hyrax/admin/collection_types_controller.rb
+++ b/app/controllers/hyrax/admin/collection_types_controller.rb
@@ -37,6 +37,7 @@ module Hyrax
 
     def edit
       setup_form
+      setup_participants_form
       add_common_breadcrumbs
       add_breadcrumb t(:'hyrax.admin.collection_types.edit.header'), hyrax.edit_admin_collection_type_path
     end
@@ -74,6 +75,10 @@ module Hyrax
         @form ||= form_class.new(collection_type: @collection_type)
       end
       alias setup_form form
+
+      def setup_participants_form
+        @collection_type_participant = Hyrax::Forms::Admin::CollectionTypeParticipantForm.new(collection_type_participant: @collection_type.collection_type_participants.build)
+      end
 
       def set_collection_type
         @collection_type = Hyrax::CollectionType.find(params[:id])

--- a/app/forms/hyrax/forms/admin/collection_type_form.rb
+++ b/app/forms/hyrax/forms/admin/collection_type_form.rb
@@ -8,7 +8,7 @@ module Hyrax
 
         delegate :title, :description, :discoverable, :nestable, :sharable,
                  :require_membership, :allow_multiple_membership, :assigns_workflow,
-                 :assigns_visibility, :id, :persisted?, to: :collection_type
+                 :assigns_visibility, :id, :collection_type_participants, :persisted?, to: :collection_type
       end
     end
   end

--- a/app/forms/hyrax/forms/admin/collection_type_participant_form.rb
+++ b/app/forms/hyrax/forms/admin/collection_type_participant_form.rb
@@ -1,0 +1,16 @@
+module Hyrax
+  module Forms
+    module Admin
+      class CollectionTypeParticipantForm
+        include ActiveModel::Model
+        attr_accessor :collection_type_participant
+        validates :agent_id, presence: true
+        validates :agent_type, presence: true
+        validates :access, presence: true
+        validates :hyrax_collection_type_id, presence: true
+
+        delegate :agent_id, :agent_type, :access, :hyrax_collection_type_id, to: :collection_type_participant
+      end
+    end
+  end
+end

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -5,6 +5,7 @@ module Hyrax
     validates :machine_id, presence: true, uniqueness: true
     before_save :ensure_no_collections
     before_destroy :ensure_no_collections
+    has_many :collection_type_participants, class_name: 'Hyrax::CollectionTypeParticipant', foreign_key: 'hyrax_collection_type_id', dependent: :destroy
 
     DEFAULT_ID = 'user_collection'.freeze
     DEFAULT_TITLE = 'User Collection'.freeze

--- a/app/models/hyrax/collection_type_participant.rb
+++ b/app/models/hyrax/collection_type_participant.rb
@@ -1,0 +1,32 @@
+module Hyrax
+  class CollectionTypeParticipant < ActiveRecord::Base
+    self.table_name = 'collection_type_participants'
+    belongs_to :hyrax_collection_type, class_name: 'CollectionType', foreign_key: 'hyrax_collection_type_id'
+    validates :agent_id, presence: true
+    validates :agent_type, presence: true
+    validates :access, presence: true
+    validates :hyrax_collection_type_id, presence: true
+
+    CREATOR = 'creator'.freeze
+    MANAGER = 'manager'.freeze
+
+    enum(
+      access: {
+        CREATOR => CREATOR,
+        MANAGER => MANAGER
+      }
+    )
+
+    def label
+      return agent_id unless agent_type == 'group'
+      case agent_id
+      when 'registered'
+        I18n.t('hyrax.admin.admin_sets.form_participant_table.registered_users')
+      when ::Ability.admin_group_name
+        I18n.t('hyrax.admin.admin_sets.form_participant_table.admin_users')
+      else
+        agent_id
+      end
+    end
+  end
+end

--- a/app/views/hyrax/admin/collection_types/_form.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form.html.erb
@@ -22,7 +22,6 @@
           </div>
         </div>
       </div>
-
       <div id="settings" class="tab-pane">
         <div class="panel panel-default labels">
           <div class="panel-body">
@@ -30,15 +29,6 @@
           </div>
         </div>
       </div>
-
-      <div id="participants" class="tab-pane">
-        <div class="panel panel-default labels">
-          <div class="panel-body">
-            <%= render 'form_participants', f: f %>
-          </div>
-        </div>
-      </div>
-
       <div class="panel-footer">
         <% if params[:action] == "new" %>
           <%= f.submit t(:'hyrax.admin.collection_types.form.submit'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "create_submit", name: "create_collection_type" %>
@@ -47,8 +37,15 @@
         <% end %>
         <%= link_to t(:'helpers.action.cancel'), hyrax.admin_collection_types_path, class: 'btn btn-link' %>
       </div>
-
-  <% end %>
-  <% # end of form %>
-
+      <% end %>
+      <% # end of form %>
+      <% # TODO: The participants partial can't sit inside the other form, moved down here temporarily %>
+      <div id="participants" class="tab-pane">
+        <div class="panel panel-default labels">
+          <div class="panel-body">
+            <%= render 'form_participants' %>
+          </div>
+        </div>
+      </div>
+  </div>
 </div>

--- a/app/views/hyrax/admin/collection_types/_form_participant_table.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_participant_table.html.erb
@@ -1,0 +1,26 @@
+<h3><%= t(".#{access}.title") %></h3>
+<p><%= t(".#{access}.help") %></p>
+<% if @form.collection_type_participants.select(&filter).any? %>
+  <table class="table table-striped share-status">
+    <thead>
+      <tr>
+        <th><%= t(".#{access}.agent_name") %></th>
+        <th><%= t(".#{access}.type") %></th>
+        <th><%= t(".#{access}.action") %></th>
+      </tr>
+    </thead>
+    <tbody>
+    <% @form.collection_type_participants.select(&filter).each do |g| %>
+      <tr>
+        <td data-agent="<%= g.agent_id %>"><%= g.label %></td>
+        <td><%= g.agent_type.titleize %></td>
+        <td>
+          <%= button_to "Remove", hyrax.admin_collection_type_participant_path(g), method: :delete, class: 'btn btn-danger' %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p><em><%= t(".#{access}.empty") %></em></p>
+<% end %>

--- a/app/views/hyrax/admin/collection_types/_form_participants.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_participants.html.erb
@@ -1,0 +1,62 @@
+<h2><%= t('.add_participants') %></h2>
+<p><%= t('.instructions') %></p>
+<% access_options = options_for_select([['Manager', 'manager'], ['Creator', 'creator']]) %>
+<% unless @collection_type_participant.nil? %>
+  <%= simple_form_for @collection_type_participant,
+                      url: hyrax.admin_collection_type_participants_path,
+                      html: { id: 'group-participants-form' },
+                      as: :collection_type_participant do |f| %>
+      <div class="clearfix spacer">
+        <div class="form-inline">
+          <label class="col-md-2 col-xs-4 control-label">Add Group</label>
+
+          <div class="col-md-10 col-xs-8 form-group">
+            <%= f.hidden_field :hyrax_collection_type_id, value: @collection_type_participant.hyrax_collection_type_id %>
+            <%= f.hidden_field :agent_type, value: 'group' %>
+            <%= f.text_field :agent_id,
+                             placeholder: "Search for a group...",
+                             class: 'form-control' %>
+            as
+            <%= f.select :access,
+                         access_options,
+                         { prompt: "Select a role..." },
+                         class: 'form-control' %>
+
+                       <%= f.submit t('.submit'), class: 'btn btn-info' %>
+          </div>
+        </div>
+      </div>
+  <% end %>
+  <%= simple_form_for @collection_type_participant,
+                      url: hyrax.admin_collection_type_participants_path,
+                      html: { id: 'user-participants-form' },
+                      as: :collection_type_participant do |f| %>
+      <div class="clearfix spacer">
+        <div class="form-inline">
+          <label class="col-md-2 col-xs-4 control-label">Add User</label>
+
+          <div class="col-md-10 col-xs-8 form-group">
+            <%= f.hidden_field :hyrax_collection_type_id, value: @collection_type_participant.hyrax_collection_type_id %>
+            <%= f.hidden_field :agent_type, value: 'user' %>
+            <%= f.text_field :agent_id,
+                             placeholder: "Search for a user...",
+                             class: 'form-control' %>
+            as
+            <%= f.select :access,
+                         access_options,
+                         { prompt: "Select a role..." },
+                         class: 'form-control' %>
+
+                       <%= f.submit t('.submit'), class: 'btn btn-info' %>
+          </div>
+        </div>
+      </div>
+  <% end %>
+<% end %>
+<div>
+  <fieldset>
+    <legend><%= t('.current_participants') %></legend>
+    <%= render 'form_participant_table', access: 'managers', filter: :manager? %>
+    <%= render 'form_participant_table', access: 'creators', filter: :creator? %>
+  </fieldset>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -176,6 +176,29 @@ en:
         form_settings:
           instructions:    "These settings determine how collections of this type can be managed and discovered."
           warning:         "Warning: These settings cannot be changed after a collection of this type has been created."
+        form_participants:
+          header:             "Collection Participants"
+          instructions:       "You can designate both groups and users as creators and managers of collections of this type"
+          add_participants:     "Add Participants"
+          submit:               "Add"
+          update_notice:        "Participants Updated"
+          remove_success:       "Participant Removed"
+          current_participants: "Current Participants"
+        form_participant_table:
+          managers:
+            action:             "Action"
+            agent_name:         "Collection Managers"
+            type:               "Type"
+            title:              "Managers"
+            help:               "Managers of collections of this type can edit collections other users have created, including adding to and removing works from a collection, modifying collection metadata, and deleting collections."
+            empty:              "No managers have been added to this collection type."
+          creators:
+            action:             "Action"
+            agent_name:         "Collection Creators"
+            type:               "Type"
+            title:              "Creators"
+            help:               "Creators of collections of this type can create and manage their own collections."
+            empty:              "No creators have been added to this collection type."
         index:
           breadcrumb:       "Collection Types"
           create_new_button: "Create new collection type"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,6 +219,7 @@ Hyrax::Engine.routes.draw do
     resources :workflow_roles
     resource :appearance
     resources :collection_types, except: :show
+    resources :collection_type_participants, only: [:create, :destroy]
   end
 
   resources :content_blocks, only: [] do

--- a/db/migrate/20170817152654_create_collection_type_participants.rb
+++ b/db/migrate/20170817152654_create_collection_type_participants.rb
@@ -1,0 +1,11 @@
+class CreateCollectionTypeParticipants < ActiveRecord::Migration[5.0]
+  def change
+    create_table :collection_type_participants do |t|
+      t.references :hyrax_collection_type, foreign_key: true, index: {:name => "hyrax_collection_type_id"}
+      t.string :agent_type
+      t.string :agent_id
+      t.string :access
+      t.timestamps
+    end
+  end
+end

--- a/spec/controllers/hyrax/admin/collection_type_participants_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/collection_type_participants_controller_spec.rb
@@ -1,0 +1,152 @@
+RSpec.describe Hyrax::Admin::CollectionTypeParticipantsController, type: :controller do
+  context 'anonymous user' do
+    let(:collection_type) { create(:collection_type) }
+    let(:valid_attributes) do
+      {
+        hyrax_collection_type_id: collection_type.id,
+        access: 'creator',
+        agent_id: 'example@example.com',
+        agent_type: 'user'
+      }
+    end
+
+    describe '#create' do
+      it 'does not create a pariticpant' do
+        post :create
+        expect do
+          post :create, params: { collection_type_participant: valid_attributes }
+        end.to change(Hyrax::CollectionTypeParticipant, :count).by(0)
+      end
+
+      it "returns http redirect" do
+        post :create
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    describe '#destroy' do
+      let!(:collection_type_participant) { create(:collection_type_participant) }
+
+      it 'does not destroy a participant' do
+        expect do
+          delete :destroy, params: { id: collection_type_participant.to_param }
+        end.to change(Hyrax::CollectionTypeParticipant, :count).by(0)
+      end
+
+      it "returns http redirect" do
+        delete :destroy, params: { id: collection_type_participant.to_param }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+
+  context "unauthorized user" do
+    let(:user) { create(:user) }
+    let(:collection_type) { create(:collection_type) }
+    let(:valid_attributes) do
+      {
+        hyrax_collection_type_id: collection_type.id,
+        access: 'creator',
+        agent_id: 'example@example.com',
+        agent_type: 'user'
+      }
+    end
+
+    before do
+      allow(controller.current_ability).to receive(:can?).with(any_args).and_return(false)
+      sign_in user
+    end
+
+    describe "#create" do
+      it 'does not create a pariticpant' do
+        post :create
+        expect do
+          post :create, params: { collection_type_participant: valid_attributes }
+        end.to change(Hyrax::CollectionTypeParticipant, :count).by(0)
+      end
+
+      it "returns http redirect" do
+        post :create
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    describe "#destroy" do
+      let!(:collection_type_participant) { create(:collection_type_participant) }
+
+      it 'does not destroy a participants' do
+        expect do
+          delete :destroy, params: { id: collection_type_participant.to_param }
+        end.to change(Hyrax::CollectionTypeParticipant, :count).by(0)
+      end
+      it "returns http redirect" do
+        delete :destroy, params: { id: :id }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+
+  context "authorized user" do
+    let(:collection_type) { create(:collection_type) }
+    let(:valid_attributes) do
+      {
+        hyrax_collection_type_id: collection_type.id,
+        access: 'creator',
+        agent_id: 'example@example.com',
+        agent_type: 'user'
+      }
+    end
+
+    let(:valid_session) { {} }
+    let(:collection_type_participant) { create(:collection_type_participant) }
+    let(:user) { create(:user) }
+
+    before do
+      allow(controller.current_ability).to receive(:can?).with(any_args).and_return(true)
+      sign_in user
+    end
+
+    describe "#create" do
+      context "with valid params" do
+        it "creates a new CollectionTypeParticipant" do
+          expect do
+            post :create, params: { collection_type_participant: valid_attributes }, session: valid_session
+          end.to change(Hyrax::CollectionTypeParticipant, :count).by(1)
+        end
+
+        it "redirects to the edit_admin_collection_type with participants panel active" do
+          post :create, params: { collection_type_participant: valid_attributes }, session: valid_session
+          expect(response).to redirect_to(edit_admin_collection_type_path(collection_type.id, anchor: 'participants'))
+        end
+
+        it "assigns all attributes" do
+          post :create, params: { collection_type_participant: valid_attributes }, session: valid_session
+          expect(assigns[:collection_type_participant].attributes.symbolize_keys).to include(valid_attributes)
+        end
+      end
+
+      context "with invalid params" do
+        it "does not create a new CollectionTypeParticipant" do
+          post :create, params: { collection_type_participant: { hyrax_collection_type_id: '1' } }, session: valid_session
+          expect do
+            post :create, params: { collection_type_participant: { hyrax_collection_type_id: '1' } }, session: valid_session
+          end.to change(Hyrax::CollectionTypeParticipant, :count).by(0)
+        end
+      end
+    end
+
+    describe "#destroy" do
+      it "destroys the requested collection_type_participant" do
+        expect(collection_type_participant).to be_persisted
+        expect do
+          delete :destroy, params: { id: collection_type_participant.to_param }, session: valid_session
+        end.to change(Hyrax::CollectionTypeParticipant, :count).by(-1)
+      end
+
+      it "redirects to edit the collections participants list" do
+        delete :destroy, params: { id: collection_type_participant.to_param }, session: valid_session
+        expect(response).to redirect_to(edit_admin_collection_type_path(collection_type_participant.hyrax_collection_type_id, anchor: 'participants'))
+      end
+    end
+  end
+end

--- a/spec/factories/collection_type_participants.rb
+++ b/spec/factories/collection_type_participants.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :collection_type_participant, class: Hyrax::CollectionTypeParticipant do
+    association :hyrax_collection_type, factory: :collection_type
+    sequence(:agent_id) { |n| "user#{n}@example.com" }
+    agent_type  'user'
+    access      'manager'
+  end
+end

--- a/spec/forms/hyrax/forms/admin/collection_type_participant_form_spec.rb
+++ b/spec/forms/hyrax/forms/admin/collection_type_participant_form_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Hyrax::Forms::Admin::CollectionTypeParticipantForm do
+  let(:collection_type_participant) { build(:collection_type_participant) }
+  let(:form) { described_class.new(collection_type_participant: collection_type_participant) }
+
+  subject { form }
+
+  it { is_expected.to delegate_method(:agent_id).to(:collection_type_participant) }
+  it { is_expected.to delegate_method(:agent_type).to(:collection_type_participant) }
+  it { is_expected.to delegate_method(:access).to(:collection_type_participant) }
+end

--- a/spec/models/hyrax/collection_type_participant_spec.rb
+++ b/spec/models/hyrax/collection_type_participant_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Hyrax::CollectionTypeParticipant, type: :model do
+  let(:collection_type_participant) { create(:collection_type_participant) }
+
+  it 'has basic metadata' do
+    expect(collection_type_participant).to respond_to(:agent_id)
+    expect(collection_type_participant.agent_id).not_to be_empty
+    expect(collection_type_participant).to respond_to(:agent_type)
+    expect(collection_type_participant.agent_type).not_to be_empty
+    expect(collection_type_participant).to respond_to(:access)
+    expect(collection_type_participant.access).not_to be_empty
+  end
+end

--- a/spec/views/hyrax/admin/collection_types/_form_participants.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_participants.html.erb_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe 'hyrax/admin/collection_types/_form_participants.html.erb', type: :view do
+  let(:collection_type) { build(:collection_type) }
+  let(:form) { Hyrax::Forms::Admin::CollectionTypeForm.new(collection_type: collection_type) }
+  let(:collection_type_participant) { build(:collection_type_participant) }
+  let(:participant_form) { Hyrax::Forms::Admin::CollectionTypeParticipantForm.new(collection_type_participant: collection_type_participant) }
+
+  before do
+    assign(:collection_type_participant, participant_form)
+    assign(:form, form)
+    render
+  end
+  it 'has the required selectors' do
+    expect(rendered).to have_selector('#user-participants-form')
+    expect(rendered).to have_selector('#group-participants-form')
+  end
+end

--- a/spec/views/hyrax/admin/collection_types/_form_participants_table.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_participants_table.html.erb_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe 'hyrax/admin/collection_types/_form_participant_table.html.erb', type: :view do
+  let(:user) { create(:user) }
+  let(:collection_type) { stub_model(Hyrax::CollectionType) }
+  let(:collection_type_participant) { stub_model(Hyrax::CollectionTypeParticipant) }
+  let(:form) do
+    instance_double(Hyrax::Forms::Admin::CollectionTypeForm,
+                    model_name: collection_type.model_name,
+                    collection_type_participants: [collection_type_participant])
+  end
+
+  before do
+    assign(:form, form)
+  end
+
+  describe 'Manager participants table' do
+    before do
+      render 'form_participant_table', access: 'managers', filter: :manager?
+    end
+
+    context 'managers exist' do
+      let(:collection_type_participant) do
+        stub_model(Hyrax::CollectionTypeParticipant,
+                   agent_type: 'user',
+                   agent_id: user.user_key,
+                   access: 'manager')
+      end
+
+      it 'lists the managers in the table' do
+        expect(rendered).to have_selector('h3', text: 'Managers')
+        expect(rendered).to have_selector('table tbody', text: user.user_key)
+      end
+    end
+
+    context 'no managers exist' do
+      let(:collection_type_participant) { stub_model(Hyrax::CollectionTypeParticipant) }
+
+      it 'displays a message and no table' do
+        expect(rendered).to have_selector('h3', text: 'Managers')
+        expect(rendered).not_to have_selector('table')
+        expect(rendered).to have_content('No managers have been added to this collection type.')
+      end
+    end
+  end
+
+  describe 'Creator participants table' do
+    before do
+      render 'form_participant_table', access: 'creators', filter: :creator?
+    end
+
+    context 'creators exist' do
+      let(:collection_type_participant) do
+        stub_model(Hyrax::CollectionTypeParticipant,
+                   agent_type: 'user',
+                   agent_id: user.user_key,
+                   access: 'creator')
+      end
+
+      it 'lists the creators in the table' do
+        expect(rendered).to have_selector('h3', text: 'Creators')
+        expect(rendered).to have_selector('table tbody', text: user.user_key)
+      end
+    end
+    context 'no creators exist' do
+      let(:collection_type_participant) { stub_model(Hyrax::CollectionTypeParticipant) }
+
+      it 'displays a message and no table' do
+        expect(rendered).to have_selector('h3', text: 'Creators')
+        expect(rendered).not_to have_selector('table')
+        expect(rendered).to have_content('No creators have been added to this collection type.')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Partially Fixes #1345 ; 
( See Previous PR for this issue for history:  #1534 )

**Description**
Adds functionality to add/remove participants to/from a collection type.
  - Form to add users or groups to a collection type either as creators or managers
  - lists current participants of the collection type, with button to remove participant

**Changes in this pull request**
- Migration for database table collection_type_participants that stores participant access info
- Adds `Admin::CollectionTypeParticipantsController`, `CollectionTypeParticipantForm`, `CollectionTypeParticipant` model associated tests
- Adds`/views/hyrax/admin/collection_types/_form_participants.html.erb` and `/views/hyrax/admin/collection_types/_form_participants_table.html.erb`


**Remaining Issues:**
- The `/views/hyrax/admin/collection_types/_form.html.erb` view and other partials (Issues: #1344, #1346, #1348) need to be rearranged a bit. The `_form_participants.html.erb` partial cannot nest within the other form but that form is spanning the other two tabs. I moved the participants partial under the submit button as a temporary measure during development, but it needs permanent solution. Maybe if the form.persisted? is true the first tab could become the "Metadata and Discovery" and contain the other two partials? That way the form could live within the first tab pane and not span them all. 

@samvera/hyrax-code-reviewers
