### PR TITLE
Use collection title in delete confirmation

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -149,11 +149,12 @@ module Hyrax
         end
       end
 
-      def after_destroy(id)
+      def after_destroy(_id)
+        # leaving id to avoid changing the method's parameters prior to release
         respond_to do |format|
           format.html do
             redirect_to my_collections_path,
-                        notice: t('hyrax.dashboard.my.action.collection_delete_success', id: id)
+                        notice: t('hyrax.dashboard.my.action.collection_delete_success')
           end
           format.json { head :no_content, location: my_collections_path }
         end
@@ -162,7 +163,7 @@ module Hyrax
       def after_destroy_error(id)
         respond_to do |format|
           format.html do
-            flash[:notice] = t('hyrax.dashboard.my.action.collection_delete_fail', id: id)
+            flash[:notice] = t('hyrax.dashboard.my.action.collection_delete_fail')
             render :edit, status: :unprocessable_entity
           end
           format.json { render json: { id: id }, status: :unprocessable_entity, location: dashboard_collection_path(@collection) }

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -670,8 +670,8 @@ de:
           add_to_collection_only: Erlaubte Aktionen sind auf das Hinzufügen von Mitgliedern beschränkt
           admin_set_confirmation: Löschen eines Admin-Set von %{application_name} ist dauerhaft. Klicken Sie auf OK, um dieses Admin-Set aus %{application_name} zu löschen, oder auf Abbrechen, um diesen Vorgang abzubrechen
           collection_create_success: Die Sammlung wurde erfolgreich erstellt.
-          collection_delete_fail: Sammlung %{id} konnte nicht gelöscht werden
-          collection_delete_success: Sammlung %{id} wurde erfolgreich gelöscht
+          collection_delete_fail: Sammlung konnte nicht gelöscht werden
+          collection_delete_success: Sammlung wurde erfolgreich gelöscht
           collection_deny_add_members: Sie verfügen nicht über ausreichende Berechtigungen zum Hinzufügen von Mitgliedern zur Sammlung
           collection_update_success: Die Sammlung wurde erfolgreich aktualisiert.
           collections_confirmation_html: "<span class='pluralized'>Diese Sammlung</span> löschen , wird permanent <span class='pluralized'>diese Sammlung</span> aus dem Repository entfernen. Elemente in <span class='pluralized'>dieser Sammlung</span> verbleiben im Repository. Möchten Sie <span class='pluralized'>diese Sammlung</span> wirklich löschen?"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -669,8 +669,8 @@ en:
           add_to_collection_only: Allowed actions are limited to adding members
           admin_set_confirmation: Deleting an admin set from %{application_name} is permanent. Click OK to delete this admin set from %{application_name}, or Cancel to cancel this operation
           collection_create_success: Collection was successfully created.
-          collection_delete_fail: Collection %{id} could not be deleted
-          collection_delete_success: Collection %{id} was successfully deleted
+          collection_delete_fail: Collection could not be deleted
+          collection_delete_success: Collection was successfully deleted
           collection_deny_add_members: You do not have sufficient privileges to add members to the collection
           collection_update_success: Collection was successfully updated.
           collections_confirmation_html: Deleting <span class='pluralized'>this collection</span> will permanently remove <span class='pluralized'>this collection</span> from the repository.  Items in <span class='pluralized'>this collection</span> will remain in the repository.  Are you sure you want to delete <span class='pluralized'>this collection</span>?

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -668,8 +668,8 @@ es:
           add_to_collection_only: Las acciones permitidas están limitadas a agregar miembros
           admin_set_confirmation: La eliminación de un conjunto de administración de %{application_name} es permanente. Haga clic en Aceptar para eliminar este conjunto de administrador de %{application_name}, o en Cancelar para cancelar esta operación
           collection_create_success: La colección fue creada con éxito.
