### PR TITLE
Disable turbolinks on work/file analytics links

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,6 +1,6 @@
 <div class="show-actions">
   <% if Hyrax.config.analytics? %>
-    <%= link_to "Analytics", presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
+    <%= link_to "Analytics", presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
   <% end %>
   <% if presenter.editor? %>
       <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -1,6 +1,6 @@
 <div class="form-actions">
   <% if Hyrax.config.analytics? %>
-    <%= link_to "Analytics", @presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
+    <%= link_to "Analytics", @presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
   <% end %>
 
   <% if @presenter.editor? %>


### PR DESCRIPTION
It causes the analytics graph not to load.

Fixes https://github.com/curationexperts/nurax/issues/83

@samvera/hyrax-code-reviewers
