### PR TITLE
merge master change from add_files_to_collection to add_works_to_collection

### DIFF
--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -34,7 +34,7 @@
         <%= t('.item_count') %> (<%= @presenter.total_items %>)
     <% end %>
     <%= link_to t('hyrax.collection.actions.add_works.label'),
-                hyrax.my_works_path(add_files_to_collection: @presenter.id),
+                hyrax.my_works_path(add_works_to_collection: @presenter.id),
                 title: t('hyrax.collection.actions.add_works.desc'),
                 class: 'btn btn-default pull-right' %>
   </h2>

--- a/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe 'hyrax/dashboard/collections/_show_actions.html.erb', type: :view
       render
       expect(rendered).to have_css('.actions-controls-collections .btn[href="/path/to/edit"]')
     end
-    it 'renders add_files_to_collection link' do
+    it 'renders add_works_to_collection link' do
       render
-      expect(rendered).to have_css(".actions-controls-collections .btn[href='#{hyrax.my_works_path(add_files_to_collection: presenter.id)}']")
+      expect(rendered).to have_css(".actions-controls-collections .btn[href='#{hyrax.my_works_path(add_works_to_collection: presenter.id)}']")
     end
     describe 'when the collection_type is nestable' do
       it 'renders a link to add_collections to this collection' do
@@ -48,9 +48,9 @@ RSpec.describe 'hyrax/dashboard/collections/_show_actions.html.erb', type: :view
       expect(rendered).not_to have_css('.actions-controls-collections .btn[href="/path/to/edit"]')
     end
 
-    it 'does not render add_files_to_collection link' do
+    it 'does not render add_works_to_collection link' do
       render
-      expect(rendered).not_to have_css(".actions-controls-collections .btn[href='#{hyrax.my_works_path(add_files_to_collection: presenter.id)}']")
+      expect(rendered).not_to have_css(".actions-controls-collections .btn[href='#{hyrax.my_works_path(add_works_to_collection: presenter.id)}']")
     end
 
     describe 'when the collection_type is not nestable' do


### PR DESCRIPTION
Fixes failing tests on collections-sprint branch that occurred after merge with master.

#### Failing test:
```
1) collection add works to collection preselects the collection we are adding works to

     Failure/Error: expect(page).not_to have_css("input#id_#{collection2.id}[checked='checked']")

       expected not to find visible css "input#id_3b65f022-a470-40b6-9062-8dcf72d4efa6[checked='checked']", found 1 match: ""
```

#### Cause and Solution
Occurrences of `add_files_to_collection` at master were changed to `add_works_to_collection` which is more accurate.  There were several uses of the old term in collections-sprint that weren't in master.  The additional occurrences are fixed by this PR.
