### PR TITLE
FIX: merge with master overwrote collections-sprint changes to batch_create_failure_service

### DIFF
--- a/app/services/hyrax/batch_create_failure_service.rb
+++ b/app/services/hyrax/batch_create_failure_service.rb
@@ -1,7 +1,7 @@
 module Hyrax
   class BatchCreateFailureService < AbstractMessageService
-    attr_reader :user
-    def initialize(user)
+    attr_reader :user, :messages
+    def initialize(user, messages)
       @user = user
       @messages = messages.to_sentence
     end


### PR DESCRIPTION

FIXES TEST FAILURE at collections-sprint:
```
 1) Hyrax::BatchCreateFailureService#call sends failing mail
     Failure/Error:
       def initialize(user)
         @user = user
         @messages = messages.to_sentence
       end

     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./app/services/hyrax/batch_create_failure_service.rb:4:in `initialize'
     # ./spec/services/hyrax/batch_create_failure_service_spec.rb:7:in `new'
     # ./spec/services/hyrax/batch_create_failure_service_spec.rb:7:in `block (3 levels) in <top (required)>'
     # ./spec/services/hyrax/batch_create_failure_service_spec.rb:10:in `block (3 levels) in <top (required)>'
```

This was caused by master merge overwriting changes to file batch_create_failure_service.rb.  The collections-sprint changes are put back in place by this PR.