### PR TITLE
Collections sprint for nesting

### DIFF
--- a/app/controllers/hyrax/dashboard/nest_collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/nest_collections_controller.rb
@@ -23,7 +23,7 @@ module Hyrax
           child = Collection.find(params.fetch(:child_id))
           authorize! :edit, child
           parent = params.key?(:parent_id) ? Collection.find(params[:parent_id]) : nil
-          form_class.new(child: child, parent: parent)
+          form_class.new(child: child, parent: parent, ability: current_ability)
         end
     end
   end

--- a/app/controllers/hyrax/dashboard/nest_collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/nest_collections_controller.rb
@@ -1,6 +1,7 @@
 module Hyrax
   module Dashboard
     class NestCollectionsController < ApplicationController
+      include Blacklight::Base
       class_attribute :form_class
       self.form_class = Hyrax::Forms::Dashboard::NestCollectionForm
       def new_within
@@ -23,7 +24,7 @@ module Hyrax
           child = Collection.find(params.fetch(:child_id))
           authorize! :edit, child
           parent = params.key?(:parent_id) ? Collection.find(params[:parent_id]) : nil
-          form_class.new(child: child, parent: parent, ability: current_ability)
+          form_class.new(child: child, parent: parent, context: self)
         end
     end
   end

--- a/app/controllers/hyrax/dashboard/nest_collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/nest_collections_controller.rb
@@ -1,0 +1,30 @@
+module Hyrax
+  module Dashboard
+    class NestCollectionsController < ApplicationController
+      class_attribute :form_class
+      self.form_class = Hyrax::Forms::Dashboard::NestCollectionForm
+      def new_within
+        @form = build_within_form
+      end
+
+      def create_within
+        @form = build_within_form
+        if @form.save
+          notice = I18n.t('create_within', scope: 'hyrax.dashboard.nest_collections_form', child_title: @form.child.title, parent_title: @form.parent.title)
+          redirect_to dashboard_collection_path(@form.child), notice: notice
+        else
+          render 'new_within'
+        end
+      end
+
+      private
+
+        def build_within_form
+          child = Collection.find(params.fetch(:child_id))
+          authorize! :edit, child
+          parent = params.key?(:parent_id) ? Collection.find(params[:parent_id]) : nil
+          form_class.new(child: child, parent: parent)
+        end
+    end
+  end
+end

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -1,0 +1,45 @@
+module Hyrax
+  module Forms
+    module Dashboard
+      # Responsible for validating that both the parent and child are valid for nesting; If so, then
+      # also responsible for persisting those changes.
+      class NestCollectionForm
+        include ActiveModel::Model
+
+        def initialize(parent: nil, child: nil)
+          self.parent = parent
+          self.child = child
+        end
+
+        attr_accessor :parent, :child
+
+        validates :parent, presence: true
+        validates :child, presence: true
+
+        def save
+          return false unless valid?
+          persist!
+        end
+
+        def save!
+          raise unless valid?
+          persist!
+        end
+
+        def available_child_collections
+          return [] if parent.blank?
+        end
+
+        def available_parent_collections
+          return [] if child.blank?
+        end
+
+        private
+
+          def persist!
+            true
+          end
+      end
+    end
+  end
+end

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -9,15 +9,15 @@ module Hyrax
         self.default_query_service = Hyrax::Collections::NestedCollectionQueryService
         self.default_persistence_service = Hyrax::Collections::NestedCollectionPersistenceService
 
-        # @param parent [Hyrax::Colection, NilClass]
-        # @param child [Hyrax::Colection, NilClass]
-        # @param ability [Ability]
+        # @param parent [Collection, NilClass]
+        # @param child [Collection, NilClass]
+        # @param context [#can?,#repository,#blacklight_config]
         # @param query_service [Hyrax::Collections::NestedCollectionQueryService]
         # @param persistence_service [Hyrax::Collections::NestedCollectionPersistenceService] responsible for persisting the parent/child relationship
-        def initialize(parent: nil, child: nil, ability:, query_service: default_query_service, persistence_service: default_persistence_service)
+        def initialize(parent: nil, child: nil, context:, query_service: default_query_service, persistence_service: default_persistence_service)
           self.parent = parent
           self.child = child
-          self.ability = ability
+          self.context = context
           self.query_service = query_service
           self.persistence_service = persistence_service
         end
@@ -36,18 +36,18 @@ module Hyrax
         # For the given parent, what are all of the available collections that
         # can be added as sub-collection of the parent.
         def available_child_collections
-          query_service.available_child_collections(parent: parent, ability: ability)
+          query_service.available_child_collections(parent: parent, context: context)
         end
 
         # For the given child, what are all of the available collections to
         # which the child can be added as a sub-collection.
         def available_parent_collections
-          query_service.available_parent_collections(child: child, ability: ability)
+          query_service.available_parent_collections(child: child, context: context)
         end
 
         private
 
-          attr_accessor :query_service, :persistence_service, :ability
+          attr_accessor :query_service, :persistence_service, :context
 
           def parent_and_child_can_be_nested
             if parent.try(:nestable?) && child.try(:nestable?)

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -6,15 +6,20 @@ module Hyrax
       class NestCollectionForm
         include ActiveModel::Model
 
-        def initialize(parent: nil, child: nil)
+        # @param [Hyrax::Colection, NilClass] parent
+        # @param [Hyrax::Colection, NilClass] child
+        # @param [Object] query_service
+        def initialize(parent: nil, child: nil, query_service: default_query_service)
           self.parent = parent
           self.child = child
+          self.query_service = query_service
         end
 
         attr_accessor :parent, :child
 
         validates :parent, presence: true
         validates :child, presence: true
+        validate :parent_and_child_can_be_nested
 
         def save
           return false unless valid?
@@ -26,16 +31,38 @@ module Hyrax
           persist!
         end
 
+        # For the given parent, what are all of the available collections that
+        # can be added as sub-collection of the parent.
         def available_child_collections
-          return [] if parent.blank?
+          query_service.available_child_collections(parent: parent)
         end
 
+        # For the given child, what are all of the available collections to
+        # which the child can be added as a sub-collection.
         def available_parent_collections
-          return [] if child.blank?
+          query_service.available_parent_collections(child: child)
         end
 
         private
 
+          attr_accessor :query_service
+
+          def default_query_service
+            raise 'TODO'
+          end
+
+          def parent_and_child_can_be_nested
+            if parent.try(:nestable?) && child.try(:nestable?)
+              return true if query_service.parent_and_child_can_nest?(parent: parent, child: child)
+              errors.add(:parent, :cannot_have_child_nested)
+              errors.add(:child, :cannot_nest_in_parent)
+            else
+              errors.add(:parent, :is_not_nestable) unless parent.try(:nestable?)
+              errors.add(:child, :is_not_nestable) unless child.try(:nestable?)
+            end
+          end
+
+          # Write the appropriate relationship.
           def persist!
             true
           end

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -11,11 +11,13 @@ module Hyrax
 
         # @param parent [Hyrax::Colection, NilClass]
         # @param child [Hyrax::Colection, NilClass]
+        # @param ability [Ability]
         # @param query_service [Hyrax::Collections::NestedCollectionQueryService]
         # @param persistence_service [Hyrax::Collections::NestedCollectionPersistenceService] responsible for persisting the parent/child relationship
-        def initialize(parent: nil, child: nil, query_service: default_query_service, persistence_service: default_persistence_service)
+        def initialize(parent: nil, child: nil, ability:, query_service: default_query_service, persistence_service: default_persistence_service)
           self.parent = parent
           self.child = child
+          self.ability = ability
           self.query_service = query_service
           self.persistence_service = persistence_service
         end
@@ -34,18 +36,18 @@ module Hyrax
         # For the given parent, what are all of the available collections that
         # can be added as sub-collection of the parent.
         def available_child_collections
-          query_service.available_child_collections(parent: parent)
+          query_service.available_child_collections(parent: parent, ability: ability)
         end
 
         # For the given child, what are all of the available collections to
         # which the child can be added as a sub-collection.
         def available_parent_collections
-          query_service.available_parent_collections(child: child)
+          query_service.available_parent_collections(child: child, ability: ability)
         end
 
         private
 
-          attr_accessor :query_service, :persistence_service
+          attr_accessor :query_service, :persistence_service, :ability
 
           def parent_and_child_can_be_nested
             if parent.try(:nestable?) && child.try(:nestable?)

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -48,7 +48,21 @@ module Hyrax
           attr_accessor :query_service
 
           def default_query_service
-            raise 'TODO'
+            QueryService.new
+          end
+
+          class QueryService
+            def available_child_collections(parent:)
+              raise NotImplementedError
+            end
+
+            def available_parent_collections(child:)
+              raise NotImplementedError
+            end
+
+            def parent_and_child_can_nest?(parent:, child:)
+              raise NotImplementedError
+            end
           end
 
           def parent_and_child_can_be_nested

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -4,35 +4,15 @@ module Hyrax
       # Responsible for validating that both the parent and child are valid for nesting; If so, then
       # also responsible for persisting those changes.
       class NestCollectionForm
-        module NestedCollectionQueryService
-          def self.available_child_collections(parent:)
-            raise NotImplementedError
-          end
-
-          def self.available_parent_collections(child:)
-            raise NotImplementedError
-          end
-
-          def self.parent_and_child_can_nest?(parent:, child:)
-            raise NotImplementedError
-          end
-        end
-
-        module NestedCollectionPersistenceService
-          def self.persist_nested_collection_for(parent:, child:)
-            raise NotImplementedError
-          end
-        end
-
         include ActiveModel::Model
         class_attribute :default_query_service, :default_persistence_service, instance_writer: false
