### PR TITLE
use created_at_dtsi for create_date

### DIFF
--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ::SolrDocument, type: :model do
     it { is_expected.to eq Date.parse('2013-03-14') }
 
     context "when a Time is provided" do
-      let(:attributes) { { 'system_create_dtsi' => Time.new(2013, 3, 14).utc } }
+      let(:attributes) { { 'created_at_dtsi' => Time.new(2013, 3, 14).utc } }
 
       it { is_expected.to eq Date.parse('2013-03-14') }
     end


### PR DESCRIPTION
Replacing `system_create_dtsi` with `created_at_dtsi` which I think was just a copy/paste error.

@samvera/hyrax-code-reviewers
