### PR TITLE
Update RuboCop support; use Bixby style guide

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,11 @@
-require: rubocop-rspec
+inherit_gem:
+  bixby: bixby_default.yml
+
 inherit_from: .rubocop_fixme.yml
 
 AllCops:
   TargetRubyVersion: 2.1
   DisplayCopNames: true
-  Include:
-    - '**/Rakefile'
-    - '**/config.ru'
   Exclude:
     - 'db/**/*'
     - 'script/**/*'
@@ -14,24 +13,9 @@ AllCops:
     - 'vendor/**/*'
     - 'lib/hyrax/specs/**/*'
 
-Bundler/DuplicatedGem:  # This doesn't work with engine_cart
-  Enabled: false
-
-Layout/IndentationConsistency:
-  EnforcedStyle: rails
-
 Lint/ImplicitStringConcatenation:
   Exclude:
     - 'lib/generators/hyrax/**/*'
-
-Lint/AmbiguousBlockAssociation:
-  Enabled: false
-
-Metrics/LineLength:
-  Max: 200
-
-Metrics/AbcSize:
-  Max: 26
 
 Metrics/BlockLength:
   ExcludedMethods: ['included']
@@ -47,12 +31,9 @@ Metrics/BlockLength:
     - 'lib/tasks/*.rake'
     - 'spec/**/*.rb'
 
-Metrics/MethodLength:
-  Max: 13
-
-Naming/FileName: # https://github.com/bbatsov/rubocop/issues/2973
-  Exclude:
-    - 'Gemfile'
+# Naming/FileName: # https://github.com/bbatsov/rubocop/issues/2973
+#   Exclude:
+#     - 'Gemfile'
 
 Style/AsciiComments:
   Enabled: false
@@ -76,19 +57,7 @@ Style/NumericPredicate:
 Style/SymbolArray:
   Enabled: false
 
-Style/WordArray:
-  Enabled: false
-
-Style/RegexpLiteral:
-  Enabled: false
-
-Style/StringLiterals:
-  Enabled: false
-
 Style/ClassAndModuleChildren:
-  Enabled: false
-
-Style/Documentation:
   Enabled: false
 
 Style/SingleLineBlockParams:
@@ -97,9 +66,6 @@ Style/SingleLineBlockParams:
 Style/ZeroLengthPredicate:
   Exclude:
     - 'app/controllers/hyrax/file_sets_controller.rb'
-
-Rails:
-  Enabled: true
 
 Rails/ApplicationJob:
   Enabled: false
@@ -141,12 +107,9 @@ RSpec/DescribeClass:
     - 'spec/tasks/rake_spec.rb'
     - 'spec/views/**/*'
 
-RSpec/ContextWording:
-  Enabled: false
-
-# By default RSpec/MessageSpies has the following:
-#   Prefer have_received for setting message expectations. Setup form as a spy using allow or instance_spy.
-# The default assumes EnforcedStyle is 'have_received'. Most of our specs are 'receive'
+# # By default RSpec/MessageSpies has the following:
+# #   Prefer have_received for setting message expectations. Setup form as a spy using allow or instance_spy.
+# # The default assumes EnforcedStyle is 'have_received'. Most of our specs are 'receive'
 RSpec/MessageSpies:
   Enabled: false
 
@@ -161,9 +124,6 @@ RSpec/LetSetup:
   Enabled: false
 
 RSpec/MessageExpectation:
-  Enabled: false
-
-RSpec/MultipleExpectations:
   Enabled: false
 
 RSpec/NestedGroups:

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem "simplecov", require: false
 end
 
+# rubocop:disable Bundler/DuplicatedGem
 # BEGIN ENGINE_CART BLOCK
 # engine_cart: 1.1.0
 # engine_cart stanza: 0.10.0
@@ -44,7 +45,6 @@ else
   end
 end
 # END ENGINE_CART BLOCK
+# rubocop:enable Bundler/DuplicatedGem
 
-unless File.exist?(file)
-  eval_gemfile File.expand_path('spec/test_app_templates/Gemfile.extra', File.dirname(__FILE__))
-end
+eval_gemfile File.expand_path('spec/test_app_templates/Gemfile.extra', File.dirname(__FILE__)) unless File.exist?(file)

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -147,7 +147,6 @@ module Hyrax
         # Must clear the fileset from the thumbnail_id, representative_id and rendering_ids fields on the work
         #   and force it to be re-solrized.
         # Although ActiveFedora clears the children nodes it leaves those fields in Solr populated.
