### PR TITLE
Use :test `QueueAdapter` in specs

### DIFF
--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       expect(IngestJob).to receive(:perform_later).with(any_args).and_return(IngestJob.new)
       expect(actor.update_content(local_file)).to be_a(IngestJob)
     end
-    it 'runs callbacks' do
+    it 'runs callbacks', :perform_enqueued do
       # Do not bother ingesting the file -- test only the result of callback
       allow(file_actor).to receive(:ingest_file).with(any_args).and_return(double)
       expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
@@ -332,18 +332,15 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     end
   end
 
-  describe '#revert_content' do
+  describe '#revert_content', :perform_enqueued do
     let(:file_set) { create(:file_set, user: user) }
     let(:file1)    { "small_file.txt" }
     let(:version1) { "version1" }
     let(:restored_content) { file_set.reload.original_file }
 
     before do
-      original_adapter = ApplicationJob.queue_adapter
-      ApplicationJob.queue_adapter = :inline
       actor.create_content(fixture_file_upload(file1))
       actor.create_content(fixture_file_upload('hyrax_generic_stub.txt'))
-      ApplicationJob.queue_adapter = original_adapter
       actor.file_set.reload
     end
 

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -218,8 +218,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       expect(IngestJob).to receive(:perform_later).with(any_args).and_return(IngestJob.new)
       expect(actor.update_content(local_file)).to be_a(IngestJob)
     end
-    it 'runs callbacks', :perform_enqueued do
-      ActiveJob::Base.queue_adapter.filter = [IngestJob]
+    it 'runs callbacks', perform_enqueued: [IngestJob] do
       # Do not bother ingesting the file -- test only the result of callback
       allow(file_actor).to receive(:ingest_file).with(any_args).and_return(double)
       expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
@@ -328,15 +327,13 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     end
   end
 
-  describe '#revert_content', :perform_enqueued do
+  describe '#revert_content', perform_enqueued: [IngestJob] do
     let(:file_set) { create(:file_set, user: user) }
     let(:file1)    { "small_file.txt" }
     let(:version1) { "version1" }
     let(:restored_content) { file_set.reload.original_file }
 
     before do
-      ActiveJob::Base.queue_adapter.filter = [IngestJob]
-
       actor.create_content(fixture_file_upload(file1))
       actor.create_content(fixture_file_upload('hyrax_generic_stub.txt'))
       actor.file_set.reload

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe Hyrax::Actors::FileSetActor do
   let(:relation)      { :original_file }
   let(:file_actor)    { Hyrax::Actors::FileActor.new(file_set, relation, user) }
 
-  before { allow(CharacterizeJob).to receive(:perform_later) } # not testing that
-
   describe 'private' do
     let(:file_set) { build(:file_set) } # avoid 130+ LDP requests
 
@@ -123,7 +121,6 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       let(:actor) { described_class.new(file_set, user) }
 
       before do
-        allow(IngestJob).to receive(:perform_later).with(JobIoWrapper)
         actor.create_content(file)
       end
 
@@ -136,14 +133,12 @@ RSpec.describe Hyrax::Actors::FileSetActor do
   describe '#create_content when from_url is true' do
     before do
       expect(JobIoWrapper).to receive(:create_with_varied_file_handling!).with(any_args).once.and_call_original
-      allow(VisibilityCopyJob).to receive(:perform_later).with(file_set.parent).and_return(true)
-      allow(InheritPermissionsJob).to receive(:perform_later).with(file_set.parent).and_return(true)
     end
 
     it 'calls ingest_file and kicks off jobs' do
       actor.create_content(file, from_url: true)
-      expect(VisibilityCopyJob).to have_received(:perform_later)
-      expect(InheritPermissionsJob).to have_received(:perform_later)
+      expect(VisibilityCopyJob).to have_been_enqueued
+      expect(InheritPermissionsJob).to have_been_enqueued
     end
 
     context 'when an alternative relationship is specified' do
@@ -224,6 +219,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       expect(actor.update_content(local_file)).to be_a(IngestJob)
     end
     it 'runs callbacks', :perform_enqueued do
