### PR TITLE
Revert to searching "member_of_collection_ids"

### DIFF
--- a/app/search_builders/hyrax/collection_member_search_builder.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder.rb
@@ -5,7 +5,7 @@ module Hyrax
     attr_reader :collection, :search_includes_models
 
     class_attribute :collection_membership_field
-    self.collection_membership_field = 'nesting_collection__parent_ids_ssim'
+    self.collection_membership_field = 'member_of_collection_ids_ssim'
 
     # Defines which search_params_logic should be used when searching for Collection members
     self.default_processor_chain += [:member_of_collection]

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hyrax::CollectionsController do
         end
       end
 
-      it "returns the collection and its members", :with_nested_reindexing do # rubocop:disable RSpec/ExampleLength
+      it "returns the collection and its members" do # rubocop:disable RSpec/ExampleLength
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :show, params: { id: collection }
         expect(response).to be_successful
@@ -43,7 +43,7 @@ RSpec.describe Hyrax::CollectionsController do
         expect(assigns[:subcollection_count]).to eq(2)
       end
 
-      context "and searching", :with_nested_reindexing do
+      context "and searching" do
         it "returns some works and subcollections" do
           # "/collections/4m90dv529?utf8=%E2%9C%93&cq=King+Louie&sort="
           get :show, params: { id: collection, cq: "Second" }

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         end
       end
 
-      it "returns the collection and its members", :with_nested_reindexing do
+      it "returns the collection and its members" do
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :show, params: { id: collection }
         expect(response).to be_successful
@@ -317,7 +317,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         expect(assigns[:subcollection_count]).to eq(2)
       end
 
-      context "and searching", :with_nested_reindexing do
+      context "and searching" do
         it "returns some works and collections" do
           # "/dashboard/collections/4m90dv529?utf8=%E2%9C%93&cq=King+Louie&sort="
           get :show, params: { id: collection, cq: "Second" }

--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_repo: true, js: true, with_nested_reindexing: true do
+RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_repo: true, js: true do
   let(:admin_user) { create(:admin, email: 'admin@example.com') }
   let(:single_membership_type_1) { create(:collection_type, :not_allow_multiple_membership, title: 'Single-membership 1') }
   let(:single_membership_type_2) { create(:collection_type, :not_allow_multiple_membership, title: 'Single-membership 2') }

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'collection', type: :feature, with_nested_reindexing: true do
+RSpec.describe 'collection', type: :feature, clean_repo: true do
   let(:user) { create(:user) }
 
   let(:collection1) { create(:public_collection, user: user) }

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       visit '/dashboard/my/collections'
     end
 
-    it 'lists all collections for all users', with_nested_reindexing: true do
+    it 'lists all collections for all users' do
       expect(page).to have_link 'All Collection'
       click_link 'All Collections'
       expect(page).to have_link(collection1.title.first)
@@ -293,6 +293,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
     end
   end
 
+  # TODO: this section is still deactivated
   describe "adding works to a collection", skip: "we need to define a dashboard/works path" do
     let!(:collection) { create!(:collection, title: ["Barrel of monkeys"], user: user, with_permission_template: true) }
     let!(:work1) { create(:work, title: ["King Louie"], user: user) }
@@ -531,7 +532,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
     end
   end
 
-  describe 'collection show page', with_nested_reindexing: true do
+  describe 'collection show page' do
     let(:collection) do
       create(:public_collection, user: user, description: ['collection description'], create_access: true)
     end
@@ -662,7 +663,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   end
 
   # TODO: this is just like the block above. Merge them.
-  describe 'show pages of a collection', with_nested_reindexing: true do
+  describe 'show pages of a collection' do
     before do
       docs = (0..12).map do |n|
         { "has_model_ssim" => ["GenericWork"], :id => "zs25x871q#{n}",
@@ -690,7 +691,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   end
 
   describe 'remove works from collection' do
-    context 'user that can edit', :with_nested_reindexing do
+    context 'user that can edit' do
       let!(:work2) { create(:work, title: ["King Louie"], member_of_collections: [collection1], user: user) }
       let!(:work1) { create(:work, title: ["King Kong"], member_of_collections: [collection1], user: user) }
 
@@ -778,14 +779,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
           expect(page).to have_field('collection_title', with: collection.title.first)
           expect(page).to have_field('collection_description', with: collection.description.first)
-
-          # TODO: These two expectations require the spec to include with_nested_reindexing: true.
-          # However, adding nested indexing causes this spec to fail to go through the update method
-          # in the controller unless js: true is also included. Including javascript greatly increases
-          # the time required for the spec to complete, so for now, I am simply commenting out these
-          # two expectations, as these are not integral to the function being tested.
-          # expect(page).to have_content(work1.title.first)
-          # expect(page).to have_content(work2.title.first)
 
           new_title = "Altered Title"
           new_description = "Completely new Description text."

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
       it { is_expected.to be_empty }
     end
 
-    context 'with a work/file attached', :with_nested_reindexing do
+    context 'with a work/file attached' do
       let!(:work) { create(:work_with_one_file, :public, member_of_collections: [collection]) }
       let(:title) { work.file_sets.first.title.first }
       let(:file_id) { work.file_sets.first.id }

--- a/spec/services/hyrax/collections/collection_member_service_spec.rb
+++ b/spec/services/hyrax/collections/collection_member_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Hyrax::Collections::CollectionMemberService, clean_repo: true, with_nested_reindexing: true do
+RSpec.describe Hyrax::Collections::CollectionMemberService, clean_repo: true do
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
   let(:current_ability) { instance_double(Ability, admin?: true) }


### PR DESCRIPTION
Resolves https://github.com/samvera/hyrax/issues/2686

Updates term in search builder. Removes "with_nested_reindexing" in specs where it is no longer necessary since the search builder no longer requires it.

@samvera/hyrax-code-reviewers
