### PR TITLE
Store manage and create in collection_type_participant_table

### DIFF
--- a/app/models/hyrax/collection_type_participant.rb
+++ b/app/models/hyrax/collection_type_participant.rb
@@ -7,15 +7,13 @@ module Hyrax
     validates :access, presence: true
     validates :hyrax_collection_type_id, presence: true
 
-    CREATOR = 'creator'.freeze
-    MANAGER = 'manager'.freeze
+    def manager?
+      access == 'manage'
+    end
 
-    enum(
-      access: {
-        CREATOR => CREATOR,
-        MANAGER => MANAGER
-      }
-    )
+    def creator?
+      access == 'create'
+    end
 
     def label
       return agent_id unless agent_type == 'group'

--- a/app/views/hyrax/admin/collection_types/_form_participants.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_participants.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t('.add_participants') %></h2>
 <p><%= t('.instructions') %></p>
-<% access_options = options_for_select([['Manager', 'manager'], ['Creator', 'creator']]) %>
+<% access_options = options_for_select([['Manager', 'manage'], ['Creator', 'create']]) %>
 <% unless @collection_type_participant.nil? %>
   <%= simple_form_for @collection_type_participant,
                       url: hyrax.admin_collection_type_participants_path,

--- a/spec/views/hyrax/admin/collection_types/_form_participants_table.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_participants_table.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_participant_table.html.erb', 
         stub_model(Hyrax::CollectionTypeParticipant,
                    agent_type: 'user',
                    agent_id: user.user_key,
-                   access: 'manager')
+                   access: 'manage')
       end
 
       it 'lists the managers in the table' do
@@ -52,7 +52,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_participant_table.html.erb', 
         stub_model(Hyrax::CollectionTypeParticipant,
                    agent_type: 'user',
                    agent_id: user.user_key,
-                   access: 'creator')
+                   access: 'create')
       end
 
       it 'lists the creators in the table' do


### PR DESCRIPTION
Fixes #1518

Store access as verbs 'manage' and 'create' in collection_types_participant table 

@samvera/hyrax-code-reviewers
