### PR TITLE
Fix edit work visibility settings

### DIFF
--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -13,9 +13,10 @@ module Hyrax
       delegate :work_members_attributes=, to: :model
       delegate :human_readable_type, :open_access?, :authenticated_only_access?,
                :open_access_with_embargo_release_date?, :private_access?,
-               :embargo_release_date, :lease_expiration_date, :member_ids,
+               :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
+               :visibility_during_lease, :lease_expiration_date, :visibility_after_lease,
                :visibility, :in_works_ids, :depositor, :on_behalf_of, :permissions,
-               :member_of_collection_ids, to: :model
+               :member_ids, :member_of_collection_ids, to: :model
 
       attr_reader :agreement_accepted
 

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -236,12 +236,44 @@ RSpec.describe Hyrax::Forms::WorkForm do
     it { is_expected.to eq work.embargo_release_date }
   end
 
+  describe "#visibility_during_embargo" do
+    let(:work) { create(:work, visibility_during_embargo: 'authenticated') }
+
+    subject { form.visibility_during_embargo }
+
+    it { is_expected.to eq work.visibility_during_embargo }
+  end
+
+  describe "#visibility_after_embargo" do
+    let(:work) { create(:work, visibility_after_embargo: 'public') }
+
+    subject { form.visibility_after_embargo }
+
+    it { is_expected.to eq work.visibility_after_embargo }
+  end
+
   describe "#lease_expiration_date" do
     let(:work) { create(:work, lease_expiration_date: 2.days.from_now) }
 
     subject { form.lease_expiration_date }
 
     it { is_expected.to eq work.lease_expiration_date }
+  end
+
+  describe "#visibility_during_lease" do
+    let(:work) { create(:work, visibility_during_lease: 'authenticated') }
+
+    subject { form.visibility_during_lease }
+
+    it { is_expected.to eq work.visibility_during_lease }
+  end
+
+  describe "#visibility_after_lease" do
+    let(:work) { create(:work, visibility_after_lease: 'private') }
+
+    subject { form.visibility_after_lease }
+
+    it { is_expected.to eq work.visibility_after_lease }
   end
 
   describe ".workflow_for" do


### PR DESCRIPTION
Fixes #1762 and curationexperts/nurax#89

The visibility settings in the WorkForm were not being properly delegated to the underlying model. This caused odd behaviors when editing works with an embargo or lease. In those situations, the visibility dropdowns would not display the correct current values (and instead would always just display the default value).

This PR consists of two commits:
* The first includes specs which prove that the behavior of the WorkForm is incorrect. These specs currently fail on `master`
* The second commit fixes the WorkForm to properly delegate these fields to the model, causing the specs to now succeed.

I've tested this code change and the dropdowns in the edit form now seem to work properly when editing a work with a previously applied embargo or lease.

@samvera/hyrax-code-reviewers
