### PR TITLE
ensures only one set of controls when a work has multiple titles

### DIFF
--- a/app/views/hyrax/base/_work_title.erb
+++ b/app/views/hyrax/base/_work_title.erb
@@ -10,7 +10,9 @@
       <% end %>
     </div>
     <div class="col-sm-4 text-right">
-      <%= render "show_actions", presenter: presenter %>
+      <% if index == 0 %>
+        <%= render "show_actions", presenter: presenter %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "display a work as its owner" do
     let(:work) do
       create(:work,
              with_admin_set: true,
-             title: ["Magnificent splendor"],
+             title: ["Magnificent splendor", "Happy little trees"],
              source: ["The Internet"],
              based_near: ["USA"],
              user: user,
@@ -27,9 +27,11 @@ RSpec.describe "display a work as its owner" do
 
     it "shows a work" do
       expect(page).to have_selector 'h2', text: 'Magnificent splendor'
+      expect(page).to have_selector 'h2', text: 'Happy little trees'
       expect(page).to have_selector 'li', text: 'The Internet'
       expect(page).to have_selector 'th', text: 'Location'
       expect(page).not_to have_selector 'th', text: 'Based near'
+      expect(page).to have_selector 'button', text: 'Attach Child', count: 1
 
       # Displays FileSets already attached to this work
       within '.related-files' do


### PR DESCRIPTION
fixes #2847 