### PR TITLE
Make work head tag title SEO friendly.

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -28,7 +28,7 @@ module Hyrax
     end
 
     def page_title
-      title.first
+      "#{human_readable_type} | #{title.first} | ID: #{id} | #{I18n.t('hyrax.product_name')}"
     end
 
     # CurationConcern methods

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "display a work as its owner" do
 
   context "as a user who is not logged in" do
     let(:work) { create(:public_generic_work, title: ["Magnificent splendor"], source: ["The Internet"], based_near: ["USA"]) }
+    let(:page_title) { { text: "Generic Work | Magnificent splendor | ID: #{work.id} | Hyrax" }.to_param }
 
     before do
       visit work_path
@@ -51,7 +52,7 @@ RSpec.describe "display a work as its owner" do
       expect(page).not_to have_selector "form#fileupload"
 
       # has some social media buttons
-      expect(page).to have_link '', href: "https://twitter.com/intent/tweet/?text=Magnificent+splendor&url=http%3A%2F%2Fwww.example.com%2Fconcern%2Fgeneric_works%2F#{work.id}"
+      expect(page).to have_link '', href: "https://twitter.com/intent/tweet/?#{page_title}&url=http%3A%2F%2Fwww.example.com%2Fconcern%2Fgeneric_works%2F#{work.id}"
 
       # exports EndNote
       expect(page).to have_link 'EndNote'

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
   describe '#page_title' do
     subject { presenter.page_title }
 
-    it { is_expected.to eq 'foo' }
+    it { is_expected.to eq 'Generic Work | foo | ID: 888888 | Hyrax' }
   end
 
   describe "#valid_child_concerns" do

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
     allow(presenter).to receive(:representative_presenter).and_return(representative_presenter)
     allow(presenter).to receive(:representative_id).and_return('123')
     allow(presenter).to receive(:tweeter).and_return("@#{depositor.twitter_handle}")
+    allow(presenter).to receive(:human_readable_type).and_return("Work")
     allow(controller).to receive(:current_user).and_return(depositor)
     allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
     allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
@@ -88,6 +89,13 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
       it 'omits the UniversalViewer' do
         expect(page).not_to have_selector 'div.viewer'
       end
+    end
+  end
+
+  describe 'head tag page title' do
+    it 'appears in head tags' do
+      head_tag = Nokogiri::HTML(rendered).xpath("//head/title")
+      expect(head_tag.text).to eq("Work | My Title | ID: 999 | Hyrax")
     end
   end
 


### PR DESCRIPTION
Fixes #1288

Refactor work head tag title to make it better for SEO accessibility.

@samvera/hyrax-code-reviewers
