### PR TITLE
 show parent collections on collection show pages 

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -9,6 +9,7 @@ Metrics/ClassLength:
     - 'app/controllers/hyrax/file_sets_controller.rb'
     - 'app/forms/hyrax/forms/permission_template_form.rb'
     - 'app/presenters/hyrax/work_show_presenter.rb'
+    - 'app/presenters/hyrax/collection_presenter.rb'
     - 'app/services/hyrax/user_stat_importer.rb'
     - 'lib/generators/hyrax/templates/catalog_controller.rb'
     - 'lib/generators/hyrax/install_generator.rb'

--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -96,4 +96,16 @@ Blacklight.onLoad(function () {
       $('#collections-to-delete-deny-modal').modal('show');
     }
   });
+
+  $('#show-more-parent-collections').on('click', function () {
+    $(this).hide();
+    $("#more-parent-collections").show();
+    $("#show-less-parent-collections").show();
+  });
+
+  $('#show-less-parent-collections').on('click', function () {
+    $(this).hide();
+    $("#more-parent-collections").hide();
+    $("#show-more-parent-collections").show();
+  });
 });

--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -624,3 +624,14 @@ button.branding-banner-remove:hover {
   margin-left: 0.5em;
 
 }
+
+.more-parent-collections-block {
+  display: none;
+}
+
+.show-more-parent-collections-btn,
+.show-less-parent-collections-btn {
+  color: #8598b7;
+  font-size: 0.8em;
+  margin-left: 10px;
+}

--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -65,6 +65,7 @@ module Hyrax
       def query_collection_members
         member_works
         member_subcollections if collection.collection_type.nestable?
+        parent_collections if collection.collection_type.nestable?
       end
 
       # Instantiate the membership query service
@@ -76,6 +77,13 @@ module Hyrax
         @response = collection_member_service.available_member_works
         @member_docs = @response.documents
         @members_count = @response.total
+      end
+
+      def parent_collections
+        col = @collection
+        col = Collection.find(collection.id) if col.blank?
+        @parent_collections = col.member_of_collections
+        @parent_collection_count = @parent_collections.size
       end
 
       def member_subcollections

--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -80,10 +80,13 @@ module Hyrax
       end
 
       def parent_collections
-        col = @collection
-        col = Collection.find(collection.id) if col.blank?
-        @parent_collections = col.member_of_collections
+        @parent_collections = collection_object.member_of_collections
         @parent_collection_count = @parent_collections.size
+        collection.parent_collections = @parent_collections if action_name == 'show'
+      end
+
+      def collection_object
+        action_name == 'show' ? Collection.find(collection.id) : collection
       end
 
       def member_subcollections

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -428,6 +428,7 @@ module Hyrax
         def query_collection_members
           member_works
           member_subcollections if collection.collection_type.nestable?
+          parent_collections if collection.collection_type.nestable?
         end
 
         # Instantiate the membership query service
@@ -445,6 +446,13 @@ module Hyrax
           results = collection_member_service.available_member_subcollections
           @subcollection_docs = results.documents
           @subcollection_count = results.total
+        end
+
+        def parent_collections
+          col = @collection
+          col = Collection.find(collection.id) if col.blank?
+          @parent_collections = col.member_of_collections
+          @parent_collection_count = @parent_collections.size
         end
 
         # You can override this method if you need to provide additional

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -449,10 +449,13 @@ module Hyrax
         end
 
         def parent_collections
-          col = @collection
-          col = Collection.find(collection.id) if col.blank?
-          @parent_collections = col.member_of_collections
+          @parent_collections = collection_object.member_of_collections
           @parent_collection_count = @parent_collections.size
+          collection.parent_collections = @parent_collections if action_name == 'show'
+        end
+
+        def collection_object
+          action_name == 'show' ? Collection.find(collection.id) : collection
         end
 
         # You can override this method if you need to provide additional

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -4,7 +4,9 @@ module Hyrax
     include PresentsAttributes
     include ActionView::Helpers::NumberHelper
     attr_accessor :solr_document, :current_ability, :request
