### PR TITLE
Refactor collection permissions to work with collection id instead of collection instance

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -7,6 +7,7 @@ module Hyrax
       include Hyrax::Ability::CollectionAbility
       include Hyrax::Ability::CollectionTypeAbility
       include Hyrax::Ability::PermissionTemplateAbility
+      include Hyrax::Ability::SolrDocumentAbility
 
       class_attribute :admin_group_name, :registered_group_name
       self.admin_group_name = 'admin'
@@ -27,6 +28,7 @@ module Hyrax
                              :collection_abilities,
                              :collection_type_abilities,
                              :permission_template_abilities,
+                             :solr_document_abilities,
                              :trophy_abilities]
     end
 

--- a/app/models/concerns/hyrax/ability/admin_set_ability.rb
+++ b/app/models/concerns/hyrax/ability/admin_set_ability.rb
@@ -1,32 +1,36 @@
 module Hyrax
   module Ability
     module AdminSetAbility
-      def admin_set_abilities # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        can :manage, AdminSet if admin?
-        can :manage_any, AdminSet if admin? ||
-                                     Hyrax::Collections::PermissionsService.can_manage_any_admin_set?(ability: self)
-        can :create_any, AdminSet if admin? ||
-                                     Hyrax::CollectionTypes::PermissionsService.can_create_admin_set_collection_type?(ability: self)
-        can :view_admin_show_any, AdminSet if admin? ||
-                                              Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_admin_set?(ability: self)
+      def admin_set_abilities # rubocop:disable Metrics/MethodLength
+        if admin?
+          can :manage, AdminSet
+          can :manage_any, AdminSet
+          can :create_any, AdminSet
+          can :view_admin_show_any, AdminSet
+        else
+          can :manage_any, AdminSet if Hyrax::Collections::PermissionsService.can_manage_any_admin_set?(ability: self)
+          can :create_any, AdminSet if Hyrax::CollectionTypes::PermissionsService.can_create_admin_set_collection_type?(ability: self)
+          can :view_admin_show_any, AdminSet if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_admin_set?(ability: self)
 
-        can [:edit, :update, :destroy], AdminSet do |admin_set| # for test by solr_doc, see solr_document_ability.rb
-          test_edit(admin_set.id)
+          can [:edit, :update, :destroy], AdminSet do |admin_set| # for test by solr_doc, see solr_document_ability.rb
+            test_edit(admin_set.id)
+          end
+
+          can :deposit, AdminSet do |admin_set| # for test by solr_doc, see collection_ability.rb
+            Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: admin_set.id)
+          end
+
+          can :view_admin_show, AdminSet do |admin_set| # admin show page # for test by solr_doc, see collection_ability.rb
+            Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: admin_set.id)
+          end
+
+          # TODO: I don't think these are needed anymore since there isn't a public show page.  Should be checking :view_admin_show ability
+          can :read, AdminSet do |admin_set| # for test by solr_doc, see solr_document_ability.rb
+            test_read(admin_set.id)
+          end
         end
 
-        can :deposit, AdminSet do |admin_set| # for test by solr_doc, see collection_ability.rb
-          Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: admin_set.id)
-        end
-
-        can :view_admin_show, AdminSet do |admin_set| # admin show page # for test by solr_doc, see collection_ability.rb
-          Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: admin_set.id)
-        end
-
-        # TODO: I don't think these are needed anymore.  Should be checking :view_admin_show ability
-        can :read, AdminSet do |admin_set| # for test by solr_doc, see solr_document_ability.rb
-          test_read(admin_set.id)
-        end
-
+        # TODO: I'm not sure why this is checked with AdminSet abilities.  It was before the refactor and since I'm not sure what the connection is, I left it here.
         can :review, :submissions do
           can_review_submissions?
         end

--- a/app/models/concerns/hyrax/ability/admin_set_ability.rb
+++ b/app/models/concerns/hyrax/ability/admin_set_ability.rb
@@ -9,16 +9,21 @@ module Hyrax
                                      Hyrax::CollectionTypes::PermissionsService.can_create_admin_set_collection_type?(ability: self)
         can :view_admin_show_any, AdminSet if admin? ||
                                               Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_admin_set?(ability: self)
