### PR TITLE
Works controller requires a change_set_persister

### DIFF
--- a/app/actors/hyrax/actors/abstract_actor.rb
+++ b/app/actors/hyrax/actors/abstract_actor.rb
@@ -69,7 +69,7 @@ module Hyrax
     #     # middleware.use MoreMiddleware
     #   end
     #
-    #   env = Hyrax::Actors::Environment.new(object, ability, attributes)
+    #   env = Hyrax::Actors::Environment.new(change_set, persister, ability, attributes)
     #   last_actor = Hyrax::Actors::Terminator.new
     #
     #   stack.build(last_actor).create(env) # or `#update/#destroy`

--- a/app/actors/hyrax/actors/environment.rb
+++ b/app/actors/hyrax/actors/environment.rb
@@ -1,20 +1,18 @@
 module Hyrax
   module Actors
     class Environment
-      # @param [Valkyrie::ChangeSet] curation_concern work to operate on
+      # @param [Valkyrie::ChangeSet] change_set work to operate on
+      # @param [Valkyrie::ChangeSetPersister] change_set_persister work to operate on
       # @param [Ability] current_ability the authorizations of the acting user
       # @param [ActionController::Parameters] attributes user provided form attributes
-      def initialize(change_set, current_ability, attributes)
+      def initialize(change_set, change_set_persister, current_ability, attributes)
         @change_set = change_set
         @current_ability = current_ability
         @attributes = attributes.to_h.with_indifferent_access
+        @change_set_persister = change_set_persister
       end
 
-      attr_reader :change_set, :current_ability, :attributes, :change_set
-
-      def change_set_persister
-        Hyrax::ChangeSetPersister.new(metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister), storage_adapter: Valkyrie.config.storage_adapter)
-      end
+      attr_reader :change_set, :current_ability, :attributes, :change_set_persister
 
       delegate :resource, to: :change_set
       alias curation_concern resource

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -66,7 +66,7 @@ module Hyrax
         file_set.date_modified = now
         file_set.creator = [user.user_key]
         if assign_visibility?(file_set_params)
-          env = Actors::Environment.new(file_set, ability, file_set_params)
+          env = Actors::Environment.new(file_set, nil, ability, file_set_params)
           CurationConcern.file_set_create_actor.create(env)
         end
         yield(file_set) if block_given?
@@ -101,7 +101,7 @@ module Hyrax
       end
 
       def update_metadata(attributes)
-        env = Actors::Environment.new(file_set, ability, attributes)
+        env = Actors::Environment.new(file_set, nil, ability, attributes)
         CurationConcern.file_set_update_actor.update(env)
       end
 

--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -84,7 +84,7 @@ module Hyrax
       def create(env)
         intention = Intention.new(env.attributes)
         attributes = intention.sanitize_params
-        new_env = Environment.new(env.change_set, env.current_ability, attributes)
+        new_env = duplicate_env(env, attributes)
         validate(env, intention, attributes) && apply_visibility(new_env, intention) &&
           next_actor.create(new_env)
       end
@@ -94,12 +94,16 @@ module Hyrax
       def update(env)
         intention = Intention.new(env.attributes)
         attributes = intention.sanitize_params
-        new_env = Environment.new(env.change_set, env.current_ability, attributes)
+        new_env = duplicate_env(env, attributes)
         validate(env, intention, attributes) && apply_visibility(new_env, intention) &&
           next_actor.update(new_env)
       end
 
       private
+
+        def duplicate_env(env, attributes)
+          Environment.new(env.change_set, env.change_set_persister, env.current_ability, attributes)
+        end
 
         # Validate against selected AdminSet's PermissionTemplate (if any)
         def validate(env, intention, attributes)

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -12,6 +12,11 @@ module Hyrax
       class_attribute :show_presenter, :search_builder_class
       self.show_presenter = Hyrax::WorkShowPresenter
       self.search_builder_class = WorkSearchBuilder
