### PR TITLE
allow works to be added to collections with deposit access

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -52,7 +52,7 @@ module Hyrax
         # along side the FileSets on the show page
         def add(env, id)
           member = Collection.find(id)
-          return unless env.current_ability.can?(:edit, member)
+          return unless env.current_ability.can?(:deposit, member)
           env.curation_concern.member_of_collections << member
         end
 

--- a/app/search_builders/hyrax/collection_search_builder.rb
+++ b/app/search_builders/hyrax/collection_search_builder.rb
@@ -6,8 +6,16 @@ module Hyrax
   # @see https://github.com/samvera/hyrax/blob/master/app/search_builders/hyrax/README.md SearchBuilders README
   # @note the default_processor_chain defined by Blacklight::Solr::SearchBuilderBehavior provides many possible points of override
   #
+  # Allows :deposit as a valid type
   class CollectionSearchBuilder < ::SearchBuilder
     include FilterByType
+
+    attr_reader :access
+
+    # Overrides Hydra::AccessControlsEnforcement
+    def discovery_permissions
+      @discovery_permissions = extract_discovery_permissions(@access)
+    end
 
     # @return [String] Solr field name indicating default sort order
     def sort_field
@@ -19,11 +27,40 @@ module Hyrax
       collection_classes
     end
 
+    def with_access(access)
+      @access = access
+      super(access)
+    end
+
     # Sort results by title if no query was supplied.
     # This overrides the default 'relevance' sort.
     def add_sorting_to_solr(solr_parameters)
       return if solr_parameters[:q]
       solr_parameters[:sort] ||= "#{sort_field} asc"
     end
+
+    # If :deposit access is requested, check to see which collections the user has
+    # deposit or manage access to.
+    # @return [Array<String>] a list of filters to apply to the solr query
+    def gated_discovery_filters(permission_types = discovery_permissions, ability = current_ability)
+      return super unless permission_types.include?("deposit")
+      ["{!terms f=id}#{collection_ids_for_deposit.join(',')}"]
+    end
+
+    private
+
+      def collection_ids_for_deposit
+        Hyrax::Collections::PermissionsService.collection_ids_for_deposit(ability: current_ability)
+      end
+
+      ACCESS_LEVELS_FOR_LEVEL = ActiveSupport::HashWithIndifferentAccess.new(
+        edit: ["edit"],
+        deposit: ["deposit"],
+        read: ["edit", "read"]
+      ).freeze
+      def extract_discovery_permissions(access)
+        access = :read if access.blank?
+        ACCESS_LEVELS_FOR_LEVEL.fetch(access)
+      end
   end
 end

--- a/app/views/hyrax/base/_form_member_of_collections.html.erb
+++ b/app/views/hyrax/base/_form_member_of_collections.html.erb
@@ -20,7 +20,7 @@ HTML Properties:
                   prompt: :translate,
                   data: {
                     autocomplete: 'collection',
-                    'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/collections?access=edit'
+                    'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/collections?access=deposit'
                   } %>
       <a class="btn btn-primary" data-behavior="add-relationship">Add</a>
   </div>

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
   let(:user) { create(:user) }
   let(:ability) { ::Ability.new(user) }
-  let(:curation_concern) { build(:work) }
+  let(:curation_concern) { build(:work, user: user) }
   let(:attributes) { {} }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:env) { Hyrax::Actors::Environment.new(curation_concern, ability, attributes) }
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
   end
 
   describe 'the next actor' do
