### PR TITLE
Add more QA objects to seeds

### DIFF
--- a/lib/generators/hyrax/templates/db/seeds.rb
+++ b/lib/generators/hyrax/templates/db/seeds.rb
@@ -21,6 +21,16 @@
 # ---------------------------------
 # methods to create various objects
 # ---------------------------------
+def create_user(email, pw)
+  # user = User.find_or_create_by(email: email) do |user|
+  user = User.find_or_create_by(Hydra.config.user_key_field => email) do |u|
+    u.email = email
+    u.password = pw
+    u.password_confirmation = pw
+  end
+  user
+end
+
 def create_collection_type(machine_id, options)
   coltype = Hyrax::CollectionType.find_by_machine_id(machine_id)
   return coltype if coltype.present?
@@ -83,32 +93,67 @@ def create_work(user, id, options)
   work
 end
 
-# ---------------------------------
-# create seeded objects for QA
-# ---------------------------------
-puts 'Create users for QA'
-User.create(Hydra.config.user_key_field => 'mgr1@example.com', email: 'mgr1@example.com', password: 'pppppp') # 6*p
-User.create(Hydra.config.user_key_field => 'mgr2@example.com', email: 'mgr2@example.com', password: 'pppppp')
-User.create(Hydra.config.user_key_field => 'dep1@example.com', email: 'dep1@example.com', password: 'pppppp')
-User.create(Hydra.config.user_key_field => 'dep2@example.com', email: 'dep2@example.com', password: 'pppppp')
-User.create(Hydra.config.user_key_field => 'vw1@example.com', email: 'vw1@example.com', password: 'pppppp')
-User.create(Hydra.config.user_key_field => 'vw2@example.com', email: 'vw2@example.com', password: 'pppppp')
+def collection_attributes_for(collection_ids)
+  attrs = {}
+  0.upto(collection_ids.size) { |i| attrs[i.to_s] = { 'id' => collection_ids[i] } }
+  attrs
+end
 
-puts 'create collection types for QA'
+puts "---------------------------------"
+puts " Create seeded objects for QA"
+puts "---------------------------------"
+puts 'Create users for QA'
+create_user('mgr1@example.com', 'pppppp') # 6*p
+create_user('mgr2@example.com', 'pppppp')
+create_user('dep1@example.com', 'pppppp')
+create_user('dep2@example.com', 'pppppp')
+create_user('vw1@example.com', 'pppppp')
+create_user('vw2@example.com', 'pppppp')
+genuser = create_user('general_user@example.com', 'pppppp')
+
+puts 'Create collection types for QA'
 _discoverable_gid = create_collection_type('discoverable_collection_type', title: 'Discoverable', description: 'Sample collection type allowing collections to be discovered.', discoverable: true).gid
 _sharable_gid = create_collection_type('sharable_collection_type', title: 'Sharable', description: 'Sample collection type allowing collections to be shared.', sharable: true).gid
 options = { title: 'Multi-membership', description: 'Sample collection type allowing works to belong to multiple collections.', allow_multiple_membership: true }
 _multi_membership_gid = create_collection_type('multi_membership_collection_type', options)
 _nestable_1_gid = create_collection_type('nestable_1_collection_type', title: 'Nestable 1', description: 'A sample collection type allowing nesting.', nestable: true).gid
 _nestable_2_gid = create_collection_type('nestable_2_collection_type', title: 'Nestable 2', description: 'Another sample collection type allowing nesting.', nestable: true).gid
+_empty_gid = create_collection_type('empty_collection_type', title: 'Test Empty Collection Type', description: 'A collection type with 0 collections of this type').gid
+inuse_gid = create_collection_type('inuse_collection_type', title: 'Test In-Use Collection Type', description: 'A collection type with at least one collection of this type').gid
 