-        self.default_query_service = NestedCollectionQueryService
-        self.default_persistence_service = NestedCollectionPersistenceService
+        self.default_query_service = Hyrax::Collections::NestedCollectionQueryService
+        self.default_persistence_service = Hyrax::Collections::NestedCollectionPersistenceService
 
         # @param parent [Hyrax::Colection, NilClass]
         # @param child [Hyrax::Colection, NilClass]
-        # @param query_service [NestedCollectionQueryService]
-        # @param persistence_service [#persist_nested_collection_for] responsible for persisting the parent/child relationship
+        # @param query_service [Hyrax::Collections::NestedCollectionQueryService]
+        # @param persistence_service [Hyrax::Collections::NestedCollectionPersistenceService] responsible for persisting the parent/child relationship
         def initialize(parent: nil, child: nil, query_service: default_query_service, persistence_service: default_persistence_service)
           self.parent = parent
           self.child = child

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -51,7 +51,7 @@ module Hyrax
 
           def parent_and_child_can_be_nested
             if parent.try(:nestable?) && child.try(:nestable?)
-              return true if query_service.parent_and_child_can_nest?(parent: parent, child: child)
+              return true if query_service.parent_and_child_can_nest?(parent: parent, child: child, context: context)
               errors.add(:parent, :cannot_have_child_nested)
               errors.add(:child, :cannot_nest_in_parent)
             else

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -4,15 +4,40 @@ module Hyrax
       # Responsible for validating that both the parent and child are valid for nesting; If so, then
       # also responsible for persisting those changes.
       class NestCollectionForm
-        include ActiveModel::Model
+        module NestedCollectionQueryService
+          def self.available_child_collections(parent:)
+            raise NotImplementedError
+          end
 
-        # @param [Hyrax::Colection, NilClass] parent
-        # @param [Hyrax::Colection, NilClass] child
-        # @param [Object] query_service
-        def initialize(parent: nil, child: nil, query_service: default_query_service)
+          def self.available_parent_collections(child:)
+            raise NotImplementedError
+          end
+
+          def self.parent_and_child_can_nest?(parent:, child:)
+            raise NotImplementedError
+          end
+        end
+
+        module NestedCollectionPersistenceService
+          def self.persist_nested_collection_for(parent:, child:)
+            raise NotImplementedError
+          end
+        end
+
+        include ActiveModel::Model
+        class_attribute :default_query_service, :default_persistence_service, instance_writer: false
+        self.default_query_service = NestedCollectionQueryService
+        self.default_persistence_service = NestedCollectionPersistenceService
+
+        # @param parent [Hyrax::Colection, NilClass]
+        # @param child [Hyrax::Colection, NilClass]
+        # @param query_service [NestedCollectionQueryService]
+        # @param persistence_service [#persist_nested_collection_for] responsible for persisting the parent/child relationship
+        def initialize(parent: nil, child: nil, query_service: default_query_service, persistence_service: default_persistence_service)
           self.parent = parent
           self.child = child
           self.query_service = query_service
+          self.persistence_service = persistence_service
         end
 
         attr_accessor :parent, :child
@@ -23,12 +48,7 @@ module Hyrax
 
         def save
           return false unless valid?
-          persist!
-        end
-
-        def save!
-          raise unless valid?
-          persist!
+          persistence_service.persist_nested_collection_for(parent: parent, child: child)
         end
 
         # For the given parent, what are all of the available collections that
@@ -45,25 +65,7 @@ module Hyrax
 
         private
 
-          attr_accessor :query_service
-
-          def default_query_service
-            QueryService.new
-          end
-
-          class QueryService
-            def available_child_collections(parent:)
-              raise NotImplementedError
-            end
-
-            def available_parent_collections(child:)
-              raise NotImplementedError
-            end
-
-            def parent_and_child_can_nest?(parent:, child:)
-              raise NotImplementedError
-            end
-          end
+          attr_accessor :query_service, :persistence_service
 
           def parent_and_child_can_be_nested
             if parent.try(:nestable?) && child.try(:nestable?)
@@ -74,11 +76,6 @@ module Hyrax
               errors.add(:parent, :is_not_nestable) unless parent.try(:nestable?)
               errors.add(:child, :is_not_nestable) unless child.try(:nestable?)
             end
-          end
-
-          # Write the appropriate relationship.
-          def persist!
-            true
           end
       end
     end

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -26,7 +26,7 @@ module Hyrax
       # before_update { |col| validate_collection_type_gid(col) }
     end
 
-    delegate :nestable?, :discoverable?, :sharable?, :allow_multiple_membership?, :require_membership?, :assigns_workflow?, :assigns_visibility?, to: :collection_type
+    delegate(*Hyrax::CollectionType.collection_type_predicate_methods, to: :collection_type)
 
     # Get (and set) the collection_type when accessed
     def collection_type

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -15,8 +15,11 @@ module Hyrax
       validates_with HasOneTitleValidator
       self.indexer = Hyrax::CollectionIndexer
 
+      class_attribute :index_collection_type_gid_as, writer: false
+      self.index_collection_type_gid_as = [:symbol]
+
       property :collection_type_gid, predicate: ::RDF::Vocab::SCHEMA.additionalType, multiple: false do |index|
-        index.as :symbol
+        index.as(*index_collection_type_gid_as)
       end
 
       after_find { |col| load_collection_type_instance(col) }
@@ -72,6 +75,10 @@ module Hyrax
           collection = ActiveSupport::Inflector.tableize(name)
           "hyrax/#{collection}/#{element}".freeze
         end
+      end
+
+      def collection_type_gid_document_field_name
+        Solrizer.solr_name('collection_type_gid', *index_collection_type_gid_as)
       end
     end
 

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -29,7 +29,7 @@ module Hyrax
       # before_update { |col| validate_collection_type_gid(col) }
     end
 
-    delegate(*Hyrax::CollectionType.collection_type_predicate_methods, to: :collection_type)
+    delegate(*Hyrax::CollectionType.collection_type_settings_methods, to: :collection_type)
 
     # Get (and set) the collection_type when accessed
     def collection_type

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -20,12 +20,12 @@ module Hyrax
 
     class_attribute :collection_type_settings_methods, instance_writer: false
     self.collection_type_settings_methods = [:nestable?,
-                                              :discoverable?,
-                                              :sharable?,
-                                              :allow_multiple_membership?,
-                                              :require_membership?,
-                                              :assigns_workflow?,
-                                              :assigns_visibility?]
+                                             :discoverable?,
+                                             :sharable?,
+                                             :allow_multiple_membership?,
+                                             :require_membership?,
+                                             :assigns_workflow?,
+                                             :assigns_visibility?]
 
     # These are provided as a convenience method based on prior design discussions.
     # The deprecations are added to allow upstream developers to continue with what

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -18,6 +18,15 @@ module Hyrax
       assign_machine_id
     end
 
+    class_attribute :collection_type_predicate_methods, instance_writer: false
+    self.collection_type_predicate_methods = [:nestable?,
+                                              :discoverable?,
+                                              :sharable?,
+                                              :allow_multiple_membership?,
+                                              :require_membership?,
+                                              :assigns_workflow?,
+                                              :assigns_visibility?]
+
     # These are provided as a convenience method based on prior design discussions.
     # The deprecations are added to allow upstream developers to continue with what
     # they had already been doing. These can be removed as part of merging

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -18,8 +18,8 @@ module Hyrax
       assign_machine_id
     end
 
