### PR TITLE
StatusListService should recognize that workflows are AdminSet-specific

### DIFF
--- a/app/indexers/hyrax/indexes_workflow.rb
+++ b/app/indexers/hyrax/indexes_workflow.rb
@@ -26,7 +26,7 @@ module Hyrax
       return unless object.persisted?
       entity = PowerConverter.convert_to_sipity_entity(object)
       return if entity.nil?
-      solr_document[workflow_role_field] = workflow_roles(entity).map { |role| "#{entity.workflow.name}-#{role}" }
+      solr_document[workflow_role_field] = workflow_roles(entity).map { |role| "#{entity.workflow.permission_template.admin_set_id}-#{entity.workflow.name}-#{role}" }
       solr_document[workflow_state_name_field] = entity.workflow_state.name if entity.workflow_state
     end
 

--- a/app/services/hyrax/workflow/status_list_service.rb
+++ b/app/services/hyrax/workflow/status_list_service.rb
@@ -50,7 +50,7 @@ module Hyrax
         def roles_for_user
           Sipity::Workflow.all.flat_map do |wf|
             workflow_roles_for_user_and_workflow(wf).map do |wf_role|
-              "#{wf.name}-#{wf_role.role.name}"
+              "#{wf.permission_template.admin_set_id}-#{wf.name}-#{wf_role.role.name}"
             end
           end
         end

--- a/spec/indexers/hyrax/generic_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/generic_work_indexer_spec.rb
@@ -89,7 +89,10 @@ RSpec.describe GenericWorkIndexer do
         .and_return(['approve', 'reject'])
     end
     it "indexed the roles and state" do
-      expect(solr_document.fetch('actionable_workflow_roles_ssim')).to eq ["#{sipity_entity.workflow.name}-approve", "#{sipity_entity.workflow.name}-reject"]
+      expect(solr_document.fetch('actionable_workflow_roles_ssim')).to eq [
+        "#{sipity_entity.workflow.permission_template.admin_set_id}-#{sipity_entity.workflow.name}-approve",
+        "#{sipity_entity.workflow.permission_template.admin_set_id}-#{sipity_entity.workflow.name}-reject"
+      ]
       expect(solr_document.fetch('workflow_state_name_ssim')).to eq "initial"
     end
   end

--- a/spec/services/hyrax/workflow/status_list_service_spec.rb
+++ b/spec/services/hyrax/workflow/status_list_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::Workflow::StatusListService do
     let(:document) do
       { id: '33333',
         has_model_ssim: ['GenericWork'],
-        actionable_workflow_roles_ssim: ["generic_work-approving", "generic_work-rejecting"],
+        actionable_workflow_roles_ssim: ["foobar-generic_work-approving", "foobar-generic_work-rejecting"],
         workflow_state_name_ssim: ["initial"],
         title_tesim: ['Hey dood!'] }
     end
@@ -25,9 +25,14 @@ RSpec.describe Hyrax::Workflow::StatusListService do
     end
 
     context "when user has roles" do
+      let(:template) { double('template', admin_set_id: 'foobar') }
+      let(:workflow) do
+        instance_double(Sipity::Workflow, name: 'generic_work', permission_template: template)
+      end
+
       before do
         allow(Hyrax::Workflow::PermissionQuery).to receive(:scope_processing_workflow_roles_for_user_and_workflow).and_return(workflow_roles)
-        allow(Sipity::Workflow).to receive(:all).and_return([instance_double(Sipity::Workflow, name: 'generic_work')])
+        allow(Sipity::Workflow).to receive(:all).and_return([workflow])
       end
 
       it "returns status rows" do


### PR DESCRIPTION
Currently when rendering the Review Submissions page, the code asks what all roles a user has. The query is asking a Solr field that currently has no knowledge that workflows are AS-specific. This change rectifies that. It requires workflows to be reindexed.

Fixes #1769 

@samvera/hyrax-code-reviewers