-    attr_writer :collection_type
+    attr_writer :collection_type, :parent_collections
+
+    NUM_PARENTS_TO_SHOW = 3
 
     class_attribute :create_work_presenter_class
     self.create_work_presenter_class = Hyrax::SelectTypeListPresenter
@@ -29,19 +31,16 @@ module Hyrax
     end
 
     # Metadata Methods
-    delegate :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language,
-             :embargo_release_date, :lease_expiration_date, :license, :date_created,
-             :resource_type, :based_near, :related_url, :identifier, :thumbnail_path,
-             :title_or_label, :collection_type_gid, :create_date, :modified_date, :visibility, :edit_groups,
-             :edit_people,
+    delegate :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language, :embargo_release_date,
+             :lease_expiration_date, :license, :date_created, :resource_type, :based_near, :related_url, :identifier, :thumbnail_path,
+             :title_or_label, :collection_type_gid, :create_date, :modified_date, :visibility, :edit_groups, :edit_people,
              to: :solr_document
 
     # Terms is the list of fields displayed by
     # app/views/collections/_show_descriptions.html.erb
     def self.terms
-      [:total_items, :size, :resource_type, :creator, :contributor, :keyword,
-       :license, :publisher, :date_created, :subject, :language, :identifier,
-       :based_near, :related_url]
+      [:total_items, :size, :resource_type, :creator, :contributor, :keyword, :license, :publisher, :date_created, :subject,
+       :language, :identifier, :based_near, :related_url]
     end
 
     def terms_with_values
@@ -81,6 +80,24 @@ module Hyrax
 
     def collection_type_badge
       collection_type.title
+    end
+
+    def parent_collection_count
+      @parent_collections.blank? ? 0 : @parent_collections.size
+    end
+
+    def more_parent_collections?
+      parent_collection_count > NUM_PARENTS_TO_SHOW
+    end
+
+    def visible_parent_collections
+      return @parent_collections[0..NUM_PARENTS_TO_SHOW - 1] if more_parent_collections?
+      @parent_collections || []
+    end
+
+    def more_parent_collections
+      return @parent_collections[NUM_PARENTS_TO_SHOW..parent_collection_count - 1] if more_parent_collections?
+      []
     end
 
     def user_can_nest_collection?

--- a/app/views/hyrax/collections/_show_parent_collections.html.erb
+++ b/app/views/hyrax/collections/_show_parent_collections.html.erb
@@ -1,14 +1,31 @@
-<% if @parent_collections.nil? || @parent_collections.empty? %>
+<% if presenter.parent_collection_count <= 0 %>
 		<div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_parent_collections') %></div>
 <% else %>
 		<div class="media-body">
 			<h4 class="media-heading">
-				<% @parent_collections.each do |document| %>
+				<div class="less-parent-collections-block" id="less-parent-collections">
+					<% presenter.visible_parent_collections.each do |document| %>
 						<ul>
 							<li>
 								<%= link_to document, [hyrax, document], id: "src_copy_link_#{document.id}" %>
 							</li>
 						</ul>
+					<% end %>
+					<% if presenter.more_parent_collections? %>
+							<button id="show-more-parent-collections" class="btn show-more-parent-collections-btn"><%= t("hyrax.collections.show.show_more_parent_collections") %></button>
+					<% end %>
+				</div>
+				<% if presenter.more_parent_collections? %>
+					<div class="more-parent-collections-block" id="more-parent-collections">
+						<% presenter.more_parent_collections.each do |document| %>
+							<ul>
+								<li>
+									<%= link_to document, [hyrax, document], id: "src_copy_link_#{document.id}" %>
+								</li>
+							</ul>
+							<button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
+						<% end %>
+					</div>
 				<% end %>
 			</h4>
 		</div>

