### PR TITLE
Use Chrome with sandboxing disabled for feature specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
-# Workaround for https://github.com/travis-ci/travis-ci/issues/8836
-# sudo: false
-sudo: required
+sudo: false
 dist: trusty
 
 addons:
@@ -12,7 +10,7 @@ cache:
 before_install:
   - gem update --system
   - gem install bundler
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+  - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
 
 rvm:
   - 2.5.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,8 +62,21 @@ WebMock.disable_net_connect!(allow_localhost: true)
 require 'i18n/debug' if ENV['I18N_DEBUG']
 require 'byebug' unless ENV['TRAVIS']
 
+# @note In January 2018, TravisCI disabled Chrome sandboxing in its Linux
+#       container build environments to mitigate Meltdown/Spectre
+#       vulnerabilities, at which point Hyrax could no longer use the
+#       Capybara-provided :selenium_chrome_headless driver (which does not
+#       include the `--no-sandbox` argument).
+Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--disable-gpu'
+  browser_options.args << '--no-sandbox'
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+end
+
 Capybara.default_driver = :rack_test # This is a faster driver
-Capybara.javascript_driver = :selenium_chrome_headless # This is slower
+Capybara.javascript_driver = :selenium_chrome_headless_sandboxless # This is slower
 
 ApplicationJob.queue_adapter = :inline
 


### PR DESCRIPTION
Use Chrome with sandboxing disabled for feature specs

 * Switch back to `sudo: false` for TravisCI builds

Also, per travis-ci/travis-ci#8836 (comment):

* Use `--no-sandbox` option instead
* Create custom Capybara Javascript driver using the `no-sandbox` flag

@samvera/hyrax-code-reviewers