-        can [:edit, :update, :destroy], AdminSet do |admin_set|
+
+        can [:edit, :update, :destroy], AdminSet do |admin_set| # for test by solr_doc, see solr_document_ability.rb
           test_edit(admin_set.id)
         end
-        can :deposit, AdminSet do |admin_set|
-          Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection: admin_set)
+
+        can :deposit, AdminSet do |admin_set| # for test by solr_doc, see collection_ability.rb
+          Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: admin_set.id)
         end
-        can :view_admin_show, AdminSet do |admin_set| # admin show page
-          Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection: admin_set)
+
+        can :view_admin_show, AdminSet do |admin_set| # admin show page # for test by solr_doc, see collection_ability.rb
+          Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: admin_set.id)
         end
-        can :read, AdminSet do |admin_set| # public show page
+
+        # TODO: I don't think these are needed anymore.  Should be checking :view_admin_show ability
+        can :read, AdminSet do |admin_set| # for test by solr_doc, see solr_document_ability.rb
           test_read(admin_set.id)
         end
 

--- a/app/models/concerns/hyrax/ability/collection_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_ability.rb
@@ -1,35 +1,38 @@
 module Hyrax
   module Ability
     module CollectionAbility
-      def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
-        can :manage, Collection if admin?
-        can :manage_any, Collection if admin? ||
-                                       Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
-        can :create_any, Collection if admin? ||
-                                       Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
-        can :view_admin_show_any, Collection if admin? ||
-                                                Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_collection?(ability: self)
+      def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        if admin?
+          can :manage, Collection
+          can :manage_any, Collection
+          can :create_any, Collection
+          can :view_admin_show_any, Collection
+        else
+          can :manage_any, Collection if Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
+          can :create_any, Collection if Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
+          can :view_admin_show_any, Collection if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_collection?(ability: self)
 
-        can [:edit, :update, :destroy], Collection do |collection| # for test by solr_doc, see solr_document_ability.rb
-          test_edit(collection.id)
-        end
+          can [:edit, :update, :destroy], Collection do |collection| # for test by solr_doc, see solr_document_ability.rb
+            test_edit(collection.id)
+          end
 
-        can :deposit, Collection do |collection|
-          Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: collection.id)
-        end
-        can :deposit, ::SolrDocument do |solr_doc|
-          Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
-        end
+          can :deposit, Collection do |collection|
+            Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: collection.id)
+          end
+          can :deposit, ::SolrDocument do |solr_doc|
+            Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
+          end
 
-        can :view_admin_show, Collection do |collection| # admin show page
-          Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: collection.id)
-        end
-        can :view_admin_show, ::SolrDocument do |solr_doc| # admin show page
-          Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
-        end
+          can :view_admin_show, Collection do |collection| # admin show page
+            Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: collection.id)
+          end
+          can :view_admin_show, ::SolrDocument do |solr_doc| # admin show page
+            Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
+          end
 
-        can :read, Collection do |collection| # public show page  # for test by solr_doc, see solr_document_ability.rb
-          test_read(collection.id)
+          can :read, Collection do |collection| # public show page  # for test by solr_doc, see solr_document_ability.rb
+            test_read(collection.id)
+          end
         end
       end
     end

--- a/app/models/concerns/hyrax/ability/collection_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_ability.rb
@@ -1,7 +1,7 @@
 module Hyrax
   module Ability
     module CollectionAbility
-      def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
         can :manage, Collection if admin?
         can :manage_any, Collection if admin? ||
                                        Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
@@ -9,16 +9,26 @@ module Hyrax
                                        Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
         can :view_admin_show_any, Collection if admin? ||
                                                 Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_collection?(ability: self)
-        can [:edit, :update, :destroy], Collection do |collection|
+
+        can [:edit, :update, :destroy], Collection do |collection| # for test by solr_doc, see solr_document_ability.rb
           test_edit(collection.id)
         end
+
         can :deposit, Collection do |collection|
-          Hyrax::Collections::PermissionsService.can_deposit_in_collection?(user: current_user, collection: collection)
+          Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: collection.id)
         end
