### PR TITLE
Change permission_template to use source_id and source_type

### DIFF
--- a/app/actors/hyrax/actors/apply_permission_template_actor.rb
+++ b/app/actors/hyrax/actors/apply_permission_template_actor.rb
@@ -13,8 +13,8 @@ module Hyrax
       private
 
         def add_edit_users(env)
-          return if env.attributes[:admin_set_id].blank?
-          template = Hyrax::PermissionTemplate.find_by!(admin_set_id: env.attributes[:admin_set_id])
+          return if env.attributes[:source_id].blank?
+          template = Hyrax::PermissionTemplate.find_by!(source_id: env.attributes[:source_id])
           env.curation_concern.edit_users += template.agent_ids_for(agent_type: 'user', access: 'manage')
           env.curation_concern.edit_groups += template.agent_ids_for(agent_type: 'group', access: 'manage')
           env.curation_concern.read_users += template.agent_ids_for(agent_type: 'user', access: 'view')

--- a/app/actors/hyrax/actors/default_admin_set_actor.rb
+++ b/app/actors/hyrax/actors/default_admin_set_actor.rb
@@ -32,7 +32,7 @@ module Hyrax
         end
 
         def ensure_permission_template!(admin_set_id:)
-          Hyrax::PermissionTemplate.find_by(admin_set_id: admin_set_id) || create_permission_template!(admin_set_id: admin_set_id)
+          Hyrax::PermissionTemplate.find_by(source_id: admin_set_id) || create_permission_template!(source_id: admin_set_id)
         end
 
         def default_admin_set_id
@@ -40,8 +40,8 @@ module Hyrax
         end
 
         # Creates a Hyrax::PermissionTemplate for the given AdminSet
-        def create_permission_template!(admin_set_id:)
-          Hyrax::PermissionTemplate.create!(admin_set_id: admin_set_id)
+        def create_permission_template!(source_id:)
+          Hyrax::PermissionTemplate.create!(source_id: source_id, source_type: 'admin_set')
         end
     end
   end

--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -104,7 +104,7 @@ module Hyrax
         # Validate against selected AdminSet's PermissionTemplate (if any)
         def validate(env, intention, attributes)
           # If AdminSet was selected, look for its PermissionTemplate
-          template = PermissionTemplate.find_by!(admin_set_id: attributes[:admin_set_id]) if attributes[:admin_set_id].present?
+          template = PermissionTemplate.find_by!(source_id: attributes[:admin_set_id]) if attributes[:admin_set_id].present?
 
           validate_lease(env, intention, template) &&
             validate_release_type(env, intention, template) &&

--- a/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
+++ b/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
@@ -10,11 +10,11 @@ module Hyrax
         end
 
         if @permission_template_access.destroyed?