-        # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/CyclomaticComplexity
         def unlink_from_work
           work = file_set.parent

--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -114,9 +114,7 @@ module Hyrax
 
         def apply_visibility(env, intention)
           result = apply_lease(env, intention) && apply_embargo(env, intention)
-          if env.attributes[:visibility]
-            env.curation_concern.visibility = env.attributes[:visibility]
-          end
+          env.curation_concern.visibility = env.attributes[:visibility] if env.attributes[:visibility]
           result
         end
 

--- a/app/actors/hyrax/actors/model_actor.rb
+++ b/app/actors/hyrax/actors/model_actor.rb
@@ -2,6 +2,9 @@ module Hyrax
   module Actors
     # This is a proxy for the model specific actor
     class ModelActor < AbstractActor
+      # See: https://github.com/bbatsov/rubocop/issues/5393
+      # rubocop:disable Rails/Delegate
+
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if update was successful
       def update(env)
@@ -19,6 +22,7 @@ module Hyrax
       def destroy(env)
         model_actor(env).destroy(env)
       end
+      # rubocop:enable Rails/Delegate
 
       private
 

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -156,9 +156,7 @@ module Hyrax
       def parent_presenter
         @parent_presenter ||=
           begin
-            if params[:parent_id]
-              @parent_presenter ||= show_presenter.new(search_result_document(id: params[:parent_id]), current_ability, request)
-            end
+            @parent_presenter ||= show_presenter.new(search_result_document(id: params[:parent_id]), current_ability, request) if params[:parent_id]
           end
       end
 

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -154,10 +154,10 @@ module Hyrax
       end
 
       def parent_presenter
+        return @parent_presenter unless params[:parent_id]
+
         @parent_presenter ||=
-          begin
-            @parent_presenter ||= show_presenter.new(search_result_document(id: params[:parent_id]), current_ability, request) if params[:parent_id]
-          end
+          show_presenter.new(search_result_document(id: params[:parent_id]), current_ability, request)
       end
 
       # Include 'hyrax/base' in the search path for views, while prefering

--- a/app/controllers/hyrax/api/items_controller.rb
+++ b/app/controllers/hyrax/api/items_controller.rb
@@ -34,13 +34,9 @@ module Hyrax
         def my_load_and_authorize_resource
           @work = Hyrax::WorkRelation.new.find(params[:id])
 
-          unless user.can? :edit, @work
-            return render plain: "#{user} lacks access to #{@work}", status: :unauthorized
-          end
+          return render plain: "#{user} lacks access to #{@work}", status: :unauthorized unless user.can? :edit, @work
 
-          if @work.arkivo_checksum.nil?
-            return render plain: "Forbidden: #{@work} not deposited via Arkivo", status: :forbidden
-          end
+          return render plain: "Forbidden: #{@work} not deposited via Arkivo", status: :forbidden if @work.arkivo_checksum.nil?
         rescue ActiveFedora::ObjectNotFoundError
           return render plain: "id '#{params[:id]}' not found", status: :not_found
         end

--- a/app/controllers/hyrax/transfers_controller.rb
+++ b/app/controllers/hyrax/transfers_controller.rb
@@ -46,9 +46,7 @@ module Hyrax
     # any existing edit permissions on the work.
     def accept
       @proxy_deposit_request.transfer!(params[:reset])
-      if params[:sticky]
-        current_user.can_receive_deposits_from << @proxy_deposit_request.sending_user
-      end
+      current_user.can_receive_deposits_from << @proxy_deposit_request.sending_user if params[:sticky]
       redirect_to hyrax.transfers_path, notice: "Transfer complete"
     end
 

--- a/app/controllers/hyrax/users_controller.rb
+++ b/app/controllers/hyrax/users_controller.rb
@@ -24,9 +24,7 @@ module Hyrax
       def search(query)
         clause = query.blank? ? nil : "%" + query.downcase + "%"
         base = ::User.where(*base_query)
