### PR TITLE
breaks very long metadata field values on show page

### DIFF
--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -52,6 +52,12 @@ ul.tabular {
 .work-type {
   margin-bottom: 18px;
   margin-top: -8px;
+  .panel-body {
+    .work_description,
+    li.attribute {
+      word-break: break-word;
+    }
+  }
 }
 
 .panel-workflow {

--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -4,7 +4,8 @@
   }
 }
 
-.no-preview, .social-media {
+.no-preview,
+.social-media {
   padding: $panel-body-padding;
 }
 
@@ -17,7 +18,8 @@ header > h1 .label {
   padding: $panel-body-padding;
 }
 
-.relationships, .attributes {
+.relationships,
+.attributes {
   tbody th {
     width: 20%;
   }
@@ -52,6 +54,7 @@ ul.tabular {
 .work-type {
   margin-bottom: 18px;
   margin-top: -8px;
+
   .panel-body {
     .work_description,
     li.attribute {


### PR DESCRIPTION
Fixes #2976 

A few basic rules to break words and maintain the layout of the page. See example screenshot:

![screen shot 2018-04-27 at 1 29 29 pm](https://user-images.githubusercontent.com/32885/39383701-1cf727d0-4a1f-11e8-9f81-4856e5cb793f.png)


@samvera/hyrax-code-reviewers
