### PR TITLE
Update search bar location and collection type label in collection public show page

### DIFF
--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -200,6 +200,10 @@ button.branding-banner-remove:hover {
   .expanded-details {
     display: none;
     padding-top: 10px;
+
+    dd {
+      text-align: left;
+    }
   }
 
   .modal {
@@ -278,7 +282,7 @@ button.branding-banner-remove:hover {
       }
 
       .label {
-        margin: 0 5px;
+        margin-left: 5px;
       }
     }
 

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -11,7 +11,7 @@
 
 			<div class="hyc-title">
 				<h1><%=@presenter.title.first%></h1>
-				<span class="label label-success">Collection</span>
+				<span class="label label-success"><%= @presenter.collection_type_badge %></span>
 				<%= @presenter.permission_badge %>
 			</div>
 
@@ -76,56 +76,49 @@
 		</div>
 	</div>
 
+	<% if @members_count > 0 %>
+		<div class="hyc-blacklight hyc-bl-title">
+			<h2>
+				<% if has_collection_search_parameters? %>
+						<%= t('hyrax.dashboard.collections.show.search_results') %>
+				<% end %>
+			</h2>
+		</div>
+	<% end %>
+
+	<!-- Search bar -->
+	<div class="hyc-blacklight hyc-bl-search hyc-body row">
+		<div class="col-sm-8">
+			<%= render 'search_form', presenter: @presenter %>
+		</div>
+	</div>
+
+	<!-- Subcollections -->
 	<% if @presenter.collection_type_is_nestable? && @subcollection_count > 0 %>
-			<div class="row hyc-blacklight hyc-bl-title">
-				<div class="col-md-12">
-					<h2>
-						<%= t('.subcollection_count') %> (<%= @subcollection_count %>)
-					</h2>
-				</div>
+			<div class="hyc-blacklight hyc-bl-title">
+				<h4><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h4>
 			</div>
-			<div class="row hyc-blacklight hyc-bl-results">
-				<div class="col-md-12">
-					<%= render 'subcollection_list', collection: @subcollection_docs %>
-				</div>
+			<div class="hyc-blacklight hyc-bl-results">
+				<%= render 'subcollection_list', collection: @subcollection_docs %>
 			</div>
 	<% end %>
 
+	<!-- Works -->
 	<% if @members_count > 0 %>
-			<div class="row hyc-blacklight hyc-bl-title">
-				<div class="col-md-12">
-					<h2>
-						<% if has_collection_search_parameters? %>
-								<%= t('hyrax.dashboard.collections.show.search_results') %>
-						<% else %>
-								<%= t('.works_in_collection') %> (<%= @members_count %>)
-						<% end %>
-					</h2>
-				</div>
+			<div class="hyc-blacklight hyc-bl-title">
+				<h4><%= t('.works_in_collection') %> (<%= @members_count %>)</h4>
 			</div>
 
-			<div class="row hyc-blacklight hyc-bl-search">
-				<div class="col-md-6 col-md-offset-6">
-					<%= render 'search_form', presenter: @presenter %>
-				</div>
+			<div class="hyc-blacklight hyc-bl-sort">
+				<%= render 'sort_and_per_page', collection: @presenter %>
 			</div>
 
-			<div class="row hyc-blacklight hyc-bl-sort">
-				<div class="col-md-12">
-					<%= render 'sort_and_per_page', collection: @presenter %>
-				</div>
+			<div class="hyc-blacklight hyc-bl-results">
+				<%= render_document_index @member_docs %>
 			</div>
 
-			<div class="row hyc-blacklight hyc-bl-results">
-				<div class="col-md-12">
-					<%= render_document_index @member_docs %>
-				</div>
-			</div>
-
-			<div class="row hyc-blacklight hyc-bl-pager">
-				<div class="col-md-12">
-					<%= render 'paginate' %>
-				</div>
+			<div class="hyc-blacklight hyc-bl-pager">
+				<%= render 'paginate' %>
 			</div>
 	<% end # if @members_count > 0 %>
 </div>

--- a/app/views/hyrax/dashboard/collections/_collection_title.html.erb
+++ b/app/views/hyrax/dashboard/collections/_collection_title.html.erb
@@ -11,7 +11,9 @@
       <div class="collection-title-row-content">
         <h3 class="collection-title"><%= title %></h3>
         <%= presenter.permission_badge %>
-        <%= presenter.collection_type_badge %>
+        <span class="label label-success">
+          <%= presenter.collection_type_badge %>
+        </span>
       </div>
       <div class="collection-title-row-content">
         <%= render 'show_actions', presenter: presenter %>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -31,7 +31,7 @@
         <div class="panel panel-default labels">
           <div class="panel-body">
 
-            <h2 class="non lower"><%= t('hyrax.collection.form.description') %></h2>
+            <h3 class="non lower"><%= t('hyrax.collection.form.description') %></h3>
             <div id="base-terms">
               <% f.object.primary_terms.each do |term| %>
                 <%= render_edit_field_partial(term, f: f) %>

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -2,7 +2,7 @@
             <div class="panel panel-default labels">
               <div class="panel-body">
                 <p><%= t('.note') %></p>
-                <h2><%= t('.add_sharing') %></h2>
+                <h3><%= t('.add_sharing') %></h3>
                 <% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
                 <%= simple_form_for @form.permission_template,
                                     url: [hyrax, :dashboard, @form, :permission_template],

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -11,10 +11,10 @@
         <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">
-        <h4 class="media-heading">
+        <h5 class="media-heading">
           <%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %>
           <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></i></a>
-        </h4>
+        </h5>
         <%= render_collection_links(document) %>
       </div>
     </div>

--- a/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
@@ -1,32 +1,28 @@
 <% if presenter.parent_collection_count <= 0 %>
 		<div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_parent_collections') %></div>
 <% else %>
-		<div class="media-body">
-			<h4 class="media-heading">
-				<div class="less-parent-collections-block" id="less-parent-collections">
-					<% presenter.visible_parent_collections.each do |document| %>
-						<ul>
-							<li>
-								<%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
-							</li>
-						</ul>
-					<% end %>
-					<% if presenter.more_parent_collections? %>
-							<button id="show-more-parent-collections" class="btn show-more-parent-collections-btn"><%= t("hyrax.collections.show.show_more_parent_collections") %></button>
-					<% end %>
-				</div>
-				<% if presenter.more_parent_collections? %>
-					<div class="more-parent-collections-block" id="more-parent-collections">
-						<% presenter.more_parent_collections.each do |document| %>
-							<ul>
-								<li>
-									<%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
-								</li>
-							</ul>
-						<% end %>
-						<button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
-					</div>
-				<% end %>
-			</h4>
+	<div class="less-parent-collections-block" id="less-parent-collections">
+		<% presenter.visible_parent_collections.each do |document| %>
+			<ul>
+				<li>
+					<strong><%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %></strong>
+				</li>
+			</ul>
+		<% end %>
+		<% if presenter.more_parent_collections? %>
+				<button id="show-more-parent-collections" class="btn show-more-parent-collections-btn"><%= t("hyrax.collections.show.show_more_parent_collections") %></button>
+		<% end %>
+	</div>
+	<% if presenter.more_parent_collections? %>
+		<div class="more-parent-collections-block" id="more-parent-collections">
+			<% presenter.more_parent_collections.each do |document| %>
+				<ul>
+					<li>
+						<strong><%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %></strong>
+					</li>
+				</ul>
+			<% end %>
+			<button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
 		</div>
+	<% end %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/_subcollection_list.html.erb
+++ b/app/views/hyrax/dashboard/collections/_subcollection_list.html.erb
@@ -1,16 +1,14 @@
 <% if @subcollection_docs.nil? || @subcollection_docs.empty? %>
   <div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_subcollections') %></div>
 <% else %>
-  <div class="media-body">
-    <h4 class="media-heading">
-      <% @subcollection_docs.each do |document| %>
-        <ul>
-         <li>
-            <% id = document.id %>
-            <%= link_to document.title_or_label, [hyrax, :dashboard, document], id: "src_copy_link_#{id}" %> <%# TODO: Get count for sub-collection %>
-          </li>
-        </ul>
-      <% end %>
-    </h4>
-  </div>
+<% @subcollection_docs.each do |document| %>
+  <ul>
+   <li>
+     <strong>
+      <% id = document.id %>
+      <%= link_to document.title_or_label, [hyrax, :dashboard, document], id: "src_copy_link_#{id}" %> <%# TODO: Get count for sub-collection %>
+      </strong>
+    </li>
+  </ul>
+<% end %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -20,7 +20,7 @@
           <div class="col-sm-9 collection-description-wrapper">
             <!-- Parent Collection(s) -->
             <% if @presenter.collection_type_is_nestable? && @presenter.parent_collection_count > 0 %>
-                <h3><%= t('.parent_collection_header') %> (<%= @presenter.parent_collection_count %>)</h3>
+                <h4><%= t('.parent_collection_header') %> (<%= @presenter.parent_collection_count %>)</h4>
                 <section class="parent-collections-wrapper">
                 <%= render 'hyrax/dashboard/collections/show_parent_collections', presenter: @presenter %>
               </section>
@@ -54,7 +54,7 @@
       <!-- Subcollections -->
       <% if @presenter.collection_type_is_nestable? %>
         <section class="sub-collections-wrapper">
-          <h3><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h3>
+          <h4><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h4>
           <div class="row">
             <div class="col-sm-6">
               <%= render 'subcollection_list', collection: @subcollection_docs %>
@@ -68,7 +68,7 @@
 
       <!-- Works -->
       <section class="works-wrapper">
-        <h3><%= t('.item_count') %> (<%= @members_count %>)</h3>
+        <h4><%= t('.item_count') %> (<%= @members_count %>)</h4>
         <%= render 'show_add_items_actions', presenter: @presenter %>
 
         <%= render 'sort_and_per_page', collection: @presenter %>

--- a/spec/views/hyrax/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/show.html.erb_spec.rb
@@ -1,10 +1,12 @@
 RSpec.describe 'hyrax/collections/show.html.erb', type: :view do
   let(:document) do
     SolrDocument.new(id: 'xyz123z4',
+                     'collection_type_gid_ssim' => [collection_type.gid],
                      'title_tesim' => ['Make Collections Great Again'],
                      'rights_tesim' => ["http://creativecommons.org/licenses/by-sa/3.0/us/"])
   end
   let(:ability) { double }
+  let(:collection_type) { create(:collection_type) }
   let(:presenter) { Hyrax::CollectionPresenter.new(document, ability) }
 
   before do


### PR DESCRIPTION

Fixes #2163 

Move the search bar above subcollections in the UI, and update the label tag overlaying the image to read collection type title, rather than hardcoded "Collection".