### PR TITLE
Initialize AuthoritySelect in editor

### DIFF
--- a/app/assets/javascripts/hyrax/authority_select.es6
+++ b/app/assets/javascripts/hyrax/authority_select.es6
@@ -1,3 +1,5 @@
+import Autocomplete from 'hyrax/autocomplete'
+
 /** Class for authority selection on an input field */
 export default class AuthoritySelect {
     /**
@@ -6,8 +8,7 @@ export default class AuthoritySelect {
      * @param {string} selectBox - The selector for the select box
      * @param {string} inputField - The selector for the input field
      */
-    constructor(editor, options) {
-      this.editor = editor
+    constructor(options) {
     	this.selectBox = options.selectBox
     	this.inputField = options.inputField
     	this.selectBoxChange();
@@ -24,8 +25,10 @@ export default class AuthoritySelect {
         var _this2 = this
       	$(selectBox).on('change', function(data) {
       	    var selectBoxValue = $(this).val();
-      	    $(inputField).each(function (data) { $(this).data('autocomplete-url', selectBoxValue) });
-      	    _this2.setupAutocomplete();
+      	    $(inputField).each(function (data) {
+              $(this).data('autocomplete-url', selectBoxValue);
+      	       _this2.setupAutocomplete()
+            });
       	});
     }
 
@@ -35,11 +38,14 @@ export default class AuthoritySelect {
     observeAddedElement() {
       	var selectBox = this.selectBox;
       	var inputField = this.inputField;
+        var _this2 = this
 
       	var observer = new MutationObserver((mutations) => {
       	    mutations.forEach((mutation) => {
-      		      $(inputField).each(function (data) { $(this).data('autocomplete-url', $(selectBox).val()) });
-      		      this.setupAutocomplete();
+      		      $(inputField).each(function (data) {
+                  $(this).data('autocomplete-url', $(selectBox).val())
+      		        _this2.setupAutocomplete();
+                });
       	    });
       	});
 
@@ -51,6 +57,8 @@ export default class AuthoritySelect {
      * intialize the Hyrax autocomplete with the fields that you are using
      */
     setupAutocomplete() {
-      this.editor.autocomplete()
+      var inputField = $(this.inputField);
+      var autocomplete = new Autocomplete()
+      autocomplete.setup(inputField, inputField.data('autocomplete'), inputField.data('autocompleteUrl'))
     }
 }

--- a/app/assets/javascripts/hyrax/editor.es6
+++ b/app/assets/javascripts/hyrax/editor.es6
@@ -24,6 +24,7 @@ export default class {
     this.relationshipsControl()
     this.saveWorkControl()
     this.saveWorkFixed()
+    this.authoritySelect()
   }
 
   // Used when you have a linked data field that can have terms from multiple
@@ -33,7 +34,7 @@ export default class {
           let authoritySelect = $(this).data().authoritySelect
           let options =  {selectBox: 'select.' + authoritySelect,
                           inputField: 'input.' + authoritySelect}
-          new AuthoritySelect(this, options);
+          new AuthoritySelect(options);
       })
   }
 

--- a/spec/javascripts/authority_select_spec.js
+++ b/spec/javascripts/authority_select_spec.js
@@ -15,7 +15,7 @@ describe('authority select', () => {
     })
 
     it('should change the data-autocomplete-url when you select an authority', () => {
-	      new AuthoritySelect(editor, { selectBox : "select.generic_work_creator", inputField : "input.generic_work_creator" }).initialize()
+	      new AuthoritySelect({ selectBox : "select.generic_work_creator", inputField : "input.generic_work_creator" })
 	      $('select.generic_work_creator').val('/authorities/search/assign_fast/all').change()
 	      expect($('input.generic_work_creator').data('autocomplete-url')).toEqual('/authorities/search/assign_fast/all')
     })


### PR DESCRIPTION
Fixes #2579 

AuthoritySelect should be automatically initialized on select fields with `data-authority-select` attributes, but this does not appear to be happening as AuthoritySelect is never initialized.

 - Initializes authoritySelect in editor
 - Removes editor argument that was being passed to AuthoritySelect as the editor was not needed and it was actually passing a select box instead anyways.
- called autocomplete setup correctly when select box value is changed or new field is added.



@samvera/hyrax-code-reviewers
