### PR TITLE
Clean up collection type filter.

### DIFF
--- a/app/controllers/hyrax/my/collections_controller.rb
+++ b/app/controllers/hyrax/my/collections_controller.rb
@@ -1,6 +1,22 @@
 module Hyrax
   module My
     class CollectionsController < MyController
+      # Define collection specific filter facets.
+      def self.configure_facets
+        configure_blacklight do |config|
+          # Name of pivot facet must match field name that uses helper_method
+          config.add_facet_field Collection.collection_type_gid_document_field_name,
+                                 helper_method: :collection_type_label, limit: 5,
+                                 pivot: ['has_model_ssim', Collection.collection_type_gid_document_field_name],
+                                 label: I18n.t('hyrax.dashboard.my.heading.collection_type')
+          # This causes AdminSets to also be shown with the Collection Type label
+          config.add_facet_field 'has_model_ssim',
+                                 label: I18n.t('hyrax.dashboard.my.heading.collection_type'),
+                                 limit: 5, show: false
+        end
+      end
+      configure_facets
+
       def search_builder_class
         Hyrax::My::CollectionsSearchBuilder
       end

--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -3,6 +3,7 @@ module Hyrax
     include Hydra::Catalog
     include Hyrax::Collections::AcceptsBatches
 
+    # Define filter facets that apply to all repository objects.
     def self.configure_facets
       # clear facet's copied from the CatalogController
       blacklight_config.facet_fields = {}
@@ -14,11 +15,6 @@ module Hyrax
         config.add_facet_field IndexesWorkflow.suppressed_field, helper_method: :suppressed_to_status
         config.add_facet_field solr_name("admin_set", :facetable), limit: 5
         config.add_facet_field solr_name("resource_type", :facetable), limit: 5
-        # Name of pivot facet must match field name that uses helper_method
-        config.add_facet_field Collection.collection_type_gid_document_field_name,
-                               helper_method: :collection_type_label, limit: 5,
-                               pivot: ['has_model_ssim', Collection.collection_type_gid_document_field_name],
-                               label: I18n.t('hyrax.dashboard.my.heading.type')
       end
     end
 

--- a/app/views/hyrax/my/_facet_pivot.html.erb
+++ b/app/views/hyrax/my/_facet_pivot.html.erb
@@ -5,7 +5,11 @@
   <% display_facet.items.each do |item| -%>
     <li>
       <span class="facet-values">
-        <%= render_facet_item(item.field, item) %>
+        <% # This prevents model Collection from being shown as a second filter along with the collection type. %>
+        <% item.fq= {} if subfacet %>
+
+        <% # The unless prevents Collection from being included in the select list for the Collection Type filter. %>
+        <%= render_facet_item(item.field, item) unless subfacet != true && item.value == "Collection" %>
       </span>
 
       <% unless item.items.blank? %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -705,6 +705,7 @@ en:
           last_modified:  "Last modified"
           title:          "Title"
           type:           "Type"
+          collection_type: "Collection Type"
           visibility:     "Visibility"
         highlighted:  "My Highlights"
         shared:       "Works Shared with Me"


### PR DESCRIPTION
Fixes #1883 

This cleans up the Collection Type filter used on Dashboard -> Collections.  It includes...
- filter labeled 'Collection type'
- includes a list of all collection types
- does not include the model Collection
- makes the AdminSet appear to be a collection type
- shows only a single filter selection (i.e. Collection Type) when the filter is applied
