### PR TITLE
Show single action button for removing items from collection

### DIFF
--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -71,7 +71,7 @@ header {
   text-align: center;
 }
 
-.edit_collection {
+.dropdown-menu .edit_collection {
   margin-top: 2 * $padding-large-vertical;
 }
 

--- a/app/assets/stylesheets/hyrax/_styles.scss
+++ b/app/assets/stylesheets/hyrax/_styles.scss
@@ -50,7 +50,7 @@ label.disabled {
   font-size: 1.5em;
 }
 
-.btn.collection-remove {
+.dropdown-menu .btn.collection-remove {
   background:none;
   border:none;
   /*     padding:0!important;
@@ -67,7 +67,7 @@ label.disabled {
   white-space: nowrap;
   border-radius:0px
 }
-.btn.collection-remove:hover{
+.dropdown-menu .btn.collection-remove:hover {
   text-decoration:underline;
   background-color:#0088CC;
 }

--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -22,8 +22,8 @@ module Hyrax
       params[:cq].present?
     end
 
-    def button_for_remove_from_collection(collection, document, label = 'Remove From Collection')
-      render 'hyrax/dashboard/collections/button_remove_from_collection', collection: collection, label: label, document: document
+    def button_for_remove_from_collection(collection, document, label: 'Remove From Collection', btn_class: 'btn-primary')
+      render 'hyrax/dashboard/collections/button_remove_from_collection', collection: collection, label: label, document: document, btn_class: btn_class
     end
 
     def button_for_remove_selected_from_collection(collection, label = 'Remove From Collection')

--- a/app/views/hyrax/dashboard/collections/_button_remove_from_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_button_remove_from_collection.html.erb
@@ -1,4 +1,4 @@
 <%= form_for collection, url: hyrax.dashboard_collection_path(collection), method: :put, as: 'collection' do |f| %>
   <%= single_item_action_remove_form_fields(f, document) %>
-  <%= f.submit label, class: "btn btn-primary collection-remove" %>
+  <%= f.submit label, class: "btn collection-remove #{btn_class}" %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -23,9 +23,9 @@
   <td class="text-center">
     <%= render_visibility_link(document) %>
   </td>
-  <% if current_user %>
+  <% if current_user and can? :edit, @collection %>
     <td class="text-center">
-      <%= render 'show_document_list_menu', document: document %>
+      <%= button_for_remove_from_collection @collection, document, label: "Remove", btn_class: "btn-danger btn-xs" %>
     </td>
   <% end %>
 </tr>

--- a/app/views/hyrax/dashboard/collections/_work_action_menu.html.erb
+++ b/app/views/hyrax/dashboard/collections/_work_action_menu.html.erb
@@ -9,7 +9,7 @@
   <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
 
     <li role="menuitem" tabindex="-1">
-      <%= button_for_remove_from_collection(@collection, document, 'Remove from Collection') %>
+      <%= button_for_remove_from_collection(@collection, document, label: 'Remove from Collection') %>
     </li>
 
     <li role="menuitem" tabindex="-1">

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -309,6 +309,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       before do
         sign_in admin_user
       end
+      # TODO: move this test to a view unit test (and solve the missing warden problem when using Ability in view tests)
       it 'shows remove action buttons' do
         visit "/dashboard/collections/#{collection1.id}"
         expect(page).to have_selector('input.collection-remove', count: 2)
@@ -321,14 +322,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         expect(page).not_to have_content(work1.title.first)
         expect(page).to have_content(work2.title.first)
       end
-      it 'removes the second work from the list of items' do
-        visit "/dashboard/collections/#{collection1.id}"
-        expect(page).to have_selector('input.collection-remove', count: 2)
-        page.all('input.collection-remove')[1].click
-        expect(page).to have_selector('input.collection-remove', count: 1)
-        expect(page).to have_content(work1.title.first)
-        expect(page).not_to have_content(work2.title.first)
-      end
       xit 'removes a sub-collection from the list of items (dependency on collection nesting)' do
       end
     end
@@ -339,6 +332,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       before do
         sign_in user
       end
+      # TODO: move this test to a view unit test (and solve the missing warden problem when using Ability in view tests)
       it 'does not show remove action buttons' do
         visit "/dashboard/collections/#{collection3.id}"
         expect(page).not_to have_selector 'input.collection-remove'

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -301,6 +301,51 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
     end
   end
 
+  describe 'remove works from collection' do
+    context 'user that can edit' do
+      let!(:work2) { create(:work, title: ["King Louie"], member_of_collections: [collection1], user: user) }
+      let!(:work1) { create(:work, title: ["King Kong"], member_of_collections: [collection1], user: user) }
+
+      before do
+        sign_in admin_user
+      end
+      it 'shows remove action buttons' do
+        visit "/dashboard/collections/#{collection1.id}"
+        expect(page).to have_selector('input.collection-remove', count: 2)
+      end
+      it 'removes the first work from the list of items' do
+        visit "/dashboard/collections/#{collection1.id}"
+        expect(page).to have_selector('input.collection-remove', count: 2)
+        page.all('input.collection-remove')[0].click
+        expect(page).to have_selector('input.collection-remove', count: 1)
+        expect(page).not_to have_content(work1.title.first)
+        expect(page).to have_content(work2.title.first)
+      end
+      it 'removes the second work from the list of items' do
+        visit "/dashboard/collections/#{collection1.id}"
+        expect(page).to have_selector('input.collection-remove', count: 2)
+        page.all('input.collection-remove')[1].click
+        expect(page).to have_selector('input.collection-remove', count: 1)
+        expect(page).to have_content(work1.title.first)
+        expect(page).not_to have_content(work2.title.first)
+      end
+      xit 'removes a sub-collection from the list of items (dependency on collection nesting)' do
+      end
+    end
+    context 'user that cannot edit' do
+      let!(:work1) { create(:work, title: ["King Louie"], member_of_collections: [collection3], user: user) }
+      let!(:work2) { create(:work, title: ["King Kong"], member_of_collections: [collection3], user: user) }
+
+      before do
+        sign_in user
+      end
+      it 'does not show remove action buttons' do
+        visit "/dashboard/collections/#{collection3.id}"
+        expect(page).not_to have_selector 'input.collection-remove'
+      end
+    end
+  end
+
   describe 'edit collection' do
     let(:collection) { create(:named_collection, user: user) }
     let!(:work1) { create(:work, title: ["King Louie"], member_of_collections: [collection], user: user) }


### PR DESCRIPTION
Fixes #1586 

Replaces action menu with 'Remove' button on Collections dashboard members list

A small refactor of the button_for_remove_from_collection helper allows it to be used both by itself and in the action menu.

@samvera/hyrax-code-reviewers
