### PR TITLE
Manage Collection Relationships Tab

### DIFF
--- a/app/assets/stylesheets/hyrax/_styles.scss
+++ b/app/assets/stylesheets/hyrax/_styles.scss
@@ -10,21 +10,6 @@
   margin: 20px;
 }
 
-/* Backport from Bootstrap 4.  Remove when app is Bootstrap 4 native. */
-.m-t-0 {
-  margin-top: 0 !important;
-}
-.m-t-1 {
-  margin-top: $padding-large-vertical !important;
-}
-.m-t-2 {
-  margin-top: ($padding-large-vertical * 1.5) !important;
-}
-.m-t-3 {
-  margin-top: ($padding-large-vertical * 3) !important;
-}
-/* End Backport */
-
 .modal-title {
   @extend h2
 }

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -90,6 +90,9 @@ module Hyrax
       def after_create
         form
         set_default_permissions
+        # if we are creating the new collection as a subcollection (via the nested collections controller),
+        # we pass the parent_id through a hidden field in the form and link the two after the create.
+        link_parent_collection(params[:parent_id]) unless params[:parent_id].nil?
         respond_to do |format|
           ActiveFedora::SolrService.instance.conn.commit
           format.html { redirect_to edit_dashboard_collection_path(@collection), notice: "Collection was successfully created." }
@@ -111,7 +114,7 @@ module Hyrax
         # collection is saved without a value for `has_model.`
         @collection = ::Collection.new
         authorize! :create, @collection
-        @collection.attributes = collection_params.except(:members)
+        @collection.attributes = collection_params.except(:members, :parent_id)
         @collection.apply_depositor_metadata(current_user.user_key)
         add_members_to_collection unless batch.empty?
         @collection.collection_type_gid = params[:collection_type_gid] if params[:collection_type_gid]
@@ -213,6 +216,11 @@ module Hyrax
       end
 
       private
+
+        def link_parent_collection(parent_id)
+          parent = ActiveFedora::Base.find(parent_id)
+          Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent, child: @collection)
+        end
 
         def uploaded_files(uploaded_file_ids)
           return [] if uploaded_file_ids.empty?

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -36,13 +36,18 @@ module Hyrax
         # For the given parent, what are all of the available collections that
         # can be added as sub-collection of the parent.
         def available_child_collections
-          query_service.available_child_collections(parent: parent, context: context)
+          query_service.available_child_collections(parent: parent, scope: context)
         end
 
         # For the given child, what are all of the available collections to
         # which the child can be added as a sub-collection.
         def available_parent_collections
-          query_service.available_parent_collections(child: child, context: context)
+          query_service.available_parent_collections(child: child, scope: context)
+        end
+
+        def validate_add
+          return true if parent.try(:nestable?)
+          errors.add(:parent, :cannot_have_child_nested)
         end
 
         private
@@ -51,7 +56,7 @@ module Hyrax
 
           def parent_and_child_can_be_nested
             if parent.try(:nestable?) && child.try(:nestable?)
-              return true if query_service.parent_and_child_can_nest?(parent: parent, child: child, context: context)
+              return true if query_service.parent_and_child_can_nest?(parent: parent, child: child, scope: context)
               errors.add(:parent, :cannot_have_child_nested)
               errors.add(:child, :cannot_nest_in_parent)
             else

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -3,7 +3,7 @@ module Hyrax
     include ModelProxy
     include PresentsAttributes
     include ActionView::Helpers::NumberHelper
-    attr_accessor :solr_document, :current_ability, :request
+    attr_accessor :solr_document, :current_ability, :request, :collection_type
 
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability
@@ -78,6 +78,14 @@ module Hyrax
 
     def collection_type_badge
       collection_type.title
+    end
+
+    def user_can_nest_collection?
+      current_ability.can?(:deposit, id)
+    end
+
+    def user_can_create_new_nest_collection?
+      current_ability.can?(:create_collection_of_type, collection_type)
     end
 
     def show_path

--- a/app/services/hyrax/collections/nested_collection_persistence_service.rb
+++ b/app/services/hyrax/collections/nested_collection_persistence_service.rb
@@ -10,14 +10,10 @@ module Hyrax
       # @param child [Collection]
       # @note There is odd permission arrangement based on the NestedCollectionQueryService:
       #       You can nest the child within a parent if you can edit the parent and read the child.
-      #       However, in the future, instead of adding that relationship to the parent, we will be
-      #       adding the relationship to the child. In a RDBMS environment, this would be resolved by
-      #       creating a join table. One that we can check who added the relationship. However, we aren't
-      #       using an RDBM.
       #       See https://wiki.duraspace.org/display/samvera/Samvera+Tech+Call+2017-08-23 for tech discussion.
       def self.persist_nested_collection_for(parent:, child:)
-        parent.members << child
-        parent.save
+        child.member_of_collections << parent
+        child.save
       end
     end
   end

--- a/app/views/hyrax/dashboard/collections/_document_list.html.erb
+++ b/app/views/hyrax/dashboard/collections/_document_list.html.erb
@@ -5,9 +5,5 @@
 <% else %>
   <% @document_list = documents %>
   <% @disable_select_all = (@document_list.count <= 1) %>
-  <% if params[:action] == "edit" %>
-    <%= render 'form_default_group', documents: documents, docs: documents %>
-  <% else %>
-    <%= render 'show_document_list', documents: documents %>
-  <% end %>
+  <%= render 'show_document_list', documents: documents %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -60,6 +60,10 @@
             <%= hidden_field_tag :type, params[:type] %>
             <%= hidden_field_tag :stay_on_edit, true %>
             <%= hidden_field_tag :collection_type_gid, @collection.collection_type_gid %>
+            <!-- parent_id may be passed from the nested collections controller to allow a subcollection relationship to be added as collection is created -->
+            <% if params[:parent_id].present? %>
+              <%= hidden_field_tag :parent_id, params[:parent_id] %>
+            <% end %>
             <% if params[:batch_document_ids].present? %>
               <% params[:batch_document_ids].each do |batch_item| %>
                 <input type="hidden" name="batch_document_ids[]" value="<%= batch_item %>"/>

--- a/app/views/hyrax/dashboard/collections/_form_default_group_delt.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_default_group_delt.html.erb
@@ -1,4 +1,6 @@
-<% # This was renamed from _default_group to prevent if from being used for All Collection index which needs to use my/collections/_default_group %>
+<%# This was renamed from _default_group to prevent if from being used for All Collection index which needs to use my/collections/_default_group %>
+<%# TODO: This partial is obsolete and has been renamed for now. Needs cleanup of this and other referenced unneeded items. %>
+
 <table class="table table-striped">
   <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
   <thead>

--- a/app/views/hyrax/dashboard/collections/_form_relationships.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_relationships.html.erb
@@ -4,80 +4,97 @@
   <section>
     <h3><%= t('.headlines.this_collection_in_other_collections') %></h3>
     <p><%= t('.this_collection_in_other_collections_description') %></p>
-
+<!-- The user should have deposit access to the parent and read access to the child (the collection we are showing). No additional testing is needed here because edit access implies read access -->
     <article class="form-inline select-wrapper">
