### PR TITLE
adding selector in app.js that CollectionControls requires for Partic…

### DIFF
--- a/app/assets/javascripts/hyrax/app.js.erb
+++ b/app/assets/javascripts/hyrax/app.js.erb
@@ -46,7 +46,7 @@ Hyrax = {
     // The Collection edit page
     collectionEditor: function() {
       var CollectionControls = require('hyrax/collections/editor');
-      var controls = new CollectionControls($('#collection-controls'));
+      var controls = new CollectionControls($('#collection_permissions'));
     },
 
     // Collection types

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -864,6 +864,15 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           expect(page).to have_link('Sharing', href: '#sharing')
         end
 
+        context "to true, limits available users", js: true do
+          it "to system users filted by select2" do
+            visit "/dashboard/collections/#{sharable_collection_id}/edit"
+            expect(page).to have_link('Sharing', href: '#sharing')
+            click_link('Sharing')
+            expect(page).to have_selector(".form-inline.add-users .select2-container")
+          end
+        end
+
         it 'to false, it hides Sharable tab' do
           visit "/dashboard/collections/#{not_sharable_collection_id}/edit"
           expect(page).not_to have_link('Sharing', href: '#sharing')


### PR DESCRIPTION
…ipants js

Fixes #2756 ; refs #2756

An old DOM id was still being used to initialize the CollectionControls js component. This PR replaces it with an appropriate selector, that the Participants component can work with.

@samvera/hyrax-code-reviewers
