### PR TITLE
fixes situation in which embargo update receives file_set ids in its …

### DIFF
--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -25,7 +25,13 @@ module Hyrax
       copy_visibility = params[:embargoes].values.map { |h| h[:copy_visibility] }
       ActiveFedora::Base.find(batch).each do |curation_concern|
         Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
-        curation_concern.copy_visibility_to_files if copy_visibility.include?(curation_concern.id)
+        # if the concern is a FileSet, set its visibility and skip the copy_visibility_to_files, which is built for Works
+        if curation_concern.file_set?
+          curation_concern.visibility = curation_concern.to_solr["visibility_after_embargo_ssim"]
+          curation_concern.save!
+        elsif copy_visibility.include?(curation_concern.id)
+          curation_concern.copy_visibility_to_files
+        end
       end
       redirect_to embargoes_path
     end

--- a/spec/controllers/hyrax/embargoes_controller_spec.rb
+++ b/spec/controllers/hyrax/embargoes_controller_spec.rb
@@ -2,7 +2,6 @@ RSpec.describe Hyrax::EmbargoesController do
   let(:user) { create(:user) }
   let(:a_work) { create(:generic_work, user: user) }
   let(:not_my_work) { create(:generic_work) }
-
   before { sign_in user }
 
   describe '#index' do
@@ -98,6 +97,37 @@ RSpec.describe Hyrax::EmbargoesController do
           patch :update, params: { batch_document_ids: [a_work.id], embargoes: { '0' => { copy_visibility: a_work.id } } }
           expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
           expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          expect(response).to redirect_to embargoes_path
+        end
+      end
+
+      context 'with an expired embargo and filesets in batch_document_ids and in embargoes' do
+        let(:file_set2) { create(:file_set, id: 'fileset_2', visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+        let(:file_set3) { create(:file_set, id: 'fileset_3', visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+        let(:release_date) { Time.zone.today - 2 }
+        let(:batch) { [file_set2.id, a_work.id] }
+        before do
+          file_set2.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          file_set2.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          file_set2.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          file_set2.embargo_release_date = release_date.to_s
+          file_set2.embargo.save(validate: false)
+          file_set2.save(validate: false)
+          file_set3.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          file_set3.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          file_set3.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          file_set3.embargo_release_date = release_date.to_s
+          file_set3.embargo.save(validate: false)
+          file_set3.save(validate: false)
+        end
+
+        it 'deactivates embargo, updates the visibility and redirects' do
+          allow(controller).to receive(:filter_docs_with_edit_access!).and_return(true)
+          patch :update, params: { batch_document_ids: batch, embargoes: { '0' => { copy_visibility: file_set2.id }, '1' => { copy_visibility: a_work.id } } }
+          expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          expect(file_set2.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          expect(file_set3.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
           expect(response).to redirect_to embargoes_path
         end
       end


### PR DESCRIPTION
…batch_document_ids. This raised an error, because the update action did not expect FileSet ids among them, and called a method only found in Works on them, which copies the Work's after-embargo visibility to it FileSets. The fix checks all objects to determine if they are FileSets and if so, updates their visibility to their after-embargo visibility, and will not call the Work method on them.

I think the UI could be better implemented to avoid this situation, but at a later date.

Fixes #2676 ; refs #2676

@samvera/hyrax-code-reviewers