-          redirect_to hyrax.edit_admin_admin_set_path(admin_set_id,
+          redirect_to hyrax.edit_admin_admin_set_path(source_id,
                                                       anchor: 'participants'),
                       notice: translate('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
         else
-          redirect_to hyrax.edit_admin_admin_set_path(admin_set_id,
+          redirect_to hyrax.edit_admin_admin_set_path(source_id,
                                                       anchor: 'participants'),
                       alert: @permission_template_access.errors.full_messages.to_sentence
 
@@ -24,8 +24,8 @@ module Hyrax
       private
 
         # @return [String] the identifier for the AdminSet for the currently loaded resource
-        def admin_set_id
-          @admin_set_id ||= @permission_template_access.permission_template.admin_set_id
+        def source_id
+          @source_id ||= @permission_template_access.permission_template.source_id
         end
 
         def update_management

--- a/app/controllers/hyrax/admin/permission_templates_controller.rb
+++ b/app/controllers/hyrax/admin/permission_templates_controller.rb
@@ -1,7 +1,7 @@
 module Hyrax
   module Admin
     class PermissionTemplatesController < ApplicationController
-      load_and_authorize_resource find_by: 'admin_set_id',
+      load_and_authorize_resource find_by: 'source_id',
                                   id_param: 'admin_set_id',
                                   class: 'Hyrax::PermissionTemplate'
 

--- a/app/forms/hyrax/forms/admin_set_form.rb
+++ b/app/forms/hyrax/forms/admin_set_form.rb
@@ -12,7 +12,7 @@ module Hyrax
 
       def permission_template
         @permission_template ||= begin
-                                   template_model = PermissionTemplate.find_or_create_by(admin_set_id: model.id)
+                                   template_model = PermissionTemplate.find_or_create_by(source_id: model.id)
                                    PermissionTemplateForm.new(template_model)
                                  end
       end

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -9,7 +9,7 @@ module Hyrax
       delegate :available_workflows, :active_workflow, :admin_set, to: :model
 
       # @return [#to_s] the primary key of the associated admin_set
-      # def admin_set_id (because you might come looking for this method)
+      # def source_id (because you might come looking for this method)
       delegate :id, to: :admin_set, prefix: :admin_set
 
       # Stores which radio button under release "Varies" option is selected

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -142,7 +142,7 @@ module Hyrax
       # @return Sipity::Workflow the current active workflow for the given AdminSet
       def self.workflow_for(admin_set_id:)
         begin
-          workflow = Hyrax::PermissionTemplate.find_by!(admin_set_id: admin_set_id).active_workflow
+          workflow = Hyrax::PermissionTemplate.find_by!(source_id: admin_set_id).active_workflow
         rescue ActiveRecord::RecordNotFound
           raise "Missing permission template for AdminSet(id:#{admin_set_id})"
         end

--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -71,7 +71,7 @@ class AdminSet < ActiveFedora::Base
   # @return [Hyrax::PermissionTemplate]
   # @raise [ActiveRecord::RecordNotFound]
   def permission_template
-    Hyrax::PermissionTemplate.find_by!(admin_set_id: id)
+    Hyrax::PermissionTemplate.find_by!(source_id: id)
   end
 
   # @api public

--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -32,7 +32,7 @@ module Hyrax
     # @return [AdminSet]
     # @raise [ActiveFedora::ObjectNotFoundError] when the we cannot find the AdminSet
     def admin_set
-      AdminSet.find(admin_set_id)
+      AdminSet.find(source_id)
     end
 
     # Valid Release Period values

--- a/app/models/sipity/workflow.rb
+++ b/app/models/sipity/workflow.rb
@@ -29,7 +29,7 @@ module Sipity
       workflows = Sipity::Workflow.arel_table
       Sipity::Workflow.where(active: true).where(
         workflows[:permission_template_id].in(
-          templates.project(templates[:id]).where(templates[:admin_set_id].eq(admin_set_id))
+          templates.project(templates[:id]).where(templates[:source_id].eq(admin_set_id))
         )
       ).first!
     end

--- a/app/presenters/hyrax/admin/workflow_role_presenter.rb
+++ b/app/presenters/hyrax/admin/workflow_role_presenter.rb
@@ -5,19 +5,19 @@ module Hyrax
       def initialize(workflow_role)
         @workflow = workflow_role.workflow
         @role = workflow_role.role
-        @admin_set_id = workflow.permission_template.admin_set_id
+        @source_id = workflow.permission_template.source_id
       end
 
       # @todo This is a hack; I don't want to include reference to the admin set;
       #       However based on the current UI, in which we list all workflows (spanning all admin sets) this is required.
       # @return [String] A meaningful label for the given WorkflowRole
       def label
-        "#{admin_set_label(admin_set_id)} - #{role.name} (#{workflow.name})"
+        "#{admin_set_label(source_id)} - #{role.name} (#{workflow.name})"
       end
 
       private
 
-        attr_accessor :workflow, :role, :admin_set_id
+        attr_accessor :workflow, :role, :source_id
 
         def admin_set_label(id)
           result = ActiveFedora::Base.search_by_id(id, fl: 'title_tesim')

--- a/app/presenters/hyrax/admin_set_options_presenter.rb
+++ b/app/presenters/hyrax/admin_set_options_presenter.rb
@@ -19,7 +19,7 @@ module Hyrax
       # later utilized by Javascript to limit new Work options based on AdminSet selected
       def data_attributes(admin_set)
         # Get permission template associated with this AdminSet (if any)
-        permission_template = PermissionTemplate.find_by(admin_set_id: admin_set.id)
+        permission_template = PermissionTemplate.find_by(source_id: admin_set.id)
 
         # Only add data attributes if permission template exists
         return {} unless permission_template

--- a/app/search_builders/hyrax/admin_set_search_builder.rb
+++ b/app/search_builders/hyrax/admin_set_search_builder.rb
@@ -30,10 +30,10 @@ module Hyrax
     # @return [Array<String>] a list of filters to apply to the solr query
     def gated_discovery_filters
       return super if @access != :deposit
-      ["{!terms f=id}#{admin_set_ids_for_deposit.join(',')}"]
+      ["{!terms f=id}#{source_ids_for_deposit.join(',')}"]
     end
 
-    delegate :admin_set_ids_for_deposit, to: :current_ability
-    private :admin_set_ids_for_deposit
+    delegate :source_ids_for_deposit, to: :current_ability
+    private :source_ids_for_deposit
   end
 end

--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -85,7 +85,7 @@ module Hyrax
       end
 
       def create_permission_template
-        PermissionTemplate.create!(admin_set_id: admin_set.id, access_grants_attributes: access_grants_attributes)
+        PermissionTemplate.create!(source_id: admin_set.id, source_type: 'admin_set', access_grants_attributes: access_grants_attributes)
       end
 
       def create_workflows_for(permission_template:)

--- a/db/migrate/20170821152307_add_source_type_to_permission_templates.rb
+++ b/db/migrate/20170821152307_add_source_type_to_permission_templates.rb
@@ -1,0 +1,7 @@
+class AddSourceTypeToPermissionTemplates < ActiveRecord::Migration[4.2]
+  def change
+    add_column :permission_templates, :source_type, :string
+    rename_column :permission_templates, :admin_set_id, :source_id
+  end
+end
+

--- a/lib/tasks/default_admin_set.rake
+++ b/lib/tasks/default_admin_set.rake
@@ -3,13 +3,13 @@ namespace :hyrax do
     desc "Create the Default Admin Set"
     task create: :environment do
       id = AdminSet.find_or_create_default_admin_set_id
-      unless Hyrax::PermissionTemplate.find_by(admin_set_id: id)
+      unless Hyrax::PermissionTemplate.find_by(source_id: id)
         $stderr.puts "ERROR: Default admin set exists but it does not have an " \
           "associated permission template.\n\nThis may happen if you cleared your " \
           "database but you did not clear out Fedora and Solr.\n\n" \
           "You could manually create the permission template in the rails console" \
           " (non-destructive):\n\n" \
-          "    Hyrax::PermissionTemplate.create!(admin_set_id: AdminSet::DEFAULT_ID)\n\n" \
+          "    Hyrax::PermissionTemplate.create!(source_id: AdminSet::DEFAULT_ID)\n\n" \
           "OR you could start fresh by clearing Fedora and Solr (destructive):\n\n" \
           "    require 'active_fedora/cleaner'\n" \
           "    ActiveFedora::Cleaner.clean!\n\n"

--- a/spec/abilities/ability_spec.rb
+++ b/spec/abilities/ability_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe 'Hyrax::Ability', type: :model do
   end
 
   describe "AdminSets and PermissionTemplates" do
-    let(:permission_template) { build(:permission_template, admin_set_id: admin_set.id) }
+    let(:permission_template) { build(:permission_template, source_id: admin_set.id) }
     let(:permission_template_access) { build(:permission_template_access, permission_template: permission_template) }
     let(:user) { create(:user) }
     let(:admin_set) { create(:admin_set) }

--- a/spec/actors/hyrax/actors/apply_permission_template_actor_spec.rb
+++ b/spec/actors/hyrax/actors/apply_permission_template_actor_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Hyrax::Actors::ApplyPermissionTemplateActor do
           edit_users: ['Kevin'],
           read_users: ['Taraji'])
   end
-  let(:attributes) { { admin_set_id: admin_set.id } }
+  let(:attributes) { { source_id: admin_set.id } }
   let(:admin_set) { create(:admin_set, with_permission_template: true) }
   let(:permission_template) { admin_set.permission_template }
 
@@ -20,16 +20,16 @@ RSpec.describe Hyrax::Actors::ApplyPermissionTemplateActor do
   end
 
   describe "create" do
-    context "when admin_set_id is blank" do
-      let(:attributes) { { admin_set_id: '' } }
+    context "when source_id is blank" do
+      let(:attributes) { { source_id: '' } }
 
       it "returns true" do
         expect(middleware.create(env)).to be true
       end
     end
 
-    context "when admin_set_id is provided" do
-      let(:attributes) { { admin_set_id: admin_set.id } }
+    context "when source_id is provided" do
+      let(:attributes) { { source_id: admin_set.id } }
 
       before do
         create(:permission_template_access,

--- a/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
   let(:depositor_ability) { ::Ability.new(depositor) }
   let(:work) { build(:generic_work) }
   let(:admin_set) { create(:admin_set) }
-  let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+  let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
   let(:env) { Hyrax::Actors::Environment.new(work, depositor_ability, attributes) }
 
   describe "create" do

--- a/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
+++ b/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
   let(:curation_concern) { GenericWork.new }
   let(:attributes) { { admin_set_id: admin_set.id } }
   let(:admin_set) { create(:admin_set) }
-  let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+  let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:one_year_from_today) { Time.zone.today + 1.year }
   let(:two_years_from_today) { Time.zone.today + 2.years }
@@ -152,7 +152,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       end
 
       context "embargo with date = one year from today, and required embargo of 6 months or less" do
-        let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_6_MONTHS) }
+        let(:permission_template) { create(:permission_template, source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_6_MONTHS) }
         let(:attributes) do
           { title: ['New embargo'],
             admin_set_id: admin_set.id,
@@ -170,7 +170,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       context "embargo with date = one year from today, and required embargo of 1 year or less" do
         let(:permission_template) do
           create(:permission_template,
-                 admin_set_id: admin_set.id,
+                 source_id: admin_set.id,
                  release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR)
         end
         let(:attributes) do
@@ -189,7 +189,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       context "embargo with date that doesn't match a required, fixed date" do
         let(:permission_template) do
           create(:permission_template,
-                 admin_set_id: admin_set.id,
+                 source_id: admin_set.id,
                  release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED,
                  release_date: one_year_from_today.to_s)
         end
@@ -210,7 +210,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       context "embargo with date matching the required, fixed date" do
         let(:permission_template) do
           create(:permission_template,
-                 admin_set_id: admin_set.id,
+                 source_id: admin_set.id,
                  release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED,
                  release_date: two_years_from_today.to_s)
         end
@@ -230,7 +230,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       context "embargo with valid embargo date and invalid post-embargo visibility" do
         let(:permission_template) do
           create(:permission_template,
-                 admin_set_id: admin_set.id,
+                 source_id: admin_set.id,
                  release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR,
                  visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
         end
@@ -252,7 +252,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       context "embargo with valid embargo date and valid post-embargo visibility" do
         let(:permission_template) do
           create(:permission_template,
-                 admin_set_id: admin_set.id,
+                 source_id: admin_set.id,
                  release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR,
                  visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
         end
@@ -273,7 +273,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       context "embargo with public visibility and public visibility required (no specified release_period in template)" do
         let(:permission_template) do
           create(:permission_template,
-                 admin_set_id: admin_set.id,
+                 source_id: admin_set.id,
                  visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
         end
         let(:attributes) do
@@ -293,7 +293,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       context "embargo with public visibility and authenticated visibility required (no specified release_period in template)" do
         let(:permission_template) do
           create(:permission_template,
-                 admin_set_id: admin_set.id,
+                 source_id: admin_set.id,
                  visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
         end
         let(:attributes) do
@@ -314,7 +314,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       context "embargo when no release delays are allowed" do
         let(:permission_template) do
           create(:permission_template,
-                 admin_set_id: admin_set.id,
+                 source_id: admin_set.id,
                  release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY)
         end
         let(:attributes) do
@@ -332,7 +332,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       end
 
       context "no embargo/lease when no release delays are allowed" do
-        let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY) }
+        let(:permission_template) { create(:permission_template, source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY) }
         let(:attributes) { { title: ['New embargo'], admin_set_id: admin_set.id, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC } }
 
         it "returns true" do
@@ -344,7 +344,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       context "visibility public (no embargo) when visibility required to be authenticated" do
         let(:permission_template) do
           create(:permission_template,
-                 admin_set_id: admin_set.id,
+                 source_id: admin_set.id,
                  release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY,
                  visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
         end
@@ -360,7 +360,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       context "visibility public (no embargo) and visibility required to be public" do
         let(:permission_template) do
           create(:permission_template,
-                 admin_set_id: admin_set.id,
+                 source_id: admin_set.id,
                  release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY,
                  visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
         end
@@ -375,7 +375,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       context "lease specified with any release/visibility requirements" do
         let(:permission_template) do
           create(:permission_template,
-                 admin_set_id: admin_set.id,
+                 source_id: admin_set.id,
                  release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR,
                  visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
         end
@@ -395,7 +395,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
       end
 
       context "lease specified with NO release/visibility requirements" do
-        let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+        let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
         let(:attributes) do
           { title: ['New embargo'],
             admin_set_id: admin_set.id,

--- a/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
   end
   let(:hyrax) { Hyrax::Engine.routes.url_helpers }
   let(:permission_template_access) { create(:permission_template_access) }
-  let(:admin_set_id) { permission_template_access.permission_template.admin_set_id }
+  let(:source_id) { permission_template_access.permission_template.source_id }
 
   describe "destroy" do
     context "without admin privleges" do
       before do
-        allow(controller.current_ability).to receive(:test_edit).with(admin_set_id).and_return(false)
+        allow(controller.current_ability).to receive(:test_edit).with(source_id).and_return(false)
       end
       it "is unauthorized" do
         delete :destroy, params: { id: permission_template_access }
@@ -26,7 +26,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
                agent_type: agent_type,
                agent_id: agent_id)
       end
-      let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+      let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
       let(:admin_set) { create(:admin_set, edit_users: ['Liz']) }
 
       context 'when deleting the admin users group' do
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
           expect do
             delete :destroy, params: { id: permission_template_access }
           end.not_to change { Hyrax::PermissionTemplateAccess.count }
-          expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(admin_set_id, locale: 'en', anchor: 'participants'))
+          expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(source_id, locale: 'en', anchor: 'participants'))
           expect(flash[:notice]).not_to eq I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
           expect(flash[:alert]).to eq 'The repository administrators group cannot be removed'
         end
@@ -52,7 +52,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
           expect do
             delete :destroy, params: { id: permission_template_access }
           end.to change { Hyrax::PermissionTemplateAccess.count }.by(-1)
-          expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(admin_set_id, locale: 'en', anchor: 'participants'))
+          expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(source_id, locale: 'en', anchor: 'participants'))
           expect(flash[:notice]).to eq(I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
           expect(admin_set.reload.edit_users).to be_empty
         end

--- a/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
         # This spec was not firing as expected. It was getting a nil permission template. This mock expectation is a bit
         # odd, but it needs to go rather deep into CanCan to behave accordingly.
         allow(controller.current_ability).to receive(:can?).with(:update, permission_template).and_return(false)
-        put :update, params: { id: permission_template, admin_set_id: permission_template.admin_set_id }
+        put :update, params: { id: permission_template, admin_set_id: permission_template.source_id }
         expect(assigns(:permission_template)).to eq(permission_template)
         expect(response).to be_unauthorized
       end
@@ -27,7 +27,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
       let!(:permission_template) { create(:permission_template) }
       let(:grant_attributes) { [{ "agent_type" => "user", "agent_id" => "bob", "access" => "view" }] }
       let(:input_params) do
-        { admin_set_id: permission_template.admin_set_id,
+        { admin_set_id: permission_template.source_id,
           permission_template: form_attributes }
       end
       let(:form_attributes) { { visibility: 'open', access_grants_attributes: grant_attributes } }
@@ -36,7 +36,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
         expect(controller).to receive(:authorize!).with(:update, permission_template)
         expect(form).to receive(:update).with(ActionController::Parameters.new(form_attributes).permit!).and_return(updated: true, content_tab: 'participants')
         put :update, params: input_params
-        expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(permission_template.admin_set_id, locale: 'en', anchor: 'participants'))
+        expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(permission_template.source_id, locale: 'en', anchor: 'participants'))
         expect(flash[:notice]).to eq(I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
       end
     end

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -9,11 +9,11 @@ FactoryGirl.define do
     # This way, we can go ahead
     after(:create) do |admin_set, evaluator|
       if evaluator.with_permission_template
-        attributes = { admin_set_id: admin_set.id }
+        attributes = { source_id: admin_set.id }
         attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
-        # There is a unique constraint on permission_templates.admin_set_id; I don't want to
+        # There is a unique constraint on permission_templates.source_id; I don't want to
         # create a permission template if one already exists for this admin_set
-        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(admin_set_id: admin_set.id)
+        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: admin_set.id)
       end
     end
 

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -1,23 +1,23 @@
 FactoryGirl.define do
   factory :permission_template, class: Hyrax::PermissionTemplate do
     # Given that there is a one to one strong relation between permission_template and admin_set,
-    # with a unique index on the admin_set_id, I don't want to have duplication in admin_set_id
-    sequence(:admin_set_id) { |n| format("%010d", n) }
+    # with a unique index on the source_id, I don't want to have duplication in source_id
+    sequence(:source_id) { |n| format("%010d", n) }
 
     before(:create) do |permission_template, evaluator|
       if evaluator.with_admin_set
-        admin_set_id = permission_template.admin_set_id
+        source_id = permission_template.source_id
         admin_set =
-          if admin_set_id.present?
+          if source_id.present?
             begin
-              AdminSet.find(admin_set_id)
+              AdminSet.find(source_id)
             rescue
-              create(:admin_set, id: admin_set_id)
+              create(:admin_set, id: source_id)
             end
           else
             create(:admin_set)
           end
-        permission_template.admin_set_id = admin_set.id
+        permission_template.source_id = admin_set.id
       end
     end
 

--- a/spec/features/admin_admin_set_spec.rb
+++ b/spec/features/admin_admin_set_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "The admin sets, through the admin dashboard" do
   end
 
   before do
-    Hyrax::PermissionTemplate.create!(admin_set_id: admin_set.id)
+    Hyrax::PermissionTemplate.create!(source_id: admin_set.id)
   end
 
   scenario do

--- a/spec/features/workflow_state_changes_spec.rb
+++ b/spec/features/workflow_state_changes_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Workflow state changes", type: :feature do
 
   let(:workflow) { Sipity::Workflow.find_by!(name: workflow_name, permission_template: permission_template) }
   let(:work) { create(:work, user: depositing_user, admin_set: admin_set) }
-  let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+  let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
 
   before do
     allow(::User.group_service).to receive(:byname).and_return(depositing_user.user_key => ['admin'], approving_user.user_key => ['admin'])

--- a/spec/forms/hyrax/forms/admin_set_form_spec.rb
+++ b/spec/forms/hyrax/forms/admin_set_form_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Hyrax::Forms::AdminSetForm do
     end
 
     context "when the PermissionTemplate exists" do
-      let(:permission_template) { Hyrax::PermissionTemplate.find_by(admin_set_id: model.id) }
+      let(:permission_template) { Hyrax::PermissionTemplate.find_by(source_id: model.id) }
       let(:model) { create(:admin_set, with_permission_template: true) }
 
       it "uses the existing template" do

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     let(:input_params) do
       ActionController::Parameters.new(access_grants_attributes: grant_attributes).permit!
     end
-    let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+    let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
 
     let(:user) { create(:user) }
     let(:user2) { create(:user) }
@@ -172,7 +172,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     context "with modifying release_period from 'fixed' to 'no_delay'" do
       let(:permission_template) do
         create(:permission_template,
-               admin_set_id: admin_set.id,
+               source_id: admin_set.id,
                visibility: "open",
                release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED,
                release_date: today + 1.month)
@@ -195,7 +195,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     context "with modifying release 'varies' from date specified to embargo specified" do
       let(:permission_template) do
         create(:permission_template,
-               admin_set_id: admin_set.id,
+               source_id: admin_set.id,
                visibility: "open",
                release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE,
                release_date: today + 1.month)
@@ -218,7 +218,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     end
 
     context "for a workflow change" do
-      let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id, with_active_workflow: true) }
+      let(:permission_template) { create(:permission_template, source_id: admin_set.id, with_active_workflow: true) }
       let(:new_workflow) { create(:workflow, permission_template: permission_template, active: false) }
       let(:input_params) do
         ActionController::Parameters.new(
@@ -244,7 +244,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
 
     let(:permission_template) do
       create(:permission_template,
-             admin_set_id: admin_set.id,
+             source_id: admin_set.id,
              access_grants_attributes:
                [{ agent_type: 'user',
                   agent_id: user.user_key,
@@ -274,7 +274,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
   end
 
   describe "#validate_visibility_combinations" do
-    let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+    let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
 
     context "validate all release option attribute combinations" do
       let(:visibility) { '' } # default values
@@ -377,7 +377,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     context "with release before date specified" do
       let(:permission_template) do
         create(:permission_template,
-               admin_set_id: admin_set.id,
+               source_id: admin_set.id,
                visibility: '',
                release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE,
                release_date: today + 1.month)
@@ -392,7 +392,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     context "with release embargo specified" do
       let(:permission_template) do
         create(:permission_template,
-               admin_set_id: admin_set.id,
+               source_id: admin_set.id,
                visibility: '',
                release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR)
       end
@@ -406,7 +406,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     context "with release no-delay (now) selected" do
       let(:permission_template) do
         create(:permission_template,
-               admin_set_id: admin_set.id,
+               source_id: admin_set.id,
                visibility: '',
                release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY)
       end
@@ -419,7 +419,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
   end
 
   describe "#permission_template_update_params" do
-    let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+    let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
 
     subject { form.send(:permission_template_update_params, input_params) }
 

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
 
       context "and a admin_set that allows grants has been selected" do
         let(:attributes) { { admin_set_id: admin_set.id, permissions_attributes: [{ type: 'person', name: 'justin', access: 'edit' }] } }
-        let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+        let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
         let!(:workflow) { create(:workflow, allows_access_grant: true, active: true, permission_template_id: permission_template.id) }
 
         it do
@@ -132,7 +132,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
 
       context "and an admin_set that doesn't allow grants has been selected" do
         let(:attributes) { { admin_set_id: admin_set.id, permissions_attributes: [{ type: 'person', name: 'justin', access: 'edit' }] } }
-        let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+        let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
         let!(:workflow) { create(:workflow, allows_access_grant: false, active: true, permission_template_id: permission_template.id) }
 
         it { is_expected.to eq ActionController::Parameters.new(admin_set_id: admin_set.id).permit! }

--- a/spec/forms/hyrax/generic_work_form_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_spec.rb
@@ -46,15 +46,15 @@ RSpec.describe Hyrax::GenericWorkForm do
   end
 
   describe '.model_attributes' do
-    let(:permission_template) { create(:permission_template, admin_set_id: admin_set_id) }
+    let(:permission_template) { create(:permission_template, source_id: source_id) }
     let!(:workflow) { create(:workflow, active: true, permission_template_id: permission_template.id) }
-    let(:admin_set_id) { '123' }
+    let(:source_id) { '123' }
     let(:params) do
       ActionController::Parameters.new(
         title: ['foo'],
         description: [''],
         visibility: 'open',
-        admin_set_id: admin_set_id,
+        source_id: source_id,
         representative_id: '456',
         thumbnail_id: '789',
         keyword: ['derp'],

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe AdminSet, type: :model do
   end
 
   describe '#permission_template' do
-    it 'queries for a Hyrax::PermissionTemplate with a matching admin_set_id' do
+    it 'queries for a Hyrax::PermissionTemplate with a matching source_id' do
       admin_set = build(:admin_set, id: '123')
       permission_template = build(:permission_template)
-      expect(Hyrax::PermissionTemplate).to receive(:find_by!).with(admin_set_id: '123').and_return(permission_template)
+      expect(Hyrax::PermissionTemplate).to receive(:find_by!).with(source_id: '123').and_return(permission_template)
       expect(admin_set.permission_template).to eq(permission_template)
     end
   end

--- a/spec/models/hyrax/permission_template_spec.rb
+++ b/spec/models/hyrax/permission_template_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Hyrax::PermissionTemplate do
   let(:admin_set) { create(:admin_set) }
   let(:permission_template) { described_class.new(attributes) }
-  let(:attributes) { { admin_set_id: admin_set.id } }
+  let(:attributes) { { source_id: admin_set.id } }
 
   subject { permission_template }
 
@@ -53,7 +53,7 @@ RSpec.describe Hyrax::PermissionTemplate do
 
   describe "#admin_set" do
     it 'leverages AdminSet.find for the given permission_template' do
-      expect(AdminSet).to receive(:find).with(permission_template.admin_set_id).and_return(admin_set)
+      expect(AdminSet).to receive(:find).with(permission_template.source_id).and_return(admin_set)
       expect(permission_template.admin_set).to eq(admin_set)
     end
   end
@@ -62,12 +62,12 @@ RSpec.describe Hyrax::PermissionTemplate do
     subject { permission_template.release_fixed_date? }
 
     context "with release_period='fixed'" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
 
       it { is_expected.to be true }
     end
     context "with other release_period" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
 
       it { is_expected.to be false }
     end
@@ -77,12 +77,12 @@ RSpec.describe Hyrax::PermissionTemplate do
     subject { permission_template.release_no_delay? }
 
     context "with release_period='now'" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
 
       it { is_expected.to be true }
     end
     context "with other release_period" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
 
       it { is_expected.to be false }
     end
@@ -92,17 +92,17 @@ RSpec.describe Hyrax::PermissionTemplate do
     subject { permission_template.release_before_date? }
 
     context "with release_period='before'" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE } }
 
       it { is_expected.to be true }
     end
     context "with maximum embargo period (release_period of 1 year)" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR } }
 
       it { is_expected.to be true }
     end
     context "with other release_period" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
 
       it { is_expected.to be false }
     end
@@ -112,17 +112,17 @@ RSpec.describe Hyrax::PermissionTemplate do
     subject { permission_template.release_max_embargo? }
 
     context "with release_period of 1 year" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR } }
 
       it { is_expected.to be true }
     end
     context "with release_period of 2 years" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_2_YEARS } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_2_YEARS } }
 
       it { is_expected.to be true }
     end
     context "with other release_period" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
 
       it { is_expected.to be false }
     end
