### PR TITLE
Prefix attribute classes with `attribute-`

### DIFF
--- a/app/renderers/hyrax/renderers/attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer.rb
@@ -25,7 +25,7 @@ module Hyrax
 
         return markup if values.blank? && !options[:include_empty]
         markup << %(<tr><th>#{label}</th>\n<td><ul class='tabular'>)
-        attributes = microdata_object_attributes(field).merge(class: "attribute #{field}")
+        attributes = microdata_object_attributes(field).merge(class: "attribute attribute-#{field}")
         Array(values).each do |value|
           markup << "<li#{html_attributes(attributes)}>#{attribute_value_to_html(value.to_s)}</li>"
         end

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -2,11 +2,10 @@
   <td class="thumbnail">
     <%= render_thumbnail_tag member %>
   </td>
-  <td class="attribute filename"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
-  <td class="attribute date_uploaded"><%= member.try(:date_uploaded) %></td>
-  <td class="attribute permission"><%= member.permission_badge %></td>
+  <td class="attribute attribute-filename"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
+  <td class="attribute attribute-date_uploaded"><%= member.try(:date_uploaded) %></td>
+  <td class="attribute attribute-permission"><%= member.permission_badge %></td>
   <td>
     <%= render 'actions', member: member %>
   </td>
 </tr>
-

--- a/app/views/hyrax/base/_relationships_parent_row.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_row.html.erb
@@ -6,7 +6,7 @@
     <% else %>
       <ul class="tabular">
         <% items.each do |item| %>
-          <li class='attribute title'>
+          <li class='attribute attribute-title'>
             <%= link_to item.title.first, url_for_document(item) %>
           </li>
         <% end %>

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "display a work as its owner" do
 
       # Displays FileSets already attached to this work
       within '.related-files' do
-        expect(page).to have_selector '.filename', text: 'A Contained FileSet'
+        expect(page).to have_selector '.attribute-filename', text: 'A Contained FileSet'
       end
     end
   end

--- a/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Hyrax::Renderers::AttributeRenderer do
       end
       let(:tr_content) do
         "<tr><th>Name</th>\n" \
-         "<td><ul class='tabular'><li class=\"attribute name\">Bob</li>\n" \
-         "<li class=\"attribute name\">Jessica</li>\n" \
+         "<td><ul class='tabular'><li class=\"attribute attribute-name\">Bob</li>\n" \
+         "<li class=\"attribute attribute-name\">Jessica</li>\n" \
          "</ul></td></tr>"
       end
 
@@ -37,7 +37,7 @@ RSpec.describe Hyrax::Renderers::AttributeRenderer do
       let(:renderer) { described_class.new(field, [567]) }
       let(:tr_content) do
         "<tr><th>Height</th>\n" \
-         "<td><ul class='tabular'><li class=\"attribute height\">567</li>\n" \
+         "<td><ul class='tabular'><li class=\"attribute attribute-height\">567</li>\n" \
          "</ul></td></tr>"
       end
 
@@ -47,9 +47,9 @@ RSpec.describe Hyrax::Renderers::AttributeRenderer do
     context 'with microdata enabled' do
       let(:tr_content) do
         "<tr><th>Name</th>\n" \
-         "<td><ul class='tabular'><li class=\"attribute name\" itemscope itemtype=\"http://schema.org/Person\" itemprop=\"name\">" \
+         "<td><ul class='tabular'><li class=\"attribute attribute-name\" itemscope itemtype=\"http://schema.org/Person\" itemprop=\"name\">" \
          "<span itemprop=\"firstName\">Bob</span></li>\n" \
-         "<li class=\"attribute name\" itemscope itemtype=\"http://schema.org/Person\" itemprop=\"name\">" \
+         "<li class=\"attribute attribute-name\" itemscope itemtype=\"http://schema.org/Person\" itemprop=\"name\">" \
          "<span itemprop=\"firstName\">Jessica</span></li>\n" \
          "</ul></td></tr>"
       end
@@ -63,7 +63,7 @@ RSpec.describe Hyrax::Renderers::AttributeRenderer do
       let(:renderer) { described_class.new(field, ['Foo < Bar http://www.example.com. & More Text']) }
       let(:tr_content) do
         "<tr><th>Description</th>\n" \
-         "<td><ul class='tabular'><li class=\"attribute description\">" \
+         "<td><ul class='tabular'><li class=\"attribute attribute-description\">" \
          "<span itemprop=\"description\">Foo &lt; Bar " \
          "<a href=\"http://www.example.com\">http://www.example.com</a>. &amp; More Text</span></li>\n" \
          "</ul></td></tr>"

--- a/spec/renderers/hyrax/renderers/date_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/date_attribute_renderer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::Renderers::DateAttributeRenderer do
         %(
       <tr><th>Embargo release date</th>
       <td><ul class="tabular">
-      <li class="attribute embargo_release_date">03/14/2013</li>
+      <li class="attribute attribute-embargo_release_date">03/14/2013</li>
       </ul></td></tr>
       )
       end
@@ -27,7 +27,7 @@ RSpec.describe Hyrax::Renderers::DateAttributeRenderer do
         %(
       <tr><th>Lease expiration date</th>
       <td><ul class="tabular">
-      <li class="attribute lease_expiration_date">03/14/2013</li>
+      <li class="attribute attribute-lease_expiration_date">03/14/2013</li>
       </ul></td></tr>
       )
       end

--- a/spec/renderers/hyrax/renderers/external_link_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/external_link_attribute_renderer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::Renderers::ExternalLinkAttributeRenderer do
     let(:tr_content) do
       "<tr><th>Name</th>\n" \
        "<td><ul class='tabular'>" \
-       "<li class=\"attribute name\">"\
+       "<li class=\"attribute attribute-name\">"\
        "<a href=\"http://example.com\">"\
        "<span class='glyphicon glyphicon-new-window'></span>&nbsp;"\
        "http://example.com</a></li>\n" \

--- a/spec/renderers/hyrax/renderers/faceted_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/faceted_attribute_renderer_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Hyrax::Renderers::FacetedAttributeRenderer do
       %(
       <tr><th>Name</th>
       <td><ul class='tabular'>
-      <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Bob">Bob</a></li>
-      <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Jessica">Jessica</a></li>
+      <li class="attribute attribute-name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Bob">Bob</a></li>
+      <li class="attribute attribute-name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Jessica">Jessica</a></li>
       </ul></td></tr>
     )
     end

--- a/spec/renderers/hyrax/renderers/license_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/license_attribute_renderer_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Hyrax::Renderers::LicenseAttributeRenderer do
     let(:tr_content) do
       "<tr><th>License</th>\n" \
        "<td><ul class='tabular'>\n" \
-       "<li class=\"attribute license\"><a href=\"http://creativecommons.org/licenses/by/3.0/us/\" target=\"_blank\">Attribution 3.0 United States</a></li>\n" \
-       "<li class=\"attribute license\"><a href=\"http://creativecommons.org/licenses/by-nd/3.0/us/\" target=\"_blank\">Attribution-NoDerivs 3.0 United States</a></li>\n" \
+       "<li class=\"attribute attribute-license\"><a href=\"http://creativecommons.org/licenses/by/3.0/us/\" target=\"_blank\">Attribution 3.0 United States</a></li>\n" \
+       "<li class=\"attribute attribute-license\"><a href=\"http://creativecommons.org/licenses/by-nd/3.0/us/\" target=\"_blank\">Attribution-NoDerivs 3.0 United States</a></li>\n" \
        "</ul></td></tr>"
     end
 

--- a/spec/renderers/hyrax/renderers/linked_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/linked_attribute_renderer_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Hyrax::Renderers::LinkedAttributeRenderer do
     let(:tr_content) do
       "<tr><th>Name</th>\n" \
        "<td><ul class='tabular'>" \
-       "<li class=\"attribute name\"><a href=\"/catalog?q=Bob&amp;search_field=name\">Bob</a></li>\n" \
-       "<li class=\"attribute name\"><a href=\"/catalog?q=Jessica&amp;search_field=name\">Jessica</a></li>\n" \
+       "<li class=\"attribute attribute-name\"><a href=\"/catalog?q=Bob&amp;search_field=name\">Bob</a></li>\n" \
+       "<li class=\"attribute attribute-name\"><a href=\"/catalog?q=Jessica&amp;search_field=name\">Jessica</a></li>\n" \
        "</ul></td></tr>"
     end
 

--- a/spec/renderers/hyrax/renderers/rights_statement_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/rights_statement_attribute_renderer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::Renderers::RightsStatementAttributeRenderer do
     let(:tr_content) do
       "<tr><th>Rights statement</th>\n" \
        "<td><ul class='tabular'>" \
-       "<li class=\"attribute rights_statement\"><a href=\"http://rightsstatements.org/vocab/InC/1.0/\" target=\"_blank\">In Copyright</a></li>" \
+       "<li class=\"attribute attribute-rights_statement\"><a href=\"http://rightsstatements.org/vocab/InC/1.0/\" target=\"_blank\">In Copyright</a></li>" \
        "</ul></td></tr>"
     end
 


### PR DESCRIPTION
Fixes #2567

Changes proposed in this pull request:
* Namespace attribute-specific CSS classes with `attribute-`
* Update test expectations accordingly

@samvera/hyrax-code-reviewers
