### PR TITLE
Adding works to collection forwards to collection admin show

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -214,7 +214,8 @@ module Hyrax
         end
 
         def update_referer
-          edit_dashboard_collection_path(@collection) + (params[:referer_anchor] || '')
+          return edit_dashboard_collection_path(@collection) + (params[:referer_anchor] || '') if params[:stay_on_edit]
+          dashboard_collection_path(@collection)
         end
 
         def determine_banner_data

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -58,6 +58,7 @@
               </div>
             <% end %>
             <%= hidden_field_tag :type, params[:type] %>
+            <%= hidden_field_tag :stay_on_edit, true %>
             <%= hidden_field_tag :collection_type_gid, @collection.collection_type_gid %>
             <% if params[:batch_document_ids].present? %>
               <% params[:batch_document_ids].each do |batch_item| %>

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -133,13 +133,24 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         end
       end
 
-      it "adds members to the collection" do
+      it "adds members to the collection from edit form" do
+        expect do
+          put :update, params: { id: collection,
+                                 collection: { members: 'add' },
+                                 batch_document_ids: [asset3.id],
+                                 stay_on_edit: true }
+        end.to change { collection.reload.member_objects.size }.by(1)
+        expect(response).to redirect_to routes.url_helpers.edit_dashboard_collection_path(collection, locale: 'en')
+        expect(assigns[:collection].member_objects).to match_array [asset1, asset2, asset3]
+      end
+
+      it "adds members to the collection from other than the edit form" do
         expect do
           put :update, params: { id: collection,
                                  collection: { members: 'add' },
                                  batch_document_ids: [asset3.id] }
         end.to change { collection.reload.member_objects.size }.by(1)
-        expect(response).to redirect_to routes.url_helpers.edit_dashboard_collection_path(collection, locale: 'en')
+        expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
         expect(assigns[:collection].member_objects).to match_array [asset1, asset2, asset3]
       end
 


### PR DESCRIPTION
Fixes #1836

Fixes bug where adding works to a collection through the dashboard forwarded to collection edit instead of collection admin show.  The default is now to go to the show page.  The edit form has a hidden field `'stay_on_edit'=true`.
