### PR TITLE
Parent collection pagination

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -65,7 +65,7 @@ module Hyrax
       def query_collection_members
         member_works
         member_subcollections if collection.collection_type.nestable?
-        parent_collections if collection.collection_type.nestable?
+        parent_collections if collection.collection_type.nestable? && action_name == 'show'
       end
 
       # Instantiate the membership query service
@@ -80,9 +80,9 @@ module Hyrax
       end
 
       def parent_collections
-        @parent_collections = collection_object.member_of_collections
-        @parent_collection_count = @parent_collections.size
-        collection.parent_collections = @parent_collections if action_name == 'show'
+        page = params[:parent_collection_page].to_i
+        query = Hyrax::Collections::NestedCollectionQueryService
+        collection.parent_collections = query.parent_collections(child: collection_object, scope: self, page: page)
       end
 
       def collection_object

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -423,7 +423,7 @@ module Hyrax
         def query_collection_members
           member_works
           member_subcollections if collection.collection_type.nestable?
-          parent_collections if collection.collection_type.nestable?
+          parent_collections if collection.collection_type.nestable? && action_name == 'show'
         end
 
         # Instantiate the membership query service
@@ -445,9 +445,9 @@ module Hyrax
         end
 
         def parent_collections
-          @parent_collections = collection_object.member_of_collections
-          @parent_collection_count = @parent_collections.size
-          collection.parent_collections = @parent_collections if action_name == 'show'
+          page = params[:parent_collection_page].to_i
+          query = Hyrax::Collections::NestedCollectionQueryService
+          collection.parent_collections = query.parent_collections(child: collection_object, scope: self, page: page)
         end
 
         def collection_object

--- a/app/search_builders/hyrax/nested_collections_parent_search_builder.rb
+++ b/app/search_builders/hyrax/nested_collections_parent_search_builder.rb
@@ -1,0 +1,27 @@
+module Hyrax
+  # Searches for all collections that are parents of a given collection.
+  class NestedCollectionsParentSearchBuilder < ::SearchBuilder
+    include Hyrax::FilterByType
+    attr_reader :child, :page, :limit
+
+    # @param [scope] Typically the controller object
+    # @param [child] The child collection
+    def initialize(scope:, child:, page:)
+      @child = child
+      @page = page
+      super(scope)
+    end
+
+    # Filters the query to only include the parent collections
+    def parent_collections_only(solr_parameters)
+      solr_parameters[:fq] ||= []
+      solr_parameters[:fq] << ActiveFedora::SolrQueryBuilder.construct_query_for_ids(child.member_of_collection_ids)
+    end
+    self.default_processor_chain += [:parent_collections_only]
+
+    def with_pagination(solr_parameters)
+      solr_parameters[:page] = page
+    end
+    self.default_processor_chain += [:with_pagination]
+  end
+end

--- a/app/views/hyrax/collections/_show_parent_collections.html.erb
+++ b/app/views/hyrax/collections/_show_parent_collections.html.erb
@@ -1,32 +1,41 @@
-<% if presenter.parent_collection_count <= 0 %>
+<% if presenter.total_parent_collections <= 0 %>
 		<div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_parent_collections') %></div>
 <% else %>
