### PR TITLE
remove permission_template and permission_template_access entries whe…

### DIFF
--- a/app/models/hyrax/permission_template_access.rb
+++ b/app/models/hyrax/permission_template_access.rb
@@ -4,7 +4,6 @@ module Hyrax
   class PermissionTemplateAccess < ActiveRecord::Base
     self.table_name = 'permission_template_accesses'
     belongs_to :permission_template
-    before_destroy :check_if_admin_group
 
     VIEW = 'view'.freeze
     DEPOSIT = 'deposit'.freeze
@@ -33,13 +32,5 @@ module Hyrax
     def admin_group?
       agent_type == 'group' && agent_id == ::Ability.admin_group_name
     end
-
-    private
-
-      def check_if_admin_group
-        return true unless admin_group?
-        errors[:base] << I18n.t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group')
-        throw :abort
-      end
   end
 end

--- a/app/views/hyrax/admin/admin_sets/_form_participant_table.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_participant_table.html.erb
@@ -15,7 +15,7 @@
                           <td data-agent="<%= g.agent_id %>"><%= g.label %></td>
                           <td><%= g.agent_type.titleize %></td>
                           <td>
-                            <% if g.admin_group? %>
+                            <% if g.admin_group? && g.access == Hyrax::PermissionTemplateAccess::MANAGE %>
                               <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
                             <% else %>
                               <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger' %>

--- a/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
@@ -33,14 +33,14 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
         let(:agent_type) { 'group' }
         let(:agent_id) { 'admin' }
 
-        it "fails" do
+        it "is successful" do
           expect(controller).to receive(:authorize!).with(:destroy, permission_template_access)
           expect do
             delete :destroy, params: { id: permission_template_access }
-          end.not_to change { Hyrax::PermissionTemplateAccess.count }
+          end.to change { Hyrax::PermissionTemplateAccess.count(-1) }
           expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(admin_set_id, locale: 'en', anchor: 'participants'))
-          expect(flash[:notice]).not_to eq I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
-          expect(flash[:alert]).to eq 'The repository administrators group cannot be removed'
+          expect(flash[:notice]).to eq I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
+          expect(admin_set.reload.edit_users).to be_empty
         end
       end
       context 'with deleting any agent other than the admin users group' do

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -47,9 +47,13 @@ RSpec.describe AdminSet, type: :model do
   end
 
   describe '.after_destroy' do
-    it 'will destroy the associated permission template' do
+    let(:permission_template_access) { create(:permission_template_access) }
+
+    it 'will destroy the associated permission template and permission template access' do
       admin_set = create(:admin_set, with_permission_template: true)
-      expect { admin_set.destroy }.to change { Hyrax::PermissionTemplate.count }.by(-1)
+      permission_template_access.permission_template_id = admin_set.permission_template.id
+      permission_template_access.save
+      expect { admin_set.destroy }.to change { Hyrax::PermissionTemplate.count }.by(-1).and change { Hyrax::PermissionTemplateAccess.count }.by(-1)
     end
   end
 

--- a/spec/models/hyrax/permission_template_access_spec.rb
+++ b/spec/models/hyrax/permission_template_access_spec.rb
@@ -25,19 +25,118 @@ RSpec.describe Hyrax::PermissionTemplateAccess do
       end
     end
     describe '#destroy' do
-      it 'aborts the destroy operation' do
+      it 'destroys the permission template access record' do
         subject.destroy
-        expect(subject).not_to be_destroyed
-        expect(subject.errors.messages[:base]).to include 'The repository administrators group cannot be removed'
+        expect(subject).to be_destroyed
       end
     end
   end
+
   context 'with an agent that is not the admin users group' do
     let(:agent_type) { 'user' }
     let(:agent_id) { 'foobar' }
 
     describe '#label' do
       it 'returns the repo admins label' do
