### PR TITLE
Add managed access to list of collections under Managed Collections tab

### DIFF
--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -31,6 +31,9 @@ module Hyrax
       []
     end
 
+    # For the Managed Collections tab, determine the label to use for the level of access the user has for this admin set.
+    # Checks from most permissive to most restrictive.
+    # @return String the access label (e.g. Manage, Deposit, View)
     def managed_access
       return I18n.t('hyrax.dashboard.my.collection_list.managed_access.manage') if current_ability.can?(:edit, solr_document)
       return I18n.t('hyrax.dashboard.my.collection_list.managed_access.deposit') if current_ability.can?(:deposit, solr_document)
@@ -38,6 +41,12 @@ module Hyrax
       ''
     end
 
+    # Determine if the user can perform batch operations on this admin set.  Currently, the only
+    # batch operation allowed is deleting, so this is equivalent to checking if the user can delete
+    # the admin set determined by criteria...
+    # * user must be able to edit the admin set to be able to delete it
+    # * the admin set itself must be able to be deleted (i.e., there cannot be any works in the admin set)
+    # @return Boolean true if the user can perform batch actions; otherwise, false
     def allow_batch?
       return false unless current_ability.can?(:edit, solr_document)
       !disable_delete?

--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -30,5 +30,17 @@ module Hyrax
     def available_parent_collections(*)
       []
     end
+
+    def managed_access
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.manage') if current_ability.can?(:edit, solr_document)
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.deposit') if current_ability.can?(:deposit, solr_document)
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.view') if current_ability.can?(:read, solr_document)
+      ''
+    end
+
+    def allow_batch?
+      return false unless current_ability.can?(:edit, solr_document)
+      !disable_delete?
+    end
   end
 end

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -158,5 +158,17 @@ module Hyrax
     def subcollection_count=(total)
       @subcollection_count = total unless total.nil?
     end
+
+    def managed_access
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.manage') if current_ability.can?(:edit, solr_document)
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.deposit') if current_ability.can?(:deposit, solr_document)
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.view') if current_ability.can?(:read, solr_document)
+      ''
+    end
+
+    def allow_batch?
+      return true if current_ability.can?(:edit, solr_document)
+      false
+    end
   end
 end

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -159,6 +159,9 @@ module Hyrax
       @subcollection_count = total unless total.nil?
     end
 
+    # For the Managed Collections tab, determine the label to use for the level of access the user has for this admin set.
+    # Checks from most permissive to most restrictive.
+    # @return String the access label (e.g. Manage, Deposit, View)
     def managed_access
       return I18n.t('hyrax.dashboard.my.collection_list.managed_access.manage') if current_ability.can?(:edit, solr_document)
       return I18n.t('hyrax.dashboard.my.collection_list.managed_access.deposit') if current_ability.can?(:deposit, solr_document)
@@ -166,6 +169,12 @@ module Hyrax
       ''
     end
 
+    # Determine if the user can perform batch operations on this collection.  Currently, the only
+    # batch operation allowed is deleting, so this is equivalent to checking if the user can delete
+    # the collection determined by criteria...
+    # * user must be able to edit the collection to be able to delete it
+    # * the collection does not have to be empty
+    # @return Boolean true if the user can perform batch actions; otherwise, false
     def allow_batch?
       return true if current_ability.can?(:edit, solr_document)
       false

--- a/app/views/hyrax/dashboard/collections/_default_group.html.erb
+++ b/app/views/hyrax/dashboard/collections/_default_group.html.erb
@@ -1,0 +1,30 @@
+<table id="collections-list-table" class="table table-striped collections-list-table">
+  <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
+  <thead>
+  <tr>
+    <th class="check-all">
+      <label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label>
+      <input type="checkbox" name="check_all" id="check_all" value="yes" />
+    </th>
+    <th><%= t("hyrax.dashboard.my.heading.title") %></th>
+    <% if !current_ability.admin? %>
+      <th><%= t("hyrax.dashboard.my.heading.access") %></th>
+    <% end %>
+    <th><%= t("hyrax.dashboard.my.heading.type") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.items") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.last_modified") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.action") %></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% docs.each_with_index do |document, counter| %>
+    <% collection_presenter = if document.admin_set?
+                                Hyrax::AdminSetPresenter.new(document, current_ability, nil)
+                              else
+                                Hyrax::CollectionPresenter.new(document, current_ability, nil)
+                              end %>
+    <%= render 'list_collections', collection_presenter: collection_presenter, counter: counter, is_admin_set: document.admin_set? %>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -1,3 +1,4 @@
+<% # used by All and Managed Collections tabs %>
 <% id = collection_presenter.id %>
 <tr id="document_<%= id %>"
   data-id="<%= id %>"
