### PR TITLE
Add repository activity link to dashboard page

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -1,5 +1,15 @@
   <li class="h5"><%= t('hyrax.admin.sidebar.activity') %></li>
 
+  <% if Flipflop.analytics_redesign? %>
+    <% if can? :read, :admin_dashboard %>
+      <li>
+        <%= menu.nav_link(hyrax.dashboard_path) do %>
+          <span class="fa fa-area-chart"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.repository_activity') %></span>
+        <% end %>
+      </li>
+    <% end %>
+  <% end %>
+
   <li>
     <%= menu.collapsable_section t('hyrax.admin.sidebar.user_activity'),
                                  icon_class: "fa fa-line-chart",

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -267,6 +267,7 @@ en:
         notifications:      "Notifications"
         pages:              "Pages"
         profile:            "Profile"
+        repository_activity: "Repository activity"
         repository_objects: "Repository Contents"
         settings:           "Settings"
         statistics:         "Reports"

--- a/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
 
       it { is_expected.to have_link t('hyrax.admin.sidebar.statistics') }
       it { is_expected.not_to have_link t('hyrax.admin.sidebar.attributes') }
+      it { is_expected.not_to have_link t('hyrax.admin.sidebar.repository_activity') }
     end
 
     context 'with the new analytics_redesign' do
@@ -58,6 +59,7 @@ RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
         render
       end
 
+      it { is_expected.to have_link t('hyrax.admin.sidebar.repository_activity') }
       it { is_expected.to have_link t('hyrax.admin.sidebar.statistics') }
       it { is_expected.to have_link t('hyrax.admin.sidebar.attributes') }
     end


### PR DESCRIPTION
Fixes #2705

Adds link to view repository statistics for admin users.

@samvera/hyrax-code-reviewers
