### PR TITLE
Adding functionality to add participants to collection types

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -3,8 +3,9 @@ module Hyrax
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :admin_group_name
+      class_attribute :admin_group_name, :registered_group_name
       self.admin_group_name = 'admin'
+      self.registered_group_name = 'registered'
       self.ability_logic += [:admin_permissions,
                              :curation_concerns_permissions,
                              :operation_abilities,
@@ -224,7 +225,7 @@ module Hyrax
 
       def registered_user?
         return false if current_user.guest?
-        user_groups.include? 'registered'
+        user_groups.include? registered_group_name
       end
 
       # Returns true if the current user is the depositor of the specified work

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -83,6 +83,8 @@ module Hyrax
     # * USER_COLLECTION_DEFAULT_TITLE
     # * Hyrax::CollectionTypes::CreateService::DEFAULT_OPTIONS
     #
+    # @see Hyrax::CollectionTypes::CreateService
+    #
     # @return [Hyrax::CollectionType] where machine_id = USER_COLLECTION_MACHINE_ID
     def self.find_or_create_default_collection_type
       find_by(machine_id: USER_COLLECTION_MACHINE_ID) || Hyrax::CollectionTypes::CreateService.create_collection_type
@@ -94,19 +96,19 @@ module Hyrax
     # * ADMIN_SET_DEFAULT_TITLE
     # * Options to override Hyrax::CollectionTypes::CreateService::DEFAULT_OPTIONS
     #
+    # @see Hyrax::CollectionTypes::CreateService
+    #
     # @return [Hyrax::CollectionType] where machine_id = ADMIN_SET_MACHINE_ID
     def self.find_or_create_admin_set_type
       return find_by_machine_id(ADMIN_SET_MACHINE_ID) if exists?(machine_id: ADMIN_SET_MACHINE_ID)
       options = {
         description: 'A collection type that provides Admin Set functionality.',
-        nestable: false,
-        discoverable: true,
-        sharable: true,
-        allow_multiple_membership: false,
-        require_membership: true,
-        assigns_workflow: true,
-        assigns_visibility: true
+        nestable: false, discoverable: true, sharable: true, allow_multiple_membership: false,
+        require_membership: true, assigns_workflow: true, assigns_visibility: true,
+        participants: [{ agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE, agent_id: ::Ability.admin_group_name, access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS },
+                       { agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE, agent_id: ::Ability.admin_group_name, access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS }]
       }
+
       Hyrax::CollectionTypes::CreateService.create_collection_type(machine_id: ADMIN_SET_MACHINE_ID, title: ADMIN_SET_DEFAULT_TITLE, options: options)
     end
 

--- a/app/models/hyrax/collection_type_participant.rb
+++ b/app/models/hyrax/collection_type_participant.rb
@@ -24,7 +24,7 @@ module Hyrax
     def label
       return agent_id unless agent_type == GROUP_TYPE
       case agent_id
-      when 'registered'
+      when ::Ability.registered_group_name
         I18n.t('hyrax.admin.admin_sets.form_participant_table.registered_users')
       when ::Ability.admin_group_name
         I18n.t('hyrax.admin.admin_sets.form_participant_table.admin_users')

--- a/app/services/hyrax/collection_types/create_service.rb
+++ b/app/services/hyrax/collection_types/create_service.rb
@@ -21,7 +21,9 @@ module Hyrax
         allow_multiple_membership: true,
         require_membership: false,
         assigns_workflow: false,
-        assigns_visibility: false
+        assigns_visibility: false,
+        participants: [{ agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE, agent_id: ::Ability.admin_group_name, access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS },
+                       { agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE, agent_id: ::Ability.registered_group_name, access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS }]
       }.freeze
 
       # @param machine_id [String]
@@ -30,7 +32,7 @@ module Hyrax
       # @return [Hyrax::CollectionType]
       def self.create_collection_type(machine_id: DEFAULT_MACHINE_ID, title: DEFAULT_TITLE, options: {})
         opts = DEFAULT_OPTIONS.merge(options)
-        Hyrax::CollectionType.create(machine_id: machine_id, title: title) do |c|
+        ct = Hyrax::CollectionType.create!(machine_id: machine_id, title: title) do |c|
           c.description = opts[:description]
           c.nestable = opts[:nestable]
           c.discoverable = opts[:discoverable]
@@ -40,6 +42,8 @@ module Hyrax
           c.assigns_workflow = opts[:assigns_workflow]
           c.assigns_visibility = opts[:assigns_visibility]
         end
