### PR TITLE
Fix the IIIF share icon link and accurately test it

### DIFF
--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -2,7 +2,7 @@
   <% if defined?(viewer) && viewer %>
     <%= PulUvRails::UniversalViewer.script_tag %>
     <div class="viewer-wrapper">
-      <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter], {} %>"></div>
+      <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter], { locale: nil } %>"></div>
     </div>
   <% else %>
     <%= media_display presenter.representative_presenter %>

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -7,14 +7,18 @@ RSpec.describe "display a work as its owner" do
 
   context "as the work owner" do
     let(:work) do
-      create(:work_with_one_file,
+      create(:work,
              with_admin_set: true,
              title: ["Magnificent splendor"],
              source: ["The Internet"],
              based_near: ["USA"],
-             user: user)
+             user: user,
+             ordered_members: [file_set],
+             representative_id: file_set.id)
     end
     let(:user) { create(:user) }
+    let(:file_set) { create(:file_set, user: user, title: ['A Contained FileSet'], content: file) }
+    let(:file) { File.open(fixture_path + '/world.png') }
 
     before do
       sign_in user
@@ -31,6 +35,9 @@ RSpec.describe "display a work as its owner" do
       within '.related-files' do
         expect(page).to have_selector '.attribute-filename', text: 'A Contained FileSet'
       end
+
+      # IIIF manifest does not include locale query param
+      expect(find('div.viewer:first')['data-uri']).to eq "/concern/generic_works/#{work.id}/manifest"
     end
   end
 

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -80,17 +80,6 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
       it 'renders the UniversalViewer' do
         expect(page).to have_selector 'div.viewer'
       end
-
-      context 'with default_url_options' do
-        before do
-          allow(controller).to receive(:default_url_options).and_return(locale: I18n.locale)
-        end
-
-        it 'strips the locale from the manifest url' do
-          expect(controller.default_url_options.keys).to include :locale
-          expect(page.find_css('div.viewer')[0]['data-uri']).to eq '/concern/generic_works/999/manifest'
-        end
-      end
     end
 
     context 'when presenter says it is disabled' do


### PR DESCRIPTION
Fixes https://github.com/curationexperts/nurax/issues/186.  This PR corrects #2731.

This PR correctly removes the locale from the iiif manifest url passed to UV.  The view test was not actually recreating the original issue so I moved it into a feature test.