### PR TITLE
Restores button for add child work.

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -7,9 +7,22 @@
       <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
       <% if presenter.member_presenters.size > 1 %>
           <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
+      <% end %> 
+      <% if presenter.valid_child_concerns.length > 0 %>
+        <div class="btn-group">
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Attach Child <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <% presenter.valid_child_concerns.each do |concern| %>
+              <li>
+                <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
       <% end %>
   <% end %>
-
   <% if presenter.work_featurable? %>
       <%= link_to "Feature", hyrax.featured_work_path(presenter, format: :json),
           data: { behavior: 'feature' },

--- a/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
@@ -62,5 +62,15 @@ RSpec.describe 'hyrax/base/_show_actions.html.erb', type: :view do
         expect(rendered).to have_link 'File Manager'
       end
     end
+
+    context "when there are valid_child_concerns" do
+      before do
+        allow(presenter).to receive(:member_presenters).and_return([])
+        render 'hyrax/base/show_actions.html.erb', presenter: presenter
+      end
+      it "creates a link to add child work" do
+        expect(rendered).to have_link 'Attach Generic Work', href: "/concern/parent/#{presenter.id}/generic_works/new"
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #1371

Restores button for add child work

Changes proposed in this pull request:
*Ports the code from https://github.com/samvera/curation_concerns/blob/master/app/views/curation_concerns/base/_show_actions.html.erb#L7 

@samvera/hyrax-code-reviewers
