### PR TITLE
Add new work to collection from collection show page

### DIFF
--- a/app/presenters/hyrax/select_type_presenter.rb
+++ b/app/presenters/hyrax/select_type_presenter.rb
@@ -19,16 +19,18 @@ module Hyrax
     end
 
     def switch_to_new_work_path(route_set:, params:)
-      if params.key?(:add_works_to_collection)
-        route_set.new_polymorphic_path(concern, add_works_to_collection: params[:add_works_to_collection])
+      col_id = collection_id(params)
+      if col_id
+        route_set.new_polymorphic_path(concern, add_works_to_collection: col_id)
       else
         route_set.new_polymorphic_path(concern)
       end
     end
 
     def switch_to_batch_upload_path(route_set:, params:)
-      if params.key?(:add_works_to_collection)
-        route_set.new_batch_upload_path(payload_concern: concern, add_works_to_collection: params[:add_works_to_collection])
+      col_id = collection_id(params)
+      if col_id
+        route_set.new_batch_upload_path(payload_concern: concern, add_works_to_collection: col_id)
       else
         route_set.new_batch_upload_path(payload_concern: concern)
       end
@@ -46,6 +48,13 @@ module Hyrax
         defaults << :"hyrax.select_type.#{key}"
         defaults << ''
         I18n.t(defaults.shift, default: defaults)
+      end
+
+      def collection_id(params)
+        return nil unless params
+        collection_id = params[:add_works_to_collection]
+        collection_id ||= params[:id] if params[:id] && params[:controller] == 'hyrax/dashboard/collections'
+        collection_id
       end
   end
 end

--- a/app/views/hyrax/dashboard/collections/_edit_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_edit_actions.html.erb
@@ -1,8 +1,8 @@
 <h2 class="sr-only"><%= t('hyrax.collection.actions.header') %></h2>
 <div class="actions-controls-collections">
-  <%= link_to t('hyrax.collection.actions.add_works.label'),
+  <%= link_to t('hyrax.collection.actions.add_existing_works.label'),
               hyrax.my_works_path(add_works_to_collection: @form.id),
-              title: t('hyrax.collection.actions.add_works.desc'),
+              title: t('hyrax.collection.actions.add_existing_works.desc'),
               class: 'btn btn-default',
               data: { turbolinks: false } %>
 </div>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -19,9 +19,9 @@
       <% end %>
     <% end %>
   </ul>
-  <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor' } do |f| %>
 
-  <div class="tab-content">
+  <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor' } do |f| %>
+    <div class="tab-content">
       <div id="description" class="tab-pane active">
         <div class="panel panel-default labels">
           <div class="panel-body">
@@ -61,7 +61,7 @@
             <% end %>
           </div>
         </div>
-      </div>
+      </div> <!-- end description -->
 
       <% if @form.persisted? %>
         <div id="branding" class="tab-pane">
@@ -97,8 +97,7 @@
         <% end %>
         <%= link_to t(:'helpers.action.cancel'), main_app.root_path, class: 'btn btn-link' %>
       </div>
+    </div> <!-- end tab-content -->
+  <% end # simple_form_for %>
 
-  <% end %>
-  <% # end of form %>
-
-</div>
+</div> <!-- end collection-controls -->

--- a/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
@@ -1,16 +1,21 @@
 <h2 class="sr-only"><%= t('hyrax.collection.actions.header') %></h2>
 <div class="actions-controls-collections">
   <% if can? :edit, presenter.solr_document # TODO: Shouldn't this be :deposit -- dependency on participants %>
-    <%= link_to t('hyrax.collection.actions.add_works.label'),
+    <%= link_to t('hyrax.collection.actions.add_existing_works.label'),
                 hyrax.my_works_path(add_works_to_collection: presenter.id),
-                title: t('hyrax.collection.actions.add_works.desc'),
+                title: t('hyrax.collection.actions.add_existing_works.desc'),
                 class: 'btn btn-default pull-right',
                 data: { turbolinks: false } %>
+    <%= link_to t('hyrax.collection.actions.add_new_work.label'),
+                '#',
+                title: t('hyrax.collection.actions.add_new_work.desc'),
+                data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single', add_works_to_collection: presenter.id },
+                class: 'btn btn-default  pull-right'  %>
     <% if presenter.collection_type_is_nestable? %>
