### PR TITLE
Prevent circular nesting

### DIFF
--- a/app/controllers/hyrax/dashboard/nest_collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/nest_collections_controller.rb
@@ -13,8 +13,7 @@ module Hyrax
           notice = I18n.t('create_within', scope: 'hyrax.dashboard.nest_collections_form', child_title: @form.child.title.first, parent_title: @form.parent.title.first)
           redirect_to redirect_path(item: @form.child), notice: notice
         else
-          flash[:error] = @form.errors.full_messages
-          redirect_to redirect_path(item: @form.child)
+          redirect_to redirect_path(item: @form.child), error: @form.errors.full_messages
         end
       end
 
@@ -24,8 +23,7 @@ module Hyrax
         if @form.validate_add
           redirect_to new_dashboard_collection_path(collection_type_id: @form.parent.collection_type.id, parent_id: @form.parent)
         else
-          flash[:error] = @form.errors.full_messages
-          redirect_to redirect_path(item: @form.parent)
+          redirect_to redirect_path(item: @form.parent), error: @form.errors.full_messages
         end
       end
 
@@ -36,8 +34,7 @@ module Hyrax
           notice = I18n.t('create_under', scope: 'hyrax.dashboard.nest_collections_form', child_title: @form.child.title.first, parent_title: @form.parent.title.first)
           redirect_to redirect_path(item: @form.parent), notice: notice
         else
-          flash[:error] = @form.errors.full_messages
-          redirect_to redirect_path(item: @form.parent)
+          redirect_to redirect_path(item: @form.parent), error: @form.errors.full_messages
         end
       end
 

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -27,6 +27,7 @@ module Hyrax
         validates :parent, presence: true
         validates :child, presence: true
         validate :parent_and_child_can_be_nested
+        validate :nesting_within_maximum_depth
 
         def save
           return false unless valid?
@@ -45,14 +46,32 @@ module Hyrax
           query_service.available_parent_collections(child: child, scope: context)
         end
 
+        # when creating a NEW collection, we need to do some basic validation before
+        # rerouting to new_dashboard_collection_path to add the new collection as
+        # a child. Since we don't yet have a child collection, the valid? option can't be used here.
         def validate_add
-          return true if parent.try(:nestable?)
-          errors.add(:parent, :cannot_have_child_nested)
+          if parent.try(:nestable?)
+            nesting_within_maximum_depth
+          else
+            errors.add(:parent, :cannot_have_child_nested)
+            false
+          end
         end
 
         private
 
-          attr_accessor :query_service, :persistence_service, :context
+          attr_accessor :query_service, :persistence_service, :context, :collection
+
+          # ideally we would love to be able to eliminate collections which exceed the
+          # maximum nesting depth from the lists of available collections, but the queries
+          # needed to make the determination are too expensive to do for every possible
+          # collection, so we only test for this situation prior to saving the new
+          # relationship.
+          def nesting_within_maximum_depth
+            return true if query_service.valid_combined_nesting_depth?(parent: parent, child: child, scope: context)
+            errors.add(:collection, :exceeds_maximum_nesting_depth)
+            false
+          end
 
           def parent_and_child_can_be_nested
             if parent.try(:nestable?) && child.try(:nestable?)

--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -5,15 +5,18 @@ module Hyrax
       # @param access [Symbol] :edit, :read, :discover - With the given :access what all can
       # @param collection [Collection]
       # @param scope [Object] Typically a controller that responds to #current_ability, #blackligh_config
-      def initialize(access:, collection:, scope:)
+      # @param nesting_attributes [NestingAttributes] an object encapsulating nesting attributes of the collection
+      # @param nest_direction [Symbol] (:as_parent or :as_child) the direction we are adding nesting to this collection
+      def initialize(access:, collection:, scope:, nesting_attributes:, nest_direction:)
         super(scope)
         @collection = collection
         @discovery_permissions = extract_discovery_permissions(access)
+        @nesting_attributes = nesting_attributes
+        @nest_direction = nest_direction
       end
 
       # Override for Hydra::AccessControlsEnforcement
       attr_reader :discovery_permissions
-
       self.default_processor_chain += [:with_pagination, :show_only_other_collections_of_the_same_collection_type]
 
       def with_pagination(solr_parameters)
@@ -23,9 +26,10 @@ module Hyrax
       def show_only_other_collections_of_the_same_collection_type(solr_parameters)
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += [
-          "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids([@collection.id]),
+          "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids(limit_ids),
           ActiveFedora::SolrQueryBuilder.construct_query(Collection.collection_type_gid_document_field_name => @collection.collection_type_gid)
         ]
