### PR TITLE
add facet for collections to dashboard -> works index

### DIFF
--- a/app/controllers/hyrax/my/works_controller.rb
+++ b/app/controllers/hyrax/my/works_controller.rb
@@ -1,6 +1,15 @@
 module Hyrax
   module My
     class WorksController < MyController
+      # Define collection specific filter facets.
+      def self.configure_facets
+        configure_blacklight do |config|
+          config.add_facet_field solr_name("admin_set", :facetable), limit: 5
+          config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5
+        end
+      end
+      configure_facets
+
       class_attribute :create_work_presenter_class
       self.create_work_presenter_class = Hyrax::SelectTypeListPresenter
 

--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -13,7 +13,6 @@ module Hyrax
                                helper_method: :visibility_badge,
                                limit: 5, label: I18n.t('hyrax.dashboard.my.heading.visibility')
         config.add_facet_field IndexesWorkflow.suppressed_field, helper_method: :suppressed_to_status
-        config.add_facet_field solr_name("admin_set", :facetable), limit: 5
         config.add_facet_field solr_name("resource_type", :facetable), limit: 5
       end
     end

--- a/app/views/hyrax/my/_facet_pivot.html.erb
+++ b/app/views/hyrax/my/_facet_pivot.html.erb
@@ -1,6 +1,6 @@
 <% if !subfacet ||= false %>
   <ul class="dropdown-menu pivot-facet list-unstyled">
-<%end %>
+<% end %>
 
   <% display_facet.items.each do |item| -%>
     <li>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -17,7 +17,8 @@ en:
     search:
       fields:
         facet:
-          admin_set_sim: Collection
+          admin_set_sim: Admin Set
+          member_of_collections_ssim: Collection
           resource_type_sim: Resource type
           suppressed_bsi: Status
         show:

--- a/spec/features/dashboard/all_works.rb
+++ b/spec/features/dashboard/all_works.rb
@@ -1,6 +1,8 @@
 RSpec.describe "As an admin user I should be able to see all works" do
-  let!(:work1) { create(:work, title: ['Testing #1']) }
-  let!(:work2) { create(:work, title: ['Testing #2']) }
+  let!(:work1) { create(:work, title: ['Testing #1'], admin_set: adminset, member_of_collections: [collection]) }
+  let!(:work2) { create(:work, title: ['Testing #2'], admin_set: adminset, member_of_collections: [collection]) }
+  let(:collection) { build(:collection_lw, with_solr_document: true) }
+  let(:adminset) { create(:admin_set) }
 
   before do
     sign_in create(:admin)
@@ -10,5 +12,11 @@ RSpec.describe "As an admin user I should be able to see all works" do
     expect(page).to have_content 'Works'
     expect(page).to have_content 'Testing #1'
     expect(page).to have_content 'Testing #2'
+
+    # check for filters
+    expect(page).to have_button('Collection')
+    expect(page).to have_link(collection.title.first, class: 'facet_select')
+    expect(page).to have_button('Admin Set')
+    expect(page).to have_link(adminset.title.first, class: 'facet_select')
   end
 end


### PR DESCRIPTION
Fixes #2602

This is not ideal.  It would be better if Admin Sets where listed in the same filter as the Collections.  But creating that filter is very complex and would likely require a kludge because Admin Sets and Collections are not stored in the same solr field.

Also, it would be even better if the facet was a pivot on collection type and collection/admin set name.  But that is even more complex.

For Hyrax 2.1 release, I recommend going with this implementation.  For a later release, we can explore putting in a more complex filter.

@samvera/hyrax-code-reviewers
