### PR TITLE
Don't render required form fields that are not terms in the form

### DIFF
--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -106,12 +106,27 @@ module Hyrax
         Hash[file_presenters.map { |file| [file.to_s, file.id] }]
       end
 
+      ##
       # Fields that are automatically drawn on the page above the fold
+      #
+      # @return [Enumerable<Symbol>] symbols representing each primary term
       def primary_terms
-        required_fields
+        primary = (required_fields & terms)
+
+        (required_fields - primary).each do |missing|
+          Rails.logger.warn("The form field #{missing} is configured as a " \
+                            'required field, but not as a term. This can lead ' \
+                            'to unexpected behavior. Did you forget to add it ' \
+                            "to `#{self.class}#terms`?")
+        end
+
+        primary
       end
 
+      ##
       # Fields that are automatically drawn on the page below the fold
+      #
+      # @return [Enumerable<Symbol>]
       def secondary_terms
         terms - primary_terms -
           [:files, :visibility_during_embargo, :embargo_release_date,

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -185,6 +185,45 @@ RSpec.describe Hyrax::Forms::WorkForm do
     it { is_expected.to eq 'restricted' }
   end
 
+  describe '#primary_terms' do
+    it 'contains the required fields' do
+      expect(form.primary_terms).to include(*form.required_fields)
+    end
+
+    context 'with a field that is not in terms' do
+      let(:bad_term) { :BadWorkFormSpecTerm }
+
+      before { form.class.required_fields += [bad_term] }
+      after  { form.class.required_fields -= [bad_term] }
+
+      it 'logs a warning' do
+        expect(Rails.logger).to receive(:warn).with(/#{bad_term}/)
+        form.primary_terms
+      end
+
+      it 'does not include the errant term' do
+        expect(form.primary_terms).not_to include bad_term
+      end
+    end
+  end
+
+  describe '#secondary_terms' do
+    it 'does not contain the primary terms' do
+      expect(form.secondary_terms).not_to include(*form.primary_terms)
+    end
+
+    context 'with a new non-primary term' do
+      let(:new_term) { :WorkFormSpecTerm }
+
+      before { form.class.terms += [new_term] }
+      after  { form.class.terms -= [new_term] }
+
+      it 'adds the term to secondary' do
+        expect(form.secondary_terms).to include new_term
+      end
+    end
+  end
+
   describe '#human_readable_type' do
     subject { form.human_readable_type }
 


### PR DESCRIPTION
Adding a `required_field` to a form class used to render an errant primary term
above the fold in the on-screen form. The data from that field was silently
ignored. We now log an warn level error and decline to render the non-term form
field.

Fixes #2569.

Changes proposed in this pull request:
* decline to render fields that aren't terms in a form.
* log warnings when implementers obviously misconfigure form terms & required fields

@samvera/hyrax-code-reviewers
