### PR TITLE
Fixity check job

### DIFF
--- a/spec/jobs/fixity_check_job_spec.rb
+++ b/spec/jobs/fixity_check_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe FixityCheckJob do
     let(:log_record) { described_class.perform_now(uri, file_set_id: file_set.id, file_id: file_id) }
 
     describe 'fixity check the content' do
-      let(:uri) { file_set.original_file.uri }
+      let(:uri) { file_set.original_file.id }
 
       it 'passes' do
         expect(log_record).to be_passed


### PR DESCRIPTION
This PR assumes that the checksum and size fields are being populated by the characterization service in FileNodeBuilder but that isn't happening currently because there aren't any services configured or available. Future work here is writing a FileCharacterizationService for hydra-file_characterization or pulling in the tika implementation from valkyrie MVP. Additionally this change might want to be pulled out into its own service analogous to ActiveFedora::FixityService.

Replaces #2097.