-    class_attribute :collection_type_predicate_methods, instance_writer: false
-    self.collection_type_predicate_methods = [:nestable?,
+    class_attribute :collection_type_settings_methods, instance_writer: false
+    self.collection_type_settings_methods = [:nestable?,
                                               :discoverable?,
                                               :sharable?,
                                               :allow_multiple_membership?,

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -18,7 +18,7 @@ module Hyrax
     delegate :stringify_keys, :human_readable_type, :collection?, :representative_id,
              :to_s, to: :solr_document
 
-    delegate(*Hyrax::CollectionType.collection_type_predicate_methods, to: :collection_type, prefix: :collection_type_is)
+    delegate(*Hyrax::CollectionType.collection_type_settings_methods, to: :collection_type, prefix: :collection_type_is)
 
     # @note This is an ugly hack. In working with Lynette, we discovered that the collection_type_gid
     #       was in the solr_document if the Collection was created via the UI. If the collection

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -18,6 +18,8 @@ module Hyrax
     delegate :stringify_keys, :human_readable_type, :collection?, :representative_id,
              :to_s, to: :solr_document
 
+    delegate(*Hyrax::CollectionType.collection_type_predicate_methods, to: :solr_document, prefix: :collection_type_is)
+
     # Metadata Methods
     delegate :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language,
              :embargo_release_date, :lease_expiration_date, :license, :date_created,

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -24,6 +24,7 @@ module Hyrax
     #       was in the solr_document if the Collection was created via the UI. If the collection
     #       was created by factory girl then collection_type_gid was not in the solr_document.
     #       The long-term solution is to ensure that the SOLR document has some key for the collection_type.
+    # @todo Change behavior when https://github.com/samvera/hyrax/pull/1556 is integrated
     def collection_type
       @collection_type ||= begin
         collection_type_gid =

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -18,7 +18,24 @@ module Hyrax
     delegate :stringify_keys, :human_readable_type, :collection?, :representative_id,
              :to_s, to: :solr_document
 
-    delegate(*Hyrax::CollectionType.collection_type_predicate_methods, to: :solr_document, prefix: :collection_type_is)
+    delegate(*Hyrax::CollectionType.collection_type_predicate_methods, to: :collection_type, prefix: :collection_type_is)
+
+    # @note This is an ugly hack. In working with Lynette, we discovered that the collection_type_gid
+    #       was in the solr_document if the Collection was created via the UI. If the collection
+    #       was created by factory girl then collection_type_gid was not in the solr_document.
+    #       The long-term solution is to ensure that the SOLR document has some key for the collection_type.
+    def collection_type
+      @collection_type ||= begin
+        collection_type_gid =
+          if solr_document.key?('collection_type_gid_ssim')
+            # Taking a short cut if we know the collection type based on the SOLR document
+            Array.wrap(solr_document.fetch('collection_type_gid_ssim')).first
+          else
+            solr_document.hydra_model.find(solr_document.id).collection_type_gid
+          end
+        CollectionType.find_by_gid!(collection_type_gid)
+      end
+    end
 
     # Metadata Methods
     delegate :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language,

--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -11,6 +11,7 @@ module Hyrax
         @discovery_permissions = extract_discovery_permissions(access)
       end
 
+      # Override for Hydra::AccessControlsEnforcement
       attr_reader :discovery_permissions
 
       self.default_processor_chain += [:with_pagination, :show_only_other_collections_of_the_same_collection_type]
@@ -29,15 +30,13 @@ module Hyrax
 
       private
 
+        ALLOWED_ACCESS_TYPES = {
+          edit: ["edit", "discover", "read"],
+          read: ["discover", "read"],
+          discover: ["discover", "read"]
+        }.freeze
         def extract_discovery_permissions(access)
-          case access
-          when :edit
-            ["edit", "discover", "read"]
-          when :read, :discover
-            ["discover", "read"]
-          else
-            []
-          end
+          ALLOWED_ACCESS_TYPES.fetch(access)
         end
     end
   end

--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -2,7 +2,7 @@ module Hyrax
   module Dashboard
     # Responsible for searching for collections of the same type that are not the given collection
     class NestedCollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
-      # @param access [Symbol] :edit, :read, :discover
+      # @param access [Symbol] :edit, :read, :discover - With the given :access what all can
       # @param collection [Collection]
       # @param scope [Object] Typically a controller that responds to #current_ability, #blackligh_config
       def initialize(access:, collection:, scope:)
@@ -30,13 +30,15 @@ module Hyrax
 
       private
 
-        ALLOWED_ACCESS_TYPES = {
-          edit: ["edit", "discover", "read"],
-          read: ["discover", "read"],
-          discover: ["discover", "read"]
+        # My intention in this implementation is that if I need at least edit access on the queried document,
+        # then I must have one of the following access-levels
+        ACCESS_LEVELS_FOR_LEVEL = {
+          edit: ["edit"],
+          read: ["edit", "read"],
+          discover: ["edit", "discover", "read"]
         }.freeze
         def extract_discovery_permissions(access)
-          ALLOWED_ACCESS_TYPES.fetch(access)
+          ACCESS_LEVELS_FOR_LEVEL.fetch(access)
         end
     end
   end

--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -1,0 +1,44 @@
+module Hyrax
+  module Dashboard
+    # Responsible for searching for collections of the same type that are not the given collection
+    class NestedCollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
+      # @param access [Symbol] :edit, :read, :discover
+      # @param collection [Collection]
+      # @param scope [Object] Typically a controller that responds to #current_ability, #blackligh_config
+      def initialize(access:, collection:, scope:)
+        super(scope)
+        @collection = collection
+        @discovery_permissions = extract_discovery_permissions(access)
+      end
+
+      attr_reader :discovery_permissions
+
+      self.default_processor_chain += [:with_pagination, :show_only_other_collections_of_the_same_collection_type]
+
+      def with_pagination(solr_parameters)
+        solr_parameters[:rows] = 1000
+      end
+
+      def show_only_other_collections_of_the_same_collection_type(solr_parameters)
+        solr_parameters[:fq] ||= []
+        solr_parameters[:fq] += [
+          "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids([@collection.id]),
+          ActiveFedora::SolrQueryBuilder.construct_query(Collection.collection_type_gid_document_field_name => @collection.collection_type_gid)
+        ]
+      end
+
+      private
+
+        def extract_discovery_permissions(access)
+          case access
+          when :edit
+            ["edit", "discover", "read"]
+          when :read, :discover
+            ["discover", "read"]
+          else
+            []
+          end
+        end
+    end
+  end
+end

--- a/app/services/hyrax/collections/nested_collection_persistence_service.rb
+++ b/app/services/hyrax/collections/nested_collection_persistence_service.rb
@@ -7,8 +7,16 @@ module Hyrax
       #
       # @param parent [Collection]
       # @param child [Collection]
+      # @note There appears to be a logical disconnect between the PCDM implementation of
+      #   Collections and the validation of nesting collections:
+      #   * For PCDM the "parent has_member child" relationship is defined, and managed on the parent.
+      #   * For the Nesting collections, we require that:
+      #     * The child is EDIT-able by the user
+      #     * The parent is READ-able by the user
+      #   The Nesting collections requirement implies that the PCDM relationship is pointing in the wrong direction.
       def self.persist_nested_collection_for(parent:, child:)
-        raise NotImplementedError
+        parent.members << child
+        parent.save
       end
     end
   end

--- a/app/services/hyrax/collections/nested_collection_persistence_service.rb
+++ b/app/services/hyrax/collections/nested_collection_persistence_service.rb
@@ -4,16 +4,17 @@ module Hyrax
       # @api public
       #
       # Responsible for persisting the relationship between the parent and the child.
+      # @see Hyrax::Collections::NestedCollectionQueryService
       #
       # @param parent [Collection]
       # @param child [Collection]
-      # @note There appears to be a logical disconnect between the PCDM implementation of
-      #   Collections and the validation of nesting collections:
-      #   * For PCDM the "parent has_member child" relationship is defined, and managed on the parent.
-      #   * For the Nesting collections, we require that:
-      #     * The child is EDIT-able by the user
-      #     * The parent is READ-able by the user
-      #   The Nesting collections requirement implies that the PCDM relationship is pointing in the wrong direction.
+      # @note There is odd permission arrangement based on the NestedCollectionQueryService:
+      #       You can nest the child within a parent if you can edit the parent and read the child.
+      #       However, in the future, instead of adding that relationship to the parent, we will be
+      #       adding the relationship to the child. In a RDBMS environment, this would be resolved by
+      #       creating a join table. One that we can check who added the relationship. However, we aren't
+      #       using an RDBM.
+      #       See https://wiki.duraspace.org/display/samvera/Samvera+Tech+Call+2017-08-23 for tech discussion.
       def self.persist_nested_collection_for(parent:, child:)
         parent.members << child
         parent.save

--- a/app/services/hyrax/collections/nested_collection_persistence_service.rb
+++ b/app/services/hyrax/collections/nested_collection_persistence_service.rb
@@ -1,0 +1,15 @@
+module Hyrax
+  module Collections
+    module NestedCollectionPersistenceService
+      # @api public
+      #
+      # Responsible for persisting the relationship between the parent and the child.
+      #
+      # @param parent [Collection]
+      # @param child [Collection]
+      def self.persist_nested_collection_for(parent:, child:)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -3,16 +3,26 @@ module Hyrax
     module NestedCollectionQueryService
       # @api public
       # @param parent [Collection]
-      def self.available_child_collections(parent:)
+      # @param ability [Ability]
+      def self.available_child_collections(parent:, ability:)
         return [] unless parent.try(:nestable?)
-        # Query SOLR for Collections with the same collection_type_gid AND are not the given parent
+        return [] unless ability.can?(:read, parent)
+        # Query SOLR for Collections:
+        # * Of the same collection_type_gid as the given parent
+        # * That the given ability can :edit
+        # * Is not the given parent
       end
 
       # @api public
       # @param child [Collection]
-      def self.available_parent_collections(child:)
+      # @param ability [Ability]
+      def self.available_parent_collections(child:, ability:)
         return [] unless child.try(:nestable?)
-        # Query SOLR for Collections with the same collection_type_gid AND are not the given child
+        return [] unless ability.can?(:edit, child)
+        # Query SOLR for Collections:
+        # * Of the same collection_type_gid as the given child
+        # * That the given ability can :read
+        # * Is not the given child
       end
 
       # @api public

--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -1,0 +1,31 @@
+module Hyrax
+  module Collections
+    module NestedCollectionQueryService
+      # @api public
+      # @param parent [Collection]
+      def self.available_child_collections(parent:)
+        return [] unless parent.try(:nestable?)
+        # Query SOLR for Collections with the same collection_type_gid AND are not the given parent
+      end
+
+      # @api public
+      # @param child [Collection]
+      def self.available_parent_collections(child:)
+        return [] unless child.try(:nestable?)
+        # Query SOLR for Collections with the same collection_type_gid AND are not the given child
+      end
+
+      # @api public
+      # @param parent [Collection]
+      # @param child [Collection]
+      # @return [Boolean] true if the parent can nest the child; false otherwise
+      # @todo Consider expanding from same collection type to a lookup table that says "This collection type can have within it, these collection types"
+      def self.parent_and_child_can_nest?(parent:, child:)
+        return false unless parent.try(:nestable?)
+        return false unless child.try(:nestable?)
+        return false if parent == child
+        parent.collection_type_gid == child.collection_type_gid
+      end
+    end
+  end
+end

--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -10,8 +10,8 @@ module Hyrax
       # @return [Array<SolrDocument>]
       def self.available_child_collections(parent:, scope:)
         return [] unless parent.try(:nestable?)
-        return [] unless scope.can?(:read, parent)
-        query_solr(collection: parent, access: :edit, scope: scope)
+        return [] unless scope.can?(:edit, parent)
+        query_solr(collection: parent, access: :read, scope: scope)
       end
 
       # @api public
@@ -23,8 +23,8 @@ module Hyrax
       # @return [Array<SolrDocument>]
       def self.available_parent_collections(child:, scope:)
         return [] unless child.try(:nestable?)
-        return [] unless scope.can?(:edit, child)
-        query_solr(collection: child, access: :read, scope: scope)
+        return [] unless scope.can?(:read, child)
+        query_solr(collection: child, access: :edit, scope: scope)
       end
 
       # @api private

--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -7,11 +7,12 @@ module Hyrax
       #
       # @param parent [Collection]
       # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
+      # @param limit_to_id [nil, String] Limit the query to just check if the given id is in the response. Useful for validation.
       # @return [Array<SolrDocument>]
-      def self.available_child_collections(parent:, scope:)
+      def self.available_child_collections(parent:, scope:, limit_to_id: nil)
         return [] unless parent.try(:nestable?)
         return [] unless scope.can?(:edit, parent)
-        query_solr(collection: parent, access: :read, scope: scope)
+        query_solr(collection: parent, access: :read, scope: scope, limit_to_id: limit_to_id)
       end
 
       # @api public
@@ -20,16 +21,24 @@ module Hyrax
       #
       # @param child [Collection]
       # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
+      # @param limit_to_id [nil, String] Limit the query to just check if the given id is in the response. Useful for validation.
       # @return [Array<SolrDocument>]
-      def self.available_parent_collections(child:, scope:)
+      def self.available_parent_collections(child:, scope:, limit_to_id: nil)
         return [] unless child.try(:nestable?)
         return [] unless scope.can?(:read, child)
-        query_solr(collection: child, access: :edit, scope: scope)
+        query_solr(collection: child, access: :edit, scope: scope, limit_to_id: limit_to_id)
       end
 
       # @api private
-      def self.query_solr(collection:, access:, scope:)
+      #
+      # @param collection [Collection]
+      # @param access [Symbol]
+      # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
+      # @param limit_to_id [nil, String] Limit the query to just check if the given id is in the response. Useful for validation.
+      def self.query_solr(collection:, access:, scope:, limit_to_id:)
         query_builder = Hyrax::Dashboard::NestedCollectionsSearchBuilder.new(access: access, collection: collection, scope: scope)
+        # No sense returning everything, just limit to a single entry
+        query_builder.where(id: limit_to_id) if limit_to_id
         scope.repository.search(query_builder.query).documents
       end
       private_class_method :query_solr
@@ -42,13 +51,15 @@ module Hyrax
       #
       # @param parent [Collection]
       # @param child [Collection]
+      # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
       # @return [Boolean] true if the parent can nest the child; false otherwise
       # @todo Consider expanding from same collection type to a lookup table that says "This collection type can have within it, these collection types"
-      def self.parent_and_child_can_nest?(parent:, child:)
-        return false unless parent.try(:nestable?)
-        return false unless child.try(:nestable?)
-        return false if parent == child
-        parent.collection_type_gid == child.collection_type_gid
+      def self.parent_and_child_can_nest?(parent:, child:, scope:)
+        return false if parent == child # Short-circuit
+        return false unless parent.collection_type_gid == child.collection_type_gid
+        return false if available_parent_collections(child: child, scope: scope, limit_to_id: parent.id).none?
+        return false if available_child_collections(parent: parent, scope: scope, limit_to_id: child.id).none?
+        true
       end
     end
   end

--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -32,7 +32,7 @@ module Hyrax
       # @api private
       #
       # @param collection [Collection]
-      # @param access [Symbol]
+      # @param access [Symbol] I need this kind of permission on the queried objects.
       # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
       # @param limit_to_id [nil, String] Limit the query to just check if the given id is in the response. Useful for validation.
       def self.query_solr(collection:, access:, scope:, limit_to_id:)

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -9,6 +9,12 @@
                   hyrax.my_works_path(add_files_to_collection: presenter.id),
                   title: t('hyrax.collection.actions.add_works.desc'),
                   class: 'btn btn-default' %>
+      <% if presenter.collection_type_is_nestable? %>
+        <%= link_to t('hyrax.collection.actions.nest_collections.label'),
+                    '/TODO/NEST_COLLECTION',
+                    title: t('hyrax.collection.actions.nest_collections.desc'),
+                    class: 'btn btn-default' %>
+      <% end %>
     <%end %>
 
     <% if can? :destroy, presenter.solr_document %>

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -11,7 +11,7 @@
                   class: 'btn btn-default' %>
       <% if presenter.collection_type_is_nestable? %>
         <%= link_to t('hyrax.collection.actions.nest_collections.label'),
-                    '/TODO/NEST_COLLECTION',
+                    hyrax.dashboard_new_nest_collection_within(child_id: presenter.id),
                     title: t('hyrax.collection.actions.nest_collections.desc'),
                     class: 'btn btn-default' %>
       <% end %>

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -9,9 +9,11 @@
                   hyrax.my_works_path(add_files_to_collection: presenter.id),
                   title: t('hyrax.collection.actions.add_works.desc'),
                   class: 'btn btn-default' %>
+      <%# TODO - The presenter's solr document does not have any collection_type information.
+          I am stuck on how to fix this. %>
       <% if presenter.collection_type_is_nestable? %>
         <%= link_to t('hyrax.collection.actions.nest_collections.label'),
-                    hyrax.dashboard_new_nest_collection_within(child_id: presenter.id),
+                    hyrax.dashboard_new_nest_collection_within_path(child_id: presenter.id),
                     title: t('hyrax.collection.actions.nest_collections.desc'),
                     class: 'btn btn-default' %>
       <% end %>

--- a/app/views/hyrax/dashboard/nest_collections/new_within.html.erb
+++ b/app/views/hyrax/dashboard/nest_collections/new_within.html.erb
@@ -1,1 +1,8 @@
 TODO - Get your ERB, JS, and HTML skills ready!
+
+* ./spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb for
+  current interface expectations.
+
+  The form is assumed to post a field with name=parent_id; This is different
+  from most simple_form_for behavior in that fields are often scoped within a
+  concept (e.g. `name=work[parent_id]` instead of `name=parent_id`).

--- a/app/views/hyrax/dashboard/nest_collections/new_within.html.erb
+++ b/app/views/hyrax/dashboard/nest_collections/new_within.html.erb
@@ -1,0 +1,1 @@
+TODO - Get your ERB, JS, and HTML skills ready!

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -404,6 +404,9 @@ en:
           desc: "Edit this collection"
           label: "Edit"
         header: "Actions"
+        nest_collections:
+          desc: "Nest other collections within this Collection"
+          label: "Nest collections"
       browse_view: "Browse View"
       document_list:
         edit: "Edit"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -552,6 +552,8 @@ en:
           press_to:         "Press to"
           show_label:       "Display all details of"
         works:        "Your Works"
+      nest_collections_form:
+        create_within:          "%{child_title} has been added to %{parent_title}"
       no_activity:              "User has no recent activity"
       no_notifications:         "User has no notifications"
       no_transfer_requests:     "You haven't received any work transfer requests"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -5,6 +5,9 @@ en:
   activemodel:
     errors:
       messages:
+        is_not_nestable: "is not nestable"
+        cannot_have_child_nested: "cannot have child nested within it"
+        cannot_nest_in_parent: "cannot nest within parent"
         conflict: "Your changes could not be saved because another user (or background job) updated this %{model} after you began editing. Please make sure all file attachments have completed successfully and try again. This form has refreshed with the most recent saved copy of the %{model}."
   blacklight:
     search:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,8 @@ Hyrax::Engine.routes.draw do
         put :remove_member
       end
     end
+    get 'collections/:child_id/within', controller: 'nest_collections', action: 'new_within', as: 'new_nest_collection_within'
+    post 'collections/:child_id/within', controller: 'nest_collections', action: 'create_within', as: 'create_nest_collection_within'
     resources :profiles, only: [:show, :edit, :update]
   end
 

--- a/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
@@ -1,0 +1,84 @@
+RSpec.describe Hyrax::Dashboard::NestCollectionsController do
+  routes { Hyrax::Engine.routes }
+  let(:child_id) { 'child1' }
+  let(:parent_id) { 'parent1' }
+  let(:child) { instance_double(Collection, title: "Awesome Child") }
+  let(:parent) { instance_double(Collection, title: "Uncool Parent") }
+
+  describe 'GET #new_within' do
+    subject { get 'new_within', params: { child_id: child_id } }
+
+    before do
+      allow(Collection).to receive(:find).with(child_id).and_return(child)
+    end
+
+    it "authorizes the child, assigns @form, and renders the template" do
+      expect(controller).to receive(:authorize!).with(:edit, child).and_return(true)
+      subject
+      expect(assigns(:form).child).to eq(child)
+      expect(assigns(:form).parent).to be_nil
+      expect(subject).to render_template('new_within')
+    end
+  end
+
+  describe 'POST #create_within' do
+    subject { post 'create_within', params: { child_id: child_id, parent_id: parent_id } }
+
+    before do
+      allow(Collection).to receive(:find).with(child_id).and_return(child)
+      allow(Collection).to receive(:find).with(parent_id).and_return(parent)
+    end
+
+    describe 'when save fails' do
+      let(:form_class_with_failed_save) do
+        Class.new do
+          attr_reader :child, :parent
+          def initialize(parent:, child:)
+            @parent = parent
+            @child = child
+          end
+
+          def save
+            false
+          end
+        end
+      end
+
+      before do
+        controller.form_class = form_class_with_failed_save
+      end
+
+      it 'authorizes then renders the form again' do
+        expect(controller).to receive(:authorize!).with(:edit, child).and_return(true)
+        subject
+        expect(response).to render_template('new_within')
+      end
+    end
+    describe 'when save succeeds' do
+      let(:form_class_with_successful_save) do
+        Class.new do
+          attr_reader :child, :parent
+          def initialize(parent:, child:)
+            @parent = parent
+            @child = child
+          end
+
+          def save
+            true
+          end
+        end
+      end
+
+      before do
+        controller.form_class = form_class_with_successful_save
+      end
+
+      it 'authorizes, flashes a notice, and redirects' do
+        expect(controller).to receive(:authorize!).with(:edit, child).and_return(true)
+        subject
+        expect(response).to redirect_to(dashboard_collection_path(child))
+        expect(flash[:notice]).to be_a(String)
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
@@ -5,6 +5,18 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
   let(:child) { instance_double(Collection, title: "Awesome Child") }
   let(:parent) { instance_double(Collection, title: "Uncool Parent") }
 
+  describe '#blacklight_config' do
+    subject { controller.blacklight_config }
+
+    it { is_expected.to be_a(Blacklight::Configuration) }
+  end
+
+  describe '#repository' do
+    subject { controller.repository }
+
+    it { is_expected.to be_a(Blacklight::Solr::Repository) }
+  end
+
   describe 'GET #new_within' do
     subject { get 'new_within', params: { child_id: child_id } }
 
@@ -33,10 +45,10 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
       let(:form_class_with_failed_save) do
         Class.new do
           attr_reader :child, :parent
-          def initialize(parent:, child:, ability:)
+          def initialize(parent:, child:, context:)
             @parent = parent
             @child = child
-            @ability = ability
+            @context = context
           end
 
           def save
@@ -59,10 +71,10 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
       let(:form_class_with_successful_save) do
         Class.new do
           attr_reader :child, :parent
-          def initialize(parent:, child:, ability:)
+          def initialize(parent:, child:, context:)
             @parent = parent
             @child = child
-            @ability = ability
+            @context = context
           end
 
           def save

--- a/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
@@ -33,9 +33,10 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
       let(:form_class_with_failed_save) do
         Class.new do
           attr_reader :child, :parent
-          def initialize(parent:, child:)
+          def initialize(parent:, child:, ability:)
             @parent = parent
             @child = child
+            @ability = ability
           end
 
           def save
@@ -58,9 +59,10 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
       let(:form_class_with_successful_save) do
         Class.new do
           attr_reader :child, :parent
-          def initialize(parent:, child:)
+          def initialize(parent:, child:, ability:)
             @parent = parent
             @child = child
+            @ability = ability
           end
 
           def save

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -1,8 +1,9 @@
-RSpec.describe 'collection', type: :feature do
+RSpec.describe 'collection', type: :feature, clean_repo: true do
   let(:user) { create(:user) }
+  let(:collection_type) { create(:collection_type) }
 
-  let(:collection1) { create(:public_collection, user: user) }
-  let(:collection2) { create(:public_collection, user: user) }
+  let(:collection1) { create(:public_collection, user: user, collection_type_gid: collection_type.gid) }
+  let(:collection2) { create(:public_collection, user: user, collection_type_gid: collection_type.gid) }
 
   describe 'create collection' do
     before do

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
 
   describe '.default_query_service' do
     subject { described_class.default_query_service }
+
     it { is_expected.to respond_to(:available_parent_collections) }
     it { is_expected.to respond_to(:available_child_collections) }
     it { is_expected.to respond_to(:parent_and_child_can_nest?) }
@@ -19,6 +20,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
 
   describe '#default_query_service' do
     subject { described_class.default_persistence_service }
+
     it { is_expected.to respond_to(:persist_nested_collection_for) }
   end
 

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
   let(:parent) { double(nestable?: true) }
   let(:child) { double(nestable?: true) }
-  let(:ability) { double('Ability') }
+  let(:context) { double('Context') }
   let(:query_service) { double('Query Service') }
   let(:persistence_service) { double('Persistence Service', persist_nested_collection: true) }
-  let(:form) { described_class.new(parent: parent, child: child, ability: ability, query_service: query_service, persistence_service: persistence_service) }
+  let(:form) { described_class.new(parent: parent, child: child, context: context, query_service: query_service, persistence_service: persistence_service) }
 
   subject { form }
 
@@ -78,7 +78,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     subject { form.available_child_collections }
 
     it 'delegates to the underlying query_service' do
-      expect(query_service).to receive(:available_child_collections).with(parent: parent, ability: ability).and_return(:results)
+      expect(query_service).to receive(:available_child_collections).with(parent: parent, context: context).and_return(:results)
       expect(subject).to eq(:results)
     end
   end
@@ -86,7 +86,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     subject { form.available_parent_collections }
 
     it 'delegates to the underlying query_service' do
-      expect(query_service).to receive(:available_parent_collections).with(child: child, ability: ability).and_return(:results)
+      expect(query_service).to receive(:available_parent_collections).with(child: child, context: context).and_return(:results)
       expect(subject).to eq(:results)
     end
   end

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -1,12 +1,38 @@
 RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
-  let(:parent) { double }
-  let(:child) { double }
-  let(:form) { described_class.new(parent: parent, child: child) }
+  let(:parent) { double(nestable?: true) }
+  let(:child) { double(nestable?: true) }
+  let(:query_service) { double('Query Service') }
+  let(:form) { described_class.new(parent: parent, child: child, query_service: query_service) }
 
   subject { form }
 
   it { is_expected.to validate_presence_of(:parent) }
   it { is_expected.to validate_presence_of(:child) }
+
+  it 'is invalid if child cannot be nested within the parent' do
+    expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child).and_return(false)
+    subject.valid?
+    expect(subject.errors[:parent]).to eq(["cannot have child nested within it"])
+    expect(subject.errors[:child]).to eq(["cannot nest within parent"])
+  end
+
+  describe 'parent is not nestable' do
+    let(:parent) { double(nestable?: false) }
+
+    it 'is not valid' do
+      subject.valid?
+      expect(subject.errors[:parent]).to eq(["is not nestable"])
+    end
+  end
+
+  describe 'child is not nestable' do
+    let(:child) { double(nestable?: false) }
+
+    it 'is not valid' do
+      subject.valid?
+      expect(subject.errors[:child]).to eq(["is not nestable"])
+    end
+  end
 
   describe '#save' do
     subject { form.save }
@@ -32,27 +58,17 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
   describe '#available_child_collections' do
     subject { form.available_child_collections }
 
-    describe 'when parent is not present' do
-      let(:parent) { nil }
-
-      it { is_expected.to eq([]) }
-    end
-
-    describe 'when parent is present' do
-      xit { is_expected.to eq([]) }
+    it 'delegates to the underlying query_service' do
+      expect(query_service).to receive(:available_child_collections).with(parent: parent).and_return(:results)
+      expect(subject).to eq(:results)
     end
   end
   describe '#available_parent_collections' do
     subject { form.available_parent_collections }
 
-    describe 'when parent is not present' do
-      let(:child) { nil }
-
-      it { is_expected.to eq([]) }
-    end
-
-    describe 'when parent is present' do
-      xit { is_expected.to eq([]) }
+    it 'delegates to the underlying query_service' do
+      expect(query_service).to receive(:available_parent_collections).with(child: child).and_return(:results)
+      expect(subject).to eq(:results)
     end
   end
 end

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
   end
 
   it 'is invalid if child cannot be nested within the parent' do
-    expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child).and_return(false)
+    expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child, context: context).and_return(false)
     subject.valid?
     expect(subject.errors[:parent]).to eq(["cannot have child nested within it"])
     expect(subject.errors[:child]).to eq(["cannot nest within parent"])

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
   it { is_expected.to validate_presence_of(:parent) }
   it { is_expected.to validate_presence_of(:child) }
 
