### PR TITLE
Cast admin_set_id to a string

### DIFF
--- a/app/models/concerns/hyrax/in_admin_set.rb
+++ b/app/models/concerns/hyrax/in_admin_set.rb
@@ -7,7 +7,7 @@ module Hyrax
     end
 
     def active_workflow
-      Sipity::Workflow.find_active_workflow_for(admin_set_id: admin_set_id)
+      Sipity::Workflow.find_active_workflow_for(admin_set_id: admin_set_id.to_s)
     end
   end
 end


### PR DESCRIPTION
Otherwise it raises an error when we attempt an ActiveRecord query with it.
