### PR TITLE
remove "my shares" <li> from search dropdown

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -29,10 +29,6 @@
             <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
                 data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
           </li>
-          <li>
-            <%= link_to t("hyrax.search.form.option.my_shares.label_long"), "#",
-                data: { "search-option" => hyrax.dashboard_shares_path, "search-label" => t("hyrax.search.form.option.my_shares.label_short") } %>
-          </li>
         <% end %>
 
       </ul>


### PR DESCRIPTION
resolves #2767

NOTE: I have not cloned hyrax locally yet, just 🤠-coding here to help with a blocker that there was no humans for. I just removed the `<li>` for now and plan to have to fix failing feature test or the like once I see cries on Travis. I suppose I could have just ran a branch and then opened up a PR, but this way we can have conversation too.