-		<div class="media-body">
-			<h4 class="media-heading">
-				<div class="less-parent-collections-block" id="less-parent-collections">
-					<% presenter.visible_parent_collections.each do |document| %>
-						<ul>
-							<li>
-								<%= link_to document, [hyrax, document], id: "src_copy_link_#{document.id}" %>
-							</li>
-						</ul>
-					<% end %>
-					<% if presenter.more_parent_collections? %>
-							<button id="show-more-parent-collections" class="btn show-more-parent-collections-btn"><%= t("hyrax.collections.show.show_more_parent_collections") %></button>
-					<% end %>
-				</div>
-				<% if presenter.more_parent_collections? %>
-					<div class="more-parent-collections-block" id="more-parent-collections">
-						<% presenter.more_parent_collections.each do |document| %>
-							<ul>
-								<li>
-									<%= link_to document, [hyrax, document], id: "src_copy_link_#{document.id}" %>
-								</li>
-							</ul>
-							<button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
-						<% end %>
-					</div>
-				<% end %>
-			</h4>
-		</div>
+  <% if presenter.use_parent_more_less? %>
+  	<div class="less-parent-collections-block" id="less-parent-collections">
+  		<% presenter.visible_parent_collections.each do |document| %>
+  			<ul>
+  				<li>
+  					<strong><%= link_to document, [hyrax, document], id: "src_copy_link_#{document.id}" %></strong>
+  				</li>
+  			</ul>
+  		<% end %>
+  		<% if presenter.more_parent_collections? %>
+  				<button id="show-more-parent-collections" class="btn show-more-parent-collections-btn"><%= t("hyrax.collections.show.show_more_parent_collections") %></button>
+  		<% end %>
+  	</div>
+  	<% if presenter.more_parent_collections? %>
+  		<div class="more-parent-collections-block" id="more-parent-collections">
+  			<% presenter.more_parent_collections.each do |document| %>
+  				<ul>
+  					<li>
+  						<strong><%= link_to document, [hyrax, document], id: "src_copy_link_#{document.id}" %></strong>
+  					</li>
+  				</ul>
+  			<% end %>
+        <button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
+  		</div>
+    <% end %>
+  <% else %>
+		<% presenter.parent_collections.documents.each do |document| %>
+			<ul>
+				<li>
+					<strong><%= link_to document, [hyrax, document], id: "src_copy_link_#{document.id}" %></strong>
+				</li>
+			</ul>
+		<% end %>
+    <div class="row">
+      <%= render 'hyrax/collections/paginate', solr_response: presenter.parent_collections, page_param_name: :parent_collection_page  %>
+    </div>
+	<% end %>
 <% end %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -56,10 +56,10 @@
 		<div class="col-md-8 hyc-description">
 			<%= render 'collection_description', presenter: @presenter %>
 
-			<% if @presenter.collection_type_is_nestable? && @presenter.parent_collection_count > 0 %>
+			<% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
 					<div class="hyc-blacklight hyc-bl-title">
 						<h2>
-							<%= t('.parent_collection_header') %> (<%= @presenter.parent_collection_count %>)
+							<%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)
 						</h2>
 					</div>
 					<div class="hyc-blacklight hyc-bl-results">

--- a/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
@@ -1,28 +1,41 @@
-<% if presenter.parent_collection_count <= 0 %>
+<% if presenter.total_parent_collections <= 0 %>
 		<div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_parent_collections') %></div>
 <% else %>
-	<div class="less-parent-collections-block" id="less-parent-collections">
-		<% presenter.visible_parent_collections.each do |document| %>
+  <% if presenter.use_parent_more_less? %>
+  	<div class="less-parent-collections-block" id="less-parent-collections">
+  		<% presenter.visible_parent_collections.each do |document| %>
+  			<ul>
+  				<li>
+  					<strong><%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %></strong>
+  				</li>
+  			</ul>
+  		<% end %>
+  		<% if presenter.more_parent_collections? %>
+  				<button id="show-more-parent-collections" class="btn show-more-parent-collections-btn"><%= t("hyrax.collections.show.show_more_parent_collections") %></button>
+  		<% end %>
+  	</div>
+  	<% if presenter.more_parent_collections? %>
+  		<div class="more-parent-collections-block" id="more-parent-collections">
+  			<% presenter.more_parent_collections.each do |document| %>
+  				<ul>
+  					<li>
+  						<strong><%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %></strong>
+  					</li>
+  				</ul>
+  			<% end %>
+  			<button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
+  		</div>
+  	<% end %>
+  <% else %>
+		<% presenter.parent_collections.documents.each do |document| %>
 			<ul>
 				<li>
 					<strong><%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %></strong>
 				</li>
 			</ul>
 		<% end %>
-		<% if presenter.more_parent_collections? %>
-				<button id="show-more-parent-collections" class="btn show-more-parent-collections-btn"><%= t("hyrax.collections.show.show_more_parent_collections") %></button>
-		<% end %>
-	</div>
-	<% if presenter.more_parent_collections? %>
-		<div class="more-parent-collections-block" id="more-parent-collections">
-			<% presenter.more_parent_collections.each do |document| %>
-				<ul>
-					<li>
-						<strong><%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %></strong>
-					</li>
-				</ul>
-			<% end %>
-			<button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
-		</div>
-	<% end %>
+    <div class="row">
+      <%= render 'hyrax/collections/paginate', solr_response: presenter.parent_collections, page_param_name: :parent_collection_page  %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -19,8 +19,8 @@
           </div>
           <div class="col-sm-9 collection-description-wrapper">
             <!-- Parent Collection(s) -->
