### PR TITLE
GA download event from Work Items drop-down

### DIFF
--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -29,8 +29,12 @@
 
   <% if can?(:download, file_set.id) %>
     <li role="menuitem" tabindex="-1">
-      <%= link_to 'Download', hyrax.download_path(file_set),
-        title: "Download #{file_set.to_s.inspect}", target: "_blank" %>
+      <%= link_to 'Download',
+                  hyrax.download_path(file_set),
+                  title: "Download #{file_set.to_s.inspect}",
+                  target: "_blank",
+                  id: "file_download",
+                  data: { label: file_set.id } %>
     </li>
   <% end %>
 

--- a/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
+  let(:file_set) { stub_model(FileSet) }
+
+  before do
+    allow(view).to receive(:can?).with(:edit, file_set.id).and_return(false)
+    allow(view).to receive(:can?).with(:destroy, file_set.id).and_return(false)
+    allow(view).to receive(:can?).with(:download, file_set.id).and_return(true)
+    render 'hyrax/file_sets/actions', file_set: file_set
+  end
+
+  it "includes google analytics data in the download link" do
+    expect(rendered).to have_css('a#file_download')
+    expect(rendered).to have_selector("a[data-label=\"#{file_set.id}\"]")
+  end
+end


### PR DESCRIPTION
Fixes #2737 

Enables the tracking of download events from the "actions" drop-down on a Work's show page.

detail:
All file download links need to have `id=file_download` and a `data-label` attribute equal to the files NOID in order for the code here to send the event to Google Analytics:
https://github.com/samvera/hyrax/blob/df1e15894f41f4d31aeaddf39845c1f0a214a781/app/assets/javascripts/hyrax/ga_events.js#L6

@samvera/hyrax-code-reviewers
