### PR TITLE
Move the `row` container within the form

### DIFF
--- a/app/views/hyrax/base/_workflow_actions.html.erb
+++ b/app/views/hyrax/base/_workflow_actions.html.erb
@@ -4,8 +4,8 @@
       <h2 class="panel-title">Review and Approval</h2>
     </a>
   </div>
-  <div id="workflow_controls_collapse" class="row panel-body panel-collapse collapse">
-    <%= form_tag main_app.hyrax_workflow_action_path(presenter), method: :put do %>
+  <%= form_tag main_app.hyrax_workflow_action_path(presenter), method: :put do %>
+    <div id="workflow_controls_collapse" class="row panel-body panel-collapse collapse">
       <div class="col-sm-3 workflow-actions">
         <h3>Actions</h3>
 
@@ -34,6 +34,6 @@
           <% end %>
         </dl>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
This appeases bootlint which wants `col-*-*` to only be children of
`row`s