-            <% if @presenter.collection_type_is_nestable? && @presenter.parent_collection_count > 0 %>
-                <h4><%= t('.parent_collection_header') %> (<%= @presenter.parent_collection_count %>)</h4>
+            <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
+                <h4><%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)</h4>
                 <section class="parent-collections-wrapper">
                 <%= render 'hyrax/dashboard/collections/show_parent_collections', presenter: @presenter %>
               </section>

--- a/lib/generators/hyrax/templates/db/seeds.rb
+++ b/lib/generators/hyrax/templates/db/seeds.rb
@@ -186,6 +186,25 @@ mpc = create_public_collection(
                      member_of_collections_attributes: collection_attributes_for([mpc.id]))
 end
 
+puts 'Create collections with many parent collections'
+# Pool of collections that will be used as parents of the collections
+parent_pool = Array.new(12) do |i|
+  create_public_collection(user,
+                           nestable_gid,
+                           "col_shared_parents_#{i}",
+                           title: ["Shared Parent collection #{i}"],
+                           description: ['Collection that shares children with multiple parents.'])
+end
+# 2 parent collection
+col_two_parents = create_public_collection(user, nestable_gid, "col_two_parents", title: ["Collection - 2 parents"], description: ['Collection that has two parents.'])
+2.times { |i| Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent_pool[i], child: col_two_parents) }
+# 6 parent collection
+col_six_parents = create_public_collection(user, nestable_gid, "col_six_parents", title: ["Collection - 6 parents"], description: ['Collection that has six parents.'])
+6.times { |i| Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent_pool[i], child: col_six_parents) }
+# 12 parent collection
+col_twelve_parents = create_public_collection(user, nestable_gid, "col_twelve_parents", title: ["Collection - 12 parents"], description: ['Collection that has twelve parents.'])
+12.times { |i| Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent_pool[i], child: col_twelve_parents) }
+
 puts 'Create works for collection nesting ad hoc testing'
 3.times do |i|
   create_public_work(user, "pub_gw_#{i}",

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -277,6 +277,8 @@ RSpec.describe Hyrax::CollectionPresenter do
   describe "#parent_collection_count" do
     subject { presenter.parent_collection_count }
 
+    let(:parent_collections) { double(Object, documents: parent_docs, response: { "numFound" => parent_docs.size }, total_pages: 1) }
+
     context('when parent_collections is nil') do
       before do
         allow(presenter).to receive(:parent_collections).and_return(nil)
@@ -286,9 +288,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context('when parent_collections is has no collections') do
-      before do
-        allow(presenter).to receive(:parent_collections).and_return([])
-      end
+      let(:parent_docs) { [] }
 
       it { is_expected.to eq 0 }
     end
@@ -296,7 +296,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     context('when parent_collections is has collections') do
       let(:collection1) { build(:collection, title: ['col1']) }
       let(:collection2) { build(:collection, title: ['col2']) }
-      let!(:parent_collections) { [collection1, collection2] }
+      let!(:parent_docs) { [collection1, collection2] }
 
       before do
         presenter.parent_collections = parent_collections
@@ -342,6 +342,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     let(:collection3) { build(:collection, title: ['col3']) }
     let(:collection4) { build(:collection, title: ['col4']) }
     let(:collection5) { build(:collection, title: ['col5']) }
+    let(:parent_collections) { double(Object, documents: parent_docs, response: { "numFound" => parent_docs.size }, total_pages: 1) }
 
     before do
       presenter.parent_collections = parent_collections
@@ -354,13 +355,13 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context('when parent_collections has less than or equal to show limit') do
-      let(:parent_collections) { [collection1, collection2, collection3] }
+      let(:parent_docs) { [collection1, collection2, collection3] }
 
       it { is_expected.to include(collection1, collection2, collection3) }
     end
 
     context('when parent_collections has more than show limit') do
-      let(:parent_collections) { [collection1, collection2, collection3, collection4, collection5] }
+      let(:parent_docs) { [collection1, collection2, collection3, collection4, collection5] }
 
       it { is_expected.to include(collection1, collection2, collection3) }
     end
@@ -374,6 +375,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     let(:collection3) { build(:collection, title: ['col3']) }
     let(:collection4) { build(:collection, title: ['col4']) }
     let(:collection5) { build(:collection, title: ['col5']) }
+    let(:parent_collections) { double(Object, documents: parent_docs, response: { "numFound" => parent_docs.size }, total_pages: 1) }
 
     before do
       presenter.parent_collections = parent_collections
@@ -385,14 +387,20 @@ RSpec.describe Hyrax::CollectionPresenter do
       it { is_expected.to eq [] }
     end
 
+    context('when parent_collections is empty') do
+      let(:parent_docs) { [] }
+
+      it { is_expected.to eq [] }
+    end
+
     context('when parent_collections has less than or equal to show limit') do
-      let(:parent_collections) { [collection1, collection2, collection3] }
+      let(:parent_docs) { [collection1, collection2, collection3] }
 
       it { is_expected.to eq [] }
     end
 
     context('when parent_collections has more than show limit') do
-      let(:parent_collections) { [collection1, collection2, collection3, collection4, collection5] }
+      let(:parent_docs) { [collection1, collection2, collection3, collection4, collection5] }
 
       it { is_expected.to include(collection4, collection5) }
     end

--- a/spec/views/hyrax/collections/_show_parent_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_parent_collections.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'hyrax/collections/_show_parent_collections.html.erb', type: :vie
       'date_created_tesim' => '2000-01-01'
     }
   end
