### PR TITLE
Add commas to collection link list

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -11,10 +11,13 @@ module Hyrax
     def render_collection_links(solr_doc)
       collection_list = Hyrax::CollectionMemberService.run(solr_doc, controller.current_ability)
       return if collection_list.empty?
-      links = collection_list.map do |collection|
-        link_to collection.title_or_label, collection_path(collection.id)
+      links = collection_list.map { |collection| link_to collection.title_or_label, collection_path(collection.id) }
+      collection_links = []
+      links.each_with_index do |link, n|
+        collection_links << link
+        collection_links << ', ' unless links[n + 1].nil?
       end
-      content_tag :span, safe_join([t('hyrax.collection.is_part_of'), ': '] + links)
+      content_tag :span, safe_join([t('hyrax.collection.is_part_of'), ': '] + collection_links)
     end
 
     # @return [Boolean]


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/2800
Inserts a comma between each collection link in the array of links.

@samvera/hyrax-code-reviewers
