### PR TITLE
replacing unreliable capybara assertions and adding chromedriver-helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem "chromedriver-helper"
   gem 'coveralls', require: false
   gem 'pry' unless ENV['CI']
   gem 'pry-byebug' unless ENV['CI']

--- a/lib/generators/hyrax/work/templates/feature_spec.rb.erb
+++ b/lib/generators/hyrax/work/templates/feature_spec.rb.erb
@@ -27,7 +27,7 @@ RSpec.feature 'Create a <%= class_name %>', js: false do
       # choose "payload_concern", option: "<%= class_name %>"
       # click_button "Create work"
 
-      expect(page).to have_content "Add New <%= human_name %>"
+      page.assert_text "Add New <%= human_name %>"
     end
   end
 end

--- a/spec/features/admin_admin_set_spec.rb
+++ b/spec/features/admin_admin_set_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe "The admin sets, through the admin dashboard" do
     click_link "Administrative Sets"
     click_link title
 
-    expect(page).to have_content "A substantial description"
-    expect(page).to have_content "Works in This Set"
+    page.assert_text "A substantial description"
+    page.assert_text "Works in This Set"
 
     click_link "Edit"
     within('#description') do
       fill_in "Title", with: 'A better unique name'
       click_button 'Save'
     end
-    expect(page).to have_content "A better unique name"
+    page.assert_text "A better unique name"
   end
 end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe "The admin dashboard", :clean_repo do
     login_as(user, scope: :user)
     visit '/dashboard'
 
-    expect(find('tr', text: 'First Admin Set').find('td:eq(2)')).to have_content(1)
-    expect(find('tr', text: 'First Admin Set').find('td:eq(3)')).to have_content(2)
+    find('tr', text: 'First Admin Set').find('td:eq(2)').assert_text(1)
+    find('tr', text: 'First Admin Set').find('td:eq(3)').assert_text(2)
 
-    expect(find('tr', text: 'Second Admin Set').find('td:eq(2)')).to have_content(2)
-    expect(find('tr', text: 'Second Admin Set').find('td:eq(3)')).to have_content(3)
+    find('tr', text: 'Second Admin Set').find('td:eq(2)').assert_text(2)
+    find('tr', text: 'Second Admin Set').find('td:eq(3)').assert_text(3)
   end
 end

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -9,10 +9,10 @@ RSpec.feature 'Batch creation of works', type: :feature do
 
   it "renders the batch create form" do
     visit hyrax.new_batch_upload_path
-    expect(page).to have_content "Add New Works by Batch"
+    page.assert_text "Add New Works by Batch"
     within("li.active") do
-      expect(page).to have_content("Files")
+      page.assert_text("Files")
     end
-    expect(page).to have_content("Each file will be uploaded to a separate new work resulting in one work per uploaded file.")
+    page.assert_text("Each file will be uploaded to a separate new work resulting in one work per uploaded file.")
   end
 end

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
       visit '/dashboard/my/works'
       check 'check_all'
       find('#batch-edit').click
-      expect(page).to have_content('Batch Edit Descriptions')
+      page.assert_text('Batch Edit Descriptions')
       batch_edit_expand("creator") do
         page.find("input#generic_work_creator[value='NEW creator']")
       end
@@ -65,6 +65,7 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
   describe 'deleting' do
     it 'destroys the selected works' do
       accept_confirm { click_button 'Delete Selected' }
+      sleep(10)
       expect(GenericWork.count).to be_zero
     end
   end

--- a/spec/features/browse_catalog_spec.rb
+++ b/spec/features/browse_catalog_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe "Browse catalog:", type: :feature do
     it 'using facet pagination to browse by keywords' do
       click_button "search-submit-header"
 
-      expect(page).to have_content 'Search Results'
-      expect(page).to have_content jills_work.title.first
-      expect(page).to have_content jacks_work.title.first
+      page.assert_text 'Search Results'
+      page.assert_text jills_work.title.first
+      page.assert_text jacks_work.title.first
 
       click_link "Keyword"
       click_link "more Keywords »"
@@ -42,20 +42,20 @@ RSpec.describe "Browse catalog:", type: :feature do
       end
 
       within(".modal-body") do
-        expect(page).not_to have_content 'keyword05'
-        expect(page).to have_content 'keyword21'
+        page.assert_no_text 'keyword05'
+        page.assert_text 'keyword21'
 
         click_link 'keyword21'
       end
 
