### PR TITLE
Update translations for 2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 
 group :development, :test do
   gem 'coveralls', require: false
+  gem 'i18n-tasks'
   gem 'pry' unless ENV['CI']
   gem 'pry-byebug' unless ENV['CI']
   gem "simplecov", require: false

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -171,7 +171,6 @@ de:
           header: Neues Admin-Set erstellen
         show:
           breadcrumb: Ansicht Admin-Set
-          confirm_delete: Sind Sie sicher, dass Sie dieses Admin-Set löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.
           header: Admin-Set
           item_list_header: Arbeiten in diesem Admin-Set
         show_actions:

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -49,6 +49,8 @@ de:
         new: Neue Sammlung
       delete: Löschen
       edit: Bearbeiten
+      less: Weniger
+      more: Mehr
       refresh: Aktualisierung
       remove: Entfernen
       work:
@@ -172,6 +174,8 @@ de:
           confirm_delete: Sind Sie sicher, dass Sie dieses Admin-Set löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.
           header: Admin-Set
           item_list_header: Arbeiten in diesem Admin-Set
+        show_actions:
+          confirm_delete: Möchten Sie dieses Verwaltungsset wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
       appearances:
         show:
           header: Design
@@ -193,6 +197,7 @@ de:
           not_empty: Der Sammlungstyp kann nicht geändert werden, da er Sammlungen enthält
         form:
           tab:
+            appearance: Abzeichen Farbe
             metadata: Beschreibung
             participants: Teilnehmer
             settings: Einstellungen
@@ -212,7 +217,9 @@ de:
             title: Manager
             type: Typ
         form_participants:
+          add_group: Gruppe hinzufügen
           add_participants: Teilnehmer hinzufügen
+          add_user: Benutzer hinzufügen
           current_participants: Aktuelle Teilnehmer
           header: Sammlungs-Teilnehmer
           instructions: Sie können sowohl Gruppen als auch Benutzer als Ersteller und Manager von Sammlungen dieses Typs festlegen
@@ -240,6 +247,7 @@ de:
             name: Name
         multiple_membership_checker:
           error_preamble: 'Fehler: Sie haben mehrere derselben Sammlungstypen mit einer einzelnen Mitgliedschaft angegeben'
+          error_type_and_collections: "(Geben Sie ein: %{type}, Sammlungen: %{collections})"
         new:
           header: Erstellen Sie einen neuen Sammlungstyp
           submit: Speichen
@@ -697,6 +705,10 @@ de:
           description: 'Beschreibung:'
           edit_access: 'Bearbeiten der Zugriffsrechte:'
           groups: 'Gruppen:'
+          managed_access:
+            deposit: Anzahlung
+            manage: Verwalten
+            view: Aussicht
           users: 'Benutzer:'
         collections: Ihre Sammlungen
         facet_label:
@@ -705,6 +717,7 @@ de:
           shared: 'Filter Freigaben:'
           works: 'Filter Arbeiten:'
         heading:
+          access: Zugriff
           action: Aktionen
           collection_type: Sammlungsart
           date_modified: Zuletzt bearbeitet
@@ -734,6 +747,7 @@ de:
         removed_relationship: "'%{child_title}' wurde aus '%{parent_title}' entfernt"
       no_activity: Benutzer hat keine aktuellen Aufgaben
       no_notifications: Benutzer hat keine Benachrichtigungen
+      no_proxies: Es sind keine Proxys zugewiesen
       no_transfer_requests: Sie haben keine Übertragungsanfragen für Arbeiten erhalten
       no_transfers: Sie haben keine Arbeit übertragen
       proxy_activity: Vertreter-Aktivität
@@ -1131,6 +1145,7 @@ de:
         allow_multiple_membership: MEHRFACHE MITGLIEDSCHAFT
         assigns_visibility: SICHTBARKEIT
         assigns_workflow: WORKFLOW
+        badge_color: Abzeichen Farbe
         brandable: HERVORHEBBAR (MARKE)
         description: Typbeschreibung
         discoverable: EINSEHBAR

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -196,10 +196,10 @@ en:
           not_empty: Collection type cannot be altered as it has collections
         form:
           tab:
