### PR TITLE
Add partial nested indexing option

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -102,6 +102,8 @@ module Hyrax
         # along side the FileSets on the show page
         def add(env, id)
           collection = Collection.find(id)
+          collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
+
           return unless env.current_ability.can?(:deposit, collection)
           env.curation_concern.member_of_collections << collection
         end

--- a/app/controllers/hyrax/dashboard/collection_members_controller.rb
+++ b/app/controllers/hyrax/dashboard/collection_members_controller.rb
@@ -25,6 +25,7 @@ module Hyrax
         after_update_error(err_msg) if err_msg.present?
         return if err_msg.present?
 
+        collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
         members = collection.add_member_objects batch_ids
         messages = members.collect { |member| member.errors.full_messages }.flatten
         if messages.size == members.size

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -144,6 +144,8 @@ module Hyrax
 
         process_member_changes
         @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE unless @collection.discoverable?
+        # we don't have to reindex the full graph when updating collection
+        @collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
         if @collection.update(collection_params.except(:members))
           after_update
         else

--- a/app/indexers/hyrax/repository_reindexer.rb
+++ b/app/indexers/hyrax/repository_reindexer.rb
@@ -10,7 +10,7 @@ module Hyrax
       # overrides https://github.com/samvera/active_fedora/blob/master/lib/active_fedora/indexing.rb#L95-L125
       # see implementation details in adapters/nesting_index_adapter.rb#each_perservation_document_id_and_parent_ids
       def reindex_everything(*)
-        Samvera::NestingIndexer.reindex_all!
+        Samvera::NestingIndexer.reindex_all!(extent: Hyrax::Adapters::NestingIndexAdapter::FULL_REINDEX)
       end
     end
   end

--- a/app/models/concerns/hyrax/collection_nesting.rb
+++ b/app/models/concerns/hyrax/collection_nesting.rb
@@ -22,18 +22,18 @@ module Hyrax
 
       def after_update_nested_collection_relationship_indices
         @during_save = false
-        reindex_nested_relationships_for(id: id)
+        reindex_nested_relationships_for(id: id, extent: reindex_extent)
       end
 
       def update_nested_collection_relationship_indices
         return if @during_save
-        reindex_nested_relationships_for(id: id)
+        reindex_nested_relationships_for(id: id, extent: reindex_extent)
       end
 
       def update_child_nested_collection_relationship_indices
         children = find_children_of(destroyed_id: id)
         children.each do |child|
-          reindex_nested_relationships_for(id: child.id)
+          reindex_nested_relationships_for(id: child.id, extent: Hyrax::Adapters::NestingIndexAdapter::FULL_REINDEX)
         end
       end
     end
@@ -46,14 +46,27 @@ module Hyrax
       ActiveFedora::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: destroyed_id))
     end
 
+    # Only models which include Hyrax::CollectionNesting will respond to this method.
+    # Used to determine whether a model gets reindexed via Samvera::NestingIndexer during full repository reindexing,
     def use_nested_reindexing?
       true
     end
 
+    # The following methods allow an option to reindex an object only if the nesting indexer fields are not
+    # already in the object's solr document. Added to prevent unnecessary indexing of all ancestors of a parent
+    # when one child gets added to the parent. By default, we do the full graph indexing.
+    def reindex_extent
+      @reindex_extent ||= Hyrax::Adapters::NestingIndexAdapter::FULL_REINDEX
+    end
+
+    def reindex_extent=(val)
+      @reindex_extent = val
+    end
+
     private
 
-      def reindex_nested_relationships_for(id:)
-        Hyrax.config.nested_relationship_reindexer.call(id: id)
+      def reindex_nested_relationships_for(id:, extent:)
+        Hyrax.config.nested_relationship_reindexer.call(id: id, extent: extent)
       end
   end
 end

--- a/app/services/hyrax/adapters/nesting_index_adapter.rb
+++ b/app/services/hyrax/adapters/nesting_index_adapter.rb
@@ -1,8 +1,10 @@
 module Hyrax
   module Adapters
     module NestingIndexAdapter
-      # @!group Providing interface for a Samvera::NestingIndexer::Adapter
+      FULL_REINDEX = "full".freeze
+      LIMITED_REINDEX = "limited".freeze
 
+      # @!group Providing interface for a Samvera::NestingIndexer::Adapter
       # @api public
       # @param id [String]
       # @return Samvera::NestingIndexer::Document::PreservationDocument
