### PR TITLE
Use #convert(to:) instead of #convert_to_sipity_entity

### DIFF
--- a/spec/conversions/power_converters/sipity_entity_spec.rb
+++ b/spec/conversions/power_converters/sipity_entity_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe 'PowerConverter' do
   context '#convert_to_sipity_entity' do
-    subject { PowerConverter.convert_to_sipity_entity(object) }
+    subject { PowerConverter.convert(object, to: :sipity_entity) }
 
     context "with a Sipity::Entity" do
       let(:object) { Sipity::Entity.new }
@@ -18,8 +18,6 @@ RSpec.describe 'PowerConverter' do
     end
 
     context "with a SolrDocument" do
-      subject { PowerConverter.convert(object, to: :sipity_entity) }
-
       let(:object) { SolrDocument.new(id: '9999', Valkyrie::Persistence::Solr::Queries::MODEL => ["GenericWork"]) }
       let(:workflow_state) { create(:workflow_state) }
       let!(:entity) do
@@ -32,22 +30,27 @@ RSpec.describe 'PowerConverter' do
     end
 
     context 'a Models::Work (because it will be processed)' do
+      let(:object) { build(:work) }
+
       # This is poking knowledge over into the inner workings of Models::Work
       # but is a reasonable place to understand this.
       it 'will raise an exception if one has not been assigned' do
-        object = build(:work)
-        expect { PowerConverter.convert_to_sipity_entity(object) }.to raise_error RuntimeError, "Can't create an entity until the model has been persisted"
+        expect { subject }.to raise_error RuntimeError, "Can't create an entity until the model has been persisted"
       end
     end
 
-    it 'will return the to_processing_entity if the object responds to the processing entity' do
-      object = double(to_sipity_entity: :processing_entity)
-      expect(PowerConverter.convert_to_sipity_entity(object)).to eq(:processing_entity)
+    context 'with an object that responds to processing_entity' do
+      let(:object) { double(to_sipity_entity: :processing_entity) }
+
+      it { is_expected.to eq :processing_entity }
     end
 
-    it 'will raise an error if it cannot convert' do
-      object = double
-      expect { PowerConverter.convert_to_sipity_entity(object) }.to raise_error PowerConverter::ConversionError
+    context 'with an invalid object' do
+      let(:object) { double }
+
+      it 'will raise an error if it cannot convert' do
+         expect { subject }.to raise_error PowerConverter::ConversionError
+       end
     end
   end
 end


### PR DESCRIPTION
Using `#convert_to_sipity_entity` caused some tests to fail with `KeyError: key not found: :to`.