+      ActiveJob::Base.queue_adapter.filter = [IngestJob]
       # Do not bother ingesting the file -- test only the result of callback
       allow(file_actor).to receive(:ingest_file).with(any_args).and_return(double)
       expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
@@ -339,6 +335,8 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     let(:restored_content) { file_set.reload.original_file }
 
     before do
+      ActiveJob::Base.queue_adapter.filter = [IngestJob]
+
       actor.create_content(fixture_file_upload(file1))
       actor.create_content(fixture_file_upload('hyrax_generic_stub.txt'))
       actor.file_set.reload

--- a/spec/actors/hyrax/actors/generic_work_actor_spec.rb
+++ b/spec/actors/hyrax/actors/generic_work_actor_spec.rb
@@ -63,13 +63,10 @@ RSpec.describe Hyrax::Actors::GenericWorkActor do
       end
     end
 
-    context 'valid attributes', :perform_enqueued do
+    context 'valid attributes', perform_enqueued: [AttachFilesToWorkJob, IngestJob] do
       let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
 
-      before do
-        redlock_client_stub
-        ActiveJob::Base.queue_adapter.filter = [AttachFilesToWorkJob, IngestJob]
-      end
+      before { redlock_client_stub }
 
       context 'with embargo' do
         context "with attached files" do

--- a/spec/actors/hyrax/actors/generic_work_actor_spec.rb
+++ b/spec/actors/hyrax/actors/generic_work_actor_spec.rb
@@ -1,6 +1,6 @@
 require 'redlock'
 
-RSpec.describe Hyrax::Actors::GenericWorkActor do
+RSpec.describe Hyrax::Actors::GenericWorkActor, :perform_enqueued do
   include ActionDispatch::TestProcess
   let(:env) { Hyrax::Actors::Environment.new(curation_concern, ability, attributes) }
   let(:user) { create(:user) }

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Hyrax::FileSetsController do
           allow(Hyrax::Actors::FileActor).to receive(:new).and_return(actor)
         end
 
-        it "spawns a ContentNewVersionEventJob" do
+        it "spawns a ContentNewVersionEventJob", :perform_enqueued do
           expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
           expect(actor).to receive(:ingest_file).with(JobIoWrapper).and_return(true)
           file = fixture_file_upload('/world.png', 'image/png')
@@ -109,7 +109,7 @@ RSpec.describe Hyrax::FileSetsController do
         end
       end
 
-      context "with two existing versions from different users" do
+      context "with two existing versions from different users", :perform_enqueued do
         let(:file1)       { "world.png" }
         let(:file2)       { "image.jpg" }
         let(:second_user) { create(:user) }

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -96,8 +96,7 @@ RSpec.describe Hyrax::FileSetsController do
           allow(Hyrax::Actors::FileActor).to receive(:new).and_return(actor)
         end
 
-        it "spawns a ContentNewVersionEventJob", :perform_enqueued do
-          ActiveJob::Base.queue_adapter.filter = [IngestJob]
+        it "spawns a ContentNewVersionEventJob", perform_enqueued: [IngestJob] do
           expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
           expect(actor).to receive(:ingest_file).with(JobIoWrapper).and_return(true)
           file = fixture_file_upload('/world.png', 'image/png')

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe Hyrax::FileSetsController do
   context "when signed in" do
     before do
       sign_in user
-      # allow_any_instance_of(User).to receive(:groups).and_return([])
-      # prevents characterization and derivative creation
-      allow(CharacterizeJob).to receive(:perform_later)
-      allow(CreateDerivativesJob).to receive(:perform_later)
     end
 
     describe "#destroy" do
@@ -101,6 +97,7 @@ RSpec.describe Hyrax::FileSetsController do
         end
 
         it "spawns a ContentNewVersionEventJob", :perform_enqueued do
+          ActiveJob::Base.queue_adapter.filter = [IngestJob]
           expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
           expect(actor).to receive(:ingest_file).with(JobIoWrapper).and_return(true)
           file = fixture_file_upload('/world.png', 'image/png')
@@ -118,6 +115,7 @@ RSpec.describe Hyrax::FileSetsController do
         let(:actor2)      { Hyrax::Actors::FileSetActor.new(file_set, second_user) }
 
         before do