-          collection_delete_fail: Colección %{id} no se pudo eliminar
-          collection_delete_success: Colección %{id} fue eliminada exitosamente
+          collection_delete_fail: Colección no se pudo eliminar
+          collection_delete_success: Colección fue eliminada exitosamente
           collection_deny_add_members: No tiene suficientes privilegios para agregar miembros a la colección
           collection_update_success: La colección fue actualizada con éxito.
           collections_confirmation_html: Eliminar <span class='pluralized'>esta colección</span> eliminará permanentemente <span class='pluralized'>esta colección</span> del repositorio. Los elementos de <span class='pluralized'>esta colección</span> permanecerán en el repositorio. ¿Seguro que quieres eliminar <span class='pluralized'>esta colección</span> ?

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -669,8 +669,8 @@ fr:
           add_to_collection_only: Les actions autorisées sont limitées à l'ajout de membres
           admin_set_confirmation: La suppression d'un ensemble d'administrateurs à partir de %{application_name} est permanente. Cliquez sur OK pour supprimer cet ensemble d'administrateurs de %{application_name}, ou sur Annuler pour annuler cette opération
           collection_create_success: La collection a été créée avec succès.
-          collection_delete_fail: La collection %{id} n'a pas pu être supprimée
-          collection_delete_success: La collection %{id} a été supprimée avec succès
+          collection_delete_fail: La collection n'a pas pu être supprimée
+          collection_delete_success: La collection a été supprimée avec succès
           collection_deny_add_members: Vous n'avez pas les privilèges suffisants pour ajouter des membres à la collection
           collection_update_success: La collection a été mise à jour avec succès.
           collections_confirmation_html: La suppression de <span class='pluralized'>cette collection</span> supprimera définitivement <span class='pluralized'>cette collection</span> du référentiel. Les éléments de <span class='pluralized'>cette collection</span> resteront dans le référentiel. Êtes-vous sûr de vouloir supprimer <span class='pluralized'>cette collection</span> ?

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -668,8 +668,8 @@ it:
           add_to_collection_only: Le azioni consentite sono limitate all'aggiunta di membri
           admin_set_confirmation: L'eliminazione di un set di amministratori da %{application_name} è permanente. Fare clic su OK per eliminare questo set di amministratori da %{application_name}, o Annulla per annullare questa operazione
           collection_create_success: La raccolta è stata creata con successo.
-          collection_delete_fail: Collezione %{id} non può essere cancellata
-          collection_delete_success: La raccolta %{id} è stata cancellata con successo
+          collection_delete_fail: Collezione non può essere cancellata
+          collection_delete_success: La raccolta è stata cancellata con successo
           collection_deny_add_members: Non disponi di privilegi sufficienti per aggiungere membri alla raccolta
           collection_update_success: La raccolta è stata aggiornata con successo.
           collections_confirmation_html: L'eliminazione di <span class='pluralized'>questa raccolta</span> rimuove definitivamente <span class='pluralized'>questa raccolta</span> dal repository. Gli articoli di <span class='pluralized'>questa raccolta</span> rimarranno nel repository. Sei sicuro di voler eliminare <span class='pluralized'>questa raccolta</span> ?

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -663,8 +663,8 @@ pt-BR:
           add_to_collection_only: As ações permitidas estão limitadas à adição de membros
           admin_set_confirmation: Excluir um conjunto de administradores de %{application_name} é permanente. Clique em OK para excluir este conjunto de administrador de %{application_name} ou Cancelar para cancelar esta operação
           collection_create_success: A coleção foi criada com sucesso.
-          collection_delete_fail: Coleção %{id} não pôde ser excluída
-          collection_delete_success: Coleção %{id} foi excluída com sucesso
+          collection_delete_fail: Coleção não pôde ser excluída
+          collection_delete_success: Coleção foi excluída com sucesso
           collection_deny_add_members: Você não tem privilégios suficientes para adicionar membros à coleção
           collection_update_success: A coleção foi atualizada com sucesso.
           collections_confirmation_html: A exclusão <span class='pluralized'>dessa coleção</span> removerá permanentemente <span class='pluralized'>essa coleção</span> do repositório. Os itens <span class='pluralized'>desta coleção</span> permanecerão no repositório. Tem certeza de que deseja excluir <span class='pluralized'>esta coleção</span> ?

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -666,8 +666,8 @@ zh:
           add_to_collection_only: 允许的操作仅限于添加成员
           admin_set_confirmation: 从%{application_name}删除管理员集合是永久性的。单击确定从%{application_name}删除此管理集，或单击取消取消此操作
           collection_create_success: 收集已成功创建。
