### PR TITLE
Change expectation to avoid warning about antipattern

### DIFF
--- a/spec/controllers/hyrax/batch_edits_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_edits_controller_spec.rb
@@ -141,15 +141,15 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
       it "fails to delete collections when user does not have edit access" do
         controller.batch = [collection1.id, collection3.id]
         delete :destroy_collection, params: { update_type: "delete_all" }
-        expect { Collection.find(collection1.id) }.not_to raise_error(Ldp::Gone)
-        expect { Collection.find(collection2.id) }.not_to raise_error(Ldp::Gone)
+        expect(Collection.exists?(collection1.id)).to eq true
+        expect(Collection.exists?(collection2.id)).to eq true
       end
 
       it "deletes collections where user has edit access, failing to delete those where user does not have edit access" do
         controller.batch = [collection1.id, collection3.id]
         delete :destroy_collection, params: { update_type: "delete_all" }
-        expect { Collection.find(collection1.id) }.not_to raise_error(Ldp::Gone)
-        expect { Collection.find(collection2.id) }.not_to raise_error(Ldp::Gone)
+        expect(Collection.exists?(collection1.id)).to eq true
+        expect(Collection.exists?(collection2.id)).to eq true
         expect { Collection.find(collection3.id) }.to raise_error(Ldp::Gone)
       end
     end


### PR DESCRIPTION
Running these two tests before would give the warning:
```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. 
```
This PR changes the expectation into a positive existence check instead.

@samvera/hyrax-code-reviewers
