### PR TITLE
Patch nested collection indexing

### DIFF
--- a/app/models/concerns/hyrax/collection_nesting.rb
+++ b/app/models/concerns/hyrax/collection_nesting.rb
@@ -12,14 +12,26 @@ module Hyrax
 
       define_model_callbacks :update_index, only: :after
       after_update_index :update_nested_collection_relationship_indices
+      after_destroy :update_child_nested_collection_relationship_indices
 
       def update_nested_collection_relationship_indices
         Hyrax.config.nested_relationship_reindexer.call(id: id)
+      end
+
+      def update_child_nested_collection_relationship_indices
+        children = find_children_of(destroyed_id: id)
+        children.each do |child|
+          Hyrax.config.nested_relationship_reindexer.call(id: child.id)
+        end
       end
     end
 
     def update_index(*args)
       _run_update_index_callbacks { super }
+    end
+
+    def find_children_of(destroyed_id:)
+      ActiveFedora::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: destroyed_id))
     end
   end
 end

--- a/spec/models/concerns/hyrax/collection_nesting_spec.rb
+++ b/spec/models/concerns/hyrax/collection_nesting_spec.rb
@@ -2,24 +2,61 @@ RSpec.describe Hyrax::CollectionNesting do
   describe 'including this module' do
     let(:klass) do
       Class.new do
+        extend ActiveModel::Callbacks
+        include ActiveModel::Validations::Callbacks
+        # Because we need these declared before we include the Hyrax::CollectionNesting
+        define_model_callbacks :destroy, only: :after
+
+        def destroy
+          true
+        end
+
         def update_index
           true
         end
 
         include Hyrax::CollectionNesting
+
         attr_accessor :id
       end
     end
 
-    subject { klass.new.tap { |obj| obj.id = '123' } }
+    let(:user) { create(:user) }
+    let!(:collection) { create(:collection, collection_type_settings: [:nestable]) }
+    let!(:child_collection) { create(:collection, collection_type_settings: [:nestable]) }
+
+    before do
+      Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: collection, child: child_collection)
+    end
+
+    subject { klass.new.tap { |obj| obj.id = collection.id } }
 
     it { is_expected.to callback(:update_nested_collection_relationship_indices).after(:update_index) }
+    it { is_expected.to callback(:update_child_nested_collection_relationship_indices).after(:destroy) }
     it { is_expected.to respond_to(:update_nested_collection_relationship_indices) }
+    it { is_expected.to respond_to(:update_child_nested_collection_relationship_indices) }
 
-    describe '#update_nested_collection_relationship_indices' do
-      it 'will call Hyrax.config.nested_relationship_reindexer' do
-        expect(Hyrax.config.nested_relationship_reindexer).to receive(:call).with(id: subject.id).and_call_original
-        subject.update_nested_collection_relationship_indices
+    context 'after_update_index callback' do
+      describe '#update_nested_collection_relationship_indices' do
+        it 'will call Hyrax.config.nested_relationship_reindexer' do
+          expect(Hyrax.config.nested_relationship_reindexer).to receive(:call).with(id: subject.id).and_call_original
+          subject.update_nested_collection_relationship_indices
+        end
+      end
+    end
+
+    context 'after_destroy callback' do
+      describe '#update_child_nested_collection_relationship_indices' do
+        it 'will call Hyrax.config.nested_relationship_reindexer' do
+          expect(Hyrax.config.nested_relationship_reindexer).to receive(:call).with(id: child_collection.id).and_call_original
+          subject.update_child_nested_collection_relationship_indices
+        end
+      end
+
+      describe '#find_children_of' do
+        it 'will return an array containing the child collection ids' do
+          expect(subject.find_children_of(destroyed_id: collection.id).first.id).to eq(child_collection.id)
+        end
       end
     end
   end

--- a/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
+++ b/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
     end
   end
 
+  # @todo
   describe '.each_preservation_document' do
     xit 'iterates through each preservation document'
   end
@@ -68,8 +69,22 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
     let(:index_document_class) { Samvera::NestingIndexer::Documents::IndexDocument }
     let(:parent) { { id: document.id } }
     let(:document) { index_document_class.new(id: 'parent-1', pathnames: ['parent-1'], parent_ids: [], ancestors: []) }
-    let(:children) { [{ id: 'child-1', ancestors_key => [document.id] }, { id: 'child-2', ancestors_key => [document.id] }] }
-    let(:not_my_children) { [{ id: 'youre-not-my-dad-1', ancestors_key => ['parent-2'] }, { id: 'i-am-your-grandchild', ancestors_key => ['parent-1/parent-3'] }] }
+    let(:children) do
+      [{ id: 'child-1',
+         member_of_collection_ids_ssim: [document.id],
+         ancestors_key => [document.id] },
+       { id: 'child-2',
+         member_of_collection_ids_ssim: [document.id],
+         ancestors_key => [document.id] }]
+    end
+    let(:not_my_children) do
+      [{ id: 'youre-not-my-dad-1',
+         member_of_collection_ids_ssim: ['parent-2'],
+         ancestors_key => ['parent-2'] },
+       { id: 'i-am-your-grandchild',
+         member_of_collection_ids_ssim: ['parent-3'],
+         ancestors_key => ['parent-1/parent-3'] }]
+    end
 
     before do
       ([parent] + children + not_my_children).each do |doc|


### PR DESCRIPTION
### Fixes bugs in the nested indexing adapter related to finding and reindexing the child collections.
Prior to this change, if you reindexed a collection, the children were not consistently found and reindexed appropriately, because the adapter was using the nested indexing solr fields which had not yet been added to the solr document. 
### Adds an after-destroy hook to reindex the children of a deleted collection.
Nested collections have several indexed fields in the solr document which reference ancestors. When a collection is destroyed, all of the child collections still reference the destroyed collection until they get reindexed.

@samvera/hyrax-code-reviewers