-          collection_delete_fail: 收藏%{id}无法删除
-          collection_delete_success: 收藏夹%{id}已成功删除
+          collection_delete_fail: 收藏无法删除
+          collection_delete_success: 收藏夹已成功删除
           collection_deny_add_members: 您没有足够的权限将成员添加到集合中
           collection_update_success: 收集已成功更新。
           collections_confirmation_html: 删除<span class='pluralized'>这个集合</span>将永久地从存储库中删除<span class='pluralized'>这个集合</span> 。 <span class='pluralized'>此集合中的</span>项目将保留在存储库中。你确定要删除<span class='pluralized'>这个集合</span>吗？

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         delete :destroy, params: { id: collection }
         expect(response).to have_http_status(:found)
         expect(response).to redirect_to(Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(flash[:notice]).to eq "Collection #{collection.id} was successfully deleted"
+        expect(flash[:notice]).to eq "Collection was successfully deleted"
       end
 
       it "returns json" do
@@ -419,7 +419,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         delete :destroy, params: { id: collection }
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(:edit)
-        expect(flash[:notice]).to eq "Collection #{collection.id} could not be deleted"
+        expect(flash[:notice]).to eq "Collection could not be deleted"
       end
 
       it "returns json" do

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -363,7 +363,9 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
       context 'and collection is empty' do
         it 'and user confirms delete, deletes the collection', :js do
-          expect(page).to have_content(empty_collection.title.first)
+          within("table#collections-list-table") do
+            expect(page).to have_content(empty_collection.title.first)
+          end
           check_tr_data_attributes(empty_collection.id, 'collection')
           # check that modal data attributes haven't been added yet
           expect(page).not_to have_selector("div[data-id='#{empty_collection.id}']")
@@ -376,11 +378,15 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           within("div#collection-empty-to-delete-modal") do
             click_button('Delete')
           end
-          expect(page).not_to have_content(empty_collection.title.first)
+          within("table#collections-list-table") do
+            expect(page).not_to have_content(empty_collection.title.first)
+          end
         end
 
         it 'and user cancels, does NOT delete the collection', :js do
-          expect(page).to have_content(empty_collection.title.first)
+          within("table#collections-list-table") do
+            expect(page).to have_content(collection.title.first)
+          end
           check_tr_data_attributes(empty_collection.id, 'collection')
           # check that modal data attributes haven't been added yet
           expect(page).not_to have_selector("div[data-id='#{empty_collection.id}']")
@@ -394,13 +400,17 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           within("div#collection-empty-to-delete-modal") do
             click_button('Cancel')
           end
-          expect(page).to have_content(empty_collection.title.first)
+          within("table#collections-list-table") do
+            expect(page).to have_content(collection.title.first)
+          end
         end
       end
 
       context 'and collection is not empty' do
         it 'and user confirms delete, deletes the collection', :js do
-          expect(page).to have_content(collection.title.first)
+          within("table#collections-list-table") do
+            expect(page).to have_content(collection.title.first)
+          end
           check_tr_data_attributes(collection.id, 'collection')
           within("#document_#{collection.id}") do
             first('button.dropdown-toggle').click
@@ -411,11 +421,15 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           within("div#collection-to-delete-modal") do
             find('button.modal-delete-button').click
           end
-          expect(page).not_to have_content(collection.title.first)
+          within("table#collections-list-table") do
+            expect(page).not_to have_content(collection.title.first)
+          end
         end
 
         it 'and user cancels, does NOT delete the collection', :js do
-          expect(page).to have_content(collection.title.first)
+          within("table#collections-list-table") do
+            expect(page).to have_content(collection.title.first)
+          end
           within("#document_#{collection.id}") do
             first('button.dropdown-toggle').click
             first('.itemtrash').click
@@ -425,7 +439,9 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           within("div#collection-to-delete-modal") do
             click_button('Cancel')
           end
-          expect(page).to have_content(collection.title.first)
+          within("table#collections-list-table") do
+            expect(page).to have_content(collection.title.first)
+          end
         end
       end
     end


### PR DESCRIPTION
Replace collection id with collection title in confirmation and error flash notices after collection deletion.

Completes https://github.com/samvera/hyrax/issues/2997

@samvera/hyrax-code-reviewers