-        <%= link_to t('hyrax.collection.actions.nest_collections.label'),
-                    hyrax.dashboard_new_nest_collection_within_path(child_id: presenter.id),
-                    title: t('hyrax.collection.actions.nest_collections.desc'),
-                    class: 'btn btn-default' %>
+      <%= link_to t('hyrax.collection.actions.nest_collections.label'),
+                  hyrax.dashboard_new_nest_collection_within_path(child_id: presenter.id),
+                  title: t('hyrax.collection.actions.nest_collections.desc'),
+                  class: 'btn btn-default' %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/shared/_select_work_type_modal.html.erb
+++ b/app/views/shared/_select_work_type_modal.html.erb
@@ -1,3 +1,4 @@
+<% # TODO: This should not live in views/shared.  It does not need to be included on every page. %>
 <div class="modal worktypes fade" id="worktypes-to-create" tabindex="-1" role="dialog" aria-labelledby="select-worktype-label">
   <div class="modal-dialog" role="document">
     <div class="modal-content">

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -400,9 +400,12 @@ en:
       search_results: "Back to search results"
     collection:
       actions:
-        add_works:
-          desc: "Add works to this Collection"
-          label: "Add works"
+        add_existing_works:
+          desc: "Add existing works to this Collection"
+          label: "Add existing works"
+        add_new_work:
+          desc: "Add new work to this Collection"
+          label: "Add new work"
         delete:
           confirmation: "Delete this collection?"
           desc: "Delete this collection"

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -286,14 +286,14 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
     it "preselects the collection we are adding works to" do
       visit "/dashboard/collections/#{collection1.id}"
-      click_link 'Add works'
+      click_link 'Add existing works'
       first('input#check_all').click
       click_button "Add to Collection"
       expect(page).to have_css("input#id_#{collection1.id}[checked='checked']")
       expect(page).not_to have_css("input#id_#{collection2.id}[checked='checked']")
 
       visit "/dashboard/collections/#{collection2.id}"
-      click_link 'Add works'
+      click_link 'Add existing works'
       first('input#check_all').click
       click_button "Add to Collection"
       expect(page).not_to have_css("input#id_#{collection1.id}[checked='checked']")

--- a/spec/presenters/hyrax/select_type_presenter_spec.rb
+++ b/spec/presenters/hyrax/select_type_presenter_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe Hyrax::SelectTypePresenter do
       it { is_expected.to eq "/concern/#{model.to_s.tableize}/new?add_works_to_collection=#{collection_id}" }
     end
 
+    context 'with id and controller params' do
+      let(:params) { { id: collection_id, controller: 'hyrax/dashboard/collections' } }
+
+      it { is_expected.to eq "/concern/#{model.to_s.tableize}/new?add_works_to_collection=#{collection_id}" }
+    end
+
     context 'with no params' do
       let(:params) { {} }
 
@@ -49,6 +55,12 @@ RSpec.describe Hyrax::SelectTypePresenter do
 
     context 'with add_works_to_collection param' do
       let(:params) { { add_works_to_collection: collection_id } }
+
+      it { is_expected.to eq "/batch_uploads/new?add_works_to_collection=#{collection_id}&payload_concern=#{model}" }
+    end
+
+    context 'with id and controller params' do
+      let(:params) { { id: collection_id, controller: 'hyrax/dashboard/collections' } }
 
       it { is_expected.to eq "/batch_uploads/new?add_works_to_collection=#{collection_id}&payload_concern=#{model}" }
     end

--- a/spec/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb_spec.rb
@@ -12,9 +12,13 @@ RSpec.describe 'hyrax/dashboard/collections/_show_add_items_actions.html.erb', t
   describe 'when user can edit the document' do
     let(:can_edit) { true }
 
-    it 'renders add_works_to_collection link' do
+    it 'renders add_existing_works_to_collection link' do
       render
       expect(rendered).to have_css(".actions-controls-collections .btn[href='#{hyrax.my_works_path(add_works_to_collection: presenter.id)}']")
