### PR TITLE
Collection presenters have counts of viewable members by type and total

### DIFF
--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -4,6 +4,10 @@ module Hyrax
       ActiveFedora::SolrService.count("{!field f=isPartOf_ssim}#{id}")
     end
 
+    def total_viewable_items
+      ActiveFedora::Base.where("isPartOf_ssim:#{id}").accessible_by(current_ability).count
+    end
+
     # AdminSet cannot be deleted if default set or non-empty
     def disable_delete?
       AdminSet.default_set?(id) || total_items > 0

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -64,6 +64,18 @@ module Hyrax
       ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}").count
     end
 
+    def total_viewable_items
+      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}").accessible_by(current_ability).count
+    end
+
+    def total_viewable_works
+      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id} AND generic_type_sim:Work").accessible_by(current_ability).count
+    end
+
+    def total_viewable_collections
+      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id} AND generic_type_sim:Collection").accessible_by(current_ability).count
+    end
+
     def collection_type_badge
       collection_type.title
     end

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -46,8 +46,7 @@
     <%= render_visibility_link(collection_presenter.solr_document) %>
   </td>
 
-  <%# TODO: Need Item count here %>
-  <td>[34]</td>
+  <td><%=collection_presenter.total_viewable_items%></td>
 
   <td class="text-center date"><%=collection_presenter.modified_date.try(:to_formatted_s, :standard) %> </td>
   <td class="text-center">

--- a/app/views/hyrax/my/collections/_default_group.html.erb
+++ b/app/views/hyrax/my/collections/_default_group.html.erb
@@ -24,9 +24,9 @@
   <tbody>
   <% docs.each_with_index do |document, counter| %>
     <% collection_presenter = if document.admin_set?
-                                Hyrax::AdminSetPresenter.new(document, nil, nil)
+                                Hyrax::AdminSetPresenter.new(document, current_ability, nil)
                               else
-                                Hyrax::CollectionPresenter.new(document, nil, nil)
+                                Hyrax::CollectionPresenter.new(document, current_ability, nil)
                               end %>
     <%= render 'list_collections', collection_presenter: collection_presenter, counter: counter %>
   <% end %>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -49,8 +49,7 @@
     <%= render_visibility_link(collection_presenter.solr_document) %>
   </td>
 
-  <%# TODO: Need Item count here %>
-  <td>[34]</td>
+  <td><%=collection_presenter.total_viewable_items%></td>
 
   <td class="text-center date"><%=collection_presenter.modified_date.try(:to_formatted_s, :standard) %> </td>
   <td class="text-center">

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -31,6 +31,10 @@ FactoryGirl.define do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
+    factory :private_work do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+
     factory :registered_generic_work do
       read_groups ["registered"]
     end

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -134,18 +134,145 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context "collection with work" do
-      let(:work) { create(:work, title: ['unimaginitive title']) }
-
-      before do
-        work.member_of_collections << collection
-        work.save!
-      end
+      let!(:work) { create(:work, member_of_collections: [collection]) }
 
       it { is_expected.to eq 1 }
     end
 
     context "null members" do
       let(:presenter) { described_class.new(SolrDocument.new(id: '123'), nil) }
+
+      it { is_expected.to eq 0 }
+    end
+  end
+
+  describe "#total_viewable_items", :clean_repo do
+    subject { presenter.total_viewable_items }
+
+    let(:user) { create(:user) }
+
+    before do
+      allow(ability).to receive(:user_groups).and_return(['public'])
+      allow(ability).to receive(:current_user).and_return(user)
+    end
+
+    context "empty collection" do
+      it { is_expected.to eq 0 }
+    end
+
+    context "collection with private work" do
+      let!(:work) { create(:private_work, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 0 }
+    end
+
+    context "collection with private collection" do
+      let!(:work) { create(:private_collection, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 0 }
+    end
+
+    context "collection with public work" do
+      let!(:work) { create(:public_work, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 1 }
+    end
+
+    context "collection with public collection" do
+      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 1 }
+    end
+
+    context "collection with public work and sub-collection" do
+      let!(:work) { create(:public_work, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 2 }
+    end
+
+    context "null members" do
+      let(:presenter) { described_class.new(SolrDocument.new(id: '123'), ability) }
+
+      it { is_expected.to eq 0 }
+    end
+  end
+
+  describe "#total_viewable_works", :clean_repo do
+    subject { presenter.total_viewable_works }
+
+    let(:user) { create(:user) }
+
+    before do
+      allow(ability).to receive(:user_groups).and_return(['public'])
+      allow(ability).to receive(:current_user).and_return(user)
+    end
+
+    context "empty collection" do
+      it { is_expected.to eq 0 }
+    end
+
+    context "collection with private work" do
+      let!(:work) { create(:private_work, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 0 }
+    end
+
+    context "collection with public work" do
+      let!(:work) { create(:public_work, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 1 }
+    end
+
+    context "collection with public work and sub-collection" do
+      let!(:work) { create(:public_work, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 1 }
+    end
+
+    context "null members" do
+      let(:presenter) { described_class.new(SolrDocument.new(id: '123'), ability) }
+
+      it { is_expected.to eq 0 }
+    end
+  end
+
+  describe "#total_viewable_collections", :clean_repo do
+    subject { presenter.total_viewable_collections }
+
+    let(:user) { create(:user) }
+
+    before do
+      allow(ability).to receive(:user_groups).and_return(['public'])
+      allow(ability).to receive(:current_user).and_return(user)
+    end
+
+    context "empty collection" do
+      it { is_expected.to eq 0 }
+    end
+
+    context "collection with private collection" do
+      let!(:subcollection) { create(:private_collection, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 0 }
+    end
+
+    context "collection with public collection" do
+      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 1 }
+    end
+
+    context "collection with public work and sub-collection" do
+      let!(:work) { create(:public_work, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 1 }
+    end
+
+    context "null members" do
+      let(:presenter) { described_class.new(SolrDocument.new(id: '123'), ability) }
 
       it { is_expected.to eq 0 }
     end

--- a/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
   let(:doc) { SolrDocument.new(attributes) }
   let(:collection) { mock_model(Collection) }
   let(:collection_type) { create(:collection_type) }
-  let(:collection_presenter) { Hyrax::CollectionPresenter.new(doc, nil, nil) }
+  let(:collection_presenter) { Hyrax::CollectionPresenter.new(doc, Ability.new(build(:user)), nil) }
 
   before do
     allow(view).to receive(:current_user).and_return(stub_model(User))


### PR DESCRIPTION
refs #1670 

This PR adds three methods to the presenter to provide counts based upon the access of the requestor by using `accessible_by` which uses the gated discovery filters (checking for index, read, or edit access on the object) but doesn't attempt to apply any of the other rules from the ability class.

The UI part of #1670 is still left to do.