### PR TITLE
[WIP] when adding works to collection fails, post an error using flash

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -406,7 +406,8 @@ module Hyrax
 
         def add_members_to_collection(collection = nil)
           collection ||= @collection
-          collection.add_member_objects batch
+          error_messages = collection.add_member_objects batch
+          flash[:notice] = error_messages.join(" ") if error_messages.any?
         end
 
         def remove_members_from_collection

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -57,17 +57,19 @@ module Hyrax
 
     # Add member objects by adding this collection to the objects' member_of_collection association.
     def add_member_objects(new_member_ids)
+      error_messages = []
       Array(new_member_ids).each do |member_id|
         member = ActiveFedora::Base.find(member_id)
-        # @note Ideally, this would be surfaced as a warning in a flash
-        #       message. Because the member is found and saved in this model
-        #       method, I am not sure it's worth the effort to rejigger things
-        #       such that this information bubbles up to the controller and
-        #       view.
-        next if Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
+        # will return and error message as a string, otherwise it will return a nil
+        message = Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
+        if message
+          error_messages << message
+          next
+        end
         member.member_of_collections << self
         member.save!
       end
+      error_messages
     end
 
     def member_objects


### PR DESCRIPTION
If an error occurs when calling MultipleMembershipChecker, trap it and report the error via flash