### PR TITLE
Change nested forms in collections > edit > sharing tab to ajax to fix broken submission

### DIFF
--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -311,8 +311,46 @@ Blacklight.onLoad(function () {
     submitModalAjax(url, 'POST', data, $(this));
   });
 
+
   // Handle add a subcollection button click on the collections show page
   $('.sub-collections-wrapper button.add-subcollection').on('click', function (e) {
     $('#add-subcollection-modal-' + $(this).data('presenterId')).modal('show');
+  });
+
+
+  // Edit Collection: Sharing tab: Add Sharing section click handlers
+  /*
+  Notes:
+  This is a workaround for a scoping issue with 'simple_form' and nested forms in the
+  'Edit Collections' partials.  All tabs were wrapped in a 'simple_form'. Nested forms, for example inside a tab partial,
+  have behaved erratically, so the pattern has been to remove nested form instances for relatively non-complex forms
+  and replace with AJAX requests.  For this instance of Add Sharing > Add user and Add group, seem more complex in how
+  the form is built from '@form.permission_template', so since it's not working, but the form is already built, this
+  code listens for a click event on the nested form submit button, prevents Default submit behavior, and manually makes
+  the form post.
+   */
+  $('#participants').find('.edit-collection-add-sharing-button').on('click', function(e) {
+    e.preventDefault();
+    var $wrapEl = $(e.target).parents('.form-add-sharing-wrapper');
+    if ($wrapEl.length === 0) {
+      return;
+    }
+    var serialized = $wrapEl.find(':input').serialize(),
+      url = '/dashboard/collections/' + $wrapEl.data('id') + '/permission_template?locale=en';
+
+    if (serialized.length === 0) {
+      return;
+    }
+
+    $.ajax({
+      type: 'POST',
+      url: url,
+      data: serialized
+    }).done(function(response) {
+      // Success handler here, possibly show alert success if page didn't reload?
+    }).fail(function(err) {
+      console.error(err);
+    });
+
   });
 });

--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -403,7 +403,8 @@ button.branding-banner-remove:hover {
       }
 
       input,
