### PR TITLE
Don't draw the select a collection modal on the collection page

### DIFF
--- a/app/views/hyrax/my/_search_header.html.erb
+++ b/app/views/hyrax/my/_search_header.html.erb
@@ -13,7 +13,7 @@
 </div>
 
 <div class="batch-info">
-  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>
+  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections if params[:controller] != 'hyrax/my/collections' %>
 
   <div class="batch-toggle">
     <% session[:batch_edit_state] = "on" %>


### PR DESCRIPTION
The instance variable used to populate this modal isn't set and
the modal is never used on the collections page.
