### PR TITLE
Fix collection presenter spec

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -48,12 +48,12 @@ module Hyrax
     end
 
     def size
-      number_to_human_size(@solr_document['bytes_lts'])
+      number_to_human_size(@solr_document['bytes_lts']) || '0 Bytes'
     end
 
     def total_items
       solr = Valkyrie::MetadataAdapter.find(:index_solr).connection
-      results = solr.get('select', params: { q: "member_of_collection_ids_ssim:#{id}",
+      results = solr.get('select', params: { q: "member_of_collection_ids_ssim:id-#{id}",
                                              rows: 0,
                                              qt: 'standard' })
       results['response']['numFound'].to_i

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Hyrax::CollectionPresenter do
       let(:persister) { Valkyrie::MetadataAdapter.find(:indexing_persister).persister }
 
       before do
-        work.member_of_collection_ids << collection.id
+        work.member_of_collection_ids += [collection.id]
         persister.save(resource: work)
       end
 


### PR DESCRIPTION
- bytes_lts is no longer in the solr_document for collections. Not sure how this was used since it seems to always return 0 values. Added handling to return 0 Bytes when null
- Fixed the total_items solr query to find with 'id-' prefix, since this prefix is added for all Valkyrie ids

@samvera/hyrax-code-reviewers
