### PR TITLE
Require pul_uv_rails outside of initializers block

### DIFF
--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -13,6 +13,7 @@ module Hyrax
     require 'qa'
     require 'clipboard/rails'
     require 'legato'
+    require 'pul_uv_rails'
 
     # Force these models to be added to Legato's registry in development mode
     config.eager_load_paths += %W[
@@ -51,7 +52,6 @@ module Hyrax
       require 'dry/struct'
       require 'dry/equalizer'
       require 'dry/validation'
-      require 'pul_uv_rails'
     end
 
     initializer 'routing' do


### PR DESCRIPTION
Else assets from the `pul_uv_rails` gem are not made available to downstream applications

@samvera/hyrax-code-reviewers