+        can :deposit, ::SolrDocument do |solr_doc|
+          Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
+        end
+
         can :view_admin_show, Collection do |collection| # admin show page
-          Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(user: current_user, collection: collection)
+          Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: collection.id)
         end
-        can :read, Collection do |collection| # public show page
+        can :view_admin_show, ::SolrDocument do |solr_doc| # admin show page
+          Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
+        end
+
+        can :read, Collection do |collection| # public show page  # for test by solr_doc, see solr_document_ability.rb
           test_read(collection.id)
         end
       end

--- a/app/models/concerns/hyrax/ability/collection_type_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_type_ability.rb
@@ -2,9 +2,13 @@ module Hyrax
   module Ability
     module CollectionTypeAbility
       def collection_type_abilities
-        can :manage, CollectionType if admin?
-        can :create_collection_of_type, CollectionType do |collection_type|
-          Hyrax::CollectionTypes::PermissionsService.can_create_collection_of_type?(user: current_user, collection_type: collection_type)
+        if admin?
+          can :manage, CollectionType
+          can :create_collection_type, CollectionType
+        else
+          can :create_collection_of_type, CollectionType do |collection_type|
+            Hyrax::CollectionTypes::PermissionsService.can_create_collection_of_type?(user: current_user, collection_type: collection_type)
+          end
         end
       end
     end

--- a/app/models/concerns/hyrax/ability/permission_template_ability.rb
+++ b/app/models/concerns/hyrax/ability/permission_template_ability.rb
@@ -2,13 +2,15 @@ module Hyrax
   module Ability
     module PermissionTemplateAbility
       def permission_template_abilities
-        can :manage, [Hyrax::PermissionTemplate, Hyrax::PermissionTemplateAccess] if admin?
-
-        can [:create, :edit, :update, :destroy], Hyrax::PermissionTemplate do |template|
-          test_edit(template.source_id)
-        end
-        can [:create, :edit, :update, :destroy], Hyrax::PermissionTemplateAccess do |access|
-          test_edit(access.permission_template.source_id)
+        if admin?
+          can :manage, [Hyrax::PermissionTemplate, Hyrax::PermissionTemplateAccess]
+        else
+          can [:create, :edit, :update, :destroy], Hyrax::PermissionTemplate do |template|
+            test_edit(template.source_id)
+          end
+          can [:create, :edit, :update, :destroy], Hyrax::PermissionTemplateAccess do |access|
+            test_edit(access.permission_template.source_id)
+          end
         end
       end
     end

