### PR TITLE
set read_access on admin sets excluding registered and public groups

### DIFF
--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -20,8 +20,9 @@ module Hyrax
     self.admin_set_create_service = AdminSetCreateService
 
     def show
+      add_breadcrumb I18n.t('hyrax.controls.home'), hyrax.root_path
       add_breadcrumb t(:'hyrax.dashboard.title'), hyrax.dashboard_path
-      add_breadcrumb t(:'hyrax.dashboard.my.collections'), hyrax.admin_admin_sets_path
+      add_breadcrumb t(:'hyrax.dashboard.my.collections'), hyrax.my_collections_path
       add_breadcrumb @admin_set.title.first
       super
     end
@@ -111,14 +112,6 @@ module Hyrax
       # initialize the form object
       def form
         @form ||= form_class.new(@admin_set, current_ability, repository)
-      end
-
-      # Overrides the parent implementation so that the returned search builder
-      #  searches for edit access
-      # Instantiates the search builder that builds a query for a single item
-      # this is useful in the show view.
-      def single_item_search_builder
-        single_item_search_builder_class.new(self, :edit).with(params.except(:q, :page))
       end
 
       def action_breadcrumb

--- a/app/models/hyrax/permission_template_access.rb
+++ b/app/models/hyrax/permission_template_access.rb
@@ -15,6 +15,9 @@ module Hyrax
     DEPOSIT = 'deposit'.freeze
     MANAGE = 'manage'.freeze
 
