### PR TITLE
fixes admin stats form to maintain locale selection

### DIFF
--- a/app/views/hyrax/admin/stats/_date_form.html.erb
+++ b/app/views/hyrax/admin/stats/_date_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_for "stats_filters", url: hyrax.admin_stats_path, method: "GET" do |f| %>
+  <input type='hidden' name='locale' value="<%= params[:locale] %>" />
   <%= f.label "Start *" %>
   <input type="date" name="stats_filters[start_date]" value="<%= @presenter.stats_filters[:start_date] %>" placeholder="yyyy-mm-dd" ></input>
   <%= f.label "end [defaults to now]" %>

--- a/spec/views/hyrax/admin/stats/show.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/stats/show.html.erb_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe "hyrax/admin/stats/show.html.erb", type: :view do
     allow(presenter).to receive(:depositors).and_return([])
   end
 
+  context 'locales' do
+    before do
+      render
+    end
+    it 'includes a default locale hidden input' do
+      expect(rendered).to have_selector 'input', exact: 'en'
+    end
+  end
+
   context "default depositors" do
     let(:top_5_active_users) do
       (1..5).map { |i| double(label: i.to_s, value: i) }


### PR DESCRIPTION
fixes #2679 

HTTP GET appears to strip the querystring, so a hidden input needs to be included in the form. OTOH, if the form (and engine cart route) allowed for HTTP POST, then the hidden input wouldn't be necessary and the form action `admin/stats?locale=de` would be passed along fine.

HTML spec: https://www.w3.org/TR/html401/interact/forms.html#h-17.13.3.4
and RFC 1866 (page 46) describe the root of the problem:

```
  To process a form whose action URL is an HTTP URL and whose method is
   `GET', the user agent starts with the action URI and appends a `?'
   and the form data set, in `application/x-www-form-urlencoded' format
   as above. The user agent then traverses the link to this URI just as
   if it were an anchor (see 7.2, "Activation of Hyperlinks").
```