### PR TITLE
Capturing end of week work for Nested Collections

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -34,7 +34,11 @@ module Hyrax
           else
             solr_document.hydra_model.find(solr_document.id).collection_type_gid
           end
-        CollectionType.find_by_gid!(collection_type_gid)
+        if collection_type_gid
+          Hyrax::CollectionType.find_by_gid!(collection_type_gid)
+        else
+          Hyrax::CollectionType.find_or_create_default_collection_type
+        end
       end
     end
 

--- a/app/services/hyrax/adapters/nesting_index_adapter.rb
+++ b/app/services/hyrax/adapters/nesting_index_adapter.rb
@@ -1,0 +1,118 @@
+module Hyrax
+  module Adapters
+    module NestingIndexAdapter
+      # @!group Providing interface for a Samvera::NestingIndexer::Adapter
+
+      # @api public
+      # @param id [String]
+      # @return Samvera::NestingIndexer::Document::PreservationDocument
+      def self.find_preservation_document_by(id:)
+        # Not everything is guaranteed to have library_collection_ids
+        # If it doesn't have it, what do we do?
+        fedora_object = ActiveFedora::Base.find(id)
+        parent_ids =
+          if fedora_object.respond_to?(:member_of_collection_ids)
+            fedora_object.member_of_collection_ids
+          else
+            []
+          end
+        Samvera::NestingIndexer::Documents::PreservationDocument.new(id: id, parent_ids: parent_ids)
+      end
+
+      # @api public
+      # @param id [String]
+      # @return Samvera::NestingIndexer::Documents::IndexDocument
+      def self.find_index_document_by(id:)
+        solr_document = find_solr_document_by(id: id)
+        coerce_solr_document_to_index_document(document: solr_document, id: id)
+      end
+
+      # @api public
+      # @yield Samvera::NestingIndexer::Document::PreservationDocument
+      # rubocop:disable Lint/UnusedMethodArgument
+      def self.each_preservation_document(&block)
+        # TODO: Enable Lint/UnusedMethodArgument once implemented
+        raise NotImplementedError
+      end
+      # rubocop:enable Lint/UnusedMethodArgument
+
+      # @api public
+      #
+      # From the given parameters, we will need to add them to the underlying SOLR document for the object
+      #
+      # @param id [String]
+      # @param parent_ids [Array<String>]
+      # @param ancestors [Array<String>]
+      # @param pathnames [Array<String>]
+      # @return Hash - the attributes written to the indexing layer
+      def self.write_document_attributes_to_index_layer(id:, parent_ids:, ancestors:, pathnames:)
+        solr_doc = ActiveFedora::Base.find(id).to_solr # What is the current state of the solr document
+
+        # Now add the details from the nesting indexor to the document
+        solr_doc[solr_field_name_for_storing_ancestors] = ancestors
+        solr_doc[solr_field_name_for_storing_parent_ids] = parent_ids
+        solr_doc[solr_field_name_for_storing_pathnames] = pathnames
+        ActiveFedora::SolrService.add(solr_doc, commit: true)
+        solr_doc
+      end
+
+      # @api public
+      # @param document [Samvera::NestingIndexer::Documents::IndexDocument]
+      # @param solr_field_name_for_ancestors [String] The SOLR field name we use to find children
+      # @yield Samvera::NestingIndexer::Documents::IndexDocument
+      def self.each_child_document_of(document:, &block)
+        raw_child_solr_documents_of(parent_document: document).each do |solr_document|
+          child_document = coerce_solr_document_to_index_document(document: solr_document, id: solr_document.fetch('id'))
+          block.call(child_document)
+        end
+      end
+      # @!endgroup
+
+      # @!group Supporting methods for interface implementation
+
+      # @api private
+      # @todo Need to implement retrieving parent_ids, pathnames, and ancestors from the given document
+      def self.coerce_solr_document_to_index_document(document:, id:)
+        Samvera::NestingIndexer::Documents::IndexDocument.new(
+          id: id,
+          parent_ids: document.fetch(solr_field_name_for_storing_parent_ids) { [] },
+          pathnames: document.fetch(solr_field_name_for_storing_pathnames) { [] },
+          ancestors: document.fetch(solr_field_name_for_storing_ancestors) { [] }
+        )
+      end
+      private_class_method :coerce_solr_document_to_index_document
+
+      # @api private
+      def self.find_solr_document_by(id:)
+        query = ActiveFedora::SolrQueryBuilder.construct_query_for_ids([id])
+        document = ActiveFedora::SolrService.query(query, rows: 1).first
+        raise "Unable to find SolrDocument with ID=#{id}" if document.nil?
+        document
+      end
+      private_class_method :find_solr_document_by
+
+      # @api private
+      def self.nesting_configuration
+        @nesting_configuration ||= Samvera::NestingIndexer.configuration
+      end
+
+      class << self
+        delegate :solr_field_name_for_storing_pathnames, :solr_field_name_for_storing_ancestors, :solr_field_name_for_storing_parent_ids, to: :nesting_configuration
+      end
+
+      # @api private
+      # @param parent_document [Curate::Indexer::Documents::IndexDocument]
+      # @return [Hash] A raw response document from SOLR
+      # @todo What is the appropriate suffix to apply to the solr_field_name?
+      def self.raw_child_solr_documents_of(parent_document:)
+        pathname_query = parent_document.pathnames.map do |pathname|
+          ActiveFedora::SolrQueryBuilder.construct_query(solr_field_name_for_storing_ancestors => pathname.gsub('"', '\"'))
+        end.join(" OR ")
+        ActiveFedora::SolrService.query(pathname_query)
+      end
+      private_class_method :raw_child_solr_documents_of
+
+      # @!endgroup
+    end
+  end
+end

