### PR TITLE
2837 add sidebar to management pages

### DIFF
--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -5,6 +5,9 @@ module Hyrax
     include Hyrax::Collections::AcceptsBatches
 
     def index
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.embargoes.index.manage_embargoes', hyrax.embargoes_path)
       authorize! :index, Hydra::AccessControls::Embargo
     end
 

--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -7,7 +7,7 @@ module Hyrax
     def index
       add_breadcrumb t(:'hyrax.controls.home'), root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb t(:'hyrax.embargoes.index.manage_embargoes', hyrax.embargoes_path)
+      add_breadcrumb t(:'hyrax.embargoes.index.manage_embargoes'), hyrax.embargoes_path
       authorize! :index, Hydra::AccessControls::Embargo
     end
 
@@ -42,6 +42,13 @@ module Hyrax
     # This allows us to use the unauthorized template in curation_concerns/base
     def self.local_prefixes
       ['hyrax/base']
+    end
+
+    def edit
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.embargoes.index.manage_embargoes'), hyrax.embargoes_path
+      add_breadcrumb t(:'hyrax.embargoes.edit.embargo_update'), '#'
     end
   end
 end

--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -5,6 +5,9 @@ module Hyrax
     include Hyrax::Collections::AcceptsBatches
 
     def index
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.leases.index.manage_leases', hyrax.leases_path)
       authorize! :index, Hydra::AccessControls::Lease
     end
 

--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -7,7 +7,7 @@ module Hyrax
     def index
       add_breadcrumb t(:'hyrax.controls.home'), root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb t(:'hyrax.leases.index.manage_leases', hyrax.leases_path)
+      add_breadcrumb t(:'hyrax.leases.index.manage_leases'), hyrax.leases_path
       authorize! :index, Hydra::AccessControls::Lease
     end
 
@@ -35,6 +35,13 @@ module Hyrax
     # This allows us to use the unauthorized template in curation_concerns/base
     def self.local_prefixes
       ['hyrax/base']
+    end
+
+    def edit
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.leases.index.manage_leases'), hyrax.leases_path
+      add_breadcrumb t(:'hyrax.leases.edit.lease_update'), '#'
     end
   end
 end

--- a/app/controllers/concerns/hyrax/manages_embargoes.rb
+++ b/app/controllers/concerns/hyrax/manages_embargoes.rb
@@ -13,9 +13,6 @@ module Hyrax
       redirect_to root_path, alert: exception.message
     end
 
-    def edit
-      add_breadcrumb t(:'hyrax.controls.home'), root_path
-      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-    end
+    def edit; end
   end
 end

--- a/app/controllers/concerns/hyrax/manages_embargoes.rb
+++ b/app/controllers/concerns/hyrax/manages_embargoes.rb
@@ -13,6 +13,9 @@ module Hyrax
       redirect_to root_path, alert: exception.message
     end
 
-    def edit; end
+    def edit
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+    end
   end
 end

--- a/app/controllers/hyrax/batch_edits_controller.rb
+++ b/app/controllers/hyrax/batch_edits_controller.rb
@@ -11,6 +11,8 @@ module Hyrax
     # provides the help_text view method
     helper PermissionsHelper
 
+    with_themed_layout 'dashboard'
+
     def edit
       work = form_class.model_class.new
       work.depositor = current_user.user_key

--- a/app/controllers/hyrax/embargoes_controller.rb
+++ b/app/controllers/hyrax/embargoes_controller.rb
@@ -1,5 +1,7 @@
 module Hyrax
   class EmbargoesController < ApplicationController
     include Hyrax::EmbargoesControllerBehavior
+
+    with_themed_layout 'dashboard'
   end
 end

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -173,10 +173,10 @@ module Hyrax
 
       def decide_layout
         layout = case action_name
-                   when 'show'
-                     '1_column'
-                   else
-                     'dashboard'
+                 when 'show'
+                   '1_column'
+                 else
+                   'dashboard'
                  end
         File.join(theme, layout)
       end

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -28,6 +28,8 @@ module Hyrax
     private :curation_concern=
     helper_method :file_set
 