+          ActiveJob::Base.queue_adapter.filter = [IngestJob]
           actor1.create_content(fixture_file_upload(file1))
           actor2.create_content(fixture_file_upload(file2))
         end

--- a/spec/controllers/hyrax/transfers_controller_spec.rb
+++ b/spec/controllers/hyrax/transfers_controller_spec.rb
@@ -78,9 +78,7 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
       end
     end
 
-    describe "#accept", :perform_enqueued do
-      before { ActiveJob::Base.queue_adapter.filter = [ContentDepositorChangeEventJob] }
-
+    describe "#accept", perform_enqueued: [ContentDepositorChangeEventJob] do
       context "when I am the receiver" do
         let!(:incoming_work) do
           GenericWork.new(title: ['incoming']) do |w|

--- a/spec/controllers/hyrax/transfers_controller_spec.rb
+++ b/spec/controllers/hyrax/transfers_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
     end
   end
 
-  describe "with a signed in user", :perform_enqueued do
+  describe "with a signed in user" do
     let(:another_user) { create(:user) }
     let(:user) { create(:user) }
 
@@ -78,7 +78,9 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
       end
     end
 
-    describe "#accept" do
+    describe "#accept", :perform_enqueued do
+      before { ActiveJob::Base.queue_adapter.filter = [ContentDepositorChangeEventJob] }
+
       context "when I am the receiver" do
         let!(:incoming_work) do
           GenericWork.new(title: ['incoming']) do |w|

--- a/spec/controllers/hyrax/transfers_controller_spec.rb
+++ b/spec/controllers/hyrax/transfers_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
     end
   end
 
-  describe "with a signed in user" do
+  describe "with a signed in user", :perform_enqueued do
     let(:another_user) { create(:user) }
     let(:user) { create(:user) }
 

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -10,13 +10,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
           with_permission_template: { deposit_groups: [::Ability.registered_group_name] })
   end
 
-  before do
-    # stub out characterization and derivatives. Travis doesn't have fits installed, and it's not relevant to the test.
-    allow(CharacterizeJob).to receive(:perform_later)
-    allow(CreateDerivativesJob).to receive(:perform_later)
-
-    sign_in user
-  end
+  before { sign_in user }
 
   it "renders the batch create form" do
     visit hyrax.new_batch_upload_path
@@ -31,6 +25,9 @@ RSpec.describe 'Batch creation of works', type: :feature do
     let(:second_user) { create(:user) }
 
     before do
+      allow(CharacterizeJob).to receive(:perform_later).and_return(true)
+      allow(CreateDerivativesJob).to receive(:perform_later).and_return(true)
+
       ProxyDepositRights.create!(grantor: second_user, grantee: user)
       sign_in user
       click_link 'Works'

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
     expect(page).to have_content("Each file will be uploaded to a separate new work resulting in one work per uploaded file.")
   end
 
-  context 'when the user is a proxy', :js, :workflow do
+  context 'when the user is a proxy', :js, :workflow, :perform_enqueued do
     let(:second_user) { create(:user) }
 
     before do

--- a/spec/features/create_work_admin_spec.rb
+++ b/spec/features/create_work_admin_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Creating a new Work as admin', :js, :workflow, :perform_enqueued do
+RSpec.describe 'Creating a new Work as admin', :js, :workflow, perform_enqueued: [AttachFilesToWorkJob, IngestJob] do
   let(:user) { create(:admin) }
   let(:admin_set_1) do
     create(:admin_set, id: AdminSet::DEFAULT_ID,
@@ -11,8 +11,6 @@ RSpec.describe 'Creating a new Work as admin', :js, :workflow, :perform_enqueued
                        description: ["A description"],
                        edit_users: [user.user_key])
   end
-
-  before { ActiveJob::Base.queue_adapter.filter = [AttachFilesToWorkJob, IngestJob] }
 
   context 'when there are multiple admin sets' do
     before do

--- a/spec/features/create_work_admin_spec.rb
+++ b/spec/features/create_work_admin_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe 'Creating a new Work as admin', :js, :workflow, :perform_enqueued
                        edit_users: [user.user_key])
   end
 
