### PR TITLE
Remove source_type column

### DIFF
--- a/app/actors/hyrax/actors/apply_permission_template_actor.rb
+++ b/app/actors/hyrax/actors/apply_permission_template_actor.rb
@@ -19,14 +19,14 @@ module Hyrax
 
         def add_admin_set_participants(env)
           return if env.attributes[:admin_set_id].blank?
-          template = Hyrax::PermissionTemplate.find_by!(source_id: env.attributes[:admin_set_id], source_type: 'admin_set')
+          template = Hyrax::PermissionTemplate.find_by!(source_id: env.attributes[:admin_set_id])
           set_curation_concern_access(env, template)
         end
 
         def add_collection_participants(env)
           return if env.attributes[:collection_id].blank?
           collection_id = env.attributes.delete(:collection_id) # delete collection_id from attributes because works do not have a collection_id property
-          template = Hyrax::PermissionTemplate.find_by!(source_id: collection_id, source_type: 'collection')
+          template = Hyrax::PermissionTemplate.find_by!(source_id: collection_id)
           set_curation_concern_access(env, template)
         end
 

--- a/app/actors/hyrax/actors/default_admin_set_actor.rb
+++ b/app/actors/hyrax/actors/default_admin_set_actor.rb
@@ -41,7 +41,7 @@ module Hyrax
 
         # Creates a Hyrax::PermissionTemplate for the given AdminSet
         def create_permission_template!(source_id:)
-          Hyrax::PermissionTemplate.create!(source_id: source_id, source_type: 'admin_set')
+          Hyrax::PermissionTemplate.create!(source_id: source_id)
         end
     end
   end

--- a/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
+++ b/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
@@ -34,11 +34,11 @@ module Hyrax
         end
 
         def after_destroy_success
-          if source_type == 'admin_set'
+          if source.admin_set?
             redirect_to hyrax.edit_admin_admin_set_path(source_id,
                                                         anchor: 'participants'),
                         notice: translate('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
-          elsif source_type == 'collection'
+          elsif source.collection?
             redirect_to hyrax.edit_dashboard_collection_path(source_id,
                                                              anchor: 'sharing'),
                         notice: translate('sharing', scope: 'hyrax.dashboard.collections.form.permission_update_notices')
@@ -46,18 +46,22 @@ module Hyrax
         end
 
         def after_destroy_error
-          if source_type == 'admin_set'
+          if source.admin_set?
             redirect_to hyrax.edit_admin_admin_set_path(source_id,
                                                         anchor: 'participants'),
                         alert: @permission_template_access.errors.full_messages.to_sentence
-          elsif source_type == 'collection'
+          elsif source.collection?
             redirect_to hyrax.edit_dashboard_collection_path(source_id,
                                                              anchor: 'sharing'),
                         alert: @permission_template_access.errors.full_messages.to_sentence
           end
         end
 
-        delegate :source_type, :source_id, to: :permission_template
+        delegate :source_id, to: :permission_template
+
+        def source
+          @source ||= ::SolrDocument.find(source_id)
+        end
 
         def remove_access!
           permission_template_form.remove_access!(@permission_template_access)

--- a/app/search_builders/hyrax/admin_set_search_builder.rb
+++ b/app/search_builders/hyrax/admin_set_search_builder.rb
@@ -35,8 +35,12 @@ module Hyrax
 
     private
 
+      # IDs of admin_sets into which a user can deposit.
+      #
+      # @return [Array<String>] IDs of admin_sets into which the user can deposit
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       def admin_set_ids_for_deposit
-        Hyrax::Collections::PermissionsService.admin_set_ids_for_deposit(ability: current_ability)
+        Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability)
       end
   end
 end

--- a/app/search_builders/hyrax/dashboard/collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/collections_search_builder.rb
@@ -24,7 +24,7 @@ module Hyrax
         solr_parameters[:fq] += ["(#{clauses.join(' OR ')})"]
       end
 
-      # Include all admin sets the user has deposit permission for.
+      # Include all admin sets and collections the user has deposit permission for.
       # @return [Array{String}] values are lucence syntax term queries suitable for :fq
       def apply_collection_deposit_permissions(_permission_types, _ability = current_ability)
         collection_ids = collection_ids_for_deposit
