### PR TITLE
get by_resource_type_spec.rb passing

### DIFF
--- a/app/services/hyrax/statistics/works/by_resource_type.rb
+++ b/app/services/hyrax/statistics/works/by_resource_type.rb
@@ -5,7 +5,7 @@ module Hyrax
         private
 
           def index_key
-            Solrizer.solr_name("resource_type", :facetable)
+            'resource_type_ssim'
           end
       end
     end


### PR DESCRIPTION
use `resource_type_ssim` rather than `resource_type_sim`

@samvera/hyrax-code-reviewers
