### PR TITLE
Updating samvera-nesting_indexer

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -71,7 +71,7 @@ SUMMARY
   spec.add_dependency 'redis-namespace', '~> 1.5'
   spec.add_dependency 'redlock', '>= 0.1.2'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
-  spec.add_dependency 'samvera-nesting_indexer', '~> 1.0'
+  spec.add_dependency 'samvera-nesting_indexer', '~> 1.0', '>= 1.0.1'
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'


### PR DESCRIPTION
## Updating samvera-nesting_indexer

670e1bf5e8352b1d9bc855ac899385adc3dd20f2

[Release v1.0.1][release] fixes
`Samvera::NestingIndexer::Documents::IndexDocument#deepest_nested_depth`
by splitting the pathnames on the delimiter.

[release]:https://github.com/samvera-labs/samvera-nesting_indexer/releases/tag/v1.0.1
