### PR TITLE
Must pass Valkyrie::ID to exists?

### DIFF
--- a/spec/services/hyrax/queries_spec.rb
+++ b/spec/services/hyrax/queries_spec.rb
@@ -22,6 +22,6 @@ RSpec.describe Hyrax::Queries do
   end
 
   it 'knows the thing that does not exist does not exist' do
-    expect(described_class.exists?('i_do_not_exist')).to be false
+    expect(described_class.exists?(Valkyrie::ID.new('i_do_not_exist'))).to be false
   end
 end


### PR DESCRIPTION
This PR updates the Hyrax::Queries tests to work with the newest Valkyrie (894e318fb3f0dc4e47c37ae9bc202fb0709f7226).