### PR TITLE
[WIP] Combine collection and admin set facets on works dashboard

### DIFF
--- a/app/controllers/hyrax/my/works_controller.rb
+++ b/app/controllers/hyrax/my/works_controller.rb
@@ -4,8 +4,15 @@ module Hyrax
       # Define collection specific filter facets.
       def self.configure_facets
         configure_blacklight do |config|
-          config.add_facet_field solr_name("admin_set", :facetable), limit: 5
-          config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5
+          config.add_facet_field solr_name('member_of_collection_ids', :symbol),
+                                 helper_method: :collection_label,
+                                 limit: 5,
+                                 pivot: [solr_name('admin_set', :facetable), solr_name('member_of_collection_ids', :symbol)],
+                                 label: I18n.t('hyrax.dashboard.my.heading.collection')
+          config.add_facet_field solr_name('admin_set', :facetable),
+                                 limit: 5,
+                                 label: I18n.t('hyrax.dashboard.my.heading.collection'),
+                                 show: false
         end
       end
       configure_facets

--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -46,6 +46,14 @@ module Hyrax
       CollectionType.find_or_create_default_collection_type.title
     end
 
+    # @param collection_id [String] The id of the Collection to be looked up
+    # @return [String] The Collection's title if found, else the id
+    def collection_label(collection_id)
+      Collection.find(collection_id).title.first
+    rescue ActiveRecord::RecordNotFound, URI::BadURIError
+      collection_id
+    end
+
     private
 
       # add hidden fields to a form for performing an action on a single document on a collection

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -17,8 +17,6 @@ en:
     search:
       fields:
         facet:
-          admin_set_sim: Admin Set
-          member_of_collections_ssim: Collection
           resource_type_sim: Resource type
           suppressed_bsi: Status
         show:
@@ -706,6 +704,7 @@ en:
           works: 'Filter works:'
         heading:
           action: Actions
+          collection: Collection
           collection_type: Collection Type
           date_modified: Last Modified
           date_uploaded: Date Added


### PR DESCRIPTION
Partial resolution for #2841

This satisfies the "minimal goal" of #2841 by combining the `Collection` and `Admin Set` facets on the works dashboard into a single facet.  

Clicking on the `Collection` facet will now list any collections that have works along with any admin sets that have works.  Items in the dropdown are sorted by count.

@elrayle 
