### PR TITLE
Do not show on Managed Collections when access is granted through registered or public only

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -9,9 +9,10 @@ module Hyrax
       include Hyrax::Ability::PermissionTemplateAbility
       include Hyrax::Ability::SolrDocumentAbility
 
-      class_attribute :admin_group_name, :registered_group_name
+      class_attribute :admin_group_name, :registered_group_name, :public_group_name
       self.admin_group_name = 'admin'
       self.registered_group_name = 'registered'
+      self.public_group_name = 'public' # TODO: find hard coded values and replace with this
       self.ability_logic += [:admin_permissions,
                              :curation_concerns_permissions,
                              :operation_abilities,

--- a/app/search_builders/hyrax/dashboard/collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/collections_search_builder.rb
@@ -35,7 +35,9 @@ module Hyrax
       private
 
         def collection_ids_for_deposit
-          Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability)
+          Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability,
+                                                                        exclude_groups: [::Ability.registered_group_name,
+                                                                                         ::Ability.public_group_name])
         end
     end
   end

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -8,9 +8,10 @@ module Hyrax
       # @param access [Array<String>] one or more types of access (e.g. Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT, Hyrax::PermissionTemplateAccess::VIEW)
       # @param ability [Ability] the ability coming from cancan ability check
       # @param source_type [String] 'collection', 'admin_set', or nil to get all types
+      # @param exclude_groups [Array<String>] name of groups to exclude from the results
       # @return [Array<String>] IDs of collections and admin sets for which the user has specified roles
-      def self.source_ids_for_user(access:, ability:, source_type: nil)
-        scope = PermissionTemplateAccess.for_user(ability: ability, access: access)
+      def self.source_ids_for_user(access:, ability:, source_type: nil, exclude_groups: [])
+        scope = PermissionTemplateAccess.for_user(ability: ability, access: access, exclude_groups: exclude_groups)
                                         .joins(:permission_template)
         ids = scope.pluck('DISTINCT source_id')
         return ids unless source_type
@@ -64,11 +65,12 @@ module Hyrax
       #
       # @param ability [Ability] the ability coming from cancan ability check
       # @param source_type [String] 'collection', 'admin_set', or nil to get all types
+      # @param exclude_groups [Array<String>] name of groups to exclude from the results
       # @return [Array<String>] IDs of collections and/or admin_sets into which the user can deposit
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
-      def self.source_ids_for_deposit(ability:, source_type: nil)
+      def self.source_ids_for_deposit(ability:, source_type: nil, exclude_groups: [])
         access = [Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT]
-        source_ids_for_user(access: access, ability: ability, source_type: source_type)
+        source_ids_for_user(access: access, ability: ability, source_type: source_type, exclude_groups: exclude_groups)
       end
 
       # @api public


### PR DESCRIPTION
Fixes #2762

For Managed Collections, it does not show Collections or Admin Sets where the only way the user has read access is by being in the registered or public groups.  Being in those groups does not imply special access to the Collections and Admin Sets and only clutters the Managed Collections view.

Working on this, I noticed two other issues effecting what is displayed in Managed Views.  Both are covered by existing issues.
* Issue #2760 Viewer of an admin set cannot see private works
* Issue #2619 Collections > Edit > Sharing: Add group form element not displaying

The summary of what you can expect with this PR...

NOTES:
* mgr@example.com is given Manage access to any AS (admin set) and UC (user collection) with participants or shared in the name
* dep@example.com is given Deposit access to any AS (admin set) and UC (user collection) with participants or shared in the name
* vw@example.com is given View access to any AS (admin set) and UC (user collection) with participants or shared in the name
* visibility is assumed private unless stated as visibility=public
```
mgr@example.com
√ AS 8.1 participants
√ AS 8.4 participants + dep registered
√ AS 8.5 participants + vw public
√ UC 8.1 shared + visibility=public
√ UC 8.2 shared
? UC 8.3 shared & dep registered         -- UNKNOWN - unable to create group access for UC
? UC 8.4 shared & vw public              -- UNKNOWN - unable to create group access for UC

dep@example.com
~ AS 8.1 participants                    -- in list, but requires auth to view
~ AS 8.4 participants + dep registered   -- in list, but requires auth to view
~ AS 8.5 participants + vw public        -- in list, but requires auth to view
√ UC 8.1 shared + visibility=public
√ UC 8.2 shared
? UC 8.3 shared & dep registered         -- UNKNOWN - unable to create group access for UC
? UC 8.4 shared & vw public              -- UNKNOWN - unable to create group access for UC

vw@example.com
X AS 8.1 participants   -- not in list
X  AS 8.4 participants + dep registered
X  AS 8.5 participants + vw public
√ UC 8.1 shared + visibility=public
√ UC 8.2 shared
? UC 8.3 shared & dep registered         -- UNKNOWN - unable to create group access for UC
? UC 8.4 shared & vw public              -- UNKNOWN - unable to create group access for UC
```

@samvera/hyrax-code-reviewers
