### PR TITLE
fix admin set show page breadcrumbs

### DIFF
--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -20,9 +20,9 @@ module Hyrax
     self.admin_set_create_service = AdminSetCreateService
 
     def show
-      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb t(:'hyrax.dashboard.my.collections'), hyrax.my_collections_path
-      add_breadcrumb presenter.to_s, request.path
+      add_breadcrumb t(:'hyrax.dashboard.title'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.dashboard.my.collections'), hyrax.admin_admin_sets_path
+      add_breadcrumb @admin_set.title.first
       super
     end
 


### PR DESCRIPTION
Fixes #2071

Fixes bugs with admin set show page breadcrumbs

Change show action code in app/controllers/hyrax/admin/admin_sets_controller.rb to display the correct breadcrumbs, see L 22-27

**Descriptive summary**

Change bread crumbs for admin set show page to match those for collection show page.

**Rationale**

Admin sets are simulating being just another collection, so the bread crumbs should look like the admin set is just another collection.

**Expected behavior**

admin/admin_sets/:id breadcrumbs should be...

My Dashboard - forward to dashboard
Your Collections - forward to dashboard/my/collections
admin set title (no link)

**Actual behavior**

admin/admin_sets/:id breadcrumbs are...

Home - forward to /
Administration - forward to dashboard
translation missing:... - forward to admin/admin_sets
View Set (no link)

**Steps to reproduce the behavior**

login as admin user
create an admin set with title 'Test Admin Set'
Dashboard -> Collections -> click title of the new admin set
 Verify that the breadcrumbs are...
Dashboard - forward to dashboard
Your Collections - forward to dashboard/my/collections
'Test Admin Set' (no link)