### PR TITLE
Focusable Skip to Content Link

### DIFF
--- a/app/assets/stylesheets/hyrax/_accessibility.scss
+++ b/app/assets/stylesheets/hyrax/_accessibility.scss
@@ -14,3 +14,24 @@
 .select2-default {
   color: #4c4c4c !important;
 }
+
+// Adds a skip to content link for keyboard users, but only makes it visible when element receives focus
+.skip-to-content a {
+  height: 1px;
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  overflow: hidden;
+}
+
+.skip-to-content a:focus {
+  background-color: $admin-content-background-color;
+  height: auto;
+  left: 1rem;
+  padding: 1.5rem;
+  position: absolute;
+  top: 0.5rem;
+  width: auto;
+  z-index: 1005;
+}

--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -67,7 +67,6 @@ body.dashboard {
     border-top: 2px solid $tab-active-accent-color;
   }
 
-
   /* The #masthead selector below could (and ideally, should) be removed if we can
    * replace the "navbar-static-top" class with "navbar-fixed-top" for the Admin UI only
    */

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -6,12 +6,13 @@
   </head>
 
   <body>
-    <a href="#skip_to_content" class="sr-only">Skip to Content</a>
+    <div class="skip-to-content">
+      <%= link_to "Skip to Content", "#skip-to-content", data: { turbolinks: false } %>
+    </div>
     <%= render '/masthead' %>
     <%= content_for(:navbar) %>
     <%= content_for(:precontainer_content) %>
     <div id="content-wrapper" class="container" role="main">
-      <a name="skip_to_content"></a>
       <%= render '/flash_msg' %>
       <%= render_breadcrumbs builder: Hyrax::BootstrapBreadcrumbsBuilder %>
       <% if content_for?(:page_header) %>
@@ -22,7 +23,9 @@
         </div>
       <% end %>
 
-      <%= content_for?(:content) ? yield(:content) : yield %>
+        <a name="skip-to-content" id="skip-to-content"></a>
+        <%= content_for?(:content) ? yield(:content) : yield %>
+
     </div><!-- /#content-wrapper -->
     <%= render 'shared/footer' %>
     <%= render 'shared/ajax_modal' %>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -6,11 +6,12 @@
   </head>
 
   <body class="dashboard">
-    <a href="#skip_to_content" class="sr-only">Skip to Content</a>
+    <div class="skip-to-content">
+      <%= link_to "Skip to Content", "#skip-to-content", data: { turbolinks: false } %>
+    </div>
     <%= render '/masthead' %>
     <%= content_for(:navbar) %>
     <div id="content-wrapper" role="main">
-      <a name="skip_to_content"></a>
       <div class="sidebar maximized">
         <%= render 'hyrax/dashboard/sidebar' %>
       </div>
@@ -25,7 +26,9 @@
           </div>
         <% end %>
 
-        <%= content_for?(:content) ? yield(:content) : yield %>
+          <a name="skip-to-content" id="skip-to-content"></a>
+          <%= content_for?(:content) ? yield(:content) : yield %>
+
       </div>
 
     </div><!-- /#content-wrapper -->


### PR DESCRIPTION
Fixes #497 

Reworks the skip to content functionality and adds the CSS to show the link to skip content when tabbing to the link. Removes the masthead fixed positioning so that the skip to content link can occupy the very top row when focused. Switches to the rails helper for link_to and disables turbolinks just for the skip link.


Changes proposed in this pull request:
* Adds CSS to the accessibility SCSS file to position the skip links off screen until a user tabs to the link
* Removes fixed positioning for the masthead in the main nav bar to allow the skip links to appear above and before the rest of the code
* Used an anchor for the link for better cross browser functionality when tabbing through the interface and selecting the skip to content link
* Turns turbolinks off for the skip link

@samvera/hyrax-code-reviewers
