### PR TITLE
fixes bug when attaching files on behalf of yourself

### DIFF
--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -56,5 +56,17 @@ RSpec.describe AttachFilesToWorkJob do
         end
       end
     end
+
+    context "deposited as 'Yourself' selected in on behalf of list" do
+      before do
+        generic_work.on_behalf_of = ''
+        generic_work.save
+      end
+      it_behaves_like 'a file attacher' do
+        it 'records the depositor(s) in edit_users' do
+          expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor]))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #2902 

Wasn't properly handling the FileSet metadata when the depositor has the ability to deposit `on_behalf_of` but had selected `Yourself` on the form. 

This scenario passes an empty string in `work.on_behalf_of`, so the application should handle it and use `work.depositor` instead.