### PR TITLE
Merge latest changes from master into collections-sprint branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
-# Workaround for https://github.com/travis-ci/travis-ci/issues/8836
-# sudo: false
-sudo: required
+sudo: false
 dist: trusty
 
 addons:
@@ -12,7 +10,7 @@ cache:
 before_install:
   - gem update --system
   - gem install bundler
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+  - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
 
 rvm:
   - 2.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 
 rvm:
-  - 2.4.2
+  - 2.5.0
 
 env:
   global:

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,5 +1,5 @@
 <% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
-  <% if viewer %>
+  <% if defined?(viewer) && viewer %>
     <%= PulUvRails::UniversalViewer.script_tag %>
     <div class="viewer-wrapper">
       <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter] %>"></div>

--- a/app/views/hyrax/my/_admin_set_action_menu.html.erb
+++ b/app/views/hyrax/my/_admin_set_action_menu.html.erb
@@ -23,19 +23,19 @@
     <% else %>
       <li role="menuitem" tabindex="-1">
         <%= link_to "#",
-            class: 'itemicon itemedit edit-collection-deny-button',
-            title: t("hyrax.dashboard.my.action.edit_collection") do %>
+                    class: 'itemicon itemedit edit-collection-deny-button',
+                    title: t("hyrax.dashboard.my.action.edit_collection") do %>
           <%= t("hyrax.dashboard.my.action.edit_collection") %>
         <% end %>
       </li>
     <% end %>
     <li role="menuitem" tabindex="-1">
       <%= link_to "#",
-                     class: 'itemicon itemtrash delete-collection-button',
-                     title: t("hyrax.dashboard.my.action.delete_admin_set"),       
-                     data: { totalitems: admin_set_presenter.total_items , 
-                             membership: admin_set_presenter.collection_type_is_require_membership? ,
-                             hasaccess: (can? :edit, admin_set_presenter.solr_document) } do %>
+                  class: 'itemicon itemtrash delete-collection-button',
+                  title: t("hyrax.dashboard.my.action.delete_admin_set"),
+                  data: { totalitems: admin_set_presenter.total_items ,
+                          membership: admin_set_presenter.collection_type_is_require_membership? ,
+                          hasaccess: (can?(:edit, admin_set_presenter.solr_document)) } do %>
         <%= t("hyrax.dashboard.my.action.delete_admin_set") %>
       <% end %>
     </li>
@@ -45,7 +45,7 @@
                       class: 'itemicon add-to-collection',
                       title: t("hyrax.dashboard.my.action.add_to_collection"),
                       data: { nestable: false,
-                              hasaccess: (can? :deposit, admin_set_presenter.solr_document) } do %>
+                              hasaccess: (can?(:deposit, admin_set_presenter.solr_document)) } do %>
               <%= t("hyrax.dashboard.my.action.add_to_collection") %>
           <% end %>
         </li>

--- a/app/views/hyrax/my/_collection_action_menu.html.erb
+++ b/app/views/hyrax/my/_collection_action_menu.html.erb
@@ -24,31 +24,31 @@
       </li>
     <% else %>
       <li role="menuitem" tabindex="-1">
-      <%= link_to "#",
-            class: 'itemicon itemedit edit-collection-deny-button',
-             title: t("hyrax.dashboard.my.action.edit_collection") do %>
-         <%= t("hyrax.dashboard.my.action.edit_collection") %>
-       <% end %>
+        <%= link_to "#",
+                    class: 'itemicon itemedit edit-collection-deny-button',
+                    title: t("hyrax.dashboard.my.action.edit_collection") do %>
+          <%= t("hyrax.dashboard.my.action.edit_collection") %>
+        <% end %>
       </li>
     <% end %>
     <li role="menuitem" tabindex="-1">
       <%= link_to "#",
-            class: 'itemicon itemtrash delete-collection-button',
-             title: t("hyrax.dashboard.my.action.delete_collection"),
-             data: { totalitems: collection_presenter.total_items ,
-                     membership: collection_presenter.collection_type_is_require_membership? ,
-                     hasaccess: (can? :edit, collection_presenter.solr_document) } do %>
-         <%= t("hyrax.dashboard.my.action.delete_collection") %>
-       <% end %>
+                  class: 'itemicon itemtrash delete-collection-button',
+                  title: t("hyrax.dashboard.my.action.delete_collection"),
+                  data: { totalitems: collection_presenter.total_items ,
+                          membership: collection_presenter.collection_type_is_require_membership? ,
+                          hasaccess: (can?(:edit, collection_presenter.solr_document)) } do %>
+        <%= t("hyrax.dashboard.my.action.delete_collection") %>
+      <% end %>
     </li>
     <% if Hyrax::CollectionType.any_nestable? %>
