### PR TITLE
Remove code that is no longer used by CollectionsController

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -16,12 +16,6 @@ module Hyrax
                       :single_item_search_builder_class,
                       :member_search_builder_class
 
-      alias_method :collection_search_builder_class, :single_item_search_builder_class
-      deprecation_deprecate collection_search_builder_class: "use single_item_search_builder_class instead"
-
-      alias_method :collection_member_search_builder_class, :member_search_builder_class
-      deprecation_deprecate collection_member_search_builder_class: "use member_search_builder_class instead"
-
       self.presenter_class = Hyrax::CollectionPresenter
 
       # The search builder to find the collection
@@ -58,17 +52,11 @@ module Hyrax
         single_item_search_builder_class.new(self).with(params.except(:q, :page))
       end
 
-      alias collection_search_builder single_item_search_builder
-      deprecation_deprecate collection_search_builder: "use single_item_search_builder instead"
-
       # Instantiates the search builder that builds a query for items that are
       # members of the current collection. This is used in the show view.
       def member_search_builder
         @member_search_builder ||= member_search_builder_class.new(self)
       end
-
-      alias collection_member_search_builder member_search_builder
-      deprecation_deprecate collection_member_search_builder: "use member_search_builder instead"
 
       def collection_params
         form_class.model_attributes(params[:collection])

--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -5,12 +5,6 @@ module Hyrax
     include Blacklight::Base
 
     included do
-      before_action :filter_docs_with_read_access!, except: :show
-
-      include Hyrax::Collections::AcceptsBatches
-
-      # include the render_check_all view helper method
-      helper Hyrax::BatchEditsHelper
       # include the display_trophy_link view helper method
       helper Hyrax::TrophyHelper
 

--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -2,8 +2,6 @@ module Hyrax
   class Admin::AdminSetsController < ApplicationController
     include Hyrax::CollectionsControllerBehavior
 
-    # added skip to allow flash notices. see https://github.com/samvera/hyrax/issues/202
-    skip_before_action :filter_docs_with_read_access!
     before_action :ensure_manager!
     load_and_authorize_resource
 

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -31,12 +31,6 @@ module Hyrax
                       :single_item_search_builder_class,
                       :member_search_builder_class
 
-      alias collection_search_builder_class single_item_search_builder_class
-      deprecation_deprecate collection_search_builder_class: "use single_item_search_builder_class instead"
-
-      alias collection_member_search_builder_class member_search_builder_class
-      deprecation_deprecate collection_member_search_builder_class: "use member_search_builder_class instead"
-
       self.presenter_class = Hyrax::CollectionPresenter
 
       self.form_class = Hyrax::Forms::CollectionForm
@@ -217,17 +211,11 @@ module Hyrax
           single_item_search_builder_class.new(self).with(params.except(:q, :page))
         end
 
-        alias collection_search_builder single_item_search_builder
-        deprecation_deprecate collection_search_builder: "use single_item_search_builder instead"
-
         # Instantiates the search builder that builds a query for items that are
         # members of the current collection. This is used in the show view.
         def member_search_builder
           @member_search_builder ||= member_search_builder_class.new(self)
         end
-
-        alias collection_member_search_builder member_search_builder
-        deprecation_deprecate collection_member_search_builder: "use member_search_builder instead"
 
         def collection_params
           form_class.model_attributes(params[:collection])


### PR DESCRIPTION
Also removed some deprecated code that was intended to be removed prior to the 2.0 release.

This probably should have been a part of https://github.com/samvera/hyrax/commit/18557e5ee4ca602d7a320b6fb91f3596326487f7