-      expect(page).to have_content jills_work.title.first
-      expect(page).not_to have_content jacks_work.title.first
+      page.assert_text jills_work.title.first
+      page.assert_no_text jacks_work.title.first
 
       # TODO:  After the _generic_work.html.erb view is finished
       #
       #      click_link jills_work.title.first
       #      expect(page).to     have_content "Download"
-      #      expect(page).not_to have_content "Edit"
+      #      expect(page).not_assert_text "Edit"
     end
   end
 end

--- a/spec/features/browse_dashboard_works_spec.rb
+++ b/spec/features/browse_dashboard_works_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe "Browse Dashboard", type: :feature do
   it "lets the user search and display their files" do
     fill_in "q", with: "PDF"
     click_button "search-submit-header"
-    expect(page).to have_content("Fake PDF Title")
+    page.assert_text("Fake PDF Title")
     within(".constraints-container") do
-      expect(page).to have_content("Filtering by:")
+      page.assert_text("Filtering by:")
       expect(page).to have_css("span.glyphicon-remove")
       find(".dropdown-toggle").click
     end
-    expect(page).to have_content("Fake Wav File")
+    page.assert_text("Fake Wav File")
 
     # Browse facets
     click_button "Status"
@@ -42,14 +42,15 @@ RSpec.describe "Browse Dashboard", type: :feature do
 
     within("#document_#{dissertation.id}") do
       click_button("Select")
-      expect(page).to have_content("Edit Work")
+      page.assert_text("Edit Work")
     end
   end
 
   it "allows me to delete works in upload_sets", js: true do
     first('input#check_all').click
-    expect do
-      accept_confirm { click_button('Delete Selected') }
-    end.to change { GenericWork.count }.by(-3)
+    number_of_works = GenericWork.count
+    accept_confirm { click_button('Delete Selected') }
+    sleep(10)
+    expect(GenericWork.count).to eq(number_of_works - 3)
   end
 end

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe 'catalog searching', type: :feature do
         click_button('Go')
       end
 
-      expect(page).to have_content('Search Results')
-      expect(page).to have_content(jills_work.title.first)
-      expect(page).to have_content(jacks_work.title.first)
-      expect(page).to have_content(collection.title.first)
+      page.assert_text('Search Results')
+      page.assert_text(jills_work.title.first)
+      page.assert_text(jacks_work.title.first)
+      page.assert_text(collection.title.first)
     end
   end
 end

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -17,38 +17,38 @@ RSpec.describe 'collection', type: :feature do
     end
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
-      expect(page).to have_content(collection.title.first)
-      expect(page).to have_content(collection.description.first)
+      page.assert_text(collection.title.first)
+      page.assert_text(collection.description.first)
       # Should not show title and description a second time
       expect(page).not_to have_css('.metadata-collections', text: collection.title.first)
       expect(page).not_to have_css('.metadata-collections', text: collection.description.first)
       # Should not have Collection Descriptive metadata table
-      expect(page).to have_content("Descriptions")
+      page.assert_text("Descriptions")
       # Should have search results / contents listing
-      expect(page).to have_content(work1.title.first)
-      expect(page).to have_content(work2.title.first)
+      page.assert_text(work1.title.first)
+      page.assert_text(work2.title.first)
       expect(page).not_to have_css(".pager")
 
       click_link "Gallery"
-      expect(page).to have_content(work1.title.first)
-      expect(page).to have_content(work2.title.first)
+      page.assert_text(work1.title.first)
+      page.assert_text(work2.title.first)
     end
 
     it "hides collection descriptive metadata when searching a collection" do
-      expect(page).to have_content(collection.title.first)
-      expect(page).to have_content(collection.description.first)
-      expect(page).to have_content(work1.title.first)
-      expect(page).to have_content(work2.title.first)
+      page.assert_text(collection.title.first)
+      page.assert_text(collection.description.first)
+      page.assert_text(work1.title.first)
+      page.assert_text(work2.title.first)
       fill_in('collection_search', with: work1.title.first)
       click_button('collection_submit')
       # Should not have Collection metadata table (only title and description)
-      expect(page).not_to have_content("Total works")
-      expect(page).to have_content(collection.title.first)
-      expect(page).to have_content(collection.description.first)
+      page.assert_no_text("Total works")
+      page.assert_text(collection.title.first)
+      page.assert_text(collection.description.first)
       # Should have search results / contents listing
-      expect(page).to have_content("Search Results")
-      expect(page).to have_content(work1.title.first)
-      expect(page).not_to have_content(work2.title.first)
+      page.assert_text("Search Results")
+      page.assert_text(work1.title.first)
+      page.assert_no_text(work2.title.first)
     end
   end
 

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe "Sending an email via the contact form", type: :feature do
   it "sends mail" do
     visit '/'
     click_link "Contact"
