### PR TITLE
Rely on FilterByType filter_models

### DIFF
--- a/app/search_builders/hyrax/deposit_search_builder.rb
+++ b/app/search_builders/hyrax/deposit_search_builder.rb
@@ -12,9 +12,6 @@ module Hyrax
       # the number of users in the database
       solr_parameters[:"facet.limit"] = ::User.count
 
-      # only get work information
-      solr_parameters[:fq] = Hyrax::WorkRelation.new.search_model_clause
-
       # we only want the facte counts not the actual data
       solr_parameters[:rows] = 0
     end
@@ -22,5 +19,11 @@ module Hyrax
     def self.depositor_field
       @depositor_field ||= Solrizer.solr_name('depositor', :symbol).freeze
     end
+
+    private
+
+      def only_works?
+        true
+      end
   end
 end

--- a/app/search_builders/hyrax/stats/work_status_search_builder.rb
+++ b/app/search_builders/hyrax/stats/work_status_search_builder.rb
@@ -1,7 +1,8 @@
 module Hyrax
   module Stats
     class WorkStatusSearchBuilder < ::SearchBuilder
-      self.default_processor_chain = [:include_suppressed_facet]
+      self.default_processor_chain = [:include_suppressed_facet, :filter_models]
+
       # includes the suppressed facet to get information on deposits.
       # use caution when combining this with other searches as it sets the rows to
       # zero to just get the facet information
@@ -9,8 +10,6 @@ module Hyrax
       def include_suppressed_facet(solr_parameters)
         solr_parameters[:"facet.field"].concat([IndexesWorkflow.suppressed_field])
         solr_parameters[:'facet.missing'] = true
-        # only get work information
-        solr_parameters[:fq] = work_relation.search_model_clause
 
         # we only want the facet counts not the actual data
         solr_parameters[:rows] = 0
@@ -18,8 +17,8 @@ module Hyrax
 
       private
 
-        def work_relation
-          Hyrax::WorkRelation.new
+        def only_works?
+          true
         end
     end
   end

--- a/spec/search_builders/hyrax/stats/work_status_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/stats/work_status_search_builder_spec.rb
@@ -11,20 +11,15 @@ RSpec.describe Hyrax::Stats::WorkStatusSearchBuilder do
   describe "#query" do
     subject { instance.query }
 
-    let(:stub_relation) do
-      instance_double(Hyrax::WorkRelation,
-                      search_model_clause: "(model clauses)")
-    end
-
     before do
-      # Prevent the stub relation from returning different filters depending on
+      # Prevent the search builder from returning different filters depending on
       # how many models have been generated
-      allow(instance).to receive(:work_relation).and_return(stub_relation)
+      allow_any_instance_of(Hyrax::FilterByType).to receive(:models_to_solr_clause).and_return("(model clauses)")
     end
 
     it "sets required parameters" do
       expect(subject['facet.field']).to eq ["suppressed_bsi"]
-      expect(subject['fq']).to eq "(model clauses)"
+      expect(subject['fq']).to eq ["{!terms f=internal_resource_ssim}(model clauses)"]
       expect(subject['facet.missing']).to eq true
       expect(subject['rows']).to eq 0
     end


### PR DESCRIPTION
These follow the pattern of other search builders of overriding `only_works?` to enable filtering to works.