### PR TITLE
adds CollectionTypes service 

### DIFF
--- a/app/services/hyrax/collection_types/permissions_service.rb
+++ b/app/services/hyrax/collection_types/permissions_service.rb
@@ -9,13 +9,13 @@ module Hyrax
       # @param roles [String] type of access, 'manage' and/or 'create'
       # @return [Array<Hyrax::CollectionType>]
       def self.collection_types_for_user(user:, roles:)
-        return Hyrax::CollectionType.all if user.groups.include? 'admin'
+        return Hyrax::CollectionType.all if user.ability.admin?
         ids = Hyrax::CollectionTypeParticipant.where(agent_type: 'user',
                                                      agent_id: user.user_key,
                                                      access: roles)
                                               .or(
                                                 CollectionTypeParticipant.where(agent_type: 'group',
-                                                                                agent_id: user.groups,
+                                                                                agent_id: user.ability.user_groups,
                                                                                 access: roles)
                                               ).pluck('DISTINCT hyrax_collection_type_id')
         Hyrax::CollectionType.where(id: ids)

--- a/app/services/hyrax/collection_types/permissions_service.rb
+++ b/app/services/hyrax/collection_types/permissions_service.rb
@@ -3,13 +3,55 @@ module Hyrax
     class PermissionsService
       # @api public
       #
+      # What types of collection can the user create or manage
+      #
+      # @param user [User] user - The user requesting to create/manage a Collection
+      # @param roles [String] type of access, 'manage' and/or 'create'
+      # @return [Array<Hyrax::CollectionType>]
+      def self.collection_types_for_user(user:, roles:)
+        return Hyrax::CollectionType.all if user.groups.include? 'admin'
+        ids = Hyrax::CollectionTypeParticipant.where(agent_type: 'user',
+                                                     agent_id: user.user_key,
+                                                     access: roles)
+                                              .or(
+                                                CollectionTypeParticipant.where(agent_type: 'group',
+                                                                                agent_id: user.groups,
+                                                                                access: roles)
+                                              ).pluck('DISTINCT hyrax_collection_type_id')
+        Hyrax::CollectionType.where(id: ids)
+      end
+
+      # @api public
+      #
       # Get a list of collection types that a user can create
       #
       # @param user [User] the user that will be creating a collection (default: current_user)
       # @return [Array<Hyrax::CollectionType>] array of collection types the user can create
       def self.can_create_collection_types(user: current_user)
-        # Stubbed to return all types.  Implement according to issue #1582
-        return Hyrax::CollectionType.all if user.present? # condition test added to allow paramter to be present
+        collection_types_for_user(user: user, roles: ['manage', 'create'])
+      end
+
+      # @api public
+      #
+      # Get a list of users who should be added as user editors for a new collection of the specified collection type
+      #
+      # @param collection_type [Hyrax::CollectionType] the type of the collection being created
+      # @return [Array<String>] array of user identifiers (typically emails) for users who can edit collections of this type
+      def self.user_edit_grants_for_collection_of_type(collection_type: nil)
+        return [] unless collection_type
+        # Stubbed to return no grants.   Implement according to issue #1600
+        []
+      end
+
+      # @api public
+      #
+      # Get a list of group that should be added as group editors for a new collection of the specified collection type
+      #
+      # @param collection_type [Hyrax::CollectionType] the type of the collection being created
+      # @return [Array<String>] array of group identifiers (typically groupname) for groups who can edit collections of this type
+      def self.group_edit_grants_for_collection_of_type(collection_type: nil)
+        return [] unless collection_type
+        # Stubbed to return no grants.   Implement according to issue #1600
         []
       end
     end

--- a/app/views/hyrax/my/collections/index.html.erb
+++ b/app/views/hyrax/my/collections/index.html.erb
@@ -16,7 +16,7 @@
       <div class="pull-right">
 
         <% if @collection_type_list_presenter.many? %>
-          <!-- # modal to select type -->
+          <% # modal to select type %>
           <button type="button"
                   class="btn btn-primary"
                   data-toggle="modal"
@@ -64,13 +64,13 @@
             </div>
           </div>
 
-        <% else %>
-        <!-- # link directly to create collection form with type -->
-            <%= link_to(
-                  t('helpers.action.collection.new'),
-                  "#{new_dashboard_collection_path}&collection_type_id=#{@collection_type_list_presenter.first_collection_type.id}",
-                  class: 'btn btn-primary'
-                ) %>
+        <% else @collection_type_list_presenter.any? %>
+          <% # link directly to create collection form with type %>
+          <%= link_to(
+                t('helpers.action.collection.new'),
+                "#{new_dashboard_collection_path}&collection_type_id=#{@collection_type_list_presenter.first_collection_type.id}",
+                class: 'btn btn-primary'
+              ) %>
         <% end %>
         </div>
     <% end %>

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -12,21 +12,33 @@ FactoryGirl.define do
     assigns_workflow false
     assigns_visibility false
 