+            appearance: Badge Color
             metadata: Description
             participants: Participants
             settings: Settings
-            appearance: Badge Color
         form_participant_table:
           creators:
             action: Action
@@ -216,9 +216,9 @@ en:
             title: Managers
             type: Type
         form_participants:
+          add_group: Add group
           add_participants: Add Participants
-          add_group: 'Add group'
-          add_user: 'Add user'
+          add_user: Add user
           current_participants: Current Participants
           header: Collection Participants
           instructions: You can designate both groups and users as creators and managers of collections of this type
@@ -246,7 +246,7 @@ en:
             name: Name
         multiple_membership_checker:
           error_preamble: 'Error: You have specified more than one of the same single-membership collection type '
-          error_type_and_collections: '(type: %{type}, collections: %{collections})'
+          error_type_and_collections: "(type: %{type}, collections: %{collections})"
         new:
           header: Create New Collection Type
           submit: Save
@@ -703,11 +703,11 @@ en:
           description: 'Description:'
           edit_access: 'Edit Access:'
           groups: 'Groups:'
-          users: 'Users:'
           managed_access:
-            manage:  'Manage'
-            deposit: 'Deposit'
-            view:    'View'
+            deposit: Deposit
+            manage: Manage
+            view: View
+          users: 'Users:'
         collections: Collections
         facet_label:
           collections: 'Filter collections:'
@@ -715,8 +715,8 @@ en:
           shared: 'Filter shares:'
           works: 'Filter works:'
         heading:
-          action: Actions
           access: Access
+          action: Actions
           collection_type: Collection Type
           date_modified: Last Modified
           date_uploaded: Date Added
@@ -745,9 +745,9 @@ en:
         removed_relationship: "'%{child_title}' has been removed from '%{parent_title}'"
       no_activity: User has no recent activity
       no_notifications: User has no notifications
+      no_proxies: There are no proxies assigned
       no_transfer_requests: You haven't received any work transfer requests
       no_transfers: You haven't transferred any work
-      no_proxies: There are no proxies assigned
       proxy_activity: Proxy Activity
       proxy_delete: Delete Proxy
       proxy_help: Select a user who can deposit works on your behalf. You will be the owner of works that this user deposits for you. You can revoke a proxy by clicking the Delete Proxy button.
@@ -830,7 +830,7 @@ en:
           video_link: Download video
     file_sets:
       groups_description:
-        description_html: 'The list of groups in the drop-down marked "Select a group" is a list of User Managed Groups that you are a member of.  You may select a specific group and assign an access level for a file within %{application_name}, similarly to adding user access levels.'
+        description_html: The list of groups in the drop-down marked "Select a group" is a list of User Managed Groups that you are a member of.  You may select a specific group and assign an access level for a file within %{application_name}, similarly to adding user access levels.
     help:
       header: User Support
       override_text: Use app/views/static/help.html.erb to override this file.

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -171,7 +171,6 @@ es:
           header: Crear Nuevo Conjunto Administrativo
         show:
           breadcrumb: Ver Conjunto
-          confirm_delete: "¿Está seguro de que desea eliminar este conjunto administrativo? Esta acción no se puede deshacer."
           header: Conjunto Administrativo
           item_list_header: Trabajos en este conjunto
         show_actions:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -49,6 +49,8 @@ es:
         new: Nueva Colección
       delete: Borrar
       edit: Editar
+      less: Menos
+      more: Más
       refresh: Refrescar
       remove: retirar
       work:
@@ -172,6 +174,8 @@ es:
           confirm_delete: "¿Está seguro de que desea eliminar este conjunto administrativo? Esta acción no se puede deshacer."
           header: Conjunto Administrativo
           item_list_header: Trabajos en este conjunto
+        show_actions:
+          confirm_delete: "¿Estás seguro de que deseas eliminar este conjunto administrativo? Esta acción no se puede deshacer."
       appearances:
         show:
           header: Apariencia
@@ -193,6 +197,7 @@ es:
           not_empty: El tipo de colección no se puede modificar ya que tiene colecciones
         form:
           tab:
