### PR TITLE
fix single membership and add single/multi-membership spec tests

### DIFF
--- a/app/controllers/hyrax/dashboard/collection_members_controller.rb
+++ b/app/controllers/hyrax/dashboard/collection_members_controller.rb
@@ -28,9 +28,9 @@ module Hyrax
         members = collection.add_member_objects batch_ids
         messages = members.collect { |member| member.errors.full_messages }.flatten
         if messages.size == members.size
-          after_update_error(messages.join(', '))
+          after_update_error(messages.uniq.join(', '))
         elsif messages.present?
-          flash[:error] = messages.join(', ')
+          flash[:error] = messages.uniq.join(', ')
           after_update
         else
           after_update

--- a/app/controllers/hyrax/dashboard/collection_members_controller.rb
+++ b/app/controllers/hyrax/dashboard/collection_members_controller.rb
@@ -26,10 +26,10 @@ module Hyrax
         return if err_msg.present?
 
         members = collection.add_member_objects batch_ids
-        messages = members.collect {|member| member.errors.full_messages }.flatten
+        messages = members.collect { |member| member.errors.full_messages }.flatten
         if messages.size == members.size
           after_update_error(messages.join(', '))
-        elsif messages.size > 0
+        elsif messages.present?
           flash[:error] = messages.join(', ')
           after_update
         else

--- a/app/controllers/hyrax/dashboard/collection_members_controller.rb
+++ b/app/controllers/hyrax/dashboard/collection_members_controller.rb
@@ -25,8 +25,16 @@ module Hyrax
         after_update_error(err_msg) if err_msg.present?
         return if err_msg.present?
 
-        collection.add_member_objects batch_ids
-        after_update
+        members = collection.add_member_objects batch_ids
+        messages = members.collect {|member| member.errors.full_messages }.flatten
+        if messages.size == members.size
+          after_update_error(messages.join(', '))
+        elsif messages.size > 0
+          flash[:error] = messages.join(', ')
+          after_update
+        else
+          after_update
+        end
       end
 
       private
@@ -50,7 +58,7 @@ module Hyrax
         end
 
         def collection
-          Collection.find(collection_id)
+          @collection ||= Collection.find(collection_id)
         end
 
         def batch_ids

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -59,7 +59,7 @@ module Hyrax
     def add_member_objects(new_member_ids)
       Array(new_member_ids).collect do |member_id|
         member = ActiveFedora::Base.find(member_id)
-        message =  Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
+        message = Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
         if message
           member.errors.add(:collections, message)
         else

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -57,16 +57,16 @@ module Hyrax
 
     # Add member objects by adding this collection to the objects' member_of_collection association.
     def add_member_objects(new_member_ids)
-      Array(new_member_ids).each do |member_id|
+      Array(new_member_ids).collect do |member_id|
         member = ActiveFedora::Base.find(member_id)
-        # @note Ideally, this would be surfaced as a warning in a flash
-        #       message. Because the member is found and saved in this model
-        #       method, I am not sure it's worth the effort to rejigger things
-        #       such that this information bubbles up to the controller and
-        #       view.
-        next if Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
-        member.member_of_collections << self
-        member.save!
+        message =  Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
+        if message
+          member.errors.add(:collections, message)
+        else
+          member.member_of_collections << self
+          member.save!
+        end
+        member
       end
     end
 

--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -40,7 +40,8 @@ module Hyrax
       collections_to_check = new_single_membership_collections
       # No need to check current members when coming in from the ActorStack, which does a wholesale collection membership replacement
       collections_to_check |= single_membership_collections(item.member_of_collection_ids) if include_current_members
-      problematic_collections = collections_to_check.group_by(&:collection_type_gid)
+      problematic_collections = collections_to_check.uniq(&:id)
+                                                    .group_by(&:collection_type_gid)
                                                     .select { |_gid, list| list.count > 1 }
       return if problematic_collections.blank?
       build_error_message(problematic_collections)

--- a/app/views/hyrax/my/works/_batch_actions.html.erb
+++ b/app/views/hyrax/my/works/_batch_actions.html.erb
@@ -9,6 +9,6 @@
     <%= batch_delete %>
     <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
         class: 'btn btn-primary submits-batches submits-batches-add',
-        data: { toggle: "modal", target: "#collection-list-container" } %>
+        data: { toggle: "modal", target: "#collection-list-container", turbolinks: false } %>
   </div>
 </div>

