### PR TITLE
refactor collection factory to avoid fedora save unless specifically requested

### DIFF
--- a/spec/authorities/qa/authorities/collections_spec.rb
+++ b/spec/authorities/qa/authorities/collections_spec.rb
@@ -1,36 +1,36 @@
 RSpec.describe Qa::Authorities::Collections, :clean_repo do
   let(:controller) { Qa::TermsController.new }
-  let(:user1) { create(:user) }
-  let(:user2) { create(:user) }
+  let(:user1) { build(:user) }
+  let(:user2) { build(:user) }
   let(:q) { "foo" }
   let(:service) { described_class.new }
-  let!(:collection1) { create(:private_collection, id: 'col-1-own', title: ['foo foo'], user: user1, create_access: true) }
-  let!(:collection2) { create(:private_collection, id: 'col-2-own', title: ['bar'], user: user1, create_access: true) }
-  let!(:collection3) { create(:private_collection, id: 'col-3-own', title: ['another foo'], user: user1, create_access: true) }
-  let!(:collection4) { create(:private_collection, id: 'col-4-none', title: ['foo foo foo'], user: user2, create_access: true) }
+  let!(:collection1) { build(:private_collection_lw, id: 'col-1-own', title: ['foo foo'], user: user1, with_permission_template: true, with_solr_document: true) }
+  let!(:collection2) { build(:private_collection_lw, id: 'col-2-own', title: ['bar'], user: user1, with_permission_template: true, with_solr_document: true) }
+  let!(:collection3) { build(:private_collection_lw, id: 'col-3-own', title: ['another foo'], user: user1, with_permission_template: true, with_solr_document: true) }
+  let!(:collection4) { build(:private_collection_lw, id: 'col-4-none', title: ['foo foo foo'], user: user2, with_permission_template: true, with_solr_document: true) }
   let!(:collection5) do
-    create(:private_collection, id: 'col-5-mgr', title: ['foo for you'], user: user2,
-                                with_permission_template: { manage_users: [user1] }, create_access: true)
+    build(:private_collection_lw, id: 'col-5-mgr', title: ['foo for you'], user: user2,
+                                  with_permission_template: { manage_users: [user1] }, with_solr_document: true)
   end
   let!(:collection6) do
-    create(:private_collection, id: 'col-6-dep', title: ['foo too'], user: user2,
-                                with_permission_template: { deposit_users: [user1] }, create_access: true)
+    build(:private_collection_lw, id: 'col-6-dep', title: ['foo too'], user: user2,
+                                  with_permission_template: { deposit_users: [user1] }, with_solr_document: true)
   end
   let!(:collection7) do
-    create(:private_collection, id: 'col-7-view', title: ['foo bar baz'], user: user2,
-                                with_permission_template: { view_users: [user1] }, create_access: true)
+    build(:private_collection_lw, id: 'col-7-view', title: ['foo bar baz'], user: user2,
+                                  with_permission_template: { view_users: [user1] }, with_solr_document: true)
   end
   let!(:collection8) do
-    create(:private_collection, id: 'col-8-mgr', title: ['bar for you'], user: user2,
-                                with_permission_template: { manage_users: [user1] }, create_access: true)
+    build(:private_collection_lw, id: 'col-8-mgr', title: ['bar for you'], user: user2,
+                                  with_permission_template: { manage_users: [user1] }, with_solr_document: true)
   end
   let!(:collection9) do
-    create(:private_collection, id: 'col-9-dep', title: ['bar too'], user: user2,
-                                with_permission_template: { deposit_users: [user1] }, create_access: true)
+    build(:private_collection_lw, id: 'col-9-dep', title: ['bar too'], user: user2,
+                                  with_permission_template: { deposit_users: [user1] }, with_solr_document: true)
   end
   let!(:collection10) do