+            appearance: Insignia de color
             metadata: Descripción
             participants: Participantes
             settings: Configuraciones
@@ -212,7 +217,9 @@ es:
             title: Gerentes
             type: Tipo
         form_participants:
+          add_group: Añadir grupo
           add_participants: Agregar participantes
+          add_user: Agregar usuario
           current_participants: Participantes actuales
           header: Participantes de la colección
           instructions: Puede designar grupos y usuarios como creadores y administradores de colecciones de este tipo
@@ -240,6 +247,7 @@ es:
             name: Nombre
         multiple_membership_checker:
           error_preamble: 'Error: ha especificado más de uno de los mismos tipos de colección de membresía única'
+          error_type_and_collections: "(tipo: %{type}, colecciones: %{collections})"
         new:
           header: Crear nuevo tipo de colección
           submit: Salvar
@@ -695,6 +703,10 @@ es:
           description: 'Descripción:'
           edit_access: 'Editar Acceso:'
           groups: 'Grupos:'
+          managed_access:
+            deposit: Depositar
+            manage: Gestionar
+            view: Ver
           users: 'Usuarios:'
         collections: Mis Colecciones
         facet_label:
@@ -703,6 +715,7 @@ es:
           shared: 'Filtrar archivos compartidos:'
           works: 'Filtrar trabajos:'
         heading:
+          access: Acceso
           action: Acciones
           collection_type: Tipo de colección
           date_modified: Última modificación
@@ -732,6 +745,7 @@ es:
         removed_relationship: "'%{child_title}' ha sido eliminado de '%{parent_title}'"
       no_activity: El usuario no tiene actividad reciente
       no_notifications: El usuario no tiene notificaciones
+      no_proxies: No hay proxies asignados
       no_transfer_requests: No ha recibido ninguna petición de transferencia
       no_transfers: No ha transferido ningún trabajo
       proxy_activity: Actividad de Proxy
@@ -1131,6 +1145,7 @@ es:
         allow_multiple_membership: MIEMBROS MÚLTIPLES
         assigns_visibility: VISIBILIDAD
         assigns_workflow: FLUJO DE TRABAJO
+        badge_color: Insignia de color
         brandable: MARCA
         description: Descripción del tipo
         discoverable: DESCUBRIMIENTO

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -49,6 +49,8 @@ fr:
         new: Nouvelle collection
       delete: Effacer
       edit: modifier
+      less: Moins
+      more: Plus
       refresh: Rafraîchir
       remove: Retirer
       work:
@@ -172,6 +174,8 @@ fr:
           confirm_delete: Êtes-vous sûr de vouloir supprimer ce Set administratif? Cette action ne peut pas être annulée.
           header: Ensemble administratif
           item_list_header: Fonctionne dans cet ensemble
+        show_actions:
+          confirm_delete: Êtes-vous sûr de vouloir supprimer cet ensemble administratif? Cette action ne peut pas être annulée.
       appearances:
         show:
           header: Apparence
@@ -193,6 +197,7 @@ fr:
           not_empty: Le type de collection ne peut pas être modifié car il a des collections
         form:
           tab:
+            appearance: Couleur du badge
             metadata: La description
             participants: Participants
             settings: Paramètres
@@ -212,7 +217,9 @@ fr:
             title: Les gestionnaires
             type: Type
         form_participants:
+          add_group: Ajouter un groupe
           add_participants: Ajouter des participants
+          add_user: Ajouter un utilisateur
           current_participants: Participants actuels
           header: Participants à la collecte
           instructions: Vous pouvez désigner des groupes et des utilisateurs en tant que créateurs et gestionnaires de collections de ce type
@@ -240,6 +247,7 @@ fr:
             name: prénom
         multiple_membership_checker:
           error_preamble: 'Erreur: vous avez spécifié plusieurs des mêmes types de collection de membres uniques'
+          error_type_and_collections: "(type: %{type}, collections: %{collections})"
         new:
           header: Créer un nouveau type de collection
           submit: sauvegarder
