### PR TITLE
fix failing tests

### DIFF
--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -319,8 +319,10 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         expect(page).to have_selector('input.collection-remove', count: 2)
         page.all('input.collection-remove')[0].click
         expect(page).to have_selector('input.collection-remove', count: 1)
-        expect(page).not_to have_content(work1.title.first)
-        expect(page).to have_content(work2.title.first)
+        # because works do not have order, you cannot guarentee that the first work added is the work getting deleted
+        has_work1 = page.has_content? work1.title.first
+        has_work2 = page.has_content? work2.title.first
+        expect(has_work1 ^ has_work2).to be true
       end
       xit 'removes a sub-collection from the list of items (dependency on collection nesting)' do
       end

--- a/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
     context "when collection_type.collections? is false" do
       before do
         collection_type_form.collection_type = collection_type
+        allow(collection_type).to receive(:collections?).and_return(false)
         assign(:form, collection_type_form)
         allow(view).to receive(:f).and_return(form)
         render
@@ -36,7 +37,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
       end
 
       INPUT_IDS.each do |id|
-        it "renders the #{id} checkbox to be disabled" do
+        it "renders the #{id} checkbox to be enabled" do
           match = rendered.match(/(<input.*id="#{id}".*>)/)
           expect(match).not_to be_nil
           expect(match[1].index('disabled="disabled"')).to be_nil


### PR DESCRIPTION
Tests at collections-sprint are failing.

TEST: hyrax/admin/collection_types/_form_settings.html.erb for non-special collection types when collection_type.collections? is false renders the all settings with checkbox to enabled
FAILING: because .collections? was not stubbed to return false