### PR TITLE
Restores ability to add existing works to existing collections via dashboard

### DIFF
--- a/app/views/hyrax/dashboard/collections/_edit_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_edit_actions.html.erb
@@ -3,5 +3,6 @@
   <%= link_to t('hyrax.collection.actions.add_works.label'),
               hyrax.my_works_path(add_works_to_collection: @form.id),
               title: t('hyrax.collection.actions.add_works.desc'),
-              class: 'btn btn-default' %>
+              class: 'btn btn-default',
+              data: { turbolinks: false } %>
 </div>

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -8,7 +8,8 @@
       <%= link_to t('hyrax.collection.actions.add_works.label'),
                   hyrax.my_works_path(add_works_to_collection: presenter.id),
                   title: t('hyrax.collection.actions.add_works.desc'),
-                  class: 'btn btn-default' %>
+                  class: 'btn btn-default',
+                  data: { turbolinks: false } %>
     <%end %>
 
     <% if can? :destroy, presenter.solr_document %>


### PR DESCRIPTION
Refs #1191

This is a workaround that restores this functionality. We suspect the bug itself is a regression in Rails or Turbolinks. See #1191 for more analysis. This patch is being put in place to allow the 2.0.0.beta1 release to ship.

@samvera/hyrax-code-reviewers