+    layout :decide_layout
+
     # GET /concern/file_sets/:id
     def edit
       initialize_edit_form
@@ -167,6 +169,16 @@ module Hyrax
       # while prefering our local paths. Thus we are unable to just override `self.local_prefixes`
       def _prefixes
         @_prefixes ||= super + ['hyrax/base']
+      end
+
+      def decide_layout
+        layout = case action_name
+                   when 'show'
+                     '1_column'
+                   else
+                     'dashboard'
+                 end
+        File.join(theme, layout)
       end
   end
 end

--- a/app/controllers/hyrax/leases_controller.rb
+++ b/app/controllers/hyrax/leases_controller.rb
@@ -1,5 +1,7 @@
 module Hyrax
   class LeasesController < ApplicationController
     include Hyrax::LeasesControllerBehavior
+
+    with_themed_layout 'dashboard'
   end
 end

--- a/app/views/hyrax/batch_edits/edit.html.erb
+++ b/app/views/hyrax/batch_edits/edit.html.erb
@@ -5,31 +5,32 @@
    <%= @form.names.join(", ").html_safe %>
 </div> <!-- /original values -->
 
-<div >
+<div>
   <h3> Descriptions:</h3>
-
+  <div class="panel panel-default tabs">
     <ul class="nav nav-tabs">
       <li id="edit_descriptions_link" class="active"><a href="#descriptions_display" data-toggle="tab"><i class="glyphicon glyphicon-tags"></i> Descriptions</a></li>
       <li id="edit_permissions_link"><a href="#permissions_display" data-toggle="tab"><i class="glyphicon glyphicon-lock"></i> Permissions</a></li>
     </ul>
-    <div class="tab-content">
-      <div class="tab-pane active" id="descriptions_display">
-        <% @form.terms.each do |term| %>
-          <div class="row">
-            <%= simple_form_for @form,
-                                url: hyrax.batch_edits_path,
-                                method: :put,
-                                remote: true,
-                                builder: Hyrax::FormBuilder,
-                                html: { id: "form_#{term.to_s}",
-                                        class: "ajax-form" },
-                                data: { model: @form.model_name.param_key } do |f| %>
-              <div class="col-xs-12 col-sm-4">
-                <a class="accordion-toggle grey glyphicon-chevron-right-helper collapsed" data-toggle="collapse" href="#collapse_<%= term %>" id="expand_link_<%=term.to_s%>">
-                  <%= f.input_label term %> <span class="chevron"></span>
-                </a>
-              </div>
-              <div id="collapse_<%= term %>" class="collapse scrolly col-xs-12 col-sm-7">
+    <div class="panel-body">
+      <div class="tab-content">
+        <div class="tab-pane active" id="descriptions_display">
+          <% @form.terms.each do |term| %>
+            <div class="row">
+              <%= simple_form_for @form,
+                                  url: hyrax.batch_edits_path,
+                                  method: :put,
+                                  remote: true,
+                                  builder: Hyrax::FormBuilder,
+                                  html: { id: "form_#{term.to_s}",
+                                          class: "ajax-form" },
+                                  data: { model: @form.model_name.param_key } do |f| %>
+                <div class="col-xs-12 col-sm-4">
+                  <a class="accordion-toggle grey glyphicon-chevron-right-helper collapsed" data-toggle="collapse" href="#collapse_<%= term %>" id="expand_link_<%=term.to_s%>">
+                    <%= f.input_label term %> <span class="chevron"></span>
+                  </a>
+                </div>
+                <div id="collapse_<%= term %>" class="collapse scrolly col-xs-12 col-sm-7">
                   <%= hidden_field_tag('update_type', 'update') %>
                   <%= hidden_field_tag('key', term.to_s) %>
                   <%# TODO we don't need to show required %>
@@ -42,34 +43,36 @@
                     <a class="btn btn-default" data-toggle="collapse" data-parent="#row_<%= term.to_s %>" href="#collapse_<%= term.to_s %>">Cancel </a>
                     <div class="status fleft"></div>
                   </div>
