### PR TITLE
Collection Types: Settings should be read only if any collections of a type exist

### DIFF
--- a/app/forms/hyrax/forms/admin/collection_type_form.rb
+++ b/app/forms/hyrax/forms/admin/collection_type_form.rb
@@ -8,7 +8,8 @@ module Hyrax
 
         delegate :title, :description, :discoverable, :nestable, :sharable,
                  :require_membership, :allow_multiple_membership, :assigns_workflow,
-                 :assigns_visibility, :id, :collection_type_participants, :persisted?, :collections?, to: :collection_type
+                 :assigns_visibility, :id, :collection_type_participants, :persisted?,
+                 :collections?, :admin_set?, :user_collection?, to: :collection_type
       end
     end
   end

--- a/app/forms/hyrax/forms/admin/collection_type_form.rb
+++ b/app/forms/hyrax/forms/admin/collection_type_form.rb
@@ -8,7 +8,7 @@ module Hyrax
 
         delegate :title, :description, :discoverable, :nestable, :sharable,
                  :require_membership, :allow_multiple_membership, :assigns_workflow,
-                 :assigns_visibility, :id, :collection_type_participants, :persisted?, to: :collection_type
+                 :assigns_visibility, :id, :collection_type_participants, :persisted?, :collections?, to: :collection_type
       end
     end
   end

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -113,28 +113,28 @@ module Hyrax
 
       def ensure_no_collections
         return true unless collections?
-        errors[:base] << I18n.t('hyrax.admin.collection_types.error_not_empty')
+        errors[:base] << I18n.t('hyrax.admin.collection_types.errors.not_empty')
         throw :abort
       end
 
       def ensure_no_settings_changes_for_admin_set_type
         return true unless admin_set? && exists_for_machine_id?(ADMIN_SET_MACHINE_ID)
         return true unless collection_type_settings_changed?
-        errors[:base] << I18n.t('hyrax.admin.collection_types.error_settings_changes')
+        errors[:base] << I18n.t('hyrax.admin.collection_types.errors.no_settings_change_for_admin_sets')
         throw :abort
       end
 
       def ensure_no_settings_changes_for_user_collection_type
         return true unless user_collection? && exists_for_machine_id?(USER_COLLECTION_MACHINE_ID)
         return true unless collection_type_settings_changed?
-        errors[:base] << I18n.t('hyrax.admin.collection_types.error_settings_changes')
+        errors[:base] << I18n.t('hyrax.admin.collection_types.errors.no_settings_change_for_user_collections')
         throw :abort
       end
 
       def ensure_no_settings_changes_if_collections_exist
         return true unless collections?
         return true unless collection_type_settings_changed?
-        errors[:base] << I18n.t('hyrax.admin.collection_types.error_settings_changes')
+        errors[:base] << I18n.t('hyrax.admin.collection_types.errors.no_settings_change_if_not_empty')
         throw :abort
       end
 

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -3,7 +3,7 @@ module Hyrax
     self.table_name = 'hyrax_collection_types'
     validates :title, presence: true, uniqueness: true
     validates :machine_id, presence: true, uniqueness: true
-    before_save :ensure_no_collections
+    before_save :ensure_no_settings_changes
     before_destroy :ensure_no_collections
     has_many :collection_type_participants, class_name: 'Hyrax::CollectionTypeParticipant', foreign_key: 'hyrax_collection_type_id', dependent: :destroy
 
@@ -117,6 +117,19 @@ module Hyrax
         return true unless collections?
         errors[:base] << I18n.t('hyrax.admin.collection_types.error_not_empty')
         throw :abort
+      end
+
+      def ensure_no_settings_changes
+        return true unless collections?
+        return true unless collection_type_properties_changed?
+        errors[:base] << I18n.t('hyrax.admin.collection_types.error_settings_changes')
+        throw :abort
+      end
+
+      def collection_type_properties_changed?
+        ['nestable', 'discoverable', 'sharable', 'allow_multiple_membership', 'require_membership', 'assigns_workflow', 'assigns_visibility'].any? do |key|
+          key.in?(changes)
+        end
       end
   end
 end

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -21,28 +21,18 @@ module Hyrax
     end
 
     class_attribute :collection_type_settings_methods, instance_writer: false