+    GROUP = 'group'.freeze
+    USER = 'user'.freeze
+
     enum(
       access: {
         VIEW => VIEW,
@@ -41,7 +44,7 @@ module Hyrax
     end
 
     def label
-      return agent_id unless agent_type == 'group'
+      return agent_id unless agent_type == GROUP
       case agent_id
       when 'registered'
         I18n.t('hyrax.admin.admin_sets.form_participant_table.registered_users')
@@ -53,7 +56,7 @@ module Hyrax
     end
 
     def admin_group?
-      agent_type == 'group' && agent_id == ::Ability.admin_group_name
+      agent_type == GROUP && agent_id == ::Ability.admin_group_name
     end
 
     # @api private
@@ -67,7 +70,7 @@ module Hyrax
     #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
     def self.user_where(access:, ability:)
       where_clause = {}
-      where_clause[:agent_type] = 'user'
+      where_clause[:agent_type] = USER
       where_clause[:agent_id] = ability.current_user.user_key
       where_clause[:access] = access
       where_clause
@@ -86,7 +89,7 @@ module Hyrax
     #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
     def self.group_where(access:, ability:, exclude_groups: [])
       where_clause = {}
-      where_clause[:agent_type] = 'group'
+      where_clause[:agent_type] = GROUP
       where_clause[:agent_id] = ability.user_groups - exclude_groups
       where_clause[:access] = access
       where_clause

--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -120,7 +120,7 @@ module Hyrax
 
       # Gives deposit access to registered users to default AdminSet
       def create_default_access_for(permission_template:, workflow:)
-        permission_template.access_grants.create(agent_type: 'group', agent_id: 'registered', access: Hyrax::PermissionTemplateAccess::DEPOSIT)
+        permission_template.access_grants.create(agent_type: 'group', agent_id: ::Ability.registered_group_name, access: Hyrax::PermissionTemplateAccess::DEPOSIT)
         deposit = Sipity::Role[Hyrax::RoleRegistry::DEPOSITING]
         workflow.update_responsibilities(role: deposit, agents: Hyrax::Group.new('registered'))
       end

--- a/app/views/hyrax/admin/admin_sets/_show_actions.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_show_actions.html.erb
@@ -1,0 +1,27 @@
+    <% if can? :edit, presenter.solr_document %>
+      <div class="panel-heading">
+        <div class="row">
+          <div class="col-sm-8">
+            <h2 class="panel-title display-page"><%= presenter.to_s %></h2>
+          </div>
+          <div class="col-sm-4">
+            <div class="pull-right">
+              <%= link_to edit_admin_admin_set_path(presenter), class: 'btn btn-primary' do %>
+                <span class="fa fa-edit"></span> <%= t(:'helpers.action.edit') %>
+              <% end %>
+              <% if presenter.disable_delete? %>
+                <span title="<%= presenter.disabled_message %>">
+                  <%= link_to admin_admin_set_path(presenter), class: 'btn btn-danger disabled' do %>
+                    <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+                  <% end %>
+                </span>
+              <% else %>
+                <%= link_to admin_admin_set_path(presenter), class: 'btn btn-danger', data: { confirm: t('.confirm_delete'), method: :delete } do %>
+                  <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>

--- a/app/views/hyrax/admin/admin_sets/show.html.erb
+++ b/app/views/hyrax/admin/admin_sets/show.html.erb
@@ -5,31 +5,7 @@
 <div class="row">
   <div class="col-md-12">
     <div class="panel panel-default">
-      <div class="panel-heading">
-        <div class="row">
-          <div class="col-sm-8">
-            <h2 class="panel-title display-page"><%= @presenter.to_s %></h2>
-          </div>
-          <div class="col-sm-4">
-            <div class="pull-right">
-              <%= link_to edit_admin_admin_set_path(@presenter), class: 'btn btn-primary' do %>
-                <span class="fa fa-edit"></span> <%= t(:'helpers.action.edit') %>
-              <% end %>
-              <% if @presenter.disable_delete? %>
-                <span title="<%= @presenter.disabled_message %>">
-                  <%= link_to admin_admin_set_path(@presenter), class: 'btn btn-danger disabled' do %>
-                    <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
-                  <% end %>
-                </span>
-              <% else %>
-                <%= link_to admin_admin_set_path(@presenter), class: 'btn btn-danger', data: { confirm: t('.confirm_delete'), method: :delete } do %>
-                  <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
-                <% end %>
-              <% end %>
-            </div>
-          </div>
-        </div>
-      </div>
+      <%= render 'show_actions', presenter: @presenter %>
 
       <div class="panel-body admin-set row">
         <div class="col-md-2">

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -169,9 +169,10 @@ en:
           header: Create New Administrative Set
         show:
           breadcrumb: View Set
-          confirm_delete: Are you sure you wish to delete this Administrative Set? This action cannot be undone.
           header: Administrative Set
           item_list_header: Works in This Set
+        show_actions:
+          confirm_delete: Are you sure you wish to delete this Administrative Set? This action cannot be undone.
       appearances:
         show:
           header: Appearance

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Hyrax::GenericWorksController do
         end
 
         it "sets breadcrumbs to authorized pages" do
+          expect(controller).to receive(:add_breadcrumb).with('Home', main_app.root_path(locale: 'en'))
           expect(controller).not_to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path(locale: 'en'))
           expect(controller).not_to receive(:add_breadcrumb).with('Your Works', hyrax.my_works_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('public thing', main_app.hyrax_generic_work_path(work.id, locale: 'en'))

--- a/spec/factories/admin_sets_lw.rb
+++ b/spec/factories/admin_sets_lw.rb
@@ -1,0 +1,215 @@
+FactoryBot.define do
+  # Tests that create a Fedora Object are very slow.  This factory lets you control which parts of the object ecosystem
+  # get built.
+  #
+  # PREFERRED: Use build whenever possible.  You can control the creation of the permission template and solr document
+  #            by passing parameters to the build(:admin_set_lw) method.  That way you can build only the parts needed
+  #            for a specific test.
+  #
+  # AVOID: Do not use create unless absolutely necessary.  It will create everything including the Fedora object.
+  #
+  # @example Simple build of an admin set with no additional parts created.  Lightest weight.
+  #          NOTE: A user is automatically created as the owner of the admin set.
+  #   let(:adminset) { build(:adminset_lw) }
+  #
+  # @example Simple build of an admin set with no additional parts created.  User is the owner of the admin set.  Lightest weight.
+  #   let(:adminset) { build(:adminset_lw, user:) }
+  #
+  # @example Simple build of an admin set with only solr-document.  Owner is given edit-access in solr-document. Light weight.
+  #   let(:adminset) { build(:adminset_lw, with_solr_document: true) }
+  #
+  # @example Simple build of an admin set with only a permission template created.  Owner is set as a manager.  Light weight.
+  #   let(:adminset) { build(:adminset_lw, with_permission_template: true) }
+  #
+  # @example Build an admin set with only a permission template created.  Permissions are set based on
+  #          attributes set for `with_permission_template`.  Middle weight.
+  #   # permissions passed thru `with_permission_template` can be any of the following in any combination
+  #   let(:permissions) { { manage_users: [user.user_key],  # multiple users can be listed
+  #                         deposit_users: [user.user_key],
+  #                         view_users: [user.user_key],
+  #                         manage_groups: [group_name],    # multiple groups can be listed
+  #                         deposit_groups: [group_name],
+  #                         view_groups: [group_name],  } }
+  #   let(:adminset) { build(:adminset_lw, user: , with_permission_template: permissions) }
+  #
+  # @example Build an admin set with permission template and solr-document created.  Permissions are set based on
+  #          attributes set for `with_permission_template`.  Solr-document includes read/edit access defined based
+  #          on attributes passed thru `with_permission_template`.  Middle weight.
+  #   # permissions passed thru `with_permission_template` can be any of the following in any combination
+  #   let(:permissions) { { manage_users: [user.user_key],  # multiple users can be listed
+  #                         deposit_users: [user.user_key],
+  #                         view_users: [user.user_key],
+  #                         manage_groups: [group_name],    # multiple groups can be listed
+  #                         deposit_groups: [group_name],
+  #                         view_groups: [group_name],  } }
+  #   let(:adminset) { build(:adminset_lw, user: , with_permission_template: permissions, with_solr_document: true) }
+  #
+  # @example Create an admin set with everything.  Extreme heavy weight.  This is very slow and should be avoided.
+  #          NOTE: Everything gets created.
+  #          NOTE: Build options effect created admin sets as follows...
+  #                 * `with_permission_template` can specify user/group permissions.  A permission template is always created.
+  #                 * `with_solr_document` is ignored.  A solr document is always created.
+  #   let(:adminset) { create(:adminset_lw) }
+  #
+  # @example Build the default admin set with permission template, solr doc, and default adminset's metadata.
+  #   let(:default_adminset) { build(:default_adminset) }
+
+  factory :adminset_lw, class: AdminSet do
+    transient do
+      user { create(:user) }
+
+      with_permission_template false
+      with_solr_document false
+    end
+    sequence(:title) { |n| ["Collection Title #{n}"] }
+
+    after(:build) do |adminset, evaluator|
+      adminset.creator = [evaluator.user.user_key]
+
+      AdminSetFactoryHelper.process_with_permission_template(adminset, evaluator)
+      AdminSetFactoryHelper.process_with_solr_document(adminset, evaluator)
+    end
+
+    before(:create) do |adminset, evaluator|
+      # force create a permission template if it doesn't exist for the newly created admin set
+      AdminSetFactoryHelper.process_with_permission_template(adminset, evaluator, true) unless evaluator.with_permission_template
+    end
+
+    after(:create) do |adminset, _evaluator|
+      adminset.reset_access_controls!
+    end
+
+    factory :default_adminset, class: AdminSet do
+      transient do
+        with_permission_template do
+          {
+            deposit_groups: [::Ability.registered_group_name],
+            manage_groups: [::Ability.admin_group_name]
+          }
+        end
+        with_solr_document true
+      end
+      id AdminSet::DEFAULT_ID
+      title AdminSet::DEFAULT_TITLE
+    end
+  end
+
+  factory :no_solr_grants_adminset, class: AdminSet do
+    # Builds a pre-Hyrax 2.1.0 adminset without edit/view grants on the admin set.
+    # Do not use with create because the save will cause the solr grants to be created.
+    transient do
+      user { create(:user) }
+      with_permission_template true
+      with_solr_document true
+    end
+
+    sequence(:title) { |n| ["No Solr Grant Admin Set Title #{n}"] }
+
+    after(:build) do |adminset, evaluator|
+      adminset.creator = [evaluator.user.user_key]
+      AdminSetFactoryHelper.process_with_permission_template(adminset, evaluator, true)
+      AdminSetFactoryHelper.process_with_solr_document(adminset, evaluator, true)
+    end
+  end
+
+  class AdminSetFactoryHelper
+    # @returns array of user keys
+    def self.permission_from_template(permission_template_attributes, permission_key)
+      permissions = []
+      return permissions if permission_template_attributes.blank?
+      return permissions unless permission_template_attributes.is_a? Hash
+      return permissions unless permission_template_attributes.key?(permission_key)
+      permission_template_attributes[permission_key]
+    end
+    private_class_method :permission_from_template
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @parem [String] creator_user is the user who created the new admin set
+    # @param [Boolean] include_creator, when true, adds the creator_user as a manager
+    # @returns array of user keys
+    def self.user_managers(permission_template_attributes, creator_user)
+      managers = permission_from_template(permission_template_attributes, :manage_users)
+      managers << creator_user
+      managers.uniq
+    end
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @returns array of user keys
+    def self.group_managers(permission_template_attributes)
+      permission_from_template(permission_template_attributes, :manage_groups).uniq
+    end
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @returns array of user keys
+    def self.user_depositors(permission_template_attributes)
+      permission_from_template(permission_template_attributes, :deposit_users).uniq
+    end
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @returns array of user keys
+    def self.group_depositors(permission_template_attributes)
+      permission_from_template(permission_template_attributes, :deposit_groups).uniq
+    end
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @returns array of user keys
+    def self.user_viewers(permission_template_attributes)
+      permission_from_template(permission_template_attributes, :view_users).uniq
+    end
+
+    # @param [Hash] permission_template_attributes where names identify the role and value are the user keys for that role
+    # @returns array of user keys
+    def self.group_viewers(permission_template_attributes)
+      permission_from_template(permission_template_attributes, :view_groups).uniq
+    end
+
+    # Process the with_permission_template transient property such that...
+    # * a permission template is created for the admin set
+    # * a permission template access is created for the admin set creator
+    # * additional permission template accesses are created for each user/group identified in the attributes
+    #   of with_permission_template (created by the permission_template factory)
+    # @param [AdminSet] admin set object being built/created by the factory
+    # @param [Class] evaluator holding the transient properties for the current build/creation process
+    # @param [Boolean] if true, force the permission template to be created
+    def self.process_with_permission_template(adminset, evaluator, force = false)
+      return unless force || evaluator.with_permission_template
+      adminset.id ||= FactoryBot.generate(:object_id)
+      attributes = { source_id: adminset.id }
+      attributes[:manage_users] = user_managers(evaluator.with_permission_template, evaluator.user)
+      attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
+      FactoryBot.create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: adminset.id)
+    end
+
+    # Process the with_solr_document transient property such that...
+    # * a solr document is created for the admin set
+    # * permissions identified by with_permission_template, if any, are added to the solr fields
+    # @param [AdminSet] adminset object being built/created by the factory
+    # @param [Class] evaluator holding the transient properties for the current build/creation process
+    def self.process_with_solr_document(adminset, evaluator, creator_only = false)
+      return unless creator_only || evaluator.with_solr_document
+      ActiveFedora::SolrService.add(solr_document_with_permissions(adminset, evaluator, creator_only), commit: true)
+    end
+
+    # Return the admin set's solr document with permissions added, such that...
+    # * permissions identified by with_permission_template, if any, are added to the solr fields
+    # @param [AdminSet] adminset object being built/created by the factory
+    # @param [Class] evaluator holding the transient properties for the current build/creation process
+    # @returns the admin set's solr document with permissions added
+    def self.solr_document_with_permissions(adminset, evaluator, creator_only)
+      adminset.id ||= FactoryBot.generate(:object_id)
+      if creator_only
+        adminset.edit_users = [evaluator.user]
+      else
+        adminset.edit_users = user_managers(evaluator.with_permission_template, evaluator.user)
+        adminset.edit_groups = group_managers(evaluator.with_permission_template)
+        adminset.read_users = user_viewers(evaluator.with_permission_template) +
+                              user_depositors(evaluator.with_permission_template)
+        adminset.read_groups = group_viewers(evaluator.with_permission_template) +
+                               group_depositors(evaluator.with_permission_template) -
+                               [::Ability.registered_group_name, ::Ability.public_group_name]
+      end
+      adminset.to_solr
+    end
+    private_class_method :solr_document_with_permissions
+  end
+end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -10,16 +10,16 @@ FactoryBot.define do
   #
   # @example Simple build of a collection with no additional parts created.  Lightest weight.
   #          NOTE: A user is automatically created as the owner of the collection.
-  #   let(:collection) { build(:collection_lw)
+  #   let(:collection) { build(:collection_lw) }
   #
   # @example Simple build of a collection with no additional parts created.  User is the owner of the collection.  Lightest weight.
-  #   let(:collection) { build(:collection_lw, user:)
+  #   let(:collection) { build(:collection_lw, user:) }
   #
   # @example Simple build of a collection with only solr-document.  Owner is given edit-access in solr-document. Light weight.
-  #   let(:collection) { build(:collection_lw, with_solr_document: true)
+  #   let(:collection) { build(:collection_lw, with_solr_document: true) }
   #
   # @example Simple build of a collection with only a permission template created.  Owner is set as a manager.  Light weight.
-  #   let(:collection) { build(:collection_lw, with_permission_template: true)
+  #   let(:collection) { build(:collection_lw, with_permission_template: true) }
   #
   # @example Build a collection with only a permission template created.  Permissions are set based on
   #          attributes set for `with_permission_template`.  Middle weight.
@@ -30,7 +30,7 @@ FactoryBot.define do
   #                         manage_groups: [group_name],    # multiple groups can be listed
   #                         deposit_groups: [group_name],
   #                         view_groups: [group_name],  } }
-  #   let(:collection) { build(:collection_lw, user: , with_permission_template: permissions)
+  #   let(:collection) { build(:collection_lw, user: , with_permission_template: permissions) }
   #
   # @example Build a collection with permission template and solr-document created.  Permissions are set based on
   #          attributes set for `with_permission_template`.  Solr-document includes read/edit access defined based
@@ -42,7 +42,7 @@ FactoryBot.define do
   #                         manage_groups: [group_name],    # multiple groups can be listed
   #                         deposit_groups: [group_name],
   #                         view_groups: [group_name],  } }
-  #   let(:collection) { build(:collection_lw, user: , with_permission_template: permissions, with_solr_document: true)
+  #   let(:collection) { build(:collection_lw, user: , with_permission_template: permissions, with_solr_document: true) }
   #
   # @example Build a collection generating its collection type with specific settings. Light Weight.
   #          NOTE: Do not use this approach if you need access to the collection type in the test.
@@ -68,8 +68,8 @@ FactoryBot.define do
   #                      :sharable,                  # OR :not_sharable OR :sharable_no_work_permissions
   #                      :allow_multiple_membership, # OR :not_allow_multiple_membership
   #                    ] }
-  #   let(:collection_type) { create(:collection_lw_type, settings)}
-  #   let(:collection) { build(:collection_lw, collection_type_gid: collection_type.gid)}
+  #   let(:collection_type) { create(:collection_lw_type, settings) }
+  #   let(:collection) { build(:collection_lw, collection_type_gid: collection_type.gid) }
   #
   # @example Build a collection with nesting fields set in the solr document.  Light weight.
   #          NOTE: The property `with_nesting_attributes` is only supported for building collections.  The attributes will
@@ -77,7 +77,7 @@ FactoryBot.define do
   #   let(:collection) { build(:collection_lw, with_nesting_attributes: { ancestors: ['Parent_1'],
   #                                                                       parent_ids: ['Parent_1'],
   #                                                                       pathnames: ['Parent_1/Collection123'],
-  #                                                                       depth: 2 })
+  #                                                                       depth: 2 }) }
   #
   # @example Create a collection with everything.  Extreme heavy weight.  This is very slow and should be avoided.
   #          NOTE: Everything gets created.
@@ -87,7 +87,7 @@ FactoryBot.define do
   #                 * `with_solr_document` is ignored.  A solr document is always created.
   #                 * `with_nested_attributes` is ignored.
   #          NOTE: Additional process is required for testing nested collections with Fedora objects.  See next example.
-  #   let(:collection) { create(:collection_lw)
+  #   let(:collection) { create(:collection_lw) }
   #
   # @example Create collections for use with nested collection index testing.
   #          NOTE: For light weight nested collection testing using solr documents only, see `with_nested_attributes` above

--- a/spec/factory_tests/adminsets_factory_spec.rb
+++ b/spec/factory_tests/adminsets_factory_spec.rb
@@ -1,0 +1,132 @@
+RSpec.describe 'AdminSets Factory' do # rubocop:disable RSpec/DescribeClass
+  let(:user) { build(:user, email: 'user@example.com') }
+  let(:user_mgr) { build(:user, email: 'user_mgr@example.com') }
+  let(:user_dep) { build(:user, email: 'user_dep@example.com') }
+  let(:user_vw) { build(:user, email: 'user_vw@example.com') }
+
+  describe 'build' do
+    context 'with_permission_template' do
+      it 'will not create a permission template or access when it is the default value of false' do
+        expect { build(:adminset_lw) }.not_to change { Hyrax::PermissionTemplate.count }
+        expect { build(:adminset_lw) }.not_to change { Hyrax::PermissionTemplateAccess.count }
+      end
+
+      it 'will create a permission template and one access for the creating user when set to true' do
+        expect { build(:adminset_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:adminset_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplateAccess.count }.by(1)
+      end
+
+      it 'will create a permission template and access for each user specified when it is set to attributes identifying access' do
+        expect { build(:adminset_lw, with_permission_template: { manage_users: [user_mgr] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:adminset_lw, with_permission_template: { manage_users: [user_mgr] }) }.to change { Hyrax::PermissionTemplateAccess.count }.by(2)
+        expect { build(:adminset_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep], view_users: [user_vw] }) }
+          .to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:adminset_lw, with_permission_template: { manage_users: [user_mgr], deposit_users: [user_dep], view_users: [user_vw] }) }
+          .to change { Hyrax::PermissionTemplateAccess.count }.by(4)
+      end
+    end
+
+    context 'with_solr_document' do
+      it 'will not create a solr document by default' do
+        adminset = build(:adminset_lw)
+        expect(adminset.id).to eq nil # no real way to confirm a solr document wasn't created if the admin set doesn't have an id
+      end
+
+      context 'true' do
+        let(:adminset) { build(:adminset_lw, with_solr_document: true) }
+
+        subject { ActiveFedora::SolrService.get("id:#{adminset.id}")["response"]["docs"].first }
+
+        it 'will create a solr document' do
+          expect(subject["id"]).to eq adminset.id
+          expect(subject["has_model_ssim"].first).to eq "AdminSet"
+          expect(subject["edit_access_person_ssim"]).not_to be_blank
+        end
+      end
+
+      context 'true and with_permission_template defines additional access' do
+        let(:adminset) do
+          build(:adminset_lw, user: user,
+                              with_solr_document: true,
+                              with_permission_template: { manage_users: [user_mgr],
+                                                          deposit_users: [user_dep],
+                                                          view_users: [user_vw] })
+        end
+
+        subject { ActiveFedora::SolrService.get("id:#{adminset.id}")["response"]["docs"].first }
+
+        it 'will created a solr document' do
+          expect(subject["id"]).to eq adminset.id
+          expect(subject["has_model_ssim"].first).to eq "AdminSet"
+          expect(subject["edit_access_person_ssim"]).to include(user.user_key, user_mgr.user_key)
+          expect(subject["read_access_person_ssim"]).to include(user_dep.user_key, user_vw.user_key)
+        end
+      end
+    end
+  end
+
+  describe 'create' do
+    # with_solr_document is tested by build
+    # with_permission_template is tested by build except that the permission template is always created for `create`
+
+    context 'with_permission_template: false' do
+      it 'will create a permission template and access even when it is the default value of false' do
+        expect { create(:adminset_lw) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { create(:adminset_lw) }.to change { Hyrax::PermissionTemplateAccess.count }.by(1)
+      end
+    end
+  end
+
+  describe 'default_adminset' do
+    let(:default_adminset) { build(:default_adminset) }
+    let(:solrdoc) { ActiveFedora::SolrService.get("id:#{default_adminset.id}")["response"]["docs"].first }
+    let(:permission_template) { default_adminset.permission_template }
+
+    it 'will create the default adminset with expected metadata' do
+      expect(default_adminset.id).to eq AdminSet::DEFAULT_ID
+      expect(default_adminset.title).to eq AdminSet::DEFAULT_TITLE
+    end
+
+    it 'will create solr doc with no access' do
+      expect(solrdoc["id"]).to eq default_adminset.id
+      expect(solrdoc["has_model_ssim"].first).to eq "AdminSet"
+      expect(solrdoc["edit_access_person_ssim"].count).to eq 1 # creator automatically assigned by factory
+      expect(solrdoc["read_access_person_ssim"]).to eq nil
+      expect(solrdoc["edit_access_group_ssim"]).to include(::Ability.admin_group_name)
+      expect(solrdoc["read_access_group_ssim"]).to eq nil
+    end
+
+    it 'will create permission template with registered users as depositors' do
+      expect(permission_template.agent_ids_for(access: 'deposit', agent_type: 'group'))
+        .to include(::Ability.registered_group_name)
+      expect(permission_template.agent_ids_for(access: 'manage', agent_type: 'group'))
+        .to include(::Ability.admin_group_name)
+    end
+  end
+
+  describe 'build no_solr_grants_adminset' do
+    let(:permissions) do
+      { manage_users: [user_mgr],
+        deposit_users: [user_dep],
+        view_users: [user_vw] }
+    end
+    let(:legacy_adminset) { build(:no_solr_grants_adminset, user: user, with_permission_template: permissions) }
+    let(:solrdoc) { ActiveFedora::SolrService.get("id:#{legacy_adminset.id}")["response"]["docs"].first }
+
+    it 'will create a permission template with all access' do
+      expect { build(:no_solr_grants_adminset, user: user, with_permission_template: permissions) }
+        .to change { Hyrax::PermissionTemplate.count }.by(1)
+      expect { build(:no_solr_grants_adminset, user: user, with_permission_template: permissions) }
+        .to change { Hyrax::PermissionTemplateAccess.count }.by(4)
+    end
+
+    it 'will create solr doc with creator access only' do
+      expect(solrdoc["id"]).to eq legacy_adminset.id
+      expect(solrdoc["has_model_ssim"].first).to eq "AdminSet"
+      expect(solrdoc["edit_access_person_ssim"]).to eq [user.user_key]
+      expect(solrdoc["read_access_person_ssim"]).to eq nil
+      expect(solrdoc["edit_access_group_ssim"]).to eq nil
+      expect(solrdoc["read_access_group_ssim"]).to eq nil
+    end
+  end
+end

--- a/spec/factory_tests/collections_factory_spec.rb
+++ b/spec/factory_tests/collections_factory_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Collections Factory' do # rubocop:disable RSpec/DescribeClass
     end
 
     context 'with_solr_document' do
-      it 'will not created a solr document by default' do
+      it 'will not create a solr document by default' do
         col = build(:collection_lw)
         expect(col.id).to eq nil # no real way to confirm a solr document wasn't created if the collection doesn't have an id
       end
@@ -69,7 +69,7 @@ RSpec.describe 'Collections Factory' do # rubocop:disable RSpec/DescribeClass
 
         subject { ActiveFedora::SolrService.get("id:#{col.id}")["response"]["docs"].first }
 
-        it 'will created a solr document' do
+        it 'will create a solr document' do
           expect(subject["id"]).to eq col.id
           expect(subject["has_model_ssim"].first).to eq "Collection"
           expect(subject["edit_access_person_ssim"]).not_to be_blank
@@ -87,7 +87,7 @@ RSpec.describe 'Collections Factory' do # rubocop:disable RSpec/DescribeClass
 
         subject { ActiveFedora::SolrService.get("id:#{col.id}")["response"]["docs"].first }
 
-        it 'will created a solr document' do
+        it 'will create a solr document' do
           expect(subject["id"]).to eq col.id
           expect(subject["has_model_ssim"].first).to eq "Collection"
           expect(subject["edit_access_person_ssim"]).to include(user.user_key, user_mgr.user_key)

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -198,15 +198,17 @@ RSpec.describe AdminSet, type: :model do
 
     before do
       allow(admin_set).to receive(:permission_template).and_return(permission_template)
-      allow(permission_template).to receive(:agent_ids_for).with(access: 'manage', agent_type: 'user').and_return(['mgr1.ex.com', 'mgr2.ex.com', user.user_key])
+      allow(permission_template).to receive(:agent_ids_for).with(access: 'manage', agent_type: 'user').and_return(['mgr1@ex.com', 'mgr2@ex.com', user.user_key])
       allow(permission_template).to receive(:agent_ids_for).with(access: 'manage', agent_type: 'group').and_return(['managers', ::Ability.admin_group_name])
-      allow(permission_template).to receive(:agent_ids_for).with(access: 'view', agent_type: 'user').and_return(['vw1.ex.com', 'vw2.ex.com'])
-      allow(permission_template).to receive(:agent_ids_for).with(access: 'view', agent_type: 'group').and_return(['viewers'])
+      allow(permission_template).to receive(:agent_ids_for).with(access: 'deposit', agent_type: 'user').and_return(['dep1@ex.com', 'dep2@ex.com'])
+      allow(permission_template).to receive(:agent_ids_for).with(access: 'deposit', agent_type: 'group').and_return(['depositors', 'registered'])
+      allow(permission_template).to receive(:agent_ids_for).with(access: 'view', agent_type: 'user').and_return(['vw1@ex.com', 'vw2@ex.com'])
+      allow(permission_template).to receive(:agent_ids_for).with(access: 'view', agent_type: 'group').and_return(['viewers', 'public'])
     end
 
     it 'resets user edit access' do
       admin_set.reset_access_controls!
-      expect(admin_set.edit_users).to match_array([user.user_key, 'mgr1.ex.com', 'mgr2.ex.com'])
+      expect(admin_set.edit_users).to match_array([user.user_key, 'mgr1@ex.com', 'mgr2@ex.com'])
     end
 
     it 'resets group edit access' do
@@ -214,14 +216,14 @@ RSpec.describe AdminSet, type: :model do
       expect(admin_set.edit_groups).to match_array(['managers', ::Ability.admin_group_name])
     end
 
-    it "doesn't reset user read access" do
+    it 'resets user read access' do
       admin_set.reset_access_controls!
-      expect(admin_set.read_users).to match_array([]) # different behavior from Collections which grants participant Viewers to have read_access in the solr doc
+      expect(admin_set.read_users).to match_array(['dep1@ex.com', 'dep2@ex.com', 'vw1@ex.com', 'vw2@ex.com'])
     end
 
-    it "doesn't reset group read access" do
+    it 'resets group read access' do
       admin_set.reset_access_controls!
-      expect(admin_set.read_groups).to match_array(['public']) # different behavior from Collections which grants participant Viewers to have read_access in the solr doc
+      expect(admin_set.read_groups).to match_array(['depositors', 'viewers'])
     end
   end
 end

--- a/spec/services/hyrax/collections/migration_service_spec.rb
+++ b/spec/services/hyrax/collections/migration_service_spec.rb
@@ -4,15 +4,21 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
   let(:editor2) { create(:user) }
   let(:reader1) { create(:user) }
   let(:reader2) { create(:user) }
+  let(:manager1) { create(:user) }
+  let(:manager2) { create(:user) }
+  let(:depositor1) { create(:user) }
+  let(:depositor2) { create(:user) }
+  let(:viewer1) { create(:user) }
+  let(:viewer2) { create(:user) }
   let(:default_gid) { create(:user_collection_type).gid }
 
   describe ".migrate_all_collections" do
     context 'when legacy collections are found (e.g. collections created before Hyrax 2.1.0)' do
       let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true) }
       let!(:col_vu) { build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
-      let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'], do_save: true) }
+      let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], do_save: true) }
       let!(:col_mu) { build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
-      let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'], do_save: true) }
+      let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
 
       it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
         Collection.all.each do |col|
@@ -28,6 +34,8 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
           expect(pt_id).not_to be_nil
           expect_access(pt_id, 'user', :manage, col.edit_users)
           expect_access(pt_id, 'group', :manage, col.edit_groups)
+          expect_access(pt_id, 'user', :deposit, [])
+          expect_access(pt_id, 'group', :deposit, [])
           expect_access(pt_id, 'user', :view, col.read_users)
           expect_access(pt_id, 'group', :view, col.read_groups)
         end
@@ -36,24 +44,107 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
 
     context 'when newer collections are found (e.g. collections created at or after Hyrax 2.1.0)' do
       let!(:collection) do
-        create(:collection, id: 'col_newer', user: user, with_permission_template: true,
-                            collection_type_settings: [:discoverable], edit_users: [user.user_key],
-                            create_access: true)
+        build(:collection_lw,
+              id: 'col_newer', user: user,
+              with_permission_template: { manage_users: [manager1.user_key] },
+              with_solr_document: true)
       end
       let!(:permission_template) { collection.permission_template }
       let!(:collection_type_gid) { collection.collection_type_gid }
       let!(:edit_users) { collection.edit_users }
 
+      before do
+        allow(Collection).to receive(:all).and_return([collection])
+      end
+
       it "doesn't change the collection" do
         expect(collection.collection_type_gid).to eq collection_type_gid
         expect(Hyrax::PermissionTemplate.find_by!(source_id: collection.id).id).to eq permission_template.id
-        expect_access(permission_template.id, 'user', :manage, edit_users)
+        expect_access(permission_template.id, 'user', :manage, [user.user_key, manager1.user_key])
 
         Hyrax::Collections::MigrationService.migrate_all_collections
 
         expect(collection.collection_type_gid).to eq collection_type_gid
         expect(Hyrax::PermissionTemplate.find_by!(source_id: collection.id).id).to eq permission_template.id
-        expect_access(permission_template.id, 'user', :manage, edit_users)
+        expect_access(permission_template.id, 'user', :manage, [user.user_key, manager1.user_key])
+      end
+    end
+
+    context 'when legacy adminsets are found (e.g. adminsets created before Hyrax 2.1.0)' do
+      let!(:as_none) { build(:no_solr_grants_adminset, id: 'as_none', user: user) }
+      let!(:as_vu) { build(:no_solr_grants_adminset, id: 'as_vu', user: user, with_permission_template: { view_users: [reader1.user_key, reader2.user_key] }) }
+      let!(:as_vg) { build(:no_solr_grants_adminset, id: 'as_vg', user: user, with_permission_template: { view_groups: ['read_group_1', 'read_group_2'] }) }
+      let!(:as_du) { build(:no_solr_grants_adminset, id: 'as_du', user: user, with_permission_template: { deposit_users: [depositor1.user_key, depositor2.user_key] }) }
+      let!(:as_dg) { build(:no_solr_grants_adminset, id: 'as_dg', user: user, with_permission_template: { deposit_groups: ['deposit_group_1', 'deposit_group_2'] }) }
+      let!(:as_mu) { build(:no_solr_grants_adminset, id: 'as_mu', user: user, with_permission_template: { manage_users: [editor1.user_key, editor2.user_key] }) }
+      let!(:as_mg) { build(:no_solr_grants_adminset, id: 'as_mg', user: user, with_permission_template: { manage_groups: ['edit_group_1', 'edit_group_2'] }) }
+
+      before do
+        allow(AdminSet).to receive(:all).and_return([as_none, as_vu, as_vg, as_du, as_dg, as_mu, as_mg])
+      end
+
+      it 'sets read and edit access in solr doc' do # rubocop:disable RSpec/ExampleLength
+        AdminSet.all.each do |adminset|
+          expect(adminset.edit_users).to include(user.user_key)
+          expect(adminset.read_users).to eq []
+        end
+
+        Hyrax::Collections::MigrationService.migrate_all_collections
+
+        AdminSet.all.each do |adminset|
+          pt_id = Hyrax::PermissionTemplate.find_by!(source_id: adminset.id)
+          expect(pt_id).not_to be_nil
+          expect_solr_access(pt_id, 'user', :manage, adminset.edit_users)
+          expect_solr_access(pt_id, 'group', :manage, adminset.edit_groups)
+          expect_solr_access(pt_id, 'user', :deposit, adminset.read_users)
+          expect_solr_access(pt_id, 'group', :deposit, adminset.read_groups)
+          expect_solr_access(pt_id, 'user', :view, adminset.read_users)
+          expect_solr_access(pt_id, 'group', :view, adminset.read_groups)
+        end
+      end
+    end
+
+    context 'when newer adminsets are found (e.g. adminsets created at or after Hyrax 2.1.0)' do
+      let!(:adminset) do
+        build(:adminset_lw,
+              id: 'as_newer', user: user,
+              with_permission_template: {
+                manage_users: [editor1.user_key, editor2.user_key],
+                deposit_users: [depositor1.user_key, depositor2.user_key],
+                view_users: [viewer1.user_key, viewer2.user_key],
+                manage_groups: ['manage_group_1', 'manage_group_2'],
+                deposit_groups: ['deposit_group_1', 'deposit_group_2'],
+                view_groups: ['view_group_1', 'view_group_2']
+              },
+              with_solr_document: true)
+      end
+      let!(:permission_template) { adminset.permission_template }
+      let!(:edit_users) { adminset.edit_users }
+
+      before do
+        allow(AdminSet).to receive(:all).and_return([adminset])
+      end
+
+      it "doesn't change the adminset" do # rubocop:disable RSpec/ExampleLength
+        pt_id = Hyrax::PermissionTemplate.find_by!(source_id: adminset.id).id
+        expect(pt_id).to eq permission_template.id
+        expect_solr_access(pt_id, 'user', :manage, adminset.edit_users)
+        expect_solr_access(pt_id, 'group', :manage, adminset.edit_groups)
+        expect_solr_access(pt_id, 'user', :deposit, adminset.read_users)
+        expect_solr_access(pt_id, 'group', :deposit, adminset.read_groups)
+        expect_solr_access(pt_id, 'user', :view, adminset.read_users)
+        expect_solr_access(pt_id, 'group', :view, adminset.read_groups)
+
+        Hyrax::Collections::MigrationService.migrate_all_collections
+
+        pt_id = Hyrax::PermissionTemplate.find_by!(source_id: adminset.id).id
+        expect(pt_id).to eq permission_template.id
+        expect_solr_access(pt_id, 'user', :manage, adminset.edit_users)
+        expect_solr_access(pt_id, 'group', :manage, adminset.edit_groups)
+        expect_solr_access(pt_id, 'user', :deposit, adminset.read_users)
+        expect_solr_access(pt_id, 'group', :deposit, adminset.read_groups)
+        expect_solr_access(pt_id, 'user', :view, adminset.read_users)
+        expect_solr_access(pt_id, 'group', :view, adminset.read_groups)
       end
     end
   end
@@ -62,16 +153,16 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
     context 'when legacy collections are found (e.g. collections created before Hyrax 2.1.0)' do
       let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true) }
       let!(:col_vu) { build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
-      let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'], do_save: true) }
+      let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], do_save: true) }
       let!(:col_mu) { build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
-      let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'], do_save: true) }
+      let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
 
       context "and collection wasn't migrated at all" do
         let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true) }
         let!(:col_vu) { build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
-        let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'], do_save: true) }
+        let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], do_save: true) }
         let!(:col_mu) { build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
-        let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'], do_save: true) }
+        let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
 
         it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
           Collection.all.each do |col|
@@ -96,9 +187,9 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       context "and collection type gid is set but permission template doesn't exist" do
         let!(:col_none) { create(:user_collection, id: 'col_none', user: user, edit_users: [user.user_key], collection_type_gid: default_gid) }
         let!(:col_vu) { create(:user_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], collection_type_gid: default_gid) }
