### PR TITLE
appends collection_type_id to existing or non-existent querystring

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -20,6 +20,15 @@ module Hyrax
       content_tag :span, safe_join([t('hyrax.collection.is_part_of'), ': '] + collection_links)
     end
 
+    ##
+    # Append a collection_type_id to the existing querystring (whether or not it has pre-existing params)
+    # @return [String] the original url with and added collection_type_id param
+    def append_collection_type_url(url, collection_type_id)
+      uri = URI.parse(url)
+      uri.query = [uri.query, "collection_type_id=#{collection_type_id}"].compact.join('&')
+      uri.to_s
+    end
+
     # @return [Boolean]
     def has_collection_search_parameters?
       params[:cq].present?

--- a/app/views/hyrax/my/collections/_modal_collection_types_to_create.html.erb
+++ b/app/views/hyrax/my/collections/_modal_collection_types_to_create.html.erb
@@ -16,7 +16,7 @@
                 <% if row_presenter.admin_set? %>
                   data-path="<%= new_admin_admin_set_path %>"
                 <% else %>
-                  data-path="<%= "#{new_dashboard_collection_path}&collection_type_id=#{row_presenter.id}" %>"
+                  data-path="<%= append_collection_type_url(new_dashboard_collection_path, row_presenter.id) %>"
                 <% end %> />
                 <h4><%= row_presenter.title %></h4>
                 <p><%= row_presenter.description %></p>

--- a/app/views/hyrax/my/collections/index.html.erb
+++ b/app/views/hyrax/my/collections/index.html.erb
@@ -33,7 +33,7 @@
         </button>
       <% else @collection_type_list_presenter.any? %>
         <% # link directly to create collection form with type %>
-        <%= link_to(t('helpers.action.collection.new'), "#{new_dashboard_collection_path}&collection_type_id=#{@collection_type_list_presenter.first_collection_type.id}", class: 'btn btn-primary') %>
+        <%= link_to(t('helpers.action.collection.new'), append_collection_type_url(new_dashboard_collection_path, @collection_type_list_presenter.first_collection_type.id), class: 'btn btn-primary') %>
       <% end %>
     <% end %>
   </section>

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -256,6 +256,11 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         expect(page).to have_content title
         expect(page).to have_content description
       end
+
+      it "has properly formed collection type buttons" do
+        expect(page).not_to have_selector("input[data-path$='collections/new&collection_type_id=1']")
+        expect(page).to have_selector("input[data-path$='collections/new?locale=en&collection_type_id=1']")
+      end
     end
 
     context 'when user can create collections of one type' do

--- a/spec/helpers/hyrax/collections_helper_spec.rb
+++ b/spec/helpers/hyrax/collections_helper_spec.rb
@@ -98,4 +98,20 @@ RSpec.describe Hyrax::CollectionsHelper do
       end
     end
   end
+
+  describe '#append_collection_type_url' do
+    let(:url) { "http://example.com" }
+    context "when a provided url has no querystring" do
+      it 'returns the url with added collection_type_id' do
+        expect(append_collection_type_url(url, '1')).to eq "#{url}?collection_type_id=1"
+      end
+    end
+
+    context "when a provided url has an existing querystring" do
+      let(:url) { "http://example.com?bob=ross" }
+      it 'return the url with added collection_type_id' do
+        expect(append_collection_type_url(url, '1')).to eq "#{url}&collection_type_id=1"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2927 

Appends the collection_type_id parameter without assuming the querystring includes any other preset parameters.


@samvera/hyrax-code-reviewers
