### PR TITLE
Fix batch create as proxy

### DIFF
--- a/app/controllers/hyrax/batch_uploads_controller.rb
+++ b/app/controllers/hyrax/batch_uploads_controller.rb
@@ -60,7 +60,7 @@ module Hyrax
         # Calling `#t` in a controller context does not mark _html keys as html_safe
         flash[:notice] = view_context.t('hyrax.works.create.after_create_html', application_name: view_context.application_name)
         if uploading_on_behalf_of?
-          redirect_to hyrax.dashboard_shares_path
+          redirect_to hyrax.dashboard_works_path
         else
           redirect_to hyrax.my_works_path
         end

--- a/spec/controllers/hyrax/batch_uploads_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_uploads_controller_spec.rb
@@ -105,10 +105,10 @@ RSpec.describe Hyrax::BatchUploadsController do
         }
       end
 
-      it 'redirects to my shares page' do
+      it 'redirects to managed works page' do
         allow(BatchCreateJob).to receive(:perform_later)
         post :create, params: post_params
-        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.dashboard_shares_path(locale: 'en')
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.dashboard_works_path(locale: 'en')
       end
     end
   end

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -2,8 +2,19 @@
 
 RSpec.describe 'Batch creation of works', type: :feature do
   let(:user) { create(:user) }
+  let!(:default_admin_set) do
+    build(:admin_set,
+          id: AdminSet::DEFAULT_ID,
+          title: ["Default Admin Set"],
+          description: ["A description"],
+          with_permission_template: { deposit_groups: [::Ability.registered_group_name] })
+  end
 
   before do
+    # stub out characterization and derivatives. Travis doesn't have fits installed, and it's not relevant to the test.
+    allow(CharacterizeJob).to receive(:perform_later)
+    allow(CreateDerivativesJob).to receive(:perform_later)
+
     sign_in user
   end
 
@@ -14,5 +25,54 @@ RSpec.describe 'Batch creation of works', type: :feature do
       expect(page).to have_content("Files")
     end
     expect(page).to have_content("Each file will be uploaded to a separate new work resulting in one work per uploaded file.")
+  end
+
+  context 'when the user is a proxy', :js, :workflow do
+    let(:second_user) { create(:user) }
+
+    before do
+      ProxyDepositRights.create!(grantor: second_user, grantee: user)
+      sign_in user
+      click_link 'Works'
+      click_link "Create batch of works"
+      choose "payload_concern", option: "GenericWork"
+      click_button 'Create work'
+    end
+
+    it "allows on-behalf-of batch deposit", :js do
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      within('span#addfiles') do
+        # two arbitrary files that aren't actually related, but should be
+        # small enough to require minimal processessing.
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/small_file.txt", visible: false)
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/png_fits.xml", visible: false)
+      end
+      click_link "Descriptions" # switch tab
+      fill_in('Creator', with: 'Doe, Jane')
+      fill_in('Keyword', with: 'testing')
+      select('In Copyright', from: 'Rights statement')
+      # With selenium and the chrome driver, focus remains on the
+      # select box. Click outside the box so the next line can't find
+      # its element
+      find('body').click
+
+      choose('batch_upload_item_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      select(second_user.user_key, from: 'On behalf of')
+      check('agreement')
+      click_on('Save')
+
+      # Expect the proxy depositor (grantor) to be able to see both uploaded files.
+      expect(page).to have_content 'small_file.txt'
+      expect(page).to have_content 'png_fits.xml'
+
+      # Sign in with the grantee user, and expect to see the works deposited
+      # on their behalf.
+      sign_in second_user
+      click_link 'Works'
+      expect(page).to have_content 'small_file.txt'
+      expect(page).to have_content 'png_fits.xml'
+    end
   end
 end


### PR DESCRIPTION
Fixes #2761 

There was a relic redirect after a batch upload that was causing path errors
when trying to render some partials. This change fixes that redirect, and adds a
test.