-    expect(page).to have_content "Contact Form"
+    page.assert_text "Contact Form"
     fill_in "Your Name", with: "Test McPherson"
     fill_in "Your Email", with: "archivist1@example.com"
     fill_in "Message", with: "I am contacting you regarding ScholarSphere."
     fill_in "Subject", with: "My Subject is Cool"
     select "Depositing content", from: "Issue Type"
     click_button "Send"
-    expect(page).to have_content "Thank you for your message!"
+    page.assert_text "Thank you for your message!"
   end
 end

--- a/spec/features/create_child_work_spec.rb
+++ b/spec/features/create_child_work_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Creating a new child Work', :workflow do
       click_on('Save')
     end
     visit "/concern/generic_works/#{parent.id}"
-    expect(page).to have_content work_title
+    page.assert_text work_title
   end
 
   context "when it's being updated" do
@@ -75,7 +75,7 @@ RSpec.feature 'Creating a new child Work', :workflow do
         click_on "Save"
 
         expect(new_parent.reload.ordered_members.to_a.length).to eq 0
-        expect(page).to have_content "Works can only be related to each other if user has ability to edit both."
+        page.assert_text "Works can only be related to each other if user has ability to edit both."
       end
     end
   end

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -27,8 +27,8 @@ RSpec.feature 'Creating a new Work', :js, :workflow do
 
     it 'creates the work' do
       click_link "Files" # switch tab
-      expect(page).to have_content "Add files"
-      expect(page).to have_content "Add folder"
+      page.assert_text "Add files"
+      page.assert_text "Add folder"
       within('span#addfiles') do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
