### PR TITLE
Access FileSet's file nodes using use RDF::URIs instead of relations

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -6,17 +6,17 @@ module Hyrax
       attr_reader :file_set, :relation, :user
 
       # @param [FileSet] file_set the parent FileSet
-      # @param [Symbol, #to_sym] relation the type/use for the file
+      # @param [RDF::URI] relation the type/use for the file
       # @param [User] user the user to record as the Agent acting upon the file
       def initialize(file_set, relation, user)
         @file_set = file_set
-        @relation = relation.to_sym
+        @relation = relation
         @user = user
       end
 
       # Persists file as part of file_set and spawns async job to characterize and create derivatives.
       # @param [JobIoWrapper] io the file to save in the repository, with mime_type and original_name
-      # @return [CharacterizeJob, FalseClass] spawned job on success, false on failure
+      # @return [FileNode, FalseClass] the created file node on success, false on failure
       # @note Instead of calling this method, use IngestJob to avoid synchronous execution cost
       # @see IngestJob
       # @todo create a job to monitor the temp directory (or in a multi-worker system, directories!) to prune old files that have made it into the repo
@@ -26,23 +26,28 @@ module Hyrax
         persister = Valkyrie::MetadataAdapter.find(:indexing_persister).persister
         node_builder = Hyrax::FileNodeBuilder.new(storage_adapter: storage_adapter,
                                                   persister: persister)
-
-        node_builder.create(file: io.file, node: io.to_file_node, file_set: file_set)
-
-        repository_file = related_file
-        Hyrax::VersioningService.create(repository_file, user)
+        unsaved_node = io.to_file_node
+        unsaved_node.use = relation
+        begin
+          saved_node = node_builder.create(file: io.file, node: unsaved_node, file_set: file_set)
+        rescue StandardError # Handle error persisting file node
+          return false
+        end
+        Hyrax::VersioningService.create(saved_node, user)
+        saved_node
       end
 
       # Reverts file and spawns async job to characterize and create derivatives.
       # @param [String] revision_id
-      # @return [CharacterizeJob, FalseClass] spawned job on success, false on failure
+      # @return [FileNode, FalseClass] reverted file node on success, false on failure
       def revert_to(revision_id)
         persister = Valkyrie::MetadataAdapter.find(:indexing_persister).persister
         repository_file = related_file
         repository_file.restore_version(revision_id)
         return false unless persister.save(resource: file_set)
         Hyrax::VersioningService.create(repository_file, user)
-        CharacterizeJob.perform_later(file_set, repository_file.id)
+        CharacterizeJob.perform_later(repository_file.id.to_s)
+        repository_file
       end
 
       # @note FileSet comparison is limited to IDs, but this should be sufficient, given that
@@ -56,7 +61,7 @@ module Hyrax
 
         # @return [Hydra::PCDM::File] the file referenced by relation
         def related_file
-          file_set.public_send(relation) || raise("No #{relation} returned for FileSet #{file_set.id}")
+          file_set.member_by(use: relation) || raise("No #{relation} returned for FileSet #{file_set.id}")
         end
     end
   end

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -3,10 +3,10 @@ class CharacterizeJob < Hyrax::ApplicationJob
   delegate :query_service, to: :metadata_adapter
 
   # @param [String] id of the FileSet to characterize
-  def perform(file_set_id)
-    file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
+  def perform(file_node_id)
+    file_node = query_service.find_by(id: Valkyrie::ID.new(file_node_id))
     metadata_adapter.persister.buffer_into_index do |buffered_adapter|
-      Valkyrie::FileCharacterizationService.for(file_node: file_set, persister: buffered_adapter.persister).characterize
+      Valkyrie::FileCharacterizationService.for(file_node: file_node, persister: buffered_adapter.persister).characterize
     end
     # TODO: derivatives
     # CreateDerivativesJob.perform_later(file_set, file_id, filepath)

