### PR TITLE
Lock `simple_form` less strictly

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -105,8 +105,9 @@ SUMMARY
   ########################################################
   # Temporarily pinned dependencies. INCLUDE EXPLANATIONS.
   #
-  # simple_form 3.5.1 broke local and Travis builds in bad ways for unknown reasons
-  spec.add_dependency 'simple_form', '=3.5.0'
+  # simple_form 3.5.1 broke hydra-editor for certain model types;
+  #   see: https://github.com/plataformatec/simple_form/issues/1549
+  spec.add_dependency 'simple_form', '~> 3.2', '<= 3.5.0'
   # parser 2.5.0.0 broke local and Travis rubocop checks due to a change in parsing
   spec.add_development_dependency 'parser', '< 2.5'
 end


### PR DESCRIPTION
We previously supported `~> 3.2`. The regression introduced in v3.5.1 is
described at https://github.com/plataformatec/simple_form/issues/1549. We'll
need to fix our presenters to be `ActiveModel` compliant to make `simple_form`
work correctly past that version.

In the meanwhile, we shouldn't require any simple_form upgrade as part of an
upcoming Hyrax release.

@samvera/hyrax-code-reviewers
