### PR TITLE
batch delete collections.

### DIFF
--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -42,8 +42,10 @@ Blacklight.onLoad(function () {
 
     tableRows.each(function(i, row) {
       checkbox = $(row).find('td:first input[type=checkbox]');
-      if (checkbox[0].checked) {
-        numRowsSelected++;
+      if (typeof checkbox[0] !== "undefined") {
+        if (checkbox[0].checked) {
+          numRowsSelected++;
+        }
       }
     });
 

--- a/app/controllers/hyrax/batch_edits_controller.rb
+++ b/app/controllers/hyrax/batch_edits_controller.rb
@@ -25,7 +25,7 @@ module Hyrax
     end
 
     def after_destroy_collection
-      redirect_to_return_controller unless request.xhr?
+      redirect_back fallback_location: hyrax.batch_edits_path
     end
 
     def check_for_empty!

--- a/app/views/hyrax/collections/_search_results.html.erb
+++ b/app/views/hyrax/collections/_search_results.html.erb
@@ -2,11 +2,9 @@
 
 <% @page_title = t('blacklight.search.title', :application_name => application_name) %>
 
-
 <% content_for(:head) do -%>
   <%= render_opensearch_response_metadata %>
 <% end -%>
-
 
 <%= render 'search_header' %>
 

--- a/app/views/hyrax/dashboard/collections/_button_for_batch_delete_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_button_for_batch_delete_collection.html.erb
@@ -1,0 +1,4 @@
+<%= button_to label, hyrax.batch_edits_path,
+              method: :delete,
+              class: "btn btn-primary submits-batches",
+              data: { behavior: 'deletes-collection'} %>

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -1,6 +1,6 @@
 <% id = collection_presenter.id %>
 <tr id="document_<%= id %>">
-  <td><% unless collection_presenter.solr_document.admin_set? %><input type="checkbox"><% end %></td>
+  <td><% unless collection_presenter.solr_document.admin_set? %><input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector" /><% end %></td>
   <td>
     <div class="thumbnail-title-wrapper">
       <div class="thumbnail-wrapper">

--- a/app/views/hyrax/my/_search_header.html.erb
+++ b/app/views/hyrax/my/_search_header.html.erb
@@ -12,6 +12,7 @@
   </div>
 </div>
 
+<% if on_my_works? %>
 <div class="batch-info">
   <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>
 
@@ -20,10 +21,9 @@
     <div class="button_to-inline">
       <%= button_to "Edit Selected", hyrax.edit_batch_edits_path, method: :get, class: "btn btn-update btn-primary hidden submits-batches", data: { behavior: 'batch-edit' }, id: 'batch-edit' %>
     </div>
-    <% if on_my_works? %>
-      <%= batch_delete %>
-      <%= button_tag "Add to Collection", class: 'btn btn-primary submits-batches submits-batches-add',
-          data: { toggle: "modal", target: "#collection-list-container" } %>
-    <% end %>
+    <%= batch_delete %>
+    <%= button_tag "Add to Collection", class: 'btn btn-primary submits-batches submits-batches-add',
+        data: { toggle: "modal", target: "#collection-list-container" } %>
   </div>
 </div>
+<% end %>

--- a/app/views/hyrax/my/collections/_default_group.html.erb
+++ b/app/views/hyrax/my/collections/_default_group.html.erb
@@ -7,10 +7,7 @@
     <tr>
       <th class="check-all">
         <label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label>
-        <%# TODO: Properly implement the check all feature below - I think there is a common
-        pattern being used somewhere in the application, but when I tried to implement, it broke
-        the page load %>
-        <input type="checkbox">
+        <input type="checkbox" name="check_all" id="check_all" value="yes" />
       </th>
       <th><%= t("hyrax.dashboard.my.heading.title") %></th>
       <th><%= t("hyrax.dashboard.my.heading.type") %></th>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -1,6 +1,6 @@
 <% id = collection_presenter.id %>
 <tr id="document_<%= id %>">
-  <td><% unless collection_presenter.solr_document.admin_set? %><input type="checkbox"><% end %></td>
+  <td><% unless collection_presenter.solr_document.admin_set? %><input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector" /><% end %></td>
   <td>
     <div class="thumbnail-title-wrapper">
       <div class="thumbnail-wrapper">

--- a/app/views/hyrax/my/collections/_modal_delete_selected_collections.html.erb
+++ b/app/views/hyrax/my/collections/_modal_delete_selected_collections.html.erb
@@ -1,15 +1,17 @@
 <div class="modal fade" id="selected-collections-delete-modal" tabindex="-1" role="dialog" aria-labelledby="delete-collection-label">
-  <div class="modal-dialog" role="document">
+  <div class="modal-dialog">
     <div class="modal-content">
-      <form class="delete-collection-form">
         <div class="modal-body">
           <p><%= t('hyrax.dashboard.my.action.collections_confirmation_html') %></p>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
-          <button type="button" class="btn btn-danger"><%= t('helpers.action.delete') %></button>
+          <div style="text-align: right; display: inline-block">
+            <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
+            <div style="float: right; margin-left: 10px;" >
+              <%= render 'hyrax/dashboard/collections/button_for_batch_delete_collection', label: t('helpers.action.delete') %>
+            </div>
+          </div>
         </div>
-      </form>
     </div>
   </div>
 </div>

--- a/spec/views/hyrax/my/_search_header.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_search_header.html.erb_spec.rb
@@ -16,19 +16,21 @@ RSpec.describe 'hyrax/my/_search_header.html.erb', type: :view do
       render 'hyrax/my/search_header', current_tab: 'works'
     end
     it "has buttons" do
+      expect(rendered).to have_selector('input[value="Delete Selected"]')
       expect(rendered).to have_selector('button', text: 'Add to Collection')
       expect(rendered).to have_selector('input[value="Edit Selected"]')
     end
   end
 
-  context "not on my works page (i.e. Works shared with me)" do
+  context "not on my works page (i.e. one of the collections index pages)" do
     before do
       allow(view).to receive(:on_my_works?).and_return(false)
       render 'hyrax/my/search_header', current_tab: 'shared'
     end
     it "has buttons" do
+      expect(rendered).not_to have_selector('input[value="Delete Selected"]')
       expect(rendered).not_to have_selector('button', text: 'Add to Collection')
-      expect(rendered).to have_selector('input[value="Edit Selected"]')
+      expect(rendered).not_to have_selector('input[value="Edit Selected"]')
     end
   end
 end


### PR DESCRIPTION
Fixes #1510 

You can now delete collections in batch. If a collection has a member, then it is not deleted, and if user does not have permission to delete it, it is not deleted.