-    create(:private_collection, id: 'col-10-view', title: ['bar bar baz'], user: user2,
-                                with_permission_template: { view_users: [user1] }, create_access: true)
+    build(:private_collection_lw, id: 'col-10-view', title: ['bar bar baz'], user: user2,
+                                  with_permission_template: { view_users: [user1] }, with_solr_document: true)
   end
 
   before do

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,0 +1,296 @@
+FactoryBot.define do
+  # Tests that create a Fedora Object are very slow.  This factory lets you control which parts of the object ecosystem
+  # get built.
+  #
+  # PREFERRED: Use build whenever possible.  You can control the creation of the permission template, collection type, and
+  #            solr document by passing parameters to the build(:collection_lw) method.  That way you can build only the parts
+  #            needed for a specific test.
+  #
+  # AVOID: Do not use create unless absolutely necessary.  It will create everything including the Fedora object.
+  #
+  # @example Simple build of a collection with no additional parts created.  Lightest weight.
+  #          NOTE: A user is automatically created as the owner of the collection.
+  #   let(:collection) { build(:collection_lw)
+  #
+  # @example Simple build of a collection with no additional parts created.  User is the owner of the collection.  Lightest weight.
+  #   let(:collection) { build(:collection_lw, user:)
+  #
+  # @example Simple build of a collection with only solr-document.  Owner is given edit-access in solr-document. Light weight.
+  #   let(:collection) { build(:collection_lw, with_solr_document: true)
+  #
+  # @example Simple build of a collection with only a permission template created.  Owner is set as a manager.  Light weight.
+  #   let(:collection) { build(:collection_lw, with_permission_template: true)
+  #
+  # @example Build a collection with only a permission template created.  Permissions are set based on
+  #          attributes set for with_permission_template.  Middle weight.
+  #   # permissions passed thru with_permission_template can be any of the following in any combination
+  #   let(:permissions) { { manage_users: [user.user_key],  # multiple users can be listed
+  #                         deposit_users: [user.user_key],
+  #                         view_users: [user.user_key],
+  #                         manage_groups: [group_name],    # multiple groups can be listed
+  #                         deposit_groups: [group_name],
+  #                         view_groups: [group_name],  } }
+  #   let(:collection) { build(:collection_lw, user: , with_permission_template: permissions)
+  #
+  # @example Build a collection with permission template and solr-document created.  Permissions are set based on
+  #          attributes set for with_permission_template.  Solr-document includes read/edit access defined based
+  #          on attributes passed thru with_permission_template.  Middle weight.
+  #   # permissions passed thru with_permission_template can be any of the following in any combination
+  #   let(:permissions) { { manage_users: [user.user_key],  # multiple users can be listed
+  #                         deposit_users: [user.user_key],
+  #                         view_users: [user.user_key],
+  #                         manage_groups: [group_name],    # multiple groups can be listed
+  #                         deposit_groups: [group_name],
+  #                         view_groups: [group_name],  } }
+  #   let(:collection) { build(:collection_lw, user: , with_permission_template: permissions, with_solr_document: true)
+  #
+  # @example Build a collection generating its collection type with specific settings. Light Weight.
+  #          NOTE: Do not use this method if you need access to the collection type in the test.
+  #          DEFAULT: If collection_type_settings and collection_type_gid are not specified, then the default
+  #          User Collection type will be used.
+  #   # Any not specified default to ON.  At least one setting should be specified.
+  #   let(:settings) { [
+  #                      :nestable,                  # OR :not_nestable,
+  #                      :discoverable,              # OR :not_discoverable
+  #                      :sharable,                  # OR :not_sharable OR :sharable_no_work_permissions
+  #                      :allow_multiple_membership, # OR :not_allow_multiple_membership
+  #                    ] }
+  #   let(:collection) { build(:collection_lw, collection_type_settings: settings) }
+  #
+  # @example Create a collection using the passed in collection type.  Light Weight.
+  #          NOTE: Use this method if you need access to the collection type in the test.
+  #   # Any not specified default to ON.  At least one setting should be specified.
+  #   let(:settings) { [
+  #                      :nestable,                  # OR :not_nestable,
+  #                      :discoverable,              # OR :not_discoverable
+  #                      :sharable,                  # OR :not_sharable OR :sharable_no_work_permissions
+  #                      :allow_multiple_membership, # OR :not_allow_multiple_membership
+  #                    ] }
+  #   let(:collection_type) { create(:collection_lw_type, settings)}
+  #   let(:collection) { build(:collection_lw, collection_type_gid: collection_type.gid)}
+  #
+  # @example Build a collection with nesting fields set in the solr document.  Heavy weight.  Runs nesting indexer.
+  #   let(:collection) { build(:collection_lw, with_nesting_attributes: true)
+  #
+  # @example Create a collection with everything.  Extreme heavy weight.  This is very slow and should be avoided.
+  #   let(:collection) { create(:collection_lw)
+
+  factory :collection_lw, class: Collection do
+    transient do
+      user { create(:user) }
+
+      # build options
+      collection_type_settings nil
+      with_permission_template false
+      with_nesting_attributes nil
+      with_solr_document false
+    end
+    sequence(:title) { |n| ["Title #{n}"] }
+
+    after(:build) do |collection, evaluator|
+      collection.apply_depositor_metadata(evaluator.user.user_key)
+
+      CollectionLwFactoryHelper.process_collection_type_settings(collection, evaluator)
+      CollectionLwFactoryHelper.process_with_permission_template(collection, evaluator)
+      CollectionLwFactoryHelper.process_with_solr_document(collection, evaluator)
+      CollectionLwFactoryHelper.process_with_nesting_attributes(collection, evaluator)
+    end
+
+    after(:create) do |collection, evaluator|
+      # TODO: -- elr -- Make create do everything
+      # create the permission template if it was requested, OR if nested reindexing is included (so we can apply the user's
+      # permissions).  Nested indexing requires that the user's permissions be saved on the Fedora object... if simply in
+      # local memory, they are lost when the adapter pulls the object from Fedora to reindex.
+      if evaluator.with_permission_template || RSpec.current_example.metadata[:with_nested_reindexing]
+        attributes = { source_id: collection.id }
+        attributes[:manage_users] = CollectionLwFactoryHelper.user_managers(evaluator.with_permission_template, evaluator.user)
+        attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
+        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
+        collection.reset_access_controls!
+      end
+    end
+
+    factory :public_collection_lw, traits: [:public]
+
+    factory :private_collection_lw do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+
+    factory :institution_collection_lw do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    end
+
+    factory :named_collection_lw do
+      title ['collection title']
+      description ['collection description']
+    end
+
+    trait :public_lw do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    trait :private_lw do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+
+    trait :institution_lw do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    end
+
+    trait :public_lw do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+  end
+
+  factory :user_collection_lw, class: Collection do
+    transient do
+      user { create(:user) }
+    end
+
+    sequence(:title) { |n| ["Title #{n}"] }
+
+    after(:build) do |collection, evaluator|
+      collection.apply_depositor_metadata(evaluator.user.user_key)
+      collection_type = create(:user_collection_type)
+      collection.collection_type_gid = collection_type.gid
+    end
+  end
+
+  factory :typeless_collection_lw, class: Collection do
+    # To create a pre-Hyrax 2.1.0 collection without a collection type gid...
+    #   col = build(:typeless_collection, ...)
+    #   col.save(validate: false)
+    transient do
+      user { create(:user) }
+      with_permission_template false
+      do_save false
+    end
+
+    sequence(:title) { |n| ["Title #{n}"] }
+
+    after(:build) do |collection, evaluator|
+      collection.apply_depositor_metadata(evaluator.user.user_key)
+      collection.save(validate: false) if evaluator.do_save || evaluator.with_permission_template
+      if evaluator.with_permission_template
+        attributes = { source_id: collection.id }
+        attributes[:manage_users] = [evaluator.user]
+        attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
+        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
+      end
+    end
+  end
+
+  class CollectionLwFactoryHelper
+    # @returns array of user keys
+    def self.permission_from_template(permission_template_attributes, permission_key)
+      permissions = []
+      return permissions if permission_template_attributes.blank?
+      return permissions unless permission_template_attributes.is_a? Hash
+      return permissions unless permission_template_attributes.key?(permission_key)
+      permission_template_attributes[permission_key]
+    end
+    private_class_method :permission_from_template
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @parem [String] creator_user is the user who created the new collection
+    # @param [Boolean] include_creator, when true, adds the creator_user as a manager
+    # @returns array of user keys
+    def self.user_managers(permission_template_attributes, creator_user)
+      managers = permission_from_template(permission_template_attributes, :manage_users)
+      managers << creator_user.user_key
+      managers
+    end
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @returns array of user keys
+    def self.group_managers(permission_template_attributes)
+      permission_from_template(permission_template_attributes, :manage_groups)
+    end
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @returns array of user keys
+    def self.user_depositors(permission_template_attributes)
+      permission_from_template(permission_template_attributes, :deposit_users)
+    end
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @returns array of user keys
+    def self.group_depositors(permission_template_attributes)
+      permission_from_template(permission_template_attributes, :deposit_groups)
+    end
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @returns array of user keys
+    def self.user_viewers(permission_template_attributes)
+      permission_from_template(permission_template_attributes, :view_users)
+    end
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @returns array of user keys
+    def self.group_viewers(permission_template_attributes)
+      permission_from_template(permission_template_attributes, :view_groups)
+    end
+
+    # Process the collection_type_settings transient property such that...
+    # * creates the collection type with specified settings if collection_type_settings has settings (ignores collection_type_gid)
+    # * uses passed in collection type if collection_type_gid is specified AND collection_type_settings is nil
+    # * uses default User Collection type if neither are specified
+    # @param [Collection] collection object being built/created by the factory
+    # @param [Class] evaluator holding the transient properties for the current build/creation process
+    def self.process_collection_type_settings(collection, evaluator)
+      if evaluator.collection_type_settings.present?
+        collection.collection_type = FactoryBot.create(:collection_type, *evaluator.collection_type_settings)
+      elsif collection.collection_type_gid.blank?
+        collection.collection_type = FactoryBot.create(:user_collection_type)
+      end
+    end
+
+    # Process the with_permission_template transient property such that...
+    # * a permission template is created for the collection
+    # * a permission template access is created for the collection creator
+    # * additional permission template accesses are created for each user/group identified in the attributes
+    #   of with_permission_template (created by the permission_template factory)
+    # @param [Collection] collection object being built/created by the factory
+    # @param [Class] evaluator holding the transient properties for the current build/creation process
+    def self.process_with_permission_template(collection, evaluator)
+      return unless evaluator.with_permission_template || RSpec.current_example.metadata[:with_nested_reindexing]
+      collection.id ||= FactoryBot.generate(:object_id)
+      attributes = { source_id: collection.id }
+      attributes[:manage_users] = user_managers(evaluator.with_permission_template, evaluator.user)
+      attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
+      FactoryBot.create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
+    end
+
+    # Process the with_solr_document transient property such that...
+    # * a solr document is created for the collection
+    # * permissions identified by with_permission_template, if any, are added to the solr fields
+    # @param [Collection] collection object being built/created by the factory
+    # @param [Class] evaluator holding the transient properties for the current build/creation process
+    def self.process_with_solr_document(collection, evaluator)
+      return unless evaluator.with_solr_document || RSpec.current_example.metadata[:with_nested_reindexing]
+      collection.id ||= FactoryBot.generate(:object_id)
+      collection.edit_users = user_managers(evaluator.with_permission_template, evaluator.user)
+      collection.edit_groups = group_managers(evaluator.with_permission_template)
+      collection.read_users = user_viewers(evaluator.with_permission_template) +
+                              user_depositors(evaluator.with_permission_template)
+      collection.read_groups = group_viewers(evaluator.with_permission_template) +
+                               group_depositors(evaluator.with_permission_template)
+      ActiveFedora::SolrService.add(collection.to_solr, commit: true)
+    end
+
+    # Process the with_nesting_attributes transient property such that...
+    # * TODO: -- elr -- describe what happens
+    # @param [Collection] collection object being built/created by the factory
+    # @param [Class] evaluator holding the transient properties for the current build/creation process
+    def self.process_with_nesting_attributes(collection, evaluator)
+      return unless evaluator.with_nesting_attributes.present? && collection.nestable?
+      Hyrax::Adapters::NestingIndexAdapter.add_nesting_attributes(
+        solr_doc: evaluator.to_solr,
+        ancestors: evaluator.with_nesting_attributes[:ancestors],
+        parent_ids: evaluator.with_nesting_attributes[:parent_ids],
+        pathnames: evaluator.with_nesting_attributes[:pathnames],
+        depth: evaluator.with_nesting_attributes[:depth]
+      )
+    end
+  end
+end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -197,7 +197,7 @@ FactoryBot.define do
     # @returns array of user keys
     def self.user_managers(permission_template_attributes, creator_user)
       managers = permission_from_template(permission_template_attributes, :manage_users)
