### PR TITLE
Fix link to duraspace wiki page that was never updated after name change

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ All code contributors must have an Individual Contributor License Agreement
 an institution, the institution must have a Corporate Contributor License 
 Agreement (cCLA) on file.
 
-https://wiki.duraspace.org/display/hydra/Hydra+Project+Intellectual+Property+Licensing+and+Ownership
+https://wiki.duraspace.org/display/samvera/Samvera+Community+Intellectual+Property+Licensing+and+Ownership
 
 You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
 


### PR DESCRIPTION
The link was pointing to a Hydra named page which was removed and didn't redirect.  The PR has the correct link to the Samvera named page.

@samvera/hyrax-code-reviewers