--- a/app/models/concerns/hyrax/file_set_behavior.rb
+++ b/app/models/concerns/hyrax/file_set_behavior.rb
@@ -33,9 +33,12 @@ module Hyrax
 
     # @return [Hyrax::FileNode] with use Valkyrie::Vocab::PCDMUse.OriginalFile
     def original_file
+      member_by(use: Valkyrie::Vocab::PCDMUse.OriginalFile)
+    end
+
+    def member_by(use:)
       return if member_ids.empty?
-      # TODO: we should be checking the use predicate here
-      Hyrax::Queries.find_by(id: Valkyrie::ID.new(member_ids.first))
+      Hyrax::Queries.find_members(resource: self, model: Hyrax::FileNode).find { |f| f.use.first == use }
     end
 
     def representative_id

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -29,7 +29,7 @@ class JobIoWrapper < ApplicationRecord
   #
   # @param [User] user - The user requesting to create this instance
   # @param [#path, Hyrax::UploadedFile] file - The file that is to be uploaded
-  # @param [String] relation
+  # @param [RDF::URI] relation
   # @param [FileSet] file_set - The associated file set
   # @return [JobIoWrapper]
   # @raise ActiveRecord::RecordInvalid - if the instance is not valid
@@ -61,7 +61,7 @@ class JobIoWrapper < ApplicationRecord
   end
 
   def file_actor
-    Hyrax::Actors::FileActor.new(file_set, relation.to_sym, user)
+    Hyrax::Actors::FileActor.new(file_set, RDF::URI.new(relation), user)
   end
 
   def ingest_file
@@ -107,6 +107,6 @@ class JobIoWrapper < ApplicationRecord
     end
 
     def static_defaults
-      self.relation ||= 'original_file'
+      self.relation ||= Valkyrie::Vocab::PCDMUse.OriginalFile.to_s
     end
 end

--- a/app/services/hyrax/file_node_builder.rb
+++ b/app/services/hyrax/file_node_builder.rb
@@ -20,8 +20,8 @@ module Hyrax
       node.file_identifiers = node.file_identifiers + [stored_file.id]
       saved_node = persister.save(resource: node)
       file_set.member_ids += [saved_node.id]
-      file_set = persister.save(resource: file_set)
-      CharacterizeJob.perform_later(file_set.id.to_s)
+      persister.save(resource: file_set)
+      CharacterizeJob.perform_later(saved_node.id.to_s)
       # note the returned saved_node does not yet contain the characterization done in the async job
       saved_node
     end

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -3,56 +3,45 @@ RSpec.describe Hyrax::Actors::FileActor do
   include Hyrax::FactoryHelpers
 
   let(:user)     { create(:user) }
-  let(:file_set) { create(:file_set) }
-  let(:relation) { :original_file }
+  let(:file_set) { create_for_repository(:file_set) }
+  let(:relation) { Valkyrie::Vocab::PCDMUse.OriginalFile }
   let(:actor)    { described_class.new(file_set, relation, user) }
   let(:fixture)  { fixture_file_upload('/world.png', 'image/png') }
-  let(:huf) { Hyrax::UploadedFile.new(user: user, file_set_uri: file_set.uri, file: fixture) }
-  let(:io) { JobIoWrapper.new(file_set_id: file_set.id, user: user, uploaded_file: huf) }
-  let(:pcdmfile) do
-    Hydra::PCDM::File.new.tap do |f|
-      f.content = File.open(fixture.path).read
-      f.original_name = fixture.original_filename
-      f.save!
-    end
+  let(:huf) { Hyrax::UploadedFile.new(user: user, file: fixture) }
+  let(:io) { JobIoWrapper.new(file_set_id: file_set.id, user: user, uploaded_file: huf, path: huf.uploader.path) }
+  let(:storage_adapter) { Valkyrie::StorageAdapter.find(:disk) }
+  let(:persister) { Valkyrie::MetadataAdapter.find(:indexing_persister).persister }
+  let(:file_node) do
+    node_builder = Hyrax::FileNodeBuilder.new(storage_adapter: storage_adapter, persister: persister)
+    node = Hyrax::FileNode.for(file: fixture)
+    node_builder.create(file: fixture, node: node, file_set: file_set)
   end
 
   context 'relation' do