-      <div class="form-group">
-        <label for="exampleInputName2"><strong><%= t('hyrax.dashboard.my.action.add_to_collection') %>:</strong></label>
-        <select class="form-control" id="add_to_collection_selection">
-          <option><%= t('.select_a_collection') %></option>
-        </select>
-      </div>
-      <button class="btn btn-primary"><%= t('helpers.action.add') %></button>
+      <%= button_tag '',
+        class: 'btn btn-primary add-to-collection',
+        onclick: "$('#add-to-collection-modal-#{@form.collection.id}').modal('show');",
+        title: t('hyrax.collection.actions.nested_subcollection.desc'),
+        type: 'button',
+        data: { nestable: @form.nestable?,
+                hasaccess: true } do %>
+        <%= t('hyrax.collection.actions.nested_subcollection.button_label') %>
+      <% end %>
     </article>
 
     <article class="collection-list-wrapper">
-      <p><strong><%= t('.collection_is_subcollection_description') %></strong></p>
-      <table class="table table-striped table-condensed">
-        <thead>
-          <tr>
-            <th><%= t('.table.collection_title') %></th>
-            <th><%= t('.table.action') %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><a href="#">Butterfiles: Our Favorites!</a></td>
-            <td><button class="btn btn-sm btn-danger remove-from-collection-button"><%= t('.buttons.remove_from_collection') %></button></td>
-          </tr>
-          <tr>
-            <td><a href="#">Recent Published Research Publications and Data On Macrolepidopteran Clade</a></td>
-            <td><button class="btn btn-sm btn-danger remove-from-collection-button"><%= t('.buttons.remove_from_collection') %></button></td>
-          </tr>
-        </tbody>
-      </table>
-    </p>
-
+      <% if @form.list_parent_collections.any? %>
+        <p><strong><%= t('.collection_is_subcollection_description') %></strong></p>
+        <table class="table table-striped table-condensed">
+          <thead>
+            <tr>
+              <th><%= t('.table.collection_title') %></th>
+              <th><%= t('.table.action') %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @form.list_parent_collections.each do |document| %>
+              <tr>
+                <td>
+                  <%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
+                </td>
+                <td><button class="btn btn-sm btn-danger remove-from-collection-button"><%= t('.buttons.remove_from_collection') %></button></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+        </p>
+      <% end %>
+    </article>
   </section>
 
   <%# Other Collections in This Collection %>
   <section>
     <h3><%= t('.headlines.other_collections_in_this_collection') %></h3>
     <p><%= t('.add_other_collections_as_sub_collections_description') %></p>
-
-    <article class="form-inline select-wrapper">
-      <div class="form-group">
-        <label for="exampleInputName2"><strong><%= t('.add_sub_collection') %>:</strong></label>
-        <select class="form-control" id="add_to_collection_selection">
-          <option>Select a collection...</option>
-        </select>
-      </div>
-      <button class="btn btn-primary"><%= t('helpers.action.add') %></button>
-    </article>
-
-    <p>
-      <button class="btn btn-primary"><%= t('.buttons.create_new_collection_as_sub_collection') %></button>
-    </p>
+<!-- The user should have deposit access to the parent (the collection we are showing) and read access to the child being added -->
+    <% if can? :deposit, @form.collection %>
+      <article class="form-inline select-wrapper">
+        <%= button_tag '',
+          class: 'btn btn-primary add-subcollection',
+          onclick: "$('#add-subcollection-modal-#{@form.collection.id}').modal('show');",
+          title: t('hyrax.collection.actions.nest_collections.desc'),
+          type: 'button',
+          data: { nestable: @form.nestable?,
+                  hasaccess: true } do %>
+          <%= t('hyrax.collection.actions.nest_collections.button_label') %>
+        <% end %>
+      </article>
+      <!-- The user should be able to create a collection of the same type as the potential parent collection -->
+      <% if can? :create_collection_of_type, @form.collection.collection_type %>
+        <article class="form-inline select-wrapper">
+          <%= link_to t('hyrax.collection.actions.add_new_nested_collection.label'),
+            hyrax.dashboard_create_subcollection_under_path(parent_id: @form.collection.id),
+            title: t('hyrax.collection.actions.add_new_nested_collection.desc'),
+            class: 'btn btn-primary',
+            data: { turbolinks: false } %>
+        </article>
+      <% end %>
+    <% end %>
 
     <article class="collection-list-wrapper">
-      <p><strong><%= t('.sub_collections_of_collection_description') %></strong></p>
-      <table class="table table-striped table-condensed">
-        <thead>
-          <tr>
-            <th><%= t('.table.collection_title') %></th>
-            <th><%= t('.table.action') %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><a href="#">Butterfly images from the Standford Digital Repository</a></td>
-            <td><button class="btn btn-sm btn-danger remove-sub-collection-button"><%= t('.buttons.remove_this_sub_collection') %></button></td>
-          </tr>
-          <tr>
-            <td><a href="#">Laboratory Experiments involving Lepidoptera</a></td>
-            <td><button class="btn btn-sm btn-danger remove-sub-collection-button"><%= t('.buttons.remove_this_sub_collection') %></button></td>
-          </tr>
-        </tbody>
-      </table>
+      <% if @form.list_child_collections.any? %>
+        <p><strong><%= t('.sub_collections_of_collection_description') %></strong></p>
+        <table class="table table-striped table-condensed">
+          <thead>
+            <tr>
+              <th><%= t('.table.collection_title') %></th>
+              <th><%= t('.table.action') %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @form.list_child_collections.each do |document| %>
+              <tr>
+                <td>
+                  <%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
+                </td>
+                <td><button class="btn btn-sm btn-danger remove-sub-collection-button"><%= t('.buttons.remove_this_sub_collection') %></button></td>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% end %>
     </article>
 
   </section>
@@ -85,4 +102,6 @@
   <%# Render modals %>
   <%= render 'modal_remove_from_collection' %>
   <%= render 'modal_remove_sub_collection' %>
+  <%= render 'hyrax/my/collections/modal_add_to_collection', id: @form.collection.id, source: 'edit' %>
+  <%= render 'hyrax/my/collections/modal_add_subcollection', id: @form.collection.id, source: 'edit' %>
 </div>

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -7,6 +7,18 @@
                 data: { confirm: t('hyrax.collection.actions.delete.confirmation'),
                         method: :delete } %>
 <% end %>
+<% if presenter.collection_type_is_nestable? %>
+<!-- The user should have deposit access to the parent and read access to the child (the collection we are already showing, so no test is necessary). -->
+    <%= button_tag '',
+                  class: 'btn btn-default pull-right add-to-collection',
+                  onclick: "$('#add-to-collection-modal-#{presenter.id}').modal('show');",
+                  title: t("hyrax.collection.actions.nested_subcollection.desc"),
+                  type: 'button',
+                  data: { nestable: presenter.collection_type_is_nestable?,
+                          hasaccess: true } do %>
+                  <%= t('hyrax.collection.actions.nested_subcollection.button_label') %>
+                <% end %>
+<% end %>
 <% if can? :edit, presenter.solr_document %>
     <%= link_to t('hyrax.collection.actions.edit.label'),
                 hyrax.edit_dashboard_collection_path(presenter),

