### PR TITLE
Add routes for collections permission templates

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,15 @@ Hyrax::Engine.routes.draw do
     get '/shares',            controller: 'my/shares', action: :index, as: 'dashboard_shares'
     get '/shares/page/:page', controller: 'my/shares', action: :index
     get '/shares/facet/:id',  controller: 'my/shares', action: :facet, as: 'dashboard_shares_facet'
+    scope :collections do
+      get '/permission_template/new' => 'admin/permission_templates#new', as: :new_dashboard_collection_permission_template
+      get '/:collection_id/permission_template/edit' => 'admin/permission_templates#edit', as: :edit_dashboard_collection_permission_template
+      get '/:collection_id/permission_template' => 'admin/permission_templates#show', as: :dashboard_collection_permission_template
+      patch '/:collection_id/permission_template' => 'admin/permission_templates#update'
+      put '/:collection_id/permission_template' => 'admin/permission_templates#update'
+      delete '/:collection_id/permission_template' => 'admin/permission_templates#destroy'
+      post '/:collection_id/permission_template' => 'admin/permission_templates#create'
+    end
   end
 
   # Contact form routes

--- a/spec/routing/collection_permission_templates_routes_spec.rb
+++ b/spec/routing/collection_permission_templates_routes_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe 'Collection Permission Templates Routes', type: :routing do
+  routes { Hyrax::Engine.routes }
+
+  it 'routes to #create' do
+    expect(post: '/dashboard/collections/1/permission_template').to route_to(controller: 'hyrax/admin/permission_templates', action: 'create', collection_id: '1')
+  end
+
+  it 'routes to #new' do
+    expect(get: '/dashboard/collections/permission_template/new').to route_to(controller: 'hyrax/admin/permission_templates', action: 'new')
+  end
+
+  it 'routes to #edit' do
+    expect(get: '/dashboard/collections/1/permission_template/edit').to route_to(controller: 'hyrax/admin/permission_templates', action: 'edit', collection_id: '1')
+  end
+
+  it 'routes to #show' do
+    expect(get: '/dashboard/collections/1/permission_template').to route_to(controller: 'hyrax/admin/permission_templates', action: 'show', collection_id: '1')
+  end
+
+  it 'routes to #update (patch)' do
+    expect(patch: '/dashboard/collections/1/permission_template').to route_to(controller: 'hyrax/admin/permission_templates', action: 'update', collection_id: '1')
+  end
+
+  it 'routes to #update (put)' do
+    expect(put: '/dashboard/collections/1/permission_template').to route_to(controller: 'hyrax/admin/permission_templates', action: 'update', collection_id: '1')
+  end
+
+  it 'routes to #destroy' do
+    expect(delete: '/dashboard/collections/1/permission_template').to route_to(controller: 'hyrax/admin/permission_templates', action: 'destroy', collection_id: '1')
+  end
+end


### PR DESCRIPTION
Fixes #1523

(collections sprint)

Adds routes for collections permission templates using the same format as the routes for admin set permission templates.  These route to the existing Hyrax::Admin::PermissionTemplatesController.

@elrayle 