### PR TITLE
Create collection migration service

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,7 @@ Metrics/BlockLength:
     - 'lib/generators/hyrax/templates/catalog_controller.rb'
     - 'lib/generators/hyrax/templates/config/initializers/simple_form_bootstrap.rb'
     - 'lib/hyrax/rails/routes.rb'
+    - 'lib/tasks/*.rake'
     - 'spec/**/*.rb'
 
 Metrics/MethodLength:

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -27,7 +27,6 @@ module Hyrax
 
       # validates that collection_type_gid is present
       validates :collection_type_gid, presence: true
-      after_initialize :ensure_collection_type_gid
 
       # Need to define here in order to override setter defined by ActiveTriples
       def collection_type_gid=(new_collection_type_gid)
@@ -146,11 +145,6 @@ module Hyrax
         return [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC] if visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
         return [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED] if visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
         []
-      end
-
-      # act like the default collection type until persisted
-      def ensure_collection_type_gid
-        self.collection_type_gid = Hyrax::CollectionType.find_or_create_default_collection_type.gid if collection_type_gid.blank?
       end
 
       # Calculate the size of all the files in the work

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -101,5 +101,9 @@ module Hyrax
                         Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
                       end
     end
+
+    def collection_type_gid
+      first('collection_type_gid_ssim')
+    end
   end
 end

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -25,15 +25,14 @@ module Hyrax
     delegate(*Hyrax::CollectionType.collection_type_settings_methods, to: :collection_type, prefix: :collection_type_is)
 
     def collection_type
-      gid = Array.wrap(solr_document.fetch('collection_type_gid_ssim', [Hyrax::CollectionType.find_or_create_default_collection_type.gid])).first
-      @collection_type ||= CollectionType.find_by_gid!(gid)
+      @collection_type ||= Hyrax::CollectionType.find_by_gid!(collection_type_gid)
     end
 
     # Metadata Methods
     delegate :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language,
              :embargo_release_date, :lease_expiration_date, :license, :date_created,
              :resource_type, :based_near, :related_url, :identifier, :thumbnail_path,
-             :title_or_label, :collection_type_gid_ssim, :create_date, :modified_date, :visibility, :edit_groups,
+             :title_or_label, :collection_type_gid, :create_date, :modified_date, :visibility, :edit_groups,
              :edit_people,
              to: :solr_document
 

