### PR TITLE
Use layer 0 for PDF and document derivatives

### DIFF
--- a/app/services/hyrax/file_set_derivatives_service.rb
+++ b/app/services/hyrax/file_set_derivatives_service.rb
@@ -48,15 +48,24 @@ module Hyrax
 
       def create_pdf_derivatives(filename)
         Hydra::Derivatives::PdfDerivatives.create(filename,
-                                                  outputs: [{ label: :thumbnail, format: 'jpg', size: '338x493', url: derivative_url('thumbnail') }])
+                                                  outputs: [{
+                                                    label: :thumbnail,
+                                                    format: 'jpg',
+                                                    size: '338x493',
+                                                    url: derivative_url('thumbnail'),
+                                                    layer: 0
+                                                  }])
         extract_full_text(filename, uri)
       end
 
       def create_office_document_derivatives(filename)
         Hydra::Derivatives::DocumentDerivatives.create(filename,
-                                                       outputs: [{ label: :thumbnail, format: 'jpg',
-                                                                   size: '200x150>',
-                                                                   url: derivative_url('thumbnail') }])
+                                                       outputs: [{
+                                                         label: :thumbnail, format: 'jpg',
+                                                         size: '200x150>',
+                                                         url: derivative_url('thumbnail'),
+                                                         layer: 0
+                                                       }])
         extract_full_text(filename, uri)
       end
 

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -83,11 +83,10 @@ RSpec.describe CreateDerivativesJob do
         .with(/test\.pdf/, outputs: [{ label: :thumbnail,
                                        format: 'jpg',
                                        size: '338x493',
-                                       url: String }])
+                                       url: String,
+                                       layer: 0 }])
       expect(Hydra::Derivatives::FullTextExtract).to receive(:create)
-        .with(/test\.pdf/, outputs: [{ url: RDF::URI,
-                                       container: "extracted_text" }])
-
+        .with(/test\.pdf/, outputs: [{ url: RDF::URI, container: "extracted_text" }])
       described_class.perform_now(file_set, file.id)
     end
   end


### PR DESCRIPTION
This is an innovation in place in more than one Sufia/Hyrax application downstream that makes derivatives work as expected.

I'd like to tag @kerchner, @awead, and @jenlindner to review this. Will this have unintended side effects?

Also, looking at [some other work](https://github.com/aic-collections/aicdams-lakeshore/commit/811c3b9e0d687c1e667d0bfdc3e765ac6248d7cf#diff-21fb19adf50f17aa1e5567a28fd37400) linked from the `garbled PDF derivatives` [thread](https://groups.google.com/d/topic/samvera-tech/DRTzwBG9WKg/discussion) on samvera-tech, should we look into switching from ImageMagick to GraphicsMagick by default either in (Hydra-Derivatives or Hyrax)?

@samvera/hyrax-code-reviewers
