### PR TITLE
Allow `representative_media` partial calls without a `viewer` flag

### DIFF
--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,5 +1,5 @@
 <% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
-  <% if viewer %>
+  <% if defined?(viewer) && viewer %>
     <%= PulUvRails::UniversalViewer.script_tag %>
     <div class="viewer-wrapper">
       <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter] %>"></div>

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
       end
     end
 
-    context 'when presenter says it is enabled' do
+    context 'when presenter says it is disabled' do
       let(:viewer_enabled) { false }
 
       it 'omits the UniversalViewer' do


### PR DESCRIPTION
The partial now treats calls without a `viewer` flag as `viewer:
false`. Applications may be calling this partial without the flag, which has
worked previously, so this improves compatibility.

We might also consider adding a warn level log in this case. It will often (but
perhaps not always) be the case that this indicates an out of date show view
attempting to render the partial.

Changes proposed in this pull request:
* Fix typo in show view spec description
* Allow `representative_media` partial calls without a `viewer` flag for compatibility with existing application side views.

@samvera/hyrax-code-reviewers
