### PR TITLE
Initial spec coverage for Analytics::Base

### DIFF
--- a/app/services/hyrax/analytics/base.rb
+++ b/app/services/hyrax/analytics/base.rb
@@ -2,25 +2,12 @@ module Hyrax
   module Analytics
     # @abstract Base class for Analytics services that support statistics needs in Hyrax.
     # Implementing subclasses must define `#connection` `#remote_statistics` and `#to_graph`
-    class Connector
+    class Base
       # Establish connection with the analytics service
       def self.connection
         raise NotImplementedError, "#{self.class}#connection is unimplemented."
       end
 
-      # Used by Hyrax::Statistic to perform live queries against the remote service
-      # @param start_date [DateTime]
-      # @param object [ActiveFedora::Base??] probably a better type for this
-      # @param query_type
-      #
-      # return [Enumerable] of objects to cache locally in DB
-      # TODO: decide best place for query types: pageview, download, returning visitors,  new visitors,..
-      def self.remote_statistics(_start_date, _object, _query_type)
-        raise NotImplementedError, "#{self.class}#remote_statistics is unimplemented."
-      end
-
-      # OR, define explicit query methods for each query?
-      # Examples
       def self.pageviews(_start_date, _object)
         raise NotImplementedError, "#{self.class}#pageviews is unimplemented."
       end

--- a/app/services/hyrax/analytics/google_analytics.rb
+++ b/app/services/hyrax/analytics/google_analytics.rb
@@ -1,6 +1,6 @@
 module Hyrax
   module Analytics
-    class GoogleAnalytics < Connector
+    class GoogleAnalytics < Hyrax::Analytics::Base
       def self.connection
         return unless config.valid?
         # an ||= to setup the GA connection using JSON

--- a/app/services/hyrax/analytics/matomo.rb
+++ b/app/services/hyrax/analytics/matomo.rb
@@ -2,7 +2,7 @@ require 'piwik'
 
 module Hyrax
   module Analytics
-    class Matomo < Base
+    class Matomo < Hyrax::Analytics::Base
       def self.connection
         return unless config.valid?
         # an ||= to setup Matomo

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -31,6 +31,7 @@ SUMMARY
 
   spec.add_dependency 'active-fedora', '~> 11.5', '>= 11.5.2'
   spec.add_dependency 'almond-rails', '~> 0.1'
+  spec.add_dependency 'autometal-piwik', '~> 1.0', require: 'piwik'
   spec.add_dependency 'awesome_nested_set', '~> 3.1'
   spec.add_dependency 'blacklight', '~> 6.14'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'

--- a/spec/services/hyrax/analytics/base_spec.rb
+++ b/spec/services/hyrax/analytics/base_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Hyrax::Analytics::Base do
+  describe '.connection' do
+    it 'is unimplemented' do
+      expect { described_class.connection }.to raise_error NotImplementedError
+    end
+  end
+
+  describe '.pageviews' do
+    it 'is unimplemented' do
+      expect { described_class.pageviews("2018-02-16", nil) }.to raise_error NotImplementedError
+    end
+  end
+
+  describe '.downloads' do
+    it 'is unimplemented' do
+      expect { described_class.downloads("2018-02-16", nil) }.to raise_error NotImplementedError
+    end
+  end
+
+  describe '.visitors' do
+    it 'is unimplemented' do
+      expect { described_class.visitors("2018-02-16") }.to raise_error NotImplementedError
+    end
+  end
+
+  describe '.returning_visitors' do
+    it 'is unimplemented' do
+      expect { described_class.returning_visitors("2018-02-16") }.to raise_error NotImplementedError
+    end
+  end
+end

--- a/spec/services/hyrax/analytics/google_analytics_spec.rb
+++ b/spec/services/hyrax/analytics/google_analytics_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Hyrax::Analytics::GoogleAnalytics do
+  describe '.connection' do
+    it 'is a pending example'
+  end
+
+  describe '.pageviews' do
+    it 'is a pending example'
+  end
+
+  describe '.downloads' do
+    it 'is a pending example'
+  end
+
+  describe '.visitors' do
+    it 'is a pending example'
+  end
+
+  describe '.returning_visitors' do
+    it 'is a pending example'
+  end
+end

--- a/spec/services/hyrax/analytics/matomo_spec.rb
+++ b/spec/services/hyrax/analytics/matomo_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Hyrax::Analytics::Matomo do
+  describe '.connection' do
+    it 'is a pending example'
+  end
+
+  describe '.pageviews' do
+    it 'is a pending example'
+  end
+
+  describe '.downloads' do
+    it 'is a pending example'
+  end
+
+  describe '.visitors' do
+    it 'is a pending example'
+  end
+
+  describe '.returning_visitors' do
+    it 'is a pending example'
+  end
+end


### PR DESCRIPTION
Changes proposed:
- Initial spec coverage for Analytics::Base
- Pending test templates for Matomo and GoogleAnalytics subclasses
- Renamed Connection to Base
- Renamed matomo_analytics.rb to matomo.rb
- Add Pikiw gem to hyrax gemspec

@samvera/hyrax-code-reviewers @nestorw @conorom @sethaj 
