### PR TITLE
Fix redirects for collection/work edit save and cancel

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -97,6 +97,7 @@
 //= require hyrax/per_page
 //= require hyrax/thumbnail_select
 //= require hyrax/batch_select
+//= require hyrax/tabbed_form
 
 // this needs to be after batch_select so that the form ids get setup correctly
 //= require hyrax/batch_edit

--- a/app/assets/javascripts/hyrax/admin/admin_set_controls.es6
+++ b/app/assets/javascripts/hyrax/admin/admin_set_controls.es6
@@ -4,6 +4,7 @@
 import Visibility from 'hyrax/admin/admin_set/visibility'
 import Participants from 'hyrax/admin/admin_set/participants'
 import ThumbnailSelect from 'hyrax/thumbnail_select'
+import tabifyForm from 'hyrax/tabbed_form'
 
 export default class {
     constructor(elem) {
@@ -11,9 +12,10 @@ export default class {
         this.thumbnailSelect = new ThumbnailSelect(url, elem.find('#admin_set_thumbnail_id'))
 
         let participants = new Participants(elem.find('#participants'))
-        participants.setup();
+        participants.setup()
 
-        let visibilityTab = new Visibility(elem.find('#visibility'));
-        visibilityTab.setup();
+        let visibilityTab = new Visibility(elem.find('#visibility'))
+        visibilityTab.setup()
+        tabifyForm(elem.find('form.edit_admin_set'))
     }
 }

--- a/app/assets/javascripts/hyrax/admin/collection_type_controls.es6
+++ b/app/assets/javascripts/hyrax/admin/collection_type_controls.es6
@@ -1,10 +1,12 @@
 // The editor for the CollectionTypeParticipant
 // Add search for user/group to the edit an admin set's participants page
 import Participants from 'hyrax/admin/collection_type/participants'
+import tabifyForm from 'hyrax/tabbed_form'
 
 export default class {
     constructor(elem) {
         let participants = new Participants(elem.find('#participants'))
-        participants.setup();
+        participants.setup()
+        tabifyForm(elem.find('form.edit_collection_type'))
     }
 }

--- a/app/assets/javascripts/hyrax/app.js
+++ b/app/assets/javascripts/hyrax/app.js
@@ -164,5 +164,4 @@ Hyrax = {
         var BatchSelect = require('hyrax/batch_select');
         BatchSelect.initialize_batch_selected();
     }
-
 };

--- a/app/assets/javascripts/hyrax/collections/editor.es6
+++ b/app/assets/javascripts/hyrax/collections/editor.es6
@@ -1,4 +1,5 @@
 import ThumbnailSelect from 'hyrax/thumbnail_select'
+import tabifyForm from 'hyrax/tabbed_form'
 
 // Controls the behavior of the Collections edit form
 // Add search for thumbnail to the edit descriptions
@@ -6,6 +7,7 @@ export default class {
   constructor(elem) {
     let url =  window.location.pathname.replace('edit', 'files')
     let field = elem.find('#collection_thumbnail_id')
-    this.thumbnailSelect = new ThumbnailSelect(url, field);
+    this.thumbnailSelect = new ThumbnailSelect(url, field)
+    tabifyForm(elem.find('form.editor'))
   }
 }

--- a/app/assets/javascripts/hyrax/save_work/save_work_control.es6
+++ b/app/assets/javascripts/hyrax/save_work/save_work_control.es6
@@ -3,6 +3,7 @@ import { ChecklistItem } from './checklist_item'
 import { UploadedFiles } from './uploaded_files'
 import { DepositAgreement } from './deposit_agreement'
 import VisibilityComponent from './visibility_component'
