### PR TITLE
fixes 1460 - do not display Discovery tab if discoverable? false

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -21,7 +21,7 @@ module Hyrax
       self.terms = [:resource_type, :title, :creator, :contributor, :description,
                     :keyword, :license, :publisher, :date_created, :subject, :language,
                     :representative_id, :thumbnail_id, :identifier, :based_near,
-                    :related_url, :visibility]
+                    :related_url, :visibility, :collection_type_gid]
 
       self.required_fields = [:title]
 

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -4,12 +4,16 @@
       <a href="#description" role="tab" data-toggle="tab"><%= t('.tabs.description') %></a>
     </li>
     <% if @form.persisted? %>
+      <% if @collection.discoverable? %>
       <li>
         <a href="#discovery" role="tab" data-toggle="tab"><%= t('.tabs.discovery') %></a>
       </li>
+      <% end %>
+      <% if @collection.sharable? %>
       <li>
         <a href="#sharing" role="tab" data-toggle="tab"><%= t('.tabs.sharing') %></a>
       </li>
+      <% end %>
     <% end %>
   </ul>
   <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor' } do |f| %>

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Hyrax::Dashboard::CollectionsController do
+RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   routes { Hyrax::Engine.routes }
   let(:user)  { create(:user) }
   let(:other) { build(:user) }
@@ -79,6 +79,28 @@ RSpec.describe Hyrax::Dashboard::CollectionsController do
         expect(asset_results["response"]["numFound"]).to eq 1
         doc = asset_results["response"]["docs"].first
         expect(doc["id"]).to eq asset1.id
+      end
+    end
+
+    context 'when setting collection type' do
+      let(:collection_type) { create(:collection_type) }
+
+      it "creates a Collection of default type when type is nil" do
+        expect do
+          post :create, params: {
+            collection: collection_attrs
+          }
+        end.to change { Collection.count }.by(1)
+        expect(assigns[:collection].collection_type.machine_id).to eq Hyrax::CollectionType::USER_COLLECTION_MACHINE_ID
+      end
+
+      it "creates a Collection of specified type" do
+        expect do
+          post :create, params: {
+            collection: collection_attrs.merge(collection_type_gid: collection_type.gid)
+          }
+        end.to change { Collection.count }.by(1)
+        expect(assigns[:collection].collection_type_gid).to eq collection_type.gid
       end
     end
 
@@ -182,7 +204,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController do
     end
 
     context "when update fails" do
-      let(:collection) { Collection.new(id: '12345') }
+      let(:collection) { create(:collection, id: '12345') }
       let(:repository) { instance_double(Blacklight::Solr::Repository, search: result) }
       let(:result) { double(documents: []) }
 

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -1,7 +1,8 @@
 FactoryGirl.define do
   factory :collection_type, class: Hyrax::CollectionType do
-    sequence(:id) { |n| n }
+    sequence(:id) { |n| format("%010d", n) }
     sequence(:title) { |n| "Title #{n}" }
+
     description 'Collection type with all options'
     nestable true
     discoverable true
@@ -14,6 +15,38 @@ FactoryGirl.define do
     factory :user_collection_type do
       title 'User Collection'
       description 'A user oriented collection type'
+    end
+
+    trait :nestable do
+      nestable true
+    end
+
+    trait :not_nestable do
+      nestable false
+    end
+
+    trait :discoverable do
+      discoverable true
+    end
+
+    trait :not_discoverable do
+      discoverable false
+    end
+
+    trait :sharable do
+      sharable true
+    end
+
+    trait :not_sharable do
+      sharable false
+    end
+
+    trait :allow_multiple_membership do
+      allow_multiple_membership true
+    end
+
+    trait :not_allow_multiple_membership do
+      allow_multiple_membership false
     end
   end
 end

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -1,12 +1,19 @@
 FactoryGirl.define do
   factory :collection do
+    # @example let(:collection) { build(:collection, collection_type_settings: [:not_nestable, :discoverable, :sharable, :allow_multiple_membership]) }
+
     transient do
       user { FactoryGirl.create(:user) }
+      collection_type_settings [:nestable, :discoverable, :sharable, :allow_multiple_membership]
     end
     sequence(:title) { |n| ["Title #{n}"] }
 