+    end
+    it 'renders add_new_work_to_collection link' do
+      render
+      expect(rendered).to have_link("Add new work")
     end
     describe 'when the collection_type is nestable' do
       it 'renders a link to add_collections to this collection' do

--- a/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
@@ -21,6 +21,6 @@ RSpec.describe 'hyrax/dashboard/collections/edit.html.erb', type: :view do
 
   it 'displays the page' do
     expect(rendered).to have_content 'Actions'
-    expect(rendered).to have_link 'Add works'
+    expect(rendered).to have_link 'Add existing works'
   end
 end

--- a/spec/views/shared/select_work_type_modal.html.erb_spec.rb
+++ b/spec/views/shared/select_work_type_modal.html.erb_spec.rb
@@ -12,14 +12,41 @@ RSpec.describe 'shared/_select_work_type_modal.html.erb', type: :view do
     allow(view).to receive(:create_work_presenter).and_return(presenter)
     # Because there is no i18n set up for this work type
     allow(row2).to receive(:name).and_return('Atlas')
-    render
   end
 
-  it 'draws the modal' do
-    expect(rendered).to have_selector '#worktypes-to-create.modal'
-    expect(rendered).to have_content 'Generic Work'
-    expect(rendered).to have_content 'Atlas'
-    expect(rendered).to have_selector 'input[type="radio"][data-single="/concern/generic_works/new"][data-batch="/batch_uploads/new?payload_concern=GenericWork"]'
-    expect(rendered).to have_selector 'input[type="radio"][data-single="/concern/rare_books/atlases/new"][data-batch="/batch_uploads/new?payload_concern=RareBooks%3A%3AAtlas"]'
+  context 'when no collections id' do
+    before do
+      render
+    end
+
+    it 'draws the modal' do
+      expect(rendered).to have_selector '#worktypes-to-create.modal'
+      expect(rendered).to have_content 'Generic Work'
+      expect(rendered).to have_content 'Atlas'
+      expect(rendered).to have_selector 'input[type="radio"][data-single="/concern/generic_works/new"][data-batch="/batch_uploads/new?payload_concern=GenericWork"]'
+      expect(rendered).to have_selector 'input[type="radio"][data-single="/concern/rare_books/atlases/new"][data-batch="/batch_uploads/new?payload_concern=RareBooks%3A%3AAtlas"]'
+    end
+  end
+
+  context 'when collection id exists' do
+    before do
+      allow(view).to receive(:params).and_return(id: '1', controller: 'hyrax/dashboard/collections')
+      render
+    end
+    it 'draws the modal with collection id' do
+      expect(rendered).to have_selector 'input[type="radio"][data-single="/concern/generic_works/new?add_works_to_collection=1"][data-batch="/batch_uploads/new?add_works_to_collection=1&payload_concern=GenericWork"]' # rubocop:disable Metrics/LineLength
+      expect(rendered).to have_selector 'input[type="radio"][data-single="/concern/rare_books/atlases/new?add_works_to_collection=1"][data-batch="/batch_uploads/new?add_works_to_collection=1&payload_concern=RareBooks%3A%3AAtlas"]' # rubocop:disable Metrics/LineLength
+    end
+  end
+
+  context 'when add_works_to_collection exists' do
+    before do
+      allow(view).to receive(:params).and_return(add_works_to_collection: '1')
+      render
+    end
+    it 'draws the modal with collection id' do
+      expect(rendered).to have_selector 'input[type="radio"][data-single="/concern/generic_works/new?add_works_to_collection=1"][data-batch="/batch_uploads/new?add_works_to_collection=1&payload_concern=GenericWork"]' # rubocop:disable Metrics/LineLength
+      expect(rendered).to have_selector 'input[type="radio"][data-single="/concern/rare_books/atlases/new?add_works_to_collection=1"][data-batch="/batch_uploads/new?add_works_to_collection=1&payload_concern=RareBooks%3A%3AAtlas"]' # rubocop:disable Metrics/LineLength
+    end
   end
 end


### PR DESCRIPTION
Fixes #1552

Completes work started by @gordonleacock 

Include `Add new work to collection` button on the Collections show page.  It automatically selects the originating collection as the work's parent collection on the new form.  When the new work process is complete, the new work is added in the collection.