@@ -39,18 +41,9 @@ module Hyrax
       end
 
       # @api public
-      # @deprecated
-      # @yield Samvera::NestingIndexer::Document::PreservationDocument
-      # rubocop:disable Lint/UnusedMethodArgument
-      def self.each_preservation_document(&block)
-        raise NotImplementedError
-      end
-      # rubocop:enable Lint/UnusedMethodArgument
-
-      # @api public
       # @yieldparam id [String]
       # @yieldparam parent_id [Array<String>]
-      # Samvera::NestingIndexer.reindex_all!
+      # Samvera::NestingIndexer.reindex_all!(extent: FULL_REINDEX)
       # rubocop:disable Lint/UnusedMethodArgument
       def self.each_perservation_document_id_and_parent_ids(&block)
         ActiveFedora::Base.descendant_uris(ActiveFedora.fedora.base_uri, exclude_uri: true).each do |uri|
@@ -67,22 +60,6 @@ module Hyrax
             ActiveFedora::SolrService.add(object.to_solr, commit: true)
           end
         end
-      end
-      # rubocop:enable Lint/UnusedMethodArgument
-
-      # @api public
-      # @deprecated
-      #
-      # From the given parameters, we will need to add them to the underlying SOLR document for the object
-      #
-      # @param id [String]
-      # @param parent_ids [Array<String>]
-      # @param ancestors [Array<String>]
-      # @param pathnames [Array<String>]
-      # @return Hash - the attributes written to the indexing layer
-      # rubocop:disable Lint/UnusedMethodArgument
-      def self.write_document_attributes_to_index_layer(id:, parent_ids:, ancestors:, pathnames:, deepest_nested_depth:)
-        raise NotImplementedError, "This method is deprecated as of v1.0.0 of samvera-nesting_indexer, prefer instead .write_nesting_document_to_index_layer"
       end
       # rubocop:enable Lint/UnusedMethodArgument
 
@@ -126,12 +103,14 @@ module Hyrax
 
       # @api public
       # @param document [Samvera::NestingIndexer::Documents::IndexDocument]
+      # @param extent [String] if not "full" or nil, doesn't yield children for reindexing
       # @param solr_field_name_for_ancestors [String] The SOLR field name we use to find children
       # @yield Samvera::NestingIndexer::Documents::IndexDocument
-      def self.each_child_document_of(document:, &block)
+      def self.each_child_document_of(document:, extent:, &block)
         raw_child_solr_documents_of(parent_document: document).each do |solr_document|
           child_document = coerce_solr_document_to_index_document(original_solr_document: solr_document, id: solr_document.fetch('id'))
-          block.call(child_document)
+          # during light reindexing, we want to reindex the child only if fields aren't already there
+          block.call(child_document) if full_reindex?(extent: extent) || child_document.pathnames.empty?
         end
       end
       # @!endgroup
@@ -165,14 +144,10 @@ module Hyrax
       end
 
       class << self
-        delegate :solr_field_name_for_storing_pathnames, :solr_field_name_for_storing_ancestors, :solr_field_name_for_storing_parent_ids, to: :nesting_configuration
-      end
-
-      # <dynamicField name="*_isi" type="int" stored="true" indexed="true" multiValued="false"/>
-      SOLR_FIELD_NAME_FOR_DEEPEST_NESTED_DEPTH = 'nesting_collection__deepest_nested_depth_isi'.freeze
-
-      def self.solr_field_name_for_deepest_nested_depth
-        SOLR_FIELD_NAME_FOR_DEEPEST_NESTED_DEPTH
+        delegate :solr_field_name_for_storing_pathnames,
+                 :solr_field_name_for_storing_ancestors,
+                 :solr_field_name_for_storing_parent_ids,
+                 :solr_field_name_for_deepest_nested_depth, to: :nesting_configuration
       end
 
       # @api private
@@ -180,12 +155,17 @@ module Hyrax
       # @return [Hash] A raw response document from SOLR
       # @todo What is the appropriate suffix to apply to the solr_field_name?
       def self.raw_child_solr_documents_of(parent_document:)
-        # query Solr for all of the documents included as a member_of_collection parent.
+        # query Solr for all of the documents included as a member_of_collection parent. Or up to 10000 of them.
         child_query = ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: parent_document.id)
