### PR TITLE
Adjust permission service methods to be what is actually needed for abilities checks

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -472,7 +472,7 @@ module Hyrax
         end
 
         def set_default_permissions
-          Collections::PermissionsService.create_default(collection: @collection, creating_user: current_user, grants: @participants)
+          Collections::PermissionsCreateService.create_default(collection: @collection, creating_user: current_user, grants: @participants)
         end
     end
   end

--- a/app/services/hyrax/collections/permissions_create_service.rb
+++ b/app/services/hyrax/collections/permissions_create_service.rb
@@ -1,0 +1,71 @@
+module Hyrax
+  module Collections
+    class PermissionsCreateService
+      # @api public
+      #
+      # Set the default permissions for a (newly created) collection
+      #
+      # @param collection [Collection] the collection the new permissions will act on
+      # @param creating_user [User] the user that created the collection
+      # @param grants [Array<Hash>] additional grants to apply to the new collection
+      # @return [Hyrax::PermissionTemplate]
+      def self.create_default(collection:, creating_user:, grants: [])
+        collection_type = Hyrax::CollectionType.find_by_gid!(collection.collection_type_gid)
+        access_grants = access_grants_attributes(collection_type: collection_type, creating_user: creating_user, grants: grants)
+        PermissionTemplate.create!(source_id: collection.id, source_type: 'collection',
+                                   access_grants_attributes: access_grants.uniq)
+        collection.update_access_controls!
+      end
+
+      # @api private
+      #
+      # Gather the default permissions needed for a new collection
+      #
+      # @param collection_type [CollectionType] the collection type of the new collection
+      # @param creating_user [User] the user that created the collection
+      # @param grants [Array<Hash>] additional grants to apply to the new collection
+      # @return [Hash] a hash containing permission attributes
+      def self.access_grants_attributes(collection_type:, creating_user:, grants:)
+        [
+          { agent_type: 'group', agent_id: admin_group_name, access: Hyrax::PermissionTemplateAccess::MANAGE }
+        ].tap do |attribute_list|
+          # Grant manage access to the creating_user if it exists
+          if creating_user
+            attribute_list << { agent_type: 'user', agent_id: creating_user.user_key, access: Hyrax::PermissionTemplateAccess::MANAGE }
+          end
+        end + managers_of_collection_type(collection_type: collection_type) + grants
+      end
+      private_class_method :access_grants_attributes
+
+      # @api private
+      #
+      # Retrieve the users or groups with manage permissions for a collection type
+      #
+      # @param collection_type [CollectionType] the collection type of the new collection
+      # @return [Hash] a hash containing permission attributes
+      def self.managers_of_collection_type(collection_type:)
+        attribute_list = []
+        user_managers = Hyrax::CollectionTypes::PermissionsService.user_edit_grants_for_collection_of_type(collection_type: collection_type)
+        user_managers.each do |user|
+          attribute_list << { agent_type: 'user', agent_id: user, access: Hyrax::PermissionTemplateAccess::MANAGE }
+        end
+        group_managers = Hyrax::CollectionTypes::PermissionsService.group_edit_grants_for_collection_of_type(collection_type: collection_type)
+        group_managers.each do |group|
+          attribute_list << { agent_type: 'group', agent_id: group, access: Hyrax::PermissionTemplateAccess::MANAGE }
+        end
+        attribute_list
+      end
+      private_class_method :managers_of_collection_type
+
+      # @api private
+      #
+      # The value of the admin group name
+      #
+      # @return [String] a string representation of the admin group name
+      def self.admin_group_name
+        ::Ability.admin_group_name
+      end
+      private_class_method :admin_group_name
+    end
+  end
+end

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -1,74 +1,105 @@
 module Hyrax
   module Collections
     class PermissionsService
-      # @api private
+      # @api public
       #
-      # IDs of collections, including admin sets, a user can access based on participant roles.
+      # IDs of admin sets a user can access based on participant roles.
       #
       # @param user [User] user
       # @param access [Array<String>] one or more types of access (e.g. Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT, Hyrax::PermissionTemplateAccess::VIEW)