@@ -6,10 +7,11 @@
   data-post-delete-url="<%= is_admin_set ? hyrax.admin_admin_set_path(id) : hyrax.dashboard_collection_path(id) %>">
 
   <td>
-    <% unless collection_presenter.solr_document.admin_set? %>
+    <% if collection_presenter.allow_batch? %>
     <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
-      data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>"
-    />
+      data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>" />
+    <% else %>
+    <input type="checkbox" class="disabled" disabled=true />
     <% end %>
   </td>
   <td>
@@ -52,6 +54,9 @@
       </div>
     </div>
   </td>
+  <% if !current_ability.admin? %>
+    <td><%= collection_presenter.managed_access %></td>
+  <% end %>
   <td class="collection_type">
     <span class="label label-success"><%= collection_presenter.collection_type_badge %></span>
   </td>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -1,5 +1,5 @@
+<% # used by Your Collections tab %>
 <% id = collection_presenter.id %>
-
 <%# Data attributes referenced by the javascript for row actions %>
 <tr id="document_<%= id %>"
   data-source="my"
@@ -8,7 +8,14 @@
   data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
   data-post-delete-url="<%= is_admin_set ? hyrax.admin_admin_set_path(id) : hyrax.dashboard_collection_path(id) %>">
 
-  <td><% unless collection_presenter.solr_document.admin_set? %><input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector" /><% end %></td>
+  <td>
+    <% if collection_presenter.allow_batch? %>
+        <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
+               data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>" />
+    <% else %>
+        <input type="checkbox" class="disabled" disabled=true />
+    <% end %>
+  </td>
   <td>
     <div class="thumbnail-title-wrapper">
       <div class="thumbnail-wrapper">

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -701,6 +701,10 @@ en:
           edit_access: 'Edit Access:'
           groups: 'Groups:'
           users: 'Users:'
+          managed_access:
+            manage:  'Manage'
+            deposit: 'Deposit'
+            view:    'View'
         collections: Collections
         facet_label:
           collections: 'Filter collections:'
@@ -709,6 +713,7 @@ en:
           works: 'Filter works:'
         heading:
           action: Actions
+          access: Access
           collection_type: Collection Type
           date_modified: Last Modified
           date_uploaded: Date Added

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -454,24 +454,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           expect(page).to have_content(collection.title.first)
         end
       end
-
-      context 'and selects the collection and clicks "Delete collections" button at top of page' do
-        it 'does not allow delete collection', js: true do
-          expect(page).to have_content(collection.title.first)
-          check_tr_data_attributes(collection.id, 'collection')
-
-          # Check the checkbox for the collection the user is not allowed to delete.
-          find("#batch_document_#{collection.id}").set(true)
-          # Click the "Delete collections" button at the top of the page.
-          find('#delete-collections-button').click
-          # Expect to see the modal that explains why the user couldn't delete the collection
-          expect(page).to have_selector('div#collections-to-delete-deny-modal', visible: true)
-          within('div#collections-to-delete-deny-modal') do
-            click_button('Close')
-          end
-          expect(page).to have_content(collection.title.first)
-        end
-      end
     end
 
     context 'when user created the admin set' do

--- a/spec/presenters/hyrax/admin_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_presenter_spec.rb
@@ -70,4 +70,74 @@ RSpec.describe Hyrax::AdminSetPresenter do
 
     it { is_expected.to eq "/admin/admin_sets/#{admin_set.id}" }
   end
