### PR TITLE
Use persisted? instead of new_record?

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -77,7 +77,7 @@ module Hyrax
       def attach_to_work(work, file_set_params = {})
         acquire_lock_for(work.id) do
           # Ensure we have an up-to-date copy of the members association, so that we append to the end of the list.
-          work.reload unless work.new_record?
+          work.reload if work.persisted?
           file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
           work.member_ids << file_set.id
           work.representative = file_set if work.representative_id.blank?

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -36,7 +36,7 @@ module Hyrax
 
       def initialize(model, current_ability, controller)
         @current_ability = current_ability
-        @agreement_accepted = !model.new_record?
+        @agreement_accepted = model.persisted?
         @controller = controller
         super(model)
       end

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -61,7 +61,7 @@ module Hyrax
     def bytes
       return 0 if member_object_ids.empty?
 
-      raise "Collection must be saved to query for bytes" if new_record?
+      raise "Collection must be saved to query for bytes" if !persisted?
 
       # One query per member_id because Solr is not a relational database
       member_object_ids.collect { |work_id| size_for_work(work_id) }.sum

--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -13,7 +13,7 @@
       <%= render 'form_visibility_error', f: f %>
     </div>
   <% end %>
-  <% if Flipflop.batch_upload? && f.object.new_record? %>
+  <% if Flipflop.batch_upload? && !f.object.persisted? %>
     <% provide :metadata_tab do %>
       <p class="switch-upload-type">To create a separate work for each of the files, go to <%= link_to "Batch upload", hyrax.new_batch_upload_path %></p>
     <% end %>

--- a/spec/views/hyrax/base/_browse_everything.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_browse_everything.html.erb_spec.rb
@@ -3,11 +3,6 @@ RSpec.describe 'hyrax/base/_browse_everything.html.erb', type: :view do
   let(:change_set) { Hyrax::GenericWorkChangeSet.new(model) }
   let(:f) { double(object: change_set) }
 
-  before do
-    # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
-    allow(model).to receive(:new_record?).and_return(false)
-  end
-
   it 'shows user timing warning' do
     render 'hyrax/base/browse_everything', f: f
     page = Capybara::Node::Simple.new(rendered)

--- a/spec/views/hyrax/base/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form.html.erb_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
   before do
     allow(Hyrax::AdminSetOptionsPresenter).to receive(:new).and_return(options_presenter)
     stub_template('hyrax/base/_form_progress.html.erb' => 'Progress')
-    # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
-    allow(work).to receive(:new_record?).and_return(true)
     allow(work).to receive(:member_ids).and_return([1, 2])
     allow(view).to receive(:curation_concern).and_return(work)
     allow(controller).to receive(:current_user).and_return(stub_model(User))

--- a/spec/views/hyrax/base/_form_child_work_relationships.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_child_work_relationships.html.erb_spec.rb
@@ -19,9 +19,6 @@ RSpec.describe "hyrax/base/_form_child_work_relationships.html.erb", type: :view
   end
 
   before do
-    # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
-    allow(work).to receive(:new_record?).and_return(false)
-
     allow(view).to receive(:params).and_return(id: work.id)
     allow(view).to receive(:curation_concern).and_return(work)
     allow(view).to receive(:f).and_return(f)

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -102,8 +102,6 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
 
   context "when the work has been saved before" do
     before do
-      # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
-      allow(work).to receive(:new_record?).and_return(false)
       assign(:change_set, change_set)
       allow(Hyrax.config).to receive(:active_deposit_agreement_acceptance)
         .and_return(true)

--- a/spec/views/hyrax/base/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/base/edit.html.erb_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe 'hyrax/base/edit.html.erb', type: :view do
   end
 
   before do
-    # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
-    allow(work).to receive(:new_record?).and_return(false)
     allow(view).to receive(:curation_concern).and_return(work)
     allow(controller).to receive(:current_user).and_return(stub_model(User))
     assign(:change_set, change_set)

--- a/spec/views/hyrax/batch_edits/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/batch_edits/edit.html.erb_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe 'hyrax/batch_edits/edit.html.erb', type: :view do
 
   before do
     allow(ActiveFedora::Base).to receive(:find).and_return(generic_work)
-    # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
-    allow(generic_work).to receive(:new_record?).and_return(false)
     # this prevents AF from hitting Fedora (permissions is a related object)
     allow(generic_work).to receive(:permissions_attributes=)
     allow(controller).to receive(:current_user).and_return(stub_model(User))


### PR DESCRIPTION
Closes #1834.  This is all of the AF::Base#new_record? references so I felt it was easiest to switch them to `!persisted?` instead of implementing `new_record?`.