### PR TITLE
Don't try to clean up temp directories and files that may still be in use

### DIFF
--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -49,15 +49,16 @@ class ImportUrlJob < Hyrax::ApplicationJob
     # @yield [IO] the stream to write to
     def copy_remote_file(uri)
       filename = File.basename(uri.path)
-      Dir.mktmpdir do |dir|
-        File.open(File.join(dir, filename), 'wb') do |f|
-          retriever = BrowseEverything::Retriever.new
-          retriever.retrieve('url' => uri) do |chunk|
-            f.write(chunk)
-          end
-          f.rewind
-          yield f
+      dir = Dir.mktmpdir
+      Rails.logger.debug("ImportUrlJob: Copying <#{uri}> to #{dir}")
+      File.open(File.join(dir, filename), 'wb') do |f|
+        retriever = BrowseEverything::Retriever.new
+        retriever.retrieve('url' => uri) do |chunk|
+          f.write(chunk)
         end
+        f.rewind
+        yield f
       end
+      Rails.logger.debug("ImportUrlJob: Closing #{File.join(dir, filename)}")
     end
 end


### PR DESCRIPTION
Fixes #2645. See issue description for full explanation.

This PR implements the first (easy) suggested fix.

Changes proposed in this pull request:
* Change the `Dir.mktmpdir` call in `ImportUrlJob` from block form to bare form
* Add a little debug-level logging code to make it easier to spot remote retrieval

@samvera/hyrax-code-reviewers