### PR TITLE
Subcollection pagination

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -91,6 +91,7 @@ module Hyrax
 
       def member_subcollections
         results = collection_member_service.available_member_subcollections
+        @subcollection_solr_response = results
         @subcollection_docs = results.documents
         @subcollection_count = results.total
       end

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -439,6 +439,7 @@ module Hyrax
 
         def member_subcollections
           results = collection_member_service.available_member_subcollections
+          @subcollection_solr_response = results
           @subcollection_docs = results.documents
           @subcollection_count = results.total
         end

--- a/app/services/hyrax/collections/collection_member_service.rb
+++ b/app/services/hyrax/collections/collection_member_service.rb
@@ -78,13 +78,13 @@ module Hyrax
 
         # @api private
         #
-        # TODO: paging is linked between both works and collections member searches due
-        # to blacklight constraints, so I've deactivated paging here, and selected
-        # a large result number to hopefully get everything.
         # Blacklight pagination still needs to be overridden and set up for the subcollections.
         # @return <Hash> the additional inputs required for the subcollection member search builder
         def params_for_subcollections
-          params.merge(rows: 50).except(:page)
+          # To differentiate current page for works vs subcollections, we have to use a sub_collection_page
+          # param. Map this to the page param before querying for subcollections, if it's present
+          params[:page] = params.delete(:sub_collection_page)
+          params
         end
     end
   end

--- a/app/views/hyrax/collections/_paginate.html.erb
+++ b/app/views/hyrax/collections/_paginate.html.erb
@@ -1,6 +1,7 @@
-<% if @response.total_pages > 1 %>
-    <div class="pager">
-      <%= paginate @response, outer_window: 2, theme: 'blacklight' %>
-      <div class="clearfix"></div>
+<% solr_response ||= @response %>
+<% page_param_name ||= :page %>
+<% if solr_response.total_pages > 1 %>
+    <div class="row record-padding col-md-9">
+      <%= paginate solr_response, outer_window: 2, theme: 'blacklight', param_name: page_param_name %>
     </div><!-- /pager -->
 <% end %>

--- a/app/views/hyrax/collections/_subcollection_list.html.erb
+++ b/app/views/hyrax/collections/_subcollection_list.html.erb
@@ -9,4 +9,5 @@
     </li>
   </ul>
 <% end %>
+<%= render 'hyrax/collections/paginate', solr_response: @subcollection_solr_response, page_param_name: :sub_collection_page  %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/_subcollection_list.html.erb
+++ b/app/views/hyrax/dashboard/collections/_subcollection_list.html.erb
@@ -11,4 +11,5 @@
     </li>
   </ul>
 <% end %>
+<%= render 'hyrax/collections/paginate', solr_response: @subcollection_solr_response, page_param_name: :sub_collection_page  %>
 <% end %>