@@ -696,6 +704,10 @@ fr:
           description: 'La description:'
           edit_access: 'Modifier l''accès:'
           groups: 'Groupes:'
+          managed_access:
+            deposit: Dépôt
+            manage: Gérer
+            view: Vue
           users: 'Utilisateurs:'
         collections: Vos collections
         facet_label:
@@ -704,6 +716,7 @@ fr:
           shared: 'Filtrer les actions:'
           works: 'Le filtre fonctionne:'
         heading:
+          access: Accès
           action: Actes
           collection_type: Type de collection
           date_modified: Dernière modification
@@ -733,6 +746,7 @@ fr:
         removed_relationship: "'%{child_title}' a été retiré de '%{parent_title}'"
       no_activity: L'utilisateur n'a aucune activité récente
       no_notifications: L'utilisateur n'a pas de notification
+      no_proxies: Il n'y a pas de proxy attribués
       no_transfer_requests: Vous n'avez reçu aucune demande de transfert de travail
       no_transfers: Vous n'avez transféré aucun travail
       proxy_activity: Activité de procuration
@@ -1130,6 +1144,7 @@ fr:
         allow_multiple_membership: MEMBRES MULTIPLES
         assigns_visibility: VISIBILITÉ
         assigns_workflow: FLUX DE TRAVAIL
+        badge_color: Couleur du badge
         brandable: L'IMAGE DE MARQUE
         description: Description du type
         discoverable: DÉCOUVERTE

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -171,7 +171,6 @@ fr:
           header: Créer un nouvel ensemble administratif
         show:
           breadcrumb: Ensemble de vues
-          confirm_delete: Êtes-vous sûr de vouloir supprimer ce Set administratif? Cette action ne peut pas être annulée.
           header: Ensemble administratif
           item_list_header: Fonctionne dans cet ensemble
         show_actions:

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -49,6 +49,8 @@ it:
         new: Nuova collezione
       delete: Elimina
       edit: Modifica
+      less: Di meno
+      more: Di Più
       refresh: ricaricare
       remove: Rimuovere
       work:
@@ -172,6 +174,8 @@ it:
           confirm_delete: Sei sicuro di voler eliminare questo set amministrativo? Questa azione non può essere annullata.
           header: Impostazione amministrativa
           item_list_header: Funziona in questo set
+        show_actions:
+          confirm_delete: Sei sicuro di voler eliminare questo set amministrativo? Questa azione non può essere annullata.
       appearances:
         show:
           header: Aspetto
@@ -193,6 +197,7 @@ it:
           not_empty: Il tipo di raccolta non può essere modificato in quanto ha collezioni
         form:
           tab:
+            appearance: Colore distintivo
             metadata: Descrizione
             participants: I partecipanti
             settings: impostazioni
@@ -212,7 +217,9 @@ it:
             title: I gestori
             type: genere
         form_participants:
+          add_group: Aggiungere gruppo
           add_participants: Aggiungi partecipanti
+          add_user: Aggiungi utente
           current_participants: Partecipanti attuali
           header: Partecipanti alla raccolta
           instructions: Puoi designare sia gruppi che utenti come creatori e gestori di raccolte di questo tipo
@@ -240,6 +247,7 @@ it:
             name: Nome
         multiple_membership_checker:
           error_preamble: 'Errore: hai specificato più di uno degli stessi tipi di raccolta a membro singolo'
+          error_type_and_collections: "(tipo: %{type}, collezioni: %{collections})"
         new:
           header: Crea un nuovo tipo di raccolta
           submit: Salvare
@@ -695,6 +703,10 @@ it:
           description: 'Descrizione:'
           edit_access: 'Modifica accesso:'
           groups: 'gruppi:'
+          managed_access:
+            deposit: Depositare
+            manage: Gestire
+            view: vista
           users: 'utenti:'
         collections: Le tue collezioni
         facet_label:
@@ -703,6 +715,7 @@ it:
           shared: 'Condivisione di filtri:'
           works: 'Funzioni di filtro:'
         heading:
+          access: Accesso
           action: Azioni
           collection_type: Tipo di raccolta
           date_modified: Ultima modifica
