### PR TITLE
User and group edit access for collection type permissions service

### DIFF
--- a/app/models/hyrax/collection_type_participant.rb
+++ b/app/models/hyrax/collection_type_participant.rb
@@ -7,16 +7,22 @@ module Hyrax
     validates :access, presence: true
     validates :hyrax_collection_type_id, presence: true
 
+    MANAGE_ACCESS = 'manage'.freeze
+    CREATE_ACCESS = 'create'.freeze
+
+    GROUP_TYPE = 'group'.freeze
+    USER_TYPE = 'user'.freeze
+
     def manager?
-      access == 'manage'
+      access == MANAGE_ACCESS
     end
 
     def creator?
-      access == 'create'
+      access == CREATE_ACCESS
     end
 
     def label
-      return agent_id unless agent_type == 'group'
+      return agent_id unless agent_type == GROUP_TYPE
       case agent_id
       when 'registered'
         I18n.t('hyrax.admin.admin_sets.form_participant_table.registered_users')

--- a/app/services/hyrax/collection_types/permissions_service.rb
+++ b/app/services/hyrax/collection_types/permissions_service.rb
@@ -6,17 +6,17 @@ module Hyrax
       # What types of collection can the user create or manage
       #
       # @param user [User] user - The user requesting to create/manage a Collection
-      # @param roles [String] type of access, 'manage' and/or 'create'
+      # @param roles [String] type of access, Hyrax::CollectionTypeParticipant::MANAGE_ACCESS and/or Hyrax::CollectionTypeParticipant::CREATE_ACCESS
       # @return [Array<Hyrax::CollectionType>]
       def self.collection_types_for_user(user:, roles:)
         return Hyrax::CollectionType.all if user.ability.admin?
