### PR TITLE
String#coerce always returns a string

### DIFF
--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -25,7 +25,7 @@ module Hyrax
         class String
           # @return [String]
           def self.coerce(input)
-            ::Array.wrap(input).first
+            ::Array.wrap(input).first.to_s
           end
         end
 
@@ -39,6 +39,15 @@ module Hyrax
             rescue ArgumentError
               Rails.logger.info "Unable to parse date: #{field.first.inspect}"
             end
+          end
+        end
+
+        class Boolean
+          # @return [Boolean]
+          def self.coerce(input)
+            field = String.coerce(input)
+            return if field.blank?
+            field == 'true'
           end
         end
       end
@@ -75,7 +84,7 @@ module Hyrax
         attribute :thumbnail_path, Solr::String, CatalogController.blacklight_config.index.thumbnail_field
         attribute :label, Solr::String, solr_name('label')
         attribute :file_format, Solr::String, solr_name('file_format')
-        attribute :suppressed?, Solr::String, solr_name('suppressed', Solrizer::Descriptor.new(:boolean, :stored, :indexed))
+        attribute :suppressed?, Solr::Boolean, solr_name('suppressed', Solrizer::Descriptor.new(:boolean, :stored, :indexed))
 
         attribute :date_modified, Solr::Date, solr_name('date_modified', :stored_sortable, type: :date)
         attribute :date_uploaded, Solr::Date, solr_name('date_uploaded', :stored_sortable, type: :date)

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe ::SolrDocument, type: :model do
 
     it { is_expected.to eq Date.parse('2013-03-14') }
 
+    context "when a Time is provided" do
+      let(:attributes) { { 'date_uploaded_dtsi' => Time.new(2013, 3, 14).utc } }
+
+      it { is_expected.to eq Date.parse('2013-03-14') }
+    end
+
     context "when an invalid type is provided" do
       let(:attributes) { { 'date_uploaded_dtsi' => 'Test' } }
 
@@ -54,6 +60,12 @@ RSpec.describe ::SolrDocument, type: :model do
     subject { document.create_date }
 
     it { is_expected.to eq Date.parse('2013-03-14') }
+
+    context "when a Time is provided" do
+      let(:attributes) { { 'system_create_dtsi' => Time.new(2013, 3, 14).utc } }
+
+      it { is_expected.to eq Date.parse('2013-03-14') }
+    end
 
     context "when an invalid type is provided" do
       let(:attributes) { { 'system_create_dtsi' => 'Test' } }


### PR DESCRIPTION
Also add Boolean#coerce to return a boolean since String was just passing it through before.  I believe this might break any customizations of SolrDocument that used `Solr::String` for boolean values unless they were changed to `Solr::Boolean`.

I made this change after finding that a `Time` object passed to `Date#coerce` threw an exception.  Now `Date#coerce` should be able to handle that and any other object that the `#to_s` of can be passed to `Date#parse`.