### PR TITLE
Remove deprecated defaultOperator and defaultSearchField solr configs

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,7 +1,5 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
-# TODO: Relax this when we're Solr 7-compliant
-version: 6.6.1
 collection:
   persist: true
   dir: solr/config/

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -334,12 +334,6 @@
    -->
  <uniqueKey>id</uniqueKey>
 
- <!-- field for the QueryParser to use when an explicit fieldname is absent -->
- <!--  <defaultSearchField>text</defaultSearchField> -->
-
- <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
-
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->


### PR DESCRIPTION
As per same fix in blacklight: https://github.com/projectblacklight/blacklight/commit/b88b93ab7cfffb03117f47b6cd92a9bde5426d6d

@samvera/hyrax-code-reviewers
