### PR TITLE
Adds confirmation alert before leaving unsaved content blocks

### DIFF
--- a/app/assets/javascripts/hyrax/content_blocks.js
+++ b/app/assets/javascripts/hyrax/content_blocks.js
@@ -9,4 +9,16 @@ Blacklight.onLoad(function() {
     $this.parent().hide();
     $($this.data('target')).show();
   });
+
+  $('.show-confirm').on('click', function(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    $('#change-tab-content-block').modal('show');
+  });
+
+  $('#change-tab-btn').on('click', function(evt) {
+    evt.preventDefault();
+    $('#change-tab-content-block').modal('hide');
+    $('.nav-tabs a[href="' + location.hash + '"]').tab('show');
+  });    
 });

--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -1,13 +1,14 @@
+<%= render "modal_content_block"%>
 <div class="panel panel-default tabs">
   <ul class="nav nav-tabs" role="tablist">
     <li class="active">
-      <a href="#announcement_text" role="tab" data-toggle="tab"><%= t(:'hyrax.content_blocks.tabs.announcement_text') %></a>
+      <a href="#announcement_text" role="tab" data-toggle="tab" class="show-confirm"><%= t(:'hyrax.content_blocks.tabs.announcement_text') %></a>
     </li>
     <li>
-      <a href="#marketing" role="tab" data-toggle="tab"><%= t(:'hyrax.content_blocks.tabs.marketing_text') %></a>
+      <a href="#marketing" role="tab" data-toggle="tab" class="show-confirm"><%= t(:'hyrax.content_blocks.tabs.marketing_text') %></a>
     </li>
     <li>
-      <a href="#researcher" role="tab" data-toggle="tab"><%= t(:'hyrax.content_blocks.tabs.featured_researcher') %></a>
+      <a href="#researcher" role="tab" data-toggle="tab" class="show-confirm"><%= t(:'hyrax.content_blocks.tabs.featured_researcher') %></a>
     </li>
   </ul>
   <div class="tab-content">

--- a/app/views/hyrax/content_blocks/_modal_content_block.html.erb
+++ b/app/views/hyrax/content_blocks/_modal_content_block.html.erb
@@ -1,0 +1,15 @@
+<div class="modal fade" id="change-tab-content-block" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="delete-collection-form">
+        <div class="modal-body">
+          <%= t(:'hyrax.content_blocks.change_tab_message') %>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
+          <%= link_to 'OK', hyrax.edit_content_blocks_path, class: 'btn btn-default', id: "change-tab-btn"%>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -531,6 +531,7 @@ de:
         featured_researcher: Ausgewählter Forscher
         marketing_text: Marketing Text
       updated: Inhaltsblöcke aktualisiert.
+      change_tab_message: Möchten Sie diesen Tab wirklich verlassen? Nicht gespeicherte Daten gehen verloren.      
     controls:
       about: Impressum
       contact: Kontakt

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -531,6 +531,7 @@ en:
         featured_researcher: Featured Researcher
         marketing_text: Marketing Text
       updated: Content blocks updated.
+      change_tab_message: Are you sure you want to leave this tab?  Any unsaved data will be lost.
     controls:
       about: About
       contact: Contact

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -530,6 +530,7 @@ es:
         featured_researcher: Investigador Destacado
         marketing_text: Texto de Marketing
       updated: Bloques de contenido actualizados.
+      change_tab_message: ¿Seguro que quieres salir de esta pestaña? Cualquier información no guardada se perderá.      
     controls:
       about: Acerca de
       contact: Contacto

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -531,6 +531,7 @@ fr:
         featured_researcher: Chercheur en vedette
         marketing_text: Texte de marketing
       updated: Les blocs de contenu sont mis à jour.
+      change_tab_message: Êtes-vous sûr de vouloir quitter cet onglet? Toutes les données non enregistrées seront perdues.      
     controls:
       about: Sur
       contact: Contact

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -530,6 +530,7 @@ it:
         featured_researcher: Ricercatore in primo piano
         marketing_text: Testo di marketing
       updated: Blocchi di contenuto aggiornati.
+      change_tab_message: Sei sicuro di voler lasciare questa scheda? Tutti i dati non salvati andranno persi.      
     controls:
       about: Di
       contact: contatto

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -525,6 +525,7 @@ pt-BR:
         featured_researcher: Pesquisador em destaque
         marketing_text: Texto de marketing
       updated: Blocos de conteúdo atualizados.
+      change_tab_message: Sei sicuro di voler lasciare questa scheda? Tutti i dati non salvati andranno persi.      
     controls:
       about: Sobre
       contact: Contato

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -528,6 +528,7 @@ zh:
         featured_researcher: 特色研究员
         marketing_text: 营销文字
       updated: 内容块已更新。
+      change_tab_message: 你确定要离开这个标签吗？任何未保存的数据都将丢失。
     controls:
       about: 关于
       contact: 联系

--- a/spec/features/edit_content_block_admin_spec.rb
+++ b/spec/features/edit_content_block_admin_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe 'Editing content blocks as admin', :js do
+  let(:user) { create(:admin) }
+
+  context 'when user wants to change tabs' do
+    let!(:confirm_modal_text) { 'Are you sure you want to leave this tab?  Any unsaved data will be lost.' }
+
+    before do
+      sign_in user
+      visit '/dashboard'
+      click_link 'Settings'
+      click_link 'Content Blocks'
+    end
+
+    it "gives a confirmation message" do
+      expect(page).to have_content('Content Blocks')
+      expect(page).to have_content('Announcement')
+      click_link 'Marketing Text'
+      within('#change-tab-content-block') do
+        expect(page).to have_content(confirm_modal_text)
+      end
+    end
+
+    it "changes tab when user accept the changing tab confirmation" do
+      expect(page).to have_selector('#announcement_text', class: 'active')
+      expect(page).not_to have_selector('#marketing', class: 'active')
+      click_link 'Marketing Text'
+      within('#change-tab-content-block') do
+        click_link('OK')
+      end
+      expect(page).to have_selector('#marketing', class: 'active')
+      expect(page).not_to have_selector('#announcement_text', class: 'active')
+    end
+
+    it "does not change tab when user cancel the changing tab confirmation" do
+      expect(page).to have_selector('#announcement_text', class: 'active')
+      expect(page).not_to have_selector('#marketing', class: 'active')
+      click_link 'Marketing Text'
+      within('#change-tab-content-block') do
+        click_button('Cancel')
+      end
+      expect(page).not_to have_selector('#marketing', class: 'active')
+      expect(page).to have_selector('#announcement_text', class: 'active')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1088  ; refs #1088 

Adds confirmation alert when changing tabs to warn user that the unsaved content will be lost.

@samvera/hyrax-code-reviewers
