### PR TITLE
Use HTTP POST to query Solr for works user can act on

### DIFF
--- a/app/services/hyrax/workflow/status_list_service.rb
+++ b/app/services/hyrax/workflow/status_list_service.rb
@@ -38,7 +38,7 @@ module Hyrax
           actionable_roles = roles_for_user
           logger.debug("Actionable roles for #{user.user_key} are #{actionable_roles}")
           return [] if actionable_roles.empty?
-          WorkRelation.new.search_with_conditions(query(actionable_roles), rows: 1000)
+          WorkRelation.new.search_with_conditions(query(actionable_roles), rows: 1000, method: :post)
         end
 
         def query(actionable_roles)

--- a/spec/services/hyrax/workflow/status_list_service_spec.rb
+++ b/spec/services/hyrax/workflow/status_list_service_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe Hyrax::Workflow::StatusListService do
         expect(results.first.to_s).to eq 'Hey dood!'
         expect(results.first.workflow_state).to eq 'initial'
       end
+
+      describe '#search_solr' do
+        let(:mock_response) { { 'response' => { 'docs' => [{}, {}, {}] } } }
+
+        it 'queries Solr via HTTP POST method' do
+          allow(ActiveFedora::SolrService).to receive(:post).and_return(mock_response)
+          allow(ActiveFedora::SolrService).to receive(:get)
+          service.send(:search_solr)
+          expect(ActiveFedora::SolrService).to have_received(:post)
+          expect(ActiveFedora::SolrService).not_to have_received(:get)
+        end
+      end
     end
 
     context "when user doesn't have roles" do


### PR DESCRIPTION
Else, clicking "Review Submissions" in the dashboard throws an exception -- `ActionView::Template::Error (RSolr::Error::Http - 414 Request-URI Too Long)` -- if the number of workflows in the system is large enough to make the GET request's query string longer than Solr can handle.

Note that this solution requires ActiveFedora 11.5.0, though this code does not break with 11.4.1; it passes an argument that AF < 11.5.0 ignores.

Fixes #1875

@samvera/hyrax-code-reviewers