--- a/app/views/hyrax/collections/_show_parent_collections.html.erb
+++ b/app/views/hyrax/collections/_show_parent_collections.html.erb
@@ -1,0 +1,15 @@
+<% if @parent_collections.nil? || @parent_collections.empty? %>
+		<div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_parent_collections') %></div>
+<% else %>
+		<div class="media-body">
+			<h4 class="media-heading">
+				<% @parent_collections.each do |document| %>
+						<ul>
+							<li>
+								<%= link_to document, [hyrax, document], id: "src_copy_link_#{document.id}" %>
+							</li>
+						</ul>
+				<% end %>
+			</h4>
+		</div>
+<% end %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -55,6 +55,22 @@
 	<div class="row hyc-body">
 		<div class="col-md-8 hyc-description">
 			<%= render 'collection_description', presenter: @presenter %>
+
+			<% if @presenter.collection_type_is_nestable? && @parent_collection_count > 0 %>
+					<div class="row hyc-blacklight hyc-bl-title">
+						<div class="col-md-12">
+							<h2>
+								<%= t('.parent_collection_header') %> (<%= @parent_collection_count %>)
+							</h2>
+						</div>
+					</div>
+					<div class="row hyc-blacklight hyc-bl-results">
+						<div class="col-md-12">
+							<%= render 'show_parent_collections', collection: @parent_collections %>
+						</div>
+					</div>
+			<% end %>
+
 		</div>
 		<div class="col-md-4 hyc-metadata">
 			<% unless has_collection_search_parameters? %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -56,18 +56,14 @@
 		<div class="col-md-8 hyc-description">
 			<%= render 'collection_description', presenter: @presenter %>
 
-			<% if @presenter.collection_type_is_nestable? && @parent_collection_count > 0 %>
-					<div class="row hyc-blacklight hyc-bl-title">
-						<div class="col-md-12">
-							<h2>
-								<%= t('.parent_collection_header') %> (<%= @parent_collection_count %>)
-							</h2>
-						</div>
+			<% if @presenter.collection_type_is_nestable? && @presenter.parent_collection_count > 0 %>
+					<div class="hyc-blacklight hyc-bl-title">
+						<h2>
+							<%= t('.parent_collection_header') %> (<%= @presenter.parent_collection_count %>)
+						</h2>
 					</div>
-					<div class="row hyc-blacklight hyc-bl-results">
-						<div class="col-md-12">
-							<%= render 'show_parent_collections', collection: @parent_collections %>
-						</div>
+					<div class="hyc-blacklight hyc-bl-results">
+						<%= render 'show_parent_collections', presenter: @presenter %>
 					</div>
 			<% end %>
 

--- a/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
@@ -1,0 +1,15 @@
+<% if @parent_collections.nil? || @parent_collections.empty? %>
+    <div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_parent_collections') %></div>
+<% else %>
+    <div class="media-body">
+      <h4 class="media-heading">
+        <% @parent_collections.each do |document| %>
+            <ul>
+              <li>
+                <%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
+              </li>
+            </ul>
+        <% end %>
+      </h4>
+    </div>
+<% end %>

--- a/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
@@ -1,15 +1,32 @@
-<% if @parent_collections.nil? || @parent_collections.empty? %>
-    <div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_parent_collections') %></div>
+<% if presenter.parent_collection_count <= 0 %>
+		<div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_parent_collections') %></div>
 <% else %>
-    <div class="media-body">
-      <h4 class="media-heading">
-        <% @parent_collections.each do |document| %>
-            <ul>
-              <li>
-                <%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
-              </li>
-            </ul>
-        <% end %>
-      </h4>
-    </div>
+		<div class="media-body">
+			<h4 class="media-heading">
+				<div class="less-parent-collections-block" id="less-parent-collections">
+					<% presenter.visible_parent_collections.each do |document| %>
+						<ul>
+							<li>
+								<%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
+							</li>
+						</ul>
+					<% end %>
+					<% if presenter.more_parent_collections? %>
+							<button id="show-more-parent-collections" class="btn show-more-parent-collections-btn"><%= t("hyrax.collections.show.show_more_parent_collections") %></button>
+					<% end %>
+				</div>
+				<% if presenter.more_parent_collections? %>
+					<div class="more-parent-collections-block" id="more-parent-collections">
+						<% presenter.more_parent_collections.each do |document| %>
+							<ul>
+								<li>
+									<%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
+								</li>
+							</ul>
+							<button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
+						<% end %>
+					</div>
+				<% end %>
+			</h4>
+		</div>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -19,8 +19,8 @@
           </div>
           <div class="col-sm-9 collection-description-wrapper">
             <!-- Parent Collection(s) -->