-    after(:build) do |work, evaluator|
-      work.apply_depositor_metadata(evaluator.user.user_key)
+    after(:build) do |collection, evaluator|
+      collection.apply_depositor_metadata(evaluator.user.user_key)
+      if collection.collection_type_gid.nil?
+        collection_type = FactoryGirl.create(:collection_type, *evaluator.collection_type_settings)
+        collection.collection_type_gid = collection_type.gid
+      end
     end
 
     factory :public_collection, traits: [:public]
@@ -26,6 +33,19 @@ FactoryGirl.define do
     factory :named_collection do
       title ['collection title']
       description ['collection description']
+    end
+  end
+
+  factory :typeless_collection, class: Collection do
+    # should not have a collection type assigned
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    sequence(:title) { |n| ["Title #{n}"] }
+
+    after(:build) do |collection, evaluator|
+      collection.apply_depositor_metadata(evaluator.user.user_key)
     end
   end
 end

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe 'collection', type: :feature do
         find('button.dropdown-toggle').click
         click_link('Edit Collection')
       end
-      # URL: /collections/collection-id/edit
+      # URL: /dashboard/collections/collection-id/edit
       expect(page).to have_field('collection_title', with: collection.title.first)
       expect(page).to have_field('collection_description', with: collection.description.first)
       expect(page).to have_content(work1.title.first)
@@ -225,6 +225,36 @@ RSpec.describe 'collection', type: :feature do
       expect(header).to have_content(new_title)
       expect(page).to have_content(new_description)
       expect(page).to have_content(creators.first)
+    end
+
+    context 'with discoverable set' do
+      let(:discoverable_collection_id) { create(:collection, user: user, collection_type_settings: [:discoverable]).id }
+      let(:not_discoverable_collection_id) { create(:collection, user: user, collection_type_settings: [:not_discoverable]).id }
+
+      it 'to true, it shows Discovery tab' do
+        visit "/dashboard/collections/#{discoverable_collection_id}"
+        expect(page).to have_link('Discovery', href: '#discovery')
+      end
+
+      it 'to false, it hides Discovery tab' do
+        visit "/dashboard/collections/#{not_discoverable_collection_id}"
+        expect(page).not_to have_link('Discovery', href: '#discovery')
+      end
+    end
+
+    context 'with sharable set' do
+      let(:sharable_collection_id) { create(:collection, user: user, collection_type_settings: [:sharable]).id }
+      let(:not_sharable_collection_id) { create(:collection, user: user, collection_type_settings: [:not_sharable]).id }
+
+      it 'to true, it shows Sharable tab' do
+        visit "/dashboard/collections/#{sharable_collection_id}"
+        expect(page).to have_link('Sharable', href: '#sharable')
+      end
+
+      it 'to false, it hides Sharable tab' do
+        visit "/dashboard/collections/#{not_sharable_collection_id}"
+        expect(page).not_to have_link('Sharable', href: '#sharable')
+      end
     end
   end
 

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Hyrax::Forms::CollectionForm do
                          :identifier,
                          :based_near,
                          :related_url,
-                         :visibility]
+                         :visibility,
+                         :collection_type_gid]
     end
   end
 
@@ -120,6 +121,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
                          { based_near: [] },
                          { related_url: [] },
                          :visibility,
+                         :collection_type_gid,
                          { permissions_attributes: [:type, :name, :access, :id, :_destroy] }]
     end
   end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Collection do
+RSpec.describe Collection, :clean_repo do
   let(:collection) { build(:public_collection) }
 
   it "has open visibility" do
@@ -146,7 +146,7 @@ RSpec.describe Collection do
     end
 
     context 'when gid in collection object is nil' do
-      let(:collection) { create(:collection, title: ['title']) }
+      let(:collection) { create(:typeless_collection, title: ['title']) }
 
       subject { described_class.find(collection.id) }
 

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Hyrax::CollectionType, type: :model do
+RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
   let(:collection_type) { build(:collection_type) }
 
   it "has basic metadata" do


### PR DESCRIPTION
Fixes #1460

Work in this PR:
* add collection_type_gid to permitted terms for collection form
* add collection_type_gid assignment to collection factory
* add traits for settings on/off to collection type factory
* force visibility=private in the controller for create and update when discoverable? false
* do not show Discovery tab in collection edit form when discoverable? false
* do not show Sharing tab in collection edit form when sharable? false
