### PR TITLE
Analytics initializer with Matomo

### DIFF
--- a/app/services/hyrax/analytics/matomo.rb
+++ b/app/services/hyrax/analytics/matomo.rb
@@ -3,58 +3,25 @@ require 'piwik'
 module Hyrax
   module Analytics
     class Matomo < Hyrax::Analytics::Base
-      def self.connection
-        return unless config.valid?
-        # an ||= to setup Matomo
-        # Piwik::PIWIK_URL = 'http://demo.piwik.org'
-        # Piwik::PIWIK_TOKEN = 'anonymous'
-        # site = Piwik::Site.load(config.site)
+      REQUIRED_KEYS = %w[matomo_site_id matomo_token matomo_url].freeze
+
+      class << self
+        attr_accessor :config
       end
 
       def self.unique_visitors(start_date)
-        Piwik::VisitsSummary.getUniqueVisitors(idSite: config.site, period: :range, date: "#{start_date},#{Time.zone.today}")
+        Piwik::VisitsSummary.getUniqueVisitors(idSite: matomo_site_id, period: :range, date: "#{start_date},#{Time.zone.today}")
         # Manipulate `result` to an agreed upon data structure
       end
 
-      # BOILERPLATE CONFIG/AUTH STUFF BELOW THAT'S INCOMPLETE/TBD
-
-      # Loads configuration options from config/analytics.yml. Expected structure:
-      # `analytics:`
-      # `  site: MATOMO_SITE_ID`
-      # `  url: MATOMO_URL`
-      # `  token: MATOMO_TOKEN`
-      # @return [Config]
-      def self.config
-        @config ||= Config.load_from_yaml
+      # @return [Boolean] are all the required values present?
+      def self.valid?
+        config_keys = @config.keys
+        REQUIRED_KEYS.all? { |required| config_keys.include?(required) }
       end
-      private_class_method :config
-      # placeholder as example of existing code
-      class Config
-        def self.load_from_yaml
-          filename = Rails.root.join('config', 'analytics.yml')
-          yaml = YAML.safe_load(File.read(filename))
-          unless yaml
-            Rails.logger.error("Unable to fetch any keys from #{filename}.")
-            return new({})
-          end
-          new yaml.fetch('analytics')
-        end
 
-        REQUIRED_KEYS = %w[app_name app_version privkey_path privkey_secret client_email].freeze
-
-        def initialize(config)
-          @config = config
-        end
-
-        # @return [Boolean] are all the required values present?
-        def valid?
-          config_keys = @config.keys
-          REQUIRED_KEYS.all? { |required| config_keys.include?(required) }
-        end
-
-        REQUIRED_KEYS.each do |key|
-          class_eval %{ def #{key};  @config.fetch('#{key}'); end }
-        end
+      REQUIRED_KEYS.each do |key|
+        class_eval %{ def self.#{key};  @config.fetch('#{key}'); end }
       end
     end
   end

--- a/app/views/_analytics.html.erb
+++ b/app/views/_analytics.html.erb
@@ -1,0 +1,6 @@
+<% case Hyrax.config.analytics %>
+<%when 'matomo' %>
+  <%= render partial: '/matomo', formats: [:html] %>
+<%when 'google' || true%>
+  <%= render partial: '/ga', formats: [:html] %>
+<%end%>

--- a/app/views/_ga.html.erb
+++ b/app/views/_ga.html.erb
@@ -2,6 +2,7 @@
 if Hyrax.config.google_analytics_id?
 tracking_id = Hyrax.config.google_analytics_id
 %>
+<!-- Google Analytics -->
 <script type="text/javascript">
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', '<%= tracking_id %>']);

--- a/app/views/_matomo.html.erb
+++ b/app/views/_matomo.html.erb
@@ -1,0 +1,19 @@
+<%
+if Hyrax::Analytics::Matomo.valid?
+%>
+<!-- Matomo -->
+<script type="text/javascript">
+var _paq = _paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="//<%= Hyrax::Analytics::Matomo.matomo_url %>/";
+  _paq.push(['setTrackerUrl', u+'piwik.php']);
+  _paq.push(['setSiteId', "<%= Hyrax::Analytics::Matomo.matomo_site_id %>"]);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+})();
+</script>
+<!-- End Matomo Code -->
+<%end%>

--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -25,8 +25,7 @@ signed in %>
 <%= tinymce_assets if can? :update, ContentBlock %>
 <%= render 'shared/appearance_styles' %>
 
-<!-- Google Analytics -->
-<%= render partial: '/ga', formats: [:html] %>
+<%= render partial: '/analytics', formats: [:html] %>
 
 <!-- for extras, e.g., a favicon -->
 <%= render partial: '/head_tag_extras', formats: [:html] %>

--- a/config/initializers/analytics.rb
+++ b/config/initializers/analytics.rb
@@ -1,0 +1,25 @@
+# Reads and sets up config for the analytics platform
+# Needs to run after other initializers
+Rails.application.config.after_initialize do
+  case Hyrax.config.analytics
+  when 'matomo'
+    require 'piwik'
+    filename = Rails.root.join('config', 'analytics.yml')
+    yaml = YAML.safe_load(File.read(filename))
+    unless yaml
+      Rails.logger.error("Unable to fetch any keys from #{filename}.")
+      return
+    end
+    config = yaml.fetch('analytics')
+    Piwik::PIWIK_URL = config['matomo_url']
+    Piwik::PIWIK_TOKEN = config['matomo_token']
+
+    Hyrax::Analytics::Matomo.config = config
+    unless Hyrax::Analytics::Matomo.valid?
+      Rails.logger.error("Invalid Matomo config from #{filename}.")
+    end
+
+  when 'google' # rubocop:disable Lint/EmptyWhen
+    # TODO: move/refactor google yaml config to here
+  end
+end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -31,7 +31,7 @@ SUMMARY
 
   spec.add_dependency 'active-fedora', '~> 11.5', '>= 11.5.2'
   spec.add_dependency 'almond-rails', '~> 0.1'
-  spec.add_dependency 'autometal-piwik', '~> 1.0'
+  spec.add_dependency 'autometal-piwik', '>= 1.0'
   spec.add_dependency 'awesome_nested_set', '~> 3.1'
   spec.add_dependency 'blacklight', '~> 6.14'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'

--- a/lib/generators/hyrax/templates/config/analytics.yml
+++ b/lib/generators/hyrax/templates/config/analytics.yml
@@ -12,3 +12,9 @@
 # analytics:
 #   view_id: 'XXXXXXXXX'
 #   privkey_path: /path/to/key_file.json
+#
+# New Matomo structure:
+# analytics:
+#   matomo_site_id: 'XXXX'
+#   matomo_token: 'XXXX'
+#   matomo_url: 'http://demo.piwik.org'


### PR DESCRIPTION
Fixes #2670 and partially #2625

New initializer for analytics config and partial for Matomo's tracking script.

The Matomo part is completed but I didn't refactor the Google part yet due to potential conflicts.
The Matomo and google tracking scripts are determined by `Hyrax.config.analytics` and should be either `google` or `matomo`. To prevent breaking changes `true` will also work for Google.