### PR TITLE
Deprecate human_readable_type=

### DIFF
--- a/app/models/concerns/hyrax/file_set_behavior.rb
+++ b/app/models/concerns/hyrax/file_set_behavior.rb
@@ -22,7 +22,6 @@ module Hyrax
 
     included do
       attr_accessor :file
-      self.human_readable_type = 'File'
     end
 
     def representative_id

--- a/app/models/concerns/hyrax/human_readable_type.rb
+++ b/app/models/concerns/hyrax/human_readable_type.rb
@@ -11,6 +11,9 @@ module Hyrax
       def human_readable_type=(val)
         @_human_readable_type = val
       end
+      deprecation_deprecate :human_readable_type= => 'human_readable_type is deprecated. ' \
+        'Set the i18n key for activefedora.models.#{model_name.i18n_key} instead. ' \
+        'This will be removed in Hyrax 3'
     end
 
     def human_readable_type

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -2,6 +2,7 @@ en:
   activefedora:
     models:
       batch_upload_item: 'Works by Batch'
+      file_set: 'File'
   activemodel:
     errors:
       messages:

--- a/lib/generators/hyrax/work/templates/model.rb.erb
+++ b/lib/generators/hyrax/work/templates/model.rb.erb
@@ -8,8 +8,6 @@ class <%= class_name %> < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.human_readable_type = '<%= name.underscore.titleize %>'
-
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/spec/models/hyrax/work_behavior_spec.rb
+++ b/spec/models/hyrax/work_behavior_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe Hyrax::WorkBehavior do
     it 'has a default' do
       expect(subject.human_readable_type).to eq 'Essential Work'
     end
-    it 'is settable' do
+    it 'is settable (deprecated)' do
+      allow(Deprecation).to receive(:warn)
       EssentialWork.human_readable_type = 'Custom Type'
       expect(subject.human_readable_type).to eq 'Custom Type'
     end


### PR DESCRIPTION
This isn't translatable. Instead, set the type by updating the i18n like
this:

```yaml
en:
  activefedora:
    models:
      generic_work: Plain Ol' Worktype

```
