### PR TITLE
[WIP] Issue#1840

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -68,7 +68,7 @@ module Hyrax
         form
       end
 
-      def show
+      def show_admin
         banner_info = CollectionBrandingInfo.where(collection_id: @collection.id.to_s).where(role: "banner")
         @banner_file = "/" + banner_info.first.local_path.split("/")[-4..-1].join("/") unless banner_info.empty?
 

--- a/app/models/concerns/hyrax/ability/collection_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_ability.rb
@@ -23,10 +23,10 @@ module Hyrax
             Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
           end
 
-          can :view_admin_show, Collection do |collection| # admin show page
+          can :show_admin, Collection do |collection| # admin show page
             Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: collection.id)
           end
-          can :view_admin_show, ::SolrDocument do |solr_doc| # admin show page
+          can :show_admin, ::SolrDocument do |solr_doc| # admin show page
             Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
           end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,7 @@ Hyrax::Engine.routes.draw do
         put :remove_member
       end
     end
+    get 'collection/:id', controller: 'collections', action: :show_admin
     get 'collections/:child_id/within', controller: 'nest_collections', action: 'new_within', as: 'new_nest_collection_within'
     post 'collections/:child_id/within', controller: 'nest_collections', action: 'create_within', as: 'create_nest_collection_within'
     post 'collections/:child_id/process_nesting', controller: 'nest_collections', action: 'process_nesting', as: 'nest_collection_process'


### PR DESCRIPTION
Fixes #1840

Users should be able to view the collection admin page for collections where they have View or Deposit access.

Users can see all collections for which they have Manage, View, and Deposit access in Dashboard -> Collections -> Managed Collections. When a collection title is clicked for View or Deposit access collections, they are forwarded to the home page with a permissions error.