-            <% if @presenter.collection_type_is_nestable? %>
-                <h3><%= t('.parent_collection_header') %> (<%= @parent_collection_count %>)</h3>
+            <% if @presenter.collection_type_is_nestable? && @presenter.parent_collection_count > 0 %>
+                <h3><%= t('.parent_collection_header') %> (<%= @presenter.parent_collection_count %>)</h3>
                 <section class="parent-collections-wrapper">
                 <%= render 'hyrax/dashboard/collections/show_parent_collections', presenter: @presenter %>
               </section>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -17,8 +17,16 @@
               <%= render 'hyrax/collections/media_display', presenter: @presenter %>
               <%= link_to t('.public_view_label'), collection_path(id: @presenter.id) %>
           </div>
-          <!-- Collection Description(s) -->
           <div class="col-sm-9 collection-description-wrapper">
+            <!-- Parent Collection(s) -->
+            <% if @presenter.collection_type_is_nestable? %>
+                <h3><%= t('.parent_collection_header') %> (<%= @parent_collection_count %>)</h3>
+                <section class="parent-collections-wrapper">
+                <%= render 'hyrax/dashboard/collections/show_parent_collections', presenter: @presenter %>
+              </section>
+            <% end %>
+
+            <!-- Collection Description(s) -->
             <section>
               <%= render 'hyrax/collections/collection_description', presenter: @presenter %>
             </section>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -487,9 +487,11 @@ en:
         label: "Search Collection %{title}"
         placeholder: "Search subcollections and works in this collection"
       show:
-        works_in_collection: "Works"
-        subcollection_count: "Subcollections"
+        no_visible_parent_collections: "There are no visible parent collections."
         no_visible_subcollections: "There are no visible subcollections."
+        parent_collection_header: "Parent Collections"
+        subcollection_count: "Subcollections"
+        works_in_collection: "Works"
     collection_type:
       default_title: "User Collection"
       admin_set_title: "Admin Set"
@@ -626,6 +628,7 @@ en:
         show:
           header: "Collection"
           item_count: "Works"
+          parent_collection_header: "Parent Collections"
           public_view_label: "Public view of Collection"
           search_results: "Search Results within this Collection"
           subcollection_count: "Subcollections"
@@ -1109,7 +1112,7 @@ en:
     labels:
       collection:
         size:                      "Size"
-        total_items:               "Total works"
+        total_items:               "Total items"
       collection_type:
         allow_multiple_membership: "MULTIPLE MEMBERSHIP"
         assigns_workflow: "WORKFLOW"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -490,6 +490,8 @@ en:
         no_visible_parent_collections: "There are no visible parent collections."
         no_visible_subcollections: "There are no visible subcollections."
         parent_collection_header: "Parent Collections"
+        show_less_parent_collections: "...show less"
+        show_more_parent_collections: "show more..."
         subcollection_count: "Subcollections"
         works_in_collection: "Works"
     collection_type:
@@ -631,6 +633,8 @@ en:
           parent_collection_header: "Parent Collections"
           public_view_label: "Public view of Collection"
           search_results: "Search Results within this Collection"
+          show_less_parent_collections: "...show less"
+          show_more_parent_collections: "show more..."
           subcollection_count: "Subcollections"
       collection_type_actions:
         close:                        "Close"

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -274,6 +274,130 @@ RSpec.describe Hyrax::CollectionPresenter do
     it { is_expected.to eq '0 Bytes' }
   end
 
