### PR TITLE
Update the message about why polyfill is necessary

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -31,7 +31,7 @@
 
 //= require clipboard
 
-// TODO: Consider removing? jcoyne thinks this is primarily needed for testing with PhantomJS:
+// This is required for Jasmine tests, specifically to polyfill the Symbol() function
 //= require babel/polyfill
 // CustomElements polyfill is a dependency of time-elements
 //= require webcomponentsjs/0.5.4/CustomElements.min


### PR DESCRIPTION
It was added here
https://github.com/samvera/hyrax/commit/eb95157b52dc72d099cc336328439ad45e34432a
It's probably not used now that we're off of phantomjs
