### PR TITLE
Fix work show presenter spec

### DIFF
--- a/Valkyrie_README.md
+++ b/Valkyrie_README.md
@@ -23,7 +23,7 @@
 * Update config/initializers/riiif.rb
   * set `Riiif::Image.file_resolver = Hyrax::Riiif::ValkyrieFileResolver.new`
   * Remove the `Riiif::Image.file_resolver.id_to_uri = lambda do |id| ... end `
-
+* There have been changes to the solr document schema, so all documents will need to be reindexed
 
 ## TODO:
 
@@ -41,3 +41,5 @@
     * Write to PCDM (no migration at all)
   * WebAC
   * Presenters: Use Draper decorators?
+* Phase ?
+  * Finish removing direct dependency on Solr

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -52,6 +52,18 @@ module Hyrax
         end
       end
 
+      # How should we be doing this? Ex: There is already a conversion that happens if using the ORMConverter:
+      # https://github.com/samvera-labs/valkyrie/blob/82c2dac448ad57b5693ee218172b8e34ed07b19a/lib/valkyrie/persistence/solr/orm_converter.rb#L39
+      module Valkyrie
+        class Id
+          # @return [Id]
+          def self.coerce(input)
+            field = ::Array.wrap(input).first.to_s
+            field.blank? ? nil : field.sub(/^id-/, '')
+          end
+        end
+      end
+
       included do
         attribute :identifier, Solr::Array, solr_name('identifier')
         attribute :based_near, Solr::Array, solr_name('based_near')
@@ -64,7 +76,7 @@ module Hyrax
         attribute :collection_ids, Solr::Array, 'collection_ids_tesim'
         attribute :admin_set, Solr::Array, solr_name('admin_set')
         attribute :member_of_collection_ids, Solr::Array, solr_name('member_of_collection_ids', :symbol)
-        attribute :member_ids, Solr::Array, Valkyrie::Persistence::Solr::Queries::MEMBER_IDS
+        attribute :member_ids, Solr::Array, ::Valkyrie::Persistence::Solr::Queries::MEMBER_IDS
         attribute :description, Solr::Array, solr_name('description')
         attribute :title, Solr::Array, solr_name('title')
         attribute :contributor, Solr::Array, solr_name('contributor')
@@ -81,7 +93,7 @@ module Hyrax
         attribute :mime_type, Solr::String, solr_name('mime_type', :symbol)
         attribute :workflow_state, Solr::String, solr_name('workflow_state_name', :symbol)
         attribute :human_readable_type, Solr::String, solr_name('human_readable_type', :stored_searchable)
-        attribute :representative_id, Solr::String, solr_name('hasRelatedMediaFragment', :symbol)
+        attribute :representative_id, Valkyrie::Id, solr_name('representative_id', :symbol)
         attribute :thumbnail_id, Solr::String, solr_name('hasRelatedImage', :symbol)
         attribute :thumbnail_path, Solr::String, CatalogController.blacklight_config.index.thumbnail_field
         attribute :label, Solr::String, solr_name('label')

--- a/app/presenters/hyrax/composite_presenter_factory.rb
+++ b/app/presenters/hyrax/composite_presenter_factory.rb
@@ -12,7 +12,7 @@ module Hyrax
 
     def new(*args)
       obj = args.first
-      if file_set_ids.include?(obj.id)
+      if file_set_ids.include?(Valkyrie::ID.new(obj.id))
         file_set_presenter_class.new(*args)
       else
         work_presenter_class.new(*args)


### PR DESCRIPTION
- The solr doc no longer includes hasRelatedMediaFragment, is now representative_id. This id is a Valkyrie::ID, which has a prefix of "id-". Had to create a custom type that would remove the prefix since the rest of Hyrax doesn't expect this atm. Updated the readme to note this change in the schema will require reindexing once these changes are released.
- Several of the tests were broken because the CompositePresenterFactory was not creating a FileSetPresenter correctly. Was due to a type mismatch in the check for inclusion in file_set_ids.
- Not entirely sure if the "displays them in order" test is still valid. ordered_member_ids is no longer a method, now uses member_ids. I'm assuming the rest of hyrax still expects that to be ordered correctly, so updated to check the member_ids order.
- Updated the solr query tests to spy on the Solr::Client instance that the metadata adapter is using since it no longer uses ActiveFedora::SolrService.

@samvera/hyrax-code-reviewers
