### PR TITLE
Add `data-sort` attributes to dataTables rows to support date sort

### DIFF
--- a/app/views/hyrax/notifications/_notifications.html.erb
+++ b/app/views/hyrax/notifications/_notifications.html.erb
@@ -12,7 +12,7 @@
       <tbody>
         <% messages.each do |msg| %>
           <tr>
-            <td>
+            <td data-sort="<%= msg.last_message.created_at.getutc.iso8601(5) %>">
               <relative-time datetime="<%= msg.last_message.created_at.getutc.iso8601 %>" title="<%= msg.last_message.created_at.to_formatted_s(:standard) %>">
                 <%= msg.last_message.created_at.to_formatted_s(:long_ordinal) %>
               </relative-time>

--- a/app/views/hyrax/transfers/_received.html.erb
+++ b/app/views/hyrax/transfers/_received.html.erb
@@ -13,7 +13,7 @@
     <% unless req.sending_user.blank? %>
     <tr>
       <td> <%= show_transfer_request_title(req) %> </td>
-      <td>
+      <td data-sort="<%= req.created_at.getutc.iso8601(5) %>">
         <relative-time datetime="<%= req.created_at.getutc.iso8601 %>" title="<%= req.created_at.to_formatted_s(:standard) %>">
           <%= req.created_at.to_formatted_s(:long_ordinal) %>
         </relative-time>

--- a/app/views/hyrax/transfers/_sent.html.erb
+++ b/app/views/hyrax/transfers/_sent.html.erb
@@ -13,7 +13,7 @@
       <% unless req.receiving_user.blank? %>
         <tr>
           <td> <%= show_transfer_request_title(req) %> </td>
-          <td>
+          <td data-sort="<%= req.created_at.getutc.iso8601(5) %>">
             <relative-time datetime="<%= req.created_at.getutc.iso8601 %>" title="<%= req.created_at.to_formatted_s(:standard) %>">
               <%= req.created_at.to_formatted_s(:long_ordinal) %>
             </relative-time>

--- a/app/views/hyrax/users/_activity_log.html.erb
+++ b/app/views/hyrax/users/_activity_log.html.erb
@@ -10,8 +10,8 @@
     <% next if event[:action].blank? or event[:timestamp].blank? %>
     <tr>
       <td><%= event[:action].html_safe %></td>
-      <td>
-        <% time = Time.zone.at(event[:timestamp].to_i) %>
+      <% time = Time.zone.at(event[:timestamp].to_i) %>
+      <td data-sort="<%= time.getutc.iso8601(5) %>">
         <relative-time datetime="<%= time.getutc.iso8601 %>" title="<%= time.to_formatted_s(:standard) %>">
           <%= time.to_formatted_s(:long_ordinal) %>
         </relative-time>


### PR DESCRIPTION
Adding a `data-sort` with ISO 8601 datetimes allows dataTables to sort
independent of the visible row values. We continue to use javascript to generate
the human-readable time for the reasons given in  #1416 (support for page
caching).

We sort to `#iso8601(5)` (i.e. to 5 decimal places). This still allows a
mismatch between displayed times and correctly sorted times (off by o.ne second),
apparently due to rounding behavior in the javascript sort dates. The actual
dates sort correctly, so display dates sort themselves out (ha!) as a
notification ages past one minute.

Related to #1653; backports #2741.

@samvera/hyrax-code-reviewers
