### PR TITLE
Setting work state to ActiveTriples::Resource.

### DIFF
--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -41,9 +41,14 @@ RSpec.describe GenericWork do
     let(:work) { described_class.new(state: inactive) }
     let(:inactive) { ::RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#inactive') }
 
-    subject { work.state.rdf_subject }
+    it 'is inactive' do
+      expect(work.state.rdf_subject).to eq inactive
+    end
 
-    it { is_expected.to eq inactive }
+    it 'allows state to be set to ActiveTriples::Resource' do
+      other_work = described_class.new(state: work.state)
+      expect(other_work.state.rdf_subject).to eq inactive
+    end
   end
 
   describe '#suppressed?' do


### PR DESCRIPTION
Refs #2108 

A test that captures the failure described in #2108. Validates that a `ActiveTriples::Resource` can be assigned to a  single valued AF property.
