### PR TITLE
apply controlled_vocabulary to linked_data_resources renaming across js and css

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -72,7 +72,7 @@
 //= require hyrax/collections/editor
 //= require hyrax/editor
 //= require hyrax/editor/admin_set_widget
-//= require hyrax/editor/controlled_vocabulary
+//= require hyrax/editor/linked_data_resource
 //= require hyrax/admin/graphs
 //= require hyrax/save_work
 //= require hyrax/permissions

--- a/app/assets/javascripts/hyrax/editor.es6
+++ b/app/assets/javascripts/hyrax/editor.es6
@@ -1,7 +1,7 @@
 import RelationshipsControl from 'hyrax/relationships/control'
 import SaveWorkControl from 'hyrax/save_work/save_work_control'
 import AdminSetWidget from 'hyrax/editor/admin_set_widget'
-import ControlledVocabulary from 'hyrax/editor/controlled_vocabulary'
+import LinkedDataResource from 'hyrax/editor/linked_data_resource'
 import Autocomplete from 'hyrax/autocomplete'
 import AuthoritySelect from 'hyrax/authority_select'
 
@@ -17,7 +17,7 @@ export default class {
     this.sharingTabElement = $('#tab-share')
 
     this.autocomplete()
-    this.controlledVocabularies()
+    this.linkedDataResources()
     this.sharingTab()
     this.relationshipsControl()
     this.saveWorkControl()
@@ -55,10 +55,10 @@ export default class {
       })
   }
 
