### PR TITLE
Update New Work visibility form to (re)enable all options on submit

### DIFF
--- a/app/assets/javascripts/hyrax/save_work/visibility_component.es6
+++ b/app/assets/javascripts/hyrax/save_work/visibility_component.es6
@@ -10,6 +10,8 @@ export default class VisibilityComponent {
     this.form = element.closest('form')
     $('.collapse').collapse({ toggle: false })
     element.find("[type='radio']").on('change', () => { this.showForm() })
+    // Ensure any disabled options are re-enabled when form submits
+    this.form.on('submit', () => { this.enableAllOptions() })
     this.showForm()
     this.limitByAdminSet()
   }

--- a/spec/javascripts/visibility_component_spec.js
+++ b/spec/javascripts/visibility_component_spec.js
@@ -4,13 +4,21 @@ describe("VisibilityComponent", function() {
   var target = null;
   var element = null;
   var admin_set = null;
+  var form = null;
 
   beforeEach(function() {
     var fixture = setFixtures(visibilityForm(''));
     element = fixture.find('.visibility');
+    form = element.closest('form');
     admin_set = new AdminSetWidget(fixture.find('select'));
     target = new VisibilityComponent(element, admin_set);
   });
+
+  it("enables all options before form submit", function() {
+    spyOn(target, 'enableAllOptions');
+    form.trigger('submit');
+    expect(target.enableAllOptions).toHaveBeenCalled();
+  })
 
   //limitByAdminSet() - Also tests restrictToVisibility(selected) which is where much of logic sits
   describe("limitByAdminSet", function() {


### PR DESCRIPTION
Fixes #1701 
Fixes curationexperts/nurax#43

The bug described in 1701 was caused by the fact that disabled options are not submitted as part of an HTML form. To resolve that, I've simply added a JS event handler to (re)enable all options when the form is submitted.  Also added Jasmine specs to prove it out.

@samvera/hyrax-code-reviewers