--- a/app/services/hyrax/adapters/nesting_index_adapter.rb
+++ b/app/services/hyrax/adapters/nesting_index_adapter.rb
@@ -9,14 +9,22 @@ module Hyrax
       def self.find_preservation_document_by(id:)
         # Not everything is guaranteed to have library_collection_ids
         # If it doesn't have it, what do we do?
-        fedora_object = ActiveFedora::Base.find(id)
-        parent_ids =
-          if fedora_object.respond_to?(:member_of_collection_ids)
-            fedora_object.member_of_collection_ids
-          else
-            []
-          end
+        parent_ids = find_preservation_parent_ids_for(id: id)
         Samvera::NestingIndexer::Documents::PreservationDocument.new(id: id, parent_ids: parent_ids)
+      end
+
+      # @api public
+      # @param id [String]
+      # @return Samvera::NestingIndexer::Document::PreservationDocument
+      def self.find_preservation_parent_ids_for(id:)
+        # Not everything is guaranteed to have library_collection_ids
+        # If it doesn't have it, what do we do?
+        fedora_object = ActiveFedora::Base.find(id)
+        if fedora_object.respond_to?(:member_of_collection_ids)
+          fedora_object.member_of_collection_ids
+        else
+          []
+        end
       end
 
       # @api public
@@ -28,9 +36,20 @@ module Hyrax
       end
 
       # @api public
+      # @deprecated
       # @yield Samvera::NestingIndexer::Document::PreservationDocument
       # rubocop:disable Lint/UnusedMethodArgument
       def self.each_preservation_document(&block)
+        # TODO: Enable Lint/UnusedMethodArgument once implemented
+        raise NotImplementedError
+      end
+      # rubocop:enable Lint/UnusedMethodArgument
+
+      # @api public
+      # @yieldparam id [String]
+      # @yieldparam parent_id [Array<String>]
+      # rubocop:disable Lint/UnusedMethodArgument
+      def self.each_perservation_document_id_and_parent_ids(&block)
         # TODO: Enable Lint/UnusedMethodArgument once implemented
         raise NotImplementedError
       end

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -9,8 +9,6 @@
                   hyrax.my_works_path(add_works_to_collection: presenter.id),
                   title: t('hyrax.collection.actions.add_works.desc'),
                   class: 'btn btn-default' %>
-      <%# TODO - The presenter's solr document does not have any collection_type information.
-          I am stuck on how to fix this. %>
       <% if presenter.collection_type_is_nestable? %>
         <%= link_to t('hyrax.collection.actions.nest_collections.label'),
                     hyrax.dashboard_new_nest_collection_within_path(child_id: presenter.id),