-    let(:relation) { :remastered }
-    let(:file_set) do
-      FileSetWithExtras.create!(attributes_for(:file_set)) do |file|
-        file.apply_depositor_metadata(user.user_key)
-      end
-    end
+    let(:relation) { RDF::URI.new("http://pcdm.org/use#remastered") }
+    let(:file_set) { create_for_repository(:file_set) }
 
-    before do
-      class FileSetWithExtras < FileSet
-        directly_contains_one :remastered, through: :files, type: ::RDF::URI('http://pcdm.org/use#IntermediateFile'), class_name: 'Hydra::PCDM::File'
-      end
-    end
-    after do
-      Object.send(:remove_const, :FileSetWithExtras)
-    end
     it 'uses the relation from the actor' do
-      expect(CharacterizeJob).to receive(:perform_later).with(FileSetWithExtras, String, huf.uploader.path)
-      actor.ingest_file(io)
+      expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileNode, user)
+      expect(CharacterizeJob).to receive(:perform_later)
+      saved_node = actor.ingest_file(io)
       reloaded = Hyrax::Queries.find_by(id: file_set.id)
-      expect(reloaded.remastered.mime_type).to eq 'image/png'
+      expect(reloaded.member_by(use: relation).id).to eq saved_node.id
     end
   end
 
   it 'uses the provided mime_type' do
     allow(fixture).to receive(:content_type).and_return('image/gif')
-    expect(CharacterizeJob).to receive(:perform_later).with(FileSet, String, huf.uploader.path)
-    actor.ingest_file(io)
-    reloaded = Hyrax::Queries.find_by(id: file_set.id)
-    expect(reloaded.original_file.mime_type).to eq 'image/gif'
+    expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileNode, user)
+    expect(CharacterizeJob).to receive(:perform_later)
+    saved_node = actor.ingest_file(io)
+    expect(saved_node.mime_type).to eq ['image/gif']
   end
 
   context 'with two existing versions from different users' do
     let(:fixture2) { fixture_file_upload('/small_file.txt', 'text/plain') }
-    let(:huf2) { Hyrax::UploadedFile.new(user: user2, file_set_uri: file_set.uri, file: fixture2) }
-    let(:io2) { JobIoWrapper.new(file_set_id: file_set.id, user: user2, uploaded_file: huf2) }
+    let(:huf2) { Hyrax::UploadedFile.new(user: user2, file: fixture2) }
+    let(:io2) { JobIoWrapper.new(file_set_id: file_set.id, user: user2, uploaded_file: huf2, path: huf2.uploader.path) }
     let(:user2) { create(:user) }
     let(:actor2) { described_class.new(file_set, relation, user2) }
     let(:versions) do
@@ -61,7 +50,9 @@ RSpec.describe Hyrax::Actors::FileActor do
     end
 
     before do
-      allow(Hydra::Works::CharacterizationService).to receive(:run).with(any_args)
+      expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileNode, user)
+      expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileNode, user2)
+      expect(CharacterizeJob).to receive(:perform_later)
       actor.ingest_file(io)
       actor2.ingest_file(io2)
     end
@@ -81,48 +72,49 @@ RSpec.describe Hyrax::Actors::FileActor do
   end
 
   describe '#ingest_file' do
-    before do
-      expect(Hydra::Works::AddFileToFileSet).to receive(:call).with(file_set, io, relation, versioning: false)
-    end
     it 'when the file is available' do
-      allow(file_set).to receive(:save).and_return(true)
-      allow(file_set).to receive(relation).and_return(pcdmfile)
-      expect(Hyrax::VersioningService).to receive(:create).with(pcdmfile, user)
-      expect(CharacterizeJob).to receive(:perform_later).with(FileSet, pcdmfile.id, huf.uploader.path)
+      expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileNode, user)
+      expect(CharacterizeJob).to receive(:perform_later)
       actor.ingest_file(io)