-      # @return [Array<String>] IDs of collections for which the user has specified roles
-      def self.collection_ids_for_user(user:, access:) # rubocop:disable Metrics/MethodLength
-        if user.ability.admin?
-          PermissionTemplate.all.where(source_type: 'collection').pluck('DISTINCT source_id')
+      # @param ability [Ability] the ability coming from cancan ability check (default: nil)
+      # @return [Array<String>] IDs of admin sets for which the user has specified roles
+      def self.admin_set_ids_for_user(user:, access:, ability: nil)
+        if user_admin?(user, ability)
+          PermissionTemplate.all.where(source_type: 'admin_set').pluck('DISTINCT source_id')
         else
           PermissionTemplateAccess.joins(:permission_template)
-                                  .where(agent_type: 'user',
-                                         agent_id: user.user_key,
-                                         access: access)
+                                  .where(user_where(user: user, access: access, source_type: 'admin_set'))
                                   .or(
                                     PermissionTemplateAccess.joins(:permission_template)
-                                                            .where(agent_type: 'group',
-                                                                   agent_id: user.groups,
-                                                                   access: access)
+                                                            .where(group_where(user: user, access: access, source_type: 'admin_set', ability: ability))
                                   ).pluck('DISTINCT source_id')
         end
       end
-      private_class_method :collection_ids_for_user
 
       # @api public
       #
-      # IDs of collections, including admin sets, for which the user is assigned view access
+      # IDs of collections a user can access based on participant roles.
       #
-      # @param user [User]
-      # @return [Array<String>] a list of collection ids for which the user is assigned view access
-      def self.collection_ids_with_view_access(user:)
-        return [] unless user
-        collection_ids_for_user(user: user, access: [Hyrax::PermissionTemplateAccess::VIEW])
+      # @param user [User] user
+      # @param access [Array<String>] one or more types of access (e.g. Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT, Hyrax::PermissionTemplateAccess::VIEW)
+      # @param ability [Ability] the ability coming from cancan ability check (default: nil)
+      # @return [Array<String>] IDs of collections for which the user has specified roles
+      def self.collection_ids_for_user(user:, access:, ability: nil)
+        if user_admin?(user, ability)
+          PermissionTemplate.all.where(source_type: 'collection').pluck('DISTINCT source_id')
+        else
+          PermissionTemplateAccess.joins(:permission_template)
+                                  .where(user_where(user: user, access: access, source_type: 'collection'))
+                                  .or(
+                                    PermissionTemplateAccess.joins(:permission_template)
+                                                            .where(group_where(user: user, access: access, source_type: 'collection', ability: ability))
+                                  ).pluck('DISTINCT source_id')
+        end
       end
 
       # @api public
       #
-      # IDs of collections, including admin sets, for which the user is assigned manage access
+      # IDs of collections and admin_sets a user can access based on participant roles.
       #
-      # @param user [User]
-      # @return [Array<String>] a list of collection ids for which the user is assigned manage access
-      def self.collection_ids_with_manage_access(user:)
-        return [] unless user
-        collection_ids_for_user(user: user, access: [Hyrax::PermissionTemplateAccess::MANAGE])
+      # @param user [User] user
+      # @param access [Array<String>] one or more types of access (e.g. Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT, Hyrax::PermissionTemplateAccess::VIEW)
+      # @param ability [Ability] the ability coming from cancan ability check (default: nil)
+      # @return [Array<String>] IDs of collections and admin sets for which the user has specified roles
+      def self.source_ids_for_user(user:, access:, ability: nil)
+        if user_admin?(user, ability)
+          PermissionTemplate.all.pluck('DISTINCT source_id')
+        else
+          PermissionTemplateAccess.joins(:permission_template)
+                                  .where(user_where(user: user, access: access))
+                                  .or(
+                                    PermissionTemplateAccess.joins(:permission_template)
+                                                            .where(group_where(user: user, access: access, ability: ability))
+                                  ).pluck('DISTINCT source_id')
+        end
       end
 
-      # @api public
+      # @api private
       #
-      # IDs of collections, including admin sets, for which the user is assigned deposit access
+      # Generate the user where clause hash for joining the permissions tables
       #
-      # @param user [User]
-      # @return [Array<String>] a list of collection ids for which the user is assigned deposit access
-      def self.collection_ids_with_deposit_access(user:)
-        return [] unless user
-        collection_ids_for_user(user: user, access: [Hyrax::PermissionTemplateAccess::DEPOSIT])
+      # @param user [User] the user wanting access
+      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param source_type [String] 'collection', 'admin_set', or nil to get all types
+      # @return [Hash] the where clause hash to pass to joins for users
+      def self.user_where(user:, access:, source_type: nil)
+        where_clause = {}
+        where_clause[:agent_type] = 'user'
+        where_clause[:agent_id] = user.user_key
+        where_clause[:access] = access
+        where_clause[:permission_templates] = { source_type: source_type } if source_type.present?
+        where_clause
       end