-<!-- The user should have deposit access to the parent we are adding, and read access to the child (the collection we are linking here). -->
+      <% # The user should have deposit access to the parent we are adding, and read access to the child (the collection we are linking here). %>
       <li role="menuitem" tabindex="-1">
         <%= link_to "#",
-          class: 'itemicon add-to-collection',
-          title: t("hyrax.dashboard.my.action.add_to_collection"),
-          data: { nestable: collection_presenter.collection_type_is_nestable? ,
-                  hasaccess: (can? :read, collection_presenter.solr_document) } do %>
+                    class: 'itemicon add-to-collection',
+                    title: t("hyrax.dashboard.my.action.add_to_collection"),
+                    data: { nestable: collection_presenter.collection_type_is_nestable? ,
+                            hasaccess: (can?(:read, collection_presenter.solr_document)) } do %>
           <%= t("hyrax.dashboard.my.action.add_to_collection") %>
         <% end %>
       </li>

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -13,6 +13,7 @@ module Hyrax
     require 'qa'
     require 'clipboard/rails'
     require 'legato'
+    require 'pul_uv_rails'
 
     # Force these models to be added to Legato's registry in development mode
     config.eager_load_paths += %W[
@@ -51,7 +52,6 @@ module Hyrax
       require 'dry/struct'
       require 'dry/equalizer'
       require 'dry/validation'
-      require 'pul_uv_rails'
     end
 
     initializer 'routing' do

--- a/spec/controllers/hyrax/admin/workflow_roles_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/workflow_roles_controller_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Hyrax::Admin::WorkflowRolesController do
-  describe "#get" do
+  describe '#index' do
     context "when you have permission" do
       before do
         allow(controller).to receive(:authorize!).with(:read, :admin_dashboard).and_return(true)
@@ -13,6 +13,56 @@ RSpec.describe Hyrax::Admin::WorkflowRolesController do
         expect(response).to be_success
         expect(assigns[:presenter]).to be_kind_of Hyrax::Admin::WorkflowRolesPresenter
         expect(response).to render_template('hyrax/dashboard')
+      end
+    end
+
+    context "when they don't have permission" do
+      it "throws a CanCan error" do
+        get :index
+        expect(response).to redirect_to main_app.new_user_session_path(locale: 'en')
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'when you have permission' do
+      let(:form) { instance_double(Hyrax::Forms::WorkflowResponsibilityForm, save!: true) }
+
+      before do
+        allow(controller).to receive(:authorize!).with(:read, :admin_dashboard).and_return(true)
+        allow(controller).to receive(:authorize!).and_return(true)
+        allow(Hyrax::Forms::WorkflowResponsibilityForm).to receive(:new).and_return(form)
+      end
+
+      it 'is successful' do
+        post :create, params: { sipity_workflow_responsibility: {} }
+        expect(controller).to have_received(:authorize!).with(:create, Sipity::WorkflowResponsibility)
+        expect(form).to have_received(:save!)
+        expect(response).to redirect_to admin_workflow_roles_path
+      end
+    end
+
+    context "when they don't have permission" do
+      it 'throws a CanCan error' do
+        post :create, params: { sipity_workflow_responsibility: {} }
+        expect(response).to redirect_to main_app.new_user_session_path(locale: 'en')
+      end
+    end
+  end
+
+  describe '#destroy' do
+    context "when you have permission" do
+      let(:responsibility) { mock_model(Sipity::WorkflowResponsibility) }
+
+      before do
+        allow(controller).to receive(:authorize!).and_return(true)
+        allow(Sipity::WorkflowResponsibility).to receive(:find).with('1').and_return(responsibility)
+      end
+
+      it "is successful" do
+        delete :destroy, params: { id: 1 }
+        expect(controller).to have_received(:authorize!).with(:destroy, Sipity::WorkflowResponsibility)
+        expect(response).to redirect_to admin_workflow_roles_path
       end
     end
 

--- a/spec/services/hyrax/embargo_service_spec.rb
+++ b/spec/services/hyrax/embargo_service_spec.rb
@@ -29,10 +29,31 @@ RSpec.describe Hyrax::EmbargoService do
 
   describe '#assets_under_embargo' do
     it 'returns all assets with embargo release date set' do
-      subject.assets_under_embargo
       returned_pids = subject.assets_under_embargo.map(&:id)
       expect(returned_pids).to include work_with_expired_embargo1.id, work_with_expired_embargo2.id, work_with_embargo_in_effect.id
       expect(returned_pids).not_to include work_without_embargo.id
+    end
+  end
+
+  describe '#assets_with_deactivated_embargoes' do
+    let(:id) { Noid::Rails::Service.new.mint }
+    let(:attributes) do
+      { 'embargo_history_ssim' => ['This is in the past'],
+        'id' => id }
+    end
+
+    before do
+      ActiveFedora::SolrService.add(attributes)
+      ActiveFedora::SolrService.commit
+    end
+
+    it 'returns all assets with embargo history set' do
+      returned_pids = subject.assets_with_deactivated_embargoes.map(&:id)
+      expect(returned_pids).to include id
+      expect(returned_pids).not_to include(work_without_embargo.id,
+                                           work_with_expired_embargo1.id,
+                                           work_with_expired_embargo2.id,
+                                           work_with_embargo_in_effect.id)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,8 +62,21 @@ WebMock.disable_net_connect!(allow_localhost: true)
 require 'i18n/debug' if ENV['I18N_DEBUG']
 require 'byebug' unless ENV['TRAVIS']
 
+# @note In January 2018, TravisCI disabled Chrome sandboxing in its Linux
+#       container build environments to mitigate Meltdown/Spectre
+#       vulnerabilities, at which point Hyrax could no longer use the
+#       Capybara-provided :selenium_chrome_headless driver (which does not
+#       include the `--no-sandbox` argument).
+Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--disable-gpu'
+  browser_options.args << '--no-sandbox'
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+end
+
 Capybara.default_driver = :rack_test # This is a faster driver
-Capybara.javascript_driver = :selenium_chrome_headless # This is slower
+Capybara.javascript_driver = :selenium_chrome_headless_sandboxless # This is slower
 
 ApplicationJob.queue_adapter = :inline
 

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
       end
     end
 
-    context 'when presenter says it is enabled' do
+    context 'when presenter says it is disabled' do
       let(:viewer_enabled) { false }
 
       it 'omits the UniversalViewer' do


### PR DESCRIPTION
NOTE: There was an update for Travis to run tests in the context of ruby 2.5.0.  This caused test failures in collections-sprint.  The failures were rather cryptic, so I will document it here in the hopes it may help someone else.

Failure:
```
  25) hyrax/my/_collection_action_menu.html.erb when user can not edit shows view, delete and hide edit
      Failure/Error: render 'hyrax/my/collection_action_menu', collection: collection_doc      
      SyntaxError:
/home/travis/build/samvera/hyrax/app/views/hyrax/my/_collection_action_menu.html.erb:40: syntax error, unexpected keyword_do, expecting keyword_end
        ...n_presenter.solr_document) } do @output_buffer.safe_append='
        ...                             ^~
/home/travis/build/samvera/hyrax/app/views/hyrax/my/_collection_action_menu.html.erb:51: syntax error, unexpected keyword_do, expecting keyword_end
        ...n_presenter.solr_document) } do @output_buffer.safe_append='
        ...                             ^~
/home/travis/build/samvera/hyrax/app/views/hyrax/my/_collection_action_menu.html.erb:55: syntax error, unexpected keyword_end, expecting end-of-input
        '.freeze;     end 
```

Problem code in context:
```
      <%= link_to "#",
                  class: 'itemicon itemtrash delete-collection-button',
                  title: t("hyrax.dashboard.my.action.delete_collection"),
                  data: { totalitems: collection_presenter.total_items ,
                          membership: collection_presenter.collection_type_is_require_membership? ,
                          hasaccess: (can?(:edit, collection_presenter.solr_document)) } do %>
        <%= t("hyrax.dashboard.my.action.delete_collection") %>
      <% end %>
```

Problem line:
```
                          hasaccess: (can? :edit, collection_presenter.solr_document) } do %>
```

Fixed line:
```
                          hasaccess: (can?(:edit, collection_presenter.solr_document)) } do %>
```

NOTE: The only change is adding parentheses around the parameters of `can?` method.

Ultimately, the error is complaining about a syntax error that can be close to the line reported in the error or farther up in the file.

You will not see these errors if running rspec tests locally under Ruby 2.4.x.