### PR TITLE
Default option for admin set release settings.

### DIFF
--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -186,6 +186,8 @@ module Hyrax
         # Removes release_varies and release_embargo from the returned attributes
         # These form fields are only used to update release_period
         # @return [Hash] attributes used to update the model
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/PerceivedComplexity
         def permission_template_update_params(raw_attributes)
           attributes = raw_attributes.except(:release_varies, :release_embargo)
           # If 'varies' before date option selected, then set release_period='before' and save release_date as-is
@@ -199,28 +201,27 @@ module Hyrax
             attributes[:release_date] = nil
           end
 
-          if attributes[:release_period] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY
-            # If release is "no delay", a release_date should never be allowed/specified
+          if attributes[:release_period] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY || (attributes[:release_period].blank? && raw_attributes[:release_varies].blank?)
+            # If release is "no delay" or is "varies" and "allow depositor to decide",
+            # then a release_date should never be allowed/specified
             attributes[:release_date] = nil
           end
 
           attributes
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/PerceivedComplexity
 
         # validate the hash of attributes used to update the visibility tab of the model
         # @param [Hash] attributes
         # @return [String, Nil] the error code if invalid, nil if valid
         # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/PerceivedComplexity
         def validate_visibility_combinations(attributes)
           return unless attributes.key?(:visibility) # only the visibility tab has validations
 
           # if "save" without any selections - none of the attributes are present
           return "nothing" if !attributes[:release_varies] && !attributes[:release_period] && !attributes[:release_date] && !attributes[:release_embargo]
-
-          # if "varies" without sub-options (in this case, release_varies will be missing)
-          return "varies" if attributes[:release_period].blank? && attributes[:release_varies].blank?
 
           # if "varies before" but date not selected
           return "no_date" if attributes[:release_varies] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE && attributes[:release_date].blank?
@@ -233,7 +234,6 @@ module Hyrax
         end
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
@@ -14,10 +14,16 @@
                   </div>
                   <div id="release-varies" class="radio">
                     <label>
-                      <%= f.radio_button :release_period, '', checked: !f.object.release_varies.blank? %>
+                      <%= f.radio_button :release_period, '', checked: f.object.release_period.blank? || !f.object.release_varies.blank? %>
                       <%= t('.release.varies.description') %>
                     </label>
                     <ul>
+                      <li class="radio form-inline">
+                        <label>
+                          <%= f.radio_button :release_varies, '' %>
+                          <%= t('.release.varies.any') %>
+                        </label>
+                      </li>
                       <li class="radio form-inline">
                         <label>
                           <%= f.radio_button :release_varies, Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -80,7 +80,6 @@ en:
             visibility:         "The administrative set's release & visibility settings have been updated."
             workflow:           "The administrative set's workflow has been updated."
           permission_update_errors:
-            varies:             "Release option 'Varies' requires a date or embargo period."
             no_date:            "A date is required for the selected release option."
             no_embargo:         "An embargo period is required for the selected option."
             nothing:            "Select release options before pressing save."
@@ -132,6 +131,7 @@ en:
             no_delay:           "No delay -- release all works as soon as they are deposited"
             title:              "Release"
             varies:
+              any:              "Allow depositor to decide"
               between:          "Between \"now\" and"
               description:      "Varies -- depositors can set the release date for an individual work:"
               embargo:

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -317,6 +317,13 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
         it_behaves_like 'valid attributes'
       end
 
+      describe 'varies, with depositor choice' do
+        let(:release_period) { '' }
+        let(:release_varies) { '' }
+
+        it_behaves_like 'valid attributes'
+      end
+
       describe 'varies, with date selected' do
         let(:release_date) { Time.zone.today + 2.months }
         let(:release_varies) { Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE }

--- a/spec/views/hyrax/admin/admin_sets/_form_visibility.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_form_visibility.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'hyrax/admin/admin_sets/_form_visibility.html.erb', type: :view d
   it "has the form" do
     expect(rendered).to have_selector('#visibility input[type=radio][name="permission_template[release_period]"][value=now]')
     expect(rendered).to have_selector('#visibility input[type=radio][name="permission_template[release_period]"][value=fixed]')
+    expect(rendered).to have_selector('#visibility input[type=radio][name="permission_template[release_varies]"][value=""]')
     expect(rendered).to have_selector('#visibility input[type=radio][name="permission_template[release_varies]"][value=before]')
     expect(rendered).to have_selector('#visibility input[type=radio][name="permission_template[release_varies]"][value=embargo]')
     expect(rendered).to have_selector('#visibility select[name="permission_template[release_embargo]"]')


### PR DESCRIPTION
Fixes #1799 

Add options to the Admin set release form to capture the default release settings. The default options allow the user to select any visibility for works, including lease and embargo.

Changes proposed in this pull request:

Admin Set Release Form now includes these options, with the indicated items selected by default:

- No Delay
- Varies (DEFAULT)
  - Allow depositor to decide (DEFAULT)
  - Between now and `{DATE}`
  - Between now and `{PERIOD}`
- Fixed

@samvera/hyrax-code-reviewers
