### PR TITLE
Use abilities *and* access controls to authorize dashboard collections view

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -46,7 +46,6 @@ module Hyrax
       # The search builder to find the collections' members
       self.member_search_builder_class = Hyrax::CollectionMemberSearchBuilder
 
-      # load_and_authorize_resource except: [:index, :show, :create], instance_name: :collection
       load_and_authorize_resource except: [:index, :create], instance_name: :collection
 
       before_action :ensure_admin!, only: :index # index for All Collections; see also Hyrax::My::CollectionsController #index for My Collections

--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -22,7 +22,7 @@ module Hyrax
     configure_facets
 
     before_action :authenticate_user!
-    before_action :enforce_show_permissions, only: :show
+    load_and_authorize_resource only: :show, instance_name: :collection
 
     # include the render_check_all view helper method
     helper Hyrax::BatchEditsHelper

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -205,74 +205,93 @@ RSpec.describe Hyrax::Dashboard::CollectionsController do
     end
   end
 
-  # TODO: Add back in when admin dashboard version of show page is created
-  # describe "#show" do
-  #   context "when signed in" do
-  #     before do
-  #       sign_in user
-  #       [asset1, asset2, asset3].each do |asset|
-  #         asset.member_of_collections = [collection]
-  #         asset.save
-  #       end
-  #     end
-  #
-  #     it "returns the collection and its members" do
-  #       expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-  #       get :show, params: { id: collection }
-  #       expect(response).to be_successful
-  #       expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
-  #       expect(assigns[:presenter].title).to match_array collection.title
-  #       expect(assigns[:member_docs].map(&:id)).to match_array [asset1, asset2, asset3].map(&:id)
-  #     end
-  #
-  #     context "and searching" do
-  #       it "returns some works" do
-  #         # "/collections/4m90dv529?utf8=%E2%9C%93&cq=King+Louie&sort="
-  #         get :show, params: { id: collection, cq: "Third" }
-  #         expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
-  #         expect(assigns[:member_docs].map(&:id)).to match_array [asset3].map(&:id)
-  #       end
-  #     end
-  #
-  #     context 'when the page parameter is passed' do
-  #       it 'loads the collection (paying no attention to the page param)' do
-  #         get :show, params: { id: collection, page: '2' }
-  #         expect(response).to be_successful
-  #         expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
-  #         expect(assigns[:presenter].to_s).to eq 'My collection'
-  #       end
-  #     end
-  #
-  #     context "without a referer" do
-  #       it "sets breadcrumbs" do
-  #         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-  #         get :show, params: { id: collection }
-  #         expect(response).to be_successful
-  #       end
-  #     end
-  #
-  #     context "with a referer" do
-  #       before do
-  #         request.env['HTTP_REFERER'] = 'http://test.host/foo'
-  #       end
-  #
-  #       it "sets breadcrumbs" do
-  #         expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-  #         expect(controller).to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-  #         expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'))
-  #         get :show, params: { id: collection }
-  #         expect(response).to be_successful
-  #       end
-  #     end
-  #   end
-  #
-  #   context "not signed in" do
-  #     it "does not show me files in the collection" do
-  #       get :show, params: { id: collection }
-  #       expect(assigns[:member_docs].count).to eq 0
-  #     end
-  #   end
-  # end
+  describe "#show" do
+    context "when signed in" do
+      before do
+        sign_in user
+        [asset1, asset2, asset3].each do |asset|
+          asset.member_of_collections = [collection]
+          asset.save
+        end
+      end
+
+      it "returns the collection and its members" do
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        get :show, params: { id: collection }
+        expect(response).to be_successful
+        expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
+        expect(assigns[:presenter].title).to match_array collection.title
+        expect(assigns[:member_docs].map(&:id)).to match_array [asset1, asset2, asset3].map(&:id)
+      end
+
+      context "and searching" do
+        it "returns some works" do
+          # "/dashboard/collections/4m90dv529?utf8=%E2%9C%93&cq=King+Louie&sort="
+          get :show, params: { id: collection, cq: "Third" }
+          expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
+          expect(assigns[:member_docs].map(&:id)).to match_array [asset3].map(&:id)
+        end
+      end
+
+      context 'when the page parameter is passed' do
+        it 'loads the collection (paying no attention to the page param)' do
+          get :show, params: { id: collection, page: '2' }
+          expect(response).to be_successful
+          expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
+          expect(assigns[:presenter].to_s).to eq 'My collection'
+        end
+      end
+
+      context "without a referer" do
+        it "sets breadcrumbs" do
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+          get :show, params: { id: collection }
+          expect(response).to be_successful
+        end
+      end
+
+      context "with a referer" do
+        before do
+          request.env['HTTP_REFERER'] = 'http://test.host/foo'
+        end
+
+        it "sets breadcrumbs" do
+          expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'))
+          get :show, params: { id: collection }
+          expect(response).to be_successful
+        end
+      end
+    end
+
+    context 'with admin user and private collection' do
+      let(:collection) do
+        create(:private_collection,
+               title: ["My collection"],
+               description: ["My incredibly detailed description of the collection"],
+               user: user)
+      end
+      let(:admin) { create(:admin) }
+
+      before do
+        sign_in admin
+        allow(controller.current_ability).to receive(:can?).with(:show, collection).and_return(true)
+      end
+
+      it "returns successfully" do
+        get :show, params: { id: collection }
+        expect(response).to be_successful
+      end
+    end
+
+    context "when not signed in" do
+      it "redirects to sign in page" do
+        get :show, params: { id: collection }
+        expect(response).to have_http_status(302)
+      end
+    end
+  end
 
   describe "#delete" do
     before { sign_in user }


### PR DESCRIPTION
Previous implementation only consulted access controls, which prevented administrative users from viewing the dashboard collections show page.

Also, remove a crufty commented-out line from related controller.

Fixes #1752
Refs curationexperts/nurax#72

@samvera/hyrax-code-reviewers
