### PR TITLE
Validate linked data attributes

### DIFF
--- a/app/change_sets/hyrax/work_change_set.rb
+++ b/app/change_sets/hyrax/work_change_set.rb
@@ -3,6 +3,8 @@ module Hyrax
     class_attribute :workflow_class, :exclude_fields, :primary_terms, :secondary_terms
     delegate :human_readable_type, to: :resource
 
+    validate :validate_linked_data_attributes
+
     # Which fields show above the fold.
     self.primary_terms = [:title, :creator, :keyword, :rights_statement]
     self.secondary_terms = [:contributor, :description, :license, :publisher,
@@ -209,6 +211,13 @@ module Hyrax
         return if visibility.blank? || wants_embargo? || wants_lease? || validate_template_visibility(visibility)
 
         errors.add(:visibility, 'Visibility specified does not match permission template visibility requirement for selected AdminSet.')
+      end
+
+      # Validate that the contents of each RDF::URI is a valid URI
+      def validate_linked_data_attributes
+        Hyrax.config.registered_linked_data_attributes.each_key do |key|
+          errors.add(:key, "contains an invalid url") if key && send(key).is_a?(Array) && send(key).map(&:valid?).include?(false)
+        end
       end
   end
 end

--- a/app/indexers/hyrax/linked_data_attributes_indexer.rb
+++ b/app/indexers/hyrax/linked_data_attributes_indexer.rb
@@ -13,9 +13,7 @@ module Hyrax
     attr_reader :solr_hash
 
     class_attribute :linked_data_attributes
-    self.linked_data_attributes = %i[
-      based_near
-    ]
+    self.linked_data_attributes = Hyrax.config.registered_linked_data_attributes.keys
 
     def initialize(resource)
       @resource = resource.fetch(:resource)

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -38,7 +38,7 @@ module Hyrax
       # class_attribute :controlled_properties
       # self.controlled_properties = [:based_near]
       # accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
-      attribute :based_near, Valkyrie::Types::Set
+      attribute :based_near, Valkyrie::Types::Set.member(Valkyrie::Types::URI)
     end
   end
 end

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -103,9 +103,12 @@ Hyrax.config do |config|
   # Replace the whole thing with
   #   config.fedora_schema = { }
 
-  # Register new linked_data_resource classes; used to define special behavior for retrieving a label from an
-  #   external service for the given attribute.
-  #   @example :based_near is already registerd to use Hyrax::LinkedDataResources::GeonamesResource
+  # Register new linked_data_attributes, and their resource fetching classes;
+  #   :class is optional. If not specificed Hyrax::LinkedDataResources::BaseResource is used
+  #   @example
+  #     {
+  #     based_near: { class: Hyrax::LinkedDataResources::GeonamesResource }
+  #     }
   # config.registered_registered_linked_data_resources[:my_new_attribute] = MyClass
 
   # Location autocomplete uses geonames to search for named regions

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -350,10 +350,12 @@ module Hyrax
     end
     alias google_analytics_id? google_analytics_id
 
-    attr_writer :registered_linked_data_resources
-    def registered_linked_data_resources
-      @registered_linked_data_resources ||= {
-        based_near: Hyrax::LinkedDataResources::GeonamesResource
+    # All linked_data_properties should be listed, class is optional
+    #   eg. subject: { }
+    attr_writer :registered_linked_data_attributes
+    def registered_linked_data_attributes
+      @registered_linked_data_attributes ||= {
+        based_near: { class: Hyrax::LinkedDataResources::GeonamesResource }
       }
     end
 

--- a/lib/hyrax/linked_data_resource_factory.rb
+++ b/lib/hyrax/linked_data_resource_factory.rb
@@ -6,7 +6,7 @@ module Hyrax
     # @param ld_uri [RDF::URI] uri from which to retrieve a label
     # @return [Hyrax::LinkedDataResources::BaseResource] or more speciic class
     def self.for(ld_attribute, ld_uri)
-      Hyrax.config.registered_linked_data_resources.fetch(ld_attribute, Hyrax::LinkedDataResources::BaseResource).new(ld_uri)
+      Hyrax.config.registered_linked_data_attributes.fetch(ld_attribute, {}).fetch(:class, Hyrax::LinkedDataResources::BaseResource).new(ld_uri)
     end
   end
 end

--- a/spec/change_sets/hyrax/generic_work_change_set_spec.rb
+++ b/spec/change_sets/hyrax/generic_work_change_set_spec.rb
@@ -355,6 +355,17 @@ RSpec.describe GenericWorkChangeSet do
         end
       end
     end
+
+    context "validates linked_data_attributes" do
+      it "validates with a valid uri " do
+        work.based_near = ['http://sws.geonames.org/3413829']
+        expect(change_set).to be_valid
+      end
+      it "does not validate with an invalid uri" do
+        work.based_near = [RDF::URI('3413829')]
+        expect(change_set).not_to be_valid
+      end
+    end
   end
 
   describe "#fields" do
@@ -362,16 +373,16 @@ RSpec.describe GenericWorkChangeSet do
 
     # rubocop:disable RSpec/ExampleLength
     it do
-      is_expected.to eq ["created_at", "updated_at", "depositor", "title",
-                         "date_uploaded", "date_modified", "admin_set_id",
-                         "state", "proxy_depositor", "on_behalf_of",
-                         "arkivo_checksum", "member_of_collection_ids",
-                         "member_ids", "thumbnail_id", "representative_id",
-                         "label", "relative_path", "resource_type", "creator",
-                         "contributor", "description", "keyword", "license",
-                         "rights_statement",
-                         "publisher", "date_created", "subject", "language",
-                         "identifier", "related_url", "source", "based_near"]
+      is_expected.to include("created_at", "updated_at", "depositor", "title",
+                             "date_uploaded", "date_modified", "admin_set_id",
+                             "state", "proxy_depositor", "on_behalf_of",
+                             "arkivo_checksum", "member_of_collection_ids",
+                             "member_ids", "thumbnail_id", "representative_id",
+                             "label", "relative_path", "resource_type", "creator",
+                             "contributor", "description", "keyword", "license",
+                             "rights_statement",
+                             "publisher", "date_created", "subject", "language",
+                             "identifier", "related_url", "source", "based_near")
     end
     # rubocop:enable RSpec/ExampleLength
   end

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:google_analytics_id?) }
   it { is_expected.to respond_to(:google_analytics_id) }
   it { is_expected.to respond_to(:libreoffice_path) }
