### PR TITLE
Create user link with user object instead of user_key

### DIFF
--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -87,7 +87,7 @@ class ProxyDepositRequest < ActiveRecord::Base
   private
 
     def send_request_transfer_message_as_part_of_create
-      user_link = link_to(sending_user.name, Hyrax::Engine.routes.url_helpers.user_path(sending_user.user_key))
+      user_link = link_to(sending_user.name, Hyrax::Engine.routes.url_helpers.user_path(sending_user))
       transfer_link = link_to('transfer requests', Hyrax::Engine.routes.url_helpers.transfers_path)
       message = "#{user_link} wants to transfer a work to you. Review all #{transfer_link}"
       Hyrax::MessengerService.deliver(::User.batch_user, receiving_user, message, "Ownership Change Request")

--- a/spec/controllers/hyrax/transfers_controller_spec.rb
+++ b/spec/controllers/hyrax/transfers_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
         # AND A NOTIFICATION SHOULD HAVE BEEN CREATED
         notification = another_user.reload.mailbox.inbox[0].messages[0]
         expect(notification.subject).to eq("Ownership Change Request")
-        expect(notification.body).to eq("<a href=\"/users/#{user.user_key}\">#{user.name}</a> " \
+        expect(notification.body).to eq("<a href=\"#{routes.url_helpers.user_path(user)}\">#{user.name}</a> " \
                                         "wants to transfer a work to you. Review all " \
                                         "<a href=\"#{routes.url_helpers.transfers_path}\">transfer requests</a>")
       end


### PR DESCRIPTION
Fixes #2788. https://github.com/curationexperts/nurax/issues/227

This PR fixes the link to the user profile in transfer notifications by passing the user object instead of the `user_key` to the `user_path` helper.  The helper uses `User#to_param` to transform `.` into `-dot-` which fixes the links.

I checked other calls to `user_path` and none of the others appear to have this problem.

@samvera/hyrax-code-reviewers