+        solr_parameters[:fq] += limit_clause if limit_clause # add limits to prevent illegal nesting arrangements
       end
 
       # If :deposit access is requested, check to see which collections the user has
@@ -52,6 +56,67 @@ module Hyrax
         ).freeze
         def extract_discovery_permissions(access)
           ACCESS_LEVELS_FOR_LEVEL.fetch(access)
+        end
+
+        def limit_ids
+          # exclude current collection from returned list
+          limit_ids = [@collection.id]
+          # cannot add a parent that is already a parent
+          limit_ids += @nesting_attributes.parents if @nesting_attributes.parents && @nest_direction == :as_parent
+          limit_ids
+        end
+
+        # remove collections from list in order to to prevent illegal nesting arrangements
+        def limit_clause
+          case @nest_direction
+          when :as_parent
+            eligible_to_be_a_parent
+          when :as_child
+            eligible_to_be_a_child
+          end
+        end
+
+        # To be eligible to be a parent collection of child "Collection G":
+        # 1) cannot have any pathnames containing Collection G's ID
+        # 2) cannot already be Collection G's direct parent
+        # => this is handled through limit_ids method
+        def eligible_to_be_a_parent
+          # Using a !lucene query allows us to get items using a wildcard query, a feature not supported via AF query builder.
+          ["-_query_:\"{!lucene df=#{Samvera::NestingIndexer.configuration.solr_field_name_for_storing_pathnames}}*#{@collection.id}*\""]
+        end
+
+        # To be eligible to be a child collection of parent "Collection F":
+        # 1) Cannot have any pathnames containing any of Collection F's pathname or ancestors
+        # 2) cannot already be Collection F's direct child
+        def eligible_to_be_a_child
+          exclude_path = []
+          exclude_path << exclude_if_paths_contain_collection
+          exclude_path << exclude_if_already_parent
+        end
+
+        def exclude_if_paths_contain_collection
+          # 1) Exclude any pathnames containing any of Collection F's pathname or ancestors
+          array_to_exclude = [] + @nesting_attributes.pathnames unless @nesting_attributes.pathnames.nil?
+          array_to_exclude += @nesting_attributes.ancestors unless @nesting_attributes.ancestors.nil?
+          # build a unique string containing all of Collection F's pathnames and ancestors
+          exclude_list = ""
+          unless array_to_exclude.nil?
+            array_to_exclude.uniq.each do |element|
+              exclude_list += ' ' unless exclude_list.empty?
+              exclude_list += element.to_s
+            end
+          end
+          # Using a !lucene query allows us to get items which match any individual element
+          # from the list. Building the query via the AF builder created a !field query which
+          # only searches the field for an exact string and doesn't allow an "OR" connection
+          # between the elements.
+          return "-_query_:\"{!lucene q.op=OR df=#{Samvera::NestingIndexer.configuration.solr_field_name_for_storing_pathnames}}#{exclude_list}\"" unless exclude_list.empty?
+          ""
+        end
+
+        def exclude_if_already_parent
+          # 2) Exclude any of Collection F's direct children
+          "-" + ActiveFedora::SolrQueryBuilder.construct_query(Samvera::NestingIndexer.configuration.solr_field_name_for_storing_parent_ids => @collection.id)
         end
     end
   end

--- a/app/services/hyrax/adapters/nesting_index_adapter.rb
+++ b/app/services/hyrax/adapters/nesting_index_adapter.rb
@@ -85,11 +85,29 @@ module Hyrax
           ActiveFedora::Base.find(nesting_document.id).to_solr # What is the current state of the solr document
         end
 
-        # Now add the details from the nesting indexor to the document
-        solr_doc[solr_field_name_for_storing_ancestors] = nesting_document.ancestors
-        solr_doc[solr_field_name_for_storing_parent_ids] = nesting_document.parent_ids
-        solr_doc[solr_field_name_for_storing_pathnames] = nesting_document.pathnames
-        solr_doc[solr_field_name_for_deepest_nested_depth] = nesting_document.deepest_nested_depth
+        # Now add the details from the nesting indexer to the document
+        add_nesting_attributes(
+          solr_doc: solr_doc,
+          ancestors: nesting_document.ancestors,
+          parent_ids: nesting_document.parent_ids,
+          pathnames: nesting_document.pathnames,
+          depth: nesting_document.deepest_nested_depth
+        )
+      end
+
+      # @api public
+      #
+      # @param solr_doc [SolrDocument]
+      # @param ancestors [Array]
+      # @param parent_ids [Array]
+      # @param pathnames [Array]
+      # @param depth [Array] the object's deepest nesting depth
+      # @return solr_doc [SolrDocument]
+      def self.add_nesting_attributes(solr_doc:, ancestors:, parent_ids:, pathnames:, depth:)
+        solr_doc[solr_field_name_for_storing_ancestors] = ancestors
+        solr_doc[solr_field_name_for_storing_parent_ids] = parent_ids
+        solr_doc[solr_field_name_for_storing_pathnames] = pathnames
+        solr_doc[solr_field_name_for_deepest_nested_depth] = depth
         ActiveFedora::SolrService.add(solr_doc, commit: true)
         solr_doc
       end

