### PR TITLE
Avoid raising errors in attribute renderers due to invalid values

### DIFF
--- a/app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb
@@ -17,7 +17,8 @@ module Hyrax
           if parsed_uri.nil?
             ERB::Util.h(value)
           else
-            %(<a href=#{ERB::Util.h(value)} target="_blank">#{Hyrax.config.rights_statement_service_class.new.label(value)}</a>)
+            label = Hyrax.config.rights_statement_service_class.new.label(value) { value }
+            %(<a href=#{ERB::Util.h(value)} target="_blank">#{label}</a>)
           end
         end
     end

--- a/app/services/hyrax/qa_select_service.rb
+++ b/app/services/hyrax/qa_select_service.rb
@@ -22,8 +22,17 @@ module Hyrax
       authority.find(id).fetch('active')
     end
 
-    def label(id)
-      authority.find(id).fetch('term')
+    ##
+    # @param id [String]
+    #
+    # @return [String] the label for the authority
+    #
+    # @yield when no 'term' value is present for the id
+    # @yieldreturn [String] an alternate label to return
+    #
+    # @raise [KeyError] when no 'term' value is present for the id
+    def label(id, &block)
+      authority.find(id).fetch('term', &block)
     end
 
     def active_elements

--- a/spec/renderers/hyrax/renderers/rights_statement_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/rights_statement_attribute_renderer_spec.rb
@@ -16,5 +16,14 @@ RSpec.describe Hyrax::Renderers::RightsStatementAttributeRenderer do
 
     it { expect(renderer).not_to be_microdata(field) }
     it { expect(subject).to be_equivalent_to(expected) }
+
+    context 'with off-authority term' do
+      let(:renderer) { described_class.new(field, [value]) }
+      let(:value)    { 'moomin' }
+
+      it 'renders a value' do
+        expect(subject.to_s).to include value
+      end
+    end
   end
 end

--- a/spec/services/hyrax/qa_select_service_spec.rb
+++ b/spec/services/hyrax/qa_select_service_spec.rb
@@ -55,7 +55,13 @@ RSpec.describe Hyrax::QaSelectService do
     end
     context 'for item without a "term" property' do
       it 'will raise KeyError' do
-        expect { qa_select_service.label('active-no-term-id') }.to raise_error(KeyError)
+        expect { qa_select_service.label('active-no-term-id') }
+          .to raise_error(KeyError)
+      end
+
+      it 'accepts a block for a backup value' do
+        expect(qa_select_service.label('active-no-term-id') { :backup })
+          .to eq :backup
       end
     end
   end


### PR DESCRIPTION
This prevents users from encountering errors due to removed `rights_statement`
authority values or valued added by a process that doesn't use authorities. The
default models don't validate rights statement terms (the authority is enforced
at the form level), so off-authority values should be handled gracefully.

The existing `#label` API is unchanged, and we introduce a block syntax for
backup values, similar to `Hash#fetch`.

Closes #2018.

Changes proposed in this pull request:
*  Avoid hitting `KeyError` in RightsStatement attribute renderers.

@samvera/hyrax-code-reviewers
