### PR TITLE
Disable discard_flash_if_xhr behavior

### DIFF
--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -172,5 +172,15 @@ module Hyrax
     def riiif_image_server
       generate 'hyrax:riiif' unless options[:'skip-riiif']
     end
+
+    # Blacklight::Controller will by default add an after_action filter to discard all flash messages on xhr requests.
+    # This has caused problems when we perform a post-redirect-get cycle using xhr and turbolinks.
+    # This injector will modify the generated ApplicationController to skip this action.
+    # TODO: This may be removed in Blacklight 7.x, so we'll likely need to remove this after updating.
+    def inject_skip_blacklilght_flash_discarding
+      insert_into_file "app/controllers/application_controller.rb", after: "include Blacklight::Controller\n" do
+        "  skip_after_action :discard_flash_if_xhr\n"
+      end
+    end
   end
 end

--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -323,13 +323,14 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
     context 'when there are no collections of this type' do
       let!(:empty_collection_type) { create(:collection_type, title: 'Empty Type', creator_user: admin_user) }
       let!(:delete_modal_text) { 'Deleting this collection type will permanently remove the type and its settings from the repository.  Are you sure you want to delete this collection type?' }
+      let!(:deleted_flash_text) { "The collection type #{empty_collection_type.title} has been deleted." }
 
       before do
         sign_in admin_user
         visit '/admin/collection_types'
       end
 
-      it 'shows warning and deletes collection type', :js do
+      it 'shows warning, deletes collection type, and shows flash message on success', :js do
         expect(page).to have_content(empty_collection_type.title)
 
         find(:xpath, "//tr[td[contains(.,'#{empty_collection_type.title}')]]/td/button", text: 'Delete').click
@@ -339,7 +340,13 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
           click_button('Delete')
         end
 
-        expect(page).not_to have_content(empty_collection_type.title)
+        within('.alert-success') do
+          expect(page).to have_content(deleted_flash_text)
+        end
+
+        within('.collection-types-table') do
+          expect(page).not_to have_content(empty_collection_type.title)
+        end
       end
     end
 


### PR DESCRIPTION
Flash messages are being discarded by Blacklight for XHR requests. This PR changes this default behavior so that XHR post-redirect-get behaviors retain flash messages.

Changes proposed in this pull request:
- install_generator now adds a skip_after_action to override Blacklight's discard_flash_if_xhr behavior at the ApplicationController level.

This fixes #2592 and additionally fixes a few unreported areas where flash messages were not being displayed:
- When deleting a collection type

Once merged:
- [ ]  Add instructions on why/how to fix for applications upgrading to 2.1 in https://github.com/samvera/hyrax/releases and https://github.com/samvera/hyrax/issues/1596

@samvera/hyrax-code-reviewers
