### PR TITLE
Cleanup legacy rights (#1765) and add a rights statement helper

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 module Hyrax
   module HyraxHelperBehavior
     include Hyrax::CitationsBehavior
@@ -198,10 +196,18 @@ module Hyrax
     end
 
     # A Blacklight index field helper_method
-    # @param [Hash] options from blacklight helper_method invocation. Maps rights URIs to links with labels.
-    # @return [ActiveSupport::SafeBuffer] rights statement links, html_safe
+    # @param [Hash] options from blacklight helper_method invocation. Maps license URIs to links with labels.
+    # @return [ActiveSupport::SafeBuffer] license links, html_safe
     def license_links(options)
       service = Hyrax::LicenseService.new
+      options[:value].map { |right| link_to service.label(right), right }.to_sentence.html_safe
+    end
+
+    # A Blacklight index field helper_method
+    # @param [Hash] options from blacklight helper_method invocation. Maps rights statement URIs to links with labels.
+    # @return [ActiveSupport::SafeBuffer] rights statement links, html_safe
+    def rights_statement_links(options)
+      service = Hyrax::RightsStatementService.new
       options[:value].map { |right| link_to service.label(right), right }.to_sentence.html_safe
     end
 

--- a/app/services/hyrax/rights_statement_service.rb
+++ b/app/services/hyrax/rights_statement_service.rb
@@ -1,6 +1,6 @@
 module Hyrax
   # Provide select options for the copyright status (edm:rights) field
-  class RightsStatements < QaSelectService
+  class RightsStatementService < QaSelectService
     def initialize
       super('rights_statements')
     end

--- a/app/views/records/edit_fields/_rights_statement.html.erb
+++ b/app/views/records/edit_fields/_rights_statement.html.erb
@@ -1,4 +1,4 @@
-<% rights_statements = Hyrax::RightsStatements.new %>
+<% rights_statements = Hyrax::RightsStatementService.new %>
 <%= f.input :rights_statement,
     collection: rights_statements.select_active_options,
     include_blank: true,

--- a/lib/generators/hyrax/templates/catalog_controller.rb
+++ b/lib/generators/hyrax/templates/catalog_controller.rb
@@ -71,7 +71,8 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
     config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
     config.add_index_field solr_name("date_created", :stored_searchable), itemprop: 'dateCreated'
-    config.add_index_field solr_name("rights", :stored_searchable), helper_method: :license_links
+    config.add_index_field solr_name("rights_statement", :stored_searchable), helper_method: :rights_statement_links
+    config.add_index_field solr_name("license", :stored_searchable), helper_method: :license_links
     config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type", link_to_search: solr_name("resource_type", :facetable)
     config.add_index_field solr_name("file_format", :stored_searchable), link_to_search: solr_name("file_format", :facetable)
     config.add_index_field solr_name("identifier", :stored_searchable), helper_method: :index_field_link, field_name: 'identifier'
@@ -92,7 +93,8 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("date_uploaded", :stored_searchable)
     config.add_show_field solr_name("date_modified", :stored_searchable)
     config.add_show_field solr_name("date_created", :stored_searchable)
-    config.add_show_field solr_name("rights", :stored_searchable)
+    config.add_show_field solr_name("rights_statement", :stored_searchable)
+    config.add_show_field solr_name("license", :stored_searchable)
     config.add_show_field solr_name("resource_type", :stored_searchable), label: "Resource Type"
     config.add_show_field solr_name("format", :stored_searchable)
     config.add_show_field solr_name("identifier", :stored_searchable)
@@ -248,8 +250,16 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('rights') do |field|
-      solr_name = solr_name("rights", :stored_searchable)
+    config.add_search_field('rights_statement') do |field|
+      solr_name = solr_name("rights_statement", :stored_searchable)
+      field.solr_local_parameters = {
+        qf: solr_name,
+        pf: solr_name
+      }
+    end
+
+    config.add_search_field('license') do |field|
+      solr_name = solr_name("license", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name

--- a/lib/generators/hyrax/templates/config/locales/hyrax.de.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.de.yml
@@ -24,8 +24,9 @@ de:
           identifier_tesim: Identifikator
           keyword_tesim: Stichwort
           language_tesim: Sprache
+          license_tesim: Lizenz
           publisher_tesim: Herausgeber
-          rights_tesim: Rechte
+          rights_statement_tesim: Rechte
           subject_tesim: Fach
         show:
           based_near_tesim: Ort
@@ -39,8 +40,9 @@ de:
           identifier_tesim: Identifikator
           keyword_tesim: Stichwort
           language_tesim: Sprache
+          license_tesim: Lizenz
           publisher_tesim: Herausgeber
-          rights_tesim: Rechte
+          rights_statement_tesim: Rechte
           subject_tesim: Fach
           title_tesim: Titel
   hyrax:

--- a/lib/generators/hyrax/templates/config/locales/hyrax.en.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.en.yml
@@ -23,8 +23,9 @@ en:
           identifier_tesim: Identifier
           keyword_tesim: Keyword
           language_tesim: Language
+          license_tesim: License
           publisher_tesim: Publisher
-          rights_tesim: Rights
+          rights_statement_tesim: Rights Statement
           subject_tesim: Subject
         show:
           based_near_tesim: Location
@@ -38,8 +39,9 @@ en:
           identifier_tesim: Identifier
           keyword_tesim: Keyword
           language_tesim: Language
+          license_tesim: License
           publisher_tesim: Publisher
-          rights_tesim: Rights
+          rights_statement_tesim: Rights Statement
           subject_tesim: Subject
           title_tesim: Title
   hyrax:

--- a/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
@@ -22,10 +22,11 @@ es:
           description_tesim: Descripción
           file_format_tesim: Formato de Archivo
           identifier_tesim: Identificador
+          license_tesim: Licencia
           keyword_tesim: Palabra clave
           language_tesim: Idioma
           publisher_tesim: Editor
-          rights_tesim: Derechos
+          rights_statement_tesim: Derechos
           subject_tesim: Tema
         show:
           based_near_tesim: Ubicación
@@ -39,8 +40,9 @@ es:
           identifier_tesim: Identificador
           keyword_tesim: Palabra clave
           language_tesim: Idioma
+          license_tesim: Licencia
           publisher_tesim: Editor
-          rights_tesim: Derechos
+          rights_statement_tesim: Derechos
           subject_tesim: Tema
           title_tesim: Título
   hyrax:

--- a/lib/generators/hyrax/templates/config/locales/hyrax.fr.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.fr.yml
@@ -24,6 +24,7 @@ fr:
           identifier_tesim: Identificateur
           keyword_tesim: Mot-clé
           language_tesim: La langue
+          license_statement_tesim: Licence
           publisher_tesim: Éditeur
           rights_tesim: Droits
           subject_tesim: Assujettir
@@ -39,6 +40,7 @@ fr:
           identifier_tesim: Identificateur
           keyword_tesim: Mot-clé
           language_tesim: La langue
+          license_statement_tesim: Licence
           publisher_tesim: Éditeur
           rights_tesim: Droits
           subject_tesim: Assujettir

--- a/lib/generators/hyrax/templates/config/locales/hyrax.it.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.it.yml
@@ -24,8 +24,9 @@ it:
           identifier_tesim: Identifier
           keyword_tesim: Parola chiave
           language_tesim: Lingua
+          license_tesim: Licenza
           publisher_tesim: Editore
-          rights_tesim: Diritti
+          rights_statement_tesim: Diritti
           subject_tesim: Soggetto
         show:
           based_near_tesim: luogo
@@ -39,8 +40,9 @@ it:
           identifier_tesim: Identifier
           keyword_tesim: Parola chiave
           language_tesim: Lingua
+          license_tesim: Licenza
           publisher_tesim: Editore
-          rights_tesim: Diritti
+          rights_statement_tesim: Diritti
           subject_tesim: Soggetto
           title_tesim: Titolo
   hyrax:

--- a/lib/generators/hyrax/templates/config/locales/hyrax.pt-BR.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.pt-BR.yml
@@ -24,8 +24,9 @@ pt-BR:
           identifier_tesim: Identificador
           keyword_tesim: Palavra-chave
           language_tesim: Língua
+          license_tesim: Licença
           publisher_tesim: Editor
-          rights_tesim: Direitos
+          rights_statement_tesim: Direitos
           subject_tesim: Sujeito
         show:
           based_near_tesim: Localização
@@ -39,8 +40,9 @@ pt-BR:
           identifier_tesim: Identificador
           keyword_tesim: Palavra-chave
           language_tesim: Língua
+          license_tesim: Licença
           publisher_tesim: Editor
-          rights_tesim: Direitos
+          rights_statement_tesim: Direitos
           subject_tesim: Sujeito
           title_tesim: Título
   hyrax:

--- a/lib/generators/hyrax/templates/config/locales/hyrax.zh.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.zh.yml
@@ -24,8 +24,9 @@ zh:
           identifier_tesim: 识别码
           keyword_tesim: 关键词
           language_tesim: 语言
+          license_tesim: 执照
           publisher_tesim: 出版者
-          rights_tesim: 权
+          rights_statement_tesim: 权
           subject_tesim: 学科
         show:
           based_near_tesim: 位置
@@ -39,8 +40,9 @@ zh:
           identifier_tesim: 识别码
           keyword_tesim: 关键词
           language_tesim: 语言
+          license_tesim: 执照
           publisher_tesim: 出版者
-          rights_tesim: 权
+          rights_statement_tesim: 权
           subject_tesim: 学科
           title_tesim: 标题
   hyrax:

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 RSpec.describe BlacklightHelper, type: :helper do
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:attributes) do
@@ -8,9 +6,10 @@ RSpec.describe BlacklightHelper, type: :helper do
       'proxy_depositor_ssim'   => ['atz@stanford.edu'],
       'description_tesim'      => ['This links to http://example.com/ What about that?'],
       'date_uploaded_dtsi'     => '2013-03-14T00:00:00Z',
-      'rights_tesim'           => ["http://creativecommons.org/publicdomain/zero/1.0/",
-                                   "http://creativecommons.org/publicdomain/mark/1.0/",
-                                   "http://www.europeana.eu/portal/rights/rr-r.html"],
+      'license_tesim' => ["http://creativecommons.org/publicdomain/zero/1.0/",
+                          "http://creativecommons.org/publicdomain/mark/1.0/",
+                          "http://www.europeana.eu/portal/rights/rr-r.html"],
+      'rights_statement_tesim' => ['http://rightsstatements.org/vocab/InC/1.0/'],
       'identifier_tesim'       => ['65434567654345654'],
       'keyword_tesim'          => ['taco', 'mustache'],
       'subject_tesim'          => ['Awesome'],
@@ -47,13 +46,21 @@ RSpec.describe BlacklightHelper, type: :helper do
       end
     end
 
-    context "rights_tesim" do
-      let(:field_name) { 'rights_tesim' }
+    context "license_tesim" do
+      let(:field_name) { 'license_tesim' }
 
       it do
         is_expected.to eq "<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">Creative Commons CC0 1.0 Universal</a>, " \
                              "<a href=\"http://creativecommons.org/publicdomain/mark/1.0/\">Creative Commons Public Domain Mark 1.0</a>, " \
                              "and <a href=\"http://www.europeana.eu/portal/rights/rr-r.html\">All rights reserved</a>"
+      end
+    end
+
+    context "rights_statement_tesim" do
+      let(:field_name) { 'rights_statement_tesim' }
+
+      it do
+        is_expected.to eq "<a href=\"http://rightsstatements.org/vocab/InC/1.0/\">In Copyright</a>"
       end
     end
 

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 def new_state
   Blacklight::SearchState.new({}, CatalogController.blacklight_config)
 end
@@ -349,6 +347,14 @@ RSpec.describe HyraxHelper, type: :helper do
       )).to eq("<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">Creative Commons CC0 1.0 Universal</a>, " \
                "<a href=\"http://creativecommons.org/publicdomain/mark/1.0/\">Creative Commons Public Domain Mark 1.0</a>, " \
                "and <a href=\"http://www.europeana.eu/portal/rights/rr-r.html\">All rights reserved</a>")
