### PR TITLE
Add participants to a new work created directly in a collection

### DIFF
--- a/app/actors/hyrax/actors/apply_permission_template_actor.rb
+++ b/app/actors/hyrax/actors/apply_permission_template_actor.rb
@@ -13,8 +13,24 @@ module Hyrax
       private
 
         def add_edit_users(env)
-          return if env.attributes[:source_id].blank?
-          template = Hyrax::PermissionTemplate.find_by!(source_id: env.attributes[:source_id])
+          add_admin_set_participants(env)
+          add_collection_participants(env)
+        end
+
+        def add_admin_set_participants(env)
+          return if env.attributes[:admin_set_id].blank?
+          template = Hyrax::PermissionTemplate.find_by!(source_id: env.attributes[:admin_set_id], source_type: 'admin_set')
+          set_curation_concern_access(env, template)
+        end
+
+        def add_collection_participants(env)
+          return if env.attributes[:collection_id].blank?
+          collection_id = env.attributes.delete(:collection_id) # delete collection_id from attributes because works do not have a collection_id property
+          template = Hyrax::PermissionTemplate.find_by!(source_id: collection_id, source_type: 'collection')
+          set_curation_concern_access(env, template)
+        end
+
+        def set_curation_concern_access(env, template)
           env.curation_concern.edit_users += template.agent_ids_for(agent_type: 'user', access: 'manage')
           env.curation_concern.edit_groups += template.agent_ids_for(agent_type: 'group', access: 'manage')
           env.curation_concern.read_users += template.agent_ids_for(agent_type: 'user', access: 'view')

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -1,4 +1,4 @@
- <% id = collection_presenter.id %>
+<% id = collection_presenter.id %>
 <tr id="document_<%= id %>">
   <td><% unless collection_presenter.solr_document.admin_set? %><input type="checkbox"><% end %></td>
   <td>

--- a/lib/generators/hyrax/templates/db/seeds.rb
+++ b/lib/generators/hyrax/templates/db/seeds.rb
@@ -9,6 +9,13 @@
 # To use this file, run the following command in the .internal_test_app:
 #   rails generate hyrax:sample_data
 
+puts "Creating users"
+User.create(email: 'mgr1@example.org', password: 'pppppp') # 6*p
+User.create(email: 'mgr2@example.org', password: 'pppppp')
+User.create(email: 'dep1@example.org', password: 'pppppp')
+User.create(email: 'dep2@example.org', password: 'pppppp')
+User.create(email: 'vw1@example.org', password: 'pppppp')
+User.create(email: 'vw2@example.org', password: 'pppppp')
 user = User.create(email: 'foo@example.org', password: 'foobarbaz')
 
 puts "Creating 'Nestable Collection' type"
@@ -20,10 +27,9 @@ options = {
                  { agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE, agent_id: ::Ability.registered_group_name, access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS }]
 }
 begin
-  puts "  attempting to create"
   coltype = Hyrax::CollectionTypes::CreateService.create_collection_type(machine_id: "nestable_collection", title: "Nestable Collection", options: options)
 rescue
-  puts "  attempting to use existing"
+  puts "  failed to create... looking for existing"
   coltype = Hyrax::CollectionType.find_by_machine_id!("nestable_collection")
 end
 nestable_gid = coltype.gid
@@ -37,10 +43,9 @@ options = {
                  { agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE, agent_id: ::Ability.registered_group_name, access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS }]
 }
 begin
-  puts "  attempting to create"
   coltype = Hyrax::CollectionTypes::CreateService.create_collection_type(machine_id: "nonnestable_collection", title: "Non-Nestable Collection", options: options)
 rescue
-  puts "  attempting to use existing"
+  puts "  failed to create... looking for existing"
   coltype = Hyrax::CollectionType.find_by_machine_id!("nonnestable_collection")
 end
 _nonnestable_gid = coltype.gid

--- a/spec/actors/hyrax/actors/apply_permission_template_actor_spec.rb
+++ b/spec/actors/hyrax/actors/apply_permission_template_actor_spec.rb
@@ -5,12 +5,15 @@ RSpec.describe Hyrax::Actors::ApplyPermissionTemplateActor do
   let(:depositor) { create(:user) }
   let(:work) do
     build(:generic_work,
+          user: depositor,
           edit_users: ['Kevin'],
           read_users: ['Taraji'])
   end
   let(:attributes) { { source_id: admin_set.id } }
   let(:admin_set) { create(:admin_set, with_permission_template: true) }
-  let(:permission_template) { admin_set.permission_template }
+  let(:as_permission_template) { admin_set.permission_template }
+  let(:collection) { create(:collection, with_permission_template: true) }
+  let(:col_permission_template) { collection.permission_template }
 
   subject(:middleware) do
     stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
@@ -21,47 +24,112 @@ RSpec.describe Hyrax::Actors::ApplyPermissionTemplateActor do
 
   describe "create" do
     context "when source_id is blank" do
-      let(:attributes) { { source_id: '' } }
+      let(:attributes) { { admin_set_id: '' } }
 
       it "returns true" do
         expect(middleware.create(env)).to be true
       end
     end
 
-    context "when source_id is provided" do
-      let(:attributes) { { source_id: admin_set.id } }
+    context "when admin_set_id only is provided" do
+      let(:attributes) { { admin_set_id: admin_set.id } }
 
       before do