@@ -43,15 +43,15 @@ RSpec.feature 'Creating a new Work', :js, :workflow do
       # its element
       find('body').click
       choose('generic_work_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      page.assert_text('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
       check('agreement')
       # These lines are for debugging, should this test fail
       # puts "Required metadata: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').requiredFields.areComplete})}"
       # puts "Required files: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').uploads.hasFiles})}"
       # puts "Agreement : #{page.evaluate_script(%{$('#form-progress').data('save_work_control').depositAgreement.isAccepted})}"
       click_on('Save')
-      expect(page).to have_content('My Test Work')
-      expect(page).to have_content "Your files are being processed by Hyrax in the background."
+      page.assert_text('My Test Work')
+      page.assert_text "Your files are being processed by Hyrax in the background."
     end
   end
 
@@ -69,7 +69,7 @@ RSpec.feature 'Creating a new Work', :js, :workflow do
 
     it "allows on-behalf-of deposit" do
       click_link "Files" # switch tab
-      expect(page).to have_content "Add files"
+      page.assert_text "Add files"
       within('span#addfiles') do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
@@ -84,7 +84,7 @@ RSpec.feature 'Creating a new Work', :js, :workflow do
       # its element
       find('body').click
       choose('generic_work_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      page.assert_text('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
       select(second_user.user_key, from: 'On behalf of')
       check('agreement')
       # These lines are for debugging, should this test fail
@@ -92,12 +92,12 @@ RSpec.feature 'Creating a new Work', :js, :workflow do
       # puts "Required files: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').uploads.hasFiles})}"
       # puts "Agreement : #{page.evaluate_script(%{$('#form-progress').data('save_work_control').depositAgreement.isAccepted})}"
       click_on('Save')
-      expect(page).to have_content('My Test Work')
-      expect(page).to have_content "Your files are being processed by Hyrax in the background."
+      page.assert_text('My Test Work')
+      page.assert_text "Your files are being processed by Hyrax in the background."
 
       sign_in second_user
       click_link 'Works'
-      expect(page).to have_content "My Test Work"
+      page.assert_text "My Test Work"
     end
   end
 end

--- a/spec/features/dashboard/all_works.rb
+++ b/spec/features/dashboard/all_works.rb
@@ -7,8 +7,8 @@ RSpec.describe "As an admin user I should be able to see all works" do
   end
   scenario do
     visit '/dashboard/works'
-    expect(page).to have_content 'Works'
-    expect(page).to have_content 'Testing #1'
-    expect(page).to have_content 'Testing #2'
+    page.assert_text 'Works'
+    page.assert_text 'Testing #1'
+    page.assert_text 'Testing #2'
   end
 end

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'collection', type: :feature do
 
     it "makes a new collection" do
       click_link "New Collection"
-      expect(page).to have_content 'Create New Collection'
+      page.assert_text 'Create New Collection'
       click_link('Additional fields')
 
       expect(page).to have_selector "input.collection_creator.multi_value"
@@ -26,9 +26,9 @@ RSpec.describe 'collection', type: :feature do
       fill_in('Related URL', with: 'http://example.com/')
 
       click_button("Create Collection")
-      expect(page).to have_content 'Works in this Collection'
-      expect(page).to have_content title
-      expect(page).to have_content description
+      page.assert_text 'Works in this Collection'
+      page.assert_text title
+      page.assert_text description
     end
   end
 
@@ -47,7 +47,7 @@ RSpec.describe 'collection', type: :feature do
       click_button "Add to Collection" # opens the modal
       # since there is only one collection, it's not necessary to choose a radio button
       click_button "Update Collection"
-      expect(page).to have_content "Works in this Collection"
+      page.assert_text "Works in this Collection"
       # There are two rows in the table per document (one for the general info, one for the details)
       # Make sure we have at least 2 documents
       expect(page).to have_selector "table.table-zebra-striped tr#document_#{work1.id}"
@@ -64,12 +64,12 @@ RSpec.describe 'collection', type: :feature do
     end
 
     it "deletes a collection" do
-      expect(page).to have_content(collection.title.first)
+      page.assert_text(collection.title.first)
       within('#document_' + collection.id) do
         first('button.dropdown-toggle').click
         first(".itemtrash").click
       end
-      expect(page).not_to have_content(collection.title.first)
+      page.assert_no_text(collection.title.first)
     end
   end
 
@@ -86,52 +86,52 @@ RSpec.describe 'collection', type: :feature do
     end
 
     it "has creation date for collections" do
-      expect(page).to have_content(collection1.create_date.to_date.to_formatted_s(:standard))
+      page.assert_text(collection1.create_date.to_date.to_formatted_s(:standard))
     end
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
-      expect(page).to have_content(collection.title.first)
+      page.assert_text(collection.title.first)
       within('#document_' + collection.id) do
         click_link("Display all details of #{collection.title.first}")
       end
-      expect(page).to have_content(collection.title.first)
-      expect(page).to have_content(collection.description.first)
+      page.assert_text(collection.title.first)
+      page.assert_text(collection.description.first)
       # Should not show title and description a second time
       expect(page).not_to have_css('.metadata-collections', text: collection.title.first)
       expect(page).not_to have_css('.metadata-collections', text: collection.description.first)
       # Should not have Collection Descriptive metadata table
-      expect(page).to have_content("Descriptions")
+      page.assert_text("Descriptions")
       # Should have search results / contents listing
-      expect(page).to have_content(work1.title.first)
-      expect(page).to have_content(work2.title.first)
+      page.assert_text(work1.title.first)
+      page.assert_text(work2.title.first)
       expect(page).not_to have_css(".pager")
 
       click_link "Gallery"
-      expect(page).to have_content(work1.title.first)
-      expect(page).to have_content(work2.title.first)
+      page.assert_text(work1.title.first)
+      page.assert_text(work2.title.first)
     end
 
     it "hides collection descriptive metadata when searching a collection" do
       # URL: /dashboard/my/collections
-      expect(page).to have_content(collection.title.first)
+      page.assert_text(collection.title.first)
       within("#document_#{collection.id}") do
         click_link("Display all details of #{collection.title.first}")
       end
       # URL: /dashboard/collections/collection-id
-      expect(page).to have_content(collection.title.first)
-      expect(page).to have_content(collection.description.first)
-      expect(page).to have_content(work1.title.first)
-      expect(page).to have_content(work2.title.first)
+      page.assert_text(collection.title.first)
+      page.assert_text(collection.description.first)
+      page.assert_text(work1.title.first)
+      page.assert_text(work2.title.first)
       fill_in('collection_search', with: work1.title.first)
       click_button('collection_submit')
       # Should not have Collection metadata table (only title and description)
-      expect(page).not_to have_content("Total works")
-      expect(page).to have_content(collection.title.first)
-      expect(page).to have_content(collection.description.first)
+      page.assert_no_text("Total works")
+      page.assert_text(collection.title.first)
+      page.assert_text(collection.description.first)
       # Should have search results / contents listing
-      expect(page).to have_content("Search Results")
-      expect(page).to have_content(work1.title.first)
-      expect(page).not_to have_content(work2.title.first)
+      page.assert_text("Search Results")
+      page.assert_text(work1.title.first)
+      page.assert_no_text(work2.title.first)
     end
   end
 
@@ -153,7 +153,7 @@ RSpec.describe 'collection', type: :feature do
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       visit '/dashboard/my/collections'
-      expect(page).to have_content(collection.title.first)
+      page.assert_text(collection.title.first)
       within('#document_' + collection.id) do
         # Now go to the collection show page
         click_link("Display all details of collection title")
@@ -198,7 +198,7 @@ RSpec.describe 'collection', type: :feature do
 
     it "edits and update collection metadata" do
       # URL: /dashboard/collections
-      expect(page).to have_content(collection.title.first)
+      page.assert_text(collection.title.first)
       within("#document_#{collection.id}") do
         find('button.dropdown-toggle').click
         click_link('Edit Collection')
@@ -206,8 +206,8 @@ RSpec.describe 'collection', type: :feature do
       # URL: /collections/collection-id/edit
       expect(page).to have_field('collection_title', with: collection.title.first)
       expect(page).to have_field('collection_description', with: collection.description.first)
-      expect(page).to have_content(work1.title.first)
-      expect(page).to have_content(work2.title.first)
+      page.assert_text(work1.title.first)
+      page.assert_text(work2.title.first)
 
       new_title = "Altered Title"
       new_description = "Completely new Description text."
@@ -220,11 +220,11 @@ RSpec.describe 'collection', type: :feature do
       end
       # URL: /dashboard/collections/collection-id
       header = find('header')
-      expect(header).not_to have_content(collection.title.first)
-      expect(header).not_to have_content(collection.description.first)
-      expect(header).to have_content(new_title)
-      expect(page).to have_content(new_description)
-      expect(page).to have_content(creators.first)
+      header.assert_no_text(collection.title.first)
+      header.assert_no_text(collection.description.first)
+      header.assert_text(new_title)
+      page.assert_text(new_description)
+      page.assert_text(creators.first)
     end
   end
 
@@ -243,20 +243,20 @@ RSpec.describe 'collection', type: :feature do
         first('button.dropdown-toggle').click
         click_button('Remove from Collection')
       end
-      expect(page).to have_content(collection.title.first)
-      expect(page).to have_content(collection.description.first)
-      expect(page).not_to have_content(work1.title.first)
-      expect(page).to have_content(work2.title.first)
+      page.assert_text(collection.title.first)
+      page.assert_text(collection.description.first)
+      page.assert_no_text(work1.title.first)
+      page.assert_text(work2.title.first)
     end
 
     xit "removes all works", :js do
       # TODO: skipping - see Hyrax issue #1488
       first('input#check_all').click
       click_button('Remove From Collection')
-      expect(page).to have_content(collection.title.first)
-      expect(page).to have_content(collection.description.first)
-      expect(page).not_to have_content(work1.title.first)
-      expect(page).not_to have_content(work2.title.first)
+      page.assert_text(collection.title.first)
+      page.assert_text(collection.description.first)
+      page.assert_no_text(work1.title.first)
+      page.assert_no_text(work2.title.first)
     end
   end
 end

--- a/spec/features/dashboard/display_dashboard_spec.rb
+++ b/spec/features/dashboard/display_dashboard_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe "The dashboard as viewed by a regular user", type: :feature do
 
   context "upon sign-in" do
     it "shows the user's information" do
-      expect(page).to have_content "My Dashboard"
-      expect(page).to have_content "User Activity"
-      expect(page).to have_content "User Notifications"
+      page.assert_text "My Dashboard"
+      page.assert_text "User Activity"
+      page.assert_text "User Notifications"
 
       within '.sidebar' do
         expect(page).to have_link "Works"

--- a/spec/features/delete_work_spec.rb
+++ b/spec/features/delete_work_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Deleting a work', type: :feature do
       visit hyrax_generic_work_path(work)
       click_on('Delete', match: :first)
       expect(page).to have_current_path(hyrax.my_works_path, only_path: true)
-      expect(page).to have_content 'Deleted Test title'
+      page.assert_text 'Deleted Test title'
     end
   end
 end

--- a/spec/features/edit_file_spec.rb
+++ b/spec/features/edit_file_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Editing a file:", type: :feature do
       visit edit_hyrax_file_set_path(file_set)
       click_link 'Versions'
       click_button 'Upload New Version'
-      expect(page).to have_content "Edit #{file_title}"
+      page.assert_text "Edit #{file_title}"
     end
   end
 end

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -16,8 +16,8 @@ RSpec.feature 'Editing a work', type: :feature do
       choose('generic_work_visibility_open')
       check('agreement')
       click_on('Save')
-      expect(page).to have_content 'Apply changes to contents?'
-      expect(page).not_to have_content "Powered by Hyrax"
+      page.assert_text 'Apply changes to contents?'
+      page.assert_no_text "Powered by Hyrax"
     end
   end
 end

--- a/spec/features/embargo_spec.rb
+++ b/spec/features/embargo_spec.rb
@@ -18,18 +18,18 @@ RSpec.feature 'embargo' do
       click_button 'Save'
 
       # chosen embargo date is on the show page
-      expect(page).to have_content(future_date.to_date.to_formatted_s(:standard))
+      page.assert_text(future_date.to_date.to_formatted_s(:standard))
 
       click_link 'Edit'
       click_link 'Embargo Management Page'
 
-      expect(page).to have_content('This Generic Work is under embargo.')
+      page.assert_text('This Generic Work is under embargo.')
       expect(page).to have_xpath("//input[@name='generic_work[embargo_release_date]' and @value='#{future_date.to_datetime.iso8601}']") # current embargo date is pre-populated in edit field
 
       fill_in 'until', with: later_future_date.to_s
 
       click_button 'Update Embargo'
-      expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard))
+      page.assert_text(later_future_date.to_date.to_formatted_s(:standard))
     end
   end
 end

