### PR TITLE
Merge master into collections-sprint

### DIFF
--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -1,6 +1,10 @@
 module Hyrax
   module Actors
-    # Attaches remote files to the work
+    # If there is a key `:remote_files' in the attributes, it attaches the files at the specified URIs
+    # to the work. e.g.:
+    #     attributes[:remote_files] = filenames.map do |name|
+    #       { url: "https://example.com/file/#{name}", file_name: name }
+    #     end
     class CreateWithRemoteFilesActor < Hyrax::Actors::AbstractActor
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if create was successful

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -6,13 +6,13 @@ module Hyrax
 
     included do
       layout :decide_layout
-
       copy_blacklight_config_from(::CatalogController)
 
       class_attribute :_curation_concern_type, :show_presenter, :work_form_service, :search_builder_class
       self.show_presenter = Hyrax::WorkShowPresenter
       self.work_form_service = Hyrax::WorkFormService
       self.search_builder_class = WorkSearchBuilder
+      self.theme = 'hyrax/1_column'
       attr_accessor :curation_concern
       helper_method :curation_concern, :contextual_path
 

--- a/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
+++ b/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
@@ -6,7 +6,7 @@ module Hyrax
       def destroy
         ActiveRecord::Base.transaction do
           @permission_template_access.destroy
-          update_access(manage_changed: @permission_template_access.manage?)
+          remove_access!
         end
 
         if @permission_template_access.destroyed?
@@ -53,6 +53,11 @@ module Hyrax
 
         def source_type
           Hyrax::PermissionTemplate.find(@permission_template_access.permission_template_id).source_type
+        end
+
+        def remove_access!
+          Forms::PermissionTemplateForm.new(@permission_template_access.permission_template)
+                                       .remove_access!(@permission_template_access)
         end
     end
   end

--- a/app/controllers/hyrax/collections_controller.rb
+++ b/app/controllers/hyrax/collections_controller.rb
@@ -5,6 +5,8 @@ module Hyrax
     layout :decide_layout
     load_and_authorize_resource except: [:index, :show, :create], instance_name: :collection
 
+    self.theme = 'hyrax/1_column'
+
     # Renders a JSON response with a list of files in this collection
     # This is used by the edit form to populate the thumbnail_id dropdown
     def files

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -68,7 +68,7 @@ module Hyrax
       # the WorkflowResponsibilities of the active workflow if this is an Admin Set
       def update_access(remove_agent: false)
         update_access_controls!
-        update_workflow_approving_responsibilities(remove_agent) if source_model.is_a?(AdminSet)
+        update_workflow_responsibilities(remove_agent: remove_agent) if source_model.is_a?(AdminSet)
       end
 
       def remove_access!(permission_template_access)

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -21,6 +21,9 @@ module Hyrax
       # Stores the selected
       attr_writer :workflow_id
 
+      # Adding attributes hash to state to avoid having to pass it around
+      attr_accessor :attributes
+
       def workflow_id
         @workflow_id || active_workflow.try(:id)
       end
@@ -42,53 +45,110 @@ module Hyrax
       # @return [Hash{Symbol => String, Boolean}] { :content_tab (for confirmation message),
       #                                             :updated (true/false),
       #                                               :error_code (for flash error lookup) }
+      # rubocop:disable Metrics/MethodLength
       def update(attributes)
-        return_info = { content_tab: tab_to_update(attributes) }
+        @attributes = attributes
+        return_info = { content_tab: tab_to_update }
         error_code = nil
         case return_info[:content_tab]
         when "participants"
-          update_participants_options(attributes)
+          update_participants_options
         when "visibility"
-          error_code = update_visibility_options(attributes)
+          error_code = update_visibility_options
         when "workflow"
-          grant_workflow_roles(attributes)
+          grant_workflow_roles
         end
         return_info[:error_code] = error_code if error_code
         return_info[:updated] = error_code ? false : true
         return_info
       end
+      # rubocop:enable Metrics/MethodLength
 