--- a/app/services/hyrax/collections/migration_service.rb
+++ b/app/services/hyrax/collections/migration_service.rb
@@ -1,0 +1,81 @@
+module Hyrax
+  module Collections
+    # Responsible for migrating legacy collections.  Legacy collections are those created before Hyrax 2.1.0 and
+    # are identified by the lack of the collection having a collection type gid.
+    class MigrationService
+      # @api public
+      #
+      # Migrate all legacy collections to extended collections with collection type assigned.  Legacy collections are those
+      # created before Hyrax 2.1.0 and are identified by the lack of the collection having a collection type gid.
+      def self.migrate_all_collections
+        Rails.logger.info "*** Migrating #{Collection.count} collections"
+        Collection.all.each do |col|
+          migrate_collection(col)
+          Rails.logger.info "  migrating collection - id: #{col.id}, title: #{col.title}"
+        end
+        Rails.logger.info "--- Migration Complete"
+      end
+
+      # @api private
+      #
+      # Migrate a single legacy collection to extended collections with collection type assigned.  Legacy collections are those
+      # created before Hyrax 2.1.0 and are identified by the lack of the collection having a collection type gid.
+      #
+      # @param collection [Collection] collection object to be migrated
+      def self.migrate_collection(collection)
+        return if collection.collection_type_gid.present? # already migrated
+        collection.collection_type_gid = Hyrax::CollectionType.find_or_create_default_collection_type.gid
+        create_permissions(collection)
+        collection.save
+      end
+      private_class_method :migrate_collection
+
+      # @api public
+      #
+      # Validate that migrated collections have both the collection type gid assigned and the permission template with
+      # access created and associated with the collection.  Any collection without collection type gid as nil or assigned
+      # the default collection type are ignored.
+      def self.repair_migrated_collections
+        Rails.logger.info "*** Repairing migrated collections"
+        Collection.all.each do |col|
+          repair_migrated_collection(col)
+          Rails.logger.info "  migrating collection - id: #{col.id}, title: #{col.title}"
+        end
+        Rails.logger.info "--- Migration Complete"
+      end
+
+      # @api private
+      #
+      # Validate and repair a migrated collection if needed.
+      #
+      # @param collection [Collection] collection object to be migrated/repaired
+      def self.repair_migrated_collection(collection)
+        return if collection.collection_type_gid.present? && collection.collection_type_gid != Hyrax::CollectionType.find_or_create_default_collection_type.gid
+        collection.collection_type_gid = Hyrax::CollectionType.find_or_create_default_collection_type.gid
+        permission_template = Hyrax::PermissionTemplate.find_by(source_id: collection.id)
+        if permission_template.present?
+          collection.update_access_controls!
+        else
+          create_permissions(collection)
+        end
+        collection.save
+      end
+      private_class_method :repair_migrated_collection
+
+      # @api private
+      #
+      # Determine if collection was already migrated.
+      #
+      # @param [Collection] collection object to be validated
+      def self.create_permissions(collection)
+        grants = []
+        collection.edit_groups.each { |g| grants << { agent_type: 'group', agent_id: g, access: Hyrax::PermissionTemplateAccess::MANAGE } }
+        collection.edit_users.each { |u| grants << { agent_type: 'user', agent_id: u, access: Hyrax::PermissionTemplateAccess::MANAGE } }
+        collection.read_groups.each { |g| grants << { agent_type: 'group', agent_id: g, access: Hyrax::PermissionTemplateAccess::VIEW } }
+        collection.read_users.each { |u| grants << { agent_type: 'user', agent_id: u, access: Hyrax::PermissionTemplateAccess::VIEW } }
+        Hyrax::Collections::PermissionsCreateService.create_default(collection: collection, creating_user: ::User.find_by_user_key(collection.depositor), grants: grants)
+      end
+      private_class_method :create_permissions
+    end
+  end
+end

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -26,5 +26,13 @@ namespace :hyrax do
         end
       end
     end
+
+    task add_collection_type_and_permissions_to_collections: :environment do
+      # Run collection migration which sets the collection_type of legacy collections to User Collection and adds
+      # a permission template assigning users/groups with edit_access to the Manager role and users/groups with
+      # read_access to the Viewer role.  Legacy collections are those created prior to collections extensions
+      # added in Hyrax 2.1.0
+      Hyrax::Collections::MigrationService.migrate_all_collections
+    end
   end
 end

--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe 'CollectionAbility' do
 
     context 'when there are collection types that have create access' do
       before do
-        Hyrax::CollectionType.find_or_create_default_collection_type
+        create(:user_collection_type)
       end
 
       it 'allows create_any' do

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   routes { Hyrax::Engine.routes }
   let(:user)  { create(:user) }
   let(:other) { build(:user) }
