### PR TITLE
Add popstate event handler to cover the case where the browser histor…

### DIFF
--- a/app/assets/javascripts/hyrax/monkey_patch_turbolinks.js.coffee
+++ b/app/assets/javascripts/hyrax/monkey_patch_turbolinks.js.coffee
@@ -9,3 +9,15 @@ if Turbolinks?
       else
         @failed = true
         @delegate.requestFailedWithStatusCode(@xhr.status, @xhr.responseText)
+
+  # Fixes a back/forward navigation problem with UV and turbolinks
+  # See https://github.com/samvera/hyrax/issues/2964
+  # This is based on https://github.com/turbolinks/turbolinks/issues/219#issuecomment-275838923
+  $(window).on 'popstate', (event) =>
+    @turbolinks_location = Turbolinks.Location.wrap(window.location)
+    return if Turbolinks.controller.location.requestURL == @turbolinks_location.requestURL
+    return if event.state?.turbolinks
+    if @window_turbolinks = window.history.state?.turbolinks
+      Turbolinks.controller.historyPoppedToLocationWithRestorationIdentifier(@turbolinks_location, @window_turbolinks.restorationIdentifier)
+    else
+      Turbolinks.controller.historyPoppedToLocationWithRestorationIdentifier(@turbolinks_location, Turbolinks.uuid())


### PR DESCRIPTION
…y state is missing a turbolinks object due to Universal Viewer's manipulation of the browser history outside of turbolinks.  This fix is based on https://github.com/turbolinks/turbolinks/issues/219#issuecomment-275838923.  This handler gets registered after the turbolinks handler which does nothing if the turbolinks object isn't in the event state (https://github.com/turbolinks/turbolinks/blob/master/src/turbolinks/history.coffee#L26-L31).

This is ugly but it was the only working solution that I could find without modifying Universal Viewer or turbolinks.  I did some manual testing locally but more testing is needed to ensure that this fix works and is safe.

Fixes #2964.

@samvera/hyrax-code-reviewers
