### PR TITLE
[WIP] Add rights statement renderer

### DIFF
--- a/app/assets/javascripts/hyrax/save_work/visibility_component.es6
+++ b/app/assets/javascripts/hyrax/save_work/visibility_component.es6
@@ -76,14 +76,9 @@ export default class VisibilityComponent {
   // Apply visibility/release restrictions based on selected AdminSet
   applyRestrictions(visibility, release_no_delay, release_date, release_before)
   {
-     // If immediate release required and visibility specified
-     if(release_no_delay && visibility) {
-       // Select required visibility
-       this.selectVisibility(visibility)
-     }
-     else if(release_no_delay) {
-       // No visibility required, but must be released today. Disable embargo & lease.
-       this.disableEmbargoAndLease();
+     // If immediate release required or the release date is in the past.
+     if(release_no_delay || (release_date && (new Date() > Date.parse(release_date)))) {
+       this.requireReleaseNow(visibility)
      }
      // Otherwise if future date and release_before==true, must be released between today and release_date
      else if(release_date && release_before) {
@@ -137,6 +132,18 @@ export default class VisibilityComponent {
     this.selectVisibilityAfterEmbargo(visibility)
   }
 
+  // Require release now
+  requireReleaseNow(visibility) {
+    if(visibility) {
+      // Select required visibility
+      this.selectVisibility(visibility)
+    }
+    else {
+      // No visibility required, but must be released today. Disable embargo & lease.
+      this.disableEmbargoAndLease()
+    }
+  }
+
   // Disable Embargo and Lease options. Work must be released immediately
   disableEmbargoAndLease() {
     this.disableVisibilityOptions(["embargo","lease"])
@@ -153,6 +160,8 @@ export default class VisibilityComponent {
       this.element.find(matchEnabled).prop("disabled", false)
     }
     this.element.find(matchDisabled).prop("disabled", true)
+
+    this.checkEnabledVisibilityOption()
   }
 
   // Disable one or more visibility option (based on array of passed in options),
@@ -166,6 +175,8 @@ export default class VisibilityComponent {
       this.element.find(matchDisabled).prop("disabled", true)
     }
     this.element.find(matchEnabled).prop("disabled", false)
+
+    this.checkEnabledVisibilityOption()
   }
 
   // Create a jQuery matcher which will match for all the specified options
@@ -253,6 +264,16 @@ export default class VisibilityComponent {
   // Get input field corresponding to visibility after embargo expires
   getVisibilityAfterEmbargoInput() {
     return this.element.find("select[id$='_visibility_after_embargo']")
+  }
+
+  // If the selected visibility option is disabled change selection to the
+  // least public option that is enabled.
+  checkEnabledVisibilityOption() {
+    if (this.element.find("[type='radio']:disabled:checked").length > 0) {
+      this.element.find("[type='radio']:enabled").last().prop('checked', true)
+      // Ensure required option is opened in form
+      this.showForm()
+    }
   }
 
   // Get today's date in YYYY-MM-DD format

--- a/app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb
@@ -1,0 +1,25 @@
+module Hyrax
+  module Renderers
+    # This is used by PresentsAttributes to show licenses
+    #   e.g.: presenter.attribute_to_html(:rights_statement, render_as: :rights_statement)
+    class RightsStatementAttributeRenderer < AttributeRenderer
+      private
+
+        ##
+        # Special treatment for license/rights.  A URL from the Hyrax gem's config/hyrax.rb is stored in the descMetadata of the
+        # curation_concern.  If that URL is valid in form, then it is used as a link.  If it is not valid, it is used as plain text.
+        def attribute_value_to_html(value)
+          begin
+            parsed_uri = URI.parse(value)
+          rescue
+            nil
+          end
+          if parsed_uri.nil?
+            ERB::Util.h(value)
+          else
+            %(<a href=#{ERB::Util.h(value)} target="_blank">#{Hyrax.config.rights_statement_service_class.new.label(value)}</a>)
+          end
+        end
+    end
+  end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -10,4 +10,4 @@
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:source) %>
-<%= presenter.attribute_to_html(:rights_statement) %>
+<%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement) %>

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -228,6 +228,17 @@ module Hyrax
       @license_service_class ||= Hyrax::LicenseService
     end
 
+    # A configuration point for changing the behavior of the rights statement service.
+    #
+    # @!attribute [w] license_service_class
+    #   A configuration point for changing the behavior of the license service.
+    #
+    #   @see Hyrax::RightsStatementService for implementation details
+    attr_writer :rights_statement_service_class
+    def rights_statement_service_class
+      @rights_statement_service_class ||= Hyrax::RightsStatementService
+    end
+
     attr_writer :banner_image
     def banner_image
       # This image can be used for free and without attribution. See here for source and license: https://github.com/samvera/hyrax/issues/1551#issuecomment-326624909

--- a/spec/javascripts/visibility_component_spec.js
+++ b/spec/javascripts/visibility_component_spec.js
@@ -169,6 +169,25 @@ describe("VisibilityComponent", function() {
         expect(target.requireEmbargo).toHaveBeenCalledWith("authenticated", futureDate);
       });
     });
+    describe("with required past release date, dont restrict visibility", function() {
+      beforeEach(function() {
+        spyOn(target, 'disableEmbargoAndLease');
+      });
+      it("require visibility", function() {
+        target.applyRestrictions(undefined, undefined, "2017-01-01", false);
+        expect(target.disableEmbargoAndLease).toHaveBeenCalled();
+      });
+    });
+    describe("with required past release date, and required visibility", function() {
+      beforeEach(function() {
+        spyOn(target, 'selectVisibility');
+      });
+      it("require visibility", function() {
+        var visibility = "authenticated";
+        target.applyRestrictions(visibility, undefined, "2017-01-01", false);
+        expect(target.selectVisibility).toHaveBeenCalledWith(visibility);
+      });
+    });
   });
 
   //selectVisibility(visibility)