-    self.collection_type_settings_methods = [:nestable?,
-                                             :discoverable?,
-                                             :sharable?,
-                                             :allow_multiple_membership?,
-                                             :require_membership?,
-                                             :assigns_workflow?,
-                                             :assigns_visibility?]
+    self.collection_type_settings_methods = [:nestable?, :discoverable?, :sharable?, :allow_multiple_membership?,
+                                             :require_membership?, :assigns_workflow?, :assigns_visibility?]
 
     # These are provided as a convenience method based on prior design discussions.
     # The deprecations are added to allow upstream developers to continue with what
     # they had already been doing. These can be removed as part of merging
     # the collections-sprint branch into master (or before hand if coordinated)
     alias_attribute :discovery, :discoverable
-    deprecation_deprecate discovery: "prefer #discoverable instead"
     alias_attribute :sharing, :sharable
-    deprecation_deprecate sharing: "prefer #sharable instead"
     alias_attribute :multiple_membership, :allow_multiple_membership
-    deprecation_deprecate multiple_membership: "prefer #allow_multiple_membership instead"
     alias_attribute :workflow, :assigns_workflow
-    deprecation_deprecate workflow: "prefer #assigns_workflow instead"
     alias_attribute :visibility, :assigns_visibility
-    deprecation_deprecate visibility: "prefer #assigns_visibility instead"
 
     # Find the collection type associated with the Global Identifier (gid)
     # @param [String] gid - Global Identifier for this collection_type (e.g. gid://internal/hyrax-collectiontype/3)
@@ -143,7 +133,7 @@ module Hyrax
       end
 
       def exists_for_machine_id?(machine_id)
-        Hyrax::CollectionType.where(machine_id: machine_id).exists?
+        Hyrax::CollectionType.exists?(machine_id: machine_id)
       end
   end
 end

--- a/app/views/hyrax/admin/collection_types/_form_settings.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_settings.html.erb
@@ -2,7 +2,7 @@
 
 <p><strong><%= t('.warning') %></strong></p>
 
-<% disabled = f.object.collections? %>
+<% disabled = (f.object.collections? || f.object.admin_set? || f.object.user_collection?) %>
 <div class="collection-types-settings">
   <div class="form-inline">
     <p><%= f.input :nestable, as: :boolean, disabled: disabled %></p>

--- a/app/views/hyrax/admin/collection_types/_form_settings.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_settings.html.erb
@@ -2,14 +2,14 @@
 
 <p><strong><%= t('.warning') %></strong></p>
 
-<%# TODO: make these settings READ ONLY if at least one collection of this collection type already exists %>
+<% disabled = f.object.collections? %>
 <div class="collection-types-settings">
   <div class="form-inline">
-    <p><%= f.input :nestable, as: :boolean %></p>
-    <p><%= f.input :discoverable, as: :boolean %></p>
-    <p><%= f.input :sharable, as: :boolean %></p>
+    <p><%= f.input :nestable, as: :boolean, disabled: disabled %></p>
+    <p><%= f.input :discoverable, as: :boolean, disabled: disabled %></p>
+    <p><%= f.input :sharable, as: :boolean, disabled: disabled %></p>
     <p><%= f.input :require_membership, as: :boolean, disabled: true %></p>
-    <p><%= f.input :allow_multiple_membership, as: :boolean %></p>
+    <p><%= f.input :allow_multiple_membership, as: :boolean, disabled: disabled %></p>
     <p><%= f.input :assigns_workflow, as: :boolean, disabled: true %></p>
     <p><%= f.input :assigns_visibility, as: :boolean, disabled: true %></p>
   </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -236,6 +236,7 @@ en:
         destroy:
           notification:     "The collection type %{name} has been deleted."
         error_not_empty:    "Collection type cannot be altered as it has collections"
+        error_settings_changes:    "Collection type settings cannot be altered as it has collections"
       features:
         index:
           header:           Features

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -235,8 +235,11 @@ en:
           notification:     "The collection type %{name} has been updated."
         destroy:
           notification:     "The collection type %{name} has been deleted."