+      reloaded = Hyrax::Queries.find_by(id: file_set.id)
+      expect(reloaded.member_by(use: relation)).not_to be_nil
     end
+    # rubocop:disable RSpec/AnyInstance
     it 'returns false when save fails' do
-      allow(file_set).to receive(:save).and_return(false)
+      expect(Hyrax::VersioningService).not_to receive(:create).with(Hyrax::FileNode, user)
+      expect(CharacterizeJob).not_to receive(:perform_later)
+      allow_any_instance_of(Hyrax::FileNodeBuilder).to receive(:create).and_raise(StandardError)
       expect(actor.ingest_file(io)).to be_falsey
     end
+    # rubocop:enable RSpec/AnyInstance
   end
 
   describe '#revert_to' do
     let(:revision_id) { 'asdf1234' }
 
     before do
-      allow(pcdmfile).to receive(:restore_version).with(revision_id)
-      allow(file_set).to receive(relation).and_return(pcdmfile)
-      expect(Hyrax::VersioningService).to receive(:create).with(pcdmfile, user)
-      expect(CharacterizeJob).to receive(:perform_later).with(file_set, pcdmfile.id)
+      allow(file_node).to receive(:restore_version).with(revision_id)
+      allow(file_set).to receive(:original_file).and_return(file_node)
+      allow(file_set).to receive(:member_by).with(use: relation).and_return(file_node)
+      expect(Hyrax::VersioningService).to receive(:create).with(file_node, user)
+      expect(CharacterizeJob).to receive(:perform_later).with(file_node.id.to_s)
     end
 
     it 'reverts to a previous version of a file' do
-      expect(file_set).not_to receive(:remastered)
-      expect(actor.relation).to eq(:original_file)
+      expect(actor.relation).to eq(relation)
       actor.revert_to(revision_id)
     end
 
     describe 'for a different relation' do
-      let(:relation) { :remastered }
+      let(:relation) { RDF::URI.new("http://pcdm.org/use#remastered") }
 
       it 'reverts to a previous version of a file' do
-        expect(actor.relation).to eq(:remastered)
+        expect(actor.relation).to eq(relation)
         actor.revert_to(revision_id)
       end
       it 'does not rely on the default relation' do
         pending "Hydra::Works::VirusCheck must support other relations: https://github.com/samvera/hyrax/issues/1187"
-        expect(actor.relation).to eq(:remastered)
+        expect(actor.relation).to eq(relation)
         expect(file_set).not_to receive(:original_file)
         actor.revert_to(revision_id)
       end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CharacterizeJob do
     end
 
     it "invokes Valkyrie::FileCharacterizationService" do
-      described_class.perform_now(file_set.id)
+      described_class.perform_now(file_id)
       # because once in the factory
       expect(char).to have_received(:characterize).twice
     end

--- a/spec/models/job_io_wrapper_spec.rb
+++ b/spec/models/job_io_wrapper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe JobIoWrapper, type: :model do
 
   describe '.create_with_wrapped_params!' do
     let(:local_file) { File.open(path) }
-    let(:relation) { :remastered }
+    let(:relation) { RDF::URI.new("http://pcdm.org/use#remastered") }
 
     subject { described_class.create_with_varied_file_handling!(user: user, file_set: file_set, file: file, relation: relation) }
 
@@ -114,12 +114,14 @@ RSpec.describe JobIoWrapper, type: :model do
   end
 
   describe '#relation' do
+    let(:remastered_relation) { RDF::URI.new("http://pcdm.org/use#remastered") }
+
     it 'has default value' do
-      expect(subject.relation).to eq('original_file')
+      expect(subject.relation).to eq(Valkyrie::Vocab::PCDMUse.OriginalFile.to_s)
     end
     it 'accepts new value' do
-      subject.relation = 'remastered'
-      expect(subject.relation).to eq('remastered')
+      subject.relation = remastered_relation
+      expect(subject.relation).to eq(remastered_relation.to_s)
     end
   end
 

