### PR TITLE
Add specific validation for modal select element values by disabling submit button

### DIFF
--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -63,6 +63,10 @@ Blacklight.onLoad(function () {
     // Build new <option>s markup and put on DOM
     selectMarkup = buildSelectMarkup($dataEl.data('collsHash'));
     $(selectMarkup).insertAfter($firstOption);
+
+    // Disable the submit button in modal by default
+    $('#add-to-collection-modal').find('.modal-submit-button').prop('disabled', true);
+    
     // Show modal
     $('#add-to-collection-modal').modal('show');
   }

--- a/app/assets/javascripts/hyrax/collections_forms.js
+++ b/app/assets/javascripts/hyrax/collections_forms.js
@@ -33,6 +33,27 @@ Blacklight.onLoad(function () {
     submitModalAjax(url, 'DELETE', data, $self);
   }
 
+  /**
+   * Generically disable modal submit buttons unless their select element
+   * has a valid value.
+   *
+   * To Use:
+   * 1.) Put the '.disable-unless-selected' class on the '.modal' element you wish to protect.
+   * 2.) Add the 'disabled' attribute to your protected submit button ie. <button disabled ...>.
+   * 3.) Put the '.modal-submit-button' class on whichever button you wish to disable for an invalid
+   * <select> value ie. <button disabled class="... modal-submit-button" ...>
+   *
+   * @return {void}
+   */
+  $('.modal.disable-unless-selected select').on('change', function() {
+    var selectValue = $(this).val(),
+      emptyValues = ['', 'none'],
+      selectHasAValue = emptyValues.indexOf(selectValue) === -1,
+      $submitButton = $(this).parents('.modal').find('.modal-submit-button');
+
+    $submitButton.prop('disabled', !selectHasAValue);
+  })
+
   // Remove from collection button clicked
   $('#collection-controls').find('.remove-from-collection-button').on('click', function (e) {
     e.preventDefault();

--- a/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
@@ -1,4 +1,4 @@
-<div class="modal fade" id="add-subcollection-modal-<%= id %>" tabindex="-1" role="dialog" aria-labelledby="add-subcollection-label">
+<div class="modal fade disable-unless-selected" id="add-subcollection-modal-<%= id %>" tabindex="-1" role="dialog" aria-labelledby="add-subcollection-label">
 <% collection = Collection.find id %>
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -23,7 +23,10 @@
 
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
-        <button type="button" class="btn btn-primary modal-add-button"
+        <button
+          disabled
+          type="button"
+          class="btn btn-primary modal-add-button modal-submit-button"
           data-post-url="<%= dashboard_create_nest_collection_under_path(collection.id) %>"
           data-source="<%= source %>">
           <%= t('hyrax.collection.actions.nest_collections.button_label') %>

--- a/app/views/hyrax/my/collections/_modal_add_to_collection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_to_collection.html.erb
@@ -1,4 +1,4 @@
-<div class="modal fade" id="add-to-collection-modal" tabindex="-1" role="dialog" aria-labelledby="add-to-collection-label">
+<div class="modal fade disable-unless-selected" id="add-to-collection-modal" tabindex="-1" role="dialog" aria-labelledby="add-to-collection-label">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
 
@@ -18,7 +18,10 @@
 
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
-        <button type="button" class="btn btn-primary modal-add-button"
+        <button
+          disabled
+          type="button"
+          class="btn btn-primary modal-add-button modal-submit-button"
           data-source="<%= source %>">
           <%= t('hyrax.collection.actions.nested_subcollection.button_label') %>
         </button>


### PR DESCRIPTION
Fixes #2650 

This fixes instances where a modal's 'Add' or 'Submit' button is enabled when no `<select>` value has been selected.   It's a specific, targeted fix for now, and could be a good candidate for a pattern to be established for how this is handled generically across the app?

There are instructions next to the function declaration on how to use:

`app/assets/javascripts/hyrax/collections_forms.js:36`

```
/**
   * Generically disable modal submit buttons unless their select element
   * has a valid value.
   *
   * To Use:
   * 1.) Put the '.disable-unless-selected' class on the '.modal' element you wish to protect.
   * 2.) Add the 'disabled' attribute to your protected submit button ie. <button disabled ...>.
   * 3.) Put the '.modal-submit-button' class on whichever button you wish to disable for an invalid
   * <select> value ie. <button disabled class="... modal-submit-button" ...>
   *
   * @return {void}
   */
```