### PR TITLE
Avoid ‘Can't verify CSRF token authenticity.’ when saving a collection

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -109,7 +109,7 @@
 
       <div class="panel-footer">
         <% if @collection.persisted? %>
-          <%= f.submit t(:'hyrax.collection.select_form.update'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "update_submit", name: "update_collection" %>
+          <%= f.submit t(:'hyrax.collection.select_form.update'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "update_submit", name: "update_collection", data: { turbolinks: false } %>
           <%= link_to t(:'helpers.action.cancel'), hyrax.dashboard_collection_path(@collection), class: 'btn btn-link' %>
         <% else %>
           <%= f.submit t(:'hyrax.collection.select_form.create'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "create_submit", name: "create_collection" %>


### PR DESCRIPTION
Related to issues
* #1191 - Adding existing works to existing collection fails
* #1489 - Throwing ActionController::InvalidAuthenticityToken when trying to add works to an existing collection