--- a/app/views/hyrax/dashboard/collections/_show_subcollection_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_subcollection_actions.html.erb
@@ -1,9 +1,26 @@
-<% if can? :edit, presenter.solr_document %>
-  <div class="sr-only">Add a nested collection</div>
-  <div class="actions-controls-collections">
-    <%= link_to t('hyrax.collection.actions.nest_collections.label'),
-                hyrax.dashboard_new_nest_collection_within_path(child_id: presenter.id),
-                title: t('hyrax.collection.actions.nest_collections.desc'),
-                class: 'btn btn-default pull-right' %>
-  </div>
+<% if presenter.collection_type_is_nestable? %>
+  <!-- The user should have deposit access to the parent (the collection we are showing) and read access to the child -->
+  <% if presenter.user_can_nest_collection? %>
+    <div class="actions-controls-collections">
+      <div class="sr-only"><% t('hyrax.collection.actions.nest_collections.desc') %></div>
+      <%= button_tag '',
+                    class: 'btn btn-default pull-right add-subcollection',
+                    onclick: "$('#add-subcollection-modal-#{presenter.id}').modal('show');",
+                    title: t('hyrax.collection.actions.nest_collections.desc'),
+                    type: 'button',
+                    data: { nestable: true,
+                            hasaccess: true } do %>
+                    <%= t('hyrax.collection.actions.nest_collections.button_label') %>
+                  <% end %>
+  <!-- The user should must have the ability to create a new collection of parent's type -->
+      <% if presenter.user_can_create_new_nest_collection? %>
+        <div class="sr-only"><% t('hyrax.collection.actions.add_new_nested_collection.desc') %></div>
+        <%= link_to t('hyrax.collection.actions.add_new_nested_collection.label'),
+          hyrax.dashboard_create_subcollection_under_path(parent_id: presenter.id),
+          title: t('hyrax.collection.actions.add_new_nested_collection.desc'),
+          class: 'btn btn-default pull-right',
+          data: { turbolinks: false } %>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/edit.html.erb
+++ b/app/views/hyrax/dashboard/collections/edit.html.erb
@@ -4,33 +4,9 @@
   <h1><span class="fa fa-edit"></span><%= t('.header', type_title: @collection.collection_type.title, title: @form.title.first) %></h1>
 <% end %>
 
-<% unless has_collection_search_parameters? %>
-  <div class="row">
-    <div class="col-md-12">
-      <%= render 'flash_msg' %>
-      <%= render 'form' %>
-    </div>
+<div class="row">
+  <div class="col-md-12">
+    <%= render 'flash_msg' %>
+    <%= render 'form' %>
   </div>
-
-  <div class="row">
-    <div class="col-md-12">
-      <div class="panel panel-default">
-        <div class="panel-body">
-          <%= render 'edit_actions' %>
-
-          <div class="row m-t-3">
-            <h2 class="col-xs-12 col-sm-6"><%= t('hyrax.collection.edit.manage_items') %></h2>
-            <div class="col-xs-12 col-sm-6">
-              <%= render 'hyrax/collections/search_form', presenter: @collection %>
-            </div>
-          </div>
-          <%= render 'hyrax/my/did_you_mean' %>
-          <%= render 'hyrax/my/facet_selected' %>
-          <%= render 'sort_and_per_page', collection: @collection if show_sort_and_per_page? %>
-          <%= render 'document_list', documents: @member_docs, document_list_format: "dashboard" %>
-          <%= render 'hyrax/collections/paginate' %>
-        </div>
-      </div>
-    </div>
-  </div>
-<% end %>
+</div>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -38,11 +38,12 @@
 </div>
 
 <% if @presenter.collection_type_is_nestable? %>
-
   <div class="row">
     <div class="col-md-12 h2">
       <%= t('.subcollection_count') %> (<%= @subcollection_count %>)
+    <article class="form-inline select-wrapper">
       <%= render 'show_subcollection_actions', presenter: @presenter %>
+    <article>
     </div>
   </div>
   <%= render 'subcollection_list', collection: @subcollection_docs %>
@@ -60,3 +61,8 @@
   <%= render_document_index @member_docs %>
   <%= render 'hyrax/collections/paginate' %>
 </div>
+
+<% if @presenter.collection_type_is_nestable? %>
+  <%= render 'hyrax/my/collections/modal_add_to_collection', id: @presenter.id, source: 'show' %>
+  <%= render 'hyrax/my/collections/modal_add_subcollection', id: @presenter.id, source: 'show' %>
+<% end %>

--- a/app/views/hyrax/dashboard/nest_collections/new_within.html.erb
+++ b/app/views/hyrax/dashboard/nest_collections/new_within.html.erb
@@ -1,8 +1,0 @@
-TODO - Get your ERB, JS, and HTML skills ready!
-
-* ./spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb for
-  current interface expectations.
-
-  The form is assumed to post a field with name=parent_id; This is different
-  from most simple_form_for behavior in that fields are often scoped within a
-  concept (e.g. `name=work[parent_id]` instead of `name=parent_id`).

--- a/app/views/hyrax/my/_collection_action_menu.html.erb
+++ b/app/views/hyrax/my/_collection_action_menu.html.erb
@@ -35,19 +35,20 @@
       <%= link_to "#",
             class: 'itemicon itemtrash delete-collection-button',
              title: t("hyrax.dashboard.my.action.delete_collection"),
