### PR TITLE
Fix tests that do database checks without visual synch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-sudo: false
+sudo: required
 dist: trusty
 
 addons:

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
   describe 'deleting' do
     it 'destroys the selected works' do
       accept_confirm { click_button 'Delete Selected' }
+      expect(page).to have_content('Batch delete complete')
       expect(GenericWork.count).to be_zero
     end
   end

--- a/spec/features/browse_dashboard_works_spec.rb
+++ b/spec/features/browse_dashboard_works_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe "Browse Dashboard", type: :feature do
     first('input#check_all').click
     expect do
       accept_confirm { click_button('Delete Selected') }
+      expect(page).to have_content('Batch delete complete')
     end.to change { GenericWork.count }.by(-3)
   end
 end

--- a/spec/features/ownership_transfer_spec.rb
+++ b/spec/features/ownership_transfer_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe 'Transferring work ownership:', type: :feature do
 
       context 'If the new owner accepts it' do
         before do
+          expect(page).to have_content('Transfer request created')
           new_owner.proxy_deposit_requests.last.transfer!
           # refresh the page
           visit '/dashboard'


### PR DESCRIPTION
Fixes #2642

This fixes poorly written tests that had issues with Capybara 2.18.0 due to it returning faster than 2.17.x when using `accept_confirm`