### PR TITLE
Get BrowseEverything working again

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -17,7 +17,7 @@ module Hyrax
       # @param [Hyrax::UploadedFile, File, ActionDigest::HTTP::UploadedFile] file the file uploaded by the user
       # @param [Symbol, #to_s] relation
       # @return [IngestJob, FalseClass] false on failure, otherwise the queued job
-      def create_content(file, relation = :original_file, from_url = false)
+      def create_content(file, relation = :original_file, from_url: false)
         # If the file set doesn't have a title or label assigned, set a default.
         file_set.label ||= label_for(file)
         file_set.title = [file_set.label] if file_set.title.blank?
@@ -27,7 +27,7 @@ module Hyrax
           # reach into the FileActor and run the ingest with the file instance in
           # hand. Do this because we don't have the underlying UploadedFile instance
           file_actor = build_file_actor(relation)
-          file_actor.ingest_file(wrapper!(file: file, relation: relation), from_url: true)
+          file_actor.ingest_file(wrapper!(file: file, relation: relation))
         else
           IngestJob.perform_later(wrapper!(file: file, relation: relation))
         end

--- a/app/channels/hyrax/application_cable/connection.rb
+++ b/app/channels/hyrax/application_cable/connection.rb
@@ -20,8 +20,6 @@ module Hyrax
 
         def user_id
           session['warden.user.user.key'][0][0]
-        rescue NoMethodError
-          nil
         end
 
         def session

--- a/app/channels/hyrax/application_cable/connection.rb
+++ b/app/channels/hyrax/application_cable/connection.rb
@@ -20,6 +20,8 @@ module Hyrax
 
         def user_id
           session['warden.user.user.key'][0][0]
+        rescue NoMethodError
+          nil
         end
 
         def session

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -29,7 +29,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
       # FileSetActor operates synchronously so that this tempfile is available.
       # If asynchronous, the job might be invoked on a machine that did not have this temp file on its file system!
       # NOTE: The return status may be successful even if the content never attaches.
-      if Hyrax::Actors::FileSetActor.new(file_set, user).create_content_from_url(f)
+      if Hyrax::Actors::FileSetActor.new(file_set, user).create_content(f, from_url: true)
         operation.success!
       else
         # send message to user on download failure

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -27,7 +27,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
       # FileSetActor operates synchronously so that this tempfile is available.
       # If asynchronous, the job might be invoked on a machine that did not have this temp file on its file system!
       # NOTE: The return status may be successful even if the content never attaches.
-      if Hyrax::Actors::FileSetActor.new(file_set, user).create_content(f)
+      if Hyrax::Actors::FileSetActor.new(file_set, user).create_content_from_url(f)
         operation.success!
       else
         # send message to user on download failure

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -20,6 +20,8 @@ class ImportUrlJob < Hyrax::ApplicationJob
     operation.performing!
     user = User.find_by_user_key(file_set.depositor)
     uri = URI(file_set.import_url)
+    # @todo Use Hydra::Works::AddExternalFileToFileSet instead of manually
+    #       copying the file here. This will be gnarly.
     copy_remote_file(uri) do |f|
       # reload the FileSet once the data is copied since this is a long running task
       file_set.reload

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
 
   describe '#create_content_from_url' do
     before do
-      expect(JobIoWrapper).to receive(:create_with_varied_file_handling!).with(any_args).and_return(JobIoWrapper.new)
+      expect(JobIoWrapper).to receive(:create_with_varied_file_handling!).with(any_args).once.and_call_original
     end
 
     it 'calls ingest_file' do
@@ -143,7 +143,12 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     end
 
     context 'when an alternative relationship is specified' do
-      let(:relation) { :remastered }
+      before do
+        # Relationship must be declared before being used. Inject it here.
+        FileSet.class_eval do
+          directly_contains_one :remastered, through: :files, type: ::RDF::URI("http://otherpcdm.example.org/use#Remastered"), class_name: 'Hydra::PCDM::File'
+        end
+      end
 
       it 'calls ingest_file' do
         actor.create_content_from_url(file, :remastered)

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -133,6 +133,75 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     end
   end
 
