### PR TITLE
Raise error when attempting to set collection_type when collection ha…

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -109,7 +109,7 @@ module Hyrax
         @collection.attributes = collection_params.except(:members)
         @collection.apply_depositor_metadata(current_user.user_key)
         add_members_to_collection unless batch.empty?
-        @collection.collection_type_gid = params[:collection_type_gid]
+        @collection.collection_type_gid = params[:collection_type_gid] if params[:collection_type_gid]
         # TODO: There has to be a better way to handle a missing gid than setting to User Collection.
         # TODO: Via UI, there should always be one defined.  It is missing right now because the modal isn't implemented yet
         # TODO: But perhaps this is needed for the case when it gets called outside the context of the UI?

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -40,7 +40,7 @@ module Hyrax
     # @return [False] if record matching gid is not found
     def self.find_by_gid(gid)
       find(GlobalID.new(gid).model_id)
-    rescue ActiveRecord::RecordNotFound
+    rescue ActiveRecord::RecordNotFound, URI::InvalidURIError
       false
     end
 
@@ -49,9 +49,9 @@ module Hyrax
     # @return [Hyrax::CollectionType] an instance of Hyrax::CollectionType with id = the model_id portion of the gid (e.g. 3)
     # @raise [ActiveRecord::RecordNotFound] if record matching gid is not found
     def self.find_by_gid!(gid)
-      find(GlobalID.new(gid).model_id)
-    rescue ActiveRecord::RecordNotFound
-      raise ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID '#{gid}'"
+      result = find_by_gid(gid)
+      raise ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID '#{gid}'" unless result
+      result
     end
 
     # Return the Global Identifier for this collection type.

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -20,26 +20,9 @@ module Hyrax
 
     delegate(*Hyrax::CollectionType.collection_type_settings_methods, to: :collection_type, prefix: :collection_type_is)
 
-    # @note This is an ugly hack. In working with Lynette, we discovered that the collection_type_gid
-    #       was in the solr_document if the Collection was created via the UI. If the collection
-    #       was created by factory girl then collection_type_gid was not in the solr_document.
-    #       The long-term solution is to ensure that the SOLR document has some key for the collection_type.
-    # @todo Change behavior when https://github.com/samvera/hyrax/pull/1556 is integrated
     def collection_type
-      @collection_type ||= begin
-        collection_type_gid =
-          if solr_document.key?('collection_type_gid_ssim')
-            # Taking a short cut if we know the collection type based on the SOLR document
-            Array.wrap(solr_document.fetch('collection_type_gid_ssim')).first
-          else
-            solr_document.hydra_model.find(solr_document.id).collection_type_gid
-          end
-        if collection_type_gid
-          Hyrax::CollectionType.find_by_gid!(collection_type_gid)
-        else
-          Hyrax::CollectionType.find_or_create_default_collection_type
-        end
-      end
+      gid = Array.wrap(solr_document.fetch('collection_type_gid_ssim', [])).first
+      @collection_type ||= CollectionType.find_by_gid!(gid)
     end
 
     # Metadata Methods

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :collection_type, class: Hyrax::CollectionType do
-    sequence(:id) { |n| format("%010d", n) }
     sequence(:title) { |n| "Title #{n}" }
 
     description 'Collection type with all options'

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -4,16 +4,16 @@ FactoryGirl.define do
 
     transient do
       user { FactoryGirl.create(:user) }
-      collection_type_settings [:nestable, :discoverable, :sharable, :allow_multiple_membership]
+      # allow defaulting to default user collection
+      collection_type_settings nil
       with_permission_template false
     end
     sequence(:title) { |n| ["Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
-      if collection.collection_type_gid.nil?
-        collection_type = FactoryGirl.create(:collection_type, *evaluator.collection_type_settings)
-        collection.collection_type_gid = collection_type.gid
+      if evaluator.collection_type_settings.present?
+        collection.collection_type = FactoryGirl.create(:collection_type, *evaluator.collection_type_settings)
       end
     end
 

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
+RSpec.describe Hyrax::CollectionType, type: :model do
   let(:collection_type) { build(:collection_type) }
 
   describe '.collection_type_settings_methods' do
@@ -90,6 +90,10 @@ RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
     it 'returns false if collection type with gid does NOT exist' do
       expect(Hyrax::CollectionType.find_by_gid(nonexistent_gid)).to eq false
     end
+
+    it 'returns false if gid is nil' do
+      expect(Hyrax::CollectionType.find_by_gid(nil)).to eq false
+    end
   end
 
   describe '.find_by_gid!' do
@@ -102,6 +106,10 @@ RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
 
     it 'raises error if collection type with gid does NOT exist' do
       expect { Hyrax::CollectionType.find_by_gid!(nonexistent_gid) }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID '#{nonexistent_gid}'")
+    end
+
+    it 'raises error if passed nil' do
+      expect { Hyrax::CollectionType.find_by_gid!(nil) }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID ''")
     end
   end
 
@@ -119,7 +127,7 @@ RSpec.describe Hyrax::CollectionType, clean_repo: true, type: :model do
     end
   end
 
-  describe "collections?" do
+  describe "collections?", :clean_repo do
     let(:collection_type) { create(:collection_type) }
 
     it 'returns true if there are any collections of this collection type' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,6 +117,7 @@ require 'shoulda/matchers'
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec
+    with.library :rails
   end
 end
 


### PR DESCRIPTION
…s already been persisted with a collection_type

Fixes #1529 

This PR has a good deal of refactoring in order to clean up and make easier the actual work on #1529.  I believe these changes will help clear up some pain points mentioned [here](https://github.com/samvera/hyrax/blob/collections-sprint/app/presenters/hyrax/collection_presenter.rb#L23-L43) and previously [here](https://github.com/samvera/hyrax/commit/ad9b00a87e76c8b86072d574f36feaa25a6e619b#diff-47461a9012b685da44afe3d1a87111ffR12) as well as others present in the spec tests.

Guiding principals for this work were:
* Collections need a collection type for delegated methods
* Every collection must have a collection type
* Once a collection is persisted with a collection type it cannot be changed
* Attempt to mimic ActiveRecord where possible

Changes proposed in this pull request beyond the original issue:
* Change assignment of unassigned collections (including `new?` collections) to a collection type from `after_find` to `after_initialize`
* Assignment of collection type of a previously persisted collection does not force saving
* Reassignment of collection type is valid up until the point of saving
* Validate the presence of collection_type_gid
* Add `with.library rails` to the shoulda-matchers configuration block per their documentation.  This fixed an issue where `validate_presence_of` wasn't visible in the collection model test.

Work still to do:
* `:clean_repo` could probably be removed from more spec blocks
* More validations may be needed to ensure that all aspects of a collection type are being adhered to since this flow might be possible: create new collection, set collection type, add works, change collection type, save collection
* `collection_type=` is a convenience method for `collection_type_gid=` but is inefficient since it does a find to get the same collection type that was passed in to `collection_type=`
* I couldn't think of a good way to test the collection_type_gid presence validation since the code ensures that every collection will always have a collection_type_gid and the`validate_presence_of` shoulda-matcher attempts to set it to `nil` which throws an error causing the matcher to fail.

@samvera/hyrax-code-reviewers