-      managers << creator_user.user_key
+      managers << creator_user
       managers
     end
 

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -110,7 +110,7 @@ FactoryBot.define do
       end
     end
 
-    factory :public_collection_lw, traits: [:public]
+    factory :public_collection_lw, traits: [:public_lw]
 
     factory :private_collection_lw do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :collection do
+    # DEPRECATION: This factory is being replaced by collection_lw defined in collections.rb.  New tests should use the
+    # light weight collection factory.  DO NOT ADD tests using this factory.
+    #
     # rubocop:disable Metrics/LineLength
     # @example let(:collection) { build(:collection, collection_type_settings: [:not_nestable, :discoverable, :sharable, :allow_multiple_membership], with_nesting_attributes: {ancestors: [], parent_ids: [], pathnames: [], depth: 1}) }
     # rubocop:enable Metrics/LineLength

--- a/spec/factories/object_id.rb
+++ b/spec/factories/object_id.rb
@@ -1,0 +1,6 @@
+# Defines a new sequence
+FactoryBot.define do
+  sequence :object_id do |n|
+    "object_id_#{n}"
+  end
+end

--- a/spec/factory_tests/collections_factory_spec.rb
+++ b/spec/factory_tests/collections_factory_spec.rb
@@ -49,8 +49,10 @@ RSpec.describe 'Collections Factory' do # rubocop:disable RSpec/DescribeClass
     it 'will create a permission template and access for each user specified when it is set to attributes identifying access' do
       expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr] }) }.to change { Hyrax::PermissionTemplateAccess.count }.by(2)
