### PR TITLE
Create dashboard collections sharing tab view

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -34,6 +34,13 @@ module Hyrax
         @repository = repository
       end
 
+      def permission_template
+        @permission_template ||= begin
+                                   template_model = PermissionTemplate.find_or_create_by(source_id: model.id)
+                                   PermissionTemplateForm.new(template_model)
+                                 end
+      end
+
       # @return [Hash] All FileSets in the collection, file.to_s is the key, file.id is the value
       def select_files
         Hash[all_files_with_access]

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -59,21 +59,23 @@
         </div>
       </div>
 
-      <div id="discovery" class="tab-pane">
-        <div class="panel panel-default labels">
-          <div class="panel-body">
-            <%= render 'form_discovery', f: f %>
+      <% if @form.persisted? %>
+        <div id="discovery" class="tab-pane">
+          <div class="panel panel-default labels">
+            <div class="panel-body">
+              <%= render 'form_discovery', f: f %>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div id="sharing" class="tab-pane">
-        <div class="panel panel-default labels" id="collection_permissions" data-param-key="<%= f.object.model_name.param_key %>">
-          <div class="panel-body">
-            <%= render 'form_share', f: f %>
+        <div id="sharing" class="tab-pane">
+          <div class="panel panel-default labels" id="collection_permissions" data-param-key="<%= f.object.model_name.param_key %>">
+            <div class="panel-body">
+              <%= render 'form_share', f: f %>
+            </div>
           </div>
         </div>
-      </div>
+      <% end %>
 
       <div class="panel-footer">
         <% if params[:action] == "new" %>

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -1,90 +1,68 @@
-<% depositor = f.object.depositor %>
+          <div id="participants" class="tab-pane">
+            <div class="panel panel-default labels">
+              <div class="panel-body">
+                <p><%= t('.note') %></p>
+                <h2><%= t('.add_sharing') %></h2>
+                <% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
+                <%= simple_form_for @form.permission_template,
+                                    url: [hyrax, :dashboard, @form, :permission_template],
+                                    html: { id: 'group-participants-form' } do |f| %>
+                  <div class="clearfix spacer">
+                  <%= f.fields_for 'access_grants_attributes',
+                                   f.object.access_grants.build(agent_type: 'group'),
+                                   index: 0 do |builder| %>
+                    <div class="form-inline">
+                      <label class="col-md-2 col-xs-4 control-label"><%= t('.add_group') %></label>
 
-<fieldset>
-  <legend>
-    Share With <small>(optional)</small>
-  </legend>
+                      <div class="col-md-10 col-xs-8 form-group">
+                        <%= builder.hidden_field :agent_type %>
+                        <%= builder.text_field :agent_id,
+                                         placeholder: "Search for a group...",
+                                         class: 'form-control' %>
+                        as
+                        <%= builder.select :access,
+                                     access_options,
+                                     { prompt: "Select a role..." },
+                                     class: 'form-control' %>
 
-  <div class="alert alert-info hidden" id="save_perm_note">Permissions are
-  <strong>not</strong> saved until the &quot;Update Collection&quot; button is pressed at the bottom of the page.</div>
+                                   <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
+                      </div>
+                    </div>
+                  <% end %>
+                  </div>
+                <% end %>
 
-  <div class="alert alert-warning hidden" role="alert" id="permissions_error">
-    <span id="permissions_error_text"></span>
-  </div>
+                <%= simple_form_for @form.permission_template,
+                                    url: [hyrax, :dashboard, @form, :permission_template],
+                                    html: { id: 'user-participants-form' } do |f| %>
+                  <%= f.fields_for 'access_grants_attributes',
+                                   f.object.access_grants.build(agent_type: 'user'),
+                                   index: 0 do |builder| %>
+                    <div class="form-inline add-users">
+                      <label class="col-md-2 col-xs-4 control-label"><%= t('.add_user') %></label>
 