-             data: { totalitems: collection_presenter.total_items , 
+             data: { totalitems: collection_presenter.total_items ,
                      membership: collection_presenter.collection_type_is_require_membership? ,
                      hasaccess: (can? :edit, collection_presenter.solr_document) } do %>
          <%= t("hyrax.dashboard.my.action.delete_collection") %>
        <% end %>
-    </li>    
+    </li>
     <% if Hyrax::CollectionType.any_nestable? %>
+<!-- The user should have deposit access to the parent we are adding, and read access to the child (the collection we are linking here). -->
       <li role="menuitem" tabindex="-1">
         <%= link_to "#",
           class: 'itemicon add-to-collection',
           title: t("hyrax.dashboard.my.action.add_to_collection"),
-          data: { nestable: collection_presenter.collection_type_is_nestable? , 
-                  hasaccess: (can? :deposit, collection_presenter.solr_document) } do %>
+          data: { nestable: collection_presenter.collection_type_is_nestable? ,
+                  hasaccess: (can? :read, collection_presenter.solr_document) } do %>
           <%= t("hyrax.dashboard.my.action.add_to_collection") %>
         <% end %>
       </li>

--- a/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
@@ -1,0 +1,28 @@
+<div class="modal fade" id="add-subcollection-modal-<%= id %>" tabindex="-1" role="dialog" aria-labelledby="add-subcollection-label">
+<% collection = Collection.find id %>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <%= form_tag(hyrax.dashboard_create_nest_collection_under_path(collection.id)) do %>
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>"><span aria-hidden="true">&times;</span></button>
+          <h2 class="modal-title" id="add-subcollection-label"><%= t('hyrax.collection.actions.nest_collections.modal_title') %></h2>
+        </div>
+        <div class="modal-body">
+          <label><%= t('hyrax.collection.actions.nest_collections.select_label') %></label>
+          <input type="hidden" name="source" value="<%= source %>"></input>
+          <select name="child_id">
+            <option value="none"><%= t("hyrax.dashboard.my.action.select") %></option>
+            <% colls = Hyrax::Collections::NestedCollectionQueryService.available_child_collections(parent: collection, scope: controller, limit_to_id: nil) %>
+            <% colls.each {|coll| %>
+              <option  value="<%= coll.id %>"><%= coll.title.first %></option>
+            <% } %>
+          </select>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
+          <input type="submit" class="btn btn-primary" value="<%= t('hyrax.collection.actions.nest_collections.button_label') %>">
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/my/collections/_modal_add_to_collection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_to_collection.html.erb
@@ -2,13 +2,13 @@
 <% collection = Collection.find id %>
   <div class="modal-dialog" role="document">
     <div class="modal-content">
-      <%= form_tag(hyrax.dashboard_nest_collection_process_path(collection.id)) do %>
+      <%= form_tag(hyrax.dashboard_create_nest_collection_within_path(collection.id)) do %>
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>"><span aria-hidden="true">&times;</span></button>
-          <h2 class="modal-title" id="add-to-collectioni-label"><%= t("hyrax.dashboard.my.action.add_to_collection") %></h2>
+          <h2 class="modal-title" id="add-to-collection-label"><%= t('hyrax.collection.actions.nested_subcollection.modal_title') %></h2>
         </div>
         <div class="modal-body">
-          <label><%= t("hyrax.dashboard.my.action.select_collection") %></label>
+          <label><%= t('hyrax.collection.actions.nested_subcollection.select_label') %></label>
           <input type="hidden" name="source" value="<%= source %>"></input>
           <select name="parent_id">
             <option value="none"><%= t("hyrax.dashboard.my.action.select") %></option>
@@ -23,7 +23,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
-          <input type="submit" class="btn btn-primary" value="<%= t("hyrax.dashboard.my.action.add_to_collection") %>">
+          <input type="submit" class="btn btn-primary" value="<%= t('hyrax.collection.actions.nested_subcollection.button_label') %>">
         </div>
       <% end %>
     </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -415,6 +415,9 @@ en:
         add_existing_works:
           desc: "Add existing works to this Collection"
           label: "Add existing works"
+        add_new_nested_collection:
+          desc: "Add new collection to this Collection"
+          label: "Create new collection as subcollection"
         add_new_work:
           desc: "Add new work to this Collection"
           label: "Add new work"
@@ -426,9 +429,16 @@ en:
           desc: "Edit this collection"
           label: "Edit"
         header: "Actions"
-        nest_collections:
+        nest_collections: # this collection is parent, modal "add-subcollection"
           desc: "Nest other collections within this Collection"
-          label: "Add existing collection"
+          button_label: "Add a subcollection"
+          modal_title: "Add a Subcollection to Collection"
+          select_label: "Select subcollection"
+        nested_subcollection: # this collection is child, modal "add-to-collection"
+          desc: "Nest this collection within another collection"
+          button_label: "Add to collection"
+          modal_title: "Add this Collection Within Another Collection"
+          select_label: "Select collection"
       browse_view: "Browse View"
       document_list:
         edit: "Edit"
@@ -562,10 +572,8 @@ en:
               label: "Logo"
               description: "One or more images to be displayed at the top of the collection pate.  For best results, upload an image (JPG, GIF orPNG) taht is 40 pixels in height.  Larger images will be resized to 40 pixels in height."
         form_relationships:
-          add_other_collections_as_sub_collections_description: "You can add other collections as sub-collections of this collection."
-          add_sub_collection: "Add sub-collection"
+          add_other_collections_as_sub_collections_description: "You can manage the sub-collections of this collection."
           buttons:
-            create_new_collection_as_sub_collection: "Create new collection as sub-collection"
             remove_from_collection: "Remove from collection"
             remove_this_sub_collection: "Remove this sub-collection"
           collection_is_subcollection_description: "This collection is currently a sub-collection of these collections"
@@ -575,7 +583,6 @@ en:
           modals:
             remove_from_collection_description: "Removing this collection will not remove it from the repository, only from this parent collection.  Are you sure you want to remove this collection?"
             remove_from_sub_collection_description: "Removing this sub-collection will not remove it from the repository, only from this parent collection.  Are you sure you want to remove this sub-collection?"
-          select_a_collection: "Select a collection..."
           sub_collections_of_collection_description: "These collections are currently sub-collections of this collection"
           table:
             action: "Action"
@@ -622,7 +629,6 @@ en:
           nesting_permission_denied: "You do not have sufficient privileges to add this collection to another collection."
           select:                  "Select"
           select_all:              "Select Current Page"
-          select_collection:       "Select a collection"
           select_none:             "Select None"
           transfer:                "Transfer Ownership of Work"
           unhighlight:             "Unhighlight Work"
@@ -663,7 +669,9 @@ en:
           show_label:       "Display all details of"
         works:        "Your Works"
       nest_collections_form:
-        create_within:          "%{child_title} has been added to %{parent_title}"
+        create_within:          "'%{child_title}' has been added to '%{parent_title}'"
+        create_under:          "'%{child_title}' has been added to '%{parent_title}'"
+        create_under_failed:   "'%{child_title}' cannot be added to '%{parent_title}'"
       no_activity:              "User has no recent activity"
       no_notifications:         "User has no notifications"
       delete_notification:      "Delete Notification"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,9 +132,9 @@ Hyrax::Engine.routes.draw do
         put :remove_member
       end
     end
-    get 'collections/:child_id/within', controller: 'nest_collections', action: 'new_within', as: 'new_nest_collection_within'
-    post 'collections/:child_id/within', controller: 'nest_collections', action: 'create_within', as: 'create_nest_collection_within'
-    post 'collections/:child_id/process_nesting', controller: 'nest_collections', action: 'process_nesting', as: 'nest_collection_process'
+    post 'collections/:child_id/within', controller: 'nest_collections', action: 'create_relationship_within', as: 'create_nest_collection_within'
+    get 'collections/:parent_id/under', controller: 'nest_collections', action: 'create_collection_under', as: 'create_subcollection_under'
+    post 'collections/:parent_id/under', controller: 'nest_collections', action: 'create_relationship_under', as: 'create_nest_collection_under'
     resources :profiles, only: [:show, :edit, :update]
   end
 

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -107,6 +107,20 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       end
     end
 
+    context "when params includes parent_id" do
+      let(:parent_collection) { create(:collection, title: ['Parent']) }
+
+      it "creates a collection as a subcollection of parent" do
+        parent_collection
+        expect do
+          post :create, params: {
+            collection: collection_attrs, parent_id: parent_collection.id
+          }
+        end.to change { Collection.count }.by(1)
+        expect(assigns[:collection].member_of_collections).to eq [parent_collection]
+      end
+    end
+
     context "when create fails" do
       let(:collection) { Collection.new }
 

--- a/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
@@ -1,9 +1,8 @@
 RSpec.describe Hyrax::Dashboard::NestCollectionsController do
   routes { Hyrax::Engine.routes }
   let(:child_id) { 'child1' }
-  let(:parent_id) { 'parent1' }
-  let(:child) { instance_double(Collection, title: "Awesome Child") }
-  let(:parent) { instance_double(Collection, title: "Uncool Parent") }
+  let(:child) { instance_double(Collection, title: ["Awesome Child"]) }
+  let(:parent) { create(:collection, id: 'parent1', collection_type_settings: :nestable, title: ["Uncool Parent"]) }
 
   describe '#blacklight_config' do
     subject { controller.blacklight_config }
@@ -17,48 +16,12 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
     it { is_expected.to be_a(Blacklight::Solr::Repository) }
   end
 
-  describe 'GET #new_within' do
-    subject { get 'new_within', params: { child_id: child_id } }
+  describe 'POST #create_relationship_within' do
+    subject { post 'create_relationship_within', params: { child_id: child_id, parent_id: parent.id, source: 'my' } }
 
     before do
       allow(Collection).to receive(:find).with(child_id).and_return(child)
-    end
-
-    it "authorizes the child, assigns @form, and renders the template" do
-      expect(controller).to receive(:authorize!).with(:edit, child).and_return(true)
-      subject
-      expect(assigns(:form).child).to eq(child)
-      expect(assigns(:form).parent).to be_nil
-      expect(subject).to render_template('new_within')
-    end
-  end
-
-  describe 'POST #process_nesting' do
-    subject { get 'process_nesting', params: { child_id: child_id, parent_id: parent_id, source: "all" } }
-
-    let(:obj) { [] }
-
-    before do
-      allow(Collection).to receive(:find).with(child_id).and_return(child)
-      allow(Collection).to receive(:find).with(parent_id).and_return(parent)
-
-      allow(child).to receive(:member_of_collections).and_return(obj)
-      allow(child).to receive(:save!).and_return(true)
-    end
-
-    it "make child collection member of parent collection" do
-      subject
-      expect(obj).to contain_exactly(parent)
-      expect(response).to redirect_to(dashboard_collections_path)
-    end
-  end
-
-  describe 'POST #create_within' do
-    subject { post 'create_within', params: { child_id: child_id, parent_id: parent_id } }
-
-    before do
-      allow(Collection).to receive(:find).with(child_id).and_return(child)
-      allow(Collection).to receive(:find).with(parent_id).and_return(parent)
+      allow(Collection).to receive(:find).with(parent.id).and_return(parent)
     end
 
     describe 'when save fails' do
@@ -74,19 +37,24 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
           def save
             false
           end
+
+          def errors; end
         end
       end
 
       before do
         controller.form_class = form_class_with_failed_save
+        allow(controller).to receive(:authorize!).with(:edit, child).and_return(true)
+        allow(controller.form_class).to receive(:errors)
+        allow(controller.form_class.errors).to receive(:full_messages).and_return(['huge mistake'])
       end
 
       it 'authorizes then renders the form again' do
-        expect(controller).to receive(:authorize!).with(:edit, child).and_return(true)
         subject
-        expect(response).to render_template('new_within')
+        expect(response).to redirect_to(my_collections_path)
       end
     end
+
     describe 'when save succeeds' do
       let(:form_class_with_successful_save) do
         Class.new do
@@ -105,14 +73,146 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
 
       before do
         controller.form_class = form_class_with_successful_save
+        allow(controller).to receive(:authorize!).with(:edit, child).and_return(true)
       end
 
       it 'authorizes, flashes a notice, and redirects' do
-        expect(controller).to receive(:authorize!).with(:edit, child).and_return(true)
         subject
-        expect(response).to redirect_to(dashboard_collection_path(child))
+        expect(response).to redirect_to(my_collections_path)
         expect(flash[:notice]).to be_a(String)
       end
+    end
+  end
+
+  describe 'GET #create_collection_under' do
+    subject { get 'create_collection_under', params: { child_id: nil, parent_id: parent.id, source: 'edit' } }
+
+    before do
+      allow(Collection).to receive(:find).with(parent.id).and_return(parent)
+    end
+
+    describe 'when validation fails' do
+      let(:form_class_with_failed_validation) do
+        Class.new do
+          attr_reader :child, :parent
+          def initialize(parent:, child:, context:)
+            @parent = parent
+            @child = child
+            @context = context
+          end
+
+          def validate_add
+            false
+          end
+
+          def errors; end
+        end
+      end
+
+      before do
+        controller.form_class = form_class_with_failed_validation
+        allow(controller).to receive(:authorize!).with(:edit, parent).and_return(true)
+        allow(controller.form_class).to receive(:errors)
+        allow(controller.form_class.errors).to receive(:full_messages).and_return(['huge mistake'])
+      end
+
+      it 'authorizes then renders the form again' do
+        subject
+        expect(response).to redirect_to(edit_dashboard_collection_path(parent.id, anchor: 'relationships'))
+      end
+    end
+
+    describe 'when validation succeeds' do
+      let(:form_class_with_successful_validation) do
+        Class.new do
+          attr_reader :child, :parent
+          def initialize(parent:, child:, context:)
+            @parent = parent
+            @child = child
+            @context = context
+          end
+
+          def validate_add
+            true
+          end
+        end
+      end
+
+      before do
+        controller.form_class = form_class_with_successful_validation
+        allow(controller).to receive(:authorize!).with(:edit, parent).and_return(true)
+      end
+
+      it 'authorizes, flashes a notice, and redirects' do
+        subject
+        expect(response).to redirect_to new_dashboard_collection_path(collection_type_id: parent.collection_type.id, parent_id: parent.id)
+      end
+    end
+  end
+
+  subject { post 'create_relationship_under', params: { child_id: child_id, parent_id: parent.id, source: 'show' } }
+
+  before do
+    allow(Collection).to receive(:find).with(child_id).and_return(child)
+    allow(Collection).to receive(:find).with(parent.id).and_return(parent)
+  end
+
+  describe 'when save fails' do
+    let(:form_class_with_failed_save) do
+      Class.new do
+        attr_reader :child, :parent
+        def initialize(parent:, child:, context:)
+          @parent = parent
+          @child = child
+          @context = context
+        end
+
+        def save
+          false
+        end
+
+        def errors; end
+      end
+    end
+
+    before do
+      controller.form_class = form_class_with_failed_save
+      allow(controller).to receive(:authorize!).with(:edit, parent).and_return(true)
+      allow(controller.form_class).to receive(:errors)
+      allow(controller.form_class.errors).to receive(:full_messages).and_return(['huge mistake'])
+    end
+
+    it 'authorizes then renders the form again' do
+      subject
+      expect(response).to redirect_to(dashboard_collection_path(parent))
+    end
+  end
+
+  describe 'when save succeeds' do
+    let(:form_class_with_successful_save) do
+      Class.new do
+        attr_reader :child, :parent
+        def initialize(parent:, child:, context:)
+          @parent = parent
+          @child = child
+          @context = context
+        end
+
+        def save
+          true
+        end
+      end
+    end
+
+    before do
+      controller.form_class = form_class_with_successful_save
+      allow(controller).to receive(:authorize!).with(:edit, parent).and_return(true)
+    end
+
+    it 'authorizes, flashes a notice, and redirects' do
+      subject
+      expect(response).to redirect_to(dashboard_collection_path(parent))
+      expect(flash[:notice]).to be_a(String)
     end
   end
 end

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -145,7 +145,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         fill_in('Related URL', with: 'http://example.com/')
 
         click_button("Save")
-        expect(page).to have_content 'Items'
         expect(page).to have_content title
         expect(page).to have_content description
       end
@@ -172,7 +171,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         fill_in('Related URL', with: 'http://example.com/')
 
         click_button("Save")
-        expect(page).to have_content 'Items'
         expect(page).to have_content title
         expect(page).to have_content description
       end
@@ -658,38 +656,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           expect(page).not_to have_link('Sharing', href: '#sharing')
         end
       end
-    end
-  end
-
-  describe "Removing works from a collection" do
-    let(:collection) { create(:named_collection, user: user, with_permission_template: true) }
-    let!(:work1) { create(:work, title: ["King Louie"], member_of_collections: [collection], user: user) }
-    let!(:work2) { create(:work, title: ["King Kong"], member_of_collections: [collection], user: user) }
-
-    before do
-      sign_in user
-      visit "/dashboard/collections/#{collection.id}/edit"
-    end
-
-    it "removes one works out of two", with_nested_reindexing: true do
-      within("#document_#{work1.id}") do
-        first('button.dropdown-toggle').click
-        click_button('Remove from Collection')
-      end
-      expect(page).to have_content(collection.title.first)
-      expect(page).to have_content(collection.description.first)
-      expect(page).not_to have_content(work1.title.first)
-      expect(page).to have_content(work2.title.first)
-    end
-
-    xit "removes all works", :js do
-      # TODO: skipping - see Hyrax issue #1488
-      first('input#check_all').click
-      click_button('Remove From Collection')
-      expect(page).to have_content(collection.title.first)
-      expect(page).to have_content(collection.description.first)
-      expect(page).not_to have_content(work1.title.first)
-      expect(page).not_to have_content(work2.title.first)
     end
   end
 end

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -73,6 +73,29 @@ RSpec.describe Hyrax::Forms::CollectionForm do
     end
   end
 
+  context "nested relationships" do
+    let(:child_collection) { build(:collection) }
+    let(:parent_collection) { build(:collection) }
+    let(:service_object) { double(available_member_subcollections: double(documents: [child_collection])) }
+
+    before do
+      allow(collection).to receive(:member_of_collections).and_return([parent_collection])
+      allow(form).to receive(:collection_member_service).and_return(service_object)
+    end
+
+    describe "#list_parent_collections" do
+      subject { form.list_parent_collections }
+
+      it { is_expected.to eq([parent_collection]) }
+    end
+
+    describe "#list_child_collections" do
+      subject { form.list_child_collections }
+
+      it { is_expected.to eq([child_collection]) }
+    end
+  end
+
   describe "#id" do
     subject { form.id }
 

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
   end
 
   it 'is invalid if child cannot be nested within the parent' do
-    expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child, context: context).and_return(false)
+    expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child, scope: context).and_return(false)
     subject.valid?
     expect(subject.errors[:parent]).to eq(["cannot have child nested within it"])
     expect(subject.errors[:child]).to eq(["cannot nest within parent"])