-    factory :user_collection_type do
-      title 'User Collection'
-      description 'A user oriented collection type'
+    transient do
+      creator_user nil
+      creator_group nil
+      manager_user nil
+      manager_group nil
     end
 
-    factory :admin_set_collection_type do
-      title 'Admin Set'
-      description 'An administrative set collection type'
-      nestable false
-      discoverable false
-      sharable true
-      allow_multiple_membership false
-      require_membership true
-      assigns_workflow true
-      assigns_visibility true
+    after(:create) do |collection_type, evaluator|
+      if evaluator.creator_user
+        attributes = { hyrax_collection_type_id: collection_type.id, access: 'create', agent_id: evaluator.creator_user, agent_type: 'user' }
+        create(:collection_type_participant, attributes)
+      end
+
+      if evaluator.creator_group
+        attributes = { hyrax_collection_type_id: collection_type.id, access: 'create', agent_id: evaluator.creator_group, agent_type: 'group' }
+        create(:collection_type_participant, attributes)
+      end
+
+      if evaluator.manager_user
+        attributes = { hyrax_collection_type_id: collection_type.id, access: 'manage', agent_id: evaluator.manager_user, agent_type: 'user' }
+        create(:collection_type_participant, attributes)
+      end
+
+      if evaluator.manager_group
+        attributes = { hyrax_collection_type_id: collection_type.id, access: 'manage', agent_id: evaluator.manager_group, agent_type: 'group' }
+        create(:collection_type_participant, attributes)
+      end
     end
 
     trait :nestable do
@@ -59,6 +71,45 @@ FactoryGirl.define do
 
     trait :not_allow_multiple_membership do
       allow_multiple_membership false
+    end
+  end
+
+  factory :user_collection_type, class: Hyrax::CollectionType do
+    title 'User Collection'
+    description 'A user oriented collection type'
+
+    nestable true
+    discoverable true
+    sharable true
+    allow_multiple_membership true
+    require_membership false
+    assigns_workflow false
+    assigns_visibility false
+
+    after(:create) do |collection_type, _evaluator|
+      attributes = { hyrax_collection_type_id: collection_type.id, access: 'create', agent_id: 'registered', agent_type: 'group' }
+      create(:collection_type_participant, attributes)
+      attributes = { hyrax_collection_type_id: collection_type.id, access: 'manage', agent_id: 'admin', agent_type: 'group' }
+      create(:collection_type_participant, attributes)
+    end
+  end
+
+  factory :admin_set_collection_type, class: Hyrax::CollectionType do
+    title 'Admin Set'
+    description 'An administrative set collection type'
+    nestable false
+    discoverable false
+    sharable true
+    allow_multiple_membership false
+    require_membership true
+    assigns_workflow true
+    assigns_visibility true
+
+    after(:create) do |collection_type, _evaluator|
+      attributes = { hyrax_collection_type_id: collection_type.id, access: 'create', agent_id: 'admin', agent_type: 'group' }
+      create(:collection_type_participant, attributes)
+      attributes = { hyrax_collection_type_id: collection_type.id, access: 'manage', agent_id: 'admin', agent_type: 'group' }
+      create(:collection_type_participant, attributes)
     end
   end
 end

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -45,6 +45,20 @@ FactoryGirl.define do
     end
   end
 
+  factory :user_collection, class: Collection do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    sequence(:title) { |n| ["Title #{n}"] }
+
+    after(:build) do |collection, evaluator|
+      collection.apply_depositor_metadata(evaluator.user.user_key)
+      collection_type = FactoryGirl.create(:user_collection_type)
+      collection.collection_type_gid = collection_type.gid
+    end
+  end
+
   factory :typeless_collection, class: Collection do
     # should not have a collection type assigned
     transient do

--- a/spec/presenters/hyrax/select_collection_type_list_presenter_spec.rb
+++ b/spec/presenters/hyrax/select_collection_type_list_presenter_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Hyrax::SelectCollectionTypeListPresenter, :clean_repo do
   let(:user) { create(:user) }
   let(:instance) { described_class.new(user) }
-  let(:collection_type) { create(:collection_type) }
+  let(:collection_type) { create(:collection_type, creator_user: user) }
   let(:user_collection_type) { create(:user_collection_type) }
 
   describe "#many?" do

--- a/spec/services/hyrax/collection_types/permissions_service_spec.rb
+++ b/spec/services/hyrax/collection_types/permissions_service_spec.rb
@@ -1,13 +1,150 @@
 RSpec.describe Hyrax::CollectionTypes::PermissionsService do
-  let(:user_collection_type) { create(:user_collection_type) }
-  let(:user) { create(:user) }
+  let(:user1) { create(:user, groups: 'create_group') }
+  let(:user2) { create(:user, groups: 'manage_group') }
+  let(:user3) { create(:user) }
+  let(:user4) { create(:user, groups: 'admin') }
+  let(:collection_type_1) { create(:collection_type) }
+  let(:collection_type_2) { create(:collection_type) }
+  let(:collection_type_3) { create(:collection_type) }
 
