### PR TITLE
Add content to dashboard collections show page

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -54,5 +54,10 @@ module Hyrax
     def total_items
       ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}").count
     end
+
+    def collection_type_badge
+      # TODO: Get from collection_type via collection_type_gid in collection document
+      'User Collection'
+    end
   end
 end

--- a/app/views/hyrax/dashboard/collections/_collection_title.erb
+++ b/app/views/hyrax/dashboard/collections/_collection_title.erb
@@ -1,0 +1,26 @@
+<% presenter.title.each_with_index do |title, index| %>
+  <% if index == 0 %>
+    <span class="h2"><%= title %></span>
+
+    <%= presenter.permission_badge %>
+    <%= presenter.collection_type_badge %>
+
+    <span class="sr-only h2"><%= t('hyrax.collection.actions.header') %></span>
+    <% if can? :destroy, presenter.solr_document %>
+      <%= link_to t('hyrax.collection.actions.delete.label'),
+                  dashboard_collection_path(presenter),
+                  title: t('hyrax.collection.actions.delete.desc'),
+                  class: 'btn btn-danger pull-right',
+                  data: { confirm: t('hyrax.collection.actions.delete.confirmation'),
+                          method: :delete } %>
+    <% end %>
+    <% if can? :edit, presenter.solr_document %>
+      <%= link_to t('hyrax.collection.actions.edit.label'),
+                  edit_dashboard_collection_path(presenter),
+                  title: t('hyrax.collection.actions.edit.desc'),
+                  class: 'btn btn-default pull-right' %>
+    <% end %>
+  <% else %>
+    <span class="h2"><%= title %></span>
+  <% end %>
+<% end %>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -1,36 +1,51 @@
 <% provide :page_title, construct_page_title(@presenter.title) %>
-<div itemscope itemtype="http://schema.org/CollectionPage" class="row collection">
-  <div class="col-sm-10 pull-right">
-    <header>
-      <%= render 'hyrax/collections/collection_title', presenter: @presenter %>
-    </header>
-    <%= render 'hyrax/collections/collection_description', presenter: @presenter %>
 
+<% provide :page_header do %>
+  <h1><span class="fa fa-file"></span> <%= t('.header') %></h1>
+<% end %>
+
+<div itemscope itemtype="http://schema.org/CollectionPage" class="row collection">
+  <header>
+    <div class="col-md-12">
+      <%= render 'collection_title', presenter: @presenter %>
+    </div>
+  </header>
+
+  <div class="col-xs-3">
+      <%= render 'hyrax/collections/media_display', presenter: @presenter %>
+      <%= link_to t('.public_view_label'), collection_path(id: @presenter.id) %>
+  </div>
+  <div>
+      <%= render 'hyrax/collections/collection_description', presenter: @presenter %>
+  </div>
+
+  <div class="col-md-12">
     <% unless has_collection_search_parameters? %>
       <%= render 'show_descriptions' %>
-    <% end %>
-  </div>
-  <div class="col-sm-2">
-    <%= render 'hyrax/collections/media_display', presenter: @presenter %>
-    <% unless has_collection_search_parameters? %>
-      <%= render 'show_actions', presenter: @presenter %>
     <% end %>
   </div>
 </div>
 
 <div class="row">
-  <h2 class="col-xs-6 col-md-7 col-lg-6">
+  <div class="col-md-12 h2">
     <% if has_collection_search_parameters? %>
-        Search Results within this Collection
+        <%= t('hyrax.collections.search_results') %>
     <% else %>
-        <%= t('.works_in_collection') %>
+        <%= t('.item_count') %> (<%= @presenter.total_items %>)
     <% end %>
+    <%= link_to t('hyrax.collection.actions.add_works.label'),
+                hyrax.my_works_path(add_files_to_collection: @presenter.id),
+                title: t('hyrax.collection.actions.add_works.desc'),
+                class: 'btn btn-default pull-right' %>
   </h2>
-  <div class="col-xs-6 col-md-5 col-lg-6"><%= render 'hyrax/collections/search_form', presenter: @presenter %></div>
 </div>
 
-<%= render 'sort_and_per_page', collection: @presenter %>
+<div class="col-xs-6 col-md-5 col-lg-6 pull-right">
+  <%= render 'hyrax/collections/search_form', presenter: @presenter %>
+</div>
 
-<%= render_document_index @member_docs %>
-
-<%= render 'hyrax/collections/paginate' %>
+<div class="col-md-12">
+  <%= render 'sort_and_per_page', collection: @presenter %>
+  <%= render_document_index @member_docs %>
+  <%= render 'hyrax/collections/paginate' %>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -494,7 +494,10 @@ en:
         new:
           header: Create New Collection
         show:
-          works_in_collection: "Works in this Collection"
+          header: "Collection"
+          item_count: "Items"
+          public_view_label: "Public view of Collection"
+          search_results: "Search Results within this Collection"
       create_work:              "Create Work"
       current_proxies:          "Current Proxies"
       heading_actions:

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'collection', type: :feature do
       fill_in('Related URL', with: 'http://example.com/')
 
       click_button("Create Collection")
-      expect(page).to have_content 'Works in this Collection'
+      expect(page).to have_content 'Items'
       expect(page).to have_content title
       expect(page).to have_content description
     end

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
 
     # Stub route because view specs don't handle engine routes
     allow(view).to receive(:edit_dashboard_collection_path).and_return("/dashboard/collection/123/edit")
-    allow(view).to receive(:collection_path).and_return("/dashboard/collection/123")
+    allow(view).to receive(:dashboard_collection_path).and_return("/dashboard/collection/123")
+    allow(view).to receive(:collection_path).and_return("/collection/123")
 
     stub_template 'hyrax/collections/_search_form.html.erb' => 'search form'
     stub_template 'hyrax/dashboard/collections/_sort_and_per_page.html.erb' => 'sort and per page'
@@ -28,10 +29,10 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
   end
 
   it 'draws the page' do
-    expect(rendered).to have_selector 'h2', text: 'Actions'
     expect(rendered).to have_link 'Edit'
     expect(rendered).to have_link 'Delete'
     expect(rendered).to have_link 'Add works'
+    expect(rendered).to have_link 'Public view of Collection'
     expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
   end
 end


### PR DESCRIPTION
Cherry pick from #1536; grab 04f678ad81a60a41b80ebcfd53a63cf0a3d84e52

Grab commit by @laritakr to add fields to display of collections. 

## Original commit message

Initial rework the content on the show page, moving around content and adding
collection type and I18n translations. Adjust spec tests to match
changes.

Relates to #1427

This is a partial PR to rearrange the layout of the dashboard/show page and add some new content.

* It does not include CSS changes to make the layout pretty.
* It does not accommodate the inclusion of new data in the list of works shown.
* It includes a stubbed collection_type_badge method, but does not yet retrieve the actual collection 
   type or format the badge layout.


@samvera/hyrax-code-reviewers