@@ -78,7 +78,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     subject { form.available_child_collections }
 
     it 'delegates to the underlying query_service' do
-      expect(query_service).to receive(:available_child_collections).with(parent: parent, context: context).and_return(:results)
+      expect(query_service).to receive(:available_child_collections).with(parent: parent, scope: context).and_return(:results)
       expect(subject).to eq(:results)
     end
   end
@@ -86,8 +86,27 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     subject { form.available_parent_collections }
 
     it 'delegates to the underlying query_service' do
-      expect(query_service).to receive(:available_parent_collections).with(child: child, context: context).and_return(:results)
+      expect(query_service).to receive(:available_parent_collections).with(child: child, scope: context).and_return(:results)
       expect(subject).to eq(:results)
+    end
+  end
+
+  describe '#validate_add' do
+    context 'when not valid' do
+      let(:parent) { double(nestable?: false) }
+
+      it 'validates the parent can contain nested subcollections' do
+        subject.validate_add
+        expect(subject.errors[:parent]).to eq(["cannot have child nested within it"])
+      end
+    end
+
+    context 'when valid' do
+      let(:parent) { double(nestable?: true) }
+
+      it 'validates the parent can contain nested subcollections' do
+        expect(subject.validate_add).to eq true
+      end
     end
   end
 end

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -284,6 +284,26 @@ RSpec.describe Hyrax::CollectionPresenter do
     it { is_expected.to eq '0 Bytes' }
   end
 
