### PR TITLE
remove uneccessary to_param override test

### DIFF
--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -77,10 +77,6 @@ RSpec.describe FileSet do
       expect(subject).to respond_to(:creator)
     end
 
-    it 'redefines to_param to make redis keys more recognizable' do
-      expect(subject.to_param).to eq subject.id
-    end
-
     describe 'that have been saved' do
       before { subject.apply_depositor_metadata('jcoyne') }
 


### PR DESCRIPTION
Removing test as I don't see where the file set is overriding `to_param`. Let me know if I'm missing something.



@samvera/hyrax-code-reviewers