+  describe '#default_query_service' do
+    subject { described_class.new.send(:default_query_service) }
+    it { is_expected.to respond_to(:available_parent_collections) }
+    it { is_expected.to respond_to(:available_child_collections) }
+    it { is_expected.to respond_to(:parent_and_child_can_nest?) }
+  end
+
   it 'is invalid if child cannot be nested within the parent' do
     expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child).and_return(false)
     subject.valid?

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
   let(:parent) { double(nestable?: true) }
   let(:child) { double(nestable?: true) }
+  let(:ability) { double('Ability') }
   let(:query_service) { double('Query Service') }
   let(:persistence_service) { double('Persistence Service', persist_nested_collection: true) }
-  let(:form) { described_class.new(parent: parent, child: child, query_service: query_service, persistence_service: persistence_service) }
+  let(:form) { described_class.new(parent: parent, child: child, ability: ability, query_service: query_service, persistence_service: persistence_service) }
 
   subject { form }
 
@@ -77,7 +78,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     subject { form.available_child_collections }
 
     it 'delegates to the underlying query_service' do
-      expect(query_service).to receive(:available_child_collections).with(parent: parent).and_return(:results)
+      expect(query_service).to receive(:available_child_collections).with(parent: parent, ability: ability).and_return(:results)
       expect(subject).to eq(:results)
     end
   end