+      self.change_set_persister = Hyrax::ChangeSetPersister.new(
+        metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
+        storage_adapter: Valkyrie.config.storage_adapter
+      )
+
       attr_accessor :curation_concern
       helper_method :curation_concern, :contextual_path
 

--- a/spec/actors/hyrax/actors/apply_permission_template_actor_spec.rb
+++ b/spec/actors/hyrax/actors/apply_permission_template_actor_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Hyrax::Actors::ApplyPermissionTemplateActor do
   let(:ability) { ::Ability.new(depositor) }
   let(:change_set) { GenericWorkChangeSet.new(work) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { double }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:depositor) { create(:user) }
   let(:work) do

--- a/spec/actors/hyrax/actors/attach_members_actor_spec.rb
+++ b/spec/actors/hyrax/actors/attach_members_actor_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Hyrax::Actors::AttachMembersActor do
   let(:ability) { ::Ability.new(depositor) }
   let(:change_set) { GenericWorkChangeSet.new(work) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { double }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:depositor) { create(:user) }
   let(:work) { create_for_repository(:work) }

--- a/spec/actors/hyrax/actors/cleanup_trophies_actor_spec.rb
+++ b/spec/actors/hyrax/actors/cleanup_trophies_actor_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Hyrax::Actors::CleanupTrophiesActor do
   let(:ability) { ::Ability.new(depositor) }
   let(:change_set) { GenericWorkChangeSet.new(work) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { double }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:depositor) { create(:user) }
   let(:work) { create_for_repository(:work) }

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
   let(:attributes) { {} }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:change_set) { GenericWorkChangeSet.new(curation_concern) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { Hyrax::ChangeSetPersister.new(metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister), storage_adapter: Valkyrie.config.storage_adapter) }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
 
   subject(:middleware) do
     stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
@@ -47,10 +48,12 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
     describe "when work is in user's own collection" do
       let(:collection) { create_for_repository(:collection, user: user, title: ['A good title']) }
       let(:attributes) { { member_of_collection_ids: [] } }
+      let(:env_initial) do
+        Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, member_of_collection_ids: [collection.id], title: ['test'])
+      end
 
       before do
-        subject.create(Hyrax::Actors::Environment.new(change_set, ability,
-                                                      member_of_collection_ids: [collection.id], title: ['test']))
+        subject.create(env_initial)
       end
 
       it "removes the work from that collection" do

--- a/spec/actors/hyrax/actors/create_with_files_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_files_actor_spec.rb
@@ -3,7 +3,8 @@ RSpec.describe Hyrax::Actors::CreateWithFilesActor do
   let(:ability) { ::Ability.new(user) }
   let(:work) { create_for_repository(:work, user: user) }
   let(:change_set) { GenericWorkChangeSet.new(work) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { double }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:uploaded_file1) { create(:uploaded_file, user: user) }
   let(:uploaded_file2) { create(:uploaded_file, user: user) }

--- a/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Hyrax::Actors::CreateWithRemoteFilesActor do
   end
   let(:attributes) { { remote_files: remote_files } }
   let(:change_set) { GenericWorkChangeSet.new(work) }
-  let(:environment) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { double }
+  let(:environment) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
 
   before do
     allow(terminator).to receive(:create).and_return(true)

--- a/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
   let(:admin_set) { create_for_repository(:admin_set) }
   let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
   let(:change_set) { GenericWorkChangeSet.new(work) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, depositor_ability, attributes) }
+  let(:change_set_persister) { double }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
 
   describe "create" do
     let(:terminator) { Hyrax::Actors::Terminator.new }

--- a/spec/actors/hyrax/actors/featured_work_actor_spec.rb
+++ b/spec/actors/hyrax/actors/featured_work_actor_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Hyrax::Actors::FeaturedWorkActor do
   let(:ability) { ::Ability.new(depositor) }
   let(:change_set) { GenericWorkChangeSet.new(work) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { double }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:depositor) { create(:user) }
   let(:work) { create_for_repository(:work) }