@@ -134,27 +134,27 @@ RSpec.describe Hyrax::PermissionTemplate do
     let(:today) { Time.zone.today }
 
     context "with today and release_fixed_date?" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: today } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: today } }
 
       it { is_expected.to eq today }
     end
     context "with today and release_before_date?" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: today } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: today } }
 
       it { is_expected.to eq today }
     end
     context "with release_period of 6 months" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_6_MONTHS } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_6_MONTHS } }
 
       it { is_expected.to eq today + 6.months }
     end
     context "with release_period of 1 year" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR } }
 
       it { is_expected.to eq today + 1.year }
     end
     context "with release_no_delay?" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
 
       it { is_expected.to eq today }
     end
@@ -166,46 +166,46 @@ RSpec.describe Hyrax::PermissionTemplate do
     subject { permission_template.valid_release_date?(date) }
 
     context "with any release date and one is not required" do
-      let(:attributes) { { admin_set_id: admin_set.id } }
+      let(:attributes) { { source_id: admin_set.id } }
 
       it { is_expected.to eq true }
     end
     context "with matching date and release_fixed_date?" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: date } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: date } }
 
       it { is_expected.to eq true }
     end
     context "with non-matching date and release_fixed_date?" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: date + 1.day } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: date + 1.day } }
 
       it { is_expected.to eq false }
     end
     context "with exact match date and release_before_date?" do
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: date } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: date } }
 
       it { is_expected.to eq true }
     end
     context "with future, valid date and release_before_date?" do
       let(:date) { Time.zone.today + 1.day }
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: Time.zone.today + 1.month } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: Time.zone.today + 1.month } }
 
       it { is_expected.to eq true }
     end
     context "with future, invalid date and release_before_date?" do
       let(:date) { Time.zone.today + 1.year }
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: Time.zone.today + 1.month } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: Time.zone.today + 1.month } }
 
       it { is_expected.to eq false }
     end
     context "with today release and release_no_delay?" do
       let(:date) { Time.zone.today }
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
 
       it { is_expected.to eq true }
     end
     context "with tomorrow release and release_no_delay?" do
       let(:date) { Time.zone.today + 1.day }