--- a/spec/javascripts/visibility_component_spec.js
+++ b/spec/javascripts/visibility_component_spec.js
@@ -173,7 +173,7 @@ describe("VisibilityComponent", function() {
       beforeEach(function() {
         spyOn(target, 'disableEmbargoAndLease');
       });
-      it("require visibility", function() {
+      it("disable embargo and lease", function() {
         target.applyRestrictions(undefined, undefined, "2017-01-01", false);
         expect(target.disableEmbargoAndLease).toHaveBeenCalled();
       });
@@ -433,6 +433,31 @@ describe("VisibilityComponent", function() {
   describe("getVisibilityAfterEmbargoInput", function() {
     it("returns visibility after embargo selectbox", function() {
       expect(target.getVisibilityAfterEmbargoInput()).toHaveProp("name", "generic_work[visibility_after_embargo]");
+    });
+  });
+
+  //checkEnabledVisibilityOption()
+  describe("checkEnabledVisibilityOption", function() {
+    describe("with disabled option selected", function() {
+      beforeEach(function() {
+        target.enableAllOptions();
+        element.find("[type='radio'][value='restricted']").prop("checked", true).prop("disabled", true);
+      });
+      it("selects last enabled radio option", function() {
+        target.checkEnabledVisibilityOption();
+        expect(element.find("[type='radio'][value='restricted']")).not.toBeChecked();
+        expect(element.find("[type='radio'][value='lease']")).toBeChecked();
+      });
+    });
+    describe("with enabled option selected", function() {
+      beforeEach(function() {
+        target.enableAllOptions();
+        element.find("[type='radio'][value='open']").prop("checked", true);
+      });
+      it("does not change selection", function() {
+        target.checkEnabledVisibilityOption();
+        expect(element.find("[type='radio'][value='open']")).toBeChecked();
+      });
     });
   });
 });

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:google_analytics_id?) }
   it { is_expected.to respond_to(:google_analytics_id) }
   it { is_expected.to respond_to(:libreoffice_path) }
+  it { is_expected.to respond_to(:license_service_class) }
+  it { is_expected.to respond_to(:license_service_class=) }
   it { is_expected.to respond_to(:max_days_between_fixity_checks=) }
   it { is_expected.to respond_to(:max_days_between_fixity_checks) }
   it { is_expected.to respond_to(:max_notifications_for_dashboard) }
@@ -52,6 +54,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:persistent_hostpath) }
   it { is_expected.to respond_to(:realtime_notifications?) }
   it { is_expected.to respond_to(:realtime_notifications=) }
+  it { is_expected.to respond_to(:rights_statement_service_class) }
+  it { is_expected.to respond_to(:rights_statement_service_class=) }
   it { is_expected.to respond_to(:redis_namespace) }
   it { is_expected.to respond_to(:subject_prefix) }
   it { is_expected.to respond_to(:translate_id_to_uri) }

--- a/spec/renderers/hyrax/renderers/rights_statement_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/rights_statement_attribute_renderer_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Hyrax::Renderers::RightsStatementAttributeRenderer do
+  let(:field) { :rights_statement }
+  let(:renderer) { described_class.new(field, ['http://rightsstatements.org/vocab/InC/1.0/']) }
+
+  describe "#attribute_to_html" do
+    subject { Nokogiri::HTML(renderer.render) }
+
+    let(:expected) { Nokogiri::HTML(tr_content) }
+
+    let(:tr_content) do
+      "<tr><th>Rights statement</th>\n" \
+       "<td><ul class='tabular'>" \
+       "<li class=\"attribute rights_statement\"><a href=\"http://rightsstatements.org/vocab/InC/1.0/\" target=\"_blank\">In Copyright</a></li>" \
+       "</ul></td></tr>"
+    end
+
+    it { expect(renderer).not_to be_microdata(field) }
+    it { expect(subject).to be_equivalent_to(expected) }
+  end
+end

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -21,6 +21,6 @@ RSpec.describe 'hyrax/base/_attribute_rows.html.erb', type: :view do
   end
 
   it 'shows rights statement with link to statement URL' do
-    expect(page).to have_link(rights_statement_uri)
+    expect(page).to have_link("In Copyright", href: rights_statement_uri)
   end
 end


### PR DESCRIPTION
Added a renderer for rights_statement so that the link text will be the rights statement label (eg. In Copyright) rather than the URL itself.

Changes made
* added new class in renderers
* added 'render_as' to the rights_statement line in app/views/hyrax/base/_attribute_rows.html.erb
* added a configuration setting for the rights statement service class to lib/hyrax/configuration.rb