### PR TITLE
Reinstate `:member_of_collection_id` argument option to Actor Stack

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -12,28 +12,29 @@ module Hyrax
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if create was successful
       def create(env)
-        attributes_collection = env.attributes.delete(:member_of_collections_attributes)
-        assign_nested_attributes_for_collection(env, attributes_collection) &&
-          next_actor.create(env)
+        assign_nested_attributes_for_collection(env) && next_actor.create(env)
       end
 
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if update was successful
       def update(env)
-        attributes_collection = env.attributes.delete(:member_of_collections_attributes)
-        assign_nested_attributes_for_collection(env, attributes_collection) &&
-          next_actor.update(env)
+        assign_nested_attributes_for_collection(env) && next_actor.update(env)
       end
 
       private
 
+        ##
         # Attaches any unattached members.  Deletes those that are marked _delete
         # @param [Hash<Hash>] a collection of members
-        def assign_nested_attributes_for_collection(env, attributes_collection)
-          return true unless attributes_collection
+        # rubocop:disable Metrics/MethodLength
+        def assign_nested_attributes_for_collection(env)
+          attributes_collection ||= env.attributes.delete(:member_of_collections_attributes)
+          return assign_for_collection_ids(env) unless attributes_collection
+
+          emit_deprecation if env.attributes.delete(:member_of_collection_ids)
+
           attributes_collection = attributes_collection.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes }
-          # checking for existing works to avoid rewriting/loading works that are
-          # already attached
+          # checking for existing works to avoid rewriting/loading works that are already attached
           existing_collections = env.curation_concern.member_of_collection_ids
           attributes_collection.each do |attributes|
             next if attributes['id'].blank?
@@ -43,6 +44,45 @@ module Hyrax
               add(env, attributes['id'])
             end
           end
+
+          true
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        ##
+        # @deprecated supports old :member_of_collection_ids arguments
+        def emit_deprecation
+          Deprecation.warn(self, ':member_of_collections_attributes and :member_of_collection_ids were both ' \
+                                 ' passed. :member_of_collection_ids is ignored when both are passed and is ' \
+                                 'deprecated for removal in Hyrax 3.0.')
+        end
+
+        ##
+        # @deprecated supports old :member_of_collection_ids arguments
+        def assign_for_collection_ids(env)
+          collection_ids = env.attributes.delete(:member_of_collection_ids)
+
+          if collection_ids
+            Deprecation.warn(self, ':member_of_collection_ids has been deprecated for removal in Hyrax 3.0. ' \
+                                   'use :member_of_collections_attributes instead.')
+
+            other_collections = collections_without_edit_access(env)
+
+            collections = ::Collection.find(collection_ids)
+            raise "Tried to assign collections with ids: #{collection_ids}, but none were found" unless
+              collections
+
+            env.curation_concern.member_of_collections = collections
+            env.curation_concern.member_of_collections.concat(other_collections)
+          end
+
+          true
+        end
+
+        ##
+        # @deprecated supports old :member_of_collection_ids arguments
+        def collections_without_edit_access(env)
+          env.curation_concern.member_of_collections.select { |coll| env.current_ability.cannot?(:edit, coll) }
         end
 
         # Adds the item to the ordered members so that it displays in the items

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -80,5 +80,51 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
         expect(curation_concern.member_of_collections).to match_array [collection, other_collection]
       end
     end
+
+    context 'when passing `member_of_collection_ids`' do
+      let(:attributes) { { member_of_collection_ids: [collection.id], title: ['test'] } }
+
+      it 'adds it to the collection' do
+        skip 'this behavior past its deprecation sunset time and can be removed' if
+          Hyrax::VERSION.split('.').first.to_i >= 3
+
+        expect(subject.create(env)).to be true
+        expect(collection.reload.member_objects).to eq [curation_concern]
+      end
+
+      context "when work is in user's own collection" do
+        let(:attributes) { { member_of_collection_ids: [] } }
+
+        it "removes the work from that collection" do
+          skip 'this behavior past its deprecation sunset time and can be removed' if
+            Hyrax::VERSION.split('.').first.to_i >= 3
+
+          expect(subject.create(env)).to be true
+          expect(collection.reload.member_objects).to be_empty
+        end
+      end
+
+      describe "when work is in another user's collection" do
+        let(:other_user)    { create(:user) }
+        let(:collection)    { create(:collection, user: other_user, title: ['A good title']) }
+        let(:my_collection) { create(:collection, title: ['My good title']) }
+
+        let(:attributes) { { member_of_collection_ids: [my_collection.id] } }
+
+        before do
+          curation_concern.member_of_collections = [collection]
+          curation_concern.save!
+        end
+
+        it "doesn't remove the work from the other user's collection" do
+          skip 'this behavior past its deprecation sunset time and can be removed' if
+            Hyrax::VERSION.split('.').first.to_i >= 3
+
+          expect(subject.create(env)).to be true
+          expect(curation_concern.member_of_collections)
+            .to contain_exactly(collection, my_collection)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
780c1489251c2d removed existing actor stack behavior. This reinstates it and deprecates it for removal in 3.0.0.

@samvera/hyrax-code-reviewers

The **Actor Stack** section of https://github.com/samvera/hyrax/issues/2326 can be edited to reflect a deprecation, rather than needed action after merge.