### PR TITLE
Only show files that users have permission to see.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Metrics/BlockLength:
     - 'app/models/concerns/hyrax/content_block_behavior.rb'
     - 'app/services/hyrax/workflow/workflow_schema.rb'
     - 'config/initializers/simple_form.rb'
+    - 'config/features.rb'
     - 'config/routes.rb'
     - 'lib/generators/hyrax/templates/catalog_controller.rb'
     - 'lib/generators/hyrax/templates/config/initializers/simple_form_bootstrap.rb'

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -152,6 +152,10 @@ module Hyrax
 
     delegate :member_presenters, :file_set_presenters, :work_presenters, to: :member_presenter_factory
 
+    def exclude_unauthorized_file_sets
+      member_presenters.delete_if { |m| m.is_a?(Hyrax::FileSetPresenter) && !current_ability.can?(:read, m.id) }
+    end
+
     def manifest_url
       manifest_helper.polymorphic_url([:manifest, self])
     end

--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -1,5 +1,5 @@
 <h2><%= t('.header') %></h2>
-<%  members = presenter.member_presenters.delete_if { |m| Flipflop.hide_private_files? && m.is_a?(Hyrax::FileSetPresenter) && !current_ability.can?(:read, m.id) } %>
+<%  members = Flipflop.hide_private_files? ? presenter.exclude_unauthorized_file_sets : presenter.member_presenters %>
 <% if members.present? %>
   <table class="table table-striped related-files">
     <thead>

--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -1,5 +1,6 @@
 <h2><%= t('.header') %></h2>
-<% if presenter.member_presenters.present? %>
+<%  members = presenter.member_presenters.delete_if { |m| Flipflop.hide_private_files? && m.is_a?(Hyrax::FileSetPresenter) && !current_ability.can?(:read, m.id) } %>
+<% if members.present? %>
   <table class="table table-striped related-files">
     <thead>
       <tr>
@@ -11,7 +12,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'member', collection: presenter.member_presenters %>
+      <%= render partial: 'member', collection: members %>
     </tbody>
   </table>
 <% elsif can? :edit, presenter.id %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -34,4 +34,8 @@ Flipflop.configure do
   feature :analytics_redesign,
           default: false,
           description: "Display new reporting features. *Very Experimental*"
+
+  feature :hide_private_files,
+          default: false,
+          description: "Do not show the private files."
 end

--- a/spec/models/flipflop_spec.rb
+++ b/spec/models/flipflop_spec.rb
@@ -30,4 +30,12 @@ RSpec.describe Flipflop do
       is_expected.to be true
     end
   end
+
+  describe "hide_private_files?" do
+    subject { described_class.hide_private_files? }
+
+    it "defaults to false" do
+      is_expected.to be false
+    end
+  end
 end

--- a/spec/views/hyrax/base/_items.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_items.html.erb_spec.rb
@@ -32,4 +32,51 @@ RSpec.describe 'hyrax/base/_items.html.erb', type: :view do
       expect(rendered).to have_css('tbody', text: member_presenters.join)
     end
   end
+
+  context "when file set members are present" do
+    let(:user) { create(:user) }
+    let(:ability) { Ability.new(user) }
+    let(:file1) { create(:file_set, :public) }
+    let(:file2) { create(:file_set) }
+
+    let(:fs_presenter_1) { Hyrax::FileSetPresenter.new(SolrDocument.new(file1.to_solr), ability) }
+    let(:fs_presenter_2) { Hyrax::FileSetPresenter.new(SolrDocument.new(file2.to_solr), ability) }
+
+    before do
+      stub_template 'hyrax/base/_member.html.erb' => '<%= member %>'
+    end
+
+    context "and a public file set" do
+      let(:member_presenters) { [fs_presenter_1] }
+
+      it "show the link for the file set" do
+        expect(Flipflop).to receive(:hide_private_files?).and_return(true)
+        render 'hyrax/base/items', presenter: presenter, current_ability: ability
+        expect(rendered).to have_content fs_presenter_1.link_name
+        expect(rendered).not_to have_content fs_presenter_2.link_name
+      end
+    end
+
+    context "and a private file set" do
+      let(:member_presenters) { [fs_presenter_2] }
+
+      it "won't show the link to the file set" do
+        expect(Flipflop).to receive(:hide_private_files?).and_return(true)
+        expect(view).to receive(:can?).with(:edit, presenter.id).and_return(false)
+        render 'hyrax/base/items', presenter: presenter, current_ability: ability
+        expect(rendered).not_to have_content fs_presenter_2.link_name
+      end
+    end
+
+    context "with public and private file sets" do
+      let(:member_presenters) { [fs_presenter_1, fs_presenter_2] }
+
+      it "only show the link to the file set that users have permission to see" do
+        expect(Flipflop).to receive(:hide_private_files?).exactly(2).times.and_return(true)
+        render 'hyrax/base/items', presenter: presenter, current_ability: ability
+        expect(rendered).to have_content fs_presenter_1.link_name
+        expect(rendered).not_to have_content fs_presenter_2.link_name
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2796

Only show files that users have permission to see when the hide private files flipper is on.

@samvera/hyrax-code-reviewers
