### PR TITLE
Pull identifiecation helper methods in from hydra-works

### DIFF
--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -42,6 +42,21 @@ module Hyrax
       title.present? ? title.join(' | ') : 'No Title'
     end
 
+    # @return [Boolean] whether this instance is a Hydra::Works Collection.
+    def collection?
+      true
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Generic Work.
+    def work?
+      false
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works::FileSet.
+    def file_set?
+      false
+    end
+
     module ClassMethods
       # This governs which partial to draw when you render this type of object
       def _to_partial_path #:nodoc:

--- a/app/models/concerns/hyrax/file_set_behavior.rb
+++ b/app/models/concerns/hyrax/file_set_behavior.rb
@@ -37,5 +37,20 @@ module Hyrax
     def to_presenter
       CatalogController.new.fetch(id).last
     end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Collection.
+    def collection?
+      false
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Generic Work.
+    def work?
+      false
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works::FileSet.
+    def file_set?
+      true
+    end
   end
 end

--- a/app/models/concerns/hyrax/work_behavior.rb
+++ b/app/models/concerns/hyrax/work_behavior.rb
@@ -40,6 +40,21 @@ module Hyrax
       ldp_source.head.etag
     end
 
+    # @return [Boolean] whether this instance is a Hydra::Works Collection.
+    def collection?
+      false
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works Generic Work.
+    def work?
+      true
+    end
+
+    # @return [Boolean] whether this instance is a Hydra::Works::FileSet.
+    def file_set?
+      false
+    end
+
     module ClassMethods
       # This governs which partial to draw when you render this type of object
       def _to_partial_path #:nodoc:


### PR DESCRIPTION
These methods allow for easy differentiation between works/file_sets/collections especially when they have been subclassed like curation concerns.  These were in hydra-works but since we're not including hydra-works anymore, I've included these here.