### PR TITLE
Updating `samvera-nesting_indexer` gem to v1.0.0

### DIFF
--- a/config/initializers/samvera-nesting_indexer_initializer.rb
+++ b/config/initializers/samvera-nesting_indexer_initializer.rb
@@ -1,6 +1,6 @@
-# rubocop:disable Style/FileName
+# rubocop:disable Naming/FileName
 require 'samvera/nesting_indexer'
-# rubocop:enable Style/FileName
+# rubocop:enable Naming/FileName
 
 Samvera::NestingIndexer.configure do |config|
   # How many layers of nesting are allowed for collections

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -71,7 +71,7 @@ SUMMARY
   spec.add_dependency 'redis-namespace', '~> 1.5'
   spec.add_dependency 'redlock', '>= 0.1.2'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
-  spec.add_dependency 'samvera-nesting_indexer', '~> 0.8'
+  spec.add_dependency 'samvera-nesting_indexer', '~> 1.0'
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'


### PR DESCRIPTION
## Updating `samvera-nesting_indexer` gem to v1.0.0

46ed2719b2beb80619bc24d5f84fa23b5ec332ee

This change updates to `samvera-nesting_indexer` v1.0.0 and addresses
the breaking upstream change for that release. See
[v1.0.0 release notes][release_notes] for details.

The driver for this change is to begin indexing the
`deepest_nested_depth` of an object. This is a necessary attribute as
it helps provide guards to prevent users from nesting objects that
would result in a graph deeper than the maximum allowed depth.

This commit also includes two Rubocop appeasements:

1. Switching from "Style/FileName" to "Naming/FileName"
2. Temporarily disabling the "Lint/UnusedMethodArgument" check

For the first appeasement (e.g. "Naming/Filename"), this addresses and
cleans up an STDOUT warning written by Rubocop.

For the second appeasement (e.g. "Lint/UnusedMethodArgument"), this
addresses the implementation details and constraints of the
`it_behaves_like 'a Samvera::NestingIndexer::Adapter'` RSpec
declaration, of which Hyrax::Adapters::NestingIndexAdapter adhears to.

Related to #2221

[release_notes]:https://github.com/samvera-labs/samvera-nesting_indexer/releases/tag/v1.0.0
