### PR TITLE
Updates to dashboard collection show ui

### DIFF
--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -42,6 +42,35 @@ header {
   text-align: center;
 }
 
+// Wrapper class for <ul> display list of parent collections, sub collections
+.collections-list {
+  li {
+    margin: 5px 0;
+  }
+
+  .flex-wrapper {
+    align-items: flex-start;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .collections-list-title {
+    font-weight: bold;
+    padding-right: 10px;
+  }
+
+  @media (max-width: 768px) {
+    .flex-wrapper,
+    .collections-list-title {
+      display: block;
+    }
+
+    .collections-list-title {
+      padding-bottom: 10px;
+    }
+  }
+}
+
 .actions-controls-collections {
   display: block;
   margin: 1em 0 0 1em;
@@ -262,7 +291,7 @@ button.branding-banner-remove:hover {
     display: flex;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @media (max-width: 992px) {
       display: block;
     }
 
@@ -270,25 +299,34 @@ button.branding-banner-remove:hover {
       align-items: center;
       display: flex;
 
-      @media (max-width: 768px) {
+      @media (max-width: 992px) {
         display: block;
         margin-bottom: 10px;
+      }
 
+      .label {
+        margin-left: 5px;
+      }
+
+      @media (max-width: 768px) {
         .btn {
           display: block;
           margin: 0 0 5px;
           width: 100%;
         }
       }
-
-      .label {
-        margin-left: 5px;
-      }
     }
 
     .collection-title {
       display: inline-block;
       margin: 0;
+      padding-right: 5px;
+
+      // Wraps each collection title text, and helpful when there are multiple titles
+      span {
+        display: block;
+        padding-bottom: 5px;
+      }
     }
   }
 

--- a/app/assets/stylesheets/hyrax/_modal.scss
+++ b/app/assets/stylesheets/hyrax/_modal.scss
@@ -2,3 +2,7 @@ div.collection-list legend {
   font-size: 1.4em;
   border: none;
 }
+
+.modal-body select {
+  max-width: 100%;
+}

--- a/app/views/hyrax/dashboard/collections/_collection_title.html.erb
+++ b/app/views/hyrax/dashboard/collections/_collection_title.html.erb
@@ -6,20 +6,20 @@
   data-colls-hash="<%= presenter.available_parent_collections(scope: controller) %>"
   data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
   data-post-delete-url="<%= hyrax.dashboard_collection_path(id) %>">
-  <% presenter.title.each_with_index do |title, index| %>
-    <% if index == 0 %>
-      <div class="collection-title-row-content">
-        <h3 class="collection-title"><%= title %></h3>
-        <%= presenter.permission_badge %>
-        <span class="label label-success">
-          <%= presenter.collection_type_badge %>
-        </span>
-      </div>
-      <div class="collection-title-row-content">
-        <%= render 'show_actions', presenter: presenter %>
-      </div>
-    <% else %>
-      <h3><%= title %></h3>
-    <% end %>
-  <% end %>
+
+    <div class="collection-title-row-content">
+      <h3 class="collection-title">
+        <% # List multiple titles %>
+        <% presenter.title.each_with_index do |title, index| %>
+          <span><%= title %></span>
+        <% end %>
+      </h3>
+      <%= presenter.permission_badge %>
+      <span class="label label-success">
+        <%= presenter.collection_type_badge %>
+      </span>
+    </div>
+    <div class="collection-title-row-content">
+      <%= render 'show_actions', presenter: presenter %>
+    </div>
 </section>

--- a/app/views/hyrax/dashboard/collections/_show_parent_collection_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_parent_collection_row.html.erb
@@ -1,6 +1,10 @@
-<li style="margin: 5px 0">
-	<%# TODO: move styling into CSS %>
-	<strong><%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %></strong>
-	<button class="btn btn-xs btn-danger remove-from-collection-button pull-right" <%= "disabled" unless can? :edit, document.id %>><%= t('hyrax.collections.show.buttons.remove_from_collection') %></button>
+<li>
+	<div class="flex-wrapper">
+		<div class="collections-list-title">
+			<%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
+		</div>
+		<button class="btn btn-xs btn-danger remove-from-collection-button" <%= "disabled" unless can? :edit, document.id %>><%= t('hyrax.collections.show.buttons.remove_from_collection') %></button>
+	</div>
+
 	<%= render 'modal_remove_from_collection', child_id: id, parent_id: document.id %>
 </li>

--- a/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_parent_collections.html.erb
@@ -3,7 +3,7 @@
 <% else %>
   <% if presenter.use_parent_more_less? %>
   	<div class="less-parent-collections-block" id="less-parent-collections">
-			<ul>
+			<ul class="collections-list">
 	  		<% presenter.visible_parent_collections.each do |document| %>
 	      	<%= render 'hyrax/dashboard/collections/show_parent_collection_row', id: presenter.id, document: document %>
 	  		<% end %>
@@ -14,7 +14,7 @@
   	</div>
   	<% if presenter.more_parent_collections? %>
   		<div class="more-parent-collections-block" id="more-parent-collections">
-				<ul>
+				<ul class="collections-list">
 	  			<% presenter.more_parent_collections.each do |document| %>
 	      		<%= render 'hyrax/dashboard/collections/show_parent_collection_row', id: presenter.id, document: document %>
 	  			<% end %>
@@ -23,7 +23,7 @@
   		</div>
   	<% end %>
   <% else %>
-		<ul>
+		<ul class="collections-list">
 			<% presenter.parent_collections.documents.each do |document| %>
 	    	<%= render 'hyrax/dashboard/collections/show_parent_collection_row', id: presenter.id, document: document %>
 			<% end %>

--- a/app/views/hyrax/dashboard/collections/_subcollection_list.html.erb
+++ b/app/views/hyrax/dashboard/collections/_subcollection_list.html.erb
@@ -1,19 +1,22 @@
 <% if @subcollection_docs.nil? || @subcollection_docs.empty? %>
-  <div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_subcollections') %></div>
+<div class="alert alert-warning" role="alert"><%= t('hyrax.collections.show.no_visible_subcollections') %></div>
 <% else %>
-  <ul>
-    <% @subcollection_docs.each do |document| %>
-     <li style="margin: 5px 0">
-   	   <%# TODO: move styling into CSS %>
-       <strong>
+<ul class="collections-list">
+  <% @subcollection_docs.each do |document| %>
+  <li>
+    <div class="flex-wrapper">
+      <div class="collections-list-title">
         <%= link_to document.title_or_label, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
-        </strong>
-         <% if can? :edit, id %>
-          <button class="btn btn-xs btn-danger remove-subcollection-button pull-right"><%= t('hyrax.collections.show.buttons.remove_this_sub_collection') %></button>
-          <%= render 'modal_remove_sub_collection', parent_id: id, child_id: document.id %>
-         <% end %>
-      </li>
+      </div>
+      <% if can? :edit, id %>
+      <button class="btn btn-xs btn-danger remove-subcollection-button"><%= t('hyrax.collections.show.buttons.remove_this_sub_collection') %></button>
+      <% end %>
+    </div>
+    <% if can? :edit, id %>
+    <%= render 'modal_remove_sub_collection', parent_id: id, child_id: document.id %>
     <% end %>
-  <ul>
+  </li>
+  <% end %>
+</ul>
 <%= render 'hyrax/collections/paginate', solr_response: @subcollection_solr_response, page_param_name: :sub_collection_page  %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -22,8 +22,8 @@
             <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
                 <h4><%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)</h4>
                 <section class="parent-collections-wrapper">
-                <%= render 'hyrax/dashboard/collections/show_parent_collections', presenter: @presenter %>
-              </section>
+                  <%= render 'hyrax/dashboard/collections/show_parent_collections', presenter: @presenter %>
+                </section>
             <% end %>
 
             <!-- Collection Description(s) -->
@@ -65,11 +65,11 @@
         <section class="sub-collections-wrapper">
           <h4><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h4>
           <div class="row">
-            <div class="col-sm-6">
+            <div class="col-md-7">
               <%= render 'subcollection_list', id: @presenter.id, collection: @subcollection_docs %>
             </div>
             <% unless has_collection_search_parameters? %>
-              <div class="col-sm-6">
+              <div class="col-md-5">
                 <%= render 'show_subcollection_actions', presenter: @presenter %>
               </div>
             <% end %>


### PR DESCRIPTION
Fixes #2685 
UI updates to the Collections show page modal select box (for very long Collection titles), and general layout updates for collections with multiple titles and very long titles.

Here are some attached screenshots.  It should work for responsive screen sizes as well.

![collections-show-ui-cleanup-modal](https://user-images.githubusercontent.com/3020266/37057018-a882eeb2-214b-11e8-96bc-c9ff08570082.png)
![collections-show-ui-cleanup-modal2](https://user-images.githubusercontent.com/3020266/37057019-a8948c44-214b-11e8-99cb-b3e5b0a8f8fc.png)
![collections-show-ui-cleanup](https://user-images.githubusercontent.com/3020266/37057020-a8a4b9de-214b-11e8-987b-357f816e8041.png)
