### PR TITLE
Strip query params from manifest url to avoid bad url for IIIF icon in UV share panel

### DIFF
--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -2,7 +2,7 @@
   <% if defined?(viewer) && viewer %>
     <%= PulUvRails::UniversalViewer.script_tag %>
     <div class="viewer-wrapper">
-      <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter] %>"></div>
+      <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter], {} %>"></div>
     </div>
   <% else %>
     <%= media_display presenter.representative_presenter %>

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -80,6 +80,17 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
       it 'renders the UniversalViewer' do
         expect(page).to have_selector 'div.viewer'
       end
+
+      context 'with default_url_options' do
+        before do
+          allow(controller).to receive(:default_url_options).and_return(locale: I18n.locale)
+        end
+
+        it 'strips the locale from the manifest url' do
+          expect(controller.default_url_options.keys).to include :locale
+          expect(page.find_css('div.viewer')[0]['data-uri']).to eq '/concern/generic_works/999/manifest'
+        end
+      end
     end
 
     context 'when presenter says it is disabled' do


### PR DESCRIPTION
Fixes https://github.com/curationexperts/nurax/issues/186

I believe this fixes the problem where the manifest url of the IIIF icon on the share panel in Universal Viewer was messed up because of multiple '?'s.  I haven't been able to test locally as my hyrax dev environment is messed up and I can't get anything ingested.

For example this url was showing up in nurax:
https://nurax.curationexperts.com/concern/images/mw22v549p/manifest?locale=en?manifest=/concern/images/mw22v549p/manifest?locale=en

But it should have been:
https://nurax.curationexperts.com/concern/images/mw22v549p/manifest?manifest=/concern/images/mw22v549p/manifest

This PR strips the query params off of the manifest url as they shouldn't be necessary or really do anything.  I believe the locale was coming in from the default_url_options defined on the controller: https://github.com/samvera/hyrax/blob/master/app/controllers/concerns/hyrax/controller.rb#L18-L20

@geekscruff @julesies 