### PR TITLE
Add service object to enforce single-membership collections

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -21,6 +21,11 @@ module Hyrax
         # Maps from collection ids to collection objects
         def assign_collections(env, collection_ids)
           return true unless collection_ids
+          multiple_memberships = Hyrax::MultipleMembershipChecker.new(item: env.curation_concern).check(collection_ids: collection_ids)
+          if multiple_memberships
+            env.curation_concern.errors.add(:collections, multiple_memberships)
+            return false
+          end
           # grab/save collections this user has no edit access to
           other_collections = collections_without_edit_access(env)
           env.curation_concern.member_of_collections = ::Collection.find(collection_ids)

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -60,6 +60,7 @@ module Hyrax
       else
         respond_to do |wants|
           wants.html do
+            flash[:error] = curation_concern.errors.messages[:collections].to_sentence
             build_form
             render 'new', status: :unprocessable_entity
           end
@@ -102,6 +103,7 @@ module Hyrax
       else
         respond_to do |wants|
           wants.html do
+            flash[:error] = curation_concern.errors.messages[:collections].to_sentence
             build_form
             render 'edit', status: :unprocessable_entity
           end

--- a/app/presenters/hyrax/menu_presenter.rb
+++ b/app/presenters/hyrax/menu_presenter.rb
@@ -13,7 +13,7 @@ module Hyrax
     # Returns true if the current controller happens to be one of the controllers that deals
     # with settings.  This is used to keep the parent section on the sidebar open.
     def settings_section?
-      %w[appearances content_blocks features pages].include?(controller_name)
+      %w[appearances content_blocks features pages collection_types].include?(controller_name)
     end
 
     # @param options [Hash, String] a hash or string representing the path. Hash is prefered as it

--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -1,0 +1,77 @@
+module Hyrax
+  # Service class for checking an item's collection memberships, to
+  # make sure that the item is not added to multiple single-membership
+  # collections
+  class MultipleMembershipChecker
+    attr_reader :item
+
+    # @param [#member_of_collection_ids] item an object that belongs to
+    #   collections
+    def initialize(item:)
+      @item = item
+    end
+
+    # @api public
+    #
+    # Scan a list of collection_ids for multiple single-membership collections.
+    #
+    # Collections that have a collection type declaring
+    # `allow_multiple_membership` as `false` require that its members do not
+    # also belong to other collections of the same type.
+    #
+    # There are two contexts in which memberships are checked: when doing a
+    # wholesale replacement and when making an incremental change, such as
+    # adding a single collection membership to an object. In the former case,
+    # `#check` only scans the passed-in collection identifiers. In the latter,
+    # `#check` must also scan the collections to which an object currently
+    # belongs for potential conflicts.
+    #
+    # @param collection_ids [Array<String>] a list of collection identifiers
+    # @param include_current_members [Boolean] a flag to also scan an object's
+    #   current collection memberships
+    #
+    # @return [nil, String] nil if no conflicts; an error message string if so
+    def check(collection_ids:, include_current_members: false)
+      # short-circuit if no single membership types have been created
+      return if single_membership_types.empty?
+      # short-circuit if no new single_membership_collections passed in
+      new_single_membership_collections = single_membership_collections(collection_ids)
+      return if new_single_membership_collections.empty?
+      collections_to_check = new_single_membership_collections
+      # No need to check current members when coming in from the ActorStack, which does a wholesale collection membership replacement
+      collections_to_check |= single_membership_collections(item.member_of_collection_ids) if include_current_members
+      problematic_collections = collections_to_check.group_by(&:collection_type_gid)
+                                                    .select { |_gid, list| list.count > 1 }
+      return if problematic_collections.empty?
+      build_error_message(problematic_collections)
+    end
+
+    private
+
+      def single_membership_collections(collection_ids)
+        return [] if collection_ids.empty?
+        Collection.where(id: collection_ids, collection_type_gid_ssim: single_membership_types.join(','))
+      end
+
+      def single_membership_types
+        Hyrax::CollectionType.where(allow_multiple_membership: false).map(&:gid)
+      end
+
+      def build_error_message(problematic_collections)
+        error_message_clauses = problematic_collections.map do |gid, list|
+          "#{collection_type_title_from_gid(gid)} (#{collection_titles_from_list(list)})"
+        end
+        "#{I18n.t('hyrax.admin.collection_types.multiple_membership_checker.error_preamble')}: #{error_message_clauses.join('; ')}"
+      end
+
+      def collection_type_title_from_gid(gid)
+        Hyrax::CollectionType.find_by_gid(gid).title
+      end
+
+      def collection_titles_from_list(collection_list)
+        collection_list.each do |collection|
+          collection.title.first
+        end.to_sentence
+      end
+  end
+end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -222,6 +222,8 @@ en:
           table:
             name:           "Name"
             actions:        "Actions"