-# -------------------------------------------------------------
-# create seeded objects for collection nesting ad hoc testing
-# -------------------------------------------------------------
+puts 'Create collections for QA'
+inuse_col = create_public_collection(genuser, inuse_gid, 'inuse_col1', title: ['Public Collection of type In-Use'], description: ['Public collection of the type Test In-Use Collection Type.'])
+
+puts 'create works for QA'
+3.times do |i|
+  create_public_work(genuser, "qa_pu_gw_#{i}",
+                     title: ["QA Public #{i}"],
+                     description: ["Public work #{i} for QA testing"],
+                     creator: ['Joan Smith'], keyword: ['test'], rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
+                     member_of_collections_attributes: collection_attributes_for([inuse_col.id]))
+end
+2.times do |i|
+  create_authenticated_work(genuser, "qa_auth_gw_#{i}",
+                            title: ["QA Authenticated #{i}"],
+                            description: ["Authenticated work #{i} for QA testing"],
+                            creator: ['John Smith'], keyword: ['test'], rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
+                            member_of_collections_attributes: collection_attributes_for([inuse_col.id]))
+end
+1.times do |i|
+  create_private_work(genuser, "qa_priv_gw_#{i}",
+                      title: ["QA Private #{i}"],
+                      description: ["Proviate work #{i} for QA testing"],
+                      creator: ['Jean Smith'], keyword: ['test'], rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
+                      member_of_collections_attributes: collection_attributes_for([inuse_col.id]))
+end
+
+puts "-------------------------------------------------------------"
+puts " Create seeded objects for collection nesting ad hoc testing"
+puts "-------------------------------------------------------------"
 puts 'Create users for collection nesting ad hoc testing'
-user = User.create(Hydra.config.user_key_field => 'foo@example.com', email: 'foo@example.com', password: 'foobarbaz')
+user = create_user('foo@example.com', 'foobarbaz')
 
-puts 'create collection types for collection nesting ad hoc testing'
+puts 'Create collection types for collection nesting ad hoc testing'
 options = { title: 'Nestable Collection', description: 'Sample collection type that allows nesting of collections.',
             nestable: true, discoverable: true, sharable: true, allow_multiple_membership: true }
 nestable_gid = create_collection_type('nestable_collection', options).gid
@@ -117,33 +162,41 @@ options = { title: 'Non-Nestable Collection', description: 'Sample collection ty
             nestable: false, discoverable: true, sharable: true, allow_multiple_membership: true }
 _nonnestable_gid = create_collection_type('nonnestable_collection', options).gid
 
-puts 'create collections for collection nesting ad hoc testing'
-pnc = create_public_collection(user, nestable_gid, 'pnc1', title: 'Public Nestable Collection', description: 'Public nestable collection for use in ad hoc tests.')
-pc = create_public_collection(user, nestable_gid, 'pc1', title: 'A Parent Collection', description: 'Public collection that will be a parent of another collection.')
-cc = create_public_collection(user, nestable_gid, 'cc1', title: 'A Child Collection', description: 'Public collection that will be a child of another collection.')
-cc.member_of_collections = [pc]
+puts 'Create collections for collection nesting ad hoc testing'
+pnc = create_public_collection(user, nestable_gid, 'pnc1', title: ['Public Nestable Collection'], description: ['Public nestable collection for use in ad hoc tests.'])
+pc = create_public_collection(user, nestable_gid, 'pc1', title: ['A Parent Collection'], description: ['Public collection that will be a parent of another collection.'])
+cc = create_public_collection(user, nestable_gid, 'cc1', title: ['A Child Collection'], description: ['Public collection that will be a child of another collection.'])
+Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: pc, child: cc)
 
 puts 'Create works for collection nesting ad hoc testing'
 3.times do |i|
-  create_public_work(user, "pub_gw_#{i}", title: "Public #{i}",
-                                          description: "Public work #{i} being added to the Public Nested Collection",
-                                          member_of_collection_ids: [pnc.id])
+  create_public_work(user, "pub_gw_#{i}",
+                     title: ["Public #{i}"],
+                     description: ["Public work #{i} being added to the Public Nested Collection"],
+                     creator: ['Joan Smith'], keyword: ['test'], rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
+                     member_of_collections_attributes: collection_attributes_for([pnc.id]))
 end
 2.times do |i|
