### PR TITLE
General collections area UI cleanup

### DIFF
--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -351,8 +351,55 @@ button.branding-banner-remove:hover {
   text-align: left;
 }
 
-// Styles for collection public landing page
+// Edit Collections - Sharing Tab
+.edit-sharing-tab {
 
+  .section-add-sharing {
+    padding-bottom: 40px;
+
+    .form-inline {
+      label,
+      input,
+      span,
+      select {
+        margin: 2px 10px;
+      }
+
+      label {
+        padding-right: 5px;
+        text-align: right;
+        width: 100px;
+      }
+
+      input,
+      select {
+        width: 200px;
+      }
+
+      .btn {
+        width: 75px;
+      }
+    }
+  }
+
+  .section-collection-sharing {
+
+    legend {
+      margin-bottom: 0;
+    }
+
+    .share-status {
+      th,
+      td {
+        &:last-of-type {
+          text-align: center;
+        }
+      }
+    }
+  }
+}
+
+// Styles for collection public landing page
 .hyc-header {
 
   margin-bottom: 2em;

--- a/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
@@ -12,10 +12,10 @@
         <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">
-        <h4 class="media-heading">
-          <%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %>
+        <p class="media-heading">
+          <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
           <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></i></a>
-        </h4>
+        </p>
         <%= render_collection_links(document) %>
       </div>
     </div>

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -11,10 +11,10 @@
         <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">
-        <h4 class="media-heading">
-          <%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %>
+        <p class="media-heading">
+          <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
           <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></i></a>
-        </h4>
+        </p>
         <%= render_collection_links(document) %>
       </div>
     </div>

--- a/app/views/hyrax/collections/_subcollection_list.html.erb
+++ b/app/views/hyrax/collections/_subcollection_list.html.erb
@@ -1,16 +1,12 @@
 <% if @subcollection_docs.nil? || @subcollection_docs.empty? %>
   <div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_subcollections') %></div>
 <% else %>
-  <div class="media-body">
-    <h4 class="media-heading">
-      <% @subcollection_docs.each do |document| %>
-        <ul>
-         <li>
-            <% id = document.id %>
-            <%= link_to document.title_or_label, [hyrax, document], id: "src_copy_link_#{id}" %> <%# TODO: Get count for sub-collection %>
-          </li>
-        </ul>
-      <% end %>
-    </h4>
-  </div>
+<% @subcollection_docs.each do |document| %>
+  <ul>
+   <li>
+      <% id = document.id %>
+      <strong><%= link_to document.title_or_label, [hyrax, document], id: "src_copy_link_#{id}" %></strong>
+    </li>
+  </ul>
+<% end %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -31,7 +31,6 @@
         <div class="panel panel-default labels">
           <div class="panel-body">
 
-            <h3 class="non lower"><%= t('hyrax.collection.form.description') %></h3>
             <div id="base-terms">
               <% f.object.primary_terms.each do |term| %>
                 <%= render_edit_field_partial(term, f: f) %>

--- a/app/views/hyrax/dashboard/collections/_form_branding.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_branding.html.erb
@@ -1,7 +1,7 @@
 <div class="set-access-controls">
-  <strong><%= t('.branding.label') %></strong>
+  <h3><%= t('.branding.label') %></h3>
   <p><%= t('.branding.description') %></p>
-  <strong><%= t('.banner.label') %></strong>
+  <label><strong><%= t('.banner.label') %></strong></label>
   <p><%= t('.banner.description') %>.</p>
 
   <div id="fileupload">
@@ -78,7 +78,7 @@
 
   <%= render 'hyrax/uploads/js_templates_branding' %>
 
-  <strong><%= t('.logo.label') %></strong>
+  <label><strong><%= t('.logo.label') %></strong></label>
   <p><%= t('.logo.description') %></p>
 
   <div id="fileuploadlogo">

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -1,68 +1,71 @@
-          <div id="participants" class="tab-pane">
-            <div class="panel panel-default labels">
-              <div class="panel-body">
-                <p><%= t('.note') %></p>
-                <h3><%= t('.add_sharing') %></h3>
-                <% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
-                <%= simple_form_for @form.permission_template,
-                                    url: [hyrax, :dashboard, @form, :permission_template],
-                                    html: { id: 'group-participants-form' } do |f| %>
-                  <div class="clearfix spacer">
-                  <%= f.fields_for 'access_grants_attributes',
-                                   f.object.access_grants.build(agent_type: 'group'),
-                                   index: 0 do |builder| %>
-                    <div class="form-inline">
-                      <label class="col-md-2 col-xs-4 control-label"><%= t('.add_group') %></label>
+<div id="participants" class="tab-pane">
+  <div class="panel panel-default labels edit-sharing-tab">
+    <div class="panel-body">
 
-                      <div class="col-md-10 col-xs-8 form-group">
-                        <%= builder.hidden_field :agent_type %>
-                        <%= builder.text_field :agent_id,
-                                         placeholder: "Search for a group...",
-                                         class: 'form-control' %>
-                        as
-                        <%= builder.select :access,
-                                     access_options,
-                                     { prompt: "Select a role..." },
-                                     class: 'form-control' %>
+      <section class="section-add-sharing">
+        <p><%= t('.note') %></p>
+        <h3><%= t('.add_sharing') %></h3>
 
-                                   <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
-                      </div>
-                    </div>
-                  <% end %>
-                  </div>
-                <% end %>
+        <% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
 
-                <%= simple_form_for @form.permission_template,
-                                    url: [hyrax, :dashboard, @form, :permission_template],
-                                    html: { id: 'user-participants-form' } do |f| %>
-                  <%= f.fields_for 'access_grants_attributes',
-                                   f.object.access_grants.build(agent_type: 'user'),
-                                   index: 0 do |builder| %>
-                    <div class="form-inline add-users">
-                      <label class="col-md-2 col-xs-4 control-label"><%= t('.add_user') %></label>
+        <%= simple_form_for @form.permission_template,
+          url: [hyrax, :dashboard, @form, :permission_template],
+          html: { id: 'group-participants-form' } do |f| %>
 
-                      <div class="col-md-10 col-xs-8 form-group">
-                        <%= builder.hidden_field :agent_type %>
-                        <%= builder.text_field :agent_id,
-                                         placeholder: "Search for a user..." %>
-                        as
-                        <%= builder.select :access,
-                                     access_options,
-                                     { prompt: "Select a role..." },
-                                     class: 'form-control' %>
+          <%= f.fields_for 'access_grants_attributes',
+            f.object.access_grants.build(agent_type: 'group'),
+            index: 0 do |builder| %>
 
-                        <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
-                      </div>
-                    </div>
-                  <% end %>
-                <% end %>
+            <div class="form-inline add-sharing-form">
+              <div class="form-group">
+                <label><%= t('.add_group') %>:</label>
+                <%= builder.hidden_field :agent_type %>
+                <%= builder.text_field :agent_id, placeholder: "Search for a group...", class: 'form-control search-input' %>
+                as
+                <%= builder.select :access, access_options,
+                { prompt: "Select a role..." },
+                class: 'form-control' %>
 
-                <fieldset class="collection-sharing">
-                  <legend><%= t(".current_shared") %></legend>
-                  <%= render 'form_share_table', access: 'managers', filter: :manage? %>
-                  <%= render 'form_share_table', access: 'depositors', filter: :deposit? %>
-                  <%= render 'form_share_table', access: 'viewers', filter: :view? %>
-                </fieldset>
+                <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
               </div>
             </div>
+
+          <% end %>
+        <% end %>
+
+        <%= simple_form_for @form.permission_template,
+          url: [hyrax, :dashboard, @form, :permission_template],
+          html: { id: 'user-participants-form' } do |f| %>
+
+          <%= f.fields_for 'access_grants_attributes',
+          f.object.access_grants.build(agent_type: 'user'),
+          index: 0 do |builder| %>
+
+          <div class="form-inline add-users">
+            <div class="form-group">
+              <label><%= t('.add_user') %>:</label>
+              <%= builder.hidden_field :agent_type %>
+              <%= builder.text_field :agent_id, placeholder: "Search for a user...", class: 'form-control search-input' %>
+              as
+              <%= builder.select :access,
+              access_options,
+              { prompt: "Select a role..." },
+              class: 'form-control' %>
+
+              <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
+            </div>
           </div>
+          <% end %>
+        <% end %>
+      </section>
+
+      <section class="section-collection-sharing">
+        <legend><%= t(".current_shared") %></legend>
+        <%= render 'form_share_table', access: 'managers', filter: :manage? %>
+        <%= render 'form_share_table', access: 'depositors', filter: :deposit? %>
+        <%= render 'form_share_table', access: 'viewers', filter: :view? %>
+      </section>
+
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -11,10 +11,10 @@
         <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">
-        <h5 class="media-heading">
-          <%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %>
+        <p class="media-heading">
+          <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
           <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></i></a>
-        </h5>
+        </p>
         <%= render_collection_links(document) %>
       </div>
     </div>


### PR DESCRIPTION
Fixes #2591 

Some general enhancements to Collections area UI, markup, and header text including:
- Consistent content headlines as `<h3>`, subheads `<h4>`
- Eliminating Bootstrap Media Object class wrappers unless there's a proper use case for applying them.
- Removing embedded nested `<ul>`s from headers (ie. `<h3>Awesome headline <ul><li>this should not be here</li></ul><some-other-random-tags-were-here /></h3`)
- Update to layout of the Collections Edit > Sharing tab content.
- Tried to follow the original mock-ups in layout of all tabs.

