### PR TITLE
BasicMetadata: use full namespace for Location vocab

### DIFF
--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -26,7 +26,7 @@ module Hyrax
       property :subject, predicate: ::RDF::Vocab::DC11.subject
       property :language, predicate: ::RDF::Vocab::DC11.language
       property :identifier, predicate: ::RDF::Vocab::DC.identifier
-      property :based_near, predicate: ::RDF::Vocab::FOAF.based_near, class_name: ControlledVocabularies::Location
+      property :based_near, predicate: ::RDF::Vocab::FOAF.based_near, class_name: Hyrax::ControlledVocabularies::Location
       property :related_url, predicate: ::RDF::RDFS.seeAlso
       property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation
       property :source, predicate: ::RDF::Vocab::DC.source


### PR DESCRIPTION
If the application has independently defined a ControlledVocabulary module, this will cause an error:

```
NameError (uninitialized constant ControlledVocabularies::Location):

/Users/alex/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/bundler/gems/hyrax-a8873d1c3647/app/models/concerns/hyrax/basic_metadata.rb:29:in
`block in <module:BasicMetadata>'
```

@samvera/hyrax-code-reviewers
