### PR TITLE
Add manage proxies to left menu

### DIFF
--- a/app/assets/javascripts/hyrax/proxy_rights.js
+++ b/app/assets/javascripts/hyrax/proxy_rights.js
@@ -42,8 +42,8 @@
     function rowTemplate (data) {
       return '<tr>'+
                 '<td class="depositor-name">'+data.name+'</td>'+
-                '<td><a class="remove-proxy-button" data-method="delete" href="'+data.delete_path+'" rel="nofollow">'+
-                  '<i class="glyphicon glyphicon-remove"></i></a>'+
+                '<td><a class="remove-proxy-button btn btn-danger" data-method="delete" href="'+data.delete_path+'" rel="nofollow">'+
+                $('#delete_button_label').data('label')+'</a>'+
                 '</td>'+
               '</tr>'
     }

--- a/app/controllers/hyrax/depositors_controller.rb
+++ b/app/controllers/hyrax/depositors_controller.rb
@@ -5,6 +5,15 @@ module Hyrax
     before_action :authenticate_user!
     before_action :validate_users, only: :create
 
+    layout :decide_layout
+
+    def index
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.dashboard.manage_proxies'), hyrax.depositors_path
+      @user = current_user
+    end
+
     def create
       grantor = authorize_and_return_grantor
       grantee = ::User.from_url_component(params[:grantee_id])
@@ -40,6 +49,16 @@ module Hyrax
         message_to_grantor = "You have assigned #{grantee.name} as a proxy depositor"
         Hyrax::MessengerService.deliver(::User.batch_user, grantor, message_to_grantor, "Proxy Depositor Added")
         Hyrax::MessengerService.deliver(::User.batch_user, grantee, message_to_grantee, "Proxy Depositor Added")
+      end
+
+      def decide_layout
+        layout = case action_name
+                 when 'index'
+                   'dashboard'
+                 else
+                   '1_column'
+                 end
+        File.join(theme, layout)
       end
   end
 end

--- a/app/presenters/hyrax/menu_presenter.rb
+++ b/app/presenters/hyrax/menu_presenter.rb
@@ -35,7 +35,7 @@ module Hyrax
       # we're using a case here because we need to differentiate UsersControllers
       # in different namespaces (Hyrax & Admin)
       case controller
-      when Hyrax::UsersController, Hyrax::NotificationsController, Hyrax::TransfersController
+      when Hyrax::UsersController, Hyrax::NotificationsController, Hyrax::TransfersController, Hyrax::DepositorsController
         true
       else
         false

--- a/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
+++ b/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
@@ -1,24 +1,30 @@
 <div class="clearfix proxy-rights">
-<div class="row">
-  <div class="col-xs-6 proxy-search">
-    <h4><%= t("hyrax.dashboard.authorize_proxies") %></h4>
-    <label class="sr-only" for="user"><%= t("hyrax.dashboard.proxy_user") %></label>
-    <%= hidden_field_tag :user, nil, data: { grantor: current_user.to_param } %>
+  <div class="row">
+    <div class="col-xs-12">
+      <p><%= t('hyrax.dashboard.proxy_help') %></p>
+    </div>
   </div>
+  <div class="row">
+    <div class="col-xs-6 proxy-search">
+      <h4><%= t("hyrax.dashboard.authorize_proxies") %></h4>
+      <label class="sr-only" for="user"><%= t("hyrax.dashboard.proxy_user") %></label>
+      <%= hidden_field_tag :user, nil, data: { grantor: current_user.to_param } %>
+      <%= hidden_field_tag :delete_button_label, nil, data: { label: I18n.t('hyrax.dashboard.proxy_delete') } %>
+    </div>
 
-  <div class="col-xs-6">
-    <h4><%= t("hyrax.dashboard.current_proxies") %></h4>
-    <table class="table table-condensed table-striped" id="authorizedProxies">
-      <tbody>
-      <% user.can_receive_deposits_from.each do |depositor| %>
-          <tr><td class="depositor-name"><%= depositor.name %></td>
-            <td><%= link_to(hyrax.user_depositor_path(user, depositor), method: :delete, class: "remove-proxy-button") do %>
-                  <span class="sr-only"><%= I18n.t('hyrax.dashboard.proxy_delete') %></span>
-                  <i class="glyphicon glyphicon-remove"></i><% end %>
-            </td></tr>
-      <% end %>
-      </tbody>
-    </table>
+    <div class="col-xs-6">
+      <h4><%= t("hyrax.dashboard.current_proxies") %></h4>
+      <table class="table table-condensed table-striped" id="authorizedProxies">
+        <tbody>
+        <% user.can_receive_deposits_from.each do |depositor| %>
+            <tr><td class="depositor-name"><%= depositor.name %></td>
+              <td><%= link_to(I18n.t('hyrax.dashboard.proxy_delete'), hyrax.user_depositor_path(user, depositor),
+                              method: :delete,
+                              class: "remove-proxy-button btn btn-danger") %>
+              </td></tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
-</div>
 </div>