+  describe "#user_can_nest_collection?" do
+    before do
+      allow(ability).to receive(:can?).with(:deposit, collection.id).and_return(true)
+    end
+
+    subject { presenter.user_can_nest_collection? }
+
+    it { is_expected.to eq true }
+  end
+
+  describe "#user_can_create_new_nest_collection?" do
+    before do
+      allow(ability).to receive(:can?).with(:create_collection_of_type, collection.collection_type).and_return(true)
+    end
+
+    subject { presenter.user_can_create_new_nest_collection? }
+
+    it { is_expected.to eq true }
+  end
+
   describe '#show_path' do
     subject { presenter.show_path }
 

--- a/spec/routing/dashboard_routes_spec.rb
+++ b/spec/routing/dashboard_routes_spec.rb
@@ -1,11 +1,15 @@
 RSpec.describe 'Dashboard Routes', type: :routing do
   routes { Hyrax::Engine.routes }
 
-  it 'routes GET /dashboard/collections/:child_id/within' do
-    expect(get: '/dashboard/collections/child1/within').to route_to(controller: 'hyrax/dashboard/nest_collections', action: 'new_within', child_id: 'child1')
+  it 'routes GET /dashboard/collections/:parent_id/under' do
+    expect(get: '/dashboard/collections/parent1/under').to route_to(controller: 'hyrax/dashboard/nest_collections', action: 'create_collection_under', parent_id: 'parent1')
+  end
+
+  it 'routes POST /dashboard/collections/:parent_id/under' do
+    expect(post: '/dashboard/collections/parent1/under').to route_to(controller: 'hyrax/dashboard/nest_collections', action: 'create_relationship_under', parent_id: 'parent1')
   end
 
   it 'routes POST /dashboard/collections/:child_id/within' do
-    expect(post: '/dashboard/collections/child1/within').to route_to(controller: 'hyrax/dashboard/nest_collections', action: 'create_within', child_id: 'child1')
+    expect(post: '/dashboard/collections/child1/within').to route_to(controller: 'hyrax/dashboard/nest_collections', action: 'create_relationship_within', child_id: 'child1')
   end
 end

--- a/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Hyrax::Collections::NestedCollectionPersistenceService do
 
     it 'creates the relationship between parent and child' do
       subject
-      expect(parent.members).to eq([child])
-      expect(child.member_of).to eq([parent])
+      expect(parent.member_objects).to eq([child])
+      expect(child.member_of_collections).to eq([parent])
     end
   end
 end