@@ -85,7 +86,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     subject { form.available_parent_collections }
 
     it 'delegates to the underlying query_service' do
-      expect(query_service).to receive(:available_parent_collections).with(child: child).and_return(:results)
+      expect(query_service).to receive(:available_parent_collections).with(child: child, ability: ability).and_return(:results)
       expect(subject).to eq(:results)
     end
   end

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
+  let(:parent) { double }
+  let(:child) { double }
+  let(:form) { described_class.new(parent: parent, child: child) }
+
+  subject { form }
+
+  it { is_expected.to validate_presence_of(:parent) }
+  it { is_expected.to validate_presence_of(:child) }
+
+  describe '#save' do
+    subject { form.save }
+
+    describe 'when not valid' do
+      before do
+        expect(form).to receive(:valid?).and_return(false)
+      end
+      it { is_expected.to be_falsey }
+      it 'does not even attempt to persist the relationship' do
+        expect(subject).not_to receive(:persist!)
+        subject
+      end
+    end
+    describe 'when valid' do
+      before do
+        expect(form).to receive(:valid?).and_return(true)
+      end
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#available_child_collections' do
+    subject { form.available_child_collections }
+
+    describe 'when parent is not present' do
+      let(:parent) { nil }
+
+      it { is_expected.to eq([]) }
+    end
+
+    describe 'when parent is present' do
+      xit { is_expected.to eq([]) }
+    end
+  end
+  describe '#available_parent_collections' do
+    subject { form.available_parent_collections }
+
+    describe 'when parent is not present' do
+      let(:child) { nil }
+
+      it { is_expected.to eq([]) }
+    end
+
+    describe 'when parent is present' do
+      xit { is_expected.to eq([]) }
+    end
+  end
+end

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -2,18 +2,24 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
   let(:parent) { double(nestable?: true) }
   let(:child) { double(nestable?: true) }
   let(:query_service) { double('Query Service') }
