### PR TITLE
Create service for collection permissions

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -92,7 +92,7 @@ module Hyrax
 
       def after_create
         form
-        PermissionTemplate.create!(source_id: @collection.id, source_type: 'collection')
+        set_default_permissions
         respond_to do |format|
           ActiveFedora::SolrService.instance.conn.commit
           format.html { redirect_to dashboard_collection_path(@collection), notice: 'Collection was successfully created.' }
@@ -446,6 +446,10 @@ module Hyrax
 
         def form
           @form ||= form_class.new(@collection, current_ability, repository)
+        end
+
+        def set_default_permissions
+          Collections::PermissionsService.create_default(collection: @collection, creating_user: current_user)
         end
     end
   end

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -1,0 +1,140 @@
+module Hyrax
+  module Collections
+    class PermissionsService
+      # @api public
+      #
+      # Get a list of users who should be added as user editors for a collection
+      #
+      # @param collection [Hyrax::Collection] the collection for which permissions are being set
+      # @return [Array<String>] array of user identifiers (typically emails) for users who can edit this collection
+      def self.user_edit_grants_for_collection(collection: nil)
+        return [] unless collection
+        # Stubbed to return no grants
+        []
+      end
+
+      # @api public
+      #
+      # Determine if the given user has permissions to deposit into the given collection
+      #
+      # @param user [User] the user that wants to deposit
+      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @return [Boolean] true if the user has permission to depoisit into the collection
+      def self.can_deposit_in_collection(user:, collection:)
+        return false unless user && collection
+        # stubbed
+      end
+
+      # @api public
+      #
+      # Get a list of users who should be added as user viewers for a collection
+      #
+      # @param collection [Hyrax::Collection] the collection for which permissions are being set
+      # @return [Array<String>] array of user identifiers (typically emails) for users who can view this collection
+      def self.user_view_grants_for_collection(collection: nil)
+        return [] unless collection
+        # Stubbed to return no grants
+        []
+      end
+
+      # @api public
+      #
+      # Get a list of groups that should be added as group editors for a collection
+      #
+      # @param collection [Hyrax::Collection] the collection for which permissions are being set
+      # @return [Array<String>] array of group identifiers (typically groupname) for groups who can edit this collection
+      def self.group_edit_grants_for_collection(collection: nil)
+        return [] unless collection
+        # Stubbed to return no grants
+        []
+      end
+
+      # @api public
+      #
+      # Get a list of groups that should be added as group depositors for a collection
+      #
+      # @param collection [Hyrax::Collection] the collection for which permissions are being set
+      # @return [Array<String>] array of group identifiers (typically groupname) for groups who can deposit to this collection
+      def self.group_deposit_grants_for_collection(collection: nil)
+        return [] unless collection
+        # Stubbed to return no grants
+        []
+      end
+
+      # @api public
+      #
+      # Get a list of groups that should be added as group viewers for a collection
+      #
+      # @param collection [Hyrax::Collection] the collection for which permissions are being set
+      # @return [Array<String>] array of group identifiers (typically groupname) for groups who can view this collection
+      def self.group_view_grants_for_collection(collection: nil)
+        return [] unless collection
+        # Stubbed to return no grants
+        []
+      end
+
+      # @api public
+      #
+      # Set the default permissions for a (newly created) collection
+      #
+      # @param collection [Collection] the collection the new permissions will act on
+      # @param creating_user [User] the user that created the collection
+      # @return [Hyrax::PermissionTemplate]
+      def self.create_default(collection:, creating_user:)
+        collection_type = Hyrax::CollectionType.find_by_gid!(collection.collection_type_gid)
+        access_grants = access_grants_attributes(collection_type: collection_type, creating_user: creating_user)
+        PermissionTemplate.create!(source_id: collection.id, source_type: 'collection',
+                                   access_grants_attributes: access_grants.uniq)
+      end
+
+      # @api private
+      #
+      # Gather the default permissions needed for a new collection
+      #
+      # @param collection_type [CollectionType] the collection type of the new collection
+      # @param creating_user [User] the user that created the collection
+      # @return [Hash] a hash containing permission attributes
+      def self.access_grants_attributes(collection_type:, creating_user:)
+        [
+          { agent_type: 'group', agent_id: admin_group_name, access: Hyrax::PermissionTemplateAccess::MANAGE }
+        ].tap do |attribute_list|
+          # Grant manage access to the creating_user if it exists
+          if creating_user
+            attribute_list << { agent_type: 'user', agent_id: creating_user.user_key, access: Hyrax::PermissionTemplateAccess::MANAGE }
+          end
+        end + managers_of_collection_type(collection_type: collection_type)
+      end
+      private_class_method :access_grants_attributes
+
+      # @api private
+      #
+      # Retrieve the users or groups with manage permissions for a collection type
+      #
+      # @param collection_type [CollectionType] the collection type of the new collection
+      # @return [Hash] a hash containing permission attributes
+      def self.managers_of_collection_type(collection_type:)
+        attribute_list = []
+        user_managers = Hyrax::CollectionTypes::PermissionsService.user_edit_grants_for_collection_of_type(collection_type: collection_type)
+        user_managers.each do |user|
+          attribute_list << { agent_type: 'user', agent_id: user, access: Hyrax::PermissionTemplateAccess::MANAGE }
+        end
+        group_managers = Hyrax::CollectionTypes::PermissionsService.group_edit_grants_for_collection_of_type(collection_type: collection_type)
+        group_managers.each do |group|
+          attribute_list << { agent_type: 'group', agent_id: group, access: Hyrax::PermissionTemplateAccess::MANAGE }
+        end
+        attribute_list
+      end
+      private_class_method :managers_of_collection_type
+
+      # @api private
+      #
+      # The value of the admin group name
+      #
+      # @return [String] a string representation of the admin group name
+      def self.admin_group_name
+        ::Ability.admin_group_name
+      end
+      private_class_method :admin_group_name
+    end
+  end
+end