@@ -732,6 +745,7 @@ it:
         removed_relationship: "'%{child_title}' è stato rimosso da '%{parent_title}'"
       no_activity: L'utente non ha attività recenti
       no_notifications: L'utente non ha notifiche
+      no_proxies: Non ci sono proxy assegnati
       no_transfer_requests: Non hai ricevuto richieste di trasferimento di lavoro
       no_transfers: Non hai trasferito alcun lavoro
       proxy_activity: Attività proxy
@@ -1129,6 +1143,7 @@ it:
         allow_multiple_membership: MULTIPLE MEMBERSHIP
         assigns_visibility: VISIBILITÀ
         assigns_workflow: FLUSSO DI LAVORO
+        badge_color: Colore distintivo
         brandable: IL BRANDING
         description: Tipo descrizione
         discoverable: SCOPERTA

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -171,7 +171,6 @@ it:
           header: Crea nuovo set amministrativo
         show:
           breadcrumb: Visualizza set
-          confirm_delete: Sei sicuro di voler eliminare questo set amministrativo? Questa azione non può essere annullata.
           header: Impostazione amministrativa
           item_list_header: Funziona in questo set
         show_actions:

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -49,6 +49,8 @@ pt-BR:
         new: Nova coleção
       delete: Excluir
       edit: Editar
+      less: Menos
+      more: Mais
       refresh: Atualizar
       remove: Remover
       work:
@@ -172,6 +174,8 @@ pt-BR:
           confirm_delete: Tem certeza de que deseja excluir este conjunto administrativo? Essa ação não pode ser desfeita.
           header: Conjunto Administrativo
           item_list_header: Funciona neste conjunto
+        show_actions:
+          confirm_delete: Tem certeza de que deseja excluir este conjunto administrativo? Essa ação não pode ser desfeita.
       appearances:
         show:
           header: Aparência
@@ -193,6 +197,7 @@ pt-BR:
           not_empty: O tipo de coleção não pode ser alterado, pois tem coleções
         form:
           tab:
+            appearance: Cor do Emblema
             metadata: Descrição
             participants: Participantes
             settings: Configurações
@@ -212,7 +217,9 @@ pt-BR:
             title: Gerentes
             type: Tipo
         form_participants:
+          add_group: Adicionar grupo
           add_participants: Adicione participantes
+          add_user: Adicionar usuário
           current_participants: Participantes atuais
           header: Participantes da coleção
           instructions: Você pode designar grupos e usuários como criadores e gerentes de coleções desse tipo
@@ -240,6 +247,7 @@ pt-BR:
             name: Nome
         multiple_membership_checker:
           error_preamble: 'Erro: você especificou mais do que um dos mesmos tipos de coleção de associação única'
+          error_type_and_collections: "(tipo: %{type}, coleções: %{collections})"
         new:
           header: Criar novo tipo de coleção
           submit: Salve 
@@ -690,6 +698,10 @@ pt-BR:
           description: 'Descrição:'
           edit_access: 'Editar acesso:'
           groups: 'Grupos:'
+          managed_access:
+            deposit: Depósito
+            manage: Gerir
+            view: Visão
           users: 'Comercial:'
         collections: Suas coleções
         facet_label:
@@ -698,6 +710,7 @@ pt-BR:
           shared: 'Compartilhamento de filtro:'
           works: 'Filtro funciona:'
         heading:
+          access: Acesso
           action: Ações
           collection_type: Tipo de Coleção
           date_modified: Última modificação
@@ -727,6 +740,7 @@ pt-BR:
         removed_relationship: "'%{child_title}' foi removido de '%{parent_title}'"
       no_activity: O usuário não tem atividade recente
       no_notifications: O usuário não possui notificações
+      no_proxies: Não há proxies designados
       no_transfer_requests: Você não recebeu nenhum pedido de transferência de trabalho
       no_transfers: Você não transferiu nenhum trabalho
       proxy_activity: Atividade de proxy
@@ -1124,6 +1138,7 @@ pt-BR:
         allow_multiple_membership: MEMBROS MÚLTIPLOS
         assigns_visibility: VISIBILIDADE
         assigns_workflow: FLUXO DE TRABALHO
