### PR TITLE
[WIP] Collection types should support restricting multiple membership

### DIFF
--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -202,7 +202,9 @@ RSpec.describe Collection do
     end
   end
 
-  describe 'collection type delegated methods' do
+  describe 'type properties' do
+    subject { collection }
+
     let(:collection_type) { build(:collection_type) }
 
     before do
@@ -210,86 +212,113 @@ RSpec.describe Collection do
     end
 
     describe '#nestable' do
-      it "returns false if collection_type's nestable property is false" do
-        collection_type.nestable = false
-        expect(collection.nestable?).to be_falsey
+      before { collection_type.nestable = property_value }
+      context 'when false' do
+        let(:property_value) { false }
+
+        it { is_expected.not_to be_nestable }
       end
 
-      it "returns true if collection_type's nestable property is true" do
-        collection_type.nestable = true
-        expect(collection.nestable?).to be_truthy
+      context 'when true' do
+        let(:property_value) { true }
+
+        it { is_expected.to be_nestable }
       end
     end
 
     describe '#discoverable' do
-      it "returns false if collection_type's discoverable property is false" do
-        collection_type.discoverable = false
-        expect(collection.discoverable?).to be_falsey
+      before { collection_type.discoverable = property_value }
+
+      context 'when false' do
+        let(:property_value) { false }
+
+        it { is_expected.not_to be_discoverable }
       end
 
-      it "returns true if collection_type's discoverable property is true" do
-        collection_type.discoverable = true
-        expect(collection.discoverable?).to be_truthy
+      context 'when true' do
+        let(:property_value) { true }
+
+        it { is_expected.to be_discoverable }
       end
     end
 
     describe '#sharable' do
-      it "returns false if collection_type's sharable property is false" do
-        collection_type.sharable = false
-        expect(collection.sharable?).to be_falsey
+      before { collection_type.sharable = property_value }
+
+      context 'when false' do
+        let(:property_value) { false }
+
+        it { is_expected.not_to be_sharable }
       end
 
-      it "returns true if collection_type's sharable property is true" do
-        collection_type.sharable = true
-        expect(collection.sharable?).to be_truthy
+      context 'when true' do
+        let(:property_value) { true }
+
+        it { is_expected.to be_sharable }
       end
     end
 
     describe '#allow_multiple_membership' do
-      it "returns false if collection_type's allow_multiple_membership property is false" do
-        collection_type.allow_multiple_membership = false
-        expect(collection.allow_multiple_membership?).to be_falsey
+      before { collection_type.allow_multiple_membership = property_value }
+
+      context 'when false' do
+        let(:property_value) { false }
+
+        it { is_expected.not_to allow_multiple_membership }
       end
 
-      it "returns true if collection_type's allow_multiple_membership property is true" do
-        collection_type.allow_multiple_membership = true
-        expect(collection.allow_multiple_membership?).to be_truthy
+      context 'when true' do
+        let(:property_value) { true }
+
+        it { is_expected.to allow_multiple_membership }
       end
     end
 
     describe '#require_membership' do
-      it "returns false if collection_type's require_membership property is false" do
-        collection_type.require_membership = false
-        expect(collection.require_membership?).to be_falsey
+      before { collection_type.require_membership = property_value }
+
+      context 'when false' do
+        let(:property_value) { false }
+
+        it { is_expected.not_to require_membership }
       end
 
-      it "returns true if collection_type's require_membership property is true" do
-        collection_type.require_membership = true
-        expect(collection.require_membership?).to be_truthy
+      context 'when true' do
+        let(:property_value) { true }
+
+        it { is_expected.to require_membership }
       end
     end
 
     describe '#assigns_workflow' do
-      it "returns false if collection_type's assigns_workflow property is false" do
-        collection_type.assigns_workflow = false
-        expect(collection.assigns_workflow?).to be_falsey
+      before { collection_type.assigns_workflow = property_value }
+
+      context 'when false' do
+        let(:property_value) { false }
+
+        it { is_expected.not_to assign_workflow }
       end
 
-      it "returns true if collection_type's assigns_workflow property is true" do
-        collection_type.assigns_workflow = true
-        expect(collection.assigns_workflow?).to be_truthy
+      context 'when true' do
+        let(:property_value) { true }
+
+        it { is_expected.to assign_workflow }
       end
     end
 
     describe '#assigns_visibility' do
-      it "returns false if collection_type's assigns_visibility property is false" do
-        collection_type.assigns_visibility = false
-        expect(collection.assigns_visibility?).to be_falsey
+      before { collection_type.assigns_visibility = property_value }
+
+      context 'when false' do
+        let(:property_value) { false }
+
+        it { is_expected.not_to assign_visibility }
       end
 