+  let(:subject) { render('show_parent_collections.html.erb', presenter: presenter) }
   let(:ability) { double }
   let(:solr_document) { SolrDocument.new(collection_doc) }
   let(:presenter) { Hyrax::CollectionPresenter.new(solr_document, ability) }
@@ -15,6 +16,7 @@ RSpec.describe 'hyrax/collections/_show_parent_collections.html.erb', type: :vie
   let(:collection3) { build(:collection, id: 'col3', title: ['col3']) }
   let(:collection4) { build(:collection, id: 'col4', title: ['col4']) }
   let(:collection5) { build(:collection, id: 'col5', title: ['col5']) }
+  let(:parent_collections) { double(Object, documents: parent_docs, response: { "numFound" => parent_docs.size }, total_pages: 1) }
 
   before do
     assign(:presenter, presenter)
@@ -25,22 +27,39 @@ RSpec.describe 'hyrax/collections/_show_parent_collections.html.erb', type: :vie
     allow(collection3).to receive(:persisted?).and_return true
     allow(collection4).to receive(:persisted?).and_return true
     allow(collection5).to receive(:persisted?).and_return true
-
-    render('show_parent_collections.html.erb', presenter: presenter)
   end
 
-  context 'when parent collection list is empty' do
+  context 'when parent collections are nil' do
     let(:parent_collections) { nil }
 
     it "posts a warning message" do
+      subject
       expect(rendered).to have_text("There are no visible parent collections.")
+    end
+
+    it 'does not render pagination' do
+      expect(subject).not_to render_template("hyrax/collections/_paginate")
     end
   end
 
-  context 'when parent collection list is not empty' do
-    let(:parent_collections) { [collection1, collection2, collection3] }
+  context 'when parent collection list is empty' do
+    let(:parent_docs) { [] }
+
+    it "posts a warning message" do
+      subject
+      expect(rendered).to have_text("There are no visible parent collections.")
+    end
+
+    it 'does not render pagination' do
+      expect(subject).not_to render_template("hyrax/collections/_paginate")
+    end
+  end
+
+  context 'when parent collection list is not empty, but small' do
+    let(:parent_docs) { [collection1, collection2, collection3] }
 
     it "posts the collection's title with a link to the collection" do
+      subject
       expect(rendered).to have_link(collection1.title.first, visible: true)
       expect(rendered).to have_link(collection2.title.first, visible: true)
       expect(rendered).to have_link(collection3.title.first, visible: true)
@@ -50,12 +69,17 @@ RSpec.describe 'hyrax/collections/_show_parent_collections.html.erb', type: :vie
     xit 'includes a count of the parent collections' do
       # TODO: add test when actual count is added to page
     end