+        badge_color: Cor do Emblema
         brandable: MARCA
         description: Descrição do tipo
         discoverable: DESCOBERTA

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -171,7 +171,6 @@ pt-BR:
           header: Criar novo conjunto administrativo
         show:
           breadcrumb: Conjunto de imagens
-          confirm_delete: Tem certeza de que deseja excluir este conjunto administrativo? Essa ação não pode ser desfeita.
           header: Conjunto Administrativo
           item_list_header: Funciona neste conjunto
         show_actions:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -171,7 +171,6 @@ zh:
           header: 创建新的管理集
         show:
           breadcrumb: 观看集
-          confirm_delete: 确定要删除吗？删除后不可复原。
           header: 管理集
           item_list_header: 集内作品
         show_actions:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -49,6 +49,8 @@ zh:
         new: 新收藏集
       delete: 删除
       edit: 编辑
+      less: 减
+      more: 更多
       refresh: 刷新
       remove: 去掉
       work:
@@ -172,6 +174,8 @@ zh:
           confirm_delete: 确定要删除吗？删除后不可复原。
           header: 管理集
           item_list_header: 集内作品
+        show_actions:
+          confirm_delete: 您确定要删除此管理集？此操作无法撤消。
       appearances:
         show:
           header: 表面
@@ -193,6 +197,7 @@ zh:
           not_empty: 集合类型不能更改，因为它具有集合
         form:
           tab:
+            appearance: 徽章颜色
             metadata: 描述
             participants: 参与者
             settings: 设置
@@ -212,7 +217,9 @@ zh:
             title: 经理
             type: 类型
         form_participants:
+          add_group: 添加组
           add_participants: 添加参与者
+          add_user: 添加用户
           current_participants: 当前参与者
           header: 收藏参与者
           instructions: 您可以将这两个组和用户指定为此类集合的创建者和管理者
@@ -240,6 +247,7 @@ zh:
             name: 名称
         multiple_membership_checker:
           error_preamble: 错误：您指定了多个相同的单一成员资格集合类型
+          error_type_and_collections: "（类型：%{type}，集合：%{collections}）"
         new:
           header: 创建新的集合类型
           submit: 保存
@@ -693,6 +701,10 @@ zh:
           description: 描述：
           edit_access: 编辑访问：
           groups: '群:'
+          managed_access:
+            deposit: 存款
+            manage: 管理
+            view: 视图
           users: '用户:'
         collections: 你的收藏集
         facet_label:
@@ -701,6 +713,7 @@ zh:
           shared: '筛选您的分享:'
           works: '筛选作品:'
         heading:
+          access: 访问
           action: 行动
           collection_type: 集合类型
           date_modified: 上一次更改
@@ -730,6 +743,7 @@ zh:
         removed_relationship: "'%{child_title}'已从'%{parent_title}'中删除"
       no_activity: 用户最近没有活动
       no_notifications: 用户没有收到通知
+      no_proxies: 没有代理分配
       no_transfer_requests: 您没有收到任何在作品转让请求
       no_transfers: 您没有转让任何作品
       proxy_activity: 代理活动
@@ -1127,6 +1141,7 @@ zh:
         allow_multiple_membership: 多会员
         assigns_visibility: 能见度
         assigns_workflow: 工作流程
+        badge_color: 徽章颜色
         brandable: 品牌
         description: 类型描述
         discoverable: 发现

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,31 +1,10 @@
+---
 en:
   simple_form:
     error_notification:
-      default_message: "Please review the problems below:"
-    # Examples
-    # labels:
-    #   defaults:
-    #     password: 'Password'
-    #   user:
-    #     new:
-    #       email: 'E-mail to sign in.'
-    #     edit:
-    #       email: 'E-mail.'
-    # hints:
-    #   defaults:
-    #     username: 'User name to sign in.'
-    #     password: 'No special characters, please.'
-    # include_blanks:
-    #   defaults:
-    #     age: 'Rather not say'
-    # prompts:
-    #   defaults:
-    #     age: 'Select your age'
-    "no": 'No'
+      default_message: 'Please review the problems below:'
+    'no': 'No'
     required:
