### PR TITLE
Use shared visibility labels instead of ones specific to edit collection form

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
@@ -5,13 +5,13 @@
 
   <div class="form-group">
     <label class="radio">
-      <input type="radio" id="visibility_open" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>" <% if @collection.open_access? %> checked="true"<% end %>/><strong><%= t('.open.label') %></strong> - <%= t('.open.description') %>
+      <input type="radio" id="visibility_open" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>" <% if @collection.open_access? %> checked="true"<% end %>/><strong><%= t('hyrax.visibility.open.text') %></strong> - <%= t('hyrax.visibility.open.note_html') %>
     </label>
     <label class="radio">
-      <input type="radio" id="visibility_registered" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if @collection.authenticated_only_access? %> checked="true"<% end %> /><strong><%= t('.institution.label') %></strong> - <%= t('.institution.description') %>
+      <input type="radio" id="visibility_registered" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if @collection.authenticated_only_access? %> checked="true"<% end %> /><strong><%= t('hyrax.visibility.authenticated.text', institution: institution_name) %></strong> - <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
     </label>
     <label class="radio">
-      <input type="radio" id="visibility_restricted" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE%>" <% if @collection.private_access? %> checked="true"<% end %>/><strong><%= t('.private.label') %></strong>- <%= t('.institution.description') %>
+      <input type="radio" id="visibility_restricted" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE%>" <% if @collection.private_access? %> checked="true"<% end %>/><strong><%= t('hyrax.visibility.restricted.text') %></strong>- <%= t('hyrax.visibility.restricted.note_html') %>
     </label>
   </div>
 

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -505,15 +505,6 @@ en:
             relationships:  "Relationships"
             sharing:        "Sharing"
         form_discovery:
-            open:
-              label:         "Open Access"
-              description:   "Visible to all"
-            institution:
-              label:         "Institution"
-              description:   "Restricted visibility to institution"
-            private:
-              label:         "Private"
-              description:   "Keep to myself with an option to share"
             para1: "These settings determine who is able to discover and view this collection's landing page; they do not affect the visibility of items in the collection."
             para2: "If you chose not to make this collection open access, you can still share the collection with specific users and groups using the Sharing tab."
         form_share_table:


### PR DESCRIPTION
Fixes #1813

Fixes labels for discovery tab options on collection edit form
