### PR TITLE
Use correct route for collection delete in show actions.

### DIFF
--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -14,7 +14,7 @@
 
     <% if can? :destroy, presenter.solr_document %>
       <%= link_to t('hyrax.collection.actions.delete.label'),
-                  collection_path(presenter),
+                  hyrax.dashboard_collection_path(presenter),
                   title: t('hyrax.collection.actions.delete.desc'),
                   class: 'btn btn-danger',
                   data: { confirm: t('hyrax.collection.actions.delete.confirmation'),


### PR DESCRIPTION
Fixes #1750

Use the correct route in collection show actions. The collection_path route doesn't exist for delete method and resulted in a routing error page. The route I changed it to is the same that's used in app/views/hyrax/my/_collection_action_menu.html.erb which works.

@samvera/hyrax-code-reviewers
