### PR TITLE
Use single valued string type where multiple: false before

### DIFF
--- a/app/models/concerns/hyrax/proxy_deposit.rb
+++ b/app/models/concerns/hyrax/proxy_deposit.rb
@@ -3,12 +3,12 @@ module Hyrax
     extend ActiveSupport::Concern
 
     included do
-      attribute :proxy_depositor, Valkyrie::Types::String
+      attribute :proxy_depositor, Valkyrie::Types::SingleValuedString
       # property :proxy_depositor, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#proxyDepositor'), multiple: false do |index|
       #   index.as :symbol
       # end
 
-      attribute :on_behalf_of, Valkyrie::Types::String
+      attribute :on_behalf_of, Valkyrie::Types::SingleValuedString
       # # This value is set when a user indicates they are depositing this for someone else
       # property :on_behalf_of, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#onBehalfOf'), multiple: false do |index|
       #   index.as :symbol

--- a/spec/services/hyrax/change_content_depositor_service_spec.rb
+++ b/spec/services/hyrax/change_content_depositor_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
     end
 
     it "changes the depositor of the child file sets" do
-      reloaded = Hyrax::Queries.find_by(id: file.id)
+      reloaded = Hyrax::Queries.find_by(id: work.id)
       expect(reloaded.depositor).to eq receiver.user_key
       expect(reloaded.edit_users).to include(receiver.user_key, depositor.user_key)
     end


### PR DESCRIPTION
The change to `SingleValuedString` fixes a different test in `change_content_depositor_service_spec.rb`