### PR TITLE
Move static form html to radio_button_tag

### DIFF
--- a/app/views/hyrax/base/_workflow_actions.html.erb
+++ b/app/views/hyrax/base/_workflow_actions.html.erb
@@ -12,7 +12,7 @@
         <% presenter.workflow.actions.each do |key, label| %>
           <div class="radio">
             <label>
-              <%= radio_button_tag 'workflow_action[name]', key, :checked => 'checked' %>
+              <%= radio_button_tag 'workflow_action[name]', key, key == 'comment_only' %>
               <%= label %>
             </label>
           </div>

--- a/app/views/hyrax/base/_workflow_actions.html.erb
+++ b/app/views/hyrax/base/_workflow_actions.html.erb
@@ -12,7 +12,7 @@
         <% presenter.workflow.actions.each do |key, label| %>
           <div class="radio">
             <label>
-              <input type="radio" name="workflow_action[name]" id="workflow_action_name_<%= key %>" value="<%= key %>">
+              <%= radio_button_tag 'workflow_action[name]', key, :checked => !!key == 'comment_only' %>
               <%= label %>
             </label>
           </div>

--- a/app/views/hyrax/base/_workflow_actions.html.erb
+++ b/app/views/hyrax/base/_workflow_actions.html.erb
@@ -12,7 +12,7 @@
         <% presenter.workflow.actions.each do |key, label| %>
           <div class="radio">
             <label>
-              <%= radio_button_tag 'workflow_action[name]', key, :checked => !!key == 'comment_only' %>
+              <%= radio_button_tag 'workflow_action[name]', key, :checked => 'checked' %>
               <%= label %>
             </label>
           </div>


### PR DESCRIPTION
Partially Addresses #1024 

This moves the existing raw html (`input type="radio"`) into `radio_button_tag` code in order to set a default checked value on the `Comment Only` option to avoid the `Not Authorized` message.

@samvera/hyrax-code-reviewers