@@ -35,7 +35,7 @@ module Hyrax
       private
 
         def collection_ids_for_deposit
-          Hyrax::Collections::PermissionsService.collection_ids_for_deposit(ability: current_ability)
+          Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability)
         end
     end
   end

--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -83,7 +83,7 @@ module Hyrax
       end
 
       def create_permission_template
-        permission_template = PermissionTemplate.create!(source_id: admin_set.id, source_type: 'admin_set', access_grants_attributes: access_grants_attributes)
+        permission_template = PermissionTemplate.create!(source_id: admin_set.id, access_grants_attributes: access_grants_attributes)
         admin_set.reset_access_controls!
         permission_template
       end

--- a/app/services/hyrax/collections/permissions_create_service.rb
+++ b/app/services/hyrax/collections/permissions_create_service.rb
@@ -12,7 +12,7 @@ module Hyrax
       def self.create_default(collection:, creating_user:, grants: [])
         collection_type = Hyrax::CollectionType.find_by_gid!(collection.collection_type_gid)
         access_grants = access_grants_attributes(collection_type: collection_type, creating_user: creating_user, grants: grants)
-        PermissionTemplate.create!(source_id: collection.id, source_type: 'collection',
+        PermissionTemplate.create!(source_id: collection.id,
                                    access_grants_attributes: access_grants.uniq)
         collection.reset_access_controls!
       end

--- a/lib/generators/hyrax/templates/db/migrate/20170821152307_add_source_type_to_permission_templates.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20170821152307_add_source_type_to_permission_templates.rb.erb
@@ -1,6 +1,0 @@
-class AddSourceTypeToPermissionTemplates < ActiveRecord::Migration<%= migration_version %>
-  def change
-    add_column :permission_templates, :source_type, :string
-    rename_column :permission_templates, :admin_set_id, :source_id
-  end
-end

--- a/lib/generators/hyrax/templates/db/migrate/20170821152307_rename_admin_set_id_to_source_id.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20170821152307_rename_admin_set_id_to_source_id.rb.erb
@@ -1,0 +1,5 @@
+class RenameAdminSetIdToSourceId < ActiveRecord::Migration<%= migration_version %>
+  def change
+    rename_column :permission_templates, :admin_set_id, :source_id
+  end
+end

--- a/spec/abilities/ability_spec.rb
+++ b/spec/abilities/ability_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Hyrax::Ability', type: :model do
     end
 
     context "when user can deposit into an admin set" do
-      let(:permission_template) { create(:permission_template, source_type: 'admin_set') }
+      let(:permission_template) { create(:permission_template, with_admin_set: true) }
 
       before do
         # Grant the user access to deposit into an admin set.

--- a/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
       end
 
       context 'when source is an admin set' do
-        let(:permission_template) { create(:permission_template, source_id: admin_set.id, source_type: 'admin_set') }
+        let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
         let(:admin_set) { create(:admin_set, edit_users: ['Liz']) }
 
         context 'when deleting the admin users group' do
@@ -64,7 +64,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
       end
 
       context 'when source is a collection' do
-        let(:permission_template) { create(:permission_template, source_id: collection.id, source_type: 'collection') }
+        let(:permission_template) { create(:permission_template, source_id: collection.id) }
         let(:collection) { create(:collection, edit_users: ['Liz']) }
 
         context 'when deleting the admin users group' do

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     # This way, we can go ahead
     after(:create) do |admin_set, evaluator|
       if evaluator.with_permission_template
-        attributes = { source_id: admin_set.id, source_type: 'admin_set' }
+        attributes = { source_id: admin_set.id }
         attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
         # There is a unique constraint on permission_templates.source_id; I don't want to
         # create a permission template if one already exists for this admin_set

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
       # permissions).  Nested indexing requires that the user's permissions be saved on the Fedora object... if simply in
       # local memory, they are lost when the adapter pulls the object from Fedora to reindex.
       if evaluator.with_permission_template || evaluator.create_access || RSpec.current_example.metadata[:with_nested_reindexing]
-        attributes = { source_id: collection.id, source_type: 'collection' }
+        attributes = { source_id: collection.id }
         attributes[:manage_users] = CollectionFactoryHelper.user_managers(evaluator.with_permission_template, evaluator.user,
                                                                           (evaluator.create_access || RSpec.current_example.metadata[:with_nested_reindexing]))
         attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
@@ -85,7 +85,7 @@ FactoryBot.define do
       collection.apply_depositor_metadata(evaluator.user.user_key)
       collection.save(validate: false) if evaluator.do_save || evaluator.with_permission_template
       if evaluator.with_permission_template
-        attributes = { source_id: collection.id, source_type: 'collection' }
+        attributes = { source_id: collection.id }
         attributes[:manage_users] = [evaluator.user] if evaluator.create_access
         attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
         create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -18,7 +18,6 @@ FactoryBot.define do
             create(:admin_set)
           end
         permission_template.source_id = admin_set.id
-        permission_template.source_type = 'admin_set'
       elsif evaluator.with_collection
         source_id = permission_template.source_id
         collection =
@@ -32,7 +31,6 @@ FactoryBot.define do
             create(:collection)
           end
         permission_template.source_id = collection.id
-        permission_template.source_type = 'collection'
       end
     end
 

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     let(:input_params) do
       ActionController::Parameters.new(access_grants_attributes: grant_attributes).permit!
     end
-    let(:permission_template) { create(:permission_template, source_id: admin_set.id, source_type: 'admin_set') }
+    let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
 
     let(:user) { create(:user) }
     let(:user2) { create(:user) }

--- a/spec/search_builders/hyrax/admin_set_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/admin_set_search_builder_spec.rb
@@ -24,31 +24,13 @@ RSpec.describe Hyrax::AdminSetSearchBuilder do
 
     context "when access is :deposit" do
       let(:access) { :deposit }
-      let(:admin_set) { create(:admin_set) }
-      let(:permission_template) { create(:permission_template, source_id: admin_set.id, source_type: 'admin_set') }
 
       context "and user has access" do
         before do
-          create(:permission_template_access,
-                 permission_template: permission_template,
-                 agent_type: 'user',
-                 agent_id: user.user_key,
-                 access: 'deposit')
+          allow(Hyrax::Collections::PermissionsService).to receive(:source_ids_for_deposit).and_return([7, 8])
         end
 
-        it { is_expected.to eq ["{!terms f=id}#{admin_set.id}"] }
-      end
-
-      context "and group has access" do
-        before do
-          create(:permission_template_access,
-                 permission_template: permission_template,
-                 agent_type: 'group',
-                 agent_id: 'registered',
-                 access: 'deposit')
-        end
-
-        it { is_expected.to eq ["{!terms f=id}#{admin_set.id}"] }
+        it { is_expected.to eq ["{!terms f=id}7,8"] }
       end
 
       context "and user has no access" do
@@ -60,7 +42,7 @@ RSpec.describe Hyrax::AdminSetSearchBuilder do
   describe ".default_processor_chain" do
     subject { described_class.default_processor_chain }
 
-    it { is_expected.to include :filter_models }
+    it { is_expected.to include(:filter_models, :add_access_controls_to_solr_params) }
   end
 
   describe "#to_h" do
@@ -83,27 +65,9 @@ RSpec.describe Hyrax::AdminSetSearchBuilder do
 
     context "when searching for deposit access" do
       let(:access) { :deposit }
-      let(:permission_template1) { create(:permission_template, source_id: 7, source_type: 'admin_set') }
-      let(:permission_template2) { create(:permission_template, source_id: 8, source_type: 'admin_set') }
-      let(:permission_template3) { create(:permission_template, source_id: 9, source_type: 'admin_set') }
 
       before do
-        create(:permission_template_access,
-               :manage,
-               permission_template: permission_template1,
-               agent_type: 'user',
-               agent_id: user.user_key,
-               access: 'deposit')
-        create(:permission_template_access,
-               :manage,
-               permission_template: permission_template2,
-               agent_type: 'user',
-               agent_id: user.user_key)
-        create(:permission_template_access,
-               :view,
-               permission_template: permission_template3,
-               agent_type: 'user',
-               agent_id: user.user_key)
+        allow(Hyrax::Collections::PermissionsService).to receive(:source_ids_for_deposit).and_return([7, 8])
       end
 
       it 'is successful' do

--- a/spec/search_builders/hyrax/dashboard/collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/collections_search_builder_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsSearchBuilder do
     subject { builder.gated_discovery_filters }
 
     let(:collection) { create(:collection) }
-    let(:permission_template) { create(:permission_template, source_id: collection.id, source_type: 'collection') }
+    let(:permission_template) { create(:permission_template, source_id: collection.id) }
 
     context "user has deposit access" do
       before do

--- a/spec/services/hyrax/collections/permissions_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Hyrax::Collections::PermissionsService do
   context 'collection specific methods' do
     let(:collection) { create(:collection) }
     let(:admin_set) { create(:admin_set) }
-    let(:col_permission_template) { create(:permission_template, source_type: 'collection', source_id: collection.id) }
-    let(:as_permission_template) { create(:permission_template, source_type: 'admin_set', source_id: admin_set.id) }
+    let(:col_permission_template) { create(:permission_template, source_id: collection.id) }
+    let(:as_permission_template) { create(:permission_template, source_id: admin_set.id) }
 
     before do
       allow(Hyrax::PermissionTemplate).to receive(:find_by!).with(source_id: collection.id).and_return(col_permission_template)
@@ -122,30 +122,6 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       allow(user).to receive(:groups).and_return(['view_group', 'deposit_group', 'manage_group'])
     end
 
-    describe '.admin_set_ids_for_user' do
-      it 'returns admin set ids where user has manage access' do
-        expect(described_class.admin_set_ids_for_user(access: 'manage', ability: ability)).to match_array [as_mu.id, as_mg.id]
-      end
-      it 'returns admin set ids where user has deposit access' do
-        expect(described_class.admin_set_ids_for_user(access: 'deposit', ability: ability)).to match_array [as_du.id, as_dg.id]
-      end
-      it 'returns admin set ids where user has view access' do
-        expect(described_class.admin_set_ids_for_user(access: 'view', ability: ability)).to match_array [as_vu.id, as_vg.id]
-      end
-      it 'returns admin set ids where user has manage, deposit, or view access' do
-        all = [as_mu.id, as_mg.id, as_du.id, as_dg.id, as_vu.id, as_vg.id]
-        expect(described_class.admin_set_ids_for_user(access: ['manage', 'deposit', 'view'], ability: ability)).to match_array all
-      end
-
-      context 'when user has no access' do
-        let(:ability) { Ability.new(user2) }
-
-        it 'returns empty array' do
-          expect(described_class.admin_set_ids_for_user(access: ['manage', 'deposit', 'view'], ability: ability)).to match_array []
-        end
-      end
-    end
-
     describe '.collection_ids_for_user' do
       it 'returns collection ids where user has manage access' do
         expect(described_class.collection_ids_for_user(access: 'manage', ability: ability)).to match_array [col_mu.id, col_mg.id]
@@ -219,20 +195,6 @@ RSpec.describe Hyrax::Collections::PermissionsService do
 
         it 'returns empty array' do
           expect(described_class.collection_ids_for_deposit(ability: ability)).to match_array []
-        end
-      end
-    end
-
-    describe '.admin_set_ids_for_deposit' do
-      it 'returns admin set ids where user has manage access' do
-        expect(described_class.admin_set_ids_for_deposit(ability: ability)).to match_array [as_du.id, as_dg.id, as_mu.id, as_mg.id]
-      end
-
-      context 'when user has no access' do
-        let(:ability) { Ability.new(user2) }
-
-        it 'returns empty array' do
-          expect(described_class.admin_set_ids_for_deposit(ability: ability)).to match_array []
         end
       end
     end


### PR DESCRIPTION
It duplicates where the knowledge of the type of object is stored which
could lead to the two stores being out of sync. There's no compelling
reason to have this stored in two separate places.

I think this also addresses #2468 