-              </div>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div><!-- #descriptions_display -->
+
+        <div id="permissions_display" class="tab-pane">
+          <%= simple_form_for @form.model,
+                              url: hyrax.batch_edits_path,
+                              method: :put,
+                              remote: true,
+                              html: { id: "form_permissions", class: "ajax-form"},
+                              data: { 'param-key' => @form.model_name.param_key } do |f| %>
+            <%= hidden_field_tag('update_type', 'update') %>
+            <%= hidden_field_tag('key', 'permissions') %>
+            <%= render "hyrax/base/form_permission", f: f %>
+            <%= render "hyrax/base/form_share", f: f %>
+
+            <% @form.batch_document_ids.each do |batch_id| %>
+              <%= hidden_field_tag "batch_document_ids[]", batch_id %>
             <% end %>
-          </div>
-        <% end %>
-      </div><!-- #descriptions_display -->
-
-    <div id="permissions_display" class="tab-pane">
-      <%= simple_form_for @form.model,
-                          url: hyrax.batch_edits_path,
-                          method: :put,
-                          remote: true,
-                          html: { id: "form_permissions", class: "ajax-form"},
-                          data: { 'param-key' => @form.model_name.param_key } do |f| %>
-        <%= hidden_field_tag('update_type', 'update') %>
-        <%= hidden_field_tag('key', 'permissions') %>
-        <%= render "hyrax/base/form_permission", f: f %>
-        <%= render "hyrax/base/form_share", f: f %>
-
-        <% @form.batch_document_ids.each do |batch_id| %>
-          <%= hidden_field_tag "batch_document_ids[]", batch_id %>
-        <% end %>
-        <div class="row">
-            <%= f.submit "Save changes", class: 'btn btn-primary', id: 'permissions_save' %>
-            <div id="status_permissions" class="status fleft"></div>
+            <div class="row">
+              <%= f.submit "Save changes", class: 'btn btn-primary', id: 'permissions_save' %>
+              <div id="status_permissions" class="status fleft"></div>
+            </div>
+          <% end %>
         </div>
-      <% end %>
+      </div> <!-- .tab-content -->
     </div>
-  </div> <!-- .tab-content -->
+  </div>
 
 <!-- Ajax call to clear the batch before page uload. -->
 <%= button_to "Clear Batch", hyrax.clear_batch_edits_path, form_class: 'hidden', remote: true, id: 'clear_batch' %>

--- a/app/views/hyrax/embargoes/edit.html.erb
+++ b/app/views/hyrax/embargoes/edit.html.erb
@@ -4,42 +4,54 @@
   <h1><%= t('.manage_embargoes_html', cc: curation_concern, cc_type: cc_type) %></h1>
 <% end %>
 
-<h2><%= t('.header.current') %></h2>
-<%= simple_form_for [main_app, curation_concern] do |f| %>
-  <fieldset class="set-access-controls">
-    <section class="help-block">
-      <p>
-        <% if curation_concern.embargo_release_date %>
-          <%= t('.embargo_true_html',  cc: cc_type) %>
-        <% else %>
-          <%= t('.embargo_false_html', cc: cc_type) %>
-        <% end %>
-      </p>
-    </section>
-
-    <div class="form-group">
-      <input type="hidden" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>" />
-      <%= render 'hyrax/base/form_permission_embargo', curation_concern: curation_concern, f: f  %>
-    </div>
-  </fieldset>
-
-  <div class="row">
-    <div class="col-md-12 form-actions">
-      <% if curation_concern.embargo_release_date %>
-        <%= f.submit t('.embargo_update'), class: 'btn btn-primary' %>
-        <%= link_to t('.embargo_deactivate'), embargo_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
-      <% else %>
-        <%= f.submit t('.embargo_apply'), class: 'btn btn-primary' %>
-      <% end %>
-      <%= link_to t('.embargo_cancel'), embargoes_path, class: 'btn btn-default' %>
-      <%= link_to t('.embargo_return', cc: cc_type), edit_polymorphic_path([main_app, curation_concern]), class: 'btn btn-default' %>
-    </div>
+<div class="panel panel-default tabs">
+  <div class="panel-heading">
+    <h2 class="panel-title"><%= t('.header.current') %></h2>
   </div>
