### PR TITLE
Ensure that empty strings are not stored for single-valued attributes

### DIFF
--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -98,6 +98,24 @@ module Hyrax
         def multivalued_form_attributes(attributes)
           attributes.select { |_, v| v.respond_to?(:select) && !v.respond_to?(:read) }
         end
+
+        # If any single-valued attributes are empty strings make them nil
+        # e.g.:
+        #   self.attributes = { 'single_valued' => '' }
+        #   remove_empty_string_attributes!
+        #   self.attributes
+        # => { 'single_valued' => nil }
+        # Return the hash of attributes that are multivalued and not uploaded files
+        def remove_empty_string_attributes!(attributes)
+          empty_string_form_attributes(attributes).each_with_object(attributes) do |(k, _), h|
+            h[k] = nil
+          end
+        end
+
+        # Return all attributes that are an empty string
+        def empty_string_form_attributes(attributes)
+          attributes.select { |_, v| v == '' }.keys.map { |k| k }
+        end
     end
   end
 end


### PR DESCRIPTION
Fixes #2296 

The commit adds methods to `Hyrax::Actors::BaseActor` to ensure that empty strings are not stored for single-valued attributes.

This fixes an issue that occurs if you create a work with single
valued attributes. When the form is submitted without values the
values in the record become and empty string: `""`. These values should
remain `nil`.

Changes proposed in this pull request:
* add methods to `BaseActor` to normalize single-valued attributes

@samvera/hyrax-code-reviewers