-      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
-      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep] }) }.to change { Hyrax::PermissionTemplateAccess.count }.by(3)
+      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep], view_users: [user_vw] }) }
+        .to change { Hyrax::PermissionTemplate.count }.by(1)
+      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep], view_users: [user_vw] }) }
+        .to change { Hyrax::PermissionTemplateAccess.count }.by(4)
     end
   end
 

--- a/spec/factory_tests/collections_factory_spec.rb
+++ b/spec/factory_tests/collections_factory_spec.rb
@@ -5,122 +5,138 @@ RSpec.describe 'Collections Factory' do # rubocop:disable RSpec/DescribeClass
   let(:user_vw) { build(:user, email: 'user_vw@example.com') }
   let(:collection_type) { create(:collection_type) }
 
-  describe 'collection_type_settings and collection_type_gid' do
-    it 'will use the default User Collection type when neither is specified' do
-      col = build(:collection_lw)
-      expect(col.collection_type.title).to eq 'User Collection'
-      expect(col.collection_type.machine_id).to eq 'user_collection'
-    end
-
-    it 'uses collection type for passed in collection_type_gid when collection_type_settings is nil' do
-      col = build(:collection_lw, collection_type_gid: collection_type.gid)
-      expect(col.collection_type_gid).to eq collection_type.gid
-    end
-
-    it 'ignores collection_type_gid when collection_type_settings is set to attributes identifying settings' do
-      col = build(:collection_lw, collection_type_settings: [:not_discoverable, :not_sharable], collection_type_gid: collection_type.gid)
-      expect(col.collection_type_gid).not_to eq collection_type.gid
-    end
-
-    it 'will create a collection type when collection_type_settings is set to attributes identifying settings' do
-      expect { build(:collection_lw, collection_type_settings: [:discoverable]) }.to change { Hyrax::CollectionType.count }.by(1)
-      expect { build(:collection_lw, collection_type_settings: [:not_discoverable, :not_sharable]) }.to change { Hyrax::CollectionType.count }.by(1)
-    end
-
-    it 'will create a collection type with specified settings when collection_type_settings is set to attributes identifying settings' do
-      col = build(:collection_lw, collection_type_settings: [:not_discoverable, :not_sharable, :nestable])
-      expect(col.collection_type.discoverable?).to be false
-      expect(col.collection_type.sharable?).to be false
-      expect(col.collection_type.nestable?).to be true
-    end
-  end
-
-  describe 'with_permission_template' do
-    it 'will not create a permission template or access when it is the default value of false' do
-      expect { build(:collection_lw) }.not_to change { Hyrax::PermissionTemplate.count }
-      expect { build(:collection_lw) }.not_to change { Hyrax::PermissionTemplateAccess.count }
-    end
-
-    it 'will create a permission template and one access for the creating user when set to true' do
-      expect { build(:collection_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
-      expect { build(:collection_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplateAccess.count }.by(1)
-    end
-
-    it 'will create a permission template and access for each user specified when it is set to attributes identifying access' do
-      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
-      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr] }) }.to change { Hyrax::PermissionTemplateAccess.count }.by(2)
-      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep], view_users: [user_vw] }) }
-        .to change { Hyrax::PermissionTemplate.count }.by(1)
-      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep], view_users: [user_vw] }) }
-        .to change { Hyrax::PermissionTemplateAccess.count }.by(4)
-    end
-  end
-
-  describe 'with_solr_document' do
-    it 'will not created a solr document by default' do
-      col = build(:collection_lw)
-      expect(col.id).to eq nil # no real way to confirm a solr document wasn't created if the collection doesn't have an id
-    end
-
-    it 'will be created when with_solr_document is true' do
-      col = build(:collection_lw, with_solr_document: true)
-      solr_doc = ActiveFedora::SolrService.get("id:#{col.id}")["response"]["docs"].first
-      expect(solr_doc["id"]).to eq col.id
-      expect(solr_doc["has_model_ssim"].first).to eq "Collection"
-      expect(solr_doc["edit_access_person_ssim"]).not_to be_blank
-    end
-
-    it 'will be created and have access defined when with_solr_document is true' do
-      col = build(:collection_lw, user: user, with_solr_document: true,
-                                  with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep], view_users: [user_vw] })
-      solr_doc = ActiveFedora::SolrService.get("id:#{col.id}")["response"]["docs"].first
-      expect(solr_doc["id"]).to eq col.id
-      expect(solr_doc["has_model_ssim"].first).to eq "Collection"
-      expect(solr_doc["edit_access_person_ssim"]).to include(user.user_key, user_mgr.user_key)
-      expect(solr_doc["read_access_person_ssim"]).to include(user_dep.user_key, user_vw.user_key)
-    end
-  end
-
-  describe 'when including nesting indexing', with_nested_reindexing: true do
-    # Nested indexing requires that the user's permissions be saved
-    # on the Fedora object... if simply in local memory, they are
-    # lost when the adapter pulls the object from Fedora to reindex.
-    let(:user) { create(:user) }
-    let(:collection) { build(:collection_lw, user: user) }
-
-    it 'will authorize the creating user' do
-      expect(user.can?(:edit, collection)).to be true
-    end
-  end
-
-  describe 'when including with_nesting_attributes' do
-    let(:collection_type) { create(:collection_type) }
-    let(:blacklight_config) { CatalogController.blacklight_config }
-    let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
-    let(:current_ability) { instance_double(Ability, admin?: true) }
-    let(:scope) { double('Scope', can?: true, current_ability: current_ability, repository: repository, blacklight_config: blacklight_config) }
-
-    context 'when building a collection' do
-      let(:coll123) do
-        build(:collection_lw,
-              id: 'Collection123',
-              collection_type_gid: collection_type.gid,
-              with_nesting_attributes:
-                  { ancestors: ['Parent_1'],
-                    parent_ids: ['Parent_1'],
-                    pathnames: ['Parent_1/Collection123'],
-                    depth: 2 })
-      end
-      let(:nesting_attributes) do
-        Hyrax::Collections::NestedCollectionQueryService::NestingAttributes.new(id: coll123.id, scope: scope)
+  describe 'build' do
+    context 'with collection_type_settings and/or collection_type_gid' do
+      it 'will use the default User Collection type when neither is specified' do
+        col = build(:collection_lw)
+        expect(col.collection_type.title).to eq 'User Collection'
+        expect(col.collection_type.machine_id).to eq 'user_collection'
       end
 
