### PR TITLE
Fix batch editing of permissions UI and functionality

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -6,6 +6,7 @@ Metrics/ClassLength:
   Exclude:
     - 'app/controllers/hyrax/dashboard/collections_controller.rb'
     - 'app/controllers/hyrax/admin/admin_sets_controller.rb'
+    - 'app/controllers/hyrax/batch_edits_controller.rb'
     - 'app/controllers/hyrax/downloads_controller.rb'
     - 'app/controllers/hyrax/file_sets_controller.rb'
     - 'app/forms/hyrax/forms/permission_template_form.rb'
@@ -83,6 +84,7 @@ RSpec/ExampleLength:
     - 'spec/actors/hyrax/actors/file_set_actor_spec.rb'
     - 'spec/actors/hyrax/actors/generic_work_actor_spec.rb'
     - 'spec/controllers/hyrax/api/items_controller_spec.rb'
+    - 'spec/controllers/hyrax/batch_edits_controller_spec.rb'
     - 'spec/controllers/hyrax/batch_uploads_controller_spec.rb'
     - 'spec/controllers/hyrax/file_sets_controller_spec.rb'
     - 'spec/controllers/hyrax/generic_works_controller_spec.rb'

--- a/app/assets/javascripts/hyrax/batch_edit.js
+++ b/app/assets/javascripts/hyrax/batch_edit.js
@@ -159,7 +159,8 @@ function batch_edit_init () {
         setTimeout(ajaxManager.runNow(), 100);
     }
 
-    $("#permissions_save").click(runSave);
+    $("#permissions_visibility_save").click(runSave);
+    $("#permissions_roles_save").click(runSave);
     $(".field-save").click(runSave);
 }
 

--- a/app/controllers/hyrax/batch_edits_controller.rb
+++ b/app/controllers/hyrax/batch_edits_controller.rb
@@ -46,9 +46,16 @@ module Hyrax
     end
 
     def update_document(obj)
-      obj.attributes = work_params
+      interpret_visiblity_params(obj)
+      obj.attributes = work_params(admin_set_id: obj.admin_set_id).except(*visibility_params)
       obj.date_modified = Time.current.ctime
-      obj.visibility = params[:visibility]
+
+      if params[:visibility]
+        Deprecation.warn(self, "visibility is not submitted by the Hyrax UI and is deprecated " \
+                               "for removal in Hyrax 3.0. Please use " \
+                               "#{form_class.model_name.param_key}[visibility] instead.")
+        obj.visibility = params[:visibility]
+      end
 
       InheritPermissionsJob.perform_now(obj)
       VisibilityCopyJob.perform_now(obj)
@@ -94,9 +101,28 @@ module Hyrax
         form_class.terms
       end
 
-      def work_params
+      def work_params(extra_params = {})
         work_params = params[form_class.model_name.param_key] || ActionController::Parameters.new
-        form_class.model_attributes(work_params)
+        form_class.model_attributes(work_params.merge(extra_params))
+      end
+
+      def interpret_visiblity_params(obj)
+        stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+          middleware.use Hyrax::Actors::InterpretVisibilityActor
+        end
+        env = Hyrax::Actors::Environment.new(obj, current_ability, work_params(admin_set_id: obj.admin_set_id))
+        last_actor = Hyrax::Actors::Terminator.new
+        stack.build(last_actor).update(env)
+      end
+
+      def visibility_params
+        ['visibility',
+         'lease_expiration_date',
+         'visibility_during_lease',
+         'visibility_after_lease',
+         'embargo_release_date',
+         'visibility_during_embargo',
+         'visibility_after_embargo']
       end
 
       def redirect_to_return_controller

--- a/app/views/hyrax/batch_edits/edit.html.erb
+++ b/app/views/hyrax/batch_edits/edit.html.erb
@@ -50,25 +50,65 @@
         </div><!-- #descriptions_display -->
 
         <div id="permissions_display" class="tab-pane">
