### PR TITLE
Share button should link to My Works

### DIFF
--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -17,7 +17,7 @@
           <% end %>
         <% end %>
       <% else %>
-        <%= link_to hyrax.dashboard_path,
+        <%= link_to hyrax.my_works_path,
           class: "btn btn-primary btn-lg" do %>
           <i class="glyphicon glyphicon-upload"></i> <%= t('hyrax.share_button') %>
         <% end %>

--- a/spec/views/hyrax/homepage/index.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/index.html.erb_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe "hyrax/homepage/index.html.erb", type: :view do
         it "displays" do
           expect(rendered).to have_content t("hyrax.share_button")
         end
+
+        it 'links to the my works path' do
+          expect(rendered).to have_selector('a[href="/dashboard/my/works"]')
+        end
       end
       context "when the button displays for users with rights" do
         let(:display_share_button) { false }


### PR DESCRIPTION
When an unauthenticated user clicks the Share Work button on the homepage, they should not be taken to the root dashboard page after logging in, because that is not where works are shared. Instead, redirect the user to the My Works page where the controls for creating works live.

Fixes #1092

@samvera/hyrax-code-reviewers