--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -1,9 +1,32 @@
 module Hyrax
   module Collections
     module NestedCollectionQueryService
+      # @api private
+      #
+      # an encapsulation of a collection's nesting index attributes
+      #
+      # @param id [String] a collection id
+      # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
+      # @return object [NestingAttributes]
+      class NestingAttributes
+        attr_accessor :parents, :pathnames, :ancestors, :depth, :id
+
+        def initialize(id:, scope:)
+          query_builder = Hyrax::CollectionSearchBuilder.new(scope).where(id: id)
+          query = Hyrax::Collections::NestedCollectionQueryService.clean_lucene_error(builder: query_builder)
+          response = scope.repository.search(query)
+          collection_doc = response.documents.first
+          @id = id
+          @parents = collection_doc[Samvera::NestingIndexer.configuration.solr_field_name_for_storing_parent_ids]
+          @pathnames = collection_doc[Samvera::NestingIndexer.configuration.solr_field_name_for_storing_pathnames]
+          @ancestors = collection_doc[Samvera::NestingIndexer.configuration.solr_field_name_for_storing_ancestors]
+          @depth = collection_doc[Hyrax::Adapters::NestingIndexAdapter.solr_field_name_for_deepest_nested_depth]
+        end
+      end
+
       # @api public
       #
-      # What possible collections can nested within the given parent collection?
+      # What possible collections can be nested within the given parent collection?
       #
       # @param parent [Collection]
       # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
@@ -12,7 +35,7 @@ module Hyrax
       def self.available_child_collections(parent:, scope:, limit_to_id: nil)
         return [] unless parent.try(:nestable?)
         return [] unless scope.can?(:deposit, parent)
-        query_solr(collection: parent, access: :read, scope: scope, limit_to_id: limit_to_id)
+        query_solr(collection: parent, access: :read, scope: scope, limit_to_id: limit_to_id, nest_direction: :as_child)
       end
 
       # @api public
@@ -26,7 +49,7 @@ module Hyrax
       def self.available_parent_collections(child:, scope:, limit_to_id: nil)
         return [] unless child.try(:nestable?)
         return [] unless scope.can?(:read, child)
-        query_solr(collection: child, access: :deposit, scope: scope, limit_to_id: limit_to_id)
+        query_solr(collection: child, access: :deposit, scope: scope, limit_to_id: limit_to_id, nest_direction: :as_parent)
       end
 
       # @api private
@@ -35,16 +58,35 @@ module Hyrax
       # @param access [Symbol] I need this kind of permission on the queried objects.
       # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
       # @param limit_to_id [nil, String] Limit the query to just check if the given id is in the response. Useful for validation.
-      def self.query_solr(collection:, access:, scope:, limit_to_id:)
-        query_builder = Hyrax::Dashboard::NestedCollectionsSearchBuilder.new(access: access, collection: collection, scope: scope)
-        # No sense returning everything, just limit to a single entry
+      # @param nest_direction [Symbol] :as_child or :as_parent
+      def self.query_solr(collection:, access:, scope:, limit_to_id:, nest_direction:)
+        nesting_attributes = NestingAttributes.new(id: collection.id, scope: scope)
+        query_builder = Hyrax::Dashboard::NestedCollectionsSearchBuilder.new(
+          access: access,
+          collection: collection,
+          scope: scope,
+          nesting_attributes: nesting_attributes,
+          nest_direction: nest_direction
+        )
+
         query_builder.where(id: limit_to_id) if limit_to_id
-        # TODO: Need to investigate further to understand why this particular query fails if prepended with `{!lucene}` when all others work with the prepend
-        query = query_builder.query.to_hash
-        query['q'].gsub!('{!lucene}', '') if query.key? 'q'
+        query = clean_lucene_error(builder: query_builder)
         scope.repository.search(query).documents
       end
       private_class_method :query_solr
