### PR TITLE
Collection Types > Participants tab UI updates

### DIFF
--- a/app/assets/stylesheets/hyrax/_collection_types.scss
+++ b/app/assets/stylesheets/hyrax/_collection_types.scss
@@ -9,8 +9,8 @@
 .collection-types-wrapper {
   @media (min-width: 900px) {
     .collection-types-table {
-      th:last-child,
-      td:last-child {
+      td:last-child,
+      th:last-child {
         width: 20%;
       }
     }
@@ -43,6 +43,49 @@
     &.open {
       &::after {
         @include toggle-arrow('\f0d7');
+      }
+    }
+  }
+}
+
+// Edit Collection Types - Participants Tab
+.collection-types-edit-participants-tab {
+  .section-participants {
+    padding-bottom: 40px;
+
+    .form-inline {
+      label {
+        padding-right: 5px;
+        text-align: right;
+        width: 100px;
+      }
+
+      .select2-container,
+      input,
+      select {
+        width: 200px;
+      }
+
+      .btn {
+        width: 75px;
+      }
+    }
+  }
+
+  .section-current-participants {
+    legend {
+      margin-bottom: 0;
+    }
+
+    .share-status {
+      td,
+      th {
+        width: 40%;
+      }
+
+      th:last-of-type {
+        text-align: center;
+        width: 20%;
       }
     }
   }

--- a/app/views/hyrax/admin/collection_types/_form.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form.html.erb
@@ -42,7 +42,7 @@
       <% # end of form %>
       <% # TODO: The participants partial can't sit inside the other form, moved down here temporarily %>
       <div id="participants" class="tab-pane">
-        <div class="panel panel-default labels">
+        <div class="panel panel-default labels collection-types-edit-participants-tab">
           <div class="panel-body">
             <%= render 'form_participants' %>
           </div>

--- a/app/views/hyrax/admin/collection_types/_form_participant_table.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_participant_table.html.erb
@@ -15,7 +15,7 @@
         <td data-agent="<%= g.agent_id %>"><%= g.label %></td>
         <td><%= g.agent_type.titleize %></td>
         <td>
-          <%= button_to "Remove", hyrax.admin_collection_type_participant_path(g), method: :delete, class: 'btn btn-danger' %>
+          <%= button_to "Remove", hyrax.admin_collection_type_participant_path(g), method: :delete, class: 'btn btn-sm btn-danger' %>
         </td>
       </tr>
     <% end %>

--- a/app/views/hyrax/admin/collection_types/_form_participants.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_participants.html.erb
@@ -1,62 +1,67 @@
-<h2><%= t('.add_participants') %></h2>
+<h3><%= t('.add_participants') %></h3>
 <p><%= t('.instructions') %></p>
 <% access_options = options_for_select([['Manager', Hyrax::CollectionTypeParticipant::MANAGE_ACCESS], ['Creator', Hyrax::CollectionTypeParticipant::CREATE_ACCESS]]) %>
 <% unless @collection_type_participant.nil? %>
-  <%= simple_form_for @collection_type_participant,
-                      url: hyrax.admin_collection_type_participants_path,
-                      html: { id: 'group-participants-form' },
-                      as: :collection_type_participant do |f| %>
-      <div class="clearfix spacer">
-        <div class="form-inline">
-          <label class="col-md-2 col-xs-4 control-label">Add Group</label>
 
-          <div class="col-md-10 col-xs-8 form-group">
-            <%= f.hidden_field :hyrax_collection_type_id, value: @collection_type_participant.hyrax_collection_type_id %>
-            <%= f.hidden_field :agent_type, value: Hyrax::CollectionTypeParticipant::GROUP_TYPE %>
-            <%= f.text_field :agent_id,
-                             placeholder: "Search for a group...",
-                             class: 'form-control' %>
-            as
-            <%= f.select :access,
-                         access_options,
-                         { prompt: "Select a role..." },
-                         class: 'form-control' %>
+  <section class="section-participants">
+    <!-- Add group form -->
+    <div class="form-add-participants-wrapper row spacer" data-id="<%= @form.id %>">
+      <%= simple_form_for @collection_type_participant,
+                          url: hyrax.admin_collection_type_participants_path,
+                          html: { id: 'group-participants-form' },
+                          as: :collection_type_participant do |f| %>
+            <div class="form-inline add-participants-form">
+            <label class="col-md-2 col-xs-4 control-label"><%= t('.add_group') %>:</label>
 
-                       <%= f.submit t('.submit'), class: 'btn btn-info' %>
+            <div class="col-md-10 col-xs-8 form-group">
+              <%= f.hidden_field :hyrax_collection_type_id, value: @collection_type_participant.hyrax_collection_type_id %>
+              <%= f.hidden_field :agent_type, value: Hyrax::CollectionTypeParticipant::GROUP_TYPE %>
+              <%= f.text_field :agent_id,
+                               placeholder: "Search for a group...",
+                               class: 'form-control' %>
+              as
+              <%= f.select :access,
+                           access_options,
+                           { prompt: "Select a role..." },
+                           class: 'form-control' %>
+
+                         <%= f.submit t('.submit'), class: 'btn btn-info' %>
+            </div>
           </div>
-        </div>
-      </div>
-  <% end %>
-  <%= simple_form_for @collection_type_participant,
-                      url: hyrax.admin_collection_type_participants_path,
-                      html: { id: 'user-participants-form' },
-                      as: :collection_type_participant do |f| %>
-      <div class="clearfix spacer">
-        <div class="form-inline">
-          <label class="col-md-2 col-xs-4 control-label">Add User</label>
+      <% end %>
+    </div>
 
-          <div class="col-md-10 col-xs-8 form-group">
-            <%= f.hidden_field :hyrax_collection_type_id, value: @collection_type_participant.hyrax_collection_type_id %>
-            <%= f.hidden_field :agent_type, value: Hyrax::CollectionTypeParticipant::USER_TYPE %>
-            <%= f.text_field :agent_id,
-                             placeholder: "Search for a user...",
+    <!-- Add user form -->
+    <div class="form-add-participants-wrapper row" data-id="<%= @form.id %>">
+      <%= simple_form_for @collection_type_participant,
+                          url: hyrax.admin_collection_type_participants_path,
+                          html: { id: 'user-participants-form' },
+                          as: :collection_type_participant do |f| %>
+            <div class="form-inline add-participants-form">
+              <label class="col-md-2 col-xs-4 control-label"><%= t('.add_user') %>:</label>
+
+              <div class="col-md-10 col-xs-8 form-group">
+                <%= f.hidden_field :hyrax_collection_type_id, value: @collection_type_participant.hyrax_collection_type_id %>
+                <%= f.hidden_field :agent_type, value: Hyrax::CollectionTypeParticipant::USER_TYPE %>
+                <%= f.text_field :agent_id,
+                                 placeholder: "Search for a user...",
+                                 class: 'form-control' %>
+                as
+                <%= f.select :access,
+                             access_options,
+                             { prompt: "Select a role..." },
                              class: 'form-control' %>
-            as
-            <%= f.select :access,
-                         access_options,
-                         { prompt: "Select a role..." },
-                         class: 'form-control' %>
 
-                       <%= f.submit t('.submit'), class: 'btn btn-info' %>
-          </div>
-        </div>
-      </div>
-  <% end %>
+                           <%= f.submit t('.submit'), class: 'btn btn-info' %>
+              </div>
+            </div>
+      <% end %>
+    </div>
+  </section>
+
 <% end %>
-<div>
-  <fieldset>
-    <legend><%= t('.current_participants') %></legend>
-    <%= render 'form_participant_table', access: 'managers', filter: :manager? %>
-    <%= render 'form_participant_table', access: 'creators', filter: :creator? %>
-  </fieldset>
-</div>
+<section class="section-current-participants">
+  <legend><%= t('.current_participants') %></legend>
+  <%= render 'form_participant_table', access: 'managers', filter: :manager? %>
+  <%= render 'form_participant_table', access: 'creators', filter: :creator? %>
+</section>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -213,6 +213,8 @@ en:
             type: Type
         form_participants:
           add_participants: Add Participants
+          add_group: 'Add group'
+          add_user: 'Add user'
           current_participants: Current Participants
           header: Collection Participants
           instructions: You can designate both groups and users as creators and managers of collections of this type


### PR DESCRIPTION
Fixes #2944 

This update makes the Collection Types Edit Form > participants tab resemble Collection Edit Form > Sharing tab for participants.  Updated UI, and hopefully thought of as improvements.  See screen shot for before / after.

Also, these UI updates will help build the class wrapper selector foundation for a forthcoming issue which will fix the Collection Types participants form submissions for adding a Group and User.  #2915 

![collection-types-participants-tab-before](https://user-images.githubusercontent.com/3020266/39007753-4ac40f92-43cc-11e8-8345-c950f7ad61fb.png)

![collection-types-participants-tab-after](https://user-images.githubusercontent.com/3020266/39007752-4ab60ff0-43cc-11e8-8c3c-013b2265f7fe.png)

@samvera/hyrax-code-reviewers
