### PR TITLE
Removed form instructions text

### DIFF
--- a/app/views/hyrax/base/_form_metadata.html.erb
+++ b/app/views/hyrax/base/_form_metadata.html.erb
@@ -1,6 +1,3 @@
-        <div class="form-instructions">
-          <p>The more descriptive information you provide the better we can serve your needs.</p>
-        </div>
         <div class="base-terms">
           <% f.object.primary_terms.each do |term| %>
             <%= render_edit_field_partial(term, f: f) %>


### PR DESCRIPTION
Instructional messaging to the user regarding amount of description
to be entered is best left to the implementer.

Fixes #2028
