### PR TITLE
Use Blacklight 6.14+ to pick up Chinese translations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
-sudo: false
+# Workaround for https://github.com/travis-ci/travis-ci/issues/8836
+# sudo: false
+sudo: required
 dist: trusty
 
 addons:

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -32,7 +32,7 @@ SUMMARY
   spec.add_dependency 'active-fedora', '~> 11.5', '>= 11.5.2'
   spec.add_dependency 'almond-rails', '~> 0.1'
   spec.add_dependency 'awesome_nested_set', '~> 3.1'
-  spec.add_dependency 'blacklight', '~> 6.11', '>= 6.11.2'
+  spec.add_dependency 'blacklight', '~> 6.14'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
   spec.add_dependency 'browse-everything', '>= 0.10.5'


### PR DESCRIPTION
Follows #2460, in which the steps documented in https://github.com/samvera/hyrax/wiki/Translations-(internationalization)#update-translations were run, one of which removed Chinese translations for Blacklight (because they do not exist in English, the base language for Hyrax). We should avoid managing Blacklight translations in Hyrax, and now that someone has contributed a Chinese translation to Blacklight, we no longer need this in Hyrax.

Refs #2444 

Also, get the build working by adding a TravisCI workaround.

@samvera/hyrax-code-reviewers

  
  