+
+      # @api private
+      #
+      # clean query for {!lucene} error
+      #
+      # @param builder [SearchBuilder]
+      # @return [Blacklight::Solr::Request] cleaned and functional query
+      def self.clean_lucene_error(builder:)
+        # TODO: Need to investigate further to understand why these particular queries using the where cause fail when others in the app apparently work
+        query = builder.query.to_hash
+        query['q'].gsub!('{!lucene}', '') if query.key? 'q'
+        query
+      end
 
       # @api public
       #
@@ -64,6 +106,64 @@ module Hyrax
         return false if available_child_collections(parent: parent, scope: scope, limit_to_id: child.id).none?
         true
       end
+
+      # @api public
+      #
+      # Does the nesting depth fall within defined limit?
+      #
+      # @param parent [Collection]
+      # @param child [nil, Collection] will be nil if we are nesting a new collection under the parent
+      # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
+      # @return [Boolean] true if the parent can nest the child; false otherwise
+      def self.valid_combined_nesting_depth?(parent:, child: nil, scope:)
+        # We limit the total depth of collections to the size specified in the samvera-nesting_indexer configuration.
+        child_depth = child_nesting_depth(child: child, scope: scope)
+        parent_depth = parent_nesting_depth(parent: parent, scope: scope)
+        return false if parent_depth + child_depth > Samvera::NestingIndexer.configuration.maximum_nesting_depth
+        true
+      end
+
+      # @api private
+      #
+      # Get the child collection's nesting depth
+      #
+      # @param child [Collection]
+      # @return [Fixnum] the largest number of collections in a path nested under this collection (including this collection)
+      def self.child_nesting_depth(child:, scope:)
+        return 1 if child.nil?
+        # The nesting depth of a child collection is found by finding the largest nesting depth
+        # among all collections which have the child in the paths, and subtractiong the nesting
+        # depth of the child collection itself.
+        # => 1) First we find all the collections with this child in the path, sort the results in descending order, and take the first result.
+        builder = Hyrax::CollectionSearchBuilder.new(scope).where("#{Samvera::NestingIndexer.configuration.solr_field_name_for_storing_pathnames}:/.*#{child.id}.*/")
+        builder.query[:sort] = "#{Hyrax::Adapters::NestingIndexAdapter.solr_field_name_for_deepest_nested_depth} desc"
+        builder.query[:rows] = Samvera::NestingIndexer.configuration.maximum_nesting_depth
+        query = clean_lucene_error(builder: builder)
+        response = scope.repository.search(query).documents.first
+
+        # Now we have the largest nesting depth for all paths containing this collection
+        descendent_depth = response[Hyrax::Adapters::NestingIndexAdapter.solr_field_name_for_deepest_nested_depth]
+
+        # => 2) Then we get the stored depth of the child collection itself to eliminate the collections above this one from our count, and add 1 to add back in this collection itself
+        child_depth = NestingAttributes.new(id: child.id, scope: scope).depth
+        nesting_depth = descendent_depth - child_depth + 1
+
+        return nesting_depth if nesting_depth > 0 # this should always be > 0, but just being safe
+        1
+      end
+      private_class_method :child_nesting_depth
+
+      # @api private
+      #
+      # Get the parent collection's nesting depth
+      #
+      # @param parent [Collection]
+      # @return [Fixnum] the largest number of collections above this collection (includes this collection)
+      def self.parent_nesting_depth(parent:, scope:)
+        return 1 if parent.nil?
+        NestingAttributes.new(id: parent.id, scope: scope).depth
+      end
+      private_class_method :parent_nesting_depth
     end
   end
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -6,6 +6,7 @@ en:
   activemodel:
     errors:
       messages:
+        exceeds_maximum_nesting_depth: "nesting exceeds the allowed maximum nesting depth."
         is_not_nestable: "is not nestable"
         cannot_have_child_nested: "cannot have child nested within it"
         cannot_nest_in_parent: "cannot nest within parent"

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -1,6 +1,18 @@
 FactoryBot.define do
   factory :collection do
