### PR TITLE
Stop granting public read access to Admin Sets by default

### DIFF
--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -53,7 +53,6 @@ module Hyrax
     # Creates an admin set, setting the creator and the default access controls.
     # @return [TrueClass, FalseClass] true if it was successful
     def create
-      admin_set.read_groups = ['public']
       admin_set.edit_groups = [admin_group_name]
       admin_set.creator = [creating_user.user_key] if creating_user
       admin_set.save.tap do |result|

--- a/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hyrax::Admin::AdminSetsController do
       context "a public admin set" do
         # Even though the user can view this admin set, the should not be able to view
         # it on the admin page.
-        let(:admin_set) { create(:admin_set, :public) }
+        let(:admin_set) { create(:admin_set, read_groups: ['public']) }
 
         it 'is unauthorized' do
           get :show, params: { id: admin_set }

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -22,8 +22,4 @@ FactoryGirl.define do
       with_permission_template false
     end
   end
-
-  trait :public do
-    read_groups ['public']
-  end
 end

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::AdminSetCreateService do
       #  * 1 depositing role for the registered group in the default workflow, equals
       #  * 7
       expect(Sipity::WorkflowResponsibility.count).to eq 7
-      expect(admin_set.read_groups).to eq ['public']
+      expect(admin_set.read_groups).not_to include('public')
       expect(admin_set.edit_groups).to eq ['admin']
       # 2 access grants because:
       #  * 1 providing deposit access to registered group
@@ -85,7 +85,7 @@ RSpec.describe Hyrax::AdminSetCreateService do
           #  * 2 available workflows, multiplied by
           #  * 3 roles (from Hyrax::RoleRegistry), equals
           #  * 12
-          expect(admin_set.read_groups).to eq ['public']
+          expect(admin_set.read_groups).not_to include('public')
           expect(admin_set.edit_groups).to eq ['admin']
           expect(admin_set.creator).to eq [user.user_key]
           expect(workflow_importer).to have_received(:call).with(permission_template: permission_template)

--- a/spec/services/hyrax/admin_set_service_spec.rb
+++ b/spec/services/hyrax/admin_set_service_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Hyrax::AdminSetService do
   describe "#search_results", :clean_repo do
     subject { service.search_results(access) }
 
-    let!(:as1) { create(:admin_set, :public, title: ['foo']) }
-    let!(:as2) { create(:admin_set, :public, title: ['bar']) }
+    let!(:as1) { create(:admin_set, read_groups: ['public'], title: ['foo']) }
+    let!(:as2) { create(:admin_set, read_groups: ['public'], title: ['bar']) }
     let!(:as3) { create(:admin_set, edit_users: [user.user_key], title: ['baz']) }
 
     before do

--- a/spec/services/hyrax/collections_service_spec.rb
+++ b/spec/services/hyrax/collections_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::CollectionsService do
     let!(:collection3) { create(:collection, :public, edit_users: [user.user_key], title: ['baz']) }
 
     before do
-      create(:admin_set, :public) # this should never be returned.
+      create(:admin_set, read_groups: ['public']) # this should never be returned.
     end
 
     context "with read access" do


### PR DESCRIPTION
This reflects an outdated understanding of how Admin Sets would be used, and we no longer require this special-casing.

@samvera/hyrax-code-reviewers
