### PR TITLE
Avoid potential infinite loop in `WorkShowPresenter`

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -72,6 +72,7 @@ module Hyrax
       @representative_presenter ||=
         begin
           result = member_presenters([representative_id]).first
+          return nil if result.try(:id) == id
           if result.respond_to?(:representative_presenter)
             result.representative_presenter
           else

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -256,6 +256,27 @@ RSpec.describe Hyrax::WorkShowPresenter do
         .and_return ["abc"]
       expect(presenter.representative_presenter).to eq("abc")
     end
+
+    context 'without a representative' do
+      let(:obj) { create(:work) }
+
+      it 'has a nil presenter' do
+        expect(presenter.representative_presenter).to be_nil
+      end
+    end
+
+    context 'when it is its own representative' do
+      let(:obj) { create(:work) }
+
+      before do
+        obj.representative_id = obj.id
+        obj.save
+      end
+
+      it 'has a nil presenter; avoids infinite loop' do
+        expect(presenter.representative_presenter).to be_nil
+      end
+    end
   end
 
   describe "#download_url" do


### PR DESCRIPTION
The `WorkShowPresenter#representative_presenter` can enter an infinite loop in
the case that it returns another instance of itself as representative. This
behavior has been spotted in production shortly after upload of a new item--
presumably while background jobs are running--when visiting the work show page
immediately after deposit. This clears itself up shortly after, and doesn't
present a major issue. Still, it seemed worth addressing the edge case.

Note that an infinite loop is still technically possible within the method; we
believe this fixes the real case we have encountered.

Changes proposed in this pull request:
* Don't recursively call `#representative_presenter` from itself.

@samvera/hyrax-code-reviewers