+import tabifyForm from 'hyrax/tabbed_form'
 
 /**
  * Polyfill String.prototype.startsWith()
@@ -92,6 +93,7 @@ export default class SaveWorkControl {
     this.preventSubmit()
     this.watchMultivaluedFields()
     this.formChanged()
+    tabifyForm(this.form)
   }
 
   preventSubmit() {

--- a/app/assets/javascripts/hyrax/save_work/save_work_control.es6
+++ b/app/assets/javascripts/hyrax/save_work/save_work_control.es6
@@ -3,7 +3,6 @@ import { ChecklistItem } from './checklist_item'
 import { UploadedFiles } from './uploaded_files'
 import { DepositAgreement } from './deposit_agreement'
 import VisibilityComponent from './visibility_component'
-import tabifyForm from 'hyrax/tabbed_form'
 
 /**
  * Polyfill String.prototype.startsWith()
@@ -93,7 +92,6 @@ export default class SaveWorkControl {
     this.preventSubmit()
     this.watchMultivaluedFields()
     this.formChanged()
-    tabifyForm(this.form)
   }
 
   preventSubmit() {

--- a/app/assets/javascripts/hyrax/tabbed_form.es6
+++ b/app/assets/javascripts/hyrax/tabbed_form.es6
@@ -1,0 +1,35 @@
+class TabbedForm {
+  /**
+   * Bootstrap Tabs use anchors to identify tabs. Anchor of active tab is added as hidden input to given form 
+   * so that active tab state can be maintained after Post.
+   * @param {form} form element that includes tabs and to which tab anchor will be added as an input
+   */
+  constructor(form) {
+    this.form = form;
+  }
+
+  setup() {
+    this.refererAnchor = this.addRefererAnchor()
+    this.watchActiveTab()
+    this.setRefererAnchor($('.nav-tabs li.active a').attr('href'))
+  }
+
+  addRefererAnchor() {
+    let referer_anchor_input = $('<input>').attr({type: 'hidden', id: 'referer_anchor', name: 'referer_anchor'}) 
+    this.form.append(referer_anchor_input)
+    return referer_anchor_input
+  }
+
+  setRefererAnchor(id) {
+    this.refererAnchor.val(id)
+  }
+
+  watchActiveTab() {
+    $('.nav-tabs a').on('shown.bs.tab', (e) => this.setRefererAnchor($(e.target).attr('href')))
+  }
+}
+
+export default function tabifyForm(form) {
+  let formTabifier = new TabbedForm(form)
+  formTabifier.setup()
+}

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -266,13 +266,21 @@ module Hyrax
         end
       end
 
+      def update_referer
+        if params[:referer_anchor]
+          edit_polymorphic_path([main_app, curation_concern]) + params[:referer_anchor]
+        else
+          polymorphic_path([main_app, curation_concern])
+        end
+      end
+
       def after_update_response
         if curation_concern.file_sets.present?
           return redirect_to hyrax.confirm_access_permission_path(curation_concern) if permissions_changed?
           return redirect_to main_app.confirm_hyrax_permission_path(curation_concern) if curation_concern.visibility_changed?
         end
         respond_to do |wants|
-          wants.html { redirect_to [main_app, curation_concern] }
+          wants.html { redirect_to update_referer, notice: "Work \"#{curation_concern}\" successfully updated." }
           wants.json { render :show, status: :ok, location: polymorphic_path([main_app, curation_concern]) }
         end
       end

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -266,21 +266,13 @@ module Hyrax
         end
       end
 
-      def update_referer
-        if params[:referer_anchor]
-          edit_polymorphic_path([main_app, curation_concern]) + params[:referer_anchor]
-        else
-          polymorphic_path([main_app, curation_concern])
-        end
-      end
-
       def after_update_response
         if curation_concern.file_sets.present?
           return redirect_to hyrax.confirm_access_permission_path(curation_concern) if permissions_changed?
           return redirect_to main_app.confirm_hyrax_permission_path(curation_concern) if curation_concern.visibility_changed?
         end
         respond_to do |wants|
-          wants.html { redirect_to update_referer, notice: "Work \"#{curation_concern}\" successfully updated." }
+          wants.html { redirect_to [main_app, curation_concern], notice: "Work \"#{curation_concern}\" successfully updated." }
           wants.json { render :show, status: :ok, location: polymorphic_path([main_app, curation_concern]) }
         end
       end

