### PR TITLE
Add default participants when new collection type created

### DIFF
--- a/app/controllers/hyrax/admin/collection_types_controller.rb
+++ b/app/controllers/hyrax/admin/collection_types_controller.rb
@@ -26,6 +26,7 @@ module Hyrax
     def create
       @collection_type = Hyrax::CollectionType.new(collection_type_params)
       if @collection_type.save
+        Hyrax::CollectionTypes::PermissionsService.add_default_participants(@collection_type.id)
         redirect_to hyrax.edit_admin_collection_type_path(@collection_type), notice: t(:'hyrax.admin.collection_types.create.notification', name: @collection_type.title)
       else
         setup_form

--- a/app/services/hyrax/collection_types/permissions_service.rb
+++ b/app/services/hyrax/collection_types/permissions_service.rb
@@ -59,6 +59,18 @@ module Hyrax
       end
 
       # @param collection_type_id [Integer]
+      def self.add_default_participants(collection_type_id)
+        return unless collection_type_id
+        default_participants = [{  agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE,
+                                   agent_id: ::Ability.admin_group_name,
+                                   access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS },
+                                { agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE,
+                                  agent_id: ::Ability.registered_group_name,
+                                  access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS }]
+        add_participants(collection_type_id, default_participants)
+      end
+
+      # @param collection_type_id [Integer]
       # @param participants [Array]
       def self.add_participants(collection_type_id, participants)
         return unless collection_type_id && participants.count > 0

--- a/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
@@ -152,6 +152,12 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller, clean
           post :create, params: { collection_type: valid_attributes }, session: valid_session
           expect(assigns[:collection_type].attributes.symbolize_keys).to include(valid_attributes)
         end
+
+        it "assigns default participants" do
+          expect do
+            post :create, params: { collection_type: valid_attributes }, session: valid_session
+          end.to change(Hyrax::CollectionTypeParticipant, :count).by(2)
+        end
       end
 
       context "with invalid params" do

--- a/spec/services/hyrax/collection_types/permissions_service_spec.rb
+++ b/spec/services/hyrax/collection_types/permissions_service_spec.rb
@@ -202,6 +202,15 @@ RSpec.describe Hyrax::CollectionTypes::PermissionsService do
     end
   end
 
+  describe '.add_default_participants' do
+    let(:coltype) { create(:collection_type) }
+
+    it 'adds the default participants to a collection type' do
+      expect(Hyrax::CollectionTypeParticipant).to receive(:create!).exactly(2).times
+      described_class.add_default_participants(coltype.id)
+    end
+  end
+
   describe ".add_participants" do
     let(:participants) { [{ agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE, agent_id: 'test_group', access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS }] }
     let(:coltype) { create(:collection_type) }


### PR DESCRIPTION
Fixes #1689

When a new Collection Type is created, adds the following Collection Type Participants
 * admin group with manage access
 * registered group with create access

@samvera/hyrax-code-reviewers