+
+  describe '#managed_access' do
+    let(:admin_set) { create(:admin_set, members: [work]) }
+
+    context 'when manager' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_document).and_return(true)
+      end
+      it 'returns Manage label' do
+        expect(presenter.managed_access).to eq 'Manage'
+      end
+    end
+
+    context 'when depositor' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
+        allow(ability).to receive(:can?).with(:deposit, solr_document).and_return(true)
+      end
+      it 'returns Deposit label' do
+        expect(presenter.managed_access).to eq 'Deposit'
+      end
+    end
+
+    context 'when manager' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
+        allow(ability).to receive(:can?).with(:deposit, solr_document).and_return(false)
+        allow(ability).to receive(:can?).with(:read, solr_document).and_return(true)
+      end
+      it 'returns View label' do
+        expect(presenter.managed_access).to eq 'View'
+      end
+    end
+  end
+
+  describe '#allow_batch?' do
+    let(:admin_set) { create(:admin_set, members: [work]) }
+
+    context 'when user cannot edit' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(presenter.allow_batch?).to be false
+      end
+    end
+
+    context 'when user can edit' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_document).and_return(true)
+      end
+
+      context 'and there are works in the admin set' do
+        it 'returns false' do
+          expect(presenter.allow_batch?).to be false
+        end
+      end
+
+      context 'and there are no works in the admin set' do
+        before do
+          allow(presenter).to receive(:total_items).and_return(0)
+        end
+
+        it 'returns true' do
+          expect(presenter.allow_batch?).to be true
+        end
+      end
+    end
+  end
 end

--- a/spec/presenters/hyrax/admin_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_presenter_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Hyrax::AdminSetPresenter do
       end
     end
 
-    context 'when manager' do
+    context 'when viewer' do
       before do
         allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
         allow(ability).to receive(:can?).with(:deposit, solr_document).and_return(false)

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -392,4 +392,58 @@ RSpec.describe Hyrax::CollectionPresenter do
   it { is_expected.to delegate_method(:related_url).to(:solr_document) }
   it { is_expected.to delegate_method(:identifier).to(:solr_document) }
   it { is_expected.to delegate_method(:date_created).to(:solr_document) }
+
+  describe '#managed_access' do
+    context 'when manager' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_doc).and_return(true)
+      end
+      it 'returns Manage label' do
+        expect(presenter.managed_access).to eq 'Manage'
+      end
+    end
+
+    context 'when depositor' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_doc).and_return(false)
+        allow(ability).to receive(:can?).with(:deposit, solr_doc).and_return(true)
+      end
+      it 'returns Deposit label' do
+        expect(presenter.managed_access).to eq 'Deposit'
+      end
+    end
+
+    context 'when manager' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_doc).and_return(false)
+        allow(ability).to receive(:can?).with(:deposit, solr_doc).and_return(false)
+        allow(ability).to receive(:can?).with(:read, solr_doc).and_return(true)
+      end
+      it 'returns View label' do
+        expect(presenter.managed_access).to eq 'View'
+      end
+    end
+  end
+
+  describe '#allow_batch?' do
+    context 'when user cannot edit' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_doc).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(presenter.allow_batch?).to be false
+      end
+    end
+
+    context 'when user can edit' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_doc).and_return(true)
+      end
+
+      it 'returns false' do
+        expect(presenter.allow_batch?).to be true
+      end
+    end
+  end
 end

--- a/spec/views/hyrax/dashboard/collections/_default_group.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_default_group.html.erb_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe 'hyrax/dashboard/collections/_default_group.html.erb', type: :view do
+  let(:ability) { double }
+
+  before do
+    allow(view).to receive(:docs).and_return([])
+    allow(view).to receive(:current_ability).and_return(ability)
+    stub_template 'hyrax/my/_list_collections.html.erb' => 'collection row'
+  end
+
+  context 'Managed Collections' do
+    before do
+      allow(ability).to receive(:admin?).and_return(false)
+      render
+    end
+
+    it 'shows collection table headings' do
+      expect(rendered).to have_text('Title')
+      expect(rendered).to have_text('Access')
+      expect(rendered).to have_text('Type')
+      expect(rendered).to have_text('Visibility')
+      expect(rendered).to have_text('Items')
+      expect(rendered).to have_text('Last modified')
+      expect(rendered).to have_text('Actions')
+    end
+  end
+
+  context 'All Collections' do
+    before do
+      allow(ability).to receive(:admin?).and_return(true)
+      render
+    end
+
+    it "doesn't show access" do
+      expect(rendered).to have_text('Title')
+      expect(rendered).not_to have_text('Access')
+      expect(rendered).to have_text('Type')
+      expect(rendered).to have_text('Visibility')
+      expect(rendered).to have_text('Items')
+      expect(rendered).to have_text('Last modified')
+      expect(rendered).to have_text('Actions')
+    end
+  end
+end

