### PR TITLE
Display collection type in collection listing

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -42,6 +42,8 @@ module Hyrax
     delegate :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language,
              :embargo_release_date, :lease_expiration_date, :license, :date_created,
              :resource_type, :based_near, :related_url, :identifier, :thumbnail_path,
+             :title_or_label, :collection_type_gid_ssim, :create_date, :visibility, :edit_groups,
+             :edit_people,
              to: :solr_document
 
     # Terms is the list of fields displayed by
@@ -76,8 +78,7 @@ module Hyrax
     end
 
     def collection_type_badge
-      # TODO: Get from collection_type via collection_type_gid in collection document
-      'User Collection'
+      collection_type.title
     end
   end
 end

--- a/app/views/hyrax/my/collections/_default_group.html.erb
+++ b/app/views/hyrax/my/collections/_default_group.html.erb
@@ -4,6 +4,7 @@
     <thead>
     <tr>
       <th><%= t("hyrax.dashboard.my.heading.title") %></th>
+      <th><%= t("hyrax.dashboard.my.heading.collection_type") %></th>
       <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
       <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
       <th><%= t("hyrax.dashboard.my.heading.action") %></th>
@@ -12,7 +13,8 @@
   <% end %>
   <tbody>
   <% docs.each_with_index do |document, counter| %>
-    <%= render 'list_collections', document: document, counter: counter %>
+    <% collection_presenter = Hyrax::CollectionPresenter.new(document, nil, nil) %>
+    <%= render 'list_collections', collection_presenter: collection_presenter, counter: counter %>
   <% end %>
   </tbody>
 </table>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -1,4 +1,4 @@
-<% id = document.id %>
+<% id = collection_presenter.id %>
 <tr id="document_<%= id %>">
   <td>
     <div class="media">
@@ -7,19 +7,22 @@
         <div class="media-heading">
           <%= link_to hyrax.dashboard_collection_path(id) do %>
               <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %> </span>
-              <%= document.title_or_label %>
+              <%= collection_presenter.title_or_label %>
           <% end %>
           <a href="#" class="small" title="Click for more details">
             <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i>
-            <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{document.title_or_label}" %></span>
+            <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{collection_presenter.title_or_label}" %></span>
           </a>
         </div>
       </div>
     </div>
   </td>
-  <td class="text-center date"><%= document.create_date.try(:to_formatted_s, :standard) %> </td>
+
+  <td class="collection_type"><%= collection_presenter.collection_type_badge %></td>
+
+  <td class="text-center date"><%=collection_presenter.create_date.try(:to_formatted_s, :standard) %> </td>
   <td class="text-center">
-    <%= render_visibility_link(document) %>
+    <%= render_visibility_link(collection_presenter.solr_document) %>
   </td>
   <td class="text-center">
     <%= render 'hyrax/my/collection_action_menu', id: id %>
@@ -29,14 +32,14 @@
   <td colspan="4">
     <dl class="expanded-details row">
       <dt class="col-xs-3 col-lg-2"><%= t("hyrax.dashboard.my.collection_list.description") %></dt>
-      <dd class="col-xs-9 col-lg-10"><%= document.description.first %></dd>
+      <dd class="col-xs-9 col-lg-10"><%= collection_presenter.description.first %></dd>
       <dt class="col-xs-3 col-lg-2"><%= t("hyrax.dashboard.my.collection_list.edit_access") %></dt>
       <dd class="col-xs-9 col-lg-10">
-      <% if document.edit_groups.present? %>
-        <%= t("hyrax.dashboard.my.collection_list.groups") %> <%= document.edit_groups.join(', ') %>
+      <% if collection_presenter.edit_groups.present? %>
+        <%= t("hyrax.dashboard.my.collection_list.groups") %> <%= collection_presenter.edit_groups.join(', ') %>
         <br/>
       <% end %>
-        <%= t("hyrax.dashboard.my.collection_list.users") %> <%= document.edit_people.join(', ') %>
+        <%= t("hyrax.dashboard.my.collection_list.users") %> <%= collection_presenter.edit_people.join(', ') %>
       </dd>
     </dl>
   </td>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -542,6 +542,7 @@ en:
           works:       "Filter works:"
         heading:
           action:         "Actions"
