### PR TITLE
Prevent overlap of object thumbnail and edit form.

### DIFF
--- a/app/assets/stylesheets/hyrax/_file_manager.scss
+++ b/app/assets/stylesheets/hyrax/_file_manager.scss
@@ -69,6 +69,9 @@
       .member_resource_options {
         @extend .col-xs-12;
         float: none;
+        span.radio:first-of-type {
+          margin-top: 50px;
+        }
         input[type=radio] {
           margin-left: 1px;
         }


### PR DESCRIPTION
Refs https://github.com/curationexperts/nurax/issues/58
Fixes #1085 

This should prevent the work thumbnail for overlapping with the title edit form.