-      mark: '*'
-      # You can uncomment the line below if you need to overwrite the whole required html.
-      # When using html, text and mark won't be used.
-      # html: '<abbr title="required">*</abbr>'
-      text: 'required'
-    "yes": 'Yes'
+      mark: "*"
+      text: required
+    'yes': 'Yes'

--- a/lib/generators/hyrax/templates/config/locales/hyrax.en.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.en.yml
@@ -1,3 +1,4 @@
+---
 en:
   blacklight:
     search:
@@ -45,13 +46,13 @@ en:
           subject_tesim: Subject
           title_tesim: Title
   hyrax:
-    account_name:           "My Institution Account Id"
+    account_name: My Institution Account Id
     directory:
-      suffix:               "@example.org"
+      suffix: "@example.org"
     footer:
       copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
-    institution_name:       "Institution"
-    institution_name_full:  "The Institution Name"
-    product_name:           "Hyrax"
+    institution_name: Institution
+    institution_name_full: The Institution Name
+    product_name: Hyrax
     product_twitter_handle: "@SamveraRepo"

--- a/spec/controllers/hyrax/admin/strategies_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/strategies_controller_spec.rb
@@ -1,14 +1,20 @@
 RSpec.describe Hyrax::Admin::StrategiesController do
   describe "#update" do
     before do
+      # Added when Flipflop bumped to 2.3.2. See also https://github.com/voormedia/flipflop/issues/26
+      features_hash = Flipflop::FeatureSet.current.instance_variable_get(:@features)
+      Flipflop::FeatureSet.current.instance_variable_set(:@features, features_hash.merge(feature_id => feature))
+
       sign_in user
     end
     let(:user) { create(:user) }
     let(:strategy) { Flipflop::Strategies::ActiveRecordStrategy.new(class: Hyrax::Feature).key }
+    let(:feature) { double('feature', id: feature_id, key: 'foo') }
+    let(:feature_id) { :my_feature }
 
     context "when not authorized" do
       it "redirects away" do
-        patch :update, params: { feature_id: '123', id: strategy }
+        patch :update, params: { feature_id: feature.id, id: strategy }
         expect(response).to redirect_to root_path
       end
     end
@@ -20,7 +26,7 @@ RSpec.describe Hyrax::Admin::StrategiesController do
       end
 
       it "is successful" do
-        patch :update, params: { feature_id: '123', id: strategy }
+        patch :update, params: { feature_id: feature.id, id: strategy }
         expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.admin_features_path(locale: 'en')
       end
     end

--- a/spec/controllers/hyrax/admin/strategies_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/strategies_controller_spec.rb
@@ -2,11 +2,16 @@ RSpec.describe Hyrax::Admin::StrategiesController do
   describe "#update" do
     before do
       # Added when Flipflop bumped to 2.3.2. See also https://github.com/voormedia/flipflop/issues/26
-      features_hash = Flipflop::FeatureSet.current.instance_variable_get(:@features)
-      Flipflop::FeatureSet.current.instance_variable_set(:@features, features_hash.merge(feature_id => feature))
+      Flipflop::FeatureSet.current.instance_variable_set(:@features, original_feature_hash.merge(feature_id => feature))
 
       sign_in user
     end
+
+    after do
+      Flipflop::FeatureSet.current.instance_variable_set(:@features, original_feature_hash)
+    end
+
+    let(:original_feature_hash) { Flipflop::FeatureSet.current.instance_variable_get(:@features) }
     let(:user) { create(:user) }
     let(:strategy) { Flipflop::Strategies::ActiveRecordStrategy.new(class: Hyrax::Feature).key }
     let(:feature) { double('feature', id: feature_id, key: 'foo') }


### PR DESCRIPTION
Ran the google translate API on untranslated keys.

Changes proposed in this pull request:
* Add `i18n-tasks` gem as development dependency
* Update translations for 2.1.0
* Remove unused translations

@samvera/hyrax-code-reviewers
