### PR TITLE
fix issue 2230 of code in breadcrumb on new coll.

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -57,10 +57,10 @@ module Hyrax
 
       def new
         collection_type_id = params[:collection_type_id]
+        @collection.collection_type_gid = CollectionType.find(collection_type_id).gid unless collection_type_id.nil?
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb t(:'hyrax.dashboard.collections.new.header'), request.path
-        @collection.collection_type_gid = CollectionType.find(collection_type_id).gid unless collection_type_id.nil?
+        add_breadcrumb t('.header', type_title: @collection.collection_type.title), request.path
         @collection.apply_depositor_metadata(current_user.user_key)
         form
       end

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -482,6 +482,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         collection1 # create collections by referencing them
         collection2
         sign_in user
+        # stub out characterization. Travis doesn't have fits installed, and it's not relevant to the test.
+        allow(CharacterizeJob).to receive(:perform_later)
       end
 
       it "preselects the collection we are adding works to and adds the new work" do


### PR DESCRIPTION
Make the last breadcrumb on new collections be: "New User Collection" with appropriate collection type instead of "New %{type_title}"

Fixes #2230 

The final crumb of the new collection form breadcrumbs should be New followed by the type of collection being create. For example, if a User Collection is being created, the breadcrumbs should be...

Home / Administration / New User Collection

instead of

Home / Administration / New %{type_title}

@samvera/hyrax-code-reviewers