### PR TITLE
Add legend for screen readers.

### DIFF
--- a/app/views/hyrax/my/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/my/_sort_and_per_page.html.erb
@@ -3,6 +3,7 @@
       <%= form_tag search_action_for_dashboard, method: :get, class: 'per_page form-inline' do %>
             <div class="form-group">
               <fieldset class="col-xs-12">
+                <legend class="sr-only"><%= t('hyrax.dashboard.my.sr.results_per_page') %></legend>
                 <%= label_tag :per_page do %>
                     Show <%= select_tag :per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])),
                                         title: "Number of results to display per page" %> per page

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -460,6 +460,7 @@ en:
           detail_label:     "Display summary details of"
           listing:          "Listing of items you have deposited in"
           press_to:         "Press to"
+          results_per_page: "Number of results to display per page"
           show_label:       "Display all details of"
         works:        "Your Works"
       no_activity:              "User has no recent activity"


### PR DESCRIPTION
Fixes #2075

Adds legend to results to show per page drop down. Legend is helpful for screen readers.