### PR TITLE
Workflow action - validate that a comment is present

### DIFF
--- a/app/controllers/hyrax/workflow_actions_controller.rb
+++ b/app/controllers/hyrax/workflow_actions_controller.rb
@@ -7,7 +7,7 @@ module Hyrax
         after_update_response
       else
         respond_to do |wants|
-          wants.html { render 'hyrax/base/unauthorized', status: :unauthorized }
+          wants.html { respond_to_html }
           wants.json { render_json_response(response_type: :unprocessable_entity, options: { errors: curation_concern.errors }) }
         end
       end
@@ -35,6 +35,14 @@ module Hyrax
         respond_to do |wants|
           wants.html { redirect_to [main_app, curation_concern], notice: "The #{curation_concern.human_readable_type} has been updated." }
           wants.json { render 'hyrax/base/show', status: :ok, location: polymorphic_path([main_app, curation_concern]) }
+        end
+      end
+
+      def respond_to_html
+        if workflow_action_form.authorized_for_processing
+          redirect_to [main_app, curation_concern], alert: "Invalid submission: comment required."
+        else
+          render 'hyrax/base/unauthorized', status: :unauthorized
         end
       end
   end

--- a/app/forms/hyrax/forms/workflow_action_form.rb
+++ b/app/forms/hyrax/forms/workflow_action_form.rb
@@ -35,6 +35,8 @@ module Hyrax
       end
 
       validates :name, presence: true
+      validate :valid_comment
+
       validate :authorized_for_processing
 
       def authorized_for_processing
@@ -53,6 +55,10 @@ module Hyrax
         def convert_to_sipity_objects!
           @subject = WorkflowActionInfo.new(work, current_user)
           @sipity_workflow_action = PowerConverter.convert_to_sipity_action(name, scope: subject.entity.workflow) { nil }
+        end
+
+        def valid_comment
+          errors.add(:base, :missing_comment) if comment.blank? && name != 'approve'
         end
 
         attr_reader :subject, :sipity_workflow_action

--- a/app/views/hyrax/base/_workflow_actions.html.erb
+++ b/app/views/hyrax/base/_workflow_actions.html.erb
@@ -1,32 +1,40 @@
 <div id="workflow_controls" class="panel panel-workflow">
   <div class="panel-heading">
     <a data-toggle="collapse" href="#workflow_controls_collapse">
-      <h2 class="panel-title">Review and Approval <i class="fa fa-chevron-right pull-right"></i></h2>
+      <h2 class="panel-title"><%= t('hyrax.base.items.workflow.review') %> <i class="fa fa-chevron-right pull-right"></i></h2>
     </a>
   </div>
   <%= form_tag main_app.hyrax_workflow_action_path(presenter), method: :put do %>
     <div id="workflow_controls_collapse" class="panel-body panel-collapse collapse">
       <div class="col-sm-3 workflow-actions">
-        <h3>Actions</h3>
+        <h3><%= t('hyrax.base.items.workflow.action') %></h3>
 
         <% presenter.workflow.actions.each do |key, label| %>
           <div class="radio">
             <label>
               <%= radio_button_tag 'workflow_action[name]', key, key == 'comment_only' %>
-              <%= label %>
+              <%= t('hyrax.base.items.workflow.actions.' + key) %>
             </label>
           </div>
         <% end %>
       </div>
       <div class="col-sm-9 workflow-comments">
-        <div class="form-group">
-          <label for="workflow_action_comment">Review comment:</label>
-          <textarea class="form-control" name="workflow_action[comment]" id="workflow_action_comment"></textarea>
-        </div>
+          <% if flash['alert'].present? %>
+            <div class="form-group has-error">
+              <label for="workflow_action_comment"><%= t('hyrax.base.items.workflow.comment_label') %>:</label>
+              <textarea class="form-control" name="workflow_action[comment]" id="workflow_action_comment"></textarea>
+              <span class="help-block"><%= t('hyrax.base.items.workflow.comment_error') %></span>
+            </div>
+          <% else %>
+            <div class="form-group">
+              <label for="workflow_action_comment"><%= t('hyrax.base.items.workflow.comment_label') %>:</label>
+              <textarea class="form-control" name="workflow_action[comment]" id="workflow_action_comment"></textarea>
+            </div>
+          <% end %>
 
         <input class="btn btn-primary" type="submit" value="Submit">
 
-        <h4>Previous Comments</h4>
+        <h4><%= t('hyrax.base.items.workflow.previous') %></h4>
         <dl>
           <% presenter.workflow.comments.each do |comment| %>
             <dt><%= comment.name_of_commentor %></dt>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -321,6 +321,17 @@ en:
         thumbnail: Thumbnail
         title: Title
         visibility: Visibility
+        workflow:
+          review: Review and Approval
+          action: Actions
+          actions:
+            request_changes: Request Changes
+            approve: Approve
+            comment_only: Comment Only
+            leave_a_comment: Leave a Comment
+          comment_label: Review comment
+          comment_error: You must enter some text before submitting a comment.
+          previous: Previous
       relationships:
         empty: This %{type} is not currently in any collections.
         header: Relationships


### PR DESCRIPTION

Fixes #1024 

Adds validation for the presence of a comment in a workflow action. If not present, adds an alert message and reloads the page instead of redirecting to a confusing "Unauthorized page"

@samvera/hyrax-code-reviewers