--- a/app/models/concerns/hyrax/ability/solr_document_ability.rb
+++ b/app/models/concerns/hyrax/ability/solr_document_ability.rb
@@ -1,0 +1,18 @@
+module Hyrax
+  module Ability
+    module SolrDocumentAbility
+      def solr_document_abilities
+        if admin?
+          can [:manage], ::SolrDocument
+        else
+          can [:edit, :update, :destroy], ::SolrDocument do |solr_doc|
+            test_edit(solr_doc.id)
+          end
+          can :read, ::SolrDocument do |solr_doc|
+            test_read(solr_doc.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -238,45 +238,45 @@ module Hyrax
       #
       # Determine if the given user has permissions to deposit into the given collection
       #
-      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param collection_id [String] id of the collection we are checking permissions on
       # @param user [User] user (required if ability is nil)
       # @param ability [Ability] the ability coming from cancan ability check (default: nil) (required if user is nil)
       # @return [Boolean] true if the user has permission to deposit into the collection
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
-      def self.can_deposit_in_collection?(collection:, user: nil, ability: nil)
-        deposit_access_to_collection?(user: user, collection: collection, ability: ability) ||
-          manage_access_to_collection?(user: user, collection: collection, ability: ability)
+      def self.can_deposit_in_collection?(collection_id:, user: nil, ability: nil)
+        deposit_access_to_collection?(user: user, collection_id: collection_id, ability: ability) ||
+          manage_access_to_collection?(user: user, collection_id: collection_id, ability: ability)
       end
 
       # @api public
       #
       # Determine if the given user has permissions to view the admin show page for the collection
       #
-      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param collection_id [String] id of the collection we are checking permissions on
       # @param user [User] user (required if ability is nil)
       # @param ability [Ability] the ability coming from cancan ability check (default: nil) (required if user is nil)
       # @return [Boolean] true if the user has permission to view the admin show page for the collection
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
-      def self.can_view_admin_show_for_collection?(collection:, user: nil, ability: nil)
-        deposit_access_to_collection?(user: user, collection: collection, ability: ability) ||
-          manage_access_to_collection?(user: user, collection: collection, ability: ability) ||
-          view_access_to_collection?(user: user, collection: collection, ability: ability)
+      def self.can_view_admin_show_for_collection?(collection_id:, user: nil, ability: nil)
+        deposit_access_to_collection?(user: user, collection_id: collection_id, ability: ability) ||
+          manage_access_to_collection?(user: user, collection_id: collection_id, ability: ability) ||
+          view_access_to_collection?(user: user, collection_id: collection_id, ability: ability)
       end
 
       # @api private
       #
       # Determine if the given user has :deposit access for the given collection
       #
-      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param collection_id [String] id of the collection we are checking permissions on
       # @param user [User] user (required if ability is nil)
       # @param ability [Ability] the ability coming from cancan ability check (default: nil) (required if user is nil)
       # @return [Boolean] true if the user has :deposit access to the collection
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
-      def self.deposit_access_to_collection?(collection:, user: nil, ability: nil)
-        access_to_collection?(user: user, collection: collection, access: 'deposit', ability: ability)
+      def self.deposit_access_to_collection?(collection_id:, user: nil, ability: nil)
+        access_to_collection?(user: user, collection_id: collection_id, access: 'deposit', ability: ability)
       end
       private_class_method :deposit_access_to_collection?
 
@@ -284,14 +284,14 @@ module Hyrax
       #
       # Determine if the given user has :manage access for the given collection
       #
-      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param collection_id [String] id of the collection we are checking permissions on
       # @param user [User] user (required if ability is nil)
       # @param ability [Ability] the ability coming from cancan ability check (default: nil) (required if user is nil)
       # @return [Boolean] true if the user has :manage access to the collection
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
-      def self.manage_access_to_collection?(collection:, user: nil, ability: nil)
-        access_to_collection?(user: user, collection: collection, access: 'manage', ability: ability)
+      def self.manage_access_to_collection?(collection_id:, user: nil, ability: nil)
+        access_to_collection?(user: user, collection_id: collection_id, access: 'manage', ability: ability)
       end
       private_class_method :manage_access_to_collection?
 
@@ -299,14 +299,14 @@ module Hyrax
       #
       # Determine if the given user has :view access for the given collection
       #
-      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param collection_id [String] id of the collection we are checking permissions on
       # @param user [User] user (required if ability is nil)
       # @param ability [Ability] the ability coming from cancan ability check (default: nil) (required if user is nil)
       # @return [Boolean] true if the user has permission to view the collection
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
-      def self.view_access_to_collection?(collection:, user: nil, ability: nil)
-        access_to_collection?(user: user, collection: collection, access: 'view', ability: ability)
+      def self.view_access_to_collection?(collection_id:, user: nil, ability: nil)
+        access_to_collection?(user: user, collection_id: collection_id, access: 'view', ability: ability)
       end
       private_class_method :view_access_to_collection?
 
@@ -314,17 +314,17 @@ module Hyrax
       #
       # Determine if the given user has specified access for the given collection
       #
-      # @param collection [Hyrax::Collection] the collection we are checking permissions on
+      # @param collection_id [String] id of the collection we are checking permissions on
       # @param access [Symbol] the access level to check
       # @param user [User] user (required if ability is nil)
       # @param ability [Ability] the ability coming from cancan ability check (default: nil) (required if user is nil)
       # @return [Boolean] true if the user has permission to view the collection
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
-      def self.access_to_collection?(collection:, access:, user: nil, ability: nil)
+      def self.access_to_collection?(collection_id:, access:, user: nil, ability: nil)
         return false unless user.present? || ability.present?
-        return false unless collection
-        template = Hyrax::PermissionTemplate.find_by!(source_id: collection.id)
+        return false unless collection_id
+        template = Hyrax::PermissionTemplate.find_by!(source_id: collection_id)
         return true if ([user_id(user, ability)] & template.agent_ids_for(agent_type: 'user', access: access)).present?
         return true if (user_groups(user, ability) & template.agent_ids_for(agent_type: 'group', access: access)).present?
         false

--- a/spec/abilities/admin_set_ability_spec.rb
+++ b/spec/abilities/admin_set_ability_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'AdminSetAbility' do
 
   context 'when admin user' do
     let(:user) { FactoryGirl.create(:admin) }
+    let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
 
     it 'allows all abilities' do # rubocop:disable RSpec/ExampleLength
       is_expected.to be_able_to(:manage, AdminSet)
@@ -24,16 +25,23 @@ RSpec.describe 'AdminSetAbility' do
       is_expected.to be_able_to(:create_any, AdminSet)
       is_expected.to be_able_to(:view_admin_show_any, AdminSet)
       is_expected.to be_able_to(:edit, admin_set)
+      is_expected.to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.to be_able_to(:update, admin_set)
+      is_expected.to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
       is_expected.to be_able_to(:destroy, admin_set)
+      is_expected.to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
       is_expected.to be_able_to(:deposit, admin_set)
+      is_expected.to be_able_to(:deposit, solr_document)
       is_expected.to be_able_to(:view_admin_show, admin_set)
+      is_expected.to be_able_to(:view_admin_show, solr_document)
       is_expected.to be_able_to(:read, admin_set) # admins can do everything
+      is_expected.to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
     end
   end
 
   context 'when admin set manager' do
-    let(:admin_set) { create(:admin_set, id: 'as_mu', with_permission_template: true) }
+    let!(:admin_set) { create(:admin_set, id: 'as_mu', with_permission_template: true) }
+    let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
 
     before do
       create(:permission_template_access,
@@ -44,15 +52,21 @@ RSpec.describe 'AdminSetAbility' do
       admin_set.update_access_controls!
     end
 
-    it 'allows most abilities' do
+    it 'allows most abilities' do # rubocop:disable RSpec/ExampleLength
       is_expected.to be_able_to(:manage_any, AdminSet)
       is_expected.to be_able_to(:view_admin_show_any, AdminSet)
-      is_expected.to be_able_to(:edit, admin_set)
-      is_expected.to be_able_to(:update, admin_set)
-      is_expected.to be_able_to(:destroy, admin_set)
+      is_expected.to be_able_to(:edit, admin_set) # defined in solr_document_ability.rb
+      is_expected.to be_able_to(:edit, solr_document)
+      is_expected.to be_able_to(:update, admin_set) # defined in solr_document_ability.rb
+      is_expected.to be_able_to(:update, solr_document)
+      is_expected.to be_able_to(:destroy, admin_set) # defined in solr_document_ability.rb
+      is_expected.to be_able_to(:destroy, solr_document)
       is_expected.to be_able_to(:deposit, admin_set)
+      is_expected.to be_able_to(:deposit, solr_document)
       is_expected.to be_able_to(:view_admin_show, admin_set)
+      is_expected.to be_able_to(:view_admin_show, solr_document)
       is_expected.to be_able_to(:read, admin_set) # edit access grants read and write
+      is_expected.to be_able_to(:read, solr_document) # edit access grants read and write # defined in solr_document_ability.rb
     end
 
     it 'denies manage ability' do
@@ -62,7 +76,8 @@ RSpec.describe 'AdminSetAbility' do
   end
 
   context 'when admin set depositor' do
-    let(:admin_set) { create(:admin_set, id: 'as_du', with_permission_template: true) }
+    let!(:admin_set) { create(:admin_set, id: 'as_du', with_permission_template: true) }
+    let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
 
     before do
       create(:permission_template_access,
@@ -76,22 +91,29 @@ RSpec.describe 'AdminSetAbility' do
     it 'allows deposit related abilities' do
       is_expected.to be_able_to(:view_admin_show_any, AdminSet)
       is_expected.to be_able_to(:deposit, admin_set)
+      is_expected.to be_able_to(:deposit, solr_document)
       is_expected.to be_able_to(:view_admin_show, admin_set)
+      is_expected.to be_able_to(:view_admin_show, solr_document)
     end
 
-    it 'denies non-deposit related abilities' do
+    it 'denies non-deposit related abilities' do # rubocop:disable RSpec/ExampleLength
       is_expected.not_to be_able_to(:manage, AdminSet)
       is_expected.not_to be_able_to(:manage_any, AdminSet)
       is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
       is_expected.not_to be_able_to(:edit, admin_set)
+      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:update, admin_set)
+      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:destroy, admin_set)
+      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:read, admin_set) # no public page for admin sets
+      is_expected.not_to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
     end
   end
 
   context 'when admin set viewer' do