+        multiple_membership_checker:
+          error_preamble: 'Error: You have specified more than one of the same single-membership collection types'
         new:
           header:           "Create New Collection Type"
         create:

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -208,10 +208,22 @@ RSpec.describe Hyrax::GenericWorksController do
     end
 
     context 'when create fails' do
+      let(:work) { create(:work) }
       let(:create_status) { false }
+      let(:errors) { double }
+      let(:messages) { double }
+      let(:error_messages) { ['Error: foo bar'] }
+
+      before do
+        allow(controller).to receive(:curation_concern).and_return(work)
+        allow(work).to receive(:errors).and_return(errors)
+        allow(errors).to receive(:messages).and_return(messages)
+        allow(messages).to receive(:[]).with(:collections).and_return(error_messages)
+      end
 
       it 'draws the form again' do
         post :create, params: { generic_work: { title: ['a title'] } }
+        expect(flash[:error]).to eq error_messages.to_sentence
         expect(response.status).to eq 422
         expect(assigns[:form]).to be_kind_of Hyrax::GenericWorkForm
         expect(response).to render_template 'new'
@@ -433,9 +445,21 @@ RSpec.describe Hyrax::GenericWorksController do
 
       describe 'update failed' do
         let(:actor) { double(update: false) }
+        let(:work) { create(:work) }
+        let(:errors) { double }
+        let(:messages) { double }
+        let(:error_messages) { ['Error: foo bar'] }
+
+        before do
+          allow(controller).to receive(:curation_concern).and_return(work)
+          allow(work).to receive(:errors).and_return(errors)
+          allow(errors).to receive(:messages).and_return(messages)
+          allow(messages).to receive(:[]).with(:collections).and_return(error_messages)
+        end
 
         it 'renders the form' do
           patch :update, params: { id: work, generic_work: {} }
+          expect(flash[:error]).to eq error_messages.to_sentence
           expect(assigns[:form]).to be_kind_of Hyrax::GenericWorkForm
           expect(response).to render_template('edit')
         end

--- a/spec/presenters/hyrax/menu_presenter_spec.rb
+++ b/spec/presenters/hyrax/menu_presenter_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Hyrax::MenuPresenter do
 
       it { is_expected.to be true }
     end
+    context "for the CollectionTypesController" do
+      let(:controller_name) { Hyrax::Admin::CollectionTypesController.controller_name }
+
+      it { is_expected.to be true }
+    end
   end
 
   describe "#collapsable_section" do

