### PR TITLE
limit the exposure of the permissions_attributes deprecation warning for collections

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -337,9 +337,10 @@ module Hyrax
 
         def extract_old_style_permission_attributes(attributes)
           # TODO: REMOVE in 3.0 - part of deprecation of permission attributes
-          Deprecation.warn(self, "passing in permissions with a new collection is deprecated and will be removed from Hyrax 3.0 ()") # TODO: elr - add alternative in ()
           permissions = attributes.delete("permissions_attributes")
           return [] unless permissions
+          Deprecation.warn(self, "Passing in permissions_attributes parameter with a new collection is deprecated and support will be removed from Hyrax 3.0. " \
+                                 "Use Hyrax::PermissionTemplate instead to grant Manage, Deposit, or View access.")
           participants = []
           permissions.each do |p|
             access = access(p)

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -39,6 +39,9 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         post :create, params: {
           collection: collection_attrs.merge(
             visibility: 'open',
+            # TODO: Tests with old approach to sharing a collection which is deprecated and
+            # will be removed in 3.0.  New approach creates a PermissionTemplate with
+            # source_id = the collection's id.
             permissions_attributes: [{ type: 'person',
                                        name: 'archivist1',
                                        access: 'edit' }]


### PR DESCRIPTION
Fixes #2388

Moved the deprecation down so users will only see it if they actually pass in read/edit permissions in the permissions_attributes.  This deprecation will never be triggered through the UI.

It is triggered through tests that confirm the older style permission parameters (e.g. read, edit) are correctly converted to the new style (e.g. manage, deposit, view).

@samvera/hyrax-code-reviewers
