### PR TITLE
fix for flash_issue#1686

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -7,7 +7,7 @@ module Hyrax
       include BreadcrumbsForCollections
       layout 'dashboard'
 
-      before_action :filter_docs_with_read_access!, except: :show
+      before_action :filter_docs_with_read_access!, except: [:show, :edit]
       before_action :remove_select_something_first_flash, except: :show
 
       include Hyrax::Collections::AcceptsBatches
@@ -93,7 +93,7 @@ module Hyrax
         set_default_permissions
         respond_to do |format|
           ActiveFedora::SolrService.instance.conn.commit
-          format.html { redirect_to edit_dashboard_collection_path(@collection), notice: 'Collection was successfully created.' }
+          format.html { redirect_to edit_dashboard_collection_path(@collection), notice: "Collection was successfully created." }
           format.json { render json: @collection, status: :created, location: dashboard_collection_path(@collection) }
         end
       end
@@ -133,11 +133,8 @@ module Hyrax
       end
 
       def after_update
-        if flash[:notice].nil?
-          flash[:notice] = 'Collection was successfully updated.'
-        end
         respond_to do |format|
-          format.html { redirect_to update_referer }
+          format.html { redirect_to update_referer, notice: 'Collection was successfully updated.' }
           format.json { render json: @collection, status: :updated, location: dashboard_collection_path(@collection) }
         end
       end

--- a/app/views/hyrax/dashboard/collections/_flash_msg.html.erb
+++ b/app/views/hyrax/dashboard/collections/_flash_msg.html.erb
@@ -1,0 +1,9 @@
+<% { notice: 'alert-success', error: 'alert-danger', alert: 'alert-warning' }.each do |type, flash_dom_class| %>
+  <% if flash[type].present? %>
+    <div class="alert <%= flash_dom_class %> alert-dismissable" role="alert">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      <%= safe_join(Array.wrap(flash[type]).map(&:html_safe), '<br/>'.html_safe) %>
+    </div>
+    <% flash.delete(type) %>
+  <% end %>
+<% end %>

--- a/app/views/hyrax/dashboard/collections/edit.html.erb
+++ b/app/views/hyrax/dashboard/collections/edit.html.erb
@@ -7,6 +7,7 @@
 <% unless has_collection_search_parameters? %>
   <div class="row">
     <div class="col-md-12">
+      <%= render 'flash_msg' %>
       <%= render 'form' %>
     </div>
   </div>

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       end.to change { Collection.count }.by(1)
       expect(assigns[:collection].visibility).to eq 'open'
       expect(assigns[:collection].edit_users).to contain_exactly "archivist1", user.email
+      expect(flash[:notice]).to eq "Collection was successfully created."
     end
 
     it "removes blank strings from params before creating Collection" do
@@ -188,6 +189,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         put :update, params: { id: collection, collection: { creator: ['Emily'] } }
         collection.reload
         expect(collection.creator).to eq ['Emily']
+        expect(flash[:notice]).to eq "Collection was successfully updated."
       end
 
       it "removes blank strings from params before updating Collection metadata" do

--- a/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'hyrax/dashboard/collections/edit.html.erb', type: :view do
     stub_template '_document_list.html.erb' => 'document list'
     stub_template 'hyrax/collections/_paginate.html.erb' => 'paginate'
     stub_template '_form.html.erb' => 'form'
+    stub_template 'hyrax/dashboard/collections/_flash_msg.html.erb' => 'flash_msg'
 
     render
   end


### PR DESCRIPTION
Fixes #1686 

Fixes issue #1686 bug in which creating or updating a collection didn't show a flash confirmation message.

Changes proposed in this pull request:
* I added another flash_msg partial, let me know if this should be handled differently.
* Commented out this line in the app/controllers/hyrax/dashboard/collections_controller.rb file:
      L10: before_action :filter_docs_with_read_access!, except: :show
* Add a line to app/views/hyrax/dashboard/collections/edit.html.erb file:
     After L10:  <%= render 'flash_msg' %>

@samvera/hyrax-code-reviewers