-  let(:form) { described_class.new(parent: parent, child: child, query_service: query_service) }
+  let(:persistence_service) { double('Persistence Service', persist_nested_collection: true) }
+  let(:form) { described_class.new(parent: parent, child: child, query_service: query_service, persistence_service: persistence_service) }
 
   subject { form }
 
   it { is_expected.to validate_presence_of(:parent) }
   it { is_expected.to validate_presence_of(:child) }
 
-  describe '#default_query_service' do
-    subject { described_class.new.send(:default_query_service) }
+  describe '.default_query_service' do
+    subject { described_class.default_query_service }
     it { is_expected.to respond_to(:available_parent_collections) }
     it { is_expected.to respond_to(:available_child_collections) }
     it { is_expected.to respond_to(:parent_and_child_can_nest?) }
+  end
+
+  describe '#default_query_service' do
+    subject { described_class.default_persistence_service }
+    it { is_expected.to respond_to(:persist_nested_collection_for) }
   end
 
   it 'is invalid if child cannot be nested within the parent' do
@@ -50,7 +56,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
       end
       it { is_expected.to be_falsey }
       it 'does not even attempt to persist the relationship' do
-        expect(subject).not_to receive(:persist!)
+        expect(persistence_service).not_to receive(:persist_nested_collection_for)
         subject
       end
     end
@@ -58,7 +64,10 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
       before do
         expect(form).to receive(:valid?).and_return(true)
       end
-      it { is_expected.to be_truthy }
+      it "returns the result of the given persistence_service's call to persist_nested_collection_for" do
+        expect(persistence_service).to receive(:persist_nested_collection_for).with(parent: parent, child: child).and_return(:persisted)
+        subject
+      end
     end
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -222,124 +222,15 @@ RSpec.describe Collection, :clean_repo do
     end
   end
 
-  describe 'type properties' do
-    subject { collection }
+  describe 'collection type delegated methods' do
+    subject { build(:collection) }
 
-    let(:collection_type) { build(:collection_type) }
-
-    before do
-      allow(collection).to receive(:collection_type).and_return(collection_type)
-    end
-
-    describe '#nestable' do
-      before { collection_type.nestable = property_value }
-      context 'when false' do
-        let(:property_value) { false }
-
-        it { is_expected.not_to be_nestable }
-      end
-
-      context 'when true' do
-        let(:property_value) { true }
-
-        it { is_expected.to be_nestable }
-      end
-    end
-
-    describe '#discoverable' do
-      before { collection_type.discoverable = property_value }
-
-      context 'when false' do
-        let(:property_value) { false }
-
-        it { is_expected.not_to be_discoverable }
-      end
-
-      context 'when true' do
-        let(:property_value) { true }
-
-        it { is_expected.to be_discoverable }
-      end
-    end
-
-    describe '#sharable' do
-      before { collection_type.sharable = property_value }
-
-      context 'when false' do
-        let(:property_value) { false }
-
-        it { is_expected.not_to be_sharable }
-      end
-
-      context 'when true' do
-        let(:property_value) { true }
-
-        it { is_expected.to be_sharable }
-      end
-    end
-
-    describe '#allow_multiple_membership' do
-      before { collection_type.allow_multiple_membership = property_value }
-
-      context 'when false' do
-        let(:property_value) { false }
-
-        it { is_expected.not_to allow_multiple_membership }
-      end
-
-      context 'when true' do
-        let(:property_value) { true }
-
-        it { is_expected.to allow_multiple_membership }
-      end
-    end
-
-    describe '#require_membership' do
-      before { collection_type.require_membership = property_value }
-
-      context 'when false' do
-        let(:property_value) { false }
-
-        it { is_expected.not_to require_membership }
-      end
-
-      context 'when true' do
-        let(:property_value) { true }
-
-        it { is_expected.to require_membership }
-      end
-    end
-
-    describe '#assigns_workflow' do
-      before { collection_type.assigns_workflow = property_value }
-
-      context 'when false' do
-        let(:property_value) { false }
-
-        it { is_expected.not_to assign_workflow }
-      end
-
-      context 'when true' do
-        let(:property_value) { true }
-
-        it { is_expected.to assign_workflow }
-      end
-    end
-
-    describe '#assigns_visibility' do
-      before { collection_type.assigns_visibility = property_value }
-
-      context 'when false' do
-        let(:property_value) { false }
-
-        it { is_expected.not_to assign_visibility }
-      end
-
-      context 'when true' do
-        let(:property_value) { true }
-
-        it { is_expected.to assign_visibility }
-      end
-    end
+    it { is_expected.to delegate_method(:nestable?).to(:collection_type) }
+    it { is_expected.to delegate_method(:discoverable?).to(:collection_type) }
+    it { is_expected.to delegate_method(:sharable?).to(:collection_type) }
+    it { is_expected.to delegate_method(:allow_multiple_membership?).to(:collection_type) }
+    it { is_expected.to delegate_method(:require_membership?).to(:collection_type) }
+    it { is_expected.to delegate_method(:assigns_workflow?).to(:collection_type) }
+    it { is_expected.to delegate_method(:assigns_visibility?).to(:collection_type) }
   end
 end

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -1,6 +1,18 @@
 RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
   let(:collection_type) { build(:collection_type) }
 
+  describe '.collection_type_predicate_methods' do
+    subject { described_class.collection_type_predicate_methods }
+
+    it { is_expected.to be_a(Array) }
+  end
+
+  describe '#collection_type_predicate_methods' do
+    subject { described_class.new.collection_type_predicate_methods }
+
+    it { is_expected.to be_a(Array) }
+  end
+
   it "has basic metadata" do
     expect(collection_type).to respond_to(:title)
     expect(collection_type.title).not_to be_empty

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
   let(:collection_type) { build(:collection_type) }
 
-  describe '.collection_type_predicate_methods' do
-    subject { described_class.collection_type_predicate_methods }
+  describe '.collection_type_settings_methods' do
+    subject { described_class.collection_type_settings_methods }
 
     it { is_expected.to be_a(Array) }
   end
 
-  describe '#collection_type_predicate_methods' do
-    subject { described_class.new.collection_type_predicate_methods }
+  describe '#collection_type_settings_methods' do
+    subject { described_class.new.collection_type_settings_methods }
 
     it { is_expected.to be_a(Array) }
   end

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Hyrax::CollectionPresenter do
   # Mock bytes so collection does not have to be saved.
   before { allow(collection).to receive(:bytes).and_return(0) }
 
+  describe "collection type methods" do
+    subject { presenter }
+
+    it { is_expected.to delegate_method(:collection_type_is_nestable?).to(:solr_document).as(:nestable?) }
+    it { is_expected.to delegate_method(:collection_type_is_discoverable?).to(:solr_document).as(:discoverable?) }
+    it { is_expected.to delegate_method(:collection_type_is_sharable?).to(:solr_document).as(:sharable?) }
+    it { is_expected.to delegate_method(:collection_type_is_allow_multiple_membership?).to(:solr_document).as(:allow_multiple_membership?) }
+    it { is_expected.to delegate_method(:collection_type_is_require_membership?).to(:solr_document).as(:require_membership?) }
+    it { is_expected.to delegate_method(:collection_type_is_assigns_workflow?).to(:solr_document).as(:assigns_workflow?) }
+    it { is_expected.to delegate_method(:collection_type_is_assigns_visibility?).to(:solr_document).as(:assigns_visibility?) }
+  end
+
   describe "#resource_type" do
     subject { presenter.resource_type }
 

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     it { is_expected.to delegate_method(:collection_type_is_assigns_visibility?).to(:collection_type).as(:assigns_visibility?) }
   end
 
+  # NOTE: The #collection_type specs will change when we go to integrate PR 1556 (https://github.com/samvera/hyrax/pull/1556)
   describe '#collection_type', clean_repo: true do
     let(:collection_type) { create(:collection_type) }
 

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -31,13 +31,38 @@ RSpec.describe Hyrax::CollectionPresenter do
   describe "collection type methods" do
     subject { presenter }
 