-        if clause.present?
-          base = base.where("#{Hydra.config.user_key_field} like lower(?) OR display_name like lower(?)", clause, clause)
-        end
+        base = base.where("#{Hydra.config.user_key_field} like lower(?) OR display_name like lower(?)", clause, clause) if clause.present?
         base.registered
             .where("#{Hydra.config.user_key_field} not in (?)",
                    [::User.batch_user_key, ::User.audit_user_key])

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -45,7 +45,6 @@ module Hyrax
       # @return [Hash{Symbol => String, Boolean}] { :content_tab (for confirmation message),
       #                                             :updated (true/false),
       #                                               :error_code (for flash error lookup) }
-      # rubocop:disable Metrics/MethodLength
       def update(attributes)
         @attributes = attributes
         return_info = { content_tab: tab_to_update }
@@ -219,9 +218,7 @@ module Hyrax
         def grants_as_collection
           return [] unless attributes[:access_grants_attributes]
           attributes_collection = attributes[:access_grants_attributes]
-          if attributes_collection.respond_to?(:permitted?)
-            attributes_collection = attributes_collection.to_h
-          end
+          attributes_collection = attributes_collection.to_h if attributes_collection.respond_to?(:permitted?)
           if attributes_collection.is_a? Hash
             attributes_collection = attributes_collection
                                     .sort_by { |i, _| i.to_i }

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -160,9 +160,7 @@ module Hyrax
       # are going into a mediated deposit workflow.
       def self.sanitize_params(form_params)
         admin_set_id = form_params[:admin_set_id]
-        if admin_set_id && workflow_for(admin_set_id: admin_set_id).allows_access_grant?
-          return super
-        end
+        return super if admin_set_id && workflow_for(admin_set_id: admin_set_id).allows_access_grant?
         params_without_permissions = permitted_params.reject { |arg| arg.respond_to?(:key?) && arg.key?(:permissions_attributes) }
         form_params.permit(*params_without_permissions)
       end

--- a/app/helpers/hyrax/citations_behaviors/common_behavior.rb
+++ b/app/helpers/hyrax/citations_behaviors/common_behavior.rb
@@ -6,9 +6,7 @@ module Hyrax
       end
 
       def clean_end_punctuation(text)
-        if text && ([".", ",", ":", ";", "/"].include? text[-1, 1])
-          return text[0, text.length - 1]
-        end
+        return text[0, text.length - 1] if text && ([".", ",", ":", ";", "/"].include? text[-1, 1])
         text
       end
     end

--- a/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
@@ -4,17 +4,13 @@ module Hyrax
       class ChicagoFormatter < BaseFormatter
         include Hyrax::CitationsBehaviors::PublicationBehavior
         include Hyrax::CitationsBehaviors::TitleBehavior
-
-        # rubocop:disable Metrics/MethodLength
         def format(work)
           text = ""
 
           # setup formatted author list
           authors_list = all_authors(work)
           text << format_authors(authors_list)
-          if text.present?
-            text = "<span class=\"citation-author\">#{text}</span>"
-          end
+          text = "<span class=\"citation-author\">#{text}</span>" if text.present?
           # Get Pub Date
           pub_date = setup_pub_date(work)
           text << " #{pub_date}." unless pub_date.nil?

--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -15,7 +15,6 @@ module Hyrax::FileSetHelper
            locals.merge(file_set: presenter)
   end
 
-  # rubocop:disable Metrics/MethodLength
   def media_display_partial(file_set)
     'hyrax/file_sets/media_display/' +
       if file_set.image?

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -273,7 +273,6 @@ module Hyrax
         end
       end
 
-      # rubocop:disable Metrics/MethodLength
       def search_action_for_dashboard
         case params[:controller]
         when "hyrax/my/collections"

--- a/app/helpers/hyrax/trophy_helper.rb
+++ b/app/helpers/hyrax/trophy_helper.rb
@@ -1,6 +1,5 @@
 module Hyrax
   module TrophyHelper
-    # rubocop:disable Metrics/MethodLength
     def display_trophy_link(user, id, args = {}, &_block)
       return unless user
       trophy = user.trophies.where(work_id: id).exists?

--- a/app/inputs/multi_value_select_input.rb
+++ b/app/inputs/multi_value_select_input.rb
@@ -39,9 +39,7 @@ class MultiValueSelectInput < MultiValueInput
     def build_field(value, index)
       render_options = select_options
       html_options = build_field_options(value)
