### PR TITLE
Test using valkyrie's shared specs

### DIFF
--- a/app/services/hyrax/queries.rb
+++ b/app/services/hyrax/queries.rb
@@ -5,7 +5,7 @@ module Hyrax
     class_attribute :metadata_adapter
     self.metadata_adapter = Valkyrie.config.metadata_adapter
     class << self
-      delegate :exists?, :find_all, :find_all_of_model, :find_by, :find_members, :find_inverse_references_by, to: :default_adapter
+      delegate :exists?, :find_all, :find_by, :find_all_of_model, :find_members, :find_references_by, :find_inverse_references_by, :find_parents, :custom_queries, to: :default_adapter
 
       def default_adapter
         new(metadata_adapter: metadata_adapter)
@@ -13,7 +13,7 @@ module Hyrax
     end
 
     attr_reader :metadata_adapter
-    delegate :find_all, :find_all_of_model, :find_by, :find_members, :find_inverse_references_by, to: :metadata_adapter_query_service
+    delegate :find_all, :custom_queries, to: :metadata_adapter_query_service
     def initialize(metadata_adapter:)
       @metadata_adapter = metadata_adapter
     end
@@ -26,5 +26,30 @@ module Hyrax
     end
 
     delegate :query_service, to: :metadata_adapter, prefix: true
+
+    # The methods below are wrapped instead of delegated so Valkyrie's shared specs will pass
+    def find_by(id:)
+      metadata_adapter_query_service.find_by(id: id)
+    end
+
+    def find_all_of_model(model:)
+      metadata_adapter_query_service.find_all_of_model(model: model)
+    end
+
+    def find_members(resource:, model: nil)
+      metadata_adapter_query_service.find_members(resource: resource, model: model)
+    end
+
+    def find_parents(resource:)
+      metadata_adapter_query_service.find_parents(resource: resource)
+    end
+
+    def find_references_by(resource:, property:)
+      metadata_adapter_query_service.find_references_by(resource: resource, property: property)
+    end
+
+    def find_inverse_references_by(resource:, property:)
+      metadata_adapter_query_service.find_inverse_references_by(resource: resource, property: property)
+    end
   end
 end

--- a/spec/services/hyrax/queries_spec.rb
+++ b/spec/services/hyrax/queries_spec.rb
@@ -1,7 +1,17 @@
+require 'valkyrie/specs/shared_specs/queries'
+
 RSpec.describe Hyrax::Queries do
-  let(:persister)                { Valkyrie.config.metadata_adapter.persister }
+  let(:adapter)                  { described_class.metadata_adapter }
+  let(:query_service)            { described_class.default_adapter }
+  let(:persister)                { adapter.persister }
   let(:thing_that_exists)        { persister.save(resource: GenericWork.new(id: 'i_exist')) }
   let(:thing_that_used_to_exist) { persister.delete(resource: persister.save(resource: GenericWork.new(id: 'i_used_to_exist'))) }
+
+  before do
+    described_class.metadata_adapter.persister.wipe!
+  end
+
+  it_behaves_like "a Valkyrie query provider"
 
   it 'knows the thing that exists exists' do
     expect(described_class.exists?(thing_that_exists.id)).to be true


### PR DESCRIPTION
Fixes #1890.

The shared specs pass right now but are bypassing Hyrax::Queries methods.  This will change when https://github.com/samvera-labs/valkyrie/pull/276 gets merged.