### PR TITLE
Add collection permissions to solr doc read/edit access

### DIFF
--- a/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
+++ b/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
@@ -6,7 +6,7 @@ module Hyrax
       def destroy
         ActiveRecord::Base.transaction do
           @permission_template_access.destroy
-          update_management if @permission_template_access.manage?
+          update_access(manage_changed: @permission_template_access.manage?)
         end
 
         if @permission_template_access.destroyed?
@@ -23,8 +23,8 @@ module Hyrax
           @source_id ||= @permission_template_access.permission_template.source_id
         end
 
-        def update_management
-          Forms::PermissionTemplateForm.new(@permission_template_access.permission_template).update_management
+        def update_access(manage_changed:)
+          Forms::PermissionTemplateForm.new(@permission_template_access.permission_template).update_access(manage_changed: manage_changed)
         end
 
         def redirect_to_edit_path

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -6,11 +6,11 @@ module Hyrax
       self.model_class = PermissionTemplate
       self.terms = []
       delegate :access_grants, :access_grants_attributes=, :release_date, :release_period, :visibility, to: :model
-      delegate :available_workflows, :active_workflow, :admin_set, to: :model
+      delegate :available_workflows, :active_workflow, :source_model, to: :model
 
-      # @return [#to_s] the primary key of the associated admin_set
+      # @return [#to_s] the primary key of the associated admin_set or collection
       # def source_id (because you might come looking for this method)
-      delegate :id, to: :admin_set, prefix: :admin_set
+      delegate :id, to: :source_model, prefix: :source
 
       # Stores which radio button under release "Varies" option is selected
       attr_accessor :release_varies
@@ -61,8 +61,9 @@ module Hyrax
       # to the edit permissions of the AdminSet and to the WorkflowResponsibilities
       # of the active workflow
       def update_management
-        admin_set.update_access_controls! if model.source_type == 'admin_set'
-        update_workflow_approving_responsibilities
+        # TODO: elr - not tested
+        source_model.update_access_controls!
+        update_workflow_approving_responsibilities if source_model.is_a?(AdminSet)
       end
 
       private

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -11,6 +11,7 @@ module Hyrax
       # @return [#to_s] the primary key of the associated admin_set or collection
       # def source_id (because you might come looking for this method)
       delegate :id, to: :source_model, prefix: :source
+      delegate :update_access_controls!, to: :source_model
 
       # Stores which radio button under release "Varies" option is selected
       attr_accessor :release_varies
@@ -60,9 +61,9 @@ module Hyrax
       # If management roles have been granted or removed, then copy this access
       # to the edit permissions of the AdminSet and to the WorkflowResponsibilities
       # of the active workflow
-      def update_management
-        # TODO: elr - not tested
-        source_model.update_access_controls!
+      def update_access(manage_changed:)
+        update_access_controls! # recalculate access controls for all participants
+        return unless manage_changed
         update_workflow_approving_responsibilities if source_model.is_a?(AdminSet)
       end
 
@@ -78,9 +79,7 @@ module Hyrax
         # @return [Void]
         def update_participants_options(attributes)
           update_permission_template(attributes)
-          # if managers were added, recalculate update the access controls on the AdminSet
-          return unless managers_updated?(attributes)
-          update_management
+          update_access(manage_changed: managers_updated?(attributes))
         end
 
         # Grant workflow approve roles for any admin set managers

--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -28,11 +28,33 @@ module Hyrax
     # In a perfect world, there would be a join table that enforced uniqueness on the ID.
     has_one :active_workflow, -> { where(active: true) }, class_name: 'Sipity::Workflow', foreign_key: :permission_template_id
 
+    # A bit of an analogue for a `belongs_to :source_model` as it crosses from Fedora to the DB
+    # @return [AdminSet | Collection]
+    # @raise [ActiveFedora::ObjectNotFoundError] when neither an AdminSet or Collection is found
+    def source_model
+      admin_set
+    rescue ActiveFedora::ObjectNotFoundError
+      collection
+    end
+
     # A bit of an analogue for a `belongs_to :admin_set` as it crosses from Fedora to the DB
     # @return [AdminSet]
     # @raise [ActiveFedora::ObjectNotFoundError] when the we cannot find the AdminSet
     def admin_set
