### PR TITLE
Stop swallowing errors

### DIFF
--- a/app/services/hyrax/collection_types/create_service.rb
+++ b/app/services/hyrax/collection_types/create_service.rb
@@ -133,8 +133,6 @@ module Hyrax
             agent_id = p.fetch(:agent_id)
             access = p.fetch(:access)
             Hyrax::CollectionTypeParticipant.create!(hyrax_collection_type_id: collection_type_id, agent_type: agent_type, agent_id: agent_id, access: access)
-          rescue => e # rubocop:disable Lint/RescueWithoutErrorClass
-            Rails.logger.error "Participant not created for collection type #{collection_type_id}: #{agent_type}, #{agent_id}, #{access} -- reason: #{e.class.name} - #{e.message}\n"
           end
         end
       end

--- a/app/services/hyrax/collection_types/create_service.rb
+++ b/app/services/hyrax/collection_types/create_service.rb
@@ -133,6 +133,11 @@ module Hyrax
             agent_id = p.fetch(:agent_id)
             access = p.fetch(:access)
             Hyrax::CollectionTypeParticipant.create!(hyrax_collection_type_id: collection_type_id, agent_type: agent_type, agent_id: agent_id, access: access)
+          rescue StandardError => error
+            Rails.logger.error "Participant not created for collection type " \
+                               "#{collection_type_id}: #{agent_type}, #{agent_id}, #{access} -- " \
+                               "reason: #{error.class.name} - #{error.message}\n"
+            raise error
           end
         end
       end

--- a/spec/services/hyrax/collection_types/create_service_spec.rb
+++ b/spec/services/hyrax/collection_types/create_service_spec.rb
@@ -87,5 +87,21 @@ RSpec.describe Hyrax::CollectionTypes::CreateService do
       expect(Hyrax::CollectionTypeParticipant).to receive(:create!)
       described_class.add_participants(coltype.id, participants)
     end
+
+    context 'when raising an error' do
+      let(:error) { 'my error' }
+
+      before { allow(Hyrax::CollectionTypeParticipant).to receive(:create!).and_raise(error) }
+
+      it 'logs errors' do
+        expect(Rails.logger).to receive(:error).with start_with('Participant not created')
+        described_class.add_participants(coltype.id, participants)
+      end
+
+      it 'reraises with a wrapped error' do
+        expect { described_class.add_participants(coltype.id, participants) }
+          .to raise_error error
+      end
+    end
   end
 end


### PR DESCRIPTION
If there is a problem writing to the database, we need to see that
exception raised so we can fix the problem. Loging the problem and
proceeding is not enough visibility. Furthermore the user has no
indication that what they thought they just succeeded at doing actually
failed.
