### PR TITLE
Updating documentation to clarify

### DIFF
--- a/app/models/sipity/workflow.rb
+++ b/app/models/sipity/workflow.rb
@@ -37,14 +37,16 @@ module Sipity
     # @api public
     #
     # Within the given permission_template scope:
-    #   * Deactivate the current active workflow (if one exists)
-    #   * Activate the specified workflow_id
+    #   * Activate the specified workflow_id or workflow_name
+    #   * Deactivate the other workflows
+    #
+    # TODO: Resolve https://github.com/samvera/hyrax/issues/2151 as the documentation is aspirational and not reality
     #
     # @param permission_template [Hyrax::PermissionTemplate] The scope for activation of the workflow id
     # @param workflow_id [Integer] The workflow_id within the given permission_template that should be activated
     # @param workflow_name [String] The name of the workflow within the given permission template that should be activated
     # @return [TrueClass]
-    # @raise [ActiveRecord::RecordNotFound] When we have a mismatch on permission template and workflow id
+    # @raise [ActiveRecord::RecordNotFound] When we have a mismatch on permission template and workflow id or workflow name
     # @raise [RuntimeError] When you don't specify a workflow_id or workflow_name
     def self.activate!(permission_template:, workflow_id: nil, workflow_name: nil)
       raise "You must specify a workflow_id or workflow_name to activate!" if workflow_id.blank? && workflow_name.blank?

--- a/spec/models/sipity/workflow_spec.rb
+++ b/spec/models/sipity/workflow_spec.rb
@@ -33,7 +33,7 @@ module Sipity
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
       context 'with :workflow_id keyword' do
-        it 'toggles current active workflows for the permission_template' do
+        it 'activates the specified workflow and deactivates the unspecified workflow for the permission_template' do
           active_workflow_wrong_template = create(:workflow, active: true, permission_template_id: other_permission_template.id)
           inactive_workflow = create(:workflow, permission_template_id: permission_template.id)
 
@@ -44,7 +44,7 @@ module Sipity
         end
       end
       context 'with :workflow_name keyword' do
-        it 'toggles current active workflows for the permission_template' do
+        it 'activates the specified workflow and deactivates the unspecified workflow for the permission_template' do
           active_workflow_wrong_template = create(:workflow, active: true, permission_template_id: other_permission_template.id)
           inactive_workflow = create(:workflow, permission_template_id: permission_template.id)
 


### PR DESCRIPTION
In reviewing the documentation, I believe there may have been confusing
inline documentation that lead to a statement that may be incorrect.

> Calling `#activate!` on a Sipity::Workflow a second time will
> *deactivate* that workflow. If you want your workflow setup script to
> be idempotent, you should add a check to see if it is already
> activated.