### PR TITLE
Fix long collection and admin set titles in facet label dropdowns to …

### DIFF
--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -159,6 +159,8 @@ body.dashboard {
       line-height: 1.42857143;
       color: #333;
       white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .facet-count {


### PR DESCRIPTION
…use ellipsis

Fixes #2793 

Admin set and Collection titles which were quite long had their text extend beyond the facet label dropdowns.  See #2793 for screen shots and more description.   Since we're using a `<select>` helper tool, it is possible to target that wrapper style directly via CSS to add overflow: hidden, and add ellipsis to long text.

Here's a screenshot of the new code:

![works-facets-label-ellipsis](https://user-images.githubusercontent.com/3020266/38628815-ebe54b3a-3d77-11e8-8dbb-a1b4491eedc8.png)
