### PR TITLE
Validate local file ingestions against a whitelist of directories

### DIFF
--- a/lib/generators/hyrax/templates/config/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/hyrax.rb
@@ -186,6 +186,22 @@ Hyrax.config do |config|
   rescue Errno::ENOENT
     config.browse_everything = nil
   end
+
+  ## Whitelist all directories which can be used to ingest from the local file
+  # system.
+  #
+  # Any file, and only those, that is anywhere under one of the specified
+  # directories can be used by CreateWithRemoteFilesActor to add local files
+  # to works. Files uploaded by the user are handled separately and the
+  # temporary directory for those need not be included here.
+  #
+  # Default value includes BrowseEverything.config['file_system'][:home] if it
+  # is set, otherwise default is an empty list. You should only need to change
+  # this if you have custom ingestions using CreateWithRemoteFilesActor to
+  # ingest files from the file system that are not part of the BrowseEverything
+  # mount point.
+  #
+  # config.whitelisted_ingest_dirs = []
 end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -226,6 +226,18 @@ module Hyrax
     end
     # rubocop:enable Metrics/MethodLength
 
+    # @!attribute [w] whitelisted_ingest_dirs
+    #   List of directories which can be used for local file system ingestion.
+    attr_writer :whitelisted_ingest_dirs
+    def whitelisted_ingest_dirs
+      @whitelisted_ingest_dirs ||= \
+        if defined? BrowseEverything
+          Array.wrap(BrowseEverything.config['file_system'].try(:[], :home)).compact
+        else
+          []
+        end
+    end
+
     callback.enable :after_create_concern, :after_create_fileset,
                     :after_update_content, :after_revert_content,
                     :after_update_metadata, :after_import_local_file_success,

--- a/spec/actors/hyrax/create_with_remote_files_actor_spec.rb
+++ b/spec/actors/hyrax/create_with_remote_files_actor_spec.rb
@@ -51,9 +51,25 @@ describe Hyrax::CreateWithRemoteFilesActor do
          file_name: "here.txt" }]
     end
 
+    before do
+      allow(Hyrax.config).to receive(:whitelisted_ingest_dirs).and_return(["/local/file/"])
+    end
+
     it "attaches files" do
       expect(IngestLocalFileJob).to receive(:perform_later).with(FileSet, "/local/file/here.txt", user)
       expect(actor.create(attributes)).to be true
+    end
+
+    context "with files from non-whitelisted directories" do
+      let(:file) { "file:///local/otherdir/test.txt" }
+
+      # rubocop:disable RSpec/AnyInstance
+      it "doesn't attach files" do
+        expect_any_instance_of(described_class).to receive(:validate_remote_url).and_call_original
+        expect(IngestLocalFileJob).not_to receive(:perform_later)
+        expect(actor.create(attributes)).to be false
+      end
+      # rubocop:enable RSpec/AnyInstance
     end
 
     context "with spaces" do
@@ -62,6 +78,28 @@ describe Hyrax::CreateWithRemoteFilesActor do
         expect(IngestLocalFileJob).to receive(:perform_later).with(FileSet, "/local/file/ pigs .txt", user)
         expect(actor.create(attributes)).to be true
       end
+    end
+  end
+
+  describe "#validate_remote_url" do
+    before do
+      allow(Hyrax.config).to receive(:whitelisted_ingest_dirs).and_return(['/test/', '/local/file/'])
+    end
+
+    it "accepts file: urls in whitelisted directories" do
+      expect(actor.actor.send(:validate_remote_url, "file:///local/file/test.txt")).to be true
+      expect(actor.actor.send(:validate_remote_url, "file:///local/file/subdirectory/test.txt")).to be true
+      expect(actor.actor.send(:validate_remote_url, "file:///test/test.txt")).to be true
+    end
+
+    it "rejects file: urls outside whitelisted directories" do
+      expect(actor.actor.send(:validate_remote_url, "file:///tmp/test.txt")).to be false
+      expect(actor.actor.send(:validate_remote_url, "file:///test/../tmp/test.txt")).to be false
+      expect(actor.actor.send(:validate_remote_url, "file:///test/")).to be false
+    end
+
+    it "accepts other types of urls" do
+      expect(actor.actor.send(:validate_remote_url, "https://example.com/test.txt")).to be true
     end
   end
 end

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -21,8 +21,14 @@ describe ImportUrlJob do
     allow(Hyrax::ImportUrlSuccessService).to receive(:new).and_return(success_service)
     allow(Hyrax::Actors::FileSetActor).to receive(:new).with(file_set, user).and_return(actor)
 
+    response_headers = { 'Content-Type' => 'image/png', 'Content-Length' => File.size(File.expand_path(file_path, __FILE__)) }
+
+    stub_request(:head, "http://example.org#{file_hash}").to_return(
+      body: "", status: 200, headers: response_headers
+    )
+
     stub_request(:get, "http://example.org#{file_hash}").to_return(
-      body: File.open(File.expand_path(file_path, __FILE__)).read, status: 200, headers: { 'Content-Type' => 'image/png' }
+      body: File.open(File.expand_path(file_path, __FILE__)).read, status: 200, headers: response_headers
     )
   end
 

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -53,4 +53,6 @@ describe Hyrax::Configuration do
   it { is_expected.to respond_to(:translate_uri_to_id) }
   it { is_expected.to respond_to(:upload_path) }
   it { is_expected.to respond_to(:work_requires_files?) }
+  it { is_expected.to respond_to(:whitelisted_ingest_dirs) }
+  it { is_expected.to respond_to(:whitelisted_ingest_dirs=) }
 end


### PR DESCRIPTION
Backports #1789 from `master` to `1-0-stable`. (Also backports #1696 to fix the build.)

From @ojlyytinen:
> Make CreateWithRemoteFilesActor to validate the list of file urls given. To pass the validation, each file path must start with a whitelisted directory path from which ingestions are allowed to happen. Without this check, users could ingest any files from the file system (as long as the server process can read them).
> 
> The default whitelist will be either empty or contain the Browse Everything file system mount point if it is defined. As far as I can tell, nothing else should need to ingest files directly from the local file system. However, people may have implemented custom ingestion mechanisms in which case they would need to add their ingestion directories in Hyrax.config.ingest_dirs.
> 
> The validation method currently allows all urls that use something else than the file: scheme. It would probably be a good idea to implement some kind of validation here as well. It is quite likely that on production systems the server can access network resources that the user shouldn't be able to access.

@samvera/hyrax-code-reviewers
