### PR TITLE
add select work type modal to collection’s admin show page

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -5,6 +5,9 @@ module Hyrax
     include ActionView::Helpers::NumberHelper
     attr_accessor :solr_document, :current_ability, :request, :collection_type
 
+    class_attribute :create_work_presenter_class
+    self.create_work_presenter_class = Hyrax::SelectTypeListPresenter
+
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability
     # @param [ActionDispatch::Request] request the http request context
@@ -111,6 +114,20 @@ module Hyrax
         logo_info << { file: logo_file, file_location: file_location, alttext: alttext, linkurl: linkurl }
       end
       logo_info
+    end
+
+    # A presenter for selecting a work type to create
+    # this is needed here because the selector is in the header on every page
+    def create_work_presenter
+      @create_work_presenter ||= create_work_presenter_class.new(current_ability.current_user)
+    end
+
+    def create_many_work_types?
+      create_work_presenter.many?
+    end
+
+    def draw_select_work_modal?
+      create_many_work_types?
     end
   end
 end

--- a/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
@@ -6,10 +6,16 @@
                 title: t('hyrax.collection.actions.add_existing_works.desc'),
                 class: 'btn btn-default pull-right',
                 data: { turbolinks: false } %>
-    <%= link_to t('hyrax.collection.actions.add_new_work.label'),
-                '#',
-                title: t('hyrax.collection.actions.add_new_work.desc'),
-                data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single', add_works_to_collection: presenter.id },
-                class: 'btn btn-default  pull-right'  %>
+    <% if @presenter.create_many_work_types? %>
+      <%= link_to t('hyrax.collection.actions.add_new_work.label'),
+                  '#',
+                  title: t('hyrax.collection.actions.add_new_work.desc'),
+                  data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single', add_works_to_collection: presenter.id },
+                  class: 'btn btn-default  pull-right'  %>
+    <% else # simple link to the first work type %>
+      <%= link_to t('hyrax.collection.actions.add_new_work.label'),
+                  new_polymorphic_path([main_app, @presenter.first_work_type, add_works_to_collection: presenter.id]),
+                  class: 'btn btn-default  pull-right'  %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -66,3 +66,5 @@
   <%= render 'hyrax/my/collections/modal_add_to_collection', id: @presenter.id, source: 'show' %>
   <%= render 'hyrax/my/collections/modal_add_subcollection', id: @presenter.id, source: 'show' %>
 <% end %>
+
+<%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>

--- a/spec/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe 'hyrax/dashboard/collections/_show_add_items_actions.html.erb', t
 
   before do
     allow(view).to receive(:presenter).and_return(presenter)
-
+    allow(presenter).to receive(:create_many_work_types?).and_return(true)
+    assign(:presenter, presenter)
     allow(view).to receive(:can?).with(:edit, solr_document).and_return(can_edit) # TODO: probably should be :deposit -- dependency on collection participants
   end
   describe 'when user can edit the document' do

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -9,10 +9,13 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
   let(:collection_type) { double }
 
   before do
+    user = stub_model(User)
     allow(document).to receive(:hydra_model).and_return(::Collection)
-    allow(controller).to receive(:current_user).and_return(stub_model(User))
+    allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:can?).with(:edit, document).and_return(true)
     allow(view).to receive(:can?).with(:destroy, document).and_return(true)
+    allow(view).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
 
     allow(presenter).to receive(:total_items).and_return(0)
     allow(presenter).to receive(:collection_type).and_return(collection_type)


### PR DESCRIPTION
Fixes #2271 

Add the select work type modal back into the collection's admin show page.  This is required for the Add new work button to be able to show the select work type modal when clicked.

@samvera/hyrax-code-reviewers