-      it 'will persist a queryable solr document with the given attributes' do
-        expect(nesting_attributes.id).to eq('Collection123')
-        expect(nesting_attributes.parents).to eq(['Parent_1'])
-        expect(nesting_attributes.pathnames).to eq(['Parent_1/Collection123'])
-        expect(nesting_attributes.ancestors).to eq(['Parent_1'])
-        expect(nesting_attributes.depth).to eq(2)
+      it 'uses collection type for passed in collection_type_gid when collection_type_settings is nil' do
+        col = build(:collection_lw, collection_type_gid: collection_type.gid)
+        expect(col.collection_type_gid).to eq collection_type.gid
+      end
+
+      it 'ignores collection_type_gid when collection_type_settings is set to attributes identifying settings' do
+        col = build(:collection_lw, collection_type_settings: [:not_discoverable, :not_sharable], collection_type_gid: collection_type.gid)
+        expect(col.collection_type_gid).not_to eq collection_type.gid
+      end
+
+      it 'will create a collection type when collection_type_settings is set to attributes identifying settings' do
+        expect { build(:collection_lw, collection_type_settings: [:discoverable]) }.to change { Hyrax::CollectionType.count }.by(1)
+        expect { build(:collection_lw, collection_type_settings: [:not_discoverable, :not_sharable]) }.to change { Hyrax::CollectionType.count }.by(1)
+      end
+
+      it 'will create a collection type with specified settings when collection_type_settings is set to attributes identifying settings' do
+        col = build(:collection_lw, collection_type_settings: [:not_discoverable, :not_sharable, :nestable])
+        expect(col.collection_type.discoverable?).to be false
+        expect(col.collection_type.sharable?).to be false
+        expect(col.collection_type.nestable?).to be true
+      end
+    end
+
+    context 'with_permission_template' do
+      it 'will not create a permission template or access when it is the default value of false' do
+        expect { build(:collection_lw) }.not_to change { Hyrax::PermissionTemplate.count }
+        expect { build(:collection_lw) }.not_to change { Hyrax::PermissionTemplateAccess.count }
+      end
+
+      it 'will create a permission template and one access for the creating user when set to true' do
+        expect { build(:collection_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplateAccess.count }.by(1)
+      end
+
+      it 'will create a permission template and access for each user specified when it is set to attributes identifying access' do
+        expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr] }) }.to change { Hyrax::PermissionTemplateAccess.count }.by(2)
+        expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep], view_users: [user_vw] }) }
+          .to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep], view_users: [user_vw] }) }
+          .to change { Hyrax::PermissionTemplateAccess.count }.by(4)
+      end
+    end
+
+    context 'with_solr_document' do
+      it 'will not created a solr document by default' do
+        col = build(:collection_lw)
+        expect(col.id).to eq nil # no real way to confirm a solr document wasn't created if the collection doesn't have an id
+      end
+
+      it 'will be created when with_solr_document is true' do
+        col = build(:collection_lw, with_solr_document: true)
+        solr_doc = ActiveFedora::SolrService.get("id:#{col.id}")["response"]["docs"].first
+        expect(solr_doc["id"]).to eq col.id
+        expect(solr_doc["has_model_ssim"].first).to eq "Collection"
+        expect(solr_doc["edit_access_person_ssim"]).not_to be_blank
+      end
+
+      it 'will be created and have access defined when with_solr_document is true' do
+        col = build(:collection_lw, user: user, with_solr_document: true,
+                                    with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep], view_users: [user_vw] })
+        solr_doc = ActiveFedora::SolrService.get("id:#{col.id}")["response"]["docs"].first
+        expect(solr_doc["id"]).to eq col.id
+        expect(solr_doc["has_model_ssim"].first).to eq "Collection"
+        expect(solr_doc["edit_access_person_ssim"]).to include(user.user_key, user_mgr.user_key)
+        expect(solr_doc["read_access_person_ssim"]).to include(user_dep.user_key, user_vw.user_key)
+      end
+    end
+
+    context 'with_nesting_attributes' do
+      let(:collection_type) { create(:collection_type) }
+      let(:blacklight_config) { CatalogController.blacklight_config }
+      let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
+      let(:current_ability) { instance_double(Ability, admin?: true) }
+      let(:scope) { double('Scope', can?: true, current_ability: current_ability, repository: repository, blacklight_config: blacklight_config) }
+
+      context 'when building a collection' do
+        let(:coll123) do
+          build(:collection_lw,
+                id: 'Collection123',
+                collection_type_gid: collection_type.gid,
+                with_nesting_attributes:
+                    { ancestors: ['Parent_1'],
+                      parent_ids: ['Parent_1'],
+                      pathnames: ['Parent_1/Collection123'],
+                      depth: 2 })
+        end
+        let(:nesting_attributes) do
+          Hyrax::Collections::NestedCollectionQueryService::NestingAttributes.new(id: coll123.id, scope: scope)
+        end
+
+        it 'will persist a queryable solr document with the given attributes' do
+          expect(nesting_attributes.id).to eq('Collection123')
+          expect(nesting_attributes.parents).to eq(['Parent_1'])
+          expect(nesting_attributes.pathnames).to eq(['Parent_1/Collection123'])
+          expect(nesting_attributes.ancestors).to eq(['Parent_1'])
+          expect(nesting_attributes.depth).to eq(2)
+        end
+      end
+    end
+  end
+
+  describe 'create' do
+    # collection_type_settings and collection_type_gid are tested by `build` and are the same for `build` and `create`
+    # with_solr_document is tested by build
+    # with_permission_template is tested by build except that the permission template is always created for `create`
+    # with_nested_attributes not supported for create
+
+    context 'with_permission_template' do
+      it 'will create a permission template and access even when it is the default value of false' do
+        expect { create(:collection_lw) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { create(:collection_lw) }.to change { Hyrax::PermissionTemplateAccess.count }.by(1)
+      end
+    end
+
+    context 'when including nesting indexing', with_nested_reindexing: true do
+      # Nested indexing requires that the user's permissions be saved
+      # on the Fedora object... if simply in local memory, they are
+      # lost when the adapter pulls the object from Fedora to reindex.
+      let(:user) { create(:user) }
+      let(:collection) { build(:collection_lw, user: user) }
+
+      it 'will authorize the creating user' do
+        expect(user.can?(:edit, collection)).to be true
       end
     end
   end

--- a/spec/factory_tests/collections_factory_spec.rb
+++ b/spec/factory_tests/collections_factory_spec.rb
@@ -1,0 +1,125 @@
+RSpec.describe 'Collections Factory' do # rubocop:disable RSpec/DescribeClass
+  let(:user) { build(:user, email: 'user@example.com') }
+  let(:user_mgr) { build(:user, email: 'user_mgr@example.com') }
+  let(:user_dep) { build(:user, email: 'user_dep@example.com') }
+  let(:user_vw) { build(:user, email: 'user_vw@example.com') }
+  let(:collection_type) { create(:collection_type) }
+
+  describe 'collection_type_settings and collection_type_gid' do
+    it 'will use the default User Collection type when neither is specified' do
+      col = build(:collection_lw)
+      expect(col.collection_type.title).to eq 'User Collection'
+      expect(col.collection_type.machine_id).to eq 'user_collection'
+    end
+
+    it 'uses collection type for passed in collection_type_gid when collection_type_settings is nil' do
+      col = build(:collection_lw, collection_type_gid: collection_type.gid)
+      expect(col.collection_type_gid).to eq collection_type.gid
+    end
+
+    it 'ignores collection_type_gid when collection_type_settings is set to attributes identifying settings' do
+      col = build(:collection_lw, collection_type_settings: [:not_discoverable, :not_sharable], collection_type_gid: collection_type.gid)
+      expect(col.collection_type_gid).not_to eq collection_type.gid
+    end
+
+    it 'will create a collection type when collection_type_settings is set to attributes identifying settings' do
+      expect { build(:collection_lw, collection_type_settings: [:discoverable]) }.to change { Hyrax::CollectionType.count }.by(1)
+      expect { build(:collection_lw, collection_type_settings: [:not_discoverable, :not_sharable]) }.to change { Hyrax::CollectionType.count }.by(1)
+    end
+
+    it 'will create a collection type with specified settings when collection_type_settings is set to attributes identifying settings' do
+      col = build(:collection_lw, collection_type_settings: [:not_discoverable, :not_sharable, :nestable])
+      expect(col.collection_type.discoverable?).to be false
+      expect(col.collection_type.sharable?).to be false
+      expect(col.collection_type.nestable?).to be true
+    end
+  end
+
+  describe 'with_permission_template' do
+    it 'will not create a permission template or access when it is the default value of false' do
+      expect { build(:collection_lw) }.not_to change { Hyrax::PermissionTemplate.count }
+      expect { build(:collection_lw) }.not_to change { Hyrax::PermissionTemplateAccess.count }
+    end
+
+    it 'will create a permission template and one access for the creating user when set to true' do
+      expect { build(:collection_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+      expect { build(:collection_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplateAccess.count }.by(1)
+    end
+
+    it 'will create a permission template and access for each user specified when it is set to attributes identifying access' do
+      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr] }) }.to change { Hyrax::PermissionTemplateAccess.count }.by(2)
+      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+      expect { build(:collection_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep] }) }.to change { Hyrax::PermissionTemplateAccess.count }.by(3)
+    end
+  end
+
+  describe 'with_solr_document' do
+    it 'will not created a solr document by default' do
+      col = build(:collection_lw)
+      expect(col.id).to eq nil # no real way to confirm a solr document wasn't created if the collection doesn't have an id
+    end
+
+    it 'will be created when with_solr_document is true' do
+      col = build(:collection_lw, with_solr_document: true)
+      solr_doc = ActiveFedora::SolrService.get("id:#{col.id}")["response"]["docs"].first
+      expect(solr_doc["id"]).to eq col.id
+      expect(solr_doc["has_model_ssim"].first).to eq "Collection"
+      expect(solr_doc["edit_access_person_ssim"]).not_to be_blank
+    end
+
+    it 'will be created and have access defined when with_solr_document is true' do
+      col = build(:collection_lw, user: user, with_solr_document: true,
+                                  with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep], view_users: [user_vw] })
+      solr_doc = ActiveFedora::SolrService.get("id:#{col.id}")["response"]["docs"].first
+      expect(solr_doc["id"]).to eq col.id
+      expect(solr_doc["has_model_ssim"].first).to eq "Collection"
+      expect(solr_doc["edit_access_person_ssim"]).to include(user.user_key, user_mgr.user_key)
+      expect(solr_doc["read_access_person_ssim"]).to include(user_dep.user_key, user_vw.user_key)
+    end
+  end
+
+  describe 'when including nesting indexing', with_nested_reindexing: true do
+    # Nested indexing requires that the user's permissions be saved
+    # on the Fedora object... if simply in local memory, they are
+    # lost when the adapter pulls the object from Fedora to reindex.
+    let(:user) { create(:user) }
+    let(:collection) { build(:collection_lw, user: user) }
+
+    it 'will authorize the creating user' do
+      expect(user.can?(:edit, collection)).to be true
+    end
+  end
+
+  describe 'when including with_nesting_attributes' do
+    let(:collection_type) { create(:collection_type) }
+    let(:blacklight_config) { CatalogController.blacklight_config }
+    let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
+    let(:current_ability) { instance_double(Ability, admin?: true) }
+    let(:scope) { double('Scope', can?: true, current_ability: current_ability, repository: repository, blacklight_config: blacklight_config) }
+
+    context 'when building a collection' do
+      let(:coll123) do
+        build(:collection_lw,
+              id: 'Collection123',
+              collection_type_gid: collection_type.gid,
+              with_nesting_attributes:
+                  { ancestors: ['Parent_1'],
+                    parent_ids: ['Parent_1'],
+                    pathnames: ['Parent_1/Collection123'],
+                    depth: 2 })
+      end
+      let(:nesting_attributes) do
+        Hyrax::Collections::NestedCollectionQueryService::NestingAttributes.new(id: coll123.id, scope: scope)
+      end
+
+      it 'will persist a queryable solr document with the given attributes' do
+        expect(nesting_attributes.id).to eq('Collection123')
+        expect(nesting_attributes.parents).to eq(['Parent_1'])
+        expect(nesting_attributes.pathnames).to eq(['Parent_1/Collection123'])
+        expect(nesting_attributes.ancestors).to eq(['Parent_1'])
+        expect(nesting_attributes.depth).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/collections/permissions_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_service_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe Hyrax::Collections::PermissionsService do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, email: 'user@example.com') }
 
   let(:ability) { Ability.new(user) }
 
   context 'collection specific methods' do
