### PR TITLE
Validate local file ingestions against a whitelist of directories.

### DIFF
--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -18,12 +18,34 @@ module Hyrax
 
       private
 
+        def whitelisted_ingest_dirs
+          Hyrax.config.whitelisted_ingest_dirs
+        end
+
+        def validate_remote_url(url)
+          uri = URI.parse(URI.encode(url))
+          if uri.scheme == 'file'
+            path = File.absolute_path(URI.decode(uri.path))
+            whitelisted_ingest_dirs.any? do |dir|
+              path.start_with?(dir) && path.length > dir.length
+            end
+          else
+            # TODO: It might be a good idea to validate other URLs as well.
+            #       The server can probably access URLs the user can't.
+            true
+          end
+        end
+
         # @param [HashWithIndifferentAccess] remote_files
         # @return [TrueClass]
         def attach_files(env, remote_files)
           return true unless remote_files
           remote_files.each do |file_info|
             next if file_info.blank? || file_info[:url].blank?
+            unless validate_remote_url(file_info[:url])
+              Rails.logger.error "User #{env.user.user_key} attempted to ingest file from url #{file_info[:url]}, which doesn't pass validation"
+              return false
+            end
             create_file_from_url(env, file_info[:url], file_info[:file_name])
           end
           true

--- a/lib/generators/hyrax/templates/config/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/hyrax.rb
@@ -201,6 +201,22 @@ Hyrax.config do |config|
   rescue Errno::ENOENT
     config.browse_everything = nil
   end
+
+  ## Whitelist all directories which can be used to ingest from the local file
+  # system.
+  #
+  # Any file, and only those, that is anywhere under one of the specified
+  # directories can be used by CreateWithRemoteFilesActor to add local files
+  # to works. Files uploaded by the user are handled separately and the
+  # temporary directory for those need not be included here.
+  #
+  # Default value includes BrowseEverything.config['file_system'][:home] if it
+  # is set, otherwise default is an empty list. You should only need to change
+  # this if you have custom ingestions using CreateWithRemoteFilesActor to
+  # ingest files from the file system that are not part of the BrowseEverything
+  # mount point.
+  #
+  # config.whitelisted_ingest_dirs = []
 end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -176,6 +176,18 @@ module Hyrax
       @bagit_dir ||= "tmp/descriptions"
     end
 
+    # @!attribute [w] whitelisted_ingest_dirs
+    #   List of directories which can be used for local file system ingestion.
+    attr_writer :whitelisted_ingest_dirs
+    def whitelisted_ingest_dirs
+      @whitelisted_ingest_dirs ||= \
+        if defined? BrowseEverything
+          Array.wrap(BrowseEverything.config['file_system'].try(:[], :home)).compact
+        else
+          []
+        end
+    end
+
     callback.enable :after_create_concern, :after_create_fileset,
                     :after_update_content, :after_revert_content,
                     :after_update_metadata, :after_import_local_file_success,

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -59,4 +59,6 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:upload_path) }
   it { is_expected.to respond_to(:work_requires_files?) }
   it { is_expected.to respond_to(:extract_full_text?) }
+  it { is_expected.to respond_to(:whitelisted_ingest_dirs) }
+  it { is_expected.to respond_to(:whitelisted_ingest_dirs=) }
 end


### PR DESCRIPTION
Make CreateWithRemoteFilesActor to validate the list of file urls given. To pass the validation, each file path must start with a whitelisted directory path from which ingestions are allowed to happen. Without this check, users could ingest any files from the file system (as long as the server process can read them).

The default whitelist will be either empty or contain the Browse Everything file system mount point if it is defined. As far as I can tell, nothing else should need to ingest files directly from the local file system. However, people may have implemented custom ingestion mechanisms in which case they would need to add their ingestion directories in Hyrax.config.ingest_dirs.

The validation method currently allows all urls that use something else than the file: scheme. It would probably be a good idea to implement some kind of validation here as well. It is quite likely that on production systems the server can access network resources that the user shouldn't be able to access. 

@samvera/hyrax-code-reviewers
