### PR TITLE
Fix the Admin::StrategiesController spec

### DIFF
--- a/spec/controllers/hyrax/admin/strategies_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/strategies_controller_spec.rb
@@ -3,14 +3,25 @@ require 'spec_helper'
 RSpec.describe Hyrax::Admin::StrategiesController do
   describe "#update" do
     before do
+      # Added when Flipflop bumped to 2.3.2. See also https://github.com/voormedia/flipflop/issues/26
+      Flipflop::FeatureSet.current.instance_variable_set(:@features, original_feature_hash.merge(feature_id => feature))
+
       sign_in user
     end
+
+    after do
+      Flipflop::FeatureSet.current.instance_variable_set(:@features, original_feature_hash)
+    end
+
+    let(:original_feature_hash) { Flipflop::FeatureSet.current.instance_variable_get(:@features) }
     let(:user) { create(:user) }
     let(:strategy) { Flipflop::Strategies::ActiveRecordStrategy.new(class: Hyrax::Feature).key }
+    let(:feature) { double('feature', id: feature_id, key: 'foo') }
+    let(:feature_id) { :my_feature }
 
     context "when not authorized" do
       it "redirects away" do
-        patch :update, params: { feature_id: '123', id: strategy }
+        patch :update, params: { feature_id: feature.id, id: strategy }
         expect(response).to redirect_to root_path
       end
     end
@@ -22,7 +33,7 @@ RSpec.describe Hyrax::Admin::StrategiesController do
       end
 
       it "is successful" do
-        patch :update, params: { feature_id: '123', id: strategy }
+        patch :update, params: { feature_id: feature.id, id: strategy }
         expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.admin_features_path(locale: 'en')
       end
     end


### PR DESCRIPTION
The 2.3.2 release of Flipflop broke this spec (probably our fault). See https://github.com/voormedia/flipflop/issues/26.

Mock a Flipflop feature and inject it into the current Flipflop::FeatureSet to prevent this spec failure

See also: #2968

@samvera/hyrax-code-reviewers