--- a/spec/services/hyrax/tika_file_characterization_service_spec.rb
+++ b/spec/services/hyrax/tika_file_characterization_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Hyrax::TikaFileCharacterizationService do
   let(:query_service) { adapter.query_service }
   let(:file) { fixture_file_upload('/world.png', 'image/png') }
   let(:valid_file_set) { create_for_repository(:file_set, content: file) }
+  let(:file_node) { valid_file_set.original_file }
 
   before do
     output = '547c81b080eb2d7c09e363a670c46960ac15a6821033263867dd59a31376509c'
@@ -15,47 +16,43 @@ RSpec.describe Hyrax::TikaFileCharacterizationService do
   end
 
   it 'characterizes a sample file' do
-    described_class.new(file_node: valid_file_set, persister: persister).characterize
+    described_class.new(file_node: file_node, persister: persister).characterize
   end
 
   it 'sets the height attribute for a file_node on characterize ' do
-    valid_file_set.original_file.height = nil
-    new_file_set = described_class.new(file_node: valid_file_set, persister: persister).characterize
-    expect(new_file_set.original_file.height).not_to be_empty
+    file_node.height = nil
+    new_file_node = described_class.new(file_node: file_node, persister: persister).characterize
+    expect(new_file_node.height).not_to be_empty
   end
 
   it 'sets the width attribute for a file_node on characterize' do
-    t_file_set = valid_file_set
-    t_file_set.original_file.width = nil
-    new_file_node = described_class.new(file_node: t_file_set, persister: persister).characterize
-    expect(new_file_node.original_file.width).not_to be_empty
+    file_node.width = nil
+    new_file_node = described_class.new(file_node: file_node, persister: persister).characterize
+    expect(new_file_node.width).not_to be_empty
   end
 
   it 'saves to the persister by default on characterize' do
-    allow(persister).to receive(:save).and_return(valid_file_set)
-    described_class.new(file_node: valid_file_set, persister: persister).characterize
+    allow(persister).to receive(:save).and_return(file_node)
+    described_class.new(file_node: file_node, persister: persister).characterize
     expect(persister).to have_received(:save).exactly(2).times
   end
 
   it 'sets the mime_type for a file_node on characterize' do
-    t_file_set = valid_file_set
-    t_file_set.original_file.mime_type = nil
-    new_file_node = described_class.new(file_node: t_file_set, persister: persister).characterize
-    expect(new_file_node.original_file.mime_type).not_to be_empty
+    file_node.mime_type = nil
+    new_file_node = described_class.new(file_node: file_node, persister: persister).characterize
+    expect(new_file_node.mime_type).not_to be_empty
   end
 
   it 'sets the checksum for a file_node on characterize' do
-    t_file_set = valid_file_set
-    t_file_set.original_file.checksum = nil
-    new_file_node = described_class.new(file_node: t_file_set, persister: persister).characterize
-    checksum = new_file_node.original_file.checksum
-    expect(checksum.count).to eq 1
-    expect(checksum.first).to be_a Hyrax::MultiChecksum
+    file_node.checksum = nil
+    new_file_node = described_class.new(file_node: file_node, persister: persister).characterize
+    expect(new_file_node.checksum.count).to eq 1
+    expect(new_file_node.checksum.first).to be_a Hyrax::MultiChecksum
   end
 
   describe "#valid?" do
     it "returns true" do
-      expect(described_class.new(file_node: valid_file_set, persister: persister).valid?).to be true
+      expect(described_class.new(file_node: file_node, persister: persister).valid?).to be true
     end
   end
 end


### PR DESCRIPTION
This PR got kind of big but the focus of activity was on fixing `file_actor_spec.rb` and the main fix was changing/implementing the way file sets access their file nodes.  I went with the PCDM use value instead of the pre-valkyrie relations which don't really exist anymore.  The other major change is having characterization happen on a file node level instead of assuming and only operating on a file set's `original_file`.  I was unsure but also changed the return values of the file actor's methods to be the file node instead of the `CharacterizeJob` because the CharacterizeJob wasn't even being returned anymore and I found the file nodes more useful.