### PR TITLE
Hide UniversalViewer when representative isn't an image

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -57,7 +57,10 @@ module Hyrax
 
     # @return [Boolean] render the UniversalViewer
     def universal_viewer?
-      Hyrax.config.iiif_image_server? &&
+      representative_id.present? &&
+        representative_presenter.present? &&
+        representative_presenter.image? &&
+        Hyrax.config.iiif_image_server? &&
         members_include_viewable_image?
     end
 

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
     let(:id_present) { false }
     let(:representative_presenter) { double('representative', present?: false) }
     let(:image_boolean) { false }
-    let(:iiif_enabled) { false }
+    let(:iiif_enabled) { true }
     let(:file_set_presenter) { Hyrax::FileSetPresenter.new(solr_document, ability) }
     let(:file_set_presenters) { [file_set_presenter] }
     let(:read_permission) { true }
@@ -77,7 +77,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
     context 'with non-image representative_presenter' do
       let(:id_present) { true }
       let(:representative_presenter) { double('representative', present?: true) }
-      let(:image_boolean) { true }
+      let(:image_boolean) { false }
 
       it { is_expected.to be false }
     end


### PR DESCRIPTION
Fixes #2965

Reverts a change made in #2846 that allowed the UV to show when the representative file isn't an image.

Also fixes a bug in the WorkShowPresenter specs that allowed some tests to pass when they shouldn't.

@samvera/hyrax-code-reviewers
