### PR TITLE
Improve save behavior for Content Blocks/Pages to remain on the tab

### DIFF
--- a/app/controllers/hyrax/pages_controller.rb
+++ b/app/controllers/hyrax/pages_controller.rb
@@ -20,7 +20,8 @@ module Hyrax
     def update
       respond_to do |format|
         if @page.update(value: update_value_from_params)
-          format.html { redirect_to hyrax.edit_pages_path, notice: t(:'hyrax.pages.updated') }
+          redirect_path = "#{hyrax.edit_pages_path}##{params[:content_block].keys.first}"
+          format.html { redirect_to redirect_path, notice: t(:'hyrax.pages.updated') }
         else
           format.html { render :edit }
         end

--- a/spec/controllers/hyrax/pages_controller_spec.rb
+++ b/spec/controllers/hyrax/pages_controller_spec.rb
@@ -80,28 +80,28 @@ RSpec.describe Hyrax::PagesController, type: :controller do
       describe "PATCH #update" do
         it "updates the about page" do
           patch :update, params: { id: about_page.id, content_block: { about: 'This is a new page about us!' } }
-          expect(response).to redirect_to(edit_pages_path)
+          expect(response).to redirect_to("#{edit_pages_path}#about")
           expect(flash[:notice]).to include 'Pages updated'
           expect(ContentBlock.for(:about).value).to eq "This is a new page about us!"
         end
 
         it "updates the help page" do
           patch :update, params: { id: help_page.id, content_block: { help: 'This page will provide more of the help you need.' } }
-          expect(response).to redirect_to(edit_pages_path)
+          expect(response).to redirect_to("#{edit_pages_path}#help")
           expect(flash[:notice]).to include 'Pages updated'
           expect(ContentBlock.for(:help).value).to eq 'This page will provide more of the help you need.'
         end
 
         it "updates the agreement page" do
           patch :update, params: { id: agreement_page.id, content_block: { agreement: 'Here is the deposit agreement' } }
-          expect(response).to redirect_to(edit_pages_path)
+          expect(response).to redirect_to("#{edit_pages_path}#agreement")
           expect(flash[:notice]).to include 'Pages updated'
           expect(ContentBlock.for(:agreement).value).to eq 'Here is the deposit agreement'
         end
 
         it "updates the terms page" do
           patch :update, params: { id: terms_page.id, content_block: { terms: 'Terms of Use are good' } }
-          expect(response).to redirect_to(edit_pages_path)
+          expect(response).to redirect_to("#{edit_pages_path}#terms")
           expect(flash[:notice]).to include 'Pages updated'
           expect(ContentBlock.for(:terms).value).to eq 'Terms of Use are good'
         end


### PR DESCRIPTION
Fixes #1454

Improve save behavior for Content Blocks/Pages.

Currently when a page or a block is updated it'll be redirected to the first tab. The change in this PR is to redirect to the tab for the block or page that are editing.

@samvera/hyrax-code-reviewers
