### PR TITLE
Fix Hyrax::FileSetFixityCheckService bug when fileset contains non-ve…

### DIFF
--- a/app/services/hyrax/file_set_fixity_check_service.rb
+++ b/app/services/hyrax/file_set_fixity_check_service.rb
@@ -78,7 +78,7 @@ module Hyrax
       def fixity_check_file(file)
         versions = file.has_versions? ? file.versions.all : [file]
 
-        versions = [versions.max_by(&:created)] if latest_version_only
+        versions = [versions.max_by(&:created)] if file.has_versions? && latest_version_only
 
         versions.collect { |v| fixity_check_file_version(file.id, v.uri.to_s) }.flatten
       end

--- a/spec/services/hyrax/file_set_fixity_check_service_spec.rb
+++ b/spec/services/hyrax/file_set_fixity_check_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Hyrax::FileSetFixityCheckService do
         let(:service_by_object) { described_class.new(f, async_jobs: false, latest_version_only: true) }
 
         before do
-          allow(f.original_file).to receive(:has_versions?) { false }
+          allow(f.original_file).to receive(:has_versions?).and_return(false)
         end
 
         subject { service_by_object.send(:fixity_check_file, f.original_file) }

--- a/spec/services/hyrax/file_set_fixity_check_service_spec.rb
+++ b/spec/services/hyrax/file_set_fixity_check_service_spec.rb
@@ -49,6 +49,19 @@ RSpec.describe Hyrax::FileSetFixityCheckService do
       specify 'returns a single result' do
         expect(subject.length).to eq(1)
       end
+      describe 'non-versioned file with latest version only' do
+        let(:service_by_object) { described_class.new(f, async_jobs: false, latest_version_only: true) }
+
+        before do
+          allow(f.original_file).to receive(:has_versions?) { false }
+        end
+
+        subject { service_by_object.send(:fixity_check_file, f.original_file) }
+
+        specify 'returns a single result' do
+          expect(subject.length).to eq(1)
+        end
+      end
     end
 
     describe '#fixity_check_file_version' do


### PR DESCRIPTION
…rsioned files; fixes #3000.

Fixes #3000 

Fixes Hyrax::FileSetFixityCheckService bug.

Hyrax::FileSetFixityCheckService currently throws an error when it is runs on a fileset that contains a non-versioned file -- i.e., a file for which `#has_versions?` returns `false`:
```
Failure/Error: versions = [versions.max_by(&:created)] if latest_version_only
     
     NoMethodError:
       undefined method `created' for #<Hydra::PCDM::File:0x007fac1bfef6e0>
       Did you mean?  create_date
                      create_or_update
                      creator
     # /Users/coblej/.rvm/gems/ruby-2.3.1@hyrax/gems/activemodel-5.1.6/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # ./app/services/hyrax/file_set_fixity_check_service.rb:81:in `each'
     # ./app/services/hyrax/file_set_fixity_check_service.rb:81:in `max_by'
     # ./app/services/hyrax/file_set_fixity_check_service.rb:81:in `fixity_check_file'
```
When `FileSetFixityCheckService#fixity_check_file` is called with a file for which `#has_versions?` returns `false`, the `versions` variable is set to an array containing that file (which is a `Hydra::PCDM::File` object):
```
versions = file.has_versions? ? file.versions.all : [file]
```
 https://github.com/samvera/hyrax/blob/master/app/services/hyrax/file_set_fixity_check_service.rb#L79

If the `latest_version_only` attribute is set to `true`, then the next line of code attempts to find the latest version:
```
versions = [versions.max_by(&:created)] if latest_version_only
```
https://github.com/samvera/hyrax/blob/master/app/services/hyrax/file_set_fixity_check_service.rb#L81
This is a problem when the file being checked is a non-versioned file because the contents of `versions` array is a `Hydra::PCDM::File`. which does not respond to the `#created` method.

Changes proposed in this pull request:
* Alter https://github.com/samvera/hyrax/blob/master/app/services/hyrax/file_set_fixity_check_service.rb#L81 so that `versions.max_by(&:created)` is called only for versioned files.

@samvera/hyrax-code-reviewers
