### PR TITLE
Handle empty string in `member_of_collection_ids`

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -79,6 +79,7 @@ module Hyrax
             Deprecation.warn(self, ':member_of_collection_ids has been deprecated for removal in Hyrax 3.0. ' \
                                    'use :member_of_collections_attributes instead.')
 
+            collection_ids = [] if collection_ids.empty?
             other_collections = collections_without_edit_access(env)
 
             collections = ::Collection.find(collection_ids)

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -111,6 +111,30 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
         expect(collection.reload.member_objects).to eq [curation_concern]
       end
 
+      context 'when it is empty' do
+        let(:attributes) { { member_of_collection_ids: [], title: ['test'] } }
+
+        it 'does not add it to a collection' do
+          skip 'this behavior past its deprecation sunset time and can be removed' if
+            Hyrax::VERSION.split('.').first.to_i >= 3
+
+          expect(subject.create(env)).to be true
+          expect(collection.reload.member_objects).to eq []
+        end
+      end
+
+      context 'when it is an empty string' do
+        let(:attributes) { { member_of_collection_ids: '', title: ['test'] } }
+
+        it 'does not add it to a collection' do
+          skip 'this behavior past its deprecation sunset time and can be removed' if
+            Hyrax::VERSION.split('.').first.to_i >= 3
+
+          expect(subject.create(env)).to be true
+          expect(collection.reload.member_objects).to eq []
+        end
+      end
+
       context "when work is in user's own collection" do
         let(:attributes) { { member_of_collection_ids: [] } }
 


### PR DESCRIPTION
When an empty string is in `member_of_collection_ids`, we want to treat it as an empty collection list. Previously we were failing with `ActiveFedora::ObjectNotFound`. This approach is more accepting of argument styles that forms can pass along.

Fixes #2918.

@samvera/hyrax-code-reviewers
