### PR TITLE
Reindex everything

### DIFF
--- a/app/indexers/hyrax/repository_reindexer.rb
+++ b/app/indexers/hyrax/repository_reindexer.rb
@@ -1,0 +1,19 @@
+require 'active_fedora/base'
+require 'active_fedora/version'
+raise "Verify this override is still needed for non 11.5.2 versions" unless ActiveFedora::VERSION == '11.5.2'
+
+module Hyrax
+  module RepositoryReindexer
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # overrides https://github.com/samvera/active_fedora/blob/master/lib/active_fedora/indexing.rb#L95-L125
+      # see implementation details in adapters/nesting_index_adapter.rb#each_perservation_document_id_and_parent_ids
+      def reindex_everything(*)
+        Samvera::NestingIndexer.reindex_all!
+      end
+    end
+  end
+end
+
+ActiveFedora::Base.module_eval { include Hyrax::RepositoryReindexer }

--- a/app/models/concerns/hyrax/collection_nesting.rb
+++ b/app/models/concerns/hyrax/collection_nesting.rb
@@ -33,5 +33,9 @@ module Hyrax
     def find_children_of(destroyed_id:)
       ActiveFedora::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: destroyed_id))
     end
+
+    def use_nested_reindexing?
+      true
+    end
   end
 end

--- a/config/initializers/samvera-nesting_indexer_initializer.rb
+++ b/config/initializers/samvera-nesting_indexer_initializer.rb
@@ -1,5 +1,6 @@
 # rubocop:disable Naming/FileName
 require 'samvera/nesting_indexer'
+require 'hyrax/repository_reindexer'
 # rubocop:enable Naming/FileName
 
 Samvera::NestingIndexer.configure do |config|

--- a/spec/indexers/hyrax/repository_reindexer_spec.rb
+++ b/spec/indexers/hyrax/repository_reindexer_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Hyrax::RepositoryReindexer do
+  let(:subject) { Samvera::NestingIndexer }
+
+  it 'overrides ActiveFedora#reindex_everything' do
+    expect(subject).to receive(:reindex_all!)
+    ActiveFedora::Base.reindex_everything
+  end
+end

--- a/spec/models/concerns/hyrax/collection_nesting_spec.rb
+++ b/spec/models/concerns/hyrax/collection_nesting_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Hyrax::CollectionNesting do
     it { is_expected.to callback(:update_child_nested_collection_relationship_indices).after(:destroy) }
     it { is_expected.to respond_to(:update_nested_collection_relationship_indices) }
     it { is_expected.to respond_to(:update_child_nested_collection_relationship_indices) }
+    it { is_expected.to respond_to(:use_nested_reindexing?) }
 
     context 'after_update_index callback' do
       describe '#update_nested_collection_relationship_indices' do


### PR DESCRIPTION
fixes https://github.com/samvera/hyrax/issues/2372

Implements #each_perservation_document_id_and_parent_ids in the
nesting index adapter to allow for Samvera::NestingIndexer.reindex_all!
Objects which include collection nesting as part of the model will be
reindexed via Samvera::NestingIndexer, while still using to_solr for
objects where collection nesting does not apply.

Adds an override of ActiveFedora's reindex_everything method, which will
now use Samvera Nesting Indexer's reindex_all!

Fixes a bug in calculating the nesting depth that was encountered when
testing reindexing triggered a situation which exceeded the maximum.

@samvera/hyrax-code-reviewers