-    let(:collection) { create(:collection) }
-    let(:admin_set) { create(:admin_set) }
+    let(:collection) { build(:collection_lw, id: 'collection_1') }
+    let(:admin_set) { build(:admin_set, id: 'adminset_1') }
     let(:col_permission_template) { create(:permission_template, source_id: collection.id) }
     let(:as_permission_template) { create(:permission_template, source_id: admin_set.id) }
 
@@ -87,31 +87,42 @@ RSpec.describe Hyrax::Collections::PermissionsService do
   end
 
   context 'methods returning ids' do
-    let(:user) { create(:user) }
-    let(:user2) { create(:user) }
+    let(:user1) { create(:user, email: 'user1@example.com') }
+    let(:user2) { create(:user, email: 'user2@example.com') }
 
-    let(:col_vu) { create(:collection, id: 'col_vu', with_permission_template: true) }
-    let(:col_vg) { create(:collection, id: 'col_vg', with_permission_template: true) }
-    let(:col_mu) { create(:collection, id: 'col_mu', with_permission_template: true) }
-    let(:col_mg) { create(:collection, id: 'col_mg', with_permission_template: true) }
-    let(:col_du) { create(:collection, id: 'col_du', with_permission_template: true) }
-    let(:col_dg) { create(:collection, id: 'col_dg', with_permission_template: true) }
+    let!(:col_vu) do
+      build(:collection_lw, id: 'collection_vu', user: user1, with_solr_document: true,
+                            with_permission_template: { view_users: [user] })
+    end
+    let!(:col_vg) do
+      build(:collection_lw, id: 'collection_vg', user: user1, with_solr_document: true,
+                            with_permission_template: { view_groups: ['view_group'] })
+    end
+    let!(:col_mu) do
+      build(:collection_lw, id: 'collection_mu', user: user1, with_solr_document: true,
+                            with_permission_template: { manage_users: [user] })
+    end
+    let!(:col_mg) do
+      build(:collection_lw, id: 'collection_mg', user: user1, with_solr_document: true,
+                            with_permission_template: { manage_groups: ['manage_group'] })
+    end
+    let!(:col_du) do
+      build(:collection_lw, id: 'collection_du', user: user1, with_solr_document: true,
+                            with_permission_template: { deposit_users: [user] })
+    end
+    let!(:col_dg) do
+      build(:collection_lw, id: 'collection_dg', user: user1, with_solr_document: true,
+                            with_permission_template: { deposit_groups: ['deposit_group'] })
+    end
 
