### PR TITLE
[WIP] Lazy load default collection type gid if gid is missing or blank

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -38,7 +38,7 @@ module Hyrax
     # @param collection_type_gid [String] The gid of the CollectionType to be looked up
     # @return [String] The CollectionType's title if found, else the gid
     def collection_type_label(collection_type_gid)
-      CollectionType.find_by_gid!(collection_type_gid).title
+      CollectionType.find_by_gid!(collection_type_gid, true).title
     rescue ActiveRecord::RecordNotFound, URI::BadURIError
       collection_type_gid
     end

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -33,10 +33,10 @@ module Hyrax
 
     # Find the collection type associated with the Global Identifier (gid)
     # @param [String] gid - Global Identifier for this collection_type (e.g. gid://internal/hyrax-collectiontype/3)
-    # @param [True|False] allow_default - if true, and gid is blank or missing, it will return the default collection type (default=true)
+    # @param [True|False] allow_default - if true, and gid is blank or missing, it will return the default collection type (default=false)
     # @return [Hyrax::CollectionType] if record matching gid is found, an instance of Hyrax::CollectionType with id = the model_id portion of the gid (e.g. 3)
     # @return [False] if record matching gid is not found
-    def self.find_by_gid(gid, allow_default=true)
+    def self.find_by_gid(gid, allow_default=false)
       return find_or_create_default_collection_type if allow_default && !gid.present?
       find(GlobalID.new(gid).model_id)
     rescue ActiveRecord::RecordNotFound, URI::InvalidURIError
@@ -45,10 +45,10 @@ module Hyrax
 
     # Find the collection type associated with the Global Identifier (gid)
     # @param [String] gid - Global Identifier for this collection_type (e.g. gid://internal/hyrax-collectiontype/3)
-    # @param [True|False] allow_default - if true, and gid is blank or missing, it will return the default collection type (default=true)
+    # @param [True|False] allow_default - if true, and gid is blank or missing, it will return the default collection type (default=false)
     # @return [Hyrax::CollectionType] an instance of Hyrax::CollectionType with id = the model_id portion of the gid (e.g. 3)
     # @raise [ActiveRecord::RecordNotFound] if record matching gid is not found
-    def self.find_by_gid!(gid, allow_default=true)
+    def self.find_by_gid!(gid, allow_default=false)
       result = find_by_gid(gid, allow_default)
       raise ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID '#{gid}'" unless result
       result

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -33,9 +33,11 @@ module Hyrax
 
     # Find the collection type associated with the Global Identifier (gid)
     # @param [String] gid - Global Identifier for this collection_type (e.g. gid://internal/hyrax-collectiontype/3)
+    # @param [True|False] allow_default - if true, and gid is blank or missing, it will return the default collection type (default=true)
     # @return [Hyrax::CollectionType] if record matching gid is found, an instance of Hyrax::CollectionType with id = the model_id portion of the gid (e.g. 3)
     # @return [False] if record matching gid is not found
-    def self.find_by_gid(gid)
+    def self.find_by_gid(gid, allow_default=true)
+      return find_or_create_default_collection_type if allow_default && !gid.present?
       find(GlobalID.new(gid).model_id)
     rescue ActiveRecord::RecordNotFound, URI::InvalidURIError
       false
@@ -43,10 +45,11 @@ module Hyrax
 
     # Find the collection type associated with the Global Identifier (gid)
     # @param [String] gid - Global Identifier for this collection_type (e.g. gid://internal/hyrax-collectiontype/3)
+    # @param [True|False] allow_default - if true, and gid is blank or missing, it will return the default collection type (default=true)
     # @return [Hyrax::CollectionType] an instance of Hyrax::CollectionType with id = the model_id portion of the gid (e.g. 3)
     # @raise [ActiveRecord::RecordNotFound] if record matching gid is not found
-    def self.find_by_gid!(gid)
-      result = find_by_gid(gid)
+    def self.find_by_gid!(gid, allow_default=true)
+      result = find_by_gid(gid, allow_default)
       raise ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID '#{gid}'" unless result
       result
     end

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -22,7 +22,7 @@ module Hyrax
 
     def collection_type
       gid = Array.wrap(solr_document.fetch('collection_type_gid_ssim', [])).first
-      @collection_type ||= CollectionType.find_by_gid!(gid)
+      @collection_type ||= CollectionType.find_by_gid!(gid, true)
     end
 
     # Metadata Methods


### PR DESCRIPTION
Fixes #2241

Hyrax::CollectionType.find_by_gid! and find_by_gid now default to return User Collection gid if the gid is missing or blank.  This can be prevented from happening by passing the second parameter as false.

The collection model has an after_find callback that will update the gid for a collection that is missing the gid and save it.  This is effectively the lazy migration of the collection to include a gid and only happens once per older collection.

@samvera/hyrax-code-reviewers
