### PR TITLE
Addressing temporal spec failure

### DIFF
--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -658,7 +658,7 @@ RSpec.describe FileSet do
     end
   end
 
-  describe "#to_global_id" do
+  describe "#to_global_id", clean_repo: true do
     let(:file_set) { described_class.new(id: '123') }
 
     subject { file_set.to_global_id }


### PR DESCRIPTION
When running the full spec suite with random seed 45750, the updated
spec failed with the following error:

```console
Failures:

  1) FileSet#to_global_id
     Failure/Error: let(:file_set) { described_class.new(id: '123') }

     ActiveFedora::IllegalOperation:
       Attempting to recreate existing ldp_source: `http://127.0.0.1:64875/rest/test/12/3/123'
      ./spec/models/file_set_spec.rb:662:in `new'
      ./spec/models/file_set_spec.rb:662:in `block (3 levels) in <top (required)>'
      ./spec/models/file_set_spec.rb:664:in `block (3 levels) in <top (required)>'
      ./spec/models/file_set_spec.rb:666:in `block (3 levels) in <top (required)>'
```

This change now means you can run the specs with the given random seed,
and the specs will pass. To duplicate the failure, checkout the commit
just before this one and run the below command:

```console
bundle exec rake SPEC_OPTS="--seed 45750"
```

@samvera/hyrax-code-reviewers