+  before { ActiveJob::Base.queue_adapter.filter = [AttachFilesToWorkJob, IngestJob] }
+
   context 'when there are multiple admin sets' do
     before do
       create(:permission_template_access,

--- a/spec/features/create_work_admin_spec.rb
+++ b/spec/features/create_work_admin_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Creating a new Work as admin', :js, :workflow do
+RSpec.describe 'Creating a new Work as admin', :js, :workflow, :perform_enqueued do
   let(:user) { create(:admin) }
   let(:admin_set_1) do
     create(:admin_set, id: AdminSet::DEFAULT_ID,

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
     end
   end
 
-  context 'when the user is a proxy' do
+  context 'when the user is a proxy', :perform_enqueued do
     let(:second_user) { create(:user) }
 
     before do

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -56,11 +56,10 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
     end
   end
 
-  context 'when the user is a proxy', :perform_enqueued do
+  context 'when the user is a proxy', perform_enqueued: [ContentDepositorChangeEventJob, AttachFilesToWorkJob, IngestJob] do
     let(:second_user) { create(:user) }
 
     before do
-      ActiveJob::Base.queue_adapter.filter = [ContentDepositorChangeEventJob, AttachFilesToWorkJob, IngestJob]
       ProxyDepositRights.create!(grantor: second_user, grantee: user)
       sign_in user
       click_link 'Works'

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
     let(:second_user) { create(:user) }
 
     before do
+      ActiveJob::Base.queue_adapter.filter = [ContentDepositorChangeEventJob, AttachFilesToWorkJob, IngestJob]
       ProxyDepositRights.create!(grantor: second_user, grantee: user)
       sign_in user
       click_link 'Works'

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AttachFilesToWorkJob do
+RSpec.describe AttachFilesToWorkJob, :perform_enqueued do
   context "happy path" do
     let(:file1) { File.open(fixture_path + '/world.png') }
     let(:file2) { File.open(fixture_path + '/image.jp2') }

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AttachFilesToWorkJob, :perform_enqueued do
+RSpec.describe AttachFilesToWorkJob, perform_enqueued: [AttachFilesToWorkJob] do
   context "happy path" do
     let(:file1) { File.open(fixture_path + '/world.png') }
     let(:file2) { File.open(fixture_path + '/image.jp2') }
@@ -7,11 +7,7 @@ RSpec.describe AttachFilesToWorkJob, :perform_enqueued do
     let(:generic_work) { create(:public_generic_work) }
     let(:user) { create(:user) }
 
-    before { ActiveJob::Base.queue_adapter.filter = [described_class] }
-
-    shared_examples 'a file attacher' do
-      before { ActiveJob::Base.queue_adapter.filter = [described_class, IngestJob] }
-
+    shared_examples 'a file attacher', perform_enqueued: [AttachFilesToWorkJob, IngestJob] do
       it 'attaches files, copies visibility and permissions and updates the uploaded files' do
         expect(CharacterizeJob).to receive(:perform_later).twice
         described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])

--- a/spec/jobs/batch_create_job_spec.rb
+++ b/spec/jobs/batch_create_job_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe BatchCreateJob do
     let(:uploaded_files) { [upload1.id.to_s, upload2.id.to_s] }
 
     subject do
-      described_class.perform_later(user,
-                                    title,
-                                    resource_types,
-                                    uploaded_files,
-                                    metadata,
-                                    operation)
+      described_class.perform_now(user,
+                                  title,
+                                  resource_types,
+                                  uploaded_files,
+                                  metadata,
+                                  operation)
     end
 
     before do

--- a/spec/jobs/create_work_job_spec.rb
+++ b/spec/jobs/create_work_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CreateWorkJob do
                              operation_type: "Create Work")
   end
 
-  describe "#perform", :perform_enqueued do
+  describe "#perform", perform_enqueued: [described_class] do
     let(:file1) { File.open(fixture_path + '/world.png') }
     let(:upload1) { Hyrax::UploadedFile.create(user: user, file: file1) }
     let(:metadata) do
