### PR TITLE
Update featured works and recently uploaded display

### DIFF
--- a/app/assets/stylesheets/hyrax/_featured.scss
+++ b/app/assets/stylesheets/hyrax/_featured.scss
@@ -6,11 +6,27 @@ ol#featured_works {
 
 /* don't nest .featured-item in the ol, because it's detached from the list when being dragged */
 .featured-item {
+  border-top: 1px solid #ddd;
+  font-size: 0.9em;
+  min-height: 100px;
+  padding: 8px;
+
   h3 {
+    font-size: 1.1em;
     margin-top: 0;
   }
+
+  img {
+    width: 90px;
+  }
+
   .main {
     padding: $padding-small-vertical;
+  }
+
+  .featured-label {
+    color: $gray;
+    font-weight: bold;
   }
 }
 

--- a/app/assets/stylesheets/hyrax/_home-page.scss
+++ b/app/assets/stylesheets/hyrax/_home-page.scss
@@ -117,3 +117,13 @@ div#announcement {
 .highlights-list {
   margin-top: 20px;
 }
+
+ol.list-group.list-group-striped {
+  li:nth-of-type(odd) {
+    background: $table-bg-accent;
+  }
+
+  li:nth-of-type(even) {
+    background: $body-bg;
+  }
+}

--- a/app/assets/stylesheets/hyrax/_hyrax.scss
+++ b/app/assets/stylesheets/hyrax/_hyrax.scss
@@ -8,7 +8,8 @@
         'hyrax/file_manager', 'hyrax/form-progress', 'hyrax/positioning',
         'hyrax/fixedsticky', 'hyrax/file_upload', 'hyrax/representative-media',
         'hyrax/footer', 'hyrax/select_work_type', 'hyrax/users', 'hyrax/dashboard',
-        'hyrax/sidebar', 'hyrax/controlled_vocabulary', 'hyrax/accessibility';
+        'hyrax/sidebar', 'hyrax/controlled_vocabulary', 'hyrax/accessibility',
+        'hyrax/recent';
 @import 'typeahead';
 @import 'sharing_buttons';
 