-    it { is_expected.to delegate_method(:collection_type_is_nestable?).to(:solr_document).as(:nestable?) }
-    it { is_expected.to delegate_method(:collection_type_is_discoverable?).to(:solr_document).as(:discoverable?) }
-    it { is_expected.to delegate_method(:collection_type_is_sharable?).to(:solr_document).as(:sharable?) }
-    it { is_expected.to delegate_method(:collection_type_is_allow_multiple_membership?).to(:solr_document).as(:allow_multiple_membership?) }
-    it { is_expected.to delegate_method(:collection_type_is_require_membership?).to(:solr_document).as(:require_membership?) }
-    it { is_expected.to delegate_method(:collection_type_is_assigns_workflow?).to(:solr_document).as(:assigns_workflow?) }
-    it { is_expected.to delegate_method(:collection_type_is_assigns_visibility?).to(:solr_document).as(:assigns_visibility?) }
+    it { is_expected.to delegate_method(:collection_type_is_nestable?).to(:collection_type).as(:nestable?) }
+    it { is_expected.to delegate_method(:collection_type_is_discoverable?).to(:collection_type).as(:discoverable?) }
+    it { is_expected.to delegate_method(:collection_type_is_sharable?).to(:collection_type).as(:sharable?) }
+    it { is_expected.to delegate_method(:collection_type_is_allow_multiple_membership?).to(:collection_type).as(:allow_multiple_membership?) }
+    it { is_expected.to delegate_method(:collection_type_is_require_membership?).to(:collection_type).as(:require_membership?) }
+    it { is_expected.to delegate_method(:collection_type_is_assigns_workflow?).to(:collection_type).as(:assigns_workflow?) }
+    it { is_expected.to delegate_method(:collection_type_is_assigns_visibility?).to(:collection_type).as(:assigns_visibility?) }
+  end
+
+  describe '#collection_type', clean_repo: true do
+    let(:collection_type) { create(:collection_type) }
+
+    describe 'when solr_document#collection_type_gid exists' do
+      let(:collection) { build(:collection, collection_type_gid: collection_type.gid) }
+      let(:solr_doc) { SolrDocument.new(collection.to_solr) }
+
+      it 'finds the collection type based on the solr_document#collection_type_gid if one exists' do
+        expect(solr_doc.key?('collection_type_gid_ssim')).to be_truthy
+        expect(solr_doc).to receive(:fetch).with('collection_type_gid_ssim').and_return(collection_type.gid)
+        expect(presenter.collection_type).to eq(collection_type)
+      end
+    end
+
+    describe 'when solr_document#collection_type_gid does not exist' do
+      let(:collection) { create(:collection, collection_type_gid: collection_type.gid) }
+      let(:solr_doc) { SolrDocument.new(collection.to_solr.except('collection_type_gid_ssim')) }
+
+      it "finds the collection's collection type of the solr document's id if the document does not have a collection_type_gid" do
+        expect(solr_doc).not_to receive(:collection_type_gid)
+        expect(presenter.collection_type).to eq(collection_type)
+      end
+    end
   end
 
   describe "#resource_type" do

--- a/spec/routing/dashboard_routes_spec.rb
+++ b/spec/routing/dashboard_routes_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe 'Dashboard Routes', type: :routing do
+  routes { Hyrax::Engine.routes }
+
+  it 'routes GET /dashboard/collections/:child_id/within' do
+    expect(get: '/dashboard/collections/child1/within').to route_to(controller: 'hyrax/dashboard/nest_collections', action: 'new_within', child_id: 'child1')
+  end
+
+  it 'routes POST /dashboard/collections/:child_id/within' do
+    expect(post: '/dashboard/collections/child1/within').to route_to(controller: 'hyrax/dashboard/nest_collections', action: 'create_within', child_id: 'child1')
+  end
+end

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Hyrax::CollectionSearchBuilder do
+  let(:scope) { double(blacklight_config: CatalogController.blacklight_config) }
+  let(:builder) { described_class.new(scope) }
+
+  describe '#sort_field' do
+    subject { builder.sort_field }
+
+    it { is_expected.to eq('title_si') }
+  end
+
+  describe '#models' do
+    subject { builder.models }
+
+    it { is_expected.to eq([Collection]) }
+  end
+end

--- a/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Hyrax::Dashboard::NestedCollectionsSearchBuilder do
     subject { builder.default_processor_chain }
 
     it { is_expected.to include(:with_pagination) }
+    it { is_expected.to include(:discovery_permissions) }
     it { is_expected.to include(:show_only_other_collections_of_the_same_collection_type) }
   end
 

--- a/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Hyrax::Dashboard::NestedCollectionsSearchBuilder do
     subject { builder.default_processor_chain }
 
     it { is_expected.to include(:with_pagination) }
-    it { is_expected.to include(:discovery_permissions) }
     it { is_expected.to include(:show_only_other_collections_of_the_same_collection_type) }
   end
 

--- a/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Hyrax::Dashboard::NestedCollectionsSearchBuilder do
+  let(:collection) { double(id: '123', collection_type_gid: 'gid/abc') }
+  let(:ability) { instance_double(Ability, admin?: true) }
+  let(:scope) { double(current_ability: ability, blacklight_config: CatalogController.blacklight_config) }
+  let(:access) { :read }
+  let(:builder) { described_class.new(scope: scope, access: access, collection: collection) }
+
+  describe '#query' do
+    subject { builder.query }
+
+    it { is_expected.to be_a(Hash) }
+  end
+
+  describe '#default_processor_chain' do
+    subject { builder.default_processor_chain }
+
+    it { is_expected.to include(:with_pagination) }
+    it { is_expected.to include(:show_only_other_collections_of_the_same_collection_type) }
+  end
+
+  describe '#show_only_other_collections_of_the_same_collection_type' do
+    let(:solr_params) { {} }
+
+    subject { builder.show_only_other_collections_of_the_same_collection_type(solr_params) }
+
+    it 'will exclude the given collection' do
+      subject
+      expect(solr_params.fetch(:fq)).to eq(["-{!terms f=id}#{collection.id}", "_query_:\"{!field f=collection_type_gid_ssim}#{collection.collection_type_gid}\""])
+    end
+  end
+end

--- a/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
@@ -3,6 +3,12 @@ RSpec.describe Hyrax::Collections::NestedCollectionPersistenceService do
   let(:child) { create(:collection) }
 
   describe '.persist_nested_collection_for' do
-    xit 'creates the relationship between parent and child'
+    subject { described_class.persist_nested_collection_for(parent: parent, child: child) }
+
+    it 'creates the relationship between parent and child' do
+      subject
+      expect(parent.members).to eq([child])
+      expect(child.member_of).to eq([parent])
+    end
   end
 end

--- a/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Hyrax::Collections::NestedCollectionPersistenceService do
+  let(:parent) { create(:collection) }
+  let(:child) { create(:collection) }
+
+  describe '.persist_nested_collection_for' do
+    xit 'creates the relationship between parent and child'
+  end
+end

--- a/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Hyrax::Collections::NestedCollectionQueryService do
+  let(:ability) { double('Ability', can?: true) }
+
   describe '.available_child_collections' do
-    subject { described_class.available_child_collections(parent: parent) }
+    subject { described_class.available_child_collections(parent: parent, ability: ability) }
 
     describe 'given parent is not nestable?' do
       let(:parent) { double(nestable?: false) }
@@ -13,7 +15,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService do
     end
   end
   describe '.available_parent_collections' do
-    subject { described_class.available_parent_collections(child: child) }
+    subject { described_class.available_parent_collections(child: child, ability: ability) }
 
     describe 'given child is not nestable?' do
       let(:child) { double(nestable?: false) }

--- a/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe Hyrax::Collections::NestedCollectionQueryService do
+  describe '.available_child_collections' do
+    subject { described_class.available_child_collections(parent: parent) }
+
+    describe 'given parent is not nestable?' do
+      let(:parent) { double(nestable?: false) }
+
+      it { is_expected.to eq([]) }
+    end
+
+    describe 'given parent is nestable?' do
+      it 'returns an array of collections of the same collection type'
+    end
+  end
+  describe '.available_parent_collections' do
+    subject { described_class.available_parent_collections(child: child) }
+
+    describe 'given child is not nestable?' do
+      let(:child) { double(nestable?: false) }
+
+      it { is_expected.to eq([]) }
+    end
+
+    describe 'given child is nestable?' do
+      it 'returns an array of collections of the same collection type'
+    end
+  end
+  describe '.parent_and_child_can_nest?' do
+    let(:child) { double(nestable?: true, collection_type_gid: 'same') }
+    let(:parent) { double(nestable?: true, collection_type_gid: 'same') }
+
+    subject { described_class.parent_and_child_can_nest?(parent: parent, child: child) }
+
+    describe 'given parent and child are nestable' do
+      describe 'and are the same object' do
+        let(:child) { parent }
+
+        it { is_expected.to eq(false) }
+      end
+      describe 'and are of the same collection type' do
+        it { is_expected.to eq(true) }
+      end
+      describe 'and are of different collection types' do
+        let(:parent) { double(nestable?: true, collection_type_gid: 'another') }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe 'given parent is not nestable?' do
+      let(:parent) { double(nestable?: false) }
+
+      it { is_expected.to eq(false) }
+    end
+    describe 'given child is not nestable?' do
+      let(:child) { double(nestable?: false) }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,6 +114,7 @@ require 'active_fedora/cleaner'
 RSpec.configure do |config|
   config.disable_monkey_patching!
   config.include Shoulda::Matchers::ActiveRecord, type: :model