-  <table class="table">
-    <tr id="file_permissions">
-      <td width="20%">
-        <%= Hyrax.config.owner_permission_levels.keys[0] %>
-      </td>
-      <td width="60%">
-        <%= label_tag :owner_access, class: "control-label" do %>
-          Depositor (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
-        <% end %>
-      </td>
-    </tr>
-    <%= f.fields_for :permissions do |permission_fields| %>
-      <%# skip the public, registered, and depositor perms as they are displayed first at the top %>
-      <% next if ['public', 'registered', depositor].include? permission_fields.object.agent_name.downcase %>
-      <tr>
-        <td>
-          <%= permission_fields.select :access, Hyrax.config.permission_levels, {}, class: 'form-control select_perm' %>
-        </td>
-        <td>
-          <%= permission_fields.label :agent_name, class: "control-label" do %>
-            <%= user_display_name_and_key(permission_fields.object.agent_name) %>
-          <% end %>
-          <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">&times;</button>
-        </td>
-      </tr>
-    <% end %>
-  </table>
+                      <div class="col-md-10 col-xs-8 form-group">
+                        <%= builder.hidden_field :agent_type %>
+                        <%= builder.text_field :agent_id,
+                                         placeholder: "Search for a user..." %>
+                        as
+                        <%= builder.select :access,
+                                     access_options,
+                                     { prompt: "Select a role..." },
+                                     class: 'form-control' %>
 
-  <h4>Share work with other users</h4>
-  <p class="sr-only">Use the add button to give access to one <%=t('hyrax.account_label') %> at a time (it will be added to the list below).
-    Select the user, by name or <%= t('hyrax.account_label') %>. Then select the access level you wish to grant and click on Add this
-    <%= t('hyrax.account_label') %> to complete adding the permission.
-  </p>
-  <div class="form-group row">
-    <div class="col-sm-5">
-      <label for="new_user_name_skel" class="sr-only"><%= t('hyrax.account_label') %> (without the <%= t('hyrax.directory.suffix') %> part)</label>
-      <%= text_field_tag 'new_user_name_skel', nil %>
-    </div>
-    <div class="col-sm-4">
-      <label for="new_user_permission_skel" class="sr-only">Access type to grant</label>
-      <%= select_tag 'new_user_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
-    </div>
-    <div class="col-sm-3">
-      <button class="btn btn-default" id="add_new_user_skel">
-        <span class="sr-only">Add this <%= t('hyrax.account_label') %></span>
-        <span aria-hidden="true"><i class="glyphicon glyphicon-plus"></i></span>
-      </button>
-      <br /> <span id="directory_user_result"></span>
-    </div>
-  </div>
+                        <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
+                      </div>
+                    </div>
+                  <% end %>
+                <% end %>
 
-  <h4>Share work with groups of users</h4>
-  <p class="sr-only">Use the add button to give access to one group at a time (it will be added to the list below).</p>
-  <div class="form-group row">
-    <div class="col-sm-5">
-      <label for="new_group_name_skel" class="sr-only">Group</label>
-      <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>
-    </div>
-    <div class="col-sm-4">
-      <label for="new_group_permission_skel" class="sr-only">Access type to grant</label>
-      <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
-    </div>
-    <div class="col-sm-3">
-      <span class="sr-only">Add this group</span>
-      <button class="btn btn-default" id="add_new_group_skel"><i class="glyphicon glyphicon-plus"></i></button>
-      <br /><span id="directory_group_result"></span>
-    </div>
-  </div>
-
-  <script type="text/x-tmpl" id="tmpl-collection-grant">
-  <tr>
-    <td>{%= o.accessLabel %}</td>
-    <td><label class="control-label">{%= o.name %}</label> <button class="btn close">&times;</button></td>
-  </tr>
-  </script>
-</fieldset>
+                <fieldset>
+                  <legend><%= t(".current_shared") %></legend>
+                  <%= render 'form_share_table', access: 'managers', filter: :manage? %>
+                  <%= render 'form_share_table', access: 'depositors', filter: :deposit? %>
+                  <%= render 'form_share_table', access: 'viewers', filter: :view? %>
+                </fieldset>
+              </div>
+            </div>
+          </div>

--- a/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
@@ -1,0 +1,30 @@
+                  <h3><%= t(".#{access}.title") %></h3>
+                  <p><%= t(".#{access}.help") %></p>
+                  <% if @form.permission_template.access_grants.select(&filter).any? %>
+                    <table class="table table-striped share-status">
+                      <thead>
+                        <tr>
+                          <th><%= t(".#{access}.agent_name") %></th>
+                          <th><%= t(".#{access}.type") %></th>
+                          <th><%= t(".#{access}.action") %></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                      <% @form.permission_template.access_grants.select(&filter).each do |g| %>
+                        <tr>
+                          <td data-agent="<%= g.agent_id %>"><%= g.label %></td>
+                          <td><%= g.agent_type.titleize %></td>
+                          <td>
+                            <% if g.admin_group? %>
+                              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
+                            <% else %>
+                              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger' %>
+                            <% end %>
+                          </td>
+                        </tr>
+                      <% end %>
+                      </tbody>
+                    </table>
+                  <% else %>
+                    <p><em><%= t(".#{access}.empty") %></em></p>
+                  <% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -501,6 +501,38 @@ en:
               description:   "Keep to myself with an option to share"
             para1: "These settings determine who is able to discover and view this collection's landing page; they do not affect the visibility of items in the collection."
             para2: "If you chose not to make this collection open access, you can still share the collection with specific users and groups using the Sharing tab."
+        form_share_table:
+          allow_all_registered: "Allow all registered"
+          depositors:
+            action: "Action"
+            agent_name: "User/Group"
+            empty: "No depositors have been added to this collection."
+            help: "Depositors of this collection can view the collection and add works to it, even if the visibility permissions of the collecton otherwise would not permit them to view it."
+            remove: "Remove"
+            title: "Depositors"
+            type: "Type"
+          managers:
+            action: "Action"
+            agent_name: "User/Group"
+            empty: "No managers have been added to this collection."
+            help: "Managers of this collection can add to and remove works from the collection, modify collection metadata, and delete the collection."
+            remove: "Remove"
+            title: "Managers"
+            type: "Type"
+          viewers:
+            action: "Action"
+            agent_name: "User/Group"
+            empty: "No viewers have been added to this collection."
+            help: "Viewers of this collection can view it even if the visibility permissions of the collection otherwise would not permit them to view it."
+            remove: "Remove"
+            title: "Viewers"
+            type: "Type"
+        form_share:
+          add_group: "Add group"
+          add_sharing: "Add Sharing"
+          add_user: "Add user"
+          current_shared: "Currently Shared With"
+          note: "Regardless of the visibility settings of this collection, you can share this collection with specific groups and users."
         new:
           header: Create New Collection
         show:

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     transient do
       user { FactoryGirl.create(:user) }
       collection_type_settings [:nestable, :discoverable, :sharable, :allow_multiple_membership]
+      with_permission_template false
     end
     sequence(:title) { |n| ["Title #{n}"] }
 
@@ -13,6 +14,14 @@ FactoryGirl.define do
       if collection.collection_type_gid.nil?
         collection_type = FactoryGirl.create(:collection_type, *evaluator.collection_type_settings)
         collection.collection_type_gid = collection_type.gid
+      end
+    end
+
+    after(:create) do |collection, evaluator|
+      if evaluator.with_permission_template
+        attributes = { source_id: collection.id }
+        attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
+        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
       end
     end
 

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -146,4 +146,28 @@ RSpec.describe Hyrax::Forms::CollectionForm do
       end
     end
   end
+
+  describe "#permission_template" do
+    subject { form.permission_template }
+
+    context "when the PermissionTemplate doesn't exist" do
+      let(:model) { create(:collection) }
+
+      it "gets created" do
+        expect(subject).to be_instance_of Hyrax::Forms::PermissionTemplateForm
+        expect(subject.model).to be_instance_of Hyrax::PermissionTemplate
+      end
+    end
+
+    context "when the PermissionTemplate exists" do
+      let(:form) { described_class.new(model, ability, repository) }
+      let(:permission_template) { Hyrax::PermissionTemplate.find_by(source_id: model.id) }
+      let(:model) { create(:collection, with_permission_template: true) }
+
+      it "uses the existing template" do
+        expect(subject).to be_instance_of Hyrax::Forms::PermissionTemplateForm
+        expect(subject.model).to eq permission_template
+      end
+    end
+  end
 end

--- a/spec/views/hyrax/dashboard/collections/_form_share.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_share.erb_spec.rb
@@ -1,42 +1,19 @@
 RSpec.describe 'hyrax/dashboard/collections/_form_share.html.erb', type: :view do
-  let(:collection) do
-    stub_model(Collection, id: '123', depositor: 'bob')
-  end
-
-  let(:form) do
-    view.simple_form_for(collection, url: '/update') do |fs_form|
-      return fs_form
-    end
+  let(:template) { stub_model(Hyrax::PermissionTemplate) }
+  let(:pt_form) do
+    instance_double(Hyrax::Forms::PermissionTemplateForm,
+                    model_name: template.model_name,
+                    to_key: template.to_key,
+                    access_grants: template.access_grants)
   end
 
   before do
-    allow(controller).to receive(:current_user).and_return(stub_model(User))
-    allow(collection).to receive(:permissions).and_return(permissions)
-    allow(view).to receive(:f).and_return(form)
-    view.lookup_context.prefixes.push 'hyrax/base'
-    view.extend Hyrax::PermissionsHelper
+    @form = instance_double(Hyrax::Forms::CollectionForm,
+                            to_model: stub_model(Collection),
+                            permission_template: pt_form)
     render
   end
-
-  context "without additional users" do
-    let(:permissions) { [] }
-
-    it "draws the permissions form without error" do
-      expect(rendered).to have_css("input#new_user_name_skel")
-      expect(rendered).not_to have_css("button.remove_perm")
-    end
-  end
-
-  context "with additional users" do
-    let(:depositor_permission) { Hydra::AccessControls::Permission.new(id: '123', name: 'bob', type: 'person', access: 'edit') }
-    let(:public_permission) { Hydra::AccessControls::Permission.new(id: '124', name: 'public', type: 'group', access: 'read') }
-    let(:other_permission) { Hydra::AccessControls::Permission.new(id: '125', name: 'joe@example.com', type: 'person', access: 'edit') }
-    let(:permissions) { [depositor_permission, public_permission, other_permission] }
-
-    it "draws the permissions form without error" do
-      expect(rendered).to have_css("input#new_user_name_skel")
-      expect(rendered).to have_css("button.remove_perm", count: 1) # depositor and public should be filtered out
-      expect(rendered).to have_css("button.remove_perm[data-index='2']")
-    end
+  it "has the required selectors" do
+    expect(rendered).to have_selector('#participants #user-participants-form input[type=text]')
   end
 end

--- a/spec/views/hyrax/dashboard/collections/_form_share_table.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_share_table.html.erb_spec.rb
@@ -1,0 +1,106 @@
+RSpec.describe 'hyrax/dashboard/collections/_form_share_table.html.erb', type: :view do
+  let(:template) { stub_model(Hyrax::PermissionTemplate) }
+  let(:user) { create(:user) }
+  let(:access_grant) { stub_model(Hyrax::PermissionTemplateAccess) }
+  let(:pt_form) do
+    instance_double(Hyrax::Forms::PermissionTemplateForm,
+                    model_name: template.model_name,
+                    to_key: template.to_key,
+                    access_grants: [access_grant])
+  end
+
+  before do
+    @form = instance_double(Hyrax::Forms::CollectionForm,
+                            to_model: stub_model(Collection),
+                            permission_template: pt_form)
+    # Ignore the delete button link
+    allow(view).to receive(:admin_permission_template_access_path).and_return("/admin/permission_template_accesses/123")
+  end
+
+  describe "Manager shares table" do
+    before do
+      render 'form_share_table', access: "managers", filter: :manage?
+    end
+
+    context "managers exist" do
+      let(:access_grant) do
+        stub_model(Hyrax::PermissionTemplateAccess,
+                   agent_type: 'user',
+                   agent_id: user.user_key,
+                   access: 'manage')
+      end
+
+      it "lists the managers in the table" do
+        expect(rendered).to have_selector("h3", text: "Managers")
+        expect(rendered).to have_selector("table tbody", text: user.user_key)
+      end
+    end
+    context "no managers exist" do
+      let(:access_grant) { stub_model(Hyrax::PermissionTemplateAccess) }
+
+      it "displays a message and no table" do
+        expect(rendered).to have_selector("h3", text: "Managers")
+        expect(rendered).not_to have_selector("table")
+        expect(rendered).to have_content("No managers have been added to this collection.")
+      end
+    end
+  end
+
+  describe "Viewer shares table" do
+    before do
+      render 'form_share_table', access: "viewers", filter: :view?
+    end
+
+    context "viewers exist" do
+      let(:access_grant) do
+        stub_model(Hyrax::PermissionTemplateAccess,
+                   agent_type: 'user',
+                   agent_id: user.user_key,
+                   access: 'view')
+      end
+
+      it "lists the viewers in the table" do
+        expect(rendered).to have_selector("h3", text: "Viewers")
+        expect(rendered).to have_selector("table tbody", text: user.user_key)
+      end
+    end
+    context "no viewers exist" do
+      let(:access_grant) { stub_model(Hyrax::PermissionTemplateAccess) }
+
+      it "displays a message and no table" do
+        expect(rendered).to have_selector("h3", text: "Viewers")
+        expect(rendered).not_to have_selector("table")
+        expect(rendered).to have_content("No viewers have been added to this collection.")
+      end
+    end
+  end
+
+  describe "Depositor shares table" do
+    before do
+      render 'form_share_table', access: "depositors", filter: :deposit?
+    end
+
+    context "depositors exist" do
+      let(:access_grant) do
+        stub_model(Hyrax::PermissionTemplateAccess,
+                   agent_type: 'user',
+                   agent_id: user.user_key,
+                   access: 'deposit')
+      end
+
+      it "lists the depositors in the table" do
+        expect(rendered).to have_selector("h3", text: "Depositors")
+        expect(rendered).to have_selector("table tbody", text: user.user_key)
+      end
+    end
+    context "no depositors exist" do
+      let(:access_grant) { stub_model(Hyrax::PermissionTemplateAccess) }
+
+      it "displays a message and no table" do
+        expect(rendered).to have_selector("h3", text: "Depositors")
+        expect(rendered).not_to have_selector("table")
+        expect(rendered).to have_content("No depositors have been added to this collection.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1378

(collections sprint)

This commit creates the share tab for collections and sets up the needed code for the form.  The tab shows when editing a work (not on create).  The form uses the new dashboard collections routes and sends the appropriate parameters.

A remaining piece is to modify the PermissionTemplates controller to receive and handle collection IDs in addition to admin set IDs.  I'm working on that now (new issue #1593), but thought it would be good to get the rest of this into a PR for people to start reviewing.
