### PR TITLE
Actually attach files as file nodes using the file actor

### DIFF
--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -23,6 +23,8 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
       # actor.attach_to_work(work)
       work.member_ids += [file_set.id]
       uploaded_file.update(file_set_uri: file_set.to_global_id)
+      io = JobIoWrapper.create_with_varied_file_handling!(user: uploaded_file.user, file: uploaded_file, file_set: file_set, relation: Valkyrie::Vocab::PCDMUse.OriginalFile)
+      io.file_actor.ingest_file(io)
     end
     metadata_adapter.persister.save(resource: work)
   end


### PR DESCRIPTION
I had problems with the carrierwave double and couldn't figure out the best way to resolve it so I had to skip the calls to `ingest_file`.  I also unwrapped the tests that were inside the shared examples block because they weren't actually sharing any context and thus incorrectly passing.