--- a/lib/generators/hyrax/templates/db/seeds.rb
+++ b/lib/generators/hyrax/templates/db/seeds.rb
@@ -168,6 +168,24 @@ pc = create_public_collection(user, nestable_gid, 'parent_nested', title: ['A Pa
 cc = create_public_collection(user, nestable_gid, 'child_nested', title: ['A Child Collection'], description: ['Public collection that will be a child of another collection.'])
 Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: pc, child: cc)
 
+puts 'Create collection with many child collections and works'
+mpc = create_public_collection(
+  user,
+  nestable_gid,
+  'parent_nested_many',
+  title: ['A Parent Collection with many Child Collections'],
+  description: ['Public collection that will be a parent of many collections.']
+)
+21.times do |i|
+  mcc = create_public_collection(user, nestable_gid, "child_nested_#{i}", title: ["Child Collection #{i}"], description: ['Public collection that will be a child of another collection.'])
+  Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: mpc, child: mcc)
+  create_public_work(user, "pub_mgw_#{i}",
+                     title: ["Public #{i}"],
+                     description: ["Public work #{i} being added to the Public Nested Collection"],
+                     creator: ['Joan Smith'], keyword: ['test'], rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
+                     member_of_collections_attributes: collection_attributes_for([mpc.id]))
+end
+
 puts 'Create works for collection nesting ad hoc testing'
 3.times do |i|
   create_public_work(user, "pub_gw_#{i}",

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'collection', type: :feature, with_nested_reindexing: true do
       expect(page).to have_content(work2.title.first)
       expect(page).to have_content(col1.title.first)
       expect(page).to have_content(col2.title.first)
-      expect(page).not_to have_css(".pager")
+      expect(page).not_to have_css(".pagination")
 
       click_link "Gallery"
       expect(page).to have_content(work1.title.first)
@@ -56,7 +56,7 @@ RSpec.describe 'collection', type: :feature, with_nested_reindexing: true do
   end
 
   # TODO: this is just like the block above. Merge them.
-  describe 'show pages of a collection' do
+  describe 'show work pages of a collection' do
     before do
       docs = (0..12).map do |n|
         { "has_model_ssim" => ["GenericWork"], :id => "zs25x871q#{n}",
@@ -74,7 +74,29 @@ RSpec.describe 'collection', type: :feature, with_nested_reindexing: true do
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       visit "/collections/#{collection.id}"
-      expect(page).to have_css(".pager")
+      expect(page).to have_css(".pagination")
+    end
+  end
+
+  describe 'show subcollection pages of a collection' do
+    before do
+      docs = (0..12).map do |n|
+        { "has_model_ssim" => ["Collection"], :id => "zs25x871q#{n}",
+          "depositor_ssim" => [user.user_key],
+          "suppressed_bsi" => false,
+          "member_of_collection_ids_ssim" => [collection.id],
+          "nesting_collection__parent_ids_ssim" => [collection.id],
+          "edit_access_person_ssim" => [user.user_key] }
+      end
+      ActiveFedora::SolrService.add(docs, commit: true)
+
+      sign_in user
+    end
+    let(:collection) { create(:named_collection, user: user) }
+
+    it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
+      visit "/collections/#{collection.id}"
+      expect(page).to have_css(".pagination")
     end
   end
 end

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -560,7 +560,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       # Should have search results / contents listing
       expect(page).to have_content(work1.title.first)
       expect(page).to have_content(work2.title.first)
-      expect(page).not_to have_css(".pager")
+      expect(page).not_to have_css(".pagination")
 
       click_link "Gallery"
       expect(page).to have_content(work1.title.first)
@@ -685,7 +685,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         # Now go to the collection show page
         click_link("Display all details of collection title")
       end
-      expect(page).to have_css(".pager")
+      expect(page).to have_css(".pagination")
     end
   end
 

--- a/spec/views/hyrax/collections/_subcollection_list.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_subcollection_list.html.erb_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe 'hyrax/collections/_subcollection_list.html.erb', type: :view do
+  let(:subject) { render('subcollection_list.html.erb', collection: subcollection) }
   let(:collection) { build(:named_collection, id: '123') }
 
   context 'when subcollection list is empty' do
@@ -20,18 +21,19 @@ RSpec.describe 'hyrax/collections/_subcollection_list.html.erb', type: :view do
     before do
       assign(:subcollection_docs, subcollection)
       assign(:document, collection)
-    end
-
-    it "posts the collection's title with a link to the collection" do
       allow(collection).to receive(:title_or_label).and_return(collection.title)
       # make the collection "persisted" so the route returned is valid for show
       allow(collection).to receive(:persisted?).and_return true
-      render('subcollection_list.html.erb', collection: subcollection)
+      stub_template "hyrax/collections/_paginate" => "<div>paginate</div>"
+    end
+
+    it "posts the collection's title with a link to the collection" do
+      subject
       expect(rendered).to have_link(collection.title.to_s)
     end
 
-    xit 'includes a count of the subcollection members' do
-      # TODO: add test when actual count is added to page
+    it 'renders pagination' do
+      expect(subject).to render_template("hyrax/collections/_paginate")
     end
   end
 end

--- a/spec/views/hyrax/dashboard/collections/_subcollection_list.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_subcollection_list.html.erb_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe 'hyrax/dashboard/collections/_subcollection_list.html.erb', type: :view do
+  let(:subject) { render('subcollection_list.html.erb', collection: subcollection) }
   let(:collection) { build(:named_collection, id: '123') }
 
   context 'when subcollection list is empty' do
@@ -20,18 +21,19 @@ RSpec.describe 'hyrax/dashboard/collections/_subcollection_list.html.erb', type:
     before do
       assign(:subcollection_docs, subcollection)
       assign(:document, collection)
-    end
-
-    it "posts the collection's title with a link to the collection" do
       allow(collection).to receive(:title_or_label).and_return(collection.title)
       # make the collection "persisted" so the route returned is valid for show
       allow(collection).to receive(:persisted?).and_return true
-      render('subcollection_list.html.erb', collection: subcollection)
+      stub_template "hyrax/collections/_paginate" => "<div>paginate</div>"
+    end
+
+    it "posts the collection's title with a link to the collection" do
+      subject
       expect(rendered).to have_link(collection.title.to_s)
     end
 
-    xit 'includes a count of the subcollection members' do
-      # TODO: add test when actual count is added to page
+    it 'renders pagination' do
+      expect(subject).to render_template("hyrax/collections/_paginate")
     end
   end
 end


### PR DESCRIPTION
Fixes #2613

This adds pagination for subcollections in both the admin and public show pages.

Changes proposed in this pull request:

- Need to pass a solr response all the way down to the Kaminari paginator, so exposed the original response to the view within collection behaviors
- Changed collection member service to pass subcollection page parameters to the solr query
- Changed the paginate partial to be a bit more generic/reusable. Now allows passing in a local to define page param name to use when creating links and a solr response variable. Will continue to use the default :page and @response instance variable if none are given, since that was the previous pattern
- Changed the styling to match other pagination within hyrax
- Added pagination renders to the subcollection_list partials, but using a page param of :sub_collection_page to differentiate it from the works page. I did not go as far as changing the works page to use a :works_page param and @works_solr_response. This would require a bit more work since the sort_and_per_page code path has lots of things that expect :page and @response, with no way to pass in alternate variables
- Added seed data to test this case.

@samvera/hyrax-code-reviewers