+  describe "#parent_collection_count" do
+    subject { presenter.parent_collection_count }
+
+    context('when parent_collections is nil') do
+      before do
+        allow(presenter).to receive(:parent_collections).and_return(nil)
+      end
+
+      it { is_expected.to eq 0 }
+    end
+
+    context('when parent_collections is has no collections') do
+      before do
+        allow(presenter).to receive(:parent_collections).and_return([])
+      end
+
+      it { is_expected.to eq 0 }
+    end
+
+    context('when parent_collections is has collections') do
+      let(:collection1) { build(:collection, title: ['col1']) }
+      let(:collection2) { build(:collection, title: ['col2']) }
+      let!(:parent_collections) { [collection1, collection2] }
+
+      before do
+        presenter.parent_collections = parent_collections
+      end
+
+      it { is_expected.to eq 2 }
+    end
+  end
+
+  describe "#more_parent_collections?" do
+    subject { presenter.more_parent_collections? }
+
+    context('when parent_collections is has no collections') do
+      before do
+        allow(presenter).to receive(:parent_collection_count).and_return(0)
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context('when parent_collections has less than or equal to show limit') do
+      before do
+        allow(presenter).to receive(:parent_collection_count).and_return(3)
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context('when parent_collections has more than show limit') do
+      before do
+        allow(presenter).to receive(:parent_collection_count).and_return(4)
+      end
+
+      it { is_expected.to eq true }
+    end
+  end
+
+  describe "#visible_parent_collections" do
+    subject { presenter.visible_parent_collections }
+
+    let(:collection1) { build(:collection, title: ['col1']) }
+    let(:collection2) { build(:collection, title: ['col2']) }
+    let(:collection3) { build(:collection, title: ['col3']) }
+    let(:collection4) { build(:collection, title: ['col4']) }
+    let(:collection5) { build(:collection, title: ['col5']) }
+
+    before do
+      presenter.parent_collections = parent_collections
+    end
+
+    context('when parent_collections is nil') do
+      let(:parent_collections) { nil }
+
+      it { is_expected.to eq [] }
+    end
+
+    context('when parent_collections has less than or equal to show limit') do
+      let(:parent_collections) { [collection1, collection2, collection3] }
+
+      it { is_expected.to include(collection1, collection2, collection3) }
+    end
+
+    context('when parent_collections has more than show limit') do
+      let(:parent_collections) { [collection1, collection2, collection3, collection4, collection5] }
+
+      it { is_expected.to include(collection1, collection2, collection3) }
+    end
+  end
+
+  describe "#more_parent_collections" do
+    subject { presenter.more_parent_collections }
+
+    let(:collection1) { build(:collection, title: ['col1']) }
+    let(:collection2) { build(:collection, title: ['col2']) }
+    let(:collection3) { build(:collection, title: ['col3']) }
+    let(:collection4) { build(:collection, title: ['col4']) }
+    let(:collection5) { build(:collection, title: ['col5']) }
+
+    before do
+      presenter.parent_collections = parent_collections
+    end
+
+    context('when parent_collections is nil') do
+      let(:parent_collections) { nil }
+
+      it { is_expected.to eq [] }
+    end
+
+    context('when parent_collections has less than or equal to show limit') do
+      let(:parent_collections) { [collection1, collection2, collection3] }
+
+      it { is_expected.to eq [] }
+    end
+
+    context('when parent_collections has more than show limit') do
+      let(:parent_collections) { [collection1, collection2, collection3, collection4, collection5] }
+
+      it { is_expected.to include(collection4, collection5) }
+    end
+  end
+
   describe "#user_can_nest_collection?" do
     before do
       allow(ability).to receive(:can?).with(:deposit, solr_doc).and_return(true)

--- a/spec/views/hyrax/collections/_show_descriptions.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_descriptions.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'hyrax/collections/_show_descriptions.html.erb', type: :view do
       render
       expect(rendered).to have_content 'Date Created'
       expect(rendered).to include('itemprop="dateCreated"')
-      expect(rendered).to have_content 'Total works'
+      expect(rendered).to have_content 'Total items'
       expect(rendered).to have_content '2'
       expect(rendered).to have_content 'Size'
       expect(rendered).to have_content '118 MB'