-      # If management roles have been granted or removed, then copy this access
-      # to the edit permissions of the AdminSet and to the WorkflowResponsibilities
-      # of the active workflow
-      def update_access(manage_changed:)
-        update_access_controls! # recalculate access controls for all participants
-        return unless manage_changed
-        update_workflow_approving_responsibilities if source_model.is_a?(AdminSet)
+      # Copy this access to the edit permissions of the Admin Set or Collection and to
+      # the WorkflowResponsibilities of the active workflow if this is an Admin Set
+      def update_access(remove_agent: false)
+        update_access_controls!
+        update_workflow_approving_responsibilities(remove_agent) if source_model.is_a?(AdminSet)
+      end
+
+      def remove_access!(permission_template_access)
+        construct_attributes_from_template_access!(permission_template_access)
+        update_access(remove_agent: true)
       end
 
       private
 
         # @return [String]
-        def tab_to_update(attributes)
+        def tab_to_update
           return "participants" if attributes[:access_grants_attributes].present?
           return "workflow" if attributes[:workflow_id].present?
           return "visibility" if attributes.key?(:visibility)
         end
 
+        # This method is used to build the attributes that this class
+        # relies on using the passed-in PermissionTemplateAccess
+        # instance. This allows the class to use the same methods for
+        # granting access (when a new Admin Set manager is added, for
+        # instance), when called via #update, for revoking access as
+        # well when called via #remove_access!
+        #
         # @return [Void]
-        def update_participants_options(attributes)
-          update_permission_template(attributes)
-          update_access(manage_changed: managers_updated?(attributes))
+        def construct_attributes_from_template_access!(permission_template_access)
+          @attributes = {
+            access_grants_attributes: {
+              "0" => {
+                access: permission_template_access.access,
+                agent_type: permission_template_access.agent_type,
+                agent_id: permission_template_access.agent_id
+              }
+            }
+          }
         end
 
-        # Grant workflow approve roles for any admin set managers
-        # and revoke the approving role for non-managers
-        def update_workflow_approving_responsibilities
-          return unless active_workflow
-          approving_role = Sipity::Role.find_by_name('approving')
-          return unless approving_role
-          active_workflow.update_responsibilities(role: approving_role, agents: manager_agents)
+        # @return [Void]
+        def update_participants_options
+          update_permission_template
+          update_access(remove_agent: false)
+        end
+
+        # Grant workflow approve roles for any admin set managers based on access specified
+        def update_workflow_responsibilities(remove_agent: false)
+          return unless available_workflows
+          roles = roles_for_agent
+          return if roles.none?
+          agents = remove_agent ? manager_agents - agents_from_attributes : manager_agents + agents_from_attributes
+          available_workflows.each do |workflow|
+            roles.each do |role|
+              workflow.update_responsibilities(role: role, agents: agents)
+            end
+          end
+        end
+
+        def roles_for_agent
+          roles = []
+          grants_as_collection.each do |grant|
+            case grant[:access]
+            when Hyrax::PermissionTemplateAccess::DEPOSIT
+              roles << Sipity::Role.find_by(name: Hyrax::RoleRegistry::DEPOSITING)
+            when Hyrax::PermissionTemplateAccess::MANAGE
+              roles += Sipity::Role.where(name: Hyrax::RoleRegistry.new.role_names)
+              # TODO: Figure out what to do here
+              # when Hyrax::PermissionTemplateAccess::VIEW
+            end
+          end
+          roles.uniq
+        end
+
+        # @return [Array<Sipity::Agent>] a list sipity agents extracted from attrs
+        def agents_from_attributes
+          grants_as_collection.map do |grant|
+            agent = if grant[:agent_type] == 'user'
+                      ::User.find_by_user_key(grant[:agent_id])
+                    else
+                      Hyrax::Group.new(grant[:agent_id])
+                    end
+            PowerConverter.convert_to_sipity_agent(agent)
+          end
         end
 
         # @return [Array<Sipity::Agent>] a list of sipity agents corresponding to the manager role of the permission_template
@@ -107,17 +167,17 @@ module Hyrax
 
         # @return [Array<PermissionTemplateAccess>] a list of grants corresponding to the manager role of the permission_template
         def manager_grants