+    end
+  end
+
+  describe "#rights_statment_links" do
+    it "maps the url to a link with a label" do
+      expect(helper.rights_statement_links(
+               value: ["http://rightsstatements.org/vocab/InC/1.0/"]
+      )).to eq("<a href=\"http://rightsstatements.org/vocab/InC/1.0/\">In Copyright</a>")
     end
   end
 

--- a/spec/services/hyrax/rights_statement_service_spec.rb
+++ b/spec/services/hyrax/rights_statement_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Hyrax::RightsStatements do
+RSpec.describe Hyrax::RightsStatementService do
   let(:service) { described_class.new }
 
   describe "#select_active_options" do

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'catalog/_index_list_default', type: :view do
       'description_tesim'    => [''],
       'date_uploaded_dtsi'   => 'a date',
       'date_modified_dtsi'   => 'a date',
-      'rights_tesim'         => [''],
+      'rights_statement_tesim' => [''],
       'embargo_release_date_dtsi' => 'a date',
       'lease_expiration_date_dtsi' => 'a date' }
   end
@@ -33,8 +33,8 @@ RSpec.describe 'catalog/_index_list_default', type: :view do
     expect(rendered).to include 'Test proxy_depositor_ssim'
     expect(rendered).to include '<span class="attribute-label h4">Owner:</span>'
     expect(rendered).to include 'Test depositor_tesim'
-    expect(rendered).to include '<span class="attribute-label h4">Rights:</span>'
-    expect(rendered).to include 'Test rights_tesim'
+    expect(rendered).to include '<span class="attribute-label h4">Rights Statement:</span>'
+    expect(rendered).to include 'Test rights_statement_tesim'
     expect(rendered).to include '<span class="attribute-label h4">Embargo release date:</span>'
     expect(rendered).to include 'Test embargo_release_date_dtsi'
     expect(rendered).to include '<span class="attribute-label h4">Lease expiration date:</span>'


### PR DESCRIPTION
This PR is to cleanup some out-of-date code relating to the `rights` property, which has been replaced by `rights_statement` and `license` in `basic_metadata`.

* removed rights from `lib/generators/hyrax/templates/catalog_controller.rb` and added license and rights_statement
* removed rights from `lib/generators/hyrax/templates/config/locales/`  and added rights statement and license (using google translate for the various languages)

In addition, 

* renamed `app/services/rights_statements.rb` to `rights_statement_service.rb` to be consistent with `license_service`
* added a `rights_statement_links` method into hyrax_helper_behavior.rb to provide linked text for the rights statement, in the same way as the existing `license_links` method
* added this method as a render in the `catalog_controller` file referenced above

