### PR TITLE
Avoid the use of deprecated sort_fields method

### DIFF
--- a/app/views/hyrax/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/collections/_sort_and_per_page.html.erb
@@ -1,13 +1,12 @@
 <div class="batch-info">
-  <%# kind of hacky way to get this to work on catalog and folder controllers.  May be able to simple do {action: "index"} but I'm not sure -%>
-  <% if @response.response['numFound'] > 1 && !sort_fields.empty? %>
+  <% if show_sort_and_per_page? && active_sort_fields.many? %>
     <div class="sort-toggle">
         <%= form_tag collection_path(collection), method: :get, class: 'per_page form-horizontal' do %>
              <div class="form-group form-group-lg">
                <fieldset class="col-xs-12 col-sm-9 col-md-8 col-lg-10">
                  <legend class="sr-only"><%= t('hyrax.sort_label') %></legend>
                  <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
-                 <%= select_tag(:sort, options_for_select(sort_fields, h(params[:sort]))) %>
+                 <%= select_tag(:sort, options_for_select(active_sort_fields, h(params[:sort]))) %>
                  <%= label_tag(:per_page) do %>
                      Show <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: "Number of results to display per page") %>
                      per page

--- a/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
@@ -1,22 +1,21 @@
 <div class="batch-info">
   <%= render 'form_for_select_collection', user_collections: @user_collections %>
 
-  <% if params[:action] == "edit" && @response.response['numFound'] > 1 %>
-  <div class="batch-toggle">
-    <% session[:batch_edit_state] = "on" %>
-    <%= button_for_remove_selected_from_collection collection %>
-  </div>
+  <% if params[:action] == "edit" && show_sort_and_per_page? %>
+    <div class="batch-toggle">
+      <% session[:batch_edit_state] = "on" %>
+      <%= button_for_remove_selected_from_collection collection %>
+    </div>
   <% end %>
 
-  <%# kind of hacky way to get this to work on catalog and folder controllers.  May be able to simple do {action: "index"} but I'm not sure -%>
-  <% if @response.response['numFound'] > 1 && !sort_fields.empty? %>
+  <% if show_sort_and_per_page? && active_sort_fields.many? %>
     <div class="sort-toggle">
         <%= form_tag dashboard_collection_path(collection), method: :get, class: 'per_page form-horizontal' do %>
              <div class="form-group form-group-lg">
                <fieldset class="col-xs-12 col-sm-9 col-md-8 col-lg-10">
                  <legend class="sr-only"><%= t('hyrax.sort_label') %></legend>
                  <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
-                 <%= select_tag(:sort, options_for_select(sort_fields, h(params[:sort]))) %>
+                 <%= select_tag(:sort, options_for_select(active_sort_fields, h(params[:sort]))) %>
                  <%= label_tag(:per_page) do %>
                      Show <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: "Number of results to display per page") %>
                      per page

--- a/app/views/hyrax/dashboard/collections/edit.html.erb
+++ b/app/views/hyrax/dashboard/collections/edit.html.erb
@@ -25,7 +25,7 @@
           </div>
           <%= render 'hyrax/my/did_you_mean' %>
           <%= render 'hyrax/my/facet_selected' %>
-          <%= render 'sort_and_per_page', collection: @collection if @response.response['numFound'] > 0 %>
+          <%= render 'sort_and_per_page', collection: @collection if show_sort_and_per_page? %>
           <%= render 'document_list', documents: @member_docs, document_list_format: "dashboard" %>
           <%= render 'hyrax/collections/paginate' %>
         </div>

--- a/app/views/hyrax/my/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/my/_sort_and_per_page.html.erb
@@ -1,17 +1,16 @@
-<% if @response.response['numFound'] > 1 %>
+<% if show_sort_and_per_page? %>
   <div class="sort-toggle">
       <%= form_tag search_action_for_dashboard, method: :get, class: 'per_page form-inline' do %>
-            <div class="form-group">
-              <fieldset class="col-xs-12">
-                <legend class="sr-only"><%= t('hyrax.dashboard.my.sr.results_per_page') %></legend>
-                <%= label_tag :per_page do %>
-                    Show <%= select_tag :per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])),
-                                        title: "Number of results to display per page" %> per page
-                <% end %>
-                <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:per_page, :sort, :utf8)) %>
-              </fieldset>
-            </div>
-
+        <div class="form-group">
+          <fieldset class="col-xs-12">
+            <legend class="sr-only"><%= t('hyrax.dashboard.my.sr.results_per_page') %></legend>
+            <%= label_tag :per_page do %>
+                Show <%= select_tag :per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])),
+                                    title: "Number of results to display per page" %> per page
+            <% end %>
+            <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:per_page, :sort, :utf8)) %>
+          </fieldset>
+        </div>
       <% end %>
   </div>
 <% end %>

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -36,7 +36,7 @@ EOF
   spec.add_dependency 'hydra-works', '~> 0.16'
   spec.add_dependency 'hydra-derivatives', '~> 3.3'
   spec.add_dependency 'browse-everything', '>= 0.10.5'
-  spec.add_dependency 'blacklight', '~> 6.9'
+  spec.add_dependency 'blacklight', '~> 6.11', '>= 6.11.2'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
   spec.add_dependency 'font-awesome-rails', '~> 4.2'

--- a/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'hyrax/dashboard/collections/edit.html.erb', type: :view do
   let(:collection) { stub_model(Collection, id: 'xyz123z4', title: ["Make Collections Great Again"]) }
   let(:form) { Hyrax::Forms::CollectionForm.new(collection, double, double) }
-  let(:solr_response) { double(response: { 'numFound' => 0 }) }
+  let(:solr_response) { instance_double(Blacklight::Solr::Response, empty?: true) }
 
   before do
     allow(view).to receive(:has_collection_search_parameters?).and_return(false)


### PR DESCRIPTION
This forces an upgrade of blacklight from `~> 6.9` to `~6.11`