-<% end %>
+  <div class="panel-body">
+    <%= simple_form_for [main_app, curation_concern] do |f| %>
+      <fieldset class="set-access-controls">
+        <section class="help-block">
+          <p>
+            <% if curation_concern.embargo_release_date %>
+              <%= t('.embargo_true_html',  cc: cc_type) %>
+            <% else %>
+              <%= t('.embargo_false_html', cc: cc_type) %>
+            <% end %>
+          </p>
+        </section>
 
-<h2><%= t('.header.past') %></h2>
-<% if curation_concern.embargo_history.empty? %>
-  <%= t('.history_empty', cc: cc_type) %>
-<% else %>
-  <%= render partial: "embargo_history", object: curation_concern.embargo_history %>
-<% end %>
+        <div class="form-group">
+          <input type="hidden" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>" />
+          <%= render 'hyrax/base/form_permission_embargo', curation_concern: curation_concern, f: f  %>
+        </div>
+      </fieldset>
+
+      <div class="row">
+        <div class="col-md-12 form-actions">
+          <% if curation_concern.embargo_release_date %>
+            <%= f.submit t('.embargo_update'), class: 'btn btn-primary' %>
+            <%= link_to t('.embargo_deactivate'), embargo_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
+          <% else %>
+            <%= f.submit t('.embargo_apply'), class: 'btn btn-primary' %>
+          <% end %>
+          <%= link_to t('.embargo_cancel'), embargoes_path, class: 'btn btn-default' %>
+          <%= link_to t('.embargo_return', cc: cc_type), edit_polymorphic_path([main_app, curation_concern]), class: 'btn btn-default' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="panel panel-default tabs">
+  <div class="panel-heading">
+    <h2 class="panel-title"><%= t('.header.past') %></h2>
+  </div>
+  <div class="panel-body">
+    <% if curation_concern.embargo_history.empty? %>
+      <%= t('.history_empty', cc: cc_type) %>
+    <% else %>
+      <%= render partial: "embargo_history", object: curation_concern.embargo_history %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/hyrax/embargoes/index.html.erb
+++ b/app/views/hyrax/embargoes/index.html.erb
@@ -2,13 +2,13 @@
   <h1><span class="fa fa-sitemap"></span><%= t('.manage_embargoes') %></h1>
 <% end %>
 
-<div class="panel panel-default">
+<div class="panel panel-default tabs">
+  <ul class="nav nav-tabs">
+    <li class="active"><a href="#active" data-toggle="tab"><%= t('.active') %></a></li>
+    <li><a href="#expired" data-toggle="tab"><%= t('.expired') %></a></li>
+    <li><a href="#deactivated" data-toggle="tab"><%= t('.deactivated') %></a></li>
+  </ul>
   <div class="panel-body">
-    <ul class="nav nav-tabs">
-      <li class="active"><a href="#active" data-toggle="tab"><%= t('.active') %></a></li>
-      <li><a href="#expired" data-toggle="tab"><%= t('.expired') %></a></li>
-      <li><a href="#deactivated" data-toggle="tab"><%= t('.deactivated') %></a></li>
-    </ul>
     <div class="tab-content">
       <div class="tab-pane active" id="active">
         <%= render "list_active_embargoes" %>
@@ -22,4 +22,3 @@
     </div>
   </div>
 </div>
-

--- a/app/views/hyrax/file_sets/edit.html.erb
+++ b/app/views/hyrax/file_sets/edit.html.erb
@@ -8,24 +8,28 @@
     <%= media_display curation_concern.to_presenter %>
   </div>
   <div class="col-xs-12 col-sm-8">
