### PR TITLE
Update UI for add collection to collection modal

### DIFF
--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -9,4 +9,9 @@ Blacklight.onLoad(function () {
       form[0].action = form[0].action.replace(string_to_replace, collection_id);
       form.append('<input type="hidden" value="add" name="collection[members]"></input>');
   });
+
+  $('#add_collection_to_collection').on('click', function(e) {
+      e.preventDefault();
+      $('#add-collection-to-collection-modal').modal('show');
+  });
 });

--- a/app/views/hyrax/my/_collection_action_menu.html.erb
+++ b/app/views/hyrax/my/_collection_action_menu.html.erb
@@ -21,5 +21,13 @@
         <i class="glyphicon glyphicon-trash" aria-hidden="true"></i> <%= t("hyrax.dashboard.my.action.delete_collection") %>
       <% end %>
     </li>
+    <li role="menuitem" tabindex="-1">
+      <%= link_to '#',
+        id: 'add_collection_to_collection',
+        class: 'itemicon',
+        title: t("hyrax.dashboard.my.action.add_collection_to_collection") do %>
+        <%= t("hyrax.dashboard.my.action.add_collection_to_collection") %>
+      <% end %>
+    </li>
   </ul>
 </div>

--- a/app/views/hyrax/my/collections/_modal_add_collection_to_collection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_collection_to_collection.html.erb
@@ -1,0 +1,26 @@
+<div class="modal fade" id="add-collection-to-collection-modal" tabindex="-1" role="dialog" aria-labelledby="add-collection-to-collection-label">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>"><span aria-hidden="true">&times;</span></button>
+        <h2 class="modal-title" id="add-collection-to-collection-label"><%= t("hyrax.dashboard.my.action.add_collection_to_collection") %></h2>
+      </div>
+      <form class="add-collection-to-collection-form">
+        <div class="modal-body">
+          <div class="form-group">
+            <label><%= t("hyrax.dashboard.my.action.select_collection") %></label>
+            <select class="form-control">
+              <option><%= t("hyrax.dashboard.my.action.select") %></option>
+              <option>Test collection hardcoded #1</option>
+              <option>Test collection hardcoded #2</option>
+            </select>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
+          <button type="button" class="btn btn-primary"><%= t("hyrax.dashboard.my.action.add_to_collection") %></button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/my/collections/index.html.erb
+++ b/app/views/hyrax/my/collections/index.html.erb
@@ -92,3 +92,6 @@
     </div>
   </div>
 </div>
+
+<!-- Render Modals -->
+<%= render 'modal_add_collection_to_collection' %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -557,6 +557,8 @@ en:
       manage_proxies:           "Manage Proxies"
       my:
         action:
+          add_collection_to_collection: "Add selected collection to collection"
+          add_to_collection:        "Add to Collection"
           collection_confirmation: "Deleting a collection from %{application_name} is permanent. Click OK to delete this collection from %{application_name}, or Cancel to cancel this operation"
           delete_collection:       "Delete Collection"
           delete_work:             "Delete Work"
@@ -565,6 +567,7 @@ en:
           highlight:               "Highlight Work on Profile"
           select:                  "Select"
           select_all:              "Select Current Page"
+          select_collection:       "Select a collection"
           select_none:             "Select None"
           transfer:                "Transfer Ownership of Work"
           unhighlight:             "Unhighlight Work"


### PR DESCRIPTION
Partially Fixes #1512  

The only failing test is the known randomly failing batch-edit feature test.  It is ok to ignore that error and merge this PR.

This adds the modal UI layout, and the action to show/hide the modal.

The following still needs to be completed:
- Permission logic applied to show/hide of the 'Add collection to collection' dropdown option.
- In the modal, populate the dropdown options with live collections.
- Handle the AJAX POST/request or however we tell the system to add the Collection to it's selected parent collection.

@samvera/hyrax-code-reviewers