--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -57,7 +57,3 @@
 
   <%= f.button '<i class="glyphicon glyphicon-save"></i> Save Profile'.html_safe, type: 'submit', class: "btn btn-primary" %>
 <% end %>
-
-<% if Flipflop.proxy_deposit? %>
-  <%= render 'hyrax/dashboard/_index_partials/proxy_rights', user: @user %>
-<% end %>

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -17,6 +17,12 @@
       <%= menu.nav_link(hyrax.transfers_path) do %>
         <span class="fa fa-arrows-h"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.transfers') %></span>
       <% end %>
+
+      <% if Flipflop.proxy_deposit? %>
+        <%= menu.nav_link(hyrax.depositors_path) do %>
+          <span class="fa fa-users"></span> <span class="sidebar-action-text"><%= t('hyrax.dashboard.manage_proxies') %></span>
+        <% end %>
+      <% end %>
     <% end %>
   </li>
 

--- a/app/views/hyrax/depositors/index.html.erb
+++ b/app/views/hyrax/depositors/index.html.erb
@@ -1,0 +1,13 @@
+<% provide :page_header do %>
+  <h1><span class="fa fa-users"></span>  <%= t("hyrax.dashboard.manage_proxies") %></h1>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <%= render 'hyrax/dashboard/_index_partials/proxy_rights', user: @user %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -28,7 +28,7 @@ en:
           keyword: Keyword
       filters:
         title: 'Filtering by:'
-      start_over: 'Start Over'
+      start_over: Start Over
   errors:
     messages:
       carrierwave_download_error: Couldn't download image.
@@ -527,12 +527,12 @@ en:
       type_label: Issue Type
     content_blocks:
       cancel: Cancel
+      change_tab_message: Are you sure you want to leave this tab?  Any unsaved data will be lost.
       tabs:
         announcement_text: Announcement Text
         featured_researcher: Featured Researcher
         marketing_text: Marketing Text
       updated: Content blocks updated.
-      change_tab_message: Are you sure you want to leave this tab?  Any unsaved data will be lost.
     controls:
       about: About
       contact: Contact
@@ -736,6 +736,7 @@ en:
       no_transfers: You haven't transferred any work
       proxy_activity: Proxy Activity
       proxy_delete: Delete Proxy
+      proxy_help: Select a user who can deposit works on your behalf. You will be the owner of works that this user deposits for you. You can revoke a proxy by clicking the Delete Proxy button.
       proxy_user: Proxy User
       show_admin:
         new_visitors: New Visitors
@@ -806,12 +807,12 @@ en:
       show:
         download: Download the file
         downloadable_content:
+          audio_link: Download audio
           default_link: Download file
           heading: Downloadable Content
           image_link: Download image
           office_link: Download file
           pdf_link: Download PDF
-          audio_link: Download audio
           video_link: Download video
     file_sets:
       groups_description:
@@ -1097,9 +1098,9 @@ en:
         allow_multiple_membership: Allow works to belong to multiple collections of this type
         assigns_visibility: Allow collections of this type to assign initial visibility settings to a new work
         assigns_workflow: Allow collections of this type to assign workflow to a new work
+        brandable: Allow collections of this type to be branded
         description: A brief statement of the general purpose of this collection type.  Users will see this if they have more than one collection type to choose from when creating a new collection.
         discoverable: Allow collections of this type to be discoverable
-        brandable: Allow collections of this type to be branded
         nestable: Allow collections of this type to be nested (a collection can contain other collections)
         require_membership: A work must belong to at least one collection of this type
         sharable: Allow users to assign collection managers, depositors, and viewers for collections they manage

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Hyrax::Engine.routes.draw do
   # Depositors routes for proxy deposit
   post 'users/:user_id/depositors' => 'depositors#create', as: 'user_depositors'
   delete 'users/:user_id/depositors/:id' => 'depositors#destroy', as: 'user_depositor'
+  get 'proxies' => 'depositors#index', as: 'depositors'
 
   resources :featured_work_lists, path: 'featured_works', only: :create
 

--- a/spec/controllers/hyrax/depositors_controller_spec.rb
+++ b/spec/controllers/hyrax/depositors_controller_spec.rb
@@ -68,6 +68,17 @@ RSpec.describe Hyrax::DepositorsController do
         expect { delete :destroy, params: revoke_proxy_params }.to change { ProxyDepositRights.count }.by(-1)
       end
     end
