### PR TITLE
Collection Types Edit Add Participants fix Add group and user via AJA…

### DIFF
--- a/app/assets/javascripts/hyrax/collection_types.es6
+++ b/app/assets/javascripts/hyrax/collection_types.es6
@@ -4,7 +4,36 @@ export default class CollectionTypes {
     if (element.length > 0) {
       this.handleCollapseToggle()
       this.handleDelete()
+
+      // Edit Collection Type
+      this.handleAddParticipants()
     }
+  }
+
+  handleAddParticipants() {
+    $('#participants').find('.add-participants-form input[type="submit"]').on('click', function(e) {
+      e.preventDefault();
+      const $wrapEl = $(e.target).parents('.form-add-participants-wrapper');
+      if ($wrapEl.length === 0) {
+        return;
+      }
+      const serialized = $wrapEl.find(':input').serialize();
+      const url = '/admin/collection_type_participants?locale=en';
+      if (serialized.length === 0) {
+        return;
+      }
+
+      $.ajax({
+        type: 'POST',
+        url: url,
+        data: serialized
+      }).done(function(response) {
+        // Success handler here, possibly show alert success if page didn't reload?
+      }).fail(function(err) {
+        console.error(err);
+      });
+
+    });
   }
 
   handleCollapseToggle() {

--- a/app/assets/stylesheets/hyrax/_collection_types.scss
+++ b/app/assets/stylesheets/hyrax/_collection_types.scss
@@ -83,7 +83,8 @@
         width: 40%;
       }
 
-      th:last-of-type {
+      th:last-of-type,
+      td:last-of-type {
         text-align: center;
         width: 20%;
       }

--- a/app/views/hyrax/admin/collection_types/_form_participant_table.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_participant_table.html.erb
@@ -15,7 +15,7 @@
         <td data-agent="<%= g.agent_id %>"><%= g.label %></td>
         <td><%= g.agent_type.titleize %></td>
         <td>
-          <%= button_to "Remove", hyrax.admin_collection_type_participant_path(g), method: :delete, class: 'btn btn-sm btn-danger' %>
+          <%= link_to t("helpers.action.remove"), hyrax.admin_collection_type_participant_path(g), method: :delete, class: 'btn btn-sm btn-danger' %>
         </td>
       </tr>
     <% end %>

--- a/app/views/hyrax/admin/collection_types/edit.html.erb
+++ b/app/views/hyrax/admin/collection_types/edit.html.erb
@@ -1,10 +1,12 @@
-<% provide :page_title, construct_page_title( t('.header') ) %>
-<% provide :page_header do %>
-  <h1><span class="fa fa-folder-open"></span> <%= t('.header') %>: <%= @form.title %></h1>
-<% end %>
+<div class="collection-types-wrapper">
+  <% provide :page_title, construct_page_title( t('.header') ) %>
+  <% provide :page_header do %>
+    <h1><span class="fa fa-folder-open"></span> <%= t('.header') %>: <%= @form.title %></h1>
+  <% end %>
 
-<div class="row">
-  <div class="col-md-12">
-    <%= render 'form' %>
+  <div class="row">
+    <div class="col-md-12">
+      <%= render 'form' %>
+    </div>
   </div>
 </div>

--- a/spec/views/hyrax/admin/collection_types/_form_participants.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_participants.html.erb_spec.rb
@@ -9,8 +9,16 @@ RSpec.describe 'hyrax/admin/collection_types/_form_participants.html.erb', type:
     assign(:form, form)
     render
   end
-  it 'has the required selectors' do
-    expect(rendered).to have_selector('#user-participants-form')
-    expect(rendered).to have_selector('#group-participants-form')
+
+  context 'Collection Types edit participants tab' do
+    it 'has the required form selectors' do
+      expect(rendered).to have_selector('#user-participants-form')
+      expect(rendered).to have_selector('#group-participants-form')
+    end
+
+    it 'has the required javascript selectors to process AJAX add user and add group requests' do
+      expect(rendered).to have_selector('.form-add-participants-wrapper')
+      expect(rendered).to have_selector('.add-participants-form')
+    end
   end
 end


### PR DESCRIPTION
…X requests

Fixes #2915 

This fix allows Groups and Users to be added in Collection Types > Edit > Participants tab Add Participants section.  It uses the same pattern applied to Collections in #2832 

#### Remaining work

- The "Add" button's dynamic disabled state fix is not a part of this PR.  I created a ticket to fix this, which will also abstract out that code from Collections so we're not duplicating code.   See #2949 for more details...
- The Add group input select might not be working properly.  It doesn't autofill with any values, but maybe this is just my configuration?  @elrayle Mind verifying this?

![collection-types-participants-tab-after](https://user-images.githubusercontent.com/3020266/39052788-c28a4c16-4472-11e8-9cf8-364e128342e0.png)

@samvera/hyrax-code-reviewers
