### PR TITLE
Use original_filename instead of original_name

### DIFF
--- a/app/jobs/ingest_file_job.rb
+++ b/app/jobs/ingest_file_job.rb
@@ -13,7 +13,7 @@ class IngestFileJob < ActiveJob::Base
     # Wrap in an IO decorator to attach passed-in options
     local_file = Hydra::Derivatives::IoDecorator.new(File.open(filepath, "rb"))
     local_file.mime_type = opts.fetch(:mime_type, nil)
-    local_file.original_name = opts.fetch(:filename, File.basename(filepath))
+    local_file.original_filename = opts.fetch(:filename, File.basename(filepath))
 
     # Tell AddFileToFileSet service to skip versioning because versions will be minted by
     # VersionCommitter when necessary during save_characterize_and_record_committer.

--- a/app/services/hyrax/persist_directly_contained_output_file_service.rb
+++ b/app/services/hyrax/persist_directly_contained_output_file_service.rb
@@ -15,7 +15,7 @@ module Hyrax
       remote_file = retrieve_remote_file(file_set, directives)
       remote_file.content = file
       remote_file.mime_type = determine_mime_type(file)
-      remote_file.original_name = determine_original_name(file)
+      remote_file.original_filename = determine_original_name(file)
       file_set.save
     end
 

--- a/app/services/hyrax/working_directory.rb
+++ b/app/services/hyrax/working_directory.rb
@@ -8,9 +8,9 @@ module Hyrax
       def find_or_retrieve(repository_file_id, id, filepath = nil)
         return filepath if filepath && File.exist?(filepath)
         repository_file = Hydra::PCDM::File.find(repository_file_id)
-        working_path = full_filename(id, repository_file.original_name)
+        working_path = full_filename(id, repository_file.original_filename)
         if File.exist?(working_path)
-          Rails.logger.debug "#{repository_file.original_name} already exists in the working directory at #{working_path}"
+          Rails.logger.debug "#{repository_file.original_filename} already exists in the working directory at #{working_path}"
           return working_path
         end
         copy_repository_resource_to_working_directory(repository_file, id)
@@ -28,9 +28,9 @@ module Hyrax
       # @param [String] id the identifier of the FileSet
       # @return [String] path of the working file
       def copy_repository_resource_to_working_directory(file, id)
-        Rails.logger.debug "Loading #{file.original_name} (#{file.id}) from the repository to the working directory"
+        Rails.logger.debug "Loading #{file.original_filename} (#{file.id}) from the repository to the working directory"
         # TODO: this causes a load into memory, which we'd like to avoid
-        copy_stream_to_working_directory(id, file.original_name, StringIO.new(file.content))
+        copy_stream_to_working_directory(id, file.original_filename, StringIO.new(file.content))
       end
 
       private

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -342,7 +342,7 @@ describe Hyrax::Actors::FileSetActor do
 
     it "restores the first versions's content and metadata" do
       actor.revert_content(version1)
-      expect(restored_content.original_name).to eq file1
+      expect(restored_content.original_filename).to eq file1
     end
   end
 end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -234,7 +234,7 @@ describe Hyrax::FileSetsController do
 
             it "restores the first versions's content and metadata" do
               # expect(restored_content.mime_type).to eq "image/png"
-              expect(restored_content.original_name).to eq file1
+              expect(restored_content.original_filename).to eq file1
               expect(versions.all.count).to eq 3
               expect(versions.last.label).to eq latest_version.label
               expect(Hyrax::VersionCommitter.where(version_id: versions.last.uri).pluck(:committer_login)).to eq [user.user_key]

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -8,7 +8,7 @@ describe CharacterizeJob do
   let(:file) do
     Hydra::PCDM::File.new.tap do |f|
       f.content = 'foo'
-      f.original_name = 'picture.png'
+      f.original_filename = 'picture.png'
       f.save!
     end
   end

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -15,7 +15,7 @@ describe CreateDerivativesJob do
     let(:file) do
       Hydra::PCDM::File.new.tap do |f|
         f.content = 'foo'
-        f.original_name = 'picture.png'
+        f.original_filename = 'picture.png'
         f.save!
       end
     end
@@ -70,7 +70,7 @@ describe CreateDerivativesJob do
     let(:file) do
       Hydra::PCDM::File.new do |f|
         f.content = File.open(File.join(fixture_path, "hyrax/hyrax_test4.pdf"))
-        f.original_name = 'test.pdf'
+        f.original_filename = 'test.pdf'
         f.mime_type = 'application/pdf'
       end
     end

--- a/spec/jobs/ingest_file_job_spec.rb
+++ b/spec/jobs/ingest_file_job_spec.rb
@@ -69,7 +69,7 @@ describe IngestFileJob do
       expect(Hyrax::VersioningService.latest_version_of(file_set.reload.original_file).label).to eq 'version2'
       expect(file_set.original_file.content).to eq File.open(file2).read
       expect(file_set.original_file.mime_type).to eq 'text/plain'
-      expect(file_set.original_file.original_name).to eq 'small_file.txt'
+      expect(file_set.original_file.original_filename).to eq 'small_file.txt'
 
       # the user for each version
       expect(Hyrax::VersionCommitter.where(version_id: versions.first.uri).pluck(:committer_login)).to eq [user.user_key]


### PR DESCRIPTION
According to the hydra-derivatives deprecation warning:
original_name is deprecated and will be removed from
a future release. Use original_filename instead.
This will be removed in hydra-derivatives 4.0
This change keeps the hyrax 1 branch forward compatible
with hydra-derivatives.

@samvera/hyrax-code-reviewers