-      AdminSet.find(source_id)
+      return AdminSet.find(source_id) if AdminSet.exists?(source_id)
+      raise ActiveFedora::ObjectNotFoundError
+    rescue ActiveFedora::ActiveFedoraError # TODO: remove the rescue when active_fedora issue #1276 is fixed
+      raise ActiveFedora::ObjectNotFoundError
+    end
+
+    # A bit of an analogue for a `belongs_to :collection` as it crosses from Fedora to the DB
+    # @return [Collection]
+    # @raise [ActiveFedora::ObjectNotFoundError] when the we cannot find the Collection
+    def collection
+      return Collection.find(source_id) if Collection.exists?(source_id)
+      raise ActiveFedora::ObjectNotFoundError
+    rescue ActiveFedora::ActiveFedoraError # TODO: remove the rescue when active_fedora issue #1276 is fixed
+      raise ActiveFedora::ObjectNotFoundError
     end
 
     # Valid Release Period values

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -85,6 +85,7 @@ module Hyrax
         access_grants = access_grants_attributes(collection_type: collection_type, creating_user: creating_user)
         PermissionTemplate.create!(source_id: collection.id, source_type: 'collection',
                                    access_grants_attributes: access_grants.uniq)
+        collection.update_access_controls!
       end
 
       # @api private

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -79,10 +79,11 @@ module Hyrax
       #
       # @param collection [Collection] the collection the new permissions will act on
       # @param creating_user [User] the user that created the collection
+      # @param grants [Array<Hash>] additional grants to apply to the new collection
       # @return [Hyrax::PermissionTemplate]
-      def self.create_default(collection:, creating_user:)
+      def self.create_default(collection:, creating_user:, grants: [])
         collection_type = Hyrax::CollectionType.find_by_gid!(collection.collection_type_gid)
-        access_grants = access_grants_attributes(collection_type: collection_type, creating_user: creating_user)
+        access_grants = access_grants_attributes(collection_type: collection_type, creating_user: creating_user, grants: grants)
         PermissionTemplate.create!(source_id: collection.id, source_type: 'collection',
                                    access_grants_attributes: access_grants.uniq)
         collection.update_access_controls!
@@ -94,8 +95,9 @@ module Hyrax
       #
       # @param collection_type [CollectionType] the collection type of the new collection
       # @param creating_user [User] the user that created the collection
+      # @param grants [Array<Hash>] additional grants to apply to the new collection
       # @return [Hash] a hash containing permission attributes
-      def self.access_grants_attributes(collection_type:, creating_user:)
+      def self.access_grants_attributes(collection_type:, creating_user:, grants:)
         [
           { agent_type: 'group', agent_id: admin_group_name, access: Hyrax::PermissionTemplateAccess::MANAGE }
         ].tap do |attribute_list|
@@ -103,7 +105,7 @@ module Hyrax
           if creating_user
             attribute_list << { agent_type: 'user', agent_id: creating_user.user_key, access: Hyrax::PermissionTemplateAccess::MANAGE }
           end
-        end + managers_of_collection_type(collection_type: collection_type)
+        end + managers_of_collection_type(collection_type: collection_type) + grants
       end
       private_class_method :access_grants_attributes
 

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -18,6 +18,19 @@ FactoryGirl.define do
             create(:admin_set)
           end
         permission_template.source_id = admin_set.id
+      elsif evaluator.with_collection
+        source_id = permission_template.source_id
+        collection =
+          if source_id.present?
+            begin
+              Collection.find(source_id)
+            rescue
+              create(:collection, id: source_id)
+            end
+          else
+            create(:collection)
+          end
+        permission_template.source_id = collection.id
       end
     end
 
