### PR TITLE
Add text for screen readers

### DIFF
--- a/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
+++ b/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
@@ -13,7 +13,7 @@
       <% user.can_receive_deposits_from.each do |depositor| %>
           <tr><td class="depositor-name"><%= depositor.name %></td>
             <td><%= link_to(hyrax.user_depositor_path(user, depositor), method: :delete, class: "remove-proxy-button") do %>
-                  <span class="sr-only">Remove Proxy</span>
+                  <span class="sr-only"><%= I18n.t('hyrax.dashboard.proxy_delete') %></span>
                   <i class="glyphicon glyphicon-remove"></i><% end %>
             </td></tr>
       <% end %>

--- a/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
+++ b/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
@@ -13,6 +13,7 @@
       <% user.can_receive_deposits_from.each do |depositor| %>
           <tr><td class="depositor-name"><%= depositor.name %></td>
             <td><%= link_to(hyrax.user_depositor_path(user, depositor), method: :delete, class: "remove-proxy-button") do %>
+                  <span class="sr-only">Remove Proxy</span>
                   <i class="glyphicon glyphicon-remove"></i><% end %>
             </td></tr>
       <% end %>

--- a/app/views/hyrax/notifications/_notifications.html.erb
+++ b/app/views/hyrax/notifications/_notifications.html.erb
@@ -24,6 +24,7 @@
                       class: "itemicon itemtrash",
                       title: t('hyrax.mailbox.delete'),
                       method: :delete do %>
+                  <span class="sr-only">Delete Item</span>
                 <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 <% end %>
             </td>

--- a/app/views/hyrax/notifications/_notifications.html.erb
+++ b/app/views/hyrax/notifications/_notifications.html.erb
@@ -24,7 +24,7 @@
                       class: "itemicon itemtrash",
                       title: t('hyrax.mailbox.delete'),
                       method: :delete do %>
-                  <span class="sr-only">Delete Item</span>
+                  <span class="sr-only"><%= I18n.t('hyrax.dashboard.delete_notification') %></span>
                 <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 <% end %>
             </td>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -462,10 +462,12 @@ en:
         works:        "Your Works"
       no_activity:              "User has no recent activity"
       no_notifications:         "User has no notifications"
+      delete_notification:      "Delete Notification"
       no_transfer_requests:     "You haven't received any work transfer requests"
       no_transfers:             "You haven't transferred any work"
       proxy_activity:           "Proxy Activity"
       proxy_user:               "Proxy User"
+      proxy_delete:              "Delete Proxy"
       show_admin:
         new_visitors:       "New Visitors"
         registered_users:   "Registered users"


### PR DESCRIPTION
Fixes #1960

Adds help text for screen readers, but is hidden from display.