--- a/spec/views/hyrax/dashboard/collections/_form_relationships.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_relationships.html.erb_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe 'hyrax/dashboard/collections/_form_relationships.html.erb', type: :view do
+  let(:collection) { create(:collection, id: '1234') }
+
+  let(:collection_type) { double('Hyrax::CollectionType', nestable?: true) }
+  let(:ability) { Ability.new(create(:user)) }
+  let(:repository) { double }
+  # let(:blacklight_config) { double(default_solr_params: nil) }
+  let(:form) { Hyrax::Forms::CollectionForm.new(collection, ability, repository) }
+  let(:can_deposit) { true }
+  let(:can_create_collection_of_type) { true }
+
+  let(:collection1) { build(:collection, title: ['Hello']) }
+  let(:collection2) { build(:collection, title: ['World']) }
+  let(:collection3) { build(:collection, title: ['Goodnight']) }
+  let(:collection4) { build(:collection, title: ['Moon']) }
+  let(:collections) { [collection1, collection2] }
+  let(:subcollections) { [collection3, collection4] }
+
+  before do
+    assign(:form, form)
+    allow(form).to receive(:list_parent_collections).and_return([])
+    allow(form).to receive(:list_child_collections).and_return([])
+    allow(collection).to receive(:collection_type).and_return(collection_type)
+    allow(view).to receive(:can?).with(:deposit, collection).and_return(can_deposit)
+    allow(view).to receive(:can?).with(:create_collection_of_type, collection_type).and_return(can_create_collection_of_type)
+  end
+
+  context "when parent & sub-collections exist" do
+    before do
+      allow(form).to receive(:list_parent_collections).and_return(collections)
+      allow(form).to receive(:list_child_collections).and_return(subcollections)
+    end
+
+    it "displays parent collections" do
+      stub_template 'hyrax/my/collections/_modal_add_to_collection.html.erb' => 'modal add as subcollection'
+      stub_template 'hyrax/my/collections/_modal_add_subcollection.html.erb' => 'modal add as parent'
+      stub_template 'modal_remove_from_collection' => 'modal remove parent'
+      stub_template 'modal_remove_sub_collection' => 'modal remove subcollection'
+      render
+
+      expect(rendered).to have_content(I18n.t('hyrax.dashboard.collections.form_relationships.collection_is_subcollection_description'))
+      expect(rendered).to have_content(I18n.t('hyrax.dashboard.collections.form_relationships.sub_collections_of_collection_description'))
+      expect(rendered).to have_link("Hello")
+      expect(rendered).to have_link("World")
+      expect(rendered).to have_link("Goodnight")
+      expect(rendered).to have_link("Moon")
+    end
+  end
+
+  context "when no parent or sub-collections exist" do
+    it "does not show parent collection headers" do
+      stub_template 'hyrax/my/collections/_modal_add_to_collection.html.erb' => 'modal add as subcollection'
+      stub_template 'hyrax/my/collections/_modal_add_subcollection.html.erb' => 'modal add as parent'
+      stub_template 'modal_remove_from_collection' => 'modal remove parent'
+      stub_template 'modal_remove_sub_collection' => 'modal remove subcollection'
+      render
+
+      expect(rendered).not_to have_content(I18n.t('hyrax.dashboard.collections.form_relationships.collection_is_subcollection_description'))
+      expect(rendered).not_to have_content(I18n.t('hyrax.dashboard.collections.form_relationships.sub_collections_of_collection_description'))
+    end
+  end
+
+  context 'with limited access' do
+    let(:can_deposit) { false }
+    let(:can_create_collection_of_type) { false }
+
+    it "does not allow show subcollection buttons without access rights" do
+      stub_template 'hyrax/my/collections/_modal_add_to_collection.html.erb' => 'modal add as subcollection'
+      stub_template 'hyrax/my/collections/_modal_add_subcollection.html.erb' => 'modal add as parent'
+      stub_template 'modal_remove_from_collection' => 'modal remove parent'
+      stub_template 'modal_remove_sub_collection' => 'modal remove subcollection'
+      render
+
+      expect(rendered).not_to have_content(I18n.t('hyrax.dashboard.collections.form_relationships.collection_is_subcollection_description'))
+      expect(rendered).not_to have_content(I18n.t('hyrax.dashboard.collections.form_relationships.sub_collections_of_collection_description'))
+    end
+  end
+end

--- a/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'hyrax/dashboard/collections/_show_actions.html.erb', type: :view
     allow(view).to receive(:can?).with(:edit, solr_document).and_return(can_edit)
     allow(view).to receive(:can?).with(:destroy, solr_document).and_return(can_destroy)
   end
+
   describe 'when user can edit the document' do
     let(:can_edit) { true }
 
@@ -29,6 +30,23 @@ RSpec.describe 'hyrax/dashboard/collections/_show_actions.html.erb', type: :view
       expect(rendered).not_to have_link('Edit this collection', href: '/path/to/edit')
     end
   end
+
+  describe 'nesting the collection within another collection' do
+    context 'with nestable collection' do
+      it 'renders add parent collection link' do
+        allow(presenter).to receive(:collection_type_is_nestable?).and_return true
+        render
+        expect(rendered).to have_button('Nest this collection')
+      end
+    end
+    context 'with non-nestable collection' do
+      it 'does not render add parent collection link' do
+        render
+        expect(rendered).not_to have_button('Nest this collection')
+      end
+    end
+  end
+
   describe 'when user can destroy the document' do
     it 'renders a link to destroy the document' do
       render

--- a/spec/views/hyrax/dashboard/collections/_show_subcollection_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_subcollection_actions.html.erb_spec.rb
@@ -1,39 +1,61 @@
 RSpec.describe 'hyrax/dashboard/collections/_show_subcollection_actions.html.erb', type: :view do
-  let(:presenter) { double('Hyrax::CollectionPresenter', collection_type_is_nestable?: is_nestable, solr_document: solr_document, id: '123') }
-  let(:solr_document) { double('Solr Document') }
+  let(:presenter) do
+    double('Hyrax::CollectionPresenter',
+           collection_type_is_nestable?: is_nestable,
+           collection: collection,
+           id: '123',
+           user_can_nest_collection?: can_deposit,
+           user_can_create_new_nest_collection?: can_create)
+  end
+  let(:collection) { double('A Collection') }
   let(:is_nestable) { true }
-  let(:can_edit) { true }
+  let(:can_deposit) { true }
+  let(:can_create) { true }
 
   before do
     allow(view).to receive(:presenter).and_return(presenter)
-
-    allow(view).to receive(:can?).with(:edit, solr_document).and_return(can_edit) # TODO: probably should be :deposit -- dependency on collection participants
   end
-  describe 'when user can edit the document' do
-    let(:can_edit) { true }
 
-    describe 'when the collection_type is nestable' do
-      it 'renders a link to add_collections to this collection' do
-        render
-        expect(rendered).to have_css(".actions-controls-collections .btn[href='#{hyrax.dashboard_new_nest_collection_within_path(child_id: presenter.id)}']")
-      end
+  describe 'when user has permission to create subcollections' do
+    before do
+      render
     end
-    describe 'when the collection_type is not nestable' do
-      let(:is_nestable) { false }
 