--- a/spec/actors/hyrax/actors/generic_work_actor_spec.rb
+++ b/spec/actors/hyrax/actors/generic_work_actor_spec.rb
@@ -3,7 +3,8 @@ require 'redlock'
 RSpec.describe Hyrax::Actors::GenericWorkActor do
   include ActionDispatch::TestProcess
   let(:change_set) { GenericWorkChangeSet.new(curation_concern) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { Hyrax::ChangeSetPersister.new(metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister), storage_adapter: Valkyrie.config.storage_adapter) }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
   let(:user) { create(:user) }
   let(:ability) { ::Ability.new(user) }
   let(:admin_set) { build(:admin_set, with_permission_template: { with_active_workflow: true }) }

--- a/spec/actors/hyrax/actors/initialize_workflow_actor_spec.rb
+++ b/spec/actors/hyrax/actors/initialize_workflow_actor_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Hyrax::Actors::InitializeWorkflowActor do
 
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:change_set) { GenericWorkChangeSet.new(curation_concern) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { Hyrax::ChangeSetPersister.new(metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister), storage_adapter: Valkyrie.config.storage_adapter) }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
 
   subject(:middleware) do
     stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|

--- a/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
+++ b/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
   let(:two_years_from_today) { Time.zone.today + 2.years }
   let(:date) { Time.zone.today + 2 }
   let(:change_set) { GenericWorkChangeSet.new(curation_concern) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { Hyrax::ChangeSetPersister.new(metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister), storage_adapter: Valkyrie.config.storage_adapter) }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
 
   subject(:middleware) do
     stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|

--- a/spec/actors/hyrax/actors/model_actor_spec.rb
+++ b/spec/actors/hyrax/actors/model_actor_spec.rb
@@ -13,9 +13,11 @@ end
 RSpec.describe Hyrax::Actors::ModelActor do
   let(:work) { MusicalWork::Cover.new }
   let(:depositor) { create(:user) }
-  let(:depositor_ability) { ::Ability.new(depositor) }
+  let(:ability) { ::Ability.new(depositor) }
+  let(:attributes) { {} }
   let(:change_set) { GenericWorkChangeSet.new(work) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, depositor_ability, {}) }
+  let(:change_set_persister) { double }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
 
   describe '#model_actor' do
     subject { described_class.new('¯\_(ツ)_/¯').send(:model_actor, env) }

--- a/spec/actors/hyrax/actors/optimistic_lock_validator_spec.rb
+++ b/spec/actors/hyrax/actors/optimistic_lock_validator_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Hyrax::Actors::OptimisticLockValidator do
   let(:change_set) { GenericWorkChangeSet.new(work) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { double }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
   let(:ability) { ::Ability.new(depositor) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:depositor) { create(:user) }

--- a/spec/actors/hyrax/actors/transactional_request_spec.rb
+++ b/spec/actors/hyrax/actors/transactional_request_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Hyrax::Actors::TransactionalRequest do
 
   let(:ability) { ::Ability.new(depositor) }
   let(:change_set) { GenericWorkChangeSet.new(work) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { double }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:depositor) { instance_double(User, new_record?: true, guest?: true, id: nil, user_key: nil) }
   let(:work) { double(:work) }

--- a/spec/actors/hyrax/actors/transfer_request_actor_spec.rb
+++ b/spec/actors/hyrax/actors/transfer_request_actor_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe Hyrax::Actors::TransferRequestActor do
   let(:ability) { ::Ability.new(depositor) }
   let(:change_set) { GenericWorkChangeSet.new(work) }
-  let(:env) { Hyrax::Actors::Environment.new(change_set, ability, attributes) }
+  let(:change_set_persister) { double }
+  let(:env) { Hyrax::Actors::Environment.new(change_set, change_set_persister, ability, attributes) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:depositor) { create(:user) }
   let(:work) do


### PR DESCRIPTION
Because the ResourceController delegates metadata_adapter to the
change_set_persister.  This lead me to invert the dependency on
Actors::Environment.