### PR TITLE
set creator edit access when admin set is created

### DIFF
--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -85,6 +85,7 @@ class AdminSet < ActiveFedora::Base
   # Calculate and update who should have edit access based on who
   # has "manage" access in the PermissionTemplateAccess
   def update_access_controls!
+    # NOTE: This is different from Collections in that it doesn't update read access.  See the notes in services/hyrax/collections/permissions_service.rb
     update!(edit_users: permission_template.agent_ids_for(access: 'manage', agent_type: 'user'),
             edit_groups: permission_template.agent_ids_for(access: 'manage', agent_type: 'group'))
   end

--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -54,7 +54,6 @@ module Hyrax
     # @return [TrueClass, FalseClass] true if it was successful
     def create
       admin_set.read_groups = ['public']
-      admin_set.edit_groups = [admin_group_name]
       admin_set.creator = [creating_user.user_key] if creating_user
       admin_set.save.tap do |result|
         if result
@@ -85,7 +84,9 @@ module Hyrax
       end
 
       def create_permission_template
-        PermissionTemplate.create!(source_id: admin_set.id, source_type: 'admin_set', access_grants_attributes: access_grants_attributes)
+        permission_template = PermissionTemplate.create!(source_id: admin_set.id, source_type: 'admin_set', access_grants_attributes: access_grants_attributes)
+        admin_set.update_access_controls!
+        permission_template
       end
 
       def create_workflows_for(permission_template:)

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -85,9 +85,12 @@ RSpec.describe Hyrax::AdminSetCreateService do
           #  * 2 available workflows, multiplied by
           #  * 3 roles (from Hyrax::RoleRegistry), equals
           #  * 12
-          expect(admin_set.read_groups).to eq ['public']
-          expect(admin_set.edit_groups).to eq ['admin']
+          expect(admin_set.edit_users).to match_array([user.user_key])
+          expect(admin_set.edit_groups).to match_array(['admin'])
+          expect(admin_set.read_users).to match_array([])
+          expect(admin_set.read_groups).to match_array(['public'])
           expect(admin_set.creator).to eq [user.user_key]
+
           expect(workflow_importer).to have_received(:call).with(permission_template: permission_template)
           expect(permission_template).to be_persisted
           expect(grants.count).to eq 2


### PR DESCRIPTION
Fixes #1666

The [Hyrax::AdminSetCreateService](https://github.com/samvera/hyrax/blob/collections-sprint/app/services/hyrax/admin_set_create_service.rb) now calls [AdminSet](https://github.com/samvera/hyrax/blob/collections-%231666-adminset_creator_edit_access/app/models/admin_set.rb).update_access_controls! after creating the permission template.  This updates edit access in the model based on access defined by the permission template.

