### PR TITLE
Collection #1533 engine_cart:after_generate

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -51,6 +51,10 @@ Style/PredicateName:
   Exclude:
     - 'app/helpers/hyrax/collections_helper.rb'
 
+Style/SpecialGlobalVars:
+  Exclude:
+    - 'tasks/hyrax_dev.rake'
+
 Rails/Output:
   Exclude:
     - 'lib/generators/**/*'


### PR DESCRIPTION
Fixes #1533 

Provides a way to automatically run tasks after engine_cart:generate.

Some actions (e.g. seeding data) need to run after the test_app has run db:migrate during generation, but engine_cart does not provide a builtin hook for doing so. Defining the engine_cart:generate task again in hyrax_dev.rake appends the action block to the existing task, and will be run after the original task's action block completes.

This feature is used to run hyrax:default_collection_type:create in the development test_app.

To avoid possible out of order execution of the task actions, if the engine_cart:generate task is not defined when hyrax_dev.rake is loaded, an exception will be raised.

Rubocop suggests the `$?` variable be replaced with a variable from the `English` library, but this appears to not already be in use in hyrax, so an exception was added.

@elrayle 