-      select {
+      select,
+      .select2-container {
         width: 200px;
       }
 
@@ -422,8 +423,10 @@ button.branding-banner-remove:hover {
     .share-status {
       th,
       td {
+        width: 40%;
         &:last-of-type {
           text-align: center;
+          width: 20%;
         }
       }
     }

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -1,3 +1,5 @@
+<% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
+
 <div id="participants" class="tab-pane">
   <div class="panel panel-default labels edit-sharing-tab">
     <div class="panel-body">
@@ -6,63 +8,68 @@
         <p><%= t('.note') %></p>
         <h3><%= t('.add_sharing') %></h3>
 
-        <% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
+        <!-- Add group form -->
+        <div class="form-add-sharing-wrapper" data-id="<%= @form.id %>">
+          <%= simple_form_for @form.permission_template,
+                              url: [hyrax, :dashboard, @form, :permission_template],
+                              html: { id: 'group-participants-form' } do |f| %>
+            <div class="clearfix spacer">
+              <%= f.fields_for 'access_grants_attributes',
+                               f.object.access_grants.build(agent_type: 'group'),
+                               index: 0 do |builder| %>
 
-        <%= simple_form_for @form.permission_template,
-                            url: [hyrax, :dashboard, @form, :permission_template],
-                            html: { id: 'group-participants-form' } do |f| %>
-          <div class="clearfix spacer">
-            <%= f.fields_for 'access_grants_attributes',
-                             f.object.access_grants.build(agent_type: 'group'),
-                             index: 0 do |builder| %>
+                <div class="form-inline add-sharing-form">
+                  <label class="col-md-2 col-xs-4 control-label"><%= t('.add_group') %>:</label>
+                  <div class="col-md-10 col-xs-8 form-group">
+                    <%= builder.hidden_field :agent_type %>
+                    <%= builder.text_field :agent_id,
+                                           placeholder: "Search for a group...",
+                                           class: 'form-control search-input' %>
+                    as
+                    <%= builder.select :access,
+                                       access_options,
+                                       { prompt: "Select a role..." },
+                                       class: 'form-control' %>
 
-              <div class="form-inline add-sharing-form">
-                <label class="col-md-2 col-xs-4 control-label"><%= t('.add_group') %>:</label>
+                    <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button' %>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+
+        <!-- Add user form -->
+        <div class="form-add-sharing-wrapper" data-id="<%= @form.id %>">
+          <%= simple_form_for @form.permission_template,
+                              url: [hyrax, :dashboard, @form, :permission_template],
+                              html: { id: 'user-participants-form' } do |f| %>
+            <div class="clearfix spacer">
+
+              <%= f.fields_for 'access_grants_attributes',
+                               f.object.access_grants.build(agent_type: 'user'),
+                               index: 0 do |builder| %>
+
+              <div class="form-inline add-users">
+                <label class="col-md-2 col-xs-4 control-label"><%= t('.add_user') %>:</label>
                 <div class="col-md-10 col-xs-8 form-group">
                   <%= builder.hidden_field :agent_type %>
                   <%= builder.text_field :agent_id,
-                                         placeholder: "Search for a group...",
-                                         class: 'form-control search-input' %>
+                                         placeholder: "Search for a user..." %>
                   as
                   <%= builder.select :access,
                                      access_options,
                                      { prompt: "Select a role..." },
                                      class: 'form-control' %>
 
-                  <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
+                  <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button' %>
                 </div>
               </div>
-            <% end %>
-          </div>
-        <% end %>
-
-        <%= simple_form_for @form.permission_template,
-                            url: [hyrax, :dashboard, @form, :permission_template],
-                            html: { id: 'user-participants-form' } do |f| %>
-          <div class="clearfix spacer">
-
-            <%= f.fields_for 'access_grants_attributes',
-                             f.object.access_grants.build(agent_type: 'user'),
-                             index: 0 do |builder| %>
-
-            <div class="form-inline add-users">
-              <label class="col-md-2 col-xs-4 control-label"><%= t('.add_user') %>:</label>
-              <div class="col-md-10 col-xs-8 form-group">
-                <%= builder.hidden_field :agent_type %>
-                <%= builder.text_field :agent_id,
-                                       placeholder: "Search for a user..." %>
-                as
-                <%= builder.select :access,
-                                   access_options,
-                                   { prompt: "Select a role..." },
-                                   class: 'form-control' %>
-
-                <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
-              </div>
+              <% end %>
             </div>
-            <% end %>
-          </div>
-        <% end %>
+          <% end %>
+        </div>
+
         <p class="help-block"><%= t('hyrax.admin.admin_sets.form.note')%></p>
       </section>
 

--- a/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
@@ -17,9 +17,9 @@
                           <td><%= g.agent_type.titleize %></td>
                           <td>
                             <% if g.admin_group? %>
-                              <%= link_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
+                              <%= link_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
                             <% else %>
-                              <%= link_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger' %>
+                              <%= link_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger' %>
                             <% end %>
                           </td>
                         </tr>

--- a/spec/views/hyrax/dashboard/collections/_form_share.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_share.erb_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'hyrax/dashboard/collections/_form_share.html.erb', type: :view d
     assign(:collection, collection)
     @form = instance_double(Hyrax::Forms::CollectionForm,
                             to_model: collection,
-                            permission_template: pt_form)
+                            permission_template: pt_form,
+                            id: '1234xyz')
     render
   end
   it "has the required selectors" do


### PR DESCRIPTION
Fixes #2619 

Fixes broken form submission resulting from nested "simple_forms", through javascript.  Blocks the default form submit event, serializes the form (or form-wrapper element) data, then makes an AJAX post.

Also did a little tweaking to the UI:
- Each share table columns is now equal width.
- The Remove button in each share table row is now a `class="btn-sm"`, to be consistent with other buttons in display table rows.

I made the following comment next to the javascript form button click listener, so other devs can hopefully understand what's going on:

**Notes:**
  This is a workaround for a scoping issue with 'simple_form' and nested forms in the  'Edit Collections' partials.  All tabs were wrapped in a 'simple_form'. Nested forms, for example inside a tab partial, have behaved erratically, so the pattern has been to remove nested form instances for relatively non-complex forms and replace with AJAX requests.  For this instance of Add Sharing > Add user and Add group, seem more complex in how the form is built from '@form.permission_template', so since it's not working, but the form is already built, this code listens for a click event on the nested form submit button, prevents Default submit behavior, and manually makes the form post.

#### Existing issues resulting from the workaround
The alert messaging which displays when a user or group is removed from a row doesn't display when adding.  Perhaps turbolinks is eating these as well?  I recall @laritakr was looking into this a few weeks back, and if there was any solution this would be a good place to see if it can be applied.

#### Future work
Wrapping the entire Collections > Edit tabs in a simple_form might not be the best approach, and scope collisions have been occurring frequently between nested forms.  In the future, a better pattern might be to place a click listener via javascript on the overall wrapper "form"... which shouldn't be a `<form>` element, and then each tab could have as many forms as it wants.