### PR TITLE
Reindex work after visibility change

### DIFF
--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -96,7 +96,7 @@ module Hyrax
         attributes = intention.sanitize_params
         new_env = Environment.new(env.curation_concern, env.current_ability, attributes)
         validate(env, intention, attributes) && apply_visibility(new_env, intention) &&
-          next_actor.update(new_env)
+          next_actor.update(new_env) && reindex_visibility_change(new_env)
       end
 
       private
@@ -226,6 +226,13 @@ module Hyrax
           env.curation_concern.apply_embargo(*intention.embargo_params)
           return unless env.curation_concern.embargo
           env.curation_concern.embargo.save # see https://github.com/samvera/hydra-head/issues/226
+        end
+
+        def reindex_visibility_change(env)
+          return true unless env.curation_concern.visibility_changed?
+          env.curation_concern.update_index
+          # Don't try to handle the indexing response and always return true
+          true
         end
     end
   end

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -279,7 +279,6 @@ module Hyrax
       end
 
       def after_update_response
-        reindex_visibility_change
         if curation_concern.file_sets.present?
           return redirect_to hyrax.confirm_access_permission_path(curation_concern) if permissions_changed?
           return redirect_to main_app.confirm_hyrax_permission_path(curation_concern) if curation_concern.visibility_changed?
@@ -311,10 +310,6 @@ module Hyrax
 
       def permissions_changed?
         @saved_permissions != curation_concern.permissions.map(&:to_hash)
-      end
-
-      def reindex_visibility_change
-        curation_concern.update_index if curation_concern.visibility_changed?
       end
   end
 end

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -279,6 +279,7 @@ module Hyrax
       end
 
       def after_update_response
+        reindex_visibility_change
         if curation_concern.file_sets.present?
           return redirect_to hyrax.confirm_access_permission_path(curation_concern) if permissions_changed?
           return redirect_to main_app.confirm_hyrax_permission_path(curation_concern) if curation_concern.visibility_changed?
@@ -310,6 +311,10 @@ module Hyrax
 
       def permissions_changed?
         @saved_permissions != curation_concern.permissions.map(&:to_hash)
+      end
+
+      def reindex_visibility_change
+        curation_concern.update_index if curation_concern.visibility_changed?
       end
   end
 end

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe 'Editing a work', type: :feature do
   end
 
   context 'when the user changes permissions' do
-    it 'confirms copying permissions to files using Hyrax layout' do
+    let(:work) { create(:private_work, user: user, admin_set: default_admin_set) }
+
+    it 'confirms copying permissions to files using Hyrax layout and shows updated value', with_nested_reindexing: true do
       # e.g. /concern/generic_works/jq085k20z/edit
       visit edit_hyrax_generic_work_path(work)
       choose('generic_work_visibility_open')
@@ -29,6 +31,10 @@ RSpec.describe 'Editing a work', type: :feature do
       click_on('Save')
       expect(page).to have_content 'Apply changes to contents?'
       expect(page).not_to have_content "Powered by Hyrax"
+      click_on("No. I'll update it manually.")
+      within(".panel-heading") do
+        expect(page).to have_content('Public')
+      end
     end
   end
 


### PR DESCRIPTION
Resolves https://github.com/samvera/hyrax/issues/2777

Adding an update_index after a visibility update to the work.
Nested reindexing causes the visibility to not be indexed on the work because the work indexing happens before the visibility is updated in fedora. (see https://github.com/samvera/hyrax/issues/1826 for more info regarding situation)

@samvera/hyrax-code-reviewers
