### PR TITLE
add fedora_schema

### DIFF
--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -97,6 +97,12 @@ Hyrax.config do |config|
   # Stream realtime notifications to users in the browser
   # config.realtime_notifications = true
 
+  # Configure the fedora_schema
+  # Add new or change existing predicates with
+  #   config.fedora_schema[:new_predicate] = RDF::URI.new('http://www.example.com/new_predicate')
+  # Replace the whole thing with
+  #   config.fedora_schema = { }
+
   # Register new linked_data_resource classes; used to define special behavior for retrieving a label from an
   #   external service for the given attribute.
   #   @example :based_near is already registerd to use Hyrax::LinkedDataResources::GeonamesResource

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -25,6 +25,7 @@ module Hyrax
     autoload :Arkivo
     autoload :Collections
     autoload :Configuration
+    autoload :FedoraSchema
     autoload :LinkedDataResourceFactory
     autoload :LinkedDataResources
     autoload :RedisEventStore

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -415,12 +415,7 @@ module Hyrax
                     end
     end
 
-    attr_writer :fedora_schema
-    def fedora_schema
-      @fedora_schema ||= {
-        depositor: RDF::URI("http://id.loc.gov/vocabulary/relators/dpt")
-      }
-    end
+    delegate :fedora_schema, :fedora_schema=, to: Hyrax::FedoraSchema
 
     private
 

--- a/lib/hyrax/fedora_schema.rb
+++ b/lib/hyrax/fedora_schema.rb
@@ -1,0 +1,47 @@
+module Hyrax
+  class FedoraSchema
+    class_attribute :fedora_schema
+
+    self.fedora_schema = {
+      # basic metadata
+      label: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, # AF alert!
+      relative_path: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#relativePath'),
+      import_url: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#importUrl'),
+      based_near: ::RDF::Vocab::FOAF.based_near,
+      creator: ::RDF::Vocab::DC11.creator,
+      contributor: ::RDF::Vocab::DC11.contributor,
+      date_created: ::RDF::Vocab::DC.created,
+      description: ::RDF::Vocab::DC11.description,
+      keyword: ::RDF::Vocab::SCHEMA.keywords, # fixes #1505
+      identifer: ::RDF::Vocab::DC.identifier,
+      language: ::RDF::Vocab::DC11.language,
+      license: ::RDF::Vocab::DC.rights,
+      publisher: ::RDF::Vocab::DC11.publisher,
+      related_url: ::RDF::Vocab::RDFS.seeAlso,
+      resource_type: ::RDF::Vocab::DC11.type,
+      rights_statement: ::RDF::Vocab::EDM.rights,
+      subject: ::RDF::Vocab::DC11.subject,
+      bibliographic_citation: ::RDF::Vocab::DC.bibliographicCitation,
+      source: ::RDF::Vocab::DC.source,
+      # core metadata
+      date_modified: ::RDF::Vocab::DC.modified,
+      date_uploaded: ::RDF::Vocab::DC.dateSubmitted,
+      depositor: ::RDF::Vocab::MARCRelators.dpt,
+      title: ::RDF::Vocab::DC.title,
+      # representative
+      representative_id: ::RDF::Vocab::EBUCore.hasRelatedMediaFragment,
+      thumbnail_id: ::RDF::Vocab::EBUCore.hasRelatedImage,
+      # admin_set
+      admin_set_id: Hyrax.config.admin_set_predicate,
+      # arkivo_checksum
+      arkivo_checksum: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#arkivoChecksum'),
+      # proxy_deposit
+      proxy_depositor: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#proxyDepositor'),
+      on_behalf_of: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#onBehalfOf'),
+      # suppressible
+      state: Vocab::FedoraResourceStatus.objState,
+      # work_behaviour
+      owner: RDF::URI.new('http://opaquenamespace.org/ns/hydra/owner')
+    }
+  end
+end

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe Hyrax::Configuration do
     it { is_expected.to eq('default') }
   end
 
+  describe "fedora_schema" do
+    subject { described_class.new.fedora_schema[:title] }
+
+    it { is_expected.to eq RDF::Vocab::DC.title }
+  end
+
   it { is_expected.to respond_to(:active_deposit_agreement_acceptance?) }
   it { is_expected.to respond_to(:active_deposit_agreement_acceptance=) }
   it { is_expected.to respond_to(:activity_to_show_default_seconds_since_now) }
@@ -40,6 +46,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:display_share_button_when_not_logged_in=) }
   it { is_expected.to respond_to(:enable_noids?) }
   it { is_expected.to respond_to(:feature_config_path) }
+  it { is_expected.to respond_to(:fedora_schema) }
+  it { is_expected.to respond_to(:fedora_schema=) }
   it { is_expected.to respond_to(:google_analytics_id?) }
   it { is_expected.to respond_to(:google_analytics_id) }
   it { is_expected.to respond_to(:libreoffice_path) }


### PR DESCRIPTION
Added fedora_schema for core_metadata, basic_metadata and a handful of other predicates scattered throughout Hyrax.

Added it to a separate class for readability.

Question: should I test these go into Fedora, or not?