--- a/spec/features/lease_spec.rb
+++ b/spec/features/lease_spec.rb
@@ -18,18 +18,18 @@ RSpec.feature 'leases' do
       click_button 'Save'
 
       # chosen lease date is on the show page
-      expect(page).to have_content(future_date.to_date.to_formatted_s(:standard))
+      page.assert_text(future_date.to_date.to_formatted_s(:standard))
 
       click_link 'Edit'
       click_link 'Lease Management Page'
 
-      expect(page).to have_content('This Generic Work is under lease.')
+      page.assert_text('This Generic Work is under lease.')
       expect(page).to have_xpath("//input[@name='generic_work[lease_expiration_date]' and @value='#{future_date.to_datetime.iso8601}']") # current lease date is pre-populated in edit field
 
       fill_in 'until', with: later_future_date.to_s
 
       click_button 'Update Lease'
-      expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard)) # new lease date is displayed in message
+      page.assert_text(later_future_date.to_date.to_formatted_s(:standard)) # new lease date is displayed in message
     end
   end
 end

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -5,16 +5,16 @@ RSpec.feature "Notifications page", type: :feature do
   end
 
   it "lists notifications with date, subject and message" do
-    expect(page).to have_content "Notifications"
+    page.assert_text "Notifications"
     expect(page).to have_selector "table.datatable"
