### PR TITLE
Update import_url_job file_set reload and spec setup

### DIFF
--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -24,7 +24,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
     #       copying the file here. This will be gnarly.
     copy_remote_file(uri) do |f|
       # reload the FileSet once the data is copied since this is a long running task
-      file_set.reload
+      file_set = Hyrax::Queries.find_by(id: file_set.id)
 
       # FileSetActor operates synchronously so that this tempfile is available.
       # If asynchronous, the job might be invoked on a machine that did not have this temp file on its file system!


### PR DESCRIPTION
Removes call to `file_set.reload` in `ImportUrlJob` and "Valkyrizes" more of the spec setup in `import_url_job_spec.rb`.