### PR TITLE
add FlipFlop for redesigned analytics

### DIFF
--- a/app/controllers/hyrax/stats_controller.rb
+++ b/app/controllers/hyrax/stats_controller.rb
@@ -5,6 +5,9 @@ module Hyrax
 
     before_action :build_breadcrumbs, only: [:work, :file]
 
+    # TODO: New reporting features FlipFlop pattern:
+    # Flipflop.enabled?(:analytics_redesign)
+
     def work
       @stats = Hyrax::WorkUsage.new(params[:id])
     end

--- a/config/features.rb
+++ b/config/features.rb
@@ -30,4 +30,8 @@ Flipflop.configure do
   feature :batch_upload,
           default: true,
           description: "Enable uploading batches of works"
+
+  feature :analytics_redesign,
+          default: false,
+          description: "Display new reporting features. *Very Experimental*"
 end


### PR DESCRIPTION
Fixes #2614 

Add FlipFlop support for future analytics and reporting changes.

This will also serve as an example PR for the Analytics working group.
Create feature branch `analytics-*` -> Merge into `analytics-sprint`
`analytics-sprint` will frequently be merged with master.

Changes proposed in this pull request:
* Add FlipFlip feature called `analytics_redesign`, Default is false

@samvera/hyrax-code-reviewers