-      it 'does not render a link to add_collections to this collection' do
-        render
-        expect(rendered).not_to have_css(".actions-controls-collections .btn[href='/TODO/NEST_COLLECTION']")
-      end
+    it 'renders a links to nest subcollection options' do
+      expect(rendered).to have_button(I18n.t('hyrax.collection.actions.nest_collections.desc'))
+      expect(rendered).to have_css(".actions-controls-collections .btn[href='#{hyrax.dashboard_create_subcollection_under_path(parent_id: presenter.id)}']")
     end
   end
-  describe 'when user cannot edit the document' do
-    let(:can_edit) { false }
+
+  describe 'when the collection_type is not nestable' do
+    let(:is_nestable) { false }
+
+    it 'does not render a link to add_collections to this collection' do
+      render
+      expect(rendered).not_to have_css(".actions-controls-collections .btn[href='#{hyrax.dashboard_create_subcollection_under_path(parent_id: presenter.id)}']")
+    end
+  end
+
+  describe 'when user has no nesting permissions' do
+    let(:can_deposit) { false }
 
     describe 'when the collection_type is nestable' do
-      it 'does not render a link to add_collections to this collection' do
+      it 'does not render a either nesting option' do
         render
-        expect(rendered).not_to have_css(".actions-controls-collections .btn[href='/TODO/NEST_COLLECTION']")
+        expect(rendered).not_to have_button(I18n.t('hyrax.collection.actions.nest_collections.desc'))
+        expect(rendered).not_to have_css(".actions-controls-collections .btn[href='#{hyrax.dashboard_create_subcollection_under_path(parent_id: presenter.id)}']")
+      end
+    end
+  end
+
+  describe 'when user cannot create new collection' do
+    let(:can_create) { false }
+
+    describe 'when the collection_type is nestable' do
+      it 'does not render a button to create a new collection' do
+        render
+        expect(rendered).to have_button(I18n.t('hyrax.collection.actions.nest_collections.desc'))
+        expect(rendered).not_to have_css(".actions-controls-collections .btn[href='#{hyrax.dashboard_create_subcollection_under_path(parent_id: presenter.id)}']")
       end
     end
   end

--- a/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
@@ -1,27 +1,18 @@
 RSpec.describe 'hyrax/dashboard/collections/edit.html.erb', type: :view do
   let(:collection) { stub_model(Collection, id: 'xyz123z4', title: ["Make Collections Great Again"]) }
   let(:form) { Hyrax::Forms::CollectionForm.new(collection, double, double) }
-  let(:solr_response) { instance_double(Blacklight::Solr::Response, empty?: true) }
 
   before do
-    allow(view).to receive(:has_collection_search_parameters?).and_return(false)
-    allow(controller).to receive(:current_user).and_return(stub_model(User))
     assign(:collection, collection)
     assign(:form, form)
-    assign(:response, solr_response)
-    stub_template 'hyrax/collections/_search_form.html.erb' => 'search form'
-    stub_template 'hyrax/my/_did_you_mean.html.erb' => 'did you mean'
-    stub_template 'hyrax/collections/_sort_and_per_page.html.erb' => 'sort and per page'
-    stub_template '_document_list.html.erb' => 'document list'
-    stub_template 'hyrax/collections/_paginate.html.erb' => 'paginate'
-    stub_template '_form.html.erb' => 'form'
-    stub_template 'hyrax/dashboard/collections/_flash_msg.html.erb' => 'flash_msg'
+    stub_template '_form.html.erb' => 'my-edit-form partial'
+    stub_template '_flash_msg.html.erb' => 'flash_msg partial'
 
     render
   end
 
   it 'displays the page' do
-    expect(rendered).to have_content 'Actions'
-    expect(rendered).to have_link 'Add existing works'
+    expect(rendered).to have_content 'my-edit-form partial'
+    expect(rendered).to have_content 'flash_msg partial'
   end
 end

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -32,9 +32,12 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     stub_template '_document_list.html.erb' => 'document list'
     # This is tested ./spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
     stub_template '_show_actions.html.erb' => '<div class="stubbed-actions">THE COLLECTION ACTIONS</div>'
+    stub_template '_show_subcollection_actions.html.erb' => '<div class="stubbed-actions">THE SUBCOLLECTION ACTIONS</div>'
     stub_template '_show_add_items_actions.html.erb' => '<div class="stubbed-actions">THE ADD ITEMS ACTIONS</div>'
     stub_template 'hyrax/collections/_paginate.html.erb' => 'paginate'
     stub_template 'hyrax/collections/_media_display.html.erb' => '<span class="fa fa-cubes collection-icon-search"></span>'
+    stub_template 'hyrax/my/collections/_modal_add_to_collection.html.erb' => 'modal add as subcollection'
+    stub_template 'hyrax/my/collections/_modal_add_subcollection.html.erb' => 'modal add as parent'
     render
   end
 

--- a/spec/views/hyrax/my/_collection_action_menu.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_collection_action_menu.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'hyrax/my/_collection_action_menu.html.erb' do
     allow(collection_doc).to receive(:fetch).with('collection_type_gid_ssim', [user_collection_type.gid]).and_return(collection_type.gid)
     allow(collection_presenter).to receive(:id).and_return(id)
     allow(collection_presenter).to receive(:solr_document).and_return(collection_doc)
-    allow(view).to receive(:can?).with(:deposit, collection_doc).and_return(true)
+    allow(view).to receive(:can?).with(:read, collection_doc).and_return(true)
     allow(view).to receive(:can?).with(:edit, collection_doc).and_return(true)
   end
 

--- a/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
     before do
       allow(view).to receive(:current_user).and_return(stub_model(User))
       allow(view).to receive(:can?).with(:edit, doc).and_return(true)
-      allow(view).to receive(:can?).with(:deposit, doc).and_return(true)
+      allow(view).to receive(:can?).with(:read, doc).and_return(true)
       allow(doc).to receive(:to_model).and_return(stub_model(Collection, id: id))
       allow(Collection).to receive(:find).with(id).and_return(collection)
       allow(collection).to receive(:id).and_return(id)
@@ -107,7 +107,7 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
     before do
       allow(view).to receive(:current_user).and_return(stub_model(User))
       allow(view).to receive(:can?).with(:edit, doc).and_return(true)
-      allow(view).to receive(:can?).with(:deposit, doc).and_return(true)
+      allow(view).to receive(:can?).with(:read, doc).and_return(true)
       allow(doc).to receive(:to_model).and_return(stub_model(Collection, id: id))
       allow(Collection).to receive(:find).with(id).and_return(collection)
       allow(collection).to receive(:id).and_return(id)


### PR DESCRIPTION
Completes issue #1719, except for todo items listed below which are moving to new issues. 

Make edit#relationships tab functional.
  - add list of parent collections
  - add list of child collections
  - chg button to add an existing collection as a parent via modal
  - remove list of parents for selection (done via modal)
  - chg button to add existing collection as a subcollection via modal
  - remove list of child collections for selection (done via modal)
  - add button functionality to create new collection as subcollection

Also add above nesting buttons to dashboard/show view.

Make all nesting ability tests consistent: _The user should have deposit access to the parent and read access to the child._

Reverse the nesting direction of the collection persistence service.

Remove the list of works in the collection, as we do not want to manage work relationships within the edit collection form.

@samvera/hyrax-code-reviewers