-        let!(:col_vg) { create(:user_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'], collection_type_gid: default_gid) }
+        let!(:col_vg) { create(:user_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], collection_type_gid: default_gid) }
         let!(:col_mu) { create(:user_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], collection_type_gid: default_gid) }
-        let!(:col_mg) { create(:user_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'], collection_type_gid: default_gid) }
+        let!(:col_mg) { create(:user_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], collection_type_gid: default_gid) }
 
         it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
           Collection.all.each do |col|
@@ -127,7 +218,7 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_vg) do
-          build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'],
+          build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mu) do
@@ -135,7 +226,7 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mg) do
-          build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'],
+          build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'],
                                       do_save: true, with_permission_template: true)
         end
 
@@ -191,7 +282,7 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_vg) do
-          build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group1', 'read_group_2'],
+          build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mu) do
@@ -199,7 +290,7 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mg) do
-          build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group1', 'edit_group_2'],
+          build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'],
                                       do_save: true, with_permission_template: true)
         end
 
@@ -250,6 +341,84 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
         expect_access(permission_template.id, 'user', :manage, edit_users)
       end
     end
+
+    context 'when legacy adminsets are found (e.g. adminsets created before Hyrax 2.1.0)' do
+      let!(:as_none) { build(:no_solr_grants_adminset, id: 'as_none', user: user) }
+      let!(:as_vu) { build(:no_solr_grants_adminset, id: 'as_vu', user: user, with_permission_template: { view_users: [reader1.user_key, reader2.user_key] }) }
+      let!(:as_vg) { build(:no_solr_grants_adminset, id: 'as_vg', user: user, with_permission_template: { view_groups: ['read_group_1', 'read_group_2'] }) }
+      let!(:as_du) { build(:no_solr_grants_adminset, id: 'as_du', user: user, with_permission_template: { deposit_users: [depositor1.user_key, depositor2.user_key] }) }
+      let!(:as_dg) { build(:no_solr_grants_adminset, id: 'as_dg', user: user, with_permission_template: { deposit_groups: ['deposit_group_1', 'deposit_group_2'] }) }
+      let!(:as_mu) { build(:no_solr_grants_adminset, id: 'as_mu', user: user, with_permission_template: { manage_users: [editor1.user_key, editor2.user_key] }) }
+      let!(:as_mg) { build(:no_solr_grants_adminset, id: 'as_mg', user: user, with_permission_template: { manage_groups: ['edit_group_1', 'edit_group_2'] }) }
+
+      before do
+        allow(AdminSet).to receive(:all).and_return([as_none, as_vu, as_vg, as_du, as_dg, as_mu, as_mg])
+      end
+
+      it 'sets read and edit access in solr doc' do # rubocop:disable RSpec/ExampleLength
+        AdminSet.all.each do |adminset|
+          expect(adminset.edit_users).to include(user.user_key)
+          expect(adminset.read_users).to eq []
+        end
+
+        Hyrax::Collections::MigrationService.repair_migrated_collections
+
+        AdminSet.all.each do |adminset|
+          pt_id = Hyrax::PermissionTemplate.find_by!(source_id: adminset.id)
+          expect(pt_id).not_to be_nil
+          expect_solr_access(pt_id, 'user', :manage, adminset.edit_users)
+          expect_solr_access(pt_id, 'group', :manage, adminset.edit_groups)
+          expect_solr_access(pt_id, 'user', :deposit, adminset.read_users)
+          expect_solr_access(pt_id, 'group', :deposit, adminset.read_groups)
+          expect_solr_access(pt_id, 'user', :view, adminset.read_users)
+          expect_solr_access(pt_id, 'group', :view, adminset.read_groups)
+        end
+      end
+    end
+
+    context 'when newer adminsets are found (e.g. adminsets created at or after Hyrax 2.1.0)' do
+      let!(:adminset) do
+        build(:adminset_lw,
+              id: 'as_newer', user: user,
+              with_permission_template: {
+                manage_users: [editor1.user_key, editor2.user_key],
+                deposit_users: [depositor1.user_key, depositor2.user_key],
+                view_users: [viewer1.user_key, viewer2.user_key],
+                manage_groups: ['manage_group_1', 'manage_group_2'],
+                deposit_groups: ['deposit_group_1', 'deposit_group_2'],
+                view_groups: ['view_group_1', 'view_group_2']
+              },
+              with_solr_document: true)
+      end
+      let!(:permission_template) { adminset.permission_template }
+      let!(:edit_users) { adminset.edit_users }
+
+      before do
+        allow(AdminSet).to receive(:all).and_return([adminset])
+      end
+
+      it "doesn't change the adminset" do # rubocop:disable RSpec/ExampleLength
+        pt_id = Hyrax::PermissionTemplate.find_by!(source_id: adminset.id).id
+        expect(pt_id).to eq permission_template.id
+        expect_solr_access(pt_id, 'user', :manage, adminset.edit_users)
+        expect_solr_access(pt_id, 'group', :manage, adminset.edit_groups)
+        expect_solr_access(pt_id, 'user', :deposit, adminset.read_users)
+        expect_solr_access(pt_id, 'group', :deposit, adminset.read_groups)
+        expect_solr_access(pt_id, 'user', :view, adminset.read_users)
+        expect_solr_access(pt_id, 'group', :view, adminset.read_groups)
+
+        Hyrax::Collections::MigrationService.repair_migrated_collections
+
+        pt_id = Hyrax::PermissionTemplate.find_by!(source_id: adminset.id).id
+        expect(pt_id).to eq permission_template.id
+        expect_solr_access(pt_id, 'user', :manage, adminset.edit_users)
+        expect_solr_access(pt_id, 'group', :manage, adminset.edit_groups)
+        expect_solr_access(pt_id, 'user', :deposit, adminset.read_users)
+        expect_solr_access(pt_id, 'group', :deposit, adminset.read_groups)
+        expect_solr_access(pt_id, 'user', :view, adminset.read_users)
+        expect_solr_access(pt_id, 'group', :view, adminset.read_groups)
+      end
+    end
   end
 
   def create_access(permission_template_id, agent_type, access, agent_ids)
