### PR TITLE
Edit work form -> Relationships tab does not select collections

### DIFF
--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -104,10 +104,10 @@ module Hyrax
         CollectionOptionsPresenter.new(service).select_options(:edit)
       end
 
-      # Select collection(s) based on passed-in params
+      # Select collection(s) based on passed-in params and existing memberships.
       # @return [Array] a list of collection identifiers
       def member_of_collections(collection_ids)
-        Array.wrap(collection_ids)
+        (member_of_collection_ids + Array.wrap(collection_ids)).uniq
       end
 
       # Sanitize the parameters coming from the form. This ensures that the client

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe Hyrax::Forms::WorkForm do
 
       it { is_expected.to match_array([args]) }
     end
+    context 'when member of other collections' do
+      let(:args) { 'bar' }
+
+      before do
+        allow(work).to receive(:member_of_collection_ids).and_return(['foo'])
+      end
+
+      it { is_expected.to match_array(['foo', args]) }
+    end
   end
 
   describe "#[]" do


### PR DESCRIPTION
Fixes #1683

Preselect existing collection memberships along with the collection passed with the `add_works_to_collection` URL parameter on work edit form.

@samvera/hyrax-code-reviewers