--- a/spec/views/hyrax/collections/_show_parent_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_parent_collections.html.erb_spec.rb
@@ -1,36 +1,68 @@
 RSpec.describe 'hyrax/collections/_show_parent_collections.html.erb', type: :view do
-  let(:collection) { build(:named_collection, id: '123') }
+  let(:collection_doc) do
+    {
+      id: '999',
+      "has_model_ssim" => ["Collection"],
+      "title_tesim" => ["Title 1"],
+      'date_created_tesim' => '2000-01-01'
+    }
+  end
+  let(:ability) { double }
+  let(:solr_document) { SolrDocument.new(collection_doc) }
+  let(:presenter) { Hyrax::CollectionPresenter.new(solr_document, ability) }
+  let(:collection1) { build(:collection, id: 'col1', title: ['col1']) }
+  let(:collection2) { build(:collection, id: 'col2', title: ['col2']) }
+  let(:collection3) { build(:collection, id: 'col3', title: ['col3']) }
+  let(:collection4) { build(:collection, id: 'col4', title: ['col4']) }
+  let(:collection5) { build(:collection, id: 'col5', title: ['col5']) }
+
+  before do
+    assign(:presenter, presenter)
+    presenter.parent_collections = parent_collections
+
+    allow(collection1).to receive(:persisted?).and_return true
+    allow(collection2).to receive(:persisted?).and_return true
+    allow(collection3).to receive(:persisted?).and_return true
+    allow(collection4).to receive(:persisted?).and_return true
+    allow(collection5).to receive(:persisted?).and_return true
+
+    render('show_parent_collections.html.erb', presenter: presenter)
+  end
 
   context 'when parent collection list is empty' do
-    let(:parentcollection) { nil }
-
-    before do
-      assign(:parent_collections, parentcollection)
-    end
+    let(:parent_collections) { nil }
 
     it "posts a warning message" do
-      render('show_parent_collections.html.erb', collection: parentcollection)
       expect(rendered).to have_text("There are no visible parent collections.")
     end
   end
 
   context 'when parent collection list is not empty' do
-    let(:parentcollection) { [collection] }
-
-    before do
-      assign(:parent_collections, parentcollection)
-      assign(:document, collection)
-      allow(collection).to receive(:title_or_label).and_return(collection.title)
-      allow(collection).to receive(:persisted?).and_return true
-      render('show_parent_collections.html.erb', collection: parentcollection)
-    end
+    let(:parent_collections) { [collection1, collection2, collection3] }
 
     it "posts the collection's title with a link to the collection" do
-      expect(rendered).to have_link(collection.title.first)
+      expect(rendered).to have_link(collection1.title.first, visible: true)
+      expect(rendered).to have_link(collection2.title.first, visible: true)
+      expect(rendered).to have_link(collection3.title.first, visible: true)
+      expect(rendered).not_to have_button('show more...')
     end
 
     xit 'includes a count of the parent collections' do
       # TODO: add test when actual count is added to page
+    end
+  end
+
+  context 'when parent collection list exceeds parents_to_show' do
+    let(:parent_collections) { [collection1, collection2, collection3, collection4, collection5] }
+
+    it "posts the collection's title with a link to the collection" do
+      expect(rendered).to have_link(collection1.title.first, visible: true)
+      expect(rendered).to have_link(collection2.title.first, visible: true)
+      expect(rendered).to have_link(collection3.title.first, visible: true)
+      expect(rendered).to have_link(collection4.title.first, visible: false)
+      expect(rendered).to have_link(collection5.title.first, visible: false)
+      expect(rendered).to have_button('show more...', visible: true)
+      expect(rendered).to have_button('...show less', visible: false)
     end
   end
 end

