### PR TITLE
Refactor UpdateCollectionTypeColumnOptions migration template to make…

### DIFF
--- a/lib/generators/hyrax/templates/db/migrate/20170810190549_update_collection_type_column_options.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20170810190549_update_collection_type_column_options.rb.erb
@@ -1,9 +1,17 @@
 class UpdateCollectionTypeColumnOptions < ActiveRecord::Migration<%= migration_version %>
-  def change
+  def up
     change_column :hyrax_collection_types, :title, :string, unique: true
     change_column :hyrax_collection_types, :machine_id, :string, unique: true
 
     remove_index :hyrax_collection_types, :machine_id
     add_index :hyrax_collection_types, :machine_id, unique: true
+  end
+
+  def down
+    change_column :hyrax_collection_types, :title, :string
+    change_column :hyrax_collection_types, :machine_id, :string
+
+    remove_index :hyrax_collection_types, :machine_id
+    add_index :hyrax_collection_types, :machine_id
   end
 end


### PR DESCRIPTION
… it reversible.

Fixes #2946 

Refactors `lib/generators/hyrax/templates/db/migrate/20170810190549_update_collection_type_column_options.rb.erb` to make the migration reversible.

As currently written, the migration generated by this template is not reversible.  The proposed change makes it reversible, which makes it possible to roll back all the database migrations introduced by the collection extensions work in v2.1.0.

@samvera/hyrax-code-reviewers
