### PR TITLE
Use standard matchers to avoid infinite loop

### DIFF
--- a/spec/controllers/hyrax/embargoes_controller_spec.rb
+++ b/spec/controllers/hyrax/embargoes_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::EmbargoesController do
     context 'when I do not have edit permissions for the object' do
       it 'redirects' do
         get :edit, params: { id: not_my_work }
-        expect(response.status).to eq 302
+        expect(response).to redirect_to(root_path)
         expect(flash[:alert]).to eq 'You are not authorized to access this page.'
       end
     end
@@ -44,7 +44,8 @@ RSpec.describe Hyrax::EmbargoesController do
     context 'when I do not have edit permissions for the object' do
       it 'denies access' do
         get :destroy, params: { id: not_my_work }
-        expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq 'You are not authorized to access this page.'
       end
     end
 

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -270,14 +270,16 @@ RSpec.describe Hyrax::FileSetsController do
     describe '#edit' do
       it 'requires login' do
         get :edit, params: { id: public_file_set }
-        expect(response).to fail_redirect_and_flash(main_app.new_user_session_path, 'You need to sign in or sign up before continuing.')
+        expect(response).to redirect_to(main_app.new_user_session_path)
+        expect(flash[:alert]).to eq 'You need to sign in or sign up before continuing.'
       end
     end
 
     describe '#show' do
       it 'denies access to private files' do
         get :show, params: { id: private_file_set }
-        expect(response).to fail_redirect_and_flash(main_app.new_user_session_path(locale: 'en'), 'You are not authorized to access this page.')
+        expect(response).to redirect_to(main_app.new_user_session_path(locale: 'en'))
+        expect(flash[:alert]).to eq 'You are not authorized to access this page.'
       end
 
       it 'allows access to public files' do

--- a/spec/controllers/hyrax/leases_controller_spec.rb
+++ b/spec/controllers/hyrax/leases_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::LeasesController do
     context 'when I do not have edit permissions for the object' do
       it 'redirects' do
         get :edit, params: { id: not_my_work }
-        expect(response.status).to eq 302
+        expect(response).to redirect_to(root_path)
         expect(flash[:alert]).to eq 'You are not authorized to access this page.'
       end
     end
@@ -43,7 +43,8 @@ RSpec.describe Hyrax::LeasesController do
     context 'when I do not have edit permissions for the object' do
       it 'denies access' do
         get :destroy, params: { id: not_my_work }
-        expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq 'You are not authorized to access this page.'
       end
     end
 

--- a/spec/support/matchers/response_matchers.rb
+++ b/spec/support/matchers/response_matchers.rb
@@ -1,7 +1,0 @@
-RSpec::Matchers.define :fail_redirect_and_flash do |path, flash_message|
-  match do |response|
-    expect(response.status).to eq 302
-    expect(response).to redirect_to(path)
-    expect(flash[:alert]).to eq flash_message
-  end
-end


### PR DESCRIPTION
This appears to fix the issue where the custom matcher `fail_redirect_and_flash` caused an infinite loop of calls to `flash` causing `stack level too deep` failures for the 4 tests which used it.