### PR TITLE
Back-port of configuration option for full-text extraction

### DIFF
--- a/app/services/hyrax/file_set_derivatives_service.rb
+++ b/app/services/hyrax/file_set_derivatives_service.rb
@@ -49,8 +49,7 @@ module Hyrax
       def create_pdf_derivatives(filename)
         Hydra::Derivatives::PdfDerivatives.create(filename,
                                                   outputs: [{ label: :thumbnail, format: 'jpg', size: '338x493', url: derivative_url('thumbnail') }])
-        Hydra::Derivatives::FullTextExtract.create(filename,
-                                                   outputs: [{ url: uri, container: "extracted_text" }])
+        extract_full_text(filename, uri)
       end
 
       def create_office_document_derivatives(filename)
@@ -58,8 +57,7 @@ module Hyrax
                                                        outputs: [{ label: :thumbnail, format: 'jpg',
                                                                    size: '200x150>',
                                                                    url: derivative_url('thumbnail') }])
-        Hydra::Derivatives::FullTextExtract.create(filename,
-                                                   outputs: [{ url: uri, container: "extracted_text" }])
+        extract_full_text(filename, uri)
       end
 
       def create_audio_derivatives(filename)
@@ -82,6 +80,16 @@ module Hyrax
 
       def derivative_path_factory
         Hyrax::DerivativePath
+      end
+
+      # Calls the Hydra::Derivates::FulltextExtraction unless the extract_full_text
+      # configuration option is set to false
+      # @param [String] filename of the object to be used for full text extraction
+      # @param [String] uri to the file set (deligated to file_set)
+      def extract_full_text(filename, uri)
+        return unless Hyrax.config.extract_full_text?
+        Hydra::Derivatives::FullTextExtract.create(filename,
+                                                   outputs: [{ url: uri, container: "extracted_text" }])
       end
   end
 end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -90,4 +90,11 @@ EOF
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'i18n-debug' unless ENV['TRAVIS']
   spec.add_development_dependency 'i18n_yaml_sorter' unless ENV['TRAVIS']
+
+  ########################################################
+  # Temporarily pinned dependencies. INCLUDE EXPLANATIONS.
+  #
+  # simple_form 3.5.1 broke hydra-editor for certain model types;
+  #   see: https://github.com/plataformatec/simple_form/issues/1549
+  spec.add_dependency 'simple_form', '~> 3.2', '<= 3.5.0'
 end

--- a/lib/generators/hyrax/templates/config/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/hyrax.rb
@@ -71,6 +71,10 @@ Hyrax.config do |config|
   # Path to the file derivatives creation tool
   # config.libreoffice_path = "soffice"
 
+  # Option to enable/disable full text extraction from PDFs
+  # Default is true, set to false to disable full text extraction
+  # config.extract_full_text = true
+
   # How many seconds back from the current time that we should show by default of the user's activity on the user's dashboard
   # config.activity_to_show_default_seconds_since_now = 24*60*60
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -428,6 +428,12 @@ module Hyrax
       @subject_prefix ||= "Contact form:"
     end
 
+    attr_writer :extract_full_text
+    def extract_full_text?
+      return @extract_full_text unless @extract_full_text.nil?
+      @extract_full_text = true
+    end
+
     attr_writer :model_to_create
     # Returns a lambda that takes a hash of attributes and returns a string of the model
     # name. This is called by the batch upload process

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -53,6 +53,7 @@ describe Hyrax::Configuration do
   it { is_expected.to respond_to(:translate_uri_to_id) }
   it { is_expected.to respond_to(:upload_path) }
   it { is_expected.to respond_to(:work_requires_files?) }
+  it { is_expected.to respond_to(:extract_full_text?) }
   it { is_expected.to respond_to(:whitelisted_ingest_dirs) }
   it { is_expected.to respond_to(:whitelisted_ingest_dirs=) }
 end


### PR DESCRIPTION
Allow configuration to turn off the full-text extraction
during derivative creation.

Fixes https://github.com/samvera/hyrax/issues/2920

    Back-port of configuration option for full-text extraction

    Allow configuration to turn off the full-text extraction
    during derivative creation.

@samvera/hyrax-code-reviewers
