### PR TITLE
Controller that adds members to a collection

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -51,15 +51,15 @@ module Hyrax
         # Adds the item to the ordered members so that it displays in the items
         # along side the FileSets on the show page
         def add(env, id)
-          member = Collection.find(id)
-          return unless env.current_ability.can?(:deposit, member)
-          env.curation_concern.member_of_collections << member
+          collection = Collection.find(id)
+          return unless env.current_ability.can?(:deposit, collection)
+          env.curation_concern.member_of_collections << collection
         end
 
         # Remove the object from the members set and the ordered members list
         def remove(curation_concern, id)
-          member = Collection.find(id)
-          curation_concern.member_of_collections.delete(member)
+          collection = Collection.find(id)
+          curation_concern.member_of_collections.delete(collection)
         end
 
         # Determines if a hash contains a truthy _destroy key.

--- a/app/controllers/hyrax/dashboard/collection_members_controller.rb
+++ b/app/controllers/hyrax/dashboard/collection_members_controller.rb
@@ -1,0 +1,65 @@
+module Hyrax
+  module Dashboard
+    ## Shows a list of all collections to the admins
+    class CollectionMembersController < Hyrax::My::CollectionsController
+      before_action :filter_docs_with_read_access!
+
+      include Hyrax::Collections::AcceptsBatches
+
+      def after_update
+        respond_to do |format|
+          format.html { redirect_to success_return_path, notice: t('hyrax.dashboard.my.action.collection_update_success') }
+          format.json { render json: @collection, status: :updated, location: dashboard_collection_path(@collection) }
+        end
+      end
+
+      def after_update_error(err_msg)
+        respond_to do |format|
+          format.html { redirect_to err_return_path, alert: err_msg }
+          format.json { render json: @collection.errors, status: :unprocessable_entity }
+        end
+      end
+
+      def update_members
+        err_msg = validate
+        after_update_error(err_msg) if err_msg.present?
+        return if err_msg.present?
+
+        collection.add_member_objects batch_ids
+        after_update
+      end
+
+      private
+
+        def validate
+          return t('hyrax.dashboard.my.action.members_no_access') if batch_ids.blank?
+          return t('hyrax.dashboard.my.action.collection_deny_add_members') unless current_ability.can?(:deposit, collection)
+          return t('hyrax.dashboard.my.action.add_to_collection_only') unless member_action == "add" # should never happen
+        end
+
+        def success_return_path
+          dashboard_collection_path(collection_id)
+        end
+
+        def err_return_path
+          dashboard_collections_path
+        end
+
+        def collection_id
+          params[:id]
+        end
+
+        def collection
+          Collection.find(collection_id)
+        end
+
+        def batch_ids
+          params[:batch_document_ids]
+        end
+
+        def member_action
+          params[:collection][:members]
+        end
+    end
+  end
+end

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -90,7 +90,7 @@ module Hyrax
         link_parent_collection(params[:parent_id]) unless params[:parent_id].nil?
         respond_to do |format|
           ActiveFedora::SolrService.instance.conn.commit
-          format.html { redirect_to edit_dashboard_collection_path(@collection), notice: "Collection was successfully created." }
+          format.html { redirect_to edit_dashboard_collection_path(@collection), notice: t('hyrax.dashboard.my.action.collection_create_success') }
           format.json { render json: @collection, status: :created, location: dashboard_collection_path(@collection) }
         end
       end
@@ -125,7 +125,7 @@ module Hyrax
 
       def after_update
         respond_to do |format|
-          format.html { redirect_to update_referer, notice: 'Collection was successfully updated.' }
+          format.html { redirect_to update_referer, notice: t('hyrax.dashboard.my.action.collection_update_success') }
           format.json { render json: @collection, status: :updated, location: dashboard_collection_path(@collection) }
         end
       end
@@ -163,7 +163,7 @@ module Hyrax
         respond_to do |format|
           format.html do
             redirect_to my_collections_path,