-    <ul class="nav nav-tabs" role="tablist">
-      <li id="edit_descriptions_link" class="active">
-        <a href="#descriptions_display" data-toggle="tab"><i class="fa fa-tags"></i> Descriptions</a>
-      </li>
-      <li id="edit_versioning_link">
-        <a href="#versioning_display" data-toggle="tab"><i class="fa fa-sitemap"></i> Versions</a>
-      </li>
-      <li id="edit_permissions_link">
-        <a href="#permissions_display" data-toggle="tab"><i class="fa fa-key"></i> Permissions</a>
-      </li>
-    </ul>
-    <div class="tab-content">
-      <div id="descriptions_display" class="tab-pane active">
-        <h2>Descriptions </h2>
-        <%= render "form" %>
+    <div class="panel panel-default tabs">
+      <ul class="nav nav-tabs" role="tablist">
+        <li id="edit_descriptions_link" class="active">
+          <a href="#descriptions_display" data-toggle="tab"><i class="fa fa-tags"></i> Descriptions</a>
+        </li>
+        <li id="edit_versioning_link">
+          <a href="#versioning_display" data-toggle="tab"><i class="fa fa-sitemap"></i> Versions</a>
+        </li>
+        <li id="edit_permissions_link">
+          <a href="#permissions_display" data-toggle="tab"><i class="fa fa-key"></i> Permissions</a>
+        </li>
+      </ul>
+      <div class="panel-body">
+        <div class="tab-content">
+          <div id="descriptions_display" class="tab-pane active">
+            <h2>Descriptions </h2>
+            <%= render "form" %>
+          </div>
+          <%= render "permission", file_set: curation_concern %>
+          <%= render "versioning", file_set: curation_concern %>
+        </div>
       </div>
-      <%= render "permission", file_set: curation_concern %>
-      <%= render "versioning", file_set: curation_concern %>
-    </div>
-  </div><!-- /.col-sm-8 -->
-</div><!-- /.row -->
+    </div><!-- /.col-sm-8 -->
+  </div><!-- /.row -->
+</div>

--- a/app/views/hyrax/leases/edit.html.erb
+++ b/app/views/hyrax/leases/edit.html.erb
@@ -4,42 +4,54 @@
     <h1><%= t('.manage_leases_html', cc: curation_concern, cc_type: cc_type) %></h1>
 <% end %>
 
-<h2><%= t('.header.current') %></h2>
-<%= simple_form_for [main_app, curation_concern] do |f| %>
-  <fieldset class="set-access-controls">
-    <section class="help-block">
-      <p>
-        <% if curation_concern.lease_expiration_date %>
-          <%= t('.lease_true_html',  cc: cc_type) %>
-        <% else %>
-          <%= t('.lease_false_html', cc: cc_type) %>
-        <% end %>
-      </p>
-    </section>
-
-    <div class="form-group">
-      <input type="hidden" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE %>" />
-      <%= render 'hyrax/base/form_permission_lease', curation_concern: curation_concern, f: f  %>
-    </div>
-  </fieldset>
-
-  <div class="row">
-    <div class="col-md-12 form-actions">
-      <% if curation_concern.lease_expiration_date %>
-        <%= f.submit t('.lease_update'), class: 'btn btn-primary' %>
-        <%= link_to t('.lease_deactivate'), lease_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
-      <% else %>
-        <%= f.submit t('.lease_apply'), class: 'btn btn-primary' %>
-      <% end %>
-      <%= link_to t('.lease_cancel'), leases_path, class: 'btn btn-default' %>
-      <%= link_to t('.lease_return', cc: cc_type), edit_polymorphic_path([main_app, curation_concern]), class: 'btn btn-default' %>
-    </div>
+<div class="panel panel-default tabs">
+  <div class="panel-heading">
+    <h2 class="panel-title"><%= t('.header.current') %></h2>
   </div>
-<% end %>
+  <div class="panel-body">
+    <%= simple_form_for [main_app, curation_concern] do |f| %>
+      <fieldset class="set-access-controls">
+        <section class="help-block">
+          <p>
+            <% if curation_concern.lease_expiration_date %>
+              <%= t('.lease_true_html',  cc: cc_type) %>
+            <% else %>
+              <%= t('.lease_false_html', cc: cc_type) %>
+            <% end %>
+          </p>
+        </section>
 