--- a/spec/views/hyrax/collections/_show_parent_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_parent_collections.html.erb_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe 'hyrax/collections/_show_parent_collections.html.erb', type: :view do
+  let(:collection) { build(:named_collection, id: '123') }
+
+  context 'when parent collection list is empty' do
+    let(:parentcollection) { nil }
+
+    before do
+      assign(:parent_collections, parentcollection)
+    end
+
+    it "posts a warning message" do
+      render('show_parent_collections.html.erb', collection: parentcollection)
+      expect(rendered).to have_text("There are no visible parent collections.")
+    end
+  end
+
+  context 'when parent collection list is not empty' do
+    let(:parentcollection) { [collection] }
+
+    before do
+      assign(:parent_collections, parentcollection)
+      assign(:document, collection)
+      allow(collection).to receive(:title_or_label).and_return(collection.title)
+      allow(collection).to receive(:persisted?).and_return true
+      render('show_parent_collections.html.erb', collection: parentcollection)
+    end
+
+    it "posts the collection's title with a link to the collection" do
+      expect(rendered).to have_link(collection.title.first)
+    end
+
+    xit 'includes a count of the parent collections' do
+      # TODO: add test when actual count is added to page
+    end
+  end
+end

--- a/spec/views/hyrax/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/show.html.erb_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'hyrax/collections/show.html.erb', type: :view do
     allow(presenter).to receive(:collection_type_is_nestable?).and_return(true)
     allow(presenter).to receive(:total_items).and_return(0)
     assign(:subcollection_count, 0)
+    assign(:parent_collection_count, 0)
     assign(:members_count, 0)
     allow(presenter).to receive(:banner_file).and_return("banner.gif")
     allow(presenter).to receive(:logo_record).and_return([{ linkurl: "logo link url", alttext: "logo alt text", file_location: "logo.gif" }])

--- a/spec/views/hyrax/dashboard/collections/_show_descriptions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_descriptions.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'hyrax/dashboard/collections/_show_descriptions.html.erb', type: 
       render
       expect(rendered).to have_content 'Date Created'
       expect(rendered).to include('itemprop="dateCreated"')
-      expect(rendered).to have_content 'Total works'
+      expect(rendered).to have_content 'Total items'
       expect(rendered).to have_content '2'
       expect(rendered).to have_content 'Size'
       expect(rendered).to have_content '118 MB'

--- a/spec/views/hyrax/dashboard/collections/_show_parent_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_parent_collections.html.erb_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe 'hyrax/dashboard/collections/_show_parent_collections.html.erb', type: :view do
+  let(:collection) { build(:named_collection, id: '123') }
+
+  context 'when parent collection list is empty' do
+    let(:parentcollection) { nil }
+
+    before do
+      assign(:parent_collections, parentcollection)
+    end
+
+    it "posts a warning message" do
+      render('show_parent_collections.html.erb', collection: parentcollection)
+      expect(rendered).to have_text("There are no visible parent collections.")
+    end
+  end
+
+  context 'when parent collection list is not empty' do
+    let(:parentcollection) { [collection] }
+
+    before do
+      assign(:parent_collections, parentcollection)
+      assign(:document, collection)
+      allow(collection).to receive(:title_or_label).and_return(collection.title)
+      allow(collection).to receive(:persisted?).and_return true
+      render('show_parent_collections.html.erb', collection: parentcollection)
+    end
+
+    it "posts the collection's title with a link to the collection" do
+      expect(rendered).to have_link(collection.title.first)
+    end
+
+    xit 'includes a count of the parent collections' do
+      # TODO: add test when actual count is added to page
+    end
+  end
+end

--- a/spec/views/hyrax/dashboard/collections/_show_parent_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_parent_collections.html.erb_spec.rb
@@ -1,36 +1,68 @@
 RSpec.describe 'hyrax/dashboard/collections/_show_parent_collections.html.erb', type: :view do