-        create(:permission_template_access,
-               :manage,
-               permission_template: permission_template,
-               agent_type: 'user',
-               agent_id: 'hannah')
-        create(:permission_template_access,
-               :manage,
-               permission_template: permission_template,
-               agent_type: 'group',
-               agent_id: 'librarians')
-        create(:permission_template_access,
-               :view,
-               permission_template: permission_template,
-               agent_type: 'user',
-               agent_id: 'gary')
-        create(:permission_template_access,
-               :view,
-               permission_template: permission_template,
-               agent_type: 'group',
-               agent_id: 'readers')
+        admin_set_access(as_permission_template)
         allow(terminator).to receive(:create).and_return(true)
       end
 
       it "adds the template users to the work" do
         expect(middleware.create(env)).to be true
-        expect(work.edit_users).to include('hannah', 'Kevin')
-        expect(work.edit_groups).to include 'librarians'
-        expect(work.read_users).to include('gary', 'Taraji')
-        expect(work.read_groups).to include 'readers'
+        expect(work.edit_users).to match_array [depositor.user_key, 'Kevin', 'hannah a. smith']
+        expect(work.edit_groups).to match_array ['librarians_as']
+        expect(work.read_users).to match_array ['Taraji', 'gary a. stevens']
+        expect(work.read_groups).to match_array ['readers_as']
       end
+    end
+
+    context "when admin_set_id and collection_id is provided" do
+      let(:attributes) { { admin_set_id: admin_set.id, collection_id: collection.id } }
+
+      before do
+        admin_set_access(as_permission_template)
+        collection_access(col_permission_template)
+        allow(terminator).to receive(:create).and_return(true)
+      end
+
+      it "adds the template users to the work" do
+        expect(middleware.create(env)).to be true
+        expect(work.edit_users).to match_array [depositor.user_key, 'Kevin', 'hannah a. smith', 'joe conrad']
+        expect(work.edit_groups).to match_array ['librarians_as', 'managers_c']
+        expect(work.read_users).to match_array ['Taraji', 'gary a. stevens', 'carol cassidy']
+        expect(work.read_groups).to match_array ['readers_as', 'viewers_c']
+      end
+    end
+
+    def admin_set_access(permission_template) # rubocop:disable Metrics/MethodLength
+      create(:permission_template_access,
+             :manage,
+             permission_template: permission_template,
+             agent_type: 'user',
+             agent_id: 'hannah a. smith')
+      create(:permission_template_access,
+             :manage,
+             permission_template: permission_template,
+             agent_type: 'group',
+             agent_id: 'librarians_as')
+      create(:permission_template_access,
+             :deposit,
+             permission_template: permission_template,
+             agent_type: 'user',
+             agent_id: 'mike a. steward')
+      create(:permission_template_access,
+             :deposit,
+             permission_template: permission_template,
+             agent_type: 'group',
+             agent_id: 'staff_as')
+      create(:permission_template_access,
+             :view,
+             permission_template: permission_template,
+             agent_type: 'user',
+             agent_id: 'gary a. stevens')
+      create(:permission_template_access,
+             :view,
+             permission_template: permission_template,
+             agent_type: 'group',
+             agent_id: 'readers_as')
+    end
+
+    def collection_access(permission_template) # rubocop:disable Metrics/MethodLength
+      create(:permission_template_access,
+             :manage,
+             permission_template: permission_template,
+             agent_type: 'user',
+             agent_id: "joe conrad")
+      create(:permission_template_access,
+             :manage,
+             permission_template: permission_template,
+             agent_type: 'group',
+             agent_id: "managers_c")
+      create(:permission_template_access,
+             :deposit,
+             permission_template: permission_template,
+             agent_type: 'user',
+             agent_id: "donny cartwright")
+      create(:permission_template_access,
+             :deposit,
+             permission_template: permission_template,
+             agent_type: 'group',
+             agent_id: "depositors_c")
+      create(:permission_template_access,
+             :view,
+             permission_template: permission_template,
+             agent_type: 'user',
+             agent_id: "carol cassidy")
+      create(:permission_template_access,
+             :view,
+             permission_template: permission_template,
+             agent_type: 'group',
+             agent_id: "viewers_c")
     end
   end
 end

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
     # This way, we can go ahead
     after(:create) do |admin_set, evaluator|
       if evaluator.with_permission_template
-        attributes = { source_id: admin_set.id }
+        attributes = { source_id: admin_set.id, source_type: 'admin_set' }
         attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
         # There is a unique constraint on permission_templates.source_id; I don't want to
         # create a permission template if one already exists for this admin_set

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -19,7 +19,7 @@ FactoryGirl.define do
 
     after(:create) do |collection, evaluator|
       if evaluator.with_permission_template
-        attributes = { source_id: collection.id }
+        attributes = { source_id: collection.id, source_type: 'collection' }
         attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
         create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
       end

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -18,6 +18,7 @@ FactoryGirl.define do
             create(:admin_set)
           end
         permission_template.source_id = admin_set.id
+        permission_template.source_type = 'admin_set'
       elsif evaluator.with_collection
         source_id = permission_template.source_id
         collection =
@@ -31,6 +32,7 @@ FactoryGirl.define do
             create(:collection)
           end
         permission_template.source_id = collection.id
+        permission_template.source_type = 'collection'
       end
     end
 


### PR DESCRIPTION
Fixes #1545

In the save new work actor stake, collection membership is processed the same.  It also determines if there is one and only one collection selected for the work.  If there is, it adds the single collection back into the Environment as :collection_id.  Later, when permissions are being applied from the admin set, it checks for :collection_id in the Environment and adds collection participants for the identified collection.

Also includes a fix for failing test for batch_create_failure_service where the rebase with master overwrote some collections-sprint changes.

NOTE to reviewer:  

To test the UI interactively, you may want to use the seed file provided in the generator code.  This adds users with names that make it easy to add  and identify managers, depositors, and viewers.

To use the seeds:
```
cd .internal_test_app
rails generate hyrax:sample_data
rake db:seed
```
  