+  let(:collection_type_gid) { create(:user_collection_type).gid }
 
   let(:collection) do
     create(:public_collection, title: ["My collection"],
@@ -17,7 +18,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   let(:unowned_asset)  { create(:work, user: other) }
 
   let(:collection_attrs) do
-    { title: ['My First Collection'], description: ["The Description\r\n\r\nand more"] }
+    { title: ['My First Collection'], description: ["The Description\r\n\r\nand more"], collection_type_gid: [collection_type_gid] }
   end
 
   describe '#new' do
@@ -185,11 +186,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       let(:asset1) { create(:generic_work, user: user) }
       let(:asset2) { create(:generic_work, user: user) }
       let(:asset3) { create(:generic_work, user: user) }
-      let(:collection2) do
-        Collection.create(title: ['Some Collection']) do |col|
-          col.apply_depositor_metadata(user.user_key)
-        end
-      end
+      let(:collection2) { create(:collection, title: ['Some Collection'], user: user) }
 
       before do
         [asset1, asset2, asset3].each do |asset|

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -95,55 +95,10 @@ FactoryBot.define do
   end
 
   factory :user_collection_type, class: Hyrax::CollectionType do
-    title 'User Collection'
-    description 'A user oriented collection type'
-
-    nestable true
-    discoverable true
-    sharable true
-    share_applies_to_new_works false
-    allow_multiple_membership true
-    require_membership false
-    assigns_workflow false
-    assigns_visibility false
-
-    after(:create) do |collection_type, _evaluator|
-      attributes = { hyrax_collection_type_id: collection_type.id,
-                     access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS,
-                     agent_id: ::Ability.registered_group_name,
-                     agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
-      create(:collection_type_participant, attributes)
-      attributes = { hyrax_collection_type_id: collection_type.id,
-                     access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS,
-                     agent_id: ::Ability.admin_group_name,
-                     agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
-      create(:collection_type_participant, attributes)
-    end
+    initialize_with { Hyrax::CollectionType.find_or_create_default_collection_type }
   end
 
   factory :admin_set_collection_type, class: Hyrax::CollectionType do
-    title 'Admin Set'
-    description 'An administrative set collection type'
-    nestable false
-    discoverable false
-    sharable true
-    share_applies_to_new_works true
-    allow_multiple_membership false
-    require_membership true
-    assigns_workflow true
-    assigns_visibility true
-
-    after(:create) do |collection_type, _evaluator|
-      attributes = { hyrax_collection_type_id: collection_type.id,
-                     access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS,
-                     agent_id: ::Ability.admin_group_name,
-                     agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
-      create(:collection_type_participant, attributes)
-      attributes = { hyrax_collection_type_id: collection_type.id,
-                     access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS,
-                     agent_id: ::Ability.admin_group_name,
-                     agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
-      create(:collection_type_participant, attributes)
-    end
+    initialize_with { Hyrax::CollectionType.find_or_create_admin_set_type }
   end
 end

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -45,6 +45,10 @@ FactoryBot.define do
         workflow = create(:workflow, active: true, permission_template: permission_template)
         create(:workflow_action, workflow: workflow) # Need to create a single action that can be taken
       end
+      if evaluator.manage_users.present?
+        AccessHelper.create_access(permission_template, 'user', :manage, evaluator.manage_users)
+      end
+      # TODO: add support for manage_groups, depositor_users/groups, viewer_users/groups and update tests to use the factory instead of creating access in the test
     end
 
     transient do
@@ -52,6 +56,20 @@ FactoryBot.define do
       with_collection false
       with_workflows false
       with_active_workflow false
+      manage_users nil
+      # TODO: add support for manage_groups, depositor_users/groups, viewer_users/groups and update tests to use the factory instead of creating access in the test
+    end
+  end
+
+  class AccessHelper
+    def self.create_access(permission_template_id, agent_type, access, agent_ids)
+      agent_ids.each do |agent_id|
+        FactoryBot.create(:permission_template_access,
+                          access,
+                          permission_template: permission_template_id,
+                          agent_type: agent_type,
+                          agent_id: agent_id)
+      end
     end
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -111,28 +111,11 @@ RSpec.describe Collection, type: :model do
     end
 
     let(:member) { Member.create }
-    let(:collection) { OtherCollection.create(title: ['test title']) }
+    let(:collection) { OtherCollection.create(title: ['test title'], collection_type_gid: create(:user_collection_type).gid) }
 
     it "have members that know about the collection", clean_repo: true do
       member.reload
       expect(member.member_of_collections).to eq [collection]
-    end
-  end
-
-  describe 'after_initialize' do
-    let(:collection_type) { create(:collection_type) }
-
-    it 'sets collection_type_gid to default collection type if not already set' do
-      expect(described_class.new.collection_type_gid).to eq Hyrax::CollectionType.find_or_create_default_collection_type.gid
-    end
-
-    it 'does not set collection_type_gid if passed in to initializer' do
-      expect(described_class.new(collection_type_gid: collection_type.gid).collection_type_gid).to eq collection_type.gid
-    end
-
-    it 'does not override preexisting collection_type_gid' do
-      collection = create(:collection, collection_type_gid: collection_type.gid)
-      expect(described_class.find(collection.id).collection_type_gid).to eq collection_type.gid
     end
   end
 
@@ -165,7 +148,7 @@ RSpec.describe Collection, type: :model do
     end
 
     it 'updates the collection_type instance variable' do
-      expect { collection.collection_type_gid = collection_type.gid }.to change { collection.collection_type }.from(Hyrax::CollectionType.find_or_create_default_collection_type).to(collection_type)
+      expect { collection.collection_type_gid = collection_type.gid }.to change { collection.collection_type }.from(create(:user_collection_type)).to(collection_type)
     end
 
     it 'throws ArgumentError if collection has already been persisted with a collection type' do

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -194,4 +194,12 @@ RSpec.describe ::SolrDocument, type: :model do
 
     it { is_expected.to be_collection }
   end
+
+  describe "#collection_type_gid?" do
+    let(:attributes) { { 'collection_type_gid_ssim' => 'gid://internal/hyrax-collectiontype/5' } }
+
+    subject { document.collection_type_gid }
+
+    it { is_expected.to eq 'gid://internal/hyrax-collectiontype/5' }
+  end
 end

--- a/spec/presenters/hyrax/admin_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_presenter_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Hyrax::AdminSetPresenter do
 
     subject { presenter.collection_type }
 
-    it { is_expected.to eq(Hyrax::CollectionType.find_or_create_admin_set_type) }
+    it { is_expected.to eq(create(:admin_set_collection_type)) }
   end
 
   describe '#show_path' do

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -49,18 +49,7 @@ RSpec.describe Hyrax::CollectionPresenter do
       let(:solr_doc) { SolrDocument.new(collection.to_solr) }
 
       it 'finds the collection type based on the solr_document#collection_type_gid if one exists' do
-        expect(solr_doc).to be_key('collection_type_gid_ssim')
-        expect(solr_doc).to receive(:fetch).with('collection_type_gid_ssim', Array).and_return(collection_type.gid)
         expect(presenter.collection_type).to eq(collection_type)
-      end
-    end
-
-    describe 'when solr_document#collection_type_gid does not exist' do
-      let(:solr_doc) { SolrDocument.new(collection.to_solr.except('collection_type_gid_ssim')) }
-
-      it "finds the collection's collection type of the solr document's id if the document does not have a collection_type_gid" do
-        expect(solr_doc).not_to receive(:collection_type_gid)
-        expect(presenter.collection_type).to eq(Hyrax::CollectionType.find_or_create_default_collection_type)
       end
     end
   end

--- a/spec/services/hyrax/collections/migration_service_spec.rb
+++ b/spec/services/hyrax/collections/migration_service_spec.rb
@@ -1,0 +1,280 @@
+RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
+  let(:user) { create(:user) }
+  let(:editor1) { create(:user) }
+  let(:editor2) { create(:user) }
+  let(:reader1) { create(:user) }
+  let(:reader2) { create(:user) }
+  let(:default_gid) { create(:user_collection_type).gid }
+
+  describe ".migrate_all_collections" do
+    context 'when legacy collections are found (e.g. collections created before Hyrax 2.1.0)' do
+      let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true) }
+      let!(:col_vu) { build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
+      let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'], do_save: true) }
+      let!(:col_mu) { build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
+      let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'], do_save: true) }
+
+      it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
+        Collection.all.each do |col|
+          expect(col.collection_type_gid).to be_nil
+          expect { Hyrax::PermissionTemplate.find_by!(source_id: col.id) }.to raise_error ActiveRecord::RecordNotFound
+        end
+
+        Hyrax::Collections::MigrationService.migrate_all_collections
+
+        Collection.all.each do |col|
+          expect(col.collection_type_gid).to eq default_gid
+          pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
+          expect(pt_id).not_to be_nil
+          expect_access(pt_id, 'user', :manage, col.edit_users)
+          expect_access(pt_id, 'group', :manage, col.edit_groups)
+          expect_access(pt_id, 'user', :view, col.read_users)
+          expect_access(pt_id, 'group', :view, col.read_groups)
+        end
+      end
+    end
+
+    context 'when newer collections are found (e.g. collections created at or after Hyrax 2.1.0)' do
+      let!(:collection) do
+        create(:collection, id: 'col_newer', user: user, with_permission_template: true,
+                            collection_type_settings: [:discoverable], edit_users: [user.user_key],
+                            create_access: true)
+      end
+      let!(:permission_template) { collection.permission_template }
+      let!(:collection_type_gid) { collection.collection_type_gid }
+      let!(:edit_users) { collection.edit_users }
+
+      it "doesn't change the collection" do
+        expect(collection.collection_type_gid).to eq collection_type_gid
+        expect(Hyrax::PermissionTemplate.find_by!(source_id: collection.id).id).to eq permission_template.id
+        expect_access(permission_template.id, 'user', :manage, edit_users)
+
+        Hyrax::Collections::MigrationService.migrate_all_collections
+
+        expect(collection.collection_type_gid).to eq collection_type_gid
+        expect(Hyrax::PermissionTemplate.find_by!(source_id: collection.id).id).to eq permission_template.id
+        expect_access(permission_template.id, 'user', :manage, edit_users)
+      end
+    end
+  end
+
+  describe ".repair_migrated_collections" do
+    context 'when legacy collections are found (e.g. collections created before Hyrax 2.1.0)' do
+      let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true) }
+      let!(:col_vu) { build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
+      let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'], do_save: true) }
+      let!(:col_mu) { build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
+      let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'], do_save: true) }
+
+      context "and collection wasn't migrated at all" do
+        let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true) }
+        let!(:col_vu) { build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
+        let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'], do_save: true) }
+        let!(:col_mu) { build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
+        let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'], do_save: true) }
+
+        it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
+          Collection.all.each do |col|
+            expect(col.collection_type_gid).to be_nil
+            expect { Hyrax::PermissionTemplate.find_by!(source_id: col.id) }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          Hyrax::Collections::MigrationService.repair_migrated_collections
+
+          Collection.all.each do |col|
+            expect(col.collection_type_gid).to eq default_gid
+            pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
+            expect(pt_id).not_to be_nil
+            expect_access(pt_id, 'user', :manage, col.edit_users)
+            expect_access(pt_id, 'group', :manage, col.edit_groups)
+            expect_access(pt_id, 'user', :view, col.read_users)
+            expect_access(pt_id, 'group', :view, col.read_groups)
+          end
+        end
+      end
+
+      context "and collection type gid is set but permission template doesn't exist" do
+        let!(:col_none) { create(:user_collection, id: 'col_none', user: user, edit_users: [user.user_key], collection_type_gid: default_gid) }
+        let!(:col_vu) { create(:user_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], collection_type_gid: default_gid) }
+        let!(:col_vg) { create(:user_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'], collection_type_gid: default_gid) }
+        let!(:col_mu) { create(:user_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], collection_type_gid: default_gid) }
+        let!(:col_mg) { create(:user_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'], collection_type_gid: default_gid) }
+
+        it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
+          Collection.all.each do |col|
+            expect(col.collection_type_gid).to eq default_gid
+            expect { Hyrax::PermissionTemplate.find_by!(source_id: col.id) }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          Hyrax::Collections::MigrationService.repair_migrated_collections
+
+          Collection.all.each do |col|
+            expect(col.collection_type_gid).to eq default_gid
+            pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
+            expect(pt_id).not_to be_nil
+            expect_access(pt_id, 'user', :manage, col.edit_users)
+            expect_access(pt_id, 'group', :manage, col.edit_groups)
+            expect_access(pt_id, 'user', :view, col.read_users)
+            expect_access(pt_id, 'group', :view, col.read_groups)
+          end
+        end
+      end
+
+      context "and collection type gid isn't set but permission template exists with access set" do
+        let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true, with_permission_template: true) }
+        let!(:col_vu) do
+          build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key],
+                                      do_save: true, with_permission_template: true)
+        end
+        let!(:col_vg) do
+          build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'],
+                                      do_save: true, with_permission_template: true)
+        end
+        let!(:col_mu) do
+          build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key],
+                                      do_save: true, with_permission_template: true)
+        end
+        let!(:col_mg) do
+          build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'],
+                                      do_save: true, with_permission_template: true)
+        end
+
+        before do
+          pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col_none.id)
+          create_access(pt_id, 'user', :manage, [user.user_key])
+
+          pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col_vu.id)
+          create_access(pt_id, 'user', :manage, [user.user_key])
+          create_access(pt_id, 'user', :view, col_vu.read_users)
+
+          pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col_vg.id)
+          create_access(pt_id, 'user', :manage, [user.user_key])
+          create_access(pt_id, 'group', :view, col_vg.read_groups)
+
+          pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col_mu.id)
+          create_access(pt_id, 'user', :manage, col_mu.edit_users)
+
+          pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col_mg.id)
+          create_access(pt_id, 'user', :manage, [user.user_key])
+          create_access(pt_id, 'group', :manage, col_mg.edit_groups)
+        end
+
+        it 'sets gid' do # rubocop:disable RSpec/ExampleLength
+          Collection.all.each do |col|
+            expect(col.collection_type_gid).to be_nil
+            pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
+            expect(pt_id).not_to be_nil
+            expect_access(pt_id, 'user', :manage, col.edit_users)
+            expect_access(pt_id, 'group', :manage, col.edit_groups)
+            expect_access(pt_id, 'user', :view, col.read_users)
+            expect_access(pt_id, 'group', :view, col.read_groups)
+          end
+
+          Hyrax::Collections::MigrationService.repair_migrated_collections
+
+          Collection.all.each do |col|
+            expect(col.collection_type_gid).to eq default_gid
+            pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
+            expect(pt_id).not_to be_nil
+            expect_access(pt_id, 'user', :manage, col.edit_users)
+            expect_access(pt_id, 'group', :manage, col.edit_groups)
+            expect_access(pt_id, 'user', :view, col.read_users)
+            expect_access(pt_id, 'group', :view, col.read_groups)
+          end
+        end
+      end
+
+      context "and collection type gid isn't set and permission template exists with access not set" do
+        let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true, with_permission_template: true) }
+        let!(:col_vu) do
+          build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key],
+                                      do_save: true, with_permission_template: true)
+        end
+        let!(:col_vg) do
+          build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'],
+                                      do_save: true, with_permission_template: true)
+        end
+        let!(:col_mu) do
+          build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key],
+                                      do_save: true, with_permission_template: true)
+        end
+        let!(:col_mg) do
+          build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'],
+                                      do_save: true, with_permission_template: true)
+        end
+
+        it 'sets gid and adds access permissions' do # rubocop:disable RSpec/ExampleLength
+          Collection.all.each do |col|
+            expect(col.collection_type_gid).to be_nil
+            pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
+            expect(pt_id).not_to be_nil
+            expect_no_access(pt_id, 'user', :manage, col.edit_users)
+            expect_no_access(pt_id, 'group', :manage, col.edit_groups)
+            expect_no_access(pt_id, 'user', :view, col.read_users)
+            expect_no_access(pt_id, 'group', :view, col.read_groups)
+          end
+
+          Hyrax::Collections::MigrationService.repair_migrated_collections
+
+          Collection.all.each do |col|
+            expect(col.collection_type_gid).to eq default_gid
+            pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
+            expect(pt_id).not_to be_nil
+            expect_access(pt_id, 'user', :manage, col.edit_users)
+            expect_access(pt_id, 'group', :manage, col.edit_groups)
+            expect_access(pt_id, 'user', :view, col.read_users)
+            expect_access(pt_id, 'group', :view, col.read_groups)
+          end
+        end
+      end
+    end
+
+    context 'when newer collections are found (e.g. collections created at or after Hyrax 2.1.0)' do
+      let!(:collection) do
+        create(:collection, id: 'col_newer', user: user, with_permission_template: true, collection_type_settings: [:discoverable],
+                            edit_users: [user.user_key], create_access: true)
+      end
+      let!(:permission_template) { collection.permission_template }
+      let!(:collection_type_gid) { collection.collection_type_gid }
+      let!(:edit_users) { collection.edit_users }
+
+      it "doesn't change the collection" do
+        expect(collection.collection_type_gid).to eq collection_type_gid
+        expect(Hyrax::PermissionTemplate.find_by!(source_id: collection.id).id).to eq permission_template.id
+        expect_access(permission_template.id, 'user', :manage, edit_users)
+
+        Hyrax::Collections::MigrationService.repair_migrated_collections
+
+        expect(collection.collection_type_gid).to eq collection_type_gid
+        expect(Hyrax::PermissionTemplate.find_by!(source_id: collection.id).id).to eq permission_template.id
+        expect_access(permission_template.id, 'user', :manage, edit_users)
+      end
+    end
+  end
+
+  def create_access(permission_template_id, agent_type, access, agent_ids)
+    agent_ids.each do |agent_id|
+      create(:permission_template_access,
+             access,
+             permission_template: permission_template_id,
+             agent_type: agent_type,
+             agent_id: agent_id)
+    end
+  end
+
+  def expect_access(permission_template_id, agent_type, access, agent_ids)
+    agent_ids.each do |agent_id|
+      pta = Hyrax::PermissionTemplateAccess.where(permission_template_id: permission_template_id, agent_type: agent_type,
+                                                  access: access, agent_id: agent_id)
+      expect(pta).not_to be_empty
+    end
+  end
+
+  def expect_no_access(permission_template_id, agent_type, access, agent_ids)
+    agent_ids.each do |agent_id|
+      pta = Hyrax::PermissionTemplateAccess.where(permission_template_id: permission_template_id, agent_type: agent_type,
+                                                  access: access, agent_id: agent_id)
+      expect(pta).to be_empty
+    end
+  end
+end

