### PR TITLE
fix namespacing on changeset generation, add in a basic factory

### DIFF
--- a/app/change_sets/hyrax/dynamic_change_set.rb
+++ b/app/change_sets/hyrax/dynamic_change_set.rb
@@ -3,7 +3,7 @@
 module Hyrax
   class DynamicChangeSet
     def self.new(obj, *args)
-      "#{obj.class}ChangeSet".constantize.new(obj, *args)
+      "Hyrax::#{obj.class}ChangeSet".constantize.new(obj, *args)
     end
   end
 end


### PR DESCRIPTION
Yesterday we removed the `Hyrax::` prefix in the dynamic changeset generator, but it appears to be needed.  When you look at how the changeset is generated in the internal test app, it ends up with the Hyrax prefix.

So when adding in a factory (so that there is a GenericWorkChangeSet in the test env) you get `Hyrax::GenericWorkChangeSet`.  I added in a basic factory and fixed the namespacing.  Tests still break, but in more expected ways that I'll work on fixing.