### PR TITLE
Display collection type as badge

### DIFF
--- a/app/views/hyrax/collections/_list_collections.html.erb
+++ b/app/views/hyrax/collections/_list_collections.html.erb
@@ -18,9 +18,9 @@
       </div>
     </div>
   </td>
-
-  <td class="collection_type"><%= collection_presenter.collection_type_badge %></td>
-
+  <td class="collection_type">
+    <span class="label label-success"><%= collection_presenter.collection_type_badge %></span>
+  </td>
   <td class="text-center date"><%=collection_presenter.modified_date.try(:to_formatted_s, :standard) %> </td>
   <td class="text-center">
     <%= render_visibility_link(collection_presenter.solr_document) %>

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -46,13 +46,11 @@
       </div>
     </div>
   </td>
-  <td class="collection_type"><%= collection_presenter.collection_type_badge %></td>
-  <td>
-    <%= render_visibility_link(collection_presenter.solr_document) %>
+  <td class="collection_type">
+    <span class="label label-success"><%= collection_presenter.collection_type_badge %></span>
   </td>
-
-  <td><%=collection_presenter.total_viewable_items%></td>
-
+  <td><%= collection_presenter.permission_badge %>  </td>
+  <td><%= collection_presenter.total_viewable_items %></td>
   <td class="date"><%=collection_presenter.modified_date.try(:to_formatted_s, :standard) %> </td>
   <td>
     <% if collection_presenter.solr_document.admin_set? %>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -49,9 +49,11 @@
       </div>
     </div>
   </td>
-  <td class="collection_type"><%= collection_presenter.collection_type_badge %></td>
-  <td><%= render_visibility_link(collection_presenter.solr_document) %></td>
-  <td><%=collection_presenter.total_viewable_items%></td>
+  <td class="collection_type">
+    <span class="label label-success"><%= collection_presenter.collection_type_badge %></span>
+  </td>
+  <td><%= collection_presenter.permission_badge %></td>
+  <td><%= collection_presenter.total_viewable_items %></td>
   <td class="date"><%=collection_presenter.modified_date.try(:to_formatted_s, :standard) %> </td>
   <td>
     <% if collection_presenter.solr_document.admin_set? %>

--- a/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
       expect(rendered).to have_link 'Edit collection', href: hyrax.edit_dashboard_collection_path(id)
       expect(rendered).to have_link 'Delete collection'
       expect(rendered).to have_link 'Add to collection'
-      expect(rendered).to have_css 'a.visibility-link', text: 'Private'
       expect(rendered).to have_css '.collection_type', text: 'User Collection'
       expect(rendered).to have_selector '.expanded-details', text: 'Collection Description'
       expect(rendered).not_to include '<span class="fa fa-cubes collection-icon-small"></span></a>'


### PR DESCRIPTION
Resolves https://github.com/samvera/hyrax/issues/2594

Adds badge to the collection type.
Changes visibility badge from link to a simple badge on collection index
lists.

@samvera/hyrax-code-reviewers
