### PR TITLE
Handle byte range requests for local files

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -6,6 +6,7 @@ Metrics/ClassLength:
   Exclude:
     - 'app/controllers/hyrax/dashboard/collections_controller.rb'
     - 'app/controllers/hyrax/admin/admin_sets_controller.rb'
+    - 'app/controllers/hyrax/downloads_controller.rb'
     - 'app/controllers/hyrax/file_sets_controller.rb'
     - 'app/forms/hyrax/forms/permission_template_form.rb'
     - 'app/presenters/hyrax/work_show_presenter.rb'

--- a/app/controllers/concerns/hyrax/local_file_downloads_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/local_file_downloads_controller_behavior.rb
@@ -1,0 +1,86 @@
+module Hyrax
+  module LocalFileDownloadsControllerBehavior
+    protected
+
+      # Handle the HTTP show request
+      def send_local_content
+        response.headers['Accept-Ranges'] = 'bytes'
+        if request.head?
+          local_content_head
+        elsif request.headers['Range']
+          send_range_for_local_file
+        else
+          send_local_file_contents
+        end
+      end
+
+      # render an HTTP Range response
+      def send_range_for_local_file
+        _, range = request.headers['Range'].split('bytes=')
+        from, to = range.split('-').map(&:to_i)
+        to = local_file_size - 1 unless to
+        length = to - from + 1
+        response.headers['Content-Range'] = "bytes #{from}-#{to}/#{local_file_size}"
+        response.headers['Content-Length'] = length.to_s
+        self.status = 206
+        prepare_local_file_headers
+        # For derivatives stored on the local file system
+        send_data IO.binread(file, length, from), local_derivative_download_options.merge(status: status)
+      end
+
+      def send_local_file_contents
+        self.status = 200
+        prepare_local_file_headers
+        # For derivatives stored on the local file system
+        send_file file, local_derivative_download_options
+      end
+
+      def local_file_size
+        File.size(file)
+      end
+
+      def local_file_mime_type
+        mime_type_for(file)
+      end
+
+      # @return [String] the filename
+      def local_file_name
+        params[:filename] || File.basename(file) || (asset.respond_to?(:label) && asset.label)
+      end
+
+      def local_file_last_modified
+        File.mtime(file) if file.is_a? String
+      end
+
+      # Override
+      # render an HTTP HEAD response
+      def local_content_head
+        response.headers['Content-Length'] = local_file_size.to_s
+        head :ok, content_type: local_file_mime_type
+      end
+
+      # Override
+      def prepare_local_file_headers
+        send_file_headers! local_content_options
+        response.headers['Content-Type'] = local_file_mime_type
+        response.headers['Content-Length'] ||= local_file_size.to_s
+        # Prevent Rack::ETag from calculating a digest over body
+        response.headers['Last-Modified'] = local_file_last_modified.utc.strftime("%a, %d %b %Y %T GMT")
+        self.content_type = local_file_mime_type
+      end
+
+    private
+
+      # Override the Hydra::Controller::DownloadBehavior#content_options so that
+      # we have an attachement rather than 'inline'
+      def local_content_options
+        { type: local_file_mime_type, filename: local_file_name, disposition: 'attachment' }
+      end
+
+      # Override this method if you want to change the options sent when downloading
+      # a derivative file
+      def local_derivative_download_options
+        { type: local_file_mime_type, filename: local_file_name, disposition: 'inline' }
+      end
+  end
+end

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -1,6 +1,7 @@
 module Hyrax
   class DownloadsController < ApplicationController
     include Hydra::Controller::DownloadBehavior
+    include Hyrax::LocalFileDownloadsControllerBehavior
 
     def self.default_content_path
       :original_file
@@ -15,98 +16,24 @@ module Hyrax
         super
       when String
         # For derivatives stored on the local file system
-        send_content
+        send_local_content
       else
         raise ActiveFedora::ObjectNotFoundError
       end
     end
-
-    protected
-
-      # Override
-      # render an HTTP Range response
-      # rubocop:disable  Metrics/AbcSize
-      def send_range
-        _, range = request.headers['Range'].split('bytes=')
-        from, to = range.split('-').map(&:to_i)
-        to = file_size - 1 unless to
-        length = to - from + 1
-        response.headers['Content-Range'] = "bytes #{from}-#{to}/#{file_size}"
-        response.headers['Content-Length'] = length.to_s
-        self.status = 206
-        prepare_file_headers
-        if file.is_a? String
-          # For derivatives stored on the local file system
-          send_data IO.binread(file, length, from), derivative_download_options.merge(status: status)
-        else
-          stream_body file.stream(request.headers['Range'])
-        end
-      end
-      # rubocop:enable  Metrics/AbcSize
-
-      # Override
-      def send_file_contents
-        self.status = 200
-        prepare_file_headers
-        if file.is_a? String
-          # For derivatives stored on the local file system
-          send_file file, derivative_download_options
-        else
-          stream_body file.stream
-        end
-      end
-
-      def file_size
-        @file_size ||= File.size(file) if file.is_a? String
-        @file_size ||= file.size
-      end
-
-      def file_mime_type
-        @file_mime_type ||= mime_type_for(file) if file.is_a? String
-        @file_mime_type ||= file.mime_type
-      end
-
-      # Override
-      # @return [String] the filename
-      def file_name
-        @file_name ||= params[:filename] || File.basename(file) || (asset.respond_to?(:label) && asset.label) if file.is_a? String
-        @file_name ||= super
-      end
-
-      def file_last_modified
-        @file_last_modified ||= File.mtime(file) if file.is_a? String
-        @file_last_modified ||= asset.modified_date
-      end
-
-      # Override
-      # render an HTTP HEAD response
-      def content_head
-        response.headers['Content-Length'] = file_size.to_s
-        head :ok, content_type: file_mime_type
-      end
-
-      # Override
-      def prepare_file_headers
-        send_file_headers! content_options
-        response.headers['Content-Type'] = file_mime_type
-        response.headers['Content-Length'] ||= file_size.to_s
-        # Prevent Rack::ETag from calculating a digest over body
-        response.headers['Last-Modified'] = file_last_modified.utc.strftime("%a, %d %b %Y %T GMT")
-        self.content_type = file_mime_type
-      end
 
     private
 
       # Override the Hydra::Controller::DownloadBehavior#content_options so that
       # we have an attachement rather than 'inline'
       def content_options
-        { type: file_mime_type, filename: file_name, disposition: 'attachment' }
+        super.merge(disposition: 'attachment')
       end
 
       # Override this method if you want to change the options sent when downloading
       # a derivative file
       def derivative_download_options
-        { type: file_mime_type, filename: file_name, disposition: 'inline' }
+        { type: mime_type_for(file), disposition: 'inline' }
       end
 
       # Customize the :read ability in your Ability class, or override this method.

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -91,6 +91,6 @@ RSpec.describe Hyrax::DownloadsController do
     end
     subject { controller.send(:derivative_download_options) }
 
-    it { is_expected.to eq(disposition: 'inline', type: 'image/png') }
+    it { is_expected.to eq(disposition: 'inline', filename: 'world.png', type: 'image/png') }
   end
 end


### PR DESCRIPTION
Fixes #2815.

Byte-range requests in hyrax for derivatives is broken keeping Safari and iOS devices from showing audio and video.  This PR attempts to fix that.

TODO
Avoid overriding so much of Hydra::DownloadController
Avoid conditional logic in most methods
Add new tests for byte-range requests

@samvera/hyrax-code-reviewers