### PR TITLE
Skip creating an ActionCable consumer if the user is not logged in

### DIFF
--- a/app/assets/javascripts/hyrax/app.js.erb
+++ b/app/assets/javascripts/hyrax/app.js.erb
@@ -88,6 +88,9 @@ Hyrax = {
 
     // ActionCable for user notifications. This is displayed in the navbar.
     notifications: function() {
+        // Do not create a consumer if user is not logged in
+        if ($("meta[name='current-user']").length === 0)
+            return;
         var consumer = ActionCable.createConsumer("<%= Hyrax::Engine.routes.url_helpers.notifications_endpoint_path %>");
         consumer.subscriptions.create("Hyrax::NotificationsChannel", {
             connected: function(data) {

--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -1,6 +1,8 @@
 <%= csrf_meta_tag %>
 <meta charset="utf-8" />
-
+<% if signed_in? %>
+    <%= tag :meta, name: 'current-user', data: { user_key: current_user.user_key } %>
+<% end %>
 <!-- added for use on small devices like phones -->
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 <link rel="resourcesync" href="<%= hyrax.capability_list_url %>"/>

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
     allow(controller).to receive(:current_user).and_return(depositor)
     allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
     allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+    allow(view).to receive(:signed_in?)
     allow(view).to receive(:on_the_dashboard?).and_return(false)
     stub_template 'hyrax/base/_metadata.html.erb' => ''
     stub_template 'hyrax/base/_relationships.html.erb' => ''

--- a/spec/views/hyrax/homepage/index.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/index.html.erb_spec.rb
@@ -4,15 +4,48 @@ RSpec.describe "hyrax/homepage/index.html.erb", type: :view do
   let(:presenter) { instance_double(Hyrax::HomepagePresenter) }
   let(:type_presenter) { instance_double(Hyrax::SelectTypeListPresenter, many?: true) }
 
+  before do
+    allow(view).to receive(:create_work_presenter).and_return(type_presenter)
+    allow(view).to receive(:signed_in?).and_return(signed_in)
+    allow(controller).to receive(:current_ability).and_return(ability)
+    assign(:presenter, presenter)
+    stub_template "hyrax/homepage/_marketing.html.erb" => "marketing"
+    stub_template "hyrax/homepage/_home_content.html.erb" => "home content"
+  end
+
+  describe 'meta tag with current user info' do
+    before do
+      allow(view).to receive(:on_the_dashboard?).and_return(false)
+      allow(controller).to receive(:current_user).and_return(current_user)
+      allow(controller).to receive(:current_ability).and_return(ability)
+      allow(presenter).to receive(:display_share_button?).and_return(true)
+      stub_template "_controls.html.erb" => "controls"
+      stub_template "_masthead.html.erb" => "masthead"
+      render template: 'hyrax/homepage/index', layout: 'layouts/homepage'
+    end
+
+    context 'when signed in' do
+      let(:signed_in) { true }
+      let(:current_user) { create(:user) }
+
+      it 'renders' do
+        expect(rendered).to have_selector('meta[name="current-user"]', visible: false)
+      end
+    end
+
+    context 'when not signed in' do
+      let(:signed_in) { false }
+      let(:current_user) { nil }
+
+      it 'does not render' do
+        expect(rendered).not_to have_selector('meta[name="current-user"]', visible: false)
+      end
+    end
+  end
+
   describe "share your work button" do
     before do
-      allow(view).to receive(:create_work_presenter).and_return(type_presenter)
-      allow(view).to receive(:signed_in?).and_return(signed_in)
-      assign(:presenter, presenter)
-      allow(controller).to receive(:current_ability).and_return(ability)
       allow(presenter).to receive(:display_share_button?).and_return(display_share_button)
-      stub_template "hyrax/homepage/_marketing.html.erb" => "marketing"
-      stub_template "hyrax/homepage/_home_content.html.erb" => "home content"
       render
     end
 

--- a/spec/views/pages/show.html.erb_spec.rb
+++ b/spec/views/pages/show.html.erb_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe "hyrax/pages/show", type: :view do
 
   before do
     assign(:page, content_block)
+    allow(view).to receive(:signed_in?)
     allow(view).to receive(:displayable_content_block)
     allow(view).to receive(:can?).and_return(false)
     stub_template 'catalog/_search_form.html.erb' => ''


### PR DESCRIPTION
This prevents unauthenticated users from attempting to create consumers. This cuts down on network traffic and keeps noise out of the server logs.

@samvera/hyrax-code-reviewers