+
+    describe "index" do
+      it "renders the page with user proxy info" do
+        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Manage Proxies', depositors_path)
+        get :index
+        expect(response).to be_successful
+        expect(response).to render_template('dashboard')
+      end
+    end
   end
 
   context "as a user without access" do

--- a/spec/features/proxy_spec.rb
+++ b/spec/features/proxy_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe 'proxy', type: :feature do
     it "creates a proxy" do
       sign_in user
       click_link "Your activity"
-      click_link "Profile"
-      click_link "Edit Profile"
+      click_link "Manage Proxies"
       expect(first("td.depositor-name")).to be_nil
 
       # BEGIN create_proxy_using_partial
@@ -18,6 +17,7 @@ RSpec.describe 'proxy', type: :feature do
       # END create_proxy_using_partial
 
       expect(page).to have_css('td.depositor-name', text: second_user.user_key)
+      expect(page).to have_link('Delete Proxy')
     end
   end
 end

--- a/spec/presenters/hyrax/menu_presenter_spec.rb
+++ b/spec/presenters/hyrax/menu_presenter_spec.rb
@@ -79,6 +79,12 @@ RSpec.describe Hyrax::MenuPresenter do
 
       it { is_expected.to be false }
     end
+
+    context "for the Hyrax::DepositorsController" do
+      let(:controller) { Hyrax::DepositorsController.new }
+
+      it { is_expected.to be true }
+    end
   end
 
   describe "#show_configuration?" do

--- a/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
@@ -107,4 +107,26 @@ RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
     it { is_expected.to have_content t('hyrax.admin.sidebar.configuration') }
     it { is_expected.to have_link t('hyrax.admin.sidebar.collection_types') }
   end
+
+  context 'when proxy deposits are enabled' do
+    before do
+      allow(Flipflop).to receive(:proxy_deposit?).and_return(true)
+      render
+    end
+
+    subject { rendered }
+
+    it { is_expected.to have_link t('hyrax.dashboard.manage_proxies') }
+  end
+
+  context 'when proxy deposits are disabled' do
+    before do
+      allow(Flipflop).to receive(:proxy_deposit?).and_return(false)
+      render
+    end
+
+    subject { rendered }
+
+    it { is_expected.not_to have_link t('hyrax.dashboard.manage_proxies') }
+  end
 end

--- a/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
@@ -13,30 +13,6 @@ RSpec.describe 'hyrax/dashboard/profiles/edit.html.erb', type: :view do
     expect(rendered).to match(/ORCID Profile/)
   end
 
-  describe 'proxy deposit' do
-    context 'when enabled' do
-      before do
-        allow(Flipflop).to receive(:proxy_deposit?).and_return(true)
-      end
-
-      it 'renders proxy partial' do
-        render
-        expect(rendered).to match(/Authorize Proxies/)
-      end
-    end
-
-    context 'when disabled' do
-      before do
-        allow(Flipflop).to receive(:proxy_deposit?).and_return(false)
-      end
-
-      it 'does not render proxy partial' do
-        render
-        expect(rendered).not_to match(/Authorize Proxies/)
-      end
-    end
-  end
-
   context 'with Zotero integration enabled' do
     before do
       allow(Hyrax.config).to receive(:arkivo_api?) { true }

--- a/spec/views/hyrax/depositors/index.html.erb_spec.rb
+++ b/spec/views/hyrax/depositors/index.html.erb_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "hyrax/depositors/index.html.erb", type: :view do
+  before do
+    allow(controller).to receive(:current_user).and_return(some_user)
+    assign :user, some_user
+  end
+
+  let(:some_user) { build(:user) }
+
+  it 'renders proxy partial' do
+    render
+    expect(rendered).to match(/Authorize Proxies/)
+  end
+end


### PR DESCRIPTION
Fixes #2811 

Moves proxy management from 'Your Activity' > 'Profile' > 'Edit' to 'Your Activity' > 'Manage Proxies'.

A new page was added to the dashboard for managing proxies when proxy deposits are enabled.

Screenshots:
before
![screen shot 2018-03-28 at 11 23 19 am](https://user-images.githubusercontent.com/7035044/38039412-34c596fa-327b-11e8-9a36-ee875eb7ac4f.png)

after
![screen shot 2018-03-28 at 11 26 04 am](https://user-images.githubusercontent.com/7035044/38039416-38f1d9be-327b-11e8-87d1-fb0e068bdbc4.png)
![screen shot 2018-03-28 at 11 29 39 am](https://user-images.githubusercontent.com/7035044/38039474-56ae798a-327b-11e8-8d25-622e427ca76d.png)

Changes proposed in this pull request:
* Remove proxy section from profile edit page
* Add new link in sidebar under 'Your Activity' for proxy management
* Add new page for managing proxies

@samvera/hyrax-code-reviewers
