### PR TITLE
Initial documentation for Analytics::Base

### DIFF
--- a/app/services/hyrax/analytics/base.rb
+++ b/app/services/hyrax/analytics/base.rb
@@ -8,18 +8,42 @@ module Hyrax
         raise NotImplementedError, "#{self.class}#connection is unimplemented."
       end
 
+      # Query the number of pageviews for a given time period against the specified object
+      # @param [DateTime] _start_date
+      # @param [ActiveFedora::Base] _object
+      #
+      # @return [OpenStruct] - Should contain attributes for date and pageviews
+      # Example: <OpenStruct date="20180201", pageviews="1">
       def self.pageviews(_start_date, _object)
         raise NotImplementedError, "#{self.class}#pageviews is unimplemented."
       end
 
+      # Query the number of downloads for a given time period against the specified object
+      # @param [DateTime] _start_date
+      # @param [FileSet] _object
+      #
+      # @return [OpenStruct] - Should contain attributes for date and totalEvents. Other attributes currently aren't
+      # used.
+      # Example: <OpenStruct eventCategory="Files", eventAction="Downloaded", eventLabel="j67313767", date="20180212", totalEvents="1">
       def self.downloads(_start_date, _object)
         raise NotImplementedError, "#{self.class}#downloads is unimplemented."
       end
 
-      def self.visitors(_start_date)
-        raise NotImplementedError, "#{self.class}#visitors is unimplemented."
+      # Query the number of unique visitors for a given time period
+      # @param [DateTime] _start_date
+      #
+      # @return [OpenStruct] - Should contain attributes for date and uniqueVisitors
+      # used.
+      # Example: <OpenStruct date="20180212", uniqueVisitors="1">
+      def self.unique_visitors(_start_date)
+        raise NotImplementedError, "#{self.class}#unique_visitors is unimplemented."
       end
 
+      # Query the number of returning visitors for a given time period
+      # @param [DateTime] _start_date
+      #
+      # @return [OpenStruct] - Should contain attributes for date and returningVisitors
+      # Example: <OpenStruct date="20180212", returningVisitors="5">
       def self.returning_visitors(_start_date)
         raise NotImplementedError, "#{self.class}#returning_visitors is unimplemented."
       end

--- a/app/services/hyrax/analytics/google_analytics.rb
+++ b/app/services/hyrax/analytics/google_analytics.rb
@@ -6,7 +6,7 @@ module Hyrax
         # an ||= to setup the GA connection using JSON
       end
 
-      def self.visitors(start_date)
+      def self.unique_visitors(start_date)
         # yanked as examplar https://github.com/google/google-api-ruby-client/blob/master/samples/cli/lib/samples/analytics.rb
         dimensions = ['ga:date']
         metrics = ['ga:sessions', 'ga:users', 'ga:newUsers', 'ga:percentNewSessions',

--- a/app/services/hyrax/analytics/matomo.rb
+++ b/app/services/hyrax/analytics/matomo.rb
@@ -11,8 +11,8 @@ module Hyrax
         # site = Piwik::Site.load(config.site)
       end
 
-      def self.visitors(start_date)
-        Piwik::VisitsSummary.getVisits(idSite: config.site, period: :range, date: "#{start_date},#{Time.zone.today}")
+      def self.unique_visitors(start_date)
+        Piwik::VisitsSummary.getUniqueVisitors(idSite: config.site, period: :range, date: "#{start_date},#{Time.zone.today}")
         # Manipulate `result` to an agreed upon data structure
       end
 

--- a/spec/services/hyrax/analytics/base_spec.rb
+++ b/spec/services/hyrax/analytics/base_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Hyrax::Analytics::Base do
     end
   end
 
-  describe '.visitors' do
+  describe '.unique_visitors' do
     it 'is unimplemented' do
-      expect { described_class.visitors("2018-02-16") }.to raise_error NotImplementedError
+      expect { described_class.unique_visitors("2018-02-16") }.to raise_error NotImplementedError
     end
   end
 

--- a/spec/services/hyrax/analytics/google_analytics_spec.rb
+++ b/spec/services/hyrax/analytics/google_analytics_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::Analytics::GoogleAnalytics do
     it 'is a pending example'
   end
 
-  describe '.visitors' do
+  describe '.unique_visitors' do
     it 'is a pending example'
   end
 

--- a/spec/services/hyrax/analytics/matomo_spec.rb
+++ b/spec/services/hyrax/analytics/matomo_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::Analytics::Matomo do
     it 'is a pending example'
   end
 
-  describe '.visitors' do
+  describe '.unique_visitors' do
     it 'is a pending example'
   end
 


### PR DESCRIPTION
Changes proposed:
  - add comments on data structure expectations for Analytics::Base
implementations. Currently sticking to existing OpenStruct format
  - rename `visitors` to `unique_visitors` and updated related tests

@samvera/hyrax-code-reviewers @nestorw @conorom 