-        error_not_empty:    "Collection type cannot be altered as it has collections"
-        error_settings_changes:    "Collection type settings cannot be altered as it has collections"
+        errors:
+          no_settings_change_for_admin_sets: "Collection type settings cannot be altered for the Administrative Set type"
+          no_settings_change_for_user_collections: "Collection type settings cannot be altered for the User Collection type"
+          no_settings_change_if_not_empty: "Collection type settings cannot be altered for a type that has collections"
+          not_empty: "Collection type cannot be altered as it has collections"
       features:
         index:
           header:           Features

--- a/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
+++ b/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
@@ -14,4 +14,5 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
   it { is_expected.to delegate_method(:assigns_visibility).to(:collection_type) }
   it { is_expected.to delegate_method(:id).to(:collection_type) }
   it { is_expected.to delegate_method(:persisted?).to(:collection_type) }
+  it { is_expected.to delegate_method(:collections?).to(:collection_type) }
 end

--- a/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
+++ b/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
@@ -15,4 +15,6 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
   it { is_expected.to delegate_method(:id).to(:collection_type) }
   it { is_expected.to delegate_method(:persisted?).to(:collection_type) }
   it { is_expected.to delegate_method(:collections?).to(:collection_type) }
+  it { is_expected.to delegate_method(:admin_set?).to(:collection_type) }
+  it { is_expected.to delegate_method(:user_collection?).to(:collection_type) }
 end

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
 
       it "fails if collections exist of this type and settings are changed" do
         expect(collection_type.save).to be false
-        expect(collection_type.errors).not_to be_empty
+        expect(collection_type.errors.messages[:base].first).to eq "Collection type settings cannot be altered for a type that has collections"
       end
     end
 
@@ -177,11 +177,11 @@ RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
 
       it 'fails if settings are changed' do
         expect(collection_type.save).to be false
-        expect(collection_type.errors).not_to be_empty
+        expect(collection_type.errors.messages[:base].first).to eq "Collection type settings cannot be altered for the Administrative Set type"
       end
     end
 
-    context 'for admin set collection type' do
+    context 'for user collection type' do
       let(:collection_type) { create(:user_collection_type) }
 
       before do
@@ -190,7 +190,7 @@ RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
 
       it 'fails if settings are changed' do
         expect(collection_type.save).to be false
-        expect(collection_type.errors).not_to be_empty
+        expect(collection_type.errors.messages[:base].first).to eq "Collection type settings cannot be altered for the User Collection type"
       end
     end
   end

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -141,13 +141,25 @@ RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
     end
   end
 
-  describe "save" do
+  describe "save (no settings changes)" do
     before do
       allow(collection_type).to receive(:collections?).and_return(true)
     end
 
-    it "fails if collections exist of this type" do
-      expect(collection_type.save).to eq false
+    it "succeeds no changes to settings are being made" do
+      expect(collection_type.save).to be true
+      expect(collection_type.errors).to be_empty
+    end
+  end
+
+  describe "save" do
+    before do
+      allow(collection_type).to receive(:collections?).and_return(true)
+      allow(collection_type).to receive(:changes).and_return('nestable' => false)
+    end
+
+    it "fails if collections exist of this type and settings are changed" do
+      expect(collection_type.save).to be false
       expect(collection_type.errors).not_to be_empty
     end
   end

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -154,13 +154,44 @@ RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
 
   describe "save" do
     before do
-      allow(collection_type).to receive(:collections?).and_return(true)
       allow(collection_type).to receive(:changes).and_return('nestable' => false)
     end
 
