### PR TITLE
[WIP] Update user and admin dash titles

### DIFF
--- a/app/views/hyrax/dashboard/show_admin.html.erb
+++ b/app/views/hyrax/dashboard/show_admin.html.erb
@@ -1,3 +1,7 @@
+<% provide :page_header do %>
+  <h1><%= t("hyrax.dashboard.title") %></h1>
+<% end %>
+
 <div class="row">
   <div class="col-md-3">
     <div class="panel panel-default">

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -738,7 +738,7 @@ en:
       proxy_user: Proxy User
       show_admin:
         new_visitors: New Visitors
-        registered_users: Registered users
+        registered_users: Registered Users
         repository_growth:
           subtitle: Past 90 days
           title: Repository Growth
@@ -757,7 +757,7 @@ en:
         files: Files deposited
         heading: Your Statistics
         works: Works created
-      title: My Dashboard
+      title: Dashboard
       transfer_of_ownership: Transfers of Ownership
       transfer_works_link: Select works to transfer
       transfers_received: Transfers Received

--- a/spec/controllers/hyrax/citations_controller_spec.rb
+++ b/spec/controllers/hyrax/citations_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::CitationsController do
       end
 
       it "is successful" do
-        expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :work, params: { id: work }
         expect(response).to be_successful
         expect(response).to render_template('layouts/hyrax/1_column')
@@ -39,7 +39,7 @@ RSpec.describe Hyrax::CitationsController do
       end
 
       it "is successful" do
-        expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         get :file, params: { id: file_set }
         expect(response).to be_successful
         expect(response).to render_template('layouts/hyrax/1_column')

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Hyrax::CollectionsController do
         end
 
         it "sets breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'))
           get :show, params: { id: collection }

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         end
 
         it "sets breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'))
           get :show, params: { id: collection }
@@ -448,7 +448,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       end
 
       it "sets breadcrumbs" do
-        expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.browse_view"), collection_path(collection.id, locale: 'en'))
         get :edit, params: { id: collection }

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Hyrax::FileSetsController do
         end
 
         it "shows me the breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Your Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set, locale: 'en'))

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Hyrax::GenericWorksController do
 
       context "without a referer" do
         it "sets breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with("My Dashboard", hyrax.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with("Dashboard", hyrax.dashboard_path(locale: 'en'))
           get :show, params: { id: work }
           expect(response).to be_successful
         end
@@ -71,7 +71,7 @@ RSpec.describe Hyrax::GenericWorksController do
         end
 
         it "sets breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('My Dashboard', hyrax.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Your Works', hyrax.my_works_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
           get :show, params: { id: work }

--- a/spec/features/dashboard/display_admin_dashboard_spec.rb
+++ b/spec/features/dashboard/display_admin_dashboard_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe "The dashboard as viewed by a admin user", type: :feature do
+  before do
+    sign_in create(:admin)
+  end
+
+  context "upon sign-in" do
+    it "shows the admin user's information" do
+      expect(page).to have_content "Dashboard"
+      expect(page).to have_content "Registered Users"
+      expect(page).to have_content "Total Visitors"
+      expect(page).to have_content "Returning Visitors"
+      expect(page).to have_content "New Visitors"
+      expect(page).to have_content "Administrative Sets"
+      expect(page).to have_content "Recent activity"
+      expect(page).to have_content "Administrative Set"
+      expect(page).to have_content "User Activity"
+      expect(page).to have_content "Repository Growth"
+      expect(page).to have_content "Repository Objects"
+
+      within '.sidebar' do
+        expect(page).to have_link "Works"
+        expect(page).to have_link "Collections"
+        expect(page).to have_content "Review Submissions"
+        expect(page).to have_content "Manage Embargoes"
+        expect(page).to have_content "Manage Leases"
+      end
+    end
+  end
+end

--- a/spec/features/dashboard/display_dashboard_spec.rb
+++ b/spec/features/dashboard/display_dashboard_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "The dashboard as viewed by a regular user", type: :feature do
 
   context "upon sign-in" do
     it "shows the user's information" do
-      expect(page).to have_content "My Dashboard"
+      expect(page).to have_content "Dashboard"
       expect(page).to have_content "User Activity"
       expect(page).to have_content "User Notifications"
 


### PR DESCRIPTION
Fixes #2818

Update dashboard title for regular users and adds a title for admin users: "Dashboard"

Details:

1. Adds title to app/views/hyrax/dashboard/show_admin.html.erb
2. Modifies hyrax.dashboard.title in hyrax.en.yml to be "Dashboard" instead of "My Dashbroad"
3. Modifies dashboard.show_admin.registered_users in hyrax.en.yml to be "Registered Users" instead of "Registered users" to be consistent with other headings
4. Modifies spec/features/dashboard/display_dashboard_spec.rb to check for new title
5. Adds new spec/features/dashboard/display_admin_dashboard_spec.rb to check for title and other headings.

```
	modified:   app/views/hyrax/dashboard/show_admin.html.erb
	modified:   config/locales/hyrax.en.yml
	new file:   spec/features/dashboard/display_admin_dashboard_spec.rb
	modified:   spec/features/dashboard/display_dashboard_spec.rb
```


@samvera/hyrax-code-reviewers