### PR TITLE
Change 'All rights reserved' to active:false

### DIFF
--- a/lib/generators/hyrax/templates/config/authorities/licenses.yml
+++ b/lib/generators/hyrax/templates/config/authorities/licenses.yml
@@ -25,4 +25,4 @@ terms:
       active: true
     - id: http://www.europeana.eu/portal/rights/rr-r.html
       term: All rights reserved
-      active: true
+      active: false


### PR DESCRIPTION
Fixes #589

Change 'All rights reserved' URI to active:false.
The RR-R URI is used in a couple specs, but it seemed they were more for formatting and thus didn't need updating.

@samvera/hyrax-code-reviewers