-          model.access_grants.where(access: 'manage'.freeze)
+          model.access_grants.where(access: Hyrax::PermissionTemplateAccess::MANAGE)
         end
 
         # @return [String, Nil] error_code if validation fails, nil otherwise
-        def update_visibility_options(attributes)
-          error_code = validate_visibility_combinations(attributes)
+        def update_visibility_options
+          error_code = validate_visibility_combinations
           return error_code if error_code
-          update_permission_template(attributes)
+          update_permission_template
         end
 
-        def activate_workflow_from(attributes)
+        def activate_workflow_from_attributes
           new_active_workflow_id = attributes[:workflow_id] || attributes['workflow_id']
           if active_workflow
             return active_workflow if new_active_workflow_id.to_s == active_workflow.id.to_s
@@ -131,28 +191,29 @@ module Hyrax
         # have all the roles for the new workflow
         # @return [Void]
         # @todo Instead of granting the manage users all of the roles (which means lots of emails), can we agree on a Managing role that all workflows should have?
-        def grant_workflow_roles(attributes)
-          new_active_workflow = activate_workflow_from(attributes)
+        def grant_workflow_roles
+          new_active_workflow = activate_workflow_from_attributes
           return unless new_active_workflow
           manager_agents.each do |agent|
-            active_workflow.workflow_roles.each do |role|
-              Sipity::WorkflowResponsibility.find_or_create_by!(workflow_role: role, agent: agent)
+            active_workflow.workflow_roles.each do |workflow_role|
+              new_workflow_role = Sipity::WorkflowRole.find_or_create_by!(workflow: new_active_workflow, role: workflow_role.role)
+              Sipity::WorkflowResponsibility.find_or_create_by!(workflow_role: new_workflow_role, agent: agent)
             end
           end
         end
 
         # @return [Nil]
-        def update_permission_template(attributes)
-          model.update(permission_template_update_params(attributes))
+        def update_permission_template
+          model.update(permission_template_update_params)
           nil
         end
 
-        def managers_updated?(attributes)
-          grants_as_collection(attributes).any? { |x| x[:access] == 'manage' }
+        def managers_updated?
+          grants_as_collection.any? { |x| x[:access] == Hyrax::PermissionTemplateAccess::MANAGE }
         end
 
         # This allows the attributes
-        def grants_as_collection(attributes)
+        def grants_as_collection
           return [] unless attributes[:access_grants_attributes]
           attributes_collection = attributes[:access_grants_attributes]
           if attributes_collection.respond_to?(:permitted?)
@@ -188,36 +249,36 @@ module Hyrax
         # @return [Hash] attributes used to update the model
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity
-        def permission_template_update_params(raw_attributes)
-          attributes = raw_attributes.except(:release_varies, :release_embargo)
+        def permission_template_update_params
+          filtered_attributes = attributes.except(:release_varies, :release_embargo)
           # If 'varies' before date option selected, then set release_period='before' and save release_date as-is
-          if raw_attributes[:release_varies] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE
-            attributes[:release_period] = Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE
+          if attributes[:release_varies] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE
+            filtered_attributes[:release_period] = Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE
           # Else if 'varies' + embargo selected, save embargo as the release_period
-          elsif raw_attributes[:release_varies] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_EMBARGO &&
-                raw_attributes[:release_embargo]
-            attributes[:release_period] = raw_attributes[:release_embargo]
+          elsif attributes[:release_varies] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_EMBARGO &&
+                attributes[:release_embargo]
+            filtered_attributes[:release_period] = attributes[:release_embargo]
             # In an embargo, the release_date should be unspecified as it is based on deposit date
-            attributes[:release_date] = nil
+            filtered_attributes[:release_date] = nil
           end
 
-          if attributes[:release_period] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY || (attributes[:release_period].blank? && raw_attributes[:release_varies].blank?)
+          if filtered_attributes[:release_period] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY || (filtered_attributes[:release_period].blank? && attributes[:release_varies].blank?)
             # If release is "no delay" or is "varies" and "allow depositor to decide",
             # then a release_date should never be allowed/specified
-            attributes[:release_date] = nil
+            filtered_attributes[:release_date] = nil
           end
 
