### PR TITLE
Code cleanup

### DIFF
--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -266,18 +266,6 @@ Blacklight.onLoad(function () {
     }
   });
 
-  $('#show-more-parent-collections').on('click', function () {
-    $(this).hide();
-    $("#more-parent-collections").show();
-    $("#show-less-parent-collections").show();
-  });
-
-  $('#show-less-parent-collections').on('click', function () {
-    $(this).hide();
-    $("#more-parent-collections").hide();
-    $("#show-more-parent-collections").show();
-  });
-
   // Add to collection modal form post
   $('#add-to-collection-modal').find('.modal-add-button').on('click', function (e) {
     var $self = $(this),

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -73,9 +73,6 @@ module Hyrax
       end
 
       def edit
-        member_works
-        # this is used to populate the "add to a collection" action for the members
-        @user_collections = find_collections_for_form
         form
       end
 
@@ -129,7 +126,6 @@ module Hyrax
 
       def after_update_error
         form
-        query_collection_members
         respond_to do |format|
           format.html { render action: 'edit' }
           format.json { render json: @collection.errors, status: :unprocessable_entity }

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -251,7 +251,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         }
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(assigns[:member_docs]).to be_kind_of Array
       end
     end
 

--- a/spec/services/hyrax/collections_service_spec.rb
+++ b/spec/services/hyrax/collections_service_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::CollectionsService do
     context "with read access" do
       let(:access) { :read }
 
-      it "returns three collections" do
+      it "returns four collections" do
         expect(subject.map(&:id)).to match_array [collection1.id, collection2.id, collection3.id, collection4.id]
       end
     end


### PR DESCRIPTION
Extract some code cleanup from another PR that is being significantly revised so it can be merged separately.

Includes:
- unnecessary javascript removed due to obsolete more/less parent collection show logic
- unnecessary queries loading info after removal of work list from collection edit view
- correction in spec description

@samvera/hyrax-code-reviewers
