### PR TITLE
stay on collection’s admin show page when initiating search from that page

### DIFF
--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -1,4 +1,4 @@
-  <%= form_for presenter, method: :get, class: "well form-search" do |f| %>
+  <%= form_for presenter, url: url, method: :get, class: "well form-search" do |f| %>
       <label class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
       <div class="input-group">
         <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('hyrax.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -76,6 +76,7 @@
 		</div>
 	</div>
 
+	<!-- Search results label -->
 	<% if @members_count > 0 %>
 		<div class="hyc-blacklight hyc-bl-title">
 			<h2>
@@ -89,7 +90,7 @@
 	<!-- Search bar -->
 	<div class="hyc-blacklight hyc-bl-search hyc-body row">
 		<div class="col-sm-8">
-			<%= render 'search_form', presenter: @presenter %>
+			<%= render 'search_form', presenter: @presenter, url: hyrax.collection_path(@presenter.id) %>
 		</div>
 	</div>
 

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -38,17 +38,25 @@
         </div>
       </section>
 
-      <!-- Search -->
+      <!-- Search results label -->
+      <% if @members_count > 0 %>
+          <div class="hyc-blacklight hyc-bl-title">
+            <h2>
+              <% if has_collection_search_parameters? %>
+                  <%= t('hyrax.dashboard.collections.show.search_results') %>
+              <% end %>
+            </h2>
+          </div>
+      <% end %>
+
+      <!-- Search bar -->
       <section class="collections-search-wrapper">
         <div class="row">
           <div class="col-sm-8">
             <%# TODO: leaving this as it was causes rerouting to the public show page. needs work %>
-            <%= render 'hyrax/collections/search_form', presenter: @presenter %>
+            <%= render 'hyrax/collections/search_form', presenter: @presenter, url: hyrax.dashboard_collection_path(@presenter.id) %>
           </div>
         </div>
-        <% if has_collection_search_parameters? %>
-            <%= t('.search_results') %>
-        <% end %>
       </section>
 
       <!-- Subcollections -->
@@ -59,9 +67,11 @@
             <div class="col-sm-6">
               <%= render 'subcollection_list', collection: @subcollection_docs %>
             </div>
-            <div class="col-sm-6">
-              <%= render 'show_subcollection_actions', presenter: @presenter %>
-            </div>
+            <% unless has_collection_search_parameters? %>
+              <div class="col-sm-6">
+                <%= render 'show_subcollection_actions', presenter: @presenter %>
+              </div>
+            <% end %>
           </div>
         </section>
       <% end %>
@@ -69,7 +79,9 @@
       <!-- Works -->
       <section class="works-wrapper">
         <h4><%= t('.item_count') %> (<%= @members_count %>)</h4>
-        <%= render 'show_add_items_actions', presenter: @presenter %>
+        <% unless has_collection_search_parameters? %>
+          <%= render 'show_add_items_actions', presenter: @presenter %>
+        <% end %>
 
         <%= render 'sort_and_per_page', collection: @presenter %>
         <%= render_document_index @member_docs %>
@@ -80,9 +92,11 @@
   </section><!-- /collections-panel-wrapper -->
 </div><!-- /collections-wrapper -->
 
-<% if @presenter.collection_type_is_nestable? %>
+<% if @presenter.collection_type_is_nestable? && !has_collection_search_parameters? %>
   <%= render 'hyrax/my/collections/modal_add_to_collection', source: 'show' %>
   <%= render 'hyrax/my/collections/modal_add_subcollection', id: @presenter.id, source: 'show' %>
 <% end %>
 
-<%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>
+<% unless has_collection_search_parameters? %>
+  <%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>
+<% end %>

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
 
     allow(presenter).to receive(:total_items).and_return(0)
     allow(presenter).to receive(:collection_type).and_return(collection_type)
+    assign(:subcollection_count, 0)
+    assign(:parent_collection_count, 0)
+    assign(:members_count, 0)
 
     allow(collection_type).to receive(:nestable?).and_return(true)
     allow(collection_type).to receive(:title).and_return("User Collection")


### PR DESCRIPTION
Fixes #2590

Sets the form url in the calling show page so the search_form partial can be shared by both the collection's admin show page and public show page.