### PR TITLE
Avoid changing names at display time

### DIFF
--- a/app/models/concerns/hyrax/user.rb
+++ b/app/models/concerns/hyrax/user.rb
@@ -112,9 +112,10 @@ module Hyrax::User
     { id: user_key, text: display_name ? "#{display_name} (#{user_key})" : user_key }
   end
 
+  ##
+  # @return [String] a name for the user
   def name
-    return display_name.titleize if display_name
-    user_key
+    display_name || user_key
   end
 
   # Redefine this for more intuitive keys in Redis


### PR DESCRIPTION
Prior to this commit, we `titleize` names prior to display. This makes some fairly fragile (wrong) assumptions about how names work, and fails on relatively common western names like `McCullough`, presumably many international naming conventions are also left out of this, as well as famous cases from academia like `bell hooks`.

@samvera/hyrax-code-reviewers
