### PR TITLE
Reinstate `:member_of_collection_id` argument option to Actor Stack 

### DIFF
--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -229,6 +229,105 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
     end
   end
 
+  context 'when old style env parameter' do
+    describe 'create' do
+      let(:collection) { create(:collection) }
+      let(:attributes) do
+        { member_of_collection_ids: [collection.id], title: ['test'] }
+      end
+
+      it 'adds it to the collection' do
+        expect(subject.create(env)).to be true
+        expect(collection.reload.member_objects).to eq [curation_concern]
+      end
+
+      context 'when multiple membership checker returns a non-nil value' do
+        before do
+          allow(Hyrax::MultipleMembershipChecker).to receive(:new).and_return(checker)
+          allow(checker).to receive(:check).and_return(error_message)
+        end
+
+        let(:checker) { double('checker') }
+        let(:error_message) { 'Error: foo bar' }
+
+        it 'adds an error and returns false' do
+          expect(env.curation_concern.errors).to receive(:add).with(:collections, error_message)
+          expect(subject.create(env)).to be false
+          expect(curation_concern.member_of_collections).to be_empty
+        end
+      end
+
+      context "when work is in user's own collection" do
+        let(:collection) { create(:collection, user: user, title: ['A good title']) }
+        let(:attributes) { { member_of_collection_ids: [] } }
+
+        before do
+          subject.create(Hyrax::Actors::Environment.new(curation_concern, ability,
+                                                        member_of_collection_ids: [collection.id], title: ['test']))
+        end
+
+        it "removes the work from that collection" do
+          expect(subject.create(env)).to be true
+          expect(curation_concern.member_of_collections).to eq []
+        end
+      end
+
+      context "when work is in another user's collection" do
+        let(:other_user) { create(:user) }
+        let(:collection) { create(:collection, user: other_user, title: ['A good title']) }
+
+        it "doesn't remove the work from that collection" do
+          subject.create(env)
+          expect(subject.create(env)).to be true
+          expect(curation_concern.member_of_collections).to eq [collection]
+        end
+      end
+
+      context "updates env" do
+        let(:collection) do
+          create(:collection, collection_type_settings: [:discoverable, :sharable])
+        end
+
+        subject(:middleware) do
+          stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+            middleware.use described_class
+          end
+          stack.build(terminator)
+        end
+
+        context "when only one collection" do
+          let(:attributes) do
+            { member_of_collection_ids: [collection.id], title: ['test'] }
+          end
+
+          it "removes member_of_collection_ids and adds collection_id to env" do
+            expect(env.attributes).to have_key(:member_of_collection_ids)
+            expect(env.attributes[:member_of_collection_ids].size).to eq 1
+            expect(subject.create(env)).to be true
+            expect(env.attributes).not_to have_key(:member_of_collection_ids)
+            expect(env.attributes).to have_key(:collection_id)
+            expect(env.attributes[:collection_id]).to eq collection.id
+          end
+        end
+
+        context "when more than one collection" do
+          let(:collection2) { create(:collection) }
+          let(:attributes) do
+            { member_of_collection_ids: [collection.id, collection2.id], title: ['test'] }
+          end
+
+          it "removes member_of_collection_ids and does NOT add collection_id" do
+            expect(env.attributes).to have_key(:member_of_collection_ids)
+            expect(env.attributes[:member_of_collection_ids].size).to eq 2
+            expect(subject.create(env)).to be true
+            expect(env.attributes).not_to have_key(:member_of_collection_ids)
+            expect(env.attributes).not_to have_key(:collection_id)
+          end
+        end
+      end
+    end
+  end
+
   class RemoveCollectionActor < Hyrax::Actors::AbstractActor
     # The collection is normally removed by ApplyPermissionTemplateActor, but this test doesn't setup and call that actor.
     # So we are faking it here and removing it before the GenericWorkActor is called.  Otherwise, it tries to save a


### PR DESCRIPTION
Refs #2545, #2533.

This merge includes some minor refactors of `#create`; including some changes to
the actor's private methods.

`#extract_collection_ids` and `#assign_nested_attributes_for_collection` now
accept only the `env` as an argument. `#assign_nested_attributes_for_collection`
ensures that the `env` is left in the correct state. This reduces the impact of
mutable state across methods.

Assigning the singleton `#collection_id` is still a separate mutation of
`env`. This may be necessary without a much more extensive refactor.

`#extract_collection_id` is updated to handle the old syntax, which
ensures that `#create` populates the `:collection_id` environment attribute in
the same way as it does for the new syntax. Likewise, `#valid_membership?` is
updated to accept the collection ids it should check; existing calls are changed
to pass the ids directly.

Changes proposed in this pull request:
* Merge commit '089bff9e8f8100db6119f5' into collections-sprint
* Support new collections features for old collections_id actor syntax

@samvera/hyrax-code-reviewers