--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -1,0 +1,185 @@
+RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_repo: true, js: true, with_nested_reindexing: true do
+  let!(:admin_user) { create(:admin, email: 'admin@example.com') }
+  let!(:single_membership_type_1) { create(:collection_type, :not_allow_multiple_membership, title: 'Single-membership 1') }
+  let!(:single_membership_type_2) { create(:collection_type, :not_allow_multiple_membership, title: 'Single-membership 2') }
+  let!(:multi_membership_type_1) { create(:collection_type, :allow_multiple_membership, title: 'Multi-membership 1') }
+  let!(:multi_membership_type_2) { create(:collection_type, :allow_multiple_membership, title: 'Multi-membership 2') }
+
+  let!(:col1_sm_1) { create(:collection_lw, id: 'col1_sm_1', title: ['Collection 1 for SM1'], user: admin_user, collection_type_gid: single_membership_type_1.gid) }
+  let!(:col2_sm_1) { create(:collection_lw, id: 'col2_sm_1', title: ['Collection 2 for SM1'], user: admin_user, collection_type_gid: single_membership_type_1.gid) }
+  let!(:col3_sm_2) { create(:collection_lw, id: 'col3_sm_2', title: ['Collection 3 for SM2'], user: admin_user, collection_type_gid: single_membership_type_2.gid) }
+  let!(:col4_mm_1) { create(:collection_lw, id: 'col4_mm_1', title: ['Collection 4 for MM1'], user: admin_user, collection_type_gid: multi_membership_type_1.gid) }
+  let!(:col5_mm_1) { create(:collection_lw, id: 'col5_mm_1', title: ['Collection 5 for MM1'], user: admin_user, collection_type_gid: multi_membership_type_1.gid) }
+  let!(:col6_mm_2) { create(:collection_lw, id: 'col6_mm_2', title: ['Collection 6 for MM2'], user: admin_user, collection_type_gid: multi_membership_type_2.gid) }
+
+  let!(:work) { create(:generic_work, user: admin_user, title: ['The highly valued work that everyone wants in their collection']) }
+
+  before do
+    admin_user
+    sign_in admin_user
+    work
+  end
+
+  describe 'when both collections support multiple membership' do
+    context 'and are of different types' do
+      before do
+        col4_mm_1
+        col6_mm_2
+      end
+
+      it 'then the work is added to both collections' do
+        # Add to the first multi-membership collection
+        visit '/dashboard/my/works'
+        check 'check_all'
+        click_button 'Add to collection' # opens the modal
+        within('div#collection-list-container') do
+          choose 'Collection 4 for MM1' # selects the collection
+          click_button "Save changes"
+        end
+
+        # forwards to collection show page
+        expect(page).to have_content(col4_mm_1.title.first)
+        expect(page).to have_content 'Works (1)'
+        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
+
+        # Add to second multi-membership collection of a different type
+        visit '/dashboard/my/works'
+        check 'check_all'
+        click_button 'Add to collection' # opens the modal
+        within('div#collection-list-container') do
+          choose 'Collection 6 for MM2' # selects the collection
+          click_button 'Save changes'
+        end
+        # forwards to collection show page
+        expect(page).to have_content(col6_mm_2.title.first)
+        expect(page).to have_content 'Works (1)'
+        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
+      end
+    end
+
+    context 'and are of the same type' do
+      it 'then the work is added to both collections' do
+        # Add to the first multi-membership collection
+        visit '/dashboard/my/works'
+        check 'check_all'
+        click_button 'Add to collection' # opens the modal
+        within('div#collection-list-container') do
+          choose 'Collection 4 for MM1' # selects the collection
+          click_button "Save changes"
+        end
+
+        # forwards to collection show page
+        expect(page).to have_content(col4_mm_1.title.first)
+        expect(page).to have_content 'Works (1)'
+        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
+
+        # Add to second multi-membership collection of the same type
+        visit '/dashboard/my/works'
+        check 'check_all'
+        click_button 'Add to collection' # opens the modal
+        within('div#collection-list-container') do
+          choose 'Collection 5 for MM1' # selects the collection
+          click_button 'Save changes'
+        end
+        # forwards to collection show page
+        expect(page).to have_content(col5_mm_1.title.first)
+        expect(page).to have_content 'Works (1)'
+        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
+      end
+    end
+  end
+
+  describe 'when both collections require single membership' do
+    context 'and are of different types' do
+      it 'then the work is added to both collections' do
+        # Add to the first single-membership collection
+        visit '/dashboard/my/works'
+        check 'check_all'
+        click_button 'Add to collection' # opens the modal
+        within('div#collection-list-container') do
+          choose 'Collection 1 for SM1' # selects the collection
+          click_button "Save changes"
+        end
+
+        # forwards to collection show page
+        expect(page).to have_content(col1_sm_1.title.first)
+        expect(page).to have_content 'Works (1)'
+        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
+
+        # Add to second single-membership collection of a different type
+        visit '/dashboard/my/works'
+        check 'check_all'
+        click_button 'Add to collection' # opens the modal
+        within('div#collection-list-container') do
+          choose 'Collection 3 for SM2' # selects the collection
+          click_button 'Save changes'
+        end
+        # forwards to collection show page
+        expect(page).to have_content(col3_sm_2.title.first)
+        expect(page).to have_content 'Works (1)'
+        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
+      end
+    end
+
+    context 'and are of the same type' do
+      before do
+        # Add to the first single-membership collection
+        visit '/dashboard/my/works'
+        check 'check_all'
+        click_button 'Add to collection' # opens the modal
+        within('div#collection-list-container') do
+          choose 'Collection 1 for SM1' # selects the collection
+          click_button "Save changes"
+        end
+      end
+
+      context 'then the work fails to add to the second collection' do
+        it 'from the dashboard->works batch add to collection' do
+          # Attempt to add to second single-membership collection of the same type
+          visit '/dashboard/my/works'
+          check 'check_all'
+          click_button 'Add to collection' # opens the modal
+          within('div#collection-list-container') do
+            choose 'Collection 2 for SM1' # selects the collection
+            click_button 'Save changes'
+          end
+          # forwards to work index page and shows flash message
+          expect(page).to have_link 'All Works'
+          expect(page).to have_link 'Your Works'
+          expect(page).to have_selector '.alert', text: 'Error: You have specified more than one of the same single-membership collection types: Single-membership 1 (Collection 1 for SM1)'
+        end
+
+        it "from the work's edit form Relationships tab" do
+          skip 'Needs additional work to find and select the second collection'
+          # Attempt to add to second single-membership collection of the same type
+          visit edit_hyrax_generic_work_path(work)
+          click_link "Relationships"
+          # TODO: not sure how to find and select the correct collection
+
+          # forwards to work index page and shows flash message
+          expect(page).to have_link 'All Works'
+          expect(page).to have_link 'Your Works'
+          expect(page).to have_selector '.alert', text: 'Error: You have specified more than one of the same single-membership collection types: Single-membership 1 (Collection 1 for SM1)'
+        end
+
+        it "from the collection's show page Addadd to collection" do
+          # Attempt to add to second single-membership collection of the same type
+          visit "/dashboard/collections/#{col2_sm_1.id}"
+          click_link 'Add existing works'
+          check 'check_all'
+          click_button 'Add to collection' # opens the modal
+          within('div#collection-list-container') do
+            choose 'Collection 2 for SM1' # selects the collection
+            click_button 'Save changes'
+          end
+          # forwards to work index page and shows flash message
+          # TODO: I'm not sure if this should be forwarding back to the collection show page and showing the flash message
+          #       or to the works index.  Ideally, it would go back to the collection show page.
+          expect(page).to have_link 'All Works'
+          expect(page).to have_link 'Your Works'
+          expect(page).to have_selector '.alert', text: 'Error: You have specified more than one of the same single-membership collection types: Single-membership 1 (Collection 1 for SM1)'
+        end
+      end
+    end
+  end
+end