--- a/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
   end
 
   context 'for admin set collection type' do
-    let(:collection_type) { build(:admin_set_collection_type) }
+    let(:collection_type) { create(:admin_set_collection_type) }
 
     before do
       collection_type_form.collection_type = collection_type
@@ -87,7 +87,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
   end
 
   context 'for user collection type' do
-    let(:collection_type) { build(:user_collection_type) }
+    let(:collection_type) { create(:user_collection_type) }
 
     before do
       collection_type_form.collection_type = collection_type

--- a/spec/views/hyrax/admin/collection_types/index.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/index.html.erb_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 RSpec.describe 'hyrax/admin/collection_types/index.html.erb', type: :view, clean_repo: true do
   before do
     assign(:collection_types, [
-             FactoryBot.create(:user_collection_type),
-             FactoryBot.create(:admin_set_collection_type),
+             create(:user_collection_type),
+             create(:admin_set_collection_type),
              FactoryBot.create(:collection_type, title: 'Test Title 1'),
              FactoryBot.create(:collection_type, title: 'Test Title 2')
            ])

--- a/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'hyrax/dashboard/collections/edit.html.erb', type: :view do
-  let(:collection) { stub_model(Collection, id: 'xyz123z4', title: ["Make Collections Great Again"]) }
+  let(:collection) { build(:collection, id: 'xyz123z4', title: ["Make Collections Great Again"]) }
   let(:form) { Hyrax::Forms::CollectionForm.new(collection, double, double) }
 
   before do