--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -47,15 +47,13 @@ module Hyrax
     # Renders a JSON response with a list of files in this admin set.
     # This is used by the edit form to populate the thumbnail_id dropdown
     def files
-      result = form.select_files.map do |label, id|
-        { id: id, text: label }
-      end
+      result = form.select_files.map { |label, id| { id: id, text: label } }
       render json: result
     end
 
     def update
       if @admin_set.update(admin_set_params)
-        redirect_to hyrax.edit_admin_admin_set_path(@admin_set), notice: I18n.t('updated_admin_set', scope: 'hyrax.admin.admin_sets.form.permission_update_notices', name: @admin_set.title.first)
+        redirect_to update_referer, notice: I18n.t('updated_admin_set', scope: 'hyrax.admin.admin_sets.form.permission_update_notices', name: @admin_set.title.first)
       else
         setup_form
         render :edit
@@ -90,6 +88,10 @@ module Hyrax
     end
 
     private
+
+      def update_referer
+        hyrax.edit_admin_admin_set_path(@admin_set) + (params[:referer_anchor] || '')
+      end
 
       def ensure_manager!
         # Even though the user can view this admin set, they may not be able to view

--- a/app/controllers/hyrax/admin/collection_types_controller.rb
+++ b/app/controllers/hyrax/admin/collection_types_controller.rb
@@ -44,7 +44,7 @@ module Hyrax
 
     def update
       if @collection_type.update(collection_type_params)
-        redirect_to hyrax.edit_admin_collection_type_path(@collection_type), notice: t(:'hyrax.admin.collection_types.update.notification', name: @collection_type.title)
+        redirect_to update_referer, notice: t(:'hyrax.admin.collection_types.update.notification', name: @collection_type.title)
       else
         setup_form
         add_common_breadcrumbs
@@ -62,6 +62,10 @@ module Hyrax
     end
 
     private
+
+      def update_referer
+        hyrax.edit_admin_collection_type_path(@collection_type) + (params[:referer_anchor] || '')
+      end
 
       def add_common_breadcrumbs
         add_breadcrumb t(:'hyrax.controls.home'), root_path

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -95,7 +95,7 @@ module Hyrax
         set_default_permissions
         respond_to do |format|
           ActiveFedora::SolrService.instance.conn.commit
-          format.html { redirect_to dashboard_collection_path(@collection), notice: 'Collection was successfully created.' }
+          format.html { redirect_to edit_dashboard_collection_path(@collection), notice: 'Collection was successfully created.' }
           format.json { render json: @collection, status: :created, location: dashboard_collection_path(@collection) }
         end
       end
@@ -139,7 +139,7 @@ module Hyrax
           flash[:notice] = 'Collection was successfully updated.'
         end
         respond_to do |format|
-          format.html { redirect_to dashboard_collection_path(@collection) }
+          format.html { redirect_to update_referer }
           format.json { render json: @collection, status: :updated, location: dashboard_collection_path(@collection) }
         end
       end
@@ -216,6 +216,10 @@ module Hyrax
         def uploaded_files(uploaded_file_ids)
           return [] if uploaded_file_ids.empty?
           UploadedFile.find(uploaded_file_ids)
+        end
+
+        def update_referer
+          edit_dashboard_collection_path(@collection) + (params[:referer_anchor] || '')
         end
 
         def determine_banner_data

--- a/app/views/hyrax/admin/admin_sets/_form.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form.html.erb
@@ -31,7 +31,8 @@
               </div>
 
               <div class="panel-footer">
