### PR TITLE
Update test to use new column name

### DIFF
--- a/lib/generators/hyrax/work/templates/feature_spec.rb.erb
+++ b/lib/generators/hyrax/work/templates/feature_spec.rb.erb
@@ -13,7 +13,7 @@ RSpec.feature 'Create a <%= class_name %>', js: false do
       User.new(user_attributes) { |u| u.save(validate: false) }
     end
     let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
-    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(admin_set_id: admin_set_id) }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
     let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
 
     before do


### PR DESCRIPTION
The work type generator creates a feature test which finds an admin set using the column `admin_set_id` but this column was renamed to `source_id` with this migration (https://github.com/samvera/hyrax/blob/master/lib/generators/hyrax/templates/db/migrate/20170821152307_rename_admin_set_id_to_source_id.rb.erb).  This PR aligns the generated test with the expected database table.

@samvera/hyrax-code-reviewers
