### PR TITLE
Fix tab focus for nav bar elements

### DIFF
--- a/app/assets/stylesheets/hyrax/_header.scss
+++ b/app/assets/stylesheets/hyrax/_header.scss
@@ -20,3 +20,9 @@
 .nav > li > .notify-number {
   padding-right: 0;
 }
+
+.dropdown-toggle:focus {
+  outline: 2px auto  Highlight; // FireFox
+  outline: 5px auto -webkit-focus-ring-color; // Chrome, Safari
+  outline: -2px;
+}


### PR DESCRIPTION
Removes dropdown-toggle class. This class sets outline to 0 on focus, breaking accessibility on the link.
Fixes issue #: https://github.com/samvera/hyrax/issues/1925