-                        notice: "Collection #{id} was successfully deleted"
+                        notice: t('hyrax.dashboard.my.action.collection_delete_success', id: id)
           end
           format.json { head :no_content, location: my_collections_path }
         end
@@ -172,7 +172,7 @@ module Hyrax
       def after_destroy_error(id)
         respond_to do |format|
           format.html do
-            flash[:notice] = "Collection #{id} could not be deleted"
+            flash[:notice] = t('hyrax.dashboard.my.action.collection_delete_fail', id: id)
             render :edit, status: :unprocessable_entity
           end
           format.json { render json: { id: id }, status: :unprocessable_entity, location: dashboard_collection_path(@collection) }

--- a/app/views/hyrax/dashboard/collections/_button_for_update_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_button_for_update_collection.html.erb
@@ -2,6 +2,6 @@
 <%# collection_id -- collection to be updated (use 'collection_replace_id' if you wish the form to be updated by a form value) %>
 <%# label -- button label %>
 <%= button_to label, hyrax.dashboard_collection_path(collection_id),
-              method: :put,
+              method: :post,
               class: "btn btn-primary submits-batches",
               data: { behavior: 'updates-collection' } %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -650,12 +650,18 @@ en:
       manage_proxies:           "Manage Proxies"
       my:
         action:
-          add_to_collection:        "Add to collection"
+          add_to_collection:       "Add to collection"
+          add_to_collection_only:  "Allowed actions are limited to adding members"
           admin_set_confirmation:  "Deleting an admin set from %{application_name} is permanent. Click OK to delete this admin set from %{application_name}, or Cancel to cancel this operation"
-          delete_admin_set_deny:   "This collection is defined as an %{type_name} and is not empty. To delete an %{type_name}, you must first remove (delete or move to another %{type_name} collection) all items from the %{type_name}."
+          collection_create_success: "Collection was successfully created."
+          collection_delete_fail:    "Collection %{id} could not be deleted"
+          collection_delete_success: "Collection %{id} was successfully deleted"
+          collection_deny_add_members: "You do not have sufficient privileges to add members to the collection"
+          collection_update_success: "Collection was successfully updated."
           collections_confirmation_html: "Deleting <span class='pluralized'>this collection</span> will permanently remove <span class='pluralized'>this collection</span> from the repository.  Items in <span class='pluralized'>this collection</span> will remain in the repository.  Are you sure you want to delete <span class='pluralized'>this collection</span>?"
           collections_confirmation_no_items_html: "Are you sure you want to delete this collection? This action cannot be undone."
           delete_admin_set:        "Delete collection" # use same term for admin sets and collections
+          delete_admin_set_deny:   "This collection is defined as an %{type_name} and is not empty. To delete an %{type_name}, you must first remove (delete or move to another %{type_name} collection) all items from the %{type_name}."
           delete_collection:       "Delete collection"
           delete_collections:      "Delete collections"
           delete_collection_deny:  "You do not have sufficient privileges to delete this document."
@@ -667,6 +673,7 @@ en:
           edit_selected:           "Edit Selected"
           edit_work:               "Edit Work"
           highlight:               "Highlight Work on Profile"
+          members_no_access: "You do not have sufficient privileges to any of the selected members"
           nesting_not_allowed:     "Collections of this type do not support nesting."
           nesting_permission_denied: "You do not have sufficient privileges to add this collection to another collection."
           select:                  "Select"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,7 @@ Hyrax::Engine.routes.draw do
         put :remove_member
       end
     end
+    post 'collections/:id', controller: 'collection_members', action: :update_members
     post 'collections/:child_id/within', controller: 'nest_collections', action: 'create_relationship_within', as: 'create_nest_collection_within'
     get 'collections/:parent_id/under', controller: 'nest_collections', action: 'create_collection_under', as: 'create_subcollection_under'
     post 'collections/:parent_id/under', controller: 'nest_collections', action: 'create_relationship_under', as: 'create_nest_collection_under'