+  config.include Shoulda::Matchers::ActiveModel, type: :form
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe 'hyrax/dashboard/collections/_show_actions.html.erb', type: :view do
+  let(:presenter) { double('Hyrax::CollectionPresenter', collection_type_is_nestable?: is_nestable, solr_document: solr_document, id: '123') }
+  let(:solr_document) { double('Solr Document') }
+  let(:is_nestable) { true }
+  let(:can_destroy) { true }
+  let(:can_edit) { true }
+
+  before do
+    allow(view).to receive(:presenter).and_return(presenter)
+    # Must stub non-hyrax routes as engines don't have access to these routes
+    allow(view).to receive(:edit_dashboard_collection_path).with(presenter).and_return('/path/to/edit')
+    allow(view).to receive(:collection_path).with(presenter).and_return('/path/to/destroy')
+
+    allow(view).to receive(:can?).with(:edit, solr_document).and_return(can_edit)
+    allow(view).to receive(:can?).with(:destroy, solr_document).and_return(can_destroy)
+  end
+  describe 'when user can edit the document' do
+    let(:can_edit) { true }
+
+    it 'renders edit collection link' do
+      render
+      expect(rendered).to have_css('.actions-controls-collections .btn[href="/path/to/edit"]')
+    end
+    it 'renders add_files_to_collection link' do
+      render
+      expect(rendered).to have_css(".actions-controls-collections .btn[href='#{hyrax.my_works_path(add_files_to_collection: presenter.id)}']")
+    end
+    describe 'when the collection_type is nestable' do
+      it 'renders a link to add_collections to this collection' do
+        render
+        expect(rendered).to have_css(".actions-controls-collections .btn[href='/TODO/NEST_COLLECTION']")
+      end
+    end
+    describe 'when the collection_type is not nestable' do
+      let(:is_nestable) { false }
+
+      it 'does not render a link to add_collections to this collection' do
+        render
+        expect(rendered).not_to have_css(".actions-controls-collections .btn[href='/TODO/NEST_COLLECTION']")
+      end
+    end
+  end
+  describe 'when user cannot edit the document' do
+    let(:can_edit) { false }
+
+    it 'does not render edit collection link' do
+      render
+      expect(rendered).not_to have_css('.actions-controls-collections .btn[href="/path/to/edit"]')
+    end
+
+    it 'does not render add_files_to_collection link' do
+      render
+      expect(rendered).not_to have_css(".actions-controls-collections .btn[href='#{hyrax.my_works_path(add_files_to_collection: presenter.id)}']")
+    end
+
+    describe 'when the collection_type is not nestable' do
+      it 'does not render a link to add_collections to this collection' do
+        render
+        expect(rendered).not_to have_css(".actions-controls-collections .btn[href='/TODO/NEST_COLLECTION']")
+      end
+    end
+    describe 'when the collection_type is nestable' do
+      it 'does not render a link to add_collections to this collection' do
+        render
+        expect(rendered).not_to have_css(".actions-controls-collections .btn[href='/TODO/NEST_COLLECTION']")
+      end
+    end
+  end
+  describe 'when user can destroy the document' do
+    it 'renders a link to destroy the document' do
+      render
+      expect(rendered).to have_css('.actions-controls-collections .btn[href="/path/to/destroy"]')
+    end
+  end
+  describe 'when user cannot destroy the document' do
+    let(:can_destroy) { false }
+
+    it 'does not render a link to destroy the document' do
+      render
+      expect(rendered).not_to have_css('.actions-controls-collections .btn[href="/path/to/destroy"]')
+    end
+  end
+end

--- a/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'hyrax/dashboard/collections/_show_actions.html.erb', type: :view
     describe 'when the collection_type is nestable' do
       it 'renders a link to add_collections to this collection' do
         render
-        expect(rendered).to have_css(".actions-controls-collections .btn[href='/TODO/NEST_COLLECTION']")
+        expect(rendered).to have_css(".actions-controls-collections .btn[href='#{hyrax.dashboard_new_nest_collection_within(child_id: presenter.id)}']")
       end
     end
     describe 'when the collection_type is not nestable' do

--- a/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'hyrax/dashboard/collections/_show_actions.html.erb', type: :view
     describe 'when the collection_type is nestable' do
       it 'renders a link to add_collections to this collection' do
         render
-        expect(rendered).to have_css(".actions-controls-collections .btn[href='#{hyrax.dashboard_new_nest_collection_within(child_id: presenter.id)}']")
+        expect(rendered).to have_css(".actions-controls-collections .btn[href='#{hyrax.dashboard_new_nest_collection_within_path(child_id: presenter.id)}']")
       end
     end
     describe 'when the collection_type is not nestable' do

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -31,14 +31,12 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
   end
 
   it 'draws the page' do
-# <<<<<<< 8fcae46a84f21467a07e25a8e39c1264b14dc0d5
+    # TODO: elr - Should these be checked here?  _show_actions spec tests this in more detail
     expect(rendered).to have_link 'Edit'
     expect(rendered).to have_link 'Delete'
     expect(rendered).to have_link 'Add works'
     expect(rendered).to have_link 'Public view of Collection'
-# =======
-    expect(rendered).to have_css('.stubbed-actions', text: 'THE ACTIONS')
-# >>>>>>> Adding specs for collection show actions view
+    expect(rendered).to have_css('.stubbed-actions', text: 'THE ACTIONS') #
     expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
   end
 end

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -23,16 +23,22 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     stub_template 'hyrax/collections/_search_form.html.erb' => 'search form'
     stub_template 'hyrax/dashboard/collections/_sort_and_per_page.html.erb' => 'sort and per page'
     stub_template '_document_list.html.erb' => 'document list'
+    # This is tested ./spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
+    stub_template '_show_actions.html.erb' => '<div class="stubbed-actions">THE ACTIONS</div>'
     stub_template 'hyrax/collections/_paginate.html.erb' => 'paginate'
     stub_template 'hyrax/collections/_media_display.html.erb' => '<span class="fa fa-cubes collection-icon-search"></span>'
     render
   end
 
   it 'draws the page' do
+# <<<<<<< 8fcae46a84f21467a07e25a8e39c1264b14dc0d5
     expect(rendered).to have_link 'Edit'
     expect(rendered).to have_link 'Delete'
     expect(rendered).to have_link 'Add works'
     expect(rendered).to have_link 'Public view of Collection'
+# =======
+    expect(rendered).to have_css('.stubbed-actions', text: 'THE ACTIONS')
+# >>>>>>> Adding specs for collection show actions view
     expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
   end
 end


### PR DESCRIPTION
## Adding class attribute for delegate methods

d95ae44a6b4978a0c854c97e699c098a5906873f

There are several points throughout the code where we may need to
delegate methods from the Collection to the Collection Type. Capture
the delegate methods and allow for dynamic assignment.

## Delegating collection_type behavioral methods

cdaa5ef0a546dcb969f79b23ff179c0222861b40

Ensuring that the CollectionPresenter has boolean methods available for
rendering purposes.

## Adding specs for collection show actions view

6b578aba4db0da04c431cc5fc33e3b054a266eee


## Spec-ing out NestCollectionForm

1f6dbe658d82b34b9c2dab0f3a1791fb53bc27bf

[skip ci]

## Updating NestCollectionForm to include behaviors

28112bed85fb49f9cb0540dfd4b4d43e76b26cb3

Need to work on collaborators but the general behavior is beginning to
work.

[skip ci]

## Working on default QueryService validation/delegation

4e2a5206938e38f74589f6b3d368f1fd65e06c34

[skip ci]

## Working on interfaces for NestCollectionForm

d5bacd2d14ffd89d17627d816b00a2a00208e4c7


## Building out routes and controller for NestCollections

bc52b29f770bd6e91af4c60823021cea93d84a60


## Extracting service modules

3c31446e7fcb9bfbbc14e60d87c086e0c2935547


## Adding NestedCollectionPersistenceService behavior

6069d2e008213d89d1066da8c22ebee0a07dbd08

This is an interstitial solution with an identified discrepancy
between the PCDM specification and the feature specs.

## Adding ability parameter to nesting considerations

3a968c275aea77f42bd7d7d84d8836f0a5a75b46

We need to know who the given user is before we allow nesting.

## Integrating collection nesting

1e76bb3fe33a385a18895dae1e1784efd82ae3e6

This does not include the modal window work, wiring up the form to
interact with the nested actions controller.

Related to #1512

## Updating available queries to reflect discussion

4cd4d0bd946a1c96d84d1feeea183d408bc50f78

There is odd permission arrangement based on the
NestedCollectionQueryService:

    You can nest the child within a parent if you can edit the parent
    and read the child. However, in the future, instead of adding that
    relationship to the parent, we will be adding the relationship to
    the child. In a RDBMS environment, this would be resolved by
    creating a join table. One that we can check who added the
    relationship. However, we aren't using an RDBM.

See https://wiki.duraspace.org/display/samvera/Samvera+Tech+Call+2017-08-23 for tech discussion.

## Ensuring nesting validation checks availability

ea5bd1d2b20f8e9515d99c36c6ecc257b806edd1

Prior to this commit, it would be possible for someone to nest a
collection in which they didn't have appropriate access. (They would
need to do DOM manipulation or POST to the end point).

## Renaming method per suggestions

4626c95345d2ace99d2110533bb38711da5584de

> Wondering about the name here predicate_methods. When I hear
> predicate, that implies to me something that will be saved in the
> model as the predicate of a triple. How about
> `collection_type_settings_methods`?

## Renaming method per suggestions

af89df4f35a85a256eb0aaca3ef05686d77b6e8c

> Wondering about the name here predicate_methods. When I hear
> predicate, that implies to me something that will be saved in the
> model as the predicate of a triple. How about
> `collection_type_settings_methods`?

## Specifying processor_chain expectations

b30e8b438a62c84bcb5ceb19bfc2ebe7d21a0b1b

Following up on:

> QUESTION: Is this requiring all 3 or one of? I don't see the
> `discovery_permissions` used anywhere else, so I'm not sure of its
> purpose at this point.

## Adding comments to address the following

de5c020bd4af80e2b0b8efc9b5bac962b639e0db

> What I expect when the solr_doc does not have a collection_type_gid
> is that this collection was created before there was a concept of
> collection_type. In the collection model, using the after_find
> callback, if a collection is read in that doesn't have a
> collection_type_gid, then it is assigned the user_collection
> collection type's gid.