@@ -275,6 +444,24 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       pta = Hyrax::PermissionTemplateAccess.where(permission_template_id: permission_template_id, agent_type: agent_type,
                                                   access: access, agent_id: agent_id)
       expect(pta).to be_empty
+    end
+  end
+
+  def expect_solr_access(permission_template_id, pt_agent_type, pt_access, solrdoc_access)
+    ptas = Hyrax::PermissionTemplateAccess.where(permission_template_id: permission_template_id, agent_type: pt_agent_type, access: pt_access)
+    expect_solr_group_access(ptas, solrdoc_access) if pt_agent_type == 'group'
+    expect_solr_user_access(ptas, solrdoc_access) if pt_agent_type == 'user'
+  end
+
+  def expect_solr_group_access(permission_templates, solrdoc_access)
+    permission_templates.each do |pta|
+      expect(solrdoc_access).to include pta.agent_id
+    end
+  end
+
+  def expect_solr_user_access(permission_templates, solrdoc_access)
+    permission_templates.each do |pta|
+      expect(solrdoc_access).to include pta.agent_id
     end
   end
 end

--- a/spec/services/hyrax/collections/permissions_create_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_create_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hyrax::Collections::PermissionsCreateService do
     end
     let!(:collection_type_participant) { create(:collection_type_participant, user_manage_attributes) }
     let!(:collection_type_participant2) { create(:collection_type_participant, group_manage_attributes) }