@@ -34,6 +47,7 @@ FactoryGirl.define do
 
     transient do
       with_admin_set false
+      with_collection false
       with_workflows false
       with_active_workflow false
     end

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
   it { is_expected.to delegate_method(:source_model).to(:model) }
   it { is_expected.to delegate_method(:visibility).to(:model) }
   it { is_expected.to delegate_method(:id).to(:source_model).with_prefix(:source) }
+  it { is_expected.to delegate_method(:update_access_controls!).to(:source_model) }
 
   it 'is expected to delegate method #active_workflow_id to #active_workflow#id' do
     workflow = double(:workflow, id: 1234, active: true)
@@ -102,7 +103,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
 
       it "doesn't adds edit_access to the AdminSet itself" do
         expect { subject }.to change { permission_template.access_grants.count }.by(1)
-        expect(admin_set.reload.edit_users).to be_empty
+        expect(admin_set.reload.edit_users).to match_array [user.user_key] # MANAGE user added in before do
       end
     end
 

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -3,13 +3,15 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
   let(:form) { described_class.new(permission_template) }
   let(:today) { Time.zone.today }
   let(:admin_set) { create(:admin_set) }
+  let(:collection) { create(:collection) }
 
   subject { form }
 
   it { is_expected.to delegate_method(:available_workflows).to(:model) }
   it { is_expected.to delegate_method(:active_workflow).to(:model) }
-  it { is_expected.to delegate_method(:admin_set).to(:model) }
+  it { is_expected.to delegate_method(:source_model).to(:model) }
   it { is_expected.to delegate_method(:visibility).to(:model) }
+  it { is_expected.to delegate_method(:id).to(:source_model).with_prefix(:source) }
 
   it 'is expected to delegate method #active_workflow_id to #active_workflow#id' do
     workflow = double(:workflow, id: 1234, active: true)
@@ -307,6 +309,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
 
         it 'trigger error from #update' do
           expect(response).to eq(content_tab: "visibility", updated: false, error_code: error_code)
+          # TODO: elr - does this error message need to be generalized?
           expect(I18n.t(response[:error_code], scope: 'hyrax.admin.admin_sets.form.permission_update_errors')).not_to include('translation missing')
         end
       end


### PR DESCRIPTION
Fixes #1543

Modifications:
* CollectionBehavior (model)
  * √ after_destroy gets rid of any permission templates for the collection
  * √ new method update_access_controls! add edit_users, edit_groups, read_users, and read_groups to solr doc based on permission template manage access

* PermissionsService
  * call update_access_controls in create_default method so solr_doc is updated with initial create

* PermissionTemplate
  * √ new method source_model which returns either and admin set or a collection
  * √ new method collection which returns the collection for the permission template (if it is a collection and it exists; otherwise throws ObjectNotFound)
  * √ update method admin_set to return the admin_set for the permission template (if it is an admin set and it exists; otherwise throws ObjectNotFound)

* PermissionTemplateForm
  * √ delegate source_model to model so it picks up both admin sets and collections
  * √ delegate id to source_model ending up with form method source_id -- gives access to both admin sets and collections
  * update_management now calls `source_model.update_access_controls!` which both admin sets and collections define

* CollectionController
  * √ process permissions passed in params with create/update

Tests:
* permission_templates factory
  * √ add with_collection support

* collection_spec
  * test after_destroy
  * test update_access_controls!
  * test collection factory

* permission_template_spec
  * test factory's with_collection parameter
  * test source_model returning admin_set, collection
  * test collection method
  * already has test for admin_set method

* permission_template_form_spec
  * update delegation check from admin_set to source_model
  * TODO: generalize error message from admin_sets to collections and admin_sets


Expected Behavior Changes:
* when you delete a collection, all related permission templates and access are also deleted
* when you add a participant, the solr doc edit/read access is updated for both admin sets and collections
* fixes bug that did not set admin_set creator with MANAGE access when admin_set is created