+        Hyrax::CollectionTypes::PermissionsService.add_participants(ct.id, opts[:participants])
+        ct
       end
     end
   end

--- a/app/services/hyrax/collection_types/permissions_service.rb
+++ b/app/services/hyrax/collection_types/permissions_service.rb
@@ -57,6 +57,22 @@ module Hyrax
                                                                                       access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS).pluck('DISTINCT agent_id')
         groups | ['admin']
       end
+
+      # @param collection_type_id [Integer]
+      # @param participants [Array]
+      def self.add_participants(collection_type_id, participants)
+        return unless collection_type_id && participants.count > 0
+        participants.each do |p|
+          begin
+            agent_type = p.fetch(:agent_type)
+            agent_id = p.fetch(:agent_id)
+            access = p.fetch(:access)
+            Hyrax::CollectionTypeParticipant.create!(hyrax_collection_type_id: collection_type_id, agent_type: agent_type, agent_id: agent_id, access: access)
+          rescue
+            Rails.logger.error "Participant not created for collection type #{collection_type_id}: #{agent_type}, #{agent_id}, #{access}\n"
+          end
+        end
+      end
     end
   end
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -233,8 +233,8 @@ en:
           notification:     "The collection type %{name} has been created."
         update:
           notification:     "The collection type %{name} has been updated."
-        destroy:
-          notification:     "The collection type %{name} has been deleted."
+        delete:
+          notification:      "The collection type %{name} has been deleted."
         errors:
           no_settings_change_for_admin_sets: "Collection type settings cannot be altered for the Administrative Set type"
           no_settings_change_for_user_collections: "Collection type settings cannot be altered for the User Collection type"

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -100,12 +100,12 @@ FactoryGirl.define do
     after(:create) do |collection_type, _evaluator|
       attributes = { hyrax_collection_type_id: collection_type.id,
                      access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS,
-                     agent_id: 'registered',
+                     agent_id: ::Ability.registered_group_name,
                      agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
       create(:collection_type_participant, attributes)
       attributes = { hyrax_collection_type_id: collection_type.id,
                      access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS,
-                     agent_id: 'admin',
+                     agent_id: ::Ability.admin_group_name,
                      agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
       create(:collection_type_participant, attributes)
     end
@@ -125,12 +125,12 @@ FactoryGirl.define do
     after(:create) do |collection_type, _evaluator|
       attributes = { hyrax_collection_type_id: collection_type.id,
                      access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS,
-                     agent_id: 'admin',
+                     agent_id: ::Ability.admin_group_name,
                      agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
       create(:collection_type_participant, attributes)
       attributes = { hyrax_collection_type_id: collection_type.id,
                      access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS,
-                     agent_id: 'admin',
+                     agent_id: ::Ability.admin_group_name,
                      agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
       create(:collection_type_participant, attributes)
     end

--- a/spec/services/hyrax/collection_types/create_service_spec.rb
+++ b/spec/services/hyrax/collection_types/create_service_spec.rb
@@ -15,5 +15,11 @@ RSpec.describe Hyrax::CollectionTypes::CreateService do
       expect(ct.description).to include('with options')
       expect(ct.discoverable?).to be_falsey
     end
+
+    it "creates collection participants defined in options" do
+      expect do
+        described_class.create_collection_type
+      end.to change(Hyrax::CollectionTypeParticipant, :count).by(described_class::DEFAULT_OPTIONS[:participants].count)
+    end
   end
 end

--- a/spec/services/hyrax/collection_types/permissions_service_spec.rb
+++ b/spec/services/hyrax/collection_types/permissions_service_spec.rb
@@ -201,4 +201,14 @@ RSpec.describe Hyrax::CollectionTypes::PermissionsService do
       it { is_expected.to match_array ['manage_group', 'admin'] }
     end
   end
+
+  describe ".add_participants" do
+    let(:participants) { [{ agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE, agent_id: 'test_group', access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS }] }
+    let(:coltype) { create(:collection_type) }
+
+    it 'adds the participants to a collection type' do
+      expect(Hyrax::CollectionTypeParticipant).to receive(:create!)
+      described_class.add_participants(coltype.id, participants)
+    end
+  end
 end


### PR DESCRIPTION
refs #1532 #1601 

Adds a method to the Collection Type Create Service to create participants for a collection type, which is then used when creating the default user collection type and the default admin set type.  The options for the participants are encapsulated in the collection type options sent to the create service.