@@ -28,7 +28,6 @@ RSpec.describe CreateWorkJob do
     end
 
     before do
-      ActiveJob::Base.queue_adapter.filter = [described_class]
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(GenericWork).to receive(:new).and_return(work)
     end

--- a/spec/jobs/create_work_job_spec.rb
+++ b/spec/jobs/create_work_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CreateWorkJob do
                              operation_type: "Create Work")
   end
 
-  describe "#perform" do
+  describe "#perform", :perform_enqueued do
     let(:file1) { File.open(fixture_path + '/world.png') }
     let(:upload1) { Hyrax::UploadedFile.create(user: user, file: file1) }
     let(:metadata) do
@@ -28,6 +28,7 @@ RSpec.describe CreateWorkJob do
     end
 
     before do
+      ActiveJob::Base.queue_adapter.filter = [described_class]
       allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
       allow(GenericWork).to receive(:new).and_return(work)
     end

--- a/spec/services/hyrax/workflow/grant_edit_to_depositor_spec.rb
+++ b/spec/services/hyrax/workflow/grant_edit_to_depositor_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::Workflow::GrantEditToDepositor do
       end
     end
 
-    context "with attached FileSets" do
+    context "with attached FileSets", :perform_enqueued do
       let(:work) { create(:work_with_one_file, user: depositor) }
       let(:file_set) do
         work.members.first.tap do |file_set|

--- a/spec/services/hyrax/workflow/grant_read_to_depositor_spec.rb
+++ b/spec/services/hyrax/workflow/grant_read_to_depositor_spec.rb
@@ -34,11 +34,9 @@ RSpec.describe Hyrax::Workflow::GrantReadToDepositor do
       end
     end
 
-    context "with attached FileSets", :perform_enqueued do
+    context "with attached FileSets", perform_enqueued: [Hyrax::GrantReadToMembersJob] do
       let(:work) { create(:work_with_one_file, user: depositor) }
       let(:file_set) { work.members.first }
-
-      before { ActiveJob::Base.queue_adapter.filter = [Hyrax::GrantReadToMembersJob] }
 
       it "grants read access" do
         # We need to reload, because this work happens in a background job

--- a/spec/services/hyrax/workflow/grant_read_to_depositor_spec.rb
+++ b/spec/services/hyrax/workflow/grant_read_to_depositor_spec.rb
@@ -38,6 +38,8 @@ RSpec.describe Hyrax::Workflow::GrantReadToDepositor do
       let(:work) { create(:work_with_one_file, user: depositor) }
       let(:file_set) { work.members.first }
 
+      before { ActiveJob::Base.queue_adapter.filter = [Hyrax::GrantReadToMembersJob] }
+
       it "grants read access" do
         # We need to reload, because this work happens in a background job
         expect { subject }.to change { file_set.reload.read_users }.from([]).to([depositor.user_key])

--- a/spec/services/hyrax/workflow/grant_read_to_depositor_spec.rb
+++ b/spec/services/hyrax/workflow/grant_read_to_depositor_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::Workflow::GrantReadToDepositor do
       end
     end
 
-    context "with attached FileSets" do
+    context "with attached FileSets", :perform_enqueued do
       let(:work) { create(:work_with_one_file, user: depositor) }
       let(:file_set) { work.members.first }
 

--- a/spec/services/hyrax/workflow/revoke_edit_from_depositor_spec.rb
+++ b/spec/services/hyrax/workflow/revoke_edit_from_depositor_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::Workflow::RevokeEditFromDepositor do
       end
     end
 
-    context "with attached FileSets" do
+    context "with attached FileSets", :perform_enqueued do
       let(:work) { create(:work_with_one_file, user: depositor) }
       let(:file_set) { work.members.first }
 

--- a/spec/services/hyrax/workflow/revoke_edit_from_depositor_spec.rb
+++ b/spec/services/hyrax/workflow/revoke_edit_from_depositor_spec.rb
@@ -34,11 +34,9 @@ RSpec.describe Hyrax::Workflow::RevokeEditFromDepositor do
       end
     end
 