--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -1,137 +1,84 @@
 RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_repo: true, js: true, with_nested_reindexing: true do
-  let!(:admin_user) { create(:admin, email: 'admin@example.com') }
-  let!(:single_membership_type_1) { create(:collection_type, :not_allow_multiple_membership, title: 'Single-membership 1') }
-  let!(:single_membership_type_2) { create(:collection_type, :not_allow_multiple_membership, title: 'Single-membership 2') }
-  let!(:multi_membership_type_1) { create(:collection_type, :allow_multiple_membership, title: 'Multi-membership 1') }
-  let!(:multi_membership_type_2) { create(:collection_type, :allow_multiple_membership, title: 'Multi-membership 2') }
-
-  let!(:col1_sm_1) { create(:collection_lw, id: 'col1_sm_1', title: ['Collection 1 for SM1'], user: admin_user, collection_type_gid: single_membership_type_1.gid) }
-  let!(:col2_sm_1) { create(:collection_lw, id: 'col2_sm_1', title: ['Collection 2 for SM1'], user: admin_user, collection_type_gid: single_membership_type_1.gid) }
-  let!(:col3_sm_2) { create(:collection_lw, id: 'col3_sm_2', title: ['Collection 3 for SM2'], user: admin_user, collection_type_gid: single_membership_type_2.gid) }
-  let!(:col4_mm_1) { create(:collection_lw, id: 'col4_mm_1', title: ['Collection 4 for MM1'], user: admin_user, collection_type_gid: multi_membership_type_1.gid) }
-  let!(:col5_mm_1) { create(:collection_lw, id: 'col5_mm_1', title: ['Collection 5 for MM1'], user: admin_user, collection_type_gid: multi_membership_type_1.gid) }
-  let!(:col6_mm_2) { create(:collection_lw, id: 'col6_mm_2', title: ['Collection 6 for MM2'], user: admin_user, collection_type_gid: multi_membership_type_2.gid) }
-
-  let!(:work) { create(:generic_work, user: admin_user, title: ['The highly valued work that everyone wants in their collection']) }
+  let(:admin_user) { create(:admin, email: 'admin@example.com') }
+  let(:single_membership_type_1) { create(:collection_type, :not_allow_multiple_membership, title: 'Single-membership 1') }
+  let(:single_membership_type_2) { create(:collection_type, :not_allow_multiple_membership, title: 'Single-membership 2') }
+  let(:multi_membership_type_1) { create(:collection_type, :allow_multiple_membership, title: 'Multi-membership 1') }
+  let(:multi_membership_type_2) { create(:collection_type, :allow_multiple_membership, title: 'Multi-membership 2') }
 
   before do
