### PR TITLE
Add unique and returning site-wide stats

### DIFF
--- a/app/models/resource_stat.rb
+++ b/app/models/resource_stat.rb
@@ -15,4 +15,10 @@ class ResourceStat < ApplicationRecord
   scope :resource_range_stats, ->(start_date, end_date, resource_id, user_id) { where('date BETWEEN ? AND ? AND resource_id = ? AND user_id = ?', start_date, end_date, resource_id, user_id) }
   # Statistics for the site, in a time range
   scope :site_range_stats, ->(start_date, end_date) { where('date BETWEEN ? AND ? AND resource_id IS NULL AND user_id IS NULL', start_date, end_date) }
+
+  # Queries for Hyrax::Statistics queries
+
+  # Unique visitors for the site
+  scope :site_unique_visitors, -> { select('unique_visitors').where('resource_id IS NULL AND user_id IS NULL') }
+  scope :site_returning_visitors, -> { select('returning_visitors').where('resource_id IS NULL AND user_id IS NULL') }
 end

--- a/app/presenters/hyrax/admin/user_activity_presenter.rb
+++ b/app/presenters/hyrax/admin/user_activity_presenter.rb
@@ -7,34 +7,22 @@ module Hyrax
       end
 
       def as_json(*)
-        new_users_list = { name: I18n.translate('hyrax.dashboard.show_admin.new_visitors'), data: [] }
-        returning_users_list = { name: I18n.translate('hyrax.dashboard.show_admin.returning_visitors'), data: [] }
+        unique_visitors_list = { name: I18n.translate('hyrax.dashboard.show_admin.new_visitors'), data: unique_visitors.to_a }
+        returning_visitors_list = { name: I18n.translate('hyrax.dashboard.show_admin.returning_visitors'), data: returning_visitors.to_a }
 
-        new_users.to_a.zip(returning_users.to_a).map do |e|
-          new_users_list[:data] << [e.first.first, e.first.last]
-
-          visitor_count = if e.last.nil?
-                            0
-                          else
-                            e.last
-                          end
-
-          returning_users_list[:data] << [e.first.first, visitor_count]
-        end
-
-        [new_users_list, returning_users_list]
+        [unique_visitors_list, returning_visitors_list]
       end
 
       private
 
-        def new_users
-          Hyrax::Statistics::Users::OverTime.new(x_min: @x_min,
-                                                 x_output: @date_format).points
+        def unique_visitors
+          Hyrax::Statistics::Site::UniqueVisitors.new(x_min: @x_min,
+                                                      x_output: @date_format).points
         end
 
-        # TODO: using google analytics
-        def returning_users
-          []
+        def returning_visitors
+          Hyrax::Statistics::Site::ReturningVisitors.new(x_min: @x_min,
+                                                         x_output: @date_format).points
         end
     end
   end

--- a/app/services/hyrax/statistics/site/returning_visitors.rb
+++ b/app/services/hyrax/statistics/site/returning_visitors.rb
@@ -1,0 +1,34 @@
+module Hyrax
+  module Statistics
+    module Site
+      class ReturningVisitors < Statistics::OverTime
+        # Overridden to do a noncumulative query
+        def points
+          Enumerator.new(size) do |y|
+            x = @x_min
+            while x <= @x_max
+              bottom = x
+              x += @delta_x.days
+              y.yield [@x_output.call(x), point(bottom, x)]
+            end
+          end
+        end
+
+        private
+
+          def relation
+            ResourceStat.site_returning_visitors
+          end
+
+          def point(min, max)
+            relation.where(query(min, max)).sum('returning_visitors')
+          end
+
+          # Override to make an activerecord date range query
+          def query(min, max)
+            { date: min..max }
+          end
+      end
+    end
+  end
+end

--- a/app/services/hyrax/statistics/site/unique_visitors.rb
+++ b/app/services/hyrax/statistics/site/unique_visitors.rb
@@ -1,0 +1,34 @@
+module Hyrax
+  module Statistics
+    module Site
+      class UniqueVisitors < Statistics::OverTime
+        # Overridden to do a noncumulative query
+        def points
+          Enumerator.new(size) do |y|
+            x = @x_min
+            while x <= @x_max
+              bottom = x
+              x += @delta_x.days
+              y.yield [@x_output.call(x), point(bottom, x)]
+            end
+          end
+        end
+
+        private
+
+          def relation
+            ResourceStat.site_unique_visitors
+          end
+
+          def point(min, max)
+            relation.where(query(min, max)).sum('unique_visitors')
+          end
+
+          # Override to make an activerecord date range query
+          def query(min, max)
+            { date: min..max }
+          end
+      end
+    end
+  end
+end

--- a/spec/models/resource_stat_spec.rb
+++ b/spec/models/resource_stat_spec.rb
@@ -66,4 +66,28 @@ RSpec.describe ResourceStat, type: :model do
       expect(ResourceStat.site_range_stats(start_date, end_date).map(&:unique_visitors)).to eq([123])
     end
   end
