### PR TITLE
show bibliographic_citation in show and edit views

### DIFF
--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -23,7 +23,7 @@ module Hyrax
 
       self.terms = [:title, :creator, :contributor, :description,
                     :keyword, :license, :rights_statement, :publisher, :date_created,
-                    :subject, :language, :identifier, :based_near, :related_url,
+                    :subject, :language, :identifier, :based_near, :related_url, :bibliographic_citation,
                     :representative_id, :thumbnail_id, :rendering_ids, :files,
                     :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
                     :visibility_during_lease, :lease_expiration_date, :visibility_after_lease,

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -66,6 +66,7 @@ module Hyrax
         attribute :source, Solr::Array, solr_name('source')
         attribute :date_created, Solr::Array, solr_name('date_created')
         attribute :rights_statement, Solr::Array, solr_name('rights_statement')
+        attribute :bibliographic_citation, Solr::Array, solr_name('bibliographic_citation')
 
         attribute :mime_type, Solr::String, solr_name('mime_type', :stored_sortable)
         attribute :workflow_state, Solr::String, solr_name('workflow_state_name', :symbol)

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -37,7 +37,7 @@ module Hyrax
 
     # Metadata Methods
     delegate :title, :date_created, :description,
-             :creator, :contributor, :subject, :publisher, :language, :embargo_release_date,
+             :creator, :contributor, :subject, :publisher, :language, :bibliographic_citation, :embargo_release_date,
              :lease_expiration_date, :license, :source, :rights_statement, :thumbnail_id, :representative_id,
              :rendering_ids, :member_of_collection_ids, to: :solr_document
 

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -12,3 +12,4 @@
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:source) %>
 <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement) %>
+<%= presenter.attribute_to_html(:bibliographic_citation) %>

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Hyrax::Forms::BatchUploadForm do
                          :identifier,
                          :based_near,
                          :related_url,
+                         :bibliographic_citation,
                          :representative_id,
                          :thumbnail_id,
                          :rendering_ids,


### PR DESCRIPTION
There is a `bibliographic_citation` property defined in `Hyrax::BasicMetadata` but it is not exposed in the edit form or display of work. 

https://github.com/samvera/hyrax/blob/1-0-stable/app/models/concerns/hyrax/basic_metadata.rb#L64

Changes proposed in this pull request:
* Display `bibliographic_citation` in edit form and on work show page.


@samvera/hyrax-code-reviewers
