### PR TITLE
Sets ingest_queue_name config param for all jobs

### DIFF
--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -1,7 +1,5 @@
 # Converts UploadedFiles into FileSets and attaches them to works.
 class AttachFilesToWorkJob < Hyrax::ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
-
   # @param [ActiveFedora::Base] work - the work object
   # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
   def perform(work, uploaded_files, **work_attributes)

--- a/app/jobs/batch_create_job.rb
+++ b/app/jobs/batch_create_job.rb
@@ -1,6 +1,4 @@
 class BatchCreateJob < Hyrax::ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
-
   before_enqueue do |job|
     operation = job.arguments.last
     operation.pending_job(self)

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,6 +1,4 @@
 class CharacterizeJob < Hyrax::ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
-
   # Characterizes the file at 'filepath' if available, otherwise, pulls a copy from the repository
   # and runs characterization on that file.
   # @param [FileSet] file_set

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -1,6 +1,4 @@
 class CreateDerivativesJob < Hyrax::ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
-
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path

--- a/app/jobs/create_work_job.rb
+++ b/app/jobs/create_work_job.rb
@@ -1,7 +1,5 @@
 # This is a job spawned by the BatchCreateJob
 class CreateWorkJob < Hyrax::ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
-
   before_enqueue do |job|
     operation = job.arguments.last
     operation.pending_job(self)

--- a/app/jobs/event_job.rb
+++ b/app/jobs/event_job.rb
@@ -8,7 +8,6 @@ class EventJob < Hyrax::ApplicationJob
   # For link_to_profile
   include HyraxHelper
 
-  queue_as Hyrax.config.ingest_queue_name
   attr_reader :depositor
 
   # @param [User] depositor the user to create the event for

--- a/app/jobs/hyrax/application_job.rb
+++ b/app/jobs/hyrax/application_job.rb
@@ -3,5 +3,6 @@ module Hyrax
   # This allows downstream applications to manipulate all the hyrax jobs by
   # including modules on this class.
   class ApplicationJob < ActiveJob::Base
+    queue_as Hyrax.config.ingest_queue_name
   end
 end

--- a/app/jobs/hyrax/grant_edit_job.rb
+++ b/app/jobs/hyrax/grant_edit_job.rb
@@ -1,8 +1,6 @@
 module Hyrax
   # Grants the user's edit access on the provided FileSet
   class GrantEditJob < ApplicationJob
-    queue_as Hyrax.config.ingest_queue_name
-
     # @param [String] file_set_id - the identifier of the object to grant access to
     # @param [String] user_key - the user to add
     def perform(file_set_id, user_key)

--- a/app/jobs/hyrax/grant_edit_to_members_job.rb
+++ b/app/jobs/hyrax/grant_edit_to_members_job.rb
@@ -1,8 +1,6 @@
 module Hyrax
   # Grants edit access for the supplied user for the members attached to a work
   class GrantEditToMembersJob < ApplicationJob
-    queue_as Hyrax.config.ingest_queue_name
-
     # @param [ActiveFedora::Base] work - the work object
     # @param [String] user_key - the user to add
     def perform(work, user_key)

--- a/app/jobs/hyrax/grant_read_job.rb
+++ b/app/jobs/hyrax/grant_read_job.rb
@@ -1,8 +1,6 @@
 module Hyrax
   # Grants the user's read access on the provided FileSet
   class GrantReadJob < ApplicationJob
-    queue_as Hyrax.config.ingest_queue_name
-
     # @param [String] file_set_id - the identifier of the object to grant access to
     # @param [String] user_key - the user to add
     def perform(file_set_id, user_key)

--- a/app/jobs/hyrax/grant_read_to_members_job.rb
+++ b/app/jobs/hyrax/grant_read_to_members_job.rb
@@ -1,8 +1,6 @@
 module Hyrax
   # Grants read access for the supplied user for the members attached to a work
   class GrantReadToMembersJob < ApplicationJob
-    queue_as Hyrax.config.ingest_queue_name
-
     # @param [ActiveFedora::Base] work - the work object
     # @param [String] user_key - the user to add
     def perform(work, user_key)

--- a/app/jobs/hyrax/revoke_edit_from_members_job.rb
+++ b/app/jobs/hyrax/revoke_edit_from_members_job.rb
@@ -1,8 +1,6 @@
 module Hyrax
   # Revokes edit access for the supplied user for the members attached to a work
   class RevokeEditFromMembersJob < ApplicationJob
-    queue_as Hyrax.config.ingest_queue_name
-
     # @param [ActiveFedora::Base] work - the work object
     # @param [String] user_key - the user to remove
     def perform(work, user_key)

--- a/app/jobs/hyrax/revoke_edit_job.rb
+++ b/app/jobs/hyrax/revoke_edit_job.rb
@@ -1,8 +1,6 @@
 module Hyrax
   # Revokes the user's edit access on the provided FileSet
   class RevokeEditJob < ApplicationJob
-    queue_as Hyrax.config.ingest_queue_name
-
     # @param [String] file_set_id - the identifier of the object to revoke access from
     # @param [String] user_key - the user to remove
     def perform(file_set_id, user_key)

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -7,8 +7,6 @@ require 'browse_everything/retriever'
 # Called by AttachFilesToWorkJob (when files are uploaded to s3)
 # and CreateWithRemoteFilesActor when files are located in some other service.
 class ImportUrlJob < Hyrax::ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
-
   before_enqueue do |job|
     operation = job.arguments.last
     operation.pending_job(job)

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -1,6 +1,4 @@
 class IngestJob < Hyrax::ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
-
   after_perform do |job|
     # We want the lastmost Hash, if any.
     opts = job.arguments.reverse.detect { |x| x.is_a? Hash } || {}

--- a/app/jobs/ingest_local_file_job.rb
+++ b/app/jobs/ingest_local_file_job.rb
@@ -1,6 +1,4 @@
 class IngestLocalFileJob < Hyrax::ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
-
   # @param [FileSet] file_set
   # @param [String] path
   # @param [User] user


### PR DESCRIPTION
`Hyrax.config.ingest_queue_name` (as set in the hyrax initializer) is not currently declared by all jobs. Therefore, if using a queue name other than `default`, only the jobs that explicitly bring in the configuration are able to find the queue. To fix this, this change sets `queue_as` in `application_job.rb` which therefore sets the queue name for each job to the name configured in the initializer.

@samvera/hyrax-code-reviewers