-          attributes
+          filtered_attributes
         end
         # rubocop:enable Metrics/CyclomaticComplexity
         # rubocop:enable Metrics/PerceivedComplexity
 
         # validate the hash of attributes used to update the visibility tab of the model
-        # @param [Hash] attributes
         # @return [String, Nil] the error code if invalid, nil if valid
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity
-        def validate_visibility_combinations(attributes)
+        # rubocop:disable Metrics/AbcSize
+        def validate_visibility_combinations
           return unless attributes.key?(:visibility) # only the visibility tab has validations
 
           # if "save" without any selections - none of the attributes are present
@@ -234,6 +295,7 @@ module Hyrax
         end
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/app/jobs/ingest_local_file_job.rb
+++ b/app/jobs/ingest_local_file_job.rb
@@ -10,7 +10,6 @@ class IngestLocalFileJob < Hyrax::ApplicationJob
     actor = Hyrax::Actors::FileSetActor.new(file_set, user)
 
     if actor.create_content(File.open(path))
-      FileUtils.rm(path)
       Hyrax.config.callback.run(:after_import_local_file_success, file_set, user, path)
     else
       Hyrax.config.callback.run(:after_import_local_file_failure, file_set, user, path)

--- a/app/search_builders/hyrax/deposit_search_builder.rb
+++ b/app/search_builders/hyrax/deposit_search_builder.rb
@@ -12,9 +12,6 @@ module Hyrax
       # the number of users in the database
       solr_parameters[:"facet.limit"] = ::User.count
 
-      # only get work information
-      solr_parameters[:fq] = Hyrax::WorkRelation.new.search_model_clause
-
       # we only want the facte counts not the actual data
       solr_parameters[:rows] = 0
     end
@@ -22,5 +19,11 @@ module Hyrax
     def self.depositor_field
       @depositor_field ||= Solrizer.solr_name('depositor', :symbol).freeze
     end
+
+    private
+
+      def only_works?
+        true
+      end
   end
 end

--- a/app/search_builders/hyrax/stats/work_status_search_builder.rb
+++ b/app/search_builders/hyrax/stats/work_status_search_builder.rb
@@ -1,7 +1,8 @@
 module Hyrax
   module Stats
     class WorkStatusSearchBuilder < ::SearchBuilder
-      self.default_processor_chain = [:include_suppressed_facet]
+      self.default_processor_chain = [:include_suppressed_facet, :filter_models]
+
       # includes the suppressed facet to get information on deposits.
       # use caution when combining this with other searches as it sets the rows to
       # zero to just get the facet information
@@ -9,8 +10,6 @@ module Hyrax
       def include_suppressed_facet(solr_parameters)
         solr_parameters[:"facet.field"].concat([IndexesWorkflow.suppressed_field])
         solr_parameters[:'facet.missing'] = true
-        # only get work information
-        solr_parameters[:fq] = work_relation.search_model_clause
 
         # we only want the facet counts not the actual data
         solr_parameters[:rows] = 0
@@ -18,8 +17,8 @@ module Hyrax
 
       private
 
-        def work_relation
-          Hyrax::WorkRelation.new
+        def only_works?
+          true
         end
     end
   end

--- a/app/services/hyrax/statistics/depositors/summary.rb
+++ b/app/services/hyrax/statistics/depositors/summary.rb
@@ -46,7 +46,7 @@ module Hyrax
           end
 
           def search_builder
-            DepositSearchBuilder.new([:include_depositor_facet], self)
+            DepositSearchBuilder.new([:include_depositor_facet, :filter_models], self)
           end
 
           # TODO: This can probably be pushed into the DepositSearchBuilder