--- a/config/initializers/samvera-nesting_indexer_initializer.rb
+++ b/config/initializers/samvera-nesting_indexer_initializer.rb
@@ -1,0 +1,15 @@
+# rubocop:disable Style/FileName
+require 'samvera/nesting_indexer'
+# rubocop:enable Style/FileName
+
+Samvera::NestingIndexer.configure do |config|
+  # How many layers of nesting are allowed for collections
+  # For maximum_nesting_depth of 3 the following will raise an exception
+  # C1 <- C2 <- C3 <- W1
+  config.maximum_nesting_depth = 5
+  require 'hyrax/adapters/nesting_index_adapter'
+  config.adapter = Hyrax::Adapters::NestingIndexAdapter
+  config.solr_field_name_for_storing_parent_ids = Solrizer.solr_name('nesting_collection__parent_ids', :symbol)
+  config.solr_field_name_for_storing_ancestors =  Solrizer.solr_name('nesting_collection__ancestors', :symbol)
+  config.solr_field_name_for_storing_pathnames =  Solrizer.solr_name('nesting_collection__pathnames', :symbol)
+end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -71,6 +71,7 @@ EOF
   spec.add_dependency 'redlock', '>= 0.1.2'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'active-fedora', '>= 11.3.1'
+  spec.add_dependency 'samvera-nesting_indexer', '~> 0.6'
   spec.add_dependency 'linkeddata' # Required for getting values from geonames
 
   spec.add_development_dependency 'engine_cart', '~> 1.0'

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -56,12 +56,25 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     describe 'when solr_document#collection_type_gid does not exist' do
-      let(:collection) { create(:collection, collection_type_gid: collection_type.gid) }
       let(:solr_doc) { SolrDocument.new(collection.to_solr.except('collection_type_gid_ssim')) }
 
-      it "finds the collection's collection type of the solr document's id if the document does not have a collection_type_gid" do
-        expect(solr_doc).not_to receive(:collection_type_gid)
-        expect(presenter.collection_type).to eq(collection_type)
+      describe 'and underlying Fedora object has a collection_type_gid' do
+        let(:collection) { create(:collection, collection_type_gid: collection_type.gid) }
+
+        it "finds the collection's collection type of the solr document's id if the document does not have a collection_type_gid" do
+          expect(solr_doc).not_to receive(:collection_type_gid)
+          expect(presenter.collection_type).to eq(collection_type)
+        end
+      end
+
+      describe 'and underlying Fedora object does not have a collection_type_gid' do
+        let(:collection) { create(:typeless_collection) }
+
+        it "finds the find_or_create_default_collection_type" do
+          expect(collection.collection_type_gid).to be_nil # Verifying that I don't have a collection_type from my factory
+          expect(solr_doc).not_to receive(:collection_type_gid)
+          expect(presenter.collection_type).to eq(Hyrax::CollectionType.find_or_create_default_collection_type)
+        end
       end
     end
   end