-  let(:collection) { build(:named_collection, id: '123') }
+  let(:collection_doc) do
+    {
+      id: '999',
+      "has_model_ssim" => ["Collection"],
+      "title_tesim" => ["Title 1"],
+      'date_created_tesim' => '2000-01-01'
+    }
+  end
+  let(:ability) { double }
+  let(:solr_document) { SolrDocument.new(collection_doc) }
+  let(:presenter) { Hyrax::CollectionPresenter.new(solr_document, ability) }
+  let(:collection1) { build(:collection, id: 'col1', title: ['col1']) }
+  let(:collection2) { build(:collection, id: 'col2', title: ['col2']) }
+  let(:collection3) { build(:collection, id: 'col3', title: ['col3']) }
+  let(:collection4) { build(:collection, id: 'col4', title: ['col4']) }
+  let(:collection5) { build(:collection, id: 'col5', title: ['col5']) }
+
+  before do
+    assign(:presenter, presenter)
+    presenter.parent_collections = parent_collections
+
+    allow(collection1).to receive(:persisted?).and_return true
+    allow(collection2).to receive(:persisted?).and_return true
+    allow(collection3).to receive(:persisted?).and_return true
+    allow(collection4).to receive(:persisted?).and_return true
+    allow(collection5).to receive(:persisted?).and_return true
+
+    render('show_parent_collections.html.erb', presenter: presenter)
+  end
 
   context 'when parent collection list is empty' do
-    let(:parentcollection) { nil }
-
-    before do
-      assign(:parent_collections, parentcollection)
-    end
+    let(:parent_collections) { nil }
 
     it "posts a warning message" do
-      render('show_parent_collections.html.erb', collection: parentcollection)
       expect(rendered).to have_text("There are no visible parent collections.")
     end
   end
 
   context 'when parent collection list is not empty' do
-    let(:parentcollection) { [collection] }
-
-    before do
-      assign(:parent_collections, parentcollection)
-      assign(:document, collection)
-      allow(collection).to receive(:title_or_label).and_return(collection.title)
-      allow(collection).to receive(:persisted?).and_return true
-      render('show_parent_collections.html.erb', collection: parentcollection)
-    end
+    let(:parent_collections) { [collection1, collection2, collection3] }
 
     it "posts the collection's title with a link to the collection" do
-      expect(rendered).to have_link(collection.title.first)
+      expect(rendered).to have_link(collection1.title.first, visible: true)
+      expect(rendered).to have_link(collection2.title.first, visible: true)
+      expect(rendered).to have_link(collection3.title.first, visible: true)
+      expect(rendered).not_to have_button('show more...')
     end
 
     xit 'includes a count of the parent collections' do
       # TODO: add test when actual count is added to page
+    end
+  end
+
+  context 'when parent collection list exceeds parents_to_show' do
+    let(:parent_collections) { [collection1, collection2, collection3, collection4, collection5] }
+
+    it "posts the collection's title with a link to the collection" do
+      expect(rendered).to have_link(collection1.title.first, visible: true)
+      expect(rendered).to have_link(collection2.title.first, visible: true)
+      expect(rendered).to have_link(collection3.title.first, visible: true)
+      expect(rendered).to have_link(collection4.title.first, visible: false)
+      expect(rendered).to have_link(collection5.title.first, visible: false)
+      expect(rendered).to have_button('show more...', visible: true)
+      expect(rendered).to have_button('...show less', visible: false)
     end
   end
 end

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     stub_template '_show_actions.html.erb' => '<div class="stubbed-actions">THE COLLECTION ACTIONS</div>'
     stub_template '_show_subcollection_actions.html.erb' => '<div class="stubbed-actions">THE SUBCOLLECTION ACTIONS</div>'
     stub_template '_show_add_items_actions.html.erb' => '<div class="stubbed-actions">THE ADD ITEMS ACTIONS</div>'
+    stub_template '_show_parent_collections.html.erb' => '<div class="stubbed-actions">THE PARENT COLLECTIONS LIST</div>'
     stub_template 'hyrax/collections/_paginate.html.erb' => 'paginate'
     stub_template 'hyrax/collections/_media_display.html.erb' => '<span class="fa fa-cubes collection-icon-search"></span>'
     stub_template 'hyrax/my/collections/_modal_add_to_collection.html.erb' => 'modal add as subcollection'


### PR DESCRIPTION
Partially Fixes #1699

Shows list of parent collections on the admin and public collection show pages.
* by default, show the first X parents based on the value of parents_to_show
* adds parents_to_show in presenter with a default value of 3
* uses javascript to show/hide parents beyond the first 3

@samvera/hyrax-code-reviewers