+      private_class_method :user_where
 
-      # @api public
+      # @api private
       #
-      # IDs of collections, including admin sets, into which the user can deposit
+      # Generate the group where clause hash for joining the permissions tables
       #
-      # @param user [User] the user that wants to deposit
-      # @return [Array<String>] a list of collection ids for collections in which the user can deposit
-      def self.collection_ids_for_deposit(user:)
-        return [] unless user
-        collection_ids_for_user(user: user, access: [Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT])
+      # @param user [User] the user wanting access
+      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param source_type [String] 'collection', 'admin_set', or nil to get all types
+      # @param ability [Ability] the ability coming from cancan ability check (default: nil)
+      # @return [Hash] the where clause hash to pass to joins for groups
+      def self.group_where(user:, access:, source_type: nil, ability: nil)
+        where_clause = {}
+        where_clause[:agent_type] = 'group'
+        where_clause[:agent_id] = user_groups(user, ability)
+        where_clause[:access] = access
+        where_clause[:permission_templates] = { source_type: source_type } if source_type.present?
+        where_clause
       end
+      private_class_method :user_where
 
       # @api public
       #
@@ -76,109 +107,102 @@ module Hyrax
       #
       # @param user [User] the user that wants to deposit
       # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param ability [Ability] the ability coming from cancan ability check (default: nil)
       # @return [Boolean] true if the user has permission to deposit into the collection
-      def self.can_deposit_in_collection(user:, collection:)
-        return false unless user && collection
-        template = Hyrax::PermissionTemplate.find_by!(source_id: collection.id)
-        return true if access_as_user?(user: user, template: template)
-        return true if access_through_group?(groups: user.user_groups, template: template)
-        false
+      def self.can_deposit_in_collection?(user:, collection:, ability: nil)
+        deposit_access_to_collection?(user: user, collection: collection, ability: ability) ||
+          manage_access_to_collection?(user: user, collection: collection, ability: ability)
       end
-
-      # @api private
-      #
-      # Does the user have 'manage' or 'deposit' access?
-      #
-      # @param user [User] the user that wants to deposit in the collection
-      # @param template [PermissionTemplate] the permission template controlling access
-      # @return [True | False] true, if user has access; otherwise, false
-      def self.access_as_user?(user:, template:)
-        return true if template.agent_ids_for(agent_type: 'user', access: 'manage').include? user.user_key
-        return true if template.agent_ids_for(agent_type: 'user', access: 'deposit').include? user.user_key
-        false
-      end
-      private_class_method :access_as_user?
-
-      # @api private
-      #
-      # Do any of the groups have 'manage' or 'deposit' access?
-      #
-      # @param groups [Array<String>] the groups for the user that wants to deposit in the collection
-      # @param template [PermissionTemplate] the permission template controlling access
-      # @return [True | False] true, if any of the groups have access; otherwise, false
-      def self.access_through_group?(groups:, template:)
-        return false if groups.blank?
-        return true if groups & template.agent_ids_for(agent_type: 'group', access: 'manage')
-        return true if groups & template.agent_ids_for(agent_type: 'group', access: 'deposit')
-        false
-      end
-      private_class_method :access_through_group?
 
       # @api public
       #
-      # Set the default permissions for a (newly created) collection
+      # Determine if the given user has permissions to view the admin show page for the collection
       #
-      # @param collection [Collection] the collection the new permissions will act on
-      # @param creating_user [User] the user that created the collection
-      # @param grants [Array<Hash>] additional grants to apply to the new collection
-      # @return [Hyrax::PermissionTemplate]
-      def self.create_default(collection:, creating_user:, grants: [])
-        collection_type = Hyrax::CollectionType.find_by_gid!(collection.collection_type_gid)
-        access_grants = access_grants_attributes(collection_type: collection_type, creating_user: creating_user, grants: grants)
-        PermissionTemplate.create!(source_id: collection.id, source_type: 'collection',
-                                   access_grants_attributes: access_grants.uniq)
-        collection.update_access_controls!
+      # @param user [User] the user that wants to view
+      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param ability [Ability] the ability coming from cancan ability check (default: nil)
+      # @return [Boolean] true if the user has permission to view the admin show page for the collection
+      def self.can_view_admin_show_for_collection?(user:, collection:, ability: nil)
+        deposit_access_to_collection?(user: user, collection: collection, ability: ability) ||
+          manage_access_to_collection?(user: user, collection: collection, ability: ability) ||
+          view_access_to_collection?(user: user, collection: collection, ability: ability)
       end
 
       # @api private
       #
