### PR TITLE
Clean up from wiring up remove collection relationships

### DIFF
--- a/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
@@ -1,37 +1,35 @@
 <% if presenter.total_parent_collections <= 0 %>
-		<div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_parent_collections') %></div>
+	<div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_parent_collections') %></div>
 <% else %>
-	<div id="remove_parent_collection">
-	  <% if presenter.use_parent_more_less? %>
-	  	<div class="less-parent-collections-block" id="less-parent-collections">
-				<ul>
-		  		<% presenter.visible_parent_collections.each do |document| %>
-		      	<%= render 'hyrax/dashboard/collections/show_parent_collection_row', id: presenter.id, document: document %>
-		  		<% end %>
-				</ul>
-	  		<% if presenter.more_parent_collections? %>
-	  				<button id="show-more-parent-collections" class="btn show-more-parent-collections-btn"><%= t("hyrax.collections.show.show_more_parent_collections") %></button>
-	  		<% end %>
-	  	</div>
-	  	<% if presenter.more_parent_collections? %>
-	  		<div class="more-parent-collections-block" id="more-parent-collections">
-					<ul>
-		  			<% presenter.more_parent_collections.each do |document| %>
-		      		<%= render 'hyrax/dashboard/collections/show_parent_collection_row', id: presenter.id, document: document %>
-		  			<% end %>
-					</ul>
-	  			<button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
-	  		</div>
-	  	<% end %>
-	  <% else %>
+  <% if presenter.use_parent_more_less? %>
+  	<div class="less-parent-collections-block" id="less-parent-collections">
 			<ul>
-				<% presenter.parent_collections.documents.each do |document| %>
-		    	<%= render 'hyrax/dashboard/collections/show_parent_collection_row', id: presenter.id, document: document %>
-				<% end %>
+	  		<% presenter.visible_parent_collections.each do |document| %>
+	      	<%= render 'hyrax/dashboard/collections/show_parent_collection_row', id: presenter.id, document: document %>
+	  		<% end %>
 			</ul>
-	    <div class="row">
-	      <%= render 'hyrax/collections/paginate', solr_response: presenter.parent_collections, page_param_name: :parent_collection_page  %>
-	    </div>
-	  <% end %>
-	<div>
+  		<% if presenter.more_parent_collections? %>
+  				<button id="show-more-parent-collections" class="btn show-more-parent-collections-btn"><%= t("hyrax.collections.show.show_more_parent_collections") %></button>
+  		<% end %>
+  	</div>
+  	<% if presenter.more_parent_collections? %>
+  		<div class="more-parent-collections-block" id="more-parent-collections">
+				<ul>
+	  			<% presenter.more_parent_collections.each do |document| %>
+	      		<%= render 'hyrax/dashboard/collections/show_parent_collection_row', id: presenter.id, document: document %>
+	  			<% end %>
+				</ul>
+  			<button id="show-less-parent-collections" class="btn show-less-parent-collections-btn"><%= t("hyrax.collections.show.show_less_parent_collections") %></button>
+  		</div>
+  	<% end %>
+  <% else %>
+		<ul>
+			<% presenter.parent_collections.documents.each do |document| %>
+	    	<%= render 'hyrax/dashboard/collections/show_parent_collection_row', id: presenter.id, document: document %>
+			<% end %>
+		</ul>
+    <div class="row">
+      <%= render 'hyrax/collections/paginate', solr_response: presenter.parent_collections, page_param_name: :parent_collection_page  %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/_subcollection_list.html.erb
+++ b/app/views/hyrax/dashboard/collections/_subcollection_list.html.erb
@@ -1,7 +1,6 @@
 <% if @subcollection_docs.nil? || @subcollection_docs.empty? %>
   <div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_subcollections') %></div>
 <% else %>
-<div id="remove_subcollection">
   <ul>
     <% @subcollection_docs.each do |document| %>
      <li style="margin: 5px 0">
@@ -16,6 +15,5 @@
       </li>
     <% end %>
   <ul>
-</div>
 <%= render 'hyrax/collections/paginate', solr_response: @subcollection_solr_response, page_param_name: :sub_collection_page  %>
 <% end %>

--- a/spec/views/hyrax/dashboard/collections/_show_parent_collection_row.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_parent_collection_row.html.erb_spec.rb
@@ -9,15 +9,31 @@ RSpec.describe 'hyrax/dashboard/collections/_show_parent_collection_row.html.erb
   let(:document) { SolrDocument.new(parent_collection_doc) }
   let(:subject) { render('show_parent_collection_row.html.erb', id: child_collection.id, document: document) }
 
-  before do
-    stub_template "_modal_remove_from_collection.html.erb" => 'modal'
-    allow(view).to receive(:can?).with(:edit, document.id).and_return(true)
+  context 'when user can edit the parent collection' do
+    before do
+      stub_template "_modal_remove_from_collection.html.erb" => 'modal'
+      allow(view).to receive(:can?).with(:edit, document.id).and_return(true)
+    end
+
+    it 'shows link to collection title and active remove button' do
+      subject
+      expect(rendered).to have_link(document.title.first)
+      expect(rendered).to have_button("Remove")
+      expect(subject).to render_template("_modal_remove_from_collection")
+    end
   end
 
-  it 'shows link to collection title and active remove button' do
-    subject
-    expect(rendered).to have_link(document.title.first)
-    expect(rendered).to have_button("Remove")
-    expect(subject).to render_template("_modal_remove_from_collection")
+  context 'disable button if no edit permission' do
+    before do
+      stub_template "_modal_remove_from_collection.html.erb" => 'modal'
+      allow(view).to receive(:can?).with(:edit, document.id).and_return(false)
+    end
+
+    it 'shows link to collection title and disabled remove button' do
+      subject
+      expect(rendered).to have_link(document.title.first)
+      expect(rendered).to have_button("Remove", disabled: true)
+      expect(subject).to render_template("_modal_remove_from_collection")
+    end
   end
 end


### PR DESCRIPTION
Related to comments on https://github.com/samvera/hyrax/pull/2692
- removes stray divs
- adds a test for when the remove button is disabled due to lack of edit authority to parent.

Completes issue #2295  

Issue #2726 would remove the need for additional feature specs to test whether the link is visible on the more/less segment of the parent list, so I am not adding any specs at this point for that feature. 

I will be revisiting the collection feature specs as part of issue #2686 which requires a fair amount of rework. 

@samvera/hyrax-code-reviewers
