### PR TITLE
[WIP] Change participant/sharing groups to a select list

### DIFF
--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -38,6 +38,7 @@ module Hyrax
     end
 
     def edit
+      @groups = groups
       setup_form
     end
 
@@ -146,6 +147,12 @@ module Hyrax
         else
           redirect_to hyrax.my_collections_path, notice: t(:'hyrax.admin.admin_sets.delete.notification')
         end
+      end
+
+      def groups
+        groups = current_user.groups || []
+        groups << ::Ability.registered_group_name if current_ability.admin?
+        groups.uniq
       end
   end
 end

--- a/app/controllers/hyrax/admin/collection_types_controller.rb
+++ b/app/controllers/hyrax/admin/collection_types_controller.rb
@@ -38,6 +38,7 @@ module Hyrax
     end
 
     def edit
+      @groups = groups
       setup_form
       setup_participants_form
       add_common_breadcrumbs
@@ -102,6 +103,12 @@ module Hyrax
       def collection_type_params
         params.require(:collection_type).permit(:title, :description, :nestable, :brandable, :discoverable, :sharable, :share_applies_to_new_works,
                                                 :allow_multiple_membership, :require_membership, :assigns_workflow, :assigns_visibility)
+      end
+
+      def groups
+        groups = current_user.groups || []
+        groups << ::Ability.registered_group_name if current_ability.admin?
+        groups.uniq
       end
   end
 end

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -76,6 +76,7 @@ module Hyrax
         member_works
         # this is used to populate the "add to a collection" action for the members
         @user_collections = find_collections_for_form
+        @groups = groups
         form
       end
 
@@ -460,6 +461,12 @@ module Hyrax
         # @return <Hash> the inputs required for the collection member search builder
         def params_for_query
           params.merge(q: params[:cq])
+        end
+
+        def groups
+          groups = current_user.groups || []
+          groups << ::Ability.registered_group_name if current_ability.admin?
+          groups.uniq
         end
     end
   end

--- a/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
@@ -15,9 +15,10 @@
 
                       <div class="col-md-10 col-xs-8 form-group">
                         <%= builder.hidden_field :agent_type %>
-                        <%= builder.text_field :agent_id,
-                                         placeholder: "Search for a group...",
-                                         class: 'form-control' %>
+                        <%= builder.select :agent_id,
+                                           @groups,
+                                           { prompt: "Select a group..." },
+                                           class: 'form-control' %>
                         as
                         <%= builder.select :access,
                                      access_options,

--- a/app/views/hyrax/admin/collection_types/_form_participants.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_participants.html.erb
@@ -16,9 +16,10 @@
             <div class="col-md-10 col-xs-8 form-group">
               <%= f.hidden_field :hyrax_collection_type_id, value: @collection_type_participant.hyrax_collection_type_id %>
               <%= f.hidden_field :agent_type, value: Hyrax::CollectionTypeParticipant::GROUP_TYPE %>
-              <%= f.text_field :agent_id,
-                               placeholder: "Search for a group...",
-                               class: 'form-control' %>
+              <%= f.select :agent_id,
+                           @groups,
+                           { prompt: "Select a group..." },
+                           class: 'form-control' %>
               as
               <%= f.select :access,
                            access_options,

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -22,9 +22,10 @@
                   <label class="col-md-2 col-xs-4 control-label"><%= t('.add_group') %>:</label>
                   <div class="col-md-10 col-xs-8 form-group">
                     <%= builder.hidden_field :agent_type %>
-                    <%= builder.text_field :agent_id,
-                                           placeholder: "Search for a group...",
-                                           class: 'form-control search-input' %>
+                    <%= builder.select :agent_id,
+                                       @groups,
+                                       { prompt: "Select a group..." },
+                                       class: 'form-control' %>
                     as
                     <%= builder.select :access,
                                        access_options,

--- a/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
       let(:attributes) { { title: 'new title' } }
       let(:default_id) { AdminSet::DEFAULT_ID }
 
-      it "gets the admin set id fro the work" do
+      it "gets the admin set id from the work" do
         expect(terminator).to receive(:update).with(Hyrax::Actors::Environment) do |k|
           expect(k.attributes).to eq('title' => 'new title', 'admin_set_id' => admin_set.id)
           true

--- a/spec/views/hyrax/admin/admin_sets/_form_participants.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_form_participants.html.erb_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe 'hyrax/admin/admin_sets/_form_participants.html.erb', type: :view
   end
 
   before do
-    @form = instance_double(Hyrax::Forms::AdminSetForm,
-                            to_model: stub_model(AdminSet),
-                            permission_template: pt_form)
+    assign(:groups, ['group1', 'admin', 'registered'])
+    assign(:form, instance_double(Hyrax::Forms::AdminSetForm,
+                                  to_model: stub_model(AdminSet),
+                                  permission_template: pt_form))
     render
   end
   it "has the required selectors" do

--- a/spec/views/hyrax/admin/collection_types/_form_participants.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_participants.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_participants.html.erb', type:
   before do
     assign(:collection_type_participant, participant_form)
     assign(:form, form)
+    assign(:groups, ['group1', 'admin', 'registered'])
     render
   end
 

--- a/spec/views/hyrax/dashboard/collections/_form_share.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_share.erb_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe 'hyrax/dashboard/collections/_form_share.html.erb', type: :view d
 
   before do
     assign(:collection, collection)
-    @form = instance_double(Hyrax::Forms::CollectionForm,
-                            to_model: collection,
-                            permission_template: pt_form,
-                            id: '1234xyz')
+    assign(:groups, ['group1', 'admin', 'registered'])
+    assign(:form, instance_double(Hyrax::Forms::CollectionForm,
+                                  to_model: collection,
+                                  permission_template: pt_form,
+                                  id: '1234xyz'))
     render
   end
   it "has the required selectors" do


### PR DESCRIPTION
Fixes #2937

For collection types, collections, and admin sets, the process for granting a group access involved typing in the name.  This has been switched to use the approach used by works new/edit form.  Each controller now passes a list of groups for the current user.  If the user is an admin, it appends the registered group to allow admins to grant access to all registered users.

@samvera/hyrax-code-reviewers
