### PR TITLE
display error message when collection type title already exists.

### DIFF
--- a/app/controllers/hyrax/admin/collection_types_controller.rb
+++ b/app/controllers/hyrax/admin/collection_types_controller.rb
@@ -29,6 +29,7 @@ module Hyrax
         Hyrax::CollectionTypes::CreateService.add_default_participants(@collection_type.id)
         redirect_to hyrax.edit_admin_collection_type_path(@collection_type), notice: t(:'hyrax.admin.collection_types.create.notification', name: @collection_type.title)
       else
+        report_error_msg
         setup_form
         add_common_breadcrumbs
         add_breadcrumb t(:'hyrax.admin.collection_types.new.header'), hyrax.new_admin_collection_type_path
@@ -63,6 +64,15 @@ module Hyrax
     end
 
     private
+
+      def report_error_msg
+        error_msg = @collection_type.errors.messages
+        msg = 'Save was not successful because '
+        error_msg.each { |k, v| msg << k.to_s + ' ' + v.join(', ') + ', and ' }
+        msg.chomp!(', and ')
+        msg << '.'
+        flash[:error] = msg
+      end
 
       def update_referer
         hyrax.edit_admin_collection_type_path(@collection_type) + (params[:referer_anchor] || '')

--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -69,6 +69,50 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
       expect(page).to have_link('Settings', href: '#settings')
       expect(page).to have_link('Participants', href: '#participants')
     end
+
+    it 'tries to make a collection type with existing title, and receives error message', :js do
+      click_link 'Create new collection type'
+
+      expect(page).to have_content 'Create New Collection Type'
+
+      # confirm only Description tab is visible
+      expect(page).to have_link('Description', href: '#metadata')
+      expect(page).not_to have_link('Settings', href: '#settings')
+      expect(page).not_to have_link('Participants', href: '#participants')
+
+      # confirm metadata fields exist
+      expect(page).to have_selector 'input#collection_type_title'
+      expect(page).to have_selector 'textarea#collection_type_description'
+
+      # set values and save
+      fill_in('Type name', with: title)
+      fill_in('Type description', with: description)
+
+      click_button('Save')
+
+      visit '/admin/collection_types'
+      click_link 'Create new collection type'
+
+      expect(page).to have_content 'Create New Collection Type'
+
+      # confirm only Description tab is visible
+      expect(page).to have_link('Description', href: '#metadata')
+      expect(page).not_to have_link('Settings', href: '#settings')
+      expect(page).not_to have_link('Participants', href: '#participants')
+
+      # confirm metadata fields exist
+      expect(page).to have_selector 'input#collection_type_title'
+      expect(page).to have_selector 'textarea#collection_type_description'
+
+      # set values and save
+      fill_in('Type name', with: title)
+      fill_in('Type description', with: description)
+
+      click_button('Save')
+
+      # Confirm error message is displayed.
+      expect(page).to have_content 'Save was not successful because title has already been taken, and machine_id has already been taken.'
+    end
   end
 
   describe 'edit collection type' do


### PR DESCRIPTION
Fixes #2757 
It will crate an error message based on the error message in @collection_type.errors.message, and display it to the user.