-    it "fails if collections exist of this type and settings are changed" do
-      expect(collection_type.save).to be false
-      expect(collection_type.errors).not_to be_empty
+    context 'for non-special collection type' do
+      before do
+        allow(collection_type).to receive(:collections?).and_return(true)
+      end
+
+      it "fails if collections exist of this type and settings are changed" do
+        expect(collection_type.save).to be false
+        expect(collection_type.errors).not_to be_empty
+      end
+    end
+
+    context 'for admin set collection type' do
+      let(:collection_type) { create(:admin_set_collection_type) }
+
+      before do
+        allow(collection_type).to receive(:collections?).and_return(false)
+      end
+
+      it 'fails if settings are changed' do
+        expect(collection_type.save).to be false
+        expect(collection_type.errors).not_to be_empty
+      end
+    end
+
+    context 'for admin set collection type' do
+      let(:collection_type) { create(:user_collection_type) }
+
+      before do
+        allow(collection_type).to receive(:collections?).and_return(false)
+      end
+
+      it 'fails if settings are changed' do
+        expect(collection_type.save).to be false
+        expect(collection_type.errors).not_to be_empty
+      end
     end
   end
 end

--- a/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
@@ -1,4 +1,16 @@
 RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :view do
+  # TODO: add fields as they become available:
+  # collection_type_assigns_workflow
+  # collection_type_require_membership
+  # collection_type_assigns_visibility
+
+  INPUT_IDS = %w[
+    collection_type_nestable
+    collection_type_discoverable
+    collection_type_sharable
+    collection_type_allow_multiple_membership
+  ].freeze
+
   let(:collection_type) { Hyrax::CollectionType.new }
   let(:collection_type_form) { Hyrax::Forms::Admin::CollectionTypeForm.new }
 
@@ -8,24 +20,45 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
     end
   end
 
-  before do
-    assign(:form, collection_type_form)
-    allow(view).to receive(:f).and_return(form)
-    render
+  context "when collection_type.collections? is false" do
+    before do
+      collection_type_form.collection_type = collection_type
+      assign(:form, collection_type_form)
+      allow(view).to receive(:f).and_return(form)
+      render
+    end
+
+    it "renders the intructions and warning" do
+      expect(rendered).to match(I18n.t("hyrax.admin.collection_types.form_settings.instructions"))
+      expect(rendered).to match(I18n.t("hyrax.admin.collection_types.form_settings.warning"))
+    end
+
+    INPUT_IDS.each do |id|
+      it "renders the #{id} checkbox to be disabled" do
+        match = rendered.match(/(<input.*id="#{id}".*>)/)
+        expect(match).not_to be_nil
+        next if match.nil?
+        expect(match[1].index('disabled="disabled"')).to be_nil
+      end
+    end
   end
 
-  it "renders the intructions and warning" do
-    expect(rendered).to have_content(I18n.t("hyrax.admin.collection_types.form_settings.instructions"))
-    expect(rendered).to have_content(I18n.t("hyrax.admin.collection_types.form_settings.warning"))
-  end
+  context "when collection_type.collections? is true" do
+    before do
+      collection_type_form.collection_type = collection_type
+      allow(collection_type).to receive(:collections?).and_return(true)
+      assign(:form, collection_type_form)
+      allow(view).to receive(:f).and_return(form)
+      render
+    end
 
-  it "renders the checkboxes" do
-    expect(rendered).to have_selector("input#collection_type_nestable")
-    expect(rendered).to have_selector("input#collection_type_discoverable")
-    expect(rendered).to have_selector("input#collection_type_sharable")
-    expect(rendered).to have_selector("input#collection_type_require_membership")
-    expect(rendered).to have_selector("input#collection_type_allow_multiple_membership")
-    expect(rendered).to have_selector("input#collection_type_assigns_workflow")
-    expect(rendered).to have_selector("input#collection_type_assigns_visibility")
+    INPUT_IDS.each do |id|
+      it "renders the #{id} checkbox to be disabled" do
+        match = rendered.match(/(<input.*id="#{id}".*>)/)
+        expect(match).not_to be_nil
+        next if match.nil?
+        expect(match[1].index('disabled="disabled"')).not_to be_nil
+      end
+    end
   end
 end

--- a/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
     collection_type_allow_multiple_membership
   ].freeze
 
-  let(:collection_type) { Hyrax::CollectionType.new }
   let(:collection_type_form) { Hyrax::Forms::Admin::CollectionTypeForm.new }
 
   let(:form) do
@@ -20,33 +19,56 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
     end
   end
 
