### PR TITLE
Modify permission_templates for collections

### DIFF
--- a/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
+++ b/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
@@ -10,14 +10,9 @@ module Hyrax
         end
 
         if @permission_template_access.destroyed?
-          redirect_to hyrax.edit_admin_admin_set_path(source_id,
-                                                      anchor: 'participants'),
-                      notice: translate('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
+          redirect_to_edit_path
         else
-          redirect_to hyrax.edit_admin_admin_set_path(source_id,
-                                                      anchor: 'participants'),
-                      alert: @permission_template_access.errors.full_messages.to_sentence
-
+          redirect_to_edit_path_with_error
         end
       end
 
@@ -30,6 +25,34 @@ module Hyrax
 
         def update_management
           Forms::PermissionTemplateForm.new(@permission_template_access.permission_template).update_management
+        end
+
+        def redirect_to_edit_path
+          if source_type == 'admin_set'
+            redirect_to hyrax.edit_admin_admin_set_path(source_id,
+                                                        anchor: 'participants'),
+                        notice: translate('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
+          elsif source_type == 'collection'
+            redirect_to hyrax.edit_dashboard_collection_path(source_id,
+                                                             anchor: 'sharing'),
+                        notice: translate('sharing', scope: 'hyrax.dashboard.collections.form.permission_update_notices')
+          end
+        end
+
+        def redirect_to_edit_path_with_error
+          if source_type == 'admin_set'
+            redirect_to hyrax.edit_admin_admin_set_path(source_id,
+                                                        anchor: 'participants'),
+                        alert: @permission_template_access.errors.full_messages.to_sentence
+          elsif source_type == 'collection'
+            redirect_to hyrax.edit_dashboard_collection_path(source_id,
+                                                             anchor: 'sharing'),
+                        alert: @permission_template_access.errors.full_messages.to_sentence
+          end
+        end
+
+        def source_type
+          Hyrax::PermissionTemplate.find(@permission_template_access.permission_template_id).source_type
         end
     end
   end

--- a/app/controllers/hyrax/admin/permission_templates_controller.rb
+++ b/app/controllers/hyrax/admin/permission_templates_controller.rb
@@ -1,30 +1,61 @@
 module Hyrax
   module Admin
     class PermissionTemplatesController < ApplicationController
-      load_and_authorize_resource find_by: 'source_id',
-                                  id_param: 'admin_set_id',
-                                  class: 'Hyrax::PermissionTemplate'
-
-      # Override the default prefixes so that we use the collection partals.
-      def self.local_prefixes
-        ["hyrax/admin/admin_sets"]
-      end
+      before_action :find_permission_template
+      authorize_resource class: 'Hyrax::PermissionTemplate', instance_name: :permission_template
 
       def update
         update_info = form.update(update_params)
         if update_info[:updated] == true # Ensure we redirect to currently active tab with the appropriate notice
-          redirect_to(edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab),
-                      notice: translate(update_info[:content_tab], scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
+          redirect_to_edit_path(update_info)
         else
-          # When we have invalid data, we are redirecting because to render, we need to set an AdminSetForm
-          # (because we are rendering admin set forms)
-          # TODO: [Jeremy Friesen says: We need to better consolidate the form logic of admin sets and permission templates
-          redirect_to(edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab),
-                      alert: translate(update_info[:error_code], scope: 'hyrax.admin.admin_sets.form.permission_update_errors'))
+          redirect_to_edit_path_with_error(update_info)
         end
       end
 
       private
+
+        # Override the default prefixes so that we use the correct partials.
+        def _prefixes
+          if admin_set?
+            @_prefixes ||= super + ['hyrax/admin/admin_sets']
+          elsif collection?
+            @_prefixes ||= super + ['hyrax/dashboard/collections']
+          end
+        end
+
+        # We need to do this manually instead of using load_and_authorize_resource
+        # because the id we are looking for is different when using an admin set vs. collection
+        def find_permission_template
+          if admin_set?
+            @permission_template = PermissionTemplate.find_by(source_id: params[:admin_set_id])
+          elsif collection?
+            @permission_template = PermissionTemplate.find_by(source_id: params[:collection_id])
+          end
+        end
+
+        def redirect_to_edit_path(update_info)
+          if admin_set?
+            redirect_to(edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab),
+                        notice: translate(update_info[:content_tab], scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
+          elsif collection?
+            redirect_to(edit_dashboard_collection_path(params[:collection_id], anchor: current_tab),
+                        notice: translate(update_info[:content_tab], scope: 'hyrax.dashboard.collections.form.permission_update_notices'))
+          end
+        end
+
+        def redirect_to_edit_path_with_error(update_info)
+          # When we have invalid data, we are redirecting because to render, we need to set an AdminSetForm
+          # (because we are rendering admin set forms)
+          # TODO: [Jeremy Friesen says: We need to better consolidate the form logic of admin sets and permission templates
+          if admin_set?
+            redirect_to(edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab),
+                        alert: translate(update_info[:error_code], scope: 'hyrax.admin.admin_sets.form.permission_update_errors'))
+          elsif collection?
+            redirect_to(edit_dashboard_collection_path(params[:collection_id], anchor: current_tab),
+                        alert: translate(update_info[:error_code], scope: 'hyrax.dashboard.collections.form.permission_update_errors'))
+          end
+        end
 
         def form
           Forms::PermissionTemplateForm.new(@permission_template)
@@ -38,14 +69,26 @@ module Hyrax
 
         # @return [String] the name of the current UI tab to show
         def current_tab
-          pt = params[:permission_template]
-          @current_tab ||= if pt[:access_grants_attributes].present?
-                             'participants'
-                           elsif pt[:workflow_id].present?
-                             'workflow'
-                           else
-                             'visibility'
-                           end
+          if collection?
+            @current_tab ||= 'sharing'
+          else
+            pt = params[:permission_template]
+            @current_tab ||= if pt[:access_grants_attributes].present?
+                               'participants'
+                             elsif pt[:workflow_id].present?
+                               'workflow'
+                             else
+                               'visibility'
+                             end
+          end
+        end
+
+        def admin_set?
+          params['admin_set_id'].present?
+        end
+
+        def collection?
+          params['collection_id'].present?
         end
     end
   end

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -85,6 +85,7 @@ module Hyrax
 
       def after_create
         form
+        PermissionTemplate.create!(source_id: @collection.id, source_type: 'collection')
         respond_to do |format|
           ActiveFedora::SolrService.instance.conn.commit
           format.html { redirect_to dashboard_collection_path(@collection), notice: 'Collection was successfully created.' }

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -61,7 +61,7 @@ module Hyrax
       # to the edit permissions of the AdminSet and to the WorkflowResponsibilities
       # of the active workflow
       def update_management
-        admin_set.update_access_controls!
+        admin_set.update_access_controls! if model.source_type == 'admin_set'
         update_workflow_approving_responsibilities
       end
 

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -485,6 +485,10 @@ en:
         edit:
           header: "Edit Collection: %{title}"
         form:
+          permission_update_notices:
+            sharing: "The collection's sharing options have been updated."
+          permission_update_errors:
+            error:   "Invalid update option for permission template."
           tabs:
             description: "Description"
             sharing:     "Sharing"

--- a/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
@@ -26,35 +26,73 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
                agent_type: agent_type,
                agent_id: agent_id)
       end
-      let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
-      let(:admin_set) { create(:admin_set, edit_users: ['Liz']) }
 
-      context 'when deleting the admin users group' do
-        let(:agent_type) { 'group' }
-        let(:agent_id) { 'admin' }
+      context 'when source is an admin set' do
+        let(:permission_template) { create(:permission_template, source_id: admin_set.id, source_type: 'admin_set') }
+        let(:admin_set) { create(:admin_set, edit_users: ['Liz']) }
 
-        it "fails" do
-          expect(controller).to receive(:authorize!).with(:destroy, permission_template_access)
-          expect do
-            delete :destroy, params: { id: permission_template_access }
-          end.not_to change { Hyrax::PermissionTemplateAccess.count }
-          expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(source_id, locale: 'en', anchor: 'participants'))
-          expect(flash[:notice]).not_to eq I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
-          expect(flash[:alert]).to eq 'The repository administrators group cannot be removed'
+        context 'when deleting the admin users group' do
+          let(:agent_type) { 'group' }
+          let(:agent_id) { 'admin' }
+
+          it "fails" do
+            expect(controller).to receive(:authorize!).with(:destroy, permission_template_access)
+            expect do
+              delete :destroy, params: { id: permission_template_access }
+            end.not_to change { Hyrax::PermissionTemplateAccess.count }
+            expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(source_id, locale: 'en', anchor: 'participants'))
+            expect(flash[:notice]).not_to eq I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
+            expect(flash[:alert]).to eq 'The repository administrators group cannot be removed'
+          end
+        end
+
+        context 'with deleting any agent other than the admin users group' do
+          let(:agent_type) { 'user' }
+          let(:agent_id) { 'Liz' }
+
+          it "is successful" do
+            expect(controller).to receive(:authorize!).with(:destroy, permission_template_access)
+            expect do
+              delete :destroy, params: { id: permission_template_access }
+            end.to change { Hyrax::PermissionTemplateAccess.count }.by(-1)
+            expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(source_id, locale: 'en', anchor: 'participants'))
+            expect(flash[:notice]).to eq(I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
+            expect(admin_set.reload.edit_users).to be_empty
+          end
         end
       end
-      context 'with deleting any agent other than the admin users group' do
-        let(:agent_type) { 'user' }
-        let(:agent_id) { 'Liz' }
 
-        it "is successful" do
-          expect(controller).to receive(:authorize!).with(:destroy, permission_template_access)
-          expect do
-            delete :destroy, params: { id: permission_template_access }
-          end.to change { Hyrax::PermissionTemplateAccess.count }.by(-1)
-          expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(source_id, locale: 'en', anchor: 'participants'))
-          expect(flash[:notice]).to eq(I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
-          expect(admin_set.reload.edit_users).to be_empty
+      context 'when source is a collection' do
+        let(:permission_template) { create(:permission_template, source_id: collection.id, source_type: 'collection') }
+        let(:collection) { create(:collection, edit_users: ['Liz']) }
+
+        context 'when deleting the admin users group' do
+          let(:agent_type) { 'group' }
+          let(:agent_id) { 'admin' }
+
+          it "fails" do
+            expect(controller).to receive(:authorize!).with(:destroy, permission_template_access)
+            expect do
+              delete :destroy, params: { id: permission_template_access }
+            end.not_to change { Hyrax::PermissionTemplateAccess.count }
+            expect(response).to redirect_to(hyrax.edit_dashboard_collection_path(source_id, locale: 'en', anchor: 'sharing'))
+            expect(flash[:notice]).not_to eq I18n.t('sharing', scope: 'hyrax.dashboard.collections.form.permission_update_notices')
+            expect(flash[:alert]).to eq 'The repository administrators group cannot be removed'
+          end
+        end
+
+        context 'with deleting any agent other than the admin users group' do
+          let(:agent_type) { 'user' }
+          let(:agent_id) { 'Liz' }
+
+          it "is successful" do
+            expect(controller).to receive(:authorize!).with(:destroy, permission_template_access)
+            expect do
+              delete :destroy, params: { id: permission_template_access }
+            end.to change { Hyrax::PermissionTemplateAccess.count }.by(-1)
+            expect(response).to redirect_to(hyrax.edit_dashboard_collection_path(source_id, locale: 'en', anchor: 'sharing'))
+            expect(flash[:notice]).to eq(I18n.t('sharing', scope: 'hyrax.dashboard.collections.form.permission_update_notices'))
+          end
         end
       end
     end

--- a/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
@@ -11,11 +11,22 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
     describe "update" do
       let(:permission_template) { create(:permission_template) }
 
-      it "is unauthorized" do
+      before do
+        allow(controller.current_ability).to receive(:can?).with(:update, permission_template).and_return(false)
+      end
+
+      it "is unauthorized for admin sets" do
         # This spec was not firing as expected. It was getting a nil permission template. This mock expectation is a bit
         # odd, but it needs to go rather deep into CanCan to behave accordingly.
-        allow(controller.current_ability).to receive(:can?).with(:update, permission_template).and_return(false)
         put :update, params: { id: permission_template, admin_set_id: permission_template.source_id }
+        expect(assigns(:permission_template)).to eq(permission_template)
+        expect(response).to be_unauthorized
+      end
+
+      it "is unauthorized for collections" do
+        # This spec was not firing as expected. It was getting a nil permission template. This mock expectation is a bit
+        # odd, but it needs to go rather deep into CanCan to behave accordingly.
+        put :update, params: { id: permission_template, collection_id: permission_template.source_id }
         expect(assigns(:permission_template)).to eq(permission_template)
         expect(response).to be_unauthorized
       end
@@ -23,21 +34,37 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
   end
 
   context "when signed in as an admin" do
-    describe "update participants" do
-      let!(:permission_template) { create(:permission_template) }
-      let(:grant_attributes) { [{ "agent_type" => "user", "agent_id" => "bob", "access" => "view" }] }
+    let!(:permission_template) { create(:permission_template) }
+    let(:grant_attributes) { [{ "agent_type" => "user", "agent_id" => "bob", "access" => "view" }] }
+    let(:form_attributes) { { visibility: 'open', access_grants_attributes: grant_attributes } }
+
+    describe "update admin set participants" do
       let(:input_params) do
         { admin_set_id: permission_template.source_id,
           permission_template: form_attributes }
       end
-      let(:form_attributes) { { visibility: 'open', access_grants_attributes: grant_attributes } }
 
       it "is successful" do
-        expect(controller).to receive(:authorize!).with(:update, permission_template)
+        expect(controller).to receive(:authorize!).with(:update, Hyrax::PermissionTemplate)
         expect(form).to receive(:update).with(ActionController::Parameters.new(form_attributes).permit!).and_return(updated: true, content_tab: 'participants')
         put :update, params: input_params
         expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(permission_template.source_id, locale: 'en', anchor: 'participants'))
         expect(flash[:notice]).to eq(I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
+      end
+    end
+
+    describe "update collection participants" do
+      let(:input_params) do
+        { collection_id: permission_template.source_id,
+          permission_template: form_attributes }
+      end
+
+      it "is successful" do
+        expect(controller).to receive(:authorize!).with(:update, Hyrax::PermissionTemplate)
+        expect(form).to receive(:update).with(ActionController::Parameters.new(form_attributes).permit!).and_return(updated: true, content_tab: 'sharing')
+        put :update, params: input_params
+        expect(response).to redirect_to(hyrax.edit_dashboard_collection_path(permission_template.source_id, locale: 'en', anchor: 'sharing'))
+        expect(flash[:notice]).to eq(I18n.t('sharing', scope: 'hyrax.dashboard.collections.form.permission_update_notices'))
       end
     end
   end

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     let(:input_params) do
       ActionController::Parameters.new(access_grants_attributes: grant_attributes).permit!
     end
-    let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
+    let(:permission_template) { create(:permission_template, source_id: admin_set.id, source_type: 'admin_set') }
 
     let(:user) { create(:user) }
     let(:user2) { create(:user) }


### PR DESCRIPTION
Fixes #1593 

(collections sprint)

Makes the necessary modifications for the "Sharing" tab on the collections edit page to function.  Managers, depositors, and viewers can be added and deleted from collections.  The Participants tab for admin sets (which same the same permissions template controller with collections) continues to work properly as well.

Using the same permission templates controller for both admin sets and collections requires a lot of conditional logic.  Normally that might indicate a separate controller for collection permission templates, but given that admin sets should eventually morph into just another type of collection, this is probably the best approach.