### PR TITLE
Change 'Admininstration' to 'Dashboard' in breadcrumbs

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -550,7 +550,7 @@ en:
         works: All Works
       authorize_proxies: Authorize Proxies
       breadcrumbs:
-        admin: Administration
+        admin: Dashboard
       collection_type_actions:
         close: Close
         create_collection: Create collection

--- a/spec/controllers/hyrax/admin/appearances_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/appearances_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Hyrax::Admin::AppearancesController do
 
       it "is successful" do
         expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
-        expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
         expect(controller).to receive(:add_breadcrumb).with('Configuration', '#')
         expect(controller).to receive(:add_breadcrumb).with('Appearance', "/admin/appearance")
         get :show

--- a/spec/controllers/hyrax/admin/features_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/features_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Hyrax::Admin::FeaturesController do
 
       it "is successful" do
         expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
-        expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
         expect(controller).to receive(:add_breadcrumb).with('Configuration', '#')
         expect(controller).to receive(:add_breadcrumb).with('Features', admin_features_path)
         get :index

--- a/spec/controllers/hyrax/admin/workflow_roles_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/workflow_roles_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::Admin::WorkflowRolesController do
 
       it "is successful" do
         expect(controller).to receive(:add_breadcrumb).with('Home', root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Workflow Roles', admin_workflow_roles_path(locale: 'en'))
         get :index
         expect(response).to be_success

--- a/spec/controllers/hyrax/admin/workflows_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/workflows_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hyrax::Admin::WorkflowsController do
     end
     it "is successful" do
       expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
-      expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path)
+      expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
       expect(controller).to receive(:add_breadcrumb).with('Tasks', '#')
       expect(controller).to receive(:add_breadcrumb).with('Review Submissions', "/admin/workflows")
 

--- a/spec/controllers/hyrax/content_blocks_controller_spec.rb
+++ b/spec/controllers/hyrax/content_blocks_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Hyrax::ContentBlocksController, type: :controller do
     describe "GET #edit" do
       it "renders breadcrumbs" do
         expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
-        expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
         expect(controller).to receive(:add_breadcrumb).with('Configuration', '#')
         expect(controller).to receive(:add_breadcrumb).with('Content Blocks', edit_content_blocks_path)
         get :edit

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe Hyrax::GenericWorksController do
 
       it 'shows me the page and sets breadcrumbs' do
         expect(controller).to receive(:add_breadcrumb).with("Home", root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with("Administration", hyrax.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with("Dashboard", hyrax.dashboard_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with("Your Works", hyrax.my_works_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with(work.title.first, main_app.hyrax_generic_work_path(work.id, locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Edit', main_app.edit_hyrax_generic_work_path(work.id))

--- a/spec/controllers/hyrax/my/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/my/collections_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyrax::My::CollectionsController, type: :controller do
         expect(controller).to receive(:search_results).with(ActionController::Parameters).and_return([response, doc_list])
 
         expect(controller).to receive(:add_breadcrumb).with('Home', root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Collections', my_collections_path(locale: 'en'))
 
         get :index, params: { per_page: 2 }

--- a/spec/controllers/hyrax/my/works_controller_spec.rb
+++ b/spec/controllers/hyrax/my/works_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hyrax::My::WorksController, type: :controller do
     it "shows search results and breadcrumbs" do
       expect(controller).to receive(:search_results).with(ActionController::Parameters).and_return([response, doc_list])
       expect(controller).to receive(:add_breadcrumb).with('Home', root_path(locale: 'en'))
-      expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path(locale: 'en'))
+      expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path(locale: 'en'))
       expect(controller).to receive(:add_breadcrumb).with('Works', my_works_path(locale: 'en'))
       expect(collection_service).to receive(:search_results).with(:deposit).and_return([my_collection])
       get :index, params: { per_page: 2 }

--- a/spec/controllers/hyrax/pages_controller_spec.rb
+++ b/spec/controllers/hyrax/pages_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Hyrax::PagesController, type: :controller do
       describe "GET #edit" do
         it "renders breadcrumbs and dashboard layout" do
           expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
-          expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
           expect(controller).to receive(:add_breadcrumb).with('Configuration', '#')
           expect(controller).to receive(:add_breadcrumb).with('Pages', edit_pages_path)
           get :edit


### PR DESCRIPTION
Fixes #2819

Breadcrumbs should use Dashboard instead of Administration #2819

1. Changed hyrax.en.yml dashboard.breadcrumbs.admin from "Administration" to "Dashboard"
2. Modified specs to check for "Dashboard"

    modified:   config/locales/hyrax.en.yml
    modified:   spec/controllers/hyrax/admin/appearances_controller_spec.rb
    modified:   spec/controllers/hyrax/admin/features_controller_spec.rb
    modified:   spec/controllers/hyrax/admin/workflow_roles_controller_spec.rb
    modified:   spec/controllers/hyrax/admin/workflows_controller_spec.rb
    modified:   spec/controllers/hyrax/content_blocks_controller_spec.rb
    modified:   spec/controllers/hyrax/generic_works_controller_spec.rb
    modified:   spec/controllers/hyrax/my/collections_controller_spec.rb
    modified:   spec/controllers/hyrax/my/works_controller_spec.rb
    modified:   spec/controllers/hyrax/pages_controller_spec.rb

@samvera/hyrax-code-reviewers