-      # Gather the default permissions needed for a new collection
+      # Determine if the given user has :deposit access for the given collection
       #
-      # @param collection_type [CollectionType] the collection type of the new collection
-      # @param creating_user [User] the user that created the collection
-      # @param grants [Array<Hash>] additional grants to apply to the new collection
-      # @return [Hash] a hash containing permission attributes
-      def self.access_grants_attributes(collection_type:, creating_user:, grants:)
-        [
-          { agent_type: 'group', agent_id: admin_group_name, access: Hyrax::PermissionTemplateAccess::MANAGE }
-        ].tap do |attribute_list|
-          # Grant manage access to the creating_user if it exists
-          if creating_user
-            attribute_list << { agent_type: 'user', agent_id: creating_user.user_key, access: Hyrax::PermissionTemplateAccess::MANAGE }
-          end
-        end + managers_of_collection_type(collection_type: collection_type) + grants
+      # @param user [User] the user who wants to deposit
+      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param ability [Ability] the ability coming from cancan ability check (default: nil)
+      # @return [Boolean] true if the user has :deposit access to the collection
+      def self.deposit_access_to_collection?(user:, collection:, ability: nil)
+        access_to_collection?(user: user, collection: collection, access: 'deposit', ability: ability)
       end
-      private_class_method :access_grants_attributes
+      private_class_method :deposit_access_to_collection?
 
       # @api private
       #
-      # Retrieve the users or groups with manage permissions for a collection type
+      # Determine if the given user has :manage access for the given collection
       #
-      # @param collection_type [CollectionType] the collection type of the new collection
-      # @return [Hash] a hash containing permission attributes
-      def self.managers_of_collection_type(collection_type:)
-        attribute_list = []
-        user_managers = Hyrax::CollectionTypes::PermissionsService.user_edit_grants_for_collection_of_type(collection_type: collection_type)
-        user_managers.each do |user|
-          attribute_list << { agent_type: 'user', agent_id: user, access: Hyrax::PermissionTemplateAccess::MANAGE }
-        end
-        group_managers = Hyrax::CollectionTypes::PermissionsService.group_edit_grants_for_collection_of_type(collection_type: collection_type)
-        group_managers.each do |group|
-          attribute_list << { agent_type: 'group', agent_id: group, access: Hyrax::PermissionTemplateAccess::MANAGE }
-        end
-        attribute_list
+      # @param user [User] the user who wants to manage
+      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param ability [Ability] the ability coming from cancan ability check (default: nil)
+      # @return [Boolean] true if the user has :manage access to the collection
+      def self.manage_access_to_collection?(user:, collection:, ability: nil)
+        access_to_collection?(user: user, collection: collection, access: 'manage', ability: ability)
       end
-      private_class_method :managers_of_collection_type
+      private_class_method :manage_access_to_collection?
 
       # @api private
       #
-      # The value of the admin group name
+      # Determine if the given user has :view access for the given collection
       #
-      # @return [String] a string representation of the admin group name
-      def self.admin_group_name
-        ::Ability.admin_group_name
+      # @param user [User] the user who wants to view
+      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param ability [Ability] the ability coming from cancan ability check (default: nil)
+      # @return [Boolean] true if the user has permission to view the collection
+      def self.view_access_to_collection?(user:, collection:, ability: nil)
+        access_to_collection?(user: user, collection: collection, access: 'view', ability: ability)
       end
