### PR TITLE
Document enabling and configuring ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ On OSX, you can use Homebrew to install ffmpeg:
 
 Otherwise, to compile ffmpeg yourself, see the [ffmpeg compilation guide](https://trac.ffmpeg.org/wiki/CompilationGuide).
 
+Once ffmpeg has been installed, enable transcoding by setting `config.enable_ffmpeg = true` in `config/initializers/hyrax.rb`.  You may also configure the location of ffmpeg using `config.ffmpeg_path`.
+
 ## Environments
 
 Note here that the following commands assume you're setting up Hyrax in a development environment (using the Rails built-in development environment). If you're setting up a production or production-like environment, you may wish to tell Rails that by prepending `RAILS_ENV=production` to the commands that follow, e.g., `rails`, `rake`, `bundle`, and so on.


### PR DESCRIPTION
The Hyrax Management Guide mentions [here](https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide#audiovisual-transcoding) that ffmpeg configuration documentation lives in the readme.  This PR adds that documentation.

@samvera/hyrax-code-reviewers
