### PR TITLE
Add a config option to disable/enable realtime notifications

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,7 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
+# TODO: Relax this when we're Solr 7-compliant
+version: 6.6.1
 collection:
   persist: true
   dir: solr/config/

--- a/app/jobs/stream_notifications_job.rb
+++ b/app/jobs/stream_notifications_job.rb
@@ -1,5 +1,7 @@
 class StreamNotificationsJob < Hyrax::ApplicationJob
   def perform(users)
+    # Do not use the ActionCable machinery if the feature is disabled
+    return unless Hyrax.config.realtime_notifications?
     Array.wrap(users).each do |user|
       mailbox = UserMailbox.new(user)
       Hyrax::NotificationsChannel.broadcast_to(user,

--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -1,6 +1,9 @@
 <%= csrf_meta_tag %>
 <meta charset="utf-8" />
-<% if signed_in? %>
+<%# Only display meta tag, which enables creation of the ActionCable
+consumer, when realtime notifications are enabled and the user is
+signed in %>
+<% if Hyrax.config.realtime_notifications? && signed_in? %>
     <%= tag :meta, name: 'current-user', data: { user_key: current_user.user_key } %>
 <% end %>
 <!-- added for use on small devices like phones -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,9 +92,11 @@ Hyrax::Engine.routes.draw do
       delete 'delete_all'
     end
   end
-  namespace :notifications do
-    # WebSocket for notifications
-    mount ActionCable.server => 'endpoint', as: :endpoint
+  if Hyrax.config.realtime_notifications?
+    namespace :notifications do
+      # WebSocket for notifications
+      mount ActionCable.server => 'endpoint', as: :endpoint
+    end
   end
 
   # User profile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,3 @@
-# @note I'm not sure where best to declare this method, which is only used here
-def die_if_unsupported_configuration!
-  return if ENV.fetch('SERVER_SOFTWARE', '').match(/Apache.*Phusion_Passenger/).nil?
-  helpful_error_message = 'ERROR: cannot deploy with realtime notifications atop Passenger + Apache. ' \
-                          'Disable this feature in config/initializers/hyrax.rb by setting config.realtime_notifications to false'
-  # It's easy to miss this error message in the server log, so also put it in the Rails log
-  Rails.logger.error(helpful_error_message)
-  raise helpful_error_message
-end
-
 Hyrax::Engine.routes.draw do
   # Downloads controller route
   resources :homepage, only: 'index'
@@ -103,7 +93,6 @@ Hyrax::Engine.routes.draw do
     end
   end
   if Hyrax.config.realtime_notifications?
-    die_if_unsupported_configuration!
     namespace :notifications do
       # WebSocket for notifications
       mount ActionCable.server => 'endpoint', as: :endpoint

--- a/lib/generators/hyrax/templates/config/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/hyrax.rb
@@ -89,6 +89,9 @@ Hyrax.config do |config|
   # of Zotero-managed research items.
   # config.arkivo_api = false
 
+  # Stream realtime notifications to users in the browser
+  # config.realtime_notifications = true
+
   # Location autocomplete uses geonames to search for named regions
   # Username for connecting to geonames
   # config.geonames_username = ''

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -271,6 +271,12 @@ module Hyrax
       @arkivo_api ||= false
     end
 
+    attr_writer :realtime_notifications
+    def realtime_notifications?
+      return @realtime_notifications unless @realtime_notifications.nil?
+      @realtime_notifications = true
+    end
+
     def geonames_username=(username)
       Qa::Authorities::Geonames.username = username
     end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -273,6 +273,11 @@ module Hyrax
 
     attr_writer :realtime_notifications
     def realtime_notifications?
+      if ENV.fetch('SERVER_SOFTWARE', '').match(/Apache.*Phusion_Passenger/).nil?
+        Rails.logger.warn('Cannot enable realtime notifications atop Passenger + Apache. ' \
+                          'Coercing `Hyrax.config.realtime_notifications` to `false`')
+        @realtime_notifications = false
+      end
       return @realtime_notifications unless @realtime_notifications.nil?
       @realtime_notifications = true
     end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -271,18 +271,21 @@ module Hyrax
       @arkivo_api ||= false
     end
 
+    # rubocop:disable Metrics/LineLength
     attr_writer :realtime_notifications
     def realtime_notifications?
       # Coerce @realtime_notifications to false if server software
       # does not support WebSockets, and warn the user that we are
-      # overriding the value in their config if set to true
+      # overriding the value in their config unless it's already
+      # flipped to false
       if ENV.fetch('SERVER_SOFTWARE', '').match(/Apache.*Phusion_Passenger/).present?
-        Rails.logger.warn('Cannot enable realtime notifications atop Passenger + Apache. Coercing `Hyrax.config.realtime_notifications` to `false`') if @realtime_notifications
+        Rails.logger.warn('Cannot enable realtime notifications atop Passenger + Apache. Coercing `Hyrax.config.realtime_notifications` to `false`. Set this value to `false` in config/initializers/hyrax.rb to stop seeing this warning.') unless @realtime_notifications == false
         @realtime_notifications = false
       end
       return @realtime_notifications unless @realtime_notifications.nil?
       @realtime_notifications = true
     end
+    # rubocop:enable Metrics/LineLength
 
     def geonames_username=(username)
       Qa::Authorities::Geonames.username = username

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -273,9 +273,11 @@ module Hyrax
 
     attr_writer :realtime_notifications
     def realtime_notifications?
-      if ENV.fetch('SERVER_SOFTWARE', '').match(/Apache.*Phusion_Passenger/).nil?
-        Rails.logger.warn('Cannot enable realtime notifications atop Passenger + Apache. ' \
-                          'Coercing `Hyrax.config.realtime_notifications` to `false`')
+      # Coerce @realtime_notifications to false if server software
+      # does not support WebSockets, and warn the user that we are
+      # overriding the value in their config if set to true
+      if ENV.fetch('SERVER_SOFTWARE', '').match(/Apache.*Phusion_Passenger/).present?
+        Rails.logger.warn('Cannot enable realtime notifications atop Passenger + Apache. Coercing `Hyrax.config.realtime_notifications` to `false`') if @realtime_notifications
         @realtime_notifications = false
       end
       return @realtime_notifications unless @realtime_notifications.nil?

--- a/spec/jobs/stream_notifications_job_spec.rb
+++ b/spec/jobs/stream_notifications_job_spec.rb
@@ -1,4 +1,10 @@
 RSpec.describe StreamNotificationsJob do
+  let(:realtime_notifications) { true }
+
+  before do
+    allow(Hyrax.config).to receive(:realtime_notifications?).and_return(realtime_notifications)
+  end
+
   describe '#perform' do
     context 'with zero users' do
       let(:users) { nil }
@@ -24,6 +30,15 @@ RSpec.describe StreamNotificationsJob do
                 notifications_count: 7,
                 notifications_label: "You've got mail!")
         described_class.perform_now(users)
