### PR TITLE
ContentBlockHelperBehavior#display_content_block? guard against nils

### DIFF
--- a/app/helpers/hyrax/content_block_helper_behavior.rb
+++ b/app/helpers/hyrax/content_block_helper_behavior.rb
@@ -1,12 +1,12 @@
 module Hyrax
   module ContentBlockHelperBehavior
     def displayable_content_block(content_block, **options)
-      return if content_block.value.blank?
+      return unless display_content_block? content_block
       content_tag :div, raw(content_block.value), options
     end
 
     def display_content_block?(content_block)
-      content_block.value.present?
+      content_block.present? && content_block.value.present?
     end
   end
 end

--- a/spec/helpers/hyrax/content_block_helper_spec.rb
+++ b/spec/helpers/hyrax/content_block_helper_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe Hyrax::ContentBlockHelper, type: :helper do
       expect(helper).to respond_to(:displayable_content_block)
     end
 
+    context 'when a block is nil' do
+      let(:content_block) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
     context 'when a block has a nil value' do
       let(:content_block) { double(value: nil) }
 


### PR DESCRIPTION
If you don't have a content block defined, you can get an error out of Hyrax:
```
ActionView::Template::Error (undefined method `value' for nil:NilClass
Did you mean?  evaluate):
    1: <% if display_content_block? @marketing_text %>
    2:   <div class="home_marketing_text">
    3:     <%= displayable_content_block @marketing_text, class: 'col-sm-offset-2 col-sm-9 col-md-offset-1 home_marketing_text' %>
    4:   </div>

/Users/alex/clones/hyrax/app/helpers/hyrax/content_block_helper_behavior.rb:9:in `display_content_block?'
```