-    expect(page.find(:xpath, '//thead/tr')).to have_content "Date"
-    expect(page.find(:xpath, '//thead/tr')).to have_content "Subject"
-    expect(page.find(:xpath, '//thead/tr')).to have_content "Message"
-    expect(page).to have_content "These files could not be updated. You do not have sufficient privileges to edit them. "
-    expect(page).to have_content "These files have been saved"
-    expect(page).to have_content "File 1 could not be updated. You do not have sufficient privileges to edit it."
-    expect(page).to have_content "File 1 has been saved"
-    expect(page).to have_content "Batch upload permission denied  "
-    expect(page).to have_content "Batch upload complete"
+    page.find(:xpath, '//thead/tr').assert_text "Date"
+    page.find(:xpath, '//thead/tr').assert_text "Subject"
+    page.find(:xpath, '//thead/tr').assert_text "Message"
+    page.assert_text "These files could not be updated. You do not have sufficient privileges to edit them. "
+    page.assert_text "These files have been saved"
+    page.assert_text "File 1 could not be updated. You do not have sufficient privileges to edit it."
+    page.assert_text "File 1 has been saved"
+    page.assert_text "Batch upload permission denied  "
+    page.assert_text "Batch upload complete"
   end
 end

--- a/spec/features/ownership_transfer_spec.rb
+++ b/spec/features/ownership_transfer_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'Transferring work ownership:', type: :feature do
     context 'To myself' do
       before { transfer_ownership_of_work work, original_owner }
       it 'displays an appropriate error message' do
-        expect(page).to have_content 'specify a different user to receive the work'
+        page.assert_text 'specify a different user to receive the work'
       end
     end
 
@@ -29,17 +29,18 @@ RSpec.feature 'Transferring work ownership:', type: :feature do
       before { transfer_ownership_of_work work, new_owner }
 
       it 'Creates a transfer request' do
-        expect(page).to have_content 'Transfer request created'
+        page.assert_text 'Transfer request created'
       end
 
       context 'If the new owner accepts it' do
         before do