-    let(:admin_set) { create(:admin_set, id: 'as_vu', with_permission_template: true) }
+    let!(:admin_set) { create(:admin_set, id: 'as_vu', with_permission_template: true) }
+    let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
 
     before do
       create(:permission_template_access,
@@ -107,20 +129,26 @@ RSpec.describe 'AdminSetAbility' do
       is_expected.to be_able_to(:view_admin_show, admin_set)
     end
 
-    it 'denies most abilities' do
+    it 'denies most abilities' do # rubocop:disable RSpec/ExampleLength
       is_expected.not_to be_able_to(:manage, AdminSet)
       is_expected.not_to be_able_to(:manage_any, AdminSet)
       is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
       is_expected.not_to be_able_to(:edit, admin_set)
+      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:update, admin_set)
+      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:destroy, admin_set)
+      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:deposit, admin_set)
+      is_expected.not_to be_able_to(:deposit, solr_document)
       is_expected.not_to be_able_to(:read, admin_set) # no public page for admin sets
+      is_expected.not_to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
     end
   end
 
   context 'when user has no special access' do
     let(:admin_set) { create(:admin_set, id: 'as', with_permission_template: true) }
+    let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
 
     it 'denies all abilities' do # rubocop:disable RSpec/ExampleLength
       is_expected.not_to be_able_to(:manage, AdminSet)
