### PR TITLE
fix 1591 - All Collections should use presenter to drive data

### DIFF
--- a/app/views/hyrax/collections/_list_collections.html.erb
+++ b/app/views/hyrax/collections/_list_collections.html.erb
@@ -1,4 +1,4 @@
-<% id = document.id %>
+<% id = collection_presenter.id %>
 <tr id="document_<%= id %>">
   <td></td>
   <td>
@@ -8,19 +8,22 @@
         <div class="media-heading">
           <%= link_to hyrax.dashboard_collection_path(id) do %>
               <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %> </span>
-              <%= document.title_or_label %>
+              <%= collection_presenter.title_or_label %>
           <% end %>
           <a href="#" class="small" title="Click for more details">
             <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i>
-            <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{document.title_or_label}" %></span>
+            <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{collection_presenter.title_or_label}" %></span>
           </a>
         </div>
       </div>
     </div>
   </td>
-  <td class="text-center"><%= document.create_date %> </td>
+
+  <td class="collection_type"><%= collection_presenter.collection_type_badge %></td>
+
+  <td class="text-center date"><%=collection_presenter.create_date.try(:to_formatted_s, :standard) %> </td>
   <td class="text-center">
-    <%= render_visibility_link(document) %>
+    <%= render_visibility_link(collection_presenter.solr_document) %>
   </td>
   <td class="text-center">
     <%= render 'collection_action_menu', id: id %>
@@ -30,14 +33,14 @@
   <td colspan="6">
     <dl class="expanded-details row">
       <dt class="col-xs-3 col-lg-2"><%= t("hyrax.dashboard.my.collection_list.description") %></dt>
-      <dd class="col-xs-9 col-lg-10"><%= document.description.first %></dd>
+      <dd class="col-xs-9 col-lg-10"><%= collection_presenter.description.first %></dd>
       <dt class="col-xs-3 col-lg-2"><%= t("hyrax.dashboard.my.collection_list.edit_access") %></dt>
       <dd class="col-xs-9 col-lg-10">
-      <% if document.edit_groups.present? %>
-        <%= t("hyrax.dashboard.my.collection_list.groups") %> <%= document.edit_groups.join(', ') %>
+      <% if collection_presenter.edit_groups.present? %>
+        <%= t("hyrax.dashboard.my.collection_list.groups") %> <%= collection_presenter.edit_groups.join(', ') %>
         <br/>
       <% end %>
-        <%= t("hyrax.dashboard.my.collection_list.users") %> <%= document.edit_people.join(', ') %>
+        <%= t("hyrax.dashboard.my.collection_list.users") %> <%= collection_presenter.edit_people.join(', ') %>
       </dd>
     </dl>
   </td>

--- a/app/views/hyrax/collections/_show_document_list.html.erb
+++ b/app/views/hyrax/collections/_show_document_list.html.erb
@@ -3,9 +3,10 @@
   <thead>
   <tr>
     <th>&nbsp;</th>
-    <th>Title</th>
-    <th>Date Uploaded</th>
-    <th>Visibility</th>
+    <th><%= t("hyrax.dashboard.my.heading.title") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.collection_type") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
   </tr>
   </thead>
   <tbody>

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -1,4 +1,4 @@
-<% id = document.id %>
+<% id = collection_presenter.id %>
 <tr id="document_<%= id %>">
   <td></td>
   <td>
@@ -8,19 +8,19 @@
         <div class="media-heading">
           <%= link_to hyrax.dashboard_collection_path(id) do %>
               <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %> </span>
-              <%= document.title_or_label %>
+              <%= collection_presenter.title_or_label %>
           <% end %>
           <a href="#" class="small" title="Click for more details">
             <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i>
-            <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{document.title_or_label}" %></span>
+            <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{collection_presenter.title_or_label}" %></span>
           </a>
         </div>
       </div>
     </div>
   </td>
-  <td class="text-center"><%= document.create_date %> </td>
+  <td class="text-center"><%= collection_presenter.create_date %> </td>
   <td class="text-center">
