### PR TITLE
Hide the search option when "All" is the only option in the search box dropdown.

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -10,18 +10,17 @@
       <button type="submit" class="btn btn-primary" id="search-submit-header">
         <%= t('hyrax.search.button.html') %>
       </button>
-      <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
-        <span data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
-        <span class="caret"></span>
-      </button>
+      <% if current_user %>
+        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+          <span data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
+          <span class="caret"></span>
+        </button>
 
-      <ul class="dropdown-menu pull-right">
-        <li>
-          <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
-              data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
-        </li>
-
-        <% if current_user %>
+        <ul class="dropdown-menu pull-right">
+          <li>
+            <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
+                data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
+          </li>
           <li>
             <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#",
                 data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -35,21 +35,18 @@ RSpec.describe 'searching' do
       # it "does not display search options for dashboard files" do
       # This section was tested on its own, and required a full setup.
       within(".input-group-btn") do
+        expect(page).not_to have_content("All")
         expect(page).not_to have_content("My Works")
         expect(page).not_to have_content("My Collections")
         expect(page).not_to have_content("My Shares")
       end
-      # end
 
-      expect(page).to have_content("All")
-      expect(page).to have_css("a[data-search-label*=All]", visible: false)
+      expect(page).not_to have_css("a[data-search-label*=All]", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Works']", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Collections']", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Highlights']", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Shares']", visible: false)
 
-      click_button("All")
-      expect(page).to have_content("All of Hyrax")
       fill_in "search-field-header", with: subject_value
       click_button("Go")
 


### PR DESCRIPTION
Fixes #1202

Search box dropdown should disappear if only "All" option is available.

@samvera/hyrax-code-reviewers