-    # @example let(:collection) { build(:collection, collection_type_settings: [:not_nestable, :discoverable, :sharable, :allow_multiple_membership]) }
+    # rubocop:disable Metrics/LineLength
+    # @example let(:collection) { build(:collection, collection_type_settings: [:not_nestable, :discoverable, :sharable, :allow_multiple_membership], with_nesting_attributes: {ancestors: [], parent_ids: [], pathnames: [], depth: 1}) }
+    # rubocop:enable Metrics/LineLength
+
+    # Regarding testing nested collections:
+    # To get the nested collection solr fields in the solr document for query purposes there are two options:
+    # => 1) use create(:collection) and add "with_nested_reindexing: true" to the spec will force the collection to be
+    #       created and run through the entire indexing.
+    #    => when you need a permission template AND nesting fields in the solr_document
+    #    => certain ability tests (:discover, for example) require the permission template be created
+    # => 2) use build(:collection) and add with_nesting_attributes: {ancestors: [], parent_ids: [], pathnames: [], depth: 1}
+    #       to the build the collection and create a solr document using the given nesting attributes
+    #    => this can be used to speed up the specs when a made-up solr document is adequate and no permission template is required
 
     transient do
       user { create(:user) }
@@ -8,6 +20,7 @@ FactoryBot.define do
       collection_type_settings nil
       with_permission_template false
       create_access false
+      with_nesting_attributes nil
     end
     sequence(:title) { |n| ["Title #{n}"] }
 
@@ -17,6 +30,19 @@ FactoryBot.define do
         collection.collection_type = create(:collection_type, *evaluator.collection_type_settings)
       elsif collection.collection_type_gid.nil?
         collection.collection_type = create(:user_collection_type)
+      end
+
+      # if requested, create a solr document and add the nesting fields into it
+      # when a nestable collection is built. This reduces the need to use
+      # create and :with_nested_indexing for nested collection testing
+      if evaluator.with_nesting_attributes.present? && collection.nestable?
+        Hyrax::Adapters::NestingIndexAdapter.add_nesting_attributes(
+          solr_doc: evaluator.to_solr,
+          ancestors: evaluator.with_nesting_attributes[:ancestors],
+          parent_ids: evaluator.with_nesting_attributes[:parent_ids],
+          pathnames: evaluator.with_nesting_attributes[:pathnames],
+          depth: evaluator.with_nesting_attributes[:depth]
+        )
       end
     end
 

--- a/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
@@ -1,88 +1,239 @@
 RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: true do
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
-
-  # The admin spec short circuits much of the query
   let(:user) { create(:user) }
   let(:ability) { ::Ability.new(user) }
   let(:current_ability) { ability }
   let(:scope) { double('Scope', can?: true, current_ability: current_ability, repository: repository, blacklight_config: blacklight_config) }
+
   let(:collection_type) { create(:collection_type) }
   let(:another_collection_type) { create(:collection_type) }
 
+  let(:coll_a) do
+    build(:public_collection,
+          id: 'Collection_A',
+          collection_type_gid: collection_type.gid,
+          with_nesting_attributes:
+          { ancestors: [],
+            parent_ids: [],
+            pathnames: ['Collection_A'],
+            depth: 1 })
+  end
+  let(:coll_b) do
+    build(:public_collection,
+          id: 'Collection_B',
+          collection_type_gid: collection_type.gid,
+          member_of_collections: [coll_a],
+          with_nesting_attributes:
+          { ancestors: ['Collection_A'],
+            parent_ids: ['Collection_A'],
+            pathnames: ['Collection_A/Collection_B'],
+            depth: 2 })
+  end
+  let(:coll_c) do
+    build(:public_collection,
+          id: 'Collection_C',
+          collection_type_gid: collection_type.gid,
+          member_of_collections: [coll_b],
+          with_nesting_attributes:
+          { ancestors: ["Collection_A",
+                        "Collection_A/Collection_B"],
+            parent_ids: ['Collection_B'],
+            pathnames: ['Collection_A/Collection_B/Collection_C'],
+            depth: 3 })
+  end
+  let(:coll_d) do
+    build(:public_collection,
+          id: 'Collection_D',
+          collection_type_gid: collection_type.gid,
+          member_of_collections: [coll_c],
+          with_nesting_attributes:
+          { ancestors: ["Collection_A",
+                        "Collection_A/Collection_B",
+                        "Collection_A/Collection_B/Collection_C"],
+            parent_ids: ['Collection_C'],
+            pathnames: ["Collection_A/Collection_B/Collection_C/Collection_D"],
+            depth: 4 })
+  end
+  let(:coll_e) do
+    build(:public_collection,
+          id: 'Collection_E',
+          collection_type_gid: collection_type.gid,
+          member_of_collections: [coll_d],
+          with_nesting_attributes:
+          { ancestors: ["Collection_A",
+                        "Collection_A/Collection_B",
+                        "Collection_A/Collection_B/Collection_C",
+                        "Collection_A/Collection_B/Collection_C/Collection_D"],
+            parent_ids: ['Collection_D'],
+            pathnames: ['Collection_A/Collection_B/Collection_C/Collection_D/Collection_E'],
+            depth: 5 })
+  end
+  let(:another) do
+    build(:public_collection,
+          id: 'Another_One',
+          collection_type_gid: collection_type.gid,
+          with_nesting_attributes:
+          { ancestors: [],
+            parent_ids: [],
+            pathnames: ['Another_One'],
+            depth: 1 })
+  end
+  let(:wrong) do
+    build(:public_collection,
+          id: 'Wrong_Type',
+          collection_type_gid: another_collection_type.gid,
+          with_nesting_attributes:
+          { ancestors: [],
+            parent_ids: [],
+            pathnames: ['Wrong_Type'],
+            depth: 1 })
+  end
+
   describe '.available_child_collections' do
