### PR TITLE
Fix models tests for valkyrie

### DIFF
--- a/app/models/batch_upload_item.rb
+++ b/app/models/batch_upload_item.rb
@@ -2,7 +2,7 @@
 # It should never actually be persisted in the repository.
 # The properties on this form should be copied to a real work type.
 class BatchUploadItem < Valkyrie::Resource
-  # include Hyrax::WorkBehavior
+  include Hyrax::WorkBehavior
   # This must come after the WorkBehavior because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/spec/models/hyrax/permissions/writable_permissions_spec.rb
+++ b/spec/models/hyrax/permissions/writable_permissions_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe Hyrax::Permissions::Writable do
   end
   let(:subject) { SampleModel.new }
 
-  describe '#permissions' do
+  describe 'permissions' do
     it 'initializes with nothing specified' do
-      expect(subject.permissions).to be_empty
+      expect(subject.read_users).to be_empty
+      expect(subject.read_groups).to be_empty
+      expect(subject.edit_users).to be_empty
+      expect(subject.edit_groups).to be_empty
     end
   end
 end

--- a/spec/models/proxy_deposit_request_spec.rb
+++ b/spec/models/proxy_deposit_request_spec.rb
@@ -146,29 +146,27 @@ RSpec.describe ProxyDepositRequest, type: :model do
 
   describe '#work' do
     let(:request) { described_class.new(work_id: work.id) }
-    let(:work) { build(:work, id: Valkyrie::ID.new(work_id)) }
+    let(:work) { create_for_repository(:work) }
 
     subject { request.work.id }
 
     context 'when it exists' do
-      before { allow(Hyrax::Queries).to receive(:find_by).with(id: Valkyrie::ID.new(request.work_id)).and_return(work) }
       it { is_expected.to eq work.id }
     end
   end
 
   describe '#to_s' do
-    let(:request) { described_class.new(work_id: work.id) }
-    let(:work) { build(:work, id: Valkyrie::ID.new(work_id), title: ["Test work"]) }
-
     subject { request.to_s }
 
     context 'when the work is deleted' do
-      before { allow(Hyrax::Queries).to receive(:exists?).with(Valkyrie::ID.new(request.work_id)).and_return(false) }
+      let(:request) { described_class.new(work_id: 'non-existant') }
+
       it { is_expected.to eq('work not found') }
     end
 
     context 'when the work is not deleted' do
-      before { allow(Hyrax::Queries).to receive(:find_by).with(id: Valkyrie::ID.new(request.work_id)).and_return(work) }
+      let(:request) { described_class.new(work_id: work.id) }
+      let(:work) { create_for_repository(:work, title: ["Test work"]) }
 
       it 'will retrieve the SOLR document and use the #to_s method of that' do
         expect(subject).to eq(work.title.first)

--- a/spec/models/work_view_stat_spec.rb
+++ b/spec/models/work_view_stat_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe WorkViewStat, type: :model do
   let(:user_id) { 123 }
   let(:date) { DateTime.new.in_time_zone }
   let(:work_stat) { described_class.create(work_views: "25", date: date, work_id: work_id, user_id: user_id) }
-  let(:work) { instance_double(GenericWork, id: 199) }
+  let(:work) { create_for_repository(:work) }
 
   it "has attributes" do
     expect(work_stat).to respond_to(:work_views)
     expect(work_stat).to respond_to(:date)
     expect(work_stat).to respond_to(:work_id)
-    expect(work_stat.work_id).to eq("199")
+    expect(work_stat.work_id).to eq(work.id.to_s)
     expect(work_stat.date).to eq(date)
     expect(work_stat.work_views).to eq(25)
     expect(work_stat.user_id).to eq(user_id)


### PR DESCRIPTION
After this PR is merged the only tests still failing in spec/models are in `spec/models/checksum_audit_log_spec.rb` and are waiting on `Hyrax::VersioningService`.