-      let(:attributes) { { admin_set_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
 
       it { is_expected.to eq false }
     end
@@ -217,17 +217,17 @@ RSpec.describe Hyrax::PermissionTemplate do
     subject { permission_template.valid_visibility?(visibility) }
 
     context "with matching visibility" do
-      let(:attributes) { { admin_set_id: admin_set.id, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC } }
+      let(:attributes) { { source_id: admin_set.id, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC } }
 
       it { is_expected.to eq true }
     end
     context "with non-matching visibility" do
-      let(:attributes) { { admin_set_id: admin_set.id, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED } }
+      let(:attributes) { { source_id: admin_set.id, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED } }
 
       it { is_expected.to eq false }
     end
     context "with visibility when none required" do
-      let(:attributes) { { admin_set_id: admin_set.id } }
+      let(:attributes) { { source_id: admin_set.id } }
 
       it { is_expected.to eq true }
     end

--- a/spec/models/sipity/workflow_spec.rb
+++ b/spec/models/sipity/workflow_spec.rb
@@ -57,18 +57,18 @@ module Sipity
     end
 
     context '.find_active_workflow_for' do
-      let(:admin_set_id) { 1234 }
-      let(:permission_template) { create(:permission_template, admin_set_id: admin_set_id) }
+      let(:source_id) { 1234 }
+      let(:permission_template) { create(:permission_template, source_id: source_id) }
 
       it 'returns the active workflow for the permission template' do
         active_workflow = create(:workflow, active: true, permission_template: permission_template)
         _inactive_workflow = create(:workflow, active: false, permission_template: permission_template)
-        expect(described_class.find_active_workflow_for(admin_set_id: admin_set_id)).to eq(active_workflow)
+        expect(described_class.find_active_workflow_for(admin_set_id: source_id)).to eq(active_workflow)
       end
 
       it 'raises an exception when none exists' do
         create(:workflow, active: false, permission_template: permission_template)
-        expect { described_class.find_active_workflow_for(admin_set_id: admin_set_id) }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { described_class.find_active_workflow_for(admin_set_id: source_id) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/presenters/hyrax/admin_set_options_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_options_presenter_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Hyrax::AdminSetOptionsPresenter do
 
       before do
         allow(presenter).to receive(:workflow) { nil }
-        create(:permission_template, admin_set_id: '123', visibility: 'open')
-        create(:permission_template, admin_set_id: '345', visibility: 'restricted')
+        create(:permission_template, source_id: '123', visibility: 'open')
+        create(:permission_template, source_id: '345', visibility: 'restricted')
       end
 
       it do
@@ -38,10 +38,10 @@ RSpec.describe Hyrax::AdminSetOptionsPresenter do
 
       before do
         allow(presenter).to receive(:workflow) { nil }
-        create(:permission_template, admin_set_id: '123', release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: today + 2.days)
-        create(:permission_template, admin_set_id: '345', release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY)
-        create(:permission_template, admin_set_id: '567', release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR)
-        create(:permission_template, admin_set_id: '789', release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: today + 1.month)
+        create(:permission_template, source_id: '123', release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: today + 2.days)
+        create(:permission_template, source_id: '345', release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY)
+        create(:permission_template, source_id: '567', release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR)
+        create(:permission_template, source_id: '789', release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: today + 1.month)
       end
 
       it do
@@ -57,7 +57,7 @@ RSpec.describe Hyrax::AdminSetOptionsPresenter do
       let(:results) { [solr_doc1] }
 
       before do
-        create(:permission_template, admin_set_id: '567')
+        create(:permission_template, source_id: '567')
       end
 
       it { is_expected.to eq [['Empty Template Set', '123', {}]] }

--- a/spec/search_builders/hyrax/admin_set_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/admin_set_search_builder_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::AdminSetSearchBuilder do
     context "when access is :deposit" do
       let(:access) { :deposit }
       let(:admin_set) { create(:admin_set) }
-      let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+      let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
 
       context "and user has access" do
         before do
@@ -83,9 +83,9 @@ RSpec.describe Hyrax::AdminSetSearchBuilder do
 
     context "when searching for deposit access" do
       let(:access) { :deposit }
-      let(:permission_template1) { create(:permission_template, admin_set_id: 7) }
-      let(:permission_template2) { create(:permission_template, admin_set_id: 8) }
-      let(:permission_template3) { create(:permission_template, admin_set_id: 9) }
+      let(:permission_template1) { create(:permission_template, source_id: 7) }
+      let(:permission_template2) { create(:permission_template, source_id: 8) }
+      let(:permission_template3) { create(:permission_template, source_id: 9) }
 
       before do
         create(:permission_template_access,

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Hyrax::AdminSetCreateService do
       subject { service.create }
 
       context "when the admin_set is valid" do
-        let(:permission_template) { Hyrax::PermissionTemplate.find_by(admin_set_id: admin_set.id) }
+        let(:permission_template) { Hyrax::PermissionTemplate.find_by(source_id: admin_set.id) }
         let(:grants) { permission_template.access_grants }
         let(:available_workflows) { [create(:workflow), create(:workflow)] }
 

--- a/spec/services/hyrax/workflow/workflow_factory_spec.rb
+++ b/spec/services/hyrax/workflow/workflow_factory_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Hyrax::Workflow::WorkflowFactory do
   describe '.create' do
     let(:work) { create(:work, with_admin_set: { with_permission_template: true }) }
-    let(:permission_template) { Hyrax::PermissionTemplate.find_by!(admin_set_id: work.admin_set_id) }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_by!(source_id: work.admin_set_id) }
     let(:workflow) { create(:workflow, active: true, permission_template: permission_template) }
     let(:attributes) { {} }
     let(:user) { create(:user) }


### PR DESCRIPTION
Fixes #1538 

(collections sprint)

This accomplishes:
* Changes the permission_templates `admin_set_id` column to `source_id` so that permission templates can be used with collections
* Adds a source_type column to permission_templates so we can identify if a template is for an admin set or collection.
* Makes the needed code changes to support the two database changes listed above.