### PR TITLE
fix share applies to new work always checked once created

### DIFF
--- a/app/assets/javascripts/hyrax/admin/collection_type/settings.es6
+++ b/app/assets/javascripts/hyrax/admin/collection_type/settings.es6
@@ -33,7 +33,7 @@ export default class {
         }
     }
     else {
-        // if sharable is not selected, then share_applies_to_enw_works must be unchecked and disabled so it cannot be changed
+        // if sharable is not selected, then share_applies_to_new_works must be unchecked and disabled so it cannot be changed
         this.applies_to_new_works.prop("checked", false)
         this.applies_to_new_works.prop("disabled", true)
         this.addDisabledClasses()

--- a/app/views/hyrax/admin/collection_types/_form_settings.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_settings.html.erb
@@ -9,11 +9,22 @@
     <p><%= f.input :sharable, as: :boolean, disabled: f.object.all_settings_disabled? %></p>
     <% # Using html instead of simple_form to allow adding of disabled class to elements through javascript settings.es6 %>
     <div class="collection-type-share-applies-to">
-      <div id="sharable-applies-to-new-works-setting-checkbox-container" class="form-group boolean optional collection_type_share_applies_to_new_works <%= 'disabled' if f.object.share_options_disabled? %>">
+      <div id="sharable-applies-to-new-works-setting-checkbox-container"
+           class="form-group boolean optional collection_type_share_applies_to_new_works <%= 'disabled' if f.object.share_options_disabled? %>">
         <div class="checkbox">
-          <input value="0" name="collection_type[share_applies_to_new_works]" type="hidden" <%= "disabled=\"disabled\"".html_safe if f.object.share_options_disabled? %> >
-          <label id="sharable-applies-to-new-works-setting-label" class="boolean optional <%= 'disabled' if f.object.share_options_disabled? %>" for="collection_type_share_applies_to_new_works">
-            <input id="collection_type_share_applies_to_new_works" class="boolean optional <%= 'disabled' if f.object.share_options_disabled? %>" value="1" checked="checked" name="collection_type[share_applies_to_new_works]" type="checkbox" <%= "disabled=\"disabled\"".html_safe if f.object.share_options_disabled? %> >
+          <input value="0"
+                 name="collection_type[share_applies_to_new_works]"
+                 type="hidden"
+                 <%= "disabled=\"disabled\"".html_safe if f.object.share_options_disabled? %> >
+          <label id="sharable-applies-to-new-works-setting-label"
+                 class="boolean optional <%= 'disabled' if f.object.share_options_disabled? %>"
+                 for="collection_type_share_applies_to_new_works">
+            <input id="collection_type_share_applies_to_new_works" <%= "disabled=\"disabled\"".html_safe if f.object.share_options_disabled? %>
+                   class="boolean optional <%= 'disabled' if f.object.share_options_disabled? %>"
+                   value="1"
+                   <%= "checked=\"checked\"".html_safe if f.object.share_applies_to_new_works %>"
+                   name="collection_type[share_applies_to_new_works]"
+                   type="checkbox">
             APPLY TO NEW WORKS
           </label>
         </div>

--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -151,6 +151,97 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
 
         # TODO: Test adding participants
       end
+
+      context 'when editing default user collection type' do
+        let(:title_old) { user_collection_type.title }
+        let(:description_old) { user_collection_type.description }
+        let(:title_new) { 'User Collection modified' }
+        let(:description_new) { 'Change in description for user collection type.' }
+
+        before do
+          user_collection_type
+          sign_in admin_user
+          visit "/admin/collection_types/#{user_collection_type.id}/edit"
+        end
+
+        it 'allows editing of metadata, but not settings', :js do
+          expect(page).to have_content "Edit Collection Type: #{title_old}"
+
+          # confirm metadata fields have original values
+          expect(page).to have_selector "input#collection_type_title[value='#{title_old}']"
+          expect(page).to have_selector 'textarea#collection_type_description', text: description_old
+
+          # set values and save
+          fill_in('Type name', with: title_new)
+          fill_in('Type description', with: description_new)
+
+          click_button('Save changes')
+
+          expect(page).to have_content "Edit Collection Type: #{title_new}"
+
+          # confirm values were set
+          expect(page).to have_selector "input#collection_type_title[value='#{title_new}']"
+          expect(page).to have_selector 'textarea#collection_type_description', text: description_new
+
+          click_link('Settings', href: '#settings')
+
+          # confirm default user collection checkboxes are set to appropriate values
+          expect(page).to have_checked_field('collection_type_nestable', disabled: true)
+          expect(page).to have_checked_field('collection_type_discoverable', disabled: true)
+          expect(page).to have_checked_field('collection_type_sharable', disabled: true)
+          expect(page).to have_unchecked_field('collection_type_share_applies_to_new_works', disabled: true)
+          expect(page).to have_checked_field('collection_type_allow_multiple_membership', disabled: true)
+
+          # confirm all admin_set only checkboxes are off and disabled
+          expect(page).to have_unchecked_field('collection_type_require_membership', disabled: true)
+          expect(page).to have_unchecked_field('collection_type_assigns_workflow', disabled: true)
+          expect(page).to have_unchecked_field('collection_type_assigns_visibility', disabled: true)
+        end
+      end
+
+      context 'when editing admin set collection type' do
+        let(:title_old) { admin_set_type.title }
+        let(:description_old) { admin_set_type.description }
+        let(:description_new) { 'Change in description for admin set collection type.' }
+
+        before do
+          admin_set_type
+          sign_in admin_user
+          visit "/admin/collection_types/#{admin_set_type.id}/edit"
+        end
+
+        it 'allows editing of metadata except title, but not settings', :js do
+          expect(page).to have_content "Edit Collection Type: #{title_old}"
+
+          # confirm metadata fields have original values
+          expect(page).to have_field("collection_type_title", disabled: true)
+          expect(page).to have_selector 'textarea#collection_type_description', text: description_old
+
+          # set values and save
+          fill_in('Type description', with: description_new)
+
+          click_button('Save changes')
+
+          expect(page).to have_content "Edit Collection Type: #{title_old}"
+
+          # confirm values were set
+          expect(page).to have_selector 'textarea#collection_type_description', text: description_new
+
+          click_link('Settings', href: '#settings')
+
+          # confirm default user collection checkboxes are set to appropriate values
+          expect(page).to have_unchecked_field('collection_type_nestable', disabled: true)
+          expect(page).to have_unchecked_field('collection_type_discoverable', disabled: true)
+          expect(page).to have_checked_field('collection_type_sharable', disabled: true)
+          expect(page).to have_checked_field('collection_type_share_applies_to_new_works', disabled: true)
+          expect(page).to have_unchecked_field('collection_type_allow_multiple_membership', disabled: true)
+
+          # confirm all admin_set only checkboxes are off and disabled
+          expect(page).to have_checked_field('collection_type_require_membership', disabled: true)
+          expect(page).to have_checked_field('collection_type_assigns_workflow', disabled: true)
+          expect(page).to have_checked_field('collection_type_assigns_visibility', disabled: true)
+        end
+      end
     end
 
     context 'when collections exist of this type' do

--- a/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
 
       INPUT_IDS.each do |id|
         it "renders the #{id} checkbox to be enabled" do
-          match = rendered.match(/(<input.*id="#{id}".*>)/)
+          match = rendered.match(/(<input.*id="#{id}".*)/)
           expect(match).not_to be_nil
           expect(match[1].index('disabled="disabled"')).to be_nil
         end
@@ -60,7 +60,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
 
       INPUT_IDS.each do |id|
         it "renders the #{id} checkbox to be disabled" do
-          match = rendered.match(/(<input.*id="#{id}".*>)/)
+          match = rendered.match(/(<input.*id="#{id}".*)/)
           expect(match).not_to be_nil
           expect(match[1].index('disabled="disabled"')).not_to be_nil
         end
@@ -79,7 +79,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
 
     INPUT_IDS.each do |id|
       it "renders the #{id} checkbox to be disabled" do
-        match = rendered.match(/(<input.*id="#{id}".*>)/)
+        match = rendered.match(/(<input.*id="#{id}".*)/)
         expect(match).not_to be_nil
         expect(match[1].index('disabled="disabled"')).not_to be_nil
       end
@@ -97,7 +97,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
 
     INPUT_IDS.each do |id|
       it "renders the #{id} checkbox to be disabled" do
-        match = rendered.match(/(<input.*id="#{id}".*>)/)
+        match = rendered.match(/(<input.*id="#{id}".*)/)
         expect(match).not_to be_nil
         expect(match[1].index('disabled="disabled"')).not_to be_nil
       end


### PR DESCRIPTION
`checked=“checked”` was always included for the share_applies_to_new_work setting of CollectionTypes. Now it is based on the value of share_applies_to_new_works.