### PR TITLE
Add sequence rendering and metadata into the IIIF manifest

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -144,15 +144,21 @@ module Hyrax
           !((file_set_params || {}).keys.map(&:to_s) & %w[visibility embargo_release_date lease_expiration_date]).empty?
         end
 
+        # Must clear the fileset from the thumbnail_id, representative_id and rendering_ids fields on the work
+        #   and force it to be re-solrized.
+        # Although ActiveFedora clears the children nodes it leaves those fields in Solr populated.
+        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/CyclomaticComplexity
         def unlink_from_work
           work = file_set.parent
-          return unless work && (work.thumbnail_id == file_set.id || work.representative_id == file_set.id)
-          # Must clear the thumbnail_id and representative_id fields on the work and force it to be re-solrized.
-          # Although ActiveFedora clears the children nodes it leaves those fields in Solr populated.
+          return unless work && (work.thumbnail_id == file_set.id || work.representative_id == file_set.id || work.rendering_ids.include?(file_set.id))
           work.thumbnail = nil if work.thumbnail_id == file_set.id
           work.representative = nil if work.representative_id == file_set.id
+          work.rendering_ids -= [file_set.id]
           work.save!
         end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/CyclomaticComplexity
     end
   end
 end

--- a/app/builders/hyrax/manifest_helper.rb
+++ b/app/builders/hyrax/manifest_helper.rb
@@ -11,5 +11,26 @@ module Hyrax
       opts[:host] ||= @hostname
       super(record, opts)
     end
