### PR TITLE
Consolidating feature specs

### DIFF
--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -19,16 +19,10 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         visit '/dashboard/my/collections'
       end
 
-      it 'has page title' do
+      it "has page title, does not have tabs, and lists only user's collections" do
         expect(page).to have_content 'Collections'
-      end
-
-      it 'does not have tabs' do
         expect(page).not_to have_link 'All Collections'
         expect(page).not_to have_link 'Your Collections'
-      end
-
-      it "lists only user's collections" do
         expect(page).to have_link(collection1.title.first)
         expect(page).to have_link(collection2.title.first)
         expect(page).not_to have_link(collection3.title.first)
@@ -46,16 +40,10 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         visit '/dashboard/my/collections'
       end
 
-      it 'has page title' do
+      it "has page title, has tabs for All and Your Collections, and lists only admin_user's collections" do
         expect(page).to have_content 'Collections'
-      end
-
-      it 'has tabs for All and Your Collections' do
         expect(page).to have_link 'All Collections'
         expect(page).to have_link 'Your Collections'
-      end
-
-      it "lists only admin_user's collections" do
         expect(page).not_to have_link(collection1.title.first)
         expect(page).not_to have_link(collection2.title.first)
         expect(page).to have_link(collection3.title.first)
@@ -164,11 +152,9 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       visit '/dashboard/my/collections'
     end
 
-    it "has creation date for collections" do
+    it "has creation date for collections and shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       expect(page).to have_content(collection1.create_date.to_date.to_formatted_s(:standard))
-    end
 
-    it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       expect(page).to have_content(collection.title.first)
       within('#document_' + collection.id) do
         click_link("Display all details of #{collection.title.first}")

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -29,8 +29,18 @@ RSpec.feature 'searching' do
       end
     end
 
-    it "only searches all" do
+    it "only searches all and does not display search options for dashboard files" do
       visit '/'
+
+      # it "does not display search options for dashboard files" do
+      # This section was tested on its own, and required a full setup.
+      within(".input-group-btn") do
+        expect(page).not_to have_content("My Works")
+        expect(page).not_to have_content("My Collections")
+        expect(page).not_to have_content("My Shares")
+      end
+      # end
+
       expect(page).to have_content("All")
       expect(page).to have_css("a[data-search-label*=All]", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Works']", visible: false)
@@ -50,15 +60,6 @@ RSpec.feature 'searching' do
 
       expect(page.body).to include "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=taco&amp;locale=en\">taco</a></span>"
       expect(page.body).to include "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=mustache&amp;locale=en\">mustache</a></span>"
-    end
-
-    it "does not display search options for dashboard files" do
-      visit "/"
-      within(".input-group-btn") do
-        expect(page).not_to have_content("My Works")
-        expect(page).not_to have_content("My Collections")
-        expect(page).not_to have_content("My Shares")
-      end
     end
   end
 end


### PR DESCRIPTION
## Consolidating related features into single `it`

f9457393aa9f9907aa1d45a498fef6ae828b9d82

Each `it` block comes with a setup time. Feature spec setup times are
even more expensive.

Before the change: `Finished in 40.03 seconds`
After the change: `Finished in 28.14 seconds`

Feature specs have a higher variance on completion time (as there is
browser interaction).

## Consolidating related features into single `it`

db57aa80399360b4bba3130b7842beb9a05a6ba6

Each `it` block comes with a setup time. Feature spec setup times are
even more expensive.

Before the change: `Finished in 6.17 seconds`
After the change: `Finished in 5.33 seconds`

It's a small performance gain, but each second matters.

Feature specs have a higher variance on completion time (as there is
browser interaction).
