### PR TITLE
Make default admin set the first item in relationship tab

### DIFF
--- a/app/views/hyrax/base/_form_relationships.html.erb
+++ b/app/views/hyrax/base/_form_relationships.html.erb
@@ -3,7 +3,8 @@
   <%= f.input :admin_set_id, as: :select,
       include_blank: false,
       collection: Hyrax::AdminSetOptionsPresenter.new(Hyrax::AdminSetService.new(controller)).select_options,
-      input_html: { class: 'form-control' } %>
+      input_html: { class: 'form-control' },
+      selected: AdminSet::DEFAULT_ID %>
 <% end %>
 
 <%= render 'form_in_works', f: f %>

--- a/spec/features/create_work_admin_spec.rb
+++ b/spec/features/create_work_admin_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe 'Creating a new Work as admin', :js, :workflow do
+  let(:user) { create(:admin) }
+  let(:admin_set_1) do
+    create(:admin_set, id: AdminSet::DEFAULT_ID,
+                       title: ["Default Admin Set"],
+                       description: ["A description"],
+                       edit_users: [user.user_key])
+  end
+  let(:admin_set_2) do
+    create(:admin_set, title: ["Second Admin Set"],
+                       description: ["A description"],
+                       edit_users: [user.user_key])
+  end
+
+  context 'when there are multiple admin sets' do
+    before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, source_id: admin_set_1.id, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, source_id: admin_set_2.id, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      sign_in user
+    end
+
+    it "allows default admin set to be the first item in the select menu" do
+      visit '/dashboard'
+      click_link 'Works'
+      click_link "Add new work"
+      choose "payload_concern", option: "GenericWork"
+      click_button 'Create work'
+      click_link "Relationship" # switch tab
+      expect(page).to have_content('Administrative Set')
+      expect(page).to have_content('Second Admin Set')
+      expect(page).to have_content('Default Admin Set')
+      expect(page).to have_selector('select#generic_work_admin_set_id')
+      expect(page).to have_select('generic_work_admin_set_id', selected: 'Default Admin Set')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1773 

Adds AdminSet::Default ID to the Administrative Set select menu so it can be always be selected by default.

@samvera/hyrax-code-reviewers
