### PR TITLE
Hardcode a version of solr to use

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,8 @@
 # Place any default configuration for solr_wrapper here
-# port: 8983
+
+# Automatically determining solr version was failing frequently on Travis.
+# so here we hard code the version:
+version: 7.1.0 
 collection:
   persist: true
   dir: solr/config/


### PR DESCRIPTION
Because the svn.apache.org was frequently not allowing Travis to connect
there.

This will have to do until something like this can be accepted: https://github.com/cbeer/solr_wrapper/pull/106
