### PR TITLE
Do not ask for the notifications_endpoint_path when compiling assets

### DIFF
--- a/app/assets/javascripts/hyrax/app.js.erb
+++ b/app/assets/javascripts/hyrax/app.js.erb
@@ -91,6 +91,7 @@ Hyrax = {
         // Do not create a consumer if user is not logged in
         if ($("meta[name='current-user']").length === 0)
             return;
+        <% if Hyrax.config.realtime_notifications? %>
         var consumer = ActionCable.createConsumer("<%= Hyrax::Engine.routes.url_helpers.notifications_endpoint_path %>");
         consumer.subscriptions.create("Hyrax::NotificationsChannel", {
             connected: function(data) {
@@ -102,6 +103,7 @@ Hyrax = {
                 new Notification($('.notify-number')).update(data.notifications_count, data.notifications_label);
             }
         });
+        <% end %>
     },
 
     // Search for a user to transfer a work to


### PR DESCRIPTION
If the feature has been disabled in config, this results in a `NoMethodError`.

@samvera/hyrax-code-reviewers