+          collection_type: "Collection Type"
           date_uploaded:  "Date Added"
           highlighted:    "Highlighted"
           title:          "Title"

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -6,13 +6,18 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
   end
   let(:ability) { double }
   let(:presenter) { Hyrax::CollectionPresenter.new(document, ability) }
+  let(:collection_type) { double }
 
   before do
     allow(document).to receive(:hydra_model).and_return(::Collection)
     allow(controller).to receive(:current_user).and_return(stub_model(User))
     allow(view).to receive(:can?).with(:edit, document).and_return(true)
     allow(view).to receive(:can?).with(:destroy, document).and_return(true)
+
     allow(presenter).to receive(:total_items).and_return(0)
+    allow(presenter).to receive(:collection_type).and_return(collection_type)
+    allow(collection_type).to receive(:title).and_return("User Collection")
+
     assign(:presenter, presenter)
 
     # Stub route because view specs don't handle engine routes
@@ -31,12 +36,10 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
   end
 
   it 'draws the page' do
-    # TODO: elr - Should these be checked here?  _show_actions spec tests this in more detail
     expect(rendered).to have_link 'Edit'
     expect(rendered).to have_link 'Delete'
     expect(rendered).to have_link 'Add works'
     expect(rendered).to have_link 'Public view of Collection'
-    expect(rendered).to have_css('.stubbed-actions', text: 'THE ACTIONS') #
     expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
   end
 end

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -36,10 +36,12 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
   end
 
   it 'draws the page' do
+    # TODO: elr - Should these be checked here?  _show_actions spec tests this in more detail
     expect(rendered).to have_link 'Edit'
     expect(rendered).to have_link 'Delete'
     expect(rendered).to have_link 'Add works'
     expect(rendered).to have_link 'Public view of Collection'
+    expect(rendered).to have_css('.stubbed-actions', text: 'THE ACTIONS')
     expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
   end
 end

--- a/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
@@ -11,13 +11,15 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
 
   let(:doc) { SolrDocument.new(attributes) }
   let(:collection) { mock_model(Collection) }
+  let(:collection_presenter) { Hyrax::CollectionPresenter.new(doc, nil, nil) }
 
   before do
     allow(view).to receive(:current_user).and_return(stub_model(User))
     allow(doc).to receive(:to_model).and_return(stub_model(Collection, id: id))
+    allow(collection_presenter).to receive(:collection_type_badge).and_return("User Collection")
     view.lookup_context.prefixes.push 'hyrax/my'
 
-    render 'hyrax/my/collections/list_collections', document: doc
+    render 'hyrax/my/collections/list_collections', collection_presenter: collection_presenter
   end
 
   it 'the line item displays the work and its actions' do
@@ -26,6 +28,7 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
     expect(rendered).to have_link 'Edit Collection', href: hyrax.edit_dashboard_collection_path(id)
     expect(rendered).to have_link 'Delete Collection', href: hyrax.dashboard_collection_path(id)
     expect(rendered).to have_css 'a.visibility-link', text: 'Private'
+    expect(rendered).to have_css '.collection_type', text: 'User Collection'
     expect(rendered).to have_selector '.expanded-details dd', text: 'Collection Description'
     expect(rendered).not_to include '<span class="fa fa-cubes collection-icon-small pull-left"></span></a>'
   end


### PR DESCRIPTION
Add a column to display the collection type in `my/collections`,
incidentally adding `#collection_type` to `CollectionPresenter`
along the way.

## Issues surfaced by this implementation

* The solr document field `"collection_type_gid_ssim"` is multi-valued,
  which doesn't make sense. If this is changed to singular, the
  method `CollectionPresenter#collection_type` will need to be
  changed.
* `hyrax.dashboard.my.heading.collection_type` is only in the english
  mapping and needs translation
* The label and data are too wide for the table cell, but I didn't see how to
  change the widths in the CSS.

## Changes:

  * `views/hyrax/my/collections/_default_group` now sends the
    `list_collections` partial a `collection_presenter` instead
    of the raw solr document
  * `collection_presenter` updated to delegate more methods
    to its solr document
  * ~~`collection_presenter` updated with `#collection_type` method to
    lazily get the actual underlying collection_type object~~ Superseded by
    implementation of `#collection_type` in #1554
  * Page updated to have extra column showing title of each
    collection's collection-type
  * Added `hyrax.dashboard.my.heading.collection_type` to
    `config/locales/hyrax.en.yml`

@samvera/hyrax-code-reviewers
