### PR TITLE
Pass an array of collection type gid strings to where query

### DIFF
--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -50,7 +50,7 @@ module Hyrax
 
       def single_membership_collections(collection_ids)
         return [] if collection_ids.blank?
-        Collection.where(id: collection_ids, collection_type_gid_ssim: single_membership_types.join(','))
+        Collection.where(id: collection_ids, collection_type_gid_ssim: single_membership_types)
       end
 
       def single_membership_types

--- a/spec/services/hyrax/multiple_membership_checker_spec.rb
+++ b/spec/services/hyrax/multiple_membership_checker_spec.rb
@@ -101,6 +101,50 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
         expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: [collection_type.gid]).once.and_return([collection2])
         expect(subject).to eq 'Error: You have specified more than one of the same single-membership collection types: Greedy (Foo and Bar)'
       end
+
+      context 'with multiple single membership collection types' do
+        let!(:collection_type_2) { create(:collection_type, title: 'Doc', allow_multiple_membership: false) }
+        let(:collection_types) { [collection_type.gid, collection_type_2.gid] }
+
+        it 'returns an error' do
+          expect(item).to receive(:member_of_collection_ids)
+          expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_types).once.and_call_original
+          expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: collection_types).once.and_call_original
+          expect(subject).to eq 'Error: You have specified more than one of the same single-membership collection types: Greedy (Foo and Bar)'
+        end
+      end
+    end
+
+    context 'when multiple single-membership collection instances are in the list, but are different collection types' do
+      let(:collection1) { create(:collection, title: ['Foo'], collection_type: collection_type) }
+      let(:collection2) { create(:collection, title: ['Bar'], collection_type: collection_type_2) }
+      let(:collections) { [collection1, collection2] }
+      let(:collection_ids) { collections.map(&:id) }
+      let(:collection_type_2) { create(:collection_type, title: 'Doc', allow_multiple_membership: false) }
+      let(:collection_types) { [collection_type.gid, collection_type_2.gid] }
+
+      it 'returns nil' do
+        expect(item).not_to receive(:member_of_collection_ids)
+        expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
+        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_types).once.and_call_original
+        expect(subject).to be nil
+      end
+
+      context 'when including current members' do
+        let(:collections) { [collection1] }
+        let(:included) { true }
+
+        before do
+          allow(item).to receive(:member_of_collection_ids).once.and_return([collection2.id])
+        end
+
+        it 'returns nil' do
+          expect(item).to receive(:member_of_collection_ids)
+          expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_types).once.and_call_original
+          expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: collection_types).once.and_call_original
+          expect(subject).to be nil
+        end
+      end
     end
   end
 end

--- a/spec/services/hyrax/multiple_membership_checker_spec.rb
+++ b/spec/services/hyrax/multiple_membership_checker_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
 
     context 'when there are no single-membership collection types' do
       before do
-        allow(Hyrax::CollectionType).to receive(:where).and_return([])
+        allow(Hyrax::CollectionType).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: []).and_return([])
       end
 
       it 'returns nil' do
-        expect(checker).to receive(:single_membership_types).and_return([]).and_call_original
+        expect(checker).to receive(:single_membership_types).and_return([])
         expect(subject).to be nil
       end
     end
@@ -40,64 +40,65 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
 
     context 'when there are no single-membership collection instances' do
       it 'returns nil' do
-        expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
-        expect(Collection).to receive(:where).once.and_return([])
+        expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_return([])
+        expect(Collection).not_to receive(:where)
         expect(subject).to be nil
       end
     end
 
     context 'when multiple single-membership collection instances are not in the list' do
-      let(:collection) { create(:collection) }
+      let(:collection) { create(:collection, collection_type: collection_type) }
       let(:collections) { [collection] }
       let(:collection_ids) { collections.map(&:id) }
 
-      before do
-        allow(collection).to receive(:collection_type_gid).and_return(collection_type.gid)
-      end
-
       it 'returns nil' do
         expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
-        expect(Collection).to receive(:where).once.and_return(collections)
+        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: [collection_type.gid]).once.and_return(collections)
         expect(subject).to be nil
       end
     end
 
     context 'when multiple single-membership collection instances are in the list, not including current members' do
-      let(:collection1) { create(:collection, title: ['Foo']) }
-      let(:collection2) { create(:collection, title: ['Bar']) }
+      let(:collection1) { create(:collection, title: ['Foo'], collection_type: collection_type) }
+      let(:collection2) { create(:collection, title: ['Bar'], collection_type: collection_type) }
       let(:collections) { [collection1, collection2] }
       let(:collection_ids) { collections.map(&:id) }
 
-      before do
-        allow(collection1).to receive(:collection_type_gid).and_return(collection_type.gid)
-        allow(collection2).to receive(:collection_type_gid).and_return(collection_type.gid)
-      end
-
-      it 'returns nil' do
+      it 'returns an error' do
         expect(item).not_to receive(:member_of_collection_ids)
         expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
-        expect(Collection).to receive(:where).once.and_return(collections)
+        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: [collection_type.gid]).once.and_return(collections)
         expect(subject).to eq 'Error: You have specified more than one of the same single-membership collection types: Greedy (Foo and Bar)'
+      end
+
+      context 'with multiple single membership collection types' do
+        let!(:collection_type_2) { create(:collection_type, title: 'Doc', allow_multiple_membership: false) }
+        let(:collection_types) { [collection_type.gid, collection_type_2.gid] }
+
+        it 'returns an error' do
+          expect(item).not_to receive(:member_of_collection_ids)
+          expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
+          expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_types).once.and_call_original
+          expect(subject).to eq 'Error: You have specified more than one of the same single-membership collection types: Greedy (Foo and Bar)'
+        end
       end
     end
 
     context 'when multiple single-membership collection instances are in the list, including current members' do
-      let(:collection1) { create(:collection, title: ['Foo']) }
-      let(:collection2) { create(:collection, title: ['Bar']) }
+      let(:collection1) { create(:collection, title: ['Foo'], collection_type: collection_type) }
+      let(:collection2) { create(:collection, title: ['Bar'], collection_type: collection_type) }
       let(:collections) { [collection1] }
       let(:collection_ids) { collections.map(&:id) }
       let(:included) { true }
 
       before do
-        allow(collection1).to receive(:collection_type_gid).and_return(collection_type.gid)
-        allow(collection2).to receive(:collection_type_gid).and_return(collection_type.gid)
         allow(item).to receive(:member_of_collection_ids).once.and_return([collection2.id])
       end
 
-      it 'returns nil' do
+      it 'returns an error' do
         expect(item).to receive(:member_of_collection_ids)
-        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_type.gid).once.and_return(collections)
-        expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: collection_type.gid).once.and_return([collection2])
+        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: [collection_type.gid]).once.and_return(collections)
+        expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: [collection_type.gid]).once.and_return([collection2])
         expect(subject).to eq 'Error: You have specified more than one of the same single-membership collection types: Greedy (Foo and Bar)'
       end
     end


### PR DESCRIPTION
The current joined string was causing solr to always return an empty set leading to a positive check instead of an error.  This PR reworks the tests to check the params of Collection#where.

Refs #1567.  Rest of work for #1567 will be in a future PR.

@samvera/hyrax-code-reviewers
