### PR TITLE
Stub a WebMock HEAD request to support browse-everything 0.14.2

### DIFF
--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -17,8 +17,14 @@ RSpec.describe ImportUrlJob do
   before do
     allow(Hyrax::Actors::FileSetActor).to receive(:new).with(file_set, user).and_return(actor)
 
+    response_headers = { 'Content-Type' => 'image/png', 'Content-Length' => File.size(File.expand_path(file_path, __FILE__)) }
+
+    stub_request(:head, "http://example.org#{file_hash}").to_return(
+      body: "", status: 200, headers: response_headers
+    )
+
     stub_request(:get, "http://example.org#{file_hash}").to_return(
-      body: File.open(File.expand_path(file_path, __FILE__)).read, status: 200, headers: { 'Content-Type' => 'image/png' }
+      body: File.open(File.expand_path(file_path, __FILE__)).read, status: 200, headers: response_headers
     )
   end
 


### PR DESCRIPTION
Present tense short summary (50 characters or less)

[browse-everything](https://github.com/samvera/browse-everything) 0.14.2 introduced two test failures into the Hyrax build, due to `HEAD` requests that Hyrax isn't mocking.

Changes proposed in this pull request:
* Stub a `HEAD` request in `import_url_job_spec.rb`
* DRY up the `GET` and `HEAD` mocks

@samvera/hyrax-code-reviewers
