### PR TITLE
Shows modal when user cannot delete collection

### DIFF
--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -240,27 +240,29 @@ Blacklight.onLoad(function () {
     };
     var $deleteWordingTarget = $('#selected-collections-delete-modal .pluralized');
 
-    tableRows.each(function(i, row) {
-      checkbox = $(row).find('td:first input[type=checkbox]');
-      if (typeof checkbox[0] !== "undefined") {
-        if (checkbox[0].checked) {
-          numRowsSelected++;
-        }
-      }
-    });
+    var canDeleteAll = true;
+    var selectedInputs = $('#documents table.collections-list-table tbody tr')
+      // Get all inputs in the table
+      .find('td:first input[type=checkbox]')
+      // Filter to those that are checked
+      .filter((i, checkbox) => checkbox.checked)
 
-    if (numRowsSelected > 0) {
+    var cannotDeleteInputs = selectedInputs.filter((i, checkbox) => (checkbox.dataset.hasaccess === "false"))
+    if(cannotDeleteInputs.length > 0) {
+      // TODO: Can we pass data to this modal to be more specific about which ones they cannot delete?
+      $('#collections-to-delete-deny-modal').modal('show');
+      return;
+    }
+
+    if (selectedInputs.length > 0) {
       // Collections are selected
       // Update singular / plural text in delete modal
-      if (numRowsSelected > 1) {
+      if (selectedInputs.length > 1) {
         $deleteWordingTarget.text(deleteWording.plural);
       } else {
         $deleteWordingTarget.text(deleteWording.singular);
       }
       $('#selected-collections-delete-modal').modal('show');
-    } else {
-      // No collections are selected
-      $('#collections-to-delete-deny-modal').modal('show');
     }
   });
 

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -5,7 +5,13 @@
   data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
   data-post-delete-url="<%= is_admin_set ? hyrax.admin_admin_set_path(id) : hyrax.dashboard_collection_path(id) %>">
 
-  <td><% unless collection_presenter.solr_document.admin_set? %><input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector" /><% end %></td>
+  <td>
+    <% unless collection_presenter.solr_document.admin_set? %>
+    <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
+      data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>"
+    />
+    <% end %>
+  </td>
   <td>
     <div class="thumbnail-title-wrapper">
       <div class="thumbnail-wrapper">

--- a/app/views/hyrax/my/collections/_modal_delete_collections_deny.html.erb
+++ b/app/views/hyrax/my/collections/_modal_delete_collections_deny.html.erb
@@ -1,0 +1,14 @@
+<div class="modal fade" id="collection-to-delete-deny-modal" tabindex="-1" role="dialog" aria-labelledby="deny-delete-collection-label">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <form class="deny-delete-collection-form">
+        <div class="modal-body">
+          <p><%= t('hyrax.dashboard.my.action.delete_collections_deny') %></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-dismiss="modal"><%= t('helpers.action.close') %></button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/my/collections/index.html.erb
+++ b/app/views/hyrax/my/collections/index.html.erb
@@ -55,6 +55,7 @@
   <%= render 'modal_delete_admin_set_deny' %>
   <%= render 'modal_delete_collection' %>
   <%= render 'modal_delete_collection_deny' %>
+  <%= render 'modal_delete_collections_deny' %>
   <%= render 'modal_delete_deny' %>
   <%= render 'modal_delete_empty_collection' %>
   <%= render 'modal_delete_selected_collections' %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -672,9 +672,9 @@ en:
           delete_admin_set: Delete collection
           delete_admin_set_deny: This collection is defined as Admin Set and is not empty. To delete this Admin Set, you must first remove (delete or move to another Admin Set collection) all items from the Admin Set.
           delete_collection: Delete collection
-          delete_collection_deny: You do not have sufficient privileges to delete this document.
+          delete_collection_deny: You do not have sufficient privileges to delete this collection.
           delete_collections: Delete collections
-          delete_collections_deny: You must select one or more collections to delete.
+          delete_collections_deny: You do not have sufficient privileges to delete one or more collections.
           delete_work: Delete Work
           edit_admin_set: Edit collection
           edit_collection: Edit collection

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -420,7 +420,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
     end
 
-
     context 'when user does not have permission to delete a collection' do
       let(:user2) { create(:user) }
 
@@ -435,7 +434,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       context 'and selects Delete from drop down within table' do
-        fit 'does not allow delete collection', js: true do
+        it 'does not allow delete collection', js: true do
           expect(page).to have_content(collection.title.first)
           check_tr_data_attributes(collection.id, 'collection')
           within("#document_#{collection.id}") do
@@ -453,7 +452,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       context 'and selects the collection and clicks "Delete collections" button at top of page' do
-        fit 'does not allow delete collection', js: true do
+        it 'does not allow delete collection', js: true do
           expect(page).to have_content(collection.title.first)
           check_tr_data_attributes(collection.id, 'collection')
 


### PR DESCRIPTION
- Changed the render of the inputs in the table to also include data on the
  checkbox that describes whether or not the current user can delete the
  corresponding collection
- Added a new modal for this specific case. This can probably be DRYed up
- Changed the js handler for batch delete. Now checks the selected inputs to see
  if any of them will deny the user, and if so, shows the modal and bails
- Also removed an additional branching in the js that was unreachable. If no
  collections are selected, then the user cannot click the delete collections
  button, so this was unreachable.

Fixes (partial) #1788.