+          sleep(10)
           new_owner.proxy_deposit_requests.last.transfer!
           # refresh the page
           visit '/dashboard'
         end
         it 'I should see it was accepted' do
-          expect(page.find('#outgoing-transfers')).to have_content 'Accepted'
+          page.find('#outgoing-transfers').assert_text 'Accepted'
         end
       end
 
@@ -48,7 +49,7 @@ RSpec.feature 'Transferring work ownership:', type: :feature do
           accept_confirm { first_sent_cancel_button.click }
         end
         it 'I should see it was cancelled' do
-          expect(page).to have_content 'Transfer canceled'
+          page.assert_text 'Transfer canceled'
         end
       end
     end
@@ -64,24 +65,24 @@ RSpec.feature 'Transferring work ownership:', type: :feature do
       # Become the new_owner so we can manage transfers sent to us
       sign_in new_owner
       visit '/dashboard'
-      expect(page).to have_content 'Transfers of Ownership'
+      page.assert_text 'Transfers of Ownership'
     end
 
     it 'I should be able to accept it' do
       within('#notifications') do
-        expect(page).to have_content "#{original_owner.name} wants to transfer a work to you"
+        page.assert_text "#{original_owner.name} wants to transfer a work to you"
       end
       first_received_accept_dropdown.click
       click_link 'Allow depositor to retain edit access'
-      expect(page).to have_content 'Transfer complete'
+      page.assert_text 'Transfer complete'
     end
 
     it 'I should be able to reject it' do
       within('#notifications') do
-        expect(page).to have_content "#{original_owner.name} wants to transfer a work to you"
+        page.assert_text "#{original_owner.name} wants to transfer a work to you"
       end
       accept_confirm { first_received_reject_button.click }
-      expect(page).to have_content 'Transfer rejected'
+      page.assert_text 'Transfer rejected'
     end
   end
 
@@ -90,7 +91,7 @@ RSpec.feature 'Transferring work ownership:', type: :feature do
 
     db_item_actions_toggle(work).click
     click_link 'Transfer Ownership of Work'
-    expect(page).to have_content I18n.t(:'hyrax.transfers.new.sr_only_description', work_title: work.title.first)
+    page.assert_text I18n.t(:'hyrax.transfers.new.sr_only_description', work_title: work.title.first)
     new_owner_dropdown.click
     new_owner_search_field.set new_owner.user_key
     new_owner_search_result.click

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -17,21 +17,21 @@ RSpec.feature 'searching' do
       visit '/'
       fill_in "search-field-header", with: "Toothbrush"
       click_button "search-submit-header"
-      expect(page).to have_content "1 entry found"
+      page.assert_text "1 entry found"
       within "#search-results" do
-        expect(page).to have_content "Toothbrush"
+        page.assert_text "Toothbrush"
       end
 
       click_link "Gallery"
-      expect(page).to have_content "Filtering by: Toothbrush"
+      page.assert_text "Filtering by: Toothbrush"
       within "#documents" do
-        expect(page).to have_content "Toothbrush"
+        page.assert_text "Toothbrush"
       end
     end
 
     it "only searches all" do
       visit '/'
-      expect(page).to have_content("All")
+      page.assert_text("All")
       expect(page).to have_css("a[data-search-label*=All]", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Works']", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Collections']", visible: false)
@@ -39,13 +39,13 @@ RSpec.feature 'searching' do
       expect(page).not_to have_css("a[data-search-label*='My Shares']", visible: false)
 
       click_button("All")
-      expect(page).to have_content("All of Hyrax")
+      page.assert_text("All of Hyrax")
       fill_in "search-field-header", with: subject_value
       click_button("Go")
 
-      expect(page).to have_content('Search Results')
-      expect(page).to have_content "Toothbrush"
-      expect(page).to have_content('collection title abc')
+      page.assert_text('Search Results')
+      page.assert_text "Toothbrush"
+      page.assert_text('collection title abc')
       expect(page).to have_css("span.collection-icon-search")
 
       expect(page.body).to include "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=taco&amp;locale=en\">taco</a></span>"
@@ -55,9 +55,9 @@ RSpec.feature 'searching' do
     it "does not display search options for dashboard files" do
       visit "/"
       within(".input-group-btn") do
-        expect(page).not_to have_content("My Works")
-        expect(page).not_to have_content("My Collections")
-        expect(page).not_to have_content("My Shares")
+        page.assert_no_text("My Works")
+        page.assert_no_text("My Collections")
+        page.assert_no_text("My Shares")
       end
     end
   end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "User Profile", type: :feature do
 
     it 'page should be editable' do
       visit profile_path