+        expect(subject.label).to eq agent_id
+      end
+    end
+    describe '#admin_group?' do
+      it 'returns true' do
+        expect(subject).not_to be_admin_group
+      end
+    end
+    describe '#destroy' do
+      it 'carries out the destroy operation' do
+        subject.destroy
+        expect(subject).to be_destroyed
+        expect(subject.errors).to be_empty
+      end
+    end
+  end
+
+  context 'with a user that is an admin set viewer' do
+    let(:agent_type) { 'user' }
+    let(:agent_id) { 'foobar' }
+
+    let(:permission_template_access) do
+      create(:permission_template_access,
+             :view,
+             permission_template: admin_set.permission_template,
+             agent_type: agent_type,
+             agent_id: agent_id)
+    end
+
+    subject { permission_template_access }
+
+    describe '#label' do
+      it 'returns the user label' do
+        expect(subject.label).to eq agent_id
+      end
+    end
+    describe '#admin_group?' do
+      it 'returns true' do
+        expect(subject).not_to be_admin_group
+      end
+    end
+    describe '#destroy' do
+      it 'carries out the destroy operation' do
+        subject.destroy
+        expect(subject).to be_destroyed
+        expect(subject.errors).to be_empty
+      end
+    end
+  end
+
+  context 'with a user that is an admin set depositor' do
+    let(:agent_type) { 'user' }
+    let(:agent_id) { 'foobar' }
+
+    let(:permission_template_access) do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: admin_set.permission_template,
+             agent_type: agent_type,
+             agent_id: agent_id)
+    end
+
+    subject { permission_template_access }
+
+    describe '#label' do
+      it 'returns the user label' do
+        expect(subject.label).to eq agent_id
+      end
+    end
+    describe '#admin_group?' do
+      it 'returns true' do
+        expect(subject).not_to be_admin_group
+      end
+    end
+    describe '#destroy' do
+      it 'carries out the destroy operation' do
+        subject.destroy
+        expect(subject).to be_destroyed
+        expect(subject.errors).to be_empty
+      end
+    end
+  end
+
+  context 'with a user that is an admin set manager' do
+    let(:agent_type) { 'user' }
+    let(:agent_id) { 'foobar' }
+
+    let(:permission_template_access) do
+      create(:permission_template_access,
+             :manage,
+             permission_template: admin_set.permission_template,
+             agent_type: agent_type,
+             agent_id: agent_id)
+    end
+
+    subject { permission_template_access }
+
+    describe '#label' do
+      it 'returns the user label' do
         expect(subject.label).to eq agent_id
       end
     end

--- a/spec/views/hyrax/admin/admin_sets/_form_participant_table.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_form_participant_table.html.erb_spec.rb
@@ -1,12 +1,13 @@
 RSpec.describe 'hyrax/admin/admin_sets/_form_participant_table.html.erb', type: :view do
   let(:template) { stub_model(Hyrax::PermissionTemplate) }
+  let(:admin) { create(:admin) }
   let(:user) { create(:user) }
-  let(:access_grant) { stub_model(Hyrax::PermissionTemplateAccess) }
+  let(:access_grants) { [stub_model(Hyrax::PermissionTemplateAccess)] }
   let(:pt_form) do
     instance_double(Hyrax::Forms::PermissionTemplateForm,
                     model_name: template.model_name,
                     to_key: template.to_key,
-                    access_grants: [access_grant])
+                    access_grants: access_grants)
   end
 
   before do
@@ -23,20 +24,27 @@ RSpec.describe 'hyrax/admin/admin_sets/_form_participant_table.html.erb', type: 
     end
 
     context "managers exist" do
-      let(:access_grant) do
-        stub_model(Hyrax::PermissionTemplateAccess,
-                   agent_type: 'user',
-                   agent_id: user.user_key,
-                   access: 'manage')
+      let(:access_grants) do
+        [stub_model(Hyrax::PermissionTemplateAccess,
+                    agent_type: 'user',
+                    agent_id: user.user_key,
+                    access: 'manage'),
+         stub_model(Hyrax::PermissionTemplateAccess,
+                    agent_type: 'group',
+                    agent_id: Ability.admin_group_name,
+                    access: 'manage')]
       end
 
       it "lists the managers in the table" do
         expect(rendered).to have_selector("h3", text: "Managers")
         expect(rendered).to have_selector("table tbody", text: user.user_key)
