### PR TITLE
Use add users search to select a user.

### DIFF
--- a/app/assets/javascripts/hyrax/collections/editor.es6
+++ b/app/assets/javascripts/hyrax/collections/editor.es6
@@ -1,4 +1,5 @@
 import ThumbnailSelect from 'hyrax/thumbnail_select'
+import Participants from 'hyrax/admin/admin_set/participants'
 import tabifyForm from 'hyrax/tabbed_form'
 
 // Controls the behavior of the Collections edit form
@@ -9,5 +10,8 @@ export default class {
     let field = elem.find('#collection_thumbnail_id')
     this.thumbnailSelect = new ThumbnailSelect(url, field)
     tabifyForm(elem.find('form.editor'))
+
+    let participants = new Participants(elem.find('#participants'))
+    participants.setup()
   }
 }

--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -358,13 +358,6 @@ button.branding-banner-remove:hover {
     padding-bottom: 40px;
 
     .form-inline {
-      label,
-      input,
-      span,
-      select {
-        margin: 2px 10px;
-      }
-
       label {
         padding-right: 5px;
         text-align: right;

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -9,54 +9,58 @@
         <% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
 
         <%= simple_form_for @form.permission_template,
-          url: [hyrax, :dashboard, @form, :permission_template],
-          html: { id: 'group-participants-form' } do |f| %>
+                            url: [hyrax, :dashboard, @form, :permission_template],
+                            html: { id: 'group-participants-form' } do |f| %>
 
           <%= f.fields_for 'access_grants_attributes',
-            f.object.access_grants.build(agent_type: 'group'),
-            index: 0 do |builder| %>
+                           f.object.access_grants.build(agent_type: 'group'),
+                           index: 0 do |builder| %>
 
             <div class="form-inline add-sharing-form">
-              <div class="form-group">
-                <label><%= t('.add_group') %>:</label>
+              <div class="form-group col-md-10 col-xs-8">
+                <label class="col-md-2 col-xs-4 control-label"><%= t('.add_group') %>:</label>
                 <%= builder.hidden_field :agent_type %>
-                <%= builder.text_field :agent_id, placeholder: "Search for a group...", class: 'form-control search-input' %>
+                <%= builder.text_field :agent_id,
+                                       placeholder: "Search for a group...",
+                                       class: 'form-control search-input' %>
                 as
-                <%= builder.select :access, access_options,
-                { prompt: "Select a role..." },
-                class: 'form-control' %>
+                <%= builder.select :access,
+                                   access_options,
+                                   { prompt: "Select a role..." },
+                                   class: 'form-control' %>
 
                 <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
               </div>
             </div>
-
           <% end %>
         <% end %>
 
         <%= simple_form_for @form.permission_template,
-          url: [hyrax, :dashboard, @form, :permission_template],
-          html: { id: 'user-participants-form' } do |f| %>
+                            url: [hyrax, :dashboard, @form, :permission_template],
+                            html: { id: 'user-participants-form' } do |f| %>
 
           <%= f.fields_for 'access_grants_attributes',
-          f.object.access_grants.build(agent_type: 'user'),
-          index: 0 do |builder| %>
+                           f.object.access_grants.build(agent_type: 'user'),
+                           index: 0 do |builder| %>
 
           <div class="form-inline add-users">
-            <div class="form-group">
-              <label><%= t('.add_user') %>:</label>
+            <div class="form-group col-md-10 col-xs-8">
+              <label class="col-md-2 col-xs-4 control-label"><%= t('.add_user') %>:</label>
               <%= builder.hidden_field :agent_type %>
-              <%= builder.text_field :agent_id, placeholder: "Search for a user...", class: 'form-control search-input' %>
+              <%= builder.text_field :agent_id,
+                                     placeholder: "Search for a user..." %>
               as
               <%= builder.select :access,
-              access_options,
-              { prompt: "Select a role..." },
-              class: 'form-control' %>
+                                 access_options,
+                                 { prompt: "Select a role..." },
+                                 class: 'form-control' %>
 
               <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
             </div>
           </div>
           <% end %>
         <% end %>
+        <p class="help-block"><%= t('hyrax.admin.admin_sets.form.note')%></p>
       </section>
 
       <section class="section-collection-sharing">

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -11,18 +11,46 @@
         <%= simple_form_for @form.permission_template,
                             url: [hyrax, :dashboard, @form, :permission_template],
                             html: { id: 'group-participants-form' } do |f| %>
+          <div class="clearfix spacer">
+            <%= f.fields_for 'access_grants_attributes',
+                             f.object.access_grants.build(agent_type: 'group'),
+                             index: 0 do |builder| %>
 
-          <%= f.fields_for 'access_grants_attributes',
-                           f.object.access_grants.build(agent_type: 'group'),
-                           index: 0 do |builder| %>
-
-            <div class="form-inline add-sharing-form">
-              <div class="form-group col-md-10 col-xs-8">
+              <div class="form-inline add-sharing-form">
                 <label class="col-md-2 col-xs-4 control-label"><%= t('.add_group') %>:</label>
+                <div class="col-md-10 col-xs-8 form-group">
+                  <%= builder.hidden_field :agent_type %>
+                  <%= builder.text_field :agent_id,
+                                         placeholder: "Search for a group...",
+                                         class: 'form-control search-input' %>
+                  as
+                  <%= builder.select :access,
+                                     access_options,
+                                     { prompt: "Select a role..." },
+                                     class: 'form-control' %>
+
+                  <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+
+        <%= simple_form_for @form.permission_template,
+                            url: [hyrax, :dashboard, @form, :permission_template],
+                            html: { id: 'user-participants-form' } do |f| %>
+          <div class="clearfix spacer">
+
+            <%= f.fields_for 'access_grants_attributes',
+                             f.object.access_grants.build(agent_type: 'user'),
+                             index: 0 do |builder| %>
+
+            <div class="form-inline add-users">
+              <label class="col-md-2 col-xs-4 control-label"><%= t('.add_user') %>:</label>
+              <div class="col-md-10 col-xs-8 form-group">
                 <%= builder.hidden_field :agent_type %>
                 <%= builder.text_field :agent_id,
-                                       placeholder: "Search for a group...",
-                                       class: 'form-control search-input' %>
+                                       placeholder: "Search for a user..." %>
                 as
                 <%= builder.select :access,
                                    access_options,
@@ -32,33 +60,8 @@
                 <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
               </div>
             </div>
-          <% end %>
-        <% end %>
-
-        <%= simple_form_for @form.permission_template,
-                            url: [hyrax, :dashboard, @form, :permission_template],
-                            html: { id: 'user-participants-form' } do |f| %>
-
-          <%= f.fields_for 'access_grants_attributes',
-                           f.object.access_grants.build(agent_type: 'user'),
-                           index: 0 do |builder| %>
-
-          <div class="form-inline add-users">
-            <div class="form-group col-md-10 col-xs-8">
-              <label class="col-md-2 col-xs-4 control-label"><%= t('.add_user') %>:</label>
-              <%= builder.hidden_field :agent_type %>
-              <%= builder.text_field :agent_id,
-                                     placeholder: "Search for a user..." %>
-              as
-              <%= builder.select :access,
-                                 access_options,
-                                 { prompt: "Select a role..." },
-                                 class: 'form-control' %>
-
-              <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
-            </div>
+            <% end %>
           </div>
-          <% end %>
         <% end %>
         <p class="help-block"><%= t('hyrax.admin.admin_sets.form.note')%></p>
       </section>


### PR DESCRIPTION
Fixes #2578

Use the same javascript used by admin sets to select a user.  This prevents garbage from being entered as a user.  Non-existent users will cause 'No matches found' to be displayed to the user.

At this point, it still needs some UI adjustments to make the Add group and Add user section align and flow better.