### PR TITLE
temporary pin of capybara to < 2.18.0 to avoid test failures with the latest version

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -76,7 +76,8 @@ SUMMARY
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
 
-  spec.add_development_dependency "capybara", '~> 2.4'
+  # temporary pin to 2.17 due to failures caused in 2.18.0
+  spec.add_development_dependency "capybara", '~> 2.4', '< 2.18.0'
   spec.add_development_dependency 'capybara-maleficent', '~> 0.2'
   spec.add_development_dependency "chromedriver-helper"
   spec.add_development_dependency 'database_cleaner', '~> 1.3'


### PR DESCRIPTION
3 tests failed when Travis automatically updated to capybara 2.18.0.  This is a temporary pin to avoid those test failures.

Issue #2642 requests the removal of the pin and resolution of the test failures.

@samvera/hyrax-code-reviewers
