### PR TITLE
Add edit button to collection public show

### DIFF
--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -12,6 +12,9 @@
   </div>
   <div class="col-sm-2">
     <%= render 'media_display', presenter: @presenter %>
+      <% unless has_collection_search_parameters? %>
+        <%= render 'hyrax/dashboard/collections/show_actions', presenter: @presenter %>
+      <% end %>
   </div>
 </div>
 

--- a/spec/views/hyrax/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/show.html.erb_spec.rb
@@ -10,23 +10,41 @@ RSpec.describe 'hyrax/collections/show.html.erb', type: :view do
   before do
     allow(document).to receive(:hydra_model).and_return(::Collection)
     allow(controller).to receive(:current_user).and_return(stub_model(User))
-    allow(view).to receive(:can?).with(:edit, document).and_return(true)
-    allow(view).to receive(:can?).with(:destroy, document).and_return(true)
     allow(presenter).to receive(:total_items).and_return(0)
     assign(:presenter, presenter)
 
     # Stub route because view specs don't handle engine routes
     allow(view).to receive(:collection_path).and_return("/collection/123")
+    allow(view).to receive(:edit_dashboard_collection_path).and_return("/dashboard/collection/123/edit")
 
     stub_template '_search_form.html.erb' => 'search form'
     stub_template 'hyrax/collections/_sort_and_per_page.html.erb' => 'sort and per page'
     stub_template 'hyrax/collections/_document_list.html.erb' => 'document list'
     stub_template 'hyrax/collections/_paginate.html.erb' => 'paginate'
     stub_template 'hyrax/collections/_media_display.html.erb' => '<span class="fa fa-cubes collection-icon-search"></span>'
-    render
   end
 
-  it 'draws the page' do
-    expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
+  describe 'as normal user' do
+    it 'draws the page' do
+      allow(view).to receive(:can?).with(:edit, document).and_return(false)
+      allow(view).to receive(:can?).with(:destroy, document).and_return(false)
+      render
+
+      expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
+    end
+  end
+
+  describe 'as editor' do
+    it 'includes edit actions' do
+      allow(view).to receive(:can?).with(:edit, document).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, document).and_return(true)
+      render
+
+      expect(rendered).to have_selector 'h2', text: 'Actions'
+      expect(rendered).to have_link 'Edit'
+      expect(rendered).to have_link 'Delete'
+      expect(rendered).to have_link 'Add works'
+      expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
+    end
   end
 end


### PR DESCRIPTION
References https://github.com/curationexperts/nurax/issues/96
Fixes https://github.com/samvera/hyrax/issues/1742

With the refactoring of collection controllers to create two collection
show pages (public and dashboard), someone given editor rights to a
collection no longer has a way to get to the editing view.

This change adds the actions onto the public show page to restore this
feature until the collections sprint work is completed.

@samvera/hyrax-code-reviewers