-          <%= simple_form_for @form.model,
-                              url: hyrax.batch_edits_path,
-                              method: :put,
-                              remote: true,
-                              html: { id: "form_permissions", class: "ajax-form"},
-                              data: { 'param-key' => @form.model_name.param_key } do |f| %>
-            <%= hidden_field_tag('update_type', 'update') %>
-            <%= hidden_field_tag('key', 'permissions') %>
-            <%= render "hyrax/base/form_permission", f: f %>
-            <%= render "hyrax/base/form_share", f: f %>
+          <div class="row">
+            <%= simple_form_for @form,
+                                url: hyrax.batch_edits_path,
+                                method: :put,
+                                remote: true,
+                                builder: Hyrax::FormBuilder,
+                                html: { id: "form_permissions_visibility", class: "ajax-form"},
+                                data: { 'param-key' => @form.model_name.param_key } do |f| %>
+              <div class="col-xs-12 col-sm-4">
+                <a class="accordion-toggle grey glyphicon-chevron-right-helper collapsed" data-toggle="collapse" href="#collapse_permissions_visibility" id="expand_link_permissions_visibility">
+                  <%= f.input_label "Visibility" %> <span class="chevron"></span>
+                </a>
+              </div>
+              <div id="collapse_permissions_visibility" class="collapse scrolly col-xs-12 col-sm-7">
+                <%= hidden_field_tag('update_type', 'update') %>
+                <%= hidden_field_tag('key', 'permissions') %>
+                <%= render "hyrax/base/form_permission", f: f %>
 
-            <% @form.batch_document_ids.each do |batch_id| %>
-              <%= hidden_field_tag "batch_document_ids[]", batch_id %>
+                <% @form.batch_document_ids.each do |batch_id| %>
+                  <%= hidden_field_tag "batch_document_ids[]", batch_id %>
+                <% end %>
+                <div>
+                  <%= f.submit "Save changes", class: 'btn btn-primary field-save', id: "permissions_visibility_save" %>
+                  <a class="btn btn-default" data-toggle="collapse" data-parent="#row_permissions_visibility" href="#collapse_permissions_visibility">Cancel </a>
+                  <div class="status fleft"></div>
+                </div>
+              </div>
             <% end %>
-            <div class="row">
-              <%= f.submit "Save changes", class: 'btn btn-primary', id: 'permissions_save' %>
-              <div id="status_permissions" class="status fleft"></div>
-            </div>
-          <% end %>
+          </div>
+
+          <div class="row">
+            <%= simple_form_for @form,
+                                url: hyrax.batch_edits_path,
+                                method: :put,
+                                remote: true,
+                                builder: Hyrax::FormBuilder,
+                                html: { id: "form_permissions", class: "ajax-form"},
+                                data: { 'param-key' => @form.model_name.param_key } do |f| %>
+              <div class="col-xs-12 col-sm-4">
+                <a class="accordion-toggle grey glyphicon-chevron-right-helper collapsed" data-toggle="collapse" href="#collapse_permissions_sharing" id="expand_link_permissions_sharing">
+                  <%= f.input_label "Sharing" %> <span class="chevron"></span>
+                </a>
+              </div>
+              <div id="collapse_permissions_sharing" class="collapse scrolly col-xs-12 col-sm-7">
+                <%= hidden_field_tag('update_type', 'update') %>
+                <%= hidden_field_tag('key', 'permissions') %>
+                <%= render "hyrax/base/form_share", f: f %>
+
+                <% @form.batch_document_ids.each do |batch_id| %>
+                  <%= hidden_field_tag "batch_document_ids[]", batch_id %>
+                <% end %>
+                <div>
+                  <%= f.submit "Save changes", class: 'btn btn-primary field-save', id: "permissions_sharing_save" %>
+                  <a class="btn btn-default" data-toggle="collapse" data-parent="#row_permissions_sharing" href="#collapse_permissions_sharing">Cancel </a>
+                  <div class="status fleft"></div>
+                </div>
+              </div>
+            <% end %>
+          </div>
         </div>
       </div> <!-- .tab-content -->
     </div>

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
         # This was `expect(page).to have_content 'Changes Saved'`, however in debugging,
         # the `have_content` check was ignoring the `within` scoping and finding
         # "Changes Saved" for other field areas
-        find('.status', text: 'Changes Saved')
+        find('.status', text: 'Changes Saved', wait: 5)
       end
 
       within "#form_permissions" do
@@ -94,7 +94,7 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
         # This was `expect(page).to have_content 'Changes Saved'`, however in debugging,
         # the `have_content` check was ignoring the `within` scoping and finding
         # "Changes Saved" for other field areas
-        find('.status', text: 'Changes Saved')
+        find('.status', text: 'Changes Saved', wait: 5)
       end
 
       # Visit work permissions and verify

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -2,10 +2,16 @@
 
 RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
   let(:current_user) { create(:user) }
