### PR TITLE
WIP: Show flash messages with modal xhr post

### DIFF
--- a/app/controllers/hyrax/dashboard/nest_collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/nest_collections_controller.rb
@@ -1,6 +1,6 @@
 module Hyrax
   module Dashboard
-    class NestCollectionsController < ApplicationController
+    class NestCollectionsController < Hyrax::My::CollectionsController
       include Blacklight::Base
       class_attribute :form_class, :new_collection_form_class
       self.form_class = Hyrax::Forms::Dashboard::NestCollectionForm

--- a/lib/generators/hyrax/templates/catalog_controller.rb
+++ b/lib/generators/hyrax/templates/catalog_controller.rb
@@ -280,6 +280,10 @@ class CatalogController < ApplicationController
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
     config.spell_max = 5
+
+    # Disable discarding of flash messages in blacklight since we are using turbolinks
+    # to handle things like following redirects after xhr posts
+    config.discard_flash_if_xhr = false
   end
 
   # disable the bookmark control from displaying in gallery view

--- a/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
@@ -3,6 +3,11 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
   let(:child_id) { 'child1' }
   let(:child) { instance_double(Collection, title: ["Awesome Child"]) }
   let(:parent) { create(:collection, id: 'parent1', collection_type_settings: :nestable, title: ["Uncool Parent"]) }
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
 
   describe '#blacklight_config' do
     subject { controller.blacklight_config }


### PR DESCRIPTION
Fix for #2592

Flash messages are being discarded by Blacklight for XHR requests. This PR changes this default behavior so that XHR post-redirect-get behaviors retain flash messages.

Changes proposed in this pull request:
- Added a way to configure blacklight's discard flash behavior and changed the catalog controller template to disable this behavior by default. For applications that don't use turbolinks, they will likely want to remove this config line to restore blacklight's solution to the UX problems mentioned in projectblacklight/blacklight@4d9290f
- Changed NestCollectionsController to inherit from Hyrax::My::CollectionsController. Without this, this controller would not run through the catalog controller's configure_blacklight step and would not get the override for the discard flash behavior
- Now that the NestCollectionsController inherits from Hyrax::My::CollectionsController, it will redirect to login page if the user is not logged in. Fixed the spec to login as a user before performing any actions.

WIP TODO:
- [ ] This depends on https://github.com/projectblacklight/blacklight/pull/1861. Once this is merged and the version is bumped/released, bump the version in Hyrax's Gemfile.

@samvera/hyrax-code-reviewers