@@ -128,11 +156,17 @@ RSpec.describe 'AdminSetAbility' do
       is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
       is_expected.not_to be_able_to(:view_admin_show_any, AdminSet)
       is_expected.not_to be_able_to(:edit, admin_set)
+      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:update, admin_set)
+      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:destroy, admin_set)
+      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:deposit, admin_set)
+      is_expected.not_to be_able_to(:deposit, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:view_admin_show, admin_set)
+      is_expected.not_to be_able_to(:view_admin_show, solr_document)
       is_expected.not_to be_able_to(:read, admin_set) # no public page for admin sets
+      is_expected.not_to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
     end
   end
 end

--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe 'CollectionAbility' do
 
   context 'when admin user' do
     let(:user) { FactoryGirl.create(:admin) }
-    let!(:collection) { create(:collection, id: 'as_au', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { create(:collection, id: 'col_au', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     it 'allows all abilities' do # rubocop:disable RSpec/ExampleLength
       is_expected.to be_able_to(:manage, Collection)
@@ -18,16 +19,23 @@ RSpec.describe 'CollectionAbility' do
       is_expected.to be_able_to(:create_any, Collection)
       is_expected.to be_able_to(:view_admin_show_any, Collection)
       is_expected.to be_able_to(:edit, collection)
+      is_expected.to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.to be_able_to(:update, collection)
+      is_expected.to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
       is_expected.to be_able_to(:destroy, collection)
+      is_expected.to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
       is_expected.to be_able_to(:deposit, collection)
+      is_expected.to be_able_to(:deposit, solr_document)
       is_expected.to be_able_to(:view_admin_show, collection)
+      is_expected.to be_able_to(:view_admin_show, solr_document)
       is_expected.to be_able_to(:read, collection)
+      is_expected.to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
     end
   end
 
   context 'when collection manager' do
-    let!(:collection) { create(:collection, id: 'as_mu', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { create(:collection, id: 'col_mu', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do
       create(:permission_template_access,
@@ -38,15 +46,21 @@ RSpec.describe 'CollectionAbility' do
       collection.update_access_controls!
     end
 
-    it 'allows most abilities' do
+    it 'allows most abilities' do # rubocop:disable RSpec/ExampleLength
       is_expected.to be_able_to(:manage_any, Collection)
       is_expected.to be_able_to(:view_admin_show_any, Collection)
       is_expected.to be_able_to(:edit, collection)
+      is_expected.to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.to be_able_to(:update, collection)
+      is_expected.to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
       is_expected.to be_able_to(:destroy, collection)
+      is_expected.to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
       is_expected.to be_able_to(:deposit, collection)
+      is_expected.to be_able_to(:deposit, solr_document)
       is_expected.to be_able_to(:view_admin_show, collection)
+      is_expected.to be_able_to(:view_admin_show, solr_document)
       is_expected.to be_able_to(:read, collection) # edit access grants read and write
+      is_expected.to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
     end
 
     it 'denies manage ability' do
@@ -55,7 +69,8 @@ RSpec.describe 'CollectionAbility' do
   end
 
   context 'when collection depositor' do
-    let!(:collection) { create(:collection, id: 'as_du', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { create(:collection, id: 'col_du', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do
       create(:permission_template_access,
@@ -69,21 +84,28 @@ RSpec.describe 'CollectionAbility' do
     it 'allows deposit related abilities' do
       is_expected.to be_able_to(:view_admin_show_any, Collection)
       is_expected.to be_able_to(:deposit, collection)
+      is_expected.to be_able_to(:deposit, solr_document)
       is_expected.to be_able_to(:view_admin_show, collection)
+      is_expected.to be_able_to(:view_admin_show, solr_document)
     end
 
-    it 'denies non-deposit related abilities' do
+    it 'denies non-deposit related abilities' do # rubocop:disable RSpec/ExampleLength
       is_expected.not_to be_able_to(:manage, Collection)
       is_expected.not_to be_able_to(:manage_any, Collection)
       is_expected.not_to be_able_to(:edit, collection)
+      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:update, collection)
+      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:destroy, collection)
+      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:read, collection)
+      is_expected.not_to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
     end
   end
 
   context 'when collection viewer' do
-    let!(:collection) { create(:collection, id: 'as_vu', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { create(:collection, id: 'col_vu', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do
       create(:permission_template_access,
@@ -97,32 +119,45 @@ RSpec.describe 'CollectionAbility' do
     it 'allows viewing only ability' do
       is_expected.to be_able_to(:view_admin_show_any, Collection)
       is_expected.to be_able_to(:view_admin_show, collection)
+      is_expected.to be_able_to(:view_admin_show, solr_document)
       is_expected.to be_able_to(:read, collection)
+      is_expected.to be_able_to(:read, solr_document)
     end
 
-    it 'denies most abilities' do
+    it 'denies most abilities' do # rubocop:disable RSpec/ExampleLength
       is_expected.not_to be_able_to(:manage, Collection)
       is_expected.not_to be_able_to(:manage_any, Collection)
       is_expected.not_to be_able_to(:edit, collection)
+      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:update, collection)
+      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:destroy, collection)
+      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:deposit, collection)
+      is_expected.not_to be_able_to(:deposit, solr_document)
     end
   end
 
   context 'when user has no special access' do
     let!(:collection) { create(:collection, id: 'as', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
-    it 'denies all abilities' do
+    it 'denies all abilities' do # rubocop:disable RSpec/ExampleLength
       is_expected.not_to be_able_to(:manage, Collection)
       is_expected.not_to be_able_to(:manage_any, Collection)
       is_expected.not_to be_able_to(:view_admin_show_any, Collection)
       is_expected.not_to be_able_to(:edit, collection)
+      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:update, collection)
+      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:destroy, collection)
+      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:deposit, collection)
+      is_expected.not_to be_able_to(:deposit, solr_document)
       is_expected.not_to be_able_to(:view_admin_show, collection)
+      is_expected.not_to be_able_to(:view_admin_show, solr_document)
       is_expected.not_to be_able_to(:read, collection)
+      is_expected.not_to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
     end
   end
 

--- a/spec/abilities/solr_document_ability_spec.rb
+++ b/spec/abilities/solr_document_ability_spec.rb
@@ -1,0 +1,27 @@
+require 'cancan/matchers'
+
+# rubocop:disable RSpec/EmptyExampleGroup
+RSpec.describe 'SolrDocumentAbility' do
+  subject { ability }
+
+  let(:ability) { Ability.new(current_user) }
+  let(:user) { create(:user) }
+  let(:current_user) { user }
+
+  context 'with Collection solr doc' do
+    # tested with collection's solr doc in collection_ability_spec.rb
+  end
+
+  context 'with admin_set' do
+    # tested with admin_set's solr doc in admin_set_ability_spec.rb
+  end
+
+  context 'with works' do
+    # Need tests for works
+  end
+
+  context 'with files' do
+    # Need tests for files
+  end
+end
+# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/abilities/solr_document_ability_spec.rb
+++ b/spec/abilities/solr_document_ability_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe 'SolrDocumentAbility' do
   end
 
   context 'with works' do
-    # Need tests for works
+    # TODO: Need tests for works
   end
 
   context 'with files' do
-    # Need tests for files
+    # TODO: Need tests for files
   end
 end
 # rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/services/hyrax/collections/permissions_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_service_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       subject { described_class }
 
       it ".can_deposit_in_collection? returns true" do
-        expect(subject.can_deposit_in_collection?(collection: collection, user: user)).to be true
+        expect(subject.can_deposit_in_collection?(collection_id: collection.id, user: user)).to be true
       end
       it ".can_view_admin_show_for_collection? returns true" do
-        expect(subject.can_view_admin_show_for_collection?(collection: collection, user: user)).to be true
+        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, user: user)).to be true
       end
     end
 
@@ -50,10 +50,10 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       subject { described_class }
 
       it ".can_deposit_in_collection? returns true" do
-        expect(subject.can_deposit_in_collection?(collection: collection, user: user)).to be true
+        expect(subject.can_deposit_in_collection?(collection_id: collection.id, user: user)).to be true
       end
       it ".can_view_admin_show_for_collection? returns true" do
-        expect(subject.can_view_admin_show_for_collection?(collection: collection, user: user)).to be true
+        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, user: user)).to be true
       end
     end
 
@@ -70,10 +70,10 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       subject { described_class }
 
       it ".can_deposit_in_collection? returns true" do
-        expect(subject.can_deposit_in_collection?(collection: collection, user: user)).to be false
+        expect(subject.can_deposit_in_collection?(collection_id: collection.id, user: user)).to be false
       end
       it ".can_view_admin_show_for_collection? returns true" do
-        expect(subject.can_view_admin_show_for_collection?(collection: collection, user: user)).to be true
+        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, user: user)).to be true
       end
     end
 
@@ -81,10 +81,10 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       subject { described_class }
 
       it ".can_deposit_in_collection? returns true" do
-        expect(subject.can_deposit_in_collection?(collection: collection, user: user)).to be false
+        expect(subject.can_deposit_in_collection?(collection_id: collection.id, user: user)).to be false
       end
       it ".can_view_admin_show_for_collection? returns true" do
-        expect(subject.can_view_admin_show_for_collection?(collection: collection, user: user)).to be false
+        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, user: user)).to be false
       end
     end
   end

--- a/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'hyrax/file_sets/_show_actions.html.erb', type: :view do
   describe 'citations' do
     before do
       Hyrax.config.citations = citations
-      allow(controller).to receive(:can?).with(:edit, presenter).and_return(false)
+      allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
       assign(:presenter, presenter)
       view.lookup_context.view_paths.push 'app/views/hyrax/base'
       render


### PR DESCRIPTION
Fixes #1902

To avoid the need to pull collection object from Fedora when checking permissions for index and show page...
* changed permissions service for collections to take collection_id as a parameter instead of collection instance  
* added abilities for SolrDocument which is used to get the collection/admin_set id to check abilities
* grant all permissions and return immediately if user is an admin to avoid additional unnecessary additional processing