### PR TITLE
do not override blacklight controller and facets set up in parent classes

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -17,11 +17,6 @@ module Hyrax
       # include the display_trophy_link view helper method
       helper Hyrax::TrophyHelper
 
-      # This is needed as of BL 3.7
-      copy_blacklight_config_from(::CatalogController)
-
-      configure_facets
-
       # Catch permission errors
       rescue_from Hydra::AccessDenied, CanCan::AccessDenied, with: :deny_collection_access
 


### PR DESCRIPTION
Fixes #2582

The blacklight config was copied into the dashboard/collections_controller which overwrite the copy brought in my my_controller.  This clears out all the facets.  Once this was removed, the call to configure_facets had to be removed as it made a second call to include the same facets twice resulting in an exception. 

