### PR TITLE
fix location of less button for parent collections

### DIFF
--- a/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
@@ -23,8 +23,8 @@
 									<%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
 								</li>
 							</ul>
-							<button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
 						<% end %>
+						<button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
 					</div>
 				<% end %>
 			</h4>


### PR DESCRIPTION
Put less button in the wrong place.  PR moves the button to the correct location.