-<h2><%= t('.header.past') %></h2>
-<% if curation_concern.lease_history.empty? %>
-  <%= t('.history_empty', cc: cc_type) %>
-<% else %>
-  <%= render partial: 'lease_history', object: curation_concern.lease_history %>
-<% end %>
+        <div class="form-group">
+          <input type="hidden" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE %>" />
+          <%= render 'hyrax/base/form_permission_lease', curation_concern: curation_concern, f: f  %>
+        </div>
+      </fieldset>
+
+      <div class="row">
+        <div class="col-md-12 form-actions">
+          <% if curation_concern.lease_expiration_date %>
+            <%= f.submit t('.lease_update'), class: 'btn btn-primary' %>
+            <%= link_to t('.lease_deactivate'), lease_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
+          <% else %>
+            <%= f.submit t('.lease_apply'), class: 'btn btn-primary' %>
+          <% end %>
+          <%= link_to t('.lease_cancel'), leases_path, class: 'btn btn-default' %>
+          <%= link_to t('.lease_return', cc: cc_type), edit_polymorphic_path([main_app, curation_concern]), class: 'btn btn-default' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="panel panel-default tabs">
+  <div class="panel-heading">
+    <h2 class="panel-title"><%= t('.header.past') %></h2>
+  </div>
+  <div class="panel-body">
+    <% if curation_concern.lease_history.empty? %>
+      <%= t('.history_empty', cc: cc_type) %>
+    <% else %>
+      <%= render partial: 'lease_history', object: curation_concern.lease_history %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/hyrax/leases/index.html.erb
+++ b/app/views/hyrax/leases/index.html.erb
@@ -2,13 +2,13 @@
   <h1><span class="fa fa-sitemap"></span><%= t('.manage_leases') %></h1>
 <% end %>
 
-<div class="panel panel-default">
+<div class="panel panel-default tabs">
+  <ul class="nav nav-tabs">
+    <li class="active"><a href="#active" data-toggle="tab"><%= t('.active') %></a></li>
+    <li><a href="#expired" data-toggle="tab"><%= t('.expired') %></a></li>
+    <li><a href="#deactivated" data-toggle="tab"><%= t('.deactivated') %></a></li>
+  </ul>
   <div class="panel-body">
-    <ul class="nav nav-tabs">
-      <li class="active"><a href="#active" data-toggle="tab"><%= t('.active') %></a></li>
-      <li><a href="#expired" data-toggle="tab"><%= t('.expired') %></a></li>
-      <li><a href="#deactivated" data-toggle="tab"><%= t('.deactivated') %></a></li>
-    </ul>
     <div class="tab-content">
       <div class="tab-pane active" id="active">
         <%= render "list_active_leases" %>

--- a/spec/controllers/hyrax/batch_edits_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_edits_controller_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
       expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
       get :edit
       expect(response).to be_successful
+      expect(response).to render_template('dashboard')
       expect(assigns[:form].model.creator).to match_array ["Fred", "Wilma"]
     end
   end

--- a/spec/controllers/hyrax/embargoes_controller_spec.rb
+++ b/spec/controllers/hyrax/embargoes_controller_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe Hyrax::EmbargoesController do
       let(:user) { create(:user, groups: ['admin']) }
 
       it 'shows me the page' do
+        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Manage Embargoes', embargoes_path)
         get :index
         expect(response).to be_success
         expect(response).to render_template('dashboard')
@@ -32,6 +35,10 @@ RSpec.describe Hyrax::EmbargoesController do
     end
     context 'when I have permission to edit the object' do
       it 'shows me the page' do
+        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Manage Embargoes', embargoes_path)
+        expect(controller).to receive(:add_breadcrumb).with('Update Embargo', '#')
         get :edit, params: { id: a_work }
         expect(response).to be_success
         expect(response).to render_template('dashboard')