--- a/app/assets/stylesheets/hyrax/_recent.scss
+++ b/app/assets/stylesheets/hyrax/_recent.scss
@@ -1,0 +1,26 @@
+.recent_uploads {
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.recent-item {
+  border-top: 1px solid #ddd;
+  font-size: 0.9em;
+  min-height: 100px;
+  padding: 8px;
+
+  h3 {
+    font-size: 1.1em;
+    margin-top: 0;
+  }
+
+  img {
+    width: 90px;
+  }
+
+  .recent-label {
+    color: $gray;
+    font-weight: bold;
+  }
+}

--- a/app/views/hyrax/homepage/_featured.html.erb
+++ b/app/views/hyrax/homepage/_featured.html.erb
@@ -1,11 +1,11 @@
 <% presenter = featured.presenter %>
 <li class="featured-item" data-id="<%= presenter.id %>">
-  <div class="main row">
-    <div class="col-sm-3">
-      <%= render_thumbnail_tag presenter, { width: 90 } %>
+  <div class="row">
+    <div class="col-sm-2">
+      <%= render_thumbnail_tag presenter %>
     </div>
-    <div class="col-sm-9">
+    <div class="col-sm-10">
       <%= render 'hyrax/homepage/featured_fields', featured: presenter %>
     </div>
-  </div>
+</div>
 </li>

--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -1,16 +1,12 @@
-<h3>
-  <span class="sr-only">Title</span>
-  <%= link_to truncate(featured.title.first, length: 28, separator: ' '), [main_app, featured] %>
-</h3>
 <div>
-  <span class="sr-only">Depositor</span>
-  <%= link_to_profile featured.depositor("no depositor value") %>
-</div>
-<div>
-  <span class="sr-only">File type</span>
-  <%= link_to_facet_list(featured.resource_type, 'resource_type', 'no resource specified') %>
-</div>
-<div>
-  <span class="sr-only">Keywords</span>
-  <%= link_to_facet_list(featured.keyword, 'keyword', 'no keywords specified') %>
+  <div class="featured-item-title">
+    <span class="sr-only"><%= t('hyrax.homepage.featured_works.document.title_label') %></span>
+    <h3><%= link_to featured.title.first, [main_app, featured] %></h3>
+  </div>
+  <div class="featured-item-depositor">
+    <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.depositor_label') %>:</span> <%= link_to_profile featured.depositor(t('hyrax.homepage.featured_works.document.depositor_missing')) %>
+  </div>
+  <div class="featured-item-keywords">
+    <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.keyword_label') %>:</span> <%= link_to_facet_list(featured.keyword, 'keyword', t('hyrax.homepage.featured_works.document.keyword_missing')) %>
+  </div>
 </div>

--- a/app/views/hyrax/homepage/_featured_works.html.erb
+++ b/app/views/hyrax/homepage/_featured_works.html.erb
@@ -13,7 +13,7 @@
     <%= f.submit("Save order", class: 'btn btn-default') %>
   <% end %>
 <% else %>
-  <ol id="featured_works">
+  <ol class="list-group list-group-striped" id="featured_works">
     <%= render partial: 'featured', collection: @featured_work_list.featured_works %>
   </ol>
 <% end %>

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -1,5 +1,5 @@
 <div class="col-xs-12 col-sm-6">
-  <ul id="homeTabs" class="nav nav-tabs">
+  <ul id="homeTabs" class="nav nav-pills">
     <li class="active"><a href="#featured_container" data-toggle="tab" role="tab" id="featureTab"><%= t('hyrax.homepage.featured_works.tab_label') %></a></li>
     <li><a href="#recently_uploaded" data-toggle="tab" role="tab" id="recentTab"><%= t('hyrax.homepage.recently_uploaded.tab_label') %></a></li>
   </ul>
@@ -15,7 +15,7 @@
 
 <div class="col-xs-12 col-sm-6">
 
-  <ul class="nav nav-tabs" role="tablist">
+  <ul class="nav nav-pills" role="tablist">
     <li class="active"><a aria-expanded="true" href="#tab-col2-first" role="tab" data-toggle="tab"><%= t('hyrax.homepage.admin_sets.title') %></a></li>
     <li class=""><a aria-expanded="false" href="#tab-col2-second" role="tab" data-toggle="tab"><%= t('hyrax.homepage.featured_researcher.tab_label') %></a></li>
   </ul>

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -1,16 +1,18 @@
-    <tr>
-      <td class="col-sm-2">
-        <%= link_to_profile recent_document.depositor("no depositor value") %>
+<li class="recent-item">
+    <div class="row">
+      <div class="col-sm-2">
         <%= link_to [main_app, recent_document] do %>
-          <%= render_thumbnail_tag recent_document, { width: 45 }, suppress_link: true %>
+          <%= render_thumbnail_tag recent_document, suppress_link: true %>
         <% end %>
-      </td>
-      <td>
-        <h3>
-          <span class="sr-only">Title</span><%= link_to truncate(recent_document.to_s, length: 28, separator: ' '), [main_app, recent_document] %>
-        </h3>
+      </div>
+      <div class="col-sm-10">
+        <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span><h3><%= link_to recent_document.to_s, [main_app, recent_document] %></h3>
         <p>
-          <span class="sr-only">Keywords</span><%= link_to_facet_list(recent_document.keyword, 'keyword', 'no keywords specified').html_safe %>
+          <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.depositor_label') %>:</span> <%= link_to_profile recent_document.depositor(t('hyrax.homepage.recently_uploaded.document.depositor_missing')) %>
         </p>
-      </td>
-    </tr>
+        <p>
+          <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.keyword_label') %>:</span> <%= link_to_facet_list(recent_document.keyword, 'keyword', t('hyrax.homepage.recently_uploaded.document.keyword_missing')).html_safe %>
+        </p>
+      </div>
+    </div>
+</li>

--- a/app/views/hyrax/homepage/_recently_uploaded.html.erb
+++ b/app/views/hyrax/homepage/_recently_uploaded.html.erb
@@ -3,12 +3,8 @@
   <p><%= t('.no_public') %></p>
 <% else %>
   <div id="recent_docs">
-    <table class="table table-bordered table-striped">
-      <tr>
-        <th scope="col"><%= t('.depositor') %></th>
-        <th scope="col"><%= t('.details') %></th>
-      </tr>
+    <ol class="list-group list-group-striped recent_uploads">
       <%= render partial: "recent_document", collection: recent_documents %>
-    </table>
+    </ol>
   </div>
 <% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -599,12 +599,24 @@ en:
         no_works:           'No works have been featured'
         tab_label:          'Featured Works'
         title:              'Featured Works'
+        document:
+          title_label:      'Title'
+          depositor_label:  'Depositor'
+          depositor_missing: 'no depositor value'
+          keyword_label:    'Keywords'
+          keyword_missing:  'no keywords specified'          
       recently_uploaded:
-        depositor:          'Depositor'
         details:            'Details'
         no_public:          'No public work has been contributed.'
         tab_label:          'Recently Uploaded'
         title:              'Recently Uploaded'
+        document:
+          title_label:      'Title'
+          depositor_label:  'Depositor'
+          depositor_missing: 'no depositor value'
+          keyword_label:    'Keywords'
+          keyword_missing:  'no keywords specified'
+
     icons:
       collection:       'fa fa-cubes'
       default:          'fa fa-cube'

--- a/spec/views/hyrax/homepage/_featured_works.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/_featured_works.html.erb_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "hyrax/homepage/_featured_works.html.erb", type: :view do
 
     before do
       allow(view).to receive(:can?).with(:update, FeaturedWork).and_return(false)
-      allow(view).to receive(:render_thumbnail_tag).with(presenter, width: 90)
+      allow(view).to receive(:render_thumbnail_tag).with(presenter)
       allow(list).to receive(:empty?).and_return(false)
       allow(list).to receive(:featured_works).and_return([featured_work])
       allow(featured_work).to receive(:presenter).and_return(presenter)


### PR DESCRIPTION
refs https://github.com/samvera-labs/hyku/issues/457

This is the initial update to the styling of the featured works list and recently uploaded list based on the homepage mockups in the above hyku issue.

The outcomes of this PR are:
- [x] Consistent styling between the featured and recent list
- [x] Updated layout to better present the information
- [x] Changes the tab panels to pill panels (in preparation for additional updates) for a more consistent look with the formatted tables of information

*DISPLAY BEFORE*
<img width="1242" alt="screen shot 2017-12-13 at 10 01 48 am" src="https://user-images.githubusercontent.com/2294288/33957511-ac99cc6e-dff6-11e7-9b24-a6d67f9f5ce9.png">

<img width="1238" alt="screen shot 2017-12-13 at 10 01 55 am" src="https://user-images.githubusercontent.com/2294288/33957528-b62ae2e0-dff6-11e7-8ac5-871b07504559.png">

*DISPLAY AFTER*

<img width="1250" alt="screen shot 2017-12-13 at 9 48 25 am" src="https://user-images.githubusercontent.com/2294288/33957564-d09a8572-dff6-11e7-857c-4631bc607d34.png">

<img width="1242" alt="screen shot 2017-12-13 at 9 48 39 am" src="https://user-images.githubusercontent.com/2294288/33957573-d7adc57c-dff6-11e7-8fd5-ac227e98603a.png">



@samvera/hyrax-code-reviewers
