### PR TITLE
The FileSet factory only takes an uploaded file now

### DIFF
--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
   let(:file_path)     { File.join(fixture_path, 'world.png') }
   let(:file)          { fixture_file_upload(file_path, 'image/png') } # we will override for the different types of File objects
   let(:local_file)    { File.open(file_path) }
-  let(:file_set)      { create_for_repository(:file_set, content: local_file) }
+  let(:file_set)      { create_for_repository(:file_set, content: fixture_file_upload(file_path, 'image/png')) }
   let(:actor)         { described_class.new(file_set, user) }
   let(:relation)      { :original_file }
   let(:file_actor)    { Hyrax::Actors::FileActor.new(file_set, relation, user) }


### PR DESCRIPTION
This avoids this error:
```
NoMethodError:
        undefined method `original_filename' for #<File:0x00007fa41e1150c0>
      # ./spec/factories/file_sets.rb:14:in `block (3 levels) in <top (required)>'
      # ./spec/support/features/create_strategy_for_repository_pattern.rb:20:in `block in result'
      # ./spec/support/features/create_strategy_for_repository_pattern.rb:16:in `tap'
      # ./spec/support/features/create_strategy_for_repository_pattern.rb:16:in `result'
```