### PR TITLE
Replace save with reindex on child collection

### DIFF
--- a/app/models/concerns/hyrax/collection_nesting.rb
+++ b/app/models/concerns/hyrax/collection_nesting.rb
@@ -22,18 +22,18 @@ module Hyrax
 
       def after_update_nested_collection_relationship_indices
         @during_save = false
-        Hyrax.config.nested_relationship_reindexer.call(id: id)
+        reindex_nested_relationships_for(id: id)
       end
 
       def update_nested_collection_relationship_indices
         return if @during_save
-        Hyrax.config.nested_relationship_reindexer.call(id: id)
+        reindex_nested_relationships_for(id: id)
       end
 
       def update_child_nested_collection_relationship_indices
         children = find_children_of(destroyed_id: id)
         children.each do |child|
-          Hyrax.config.nested_relationship_reindexer.call(id: child.id)
+          reindex_nested_relationships_for(id: child.id)
         end
       end
     end
@@ -49,5 +49,11 @@ module Hyrax
     def use_nested_reindexing?
       true
     end
+
+    private
+
+      def reindex_nested_relationships_for(id:)
+        Hyrax.config.nested_relationship_reindexer.call(id: id)
+      end
   end
 end

--- a/app/services/hyrax/collections/nested_collection_persistence_service.rb
+++ b/app/services/hyrax/collections/nested_collection_persistence_service.rb
@@ -11,14 +11,18 @@ module Hyrax
       # @note There is odd permission arrangement based on the NestedCollectionQueryService:
       #       You can nest the child within a parent if you can edit the parent and read the child.
       #       See https://wiki.duraspace.org/display/samvera/Samvera+Tech+Call+2017-08-23 for tech discussion.
+      # @note Adding the member_of_collections method doesn't trigger reindexing of the child so we have to do it manually.
+      #       However it save and reindexes the parent unnecessarily!!
       def self.persist_nested_collection_for(parent:, child:)
-        child.member_of_collections << parent
-        child.save
+        child.member_of_collections.push(parent)
+        child.update_nested_collection_relationship_indices
       end
 
+      # @note Removing the member_of_collections method doesn't trigger reindexing of the child so we have to do it manually.
+      #       However it doesn't save and reindex the parent, as it does when a parent is added!!
       def self.remove_nested_relationship_for(parent:, child:)
         child.member_of_collections.delete(parent)
-        child.save
+        child.update_nested_collection_relationship_indices
         true
       end
     end

--- a/spec/models/concerns/hyrax/collection_nesting_spec.rb
+++ b/spec/models/concerns/hyrax/collection_nesting_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Hyrax::CollectionNesting do
       end
     end
 
-    context 'after_destroy callback' do
+    context 'after_destroy callback', with_nested_reindexing: true do
       describe '#update_child_nested_collection_relationship_indices' do
         it 'will call Hyrax.config.nested_relationship_reindexer' do
           expect(Hyrax.config.nested_relationship_reindexer).to receive(:call).with(id: child_collection.id).and_call_original

--- a/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Hyrax::Collections::NestedCollectionPersistenceService do
+RSpec.describe Hyrax::Collections::NestedCollectionPersistenceService, with_nested_reindexing: true do
   let(:parent) { create(:collection) }
   let(:child) { create(:collection) }
 


### PR DESCRIPTION
References https://github.com/samvera/hyrax/issues/2798

This is a PR to reduce some unnecessary overhead, but it doesn't actually solve the referenced issue.

In the case of adding a `member_of_collections` relationship (either work and collection), Active Fedora saves and reindexes the parent, which triggers the nested reindexer to reindex the parent and ALL of its child works AND collections. This is a lot of unnecessarily overhead because nothing is changing on the parent, and only the one child work or collection actually needs to change.

The nested child persistence service updates the `member_of_collections` relationship between a child and parent collection. Active Fedora makes all of the expected changes to the data in Fedora with no need for a subsequent save. However, it doesn't cause a subsequent reindex on the child collection to record the relationship in Solr. 

This reindexing had previously been accommodated by a subsequent `child.save`. Since all that we really need is to reindex the child, this PR is changing the save to simply force reindexing. It calls the nested reindexer directly, rather than using `update_index` which would trigger the additional call to the reindexer, thereby reindexing the child collection twice.

**Note:** I've been told that the indirect container relationship requires that the parent be saved, though I can't claim to understand why, especially since it only does this when adding the `member_of_collections` relationship, and  doesn't do  it while removing the same relationship. 

@samvera/hyrax-code-reviewers