-  // initialize any controlled vocabulary widgets
-  controlledVocabularies() {
-    this.element.find('.controlled_vocabulary.form-group').each((_idx, controlled_field) =>
-      new ControlledVocabulary(controlled_field, this.paramKey)
+  // initialize any linked_data_resource widgets
+  linkedDataResources() {
+    this.element.find('.linked_data_resource.form-group').each((_idx, controlled_field) =>
+      new LinkedDataResource(controlled_field, this.paramKey)
     )
   }
 

--- a/app/assets/javascripts/hyrax/editor/linked_data_resource.es6
+++ b/app/assets/javascripts/hyrax/editor/linked_data_resource.es6
@@ -4,7 +4,7 @@ import { FieldManager } from 'hydra-editor/field_manager'
 import Handlebars from 'handlebars'
 import Autocomplete from 'hyrax/autocomplete'
 
-export default class ControlledVocabulary extends FieldManager {
+export default class LinkedDataResource extends FieldManager {
 
   constructor(element, paramKey) {
       let options = {
@@ -17,7 +17,7 @@ export default class ControlledVocabulary extends FieldManager {
         fieldWrapperClass: '.field-wrapper',
         warningClass:      '.has-warning',
         listClass:         '.listing',
-        inputTypeClass:    '.controlled_vocabulary',
+        inputTypeClass:    '.linked_data_resource',
 
         addHtml:           '<button type=\"button\" class=\"btn btn-link add\"><span class=\"glyphicon glyphicon-plus\"></span><span class="controls-add-text"></span></button>',
         addText:           'Add another',
@@ -74,7 +74,7 @@ export default class ControlledVocabulary extends FieldManager {
       let row =  $(rowTemplate({ "paramKey": this.paramKey,
                                  "name": this.fieldName,
                                  "index": index,
-                                 "class": "controlled_vocabulary" }))
+                                 "class": "linked_data_resource" }))
                   .append(controls)
       return row
   }

--- a/app/assets/stylesheets/hyrax/_hyrax.scss
+++ b/app/assets/stylesheets/hyrax/_hyrax.scss
@@ -8,7 +8,7 @@
         'hyrax/file_manager', 'hyrax/form-progress', 'hyrax/positioning',
         'hyrax/fixedsticky', 'hyrax/file_upload', 'hyrax/representative-media',
         'hyrax/footer', 'hyrax/select_work_type', 'hyrax/users', 'hyrax/dashboard',
-        'hyrax/sidebar', 'hyrax/controlled_vocabulary', 'hyrax/work_editor';
+        'hyrax/sidebar', 'hyrax/linked_data_resource', 'hyrax/work_editor';
 @import 'typeahead';
 @import 'sharing_buttons';
 
@@ -25,6 +25,6 @@
   display: inline-block;
 }
 
-.controlled_vocabulary {
+.linked_data_resource {
   @extend .multi_value;
 }

--- a/app/assets/stylesheets/hyrax/_linked_data_resource.scss
+++ b/app/assets/stylesheets/hyrax/_linked_data_resource.scss
@@ -1,4 +1,4 @@
-.controlled_vocabulary {
+.linked_data_resource {
   @extend .multi_value;
 
   .listing li:only-of-type .remove {

--- a/app/inputs/linked_data_resource_input.rb
+++ b/app/inputs/linked_data_resource_input.rb
@@ -44,7 +44,7 @@ class LinkedDataResourceInput < MultiValueInput
     def hidden_id_field(value, index)
       name = name_for(attribute_name, index, 'id')
       id = id_for(attribute_name, index, 'id')
-      hidden_value = value.node? ? '' : value.rdf_subject
+      hidden_value = value.rdf_subject.to_s
       @builder.hidden_field(attribute_name, name: name, id: id, value: hidden_value, data: { id: 'remote' })
     end
 
@@ -53,7 +53,7 @@ class LinkedDataResourceInput < MultiValueInput
       options[:data] ||= {}
       options[:data][:attribute] = attribute_name
       options[:id] = id_for_hidden_label(index)
-      if value.node?
+      if value.rdf_subject.blank?
         build_options_for_new_row(attribute_name, index, options)
       else
         build_options_for_existing_row(attribute_name, index, value, options)
@@ -75,13 +75,5 @@ class LinkedDataResourceInput < MultiValueInput
 
     def id_for(attribute_name, index, field)
       [@builder.object_name, "#{attribute_name}_attributes", index, field].join('_')
-    end
-
-    def collection
-      @collection ||= begin
-        val = object[attribute_name]
-        col = val.respond_to?(:to_ary) ? val.to_ary : val
-        col.reject { |value| value.to_s.strip.blank? }
-      end
     end
 end

--- a/app/views/records/edit_fields/_based_near.html.erb
+++ b/app/views/records/edit_fields/_based_near.html.erb
@@ -6,7 +6,7 @@
               data: { 'autocomplete-url' => "/authorities/search/geonames",
                       'autocomplete' => key }
             },
-            ### Required for the ControlledVocabulary javascript:
+            ### Required for the LinkedDataResource javascript:
             wrapper_html: { data: { 'autocomplete-url' => "/authorities/search/geonames",
                                     'field-name' => key }},
             required: f.object.required?(key) %>

--- a/lib/hyrax/linked_data_resource_factory.rb
+++ b/lib/hyrax/linked_data_resource_factory.rb
@@ -6,7 +6,7 @@ module Hyrax
     # @param ld_uri [RDF::URI] uri from which to retrieve a label
     # @return [Hyrax::LinkedDataResources::BaseResource] or more speciic class
     def self.for(ld_attribute, ld_uri)
-      Hyrax.config.registered_linked_data_resources.fetch(ld_attribute, Hyrax::LinkedDataResources::BaseResource).new(ld_uri)
+      Hyrax.config.registered_linked_data_resources.fetch(ld_attribute.to_sym, Hyrax::LinkedDataResources::BaseResource).new(ld_uri)
     end
   end
 end

--- a/spec/inputs/linked_data_resource_input_spec.rb
+++ b/spec/inputs/linked_data_resource_input_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'LinkedDataResourceInput', type: :input do
   let(:work) { GenericWork.new }
   let(:builder) { SimpleForm::FormBuilder.new(:generic_work, work, view, {}) }
-  let(:input) { LinkedDataResourceInput.new(builder, :based_near, nil, :multi_value, {}) }
+  let(:input) { LinkedDataResourceInput.new(builder, :based_near, nil, :linked_data_resource, {}) }
 
   describe '#input' do
     before { allow(work).to receive(:[]).with(:based_near).and_return([item1, item2]) }
@@ -11,16 +11,17 @@ RSpec.describe 'LinkedDataResourceInput', type: :input do
     it 'renders multi-value' do
       expect(input).to receive(:build_field).with(item1, 0)
       expect(input).to receive(:build_field).with(item2, 1)
+      expect(input).to receive(:build_field).with('', 2)
       input.input({})
     end
   end
 
   describe '#collection' do
-    let(:work) { GenericWork.new(based_near: [::RDF::URI('http://example.org/1')]) }
+    let(:work) { GenericWork.new(based_near: ['http://example.org/1']) }
 
     subject { input.send(:collection) }
 
-    it { is_expected.to all(be_a(RDF::URI)) }
+    it { is_expected.to all(be_a(String)) }
   end
 
   describe '#build_field' do
@@ -30,7 +31,7 @@ RSpec.describe 'LinkedDataResourceInput', type: :input do
       let(:value) { 'http://example.org/1' }
 
       it 'renders multi-value' do
-        expect(subject).to have_selector('input.generic_work_based_near.multi_value')
+        expect(subject).to have_selector('input.generic_work_based_near.linked_data_resource')
         # without fetching_external (resource intensive) or retrieving existing labels via solr (not yet implemented) the label will be the rdf_subject
         expect(subject).to have_field('generic_work[based_near_attributes][0][hidden_label]', with: 'http://example.org/1')
         expect(subject).to have_selector('input[name="generic_work[based_near_attributes][0][id]"][value="http://example.org/1"]', visible: false)


### PR DESCRIPTION
Fixes failing test on _based_near.html.erb