### PR TITLE
[DON'T MERGE] Updated selector to match generated html

### DIFF
--- a/spec/views/records/edit_fields/_based_near.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_based_near.html.erb_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe 'records/edit_fields/_based_near.html.erb', type: :view do
   end
 
   it 'has url for autocomplete service' do
-    expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/geonames"][data-autocomplete="based_near"]')
+    expect(rendered).to have_selector('div[data-autocomplete-url="/authorities/search/geonames"][data-field-name="based_near"]')
   end
 end


### PR DESCRIPTION
The generated html changed so I updated the test to reflect what was being generated.  I'm not sure if this is the right thing to do here or if we should coerce the html to match what was being generated before.