--- a/spec/views/hyrax/my/_collection_action_menu.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_collection_action_menu.html.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'hyrax/my/_collection_action_menu.html.erb' do
   let(:id) { '123' }
   let(:collection) { create(:collection, id: id) }
-  let(:collection_doc) { SolrDocument.new(id: id, has_model_ssim: 'Collection') }
+  let(:collection_doc) { SolrDocument.new(id: id, has_model_ssim: 'Collection', collection_type_gid_ssim: collection.collection_type_gid) }
   let(:collection_type) { create(:collection_type) }
   let(:user_collection_type) { create(:user_collection_type) }
   let(:user) { build(:user) }
@@ -11,7 +11,6 @@ RSpec.describe 'hyrax/my/_collection_action_menu.html.erb' do
   before do
     allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:collection_presenter).and_return(collection_presenter)
-    allow(collection_doc).to receive(:fetch).with('collection_type_gid_ssim', [user_collection_type.gid]).and_return(collection_type.gid)
     allow(collection_presenter).to receive(:id).and_return(id)
     allow(collection_presenter).to receive(:solr_document).and_return(collection_doc)
     allow(view).to receive(:can?).with(:read, collection_doc).and_return(true)

--- a/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
@@ -87,47 +87,4 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
       expect(rendered).to include Date.parse(modified_date).to_formatted_s(:standard)
     end
   end
