### PR TITLE
Don't show the sort-toggle box if it doesn't have content

### DIFF
--- a/app/views/hyrax/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/collections/_sort_and_per_page.html.erb
@@ -1,7 +1,7 @@
 <div class="batch-info">
-   <div class="sort-toggle">
-     <%# kind of hacky way to get this to work on catalog and folder controllers.  May be able to simple do {action: "index"} but I'm not sure -%>
-     <% if @response.response['numFound'] > 1 && !sort_fields.empty? %>
+  <%# kind of hacky way to get this to work on catalog and folder controllers.  May be able to simple do {action: "index"} but I'm not sure -%>
+  <% if @response.response['numFound'] > 1 && !sort_fields.empty? %>
+    <div class="sort-toggle">
         <%= form_tag collection_path(collection), method: :get, class: 'per_page form-horizontal' do %>
              <div class="form-group form-group-lg">
                <fieldset class="col-xs-12 col-sm-9 col-md-8 col-lg-10">
@@ -19,6 +19,6 @@
                <%= render 'view_type_group' %>
              </div>
          <% end %>
-      <% end %>
-   </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
@@ -7,9 +7,9 @@
     <%= button_for_remove_selected_from_collection collection %>
   </div>
   <% end %>
-   <div class="sort-toggle">
-     <%# kind of hacky way to get this to work on catalog and folder controllers.  May be able to simple do {action: "index"} but I'm not sure -%>
-     <% if @response.response['numFound'] > 1 && !sort_fields.empty? %>
+  <%# kind of hacky way to get this to work on catalog and folder controllers.  May be able to simple do {action: "index"} but I'm not sure -%>
+  <% if @response.response['numFound'] > 1 && !sort_fields.empty? %>
+    <div class="sort-toggle">
         <%= form_tag collection_path(collection), method: :get, class: 'per_page form-horizontal' do %>
              <div class="form-group form-group-lg">
                <fieldset class="col-xs-12 col-sm-9 col-md-8 col-lg-10">
@@ -27,6 +27,6 @@
                <%= render 'view_type_group' %>
              </div>
          <% end %>
-      <% end %>
-   </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/hyrax/my/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/my/_sort_and_per_page.html.erb
@@ -1,5 +1,5 @@
+<% if @response.response['numFound'] > 1 %>
   <div class="sort-toggle">
-    <% if @response.response['numFound'] > 1 %>
       <%= form_tag search_action_for_dashboard, method: :get, class: 'per_page form-inline' do %>
             <div class="form-group">
               <fieldset class="col-xs-12">
@@ -13,5 +13,5 @@
             </div>
 
       <% end %>
-    <% end %>
   </div>
+<% end %>


### PR DESCRIPTION
Before:

<img width="886" alt="screen shot 2017-11-10 at 9 25 23 am" src="https://user-images.githubusercontent.com/92044/32665261-4ad602f2-c5f9-11e7-806b-d3557195bdf4.png">


After:

<img width="878" alt="screen shot 2017-11-10 at 9 25 57 am" src="https://user-images.githubusercontent.com/92044/32665270-514fa098-c5f9-11e7-93ef-f69e1d74c20a.png">
