### PR TITLE
Depositor should always be able to see their own work.

### DIFF
--- a/app/search_builders/hyrax/filter_suppressed_with_roles.rb
+++ b/app/search_builders/hyrax/filter_suppressed_with_roles.rb
@@ -13,7 +13,7 @@ module Hyrax
     # workflow actions on the work corresponding to the SolrDocument
     # with id = `blacklight_params[:id]`
     def only_active_works(solr_parameters)
-      return if user_has_active_workflow_role?
+      return if user_has_active_workflow_role? || depositor?
       super
     end
 
@@ -28,6 +28,10 @@ module Hyrax
       rescue PowerConverter::ConversionError
         # The current_work doesn't have a sipity workflow entity
         false
+      end
+
+      def depositor?
+        current_work[DepositSearchBuilder.depositor_field].first == current_ability.current_user.user_key
       end
   end
 end

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -26,6 +26,24 @@ RSpec.describe Hyrax::GenericWorksController do
     end
   end
 
+  describe 'integration test for depositor of a suppressed documents without a workflow role' do
+    let(:work) do
+      create(:work, :public, state: Vocab::FedoraResourceStatus.inactive, user: user)
+    end
+
+    before do
+      create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+    end
+
+    it 'renders without the unauthorized message' do
+      get :show, params: { id: work.id }
+      expect(response.code).to eq '200'
+      expect(response).to render_template(:show)
+      expect(assigns[:presenter]).to be_instance_of Hyrax::GenericWorkPresenter
+      expect(flash[:notice]).to be_nil
+    end
+  end
+
   describe '#show' do
     before do
       create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)

--- a/spec/search_builders/hyrax/work_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/work_search_builder_spec.rb
@@ -44,11 +44,29 @@ RSpec.describe Hyrax::WorkSearchBuilder do
       context "and the current user doesn't have a role" do
         let(:roles) { [] }
 
-        it "filters for id, access, suppressed and type" do
-          expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                      "{!terms f=has_model_ssim}GenericWork,Collection",
-                                      "-suppressed_bsi:true",
-                                      "{!raw f=id}123abc"]
+        context "and the current user is not the depositor" do
+          before do
+            allow(builder).to receive(:depositor?).and_return(false)
+          end
+
+          it "filters for id, access, suppressed and type" do
+            expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
+                                        "{!terms f=has_model_ssim}GenericWork,Collection",
+                                        "-suppressed_bsi:true",
+                                        "{!raw f=id}123abc"]
+          end
+        end
+
+        context "and the current user is the depositor" do
+          before do
+            allow(builder).to receive(:depositor?).and_return(true)
+          end
+
+          it "filters for id, access, suppressed and type" do
+            expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
+                                        "{!terms f=has_model_ssim}GenericWork,Collection",
+                                        "{!raw f=id}123abc"]
+          end
         end
       end
     end
@@ -58,11 +76,30 @@ RSpec.describe Hyrax::WorkSearchBuilder do
         expect(Hyrax::Workflow::PermissionQuery).to receive(:scope_permitted_workflow_actions_available_for_current_state)
           .and_raise(PowerConverter::ConversionError.new(double, {}))
       end
-      it "filters for id, access, suppressed and type" do
-        expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                    "{!terms f=has_model_ssim}GenericWork,Collection",
-                                    "-suppressed_bsi:true",
-                                    "{!raw f=id}123abc"]
+
+      context "and the current user is not the depositor" do
+        before do
+          allow(builder).to receive(:depositor?).and_return(false)
+        end
+
+        it "filters for id, access, suppressed and type" do
+          expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
+                                      "{!terms f=has_model_ssim}GenericWork,Collection",
+                                      "-suppressed_bsi:true",
+                                      "{!raw f=id}123abc"]
+        end
+      end
+
+      context "and the current user is the depositor" do
+        before do
+          allow(builder).to receive(:depositor?).and_return(true)
+        end
+
+        it "filters for id, access, suppressed and type" do
+          expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
+                                      "{!terms f=has_model_ssim}GenericWork,Collection",
+                                      "{!raw f=id}123abc"]
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #1421

Depositor should always be able to see their own work. This will allow the depositor to view their own work even they don't have a work flow role.


Changes proposed in this pull request:
* Tweak with the search builder to make their own work available to the depositor.


@samvera/hyrax-code-reviewers