-    admin_user
     sign_in admin_user
-    work
   end
 
   describe 'when both collections support multiple membership' do
+    let(:old_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_1.gid) }
+    let!(:work) { create(:generic_work, user: admin_user, member_of_collections: [old_collection], title: ['The highly valued work that everyone wants in their collection']) }
+
     context 'and are of different types' do
-      before do
-        col4_mm_1
-        col6_mm_2
-      end
+      let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_2.gid) }
 
       it 'then the work is added to both collections' do
-        # Add to the first multi-membership collection
-        visit '/dashboard/my/works'
-        check 'check_all'
-        click_button 'Add to collection' # opens the modal
-        within('div#collection-list-container') do
-          choose 'Collection 4 for MM1' # selects the collection
-          click_button "Save changes"
-        end
-
-        # forwards to collection show page
-        expect(page).to have_content(col4_mm_1.title.first)
-        expect(page).to have_content 'Works (1)'
-        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
-
         # Add to second multi-membership collection of a different type
         visit '/dashboard/my/works'
         check 'check_all'
         click_button 'Add to collection' # opens the modal
         within('div#collection-list-container') do
-          choose 'Collection 6 for MM2' # selects the collection
+          choose new_collection.title.first # selects the collection
           click_button 'Save changes'
         end
+
         # forwards to collection show page
-        expect(page).to have_content(col6_mm_2.title.first)
+        expect(page).to have_content new_collection.title.first
         expect(page).to have_content 'Works (1)'
-        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
+        expect(page).to have_content work.title.first
       end
     end
 
     context 'and are of the same type' do
+      let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_1.gid) }
+
       it 'then the work is added to both collections' do
-        # Add to the first multi-membership collection
+        # Add to second multi-membership collection of a different type
         visit '/dashboard/my/works'
         check 'check_all'
         click_button 'Add to collection' # opens the modal
         within('div#collection-list-container') do
-          choose 'Collection 4 for MM1' # selects the collection
-          click_button "Save changes"
-        end
-
-        # forwards to collection show page
-        expect(page).to have_content(col4_mm_1.title.first)
-        expect(page).to have_content 'Works (1)'
-        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
-
-        # Add to second multi-membership collection of the same type
-        visit '/dashboard/my/works'
-        check 'check_all'
-        click_button 'Add to collection' # opens the modal
-        within('div#collection-list-container') do
-          choose 'Collection 5 for MM1' # selects the collection
+          choose new_collection.title.first # selects the collection
           click_button 'Save changes'
         end
+
         # forwards to collection show page
-        expect(page).to have_content(col5_mm_1.title.first)
+        expect(page).to have_content new_collection.title.first
         expect(page).to have_content 'Works (1)'
-        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
+        expect(page).to have_content work.title.first
       end
     end
   end
 
   describe 'when both collections require single membership' do
+    let(:old_collection) { create(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_1.gid) }
+    let!(:work) { create(:generic_work, user: admin_user, member_of_collections: [old_collection], title: ['The highly valued work that everyone wants in their collection']) }
+
     context 'and are of different types' do
+      let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_2.gid) }
+
       it 'then the work is added to both collections' do
