### PR TITLE
Remove duplicate setting keeping eslint from running

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -70,7 +70,6 @@ rules:
   no-implied-eval: 2
   no-invalid-this: 0
   no-iterator: 2
-  no-labels: 0
   no-lone-blocks: 2
   no-loop-func: 2
   no-magic-number: 0


### PR DESCRIPTION
I let the stricter of the two settings win since the error wasn't found when running `eslint` locally.