--- a/app/services/hyrax/workflow/abstract_notification.rb
+++ b/app/services/hyrax/workflow/abstract_notification.rb
@@ -41,7 +41,8 @@ module Hyrax
         @work_id = entity.proxy_for_global_id.sub(/.*\//, '')
         @title = entity.proxy_for.title.first
         @comment = comment.respond_to?(:comment) ? comment.comment.to_s : ''
-        @recipients = recipients
+        # Convert to hash with indifferent access to allow both string and symbol keys
+        @recipients = recipients.with_indifferent_access
         @user = user
         @entity = entity
       end
@@ -73,7 +74,7 @@ module Hyrax
         end
 
         def users_to_notify
-          recipients.fetch('to', []) + recipients.fetch('cc', [])
+          recipients.fetch(:to, []) + recipients.fetch(:cc, [])
         end
     end
   end

--- a/app/services/hyrax/workflow/notification_service.rb
+++ b/app/services/hyrax/workflow/notification_service.rb
@@ -48,18 +48,9 @@ module Hyrax
       # @return [Hash<String, Array>] a hash with keys being the strategy (e.g. "to", "cc") and
       #                               the values are a list of users.
       def recipients(notification)
-        case entity.workflow_state.name
-        when 'pending_review'
-          # notify the managers to review the deposit (CC depositors)
-          {
-            to: entity.workflow.permission_template.agent_ids_for(access: 'manage',  agent_type: 'user'),
-            cc: entity.workflow.permission_template.agent_ids_for(access: 'deposit', agent_type: 'user')
-          }
-        else
-          notification.recipients.each_with_object({}) do |r, h|
-            h[r.recipient_strategy] ||= []
-            h[r.recipient_strategy] += PermissionQuery.scope_users_for_entity_and_roles(entity: entity, roles: r.role)
-          end
+        notification.recipients.each_with_object({}) do |r, h|
+          h[r.recipient_strategy] ||= []
+          h[r.recipient_strategy] += PermissionQuery.scope_users_for_entity_and_roles(entity: entity, roles: r.role)
         end
       end
 

--- a/app/services/hyrax/workflow/permission_query.rb
+++ b/app/services/hyrax/workflow/permission_query.rb
@@ -231,8 +231,8 @@ module Hyrax
       #
       # An ActiveRecord::Relation scope that meets the following criteria:
       #
-      # * Users that are directly associated with the given entity through on or
-      #   more of the given roles
+      # * Users that are directly associated with the given entity through one or
+      #   more of the given roles within the entity's workflow
       # * Users that are indirectly associated with the given entity by group
       #   and role.
       #
@@ -248,7 +248,7 @@ module Hyrax
         agent_table = Sipity::Agent.arel_table
 
         workflow_role_id_subquery = workflow_roles.project(workflow_roles[:id]).where(
-          workflow_roles[:role_id].in(role_ids)
+          workflow_roles[:workflow_id].eq(entity.workflow_id).and(workflow_roles[:role_id].in(role_ids))
         )
 
         workflow_agent_id_subquery = workflow_responsibilities.project(workflow_responsibilities[:agent_id]).where(

--- a/app/services/hyrax/workflow/status_list_service.rb
+++ b/app/services/hyrax/workflow/status_list_service.rb
@@ -38,7 +38,7 @@ module Hyrax
           actionable_roles = roles_for_user
           logger.debug("Actionable roles for #{user.user_key} are #{actionable_roles}")
           return [] if actionable_roles.empty?
-          WorkRelation.new.search_with_conditions(query(actionable_roles), rows: 1000)
+          WorkRelation.new.search_with_conditions(query(actionable_roles), rows: 1000, method: :post)
         end
 
         def query(actionable_roles)

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -133,7 +133,7 @@ de:
             no_delay: Keine Verzögerung - Freigabe aller Arbeiten, sobald sie hinterlegt sind
             title: Freigabe
             varies:
-              any: Dem Einzahler erlauben, sich zu entscheiden
+              any: Dem Deponierer erlauben, sich zu entscheiden
               between: Zwischen "jetzt" und
               description: 'Variabel - Deponenten können den Freigabedatum für eine einzelne Arbeit festlegen:'
               embargo:
@@ -170,8 +170,8 @@ de:
         index:
           action: Aktion
           description: Beschreibung
-          feature: Charakteristisch
-          header: Charakteristik
+          feature: Features
+          header: Features
       sidebar:
         activity: Aktivität
         admin_sets: Admin-Sets

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -104,7 +104,7 @@ EOF
   spec.add_development_dependency 'rubocop', '~> 0.49.1'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.16.0'
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
-  spec.add_development_dependency 'rails-controller-testing', '~> 0'
+  spec.add_development_dependency 'rails-controller-testing', '~> 1'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'i18n-debug' if ENV['I18N_DEBUG']
   spec.add_development_dependency 'i18n_yaml_sorter' unless ENV['TRAVIS']

--- a/spec/controllers/hyrax/citations_controller_spec.rb
+++ b/spec/controllers/hyrax/citations_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::CitationsController do
         expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :work, params: { id: work }
         expect(response).to be_successful
-        expect(response).to render_template('layouts/hyrax')
+        expect(response).to render_template('layouts/hyrax/1_column')
         expect(assigns(:presenter)).to be_kind_of Hyrax::WorkShowPresenter
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe Hyrax::CitationsController do
         expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :file, params: { id: file_set }
         expect(response).to be_successful
-        expect(response).to render_template('layouts/hyrax')
+        expect(response).to render_template('layouts/hyrax/1_column')
         expect(assigns(:presenter)).to be_kind_of Hyrax::FileSetPresenter
       end
     end

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Hyrax::CollectionsController do
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :show, params: { id: collection }
         expect(response).to be_successful
+        expect(response).to render_template("layouts/hyrax/1_column")
         expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
         expect(assigns[:presenter].title).to match_array collection.title
         expect(assigns[:member_docs].map(&:id)).to match_array [asset1, asset2, asset3].map(&:id)

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hyrax::CollectionsController do
         end
       end
 
-      it "returns the collection and its members", :with_nested_reindexing do
+      it "returns the collection and its members", :with_nested_reindexing do # rubocop:disable RSpec/ExampleLength
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :show, params: { id: collection }
         expect(response).to be_successful

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Hyrax::GenericWorksController do
           expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
           get :show, params: { id: work }
           expect(response).to be_successful
-          expect(response).to render_template("layouts/hyrax")
+          expect(response).to render_template("layouts/hyrax/1_column")
         end
       end
 

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -20,6 +20,111 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     expect(form.workflow_id).to eq(workflow.id)
   end
 
+  describe 'integration tests' do
+    let(:permission_template) { create(:permission_template, with_admin_set: true, with_workflows: true) }
+
+    subject do
+      form.update(
+        ActionController::Parameters.new(
+          access_grants_attributes: [
+            ActionController::Parameters.new(agent_type: "user",
+                                             agent_id: user.user_key,
+                                             access: access_level).permit!
+          ]
+        ).permit!
+      )
+    end
+
+    before do
+      # Create MANAGING role manually
+      Sipity::Role[Hyrax::RoleRegistry::MANAGING]
+    end
+
+    def count_template_accesses_for(user, access_level)
+      Hyrax::PermissionTemplateAccess.where(
+        agent_id: user.user_key,
+        access: access_level
+      ).count
+    end
+
+    def count_workflow_responsibilities_for(user)
+      Sipity::WorkflowResponsibility.where(agent: user.to_sipity_agent).count
+    end
+
+    it 'starts with no PTAs' do
+      expect(permission_template.access_grants).to be_empty
+    end
+
+    context 'with manager users' do
+      let(:user) { create(:user) }
+      let(:access_level) { 'manage' }
+
+      it 'adds the expected permission template accesses and workflow responsibilities' do
+        expect { subject }.to change {
+          count_template_accesses_for(user, access_level)
+        }.from(0).to(1).and change {
+          count_workflow_responsibilities_for(user)
+        }.from(0).to(6)
+      end
+
+      it 'removes workflow responsibilities' do
+        subject
+        expect do
+          form.remove_access!(
+            permission_template.access_grants.find_by(agent_id: user.user_key, access: access_level)
+          )
+        end.to change { count_workflow_responsibilities_for(user) }
+          .from(6).to(0)
+      end
+    end
+
+    context 'with depositor users' do
+      let(:user) { create(:user) }
+      let(:access_level) { 'deposit' }
+
+      it 'adds the expected permission template accesses and workflow responsibilities' do
+        expect { subject }.to change {
+          count_template_accesses_for(user, access_level)
+        }.from(0).to(1).and change {
+          count_workflow_responsibilities_for(user)
+        }.from(0).to(2)
+      end
+
+      it 'removes workflow responsibilities' do
+        subject
+        expect do
+          form.remove_access!(
+            permission_template.access_grants.find_by(agent_id: user.user_key, access: access_level)
+          )
+        end.to change { count_workflow_responsibilities_for(user) }
+          .from(2).to(0)
+      end
+    end
+
+    context 'with viewer users' do
+      let(:user) { create(:user) }
+      let(:access_level) { 'view' }
+
+      it 'adds the expected permission template accesses and workflow responsibilities' do
+        expect { subject }.to change {
+          count_template_accesses_for(user, access_level)
+        }.from(0).to(1).and change {
+          count_workflow_responsibilities_for(user)
+        }.by(0)
+      end
+
+      it 'does nothing (yet)' do
+        subject
+        expect do
+          form.remove_access!(
+            permission_template.access_grants.find_by(agent_id: user.user_key, access: access_level)
+          )
+        end.to change { count_workflow_responsibilities_for(user) }
+          .by(0)
+      end
+    end
+  end
+
   describe "#update" do
     subject { form.update(input_params) }
 
@@ -237,7 +342,10 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
   end
 
   describe "#grant_workflow_roles" do
-    subject { form.send(:grant_workflow_roles, attributes) }
+    subject do
+      form.attributes = attributes
+      form.send(:grant_workflow_roles)
+    end
 
     let(:attributes) { { workflow_id: workflow.id } }
     let(:workflow) { create(:workflow, permission_template: permission_template, active: true) }
@@ -432,7 +540,10 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
   describe "#permission_template_update_params" do
     let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
 
-    subject { form.send(:permission_template_update_params, input_params) }
+    subject do
+      form.attributes = input_params
+      form.send(:permission_template_update_params)
+    end
 
     context "with release varies by date selected" do
       let(:input_params) do

--- a/spec/jobs/ingest_local_file_job_spec.rb
+++ b/spec/jobs/ingest_local_file_job_spec.rb
@@ -4,16 +4,13 @@ RSpec.describe IngestLocalFileJob do
   let(:file_set) { FileSet.new }
   let(:actor) { double }
 
-  let(:mock_upload_directory) { 'spec/mock_upload_directory' }
-
   before do
-    Dir.mkdir mock_upload_directory unless File.exist? mock_upload_directory
-    FileUtils.copy(File.expand_path('../../fixtures/world.png', __FILE__), mock_upload_directory)
     allow(Hyrax::Actors::FileSetActor).to receive(:new).with(file_set, user).and_return(actor)
   end
 
   it 'has attached a file' do
+    expect(FileUtils).not_to receive(:rm)
     expect(actor).to receive(:create_content).and_return(true)
-    described_class.perform_now(file_set, File.join(mock_upload_directory, 'world.png'), user)
+    described_class.perform_now(file_set, File.join(fixture_path, 'world.png'), user)
   end
 end

--- a/spec/search_builders/hyrax/stats/work_status_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/stats/work_status_search_builder_spec.rb
@@ -11,22 +11,22 @@ RSpec.describe Hyrax::Stats::WorkStatusSearchBuilder do
   describe "#query" do
     subject { instance.query }
 
-    let(:stub_relation) do
-      instance_double(Hyrax::WorkRelation,
-                      search_model_clause: "(model clauses)")
-    end
-
-    before do
-      # Prevent the stub relation from returning different filters depending on
-      # how many models have been generated
-      allow(instance).to receive(:work_relation).and_return(stub_relation)
-    end
-
     it "sets required parameters" do
       expect(subject['facet.field']).to eq ["suppressed_bsi"]
-      expect(subject['fq']).to eq "(model clauses)"
       expect(subject['facet.missing']).to eq true
       expect(subject['rows']).to eq 0
     end
+  end
+
+  describe "#only_works?" do
+    subject { instance.send(:only_works?) }
+
+    it { is_expected.to be true }
+  end
+
+  describe "::default_processor_chain" do
+    subject { described_class.default_processor_chain }
+
+    it { is_expected.to include(:filter_models) }
   end
 end

--- a/spec/services/hyrax/workflow/notification_service_spec.rb
+++ b/spec/services/hyrax/workflow/notification_service_spec.rb
@@ -23,44 +23,11 @@ RSpec.describe Hyrax::Workflow::NotificationService do
   let(:action) { Sipity::WorkflowAction.new(notifiable_contexts: [notifiable_context]) }
   let(:entity) { Sipity::Entity.new }
   let(:user) { User.new }
-
-  let(:workflow) { Sipity::Workflow.new }
-  let(:workflow_state) { Sipity::WorkflowState.new }
-  let(:permission_template) { Hyrax::PermissionTemplate.new }
-
   let(:instance) do
     described_class.new(entity: entity,
                         action: action,
                         comment: "A pleasant read",
                         user: user)
-  end
-
-  describe '#recipients' do
-    context 'when an entity requires review' do
-      let(:creator) { [instance_double(User)] }
-      let(:managers) { [instance_double(User), instance_double(User)] }
-      let(:notification) { Sipity::Notification.new(name: 'pending review notification') }
-
-      before do
-        allow(instance).to receive(:send_notification) # mock it so it does nothing
-        allow(entity).to receive(:workflow_state).and_return(workflow_state)
-        allow(workflow_state).to receive(:name).and_return('pending_review')
-        allow(entity).to receive(:workflow).and_return(workflow)
-        # Mock the permission_template queries
-        allow(workflow).to receive(:permission_template).and_return(permission_template)
-        allow(permission_template).to receive(:agent_ids_for)
-          .with(access: 'manage', agent_type: 'user')
-          .and_return(managers)
-        allow(permission_template).to receive(:agent_ids_for)
-          .with(access: 'deposit', agent_type: 'user')
-          .and_return(creator)
-      end
-
-      it 'identifies the managers and depositor for notifications' do
-        recipients = instance.recipients(notification)
-        expect(recipients).to eq(to: managers, cc: creator)
-      end
-    end
   end
 
   describe "#call" do
@@ -81,8 +48,6 @@ RSpec.describe Hyrax::Workflow::NotificationService do
       let(:creator_rel) { double(ActiveRecord::Relation, to_ary: creator) }
 
       before do
-        allow(entity).to receive(:workflow_state).and_return(workflow_state)
-        allow(workflow_state).to receive(:name).and_return('not_pending_review')
         allow(Hyrax::Workflow::PermissionQuery).to receive(:scope_users_for_entity_and_roles)
           .with(entity: entity,
                 roles: advising)

--- a/spec/services/hyrax/workflow/status_list_service_spec.rb
+++ b/spec/services/hyrax/workflow/status_list_service_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe Hyrax::Workflow::StatusListService do
         expect(results.first.to_s).to eq 'Hey dood!'
         expect(results.first.workflow_state).to eq 'initial'
       end
+
+      describe '#search_solr' do
+        let(:mock_response) { { 'response' => { 'docs' => [{}, {}, {}] } } }
+
+        it 'queries Solr via HTTP POST method' do
+          allow(ActiveFedora::SolrService).to receive(:post).and_return(mock_response)
+          allow(ActiveFedora::SolrService).to receive(:get)
+          service.send(:search_solr)
+          expect(ActiveFedora::SolrService).to have_received(:post)
+          expect(ActiveFedora::SolrService).not_to have_received(:get)
+        end
+      end
     end
 
     context "when user doesn't have roles" do


### PR DESCRIPTION
Merges the latest changes from master into collections-sprint branch.  Only notable change that required resolution is...
* app/controller/hyrax/admin/permission_template_access_controller.rb
  * removed update_access method which was called from destroy
  * added remove_access method which is now called from destroy
* app/forms/hyrax/forms/permission_template_form.rb
  * added attributes instance variable which removed the need to pass attributes to every method
  * multiple changes were made effecting workflow roles
  * added remove_access! method which is called from permission_template_access_controller
  * had to reconcile collections-sprint changes that update_access for admin_sets and collections