### PR TITLE
Display an admin set even if it doesn't have a description

### DIFF
--- a/app/views/hyrax/collections/_collection_description.erb
+++ b/app/views/hyrax/collections/_collection_description.erb
@@ -1,3 +1,3 @@
-<% presenter.description.each do |description| %>
+<% presenter.description.try(:each) do |description| %>
     <p class="collection_description"><%= iconify_auto_link(description) %></p>
 <% end %>

--- a/spec/features/show_admin_set_spec.rb
+++ b/spec/features/show_admin_set_spec.rb
@@ -1,0 +1,11 @@
+RSpec.feature 'show admin set' do
+  let(:admin_set) { FactoryGirl.create(:admin_set) }
+  let(:admin) { FactoryGirl.create(:admin) }
+
+  scenario "show admin set" do
+    login_as admin
+    expect(admin_set.description).to be_empty
+    visit("/admin/admin_sets/#{admin_set.id}")
+    expect(page).to have_content admin_set.title.first
+  end
+end


### PR DESCRIPTION
Fixes #2575 

In Hyrax 1.x, you cannot display an admin_set if it does not have a description -- it throws an exception. This fixes that problem by using `try` instead of assuming the description exists.

@samvera/hyrax-code-reviewers
