### PR TITLE
Remove Your pronoun from breadcrumbs

### DIFF
--- a/app/views/hyrax/my/collections/_tabs.html.erb
+++ b/app/views/hyrax/my/collections/_tabs.html.erb
@@ -4,6 +4,6 @@
       <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.collections"), hyrax.dashboard_collections_path %>
     </li>
   <li<%= ' class="active"'.html_safe if current_page?(hyrax.my_collections_path(locale: nil)) %>>
-    <%= link_to t('hyrax.dashboard.my.collections'), hyrax.my_collections_path %>
+    <%= link_to t('hyrax.dashboard.my.your_collections'), hyrax.my_collections_path %>
   </li>
 </ul>

--- a/app/views/hyrax/my/works/_tabs.html.erb
+++ b/app/views/hyrax/my/works/_tabs.html.erb
@@ -4,6 +4,6 @@
     <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.works"), hyrax.dashboard_works_path, data: { turbolinks: false } %>
   </li>
   <li<%= ' class="active"'.html_safe if current_page?(hyrax.my_works_path(locale: nil)) %>>
-    <%= link_to t('hyrax.dashboard.my.works'), hyrax.my_works_path, data: { turbolinks: false } %>
+    <%= link_to t('hyrax.dashboard.my.your_works'), hyrax.my_works_path, data: { turbolinks: false } %>
   </li>
 </ul>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -698,7 +698,8 @@ en:
           edit_access: 'Edit Access:'
           groups: 'Groups:'
           users: 'Users:'
-        collections: Your Collections
+        collections: Collections
+        your_collections: Your Collections
         facet_label:
           collections: 'Filter collections:'
           highlighted: 'Filter highlights:'
@@ -725,7 +726,8 @@ en:
           press_to: Press to
           results_per_page: Number of results to display per page
           show_label: Display all details of
-        works: Your Works
+        works: Works
+        your_works: Your Works
       nest_collections_form:
         create_under: "'%{child_title}' has been added to '%{parent_title}'"
         create_within: "'%{child_title}' has been added to '%{parent_title}'"

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Hyrax::CollectionsController do
         it "sets breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'))
           get :show, params: { id: collection }
           expect(response).to be_successful

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         it "sets breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'))
           get :show, params: { id: collection }
           expect(response).to be_successful
@@ -454,7 +454,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       it "sets breadcrumbs" do
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.browse_view"), collection_path(collection.id, locale: 'en'))
         get :edit, params: { id: collection }
         expect(response).to be_successful

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe Hyrax::FileSetsController do
         it "shows me the breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Your Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set, locale: 'en'))
           get :show, params: { id: file_set }

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Hyrax::GenericWorksController do
         it "sets breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Your Works', hyrax.my_works_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Works', hyrax.my_works_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
           get :show, params: { id: work }
           expect(response).to be_successful
@@ -355,7 +355,7 @@ RSpec.describe Hyrax::GenericWorksController do
       it 'shows me the page and sets breadcrumbs' do
         expect(controller).to receive(:add_breadcrumb).with("Home", root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with("Dashboard", hyrax.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with("Your Works", hyrax.my_works_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with("Works", hyrax.my_works_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with(work.title.first, main_app.hyrax_generic_work_path(work.id, locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Edit', main_app.edit_hyrax_generic_work_path(work.id))
 

--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -94,8 +94,10 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
             click_button 'Save changes'
           end
           # forwards to collections index page and shows flash message
-          expect(page).to have_link 'All Collections'
-          expect(page).to have_link 'Your Collections'
+          within('section.tabs-row') do
+            expect(page).to have_link 'All Collections'
+            expect(page).to have_link 'Your Collections'
+          end
 
           err_message = "Error: You have specified more than one of the same single-membership collection types: " \
                         "Single-membership 1 (#{new_collection.title.first} and #{old_collection.title.first})"
@@ -129,9 +131,10 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
             click_button 'Save changes'
           end
           # forwards to collections index page and shows flash message
-          expect(page).to have_link 'All Collections'
-          expect(page).to have_link 'Your Collections'
-
+          within('section.tabs-row') do
+            expect(page).to have_link 'All Collections'
+            expect(page).to have_link 'Your Collections'
+          end
           err_message = "Error: You have specified more than one of the same single-membership collection types: " \
                         "Single-membership 1 (#{new_collection.title.first} and #{old_collection.title.first})"
           expect(page).to have_selector '.alert', text: err_message

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       it "has page title, does not have tabs, and lists only user's collections" do
         expect(page).to have_content 'Collections'
         expect(page).not_to have_link 'All Collections'
-        expect(page).not_to have_link 'Your Collections'
+        within('section.tabs-row') do
+          expect(page).not_to have_link 'Your Collections'
+        end
         expect(page).to have_link(collection1.title.first)
         expect(page).to have_link(collection2.title.first)
         expect(page).to have_link(admin_set_b.title.first)
@@ -85,7 +87,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         visit '/dashboard/my/collections'
       end
 
-      it "has page title, has tabs for All and Your Collections, and lists collections with edit access" do
+      it "has page title, has tabs for All Collections and Your Collections, and lists collections with edit access" do
         expect(page).to have_content 'Collections'
         expect(page).to have_link 'All Collections'
         expect(page).to have_link 'Your Collections'


### PR DESCRIPTION
Fixes #2829

Removes the "Your" pronoun from breadcrumbs, using "Collections" or "Works" instead.

Bread crumbs that link to the works index page should use label: Your Works
Bread crumbs that link to the collections index page should use label: Your Collections

File changed or added:
    modified:   config/locales/hyrax.en.yml
    modified:   spec/controllers/hyrax/collections_controller_spec.rb
    modified:   spec/controllers/hyrax/dashboard/collections_controller_spec.rb
    modified:   spec/controllers/hyrax/file_sets_controller_spec.rb
    modified:   spec/controllers/hyrax/generic_works_controller_spec.rb
    modified:   spec/features/collection_multi_membership_spec.rb

@samvera/hyrax-code-reviewers