### PR TITLE
Force loading of UV

### DIFF
--- a/app/assets/javascripts/hyrax/turbolinks_events.js
+++ b/app/assets/javascripts/hyrax/turbolinks_events.js
@@ -2,4 +2,7 @@
 // See https://github.com/rails/jquery-ujs/issues/456
 $(document).on('turbolinks:load', function() {
   $.rails.refreshCSRFTokens();
+  // Explicitly set flag to false to force loading of UV
+  // See https://github.com/samvera/hyrax/issues/2906
+  window.embedScriptIncluded = false;
 });


### PR DESCRIPTION
Fixes #2906.

Set flag to false before loading UV embed javascript (https://github.com/pulibrary/pul_uv_rails/blob/master/public/universalviewer/dist/uv-2.0.1/lib/embed.js#L77-L80) to force loading of UV.  Without this the UV loading script will sometimes think UV is already loaded and skip the loading.  This is probably due to turbolinks keeping the parent window context.

I took this approach of inlining the javascript to keep it close to what it is related to and avoid having to make changes to `pul_uv_rails` or `universalviewer`.  If there is a more elegant solution or if disabling turbolinks is preferred I'd happily close this PR.

@samvera/hyrax-code-reviewers