### PR TITLE
Use WorksSearchBuilder instead of WorkRelation

### DIFF
--- a/app/change_sets/hyrax/work_change_set.rb
+++ b/app/change_sets/hyrax/work_change_set.rb
@@ -33,6 +33,8 @@ module Hyrax
     collection :permissions, virtual: true
     collection :work_members, virtual: true
 
+    property :admin_set_id, virtual: false
+
     validate :validate_lease
     validate :validate_embargo
     validate :validate_release_type

--- a/app/services/hyrax/workflow/status_list_service.rb
+++ b/app/services/hyrax/workflow/status_list_service.rb
@@ -2,6 +2,8 @@ module Hyrax
   module Workflow
     # Finds a list of works that we can perform a workflow action on
     class StatusListService
+      include Blacklight::SearchHelper
+
       # @param context [#current_user, #logger]
       # @param filter_condition [String] a solr filter
       def initialize(context, filter_condition)
@@ -28,8 +30,9 @@ module Hyrax
       private
 
         delegate :logger, to: :context
+        delegate :blacklight_config, to: CatalogController
 
-        # @return [Hash<String,SolrDocument>] a hash of id to solr document
+        # @return [Array<SolrDocument>] array of matching solr documents
         def solr_documents
           search_solr.map { |result| ::SolrDocument.new(result) }
         end
@@ -38,7 +41,10 @@ module Hyrax
           actionable_roles = roles_for_user
           logger.debug("Actionable roles for #{user.user_key} are #{actionable_roles}")
           return [] if actionable_roles.empty?
-          WorkRelation.new.search_with_conditions(query(actionable_roles), rows: 1000)
+          work_query = WorksSearchBuilder.new([:filter_models], self).query
+          work_query["fq"] += query(actionable_roles)
+          work_query["rows"] = 1000
+          repository.search(work_query).response["docs"]
         end
 
         def query(actionable_roles)

--- a/lib/hyrax/move_all_works_to_admin_set.rb
+++ b/lib/hyrax/move_all_works_to_admin_set.rb
@@ -1,8 +1,46 @@
 # If you want to move all your works to an admin set run this.
 class MoveAllWorksToAdminSet
+  include Blacklight::SearchHelper
+
   def self.run(admin_set)
-    Hyrax::WorkRelation.new.find_each do |w|
-      w.update(admin_set: admin_set)
+    new(admin_set).run
+  end
+
+  def initialize(admin_set)
+    @admin_set = admin_set
+  end
+
+  def run
+    work_ids.each do |id|
+      work = Hyrax::Queries.find_by(id: Valkyrie::ID.new(id))
+      change_set = Hyrax::WorkChangeSet.new(work)
+      params = { admin_set_id: @admin_set.id }
+      raise "Unable to update work. #{change_set.errors.messages}" unless change_set.validate(params)
+      change_set.sync
+      change_set_persister.save(change_set: change_set)
     end
   end
+
+  private
+
+    delegate :blacklight_config, to: CatalogController
+
+    def change_set_persister
+      Hyrax::WorkChangeSetPersister.new(
+        metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
+        storage_adapter: Valkyrie.config.storage_adapter
+      )
+    end
+
+    class SearchContext
+      def initialize(user = nil)
+        @user = user
+      end
+      attr_reader :user
+    end
+
+    def work_ids
+      query = Hyrax::WorksSearchBuilder.new([:filter_models], self).query
+      repository.search(query).response["docs"].map { |doc| doc["id"] }
+    end
 end

--- a/spec/lib/hyrax/move_all_works_to_admin_set_spec.rb
+++ b/spec/lib/hyrax/move_all_works_to_admin_set_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe MoveAllWorksToAdminSet, :clean_repo do
 
   it "moves the work into the admin set" do
     subject
-    expect(work.reload.admin_set).to eq admin_set
+    reloaded = Hyrax::Queries.find_by(id: work.id)
+    expect(reloaded.admin_set_id).to eq admin_set.id
   end
 end


### PR DESCRIPTION
After this PR there are two remaining references to WorkRelation: `Hyrax::Statistics::Works::OverTime` and `Hyrax::ResourceSync::ResourceListWriter`