### PR TITLE
propagate batch permissions changes to file sets

### DIFF
--- a/app/controllers/hyrax/batch_edits_controller.rb
+++ b/app/controllers/hyrax/batch_edits_controller.rb
@@ -49,6 +49,10 @@ module Hyrax
       obj.attributes = work_params
       obj.date_modified = Time.current.ctime
       obj.visibility = params[:visibility]
+
+      InheritPermissionsJob.perform_now(obj)
+      VisibilityCopyJob.perform_now(obj)
+
       obj.save
     end
 

--- a/spec/controllers/hyrax/batch_edits_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_edits_controller_spec.rb
@@ -43,9 +43,16 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
       create(:work, creator: ["Fred"], title: ["abc"], language: ['en'])
     end
 
+    let!(:file_set) do
+      create(:file_set, creator: ["Fred"])
+    end
+
     let(:mycontroller) { "hyrax/my/works" }
 
     before do
+      one.members << file_set
+      one.save!
+
       # TODO: why aren't we just submitting batch_document_ids[] as a parameter?
       controller.batch = [one.id, two.id, three.id]
       expect(controller).to receive(:can?).with(:edit, one.id).and_return(true)
@@ -77,7 +84,11 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
     it "updates permissions" do
       put :update, params: { update_type: "update", visibility: "authenticated" }
       expect(response).to be_redirect
-      expect(GenericWork.find(one.id).visibility).to eq "authenticated"
+
+      work1 = GenericWork.find(one.id)
+      expect(work1.visibility).to eq "authenticated"
+      expect(work1.file_sets.map(&:visibility)).to eq ["authenticated"]
+
       expect(GenericWork.find(two.id).visibility).to eq "authenticated"
       expect(GenericWork.find(three.id).visibility).to eq "restricted"
     end


### PR DESCRIPTION
Part of GH-2827. See https://github.com/samvera/hyrax/issues/2827#issuecomment-377326086:

> for batch editing visibility, the work visibility is updated properly, however the File visibility is not changed.

@samvera/hyrax-code-reviewers
