### PR TITLE
Remove position: fixed from workflow-affix as it breaks scrolling in …

### DIFF
--- a/app/assets/stylesheets/hyrax/_positioning.scss
+++ b/app/assets/stylesheets/hyrax/_positioning.scss
@@ -17,7 +17,6 @@
 }
 
 .workflow-affix {
-  position: fixed;
   bottom: 0;
   background: #FFF;
   z-index: 2;

--- a/app/views/hyrax/base/_workflow_actions.html.erb
+++ b/app/views/hyrax/base/_workflow_actions.html.erb
@@ -1,4 +1,4 @@
-<div id="workflow_controls"class="panel panel-default workflow-affix">
+<div id="workflow_controls" class="panel panel-default workflow-affix">
   <div class="panel-heading">
     <a data-toggle="collapse" href="#workflow_controls_collapse">
       <h2 class="panel-title">Review and Approval</h2>


### PR DESCRIPTION
A small update to remove `position: fixed` from the workflow-affix class as it breaks the scrolling on the reformatted work-show page. Also add a missing space in the html.

@samvera/hyrax-code-reviewers
