### PR TITLE
Restore change_set_persister

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -12,6 +12,10 @@ module Hyrax
       class_attribute :show_presenter, :search_builder_class
       self.show_presenter = Hyrax::WorkShowPresenter
       self.search_builder_class = WorkSearchBuilder
+      self.change_set_persister = Hyrax::CollectionChangeSetPersister.new(
+        metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
+        storage_adapter: Valkyrie.config.storage_adapter
+      )
       attr_accessor :curation_concern
       helper_method :curation_concern, :contextual_path
 


### PR DESCRIPTION
Without this the controllers which include `WorksControllerBehavior` throw exceptions whenever trying to use the metadata_adapter since it is delegated to `change_set_persister`.  I just copied what was in `AdminSetsController`.  Since all of the controllers so far use this same configuration maybe it makes sense to pull it up into `ResourceController`.