### PR TITLE
Updating abc rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,7 @@ Metrics/LineLength:
   Max: 200
 
 Metrics/AbcSize:
-  Max: 27
+  Max: 26
 
 Metrics/BlockLength:
   ExcludedMethods: ['included']

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,7 @@ Metrics/LineLength:
   Max: 200
 
 Metrics/AbcSize:
-  Max: 28
+  Max: 27
 
 Metrics/BlockLength:
   ExcludedMethods: ['included']

--- a/lib/generators/hyrax/work/work_generator.rb
+++ b/lib/generators/hyrax/work/work_generator.rb
@@ -70,14 +70,12 @@ class Hyrax::WorkGenerator < Rails::Generators::NamedBase
     end
   end
 
+  LOCALES = %w[en es zh de fr it pt-BR].freeze
+
   def create_i18n
-    template('locale.en.yml.erb', File.join('config/locales/', class_path, "#{file_name}.en.yml"))
-    template('locale.es.yml.erb', File.join('config/locales/', class_path, "#{file_name}.es.yml"))
-    template('locale.zh.yml.erb', File.join('config/locales/', class_path, "#{file_name}.zh.yml"))
-    template('locale.de.yml.erb', File.join('config/locales/', class_path, "#{file_name}.de.yml"))
-    template('locale.fr.yml.erb', File.join('config/locales/', class_path, "#{file_name}.fr.yml"))
-    template('locale.it.yml.erb', File.join('config/locales/', class_path, "#{file_name}.it.yml"))
-    template('locale.pt-BR.yml.erb', File.join('config/locales/', class_path, "#{file_name}.pt-BR.yml"))
+    LOCALES.each do |locale|
+      template("locale.#{locale}.yml.erb", File.join('config/locales/', class_path, "#{file_name}.#{locale}.yml"))
+    end
   end
 
   def create_actor_spec

--- a/lib/hyrax/arkivo/actor.rb
+++ b/lib/hyrax/arkivo/actor.rb
@@ -18,7 +18,6 @@ module Hyrax
 
       def create_work_from_item
         work = Hyrax.primary_work_type.new
-        current_ability = ::Ability.new(user)
         work_actor = Hyrax::CurationConcern.actor
         create_attrs = attributes.merge(arkivo_checksum: item['file']['md5'])
         env = Actors::Environment.new(work, current_ability, create_attrs)
@@ -37,7 +36,6 @@ module Hyrax
 
       def update_work_from_item(work)
         work_actor = Hyrax::CurationConcern.actor
-        current_ability = ::Ability.new(user)
         work_attributes = default_attributes.merge(attributes).merge(arkivo_checksum: item['file']['md5'])
         env = Actors::Environment.new(work, current_ability, work_attributes)
         work_actor.update(env)
@@ -53,6 +51,10 @@ module Hyrax
       end
 
       private
+
+        def current_ability
+          @current_ability ||= ::Ability.new(user)
+        end
 
         # @return [Hash<String, Array>] a list of properties to set on the work. Keys must be strings in order for them to correctly merge with the values from arkivio (in `@item`)
         # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
## Reducing Rubocop ABC threshold to 27

2eb416a19de3f453b3f5309c979df5401eb8ef0c

We are already mostly doing it, so lets acknowledge this and stake out
a higher bar of excellence.

## Reducing Rubocop ABC threshold to 26

f519cf9143fe8c966f90e6924429ba6e2d834568

We are already mostly doing it, so lets acknowledge this and stake out
a higher bar of excellence.

(For reference: ABC of 25 or less requires 4 files to change)