-      if options[:item_helper]
-        (render_options, html_options) = options[:item_helper].call(value, index, render_options, html_options)
-      end
+      (render_options, html_options) = options[:item_helper].call(value, index, render_options, html_options) if options[:item_helper]
       template.select_tag(attribute_name, template.options_for_select(render_options, value), html_options)
     end
 end

--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -38,8 +38,6 @@ class AdminSet < ActiveFedora::Base
   property :creator, predicate: ::RDF::Vocab::DC11.creator do |index|
     index.as :symbol
   end
-
-  # rubocop:disable Rails/HasManyOrHasOneDependent
   has_many :members,
            predicate:  Hyrax.config.admin_set_predicate,
            class_name: 'ActiveFedora::Base'
@@ -58,9 +56,7 @@ class AdminSet < ActiveFedora::Base
 
   # Creates the default AdminSet and an associated PermissionTemplate with workflow
   def self.find_or_create_default_admin_set_id
-    unless exists?(DEFAULT_ID)
-      Hyrax::AdminSetCreateService.create_default_admin_set(admin_set_id: DEFAULT_ID, title: DEFAULT_TITLE)
-    end
+    Hyrax::AdminSetCreateService.create_default_admin_set(admin_set_id: DEFAULT_ID, title: DEFAULT_TITLE) unless exists?(DEFAULT_ID)
     DEFAULT_ID
   end
 

--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -112,9 +112,7 @@ module Hyrax
           end
         end
 
-        if Flipflop.proxy_deposit? && registered_user?
-          can :create, ProxyDepositRequest
-        end
+        can :create, ProxyDepositRequest if Flipflop.proxy_deposit? && registered_user?
 
         can :accept, ProxyDepositRequest, receiving_user_id: current_user.id, status: 'pending'
         can :reject, ProxyDepositRequest, receiving_user_id: current_user.id, status: 'pending'

--- a/app/models/concerns/hyrax/suppressible.rb
+++ b/app/models/concerns/hyrax/suppressible.rb
@@ -15,9 +15,7 @@ module Hyrax
     # Override this method if you have some criteria by which records should not display in the search results.
     def suppressed?
       return false if state.nil?
-      # This is a clumsy check only needed under RDF < 2.0 where there
-      # is a bug with `AT::Resource#==`
-      return state.rdf_subject == Vocab::FedoraResourceStatus.inactive if RDF::VERSION.to_s < '2.0'
+
       state == Vocab::FedoraResourceStatus.inactive
     end
 

--- a/app/models/concerns/hyrax/suppressible.rb
+++ b/app/models/concerns/hyrax/suppressible.rb
@@ -17,9 +17,7 @@ module Hyrax
       return false if state.nil?
       # This is a clumsy check only needed under RDF < 2.0 where there
       # is a bug with `AT::Resource#==`
-      if RDF::VERSION.to_s < '2.0'
-        return state.rdf_subject == Vocab::FedoraResourceStatus.inactive
-      end
+      return state.rdf_subject == Vocab::FedoraResourceStatus.inactive if RDF::VERSION.to_s < '2.0'
       state == Vocab::FedoraResourceStatus.inactive
     end
 

--- a/app/models/featured_work_list.rb
+++ b/app/models/featured_work_list.rb
@@ -3,9 +3,7 @@ class FeaturedWorkList
 
   # @param [ActionController::Parameters] a collection of nested perameters
   def featured_works_attributes=(attributes_collection)
-    if attributes_collection.respond_to?(:permitted?)
-      attributes_collection = attributes_collection.to_h
-    end
+    attributes_collection = attributes_collection.to_h if attributes_collection.respond_to?(:permitted?)
     attributes_collection = attributes_collection.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes } if attributes_collection.is_a? Hash
     attributes_collection.each do |attributes|
       raise "Missing id" if attributes['id'].blank?

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -194,9 +194,7 @@ module Hyrax
       end
 
       def featured?
-        if @featured.nil?
-          @featured = FeaturedWork.where(work_id: solr_document.id).exists?
-        end
+        @featured = FeaturedWork.where(work_id: solr_document.id).exists? if @featured.nil?
         @featured
       end
 

