### PR TITLE
Add "Managed Works" tab to dashboard.

### DIFF
--- a/app/controllers/hyrax/dashboard/works_controller.rb
+++ b/app/controllers/hyrax/dashboard/works_controller.rb
@@ -2,21 +2,13 @@ module Hyrax
   module Dashboard
     ## Shows a list of all works to the admins
     class WorksController < Hyrax::My::WorksController
-      before_action :ensure_admin!
-
       # Search builder for a list of works
       # Override of Blacklight::RequestBuilders
       def search_builder_class
-        Hyrax::WorksSearchBuilder
+        Hyrax::Dashboard::WorksSearchBuilder
       end
 
       private
-
-        def ensure_admin!
-          # Even though the user can view this admin set, they may not be able to view
-          # it on the admin page.
-          authorize! :read, :admin_dashboard
-        end
 
         def search_action_url(*args)
           hyrax.dashboard_works_url(*args)

--- a/app/controllers/hyrax/my/works_controller.rb
+++ b/app/controllers/hyrax/my/works_controller.rb
@@ -11,7 +11,7 @@ module Hyrax
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
         add_breadcrumb t(:'hyrax.admin.sidebar.works'), hyrax.my_works_path
-
+        managed_works_count
         super
       end
 
@@ -24,6 +24,10 @@ module Hyrax
         # The url of the "more" link for additional facet values
         def search_facet_path(args = {})
           hyrax.my_dashboard_works_facet_path(args[:id])
+        end
+
+        def managed_works_count
+          @managed_works_count = Hyrax::Works::ManagedWorksService.managed_works_count(scope: self)
         end
     end
   end

--- a/app/search_builders/hyrax/dashboard/collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/collections_search_builder.rb
@@ -1,6 +1,8 @@
 module Hyrax
   module Dashboard
     class CollectionsSearchBuilder < Hyrax::CollectionSearchBuilder
+      include Hyrax::Dashboard::ManagedSearchFilters
+
       self.solr_access_filters_logic += [:apply_admin_set_deposit_permissions]
       self.default_processor_chain += [:show_only_managed_collections_for_non_admins]
 
@@ -20,23 +22,6 @@ module Hyrax
         ]
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += ["(#{clauses.join(' OR ')})"]
-      end
-
-      # This includes collection/admin the user can manage and view.
-      def discovery_permissions
-        @discovery_permissions ||= %w[edit read]
-      end
-
-      # Override to exclude 'public' and 'registered' groups from read access.
-      def apply_group_permissions(permission_types, ability = current_ability)
-        groups = ability.user_groups
-        return [] if groups.empty?
-        permission_types.map do |type|
-          field = solr_field_for(type, 'group')
-          user_groups = type == 'read' ? groups - ['public', 'registered'] : groups
-          next if user_groups.empty?
-          "({!terms f=#{field}}#{user_groups.join(',')})" # parens required to properly OR the clauses together.
-        end
       end
 
       # Include all admin sets the user has deposit permission for.

--- a/app/search_builders/hyrax/dashboard/managed_search_filters.rb
+++ b/app/search_builders/hyrax/dashboard/managed_search_filters.rb
@@ -1,0 +1,24 @@
+module Hyrax
+  module Dashboard
+    module ManagedSearchFilters
+      extend ActiveSupport::Concern
+
+      # This includes collection/admin the user can manage and view.
+      def discovery_permissions
+        @discovery_permissions ||= %w[edit read]
+      end
+
+      # Override to exclude 'public' and 'registered' groups from read access.
+      def apply_group_permissions(permission_types, ability = current_ability)
+        groups = ability.user_groups
+        return [] if groups.empty?
+        permission_types.map do |type|
+          field = solr_field_for(type, 'group')
+          user_groups = type == 'read' ? groups - ['public', 'registered'] : groups
+          next if user_groups.empty?
+          "({!terms f=#{field}}#{user_groups.join(',')})" # parens required to properly OR the clauses together.
+        end
+      end
+    end
+  end
+end

--- a/app/search_builders/hyrax/dashboard/works_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/works_search_builder.rb
@@ -1,0 +1,18 @@
+module Hyrax
+  module Dashboard
+    class WorksSearchBuilder < Hyrax::WorksSearchBuilder
+      include Hyrax::Dashboard::ManagedSearchFilters
+
+      self.default_processor_chain += [:show_only_managed_works_for_non_admins]
+
+      # Adds a filter to exclude works created by the current user if the
+      # current user is not an admin.
+      # @param [Hash] solr_parameters
+      def show_only_managed_works_for_non_admins(solr_parameters)
+        return if current_ability.admin?
+        solr_parameters[:fq] ||= []
+        solr_parameters[:fq] << '-' + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/works/managed_works_service.rb
+++ b/app/services/hyrax/works/managed_works_service.rb
@@ -1,0 +1,16 @@
+module Hyrax
+  module Works
+    module ManagedWorksService
+      # @api public
+      #
+      # Count of works the current user can manage.
+      #
+      # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
+      # @return [Array<SolrDocument>]
+      def self.managed_works_count(scope:)
+        query_builder = Hyrax::Dashboard::WorksSearchBuilder.new(scope).rows(0)
+        scope.repository.search(query_builder.query).response["numFound"]
+      end
+    end
+  end
+end

