### PR TITLE
Remove nested modal forms from collections edit

### DIFF
--- a/app/assets/javascripts/hyrax/collections_forms.js
+++ b/app/assets/javascripts/hyrax/collections_forms.js
@@ -1,5 +1,27 @@
 Blacklight.onLoad(function () {
 
+  // Post modal data via Ajax to avoid nesting <forms> in edit collections tabs screen
+  function submitModalAjax(url, data, $self) {
+    $.ajax({
+      type: 'POST',
+      url: url,
+      data: data
+    }).done(function(response) {
+      console.log('response', response);
+    }).fail(function(err) {
+      var alertNode = buildModalErrorAlert(err);
+      var $alert = $self.closest('.modal').find('.modal-ajax-alert');
+      $alert.html(alertNode);
+    });
+  }
+
+  // HTML for ajax error alert message, in case the AJAX request fails
+  function buildModalErrorAlert(err) {
+    var message = (err.responseText ? err.responseText : 'An unknown error has occurred');
+    var el = '<div class="alert alert-danger alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><span class="message">' + message + '</span></div>';
+    return el;
+  }
+
   // Remove from collection button clicked
   $('#collection-controls').find('.remove-from-collection-button').on('click', function (e) {
     e.preventDefault();
@@ -10,6 +32,35 @@ Blacklight.onLoad(function () {
   $('#collection-controls').find('.remove-sub-collection-button').on('click', function (e) {
     e.preventDefault();
     $('#collection-remove-sub-collection').modal('show');
+  });
+
+  // Add to collection modal form post
+  $('[id^="add-to-collection-modal-"]').find('.modal-add-button').on('click', function (e) {
+    var url = $(this).data('postUrl'),
+      parentId = $(this).closest('.modal').find('[name="parent_id"]').val(),
+      $self = $(this),
+      data = {
+      parent_id: parentId,
+      source: $(this).data('source')
+    };
+    if (url.length === 0) {
+      return;
+    }
+    submitModalAjax(url, data, $self);
+  });
+
+  // Add sub collection to collection form post
+  $('[id^="add-subcollection-modal-"]').find('.modal-add-button').on('click', function (e) {
+    var url = $(this).data('postUrl'),
+      childId = $(this).closest('.modal').find('[name="child_id"]').val(),
+      data = {
+      child_id: childId,
+      source: $(this).data('source')
+    };
+    if (url.length === 0) {
+      return;
+    }
+    submitModalAjax(url, data);
   });
 
 });

--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -133,6 +133,10 @@ button.branding-banner-remove:hover {
         text-align: left;
       }
     }
+
+    .modal {
+      text-align: left;
+    }
   }
 
   // Datatable overwrites
@@ -206,6 +210,13 @@ button.branding-banner-remove:hover {
 
     .collection-type-title {
       margin-top: 0;
+    }
+
+    // List of radio inputs in modal window
+    .radio-button-list {
+      h4 {
+        margin-top: 2px;
+      }
     }
   }
 }

--- a/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
@@ -17,9 +17,9 @@
                           <td><%= g.agent_type.titleize %></td>
                           <td>
                             <% if g.admin_group? %>
-                              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
+                              <%= link_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
                             <% else %>
-                              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger' %>
+                              <%= link_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger' %>
                             <% end %>
                           </td>
                         </tr>

--- a/app/views/hyrax/dashboard/collections/_modal_remove_from_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_modal_remove_from_collection.html.erb
@@ -1,7 +1,7 @@
 <div class="modal fade" id="collection-remove-from-collection" tabindex="-1" role="dialog">
   <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <form class="delete-collection-form">
+    <div class="modal-content adam">
+      <div class="delete-collection-form">
         <div class="modal-body">
           <p><%= t('hyrax.dashboard.collections.form_relationships.modals.remove_from_collection_description') %></p>
         </div>
@@ -9,7 +9,7 @@
           <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
           <button type="button" class="btn btn-danger"><%= t('helpers.action.remove') %></button>
         </div>
-      </form>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/hyrax/dashboard/collections/_modal_remove_sub_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_modal_remove_sub_collection.html.erb
@@ -1,7 +1,7 @@
 <div class="modal fade" id="collection-remove-sub-collection" tabindex="-1" role="dialog">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
-      <form class="delete-collection-form">
+      <div class="delete-collection-form">
         <div class="modal-body">
           <p><%= t('hyrax.dashboard.collections.form_relationships.modals.remove_from_sub_collection_description') %></p>
         </div>
@@ -9,7 +9,7 @@
           <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
           <button type="button" class="btn btn-danger"><%= t('helpers.action.remove') %></button>
         </div>
-      </form>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -44,14 +44,14 @@
 
   <td class="collection_type"><%= collection_presenter.collection_type_badge %></td>
 
-  <td class="text-center">
+  <td>
     <%= render_visibility_link(collection_presenter.solr_document) %>
   </td>
 
   <td><%=collection_presenter.total_viewable_items%></td>
 
-  <td class="text-center date"><%=collection_presenter.modified_date.try(:to_formatted_s, :standard) %> </td>
-  <td class="text-center">
+  <td class="date"><%=collection_presenter.modified_date.try(:to_formatted_s, :standard) %> </td>
+  <td>
     <% if collection_presenter.solr_document.admin_set? %>
       <%= render '/hyrax/my/admin_set_action_menu', admin_set_presenter: collection_presenter %>
       <%= render 'modal_delete_empty_admin_set', id: id %>
@@ -60,7 +60,7 @@
       <%= render 'hyrax/my/collection_action_menu', collection_presenter: collection_presenter %>
       <!-- Render delete modal -->
       <%= render 'modal_add_to_collection', id: id, source: "my" %>
-      <%= render 'modal_delete_collection', id: id %>      
+      <%= render 'modal_delete_collection', id: id %>
       <%= render 'modal_delete_empty_collection', id: id %>
     <% end %>
    </td>

--- a/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
@@ -2,27 +2,34 @@
 <% collection = Collection.find id %>
   <div class="modal-dialog" role="document">
     <div class="modal-content">
-      <%= form_tag(hyrax.dashboard_create_nest_collection_under_path(collection.id)) do %>
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>"><span aria-hidden="true">&times;</span></button>
-          <h2 class="modal-title" id="add-subcollection-label"><%= t('hyrax.collection.actions.nest_collections.modal_title') %></h2>
-        </div>
-        <div class="modal-body">
-          <label><%= t('hyrax.collection.actions.nest_collections.select_label') %></label>
-          <input type="hidden" name="source" value="<%= source %>"></input>
-          <select name="child_id">
-            <option value="none"><%= t("hyrax.dashboard.my.action.select") %></option>
-            <% colls = Hyrax::Collections::NestedCollectionQueryService.available_child_collections(parent: collection, scope: controller, limit_to_id: nil) %>
-            <% colls.each {|coll| %>
-              <option  value="<%= coll.id %>"><%= coll.title.first %></option>
-            <% } %>
-          </select>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
-          <input type="submit" class="btn btn-primary" value="<%= t('hyrax.collection.actions.nest_collections.button_label') %>">
-        </div>
-      <% end %>
+
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="add-subcollection-label"><%= t('hyrax.collection.actions.nest_collections.modal_title') %></h4>
+      </div>
+
+      <div class="modal-body">
+        <div class="modal-ajax-alert"></div>
+        <label><%= t('hyrax.collection.actions.nest_collections.select_label') %></label>
+        <input type="hidden" name="source" value="<%= source %>"></input>
+        <select name="child_id">
+          <option value="none"><%= t("hyrax.dashboard.my.action.select") %></option>
+          <% colls = Hyrax::Collections::NestedCollectionQueryService.available_child_collections(parent: collection, scope: controller, limit_to_id: nil) %>
+          <% colls.each {|coll| %>
+            <option  value="<%= coll.id %>"><%= coll.title.first %></option>
+          <% } %>
+        </select>
+      </div>
+
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
+        <button type="button" class="btn btn-primary modal-add-button"
+          data-post-url="<%= dashboard_create_nest_collection_under_path(collection.id) %>"
+          data-source="<%= source %>">
+          <%= t('hyrax.collection.actions.nest_collections.button_label') %>
+        </button>
+      </div>
+
     </div>
   </div>
 </div>

--- a/app/views/hyrax/my/collections/_modal_add_to_collection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_to_collection.html.erb
@@ -2,30 +2,36 @@
 <% collection = Collection.find id %>
   <div class="modal-dialog" role="document">
     <div class="modal-content">
-      <%= form_tag(hyrax.dashboard_create_nest_collection_within_path(collection.id)) do %>
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>"><span aria-hidden="true">&times;</span></button>
-          <h2 class="modal-title" id="add-to-collection-label"><%= t('hyrax.collection.actions.nested_subcollection.modal_title') %></h2>
+
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="add-to-collection-label"><%= t('hyrax.collection.actions.nested_subcollection.modal_title') %></h4>
+      </div>
+
+      <div class="modal-body">
+        <div class="modal-ajax-alert"></div>
+        <label><%= t('hyrax.collection.actions.nested_subcollection.select_label') %></label>
+        <input type="hidden" name="source" value="<%= source %>"></input>
+        <select name="parent_id">
+          <option value="none"><%= t("hyrax.dashboard.my.action.select") %></option>
+          <% colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: controller, limit_to_id: nil) %>
+          <% ids = collection.member_of_collection_ids %>
+          <% colls.each {|coll| %>
+               <% unless ids.include?(coll.id) %>
+                 <option  value="<%= coll.id %>"><%= coll.title.first %></option>
+               <% end %>
+          <% } %>
+        </select>
+      </div>
+
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
+        <button type="button" class="btn btn-primary modal-add-button"
+          data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(collection.id) %>"
+          data-source="<%= source %>">
+          <%= t('hyrax.collection.actions.nested_subcollection.button_label') %>
+        </button>
         </div>