-        # Add to the first single-membership collection
-        visit '/dashboard/my/works'
-        check 'check_all'
-        click_button 'Add to collection' # opens the modal
-        within('div#collection-list-container') do
-          choose 'Collection 1 for SM1' # selects the collection
-          click_button "Save changes"
-        end
-
-        # forwards to collection show page
-        expect(page).to have_content(col1_sm_1.title.first)
-        expect(page).to have_content 'Works (1)'
-        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
-
         # Add to second single-membership collection of a different type
         visit '/dashboard/my/works'
         check 'check_all'
         click_button 'Add to collection' # opens the modal
         within('div#collection-list-container') do
-          choose 'Collection 3 for SM2' # selects the collection
+          choose new_collection.title.first # selects the collection
           click_button 'Save changes'
         end
         # forwards to collection show page
-        expect(page).to have_content(col3_sm_2.title.first)
+        expect(page).to have_content new_collection.title.first
         expect(page).to have_content 'Works (1)'
-        expect(page).to have_content 'The highly valued work that everyone wants in their collection'
+        expect(page).to have_content work.title.first
       end
     end
 
     context 'and are of the same type' do
-      before do
-        # Add to the first single-membership collection
-        visit '/dashboard/my/works'
-        check 'check_all'
-        click_button 'Add to collection' # opens the modal
-        within('div#collection-list-container') do
-          choose 'Collection 1 for SM1' # selects the collection
-          click_button "Save changes"
-        end
-      end
+      let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_1.gid) }
 
       context 'then the work fails to add to the second collection' do
         it 'from the dashboard->works batch add to collection' do
@@ -140,7 +87,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
           check 'check_all'
           click_button 'Add to collection' # opens the modal
           within('div#collection-list-container') do
-            choose 'Collection 2 for SM1' # selects the collection
+            choose new_collection.title.first # selects the collection
             click_button 'Save changes'
           end
           # forwards to work index page and shows flash message
@@ -162,14 +109,14 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
           expect(page).to have_selector '.alert', text: 'Error: You have specified more than one of the same single-membership collection types: Single-membership 1 (Collection 1 for SM1)'
         end
 
-        it "from the collection's show page Addadd to collection" do
+        it "from the collection's show page Add to collection" do
           # Attempt to add to second single-membership collection of the same type
-          visit "/dashboard/collections/#{col2_sm_1.id}"
+          visit "/dashboard/collections/#{new_collection.id}"
           click_link 'Add existing works'
           check 'check_all'
           click_button 'Add to collection' # opens the modal
           within('div#collection-list-container') do
-            choose 'Collection 2 for SM1' # selects the collection
+            choose new_collection.title.first # selects the collection
             click_button 'Save changes'
           end
           # forwards to work index page and shows flash message

--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -90,10 +90,10 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
             choose new_collection.title.first # selects the collection
             click_button 'Save changes'
           end
-          # forwards to work index page and shows flash message
-          expect(page).to have_link 'All Works'
-          expect(page).to have_link 'Your Works'
-          expect(page).to have_selector '.alert', text: 'Error: You have specified more than one of the same single-membership collection types: Single-membership 1 (Collection 1 for SM1)'
+          # forwards to collections index page and shows flash message
+          expect(page).to have_link 'All Collections'
+          expect(page).to have_link 'Your Collections'
+          expect(page).to have_selector '.alert', text: "Error: You have specified more than one of the same single-membership collection types: Single-membership 1 (#{new_collection.title.first} and #{old_collection.title.first})"
         end
 
         it "from the work's edit form Relationships tab" do
@@ -119,12 +119,10 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
             choose new_collection.title.first # selects the collection
             click_button 'Save changes'
           end
-          # forwards to work index page and shows flash message
-          # TODO: I'm not sure if this should be forwarding back to the collection show page and showing the flash message
-          #       or to the works index.  Ideally, it would go back to the collection show page.
-          expect(page).to have_link 'All Works'
-          expect(page).to have_link 'Your Works'
-          expect(page).to have_selector '.alert', text: 'Error: You have specified more than one of the same single-membership collection types: Single-membership 1 (Collection 1 for SM1)'
+          # forwards to collections index page and shows flash message
+          expect(page).to have_link 'All Collections'
+          expect(page).to have_link 'Your Collections'
+          expect(page).to have_selector '.alert', text: "Error: You have specified more than one of the same single-membership collection types: Single-membership 1 (#{new_collection.title.first} and #{old_collection.title.first})"
         end
       end
     end


### PR DESCRIPTION
Right now, all tests allow the work to be added to both collections even when it shouldn’t.  These tests can be used to determine when the problem is fixed.

There is one tests for single membership that is incomplete, set to skip, and marked with a TODO because I wasn’t sure how to get capybara to do the collection selection process on the work’s edit form Relationships tab.

Addresses #2651 which sets up testing for a fix of multiple membership validation
