### PR TITLE
fix merge failures

### DIFF
--- a/app/indexers/hyrax/indexes_workflow.rb
+++ b/app/indexers/hyrax/indexes_workflow.rb
@@ -26,7 +26,7 @@ module Hyrax
       return unless object.persisted?
       entity = PowerConverter.convert_to_sipity_entity(object)
       return if entity.nil?
-      solr_document[workflow_role_field] = workflow_roles(entity).map { |role| "#{entity.workflow.permission_template.admin_set_id}-#{entity.workflow.name}-#{role}" }
+      solr_document[workflow_role_field] = workflow_roles(entity).map { |role| "#{entity.workflow.permission_template.source_id}-#{entity.workflow.name}-#{role}" }
       solr_document[workflow_state_name_field] = entity.workflow_state.name if entity.workflow_state
     end
 

--- a/app/services/hyrax/workflow/status_list_service.rb
+++ b/app/services/hyrax/workflow/status_list_service.rb
@@ -50,7 +50,7 @@ module Hyrax
         def roles_for_user
           Sipity::Workflow.all.flat_map do |wf|
             workflow_roles_for_user_and_workflow(wf).map do |wf_role|
-              "#{wf.permission_template.admin_set_id}-#{wf.name}-#{wf_role.role.name}"
+              "#{wf.permission_template.source_id}-#{wf.name}-#{wf_role.role.name}"
             end
           end
         end

--- a/spec/indexers/hyrax/generic_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/generic_work_indexer_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe GenericWorkIndexer do
     end
     it "indexed the roles and state" do
       expect(solr_document.fetch('actionable_workflow_roles_ssim')).to eq [
-        "#{sipity_entity.workflow.permission_template.admin_set_id}-#{sipity_entity.workflow.name}-approve",
-        "#{sipity_entity.workflow.permission_template.admin_set_id}-#{sipity_entity.workflow.name}-reject"
+        "#{sipity_entity.workflow.permission_template.source_id}-#{sipity_entity.workflow.name}-approve",
+        "#{sipity_entity.workflow.permission_template.source_id}-#{sipity_entity.workflow.name}-reject"
       ]
       expect(solr_document.fetch('workflow_state_name_ssim')).to eq "initial"
     end

--- a/spec/services/hyrax/workflow/status_list_service_spec.rb
+++ b/spec/services/hyrax/workflow/status_list_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::Workflow::StatusListService do
     end
 
     context "when user has roles" do
-      let(:template) { double('template', admin_set_id: 'foobar') }
+      let(:template) { double('template', source_id: 'foobar') }
       let(:workflow) do
         instance_double(Sipity::Workflow, name: 'generic_work', permission_template: template)
       end


### PR DESCRIPTION
Fixes failures from merge with master.

`permission_template.admin_set_id` had to be changed to `permission_template.source_id`

This is related to issue #1769 fixed by PR #1779.