--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -72,9 +72,7 @@ module Hyrax
           { agent_type: 'group', agent_id: admin_group_name, access: Hyrax::PermissionTemplateAccess::MANAGE }
         ].tap do |attribute_list|
           # Grant manage access to the creating_user if it exists. Should exist for all but default Admin Set
-          if creating_user
-            attribute_list << { agent_type: 'user', agent_id: creating_user.user_key, access: Hyrax::PermissionTemplateAccess::MANAGE }
-          end
+          attribute_list << { agent_type: 'user', agent_id: creating_user.user_key, access: Hyrax::PermissionTemplateAccess::MANAGE } if creating_user
         end
       end
 

--- a/app/services/hyrax/analytics.rb
+++ b/app/services/hyrax/analytics.rb
@@ -57,9 +57,7 @@ module Hyrax
     end
 
     def self.auth_client(scope)
-      unless File.exist?(config.privkey_path)
-        raise "Private key file for Google analytics was expected at '#{config.privkey_path}', but no file was found."
-      end
+      raise "Private key file for Google analytics was expected at '#{config.privkey_path}', but no file was found." unless File.exist?(config.privkey_path)
       private_key = File.read(config.privkey_path)
       Signet::OAuth2::Client.new token_credential_uri: 'https://accounts.google.com/o/oauth2/token',
                                  audience: 'https://accounts.google.com/o/oauth2/token',

--- a/app/services/hyrax/collection_types/create_service.rb
+++ b/app/services/hyrax/collection_types/create_service.rb
@@ -133,7 +133,7 @@ module Hyrax
             agent_id = p.fetch(:agent_id)
             access = p.fetch(:access)
             Hyrax::CollectionTypeParticipant.create!(hyrax_collection_type_id: collection_type_id, agent_type: agent_type, agent_id: agent_id, access: access)
-          rescue => e # rubocop:disable Lint/RescueWithoutErrorClass
+          rescue => e
             Rails.logger.error "Participant not created for collection type #{collection_type_id}: #{agent_type}, #{agent_id}, #{access} -- reason: #{e.class.name} - #{e.message}\n"
           end
         end

--- a/app/services/hyrax/collections/permissions_create_service.rb
+++ b/app/services/hyrax/collections/permissions_create_service.rb
@@ -30,9 +30,7 @@ module Hyrax
           { agent_type: 'group', agent_id: admin_group_name, access: Hyrax::PermissionTemplateAccess::MANAGE }
         ].tap do |attribute_list|
           # Grant manage access to the creating_user if it exists
-          if creating_user
-            attribute_list << { agent_type: 'user', agent_id: creating_user.user_key, access: Hyrax::PermissionTemplateAccess::MANAGE }
-          end
+          attribute_list << { agent_type: 'user', agent_id: creating_user.user_key, access: Hyrax::PermissionTemplateAccess::MANAGE } if creating_user
         end + managers_of_collection_type(collection_type: collection_type) + grants
       end
       private_class_method :access_grants_attributes

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -93,21 +93,11 @@ SUMMARY
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency "selenium-webdriver"
   spec.add_development_dependency 'solr_wrapper', '~> 1.1'
-  # Pin rubocop and rubocop-rspec tightly. Minor-level version bumps
-  # in these gems cause Rubocop violations, and those violations cause
-  # continuous integration builds to fail, and those failures prevent
-  # us from merging pull requests. As a community, we have decided
-  # that it is not reasonable to manage style violations to be dealt
-  # with in a pull request *unless* said pull request's intent is to
-  # bring the codebase in further alignment with community style
-  # conventions. This allows us to take a managed approach to code
-  # style -- we choose to update style when we wish, not when a
-  # minor-level version bump in a dependency comes out.
   spec.add_development_dependency 'i18n-debug' if ENV['I18N_DEBUG']
   spec.add_development_dependency 'i18n_yaml_sorter' unless ENV['TRAVIS']
   spec.add_development_dependency 'rails-controller-testing', '~> 1'
-  spec.add_development_dependency 'rubocop', '~> 0.51.0'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.20.1'
+  # the hyrax style guide is based on `bixby`. see `.rubocop.yml`
+  spec.add_development_dependency 'bixby', '~> 1.0.0'
   spec.add_development_dependency 'shoulda-callback-matchers', '~> 1.1.1'
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
   spec.add_development_dependency 'webmock'

