### PR TITLE
Work show view modifications for collections

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -9,7 +9,7 @@ module Hyrax
     end
 
     def render_collection_links(solr_doc)
-      collection_list = Hyrax::CollectionMemberService.run(solr_doc)
+      collection_list = Hyrax::CollectionMemberService.run(solr_doc, controller.current_ability)
       return if collection_list.empty?
       links = collection_list.map do |collection|
         link_to collection.title_or_label, collection_path(collection.id)

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -81,7 +81,7 @@ module Hyrax
     # Get presenters for the collections this work is a member of via the member_of_collections association.
     # @return [Array<CollectionPresenter>] presenters
     def member_of_collection_presenters
-      PresenterFactory.build_for(ids: member_of_collection_ids,
+      PresenterFactory.build_for(ids: member_of_authorized_parent_collections,
                                  presenter_class: collection_presenter_class,
                                  presenter_args: presenter_factory_arguments)
     end
@@ -212,6 +212,11 @@ module Hyrax
 
       def graph
         GraphExporter.new(solr_document, request).fetch
+      end
+
+      def member_of_authorized_parent_collections
+        # member_of_collection_ids with current_ability access
+        @member_of ||= Hyrax::CollectionMemberService.run(solr_document, current_ability).map(&:id)
       end
   end
 end

--- a/app/search_builders/hyrax/parent_collection_search_builder.rb
+++ b/app/search_builders/hyrax/parent_collection_search_builder.rb
@@ -3,10 +3,10 @@ module Hyrax
   class ParentCollectionSearchBuilder < Hyrax::CollectionSearchBuilder
     delegate :item, to: :scope
 
-    # include filters into the query to only include the collection memebers
+    # include filters into the query to only include the collections containing this item
     def include_item_ids(solr_parameters)
       solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << "child_object_ids_ssim:#{item.id}"
+      solr_parameters[:fq] << ActiveFedora::SolrQueryBuilder.construct_query_for_ids(item.member_of_collection_ids)
     end
   end
 end

--- a/app/services/hyrax/collection_member_service.rb
+++ b/app/services/hyrax/collection_member_service.rb
@@ -4,17 +4,18 @@ module Hyrax
     include Blacklight::Configurable
     include Blacklight::SearchHelper
 
-    attr_reader :item
+    attr_reader :item, :current_ability
 
     copy_blacklight_config_from(CatalogController)
 
     # @param [SolrDocument] item represents a work
-    def self.run(item)
-      new(item).list_collections
+    def self.run(item, ability)
+      new(item, ability).list_collections
     end
 
-    def initialize(item)
+    def initialize(item, ability)
       @item = item
+      @current_ability = ability
     end
 
     def list_collections
@@ -24,7 +25,7 @@ module Hyrax
     end
 
     def collection_search_builder
-      @collection_search_builder ||= ParentCollectionSearchBuilder.new([:include_item_ids, :add_paging_to_solr], self)
+      @collection_search_builder ||= ParentCollectionSearchBuilder.new([:include_item_ids, :add_paging_to_solr, :add_access_controls_to_solr_params], self)
     end
   end
 end

--- a/app/views/hyrax/base/_relationships_parent_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_rows.html.erb
@@ -10,4 +10,6 @@
   <% end %>
 <% end %>
 
-<%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>
+<% if current_user %>
+  <%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>
+<% end %>

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :collection_type, class: Hyrax::CollectionType do
-    sequence(:title) { |n| "Title #{n}" }
+    sequence(:title) { |n| "Collection Type #{n}" }
     sequence(:machine_id) { |n| "title_#{n}" }
 
     description 'Collection type with all options'

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -107,7 +107,7 @@ FactoryBot.define do
       with_nesting_attributes nil
       with_solr_document false
     end
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
@@ -164,7 +164,7 @@ FactoryBot.define do
       user { create(:user) }
     end
 
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["User Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
@@ -183,7 +183,7 @@ FactoryBot.define do
       do_save false
     end
 
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["Typeless Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
       create_access false
       with_nesting_attributes nil
     end
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
@@ -88,7 +88,7 @@ FactoryBot.define do
       user { create(:user) }
     end
 
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["User Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
@@ -108,7 +108,7 @@ FactoryBot.define do
       do_save false
     end
 
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["Typeless Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe 'Creating a new Work', :js, :workflow do
   let(:user) { create(:user) }
+  let!(:ability) { ::Ability.new(user) }
   let(:file1) { File.open(fixture_path + '/world.png') }
   let(:file2) { File.open(fixture_path + '/image.jp2') }
   let!(:uploaded_file1) { Hyrax::UploadedFile.create(file: file1, user: user) }

--- a/spec/search_builders/hyrax/parent_collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/parent_collection_search_builder_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Hyrax::ParentCollectionSearchBuilder do
+  let(:solr_params) { { fq: [] } }
+  let(:item) { double(id: '12345', member_of_collection_ids: ['col1']) }
+  let(:builder) { described_class.new(solr_params, context) }
+  let(:context) { double("context", blacklight_config: CatalogController.blacklight_config, item: item) }
+
+  describe '#include_item_ids' do
+    let(:subject) { builder.include_item_ids(solr_params) }
+
+    it 'updates solr_parameters[:fq]' do
+      subject
+      expect(solr_params[:fq]).to include("{!terms f=id}col1")
+    end
+  end
+end

--- a/spec/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe 'hyrax/admin/admin_sets/_show_document_list_row.html.erb', type: :view do
   let(:user) { create(:user, groups: 'admin') }
+  let(:ability) { Ability.new(user) }
 
   let(:work) do
     create(:work, user: user, creator: ["ggm"], title: ['One Hundred Years of Solitude'])
@@ -7,6 +8,7 @@ RSpec.describe 'hyrax/admin/admin_sets/_show_document_list_row.html.erb', type: 
 
   before do
     view.blacklight_config = Blacklight::Configuration.new
+    allow(controller).to receive(:current_ability).and_return(ability)
     allow(view).to receive(:current_user).and_return(user)
     allow(work).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
     allow(work).to receive(:edit_groups).and_return([user])

--- a/spec/views/hyrax/base/_attributes.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attributes.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'hyrax/base/_attributes.html.erb' do
       description_tesim: description
     }
   end
-  let(:ability) { nil }
+  let(:ability) { double(admin?: true) }
   let(:presenter) do
     Hyrax::WorkShowPresenter.new(solr_document, ability)
   end

--- a/spec/views/hyrax/base/_relationships.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_relationships.html.erb_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe 'hyrax/base/relationships', type: :view do
-  let(:ability) { double }
+  let(:user) { create(:user, groups: 'admin') }
+  let(:ability) { Ability.new(user) }
   let(:solr_doc) { instance_double(SolrDocument, id: '123', human_readable_type: 'Work', admin_set: nil) }
   let(:presenter) { Hyrax::WorkShowPresenter.new(solr_doc, ability) }
   let(:generic_work) do
@@ -29,6 +30,7 @@ RSpec.describe 'hyrax/base/relationships', type: :view do
     let(:member_of_collection_presenters) { [collection] }
 
     before do
+      allow(controller).to receive(:current_user).and_return user
       allow(view).to receive(:contextual_path).and_return("/collections/456")
       allow(presenter).to receive(:member_of_collection_presenters).and_return(member_of_collection_presenters)
       render 'hyrax/base/relationships', presenter: presenter
@@ -44,6 +46,7 @@ RSpec.describe 'hyrax/base/relationships', type: :view do
     let(:member_of_collection_presenters) { [generic_work] }
 
     before do
+      allow(controller).to receive(:current_user).and_return user
       allow(view).to receive(:contextual_path).and_return("/concern/generic_works/456")
       allow(presenter).to receive(:member_of_collection_presenters).and_return(member_of_collection_presenters)
       render 'hyrax/base/relationships', presenter: presenter
@@ -59,6 +62,7 @@ RSpec.describe 'hyrax/base/relationships', type: :view do
     let(:member_of_collection_presenters) { [generic_work, collection] }
 
     before do
+      allow(controller).to receive(:current_user).and_return user
       allow(view).to receive(:contextual_path).and_return("/concern/generic_works/456")
       allow(presenter).to receive(:member_of_collection_presenters).and_return(member_of_collection_presenters)
       render 'hyrax/base/relationships', presenter: presenter
@@ -71,8 +75,16 @@ RSpec.describe 'hyrax/base/relationships', type: :view do
 
   context "with admin sets" do
     it "renders using attribute_to_html" do
+      allow(controller).to receive(:current_user).and_return(user)
       allow(solr_doc).to receive(:member_of_collection_ids).and_return([])
       expect(presenter).to receive(:attribute_to_html).with(:admin_set, render_as: :faceted)
+      render 'hyrax/base/relationships', presenter: presenter
+    end
+
+    it "skips admin sets if user not logged in" do
+      allow(controller).to receive(:current_user).and_return(nil)
+      allow(solr_doc).to receive(:member_of_collection_ids).and_return([])
+      expect(presenter).not_to receive(:attribute_to_html).with(:admin_set, render_as: :faceted)
       render 'hyrax/base/relationships', presenter: presenter
     end
   end


### PR DESCRIPTION
Resolves https://github.com/samvera/hyrax/issues/2220
- fixes Hyrax::CollectionMemberService, and adds permission test to
the search.

Resolves https://github.com/samvera/hyrax/issues/2677 (remaining work moved to issue https://github.com/samvera/hyrax/issues/2796)
- shows admin sets only if user is logged in
- shows only authorized collections

Renames titles in collection and collection type factories to avoid
duplicate titles. This fixes a random spec failure.

Suggest removing Hyrax::CollectionSizeService which doesn't work and isn't used.  Opened issue #2801 for this work.

@samvera/hyrax-code-reviewers
