### PR TITLE
Replace AF::Base.exists?(id) with a Hyrax service call

### DIFF
--- a/app/services/hyrax/queries.rb
+++ b/app/services/hyrax/queries.rb
@@ -5,7 +5,7 @@ module Hyrax
     class_attribute :metadata_adapter
     self.metadata_adapter = Valkyrie.config.metadata_adapter
     class << self
-      delegate :find_all, :find_all_of_model, :find_by, :find_members, :find_inverse_references_by, to: :default_adapter
+      delegate :exists?, :find_all, :find_all_of_model, :find_by, :find_members, :find_inverse_references_by, to: :default_adapter
 
       def default_adapter
         new(metadata_adapter: metadata_adapter)
@@ -16,6 +16,13 @@ module Hyrax
     delegate :find_all, :find_all_of_model, :find_by, :find_members, :find_inverse_references_by, to: :metadata_adapter_query_service
     def initialize(metadata_adapter:)
       @metadata_adapter = metadata_adapter
+    end
+
+    def exists?(id)
+      find_by(id: id)
+      return true
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      return false
     end
 
     delegate :query_service, to: :metadata_adapter, prefix: true

--- a/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Hyrax::Admin::AdminSetsController do
           expect(response).to have_http_status(:found)
           expect(response).to redirect_to(admin_admin_sets_path)
           expect(flash[:notice]).to eq "Administrative set successfully deleted"
-          expect(AdminSet.exists?(admin_set.id)).to be false
+          expect(Hyrax::Queries.exists?(admin_set.id)).to be false
         end
       end
 
@@ -168,8 +168,8 @@ RSpec.describe Hyrax::Admin::AdminSetsController do
           expect(response).to have_http_status(:found)
           expect(response).to redirect_to(admin_admin_set_path(admin_set))
           expect(flash[:alert]).to eq "Administrative set cannot be deleted as it is not empty"
-          expect(AdminSet.exists?(admin_set.id)).to be true
-          expect(GenericWork.exists?(work.id)).to be true
+          expect(Hyrax::Queries.exists?(admin_set.id)).to be true
+          expect(Hyrax::Queries.exists?(work.id)).to be true
         end
       end
 
@@ -181,7 +181,7 @@ RSpec.describe Hyrax::Admin::AdminSetsController do
           expect(response).to have_http_status(:found)
           expect(response).to redirect_to(admin_admin_set_path(admin_set))
           expect(flash[:alert]).to eq "Administrative set cannot be deleted as it is the default set"
-          expect(AdminSet.exists?(admin_set.id)).to be true
+          expect(Hyrax::Queries.exists?(admin_set.id)).to be true
         end
       end
     end

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -147,9 +147,9 @@ RSpec.describe AdminSet, type: :model do
 
       it "does not delete adminset or member works" do
         expect(subject.errors.full_messages).to eq ["Administrative set cannot be deleted as it is not empty"]
-        expect(AdminSet.exists?(admin_set.id)).to be true
-        expect(GenericWork.exists?(gf1.id)).to be true
-        expect(GenericWork.exists?(gf2.id)).to be true
+        expect(Hyrax::Queries.exists?(admin_set.id)).to be true
+        expect(Hyrax::Queries.exists?(gf1.id)).to be true
+        expect(Hyrax::Queries.exists?(gf2.id)).to be true
       end
     end
 
@@ -159,7 +159,7 @@ RSpec.describe AdminSet, type: :model do
       end
 
       it "deletes the adminset" do
-        expect(AdminSet.exists?(admin_set.id)).to be false
+        expect(Hyrax::Queries.exists?(admin_set.id)).to be false
       end
     end
 
@@ -172,7 +172,7 @@ RSpec.describe AdminSet, type: :model do
 
       it "does not delete the adminset" do
         expect(admin_set.errors.full_messages).to eq ["Administrative set cannot be deleted as it is the default set"]
-        expect(AdminSet.exists?(described_class::DEFAULT_ID)).to be true
+        expect(Hyrax::Queries.exists?(described_class::DEFAULT_ID)).to be true
       end
     end
   end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Collection do
     end
 
     it "does not delete member files when deleted" do
-      expect(GenericWork.exists?(work1.id)).to be true
+      expect(Hyrax::Queries.exists?(work1.id)).to be true
     end
   end
 

--- a/spec/services/hyrax/queries_spec.rb
+++ b/spec/services/hyrax/queries_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Hyrax::Queries do
+  let(:persister)                { Valkyrie.config.metadata_adapter.persister }
+  let(:thing_that_exists)        { persister.save(resource: GenericWork.new(id: 'i_exist')) }
+  let(:thing_that_used_to_exist) { persister.delete(resource: persister.save(resource: GenericWork.new(id: 'i_used_to_exist'))) }
+
+  it 'knows the thing that exists exists' do
+    expect(described_class.exists?(thing_that_exists.id)).to be true
+  end
+
+  it 'knows the thing that used to exist does not exist' do
+    expect(described_class.exists?(thing_that_used_to_exist.id)).to be false
+  end
+
+  it 'knows the thing that does not exist does not exist' do
+    expect(described_class.exists?('i_do_not_exist')).to be false
+  end
+end


### PR DESCRIPTION
Fixes #1835 

Adds a `Hyrax::Queries.exists?(id)` method to the queries service, and changes existing references to `ActiveFedora::Base` (and descendant classes) `.exists?` to use the service instead.