### PR TITLE
Use SearchBuilders instead of relations

### DIFF
--- a/app/search_builders/hyrax/exposed_models_relation.rb
+++ b/app/search_builders/hyrax/exposed_models_relation.rb
@@ -1,8 +1,0 @@
-module Hyrax
-  # A relation that scopes to all user visible models (e.g. works + collections + file sets)
-  class ExposedModelsRelation < AbstractTypeRelation
-    def allowable_types
-      Hyrax.config.curation_concerns + [Collection, ::FileSet]
-    end
-  end
-end

--- a/app/search_builders/hyrax/exposed_models_search_builder.rb
+++ b/app/search_builders/hyrax/exposed_models_search_builder.rb
@@ -1,0 +1,13 @@
+module Hyrax
+  # A search builder that scopes to all user visible models (e.g. works + collections + file sets)
+  class ExposedModelsSearchBuilder < ::SearchBuilder
+    self.default_processor_chain = [:filter_models]
+
+    private
+
+      # This overrides the models in FilterByType
+      def models
+        Hyrax.config.curation_concerns + [Collection, ::FileSet]
+      end
+  end
+end

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -15,16 +15,18 @@ FactoryGirl.define do
     end
 
     factory :public_collection, traits: [:public]
+    factory :private_collection, traits: [:private]
+    factory :institution_collection, traits: [:institution]
 
     trait :public do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
-    factory :private_collection do
+    trait :private do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
     end
 
-    factory :institution_collection do
+    trait :institution do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
     end
 

--- a/spec/lib/hyrax/resource_sync/change_list_writer_spec.rb
+++ b/spec/lib/hyrax/resource_sync/change_list_writer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Hyrax::ResourceSync::ChangeListWriter, :clean_repo do
   let(:sitemap) { 'http://www.sitemaps.org/schemas/sitemap/0.9' }
-  let(:public_collection) { create(:public_collection) }
+  let(:public_collection) { create_for_repository(:collection, :public) }
   let(:public_work) { create_for_repository(:work, :public) }
   let(:file_set) { create_for_repository(:file_set, :public) }
   let(:capability_list) { 'http://example.com/capabilityList.xml' }
@@ -38,13 +38,13 @@ RSpec.describe Hyrax::ResourceSync::ChangeListWriter, :clean_repo do
       expect(capability).to eq capability_list
 
       expect(location(1)).to eq "http://example.com/concern/file_sets/#{file_set.id}"
-      expect(change(1)).to eq "created"
+      expect(change(1)).to eq "updated"
 
       expect(location(2)).to eq "http://example.com/concern/generic_works/#{public_work.id}"
-      expect(change(2)).to eq "created"
+      expect(change(2)).to eq "updated"
 
       expect(location(3)).to eq "http://example.com/collections/#{public_collection.id}"
-      expect(change(3)).to eq "created"
+      expect(change(3)).to eq "updated"
 
       expect(url_list.count).to eq 3
     end

--- a/spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb
+++ b/spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Hyrax::ResourceSync::ResourceListWriter, :clean_repo do
   let(:sitemap) { 'http://www.sitemaps.org/schemas/sitemap/0.9' }
-  let!(:private_collection) { create(:private_collection) }
-  let!(:public_collection) { create(:public_collection) }
+  let!(:private_collection) { create_for_repository(:collection, :private) }
+  let!(:public_collection) { create_for_repository(:collection, :public) }
   let!(:public_work) { create_for_repository(:work, :public) }
   let!(:private_work) { create_for_repository(:work) }
   let!(:file_set) { create_for_repository(:file_set, :public) }


### PR DESCRIPTION
After this and #2125 are merged then I believe AbstractTypeRelation and WorkRelation can be removed after `Hyrax::WorkRelation::DummyModel.primary_concern` gets moved.