-
-  context "check for legacy collections (<= Hyrax 2.0)" do
-    let(:attributes) do # missing collection_type_gid indicates collection is <= Hyrax 2.0
-      {
-        id: id,
-        "has_model_ssim" => ["Collection"],
-        "title_tesim" => ["Collection Title"],
-        "description_tesim" => ["Collection Description"],
-        "system_modified_dtsi" => modified_date
-      }
-    end
-
-    let(:doc) { SolrDocument.new(attributes) }
-    let(:collection) { mock_model(Collection) }
-    let(:collection_type) { create(:collection_type) }
-    let(:collection_presenter) { Hyrax::CollectionPresenter.new(doc, Ability.new(build(:user)), nil) }
-
-    before do
-      allow(view).to receive(:current_user).and_return(stub_model(User))
-      allow(view).to receive(:can?).with(:edit, doc).and_return(true)
-      allow(view).to receive(:can?).with(:read, doc).and_return(true)
-      allow(doc).to receive(:to_model).and_return(stub_model(Collection, id: id))
-      allow(Collection).to receive(:find).with(id).and_return(collection)
-      allow(collection).to receive(:id).and_return(id)
-      allow(collection).to receive(:member_of_collection_ids).and_return(["abc", "123"])
-      allow(collection_presenter).to receive(:collection_type_badge).and_return("User Collection")
-      view.lookup_context.prefixes.push 'hyrax/my'
-
-      render 'hyrax/my/collections/list_collections', collection_presenter: collection_presenter
-    end
-
-    it 'the line item displays the work and its actions' do
-      expect(rendered).to have_selector("tr#document_#{id}")
-      expect(rendered).to have_link 'Collection Title', href: hyrax.dashboard_collection_path(id)
-      expect(rendered).to have_link 'Edit collection', href: hyrax.edit_dashboard_collection_path(id)
-      expect(rendered).to have_link 'Delete collection', href: hyrax.dashboard_collection_path(id)
-      expect(rendered).to have_css 'a.visibility-link', text: 'Private'
-      expect(rendered).to have_css '.collection_type', text: 'User Collection'
-      expect(rendered).to have_selector '.expanded-details', text: 'Collection Description'
-      expect(rendered).not_to include '<span class="fa fa-cubes collection-icon-small"></span></a>'
-      expect(rendered).to include Date.parse(modified_date).to_formatted_s(:standard)
-    end
-  end
 end


### PR DESCRIPTION
Fixes #2351 

Move away from lazy migration which complicates the code and potentially could have performance impacts.  The Hyrax::Collections::MigrationService.migrate_all_collections process in this PR adds the default collection type gid to collections and creating a permission template with permission access assigned for each collection in the repository as part of the migration from Hyrax 2.0.x to Hyrax 2.1.x.

Access is assigned to collections as...
* users/groups are made managers of the collection if they currently have edit access to the collection
* users/groups are made viewers of the collection if they currently have view access to the collection

Also, uses collection type create service to create User Collection and Admin Set collection types instead of FactoryBot.  There were conflicts when FactoryBot was used to create these more than once in a test which isn't allowed.

NOTE:  Lazy migration was removed.  In dashboard/collection_controller.rb, there remains code that assigns the collection_type_gid to be the default user collection type in #new and #create.  These are provided to support backward compatibility of API access.  Any calls coming from the UI should have collection_type_gid as a parameter.  In the long run, the API should probably also require the collection_type_gid to be passed in.

@samvera/hyrax-code-reviewers