-    let(:as_vu) { create(:admin_set, id: 'as_vu', with_permission_template: true) }
-    let(:as_vg) { create(:admin_set, id: 'as_vg', with_permission_template: true) }
-    let(:as_mu) { create(:admin_set, id: 'as_mu', with_permission_template: true) }
-    let(:as_mg) { create(:admin_set, id: 'as_mg', with_permission_template: true) }
-    let(:as_du) { create(:admin_set, id: 'as_du', with_permission_template: true) }
-    let(:as_dg) { create(:admin_set, id: 'as_dg', with_permission_template: true) }
+    let(:as_vu) { create(:admin_set, id: 'adminset_vu', with_permission_template: true) }
+    let(:as_vg) { create(:admin_set, id: 'adminset_vg', with_permission_template: true) }
+    let(:as_mu) { create(:admin_set, id: 'adminset_mu', with_permission_template: true) }
+    let(:as_mg) { create(:admin_set, id: 'adminset_mg', with_permission_template: true) }
+    let(:as_du) { create(:admin_set, id: 'adminset_du', with_permission_template: true) }
+    let(:as_dg) { create(:admin_set, id: 'adminset_dg', with_permission_template: true) }
 
     before do
-      source_access(col_vu.permission_template, 'user', user.user_key, :view)
-      source_access(col_vg.permission_template, 'group', 'view_group', :view)
-      source_access(col_mu.permission_template, 'user', user.user_key, :manage)
-      source_access(col_mg.permission_template, 'group', 'manage_group', :manage)
-      source_access(col_du.permission_template, 'user', user.user_key, :deposit)
-      source_access(col_dg.permission_template, 'group', 'deposit_group', :deposit)
-
       source_access(as_vu.permission_template, 'user', user.user_key, :view)
       source_access(as_vg.permission_template, 'group', 'view_group', :view)
       source_access(as_mu.permission_template, 'user', user.user_key, :manage)
