### PR TITLE
Update to Collections Edit sharing tab add participants button dynami…

### DIFF
--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -355,4 +355,48 @@ Blacklight.onLoad(function () {
     });
 
   });
+
+  /**
+   * Mapping object to organize Collections Sharing tab specific functions & data
+   */
+  var sharingTabHelper = {
+    handleFormSharingWrapperOnChange: function(e) {
+      var inputs = $(this).find('.form-control');
+      var $addButton = $(this).find('.edit-collection-add-sharing-button');
+      var inputsPass = sharingTabHelper.checkInputsPass(inputs);
+      var select2Pass = sharingTabHelper.checkSelect2Pass($(this));
+      $addButton.prop('disabled', !(inputsPass && select2Pass));
+    },
+    checkInputsPass: function(inputs) {
+      var inputsPass = true;
+
+      inputs.each(function(i) {
+        if ($(this).val() === '') {
+          inputsPass = false;
+          return false;
+        }
+      });
+      return inputsPass;
+    },
+    // This checks that the select2 input is not the default value
+    checkSelect2Pass: function(context) {
+      var $select2 = context.find('.select2-container');
+      // No select2 element present, so it passes by default
+      if ($select2.length === 0) {
+        return true;
+      }
+      var $placeholder = $select2.siblings('[placeholder]');
+      var placeholderValue = $placeholder.attr('placeholder');
+      var chosenValue = $select2.find('.select2-chosen').text();
+
+      return placeholderValue !== chosenValue;
+    }
+  };
+
+  // Add a change event listener for
+  // Edit Collections: Sharing Tab: 'Add Sharing' section pseudo-forms
+  $('#participants')
+  .find('.form-add-sharing-wrapper')
+  .on('change', sharingTabHelper.handleFormSharingWrapperOnChange);
+
 });

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -31,7 +31,7 @@
                                        { prompt: "Select a role..." },
                                        class: 'form-control' %>
 
-                    <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button' %>
+                    <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button', :disabled => true %>
                   </div>
                 </div>
               <% end %>
@@ -62,7 +62,7 @@
                                      { prompt: "Select a role..." },
                                      class: 'form-control' %>
 
-                  <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button' %>
+                  <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button', :disabled => true %>
                 </div>
               </div>
               <% end %>


### PR DESCRIPTION
…c disabled state via javascript

Fixes #2921 

Previously the Add button for Add Participants > Add Groups / Add Users was always enabled, thereby allowing blank Groups or Users to be added. 

The fix now disables Add buttons contained in a mock form class wrapper within this tab.  If the user enters a value for all allowed input fields, then the Add button dynamically enables.  Likewise it will dynamically disable.

![collections-participants-add-button1](https://user-images.githubusercontent.com/3020266/38956322-d47f405e-431c-11e8-9f3b-481ac6c9c139.png)

![collections-participants-add-button2](https://user-images.githubusercontent.com/3020266/38956321-d4700aee-431c-11e8-8e9f-ffb06ab55fef.png)

![collections-participants-add-button3](https://user-images.githubusercontent.com/3020266/38956320-d45d7712-431c-11e8-8228-c2104a616e19.png)
