### PR TITLE
Fix for #2873 - CSRF Exception after adding to Collections/Sharing

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -99,6 +99,7 @@
 //= require hyrax/thumbnail_select
 //= require hyrax/batch_select
 //= require hyrax/tabbed_form
+//= require hyrax/turbolinks_events
 
 // this needs to be after batch_select so that the form ids get setup correctly
 //= require hyrax/batch_edit

--- a/app/assets/javascripts/hyrax/turbolinks_events.js
+++ b/app/assets/javascripts/hyrax/turbolinks_events.js
@@ -1,0 +1,5 @@
+// Fixes a problem with csrf tokens and turbolinks
+// See https://github.com/rails/jquery-ujs/issues/456
+$(document).on('turbolinks:load', function() {
+  $.rails.refreshCSRFTokens();
+});

--- a/app/views/hyrax/my/_collection_action_menu.html.erb
+++ b/app/views/hyrax/my/_collection_action_menu.html.erb
@@ -18,8 +18,7 @@
       <li role="menuitem" tabindex="-1">
         <%= link_to hyrax.edit_dashboard_collection_path(id),
                     class: 'itemicon itemedit',
-                    title: t("hyrax.dashboard.my.action.edit_collection"),
-                    data: { turbolinks: false }  do %>
+                    title: t("hyrax.dashboard.my.action.edit_collection")  do %>
           <%= t("hyrax.dashboard.my.action.edit_collection") %>
         <% end %>
       </li>

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe 'collection', type: :feature, clean_repo: true do
+  include Selectors::Dashboard
+
   let(:user) { create(:user) }
   let(:admin_user) { create(:admin) }
   let(:collection_type) { create(:collection_type, creator_user: user) }
@@ -865,11 +867,16 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         end
 
         context "to true, limits available users", js: true do
+          let(:user2) { create(:user) }
           it "to system users filted by select2" do
             visit "/dashboard/collections/#{sharable_collection_id}/edit"
             expect(page).to have_link('Sharing', href: '#sharing')
             click_link('Sharing')
             expect(page).to have_selector(".form-inline.add-users .select2-container")
+            select_user(user2, 'Depositor')
+            click_button('Save')
+            click_link('Sharing')
+            expect(page).to have_selector('td', text: user2.user_key)
           end
         end
 

--- a/spec/support/selectors.rb
+++ b/spec/support/selectors.rb
@@ -5,6 +5,21 @@ module Selectors
         find '.dropdown-toggle'
       end
     end
+
+    # For use with javascript user selector that allows for searching for an existing user
+    # and granting them permission to an object.
+    # @param [User] user to select
+    # @param [String] role granting the user permission (e.g. 'Manager' | 'Depositor' | 'Viewer')
+    def select_user(user, role = 'Depositor')
+      first('a.select2-choice').click
+      find('.select2-input').set(user.user_key)
+      sleep 1
+      first('div.select2-result-label').click
+      within('div.add-users') do
+        select(role)
+        find('input.edit-collection-add-sharing-button').click
+      end
+    end
   end
 
   module NewTransfers


### PR DESCRIPTION
- Found the root issue is related to turbolinks + jquery-ujs + a button that uses ajax to post. This may also fix #1191. Adding a call to refresh the CSRF tokens in the rendered DOM after turbolinks loads fixes it.

Related to https://github.com/rails/jquery-ujs/issues/456

@samvera/hyrax-code-reviewers
