### PR TITLE
Stop checking user agent to decide whether to render folder upload widget

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -47,13 +47,6 @@ module Hyrax
       "https://www.zotero.org/users/#{zotero_user_id}"
     end
 
-    # Only Chrome supports this
-    # @return [Boolean]
-    # @todo Replace uses with more granular client-side detection (as jQuery-fileuploader already does)
-    def browser_supports_directory_upload?
-      user_agent.include? 'Chrome'
-    end
-
     # @param [User] user
     def render_notifications(user:)
       mailbox = UserMailbox.new(user)

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -14,14 +14,12 @@
                     <span>Add files...</span>
                     <input type="file" name="files[]" multiple>
                 </span>
-                <% if browser_supports_directory_upload? %>
                 <!-- The fileinput-button span is used to style the file input field as button -->
                 <span id="addfolder" class="btn btn-success fileinput-button">
                     <span class="glyphicon glyphicon-plus"></span>
                     <span>Add folder...</span>
                     <input type="file" name="files[]" multiple directory webkitdirectory>
                 </span>
-                <% end %>
                 <button type="reset" class="btn btn-warning cancel hidden">
                     <span class="glyphicon glyphicon-ban-circle"></span>
                     <span>Cancel upload</span>

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -283,19 +283,6 @@ RSpec.describe HyraxHelper, type: :helper do
     end
   end
 
-  describe '#browser_supports_directory_upload?' do
-    subject { helper.browser_supports_directory_upload? }
-
-    context 'with Chrome' do
-      before { controller.request.env['HTTP_USER_AGENT'] = 'Chrome' }
-      it { is_expected.to be true }
-    end
-    context 'with a non-chrome browser' do
-      before { controller.request.env['HTTP_USER_AGENT'] = 'Firefox' }
-      it { is_expected.to be false }
-    end
-  end
-
   describe '#zotero_label' do
     subject { helper }
 

--- a/spec/views/hyrax/base/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form.html.erb_spec.rb
@@ -74,17 +74,8 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
     end
 
     describe 'uploading a folder' do
-      context 'with Chrome' do
-        before { allow(view).to receive(:browser_supports_directory_upload?) { true } }
-        it 'renders the add folder button' do
-          expect(page).to have_content('Add folder...')
-        end
-      end
-      context 'with a non-Chrome browser' do
-        before { allow(view).to receive(:browser_supports_directory_upload?) { false } }
-        it 'does not render the add folder button' do
-          expect(page).not_to have_content('Add folder...')
-        end
+      it 'renders the add folder button' do
+        expect(page).to have_content('Add folder...')
       end
     end
   end


### PR DESCRIPTION
This used to be supported only in Chrome, but that no longer appears to be the case. Render the folder upload widget for all browsers.

Refs curationexperts/nurax#64

@samvera/hyrax-code-reviewers