+
+    # Build a rendering hash
+    #
+    # @return [Hash] rendering
+    def build_rendering(file_set_id)
+      file_set_document = query_for_rendering(file_set_id)
+      label = file_set_document.label.present? ? ": #{file_set_document.label}" : ''
+      mime = file_set_document.mime_type.present? ? file_set_document.mime_type : I18n.t("hyrax.manifest.unknown_mime_text")
+      {
+        '@id' => Hyrax::Engine.routes.url_helpers.download_url(file_set_document.id, host: @hostname),
+        'format' => mime,
+        'label' => I18n.t("hyrax.manifest.download_text") + label
+      }
+    end
+
+    # Query for the properties to create a rendering
+    #
+    # @return [SolrDocument] query result
+    def query_for_rendering(file_set_id)
+      ::SolrDocument.find(file_set_id)
+    end
   end
 end

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -24,7 +24,7 @@ module Hyrax
       self.terms = [:title, :creator, :contributor, :description,
                     :keyword, :license, :rights_statement, :publisher, :date_created,
                     :subject, :language, :identifier, :based_near, :related_url,
-                    :representative_id, :thumbnail_id, :files,
+                    :representative_id, :thumbnail_id, :rendering_ids, :files,
                     :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
                     :visibility_during_lease, :lease_expiration_date, :visibility_after_lease,
                     :visibility, :ordered_member_ids, :source, :in_works_ids,
@@ -117,7 +117,7 @@ module Hyrax
           [:files, :visibility_during_embargo, :embargo_release_date,
            :visibility_after_embargo, :visibility_during_lease,
            :lease_expiration_date, :visibility_after_lease, :visibility,
-           :thumbnail_id, :representative_id, :ordered_member_ids,
+           :thumbnail_id, :representative_id, :rendering_ids, :ordered_member_ids,
            :member_of_collection_ids, :in_works_ids, :admin_set_id]
       end
 

--- a/app/models/concerns/hyrax/file_set/belongs_to_works.rb
+++ b/app/models/concerns/hyrax/file_set/belongs_to_works.rb
@@ -3,10 +3,6 @@ module Hyrax
     module BelongsToWorks
       extend ActiveSupport::Concern
 
-      included do
-        before_destroy :remove_representative_relationship
-      end
-
       def parents
         in_works
       end
@@ -33,17 +29,6 @@ module Hyrax
           end
         end
       end
-
-      # If any parent objects are pointing at this object as their
-      # representative, remove that pointer.
-      def remove_representative_relationship
-        parent_objects = parents
-        return if parent_objects.empty?
-        parent_objects.each do |work|
-          work.update(representative_id: nil) if work.representative_id == id
-        end
-      end
     end
   end
 end
-\

--- a/app/models/concerns/hyrax/has_rendering.rb
+++ b/app/models/concerns/hyrax/has_rendering.rb
@@ -1,0 +1,11 @@
+module Hyrax::HasRendering
+  extend ActiveSupport::Concern
+
+  included do
+    # rubocop:disable Rails/HasAndBelongsToMany
+    has_and_belongs_to_many :renderings,
+                            predicate: Hyrax.config.rendering_predicate,
+                            class_name: 'ActiveFedora::Base'
+    # rubocop:enable Rails/HasAndBelongsToMany
+  end
+end

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -71,6 +71,8 @@ module Hyrax
         attribute :workflow_state, Solr::String, solr_name('workflow_state_name', :symbol)
         attribute :human_readable_type, Solr::String, solr_name('human_readable_type', :stored_searchable)
         attribute :representative_id, Solr::String, solr_name('hasRelatedMediaFragment', :symbol)
+        # extract the term name from the rendering_predicate (it might be after the final / or #)
+        attribute :rendering_ids, Solr::Array, solr_name(Hyrax.config.rendering_predicate.value.split(/#|\/|,/).last, :symbol)
         attribute :thumbnail_id, Solr::String, solr_name('hasRelatedImage', :symbol)
         attribute :thumbnail_path, Solr::String, CatalogController.blacklight_config.index.thumbnail_field
         attribute :label, Solr::String, solr_name('label')

--- a/app/models/concerns/hyrax/work_behavior.rb
+++ b/app/models/concerns/hyrax/work_behavior.rb
@@ -9,6 +9,7 @@ module Hyrax
     include Hydra::WithDepositor
     include Solrizer::Common
     include HasRepresentative
+    include HasRendering
     include WithFileSets
     include Naming
     include CoreMetadata

--- a/app/views/hyrax/base/_form_media.html.erb
+++ b/app/views/hyrax/base/_form_media.html.erb
@@ -1,4 +1,5 @@
 <% if f.object.persisted? && f.object.member_ids.present? %>
   <%= render 'form_representative', f: f %>
   <%= render 'form_thumbnail', f: f %>
+  <%= render 'form_rendering', f: f %>
 <% end %>

--- a/app/views/hyrax/base/_form_rendering.html.erb
+++ b/app/views/hyrax/base/_form_rendering.html.erb
@@ -1,0 +1,14 @@
+<div class="row">
+  <div class="col-md-12">
+    <fieldset id="representative-media">
+      <legend>
+        <%= t("hyrax.base.form_rendering.legend_html") %>
+      </legend>
+      <p><%= t("hyrax.base.form_rendering.help_html") %></p>
+      <%= f.select :rendering_ids,
+                   f.object.select_files,
+                   { include_blank: true },
+                   { class: 'form-control', multiple: true } %>
+    </fieldset>
+  </div>
+</div>

--- a/app/views/hyrax/base/_form_representative.html.erb
+++ b/app/views/hyrax/base/_form_representative.html.erb
@@ -2,9 +2,9 @@
     <div class="col-md-12">
       <fieldset id="representative-media">
         <legend>
-          Representative Media
+          <%= t("hyrax.base.form_representative.legend_html") %>
         </legend>
-        <p>Select the file with media that represents this <%= f.object.human_readable_type %>.</p>
+        <p><%= t("hyrax.base.form_representative.help_html") %></p>
         <%= f.select :representative_id, @form.select_files, {}, { class: 'form-control' } %>
       </fieldset>
     </div>

--- a/app/views/hyrax/base/_form_thumbnail.html.erb
+++ b/app/views/hyrax/base/_form_thumbnail.html.erb
@@ -2,9 +2,9 @@
     <div class="col-md-12">
       <fieldset id="representative-image">
         <legend>
-           Thumbnail
+          <%= t("hyrax.base.form_thumbnail.legend_html") %>
         </legend>
-        <p>Select the file to be used as the thumbnail for this <%= f.object.human_readable_type %>.</p>
+        <p><%= t("hyrax.base.form_thumbnail.help_html") %></p>
         <%= f.select :thumbnail_id, @form.select_files, {}, { class: 'form-control' } %>
       </fieldset>
     </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -308,10 +308,19 @@ en:
         required_descriptions: Describe your work
         required_files:        Add files
         requirements:          Requirements
+      form_representative:
+        legend_html:           Representative Media
+        help_html:             "Select the file with media that represents this work."
+      form_rendering:
+        legend_html:           Rendering
+        help_html:             "Select file(s) to be offered as a download for every image in Universal Viewer, for example a PDF of the whole work."
       form_share:
         add_sharing: Add Sharing
         currently_sharing: Currently Shared With
         directions: Regardless of the visibility settings for this work, you can also share it with other users and groups.
+      form_thumbnail:
+        legend_html:           Thumbnail
+        help_html:             "Select the file to be used as the thumbnail for this work."
       items:
         actions: Actions
         date_uploaded: "Date Uploaded"
@@ -533,6 +542,9 @@ en:
       suffix:           "@example.org"
     document_language:  "en"
     edit_profile:       "Edit Profile"
+    manifest:
+      download_text:         Download whole resource
+      unknown_mime_text:     unknown mime type
     embargoes:
       edit:
         embargo_apply: Apply Embargo
@@ -898,6 +910,7 @@ en:
         license:                   "License"
         member_of_collection_ids:  "Add to collection"
         related_url:               "Related URL"
+        rights_statement:          "Rights statement"
         title:                     "Title"
         visibility_after_embargo:  'then open it up to'
         visibility_after_lease:    'then restrict it to'

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -16,6 +16,11 @@ Hyrax.config do |config|
   # avoid clashes if you plan to use the default (dct:isPartOf) for other relations.
   # config.admin_set_predicate = ::RDF::DC.isPartOf
 
+  # Which RDF term should be used to relate objects to a rendering?
+  # If this is a new repository, you may want to set a custom predicate term here to
+  # avoid clashes if you plan to use the default (dct:hasFormat) for other relations.
+  # config.rendering_predicate = ::RDF::DC.hasFormat
+
   # Email recipient of messages sent via the contact form
   # config.contact_email = "repo-admin@example.org"
 
@@ -142,6 +147,9 @@ Hyrax.config do |config|
 
   # Returns a IIIF image size default
   # config.iiif_image_size_default = '600,'
+
+  # Fields to display in the IIIF metadata section; default is the required fields
+  # config.iiif_metadata_fields = Hyrax::Forms::WorkForm.required_fields
 
   # Should a button with "Share my work" show on the front page to all users (even those not logged in)?
   # config.display_share_button_when_not_logged_in = true

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -321,6 +321,13 @@ module Hyrax
       @admin_set_predicate ||= ::RDF::Vocab::DC.isPartOf
     end
 
+    # Set predicate for rendering to dc:hasFormat as defined in
+    #   IIIF Presentation API context:  http://iiif.io/api/presentation/2/context.json
+    attr_writer :rendering_predicate
+    def rendering_predicate
+      @rendering_predicate ||= ::RDF::Vocab::DC.hasFormat
+    end
+
     attr_writer :work_requires_files
     def work_requires_files?
       return true if @work_requires_files.nil?
@@ -401,6 +408,14 @@ module Hyrax
       @iiif_image_size_default ||= '600,'
     end
     attr_writer :iiif_image_size_default
+
+    # IIIF metadata - fields to display in the metadata section
+    #
+    # @return [#Array] fields
+    def iiif_metadata_fields
+      @iiif_metadata_fields ||= Hyrax::Forms::WorkForm.required_fields
+    end
+    attr_writer :iiif_metadata_fields
 
     # Should a button with "Share my work" show on the front page to users who are not logged in?
     attr_writer :display_share_button_when_not_logged_in

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       expect { file_set.reload }.to raise_error ActiveFedora::ObjectNotFoundError
     end
 
-    context "representative and thumbnail of a work" do
+    context "representative, renderings and thumbnail of a work" do
       let!(:work) do
         work = create(:generic_work)
         # this is not part of a block on the create, since the work must be saved
@@ -245,11 +245,12 @@ RSpec.describe Hyrax::Actors::FileSetActor do
         work.ordered_members << file_set
         work.representative = file_set
         work.thumbnail = file_set
+        work.renderings = [file_set]
         work.save
         work
       end
 
-      it "removes representative, thumbnail, and the proxy association" do
+      it "removes representative, renderings, thumbnail, and the proxy association" do
         gw = GenericWork.find(work.id)
         expect(gw.representative_id).to eq(file_set.id)
         expect(gw.thumbnail_id).to eq(file_set.id)
@@ -257,6 +258,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
         gw.reload
         expect(gw.representative_id).to be_nil
         expect(gw.thumbnail_id).to be_nil
+        expect(gw.rendering_ids).to eq([])
       end
     end
   end

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Hyrax::Forms::BatchUploadForm do
                          :related_url,
                          :representative_id,
                          :thumbnail_id,
+                         :rendering_ids,
                          :files,
                          :visibility_during_embargo,
                          :embargo_release_date,

--- a/spec/forms/hyrax/generic_work_form_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Hyrax::GenericWorkForm do
     let(:permission_template) { create(:permission_template, admin_set_id: admin_set_id) }
     let!(:workflow) { create(:workflow, active: true, permission_template_id: permission_template.id) }
     let(:admin_set_id) { '123' }
+    let(:file_set) { create(:file_set) }
     let(:params) do
       ActionController::Parameters.new(
         title: ['foo'],
@@ -56,6 +57,7 @@ RSpec.describe Hyrax::GenericWorkForm do
         visibility: 'open',
         admin_set_id: admin_set_id,
         representative_id: '456',
+        rendering_ids: [file_set.id],
         thumbnail_id: '789',
         keyword: ['derp'],
         license: ['http://creativecommons.org/licenses/by/3.0/us/'],
@@ -72,6 +74,7 @@ RSpec.describe Hyrax::GenericWorkForm do
       expect(subject['license']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
       expect(subject['keyword']).to eq ['derp']
       expect(subject['member_of_collection_ids']).to eq ['123456', 'abcdef']
+      expect(subject['rendering_ids']).to eq [file_set.id]
     end
 
     context '.model_attributes' do

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:iiif_image_compliance_level_uri=) }
   it { is_expected.to respond_to(:iiif_image_size_default) }
   it { is_expected.to respond_to(:iiif_image_size_default=) }
+  it { is_expected.to respond_to(:iiif_metadata_fields) }
+  it { is_expected.to respond_to(:iiif_metadata_fields=) }
   it { is_expected.to respond_to(:libreoffice_path) }
   it { is_expected.to respond_to(:license_service_class) }
   it { is_expected.to respond_to(:license_service_class=) }
@@ -64,6 +66,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:persistent_hostpath) }
   it { is_expected.to respond_to(:realtime_notifications?) }
   it { is_expected.to respond_to(:realtime_notifications=) }
+  it { is_expected.to respond_to(:rendering_predicate) }
+  it { is_expected.to respond_to(:rendering_predicate=) }
   it { is_expected.to respond_to(:rights_statement_service_class) }
   it { is_expected.to respond_to(:rights_statement_service_class=) }
   it { is_expected.to respond_to(:redis_namespace) }

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -379,4 +379,40 @@ RSpec.describe Hyrax::WorkShowPresenter do
       end
     end
   end
+
+  describe "#manifest" do
+    let(:work) { create(:work_with_one_file) }
+    let(:solr_document) { SolrDocument.new(work.to_solr) }
+
+    describe "#sequence_rendering" do
+      subject do
+        presenter.sequence_rendering
+      end
+
+      before do
+        Hydra::Works::AddFileToFileSet.call(work.file_sets.first,
+                                            File.open(fixture_path + '/world.png'), :original_file)
+      end
+
+      it "returns a hash containing the rendering information" do
+        work.rendering_ids = [work.file_sets.first.id]
+        expect(subject).to be_an Array
+      end
+    end
+
+    describe "#manifest_metadata" do
+      subject do
+        presenter.manifest_metadata
+      end
+
+      before do
+        work.title = ['Test title', 'Another test title']
+      end
+
+      it "returns an array of metadata values" do
+        expect(subject[0]['label']).to eq('Title')
+        expect(subject[0]['value']).to include('Test title', 'Another test title')
+      end
+    end
+  end
 end

--- a/spec/views/hyrax/base/_form_rendering.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_rendering.html.erb_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe 'hyrax/base/_form_rendering.html.erb', type: :view do
+  let(:ability) { double }
+  let(:work) { create(:work_with_one_file) }
+  let(:form) do
+    Hyrax::GenericWorkForm.new(work, ability, controller)
+  end
+
+  let(:page) do
+    view.simple_form_for form do |f|
+      render 'hyrax/base/form_rendering', f: f
+    end
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  it 'has a rendering_ids field' do
+    expect(page).to have_selector("select#generic_work_rendering_ids", count: 1)
+  end
+end


### PR DESCRIPTION
This PR pulls in Hyku PRs [1376 ](https://github.com/samvera-labs/hyku/pull/1376) and [1436 ](https://github.com/samvera-labs/hyku/pull/1436).

Description of Main Changes

**Metadata:**

- Adds a metadata block to the IIIF manifest, which in UV will display in the more info panel.
- Adds a configuration for the fields to include in this section.
- Uses the Hyrax::Form::WorkForm.required_fields as the default

**Rendering**

- Adds a sequences#rendering block to the IIIF manifest - items in this block are displayed as a download in UV and are used for a download which represents the whole item, rather than the single page being displayed (eg. a PDF of a book)
- Adds rendering_ids into the form so that one or more 'renderings' can be selected

See [hydrox 88](https://github.com/sul-dlss/hydrox/issues/88) 