### PR TITLE
Update null source_type on permission templates

### DIFF
--- a/db/migrate/20171205205934_update_null_source_type_on_permission_templates.rb
+++ b/db/migrate/20171205205934_update_null_source_type_on_permission_templates.rb
@@ -1,4 +1,4 @@
-class UpdateNullSourceTypeOnPermissionTemplates < ActiveRecord::Migration[5.1]
+class UpdateNullSourceTypeOnPermissionTemplates < ActiveRecord::Migration[5.0]
   def up
     Hyrax::PermissionTemplate.find_each do |permission_template|
       permission_template.source_type = 'admin_set' if permission_template.source_type.nil?

--- a/db/migrate/20171205205934_update_null_source_type_on_permission_templates.rb
+++ b/db/migrate/20171205205934_update_null_source_type_on_permission_templates.rb
@@ -1,0 +1,8 @@
+class UpdateNullSourceTypeOnPermissionTemplates < ActiveRecord::Migration[5.1]
+  def up
+    Hyrax::PermissionTemplate.find_each do |permission_template|
+      permission_template.source_type = 'admin_set' if permission_template.source_type.nil?
+      permission_template.save!
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1580

This fixes the missed data migration in [20170821152307_add_source_type_to_permission_templates](https://github.com/samvera/hyrax/blob/collections-sprint/db/migrate/20170821152307_add_source_type_to_permission_templates.rb). At this point, time has passed and users have likely run migrations on their dbs, so had to add this as a new migration and assume that any nils are due to this missed data migration.