### PR TITLE
Don't call prepopulate before update

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -34,7 +34,7 @@ module Hyrax
     end
 
     def update
-      @change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
+      @change_set = change_set_class.new(find_resource(params[:id]))
       authorize! :update, @change_set.resource
       if actor.update(actor_environment)
         after_update_success(@change_set.resource, @change_set)


### PR DESCRIPTION
It says not to do that here:
http://trailblazer.to/gems/reform/prepopulator.html#prepopulate-is-not-populate

> :populator and :populate_if_empty will be run automatically in
> validate. Do not call prepopulate! before validate if you use the
> populator options. This will usually result in “more” nested forms
> being added as you wanted (unless you know what you’re doing).
>
> Prepopulators are a concept designed to prepare a form for
> rendering, whereas populators are meant to set up the form in
> validate when the input hash is deserialized.
