### PR TITLE
Allow attribute labels to vary by work type optionally.

### DIFF
--- a/app/presenters/hyrax/presents_attributes.rb
+++ b/app/presenters/hyrax/presents_attributes.rb
@@ -11,6 +11,7 @@ module Hyrax
     #   you can explicitly set the URL's search field name
     # @option options [String] :label The default label for the field if no translation is found
     # @option options [TrueClass, FalseClass] :include_empty should we display a row if there are no values?
+    # @option options [String] :work_type name of work type class (e.g., "GenericWork")
     def attribute_to_html(field, options = {})
       unless respond_to?(field)
         Rails.logger.warn("#{self.class} attempted to render #{field}, but no method exists with that name.")

--- a/app/renderers/hyrax/renderers/attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer.rb
@@ -38,8 +38,10 @@ module Hyrax
       #   name. Can be overridden if more complicated logic is needed.
       def label
         translate(
-          :"blacklight.search.fields.show.#{field}",
-          default: [:"blacklight.search.fields.#{field}", options.fetch(:label, field.to_s.humanize)]
+          :"blacklight.search.fields.#{work_type_label_key}.show.#{field}",
+          default: [:"blacklight.search.fields.show.#{field}",
+                    :"blacklight.search.fields.#{field}",
+                    options.fetch(:label, field.to_s.humanize)]
         )
       end
 
@@ -64,6 +66,10 @@ module Hyrax
 
         def li_value(value)
           auto_link(ERB::Util.h(value))
+        end
+
+        def work_type_label_key
+          options[:work_type] ? options[:work_type].underscore : nil
         end
     end
   end

--- a/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
@@ -72,4 +72,28 @@ RSpec.describe Hyrax::Renderers::AttributeRenderer do
       it { expect(subject).to be_equivalent_to(expected) }
     end
   end
+
+  describe "#label" do
+    subject { renderer }
+
+    context 'with work type option' do
+      let(:work_type) { "GenericWork".underscore }
+      let(:renderer) { described_class.new(field, ['Bob', 'Jessica'], work_type: work_type) }
+
+      context 'no work type specific label' do
+        it { expect(subject.label).to eq(field.to_s.humanize) }
+      end
+      context 'work type specific label' do
+        let(:work_type_name_label) { "Appellation" }
+
+        before do
+          allow(I18n).to receive(:translate).and_call_original
+          allow(I18n).to receive(:translate).with(:"blacklight.search.fields.#{work_type}.show.#{field}", Hash) do
+            work_type_name_label
+          end
+        end
+        it { expect(subject.label).to eq(work_type_name_label) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Optionally set show page attribute labels by work type.

Adds a `:work_type` option to `Hyrax::PresentsAttributes` that is passed on to the appropriate renderer.  Alters `Hyrax::Renderers::AttributeRenderer#label` to use the `:work_type` option, if present, to look first for a work-type-specific label for the field in the appropriate I18n locale file.  If the `:work_type` option is not present or if it is but a work-type-specific label is not found in the locale file, the `#label` method falls back to its current behavior. 

Consider the following locale file snippet:
```yaml
en:
  blacklight:
    search:
      fields:
        scholarly_article:
          show:
            creator_sim: Author
        show:
          creator_sim: Maker
```
Providing a `work_type: ScholarlyArticle` option when calling `Hyrax::PresentsAttributes#attribute_to_html` will result in a field label of "Author", whereas not providing a `:work_type` option or providing a `:work_type` with a different value will result in a field label of "Maker".

Changes proposed in this pull request:
* Adds `:work_type` option to `Hyrax::PresentsAttributes#attribute_to_html`.
* Alters implementation of `Hyrax::Renderers::AttributeRenderer#label` to use the `:work_type` option if present.

@samvera/hyrax-code-reviewers
