### PR TITLE
adjust namespace for noid-rails

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -118,7 +118,7 @@ module Hyrax
 
     attr_writer :noid_minter_class
     def noid_minter_class
-      @noid_minter_class ||= Noid::Rails::Minter::Db
+      @noid_minter_class ||= ::Noid::Rails::Minter::Db
     end
 
     attr_writer :minter_statefile

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -90,9 +90,9 @@ module Hyrax
         ActiveFedora::Base.translate_uri_to_id = c.translate_uri_to_id
         ActiveFedora::Base.translate_id_to_uri = c.translate_id_to_uri
 
-        Noid::Rails.config.template = c.noid_template
-        Noid::Rails.config.minter_class = c.noid_minter_class
-        Noid::Rails.config.statefile = c.minter_statefile
+        ::Noid::Rails.config.template = c.noid_template
+        ::Noid::Rails.config.minter_class = c.noid_minter_class
+        ::Noid::Rails.config.statefile = c.minter_statefile
       end
     end
 


### PR DESCRIPTION
Fixes #2842

Addresses issue I had upgrading from 2.0 to 2.1.0beta1.  It seemed like there was a scope issue with the name spacing of `noid-rails`, some references already were using a `::` prefix.

Changes proposed in this pull request:
* change namespace scoping of noid rails

@samvera/hyrax-code-reviewers
