### PR TITLE
[WIP] Coll 2071 - Fix admin_set controller to add proper breadcrumbs

### DIFF
--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -24,8 +24,8 @@ module Hyrax
     def show
       add_breadcrumb t(:'hyrax.controls.home'), root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb t(:'hyrax.admin.sidebar.admin_sets'), hyrax.admin_admin_sets_path
-      add_breadcrumb t(:'hyrax.admin.admin_sets.show.breadcrumb'), request.path
+      add_breadcrumb t(:'hyrax.dashboard.my.collections'), hyrax.my_collections_path
+      add_breadcrumb presenter.to_s, request.path
       super
     end
 
@@ -106,7 +106,7 @@ module Hyrax
       def setup_form
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb t(:'hyrax.admin.sidebar.admin_sets'), hyrax.admin_admin_sets_path
+        add_breadcrumb t(:'hyrax.dashboard.my.collections'), hyrax.my_collections_path
         add_breadcrumb action_breadcrumb, request.path
         form
       end


### PR DESCRIPTION
Fixes #2071 

Descriptive summary

Change bread crumbs for admin set show page to match those for collection show page.

Rationale
Admin sets are simulating being just another collection, so the bread crumbs should look like the admin set is just another collection.

Expected behavior
admin/admin_sets/:id breadcrumbs should be...

The consistent set of breadcrumbs starts with...
* Home - `/`
* Administration - `/dashboard`
* Your Collections - `/dashboard/my/collections`
* admin set/collection title