--- a/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
+++ b/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
@@ -1,0 +1,135 @@
+require 'samvera/nesting_indexer/adapters/interface_behavior_spec'
+
+RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
+  it_behaves_like 'a Samvera::NestingIndexer::Adapter'
+
+  describe '.find_preservation_document_by' do
+    let(:id) { '123' }
+
+    subject { described_class.find_preservation_document_by(id: id) }
+
+    context 'with a not found fedora document ' do
+      let(:id) { 'so-very-missing-no-document-here' }
+
+      it 'raises ActiveFedora::ObjectNotFound' do
+        expect { subject }.to raise_error(ActiveFedora::ObjectNotFoundError)
+      end
+    end
+    context 'with fedora document that does not have #member_of_collection_ids' do
+      let(:document) { double("Document", id: id) }
+
+      before do
+        expect(ActiveFedora::Base).to receive(:find).with(document.id).and_return(document)
+      end
+
+      it { is_expected.to be_a(Samvera::NestingIndexer::Documents::PreservationDocument) }
+    end
+    context 'with fedora document that has #member_of_collection_ids' do
+      let(:document) { double("Document", id: id, member_of_collection_ids: ['456', '789']) }
+
+      before do
+        expect(ActiveFedora::Base).to receive(:find).with(document.id).and_return(document)
+      end
+
+      it { is_expected.to be_a(Samvera::NestingIndexer::Documents::PreservationDocument) }
+    end
+  end
+
+  describe '.find_index_document_by' do
+    subject { described_class.find_index_document_by(id: id) }
+
+    context 'with a not found id ' do
+      let(:id) { 'so-very-missing-no-document-here' }
+
+      it 'raises RuntimeError' do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'with a found id' do
+      let(:id) { "abc-def-ghi" }
+      let(:document) { { id: id } }
+
+      before do
+        ActiveFedora::SolrService.delete(id)
+        ActiveFedora::SolrService.add(document, commit: true)
+      end
+
+      it { is_expected.to be_a(Samvera::NestingIndexer::Documents::IndexDocument) }
+    end
+  end
+
+  describe '.each_preservation_document' do
+    xit 'iterates through each preservation document'
+  end
+
+  describe '.each_child_document_of', clean_repo: true do
+    let(:ancestors_key) { described_class.solr_field_name_for_storing_ancestors }
+    let(:index_document_class) { Samvera::NestingIndexer::Documents::IndexDocument }
+    let(:parent) { { id: document.id } }
+    let(:document) { index_document_class.new(id: 'parent-1', pathnames: ['parent-1'], parent_ids: [], ancestors: []) }
+    let(:children) { [{ id: 'child-1', ancestors_key => [document.id] }, { id: 'child-2', ancestors_key => [document.id] }] }
+    let(:not_my_children) { [{ id: 'youre-not-my-dad-1', ancestors_key => ['parent-2'] }, { id: 'i-am-your-grandchild', ancestors_key => ['parent-1/parent-3'] }] }
+
+    before do
+      ([parent] + children + not_my_children).each do |doc|
+        ActiveFedora::SolrService.add(doc, commit: true)
+      end
+    end
+
+    it 'yields all of the child solr-documents of the given document' do
+      child_index_documents = []
+      described_class.each_child_document_of(document: document) do |doc|
+        child_index_documents << doc
+      end
+      expect(child_index_documents.count).to eq(2)
+      child_index_documents.each do |child|
+        expect(child).to be_a(index_document_class)
+        expect(child.ancestors).to eq([document.id])
+      end
+    end
+  end
+
+  describe '.write_document_attributes_to_index_layer' do
+    let(:work) { create(:work) }
+    let(:query_for_works_solr_document) { ->(id:) { ActiveFedora::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query_for_ids([id])).first } }
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'will append parent_ids, ancestors, and pathnames' do
+      previous_solr_keys = work.to_solr.keys
+      expect(previous_solr_keys).not_to include(described_class.solr_field_name_for_storing_ancestors)
+      expect(previous_solr_keys).not_to include(described_class.solr_field_name_for_storing_parent_ids)
+      expect(previous_solr_keys).not_to include(described_class.solr_field_name_for_storing_pathnames)
+
+      existing_queried_solr_document = query_for_works_solr_document.call(id: work.id)
+      expect(existing_queried_solr_document.key?(described_class.solr_field_name_for_storing_ancestors)).to be_falsey
+      expect(existing_queried_solr_document.key?(described_class.solr_field_name_for_storing_parent_ids)).to be_falsey
+      expect(existing_queried_solr_document.key?(described_class.solr_field_name_for_storing_pathnames)).to be_falsey
+
+      kwargs = { id: work.id, parent_ids: ['123'], pathnames: ["123/#{work.id}"], ancestors: ['123'] }
+      returned_solr_document = described_class.write_document_attributes_to_index_layer(**kwargs)
+
+      expect(returned_solr_document.fetch(described_class.solr_field_name_for_storing_ancestors)).to eq(kwargs.fetch(:ancestors))
+      expect(returned_solr_document.fetch(described_class.solr_field_name_for_storing_parent_ids)).to eq(kwargs.fetch(:parent_ids))
+      expect(returned_solr_document.fetch(described_class.solr_field_name_for_storing_pathnames)).to eq(kwargs.fetch(:pathnames))
+
+      newly_queried_solr_document = query_for_works_solr_document.call(id: work.id)
+      expect(newly_queried_solr_document.fetch(described_class.solr_field_name_for_storing_ancestors)).to eq(kwargs.fetch(:ancestors))
+      expect(newly_queried_solr_document.fetch(described_class.solr_field_name_for_storing_parent_ids)).to eq(kwargs.fetch(:parent_ids))
+      expect(newly_queried_solr_document.fetch(described_class.solr_field_name_for_storing_pathnames)).to eq(kwargs.fetch(:pathnames))
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
+  describe '.solr_field_name_for_storing_ancestors' do
+    subject { described_class.solr_field_name_for_storing_ancestors }
+
+    it { is_expected.to match(/_ssim$/) }
+  end
+
+  describe '.solr_field_name_for_storing_parent_ids' do
+    subject { described_class.solr_field_name_for_storing_parent_ids }
+
+    it { is_expected.to match(/_ssim$/) }
+  end
+end

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -36,11 +36,6 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
   end
 
   it 'draws the page' do
