### PR TITLE
Update Travis badge on README.md to represent branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Logo](https://raw.githubusercontent.com/samvera/hyrax/gh-pages/assets/images/hyrax_logo_horizontal_white_background.png)
 
 Code: [![Version](https://badge.fury.io/rb/hyrax.png)](http://badge.fury.io/rb/hyrax)
-[![Build Status](https://travis-ci.org/samvera/hyrax.png?branch=master)](https://travis-ci.org/samvera/hyrax)
+[![Build Status](https://travis-ci.org/samvera/hyrax.png?branch=2.0-stable)](https://travis-ci.org/samvera/hyrax/branches)
 [![Coverage Status](https://coveralls.io/repos/github/samvera/hyrax/badge.svg?branch=master)](https://coveralls.io/github/samvera/hyrax?branch=master)
 [![Code Climate](https://codeclimate.com/github/samvera/hyrax/badges/gpa.svg)](https://codeclimate.com/github/samvera/hyrax)
 [![Dependency Update Status](https://gemnasium.com/samvera/hyrax.png)](https://gemnasium.com/samvera/hyrax)


### PR DESCRIPTION
We will add a weekly build for the 2.0.x branch; this ensures that status
displays on the branch's README.md.

@samvera/hyrax-code-reviewers