-    let(:collection) { create(:collection) }
+    let(:collection) { create(:collection, create_access: true) }
     let(:attributes) do
       {
         member_of_collections_attributes: { '0' => { id: '123' } },
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
   end
 
   describe 'create' do
-    let(:collection) { create(:collection, collection_type_settings: [:discoverable], edit_users: [user.user_key]) }
+    let(:collection) { create(:collection, collection_type_settings: [:discoverable], user: user, create_access: true) }
     let(:attributes) do
       {
         member_of_collections_attributes: { '0' => { id: collection.id } },
@@ -68,7 +68,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
     end
 
     context "when work is in user's own collection and destroy is passed" do
-      let(:collection) { create(:collection, user: user, title: ['A good title']) }
+      let(:collection) { create(:collection, user: user, title: ['A good title'], create_access: true) }
       let(:attributes) do
         { member_of_collections_attributes: { '0' => { id: collection.id, _destroy: 'true' } } }
       end
@@ -86,7 +86,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
 
     context "when work is in another user's collection" do
       let(:other_user) { create(:user) }
-      let(:other_collection) { create(:collection, user: other_user, title: ['A good title']) }
+      let(:other_collection) { create(:collection, user: other_user, title: ['A good title'], create_access: true) }
 
       before do
         curation_concern.member_of_collections = [other_collection]
@@ -102,7 +102,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
 
     context "updates env" do
       let!(:collection_type) { create(:collection_type) }
-      let!(:collection) { create(:collection, collection_type_gid: collection_type.gid) }
+      let!(:collection) { create(:collection, collection_type_gid: collection_type.gid, create_access: true) }
 
       subject(:middleware) do
         stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
@@ -135,7 +135,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
         end
 
         context "when more than one collection" do
-          let(:collection2) { create(:collection) }
+          let(:collection2) { create(:collection, create_access: true) }
           let(:attributes) do
             {
               member_of_collections_attributes: {

--- a/spec/authorities/qa/authorities/collections_spec.rb
+++ b/spec/authorities/qa/authorities/collections_spec.rb
@@ -3,12 +3,35 @@ RSpec.describe Qa::Authorities::Collections, :clean_repo do
   let(:user1) { create(:user) }
   let(:user2) { create(:user) }
   let(:q) { "foo" }
-  let(:params) { ActionController::Parameters.new(q: q, access: 'edit') }
   let(:service) { described_class.new }
-  let!(:collection1) { create(:collection, :public, title: ['foo foo'], user: user1) }
-  let!(:collection2) { create(:collection, :public, title: ['bar'], user: user1) }
-  let!(:collection3) { create(:collection, :public, title: ['another foo'], user: user1) }
-  let!(:collection4) { create(:collection, :public, title: ['foo foo foo'], user: user2) }
+  let!(:collection1) { create(:private_collection, id: 'col-1-own', title: ['foo foo'], user: user1, create_access: true) }
+  let!(:collection2) { create(:private_collection, id: 'col-2-own', title: ['bar'], user: user1, create_access: true) }
+  let!(:collection3) { create(:private_collection, id: 'col-3-own', title: ['another foo'], user: user1, create_access: true) }
+  let!(:collection4) { create(:private_collection, id: 'col-4-none', title: ['foo foo foo'], user: user2, create_access: true) }
+  let!(:collection5) do
+    create(:private_collection, id: 'col-5-mgr', title: ['foo for you'], user: user2,
+                                with_permission_template: { manage_users: [user1] }, create_access: true)
+  end
+  let!(:collection6) do
+    create(:private_collection, id: 'col-6-dep', title: ['foo too'], user: user2,
+                                with_permission_template: { deposit_users: [user1] }, create_access: true)
+  end
+  let!(:collection7) do
+    create(:private_collection, id: 'col-7-view', title: ['foo bar baz'], user: user2,
+                                with_permission_template: { view_users: [user1] }, create_access: true)
+  end
+  let!(:collection8) do
+    create(:private_collection, id: 'col-8-mgr', title: ['bar for you'], user: user2,
+                                with_permission_template: { manage_users: [user1] }, create_access: true)
+  end
+  let!(:collection9) do
+    create(:private_collection, id: 'col-9-dep', title: ['bar too'], user: user2,
+                                with_permission_template: { deposit_users: [user1] }, create_access: true)
+  end
+  let!(:collection10) do
+    create(:private_collection, id: 'col-10-view', title: ['bar bar baz'], user: user2,
+                                with_permission_template: { view_users: [user1] }, create_access: true)
+  end
 
   before do
     allow(controller).to receive(:params).and_return(params)
@@ -18,8 +41,28 @@ RSpec.describe Qa::Authorities::Collections, :clean_repo do
   subject { service.search(q, controller) }
 
   describe '#search' do
-    it 'displays a list of collections for the current user' do
-      expect(subject.map { |result| result[:id] }).to match_array [collection1.id, collection3.id]
+    context 'when access is read' do
+      let(:params) { ActionController::Parameters.new(q: q, access: 'read') }
+
+      it 'displays a list of read collections for the current user' do
+        expect(subject.map { |result| result[:id] }).to match_array [collection1.id, collection3.id, collection5.id, collection6.id, collection7.id]
+      end
+    end
+
+    context 'when access is edit' do
+      let(:params) { ActionController::Parameters.new(q: q, access: 'edit') }
+
+      it 'displays a list of edit collections for the current user' do
+        expect(subject.map { |result| result[:id] }).to match_array [collection1.id, collection3.id, collection5.id]
+      end
+    end
+
+    context 'when access is deposit' do
+      let(:params) { ActionController::Parameters.new(q: q, access: 'deposit') }
+
+      it 'displays a list of edit and deposit collections for the current user' do
+        expect(subject.map { |result| result[:id] }).to match_array [collection1.id, collection3.id, collection5.id, collection6.id]
+      end
     end
   end
 end

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -45,10 +45,12 @@ FactoryBot.define do
         workflow = create(:workflow, active: true, permission_template: permission_template)
         create(:workflow_action, workflow: workflow) # Need to create a single action that can be taken
       end
-      if evaluator.manage_users.present?
-        AccessHelper.create_access(permission_template, 'user', :manage, evaluator.manage_users)
-      end
-      # TODO: add support for manage_groups, depositor_users/groups, viewer_users/groups and update tests to use the factory instead of creating access in the test
+      AccessHelper.create_access(permission_template, 'user', :manage, evaluator.manage_users) if evaluator.manage_users.present?
+      AccessHelper.create_access(permission_template, 'group', :manage, evaluator.manage_groups) if evaluator.manage_groups.present?
+      AccessHelper.create_access(permission_template, 'user', :deposit, evaluator.deposit_users) if evaluator.deposit_users.present?
+      AccessHelper.create_access(permission_template, 'group', :deposit, evaluator.deposit_groups) if evaluator.deposit_groups.present?
+      AccessHelper.create_access(permission_template, 'user', :view, evaluator.view_users) if evaluator.view_users.present?
+      AccessHelper.create_access(permission_template, 'group', :view, evaluator.view_groups) if evaluator.view_groups.present?
     end
 
     transient do
@@ -57,7 +59,11 @@ FactoryBot.define do
       with_workflows false
       with_active_workflow false
       manage_users nil
-      # TODO: add support for manage_groups, depositor_users/groups, viewer_users/groups and update tests to use the factory instead of creating access in the test
+      manage_groups nil
+      deposit_users nil
+      deposit_groups nil
+      view_users nil
+      view_groups nil
     end
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -231,13 +231,43 @@ RSpec.describe Collection, type: :model do
   end
 
   context 'collection factory' do
-    describe 'when creating permission templates' do
-      it 'will create a permission_template when one is requested' do
+    let(:user) { build(:user) }
+
+    describe 'permission template' do
+      it 'will be created when with_permission_template is true' do
         expect { create(:collection, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       end
 
-      it 'will not create a permission_template by default' do
+      it 'will be created when with_permission_template is set to attributes identifying access' do
+        expect { create(:collection, with_permission_template: { manage_users: [user] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { create(:collection, with_permission_template: { manage_users: [user], deposit_users: [user] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+      end
+
+      it 'will be created when create_access is true' do
+        expect { create(:collection, create_access: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+      end
+
+      it 'will not be created by default' do
         expect { create(:collection) }.not_to change { Hyrax::PermissionTemplate.count }
+      end
+    end
+
+    describe 'permission template access' do
+      it 'will not be created when with_permission_template is true' do
+        expect { create(:collection, with_permission_template: true) }.not_to change { Hyrax::PermissionTemplateAccess.count }
+      end
+
+      it 'will be created when with_permission_template is set to attributes identifying access' do
+        expect { create(:collection, with_permission_template: { manage_users: [user] }) }.to change { Hyrax::PermissionTemplateAccess.count }.by(1)
+        expect { create(:collection, with_permission_template: { manage_users: [user], deposit_users: [user] }) }.to change { Hyrax::PermissionTemplateAccess.count }.by(2)
+      end
+
+      it 'will be created when create_access is true' do
+        expect { create(:collection, user: user, create_access: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+      end
+
+      it 'will not be created by default' do
+        expect { create(:collection) }.not_to change { Hyrax::PermissionTemplateAccess.count }
       end
     end
 

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -1,16 +1,74 @@
 RSpec.describe Hyrax::CollectionSearchBuilder do
-  let(:scope) { double(blacklight_config: CatalogController.blacklight_config) }
-  let(:builder) { described_class.new(scope) }
+  let(:scope) do
+    double(blacklight_config: CatalogController.blacklight_config,
+           current_ability: ability)
+  end
+  let(:user) { create(:user) }
+  let(:ability) { ::Ability.new(user) }
+  let(:builder) { described_class.new(scope).with_access(access) }
 
   describe '#sort_field' do
+    let(:access) { :read }
+
     subject { builder.sort_field }
 
     it { is_expected.to eq('title_si') }
   end
 
   describe '#models' do
+    let(:access) { :read }
+
     subject { builder.models }
 
     it { is_expected.to eq([Collection]) }
+  end
+
+  describe '#discovery_permissions' do
+    subject { builder.discovery_permissions }
+
+    context 'when access is read' do
+      let(:access) { :read }
+
+      it { is_expected.to eq %w[edit read] }
+    end
+
+    context 'when access is edit' do
+      let(:access) { :edit }
+
+      it { is_expected.to eq %w[edit] }
+    end
+
+    context 'when access is deposit' do
+      let(:access) { :deposit }
+
+      it { is_expected.to eq %w[deposit] }
+    end
+  end
+
+  describe '#gated_discovery_filters' do
+    subject { builder.gated_discovery_filters(access, ability) }
+
+    context 'when access is :deposit' do
+      let(:access) { "deposit" }
+      let!(:collection) { create(:collection, with_permission_template: attributes) }
+
+      context 'and user has access' do
+        let(:attributes) { { deposit_users: [user.user_key] } }
+
+        it { is_expected.to eq ["{!terms f=id}#{collection.id}"] }
+      end
+
+      context 'and group has access' do
+        let(:attributes) { { deposit_groups: ['registered'] } }
+
+        it { is_expected.to eq ["{!terms f=id}#{collection.id}"] }
+      end
+
+      context "and user has no access" do
+        let(:attributes) { true }
+
+        it { is_expected.to eq ["{!terms f=id}"] }
+      end
+    end
   end
 end

--- a/spec/services/hyrax/collections_service_spec.rb
+++ b/spec/services/hyrax/collections_service_spec.rb
@@ -2,38 +2,57 @@ RSpec.describe Hyrax::CollectionsService do
   let(:controller) { ::CatalogController.new }
 
   let(:context) do
-    double(current_ability: Ability.new(user),
+    double(current_ability: Ability.new(user1),
            repository: controller.repository,
            blacklight_config: controller.blacklight_config)
   end
 
   let(:service) { described_class.new(context) }
-  let(:user) { create(:user) }
+  let(:user1) { create(:user) }
 
   describe "#search_results", :clean_repo do
     subject { service.search_results(access) }
 
-    let!(:collection1) { create(:collection, :public, title: ['foo']) }
-    let!(:collection2) { create(:collection, :public, title: ['bar']) }
-    let!(:collection3) { create(:collection, :public, edit_users: [user.user_key], title: ['baz']) }
+    let(:user2) { create(:user) }
+    let!(:collection1) { create(:private_collection, id: 'col-1-own', title: ['user1 created'], user: user1, create_access: true) }
+    let!(:collection2) do
+      create(:private_collection, id: 'col-2-mgr', title: ['user2 shares manage access with user1'], user: user2,
+                                  with_permission_template: { manage_users: [user1] }, create_access: true)
+    end
+    let!(:collection3) do
+      create(:private_collection, id: 'col-3-dep', title: ['user2 shares deposit access with user1'], user: user2,
+                                  with_permission_template: { deposit_users: [user1] }, create_access: true)
+    end
+    let!(:collection4) do
+      create(:private_collection, id: 'col-4-view', title: ['user2 shares view access with user1'], user: user2,
+                                  with_permission_template: { view_users: [user1] }, create_access: true)
+    end
 
     before do
-      create(:admin_set, read_groups: ['public']) # this should never be returned.
+      create(:admin_set, id: 'as-1', read_groups: ['public']) # this should never be returned.
     end
 
     context "with read access" do
       let(:access) { :read }
 
       it "returns three collections" do
-        expect(subject.map(&:id)).to match_array [collection1.id, collection2.id, collection3.id]
+        expect(subject.map(&:id)).to match_array [collection1.id, collection2.id, collection3.id, collection4.id]
       end
     end
 
     context "with edit access" do
       let(:access) { :edit }
 
+      it "returns two collections" do
+        expect(subject.map(&:id)).to match_array [collection1.id, collection2.id]
+      end
+    end
+
+    context "with deposit access" do
+      let(:access) { :deposit }
+
       it "returns one collections" do
-        expect(subject.map(&:id)).to match_array [collection3.id]
+        expect(subject.map(&:id)).to match_array [collection1.id, collection2.id, collection3.id]
       end
     end
   end


### PR DESCRIPTION
Fixes #2219

Allows user to select a collection for which they have deposit access from the new/edit work's relationship tab.

Also added the ability to set access from the collection and permission template factories.

@samvera/hyrax-code-reviewers