-      it "returns true if collection_type's assigns_visibility property is true" do
-        collection_type.assigns_visibility = true
-        expect(collection.assigns_visibility?).to be_truthy
+      context 'when true' do
+        let(:property_value) { true }
+
+        it { is_expected.to assign_visibility }
       end
     end
   end

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   it "has configuration properties with defaults" do
-    expect(collection_type.nestable?).to be_truthy
-    expect(collection_type.discoverable?).to be_truthy
-    expect(collection_type.sharable?).to be_truthy
-    expect(collection_type.allow_multiple_membership?).to be_truthy
-    expect(collection_type.require_membership?).to be_falsey
-    expect(collection_type.assigns_workflow?).to be_falsey
-    expect(collection_type.assigns_visibility?).to be_falsey
+    expect(collection_type).to be_nestable
+    expect(collection_type).to be_discoverable
+    expect(collection_type).to be_sharable
+    expect(collection_type).to allow_multiple_membership
+    expect(collection_type).not_to require_membership
+    expect(collection_type).not_to assign_workflow
+    expect(collection_type).not_to assign_visibility
   end
 
   describe '#gid' do
@@ -36,7 +36,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
 
     it 'creates a default collection type' do
       subject
-      expect(described_class.exists?(machine_id: described_class::DEFAULT_ID)).to be_truthy
+      expect(described_class).to exist(machine_id: described_class::DEFAULT_ID)
     end
   end
 
@@ -65,7 +65,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     end
 
     it 'returns false if collection type with gid does NOT exist' do
-      expect(Hyrax::CollectionType.find_by_gid(nonexistent_gid)).to be_falsey
+      expect(Hyrax::CollectionType.find_by_gid(nonexistent_gid)).to eq false
     end
   end
 
@@ -91,7 +91,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     end
 
     it 'returns empty array if gid is nil' do
-      expect(Collection.count > 0).to be_truthy
+      expect(Collection.count).not_to be_zero
       expect(build(:collection_type).collections).to eq []
     end
   end
@@ -101,10 +101,10 @@ RSpec.describe Hyrax::CollectionType, type: :model do
 
     it 'returns true if there are any collections of this collection type' do
       create(:collection, collection_type_gid: collection_type.gid.to_s)
-      expect(collection_type.collections?).to be_truthy
+      expect(collection_type).to have_collections
     end
     it 'returns false if there are not any collections of this collection type' do
-      expect(collection_type.collections?).to be_falsey
+      expect(collection_type).not_to have_collections
     end
   end
 
@@ -124,7 +124,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     end
 
     it "fails if collections exist of this type" do
-      expect(collection_type.destroy).to be_falsey
+      expect(collection_type.destroy).to eq false
       expect(collection_type.errors).not_to be_empty
     end
   end
@@ -135,7 +135,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     end
 
     it "fails if collections exist of this type" do
-      expect(collection_type.save).to be_falsey
+      expect(collection_type.save).to eq false
       expect(collection_type.errors).not_to be_empty
     end
   end

--- a/spec/support/matchers/collection_type_property_matchers.rb
+++ b/spec/support/matchers/collection_type_property_matchers.rb
@@ -21,3 +21,9 @@ RSpec::Matchers.define :assign_workflow do
     actual && actual.assigns_workflow?
   end
 end
+
+RSpec::Matchers.define :have_collections do
+  match do |actual|
+    actual && actual.collections?
+  end
+end

--- a/spec/support/matchers/collection_type_property_matchers.rb
+++ b/spec/support/matchers/collection_type_property_matchers.rb
@@ -1,0 +1,23 @@
+RSpec::Matchers.define :require_membership do
+  match do |actual|
+    actual && actual.require_membership?
+  end
+end
+
+RSpec::Matchers.define :allow_multiple_membership do
+  match do |actual|
+    actual && actual.allow_multiple_membership?
+  end
+end
+
+RSpec::Matchers.define :assign_visibility do
+  match do |actual|
+    actual && actual.assigns_visibility?
+  end
+end
+
+RSpec::Matchers.define :assign_workflow do
+  match do |actual|
+    actual && actual.assigns_workflow?
+  end
+end


### PR DESCRIPTION
This is a WIP branch, and further commits will be flowing in soon.

Refs #1549

* Restructure collection type-related model specs to use predicate matchers. The restructuring creates the following output:

```
Collection
  type properties
    #nestable
      when true
.        should be nestable
      when false
.        should not be nestable
    #sharable
      when false
.        should not be sharable
      when true
.        should be sharable
    #assigns_visibility
      when false
.        should not assign visibility
      when true
.        should assign visibility
    #allow_multiple_membership
      when true
.        should allow multiple membership
      when false
.        should not allow multiple membership
    #assigns_workflow
      when false
.        should not assign workflow
      when true
.        should assign workflow
    #require_membership
      when false
.        should not require membership
      when true
.        should require membership
    #discoverable
      when false
.        should not be discoverable
      when true
.        should be discoverable
```

@samvera/hyrax-code-reviewers
