### PR TITLE
Do not setup autocomplete on fields without URIs

### DIFF
--- a/app/assets/javascripts/hyrax/autocomplete/default.es6
+++ b/app/assets/javascripts/hyrax/autocomplete/default.es6
@@ -1,7 +1,8 @@
 export default class Default {
   constructor(element, url) {
     this.url = url;
-    element.autocomplete(this.options(element));
+    if (this.url !== undefined)
+      element.autocomplete(this.options(element))
   }
 
   options(element) {

--- a/spec/javascripts/autocomplete_spec.js.coffee
+++ b/spec/javascripts/autocomplete_spec.js.coffee
@@ -15,6 +15,45 @@ describe "auto complete", ->
     #undefine the jasmine clock so time goes back to normal
     jasmine.clock().uninstall()
 
+  describe "title", ->
+    beforeEach ->
+      # setup two inputs for us to attach auto complete to
+      setFixtures  '<form data-behavior="work-form">
+                    <input class="generic_work_title"  value="" id="generic_work_title" type="text">
+                    <input class="generic_work_title"  value="" type="text">
+                    </form>'
+
+      # run all Blacklight.onload functions
+      Blacklight.activate()
+
+    describe "first input", ->
+      # field doesn't trigger auto complete
+      it "does not auto complete on typing", ->
+        # send a key stroke to the target input to activate the auto complete
+        target = $($("input.generic_work_title")[0])
+        target.val('fre')
+        target.trigger(@typeEvent)
+
+        # move time along so that events have a chance to happen
+        jasmine.clock().tick(800)
+
+        # verify that the ajax call was made
+        expect(@spy_on_json).not.toHaveBeenCalled()
+
+    describe "second input", ->
+      # field doesn't trigger auto complete
+      it "does not auto complete on typing", ->
+        # send a key stroke to the target input to activate the auto complete
+        target = $($("input.generic_work_title")[1])
+        target.val('fre')
+        target.trigger(@typeEvent)
+
+        # move time along so that events have a chance to happen
+        jasmine.clock().tick(800)
+
+        # verify that the ajax call was not made
+        expect(@spy_on_json).not.toHaveBeenCalled()
+
   describe "language", ->
     beforeEach ->
       # setup two inputs for us to attach  auto complete to
@@ -40,7 +79,6 @@ describe "auto complete", ->
 
         # verify that the ajax call was made
         expect(@spy_on_json).toHaveBeenCalled()
-
 
     describe "second input", ->
 
@@ -83,7 +121,6 @@ describe "auto complete", ->
         # verify that the ajax call was made
         expect(@spy_on_json).toHaveBeenCalled()
 
-
     describe "second input", ->
 
       # field triggers auto complete
@@ -98,7 +135,6 @@ describe "auto complete", ->
 
         # verify that the ajax call was made
         expect(@spy_on_json).toHaveBeenCalled()
-
 
   describe "location", ->
     beforeEach ->
@@ -125,7 +161,6 @@ describe "auto complete", ->
 
         # verify that the ajax call was made
         expect(@spy_on_json).toHaveBeenCalled()
-
 
     describe "second input", ->
 


### PR DESCRIPTION
This fixes a bug in Hyrax whenever *any* field is added to the form, e.g., a second title field or a third creator field.

@samvera/hyrax-code-reviewers