-  let!(:work1)       { create(:public_work, user: current_user) }
-  let!(:work2)       { create(:public_work, user: current_user) }
+  let(:admin_set) { create(:admin_set) }
+  let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
+  let!(:workflow) { create(:workflow, allows_access_grant: true, active: true, permission_template_id: permission_template.id) }
+
+  let!(:work1)       { create(:public_work, admin_set_id: admin_set.id, user: current_user, members: [file_set]) }
+  let!(:work2)       { create(:public_work, admin_set_id: admin_set.id, user: current_user) }
+  let!(:file_set)    { create(:file_set) }
 
   before do
+    RoleMapper.byname[current_user.user_key] << 'donor'
     sign_in current_user
     visit '/dashboard/my/works'
     check 'check_all'
@@ -59,6 +65,47 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
       batch_edit_expand("related_url") do
         page.find("input#generic_work_related_url[value='NEW related_url']")
       end
+    end
+
+    it 'updates permissions and roles' do
+      click_on 'batch-edit'
+      find('#edit_permissions_link').click
+      expect(page).to have_content('Batch Edit Descriptions')
+
+      # Set visibility to private
+      within "#form_permissions_visibility" do
+        batch_edit_expand('permissions_visibility')
+        find('#generic_work_visibility_authenticated').click
+        find('#permissions_visibility_save').click
+        # This was `expect(page).to have_content 'Changes Saved'`, however in debugging,
+        # the `have_content` check was ignoring the `within` scoping and finding
+        # "Changes Saved" for other field areas
+        find('.status', text: 'Changes Saved')
+      end
+
+      within "#form_permissions" do
+        batch_edit_expand('permissions_sharing')
+        page.select('donor', from: 'new_group_name_skel')
+        page.select('View/Download', from: 'new_group_permission_skel')
+        page.find('#add_new_group_skel').click
+        find('#collapse_permissions_sharing table', text: 'View/Download')
+        find('#collapse_permissions_sharing table', text: 'donor')
+        find('#permissions_sharing_save').click
+        # This was `expect(page).to have_content 'Changes Saved'`, however in debugging,
+        # the `have_content` check was ignoring the `within` scoping and finding
+        # "Changes Saved" for other field areas
+        find('.status', text: 'Changes Saved')
+      end
+
+      # Visit work permissions and verify
+      visit "/concern/generic_works/#{work1.id}/edit#share"
+      page.find('#generic_work_visibility_authenticated:checked')
+      page.find('#share table', text: 'donor')
+
+      # Visit file permissions and verify
+      visit "concern/file_sets/#{work1.file_sets.first.id}/edit#permissions_display"
+      page.find('#file_set_visibility_authenticated:checked')
+      page.find('#permissions_display table', text: 'donor')
     end
   end
 

--- a/spec/support/features/batch_edit_actions.rb
+++ b/spec/support/features/batch_edit_actions.rb
@@ -17,7 +17,7 @@ def fill_in_batch_edit_fields_and_verify!
       # This was `expect(page).to have_content 'Changes Saved'`, however in debugging,
       # the `have_content` check was ignoring the `within` scoping and finding
       # "Changes Saved" for other field areas
-      find('.status', text: 'Changes Saved')
+      find('.status', text: 'Changes Saved', wait: 5)
     end
   end
 end


### PR DESCRIPTION
Pass along the object's admin_set_id to the param sanitization to ensure that permissions params are returned or stripped based upon the active workflow for the admin set.  Without this the batch edit of permissions silently fails because it doesn't see any params to operate on.  Then pass those params to the InterpretVisibilityActor to properly apply visibility/lease/embargo params.

This commit also fixes the params for the visibility tests based upon browser testing.  The line reading the visibility from the bare param could be removed since it isn't used so I marked it as deprecated.

This PR changes the visual layout of the bulk edit permissions tab to be similar to the description tab such that visibility and sharing each are their own collapsable form.  This was done to avoid cross-pollination where submitting the form to save added roles also submitted visibility at the same time.

<img width="266" alt="screenshot-batch-permissions" src="https://user-images.githubusercontent.com/1053603/39080983-dc5521ae-4506-11e8-90be-41b5b4bd0212.png">

Fixes #2827.

@samvera/hyrax-code-reviewers