--- a/spec/views/hyrax/dashboard/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_list_collections.html.erb_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe 'hyrax/dashboard/collections/_list_collections.html.erb', type: :view do
-  let(:subject) { render('list_collections.html.erb', presenter: presenter) }
   let(:ability) { double }
   let(:solr_document) { SolrDocument.new(collection_doc) }
   let(:presenter) { Hyrax::CollectionPresenter.new(solr_document, ability) }
@@ -7,8 +6,8 @@ RSpec.describe 'hyrax/dashboard/collections/_list_collections.html.erb', type: :
   let(:collection_doc) do
     {
       id: '999',
-      "has_model_ssim" => ["Collection"],
-      "title_tesim" => ["Title 1"],
+      'has_model_ssim' => ['Collection'],
+      'title_tesim' => ['Title 1'],
       'date_created_tesim' => '2000-01-01'
     }
   end
@@ -17,8 +16,6 @@ RSpec.describe 'hyrax/dashboard/collections/_list_collections.html.erb', type: :
     allow(view).to receive(:is_admin_set).and_return(false)
     allow(view).to receive(:current_ability).and_return(ability)
     allow(presenter).to receive(:available_parent_collections).and_return([])
-    allow(presenter).to receive(:solr_document).and_return(solr_document)
-    allow(presenter).to receive(:allow_batch?).and_return(false)
     allow(presenter).to receive(:collection_type_badge).and_return('A Collection Type')
     allow(presenter).to receive(:total_viewable_items).and_return(3)
     allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
@@ -29,40 +26,14 @@ RSpec.describe 'hyrax/dashboard/collections/_list_collections.html.erb', type: :
   context 'Managed Collections' do
     before do
       allow(ability).to receive(:admin?).and_return(false)
+      allow(presenter).to receive(:managed_access).and_return('Manage Access')
+      render('list_collections.html.erb', collection_presenter: presenter)
     end
-    context 'show access' do
-      context 'for manager' do
-        before do
-          allow(presenter).to receive(:managed_access).and_return('Manage')
-        end
-        it "shows Manage access" do
-          allow(view).to receive(:current_user).and_return(true)
-          render('list_collections.html.erb', collection_presenter: presenter)
-          expect(rendered).to have_text('Manage')
-        end
-      end
 
-      context 'for depositer' do
-        before do
-          allow(presenter).to receive(:managed_access).and_return('Deposit')
-        end
-        it "shows Deposit access" do
-          allow(view).to receive(:current_user).and_return(true)
-          render('list_collections.html.erb', collection_presenter: presenter)
-          expect(rendered).to have_text('Deposit')
-        end
-      end
-
-      context 'for viewer' do
-        before do
-          allow(presenter).to receive(:managed_access).and_return('Viewer')
-        end
-        it "shows View access" do
-          allow(view).to receive(:current_user).and_return(true)
-          render('list_collections.html.erb', collection_presenter: presenter)
-          expect(rendered).to have_text('View')
-        end
-      end
+    # NOTE: Real labels are Manage, Deposit, or View, but UI shows whatever label gets returned,
+    # so no need to test all conditions.
+    it 'shows access label as returned by presenter' do
+      expect(rendered).to have_text('Manage Access')
     end
   end
 
@@ -70,11 +41,10 @@ RSpec.describe 'hyrax/dashboard/collections/_list_collections.html.erb', type: :
     before do
       allow(ability).to receive(:admin?).and_return(true)
       allow(presenter).to receive(:managed_access).and_return('Manage')
+      render('list_collections.html.erb', collection_presenter: presenter)
     end
 
     it "doesn't show access" do
-      allow(view).to receive(:current_user).and_return(true)
-      render('list_collections.html.erb', collection_presenter: presenter)
       expect(rendered).not_to have_text('Manage')
     end
   end

