### PR TITLE
Remove outdated task from template

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -1,8 +1,4 @@
 gem 'hyrax'
-
 run 'bundle install'
-
 generate 'hyrax:install', '-f'
-
 rails_command 'db:migrate'
-rails_command 'hyrax:workflow:load'


### PR DESCRIPTION
One no longer needs to manually load workflows; workflows are automatically loaded when an Admin Set is created.

@samvera/hyrax-code-reviewers