-      private_class_method :admin_group_name
+      private_class_method :view_access_to_collection?
+
+      # @api private
+      #
+      # Determine if the given user has specified access for the given collection
+      #
+      # @param user [User] the user who wants to view
+      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param access [Symbol] the access level to check
+      # @param ability [Ability] the ability coming from cancan ability check (default: nil)
+      # @return [Boolean] true if the user has permission to view the collection
+      def self.access_to_collection?(user:, collection:, access:, ability: nil)
+        return false unless user && collection
+        template = Hyrax::PermissionTemplate.find_by!(source_id: collection.id)
+        return true if (user_id(user) & template.agent_ids_for(agent_type: 'user', access: access)).present?
+        return true if (user_groups(user, ability) & template.agent_ids_for(agent_type: 'group', access: access)).present?
+        false
+      end
+      private_class_method :access_to_collection?
+
+      def self.user_groups(user, ability)
+        # if called from abilities class, use ability instead of user; otherwise, you end up in an infinite loop
+        return ability.user_groups if ability.present?
+        user.ability.user_groups
+      end
+      private_class_method :user_groups
+
+      def self.user_admin?(user, ability)
+        # if called from abilities class, use ability instead of user; otherwise, you end up in an infinite loop
+        return ability.admin? if ability.present?
+        user.ability.admin?
+      end
+      private_class_method :user_groups
+
+      def self.user_id(user)
+        [user.user_key]
+      end
+      private_class_method :user_id
     end
   end
 end

--- a/spec/services/hyrax/collections/permissions_create_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_create_service_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Hyrax::Collections::PermissionsCreateService do
+  let(:user) { create(:user) }
+  let(:user2) { create(:user) }
+
+  describe ".create_default" do
+    subject { described_class.create_default(collection: collection, creating_user: user) }
+
+    let(:collection_type) { create(:collection_type) }
+    let(:user_manage_attributes) do
+      {
+        hyrax_collection_type_id: collection_type.id,
+        access: 'manage',
+        agent_id: user2.user_key,
+        agent_type: 'user'
+      }
+    end
+    let(:group_manage_attributes) do
+      {
+        hyrax_collection_type_id: collection_type.id,
+        access: 'manage',
+        agent_id: 'manage_group',
+        agent_type: 'group'
+      }
+    end
+    let!(:collection_type_participant) { create(:collection_type_participant, user_manage_attributes) }
+    let!(:collection_type_participant2) { create(:collection_type_participant, group_manage_attributes) }
+    let(:collection) { create(:collection, collection_type_gid: collection_type.gid) }
+
+    before do
+      subject
+    end
+
+    it "creates the default permission template for the collection" do
+      expect(Hyrax::PermissionTemplate.find_by_source_id(collection.id)).to be_persisted
+    end
+
+    it "creates the default permission template access entries for the collection" do
+      expect(Hyrax::PermissionTemplate.find_by_source_id(collection.id).access_grants.count).to eq 4
+    end
+  end
+end

--- a/spec/services/hyrax/collections/permissions_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_service_spec.rb
@@ -2,55 +2,23 @@ RSpec.describe Hyrax::Collections::PermissionsService do
   let(:user) { create(:user) }
   let(:user2) { create(:user) }
 
-  describe ".create_default" do
-    subject { described_class.create_default(collection: collection, creating_user: user) }
+  describe ".can_deposit_in_collection?" do
+    subject { described_class.can_deposit_in_collection?(collection: collection, user: user) }
 
-    let(:collection_type) { create(:collection_type) }
-    let(:user_manage_attributes) do
-      {
-        hyrax_collection_type_id: collection_type.id,
-        access: 'manage',
-        agent_id: user2.user_key,
-        agent_type: 'user'
-      }
-    end
-    let(:group_manage_attributes) do
-      {
-        hyrax_collection_type_id: collection_type.id,
-        access: 'manage',
-        agent_id: 'manage_group',
-        agent_type: 'group'
-      }
-    end
-    let!(:collection_type_participant) { create(:collection_type_participant, user_manage_attributes) }
-    let!(:collection_type_participant2) { create(:collection_type_participant, group_manage_attributes) }
-    let(:collection) { create(:collection, collection_type_gid: collection_type.gid) }
-
-    before do
-      subject
-    end
-
-    it "creates the default permission template for the collection" do
-      expect(Hyrax::PermissionTemplate.find_by_source_id(collection.id)).to be_persisted
-    end
-
-    it "creates the default permission template access entries for the collection" do
-      expect(Hyrax::PermissionTemplate.find_by_source_id(collection.id).access_grants.count).to eq 4
-    end
-  end
-
-  describe ".can_deposit_in_collection" do
-    subject { described_class.can_deposit_in_collection(collection: collection, user: user) }
+    let(:ability) { double }
 
     let(:permission_template) { create(:permission_template) }
     let(:collection) { create(:collection, user: user) }
 
     before do
       allow(Hyrax::PermissionTemplate).to receive(:find_by!).with(source_id: collection.id).and_return(permission_template)