-        ActiveFedora::SolrService.query(child_query)
+        ActiveFedora::SolrService.query(child_query, rows: 10_000.to_i)
       end
       private_class_method :raw_child_solr_documents_of
 
+      def self.full_reindex?(extent:)
+        return true if extent == FULL_REINDEX
+        false
+      end
+      private_class_method :full_reindex?
       # @!endgroup
     end
   end

--- a/app/services/hyrax/collections/nested_collection_persistence_service.rb
+++ b/app/services/hyrax/collections/nested_collection_persistence_service.rb
@@ -14,6 +14,7 @@ module Hyrax
       # @note Adding the member_of_collections method doesn't trigger reindexing of the child so we have to do it manually.
       #       However it save and reindexes the parent unnecessarily!!
       def self.persist_nested_collection_for(parent:, child:)
+        parent.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
         child.member_of_collections.push(parent)
         child.update_nested_collection_relationship_indices
       end

--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -20,7 +20,7 @@ module Hyrax
           @parents = collection_doc[Samvera::NestingIndexer.configuration.solr_field_name_for_storing_parent_ids]
           @pathnames = collection_doc[Samvera::NestingIndexer.configuration.solr_field_name_for_storing_pathnames]
           @ancestors = collection_doc[Samvera::NestingIndexer.configuration.solr_field_name_for_storing_ancestors]
-          @depth = collection_doc[Hyrax::Adapters::NestingIndexAdapter.solr_field_name_for_deepest_nested_depth]
+          @depth = collection_doc[Samvera::NestingIndexer.configuration.solr_field_name_for_deepest_nested_depth]
         end
       end
 
@@ -154,13 +154,13 @@ module Hyrax
         # note: We need to include works in this search. They are included in the depth validations in
         # the indexer, so we do NOT use collection search builder here.
         builder = Hyrax::SearchBuilder.new(scope).where("#{Samvera::NestingIndexer.configuration.solr_field_name_for_storing_pathnames}:/.*#{child.id}.*/")
-        builder.query[:sort] = "#{Hyrax::Adapters::NestingIndexAdapter.solr_field_name_for_deepest_nested_depth} desc"
+        builder.query[:sort] = "#{Samvera::NestingIndexer.configuration.solr_field_name_for_deepest_nested_depth} desc"
         builder.query[:rows] = 1
         query = clean_lucene_error(builder: builder)
         response = scope.repository.search(query).documents.first
 
         # Now we have the largest nesting depth for all paths containing this collection
-        descendant_depth = response[Hyrax::Adapters::NestingIndexAdapter.solr_field_name_for_deepest_nested_depth]
+        descendant_depth = response[Samvera::NestingIndexer.configuration.solr_field_name_for_deepest_nested_depth]
 
         # => 2) Then we get the stored depth of the child collection itself to eliminate the collections above this one from our count, and add 1 to add back in this collection itself
         child_depth = NestingAttributes.new(id: child.id, scope: scope).depth

--- a/config/initializers/samvera-nesting_indexer_initializer.rb
+++ b/config/initializers/samvera-nesting_indexer_initializer.rb
@@ -12,4 +12,5 @@ Samvera::NestingIndexer.configure do |config|
   config.solr_field_name_for_storing_parent_ids = Solrizer.solr_name('nesting_collection__parent_ids', :symbol)
   config.solr_field_name_for_storing_ancestors =  Solrizer.solr_name('nesting_collection__ancestors', :symbol)
   config.solr_field_name_for_storing_pathnames =  Solrizer.solr_name('nesting_collection__pathnames', :symbol)
+  config.solr_field_name_for_deepest_nested_depth = 'nesting_collection__deepest_nested_depth_isi'
 end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -71,7 +71,7 @@ SUMMARY
   spec.add_dependency 'redis-namespace', '~> 1.5'
   spec.add_dependency 'redlock', '>= 0.1.2'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
-  spec.add_dependency 'samvera-nesting_indexer', '~> 1.0', '>= 1.0.1'
+  spec.add_dependency 'samvera-nesting_indexer', '~> 2.0'
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -503,7 +503,7 @@ module Hyrax
     attr_accessor :nested_relationship_reindexer
 
     def default_nested_relationship_reindexer
-      ->(id:) { Samvera::NestingIndexer.reindex_relationships(id: id) }
+      ->(id:, extent:) { Samvera::NestingIndexer.reindex_relationships(id: id, extent: extent) }
     end
 
     private