-  # TODO: stubbed method returns all collection types. complete spec when corresponding method stub is complete.
-  describe "#can_create_collection_types" do
-    let(:subject) { described_class.can_create_collection_types(user: user) }
+  let(:user_create_attributes) do
+    {
+      hyrax_collection_type_id: collection_type_1.id,
+      access: 'create',
+      agent_id: user1.user_key,
+      agent_type: 'user'
+    }
+  end
+  let(:group_create_attributes) do
+    {
+      hyrax_collection_type_id: collection_type_2.id,
+      access: 'create',
+      agent_id: 'create_group',
+      agent_type: 'group'
+    }
+  end
+  let(:user_manage_attributes) do
+    {
+      hyrax_collection_type_id: collection_type_1.id,
+      access: 'manage',
+      agent_id: user2.user_key,
+      agent_type: 'user'
+    }
+  end
+  let(:group_manage_attributes) do
+    {
+      hyrax_collection_type_id: collection_type_3.id,
+      access: 'manage',
+      agent_id: 'manage_group',
+      agent_type: 'group'
+    }
+  end
+  let!(:collection_type_participant1) { create(:collection_type_participant, user_create_attributes) }
+  let!(:collection_type_participant2) { create(:collection_type_participant, group_create_attributes) }
+  let!(:collection_type_participant3) { create(:collection_type_participant, user_manage_attributes) }
+  let!(:collection_type_participant4) { create(:collection_type_participant, group_manage_attributes) }
 
-    it 'returns types of collections user is authorized to create' do
-      expect(subject).to eq(Hyrax::CollectionType.all)
+  describe '.collection_type_for_user search results' do
+    subject { described_class.collection_types_for_user(user: user, roles: access) }
+
+    context 'users with create access' do
+      let(:user) { user1 }
+      let(:access) { 'create' }
+
+      it "returns two collection types" do
+        expect(subject.map(&:id)).to match_array [collection_type_1.id, collection_type_2.id]
+      end
+    end
+
+    context 'users with manage access' do
+      let(:user) { user2 }
+      let(:access) { 'manage' }
+
+      it "returns two collection types" do
+        expect(subject.map(&:id)).to match_array [collection_type_1.id, collection_type_3.id]
+      end
+    end
+
+    context 'users with no access' do
+      let(:user) { user3 }
+      let(:access) { ['manage', 'create'] }
+
+      it "returns no collection types" do
+        expect(subject.map(&:id)).to match_array []
+      end
+    end
+
+    context 'admin users' do
+      let(:user) { user4 }
+      let(:access) { ['manage', 'create'] }
+
+      it "returns all collection types" do
+        expect(subject.map(&:id)).to match_array [collection_type_1.id, collection_type_2.id, collection_type_3.id]
+      end
+    end
+
+    describe '.can_create_collection_types results' do
+      subject { described_class.can_create_collection_types(user: user) }
+
+      context 'user with create access' do
+        let(:user) { user1 }
+
+        it "finds two collection types" do
+          expect(subject.map(&:id)).to match_array [collection_type_1.id, collection_type_2.id]
+        end
+      end
+
+      context 'admin users' do
+        let(:user) { user4 }
+
+        it "returns all collection types" do
+          expect(subject.map(&:id)).to match_array [collection_type_1.id, collection_type_2.id, collection_type_3.id]
+        end
+      end
+
+      context 'users with no access' do
+        let(:user) { user3 }
+
+        it "returns no collection types" do
+          expect(subject.map(&:id)).to match_array []
+        end
+      end
+
+      context 'users with manage access' do
+        let(:user) { user2 }
+
+        it "returns two collection types" do
+          expect(subject.map(&:id)).to match_array [collection_type_1.id, collection_type_3.id]
+        end
+      end
+
+      context 'users with both manage and create access' do
+        let(:user5) { create(:user, groups: 'manage_group') }
+        let(:user) { user5 }
+        let(:collection_type_4) { create(:collection_type) }
+        let(:user5_user_create_attributes) do
+          {
+            hyrax_collection_type_id: collection_type_1.id,
+            access: 'create',
+            agent_id: user5.user_key,
+            agent_type: 'user'
+          }
+        end
+        let(:user5_group_manage_attributes) do
+          {
+            hyrax_collection_type_id: collection_type_3.id,
+            access: 'manage',
+            agent_id: 'manage_group',
+            agent_type: 'group'
+          }
+        end
+        let!(:collection_type_participant5) { create(:collection_type_participant, user5_user_create_attributes) }
+        let!(:collection_type_participant6) { create(:collection_type_participant, user5_group_manage_attributes) }
+
+        it "returns two collection types" do
+          expect(subject.map(&:id)).to match_array [collection_type_1.id, collection_type_3.id]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #1582

provides service for requesting collection types a user has access to
Hyrax::Collections::CollectionTypesService.collection_types_for_user

- pass the user and access type to check ('create', 'manage', or 'both').
- the service checks collection_type_participants table to find Collection Types where user has access of the given type(s), or a group the user belongs to has group access of the given type(s)
- Returns array of CollectionTypes

@samvera/hyrax-code-reviewers