+      allow(ability).to receive(:current_user).and_return(user)
+      allow(user).to receive(:ability).and_return(ability)
+      allow(ability).to receive(:user_groups).and_return(['public', 'registered'])
     end
 
     it "exists" do
-      expect(described_class).to respond_to(:can_deposit_in_collection)
+      expect(described_class).to respond_to(:can_deposit_in_collection?)
     end
 
     it "returns true when user is a manager" do
@@ -69,6 +37,16 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       expect(subject).to be true
     end
 
+    it "returns false when user is a viewer" do
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([user.user_key])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
+      expect(subject).to be false
+    end
+
     context "when manage group access defined" do
       before do
         allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
@@ -77,18 +55,13 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return([])
       end
 
-      it "returns false if no user groups" do
-        allow(user).to receive(:user_groups).and_return([])
-        expect(subject).to be false
-      end
-
       it "returns true if user has any valid group" do
-        allow(user).to receive(:user_groups).and_return(['managers'])
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'managers'])
         expect(subject).to be true
       end
 
       it "returns true if user has multiple valid groups" do
-        allow(user).to receive(:user_groups).and_return(['more managers', 'managers', 'other_group'])
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'more_managers', 'managers', 'other_group'])
         expect(subject).to be true
       end
     end
@@ -101,19 +74,35 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return(['depositors', 'more_depositors'])
       end
 
-      it "returns false if no user groups" do
-        allow(user).to receive(:user_groups).and_return([])
-        expect(subject).to be false
-      end
-
       it "returns true if user has any valid group" do
-        allow(user).to receive(:user_groups).and_return(['depositors'])
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'depositors'])
         expect(subject).to be true
       end
 
       it "returns true if user has multiple valid groups" do
-        allow(user).to receive(:user_groups).and_return(['more depositors', 'depositors', 'other_group'])
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'more_depositors', 'depositors', 'other_group'])
         expect(subject).to be true
+      end
+    end
+
+    context "when view group access defined" do
+      before do
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return(['viewers', 'more_viewers'])
+      end
+
+      it "returns false if user has any view group" do
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'viewers'])
+        expect(subject).to be false
+      end
+
+      it "returns false if user has multiple view groups" do
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'more_viewers', 'viewers', 'other_group'])
+        expect(subject).to be false
       end
     end
 
@@ -122,56 +111,213 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([user2.user_key])
       allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return(['managers', 'more_managers'])
       allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return(['depositors', 'more_depositors'])