-        <div class="modal-body">
-          <label><%= t('hyrax.collection.actions.nested_subcollection.select_label') %></label>
-          <input type="hidden" name="source" value="<%= source %>"></input>
-          <select name="parent_id">
-            <option value="none"><%= t("hyrax.dashboard.my.action.select") %></option>
-            <% colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: controller, limit_to_id: nil) %>
-            <% ids = collection.member_of_collection_ids %>
-            <% colls.each {|coll| %>
-                 <% unless ids.include?(coll.id) %>
-                   <option  value="<%= coll.id %>"><%= coll.title.first %></option>
-                 <% end %>
-            <% } %>
-          </select>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
-          <input type="submit" class="btn btn-primary" value="<%= t('hyrax.collection.actions.nested_subcollection.button_label') %>">
-        </div>
-      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/hyrax/my/collections/_modal_collection_types_to_create.html.erb
+++ b/app/views/hyrax/my/collections/_modal_collection_types_to_create.html.erb
@@ -5,26 +5,23 @@
 
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.collection_type_actions.close') %>"><span aria-hidden="true">&times;</span></button>
-          <h2 class="modal-title" id="select-collectiontype-label"><%= t('hyrax.dashboard.collection_type_actions.select_type_of_collection') %></h2>
+          <h4 class="modal-title" id="select-collectiontype-label"><%= t('hyrax.dashboard.collection_type_actions.select_type_of_collection') %></h4>
         </div>
 
         <div class="modal-body">
           <% @collection_type_list_presenter.each do |row_presenter| %>