+
+    it 'does not render pagination' do
+      expect(subject).not_to render_template("hyrax/collections/_paginate")
+    end
   end
 
   context 'when parent collection list exceeds parents_to_show' do
-    let(:parent_collections) { [collection1, collection2, collection3, collection4, collection5] }
+    let(:parent_docs) { [collection1, collection2, collection3, collection4, collection5] }
 
     it "posts the collection's title with a link to the collection" do
+      subject
       expect(rendered).to have_link(collection1.title.first, visible: true)
       expect(rendered).to have_link(collection2.title.first, visible: true)
       expect(rendered).to have_link(collection3.title.first, visible: true)
@@ -63,6 +87,38 @@ RSpec.describe 'hyrax/collections/_show_parent_collections.html.erb', type: :vie
       expect(rendered).to have_link(collection5.title.first, visible: false)
       expect(rendered).to have_button('show more...', visible: true)
       expect(rendered).to have_button('...show less', visible: false)
+    end
+
+    it 'renders pagination' do
+      expect(subject).not_to render_template("hyrax/collections/_paginate")
+    end
+  end
+
+  context 'when parent collection list has multiple pages' do
+    let(:parent_docs) { [collection1, collection2, collection3, collection4, collection5] }
+    let(:parent_collections) { double(Object, documents: parent_docs, response: { "numFound" => parent_docs.size }, total_pages: 2) }
+
+    before do
+      stub_template "hyrax/collections/_paginate" => "paginate"
+    end
+
+    it "renders a link to all collections" do
+      subject
+      expect(rendered).to have_link(collection1.title.first, visible: true)
+      expect(rendered).to have_link(collection2.title.first, visible: true)
+      expect(rendered).to have_link(collection3.title.first, visible: true)
+      expect(rendered).to have_link(collection4.title.first, visible: false)
+      expect(rendered).to have_link(collection5.title.first, visible: false)
+    end
+
+    it "does not render the more/less buttons" do
+      subject
+      expect(rendered).not_to have_button('show more...', visible: true)
+      expect(rendered).not_to have_button('...show less', visible: false)
+    end
+
+    it 'renders pagination' do
+      expect(subject).to render_template("hyrax/collections/_paginate")
     end
   end
 end

--- a/spec/views/hyrax/dashboard/collections/_show_parent_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_parent_collections.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'hyrax/dashboard/collections/_show_parent_collections.html.erb', 
       'date_created_tesim' => '2000-01-01'
     }
   end
+  let(:subject) { render('show_parent_collections.html.erb', presenter: presenter) }
   let(:ability) { double }
   let(:solr_document) { SolrDocument.new(collection_doc) }
   let(:presenter) { Hyrax::CollectionPresenter.new(solr_document, ability) }
@@ -15,6 +16,7 @@ RSpec.describe 'hyrax/dashboard/collections/_show_parent_collections.html.erb', 
   let(:collection3) { build(:collection, id: 'col3', title: ['col3']) }
   let(:collection4) { build(:collection, id: 'col4', title: ['col4']) }
   let(:collection5) { build(:collection, id: 'col5', title: ['col5']) }
+  let(:parent_collections) { double(Object, documents: parent_docs, response: { "numFound" => parent_docs.size }, total_pages: 1) }
 
   before do
     assign(:presenter, presenter)
@@ -25,22 +27,39 @@ RSpec.describe 'hyrax/dashboard/collections/_show_parent_collections.html.erb', 
     allow(collection3).to receive(:persisted?).and_return true
     allow(collection4).to receive(:persisted?).and_return true
     allow(collection5).to receive(:persisted?).and_return true
-
-    render('show_parent_collections.html.erb', presenter: presenter)
   end
 
-  context 'when parent collection list is empty' do
+  context 'when parent collections are nil' do
     let(:parent_collections) { nil }
 
     it "posts a warning message" do
+      subject
       expect(rendered).to have_text("There are no visible parent collections.")
+    end
+
+    it 'does not render pagination' do
+      expect(subject).not_to render_template("hyrax/collections/_paginate")
     end
   end
 