-                <%= link_to t('.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+                <% cancel_path = f.object.persisted? ? hyrax.admin_admin_set_path(f.object) : hyrax.dashboard_collections_path %>
+                <%= link_to t('.cancel'), cancel_path, class: 'btn btn-default pull-right' %>
                 <%= f.button :submit, class: 'btn btn-primary pull-right'%>
               </div>
             <% end %>

--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -45,8 +45,9 @@
       <% end %>
     <% end %>
     <br>
+    <% cancel_path = f.object.persisted? ? polymorphic_path([main_app, f.object]) : hyrax.my_works_path %>
     <%= link_to t(:'helpers.action.cancel'),
-                hyrax.dashboard_path,
+                cancel_path,
                 class: 'btn btn-default' %>
     <%# TODO: If we start using ActionCable, we could listen for object updates and
               alert the user that the object has changed by someone else %>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -90,12 +90,13 @@
       <% end %>
 
       <div class="panel-footer">
-        <% if params[:action] == "new" %>
-          <%= f.submit t(:'hyrax.collection.select_form.create'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "create_submit", name: "create_collection" %>
-        <% else %>
+        <% if @collection.persisted? %>
           <%= f.submit t(:'hyrax.collection.select_form.update'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "update_submit", name: "update_collection" %>
+          <%= link_to t(:'helpers.action.cancel'), hyrax.collection_path(@collection), class: 'btn btn-link' %>
+        <% else %>
+          <%= f.submit t(:'hyrax.collection.select_form.create'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "create_submit", name: "create_collection" %>
+          <%= link_to t(:'helpers.action.cancel'), hyrax.my_collections_path, class: 'btn btn-link' %>
         <% end %>
-        <%= link_to t(:'helpers.action.cancel'), main_app.root_path, class: 'btn btn-link' %>
       </div>
     </div> <!-- end tab-content -->
   <% end # simple_form_for %>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -92,7 +92,7 @@
       <div class="panel-footer">
         <% if @collection.persisted? %>
           <%= f.submit t(:'hyrax.collection.select_form.update'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "update_submit", name: "update_collection" %>
-          <%= link_to t(:'helpers.action.cancel'), hyrax.collection_path(@collection), class: 'btn btn-link' %>
+          <%= link_to t(:'helpers.action.cancel'), hyrax.dashboard_collection_path(@collection), class: 'btn btn-link' %>
         <% else %>
           <%= f.submit t(:'hyrax.collection.select_form.create'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "create_submit", name: "create_collection" %>
           <%= link_to t(:'helpers.action.cancel'), hyrax.my_collections_path, class: 'btn btn-link' %>

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
                                  collection: { members: 'add' },
                                  batch_document_ids: [asset3.id] }
         end.to change { collection.reload.member_objects.size }.by(1)
-        expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
+        expect(response).to redirect_to routes.url_helpers.edit_dashboard_collection_path(collection, locale: 'en')
         expect(assigns[:collection].member_objects).to match_array [asset1, asset2, asset3]
       end
 

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -376,13 +376,12 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         within('.panel-footer') do
           click_button('Update Collection')
         end
-        # URL: /dashboard/collections/collection-id
-        header = find('header')
-        expect(header).not_to have_content(collection.title.first)
-        expect(header).not_to have_content(collection.description.first)
-        expect(header).to have_content(new_title)
-        expect(page).to have_content(new_description)
-        expect(page).to have_content(creators.first)
+        # URL: /dashboard/collections/collection-id/edit
+        expect(page).not_to have_field('collection_title', with: collection.title.first)
+        expect(page).not_to have_field('collection_description', with: collection.description.first)
+        expect(page).to have_field('collection_title', with: new_title)
+        expect(page).to have_field('collection_description', with: new_description)
+        expect(page).to have_field('collection_creator', with: creators.first)
       end
     end
 

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
     it "renders the deposit agreement already checked and the version" do
       expect(page).to have_selector("#agreement[checked]")
       expect(page).to have_selector("input#generic_work_version[value=\"123456\"]", visible: false)
-      expect(page).to have_link("Cancel", href: "/dashboard")
+      expect(page).to have_link("Cancel", href: polymorphic_path([main_app, work]))
     end
   end
 end


### PR DESCRIPTION
Fixes #1578 

Changes page forwarding for save/cancel actions on new/edit forms for collection types, admin sets, collections, and works

Edit pages have tabbed content. Those tabs are coded as anchors on the page. Since a request's referrer never includes an anchor in it's url, this change adds the anchor as a hidden input on the form. The controllers then use that anchor param when constructing urls for redirection back to the appropriate tab.

@samvera/hyrax-code-reviewers
