### PR TITLE
Retreive files from Valkyrie

### DIFF
--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -10,16 +10,13 @@ module Hyrax
     # Otherwise renders the file.
     def show
       case file
-      when ActiveFedora::File
-        # For original files that are stored in fedora
-        super
-      when String
+      when String, File
         # For derivatives stored on the local file system
         response.headers['Accept-Ranges'] = 'bytes'
         response.headers['Content-Length'] = File.size(file).to_s
         send_file file, derivative_download_options
       else
-        raise ActiveFedora::ObjectNotFoundError
+        raise Hyrax::ObjectNotFoundError
       end
     end
 
@@ -70,8 +67,7 @@ module Hyrax
                                  else
                                    DownloadsController.default_content_path
                                  end
-        association = dereference_file(default_file_reference)
-        association.reader if association
+        dereference_file(default_file_reference)
       end
 
       def mime_type_for(file)
@@ -80,8 +76,15 @@ module Hyrax
 
       def dereference_file(file_reference)
         return false if file_reference.nil?
-        association = asset.association(file_reference.to_sym)
-        association if association && association.is_a?(ActiveFedora::Associations::SingularAssociation)
+        return false unless asset.respond_to?(file_reference)
+        file_node = asset.send(file_reference)
+        file = Valkyrie::StorageAdapter.find_by(id: file_node.file_identifiers.first)
+        file.io
+      end
+
+      # Overrides Hydra::Controller::DownloadBehavior#asset
+      def asset
+        @asset ||= Hyrax::Queries.find_by(id: Valkyrie::ID.new(params[asset_param_key]))
       end
   end
 end

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -38,7 +38,7 @@ module Hyrax
       # Hydra::Ability#download_permissions can't be used in this case because it assumes
       # that files are in a LDP basic container, and thus, included in the asset's uri.
       def authorize_download!
-        authorize! :download, params[asset_param_key]
+        authorize! :download, params[asset_param_key].to_s
       rescue CanCan::AccessDenied
         redirect_to default_image
       end

--- a/app/controllers/hyrax/single_use_links_viewer_controller.rb
+++ b/app/controllers/hyrax/single_use_links_viewer_controller.rb
@@ -14,7 +14,6 @@ module Hyrax
 
     def download
       raise not_found_exception unless single_use_link.path == hyrax.download_path(id: @asset)
-      # send_content
       # TODO: copied from DownloadsController#show and isn't handling HEAD or range requests
       response.headers['Accept-Ranges'] = 'bytes'
       response.headers['Content-Length'] = File.size(file).to_s

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Hyrax::DownloadsController do
       before { sign_in user }
 
       it 'sends the original file' do
-        get :show, params: { id: file_set }
-        expect(response.body).to eq file_set.original_file.content
+        get :show, params: { id: file_set.to_param }
+        expect(response.body).to eq file.tempfile.read
       end
 
       context "with an alternative file" do
@@ -56,7 +56,7 @@ RSpec.describe Hyrax::DownloadsController do
           end
 
           it 'sends requested file content' do
-            get :show, params: { id: file_set, file: 'thumbnail' }
+            get :show, params: { id: file_set.to_param, file: 'thumbnail' }
             expect(response).to be_success
             expect(response.body).to eq content
             expect(response.headers['Content-Length']).to eq "4218"
@@ -65,23 +65,23 @@ RSpec.describe Hyrax::DownloadsController do
 
           it 'retrieves the thumbnail without contacting Fedora' do
             expect(ActiveFedora::Base).not_to receive(:find).with(file_set.id)
-            get :show, params: { id: file_set, file: 'thumbnail' }
+            get :show, params: { id: file_set.to_param, file: 'thumbnail' }
           end
         end
 
         context "that isn't persisted" do
           it "raises an error if the requested file does not exist" do
             expect do