--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -8,22 +8,24 @@
 
   <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
 
-    <li role="menuitem" tabindex="-1">
-      <%= link_to [main_app, :edit, document] do %>
-        <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
-        <span> <%= t("hyrax.dashboard.my.action.edit_work") %> </span>
-      <% end %>
-    </li>
+    <% if can? :edit, document.id %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to [main_app, :edit, document] do %>
+          <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
+          <span> <%= t("hyrax.dashboard.my.action.edit_work") %> </span>
+        <% end %>
+      </li>
 
-    <li role="menuitem" tabindex="-1">
-      <%= link_to [main_app, document],
-                  method: :delete,
-                  data: {
-                    confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
-        <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
-        <span> <%= t("hyrax.dashboard.my.action.delete_work") %> </span>
-      <% end %>
-    </li>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to [main_app, document],
+                    method: :delete,
+                    data: {
+                      confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
+          <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
+          <span> <%= t("hyrax.dashboard.my.action.delete_work") %> </span>
+        <% end %>
+      </li>
+    <% end %>
 
     <li role="menuitem" tabindex="-1">
       <%= display_trophy_link(current_user, document.id) do |text| %>

--- a/app/views/hyrax/my/works/_tabs.html.erb
+++ b/app/views/hyrax/my/works/_tabs.html.erb
@@ -1,7 +1,7 @@
 <ul class="nav nav-tabs" id="my_nav" role="navigation">
   <span class="sr-only">You are currently listing your works.  You have <%= @response.docs.count %> <%= 'work'.pluralize(@response.docs.count)%> </span>
   <li<%= ' class="active"'.html_safe if current_page?(hyrax.dashboard_works_path(locale: nil)) %>>
-    <%= link_to t('hyrax.dashboard.all.works'), hyrax.dashboard_works_path %>
+    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.works"), hyrax.dashboard_works_path %>
   </li>
   <li<%= ' class="active"'.html_safe if current_page?(hyrax.my_works_path(locale: nil)) %>>
     <%= link_to t('hyrax.dashboard.my.works'), hyrax.my_works_path, data: { turbolinks: false } %>

--- a/app/views/hyrax/my/works/index.html.erb
+++ b/app/views/hyrax/my/works/index.html.erb
@@ -48,8 +48,8 @@
 
 <div class="row">
   <div class="col-md-12">
-    <div class="panel panel-default<%= ' tabs' if can?(:read, :admin_dashboard) %>">
-      <%= render 'tabs' if can?(:read, :admin_dashboard) %>
+    <div class="panel panel-default <%= 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>">
+      <%= render 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>
       <div class="panel-body">
         <%= render 'search_header' %>
         <h2 class="sr-only">Works listing</h2>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -485,6 +485,7 @@ en:
         works:                  "All Works"
       managed:
         collections:            "Managed Collections"
+        works:                  "Managed Works"
       authorize_proxies:        "Authorize Proxies"
       breadcrumbs:
         admin:                  "Administration"

--- a/spec/controllers/hyrax/dashboard/works_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/works_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Hyrax::Dashboard::WorksController, type: :controller do
   describe "#search_builder_class" do
     subject { controller.search_builder_class }
 
-    it { is_expected.to eq Hyrax::WorksSearchBuilder }
+    it { is_expected.to eq Hyrax::Dashboard::WorksSearchBuilder }
   end
 
   describe "#search_facet_path" do

--- a/spec/controllers/hyrax/my/works_controller_spec.rb
+++ b/spec/controllers/hyrax/my/works_controller_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe Hyrax::My::WorksController, type: :controller do
 
     before do
       allow(Hyrax::CollectionsService).to receive(:new).and_return(collection_service)
+      allow(Hyrax::Works::ManagedWorksService).to receive(:managed_works_count).and_return(1)
     end
+
     it "shows search results and breadcrumbs" do
       expect(controller).to receive(:search_results).with(ActionController::Parameters).and_return([response, doc_list])
       expect(controller).to receive(:add_breadcrumb).with('Home', root_path(locale: 'en'))
@@ -21,6 +23,7 @@ RSpec.describe Hyrax::My::WorksController, type: :controller do
       get :index, params: { per_page: 2 }
       expect(assigns[:document_list].length).to eq 2
       expect(assigns[:user_collections]).to contain_exactly(my_collection)
+      expect(assigns[:managed_works_count]).to eq 1
     end
   end
 

--- a/spec/search_builders/hyrax/dashboard/works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/works_search_builder_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe Hyrax::Dashboard::WorksSearchBuilder do
+  let(:context) do
+    double(blacklight_config: CatalogController.blacklight_config,
+           current_ability: ability,
+           current_user: user)
+  end
+  let(:ability) do
+    ::Ability.new(user)
+  end
+  let(:user) { create(:user, groups: 'registered') }
+  let(:builder) { described_class.new(context) }
+
+  describe ".default_processor_chain" do
+    subject { described_class.default_processor_chain }
+
+    it { is_expected.to include :show_only_managed_works_for_non_admins }
+  end
+
+  describe '#discovery_permissions' do
+    subject { builder.discovery_permissions }
+
+    it { is_expected.to eq %w[edit read] }
+  end
+
+  describe "#show_only_managed_works_for_non_admins" do
+    subject { builder.show_only_managed_works_for_non_admins(solr_params) }
+
+    let(:solr_params) { Blacklight::Solr::Request.new }
+
+    it "has filter that excludes depositor" do
+      subject
+      expect(solr_params[:fq]).to eq ["-_query_:\"{!raw f=depositor_ssim}#{user.user_key}\""]
+    end
+
+    context "as admin" do
+      let(:user) { create(:user, groups: 'admin') }
+
+      it "does nothing" do
+        subject
+        expect(solr_params[:fq]).to eq []
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/works/managed_works_service_spec.rb
+++ b/spec/services/hyrax/works/managed_works_service_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Hyrax::Works::ManagedWorksService, clean_repo: true do
+  let(:blacklight_config) { CatalogController.blacklight_config }
+  let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
+
+  let(:current_ability) { instance_double(Ability, admin?: true) }
+  let(:scope) { double('Scope', can?: true, current_ability: current_ability, repository: repository, blacklight_config: blacklight_config) }
+
+  describe '.managed_works_count' do
+    subject { described_class.managed_works_count(scope: scope) }
+
+    let!(:work) { create(:public_work) }
+
+    it 'returns number of works that can be managed' do
+      expect(subject).to eq(1)
+    end
+  end
+end

--- a/spec/views/hyrax/my/_work_action_menu.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_work_action_menu.html.erb_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe 'hyrax/my/_work_action_menu.html.erb' do
     allow(view).to receive(:display_trophy_link).and_return("Highlight Work on Profile")
   end
 
-  context "When the user can transfer works" do
+  context "When the user can transfer and edit works" do
     before do
       allow(view).to receive(:can?).with(:transfer, id).and_return(true)
+      allow(view).to receive(:can?).with(:edit, id).and_return(true)
       render 'hyrax/my/work_action_menu', document: document
     end
 
@@ -22,16 +23,17 @@ RSpec.describe 'hyrax/my/_work_action_menu.html.erb' do
     end
   end
 
-  context "when the user can't transfer works" do
+  context "when the user can't transfer or edit works" do
     before do
       allow(view).to receive(:can?).with(:transfer, id).and_return(false)
+      allow(view).to receive(:can?).with(:edit, id).and_return(false)
       render 'hyrax/my/work_action_menu', document: document
     end
 
     it "draws the page" do
       expect(rendered).not_to have_link "Transfer Ownership of Work"
-      expect(rendered).to have_link 'Edit Work', href: edit_hyrax_generic_work_path(id)
-      expect(rendered).to have_link 'Delete Work', href: hyrax_generic_work_path(id)
+      expect(rendered).not_to have_link 'Edit Work', href: edit_hyrax_generic_work_path(id)
+      expect(rendered).not_to have_link 'Delete Work', href: hyrax_generic_work_path(id)
       expect(rendered).to have_content 'Highlight Work on Profile'
     end
   end

--- a/spec/views/hyrax/my/works/index.html.erb_spec.rb
+++ b/spec/views/hyrax/my/works/index.html.erb_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'hyrax/my/works/index.html.erb', type: :view do
     stub_template 'hyrax/my/works/_document_list.html.erb' => 'list'
     stub_template 'hyrax/my/works/_results_pagination.html.erb' => 'pagination'
     stub_template 'hyrax/my/works/_scripts.js.erb' => 'batch edit stuff'
+    assign(:managed_works_count, 1)
     render
   end
 


### PR DESCRIPTION
Fixes #1705 

Adds a "Managed Works" tab to the Works dashboard for non-admin users. The managed work tab includes works the user has EDIT or READ access (excluding READ access for public/registered groups and works the current user deposited).

@samvera/hyrax-code-reviewers
