### PR TITLE
Make IngestLocalFileJob not remove the ingested file.

### DIFF
--- a/app/jobs/ingest_local_file_job.rb
+++ b/app/jobs/ingest_local_file_job.rb
@@ -10,7 +10,6 @@ class IngestLocalFileJob < Hyrax::ApplicationJob
     actor = Hyrax::Actors::FileSetActor.new(file_set, user)
 
     if actor.create_content(File.open(path))
-      FileUtils.rm(path)
       Hyrax.config.callback.run(:after_import_local_file_success, file_set, user, path)
     else
       Hyrax.config.callback.run(:after_import_local_file_failure, file_set, user, path)

--- a/spec/jobs/ingest_local_file_job_spec.rb
+++ b/spec/jobs/ingest_local_file_job_spec.rb
@@ -4,16 +4,13 @@ RSpec.describe IngestLocalFileJob do
   let(:file_set) { FileSet.new }
   let(:actor) { double }
 
-  let(:mock_upload_directory) { 'spec/mock_upload_directory' }
-
   before do
-    Dir.mkdir mock_upload_directory unless File.exist? mock_upload_directory
-    FileUtils.copy(File.expand_path('../../fixtures/world.png', __FILE__), mock_upload_directory)
     allow(Hyrax::Actors::FileSetActor).to receive(:new).with(file_set, user).and_return(actor)
   end
 
   it 'has attached a file' do
+    expect(FileUtils).not_to receive(:rm)
     expect(actor).to receive(:create_content).and_return(true)
-    described_class.perform_now(file_set, File.join(mock_upload_directory, 'world.png'), user)
+    described_class.perform_now(file_set, File.join(fixture_path, 'world.png'), user)
   end
 end


### PR DESCRIPTION
Fixes #1814.

IngestLocalFileJob no longer removes the ingested file. Based on how the spec for this job was written, it seems that this job maybe(?) was used before for uploaded files for which deleting them after ingestion makes sense. However, now it's only referred to in CreateWithRemoteFilesActor. In this case it doesn't seem appropriate to delete the file.

Furthermore, as explained in #1814, the way IngestLocalFileJob interacts with FileSetActor and IngestJob means that deleting the file in IngestLocalFileJob#perform will just cause the other IngestJob to fail and the whole ingestion go wrong.

@samvera/hyrax-code-reviewers
