### PR TITLE
Use analytics fixture in analytics spec tests

### DIFF
--- a/spec/fixtures/config/analytics.yml
+++ b/spec/fixtures/config/analytics.yml
@@ -1,0 +1,7 @@
+---
+analytics:
+  app_name: 'My App Name'
+  app_version: '0.0.1'
+  privkey_path: '/tmp/privkey.p12'
+  privkey_secret: 's00pers3kr1t'
+  client_email: 'oauth@example.org'

--- a/spec/lib/hyrax/analytics_spec.rb
+++ b/spec/lib/hyrax/analytics_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Hyrax::Analytics do
+  let(:config_file_path) { File.join(fixture_path, 'config', 'analytics.yml') }
+
   before do
     described_class.send(:remove_instance_variable, :@config) if described_class.send(:instance_variable_defined?, :@config)
   end
@@ -7,6 +9,9 @@ RSpec.describe Hyrax::Analytics do
     let(:config) { described_class.send(:config) }
 
     context "When the yaml file has values" do
+      before do
+        allow(File).to receive(:read).and_return(File.read(config_file_path))
+      end
       it "is valid" do
         expect(config).to be_valid
       end
@@ -47,6 +52,9 @@ RSpec.describe Hyrax::Analytics do
     subject { described_class.profile }
 
     context "when the private key file is missing" do
+      before do
+        allow(File).to receive(:read).and_return(File.read(config_file_path))
+      end
       it "raises an error" do
         expect { subject }.to raise_error RuntimeError, "Private key file for Google analytics was expected at '/tmp/privkey.p12', but no file was found."
       end


### PR DESCRIPTION
The current `analytics_spec` class assumes that there are no changes
made to the config file generated by engine_cart. The Analytics team is,
however, needing to run local google analytics and as a result of
updating this file tests are failing.

Changes proposed in this pull request:
* Add an analytics.yml fixture which mirrors the engine_cart generated
yml
* allow the tests to use the fixture file rather than the current file
on disk

@samvera/hyrax-code-reviewers @conorom @nestorw 