+
+  describe ".site_unique_visitors" do
+    let(:user_id) { 123 }
+    let(:resource_id) { "199" }
+
+    it 'finds site-wide statistics in a given time range' do
+      ResourceStat.create(date: DateTime.new(2018, 2, 4).in_time_zone, unique_visitors: 123)
+      ResourceStat.create(date: DateTime.new(2018, 2, 17).in_time_zone, unique_visitors: 234, resource_id: resource_id, user_id: 123)
+
+      expect(ResourceStat.site_unique_visitors.map(&:unique_visitors)).to eq([123])
+    end
+  end
+
+  describe ".site_returning_visitors" do
+    let(:user_id) { 123 }
+    let(:resource_id) { "199" }
+
+    it 'finds site-wide statistics in a given time range' do
+      ResourceStat.create(date: DateTime.new(2018, 2, 4).in_time_zone, returning_visitors: 123)
+      ResourceStat.create(date: DateTime.new(2018, 2, 17).in_time_zone, returning_visitors: 234, resource_id: resource_id, user_id: 123)
+
+      expect(ResourceStat.site_returning_visitors.map(&:returning_visitors)).to eq([123])
+    end
+  end
 end

--- a/spec/presenters/hyrax/admin/user_activity_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin/user_activity_presenter_spec.rb
@@ -4,17 +4,23 @@ RSpec.describe Hyrax::Admin::UserActivityPresenter do
   describe "#to_json" do
     subject { instance.to_json }
 
-    let(:users) do
-      instance_double(Hyrax::Statistics::Users::OverTime,
-                      points: [['2017-02-16', '12']])
+    let(:unique_visitors) do
+      instance_double(Hyrax::Statistics::Site::UniqueVisitors,
+                      points: [["Feb 21", 0], ["Feb 28", 20], ["Mar 7", 10]])
+    end
+
+    let(:returning_visitors) do
+      instance_double(Hyrax::Statistics::Site::ReturningVisitors,
+                      points: [["Feb 21", 5], ["Feb 28", 10], ["Mar 7", 0]])
     end
 
     before do
-      allow(Hyrax::Statistics::Users::OverTime).to receive(:new).and_return(users)
+      allow(Hyrax::Statistics::Site::UniqueVisitors).to receive(:new).and_return(unique_visitors)
+      allow(Hyrax::Statistics::Site::ReturningVisitors).to receive(:new).and_return(returning_visitors)
     end
 
     it "returns points" do
-      expect(subject).to eq '[{"name":"New Visitors","data":[["2017-02-16","12"]]},{"name":"Returning Visitors","data":[["2017-02-16",0]]}]'
+      expect(subject).to eq '[{"name":"New Visitors","data":[["Feb 21",0],["Feb 28",20],["Mar 7",10]]},{"name":"Returning Visitors","data":[["Feb 21",5],["Feb 28",10],["Mar 7",0]]}]'
     end
   end
 end

--- a/spec/services/hyrax/statistics/site/returning_visitors_spec.rb
+++ b/spec/services/hyrax/statistics/site/returning_visitors_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Hyrax::Statistics::Site::ReturningVisitors do
+  before do
+    ResourceStat.create(date: 1.week.ago, returning_visitors: 20)
+    ResourceStat.create(date: 2.days.ago, returning_visitors: 10)
+    ResourceStat.create(date: 1.week.ago, returning_visitors: 5, resource_id: '199', user_id: 123)
+  end
+
+  let(:instance) do
+    described_class.new(x_min: 3.weeks.ago,
+                        x_output: ->(x) { x.strftime('%b %-d') })
+  end
+
+  describe "#points" do
+    subject { instance.points }
+
+    it "has returning_visitor counts" do
+      expect(subject.size).to eq 4
+      expect(subject.to_a.second.last).to eq 20
+      expect(subject.to_a.third.last).to eq 10
+    end
+  end
+end

--- a/spec/services/hyrax/statistics/site/unique_visitors_spec.rb
+++ b/spec/services/hyrax/statistics/site/unique_visitors_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Hyrax::Statistics::Site::UniqueVisitors do
+  before do
+    ResourceStat.create(date: 1.week.ago, unique_visitors: 20)
+    ResourceStat.create(date: 2.days.ago, unique_visitors: 10)
+    ResourceStat.create(date: 1.week.ago, unique_visitors: 5, resource_id: '199', user_id: 123)
+  end
+
+  let(:instance) do
+    described_class.new(x_min: 3.weeks.ago,
+                        x_output: ->(x) { x.strftime('%b %-d') })
+  end
+
+  describe "#points" do
+    subject { instance.points }
+
+    it "has unique_visitor counts" do
+      expect(subject.size).to eq 4
+      expect(subject.to_a.second.last).to eq 20
+      expect(subject.to_a.third.last).to eq 10
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2776 

This provides an updated implemenation of the `UserActivityPresenter` that pulls Analytics data for both unique and returning visitors, per the discussion in #2772 

Changes proposed in this pull request:
* Update `UserActivityPresenter` to pull analytics data instead of registered users data
* Implement `returning_users` (renamed to `returning_visitors`
* Implement `Site::UniqueVisitors` and Site::ReturningVisitors` subclasses of the `Hyrax::Statistics::OverTime` abstract class

Note: The implementation of `to_json` in `UserActivityPresenter` is pretty dramatically simplified. I'd appreciate any thoughts of edge cases that this might miss.

@samvera/hyrax-code-reviewers @nestorw @lfarrell