--- a/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
@@ -1,0 +1,408 @@
+RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
+  routes { Hyrax::Engine.routes }
+  let(:user)  { create(:user) }
+  let(:other) { build(:user) }
+
+  let(:work_1_own) { create(:work, id: 'work-1-own', title: ['First of the Assets'], user: user) }
+  let(:work_2_own) { create(:work, id: 'work-2-own', title: ['Second of the Assets'], user: user) }
+  let(:work_3_own) { create(:work, id: 'work-3-own', title: ['Third of the Assets'], user: user) }
+  let(:work_4_edit) { create(:work, id: 'work-4-edit', title: ["Other's work with edit access"], user: other, edit_users: [user]) }
+  let(:work_5_read) { create(:work, id: 'work-5-read', title: ["Other's work with read access"], user: other, read_users: [user]) }
+  let(:work_6_noaccess) { create(:work, id: 'work-6-no_access', title: ["Other's work with no access"], user: other) }
+
+  let(:coll_1_own) { create(:private_collection, id: 'col-1-own', title: ['User created'], user: user, create_access: true) }
+  let(:coll_2_mgr) do
+    create(:private_collection, id: 'col-2-mgr', title: ['User has manage access'], user: other,
+                                with_permission_template: { manage_users: [user] }, create_access: true)
+  end
+  let(:coll_3_dep) do
+    create(:private_collection, id: 'col-3-dep', title: ['User has deposit access'], user: other,
+                                with_permission_template: { deposit_users: [user] }, create_access: true)
+  end
+  let(:coll_4_view) do
+    create(:private_collection, id: 'col-4-dep', title: ['User has view access'], user: other,
+                                with_permission_template: { view_users: [user] }, create_access: true)
+  end
+  let(:coll_5_noaccess) { create(:private_collection, id: 'col-5-no_access', title: ['Other user created'], user: other, create_access: true) }
+
+  describe '#update_members' do
+    context 'when user created the collection' do
+      before do
+        sign_in user
+        [work_1_own, work_2_own].each do |asset|
+          asset.member_of_collections << coll_1_own
+          asset.save!
+        end
+      end
+
+      context 'and user created the work' do
+        it 'adds members to the collection' do
+          expect do
+            post :update_members, params: { id: coll_1_own,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_3_own.id] }
+          end.to change { coll_1_own.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_1_own, locale: 'en')
+          expect(coll_1_own.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
+        end
+      end
+
+      context 'and user has edit access to works' do
+        it 'adds members to the collection' do
+          expect do
+            post :update_members, params: { id: coll_1_own,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_4_edit.id] }
+          end.to change { coll_1_own.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_1_own, locale: 'en')
+          expect(coll_1_own.member_objects).to match_array [work_1_own, work_2_own, work_4_edit]
+        end
+      end
+
+      context 'and user has read access to works' do
+        it 'adds members to the collection' do
+          expect do
+            post :update_members, params: { id: coll_1_own,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_5_read.id] }
+          end.to change { coll_1_own.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_1_own, locale: 'en')
+          expect(coll_1_own.member_objects).to match_array [work_1_own, work_2_own, work_5_read]
+        end
+      end
+
+      context 'and user has no access to a work' do
+        it 'adds only members with read access' do
+          expect do
+            post :update_members, params: { id: coll_1_own,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_3_own.id, work_6_noaccess.id] }
+          end.to change { coll_1_own.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_1_own, locale: 'en')
+          expect(coll_1_own.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
+        end
+
+        it 'displays error message if none of the members have read access' do
+          expect do
+            post :update_members, params: { id: coll_1_own,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_6_noaccess.id] }
+          end.to change { coll_1_own.reload.member_objects.size }.by(0)
+          expect(flash[:alert]).to eq 'You do not have sufficient privileges to any of the selected members'
+          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
+          expect(coll_1_own.member_objects).to match_array [work_1_own, work_2_own]
+        end
+      end
+
+      context 'and user adds a subcollection' do
+        let(:parent_collection) { create(:private_collection, id: 'pcol', title: ['User created another'], user: user, create_access: true) }
+
+        it 'adds collection user created' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_1_own.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_1_own]
+        end
+
+        it 'adds collection with manage access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_2_mgr.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_2_mgr]
+        end
+
+        it 'adds collection with deposit access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_3_dep.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_3_dep]
+        end
+
+        it 'adds collection with view access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_4_view.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_4_view]
+        end
+
+        it 'displays error message for collection with no access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_5_noaccess.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(0)
+          expect(flash[:alert]).to eq 'You do not have sufficient privileges to any of the selected members'
+          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
+          expect(parent_collection.member_objects).to match_array []
+        end
+      end
+    end
+
+    context 'when user is manager of the collection' do
+      before do
+        sign_in user
+        [work_1_own, work_2_own].each do |asset|
+          asset.member_of_collections << coll_2_mgr
+          asset.save!
+        end
+      end
+
+      context 'and user created the work' do
+        it 'adds members to the collection' do
+          expect do
+            post :update_members, params: { id: coll_2_mgr,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_3_own.id] }
+          end.to change { coll_2_mgr.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_2_mgr, locale: 'en')
+          expect(coll_2_mgr.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
+        end
+      end
+
+      context 'and user has edit access to works' do
+        it 'adds members to the collection' do
+          expect do
+            post :update_members, params: { id: coll_2_mgr,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_4_edit.id] }
+          end.to change { coll_2_mgr.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_2_mgr, locale: 'en')
+          expect(coll_2_mgr.member_objects).to match_array [work_1_own, work_2_own, work_4_edit]
+        end
+      end
+
+      context 'and user has read access to works' do
+        it 'adds members to the collection' do
+          expect do
+            post :update_members, params: { id: coll_2_mgr,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_5_read.id] }
+          end.to change { coll_2_mgr.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_2_mgr, locale: 'en')
+          expect(coll_2_mgr.member_objects).to match_array [work_1_own, work_2_own, work_5_read]
+        end
+      end
+
+      context 'and user has no access to a work' do
+        it 'adds only members with read access' do
+          expect do
+            post :update_members, params: { id: coll_2_mgr,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_3_own.id, work_6_noaccess.id] }
+          end.to change { coll_2_mgr.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_2_mgr, locale: 'en')
+          expect(coll_2_mgr.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
+        end
+      end
+
+      context 'and user adds a subcollection' do
+        let(:parent_collection) do
+          create(:private_collection, id: 'pcol-mgr', title: ['User has manage access to another'], user: other,
+                                      with_permission_template: { manage_users: [user] }, create_access: true)
+        end
+
+        it 'adds collection user created' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_1_own.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_1_own]
+        end
+
+        it 'adds collection with manage access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_2_mgr.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_2_mgr]
+        end
+
+        it 'adds collection with deposit access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_3_dep.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_3_dep]
+        end
+
+        it 'adds collection with view access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_4_view.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_4_view]
+        end
+
+        it 'displays error message for collection with no access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_5_noaccess.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(0)
+          expect(flash[:alert]).to eq 'You do not have sufficient privileges to any of the selected members'
+          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
+          expect(parent_collection.member_objects).to match_array []
+        end
+      end
+    end
+
+    context 'when user is depositor of the collection' do
+      before do
+        sign_in user
+        [work_1_own, work_2_own].each do |asset|
+          asset.member_of_collections << coll_3_dep
+          asset.save!
+        end
+      end
+
+      context 'and user created the work' do
+        it 'adds members to the collection' do
+          expect do
+            post :update_members, params: { id: coll_3_dep,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_3_own.id] }
+          end.to change { coll_3_dep.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_3_dep, locale: 'en')
+          expect(coll_3_dep.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
+        end
+      end
+
+      context 'and user has edit access to works' do
+        it 'adds members to the collection' do
+          expect do
+            post :update_members, params: { id: coll_3_dep,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_4_edit.id] }
+          end.to change { coll_3_dep.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_3_dep, locale: 'en')
+          expect(coll_3_dep.member_objects).to match_array [work_1_own, work_2_own, work_4_edit]
+        end
+      end
+
+      context 'and user has read access to works' do
+        it 'adds members to the collection' do
+          expect do
+            post :update_members, params: { id: coll_3_dep,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_5_read.id] }
+          end.to change { coll_3_dep.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_3_dep, locale: 'en')
+          expect(coll_3_dep.member_objects).to match_array [work_1_own, work_2_own, work_5_read]
+        end
+      end
+
+      context 'and user has no access to a work' do
+        it 'adds only members with read access' do
+          expect do
+            post :update_members, params: { id: coll_3_dep,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_3_own.id, work_6_noaccess.id] }
+          end.to change { coll_3_dep.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_3_dep, locale: 'en')
+          expect(coll_3_dep.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
+        end
+      end
+
+      context 'and user adds a subcollection' do
+        let(:parent_collection) do
+          create(:private_collection, id: 'pcol-dep', title: ['User has deposit access to another'], user: other,
+                                      with_permission_template: { deposit_users: [user] }, create_access: true)
+        end
+
+        it 'adds collection user created' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_1_own.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_1_own]
+        end
+
+        it 'adds collection with manage access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_2_mgr.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_2_mgr]
+        end
+
+        it 'adds collection with deposit access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_3_dep.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_3_dep]
+        end
+
+        it 'adds collection with view access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_4_view.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(1)
+          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
+          expect(parent_collection.member_objects).to match_array [coll_4_view]
+        end
+
+        it 'displays error message for collection with no access' do
+          expect do
+            post :update_members, params: { id: parent_collection,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [coll_5_noaccess.id] }
+          end.to change { parent_collection.reload.member_objects.size }.by(0)
+          expect(flash[:alert]).to eq 'You do not have sufficient privileges to any of the selected members'
+          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
+          expect(parent_collection.member_objects).to match_array []
+        end
+      end
+    end
+
+    context 'when user is viewer of the collection' do
+      before do
+        sign_in user
+        [work_1_own, work_2_own].each do |asset|
+          asset.member_of_collections << coll_4_view
+          asset.save!
+        end
+      end
+
+      context 'and user created the work' do
+        it "displays error message if user can't deposit to collection" do
+          expect do
+            post :update_members, params: { id: coll_4_view,
+                                            collection: { members: 'add' },
+                                            batch_document_ids: [work_3_own.id] }
+          end.to change { coll_4_view.reload.member_objects.size }.by(0)
+          expect(flash[:alert]).to eq 'You do not have sufficient privileges to add members to the collection'
+          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
+          expect(coll_4_view.member_objects).to match_array [work_1_own, work_2_own]
+        end
+      end
+    end
+  end
+end

--- a/spec/routing/dashboard_routes_spec.rb
+++ b/spec/routing/dashboard_routes_spec.rb
@@ -12,4 +12,8 @@ RSpec.describe 'Dashboard Routes', type: :routing do
   it 'routes POST /dashboard/collections/:child_id/within' do
     expect(post: '/dashboard/collections/child1/within').to route_to(controller: 'hyrax/dashboard/nest_collections', action: 'create_relationship_within', child_id: 'child1')
   end
+
+  it 'routes POST /dashboard/collections/:id' do
+    expect(post: '/dashboard/collections/id').to route_to(controller: 'hyrax/dashboard/collection_members', action: 'update_members', id: 'id')
+  end
 end


### PR DESCRIPTION

Partially Fixes #2489

This allows members to be added to a collection from Dashboard -> Works -> batch Add Collection -> select a collection with deposit access.  You cannot use the regular controller for Dashboard -> Collections -> edit collection because it enforces edit access on the collection, as it should.  To be able to add a member, the user only needs deposit access.  The update member controller enforces read access on the members and deposit access on the collection.

@samvera/hyrax-code-reviewers