-    subject { described_class.available_child_collections(parent: parent, scope: scope) }
-
     describe 'given parent is not nestable?' do
-      let(:parent) { double(nestable?: false) }
+      subject { described_class.available_child_collections(parent: parent_double, scope: scope) }
+
+      let(:parent_double) { double(nestable?: false) }
 
       it { is_expected.to eq([]) }
     end
 
-    describe 'given parent is nestable?', clean_repo: true do
-      let!(:parent) { create(:public_collection, collection_type_gid: collection_type.gid) }
-      let!(:another) { create(:public_collection, collection_type_gid: collection_type.gid) }
-      let!(:wrong_type) { create(:public_collection, collection_type_gid: another_collection_type.gid) }
+    describe 'given parent is nestable?' do
+      subject { described_class.available_child_collections(parent: coll_c, scope: scope) }
 
       before do
-        allow(parent).to receive(:nestable?).and_return(true)
+        coll_e # this will also build coll_a through coll_d
+        another
+        wrong
       end
 
-      describe 'and cannot edit the parent' do
+      describe 'and cannot deposit to the parent' do
         it 'returns an empty array' do
-          expect(scope).to receive(:can?).with(:deposit, parent).and_return(false)
+          expect(scope).to receive(:can?).with(:deposit, coll_c).and_return(false)
           expect(described_class).not_to receive(:query_solr)
           expect(subject).to eq([])
         end
       end
 
-      it 'returns an array of collections of the same collection type excluding the given collection' do
-        expect(scope).to receive(:can?).with(:deposit, parent).and_return(true)
-        expect(described_class).to receive(:query_solr).with(collection: parent, access: :read, scope: scope, limit_to_id: nil).and_call_original
-        expect(subject.map(&:id)).to eq([another.id])
+      describe 'and can deposit to the parent' do
+        describe 'it prevents circular nesting' do
+          it 'returns an array of valid collections of the same collection type' do
+            expect(scope).to receive(:can?).with(:deposit, coll_c).and_return(true)
+            expect(described_class).to receive(:query_solr).with(collection: coll_c, access: :read, scope: scope, limit_to_id: nil, nest_direction: :as_child).and_call_original
+            expect(subject.map(&:id)).to contain_exactly(another.id, coll_e.id)
+          end
+        end
       end
     end
   end
+
   describe '.available_parent_collections' do
-    subject { described_class.available_parent_collections(child: child, scope: scope) }
-
     describe 'given child is not nestable?' do
-      let(:child) { double(nestable?: false) }
+      subject { described_class.available_parent_collections(child: child_double, scope: scope) }
+
+      let(:child_double) { double(nestable?: false) }
 
       it { is_expected.to eq([]) }
     end
 
-    describe 'given child is nestable?', clean_repo: true do
-      let!(:child) { create(:public_collection, collection_type_gid: collection_type.gid, user: user, create_access: true) }
-      let!(:another) { create(:public_collection, collection_type_gid: collection_type.gid, user: user, create_access: true) }
-      let!(:wrong_type) { create(:public_collection, collection_type_gid: another_collection_type.gid, user: user, create_access: true) }
+    describe 'given child is nestable?' do
+      describe 'and cannot read the child' do
+        subject { described_class.available_parent_collections(child: coll_c, scope: scope) }
 
-      before do
-        allow(child).to receive(:nestable?).and_return(true)
-      end
-
-      describe 'and cannot edit the child' do
         it 'returns an empty array' do
-          expect(scope).to receive(:can?).with(:read, child).and_return(false)
+          expect(scope).to receive(:can?).with(:read, coll_c).and_return(false)
           expect(described_class).not_to receive(:query_solr)
           expect(subject).to eq([])
         end
       end
 