-      expect(page).to have_content(user.email)
+      page.assert_text(user.email)
 
       within '.highlighted-works' do
         expect(page).to have_link(work.to_s)
@@ -25,7 +25,7 @@ RSpec.feature "User Profile", type: :feature do
       end
       fill_in 'user_twitter_handle', with: 'curatorOfData'
       click_button 'Save Profile'
-      expect(page).to have_content 'Your profile has been updated'
+      page.assert_text 'Your profile has been updated'
       expect(page).to have_link('curatorOfData', href: 'http://twitter.com/curatorOfData')
     end
   end

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -56,11 +56,11 @@ RSpec.feature "display a work as its owner" do
       # exports EndNote
       expect(page).to have_link 'EndNote'
       click_link 'EndNote'
-      expect(page).to have_content '%0 Generic Work'
-      expect(page).to have_content '%T Magnificent splendor'
-      expect(page).to have_content '%R http://localhost/files/'
-      expect(page).to have_content '%~ Hyrax'
-      expect(page).to have_content '%W Institution'
+      page.assert_text '%0 Generic Work'
+      page.assert_text '%T Magnificent splendor'
+      page.assert_text '%R http://localhost/files/'
+      page.assert_text '%~ Hyrax'
+      page.assert_text '%W Institution'
     end
   end
 end

--- a/spec/features/workflow_roles_spec.rb
+++ b/spec/features/workflow_roles_spec.rb
@@ -41,6 +41,6 @@ RSpec.feature "Manage workflow roles", type: :feature do
   it "shows the roles" do
     login_as(user, scope: :user)
     visit '/admin/workflow_roles'
-    expect(page).to have_content 'approving (one_step)'
+    page.assert_text 'approving (one_step)'
   end
 end

--- a/spec/features/workflow_state_changes_spec.rb
+++ b/spec/features/workflow_state_changes_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Workflow state changes", type: :feature do
           page.fill_in('workflow_action_comment', with: the_comment)
           page.click_on('Submit')
         end
-        expect(page).to have_content(the_comment)
+        page.assert_text(the_comment)
       end.not_to change { work.to_sipity_entity.reload.workflow_state_name }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,7 +53,12 @@ require 'i18n/debug' if ENV['I18N_DEBUG']
 require 'byebug' unless ENV['TRAVIS']
 
 Capybara.default_driver = :rack_test # This is a faster driver
-Capybara.javascript_driver = :selenium_chrome_headless # This is slower
+
+Capybara.register_driver :selenium do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+# Capybara.javascript_driver = :selenium_chrome_headless # This is slower
 
 ActiveJob::Base.queue_adapter = :inline
 

--- a/spec/support/features/batch_edit_actions.rb
+++ b/spec/support/features/batch_edit_actions.rb
@@ -14,7 +14,7 @@ def fill_in_batch_edit_fields_and_verify!
       fill_in "generic_work_#{field_id}", with: "NEW #{field_id}"
 
       find("##{field_id}_save").click
-      # This was `expect(page).to have_content 'Changes Saved'`, however in debugging,
+      # This was `page.assert_text 'Changes Saved'`, however in debugging,
       # the `have_content` check was ignoring the `within` scoping and finding
       # "Changes Saved" for other field areas
       find('.status', text: 'Changes Saved')

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -8,7 +8,7 @@ module Features
       fill_in 'Email', with: user.email
       fill_in 'Password', with: user.password
       click_button 'Log in'
-      expect(page).not_to have_text 'Invalid email or password.'
+      page.assert_no_text 'Invalid email or password.'
     end
   end
 end


### PR DESCRIPTION
Fixes #1592 ; refs ##1592

Replace have_content and have_text with assert_test in feature tests, as they've proven unreliable, and the latter has proven reliable, to the best of our present knowledge. And adding chromedriver-helper gem, for easy use of chromedriver, added a few sleeps to adjust for slowness of persistence. 
  
@laritakr's comments: 
Based on testing within numerous spec files, have_content and have_text are consistently returning false passing results. In my testing, I did not find a single case where have_content or have_text produced errors as expected.

Acting on this issue involves the following:

    search for all instances of have_content and have_text
    replace all instances with assert_text as in the comment above.


Changes proposed in this pull request:
* Adding Chromedriver-helper gem
* Replacing have_content and have_text with asset_text
* added a few sleeps in places where code updates backend and then checks it 

@samvera/hyrax-code-reviewers
@elrayle 
@laritakr 
@jcoyne
@mjgiarlo  
