### PR TITLE
When only one work type is available, rendering Add New Work button on collection show page

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -130,5 +130,9 @@ module Hyrax
     def draw_select_work_modal?
       create_many_work_types?
     end
+
+    def first_work_type
+      create_work_presenter.first_model
+    end
   end
 end

--- a/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
@@ -6,6 +6,7 @@
                 title: t('hyrax.collection.actions.add_existing_works.desc'),
                 class: 'btn btn-default pull-right',
                 data: { turbolinks: false } %>
+      
     <% if @presenter.create_many_work_types? %>
       <%= link_to t('hyrax.collection.actions.add_new_work.label'),
                   '#',
@@ -14,7 +15,7 @@
                   class: 'btn btn-default  pull-right'  %>
     <% else # simple link to the first work type %>
       <%= link_to t('hyrax.collection.actions.add_new_work.label'),
-                  new_polymorphic_path([main_app, @presenter.first_work_type, add_works_to_collection: presenter.id]),
+                  new_polymorphic_path([main_app, @presenter.first_work_type], add_works_to_collection: presenter.id),
                   class: 'btn btn-default  pull-right'  %>
     <% end %>
   <% end %>

--- a/spec/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb_spec.rb
@@ -29,4 +29,16 @@ RSpec.describe 'hyrax/dashboard/collections/_show_add_items_actions.html.erb', t
       expect(rendered).not_to have_css(".actions-controls-collections .btn[href='#{hyrax.my_works_path(add_works_to_collection: presenter.id)}']")
     end
   end
+
+  describe 'when there is only one work type' do
+    let(:can_edit) { true }
+
+    it 'renders add_new_work_to_collection link' do
+      allow(presenter).to receive(:create_many_work_types?).and_return(false)
+      allow(presenter).to receive(:first_work_type).and_return(GenericWork)
+
+      render
+      expect(rendered).to have_link("Add new work")
+    end
+  end
 end


### PR DESCRIPTION
When only one work type error when rendering Add New Work button on collections show page.

Fixes #2350 