+      end
+
+      context 'when realtime notifications feature is disabled' do
+        let(:realtime_notifications) { false }
+
+        it 'does not broadcast' do
+          expect(Hyrax::NotificationsChannel).not_to receive(:broadcast_to)
+          described_class.perform_now(users)
+        end
       end
     end
   end

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:permission_levels) }
   it { is_expected.to respond_to(:permission_options) }
   it { is_expected.to respond_to(:persistent_hostpath) }
+  it { is_expected.to respond_to(:realtime_notifications?) }
+  it { is_expected.to respond_to(:realtime_notifications=) }
   it { is_expected.to respond_to(:redis_namespace) }
   it { is_expected.to respond_to(:subject_prefix) }
   it { is_expected.to respond_to(:translate_id_to_uri) }

--- a/spec/views/hyrax/homepage/index.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/index.html.erb_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe "hyrax/homepage/index.html.erb", type: :view do
   end
 
   describe 'meta tag with current user info' do
+    let(:realtime_notifications) { true }
+
     before do
+      allow(Hyrax.config).to receive(:realtime_notifications?).and_return(realtime_notifications)
       allow(view).to receive(:on_the_dashboard?).and_return(false)
       allow(controller).to receive(:current_user).and_return(current_user)
       allow(controller).to receive(:current_ability).and_return(ability)
@@ -30,6 +33,14 @@ RSpec.describe "hyrax/homepage/index.html.erb", type: :view do
 
       it 'renders' do
         expect(rendered).to have_selector('meta[name="current-user"]', visible: false)
+      end
+
+      context 'when realtime notifications are disabled' do
+        let(:realtime_notifications) { false }
+
+        it 'does not render' do
+          expect(rendered).not_to have_selector('meta[name="current-user"]', visible: false)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #1633 

This change allows applications to disable the realtime notification feature, which may be required if using Passenger + Apache (this configuration does not support WebSockets). How to do this has been added to the [Hyrax Management Guide](https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide#notifications) and the Hyrax [2.0.0 release notes](https://github.com/samvera/hyrax/releases/tag/v2.0.0.beta2).

Also:

* Clean up an empty file that was deleted in #1624 

@samvera/hyrax-code-reviewers
