### PR TITLE
Single instance of Hyrax::DefaultMiddlewareStack

### DIFF
--- a/app/services/hyrax/curation_concern.rb
+++ b/app/services/hyrax/curation_concern.rb
@@ -17,7 +17,7 @@ module Hyrax
     # is used.  Once it is used, it becomes immutable.
     # @return [ActionDispatch::MiddlewareStack]
     def self.actor_factory
-      @middleware_stack ||= Hyrax::DefaultMiddlewareStack.build_stack
+      @actor_factory ||= Hyrax::DefaultMiddlewareStack.build_stack
     end
 
     # A consumer of this method can inject a different factory

--- a/app/services/hyrax/curation_concern.rb
+++ b/app/services/hyrax/curation_concern.rb
@@ -17,7 +17,7 @@ module Hyrax
     # is used.  Once it is used, it becomes immutable.
     # @return [ActionDispatch::MiddlewareStack]
     def self.actor_factory
-      Hyrax::DefaultMiddlewareStack.build_stack
+      @middleware_stack ||= Hyrax::DefaultMiddlewareStack.build_stack
     end
 
     # A consumer of this method can inject a different factory

--- a/spec/services/hyrax/curation_concern_spec.rb
+++ b/spec/services/hyrax/curation_concern_spec.rb
@@ -7,4 +7,12 @@ RSpec.describe Hyrax::CurationConcern do
 
     it { is_expected.to be_kind_of Hyrax::Actors::TransactionalRequest }
   end
+
+  describe ".actor_factory" do
+    subject { described_class.actor_factory }
+
+    it "returns same ActionDispatch::MiddlewareStack instance" do
+      is_expected.to eq described_class.actor_factory
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1643

Changes `Hyrax::CurationConcern.actor_factory` to return the same instance of `Hyrax::DefaultMiddlewareStack` to allow customization of the actor stack.

@samvera/hyrax-code-reviewers