--- a/spec/services/hyrax/collections/permissions_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_service_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe Hyrax::Collections::PermissionsService do
+  describe "create_default" do
+    subject { described_class.create_default(collection: collection, creating_user: user) }
+
+    let(:user) { create(:user) }
+    let(:user2) { create(:user) }
+    let(:collection_type) { create(:collection_type) }
+    let(:user_manage_attributes) do
+      {
+        hyrax_collection_type_id: collection_type.id,
+        access: 'manage',
+        agent_id: user2.user_key,
+        agent_type: 'user'
+      }
+    end
+    let(:group_manage_attributes) do
+      {
+        hyrax_collection_type_id: collection_type.id,
+        access: 'manage',
+        agent_id: 'manage_group',
+        agent_type: 'group'
+      }
+    end
+    let!(:collection_type_participant) { create(:collection_type_participant, user_manage_attributes) }
+    let!(:collection_type_participant2) { create(:collection_type_participant, group_manage_attributes) }
+    let(:collection) { create(:collection, collection_type_gid: collection_type.gid) }
+
+    before do
+      subject
+    end
+
+    it "creates the default permission template for the collection" do
+      expect(Hyrax::PermissionTemplate.find_by_source_id(collection.id)).to be_persisted
+    end
+
+    it "creates the default permission template access entries for the collection" do
+      expect(Hyrax::PermissionTemplate.find_by_source_id(collection.id).access_grants.count).to eq 4
+    end
+  end
+
+  describe "user_edit_grants_for_collection" do
+    it "exists" do
+      expect(described_class).to respond_to(:user_edit_grants_for_collection)
+    end
+  end
+
+  describe "can_deposit_in_collection" do
+    it "exists" do
+      expect(described_class).to respond_to(:can_deposit_in_collection)
+    end
+  end
+
+  describe "user_view_grants_for_collection" do
+    it "exists" do
+      expect(described_class).to respond_to(:user_view_grants_for_collection)
+    end
+  end
+
+  describe "group_edit_grants_for_collection" do
+    it "exists" do
+      expect(described_class).to respond_to(:group_edit_grants_for_collection)
+    end
+  end
+
+  describe "group_deposit_grants_for_collection" do
+    it "exists" do
+      expect(described_class).to respond_to(:group_deposit_grants_for_collection)
+    end
+  end
+
+  describe "group_view_grants_for_collection" do
+    it "exists" do
+      expect(described_class).to respond_to(:group_view_grants_for_collection)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1540

(collections sprint)

This commit creates a service for collection permissions.  Main use right now is to create the permissions template whenever a collection is created and also set the default access rights.

Other permissions methods are stubbed for now.