--- a/spec/services/hyrax/multiple_membership_checker_spec.rb
+++ b/spec/services/hyrax/multiple_membership_checker_spec.rb
@@ -1,0 +1,105 @@
+RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
+  let(:item) { double }
+
+  describe '#initialize' do
+    subject { described_class.new(item: item) }
+
+    it 'exposes an attr_reader' do
+      expect(subject.item).to eq item
+    end
+  end
+
+  describe '#check' do
+    let(:checker) { described_class.new(item: item) }
+    let(:collection_ids) { ['foobar'] }
+    let(:included) { false }
+    let!(:collection_type) { create(:collection_type, title: 'Greedy', allow_multiple_membership: false) }
+
+    subject { checker.check(collection_ids: collection_ids, include_current_members: included) }
+
+    context 'when there are no single-membership collection types' do
+      before do
+        allow(Hyrax::CollectionType).to receive(:where).and_return([])
+      end
+
+      it 'returns nil' do
+        expect(checker).to receive(:single_membership_types).and_return([]).and_call_original
+        expect(subject).to be nil
+      end
+    end
+
+    context 'when collection_ids is empty' do
+      let(:collection_ids) { [] }
+
+      it 'returns nil' do
+        expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
+        expect(Collection).not_to receive(:where)
+        expect(subject).to be nil
+      end
+    end
+
+    context 'when there are no single-membership collection instances' do
+      it 'returns nil' do
+        expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
+        expect(Collection).to receive(:where).once.and_return([])
+        expect(subject).to be nil
+      end
+    end
+
+    context 'when multiple single-membership collection instances are not in the list' do
+      let(:collection) { create(:collection) }
+      let(:collections) { [collection] }
+      let(:collection_ids) { collections.map(&:id) }
+
+      before do
+        allow(collection).to receive(:collection_type_gid).and_return(collection_type.gid)
+      end
+
+      it 'returns nil' do
+        expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
+        expect(Collection).to receive(:where).once.and_return(collections)
+        expect(subject).to be nil
+      end
+    end
+
+    context 'when multiple single-membership collection instances are in the list, not including current members' do
+      let(:collection1) { create(:collection, title: ['Foo']) }
+      let(:collection2) { create(:collection, title: ['Bar']) }
+      let(:collections) { [collection1, collection2] }
+      let(:collection_ids) { collections.map(&:id) }
+
+      before do
+        allow(collection1).to receive(:collection_type_gid).and_return(collection_type.gid)
+        allow(collection2).to receive(:collection_type_gid).and_return(collection_type.gid)
+      end
+
+      it 'returns nil' do
+        expect(item).not_to receive(:member_of_collection_ids)
+        expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
+        expect(Collection).to receive(:where).once.and_return(collections)
+        expect(subject).to eq 'Error: You have specified more than one of the same single-membership collection types: Greedy (Foo and Bar)'
+      end
+    end
+
+    context 'when multiple single-membership collection instances are in the list, including current members' do
+      let(:collection1) { create(:collection, title: ['Foo']) }
+      let(:collection2) { create(:collection, title: ['Bar']) }
+      let(:collections) { [collection1] }
+      let(:collection_ids) { collections.map(&:id) }
+      let(:included) { true }
+
+      before do
+        allow(collection1).to receive(:collection_type_gid).and_return(collection_type.gid)
+        allow(collection2).to receive(:collection_type_gid).and_return(collection_type.gid)
+        allow(item).to receive(:member_of_collection_ids).once.and_return([collection2.id])
+      end
+
+      it 'returns nil' do
+        expect(item).to receive(:member_of_collection_ids)
+        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_type.gid).once.and_return(collections)
+        expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: collection_type.gid).once.and_return([collection2])
+        expect(subject).to eq 'Error: You have specified more than one of the same single-membership collection types: Greedy (Foo and Bar)'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1549

Also adds:
* Collection types dashboard menu should keep the settings section expanded

This PR is ready, and would benefit from:

- [ ] Code review -- `Hyrax::MultipleMembershipChecker` feels a bit verbose to me, particularly the `#check` method, but I am hesitant to refactor before getting feedback. Not yet sure what the right refactoring is, if any.
- [ ] QA testing -- grab this branch and try (via the UI) to find a way to add one or more works to multiple single-membership collections, *i.e.*, try to break the code or find loopholes!

@samvera/hyrax-code-reviewers
