### PR TITLE
Show download link with analytics tracking for audio and video

### DIFF
--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -1,5 +1,23 @@
-  <audio controls="controls" class="audiojs" style="width:100%" preload="auto">
-    <source src="<%= hyrax.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />
-    <source src="<%= hyrax.download_path(file_set, file: 'mp3') %>" type="audio/mpeg" />
-    Your browser does not support the audio tag.
-  </audio>
+<% if Hyrax.config.display_media_download_link? %>
+    <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp3') %>" type="audio/mpeg" />
+        Your browser does not support the audio tag.
+      </audio>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.audio_link'),
+                  hyrax.download_path(file_set),
+                  data: { turbolinks: false, label: file_set.id },
+                  target: :_blank,
+                  id: "file_download" %>
+    </div>
+<% else %>
+    <div>
+      <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp3') %>" type="audio/mpeg" />
+        Your browser does not support the audio tag.
+      </audio>
+    </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,6 +1,23 @@
-  <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" preload="auto">
-    <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
-    <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
-    Your browser does not support the video tag.
-  </video>
-
+<% if Hyrax.config.display_media_download_link? %>
+    <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+        Your browser does not support the video tag.
+      </video>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.video_link'),
+                  hyrax.download_path(file_set),
+                  data: { turbolinks: false, label: file_set.id },
+                  target: :_blank,
+                  id: "file_download" %>
+    </div>
+<% else %>
+    <div>
+      <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+        Your browser does not support the video tag.
+      </video>
+    </div>
+<% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -809,6 +809,8 @@ en:
           image_link: Download image
           office_link: Download file
           pdf_link: Download PDF
+          audio_link: Download audio
+          video_link: Download video
     file_sets:
       groups_description:
         description_html: 'The list of groups in the drop-down marked "Select a group" is a list of User Managed Groups that you are a member of.  You may select a specific group and assign an access level for a file within %{application_name}, similarly to adding user access levels.

--- a/spec/views/hyrax/file_sets/media_display/_audio.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_audio.html.erb_spec.rb
@@ -1,16 +1,16 @@
-RSpec.describe 'hyrax/file_sets/media_display/_default.html.erb', type: :view do
+RSpec.describe 'hyrax/file_sets/media_display/_audio.html.erb', type: :view do
   let(:file_set) { stub_model(FileSet) }
   let(:config) { double }
   let(:link) { true }
 
   before do
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
-    render 'hyrax/file_sets/media_display/default', file_set: file_set
+    render 'hyrax/file_sets/media_display/audio', file_set: file_set
   end
 
   it "draws the view with the link" do
-    expect(rendered).to have_css('div.no-preview')
-    expect(rendered).to have_css('a', text: 'Download the file')
+    expect(rendered).to have_selector("audio")
+    expect(rendered).to have_css('a', text: 'Download audio')
   end
 
   it "includes google analytics data in the download link" do
@@ -22,8 +22,8 @@ RSpec.describe 'hyrax/file_sets/media_display/_default.html.erb', type: :view do
     let(:link) { false }
 
     it "draws the view without the link" do
-      expect(rendered).to have_css('div.no-preview')
-      expect(rendered).not_to have_css('a', text: 'Download the file')
+      expect(rendered).to have_selector("audio")
+      expect(rendered).not_to have_css('a', text: 'Download audio')
     end
   end
 end

--- a/spec/views/hyrax/file_sets/media_display/_video.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_video.html.erb_spec.rb
@@ -1,16 +1,16 @@
-RSpec.describe 'hyrax/file_sets/media_display/_default.html.erb', type: :view do
+RSpec.describe 'hyrax/file_sets/media_display/_video.html.erb', type: :view do
   let(:file_set) { stub_model(FileSet) }
   let(:config) { double }
   let(:link) { true }
 
   before do
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
-    render 'hyrax/file_sets/media_display/default', file_set: file_set
+    render 'hyrax/file_sets/media_display/video', file_set: file_set
   end
 
   it "draws the view with the link" do
-    expect(rendered).to have_css('div.no-preview')
-    expect(rendered).to have_css('a', text: 'Download the file')
+    expect(rendered).to have_selector("video")
+    expect(rendered).to have_css('a', text: 'Download video')
   end
 
   it "includes google analytics data in the download link" do
@@ -22,8 +22,8 @@ RSpec.describe 'hyrax/file_sets/media_display/_default.html.erb', type: :view do
     let(:link) { false }
 
     it "draws the view without the link" do
-      expect(rendered).to have_css('div.no-preview')
-      expect(rendered).not_to have_css('a', text: 'Download the file')
+      expect(rendered).to have_selector("video")
+      expect(rendered).not_to have_css('a', text: 'Download video')
     end
   end
 end


### PR DESCRIPTION
Fixes #2795. 

Chrome's HTML5 audio and video player have download buttons by default which allows a user to download the loaded source which is a derivative instead of the original file.   This PR turns off that download button, provides a download link with analytics tracking, and aligns the view partials with the other content types.

Two new i18n strings ("Download audio" and "Download video") were added that will need to be translated to other supported locales.

### Future Work
More testing in different browsers and platforms including mobile.
Fix video playback in Safari (it's not working at all for me)
Fix audio player in Safari so scrubber appears (currently it says "Live Broadcast" instead of the showing the scrubber)

@samvera/hyrax-code-reviewers