-      describe 'and can read the child' do
-        it 'returns an array of collections of the same collection type excluding the given collection' do
-          expect(scope).to receive(:can?).with(:read, child).and_return(true)
-          expect(described_class).to receive(:query_solr).with(collection: child, access: :deposit, scope: scope, limit_to_id: nil).and_call_original
-          expect(subject.map(&:id)).to eq([another.id])
+      describe 'and can read the child', with_nested_reindexing: true do
+        subject { described_class.available_parent_collections(child: coll_c, scope: scope) }
+
+        # using create option here because permission template is required for testing :deposit access
+        let(:coll_a) do
+          create(:public_collection,
+                 id: 'Collection_A',
+                 collection_type_gid: collection_type.gid,
+                 user: user,
+                 create_access: true)
+        end
+        let(:coll_b) do
+          create(:public_collection,
+                 id: 'Collection_B',
+                 collection_type_gid: collection_type.gid,
+                 user: user,
+                 create_access: true,
+                 member_of_collections: [coll_a])
+        end
+        let(:coll_c) do
+          create(:public_collection,
+                 id: 'Collection_C',
+                 collection_type_gid: collection_type.gid,
+                 user: user,
+                 create_access: true,
+                 member_of_collections: [coll_b])
+        end
+        let(:coll_d) do
+          create(:public_collection,
+                 id: 'Collection_D',
+                 collection_type_gid: collection_type.gid,
+                 user: user,
+                 create_access: true,
+                 member_of_collections: [coll_c])
+        end
+        let(:coll_e) do
+          create(:public_collection,
+                 id: 'Collection_E',
+                 collection_type_gid: collection_type.gid,
+                 user: user,
+                 create_access: true,
+                 member_of_collections: [coll_d])
+        end
+        let(:another) do
+          create(:public_collection,
+                 id: 'Another_One',
+                 collection_type_gid: collection_type.gid,
+                 user: user,
+                 create_access: true)
+        end
+        let(:wrong) do
+          create(:public_collection,
+                 id: 'Wrong_Type',
+                 collection_type_gid: another_collection_type.gid,
+                 user: user,
+                 create_access: true)
+        end
+
+        before do
+          coll_e # this will also build coll_a through coll_d
+          another
+          wrong
+        end
+
+        describe 'it prevents circular nesting' do
+          it 'returns an array of collections of the same collection type excluding the given collection' do
+            expect(scope).to receive(:can?).with(:read, coll_c).and_return(true)
+            expect(described_class).to receive(:query_solr).with(collection: coll_c, access: :deposit, scope: scope, limit_to_id: nil, nest_direction: :as_parent).and_call_original
+            expect(subject.map(&:id)).to contain_exactly(coll_a.id, another.id)
+          end
         end
       end
     end
   end
+
   describe '.parent_and_child_can_nest?' do
-    let(:child) { double('Child', nestable?: true, collection_type_gid: 'same', id: 'child') }
-    let(:parent) { double('Parent', nestable?: true, collection_type_gid: 'same', id: 'parent') }
+    let(:parent) { coll_c }
+    let(:child) { another }
 
     subject { described_class.parent_and_child_can_nest?(parent: parent, child: child, scope: scope) }
+
+    before do
+      coll_e
+      another
+      wrong
+    end
 
     describe 'given parent and child are nestable' do
       describe 'and are the same object' do
@@ -90,9 +241,23 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
 
         it { is_expected.to eq(false) }
       end
-      describe 'and are of the same collection type' do
-        let!(:child) { create(:public_collection, collection_type_gid: collection_type.gid, user: user, create_access: true) }
-        let!(:parent) { create(:public_collection, collection_type_gid: collection_type.gid, user: user, create_access: true) }
+
+      describe 'and are of the same collection type', with_nested_reindexing: true do
+        # using create option here because permission template is required for testing :deposit access
+        let!(:parent) do
+          create(:public_collection,
+                 id: 'Parent_Collecton',
+                 collection_type_gid: collection_type.gid,
+                 user: user,
+                 create_access: true)
+        end
+        let!(:child) do
+          create(:public_collection,
+                 id: 'Child_Collection',
+                 collection_type_gid: collection_type.gid,
+                 user: user,
+                 create_access: true)
+        end
 
         it { is_expected.to eq(true) }
       end
@@ -104,21 +269,85 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
         it { is_expected.to eq(false) }
       end
       describe 'and are of different collection types' do
-        let(:parent) { double(nestable?: true, collection_type_gid: 'another') }
+        let(:parent) { double(nestable?: true, collection_type_gid: 'another', id: 'parent_collection') }
 
         it { is_expected.to eq(false) }
       end
     end
 
     describe 'given parent is not nestable?' do
