### PR TITLE
Update to search results layout

### DIFF
--- a/app/assets/stylesheets/hyrax/_catalog.scss
+++ b/app/assets/stylesheets/hyrax/_catalog.scss
@@ -25,12 +25,14 @@
 // Styles added to help with newly implemented
 // Bootstrap row / column setup for search results
 .search-result-wrapper {
-  padding-bottom: 30px;
+  border-bottom: 1px dashed #ccc;
+  margin-bottom: 30px;
+  padding-bottom: 0;
 
   .search-results-title-row {
     align-items: center;
     display: flex;
-    padding: 0 0 10px;
+    padding: 0 0 15px;
 
     .search-result-title {
       display: inline-block;
@@ -53,36 +55,38 @@
 
   .list-thumbnail {
     float: none;
+    padding-bottom: 20px;
     width: 100%;
+
+    @media (max-width: 768px) {
+      img {
+        max-height: 200px;
+      }
+
+    }
+  }
+
+  .collection-icon-search {
+    padding-bottom: 20px;
   }
 
   .metadata {
     width: 100%;
   }
 
-  .metadata-row {
-
-    > div:first-child {
-      font-weight: bold;
-      padding-right: 0;
-      text-align: right;
-
-      @media (max-width: 768px) {
-        text-align: left;
-      }
-    }
-  }
-
   .collection-counts-wrapper {
     text-align: right;
 
-    @media (max-width: 768px) {
+    @media (max-width: 992px) {
       text-align: left;
     }
 
     .collection-counts-item {
       background-color: #f5f5f5;
+      color: #666;
       display: inline-block;
+      font-size: 13px;
+      font-weight: bold;
       margin-left: 10px;
       padding: 8px;
       text-align: center;
@@ -94,6 +98,7 @@
       span {
         display: block;
         font-size: 18px;
+        font-weight: normal;
         line-height: 1;
       }
     }

--- a/app/assets/stylesheets/hyrax/_settings.scss
+++ b/app/assets/stylesheets/hyrax/_settings.scss
@@ -22,7 +22,7 @@ $icon-border-color-hover: $gray-base !default;
 $icon-font-color-hover: $gray-base !default;
 
 // Collection Icon
-$collection-icon-search-lg: 8em !default;
+$collection-icon-search-lg: 7em !default;
 
 // File Show Page
 $file-show-term-color: $gray-dark !default;

--- a/app/views/catalog/_index_header_list_collection.html.erb
+++ b/app/views/catalog/_index_header_list_collection.html.erb
@@ -1,4 +1,4 @@
 <div class="search-results-title-row">
-  <h3 class="search-result-title"><%= link_to document.title_or_label, [hyrax, document] %></h3>
+  <h4 class="search-result-title"><%= link_to document.title_or_label, [hyrax, document] %></h4>
   <span class="label label-success"><%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %></span>
 </div>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,3 +1,3 @@
 <div class="search-results-title-row">
-  <h3 class="search-result-title"><%= link_to document.title_or_label, document %></h3>
+  <h4 class="search-result-title"><%= link_to document.title_or_label, document %></h4>
 </div>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,23 +1,19 @@
-<div class="col-sm-5">
+<div class="col-md-6">
   <div class="metadata">
+    <dl class="dl-horizontal">
     <% doc_presenter = index_presenter(document) %>
     <% index_fields(document).each do |field_name, field| -%>
       <% if should_render_index_field? document, field %>
-        <div class="row metadata-row">
-          <div class="col-sm-4">
-            <%= render_index_field_label document, field: field_name %>
-          </div>
-          <div class="col-sm-8">
-            <%= doc_presenter.field_value field_name %>
-          </div>
-        </div>
+          <dt><%= render_index_field_label document, field: field_name %></dt>
+          <dd><%= doc_presenter.field_value field_name %></dd>
       <% end %>
     <% end %>
+    </dl>
   </div>
 </div>
 <% if(doc_presenter.field_value('has_model_ssim') == 'Collection') %>
     <% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
-<div class="col-sm-4">
+<div class="col-md-4">
   <div class="collection-counts-wrapper">
     <div class="collection-counts-item">
       <span><%= collection_presenter.total_viewable_collections %></span>Collections

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,3 +1,3 @@
-<div class="col-sm-3">
+<div class="col-md-2">
   <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-search"></span>
 </div>

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,4 +1,4 @@
-<div class="col-sm-3">
+<div class="col-md-2">
   <div class="list-thumbnail">
     <%= render_thumbnail_tag document %>
   </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -27,7 +27,7 @@ en:
           keyword: Keyword
       filters:
         title: 'Filtering by:'
-      start_over: Clear filters
+      start_over: 'Start Over'
   errors:
     messages:
       carrierwave_download_error: Couldn't download image.


### PR DESCRIPTION
Fixes #2680 
Updates to Search Results layout.

Added in some dividing lines between search results, and some other UI enhancements to make the results page more closely match the mockup provided in #2680 
