### PR TITLE
allow deposit user to create a new collection as a subcollection

### DIFF
--- a/app/controllers/hyrax/dashboard/nest_collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/nest_collections_controller.rb
@@ -45,21 +45,21 @@ module Hyrax
 
         def build_within_form
           child = Collection.find(params.fetch(:child_id))
-          authorize! :edit, child
+          authorize! :read, child
           parent = params.key?(:parent_id) ? Collection.find(params[:parent_id]) : nil
           form_class.new(child: child, parent: parent, context: self)
         end
 
         def build_under_form
           parent = Collection.find(params.fetch(:parent_id))
-          authorize! :edit, parent
+          authorize! :deposit, parent
           child = params.key?(:child_id) ? Collection.find(params[:child_id]) : nil
           form_class.new(child: child, parent: parent, context: self)
         end
 
         def build_create_collection_form
           parent = Collection.find(params.fetch(:parent_id))
-          authorize! :edit, parent
+          authorize! :deposit, parent
           form_class.new(child: nil, parent: parent, context: self)
         end
 

--- a/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
 
       before do
         controller.form_class = form_class_with_failed_save
-        allow(controller).to receive(:authorize!).with(:edit, child).and_return(true)
+        allow(controller).to receive(:authorize!).with(:read, child).and_return(true)
         allow(controller.form_class).to receive(:errors)
         allow(controller.form_class.errors).to receive(:full_messages).and_return(['huge mistake'])
       end
@@ -73,7 +73,7 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
 
       before do
         controller.form_class = form_class_with_successful_save
-        allow(controller).to receive(:authorize!).with(:edit, child).and_return(true)
+        allow(controller).to receive(:authorize!).with(:read, child).and_return(true)
       end
 
       it 'authorizes, flashes a notice, and redirects' do
@@ -111,7 +111,7 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
 
       before do
         controller.form_class = form_class_with_failed_validation
-        allow(controller).to receive(:authorize!).with(:edit, parent).and_return(true)
+        allow(controller).to receive(:authorize!).with(:deposit, parent).and_return(true)
         allow(controller.form_class).to receive(:errors)
         allow(controller.form_class.errors).to receive(:full_messages).and_return(['huge mistake'])
       end
@@ -140,7 +140,7 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
 
       before do
         controller.form_class = form_class_with_successful_validation
-        allow(controller).to receive(:authorize!).with(:edit, parent).and_return(true)
+        allow(controller).to receive(:authorize!).with(:deposit, parent).and_return(true)
       end
 
       it 'authorizes, flashes a notice, and redirects' do
@@ -177,7 +177,7 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
 
     before do
       controller.form_class = form_class_with_failed_save
-      allow(controller).to receive(:authorize!).with(:edit, parent).and_return(true)
+      allow(controller).to receive(:authorize!).with(:deposit, parent).and_return(true)
       allow(controller.form_class).to receive(:errors)
       allow(controller.form_class.errors).to receive(:full_messages).and_return(['huge mistake'])
     end
@@ -206,7 +206,7 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
 
     before do
       controller.form_class = form_class_with_successful_save
-      allow(controller).to receive(:authorize!).with(:edit, parent).and_return(true)
+      allow(controller).to receive(:authorize!).with(:deposit, parent).and_return(true)
     end
 
     it 'authorizes, flashes a notice, and redirects' do


### PR DESCRIPTION
Partial Fix for #2489

The access checks for whether a collection can be a parent or subcollection were too restrictive.  The expected access requirements are...
* require deposit access for parent collection
* require read access for sub-collection

@samvera/hyrax-code-reviewers
