### PR TITLE
Addresses accessibility errors for contrast

### DIFF
--- a/app/assets/stylesheets/_bootstrap-default-overrides.scss
+++ b/app/assets/stylesheets/_bootstrap-default-overrides.scss
@@ -3,3 +3,18 @@ $brand-danger: #d33a35 !default;
 $brand-success: #387f38 !default;
 $brand-info: #2c76c7 !default;
 $brand-warning: #565653 !default;
+
+// Overrides for accessibility compliance
+// Testing: WAVE evaluation tool: http://wave.webaim.org/
+// Chrome has a WAVE extension that you can toggle on/off for testing
+
+// Bootsrap upto v4.0 has poor styling for color-contrast that causes the WAVE
+// tool to throw contrast errors
+// Read more: https://getbootstrap.com/docs/4.0/getting-started/accessibility/#color-contrast
+// These changes meet WCAG AA and AAA compliance standard
+// I'm passing values to bootstrap variables as listed here:
+// https://getbootstrap.com/docs/3.3/customize/#less-variables
+// * Darkens the text for active breadcrumb on every page. Meets WCAG AA and AAA
+// * Darkens the text for disabled pagination buttons on every page.
+$breadcrumb-active-color: #4c4c4c;
+$pagination-disabled-color: #4c4c4c;

--- a/app/assets/stylesheets/hyrax/_accessibility.scss
+++ b/app/assets/stylesheets/hyrax/_accessibility.scss
@@ -1,0 +1,16 @@
+// This stylesheet is a place to apply styling changes for improving the
+// accessibility of Hyrax vanilla
+// Use https://github.com/samvera/hyrax/blob/master/app/assets/stylesheets/_bootstrap-default-overrides.scss
+// for overriding bootstrap variables
+
+// NOTE: This isn't an ideal fix. We're using select2-rails v3.5
+// for styling dropdowns. This can be fixed by updating to select2-rails
+// v4.0.3 but it throws an uncaught error and fails to
+// display the dropdown at all.
+// TODO: I opened an issue that we should follow up on later
+// https://github.com/argerim/select2-rails/issues/176
+// Darkens the 'Search for a user' text in dropdown on 'Dashboard page'
+// Meets WCAG AA and AAA compliance standard
+.select2-default {
+  color: #4c4c4c !important;
+}

--- a/app/assets/stylesheets/hyrax/_hyrax.scss
+++ b/app/assets/stylesheets/hyrax/_hyrax.scss
@@ -8,7 +8,7 @@
         'hyrax/file_manager', 'hyrax/form-progress', 'hyrax/positioning',
         'hyrax/fixedsticky', 'hyrax/file_upload', 'hyrax/representative-media',
         'hyrax/footer', 'hyrax/select_work_type', 'hyrax/users', 'hyrax/dashboard',
-        'hyrax/sidebar', 'hyrax/controlled_vocabulary', 'hyrax/work_editor', 'hyrax/accessibility';
+        'hyrax/sidebar', 'hyrax/controlled_vocabulary', 'hyrax/accessibility';
 @import 'typeahead';
 @import 'sharing_buttons';
 

--- a/app/assets/stylesheets/hyrax/_hyrax.scss
+++ b/app/assets/stylesheets/hyrax/_hyrax.scss
@@ -8,7 +8,7 @@
         'hyrax/file_manager', 'hyrax/form-progress', 'hyrax/positioning',
         'hyrax/fixedsticky', 'hyrax/file_upload', 'hyrax/representative-media',
         'hyrax/footer', 'hyrax/select_work_type', 'hyrax/users', 'hyrax/dashboard',
-        'hyrax/sidebar', 'hyrax/controlled_vocabulary';
+        'hyrax/sidebar', 'hyrax/controlled_vocabulary', 'hyrax/work_editor', 'hyrax/accessibility';
 @import 'typeahead';
 @import 'sharing_buttons';
 

--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -46,7 +46,7 @@ module Hyrax
 
         # The color links
         def link_color
-          block_for('link_color', '#337ab7')
+          block_for('link_color', '#2e74b2')
         end
 
         # The color for links in the footer


### PR DESCRIPTION
This PR addresses contrast errors on the Dashboard page [reported](https://github.com/samvera/hyrax/issues/1962) during accessibility testing for Hyrax v2.0.0

Changes proposed in this pull request:
* Changed the default color for link text, addresses item 2 (breadcrumb link color) and 6 (Transfer link text)
* Overrides bootstrap styling for items 3 (breadcrumb link color and text color) and 4 (previous and next link color for pagination) by creating a separate accessibility stylesheet.
* Temporary fix for  item 5 'search placeholder text' is also on override. But I've reported an upstream [issue](https://github.com/argerim/select2-rails/issues/176) in select2-rails gem

@samvera/hyrax-code-reviewers
