### PR TITLE
Don't show 'Remove Highlight Designation' in edit user profile without highlighted works.

### DIFF
--- a/app/views/hyrax/dashboard/profiles/_trophy_edit.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_trophy_edit.html.erb
@@ -1,14 +1,16 @@
-<div class="form-group">
-  <span>
-    <i class="glyphicon glyphicon-star trophy-on" ></i> Remove Highlight Designation
-    <a href="#" id="remove_trophy_help" data-toggle="popover" data-content="If you would like to remove a highlight designation, check the box and save your profile." data-original-title="Remove Highlight Designation"><i class="glyphicon glyphicon-question-sign"></i></a>
-  </span>
-  <% trophies.each do |t| %>
-    <div class="checkbox">
-      <label>
-        <%= check_box_tag "remove_trophy_#{t.id}" %>
-        <%= link_to t, [main_app, t] %>
-      </label>
-    </div>
-  <% end %>
-</div>
+<% if trophies.any? %> 
+  <div class="form-group">
+    <span>
+      <i class="glyphicon glyphicon-star trophy-on" ></i> Remove Highlight Designation
+      <a href="#" id="remove_trophy_help" data-toggle="popover" data-content="If you would like to remove a highlight designation, check the box and save your profile." data-original-title="Remove Highlight Designation"><i class="glyphicon glyphicon-question-sign"></i></a>
+    </span>
+    <% trophies.each do |t| %>
+      <div class="checkbox">
+        <label>
+          <%= check_box_tag "remove_trophy_#{t.id}" %>
+          <%= link_to t, [main_app, t] %>
+        </label>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/spec/views/hyrax/dashboard/profiles/_trophy_edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/profiles/_trophy_edit.html.erb_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe 'hyrax/dashboard/profiles/_trophy_edit.html.erb', type: :view do
+  let(:user) { stub_model(User, user_key: 'mjg') }
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  before do
+    allow(view).to receive(:signed_in?).and_return(true)
+    allow(view).to receive(:current_user).and_return(user)
+    assign(:user, user)
+  end
+
+  context "when there are no highlighted works" do
+    before do
+      assign(:trophies, [])
+      render 'edit_primary'
+    end
+
+    it "has no trophy" do
+      expect(page).not_to have_css('a#remove_trophy_help')
+      expect(page).not_to have_content('Remove Highlight Designation')
+    end
+  end
+
+  context "when there are highlighted works" do
+    let(:solr_document) { SolrDocument.new(id: 'abc123', has_model_ssim: 'GenericWork', title_tesim: ['Title']) }
+
+    before do
+      assign(:trophies, [Hyrax::TrophyPresenter.new(solr_document)])
+      render 'edit_primary'
+    end
+
+    it "has trophy" do
+      expect(page).to have_css('a#remove_trophy_help')
+      expect(page).to have_selector("#remove_trophy_abc123")
+    end
+  end
+end

--- a/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
@@ -38,16 +38,27 @@ RSpec.describe 'hyrax/dashboard/profiles/edit.html.erb', type: :view do
   end
 
   context "with trophy" do
-    let(:solr_document) { SolrDocument.new(id: 'abc123', has_model_ssim: 'GenericWork', title_tesim: ['Title']) }
     let(:page) { Capybara::Node::Simple.new(rendered) }
 
-    before do
-      assign(:trophies, [Hyrax::TrophyPresenter.new(solr_document)])
-      render
+    context "and there are no highlighted works" do
+      it "has no trophy" do
+        expect(page).not_to have_css('a#remove_trophy_help')
+        expect(page).not_to have_content('Remove Highlight Designation')
+      end
     end
 
-    it "has trophy" do
-      expect(page).to have_selector("#remove_trophy_abc123")
+    context "and there are highlighted works" do
+      let(:solr_document) { SolrDocument.new(id: 'abc123', has_model_ssim: 'GenericWork', title_tesim: ['Title']) }
+
+      before do
+        assign(:trophies, [Hyrax::TrophyPresenter.new(solr_document)])
+        render
+      end
+
+      it "has trophy" do
+        expect(page).to have_css('a#remove_trophy_help')
+        expect(page).to have_selector("#remove_trophy_abc123")
+      end
     end
   end
 

--- a/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
@@ -37,31 +37,6 @@ RSpec.describe 'hyrax/dashboard/profiles/edit.html.erb', type: :view do
     end
   end
 
-  context "with trophy" do
-    let(:page) { Capybara::Node::Simple.new(rendered) }
-
-    context "and there are no highlighted works" do
-      it "has no trophy" do
-        expect(page).not_to have_css('a#remove_trophy_help')
-        expect(page).not_to have_content('Remove Highlight Designation')
-      end
-    end
-
-    context "and there are highlighted works" do
-      let(:solr_document) { SolrDocument.new(id: 'abc123', has_model_ssim: 'GenericWork', title_tesim: ['Title']) }
-
-      before do
-        assign(:trophies, [Hyrax::TrophyPresenter.new(solr_document)])
-        render
-      end
-
-      it "has trophy" do
-        expect(page).to have_css('a#remove_trophy_help')
-        expect(page).to have_selector("#remove_trophy_abc123")
-      end
-    end
-  end
-
   context 'with Zotero integration enabled' do
     before do
       allow(Hyrax.config).to receive(:arkivo_api?) { true }


### PR DESCRIPTION
Fixes #1098

Don't show 'Remove Highlight Designation' in edit user profile when there are no highlighted works.

@samvera/hyrax-code-reviewers
