### PR TITLE
Restrict visibility options based on AS template.

### DIFF
--- a/app/assets/javascripts/hyrax/save_work/visibility_component.es6
+++ b/app/assets/javascripts/hyrax/save_work/visibility_component.es6
@@ -76,14 +76,9 @@ export default class VisibilityComponent {
   // Apply visibility/release restrictions based on selected AdminSet
   applyRestrictions(visibility, release_no_delay, release_date, release_before)
   {
-     // If immediate release required and visibility specified
-     if(release_no_delay && visibility) {
-       // Select required visibility
-       this.selectVisibility(visibility)
-     }
-     else if(release_no_delay) {
-       // No visibility required, but must be released today. Disable embargo & lease.
-       this.disableEmbargoAndLease();
+     // If immediate release required or the release date is in the past.
+     if(release_no_delay || (release_date && (new Date() > Date.parse(release_date)))) {
+       this.requireReleaseNow(visibility)
      }
      // Otherwise if future date and release_before==true, must be released between today and release_date
      else if(release_date && release_before) {
@@ -137,6 +132,18 @@ export default class VisibilityComponent {
     this.selectVisibilityAfterEmbargo(visibility)
   }
 
+  // Require release now
+  requireReleaseNow(visibility) {
+    if(visibility) {
+      // Select required visibility
+      this.selectVisibility(visibility)
+    }
+    else {
+      // No visibility required, but must be released today. Disable embargo & lease.
+      this.disableEmbargoAndLease()
+    }
+  }
+
   // Disable Embargo and Lease options. Work must be released immediately
   disableEmbargoAndLease() {
     this.disableVisibilityOptions(["embargo","lease"])
@@ -153,6 +160,8 @@ export default class VisibilityComponent {
       this.element.find(matchEnabled).prop("disabled", false)
     }
     this.element.find(matchDisabled).prop("disabled", true)
+
+    this.checkEnabledVisibilityOption()
   }
 
   // Disable one or more visibility option (based on array of passed in options),
@@ -166,6 +175,8 @@ export default class VisibilityComponent {
       this.element.find(matchDisabled).prop("disabled", true)
     }
     this.element.find(matchEnabled).prop("disabled", false)
+
+    this.checkEnabledVisibilityOption()
   }
 
   // Create a jQuery matcher which will match for all the specified options
@@ -253,6 +264,16 @@ export default class VisibilityComponent {
   // Get input field corresponding to visibility after embargo expires
   getVisibilityAfterEmbargoInput() {
     return this.element.find("select[id$='_visibility_after_embargo']")
+  }
+
+  // If the selected visibility option is disabled change selection to the
+  // least public option that is enabled.
+  checkEnabledVisibilityOption() {
+    if (this.element.find("[type='radio']:disabled:checked").length > 0) {
+      this.element.find("[type='radio']:enabled").last().prop('checked', true)
+      // Ensure required option is opened in form
+      this.showForm()
+    }
   }
 
   // Get today's date in YYYY-MM-DD format

--- a/spec/javascripts/visibility_component_spec.js
+++ b/spec/javascripts/visibility_component_spec.js
@@ -169,6 +169,25 @@ describe("VisibilityComponent", function() {
         expect(target.requireEmbargo).toHaveBeenCalledWith("authenticated", futureDate);
       });
     });
+    describe("with required past release date, dont restrict visibility", function() {
+      beforeEach(function() {
+        spyOn(target, 'disableEmbargoAndLease');
+      });
+      it("require visibility", function() {
+        target.applyRestrictions(undefined, undefined, "2017-01-01", false);
+        expect(target.disableEmbargoAndLease).toHaveBeenCalled();
+      });
+    });
+    describe("with required past release date, and required visibility", function() {
+      beforeEach(function() {
+        spyOn(target, 'selectVisibility');
+      });
+      it("require visibility", function() {
+        var visibility = "authenticated";
+        target.applyRestrictions(visibility, undefined, "2017-01-01", false);
+        expect(target.selectVisibility).toHaveBeenCalledWith(visibility);
+      });
+    });
   });
 
   //selectVisibility(visibility)

--- a/spec/javascripts/visibility_component_spec.js
+++ b/spec/javascripts/visibility_component_spec.js
@@ -173,7 +173,7 @@ describe("VisibilityComponent", function() {
       beforeEach(function() {
         spyOn(target, 'disableEmbargoAndLease');
       });
-      it("require visibility", function() {
+      it("disable embargo and lease", function() {
         target.applyRestrictions(undefined, undefined, "2017-01-01", false);
         expect(target.disableEmbargoAndLease).toHaveBeenCalled();
       });
@@ -433,6 +433,31 @@ describe("VisibilityComponent", function() {
   describe("getVisibilityAfterEmbargoInput", function() {
     it("returns visibility after embargo selectbox", function() {
       expect(target.getVisibilityAfterEmbargoInput()).toHaveProp("name", "generic_work[visibility_after_embargo]");
+    });
+  });
+
+  //checkEnabledVisibilityOption()
+  describe("checkEnabledVisibilityOption", function() {
+    describe("with disabled option selected", function() {
+      beforeEach(function() {
+        target.enableAllOptions();
+        element.find("[type='radio'][value='restricted']").prop("checked", true).prop("disabled", true);
+      });
+      it("selects last enabled radio option", function() {
+        target.checkEnabledVisibilityOption();
+        expect(element.find("[type='radio'][value='restricted']")).not.toBeChecked();
+        expect(element.find("[type='radio'][value='lease']")).toBeChecked();
+      });
+    });
+    describe("with enabled option selected", function() {
+      beforeEach(function() {
+        target.enableAllOptions();
+        element.find("[type='radio'][value='open']").prop("checked", true);
+      });
+      it("does not change selection", function() {
+        target.checkEnabledVisibilityOption();
+        expect(element.find("[type='radio'][value='open']")).toBeChecked();
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #1801 

When trying to add a work to an Admin set with a fixed release date setting that has passed, the work fails server-side validation. 

Changes proposed in this pull request:
* When the selected admin set has a release date that has passed, force the user to select a valid visibility (not lease or embargo). 
* If a disabled visibility option is selected then automatically change the selection to least public option that is enabled.

@samvera/hyrax-code-reviewers
