### PR TITLE
Render controls navbar in work and collection show views

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -6,13 +6,13 @@ module Hyrax
 
     included do
       layout :decide_layout
-
       copy_blacklight_config_from(::CatalogController)
 
       class_attribute :_curation_concern_type, :show_presenter, :work_form_service, :search_builder_class
       self.show_presenter = Hyrax::WorkShowPresenter
       self.work_form_service = Hyrax::WorkFormService
       self.search_builder_class = WorkSearchBuilder
+      self.theme = 'hyrax/1_column'
       attr_accessor :curation_concern
       helper_method :curation_concern, :contextual_path
 

--- a/app/controllers/hyrax/collections_controller.rb
+++ b/app/controllers/hyrax/collections_controller.rb
@@ -5,6 +5,8 @@ module Hyrax
     layout :decide_layout
     load_and_authorize_resource except: [:index, :show, :create], instance_name: :collection
 
+    self.theme = 'hyrax/1_column'
+
     # Renders a JSON response with a list of files in this collection
     # This is used by the edit form to populate the thumbnail_id dropdown
     def files

--- a/spec/controllers/hyrax/citations_controller_spec.rb
+++ b/spec/controllers/hyrax/citations_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::CitationsController do
         expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :work, params: { id: work }
         expect(response).to be_successful
-        expect(response).to render_template('layouts/hyrax')
+        expect(response).to render_template('layouts/hyrax/1_column')
         expect(assigns(:presenter)).to be_kind_of Hyrax::WorkShowPresenter
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe Hyrax::CitationsController do
         expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :file, params: { id: file_set }
         expect(response).to be_successful
-        expect(response).to render_template('layouts/hyrax')
+        expect(response).to render_template('layouts/hyrax/1_column')
         expect(assigns(:presenter)).to be_kind_of Hyrax::FileSetPresenter
       end
     end

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Hyrax::CollectionsController do
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :show, params: { id: collection }
         expect(response).to be_successful
+        expect(response).to render_template("layouts/hyrax/1_column")
         expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
         expect(assigns[:presenter].title).to match_array collection.title
         expect(assigns[:member_docs].map(&:id)).to match_array [asset1, asset2, asset3].map(&:id)

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Hyrax::GenericWorksController do
           expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
           get :show, params: { id: work }
           expect(response).to be_successful
-          expect(response).to render_template("layouts/hyrax")
+          expect(response).to render_template("layouts/hyrax/1_column")
         end
       end
 


### PR DESCRIPTION
Set the (overrideable) theme to be used in the work and collection controlers, and use the `hyrax/1_column` layout to pick up the controls navbar.

Fixes curationexperts/nurax#71

@samvera/hyrax-code-reviewers
