### PR TITLE
Move callbacks out of the model and into actors

### DIFF
--- a/app/actors/hyrax/actors/transfer_request_actor.rb
+++ b/app/actors/hyrax/actors/transfer_request_actor.rb
@@ -1,0 +1,23 @@
+module Hyrax
+  module Actors
+    # Notify the provided owner that their proxy wants to make a
+    # deposit on their behalf
+    class TransferRequestActor < AbstractActor
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if create was successful
+      def create(env)
+        next_actor.create(env) && create_proxy_deposit_request(env)
+      end
+
+      private
+
+        def create_proxy_deposit_request(env)
+          proxy = env.curation_concern.on_behalf_of
+          return true if proxy.blank?
+          ContentDepositorChangeEventJob.perform_later(env.curation_concern,
+                                                       ::User.find_by_user_key(proxy))
+          true
+        end
+    end
+  end
+end

--- a/app/models/concerns/hyrax/proxy_deposit.rb
+++ b/app/models/concerns/hyrax/proxy_deposit.rb
@@ -11,14 +11,6 @@ module Hyrax
       property :on_behalf_of, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#onBehalfOf'), multiple: false do |index|
         index.as :symbol
       end
-
-      after_create :create_transfer_request
-    end
-
-    def create_transfer_request
-      return if on_behalf_of.blank?
-      ContentDepositorChangeEventJob.perform_later(self,
-                                                   ::User.find_by_user_key(on_behalf_of))
     end
 
     def request_transfer_to(target)

--- a/app/services/hyrax/default_middleware_stack.rb
+++ b/app/services/hyrax/default_middleware_stack.rb
@@ -13,6 +13,7 @@ module Hyrax
         middleware.use Hyrax::Actors::AttachMembersActor
         middleware.use Hyrax::Actors::ApplyOrderActor
         middleware.use Hyrax::Actors::InterpretVisibilityActor
+        middleware.use Hyrax::Actors::TransferRequestActor
         middleware.use Hyrax::Actors::DefaultAdminSetActor
         middleware.use Hyrax::Actors::ApplyPermissionTemplateActor
         middleware.use Hyrax::Actors::CleanupFileSetsActor

--- a/spec/actors/hyrax/actors/transfer_request_actor_spec.rb
+++ b/spec/actors/hyrax/actors/transfer_request_actor_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::TransferRequestActor do
+  let(:ability) { ::Ability.new(depositor) }
+  let(:env) { Hyrax::Actors::Environment.new(work, ability, attributes) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:depositor) { create(:user) }
+  let(:work) do
+    build(:generic_work, on_behalf_of: proxied_to)
+  end
+  let(:attributes) { {} }
+
+  subject(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+    end
+    stack.build(terminator)
+  end
+
+  describe "create" do
+    context "when on_behalf_of is blank" do
+      let(:proxied_to) { '' }
+
+      it "returns true" do
+        expect(middleware.create(env)).to be true
+      end
+    end
+
+    context "when proxied_to is provided" do
+      let(:proxied_to) { 'james@example.com' }
+
+      before do
+        create(:user, email: proxied_to)
+        allow(terminator).to receive(:create).and_return(true)
+      end
+
+      it "adds the template users to the work" do
+        expect(ContentDepositorChangeEventJob).to receive(:perform_later).with(work, User)
+        expect(middleware.create(env)).to be true
+      end
+    end
+  end
+end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -74,17 +74,6 @@ RSpec.describe GenericWork do
     end
   end
 
-  describe "created for someone (proxy)" do
-    let(:work) { described_class.new(title: ['demoname']) { |gw| gw.apply_depositor_metadata("user") } }
-    let(:transfer_to) { create(:user) }
-
-    it "transfers the request" do
-      work.on_behalf_of = transfer_to.user_key
-      expect(ContentDepositorChangeEventJob).to receive(:perform_later).once
-      work.save!
-    end
-  end
-
   describe "delegations" do
     let(:work) { described_class.new { |gw| gw.apply_depositor_metadata("user") } }
     let(:proxy_depositor) { create(:user) }

--- a/spec/services/hyrax/default_middleware_stack_spec.rb
+++ b/spec/services/hyrax/default_middleware_stack_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Hyrax::DefaultMiddlewareStack do
         Hyrax::Actors::AttachMembersActor,
         Hyrax::Actors::ApplyOrderActor,
         Hyrax::Actors::InterpretVisibilityActor,
+        Hyrax::Actors::TransferRequestActor,
         Hyrax::Actors::DefaultAdminSetActor,
         Hyrax::Actors::ApplyPermissionTemplateActor,
         Hyrax::Actors::CleanupFileSetsActor,


### PR DESCRIPTION
Actors are a more appropriate place for business logic than models.
This will help support the change to alternative persistence strategies
(e.g. Valkyrie)