-  create_authenticated_work(user, "auth_gw_#{i}", title: "Authenticated #{i}",
-                                                  description: "Authenticated work #{i} being added to the Parent Collection",
-                                                  member_of_collection_ids: [pc.id])
+  create_authenticated_work(user, "auth_gw_#{i}",
+                            title: ["Authenticated #{i}"],
+                            description: ["Authenticated work #{i} being added to the Parent Collection"],
+                            creator: ['John Smith'], keyword: ['test'], rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
+                            member_of_collections_attributes: collection_attributes_for([pc.id]))
 end
 1.times do |i|
-  create_private_work(user, "priv_gw_#{i}", title: "Private #{i}",
-                                            description: "Proviate work #{i} being added to the Child Collection",
-                                            member_of_collection_ids: [cc.id])
+  create_private_work(user, "priv_gw_#{i}",
+                      title: ["Private #{i}"],
+                      description: ["Proviate work #{i} being added to the Child Collection"],
+                      creator: ['Jean Smith'], keyword: ['test'], rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
+                      member_of_collections_attributes: collection_attributes_for([cc.id]))
 end
 
-# -----------------------------------------------------
-# create seeded objects for embargo ad hoc testing
-# -----------------------------------------------------
-# Active, Private Embargo
+puts "-----------------------------------------------------"
+puts " Create seeded objects for embargo ad hoc testing"
+puts "-----------------------------------------------------"
+# TODO: update to use create_work method which uses actor stack to create works
+
+puts 'Create Active, Private Embargo works'
 3.times do |i|
   GenericWork.create(title: ["Active Private #{i}"]) do |work|
     work.apply_depositor_metadata(user)
@@ -151,7 +204,7 @@ end
   end
 end
 
-# Active, Authenticated Embargo
+puts 'Create Active, Authenticated Embargo works'
 2.times do |i|
   GenericWork.create(title: ["Active Authenticated #{i}"]) do |work|
     work.apply_depositor_metadata(user)
@@ -159,7 +212,7 @@ end
   end
 end
 
-# Expired, Authenticated Embargo
+puts 'Create Expired, Authenticated Embargo works'
 1.times do |i|
   GenericWork.create(title: ["Expired Authenticated #{i}"], read_groups: ['registered']) do |work|
     work.apply_depositor_metadata(user)
@@ -167,7 +220,7 @@ end
   end
 end
 
-# Expired, Public Embargo
+puts 'Create Expired, Public Embargo works'
 3.times do |i|
   GenericWork.create(title: ["Expired Public #{i}"], read_groups: ['public']) do |work|
     work.apply_depositor_metadata(user)
@@ -175,7 +228,7 @@ end
   end
 end
 
-# Active, Public Lease
+puts 'Create Active, Public Lease works'
 3.times do |i|
   GenericWork.create(title: ["Active Public #{i}"], read_groups: ['public']) do |work|
     work.apply_depositor_metadata(user)
@@ -183,7 +236,7 @@ end
   end
 end
 
-# Active, Authenticated Lease
+puts 'Create Active, Authenticated Lease works'
 2.times do |i|
   GenericWork.create(title: ["Active Authenticated #{i}"], read_groups: ['registered']) do |work|
     work.apply_depositor_metadata(user)
@@ -191,7 +244,7 @@ end
   end
 end
 
-# Expired, Authenticated Lease
+puts 'Create Expired, Authenticated Lease works'
 1.times do |i|
   GenericWork.create(title: ["Expired Authenticated #{i}"], read_groups: ['registered']) do |work|
     work.apply_depositor_metadata(user)
@@ -199,7 +252,7 @@ end
   end
 end
 
-# Expired, Private Lease
+puts 'Create Expired, Private Lease works'
 3.times do |i|
   GenericWork.create(title: ["Expired Public #{i}"]) do |work|
     work.apply_depositor_metadata(user)


### PR DESCRIPTION
* Fixes non-scalar values for title and description
* Adds QA empty and in-use collection types
* Adds QA in-use collection and works
* Returns existing users if they were created on a previous run of the seed file
* Update to use collection_attributess instead of just ids