-  it { is_expected.to respond_to(:registered_linked_data_resource) }
-  it { is_expected.to respond_to(:registered_linked_data_resource=) }
+  it { is_expected.to respond_to(:registered_linked_data_attributes) }
+  it { is_expected.to respond_to(:registered_linked_data_attributes=) }
   it { is_expected.to respond_to(:max_days_between_fixity_checks=) }
   it { is_expected.to respond_to(:max_days_between_fixity_checks) }
   it { is_expected.to respond_to(:max_notifications_for_dashboard) }

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -118,5 +118,9 @@ RSpec.describe GenericWork do
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:identifier)
     end
+    it "casts based_near to a RDF::URI" do
+      subject.based_near = ['http://sws.geonames.org/3413829']
+      expect(subject.based_near).to eq([RDF::URI('http://sws.geonames.org/3413829')])
+    end
   end
 end


### PR DESCRIPTION

Made linked_data_attributes in basic_metadata into a Set of Valkyrie::Types::URI ... this means that the String value gets cast to a RDF::URI.

Added validation of linked_data_attributes (based_near) in the changeset to ensure that the RDF::URI contains a valid URI.

Also modified the indexer and configuration so that the linked_data_attributes are a configuration rather than an array baked into the indexer file, so that they can be accessed from other places (in this case the changeset).