+        expect(rendered).to have_selector("table tbody", text: 'Repository Administrators')
+        expect(rendered).to have_button(class: 'btn-danger', disabled: true,
+                                        title: 'The repository administrators group cannot be removed')
       end
     end
     context "no managers exist" do
-      let(:access_grant) { stub_model(Hyrax::PermissionTemplateAccess) }
+      let(:access_grants) { [stub_model(Hyrax::PermissionTemplateAccess)] }
 
       it "displays a message and no table" do
         expect(rendered).to have_selector("h3", text: "Managers")
@@ -52,20 +60,27 @@ RSpec.describe 'hyrax/admin/admin_sets/_form_participant_table.html.erb', type: 
     end
 
     context "viewers exist" do
-      let(:access_grant) do
-        stub_model(Hyrax::PermissionTemplateAccess,
-                   agent_type: 'user',
-                   agent_id: user.user_key,
-                   access: 'view')
+      let(:access_grants) do
+        [stub_model(Hyrax::PermissionTemplateAccess,
+                    agent_type: 'user',
+                    agent_id: user.user_key,
+                    access: 'view'),
+         stub_model(Hyrax::PermissionTemplateAccess,
+                    agent_type: 'group',
+                    agent_id: Ability.admin_group_name,
+                    access: 'view')]
       end
 
       it "lists the viewers in the table" do
         expect(rendered).to have_selector("h3", text: "Viewers")
         expect(rendered).to have_selector("table tbody", text: user.user_key)
+        expect(rendered).to have_selector("table tbody", text: 'Repository Administrators')
+        expect(rendered).not_to have_button(class: 'btn-danger', disabled: true,
+                                            title: 'The repository administrators group cannot be removed')
       end
     end
     context "no viewers exist" do
-      let(:access_grant) { stub_model(Hyrax::PermissionTemplateAccess) }
+      let(:access_grants) { [stub_model(Hyrax::PermissionTemplateAccess)] }
 
       it "displays a message and no table" do
         expect(rendered).to have_selector("h3", text: "Viewers")
@@ -81,20 +96,27 @@ RSpec.describe 'hyrax/admin/admin_sets/_form_participant_table.html.erb', type: 
     end
 
     context "depositors exist" do
-      let(:access_grant) do
-        stub_model(Hyrax::PermissionTemplateAccess,
-                   agent_type: 'user',
-                   agent_id: user.user_key,
-                   access: 'deposit')
+      let(:access_grants) do
+        [stub_model(Hyrax::PermissionTemplateAccess,
+                    agent_type: 'user',
+                    agent_id: user.user_key,
+                    access: 'deposit'),
+         stub_model(Hyrax::PermissionTemplateAccess,
+                    agent_type: 'group',
+                    agent_id: Ability.admin_group_name,
+                    access: 'deposit')]
       end
 
       it "lists the depositors in the table" do
         expect(rendered).to have_selector("h3", text: "Depositors")
         expect(rendered).to have_selector("table tbody", text: user.user_key)
+        expect(rendered).to have_selector("table tbody", text: 'Repository Administrators')
+        expect(rendered).not_to have_button(class: 'btn-danger', disabled: true,
+                                            title: 'The repository administrators group cannot be removed')
       end
     end
     context "no depositors exist" do
-      let(:access_grant) { stub_model(Hyrax::PermissionTemplateAccess) }
+      let(:access_grants) { [stub_model(Hyrax::PermissionTemplateAccess)] }
 
       it "displays a message and no table" do
         expect(rendered).to have_selector("h3", text: "Depositors")


### PR DESCRIPTION
Fixes #1673 

When an admin set is deleted remove entries from permission_templates and permission_template_accesses.