-          <div class="select-collectiontype">
-            <label>
-              <input type="radio"
-              name="collection_type"
-              <% if row_presenter.admin_set? %>
-              data-path="<%= new_admin_admin_set_path %>"
-              <% else %>
-              data-path="<%= "#{new_dashboard_collection_path}&collection_type_id=#{row_presenter.id}" %>"
-              <% end %>>
-              <div class="select-collectiontype-label">
-                <div class="h3 collection-type-title"><%= row_presenter.title %></div>
+            <div class="radio radio-button-list">
+              <label>
+                <input type="radio" name="collection_type"
+                <% if row_presenter.admin_set? %>
+                  data-path="<%= new_admin_admin_set_path %>"
+                <% else %>
+                  data-path="<%= "#{new_dashboard_collection_path}&collection_type_id=#{row_presenter.id}" %>"
+                <% end %>>
+                <h4><%= row_presenter.title %></h4>
                 <p><%= row_presenter.description %></p>
-              </div>
-            </label>
-          </div>
+              </label>
+            </div>
           <% end %>
         </div>
 

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -620,12 +620,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
     context 'from dashboard -> collections action menu' do
       before do
-        # TODO: The following allow_any_instance_of statement avoids an error that occurs due to nesting of forms on the
-        #       collection edit form.  This line should be removed when Issue #2457 is complete.
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(ActiveRecord::Associations::CollectionProxy).to receive(:select).with(any_args).and_return([])
-        # rubocop:enable RSpec/AnyInstance
-
         sign_in user
         visit '/dashboard/my/collections'
       end


### PR DESCRIPTION
Fixes #2457 

This establishes a pattern for how to handle posting data via AJAX, within a previously nested form contained in a modal.
