### PR TITLE
Set video width to force it to stay inside column

### DIFF
--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -1,6 +1,5 @@
-  <audio controls="controls" class="audiojs" preload="auto">
+  <audio controls="controls" class="audiojs" style="width:100%" preload="auto">
     <source src="<%= hyrax.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />
     <source src="<%= hyrax.download_path(file_set, file: 'mp3') %>" type="audio/mpeg" />
     Your browser does not support the audio tag.
   </audio>
-

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,4 +1,4 @@
-  <video controls="controls" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
+  <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" preload="auto">
     <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
     <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
     Your browser does not support the video tag.


### PR DESCRIPTION
Fixes #2744.

## Before
<img width="705" alt="before" src="https://user-images.githubusercontent.com/1053603/37186979-1ba6607e-2316-11e8-9f32-7e902dd2899c.png">

The native browser video player was sizing itself and overflowing the allotted column width of the parent `col-sm-3` div.  For the nurax item linked in #2744 the right-side metadata column was overlaying the buttons making them unactionable.

## After
<img width="742" alt="after" src="https://user-images.githubusercontent.com/1053603/37187021-5bcdce30-2316-11e8-9729-6b60edc615a5.png">

The player is constrained to the column by setting its width to 100%.  This does make the player seem really tiny but it is a larger problem to resize the parent `col-sm-3` div.

## Incorrect file downloads
Issue #2744 mentions the download button downloading the incorrect file but doesn't go into too much detail.  I believe the issue is that the download button on the player is a download of the source loaded in the video player thus a derivative file and not the original file.  This can be confusing since the download action on the file in the items section will give you the original file.  I believe this is out of scope to fix since this is the default behavior of the native browser player.  Future work could change this player to a JS player like mediaelement.js or a IIIF presentation 3.0 player like UV 3.0 (both of which are still in development).

@samvera/hyrax-code-reviewers