-        ids = Hyrax::CollectionTypeParticipant.where(agent_type: 'user',
+        ids = Hyrax::CollectionTypeParticipant.where(agent_type: Hyrax::CollectionTypeParticipant::USER_TYPE,
                                                      agent_id: user.user_key,
                                                      access: roles)
                                               .or(
-                                                CollectionTypeParticipant.where(agent_type: 'group',
-                                                                                agent_id: user.ability.user_groups,
-                                                                                access: roles)
+                                                Hyrax::CollectionTypeParticipant.where(agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE,
+                                                                                       agent_id: user.ability.user_groups,
+                                                                                       access: roles)
                                               ).pluck('DISTINCT hyrax_collection_type_id')
         Hyrax::CollectionType.where(id: ids)
       end
@@ -28,7 +28,7 @@ module Hyrax
       # @param user [User] the user that will be creating a collection (default: current_user)
       # @return [Array<Hyrax::CollectionType>] array of collection types the user can create
       def self.can_create_collection_types(user: current_user)
-        collection_types_for_user(user: user, roles: ['manage', 'create'])
+        collection_types_for_user(user: user, roles: [Hyrax::CollectionTypeParticipant::MANAGE_ACCESS, Hyrax::CollectionTypeParticipant::CREATE_ACCESS])
       end
 
       # @api public
@@ -39,8 +39,9 @@ module Hyrax
       # @return [Array<String>] array of user identifiers (typically emails) for users who can edit collections of this type
       def self.user_edit_grants_for_collection_of_type(collection_type: nil)
         return [] unless collection_type
-        # Stubbed to return no grants.   Implement according to issue #1600
-        []
+        Hyrax::CollectionTypeParticipant.joins(:hyrax_collection_type).where(hyrax_collection_type_id: collection_type.id,
+                                                                             agent_type: Hyrax::CollectionTypeParticipant::USER_TYPE,
+                                                                             access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS).pluck('DISTINCT agent_id')
       end
 
       # @api public
@@ -51,8 +52,10 @@ module Hyrax
       # @return [Array<String>] array of group identifiers (typically groupname) for groups who can edit collections of this type
       def self.group_edit_grants_for_collection_of_type(collection_type: nil)
         return [] unless collection_type
-        # Stubbed to return no grants.   Implement according to issue #1600
-        []
+        groups = Hyrax::CollectionTypeParticipant.joins(:hyrax_collection_type).where(hyrax_collection_type_id: collection_type.id,
+                                                                                      agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE,
+                                                                                      access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS).pluck('DISTINCT agent_id')
+        groups | ['admin']
       end
     end
   end

--- a/app/views/hyrax/admin/collection_types/_form_participants.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_participants.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t('.add_participants') %></h2>
 <p><%= t('.instructions') %></p>
-<% access_options = options_for_select([['Manager', 'manage'], ['Creator', 'create']]) %>
+<% access_options = options_for_select([['Manager', Hyrax::CollectionTypeParticipant::MANAGE_ACCESS], ['Creator', Hyrax::CollectionTypeParticipant::CREATE_ACCESS]]) %>
 <% unless @collection_type_participant.nil? %>
   <%= simple_form_for @collection_type_participant,
                       url: hyrax.admin_collection_type_participants_path,
@@ -12,7 +12,7 @@
 
           <div class="col-md-10 col-xs-8 form-group">
             <%= f.hidden_field :hyrax_collection_type_id, value: @collection_type_participant.hyrax_collection_type_id %>
-            <%= f.hidden_field :agent_type, value: 'group' %>
+            <%= f.hidden_field :agent_type, value: Hyrax::CollectionTypeParticipant::GROUP_TYPE %>
             <%= f.text_field :agent_id,
                              placeholder: "Search for a group...",
                              class: 'form-control' %>
@@ -37,7 +37,7 @@
 
           <div class="col-md-10 col-xs-8 form-group">
             <%= f.hidden_field :hyrax_collection_type_id, value: @collection_type_participant.hyrax_collection_type_id %>
-            <%= f.hidden_field :agent_type, value: 'user' %>
+            <%= f.hidden_field :agent_type, value: Hyrax::CollectionTypeParticipant::USER_TYPE %>
             <%= f.text_field :agent_id,
                              placeholder: "Search for a user...",
                              class: 'form-control' %>

--- a/spec/factories/collection_type_participants.rb
+++ b/spec/factories/collection_type_participants.rb
@@ -3,6 +3,6 @@ FactoryGirl.define do
     association :hyrax_collection_type, factory: :collection_type
     sequence(:agent_id) { |n| "user#{n}@example.com" }
     agent_type  'user'
-    access      'manager'
+    access      'manage'
   end
 end

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -20,22 +20,34 @@ FactoryGirl.define do
 
     after(:create) do |collection_type, evaluator|
       if evaluator.creator_user
-        attributes = { hyrax_collection_type_id: collection_type.id, access: 'create', agent_id: evaluator.creator_user, agent_type: 'user' }
+        attributes = { hyrax_collection_type_id: collection_type.id,
+                       access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS,
+                       agent_id: evaluator.creator_user,
+                       agent_type: Hyrax::CollectionTypeParticipant::USER_TYPE }
         create(:collection_type_participant, attributes)
       end
 
       if evaluator.creator_group
-        attributes = { hyrax_collection_type_id: collection_type.id, access: 'create', agent_id: evaluator.creator_group, agent_type: 'group' }
+        attributes = { hyrax_collection_type_id: collection_type.id,
+                       access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS,
+                       agent_id: evaluator.creator_group,
+                       agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
         create(:collection_type_participant, attributes)
       end
 
       if evaluator.manager_user
-        attributes = { hyrax_collection_type_id: collection_type.id, access: 'manage', agent_id: evaluator.manager_user, agent_type: 'user' }
+        attributes = { hyrax_collection_type_id: collection_type.id,
+                       access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS,
+                       agent_id: evaluator.manager_user,
+                       agent_type: Hyrax::CollectionTypeParticipant::USER_TYPE }
         create(:collection_type_participant, attributes)
       end
 
       if evaluator.manager_group
-        attributes = { hyrax_collection_type_id: collection_type.id, access: 'manage', agent_id: evaluator.manager_group, agent_type: 'group' }
+        attributes = { hyrax_collection_type_id: collection_type.id,
+                       access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS,
+                       agent_id: evaluator.manager_group,
+                       agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
         create(:collection_type_participant, attributes)
       end
     end
@@ -86,9 +98,15 @@ FactoryGirl.define do
     assigns_visibility false
 
     after(:create) do |collection_type, _evaluator|
-      attributes = { hyrax_collection_type_id: collection_type.id, access: 'create', agent_id: 'registered', agent_type: 'group' }
+      attributes = { hyrax_collection_type_id: collection_type.id,
+                     access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS,
+                     agent_id: 'registered',
+                     agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
       create(:collection_type_participant, attributes)
-      attributes = { hyrax_collection_type_id: collection_type.id, access: 'manage', agent_id: 'admin', agent_type: 'group' }
+      attributes = { hyrax_collection_type_id: collection_type.id,
+                     access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS,
+                     agent_id: 'admin',
+                     agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
       create(:collection_type_participant, attributes)
     end
   end
@@ -105,9 +123,15 @@ FactoryGirl.define do
     assigns_visibility true
 
     after(:create) do |collection_type, _evaluator|
-      attributes = { hyrax_collection_type_id: collection_type.id, access: 'create', agent_id: 'admin', agent_type: 'group' }
+      attributes = { hyrax_collection_type_id: collection_type.id,
+                     access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS,
+                     agent_id: 'admin',
+                     agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
       create(:collection_type_participant, attributes)
-      attributes = { hyrax_collection_type_id: collection_type.id, access: 'manage', agent_id: 'admin', agent_type: 'group' }
+      attributes = { hyrax_collection_type_id: collection_type.id,
+                     access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS,
+                     agent_id: 'admin',
+                     agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
       create(:collection_type_participant, attributes)
     end
   end

--- a/spec/views/hyrax/admin/collection_types/_form_participants_table.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_participants_table.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_participant_table.html.erb', 
         stub_model(Hyrax::CollectionTypeParticipant,
                    agent_type: 'user',
                    agent_id: user.user_key,
-                   access: 'manage')
+                   access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS)
       end
 
       it 'lists the managers in the table' do
@@ -52,7 +52,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_participant_table.html.erb', 
         stub_model(Hyrax::CollectionTypeParticipant,
                    agent_type: 'user',
                    agent_id: user.user_key,
-                   access: 'create')
+                   access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS)
       end
 
       it 'lists the creators in the table' do


### PR DESCRIPTION
Fixes #1600 

Adds Hyrax::CollectionTypes::PermissionsService.user_edit_grants_for_collection_of_type to return users with edit access to a collection type

Adds Hyrax::CollectionTypes::PermissionsService.group_edit_grants_for_collection_of_type to return groups with edit access to a collection type


@samvera/hyrax-code-reviewers
