### PR TITLE
grant collection depositors read access to the collection

### DIFF
--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -122,13 +122,16 @@ module Hyrax
       Hyrax::PermissionTemplate.find_by!(source_id: id)
     end
 
-    # Calculate and update who should have edit access based on who
-    # has "manage" access in the PermissionTemplateAccess
+    # Calculate and update who should have read/edit access to the collections based on who
+    # has access in PermissionTemplateAccess
     def update_access_controls!
       edit_users = permission_template.agent_ids_for(access: 'manage', agent_type: 'user')
       edit_groups = permission_template.agent_ids_for(access: 'manage', agent_type: 'group')
-      read_users = permission_template.agent_ids_for(access: 'view', agent_type: 'user')
-      read_groups = (permission_template.agent_ids_for(access: 'view', agent_type: 'group') + visibility_group).uniq
+      read_users = permission_template.agent_ids_for(access: 'view', agent_type: 'user') +
+                   permission_template.agent_ids_for(access: 'deposit', agent_type: 'user')
+      read_groups = (permission_template.agent_ids_for(access: 'view', agent_type: 'group') +
+                     permission_template.agent_ids_for(access: 'deposit', agent_type: 'group') +
+                     visibility_group).uniq
       update!(edit_users: edit_users,
               edit_groups: edit_groups,
               read_users: read_users,

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -197,16 +197,18 @@ RSpec.describe Collection, type: :model do
 
     before do
       allow(collection).to receive(:permission_template).and_return(permission_template)
-      allow(permission_template).to receive(:agent_ids_for).with(access: 'manage', agent_type: 'user').and_return(['mgr1.ex.com', 'mgr2.ex.com', user.user_key])
+      allow(permission_template).to receive(:agent_ids_for).with(access: 'manage', agent_type: 'user').and_return(['mgr1@ex.com', 'mgr2@ex.com', user.user_key])
       allow(permission_template).to receive(:agent_ids_for).with(access: 'manage', agent_type: 'group').and_return(['managers', ::Ability.admin_group_name])
-      allow(permission_template).to receive(:agent_ids_for).with(access: 'view', agent_type: 'user').and_return(['vw1.ex.com', 'vw2.ex.com'])
+      allow(permission_template).to receive(:agent_ids_for).with(access: 'deposit', agent_type: 'user').and_return(['dep1@ex.com', 'dep2@ex.com'])
+      allow(permission_template).to receive(:agent_ids_for).with(access: 'deposit', agent_type: 'group').and_return(['depositors', ::Ability.admin_group_name])
+      allow(permission_template).to receive(:agent_ids_for).with(access: 'view', agent_type: 'user').and_return(['vw1@ex.com', 'vw2@ex.com'])
       allow(permission_template).to receive(:agent_ids_for).with(access: 'view', agent_type: 'group').and_return(['viewers', ::Ability.admin_group_name])
     end
 
     it 'updates user edit access' do
       expect(collection.edit_users).to match_array([user.user_key])
       collection.update_access_controls!
-      expect(collection.edit_users).to match_array([user.user_key, 'mgr1.ex.com', 'mgr2.ex.com'])
+      expect(collection.edit_users).to match_array([user.user_key, 'mgr1@ex.com', 'mgr2@ex.com'])
     end
 
     it 'updates group edit access' do
@@ -218,13 +220,13 @@ RSpec.describe Collection, type: :model do
     it 'updates user read access' do
       expect(collection.read_users).to match_array([])
       collection.update_access_controls!
-      expect(collection.read_users).to match_array(['vw1.ex.com', 'vw2.ex.com'])
+      expect(collection.read_users).to match_array(['vw1@ex.com', 'vw2@ex.com', 'dep1@ex.com', 'dep2@ex.com'])
     end
 
     it 'updates group read access' do
       expect(collection.read_groups).to match_array([])
       collection.update_access_controls!
-      expect(collection.read_groups).to match_array(['viewers', ::Ability.admin_group_name])
+      expect(collection.read_groups).to match_array(['viewers', 'depositors', ::Ability.admin_group_name])
     end
   end
 


### PR DESCRIPTION
Fixes #1840

Grants read access to users/groups with deposit access for a collection.  It does not grant any additional access to works created in the collection.

This allows deposit users to view the admin show page.  They continue to only see works on the show page for which they already have view access (i.e. public works, works they created, and works shared with them).

[WIP] working on adjusting tests

@samvera/hyrax-code-reviewers