-              get :show, params: { id: file_set, file: 'thumbnail' }
-            end.to raise_error ActiveFedora::ObjectNotFoundError
+              get :show, params: { id: file_set.to_param, file: 'thumbnail' }
+            end.to raise_error Hyrax::ObjectNotFoundError
           end
         end
       end
 
       it "raises an error if the requested association does not exist" do
         expect do
-          get :show, params: { id: file_set, file: 'non-existant' }
-        end.to raise_error ActiveFedora::ObjectNotFoundError
+          get :show, params: { id: file_set.to_param, file: 'non-existant' }
+        end.to raise_error Hyrax::ObjectNotFoundError
       end
     end
   end

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -21,20 +21,20 @@ RSpec.describe Hyrax::DownloadsController do
       before { sign_in another_user }
 
       it 'redirects to the default image' do
-        get :show, params: { id: file_set.to_param }
+        get :show, params: { id: file_set }
         expect(response).to redirect_to default_image
       end
     end
 
     context "when user isn't logged in" do
       it 'redirects to the default image' do
-        get :show, params: { id: file_set.to_param }
+        get :show, params: { id: file_set }
         expect(response).to redirect_to default_image
       end
 
       it 'authorizes the resource using only the id' do
         expect(controller).to receive(:authorize!).with(:download, file_set.id.to_s)
-        get :show, params: { id: file_set.to_param }
+        get :show, params: { id: file_set }
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe Hyrax::DownloadsController do
       before { sign_in user }
 
       it 'sends the original file' do
-        get :show, params: { id: file_set.to_param }
+        get :show, params: { id: file_set }
         expect(response.body).to eq file.tempfile.read
       end
 
@@ -56,7 +56,7 @@ RSpec.describe Hyrax::DownloadsController do
           end
 
           it 'sends requested file content' do
-            get :show, params: { id: file_set.to_param, file: 'thumbnail' }
+            get :show, params: { id: file_set, file: 'thumbnail' }
             expect(response).to be_success
             expect(response.body).to eq content
             expect(response.headers['Content-Length']).to eq "4218"
@@ -65,14 +65,14 @@ RSpec.describe Hyrax::DownloadsController do
 
           it 'retrieves the thumbnail without contacting Fedora' do
             expect(ActiveFedora::Base).not_to receive(:find).with(file_set.id)
-            get :show, params: { id: file_set.to_param, file: 'thumbnail' }
+            get :show, params: { id: file_set, file: 'thumbnail' }
           end
         end
 
         context "that isn't persisted" do
           it "raises an error if the requested file does not exist" do
             expect do
-              get :show, params: { id: file_set.to_param, file: 'thumbnail' }
+              get :show, params: { id: file_set, file: 'thumbnail' }
             end.to raise_error Hyrax::ObjectNotFoundError
           end
         end
@@ -80,7 +80,7 @@ RSpec.describe Hyrax::DownloadsController do
 
       it "raises an error if the requested association does not exist" do
         expect do
-          get :show, params: { id: file_set.to_param, file: 'non-existant' }
+          get :show, params: { id: file_set, file: 'non-existant' }
         end.to raise_error Hyrax::ObjectNotFoundError
       end
     end

--- a/spec/controllers/hyrax/single_use_links_viewer_controller_spec.rb
+++ b/spec/controllers/hyrax/single_use_links_viewer_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::SingleUseLinksViewerController do
   let(:download_link_hash) { download_link.downloadKey }
 
   describe "GET 'download'" do
-    let(:expected_content) { file.original_file.content }
+    let(:expected_content) { content.tempfile.read }
 
     it "downloads the file and deletes the link from the database" do
       expect(controller).to receive(:send_file_headers!).with(filename: 'world.png', disposition: 'attachment', type: 'image/png')


### PR DESCRIPTION
One of the tests (spec/controllers/hyrax/downloads_controller_spec.rb:84) randomly fails with `uninitialized constant Hyrax::ObjectNotFoundError`.  If you run it directly it always fails but when the whole file is run it only fails some of the time.  I can't find what would be different from a different run order.