--- a/spec/indexers/hyrax/repository_reindexer_spec.rb
+++ b/spec/indexers/hyrax/repository_reindexer_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Hyrax::RepositoryReindexer do
   let(:subject) { Samvera::NestingIndexer }
 
   it 'overrides ActiveFedora#reindex_everything' do
-    expect(subject).to receive(:reindex_all!)
+    expect(subject).to receive(:reindex_all!).with(extent: Hyrax::Adapters::NestingIndexAdapter::FULL_REINDEX)
     ActiveFedora::Base.reindex_everything
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe Collection, type: :model do
 
   describe '#update_nested_collection_relationship_indices', :with_nested_reindexing do
     it 'will be called after save' do
-      expect(Samvera::NestingIndexer).to receive(:reindex_relationships).with(id: kind_of(String))
+      expect(Samvera::NestingIndexer).to receive(:reindex_relationships).with(id: kind_of(String), extent: kind_of(String))
       collection.save!
     end
   end

--- a/spec/models/concerns/hyrax/collection_nesting_spec.rb
+++ b/spec/models/concerns/hyrax/collection_nesting_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Hyrax::CollectionNesting do
     let(:user) { create(:user) }
     let!(:collection) { create(:collection, collection_type_settings: [:nestable]) }
     let!(:child_collection) { create(:collection, collection_type_settings: [:nestable]) }
+    let(:extent) { Hyrax::Adapters::NestingIndexAdapter::FULL_REINDEX }
 
     before do
       Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: collection, child: child_collection)
@@ -47,11 +48,13 @@ RSpec.describe Hyrax::CollectionNesting do
     it { is_expected.to respond_to(:update_nested_collection_relationship_indices) }
     it { is_expected.to respond_to(:update_child_nested_collection_relationship_indices) }
     it { is_expected.to respond_to(:use_nested_reindexing?) }
+    it { is_expected.to respond_to(:reindex_extent) }
+    it { is_expected.to respond_to(:reindex_extent=) }
 
     context 'after_update_index callback' do
       describe '#update_nested_collection_relationship_indices' do
         it 'will call Hyrax.config.nested_relationship_reindexer' do
-          expect(Hyrax.config.nested_relationship_reindexer).to receive(:call).with(id: subject.id).and_call_original
+          expect(Hyrax.config.nested_relationship_reindexer).to receive(:call).with(id: subject.id, extent: extent).and_call_original
           subject.update_nested_collection_relationship_indices
         end
 
@@ -65,7 +68,7 @@ RSpec.describe Hyrax::CollectionNesting do
     context 'after_destroy callback', with_nested_reindexing: true do
       describe '#update_child_nested_collection_relationship_indices' do
         it 'will call Hyrax.config.nested_relationship_reindexer' do
-          expect(Hyrax.config.nested_relationship_reindexer).to receive(:call).with(id: child_collection.id).and_call_original
+          expect(Hyrax.config.nested_relationship_reindexer).to receive(:call).with(id: child_collection.id, extent: extent).and_call_original
           subject.update_child_nested_collection_relationship_indices
         end
       end

--- a/spec/models/hyrax/work_behavior_spec.rb
+++ b/spec/models/hyrax/work_behavior_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Hyrax::WorkBehavior do
 
   describe '#update_nested_collection_relationship_indices', :with_nested_reindexing do
     it 'will be called after save' do
-      expect(Samvera::NestingIndexer).to receive(:reindex_relationships).with(id: kind_of(String))
+      expect(Samvera::NestingIndexer).to receive(:reindex_relationships).with(id: kind_of(String), extent: kind_of(String))
       subject.save!
     end
   end

--- a/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
+++ b/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
@@ -80,13 +80,15 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
 
   describe '.each_child_document_of', clean_repo: true do
     let(:ancestors_key) { described_class.solr_field_name_for_storing_ancestors }
+    let(:pathnames_key) { described_class.solr_field_name_for_storing_pathnames }
     let(:index_document_class) { Samvera::NestingIndexer::Documents::IndexDocument }
     let(:parent) { { id: document.id } }
     let(:document) { index_document_class.new(id: 'parent-1', pathnames: ['parent-1'], parent_ids: [], ancestors: []) }
     let(:children) do
       [{ id: 'child-1',
          member_of_collection_ids_ssim: [document.id],
-         ancestors_key => [document.id] },
+         ancestors_key => [document.id],
+         pathnames_key => ['child-1'] },
        { id: 'child-2',
          member_of_collection_ids_ssim: [document.id],
          ancestors_key => [document.id] }]