-      allow(user).to receive(:user_groups).and_return([])
+      allow(ability).to receive(:user_groups).and_return(['public', 'registered'])
+      expect(subject).to be false
+    end
+  end
+
+  describe ".can_view_admin_show_for_collection?" do
+    subject { described_class.can_view_admin_show_for_collection?(collection: collection, user: user) }
+
+    let(:ability) { double }
+    let(:permission_template) { create(:permission_template) }
+    let(:collection) { create(:collection, user: user) }
+
+    before do
+      allow(Hyrax::PermissionTemplate).to receive(:find_by!).with(source_id: collection.id).and_return(permission_template)
+      allow(ability).to receive(:current_user).and_return(user)
+      allow(user).to receive(:ability).and_return(ability)
+      allow(ability).to receive(:user_groups).and_return(['public', 'registered'])
+    end
+
+    it "exists" do
+      expect(described_class).to respond_to(:can_view_admin_show_for_collection?)
+    end
+
+    it "returns true when user is a manager" do
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([user.user_key])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
+      expect(subject).to be true
+    end
+
+    it "returns true when user is a depositor" do
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([user.user_key])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
+      expect(subject).to be true
+    end
+
+    it "returns true when user is a viewer" do
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([user.user_key])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return([])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
+      expect(subject).to be true
+    end
+
+    context "when manage group access defined" do
+      before do
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return(['managers', 'more_managers'])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
+      end
+
+      it "returns false if no user groups" do
+        allow(ability).to receive(:user_groups).and_return([])
+        expect(subject).to be false
+      end
+
+      it "returns true if user has any valid group" do
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'managers'])
+        expect(subject).to be true
+      end
+
+      it "returns true if user has multiple valid groups" do
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'more_managers', 'managers', 'other_group'])
+        expect(subject).to be true
+      end
+    end
+
+    context "when deposit group access defined" do
+      before do
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return(['depositors', 'more_depositors'])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
+      end
+
+      it "returns true if user has any valid group" do
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'depositors'])
+        expect(subject).to be true
+      end
+
+      it "returns true if user has multiple valid groups" do
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'more_depositors', 'depositors', 'other_group'])
+        expect(subject).to be true
+      end
+    end
+
+    context "when view group access defined" do
+      before do
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return([])
+        allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return(['viewers', 'more_viewers'])
+      end
+
+      it "returns true if user has any valid group" do
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'viewers'])
+        expect(subject).to be true
+      end
+
+      it "returns true if user has multiple valid groups" do
+        allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'more_viewers', 'viewers', 'other_group'])
+        expect(subject).to be true
+      end
+    end
+
+    it "returns false when user is does not have access as manager, depositor, or viewer" do
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([user2.user_key])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([user2.user_key])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([user2.user_key])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return(['managers', 'more_managers'])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return(['depositors', 'more_depositors'])
+      allow(permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return(['viewers', 'more_viewers'])
+      allow(ability).to receive(:user_groups).and_return([])
       expect(subject).to be false
     end
   end
 
   context "access helper method" do
+    let(:ability) { double }
     let(:user) { create(:user) }
-    let(:col_vu) { create(:collection, with_permission_template: true) }
-    let(:col_vg) { create(:collection, with_permission_template: true) }
-    let(:col_mu) { create(:collection, with_permission_template: true) }
-    let(:col_mg) { create(:collection, with_permission_template: true) }
-    let(:col_du) { create(:collection, with_permission_template: true) }
-    let(:col_dg) { create(:collection, with_permission_template: true) }
+    let(:col_vu) { create(:collection, id: 'col_vu', with_permission_template: true) }
+    let(:col_vg) { create(:collection, id: 'col_vg', with_permission_template: true) }
+    let(:col_mu) { create(:collection, id: 'col_mu', with_permission_template: true) }
+    let(:col_mg) { create(:collection, id: 'col_mg', with_permission_template: true) }
+    let(:col_du) { create(:collection, id: 'col_du', with_permission_template: true) }
+    let(:col_dg) { create(:collection, id: 'col_dg', with_permission_template: true) }
+    let(:as_vu) { create(:admin_set, id: 'as_vu', with_permission_template: true) }
+    let(:as_vg) { create(:admin_set, id: 'as_vg', with_permission_template: true) }
+    let(:as_mu) { create(:admin_set, id: 'as_mu', with_permission_template: true) }
+    let(:as_mg) { create(:admin_set, id: 'as_mg', with_permission_template: true) }
+    let(:as_du) { create(:admin_set, id: 'as_du', with_permission_template: true) }
+    let(:as_dg) { create(:admin_set, id: 'as_dg', with_permission_template: true) }
 
     before do
-      collection_access(col_vu.permission_template, 'user', user.user_key, :view)
-      collection_access(col_vg.permission_template, 'group', 'view_group', :view)
-      collection_access(col_mu.permission_template, 'user', user.user_key, :manage)
-      collection_access(col_mg.permission_template, 'group', 'manage_group', :manage)
-      collection_access(col_du.permission_template, 'user', user.user_key, :deposit)
-      collection_access(col_dg.permission_template, 'group', 'deposit_group', :deposit)
-      allow(user).to receive(:groups).and_return(['view_group', 'deposit_group', 'manage_group'])
+      source_access(col_vu.permission_template, 'user', user.user_key, :view)
+      source_access(col_vg.permission_template, 'group', 'view_group', :view)
+      source_access(col_mu.permission_template, 'user', user.user_key, :manage)
+      source_access(col_mg.permission_template, 'group', 'manage_group', :manage)
+      source_access(col_du.permission_template, 'user', user.user_key, :deposit)
+      source_access(col_dg.permission_template, 'group', 'deposit_group', :deposit)
+      source_access(as_vu.permission_template, 'user', user.user_key, :view)
+      source_access(as_vg.permission_template, 'group', 'view_group', :view)
+      source_access(as_mu.permission_template, 'user', user.user_key, :manage)
+      source_access(as_mg.permission_template, 'group', 'manage_group', :manage)
+      source_access(as_du.permission_template, 'user', user.user_key, :deposit)
+      source_access(as_dg.permission_template, 'group', 'deposit_group', :deposit)
+
+      allow(ability).to receive(:current_user).and_return(user)
+      allow(user).to receive(:ability).and_return(ability)
+      allow(ability).to receive(:user_groups).and_return(['public', 'registered', 'view_group', 'manage_group', 'deposit_group'])
+      allow(ability).to receive(:admin?).and_return(false)
     end
 
-    describe '.collection_ids_with_view_access' do
-      it 'returns ids for view user and group' do
-        expect(described_class.collection_ids_with_view_access(user: user)).to match_array [col_vu.id, col_vg.id]
+    describe '.admin_set_ids_for_user' do
+      it 'returns ids for admin sets with view user and group' do
+        expect(described_class.admin_set_ids_for_user(user: user, access: 'view')).to match_array [as_vu.id, as_vg.id]
+      end
+      it 'returns ids for admin sets with manage user and group' do
+        expect(described_class.admin_set_ids_for_user(user: user, access: 'manage')).to match_array [as_mu.id, as_mg.id]
+      end
+      it 'returns ids for admin sets with deposit user and group' do
+        expect(described_class.admin_set_ids_for_user(user: user, access: 'deposit')).to match_array [as_du.id, as_dg.id]
       end
     end
 
-    describe '.collection_ids_with_manage_access' do
-      it 'returns ids for manage user and group' do
-        expect(described_class.collection_ids_with_manage_access(user: user)).to match_array [col_mu.id, col_mg.id]
+    describe '.collection_ids_for_user' do
+      it 'returns ids for collections with view user and group' do
+        expect(described_class.collection_ids_for_user(user: user, access: 'view')).to match_array [col_vu.id, col_vg.id]
+      end
+      it 'returns ids for collections with manage user and group' do
+        expect(described_class.collection_ids_for_user(user: user, access: 'manage')).to match_array [col_mu.id, col_mg.id]
+      end
+      it 'returns ids for collections with deposit user and group' do
+        expect(described_class.collection_ids_for_user(user: user, access: 'deposit')).to match_array [col_du.id, col_dg.id]
       end
     end
 
-    describe '.collection_ids_with_deposit_access' do
-      it 'returns ids for deposit user and group' do
-        expect(described_class.collection_ids_with_deposit_access(user: user)).to match_array [col_du.id, col_dg.id]
+    describe '.source_ids_for_user' do
+      it 'returns ids for collections with view user and group' do
+        expect(described_class.source_ids_for_user(user: user, access: 'view')).to match_array [col_vu.id, col_vg.id, as_vu.id, as_vg.id]
       end
-    end
-
-    describe '.collection_ids_for_deposit' do
-      it 'returns ids for deposit user and group and manage user and group' do
-        expect(described_class.collection_ids_for_deposit(user: user)).to match_array [col_du.id, col_dg.id, col_mu.id, col_mg.id]
+      it 'returns ids for collections with manage user and group' do
+        expect(described_class.source_ids_for_user(user: user, access: 'manage')).to match_array [col_mu.id, col_mg.id, as_mu.id, as_mg.id]
+      end
+      it 'returns ids for collections with deposit user and group' do
+        expect(described_class.source_ids_for_user(user: user, access: 'deposit')).to match_array [col_du.id, col_dg.id, as_du.id, as_dg.id]
       end
     end
   end
 
-  def collection_access(permission_template, agent_type, agent_id, access)
+  def source_access(permission_template, agent_type, agent_id, access)
     create(:permission_template_access,
            access,
            permission_template: permission_template,


### PR DESCRIPTION
Partial Fixes #1669

### Adds methods required for checking abilities.

The following methods are used in the cancan abilities definitions.
* `.source_ids_for_user(user:, access:)` - queries permission template and permission template access tables for users with access
* `.admin_set_ids_for_user(user:, access:)` - queries permission template and permission template access tables for users with access and limits the ids returned to admin sets
* `.collection_ids_for_user(user:, access:)` - queries permission template and permission template access tables for users with access and limits the ids returned to collections
* `.can_deposit_in_collection?(user:, collection:)`
* `.can_view_admin_show_for_collection?(user:, collection:)`
* and supporting private methods

### Removes methods that are not being used.

* `.collection_ids_with_view_access(user:)`
* `.collection_ids_with_manage_access(user:)`
* `.collection_ids_with_deposit_access(user:)`
* and supporting private methods

### Splits permissions service into create services and query services

* Hyrax::Collections::PermissionsCreateService - create services
* Hyrax::Collections::PermissionsService - query services