-    <%= render_visibility_link(document) %>
+    <%= render_visibility_link(collection_presenter.solr_document) %>
   </td>
   <td class="text-center">
     <%= render 'collection_action_menu', id: id %>
@@ -30,14 +30,14 @@
   <td colspan="6">
     <dl class="expanded-details row">
       <dt class="col-xs-3 col-lg-2"><%= t("hyrax.dashboard.my.collection_list.description") %></dt>
-      <dd class="col-xs-9 col-lg-10"><%= document.description.first %></dd>
+      <dd class="col-xs-9 col-lg-10"><%= collection_presenter.description.first %></dd>
       <dt class="col-xs-3 col-lg-2"><%= t("hyrax.dashboard.my.collection_list.edit_access") %></dt>
       <dd class="col-xs-9 col-lg-10">
-      <% if document.edit_groups.present? %>
-        <%= t("hyrax.dashboard.my.collection_list.groups") %> <%= document.edit_groups.join(', ') %>
+      <% if collection_presenter.edit_groups.present? %>
+        <%= t("hyrax.dashboard.my.collection_list.groups") %> <%= collection_presenter.edit_groups.join(', ') %>
         <br/>
       <% end %>
-        <%= t("hyrax.dashboard.my.collection_list.users") %> <%= document.edit_people.join(', ') %>
+        <%= t("hyrax.dashboard.my.collection_list.users") %> <%= collection_presenter.edit_people.join(', ') %>
       </dd>
     </dl>
   </td>

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -1,9 +1,72 @@
 RSpec.describe 'collection', type: :feature, clean_repo: true do
   let(:user) { create(:user) }
+  let(:admin_user) { create(:admin) }
   let(:collection_type) { create(:collection_type) }
 
   let(:collection1) { create(:public_collection, user: user, collection_type_gid: collection_type.gid) }
   let(:collection2) { create(:public_collection, user: user, collection_type_gid: collection_type.gid) }
+  let(:collection3) { create(:public_collection, user: admin_user, collection_type_gid: collection_type.gid) }
+
+  describe 'Your Collections tab' do
+    context 'when non-admin user' do
+      before do
+        sign_in user
+        visit '/dashboard/my/collections'
+      end
+
+      it 'has page title' do
+        expect(page).to have_content 'Collections'
+      end
+
+      it 'does not have tabs' do
+        expect(page).not_to have_link 'All Collections'
+        expect(page).not_to have_link 'Your Collections'
+      end
+
+      it "lists only user's collections" do
+        expect(page).to have_link(collection1.title)
+        expect(page).to have_link(collection2.title)
+        expect(page).not_to have_link(collection3.title)
+      end
+    end
+
+    context 'when admin user' do
+      before do
+        sign_in admin_user
+        visit '/dashboard/my/collections'
+      end
+
+      it 'has page title' do
+        expect(page).to have_content 'Collections'
+      end
+
+      it 'has tabs for All and Your Collections' do
+        expect(page).to have_link 'All Collections'
+        expect(page).to have_link 'Your Collections'
+      end
+
+      it "lists only admin_user's collections" do
+        expect(page).not_to have_link(collection1.title)
+        expect(page).not_to have_link(collection2.title)
+        expect(page).to have_link(collection3.title)
+      end
+    end
+  end
+
+  describe 'All Collections tab (for admin users only)' do
+    before do
+      sign_in admin_user
+      visit '/dashboard/my/collections'
+    end
+
+    it 'lists all collections for all users' do
+      expect(page).to have_link 'All Collection'
+      click_link 'All Collections'
+      expect(page).to have_link(collection1.title)
+      expect(page).to have_link(collection2.title)
+      expect(page).to have_link(collection3.title)
+    end
+  end
 
   describe 'create collection' do
     before do


### PR DESCRIPTION
Fixes #1591

Your Collections was updated to use the collection presenter to drive the data.  The same change needed to be made for All Collections.

I also added tests to catch when a change was made to one, but not the other.  If either page falls over with an exception, the tests will now catch that.