@@ -94,10 +96,12 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
     let(:not_my_children) do
       [{ id: 'youre-not-my-dad-1',
          member_of_collection_ids_ssim: ['parent-2'],
-         ancestors_key => ['parent-2'] },
+         ancestors_key => ['parent-2'],
+         pathnames_key => ['youre-not-my-dad-1'] },
        { id: 'i-am-your-grandchild',
          member_of_collection_ids_ssim: ['parent-3'],
-         ancestors_key => ['parent-1/parent-3'] }]
+         ancestors_key => ['parent-1/parent-3'],
+         pathnames_key => ['i-am-your-grandchild'] }]
     end
 
     before do
@@ -106,15 +110,31 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
       end
     end
 
-    it 'yields all of the child solr-documents of the given document' do
-      child_index_documents = []
-      described_class.each_child_document_of(document: document) do |doc|
-        child_index_documents << doc
+    context 'with full reindexing extent' do
+      it 'yields all of the child solr-documents of the given document' do
+        child_index_documents = []
+        described_class.each_child_document_of(document: document, extent: Hyrax::Adapters::NestingIndexAdapter::FULL_REINDEX) do |doc|
+          child_index_documents << doc
+        end
+        expect(child_index_documents.count).to eq(2)
+        child_index_documents.each do |child|
+          expect(child).to be_a(index_document_class)
+          expect(child.ancestors).to eq([document.id])
+        end
       end
-      expect(child_index_documents.count).to eq(2)
-      child_index_documents.each do |child|
-        expect(child).to be_a(index_document_class)
-        expect(child.ancestors).to eq([document.id])
+    end
+
+    context 'with limited reindexing extent' do
+      it 'yields only child documents without pathnames' do
+        child_index_documents = []
+        described_class.each_child_document_of(document: document, extent: Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX) do |doc|
+          child_index_documents << doc
+        end
+        expect(child_index_documents.count).to eq(1)
+        child_index_documents.each do |child|
+          expect(child).to be_a(index_document_class)
+          expect(child.ancestors).to eq([document.id])
+        end
       end
     end
   end
@@ -157,16 +177,6 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
       expect(newly_queried_solr_document.fetch(described_class.solr_field_name_for_deepest_nested_depth)).to eq(nesting_document.deepest_nested_depth)
     end
     # rubocop:enable RSpec/ExampleLength
-  end
-
-  describe '.write_document_attributes_to_index_layer' do
-    it 'is not implemented and deprecated' do
-      expect do
-        described_class.write_document_attributes_to_index_layer(
-          id: 1, parent_ids: 2, ancestors: 3, pathnames: 4, deepest_nested_depth: 5
-        )
-      end.to raise_error(NotImplementedError)
-    end
   end
 
   describe '.solr_field_name_for_storing_ancestors' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -179,7 +179,7 @@ RSpec.configure do |config|
                                                    Hyrax.config.default_nested_relationship_reindexer
                                                  else
                                                    # Don't use the nested relationship reindexer. This slows everything down quite a bit.
-                                                   ->(id:) {}
+                                                   ->(id:, extent:) {}
                                                  end
   end
 


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/2798

While this doesn't solve the issue of the unnecessary save of the parent collection when adding a subcollection or work to the collection, it does solve the problematic results of that save (the nested reindexing of the parent's entire graph).

Saving the parent collection loses its nested indexing fields as it goes through AF indexing, so the nested reindexing is necessary for the parent collection. But by adding a parameter to the nesting indexer, this parameter can be referenced by the adapter to allow the children of this parent to be reindexed only if necessary (only when they are missing THEIR nested indexing fields).

By removing the reindexing of all child collections and child works, this change will remove most of the issues with in-line indexing of nested collections. There is still a necessary delay for reindexing when adding or removing a large subcollection, but the implications when nesting works and subcollections based on the parent collection's size is removed.

Limited reindexing will be used for:
- indexing of collection when adding a work to a collection
- indexing of parent collection when adding a subcollection
- indexing a collection update where no nesting changes take place

depends on newly released samvera-nesting_indexer v2.0.0 gem

@samvera/hyrax-code-reviewers