-  context 'when parent collection list is not empty' do
-    let(:parent_collections) { [collection1, collection2, collection3] }
+  context 'when parent collection list is empty' do
+    let(:parent_docs) { [] }
+
+    it "posts a warning message" do
+      subject
+      expect(rendered).to have_text("There are no visible parent collections.")
+    end
+
+    it 'does not render pagination' do
+      expect(subject).not_to render_template("hyrax/collections/_paginate")
+    end
+  end
+
+  context 'when parent collection list is not empty, but small' do
+    let(:parent_docs) { [collection1, collection2, collection3] }
 
     it "posts the collection's title with a link to the collection" do
+      subject
       expect(rendered).to have_link(collection1.title.first, visible: true)
       expect(rendered).to have_link(collection2.title.first, visible: true)
       expect(rendered).to have_link(collection3.title.first, visible: true)
@@ -50,12 +69,17 @@ RSpec.describe 'hyrax/dashboard/collections/_show_parent_collections.html.erb', 
     xit 'includes a count of the parent collections' do
       # TODO: add test when actual count is added to page
     end
+
+    it 'does not render pagination' do
+      expect(subject).not_to render_template("hyrax/collections/_paginate")
+    end
   end
 
   context 'when parent collection list exceeds parents_to_show' do
-    let(:parent_collections) { [collection1, collection2, collection3, collection4, collection5] }
+    let(:parent_docs) { [collection1, collection2, collection3, collection4, collection5] }
 
     it "posts the collection's title with a link to the collection" do
+      subject
       expect(rendered).to have_link(collection1.title.first, visible: true)
       expect(rendered).to have_link(collection2.title.first, visible: true)
       expect(rendered).to have_link(collection3.title.first, visible: true)
@@ -63,6 +87,38 @@ RSpec.describe 'hyrax/dashboard/collections/_show_parent_collections.html.erb', 
       expect(rendered).to have_link(collection5.title.first, visible: false)
       expect(rendered).to have_button('show more...', visible: true)
       expect(rendered).to have_button('...show less', visible: false)
+    end
+
+    it 'renders pagination' do
+      expect(subject).not_to render_template("hyrax/collections/_paginate")
+    end
+  end
+
+  context 'when parent collection list has multiple pages' do
+    let(:parent_docs) { [collection1, collection2, collection3, collection4, collection5] }
+    let(:parent_collections) { double(Object, documents: parent_docs, response: { "numFound" => parent_docs.size }, total_pages: 2) }
+
+    before do
+      stub_template "hyrax/collections/_paginate" => "paginate"
+    end
+
+    it "renders a link to all collections" do
+      subject
+      expect(rendered).to have_link(collection1.title.first, visible: true)
+      expect(rendered).to have_link(collection2.title.first, visible: true)
+      expect(rendered).to have_link(collection3.title.first, visible: true)
+      expect(rendered).to have_link(collection4.title.first, visible: false)
+      expect(rendered).to have_link(collection5.title.first, visible: false)
+    end
+
+    it "does not render the more/less buttons" do
+      subject
+      expect(rendered).not_to have_button('show more...', visible: true)
+      expect(rendered).not_to have_button('...show less', visible: false)
+    end
+
+    it 'renders pagination' do
+      expect(subject).to render_template("hyrax/collections/_paginate")
     end
   end
 end


### PR DESCRIPTION
 Fix for #2618

Adds pagination to the rendering of parent collections in both the dashboard and public views.

Summary of changes:
- Added seed data to test these scenarios
- Changed Dashboard/CollectionsController and CollectionsControllerBehavior to execute a solr query instead of a Fedora query to get parent member docs. This is so that the underlying pagination partial that we've been reusing can consume a solr response.
- CollectionPresenter now expects is parent_collections attribute to be of type Blacklight::Solr::Response. Changed all of the points in the code that interact with this to work with a solr response instead of an array. The operations are in most cases the same, just have to fetch the appropriate member of the response that it cares about.
- Added a total_parent_collections method to CollectionPresenter. This is to differentiate the total number of parents that the collection belongs to from the number of collections that were retrieved for the current page.
- Added rendering of paginate to both views
- Created a new search builder to limit the search to parent collections of a given child.
- Unrelated: Changed the formatting in app/views/hyrax/collections/_show_parent_collections.html.erb to match the other sections of the show page, such as subcollections

@samvera/hyrax-code-reviewers
