### PR TITLE
Don't reference errors on the import failure service

### DIFF
--- a/app/services/hyrax/import_url_failure_service.rb
+++ b/app/services/hyrax/import_url_failure_service.rb
@@ -1,7 +1,7 @@
 module Hyrax
   class ImportUrlFailureService < AbstractMessageService
     def message
-      file_set.errors.full_messages.join(', ')
+      "There was a problem importing from #{file_set.import_url}"
     end
 
     def subject

--- a/spec/services/hyrax/import_url_failure_service_spec.rb
+++ b/spec/services/hyrax/import_url_failure_service_spec.rb
@@ -2,17 +2,13 @@
 RSpec.describe Hyrax::ImportUrlFailureService do
   let!(:depositor) { create(:user) }
   let(:inbox) { depositor.mailbox.inbox }
-  let(:file) do
-    create_for_repository(:file_set, user: depositor)
-  end
-
-  before do
-    allow(file.errors).to receive(:full_messages).and_return(['huge mistake'])
+  let(:file_set) do
+    create_for_repository(:file_set, user: depositor, import_url: 'http://example.com/image.png')
   end
 
   describe "#call" do
     before do
-      described_class.new(file, depositor).call
+      described_class.new(file_set, depositor).call
     end
 
     it "sends failing mail" do


### PR DESCRIPTION
Validations are no longer on the model instance