--- a/lib/generators/hyrax/models_generator.rb
+++ b/lib/generators/hyrax/models_generator.rb
@@ -17,7 +17,6 @@ class Hyrax::ModelsGenerator < Rails::Generators::Base
   end
 
   # Add behaviors to the user model
-  # rubocop:disable Metrics/MethodLength
   def inject_user_behavior
     file_path = "app/models/#{model_name.underscore}.rb"
     if File.exist?(file_path)

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -206,9 +206,7 @@ module Hyrax
     # @param [Array<Symbol>,Symbol] curation_concern_types
     def register_curation_concern(*curation_concern_types)
       Array.wrap(curation_concern_types).flatten.compact.each do |cc_type|
-        unless @registered_concerns.include?(cc_type)
-          @registered_concerns << cc_type
-        end
+        @registered_concerns << cc_type unless @registered_concerns.include?(cc_type)
       end
     end
 

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -9,9 +9,7 @@ FactoryBot.define do
     end
 
     after(:create) do |file, evaluator|
-      if evaluator.content
-        Hydra::Works::UploadFileToFileSet.call(file, evaluator.content)
-      end
+      Hydra::Works::UploadFileToFileSet.call(file, evaluator.content) if evaluator.content
     end
 
     trait :public do
@@ -27,9 +25,7 @@ FactoryBot.define do
         file.title = ['testfile']
       end
       after(:create) do |file, evaluator|
-        if evaluator.content
-          Hydra::Works::UploadFileToFileSet.call(file, evaluator.content)
-        end
+        Hydra::Works::UploadFileToFileSet.call(file, evaluator.content) if evaluator.content
         create(:work, user: evaluator.user).members << file
       end
     end

--- a/spec/helpers/hyrax/ability_helper_spec.rb
+++ b/spec/helpers/hyrax/ability_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::AbilityHelper do
       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC =>
         "<span class=\"label label-success\">Public</span>",
       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED =>
-        "<span class=\"label label-info\">%s</span>",
+        "<span class=\"label label-info\">%<name>s</span>",
       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE =>
         "<span class=\"label label-danger\">Private</span>",
       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO =>
@@ -17,7 +17,7 @@ RSpec.describe Hyrax::AbilityHelper do
       context value do
         let(:visibility) { value }
 
-        it { expect(subject).to eql(output % t('hyrax.institution_name')) }
+        it { expect(subject).to eql(format(output, name: t('hyrax.institution_name'))) }
       end
     end
   end

--- a/spec/services/hyrax/qa_select_service_spec.rb
+++ b/spec/services/hyrax/qa_select_service_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe Hyrax::QaSelectService do
   let(:authority) do
     # Implementing an ActiveRecord interface as required for this spec
-    # rubocop:disable RSpec/InstanceVariable
     Class.new do
       def initialize(map)
         @map = map

--- a/tasks/hyrax_dev.rake
+++ b/tasks/hyrax_dev.rake
@@ -45,9 +45,7 @@ if Gem.loaded_specs.key? 'engine_cart'
     task :after_generate do
       puts 'Creating default collection type...'
       EngineCart.within_test_app do
-        unless system "bundle exec rake hyrax:default_collection_types:create"
-          raise "EngineCart failed on with: #{$?}"
-        end
+        raise "EngineCart failed on with: #{$?}" unless system "bundle exec rake hyrax:default_collection_types:create"
       end
     end
   end


### PR DESCRIPTION
Bixby is a RuboCop style guide that decouples (to the degree possible) RuboCop
software updates from unrelated style guide updates. Bixby disables all rules by
default, and re-enables rules that are adopted in the community in general.

Bixby's promise is to avoid adding rules without bumping major
version. Pinning to the current v1.0.0 will allow us to update software versions
with reduced changes (ideally none) to code style. Enforcement of existing rules
may still change to become more strict based on updates to rule enforcement
code.

Several rule exceptions and other configurations that I could identify as being
inherited from Bixby are removed from the local `.rubocop.yml`.

Closes #2568.

Changes proposed in this pull request:
* Update RuboCop dependency to Bixby
* Fix style violations to align with current style guide

@samvera/hyrax-code-reviewers