-    # TODO: elr - Should these be checked here?  _show_actions spec tests this in more detail
-    expect(rendered).to have_link 'Edit'
-    expect(rendered).to have_link 'Delete'
-    expect(rendered).to have_link 'Add works'
-    expect(rendered).to have_link 'Public view of Collection'
     expect(rendered).to have_css('.stubbed-actions', text: 'THE ACTIONS')
     expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
   end

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
   end
 
   it 'draws the page' do
+    # Making sure that we are verifying that the _show_actions.html.erb is rendering
     expect(rendered).to have_css('.stubbed-actions', text: 'THE ACTIONS')
     expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
   end


### PR DESCRIPTION
## Capturing end of week work

4384b808234e742688f9c41609f04d27300e5aac

This commit is to capture and move forward the work I have done this
week at the Collection Extensions sprint. It is not a complete solution
but one that I want to begin discussions on. I also want to leave time
to capture what are the next steps forward. As I see them there are
three major pieces.

**Major Pieces**

1. Via the UI, how do I nest a collection within another collection
2. Within the UI, how do I see the nested collections?
3. When I nest a collection, I need to run a reindex the relationships
   on that object.
   - This reindex can be a rather slow going affair, so it should run
      outside of the request cycle.
   - see [Samvera::NestingIndexer.reindex_relationships][1]

**Other Dependences**

1. As a community, we need to decide if we are going to reverse the
   relationship of collections (from a hasMember to isMemberOf style
   relationship). This decision would mean that we punt on the
   functionality of ordering collections within other collections. We've
   already punted on the ability to order works within collections.
1. Implement the reindex the whole repository method in a meaningful
   manner. We want to reindex objects that are not in a collection
   first (to build the correct behavior).

Assuming that we implement major piece 3 (e.g. Reindex the object)
If we choose to delay the direction reversal of the collection property,
we would need to provide a data migration path/script to add this
functionality.

Related to #1512

[1]:https://github.com/samvera-labs/samvera-nesting_indexer/blob/106fa93858d47f915f9802b8efa036d518c29157/lib/samvera/nesting_indexer.rb#L19

## Adding specs for collection show actions view

6e1ae891f75b071e839f66b877ca283f31fbad42


## Addressing collection presenter without type

dfdeb3d5843c74e6c6aca942e2ff582138efef5a

From @elrayle:

> NEW: You might not find a gid in the fedora model either. This
> happens for collections that existed before the concept of collection
> types. Those default to user_collections. You can use
> `Hyrax::CollectionType.find_or_create_default_collection_type` to get
> the default collection type

Related to PR #1554

## Adding samvera-nesting_indexer

7027f2b840d07f4a0d61a7ce73e55012117cb401


## Adding partial implementation of Nesting adapter

d672fab9b2f3c79c0653762389f6a195e010e274

With these methods we are able to reindex a single item. The reindexing
all objects will not work. There is a larger discussion to have in the
community about how we might go about doing that.

