### PR TITLE
Remove an unnecessary wrapping div

### DIFF
--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -12,19 +12,17 @@
     <%= content_for(:precontainer_content) %>
     <div id="content-wrapper" class="container" role="main">
       <a name="skip_to_content"></a>
-      <div class="col-xs-12">
-        <%= render '/flash_msg' %>
-        <%= render_breadcrumbs builder: Hyrax::BootstrapBreadcrumbsBuilder %>
-        <% if content_for?(:page_header) %>
-          <div class="row">
-            <div class="col-xs-12 main-header">
-              <%= yield(:page_header) %>
-            </div>
+      <%= render '/flash_msg' %>
+      <%= render_breadcrumbs builder: Hyrax::BootstrapBreadcrumbsBuilder %>
+      <% if content_for?(:page_header) %>
+        <div class="row">
+          <div class="col-xs-12 main-header">
+            <%= yield(:page_header) %>
           </div>
-        <% end %>
+        </div>
+      <% end %>
 
-        <%= content_for?(:content) ? yield(:content) : yield %>
-      </div>
+      <%= content_for?(:content) ? yield(:content) : yield %>
     </div><!-- /#content-wrapper -->
     <%= render 'shared/footer' %>
     <%= render 'shared/ajax_modal' %>


### PR DESCRIPTION
`col-*-*` classes are only supposed to be children of `rows` per
bootlint.  This one was not.
