### PR TITLE
Citations controller should decide layout like other controllers do

### DIFF
--- a/app/controllers/hyrax/citations_controller.rb
+++ b/app/controllers/hyrax/citations_controller.rb
@@ -4,6 +4,7 @@ module Hyrax
     include Breadcrumbs
     include SingularSubresourceController
 
+    layout :decide_layout
     before_action :build_breadcrumbs, only: [:work, :file]
 
     def work
@@ -23,6 +24,17 @@ module Hyrax
 
       def show_presenter
         WorkShowPresenter
+      end
+
+      def decide_layout
+        case action_name
+        when 'work', 'file'
+          theme
+        else
+          # Not currently used in this controller, but left here to
+          # support dashboard-based work views which are ticketed
+          'dashboard'
+        end
       end
   end
 end

--- a/spec/controllers/hyrax/citations_controller_spec.rb
+++ b/spec/controllers/hyrax/citations_controller_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Hyrax::CitationsController do
         expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :work, params: { id: work }
         expect(response).to be_successful
+        expect(response).to render_template('layouts/hyrax')
         expect(assigns(:presenter)).to be_kind_of Hyrax::WorkShowPresenter
       end
     end
@@ -41,6 +42,7 @@ RSpec.describe Hyrax::CitationsController do
         expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :file, params: { id: file_set }
         expect(response).to be_successful
+        expect(response).to render_template('layouts/hyrax')
         expect(assigns(:presenter)).to be_kind_of Hyrax::FileSetPresenter
       end
     end


### PR DESCRIPTION
Fixes curationexperts/nurax#40

Otherwise the citation link -- which is publicly viewable -- uses the dashboard layout, which is not used for public users. Using the `decide_layout` strategy like in other Hyrax controllers, though the branch that renders the `dashboard` layout is not currently used. Work to render dashboard-baed work show views is ticketed, so I leave this code as is for consistency and as a foundation for upcoming work.

@samvera/hyrax-code-reviewers
