### PR TITLE
refactor controlled_vocabulary_input in line with linked_data_resources

### DIFF
--- a/app/inputs/linked_data_resource_input.rb
+++ b/app/inputs/linked_data_resource_input.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ControlledVocabularyInput < MultiValueInput
+class LinkedDataResourceInput < MultiValueInput
   # # Overriding so that the class is correct and the javascript for will activate for this element.
   # # See https://github.com/samvera/hydra-editor/blob/4da9c0ea542f7fde512a306ec3cc90380691138b/app/assets/javascripts/hydra-editor/field_manager.es6#L61
   # def input_type
@@ -12,7 +12,7 @@ class ControlledVocabularyInput < MultiValueInput
     def build_field(value, index)
       options = input_html_options.dup
       value = value.resource if value.is_a? ActiveFedora::Base
-
+      value = Hyrax::LinkedDataResourceFactory.for(attribute_name, value)
       build_options(value, index, options) if value.respond_to?(:rdf_label)
       options[:required] = nil if @rendered_first_element
       options[:class] ||= []
@@ -79,9 +79,9 @@ class ControlledVocabularyInput < MultiValueInput
 
     def collection
       @collection ||= begin
-                        val = object[attribute_name]
-                        col = val.respond_to?(:to_ary) ? val.to_ary : val
-                        col.reject { |value| value.to_s.strip.blank? }
-                      end
+        val = object[attribute_name]
+        col = val.respond_to?(:to_ary) ? val.to_ary : val
+        col.reject { |value| value.to_s.strip.blank? }
+      end
     end
 end

--- a/app/views/records/edit_fields/_based_near.html.erb
+++ b/app/views/records/edit_fields/_based_near.html.erb
@@ -1,5 +1,5 @@
 <%= f.input key,
-            as: :controlled_vocabulary,
+            as: :linked_data_resource,
             placeholder: 'Search for a location',
             input_html: {
               class: 'form-control',

--- a/lib/hyrax/linked_data_resources/base_resource.rb
+++ b/lib/hyrax/linked_data_resources/base_resource.rb
@@ -19,6 +19,7 @@ module Hyrax
     #   ActiveTriples::RDFSource#default_labels and thus to respond to rdf_label
     class BaseResource < ActiveTriples::Resource
       # @return [String] rdf_label
+      # @todo fetch from solr, if the term is already indexed
       def fetch_external
         fetch_value
         rdf_label.first.to_s

--- a/lib/hyrax/linked_data_resources/geonames_resource.rb
+++ b/lib/hyrax/linked_data_resources/geonames_resource.rb
@@ -1,17 +1,17 @@
 module Hyrax
   module LinkedDataResources
-    # Do not Extend BaseResource For Geonames.
     # We can get richer information from the JSON API, so let's do that instead.
-    class GeonamesResource
+    class GeonamesResource < BaseResource
       attr_reader :rdf_subject
 
       def initialize(rdf_subject)
-        @rdf_subject = rdf_subject
+        @rdf_subject = RDF::URI(rdf_subject)
       end
 
-      # @return [String] rdf_label
-      def fetch_external
-        fetch_value
+      # Override rdf_label
+      # @return [Array] rdf_label
+      def rdf_label
+        @rdf_label ||= [rdf_subject.to_s]
       end
 
       private
@@ -21,7 +21,7 @@ module Hyrax
           Rails.logger.info "Fetching #{rdf_subject} from the authorative source."
           response = Faraday.get build_json_uri(rdf_subject)
           return rdf_subject.to_s if response.status != 200
-          label(response.body)
+          @rdf_label = [label(response.body)]
         rescue IOError, Faraday::ConnectionFailed, ArgumentError => e
           # IOError could result from a 500 error on the remote server
           # Faraday::ConnectionFailed results if there is no server to connect to

--- a/spec/inputs/linked_data_resource_input_spec.rb
+++ b/spec/inputs/linked_data_resource_input_spec.rb
@@ -1,12 +1,12 @@
-RSpec.describe 'ControlledVocabularyInput', type: :input do
+RSpec.describe 'LinkedDataResourceInput', type: :input do
   let(:work) { GenericWork.new }
   let(:builder) { SimpleForm::FormBuilder.new(:generic_work, work, view, {}) }
-  let(:input) { ControlledVocabularyInput.new(builder, :based_near, nil, :multi_value, {}) }
+  let(:input) { LinkedDataResourceInput.new(builder, :based_near, nil, :multi_value, {}) }
 
   describe '#input' do
     before { allow(work).to receive(:[]).with(:based_near).and_return([item1, item2]) }
-    let(:item1) { double('value 1', rdf_label: ['Item 1'], rdf_subject: 'http://example.org/1', node?: false) }
-    let(:item2) { double('value 2', rdf_label: ['Item 2'], rdf_subject: 'http://example.org/2') }
+    let(:item1) { 'http://example.org/1' }
+    let(:item2) { 'http://example.org/2' }
 
     it 'renders multi-value' do
       expect(input).to receive(:build_field).with(item1, 0)
@@ -26,12 +26,13 @@ RSpec.describe 'ControlledVocabularyInput', type: :input do
   describe '#build_field' do
     subject { input.send(:build_field, value, 0) }
 
-    context 'for a resource' do
-      let(:value) { double('value 1', rdf_label: ['Item 1'], rdf_subject: 'http://example.org/1', node?: false) }
+    context 'with a resource' do
+      let(:value) { 'http://example.org/1' }
 
       it 'renders multi-value' do
         expect(subject).to have_selector('input.generic_work_based_near.multi_value')
-        expect(subject).to have_field('generic_work[based_near_attributes][0][hidden_label]', with: 'Item 1')
+        # without fetching_external (resource intensive) or retrieving existing labels via solr (not yet implemented) the label will be the rdf_subject
+        expect(subject).to have_field('generic_work[based_near_attributes][0][hidden_label]', with: 'http://example.org/1')
         expect(subject).to have_selector('input[name="generic_work[based_near_attributes][0][id]"][value="http://example.org/1"]', visible: false)
         expect(subject).to have_selector('input[name="generic_work[based_near_attributes][0][_destroy]"][value=""][data-destroy]', visible: false)
       end


### PR DESCRIPTION
The refactoring of controlled_vocabulary to linked_data_resources means that the form no longer receives a object as expected. Although the tests for controlled_vocabulary_input pass, in the application itself this would fail as the form is trying to call node? on a String. This PR fixes it by creating an object via the linked_data_resource_factory which will response to node? and rdf_subject and rdf_label. I've renamed it in line with the renaming to linked_data_resource in other bits of the stack. For this to work GeonamesResource needs to respond to node? and rdf_label.

There is an outstanding issue that the rdf_label (ie. the place name) is not retrieved, but I have a TODO elsewhere to fix that with a solr query. This is the same as current behaviour AFAIK.