+  describe '#create_content_from_url' do
+    before do
+      expect(JobIoWrapper).to receive(:create_with_varied_file_handling!).with(any_args).and_return(JobIoWrapper.new)
+    end
+
+    it 'calls ingest_file' do
+      actor.create_content_from_url(file)
+    end
+
+    context 'when an alternative relationship is specified' do
+      let(:relation) { :remastered }
+
+      it 'calls ingest_file' do
+        actor.create_content_from_url(file, :remastered)
+      end
+    end
+
+    context 'using ::File' do
+      let(:file) { local_file }
+
+      before { actor.create_content_from_url(local_file) }
+
+      it 'sets the label and title' do
+        expect(file_set.label).to eq(File.basename(local_file))
+        expect(file_set.title).to eq([File.basename(local_file)])
+      end
+
+      it 'gets the mime_type from original_file' do
+        expect(file_set.mime_type).to eq('image/png')
+      end
+    end
+
+    context 'when file_set.title is empty and file_set.label is not' do
+      let(:long_name) do
+        'an absurdly long title that goes on way to long and messes up the display of the page which should not need ' \
+          'to be this big in order to show this impossibly long, long, long, oh so long string'
+      end
+      let(:short_name) { 'Nice Short Name' }
+
+      before do
+        allow(file_set).to receive(:label).and_return(short_name)
+        actor.create_content_from_url(file)
+      end
+
+      subject { file_set.title }
+
+      it { is_expected.to match_array [short_name] }
+    end
+
+    context 'when a label is already specified' do
+      let(:label) { 'test_file.png' }
+      let(:file_set) do
+        FileSet.new do |f|
+          f.apply_depositor_metadata(user.user_key)
+          f.label = label
+        end
+      end
+      let(:actor) { described_class.new(file_set, user) }
+
+      before do
+        actor.create_content_from_url(file)
+      end
+
+      it "retains the object's original label" do
+        expect(file_set.label).to eql(label)
+      end
+    end
+  end
+
   describe "#update_metadata" do
     it "is successful" do
       expect(actor.update_metadata("title" => ["updated title"])).to be true

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -133,13 +133,13 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     end
   end
 
-  describe '#create_content_from_url' do
+  describe '#create_content when from_url is true' do
     before do
       expect(JobIoWrapper).to receive(:create_with_varied_file_handling!).with(any_args).once.and_call_original
     end
 
     it 'calls ingest_file' do
-      actor.create_content_from_url(file)
+      actor.create_content(file, from_url: true)
     end
 
     context 'when an alternative relationship is specified' do
@@ -151,14 +151,14 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       end
 
       it 'calls ingest_file' do
-        actor.create_content_from_url(file, :remastered)
+        actor.create_content(file, :remastered, from_url: true)
       end
     end
 
     context 'using ::File' do
       let(:file) { local_file }
 
-      before { actor.create_content_from_url(local_file) }
+      before { actor.create_content(local_file, from_url: true) }
 
       it 'sets the label and title' do
         expect(file_set.label).to eq(File.basename(local_file))
@@ -173,13 +173,13 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     context 'when file_set.title is empty and file_set.label is not' do
       let(:long_name) do
         'an absurdly long title that goes on way to long and messes up the display of the page which should not need ' \
-          'to be this big in order to show this impossibly long, long, long, oh so long string'
+        'to be this big in order to show this impossibly long, long, long, oh so long string'
       end
       let(:short_name) { 'Nice Short Name' }
 
       before do
         allow(file_set).to receive(:label).and_return(short_name)
-        actor.create_content_from_url(file)
+        actor.create_content(file, from_url: true)
       end
 
       subject { file_set.title }
@@ -198,7 +198,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       let(:actor) { described_class.new(file_set, user) }
 
       before do
-        actor.create_content_from_url(file)
+        actor.create_content(file, from_url: true)
       end
 
       it "retains the object's original label" do

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ImportUrlJob do
   end
 
   let(:operation) { create(:operation) }
-  let(:actor) { instance_double(Hyrax::Actors::FileSetActor, create_content_from_url: true) }
+  let(:actor) { instance_double(Hyrax::Actors::FileSetActor, create_content: true) }
 
   before do
     allow(Hyrax::Actors::FileSetActor).to receive(:new).with(file_set, user).and_return(actor)
@@ -29,7 +29,7 @@ RSpec.describe ImportUrlJob do
     end
 
     it 'creates the content and updates the associated operation' do
-      expect(actor).to receive(:create_content_from_url).with(File).and_return(true)
+      expect(actor).to receive(:create_content).with(File, from_url: true).and_return(true)
       described_class.perform_now(file_set, operation)
       expect(operation).to be_success
     end

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ImportUrlJob do
   end
 
   let(:operation) { create(:operation) }
-  let(:actor) { instance_double(Hyrax::Actors::FileSetActor, create_content: true) }
+  let(:actor) { instance_double(Hyrax::Actors::FileSetActor, create_content_from_url: true) }
 
   before do
     allow(Hyrax::Actors::FileSetActor).to receive(:new).with(file_set, user).and_return(actor)
@@ -29,7 +29,7 @@ RSpec.describe ImportUrlJob do
     end
 
     it 'creates the content and updates the associated operation' do
-      expect(actor).to receive(:create_content).with(File).and_return(true)
+      expect(actor).to receive(:create_content_from_url).with(File).and_return(true)
       described_class.perform_now(file_set, operation)
       expect(operation).to be_success
     end


### PR DESCRIPTION
Do this by adding a new (admittedly not DRY method) method that short-circuits the IngestJob machinery which is not needed here, since we do not have UploadedFiles in hand.

I don't love this solution, but I'd like this fixed before we cut 2.0.0.rc1.

Fixes #1654 
Fixes #1139 

@samvera/hyrax-code-reviewers