--- a/spec/views/hyrax/dashboard/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_list_collections.html.erb_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe 'hyrax/dashboard/collections/_list_collections.html.erb', type: :view do
+  let(:subject) { render('list_collections.html.erb', presenter: presenter) }
+  let(:ability) { double }
+  let(:solr_document) { SolrDocument.new(collection_doc) }
+  let(:presenter) { Hyrax::CollectionPresenter.new(solr_document, ability) }
+
+  let(:collection_doc) do
+    {
+      id: '999',
+      "has_model_ssim" => ["Collection"],
+      "title_tesim" => ["Title 1"],
+      'date_created_tesim' => '2000-01-01'
+    }
+  end
+
+  before do
+    allow(view).to receive(:is_admin_set).and_return(false)
+    allow(view).to receive(:current_ability).and_return(ability)
+    allow(presenter).to receive(:available_parent_collections).and_return([])
+    allow(presenter).to receive(:solr_document).and_return(solr_document)
+    allow(presenter).to receive(:allow_batch?).and_return(false)
+    allow(presenter).to receive(:collection_type_badge).and_return('A Collection Type')
+    allow(presenter).to receive(:total_viewable_items).and_return(3)
+    allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
+
+    stub_template 'hyrax/my/_collection_action_menu.html.erb' => 'actions'
+  end
+
+  context 'Managed Collections' do
+    before do
+      allow(ability).to receive(:admin?).and_return(false)
+    end
+    context 'show access' do
+      context 'for manager' do
+        before do
+          allow(presenter).to receive(:managed_access).and_return('Manage')
+        end
+        it "shows Manage access" do
+          allow(view).to receive(:current_user).and_return(true)
+          render('list_collections.html.erb', collection_presenter: presenter)
+          expect(rendered).to have_text('Manage')
+        end
+      end
+
+      context 'for depositer' do
+        before do
+          allow(presenter).to receive(:managed_access).and_return('Deposit')
+        end
+        it "shows Deposit access" do
+          allow(view).to receive(:current_user).and_return(true)
+          render('list_collections.html.erb', collection_presenter: presenter)
+          expect(rendered).to have_text('Deposit')
+        end
+      end
+
+      context 'for viewer' do
+        before do
+          allow(presenter).to receive(:managed_access).and_return('Viewer')
+        end
+        it "shows View access" do
+          allow(view).to receive(:current_user).and_return(true)
+          render('list_collections.html.erb', collection_presenter: presenter)
+          expect(rendered).to have_text('View')
+        end
+      end
+    end
+  end
+
+  context 'All Collections' do
+    before do
+      allow(ability).to receive(:admin?).and_return(true)
+      allow(presenter).to receive(:managed_access).and_return('Manage')
+    end
+
+    it "doesn't show access" do
+      allow(view).to receive(:current_user).and_return(true)
+      render('list_collections.html.erb', collection_presenter: presenter)
+      expect(rendered).not_to have_text('Manage')
+    end
+  end
+end

--- a/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
       allow(collection).to receive(:id).and_return(id)
       allow(collection).to receive(:member_of_collection_ids).and_return(["abc", "123"])
       allow(collection_presenter).to receive(:collection_type_badge).and_return("User Collection")
+      allow(collection_presenter).to receive(:allow_batch?).and_return(true)
       view.lookup_context.prefixes.push 'hyrax/my'
       render 'hyrax/my/collections/list_collections', collection_presenter: collection_presenter, is_admin_set: doc.admin_set?
     end
@@ -79,6 +80,7 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
       allow(view).to receive(:can?).with(:edit, doc).and_return(true)
       allow(doc).to receive(:to_model).and_return(stub_model(AdminSet, id: id))
       allow(collection_presenter).to receive(:collection_type_badge).and_return("Admin Set")
+      allow(collection_presenter).to receive(:allow_batch?).and_return(true)
       view.lookup_context.prefixes.push 'hyrax/my'
 
       render 'hyrax/my/collections/list_collections', collection_presenter: collection_presenter, is_admin_set: doc.admin_set?


### PR DESCRIPTION
Adds a column to the collections list that shows the level of managed access a user has to each collection.  This applies to the Managed Collections tab only.  On Your Collections and All Collections the access level is always Manage and adds no additional information for the user.

I would also like to see a filter by managed access.

@samvera/hyrax-code-reviewers
