### PR TITLE
Only show viewable images with UniversalViewer

### DIFF
--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -10,7 +10,7 @@ module Hyrax
     #
     # @return [IIIFManifest::DisplayImage] the display image required by the manifest builder.
     def display_image
-      return nil unless ::FileSet.exists?(id) && solr_document.image?
+      return nil unless ::FileSet.exists?(id) && solr_document.image? && current_ability.can?(:read, id)
       # @todo this is slow, find a better way (perhaps index iiif url):
       original_file = ::FileSet.find(id).original_file
 

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -57,10 +57,8 @@ module Hyrax
 
     # @return [Boolean] render the UniversalViewer
     def universal_viewer?
-      representative_id.present? &&
-        representative_presenter.present? &&
-        representative_presenter.image? &&
-        Hyrax.config.iiif_image_server?
+      Hyrax.config.iiif_image_server? &&
+        members_include_viewable_image?
     end
 
     # @return FileSetPresenter presenter for the representative FileSets
@@ -217,6 +215,10 @@ module Hyrax
       def member_of_authorized_parent_collections
         # member_of_collection_ids with current_ability access
         @member_of ||= Hyrax::CollectionMemberService.run(solr_document, current_ability).map(&:id)
+      end
+
+      def members_include_viewable_image?
+        file_set_presenters.any? { |presenter| presenter.image? && current_ability.can?(:read, presenter.id) }
       end
   end
 end

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -284,8 +284,13 @@ RSpec.describe Hyrax::FileSetPresenter do
     let(:file_set) { create(:file_set) }
     let(:solr_document) { SolrDocument.new(file_set.to_solr) }
     let(:request) { double(base_url: 'http://test.host') }
-    let(:presenter) { described_class.new(solr_document, nil, request) }
+    let(:presenter) { described_class.new(solr_document, ability, request) }
     let(:id) { CGI.escape(file_set.original_file.id) }
+    let(:read_permission) { true }
+
+    before do
+      allow(ability).to receive(:can?).with(:read, solr_document.id).and_return(read_permission)
+    end
 
     describe "#display_image" do
       subject { presenter.display_image }
@@ -310,6 +315,10 @@ RSpec.describe Hyrax::FileSetPresenter do
 
         context "when the file is an image" do
           let(:file_path) { File.open(fixture_path + '/world.png') }
+
+          before do
+            allow(solr_document).to receive(:image?).and_return(true)
+          end
 
           it { is_expected.to be_instance_of IIIFManifest::DisplayImage }
           its(:url) { is_expected.to eq "http://test.host/images/#{id}/full/600,/0/default.jpg" }
@@ -343,6 +352,12 @@ RSpec.describe Hyrax::FileSetPresenter do
 
             it { is_expected.to be_instance_of IIIFManifest::DisplayImage }
             its(:url) { is_expected.to eq "http://test.host/downloads/#{id.split('/').first}" }
+          end
+
+          context "when the user doesn't have permission to view the image" do
+            let(:read_permission) { false }
+
+            it { is_expected.to be_nil }
           end
         end
       end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
       "date_created_tesim" => ['an unformatted date'],
       "depositor_tesim" => user_key }
   end
-  let(:ability) { nil }
+  let(:ability) { double Ability }
   let(:presenter) { described_class.new(solr_document, ability, request) }
 
   subject { described_class.new(double, double) }
@@ -48,10 +48,16 @@ RSpec.describe Hyrax::WorkShowPresenter do
     let(:representative_presenter) { double('representative', present?: false) }
     let(:image_boolean) { false }
     let(:iiif_enabled) { false }
+    let(:file_set_presenter) { Hyrax::FileSetPresenter.new(solr_document, ability) }
+    let(:file_set_presenters) { [file_set_presenter] }
+    let(:read_permission) { true }
 
     before do
       allow(presenter).to receive(:representative_id).and_return(id_present)
       allow(presenter).to receive(:representative_presenter).and_return(representative_presenter)
+      allow(presenter).to receive(:file_set_presenters).and_return(file_set_presenters)
+      allow(file_set_presenter).to receive(:image?).and_return(true)
+      allow(ability).to receive(:can?).with(:read, solr_document.id).and_return(read_permission)
       allow(representative_presenter).to receive(:image?).and_return(image_boolean)
       allow(Hyrax.config).to receive(:iiif_image_server?).and_return(iiif_enabled)
     end
@@ -92,6 +98,12 @@ RSpec.describe Hyrax::WorkShowPresenter do
       let(:iiif_enabled) { true }
 
       it { is_expected.to be true }
+
+      context "when the user doesn't have permission to view the image" do
+        let(:read_permission) { false }
+
+        it { is_expected.to be false }
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #2802 

Only shows the UV on a work when there is at least one attached image that the user has permission to view.

If UV is displayed, the only images loaded into the viewer are files that the user has permission to view.