-    let(:collection) { create(:collection, collection_type_gid: collection_type.gid) }
+    let(:collection) { build(:collection_lw, id: 'collection1', collection_type_gid: collection_type.gid) }
 
     before do
       subject

--- a/spec/services/hyrax/collections/permissions_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_service_spec.rb
@@ -187,6 +187,10 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       it 'returns admin set ids where user has deposit access' do
         expect(described_class.source_ids_for_deposit(ability: ability, source_type: 'admin_set')).to match_array [as_du.id, as_dg.id, as_mu.id, as_mg.id]
       end
+      it 'returns admin set ids where user has deposit access except excluded groups' do
+        expect(described_class.source_ids_for_deposit(ability: ability, source_type: 'admin_set', exclude_groups: ['deposit_group']))
+          .to match_array [as_du.id, as_mu.id, as_mg.id]
+      end
 
       context 'when user has no access' do
         let(:ability) { Ability.new(user2) }

--- a/spec/views/hyrax/admin/admin_sets/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_show_actions.html.erb_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe 'hyrax/admin/admin_sets/_show_actions.html.erb', type: :view do
+  let(:solr_document) { SolrDocument.new }
+  let(:ability) { instance_double("Ability") }
+  let(:presenter) { Hyrax::AdminSetPresenter.new(solr_document, ability) }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(view).to receive(:presenter).and_return(presenter)
+
+    # Stub route because view specs don't handle engine routes
+    allow(view).to receive(:edit_admin_admin_set_path).with(presenter).and_return("/admin/admin_sets/123/edit")
+    allow(view).to receive(:admin_admin_set_path).with(presenter).and_return("/admin/admin_sets/123")
+  end
+
+  context 'when editor of the admin_set' do
+    before do
+      allow(ability).to receive(:can?).with(:edit, solr_document).and_return(true)
+    end
+
+    context "when presenter has delete disabled" do
+      before do
+        allow(presenter).to receive(:disable_delete?).and_return(true)
+        render
+      end
+      it "displays a disabled delete button" do
+        expect(rendered).to have_selector(:css, "a.btn-danger.disabled")
+        expect(rendered).to have_selector(:css, "a.btn-primary")
+      end
+    end
+
+    context "with empty admin set" do
+      before do
+        allow(presenter).to receive(:disable_delete?).and_return(false)
+        render
+      end
+      it "displays an enabled delete button" do
+        expect(rendered).to have_selector(:css, "a.btn-danger")
+        expect(rendered).not_to have_selector(:css, "a.btn-danger.disabled")
+        expect(rendered).to have_selector(:css, "a.btn-primary")
+      end
+    end
+
+    context "with default admin set" do
+      before do
+        allow(presenter).to receive(:disable_delete?).and_return(true)
+        render
+      end
+      it "displays a disabled delete button" do
+        expect(rendered).to have_selector(:css, "a.btn-danger.disabled")
+        expect(rendered).to have_selector(:css, "a.btn-primary")
+      end
+    end
+  end
+
+  context 'when reader of the admin_set' do
+    before do
+      allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
+      render
+    end
+
+    it "doesn't display any action buttons" do
+      expect(rendered).not_to have_selector(:css, "a.btn-danger")
+      expect(rendered).not_to have_selector(:css, "a.btn-primary")
+    end
+  end
+end

