### PR TITLE
Add embargo and lease links to admin dashboard in tasks section

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -15,9 +15,7 @@
     <%= menu.nav_link(hyrax.embargoes_path) do %>
       <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.embargoes.index.manage_embargoes') %></span>
     <% end %>
-  <% end %>
 
-  <% if can? :read, :admin_dashboard %>
     <%= menu.nav_link(hyrax.leases_path) do %>
       <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.leases.index.manage_leases') %></span>
     <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -10,3 +10,15 @@
       <span class="fa fa-user"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
     <% end %>
   <% end %>
+
+  <% if can? :read, :admin_dashboard %>
+    <%= menu.nav_link(hyrax.embargoes_path) do %>
+      <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.embargoes.index.manage_embargoes') %></span>
+    <% end %>
+  <% end %>
+
+  <% if can? :read, :admin_dashboard %>
+    <%= menu.nav_link(hyrax.leases_path) do %>
+      <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.leases.index.manage_leases') %></span>
+    <% end %>
+  <% end %>

--- a/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
     subject { rendered }
 
     it { is_expected.to have_link t('hyrax.admin.sidebar.statistics') }
+    it { is_expected.to have_link t('hyrax.embargoes.index.manage_embargoes') }
+    it { is_expected.to have_link t('hyrax.leases.index.manage_leases') }
   end
 
   context 'with a user who can review submissions' do


### PR DESCRIPTION
Resolves #1127 

Adds links to embargo and lease management pages in the admin dashboard task section for all users who can access the admin dashboard.  

@samvera/hyrax-code-reviewers
