### PR TITLE
Bumping samvera-nesting_indexer to 0.8.0

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -73,7 +73,7 @@ EOF
   spec.add_dependency 'redlock', '>= 0.1.2'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'active-fedora', '>= 11.3.1'
-  spec.add_dependency 'samvera-nesting_indexer', '~> 0.6'
+  spec.add_dependency 'samvera-nesting_indexer', '~> 0.8'
   spec.add_dependency 'linkeddata' # Required for getting values from geonames
 
   spec.add_development_dependency 'engine_cart', '~> 1.2'


### PR DESCRIPTION
From the v0.8.0 release notes:

* Updating documentation.
* Adding TODO section of the README.
* Clarifying exceptions raised when cyclic graphs are detected.
* Adding short-circuit when attempting to reindex a document that is
  its own ancestor.

[release_notes]:https://github.com/samvera-labs/samvera-nesting_indexer/releases/tag/v0.8.0
