### PR TITLE
Fix hyrax base show.json.jbuilder_spec.rb

### DIFF
--- a/spec/views/hyrax/base/show.json.jbuilder_spec.rb
+++ b/spec/views/hyrax/base/show.json.jbuilder_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'hyrax/base/show.json.jbuilder' do
 
   before do
     allow(curation_concern).to receive(:etag).and_return('W/"87f79d2244ded4239ad1f0e822c8429b1e72b66c"')
-    assign(:curation_concern, curation_concern)
+    assign(:resource, curation_concern)
     render
   end
 


### PR DESCRIPTION
- The jbuilder now expects @resource instead of @curation_concern, https://github.com/samvera/hyrax/commit/b4b2b5178a57cd741ea3cecdebab326652a3e46f

@samvera/hyrax-code-reviewers