-  context "when collection_type.collections? is false" do
-    before do
-      collection_type_form.collection_type = collection_type
-      assign(:form, collection_type_form)
-      allow(view).to receive(:f).and_return(form)
-      render
+  context 'for non-special collection types' do
+    let(:collection_type) { create(:collection_type) }
+
+    context "when collection_type.collections? is false" do
+      before do
+        collection_type_form.collection_type = collection_type
+        assign(:form, collection_type_form)
+        allow(view).to receive(:f).and_return(form)
+        render
+      end
+
+      it "renders the intructions and warning" do
+        expect(rendered).to match(I18n.t("hyrax.admin.collection_types.form_settings.instructions"))
+        expect(rendered).to match(I18n.t("hyrax.admin.collection_types.form_settings.warning"))
+      end
+
+      INPUT_IDS.each do |id|
+        it "renders the #{id} checkbox to be disabled" do
+          match = rendered.match(/(<input.*id="#{id}".*>)/)
+          expect(match).not_to be_nil
+          expect(match[1].index('disabled="disabled"')).to be_nil
+        end
+      end
     end
 
-    it "renders the intructions and warning" do
-      expect(rendered).to match(I18n.t("hyrax.admin.collection_types.form_settings.instructions"))
-      expect(rendered).to match(I18n.t("hyrax.admin.collection_types.form_settings.warning"))
-    end
+    context "when collection_type.collections? is true" do
+      before do
+        collection_type_form.collection_type = collection_type
+        allow(collection_type).to receive(:collections?).and_return(true)
+        assign(:form, collection_type_form)
+        allow(view).to receive(:f).and_return(form)
+        render
+      end
 
-    INPUT_IDS.each do |id|
-      it "renders the #{id} checkbox to be disabled" do
-        match = rendered.match(/(<input.*id="#{id}".*>)/)
-        expect(match).not_to be_nil
-        next if match.nil?
-        expect(match[1].index('disabled="disabled"')).to be_nil
+      INPUT_IDS.each do |id|
+        it "renders the #{id} checkbox to be disabled" do
+          match = rendered.match(/(<input.*id="#{id}".*>)/)
+          expect(match).not_to be_nil
+          expect(match[1].index('disabled="disabled"')).not_to be_nil
+        end
       end
     end
   end
 
-  context "when collection_type.collections? is true" do
+  context 'for admin set collection type' do
+    let(:collection_type) { build(:admin_set_collection_type) }
+
     before do
       collection_type_form.collection_type = collection_type
-      allow(collection_type).to receive(:collections?).and_return(true)
+      allow(collection_type).to receive(:collections?).and_return(false)
       assign(:form, collection_type_form)
       allow(view).to receive(:f).and_return(form)
       render
@@ -56,7 +78,26 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
       it "renders the #{id} checkbox to be disabled" do
         match = rendered.match(/(<input.*id="#{id}".*>)/)
         expect(match).not_to be_nil
-        next if match.nil?
+        expect(match[1].index('disabled="disabled"')).not_to be_nil
+      end
+    end
+  end
+
+  context 'for user collection type' do
+    let(:collection_type) { build(:user_collection_type) }
+
+    before do
+      collection_type_form.collection_type = collection_type
+      allow(collection_type).to receive(:collections?).and_return(false)
+      assign(:form, collection_type_form)
+      allow(view).to receive(:f).and_return(form)
+      render
+    end
+
+    INPUT_IDS.each do |id|
+      it "renders the #{id} checkbox to be disabled" do
+        match = rendered.match(/(<input.*id="#{id}".*>)/)
+        expect(match).not_to be_nil
         expect(match[1].index('disabled="disabled"')).not_to be_nil
       end
     end


### PR DESCRIPTION
Fixes #1531

Present tense short summary (50 characters or less)

More detailed description, if necessary. Try to be as descriptive as you can: even if you think that the PR content is obvious, it may not be obvious to others. Include tracebacks if helpful, and be sure to call out any bits of the PR that may be work-in-progress.

If a collection type has collections, its settings fields should be read-only:

* CollectionType: limit before_save to prevent updates to settings
* force settings inputs to be disabled if collectiontype has collections
* fix collection type settings partial tests

@samvera/hyrax-code-reviewers
