### PR TITLE
Fix sorting works in a collection

### DIFF
--- a/app/views/hyrax/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/collections/_sort_and_per_page.html.erb
@@ -6,7 +6,7 @@
                <fieldset class="col-xs-12 col-sm-9 col-md-8 col-lg-10">
                  <legend class="sr-only"><%= t('hyrax.sort_label') %></legend>
                  <%= label_tag(:sort, 'Sort By:') %>
-                 <%= select_tag(:sort, options_for_select(active_sort_fields, h(params[:sort]))) %>
+                 <%= select_tag(:sort, options_from_collection_for_select(active_sort_fields, 'first', lambda {|field| field.last.label}, h(params[:sort]))) %>
                  <%= label_tag(:per_page) do %>
                      Show <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: "Number of results to display per page") %>
                      per page

--- a/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
@@ -15,7 +15,7 @@
                <fieldset class="col-xs-12 col-sm-9 col-md-8 col-lg-10">
                  <legend class="sr-only"><%= t('hyrax.sort_label') %></legend>
                  <%= label_tag(:sort, 'Sort By:') %>
-                 <%= select_tag(:sort, options_for_select(active_sort_fields, h(params[:sort]))) %>
+                 <%= select_tag(:sort, options_from_collection_for_select(active_sort_fields, 'first', lambda {|field| field.last.label}, h(params[:sort]))) %>
                  <%= label_tag(:per_page) do %>
                      Show <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: "Number of results to display per page") %>
                      per page

--- a/spec/views/hyrax/collections/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_sort_and_per_page.html.erb_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe 'hyrax/collections/_sort_and_per_page.html.erb', type: :view do
+  let(:subject) { 'hyrax/collections/sort_and_per_page.html.erb' }
+  let(:collection) { instance_double(Collection) }
+
+  before do
+    allow(view).to receive(:show_sort_and_per_page?).and_return(true)
+    allow(view).to receive(:collection_path).and_return("collection/path")
+    stub_template('_view_type_group.erb' => "")
+  end
+
+  context "when there are multiple sort fields" do
+    let(:active_sort_fields) do
+      {
+        "sort field value 1" => Blacklight::Configuration::SortField.new(label: "sort field label 1"),
+        "sort field value 2" => Blacklight::Configuration::SortField.new(label: "sort field label 2")
+      }
+    end
+
+    it "renders the sort options without any selected when no sort param given" do
+      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: [])
+    end
+
+    it "renders the sort options with the correct option selected when a valid sort param given" do
+      allow(view).to receive(:params).and_return(sort: "sort field value 1")
+      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: ["sort field label 1"])
+    end
+
+    it "renders the sort options without any selected when an invalid sort param given" do
+      allow(view).to receive(:params).and_return(sort: "sort field value DNE")
+      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: [])
+    end
+  end
+
+  context "when there is only one sort field" do
+    let(:active_sort_fields) do
+      {
+        "sort field value 1" => Blacklight::Configuration::SortField.new(label: "sort field label 1")
+      }
+    end
+
+    it "does not render sort options" do
+      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      expect(rendered).not_to have_select('sort')
+    end
+  end
+
+  context "when there are no sort fields" do
+    let(:active_sort_fields) do
+      {}
+    end
+
+    it "does not render sort options" do
+      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      expect(rendered).not_to have_select('sort')
+    end
+  end
+end

--- a/spec/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe 'hyrax/dashboard/collections/_sort_and_per_page.html.erb', type: :view do
+  let(:subject) { 'hyrax/dashboard/collections/sort_and_per_page.html.erb' }
+  let(:collection) { instance_double(Collection) }
+
+  before do
+    allow(view).to receive(:show_sort_and_per_page?).and_return(true)
+    allow(view).to receive(:dashboard_collection_path).and_return("collection/path")
+    stub_template('_view_type_group.erb' => "")
+  end
+
+  context "when there are multiple sort fields" do
+    let(:active_sort_fields) do
+      {
+        "sort field value 1" => Blacklight::Configuration::SortField.new(label: "sort field label 1"),
+        "sort field value 2" => Blacklight::Configuration::SortField.new(label: "sort field label 2")
+      }
+    end
+
+    it "renders the sort options without any selected when no sort param given" do
+      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: [])
+    end
+
+    it "renders the sort options with the correct option selected when a valid sort param given" do
+      allow(view).to receive(:params).and_return(sort: "sort field value 1")
+      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: ["sort field label 1"])
+    end
+
+    it "renders the sort options without any selected when an invalid sort param given" do
+      allow(view).to receive(:params).and_return(sort: "sort field value DNE")
+      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: [])
+    end
+  end
+
+  context "when there is only one sort field" do
+    let(:active_sort_fields) do
+      {
+        "sort field value 1" => Blacklight::Configuration::SortField.new(label: "sort field label 1")
+      }
+    end
+
+    it "does not render sort options" do
+      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      expect(rendered).not_to have_select('sort')
+    end
+  end
+
+  context "when there are no sort fields" do
+    let(:active_sort_fields) do
+      {}
+    end
+
+    it "does not render sort options" do
+      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      expect(rendered).not_to have_select('sort')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2286

The views were changed to use active_sort_fields instead of deprecated sort_fields (8ab573513d3ea6f73bc4d61c8cee7f8911633bdf). This data structure is different, was an array of key value pairs, ex:
  ```ruby
[ [ "relevance", "score desc, system_create_dtsi desc"], ... ]
```
is now an object with each sort field, ex:
  ```ruby 
{ "score desc, system_create_dtsi desc" => #<Blacklight::Configuration::SortField label="relevance", key="score desc, system_create_dtsi desc", field="score desc, system_create_dtsi desc", if=true, unless=false, sort="score desc, system_create_dtsi desc">, ... }
```

Changed how the views map the collection to select options.

@samvera/hyrax-code-reviewers