--- a/spec/views/hyrax/admin/admin_sets/show.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/show.html.erb_spec.rb
@@ -1,50 +1,21 @@
 RSpec.describe "hyrax/admin/admin_sets/show.html.erb", type: :view do
   let(:solr_document) { SolrDocument.new }
-  let(:ability) { double }
+  let(:ability) { instance_double("Ability") }
   let(:presenter) { Hyrax::AdminSetPresenter.new(solr_document, ability) }
 
   before do
-    allow(presenter).to receive(:total_items).and_return(0)
-    # Stub route because view specs don't handle engine routes
-    allow(view).to receive(:edit_admin_admin_set_path).and_return("/admin/admin_sets/123/edit")
-    allow(view).to receive(:admin_admin_set_path).and_return("/admin/admin_sets/123")
-
     stub_template '_collection_description.html.erb' => ''
+    stub_template '_show_actions.erb' => ''
     stub_template '_show_descriptions.erb' => ''
     stub_template '_sort_and_per_page.html.erb' => 'sort and per page'
     stub_template '_document_list.html.erb' => 'document list'
     stub_template '_paginate.html.erb' => 'paginate'
 
     assign(:presenter, presenter)
+    render
   end
 
-  context "when presenter has delete disabled" do
-    before do
-      allow(presenter).to receive(:disable_delete?).and_return(true)
-      render
-    end
-    it "displays a disabled delete button" do
-      expect(rendered).to have_selector(:css, "a.btn-danger.disabled")
-    end
-  end
-
-  context "with empty admin set" do
-    before do
-      render
-    end
-    it "displays an enabled delete button" do
-      expect(rendered).to have_selector(:css, "a.btn-danger")
-      expect(rendered).not_to have_selector(:css, "a.btn-danger.disabled")
-    end
-  end
-
-  context "with default admin set" do
-    before do
-      allow(presenter).to receive(:disable_delete?).and_return(true)
-      render
-    end
-    it "displays a disabled delete button" do
-      expect(rendered).to have_selector(:css, "a.btn-danger.disabled")
-    end
+  it "displays a disabled delete button" do
+    expect(rendered).to have_selector('div.admin-set')
   end
 end


### PR DESCRIPTION
Fixes #2760

Sets user read access to all users with Deposit and View access.
Sets group read access to all groups with Deposit and View access EXCEPT registered group (i.e. all users with logins) and public group (i.e. everyone)
