### PR TITLE
Lookup objects using Valkyrie

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -75,7 +75,7 @@ module Hyrax
         wants.html { presenter && parent_presenter }
         wants.json do
           # load and authorize @curation_concern manually because it's skipped for html
-          @curation_concern = _curation_concern_type.find(params[:id]) unless curation_concern
+          @curation_concern = Hyrax::Queries.find_by(id: Valkyrie::ID.new(params[:id])) unless curation_concern
           authorize! :show, @curation_concern
           render :show, status: :ok
         end

--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -32,7 +32,7 @@ module Hyrax
     # @return [AdminSet]
     # @raise [ActiveFedora::ObjectNotFoundError] when the we cannot find the AdminSet
     def admin_set
-      AdminSet.find(admin_set_id)
+      Hyrax::Queries.find_by(id: admin_set_id)
     end
 
     # Valid Release Period values

--- a/app/services/hyrax/working_directory.rb
+++ b/app/services/hyrax/working_directory.rb
@@ -10,7 +10,7 @@ module Hyrax
       # @return [String] path of the working file
       def find_or_retrieve(repository_file_id, id, filepath = nil)
         return filepath if filepath && File.exist?(filepath)
-        repository_file = Hydra::PCDM::File.find(repository_file_id)
+        repository_file = Hyrax::Queries.find_by(id: repository_file_id)
         working_path = full_filename(id, repository_file.original_name)
         if File.exist?(working_path)
           Rails.logger.debug "#{repository_file.original_name} already exists in the working directory at #{working_path}"

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -2,7 +2,7 @@ namespace :hyrax do
   namespace :migrate do
     task move_all_works_to_admin_set: :environment do
       require 'hyrax/move_all_works_to_admin_set'
-      MoveAllWorksToAdminSet.run(AdminSet.find(AdminSet::DEFAULT_ID))
+      MoveAllWorksToAdminSet.run(Hyrax::Queries.find_by(id: AdminSet::DEFAULT_ID))
     end
 
     task add_admin_group_to_admin_sets: :environment do

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       end
 
       it "removes representative, thumbnail, and the proxy association" do
-        gw = GenericWork.find(work.id)
+        gw = Hyrax::Queries.find_by(id: work.id)
         expect(gw.representative_id).to eq(file_set.id)
         expect(gw.thumbnail_id).to eq(file_set.id)
         expect { actor.destroy }.to change { ActiveFedora::Aggregation::Proxy.count }.by(-1)
@@ -294,12 +294,10 @@ RSpec.describe Hyrax::Actors::FileSetActor do
 
     context 'with multiple versions' do
       let(:persister) { Valkyrie.config.metadata_adapter.persister }
-      let(:query_service) { Valkyrie::MetadataAdapter.find(:indexing_persister).query_service }
       let(:work_v1) { create_for_repository(:work) } # this version of the work has no members
 
       before do # another version of the same work is saved with a member
-        query_service = Valkyrie::MetadataAdapter.find(:indexing_persister).query_service
-        work_v2 = query_service.find_by(id: Valkyrie::ID.new(work_v1.id.to_s))
+        work_v2 = Hyrax::Queries.find_by(id: work_v1.id)
         work_v2.member_ids << create_for_repository(:file_set).id
         persister.save(resource: work_v2)
       end

--- a/spec/controllers/hyrax/batch_edits_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_edits_controller_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
     it "is successful" do
       put :update, params: { update_type: "delete_all" }
       expect(response).to redirect_to(dashboard_path(locale: 'en'))
-      expect { GenericWork.find(one.id) }.to raise_error(Ldp::Gone)
-      expect { GenericWork.find(two.id) }.to raise_error(Ldp::Gone)
+      expect { Hyrax::Queries.find_by(id: one.id) }.to raise_error(Ldp::Gone)
+      expect { Hyrax::Queries.find_by(id: two.id) }.to raise_error(Ldp::Gone)
     end
 
     it "redirects to the return controller" do
@@ -59,15 +59,15 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
     it "updates the records" do
       put :update, params: { update_type: "update", generic_work: { subject: ["zzz"] } }
       expect(response).to be_redirect
-      expect(GenericWork.find(one.id).subject).to eq ["zzz"]
-      expect(GenericWork.find(two.id).subject).to eq ["zzz"]
+      expect(Hyrax::Queries.find_by(id: one.id).subject).to eq ["zzz"]
+      expect(Hyrax::Queries.find_by(id: two.id).subject).to eq ["zzz"]
     end
 
     it "updates permissions" do
       put :update, params: { update_type: "update", visibility: "authenticated" }
       expect(response).to be_redirect
-      expect(GenericWork.find(one.id).visibility).to eq "authenticated"
-      expect(GenericWork.find(two.id).visibility).to eq "authenticated"
+      expect(Hyrax::Queries.find_by(id: one.id).visibility).to eq "authenticated"
+      expect(Hyrax::Queries.find_by(id: two.id).visibility).to eq "authenticated"
     end
   end
 end

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
         admin_set =
           if admin_set_id.present?
             begin
-              AdminSet.find(admin_set_id)
+              Hyrax::Queries.find_by(id: admin_set_id)
             rescue
               create_for_repository(:admin_set, id: admin_set_id)
             end

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Hyrax::AdminSetCreateService do
   let(:user) { create(:user) }
 
   describe '.create_default_admin_set', :clean_repo do
-    let(:admin_set) { AdminSet.find(AdminSet::DEFAULT_ID) }
+    let(:admin_set) { Hyrax::Queries.find_by(id: AdminSet::DEFAULT_ID) }
 
     # It is important to test the side-effects as a default admin set is a fundamental assumption for Hyrax.
     it 'creates AdminSet, Hyrax::PermissionTemplate, Sipity::Workflow(s), and activates a Workflow', slow: true do


### PR DESCRIPTION
Fixes #1823.  AFAICT this removes the last of the ActiveFedora::Base and subclass `.find` calls.