-      let(:parent) { double(nestable?: false, collection_type_gid: 'same', id: 'parent') }
+      let(:parent) { double(nestable?: false, collection_type_gid: 'same', id: 'parent_collection') }
 
       it { is_expected.to eq(false) }
     end
     describe 'given child is not nestable?' do
-      let(:child) { double(nestable?: false, collection_type_gid: 'same', id: 'child') }
+      let(:child) { double(nestable?: false, collection_type_gid: 'same', id: 'child_collection') }
 
       it { is_expected.to eq(false) }
+    end
+    describe 'not in available parent collections' do
+      before do
+        allow(described_class).to receive(:available_parent_collections).with(child: child, scope: scope, limit_to_id: parent.id).and_return([])
+      end
+
+      it { is_expected.to eq(false) }
+    end
+    describe 'not in available child collections' do
+      before do
+        allow(described_class).to receive(:available_child_collections).with(parent: parent, scope: scope, limit_to_id: child.id).and_return([])
+      end
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe '.valid_combined_nesting_depth?' do
+    subject { described_class.valid_combined_nesting_depth?(parent: parent, child: child, scope: scope) }
+
+    context 'when total depth > limit' do
+      let(:parent) { coll_e }
+      let(:child) { another }
+
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+
+    context 'when valid combined depth' do
+      let(:parent) { coll_c }
+      let(:child) { coll_e }
+
+      it 'returns true' do
+        expect(subject).to eq true
+      end
+    end
+  end
+
+  describe 'nesting attributes object', with_nested_reindexing: true do
+    let(:user) { create(:user) }
+    let!(:parent) { create(:collection, id: 'Parent_Coll', collection_type_gid: collection_type.gid, user: user) }
+    let!(:child) { create(:user_collection, id: 'Child_Coll', collection_type_gid: collection_type.gid, user: user) }
+    let(:nesting_attributes) { Hyrax::Collections::NestedCollectionQueryService::NestingAttributes.new(id: child.id, scope: scope) }
+
+    before do
+      Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent, child: child)
+    end
+
+    it 'will respond to expected methods' do
+      expect(nesting_attributes).to respond_to(:id)
+      expect(nesting_attributes).to respond_to(:parents)
+      expect(nesting_attributes).to respond_to(:pathnames)
+      expect(nesting_attributes).to respond_to(:ancestors)
+      expect(nesting_attributes).to respond_to(:depth)
+    end
+
+    it 'will encapsulate the nesting attributes in an object' do
+      expect(nesting_attributes).to be_a(Hyrax::Collections::NestedCollectionQueryService::NestingAttributes)
+      expect(nesting_attributes.id).to eq('Child_Coll')
+      expect(nesting_attributes.parents).to eq(['Parent_Coll'])
+      expect(nesting_attributes.pathnames).to eq(['Parent_Coll/Child_Coll'])
+      expect(nesting_attributes.ancestors).to eq(['Parent_Coll'])
+      expect(nesting_attributes.depth).to eq(2)
     end
   end
 end


### PR DESCRIPTION
Fixes #2221

1. The nested collection query service needs to remove collections from the lists for nesting if they would cause nested indexing errors. This updates the query service to exclude collections which would cause circular indexing errors. 
2. It also prevents nesting of collections which would exceed the total nesting depth. However, this logic is too expensive to justify being done on each potential collection, so the nesting depth is only checked for the selected collection, prior to making the requested connection.
3. Additionally this implements a modification to the collection factory which allows for creating a solr_document for a nestable collection for querying purposes, using the build(:collection) option, without requiring the full collection creation and nested indexing process. 

### The rules for allowed nesting between collections are as follows:

**if adding as a parent collection:**
1) cannot have any pathnames containing the collection's ID
2) cannot already be Collection G's direct parent
3) cannot cause total nesting depth to exceed limit

**if adding as a child (subcollection):**
1) Cannot have any pathnames containing any of the child's pathname or ancestors
2) cannot already be the collection's direct child
3) cannot cause total nesting depth to exceed limit

_Note:_ due to the wildcard search, etc, the queries ARE expensive (the inclusion of the ability to add a subcollection on the index page concerns me for this reason... ideally this should only happen when someone wants to add a subcollection, not for each collection as an index page is loaded). However, in general, the use of nesting is a minor portion of the code, and as this is a necessity, any changes should focus on refactoring its use on the index page. It's my understanding that https://github.com/samvera/hyrax/pull/2573 accomplishes this.
 
@samvera/hyrax-code-reviewers
