### PR TITLE
Bump ActiveFedora dependency to 11.5.1

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -72,7 +72,7 @@ EOF
   spec.add_dependency 'dry-struct', '~> 0.1'
   spec.add_dependency 'redlock', '>= 0.1.2'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
-  spec.add_dependency 'active-fedora', '>= 11.3.1'
+  spec.add_dependency 'active-fedora', '~> 11.5', '>= 11.5.2'
   spec.add_dependency 'linkeddata' # Required for getting values from geonames
 
   spec.add_development_dependency 'engine_cart', '~> 1.2'


### PR DESCRIPTION
We need this release to fix a major bug in the nested works feature. See samvera/active_fedora#1286 and #2108.

Fixes #2108.

The version requirement continues to be `>=`, it looks as though `hydra-head` locks us to `< 12.0.0`.

@samvera/hyrax-code-reviewers