### PR TITLE
Add initial finders for ResourceStat

### DIFF
--- a/app/models/resource_stat.rb
+++ b/app/models/resource_stat.rb
@@ -5,4 +5,17 @@
 # `user_id` and a `resource_id`. But that is dependent on context and documented in the scopes and related tests.
 class ResourceStat < ApplicationRecord
   validates :date, presence: true
+
+  # Daily statistics for a given resource (Work, FileSet) associated with a User
+  scope :resource_daily_stats, ->(date, resource_id, user_id) { where('date = ? AND resource_id = ? AND user_id = ?', date, resource_id, user_id) }
+  # Daily statistics for the site
+  scope :site_daily_stats, ->(date) { where('date = ? AND resource_id IS NULL AND user_id IS NULL', date) }
+
+  # Statistics for a given resource (Work, FileSet) associated with a User, in a time range
+  scope :resource_range_stats, ->(start_date, end_date, resource_id, user_id) { where('date BETWEEN ? AND ? AND resource_id = ? AND user_id = ?', start_date, end_date, resource_id, user_id) }
+  # Statistics for the site, in a time range
+  scope :site_range_stats, ->(start_date, end_date) { where('date BETWEEN ? AND ? AND resource_id IS NULL AND user_id IS NULL', start_date, end_date) }
+
+
+
 end

--- a/spec/models/resource_stat_spec.rb
+++ b/spec/models/resource_stat_spec.rb
@@ -9,4 +9,61 @@ RSpec.describe ResourceStat, type: :model do
     expect { described_class.create! }.to raise_error ActiveRecord::RecordInvalid
     expect { subject.save! }.not_to raise_error
   end
+
+  describe ".resource_daily_stats" do
+    let(:date) { DateTime.new(2018, 3, 2).in_time_zone }
+    let(:non_matching_date) { DateTime.new(2017, 2, 2).in_time_zone }
+    let(:user_id) { 123 }
+    let(:resource_id) { "199" }
+
+    it 'finds daily statistics for a given resource' do
+      ResourceStat.create(date: date, pageviews: 123, resource_id: resource_id, user_id: 123)
+      ResourceStat.create(date: non_matching_date, pageviews: 456, resource_id: resource_id, user_id: 123)
+
+      expect(ResourceStat.resource_daily_stats(date, resource_id, user_id).map(&:pageviews)).to eq([123])
+    end
+  end
+
+  describe ".site_daily_stats" do
+    let(:date) { DateTime.new(2018, 3, 2).in_time_zone }
+    let(:user_id) { 123 }
+    let(:resource_id) { "199" }
+
+    it 'finds site-wide statistics and ignores resource statistics' do
+      ResourceStat.create(date: date, unique_visitors: 123)
+      ResourceStat.create(date: date, unique_visitors: 456, resource_id: resource_id, user_id: 123)
+
+      expect(ResourceStat.site_daily_stats(date).map(&:unique_visitors)).to eq([123])
+    end
+  end
+
+  describe ".resource_range_stats" do
+    let(:start_date) { DateTime.new(2018, 2, 2).in_time_zone }
+    let(:end_date) { DateTime.new(2018, 3, 2).in_time_zone }
+    let(:user_id) { 123 }
+    let(:resource_id) { "199" }
+
+    it 'finds statistics for a resource in a given time range' do
+      ResourceStat.create(date: DateTime.new(2018, 2, 4).in_time_zone, unique_visitors: 123, resource_id: resource_id, user_id: 123)
+      ResourceStat.create(date: DateTime.new(2018, 2, 17).in_time_zone, unique_visitors: 234, resource_id: resource_id, user_id: 123)
+      ResourceStat.create(date: DateTime.new(2018, 3, 9).in_time_zone, unique_visitors: 567, resource_id: resource_id, user_id: 123)
+
+      expect(ResourceStat.resource_range_stats(start_date, end_date, resource_id, user_id).map(&:unique_visitors)).to eq([123, 234])
+    end
+  end
+
+  describe ".site_range_stats" do
+    let(:start_date) { DateTime.new(2018, 2, 2).in_time_zone }
+    let(:end_date) { DateTime.new(2018, 3, 2).in_time_zone }
+    let(:user_id) { 123 }
+    let(:resource_id) { "199" }
+
+    it 'finds site-wide statistics in a given time range' do
+      ResourceStat.create(date: DateTime.new(2018, 2, 4).in_time_zone, unique_visitors: 123)
+      ResourceStat.create(date: DateTime.new(2018, 2, 17).in_time_zone, unique_visitors: 234, resource_id: resource_id, user_id: 123)
+      ResourceStat.create(date: DateTime.new(2018, 3, 9).in_time_zone, unique_visitors: 567)
+
+      expect(ResourceStat.site_range_stats(start_date, end_date).map(&:unique_visitors)).to eq([123])
+    end
+  end
 end


### PR DESCRIPTION
Changes proposed:
  * `resource_daily_stats` - daily stats query for a user/resource
combination
  * `site_daily_stats` - daily stats query for the entire site
  * `resource_range_stats` - date range query for a user/resource
combination
  * `site_range_stats` - date range query for the entire site

@nestorw @lfarrell -- Please let me know if these initial queries are a good starting point, if I'm missing any that should be added, etc. I tried to base these on what I'm seeing in the mockups, assuming there might be some front-end manipulation/sorting of the data. So, feedback welcome :smile: 

Fixes #2736 

@samvera/hyrax-code-reviewers 