--- a/spec/controllers/hyrax/embargoes_controller_spec.rb
+++ b/spec/controllers/hyrax/embargoes_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Hyrax::EmbargoesController do
       it 'shows me the page' do
         get :index
         expect(response).to be_success
+        expect(response).to render_template('dashboard')
       end
     end
   end
@@ -33,6 +34,7 @@ RSpec.describe Hyrax::EmbargoesController do
       it 'shows me the page' do
         get :edit, params: { id: a_work }
         expect(response).to be_success
+        expect(response).to render_template('dashboard')
       end
     end
   end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Hyrax::FileSetsController do
         expect(assigns[:version_list]).to be_kind_of Hyrax::VersionListPresenter
         expect(assigns[:parent]).to eq parent
         expect(response).to render_template(:edit)
+        expect(response).to render_template('dashboard')
       end
     end
 
@@ -150,6 +151,7 @@ RSpec.describe Hyrax::FileSetsController do
               post :update, params: { id: file_set, revision: version1 }
               expect(response.code).to eq '401'
               expect(response).to render_template 'unauthorized'
+              expect(response).to render_template('dashboard')
             end
           end
         end
@@ -196,6 +198,7 @@ RSpec.describe Hyrax::FileSetsController do
           post :update, params: { id: file_set, file_set: { keyword: [''] } }
           expect(response.code).to eq '422'
           expect(response).to render_template('edit')
+          expect(response).to render_template('dashboard')
           expect(assigns[:file_set]).to eq file_set
         end
       end
@@ -220,6 +223,7 @@ RSpec.describe Hyrax::FileSetsController do
           get :edit, params: { id: file_set }
           expect(response.code).to eq '401'
           expect(response).to render_template('unauthorized')
+          expect(response).to render_template('dashboard')
         end
       end
     end
@@ -278,6 +282,7 @@ RSpec.describe Hyrax::FileSetsController do
           get :edit, params: { id: public_file_set }
           expect(response.code).to eq '401'
           expect(response).to render_template(:unauthorized)
+          expect(response).to render_template('dashboard')
         end
       end
 

--- a/spec/controllers/hyrax/leases_controller_spec.rb
+++ b/spec/controllers/hyrax/leases_controller_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Hyrax::LeasesController do
       let(:user) { create(:user, groups: ['admin']) }
 
       it 'shows me the page' do
+        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Manage Leases', leases_path)
+
         get :index
         expect(response).to be_success
         expect(response).to render_template('dashboard')
@@ -33,6 +37,11 @@ RSpec.describe Hyrax::LeasesController do
     end
     context 'when I have permission to edit the object' do
       it 'shows me the page' do
+        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Manage Leases', leases_path)
+        expect(controller).to receive(:add_breadcrumb).with('Update Lease', '#')
+
         get :edit, params: { id: a_work }
         expect(response).to be_success
         expect(response).to render_template('dashboard')

--- a/spec/controllers/hyrax/leases_controller_spec.rb
+++ b/spec/controllers/hyrax/leases_controller_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Hyrax::LeasesController do
       it 'shows me the page' do
         get :index
         expect(response).to be_success
+        expect(response).to render_template('dashboard')
       end
     end
   end
@@ -34,6 +35,7 @@ RSpec.describe Hyrax::LeasesController do
       it 'shows me the page' do
         get :edit, params: { id: a_work }
         expect(response).to be_success
+        expect(response).to render_template('dashboard')
       end
     end
   end


### PR DESCRIPTION
Fixes #2837 

Adds the dashboard layout to the lease management, embargo management, batch edit, and file set edit pages as mentioned in #2837 and in https://github.com/curationexperts/nurax/issues/239.

Panels were added to the batch edit and file set edit views, and breadcrumbs were added to the lease and embargo management views for consistency.

Changes proposed in this pull request:
* add dashboard layout to lease, embargo, batch edit, and file set edit views
* add panel to batch edit and file set edit views
* add breadcrumbs to lease and embargo views

@samvera/hyrax-code-reviewers