@@ -185,6 +196,7 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         end
       end
     end
+
     describe '.collection_ids_for_deposit' do
       it 'returns collection ids where user has manage access' do
         expect(described_class.collection_ids_for_deposit(ability: ability)).to match_array [col_du.id, col_dg.id, col_mu.id, col_mg.id]

--- a/spec/services/hyrax/collections_service_spec.rb
+++ b/spec/services/hyrax/collections_service_spec.rb
@@ -8,24 +8,27 @@ RSpec.describe Hyrax::CollectionsService do
   end
 
   let(:service) { described_class.new(context) }
-  let(:user1) { create(:user) }
+  let(:user1) { build(:user) }
 
   describe "#search_results", :clean_repo do
     subject { service.search_results(access) }
 
-    let(:user2) { create(:user) }
-    let!(:collection1) { create(:private_collection, id: 'col-1-own', title: ['user1 created'], user: user1, create_access: true) }
+    let(:user2) { build(:user) }
+    let!(:collection1) do
+      build(:private_collection_lw, id: 'col-1-own', title: ['user1 created'], user: user1,
+                                    with_permission_template: true, with_solr_document: true)
+    end
     let!(:collection2) do
-      create(:private_collection, id: 'col-2-mgr', title: ['user2 shares manage access with user1'], user: user2,
-                                  with_permission_template: { manage_users: [user1] }, create_access: true)
+      build(:private_collection_lw, id: 'col-2-mgr', title: ['user2 shares manage access with user1'], user: user2,
+                                    with_permission_template: { manage_users: [user1] }, with_solr_document: true)
     end
     let!(:collection3) do
-      create(:private_collection, id: 'col-3-dep', title: ['user2 shares deposit access with user1'], user: user2,
-                                  with_permission_template: { deposit_users: [user1] }, create_access: true)
+      build(:private_collection_lw, id: 'col-3-dep', title: ['user2 shares deposit access with user1'], user: user2,
+                                    with_permission_template: { deposit_users: [user1] }, with_solr_document: true)
     end
     let!(:collection4) do
-      create(:private_collection, id: 'col-4-view', title: ['user2 shares view access with user1'], user: user2,
-                                  with_permission_template: { view_users: [user1] }, create_access: true)
+      build(:private_collection_lw, id: 'col-4-view', title: ['user2 shares view access with user1'], user: user2,
+                                    with_permission_template: { view_users: [user1] }, with_solr_document: true)
     end
 
     before do


### PR DESCRIPTION
Temporarily, there are two factories to build/create collections.

* collections_factory.rb is the current factory unchanged.  Use `create(:collection)` or `build(:collection)` to use.  NOTE: All new tests should use **NOT** use this factory.  The new light weight factory should be used.
* collections.rb is the new factory that only creates parts related to the collection when they are specifically requested.  Use `build(:collection_lw)`.  You can use `create(:collection_lw)`, but it is discouraged unless you really need the object saved in Fedora.  See the factory for documentation of options that can be passed to `build`.  NOTE: All new tests should use this factory.

Several tests were updated to use the new light-weight factory with the following results.

spec/authorities/qa/authorities/collections_spec
```
  BEFORE:  12.8s
  AFTER:    6.0s
```

spec/services/hyrax/collections_service_spec
```
  BEFORE:  8.7ss
  AFTER:   3.9s
```

spec/services/hyrax/multiple_membership_checker_spec
```
   BEFORE: 13.5s
   AFTER:   3.1s
```

spec/services/hyrax/collections/permissions_service_spec
```
   BEFORE: 1m 8.2s
   AFTER:   37.4s
```

**Next Steps:**  Rewrite other tests that build/create collections.  Once all are converted to the light weight factory, the old factory can be deleted.

@samvera/hyrax-code-reviewers
