### PR TITLE
Allow configuration of the predicate used for AdminSet inclusion

### DIFF
--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -40,7 +40,7 @@ class AdminSet < ActiveFedora::Base
   end
 
   has_many :members,
-           predicate: ::RDF::Vocab::DC.isPartOf,
+           predicate:  Hyrax.config.admin_set_predicate,
            class_name: 'ActiveFedora::Base'
 
   before_destroy :check_if_not_default_set, :check_if_empty

--- a/app/models/concerns/hyrax/in_admin_set.rb
+++ b/app/models/concerns/hyrax/in_admin_set.rb
@@ -3,7 +3,7 @@ module Hyrax
     extend ActiveSupport::Concern
 
     included do
-      belongs_to :admin_set, predicate: ::RDF::Vocab::DC.isPartOf
+      belongs_to :admin_set, predicate: Hyrax.config.admin_set_predicate
     end
 
     def active_workflow

--- a/lib/generators/hyrax/templates/config/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/hyrax.rb
@@ -11,6 +11,11 @@ Hyrax.config do |config|
   # @see Hyrax::Configuration for additional details and defaults.
   # config.default_active_workflow_name = 'default'
 
+  # Which RDF term should be used to relate objects to an admin set?
+  # If this is a new repository, you may want to set a custom predicate term here to
+  # avoid clashes if you plan to use the default (dct:isPartOf) for other relations.
+  # config.admin_set_predicate = ::RDF::DC.isPartOf
+
   # Email recipient of messages sent via the contact form
   # config.contact_email = "repo-admin@example.org"
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -297,6 +297,11 @@ module Hyrax
       @active_deposit_agreement_acceptance
     end
 
+    attr_writer :admin_set_predicate
+    def admin_set_predicate
+      @admin_set_predicate ||= ::RDF::Vocab::DC.isPartOf
+    end
+
     attr_writer :work_requires_files
     def work_requires_files?
       return true if @work_requires_files.nil?

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:active_deposit_agreement_acceptance?) }
   it { is_expected.to respond_to(:active_deposit_agreement_acceptance=) }
   it { is_expected.to respond_to(:activity_to_show_default_seconds_since_now) }
+  it { is_expected.to respond_to(:admin_set_predicate) }
+  it { is_expected.to respond_to(:admin_set_predicate=) }
   it { is_expected.to respond_to(:always_display_share_button?) } # deprecated
   it { is_expected.to respond_to(:always_display_share_button=) } # deprecated
   it { is_expected.to respond_to(:analytic_start_date) }


### PR DESCRIPTION
Allow configuration of the predicate used for AdminSet inclusion

Allow a custom predicate to be used to relate objects to their administrative sets. The default remains `dcterms:isPartOf`. This is the first step in a process to change the default predicate for this relation. A follow-up PR, to be merged after the Hyrax 2.0.0 release, will provide warnings for changed usage
and add migration tooling.

This addresses "Phase 1" of #1461 as described at https://github.com/samvera/hyrax/issues/1461#issuecomment-331205110.

Changes proposed in this pull request:
* Add a configuration option to `Hyrax::Configuration` to set the admin set predicate.
* Use the configured predicate for the `AdminSet#members` `has_many` and `belongs_to` relations.

@samvera/hyrax-code-reviewers
