### PR TITLE
fixes scenario when application has no models

### DIFF
--- a/app/search_builders/hyrax/abstract_type_relation.rb
+++ b/app/search_builders/hyrax/abstract_type_relation.rb
@@ -16,7 +16,8 @@ module Hyrax
       clauses = allowable_types.map do |k|
         ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: k.to_s)
       end
-      clauses.size == 1 ? clauses.first : "(#{clauses.join(' OR ')})"
+      # empty array returns nil, AF finder method handles it properly, see hyrax issue #2844
+      clauses.size <= 1 ? clauses.first : "(#{clauses.join(' OR ')})"
     end
 
     class DummyModel

--- a/spec/search_builders/hyrax/abstract_type_relation_spec.rb
+++ b/spec/search_builders/hyrax/abstract_type_relation_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Hyrax::AbstractTypeRelation, :clean_repo do
+  before do
+    stub_const 'AnotherWork', Class.new
+  end
+  it 'returns nil when no allowable types exist' do
+    allow(subject).to receive(:allowable_types).and_return([])
+    expect(subject.search_model_clause).to be_nil
+  end
+  it 'returns GenericWork when allowable types exist' do
+    allow(subject).to receive(:allowable_types).and_return([GenericWork])
+    expect(subject.search_model_clause).to include('GenericWork')
+  end
+  it 'returns both works when allowable types exist' do
+    allow(subject).to receive(:allowable_types).and_return([GenericWork, AnotherWork])
+    expect(subject.search_model_clause).to include('GenericWork')
+    expect(subject.search_model_clause).to include('AnotherWork')
+  end
+end


### PR DESCRIPTION
Fixes #2844 

When a new Hyrax application is first built, without an initial model built, the RSolr query for the Admin Dashboard fails by generating an invalid query with the first clause being an empty parens. This fix ensures that the first clause is returned if there are no models in the system, which would be a `nil` in this case. ActiveFedora, that eventually calls the affected method, properly handles when `nil` is returned and structures the resulting query without an empty parens. 

Tests included to cover the three scenarios (no models, 1 model, and multiple models).


<img width="1351" alt="screen shot 2018-03-28 at 9 42 25 am" src="https://user-images.githubusercontent.com/32885/38043642-8c0dedf4-326c-11e8-82e0-0fb526a885db.png">