-    context "with attached FileSets", :perform_enqueued do
+    context "with attached FileSets", perform_enqueued: [Hyrax::RevokeEditFromMembersJob] do
       let(:work) { create(:work_with_one_file, user: depositor) }
       let(:file_set) { work.members.first }
-
-      before { ActiveJob::Base.queue_adapter.filter = [Hyrax::RevokeEditFromMembersJob] }
 
       it "removes edit access" do
         # We need to reload, because this work happens in a background job

--- a/spec/services/hyrax/workflow/revoke_edit_from_depositor_spec.rb
+++ b/spec/services/hyrax/workflow/revoke_edit_from_depositor_spec.rb
@@ -38,6 +38,8 @@ RSpec.describe Hyrax::Workflow::RevokeEditFromDepositor do
       let(:work) { create(:work_with_one_file, user: depositor) }
       let(:file_set) { work.members.first }
 
+      before { ActiveJob::Base.queue_adapter.filter = [Hyrax::RevokeEditFromMembersJob] }
+
       it "removes edit access" do
         # We need to reload, because this work happens in a background job
         expect { subject }.to change { file_set.reload.edit_users }.from([depositor.user_key]).to([])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -249,16 +249,29 @@ RSpec.configure do |config|
 
   # Use this example metadata when you want to perform jobs inline during testing.
   #
+  #   describe '#my_method`, :perform_enqueued do
+  #     ...
+  #   end
+  #
+  # If you pass an `Array` of job classes, they will be treated as the filter list.
+  #
+  #   describe '#my_method`, perform_enqueued: [MyJobClass] do
+  #     ...
+  #   end
+  #
   # Limit to specific job classes with:
   #
   #   ActiveJob::Base.queue_adapter.filter = [JobClass]
-  config.before(perform_enqueued: true) do
-    ActiveJob::Base.queue_adapter.filter                   = nil
+  #
+  config.before(:example, :perform_enqueued) do |example|
+    ActiveJob::Base.queue_adapter.filter =
+      example.metadata[:perform_enqueued].try(:to_a)
+
     ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = true
     ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
   end
 
-  config.after(perform_enqueued: true) do
+  config.after(:example, :perform_enqueued) do
     ActiveJob::Base.queue_adapter.filter         = nil
     ActiveJob::Base.queue_adapter.enqueued_jobs  = []
     ActiveJob::Base.queue_adapter.performed_jobs = []

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,7 @@ end
 Capybara.default_driver = :rack_test # This is a faster driver
 Capybara.javascript_driver = :selenium_chrome_headless_sandboxless # This is slower
 
-ApplicationJob.queue_adapter = :inline
+ActiveJob::Base.queue_adapter = :test
 
 # require 'http_logger'
 # HttpLogger.logger = Logger.new(STDOUT)
@@ -246,4 +246,24 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = 'spec/examples.txt'
 
   config.profile_examples = 10
+
+  # Use this example metadata when you want to perform jobs inline during testing.
+  #
+  # Limit to specific job classes with:
+  #
+  #   ActiveJob::Base.queue_adapter.filter = [JobClass]
+  config.before(perform_enqueued: true) do
+    ActiveJob::Base.queue_adapter.filter                   = nil
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = true
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
+  end
+
+  config.after(perform_enqueued: true) do
+    ActiveJob::Base.queue_adapter.filter         = nil
+    ActiveJob::Base.queue_adapter.enqueued_jobs  = []
+    ActiveJob::Base.queue_adapter.performed_jobs = []
+
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = false
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
+  end
 end


### PR DESCRIPTION
Fixes #2888

The test suite used :inline as the ActiveJob adapter, which performs jobs
inline. This is expensive and unnecessary in most cases.

The `TestAdapter` supports an in-memory queue which makes it easy to test which
jobs have been enqueued without processing them, or to process jobs selectively. See:
http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/TestAdapter.html

We also introduce RSpec example metadata for `:perform_enqueued`, making it easy
to turn on job processing for particular example groups.

Changes proposed in this pull request:
* Use `:test` as the queue adapter when running specs
* Add `before` and `after` behavior for `:perform_enqueued`
* Setup `:perform_enqueued` metadata for jobs that need to run enqueued jobs.

@samvera/hyrax-code-reviewers
