### PR TITLE
adjust Remove button for parent collections

### DIFF
--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -194,6 +194,12 @@ Blacklight.onLoad(function () {
     $('#collections-to-edit-deny-modal').modal('show');
   });
 
+  // Display access deny for remove parent collection button.
+  $('#parent-collections-wrapper').find('.remove-parent-from-collection-deny-button').on('click', function (e) {
+    e.preventDefault();
+    $('#parent-collection-to-remove-deny-modal').modal('show');
+  });
+
   // Remove this parent collection list button clicked
   $('#parent-collections-wrapper')
     .find('.remove-from-collection-button')

--- a/app/views/hyrax/dashboard/collections/_modal_parent_collection_remove_deny.html.erb
+++ b/app/views/hyrax/dashboard/collections/_modal_parent_collection_remove_deny.html.erb
@@ -1,0 +1,14 @@
+<div class="modal fade" id="parent-collection-to-remove-deny-modal" tabindex="-1" role="dialog" aria-labelledby="remove-parent-collection-label">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <form class="delete-collection-form">
+        <div class="modal-body">
+          <p><%= t('hyrax.dashboard.collections.form_relationships.modals.remove_parent_collection_deny') %></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-dismiss="modal"><%= t('helpers.action.close') %></button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/dashboard/collections/_show_parent_collection_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_parent_collection_row.html.erb
@@ -6,6 +6,16 @@
     <div class="collections-list-title">
       <%= link_to document, [hyrax, :dashboard, document], id: "src_copy_link_#{document.id}" %>
     </div>
-    <button class="btn btn-xs btn-danger remove-from-collection-button" <%= "disabled" unless can? :edit, document.id %>><%= t('hyrax.collections.show.buttons.remove_from_collection') %></button>
+    <% if can? :edit, id %>
+      <% if can? :edit, document.id %>
+        <button class="btn btn-xs btn-danger remove-from-collection-button"><%= t('hyrax.collections.show.buttons.remove_from_collection') %></button>
+      <% else %>
+        <%= link_to "#",
+                    class: 'btn btn-xs btn-danger remove-parent-from-collection-deny-button',
+                    title: t('hyrax.collections.show.buttons.remove_from_collection') do %>
+            <%= t('hyrax.collections.show.buttons.remove_from_collection') %>
+        <% end %>
+      <% end %>
+    <% end %>
   </div>
 </li>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -96,6 +96,7 @@
 <% if @presenter.collection_type_is_nestable? && !has_collection_search_parameters? %>
   <%= render 'hyrax/my/collections/modal_add_to_collection', source: 'show' %>
   <%= render 'hyrax/my/collections/modal_add_subcollection', id: @presenter.id, source: 'show' %>
+  <%= render 'hyrax/dashboard/collections/modal_parent_collection_remove_deny', source: 'show' %>
 <% end %>
 
 <% unless has_collection_search_parameters? %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -602,6 +602,7 @@ en:
           modals:
             remove_from_collection_description: Removing this collection will not remove it from the repository, only as a parent of this collection.  Are you sure you want to remove this collection?
             remove_this_sub_collection_description: Removing this sub-collection will not remove it from the repository, only from this parent collection.  Are you sure you want to remove this sub-collection?
+            remove_parent_collection_deny: You do not have sufficient privileges for the parent collection to be able to remove it.
           sub_collections_of_collection_description: These collections are currently sub-collections of this collection
           table:
             action: Action

--- a/spec/views/hyrax/dashboard/collections/_show_parent_collection_row.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_parent_collection_row.html.erb_spec.rb
@@ -9,33 +9,53 @@ RSpec.describe 'hyrax/dashboard/collections/_show_parent_collection_row.html.erb
   let(:document) { SolrDocument.new(parent_collection_doc) }
   let(:subject) { render('show_parent_collection_row.html.erb', id: child_collection.id, document: document) }
 
-  context 'when user can edit the parent collection' do
+  context 'when user cannot edit the child collection' do
     before do
+      allow(view).to receive(:can?).with(:edit, child_collection.id).and_return(false)
       allow(view).to receive(:can?).with(:edit, document.id).and_return(true)
     end
 
-    it 'shows link to collection title and active remove button' do
+    it 'does shows link to collection title but not the remove button' do
       subject
       expect(rendered).to have_link(document.title.first)
-      expect(rendered).to have_button("Remove")
-    end
-
-    it "renders the proper data attributes on list element" do
-      expect(subject).to have_selector(:css, 'li[data-post-url="/dashboard/collections/123/remove_parent/999"]')
-      expect(subject).to have_selector(:css, 'li[data-id="123"]')
-      expect(subject).to have_selector(:css, 'li[data-parent-id="999"]')
+      expect(rendered).not_to have_button("Remove")
+      expect(rendered).not_to have_link("Remove")
     end
   end
 
-  context 'disable button if no edit permission' do
+  context 'when user can edit the child collection' do
     before do
-      allow(view).to receive(:can?).with(:edit, document.id).and_return(false)
+      allow(view).to receive(:can?).with(:edit, child_collection.id).and_return(true)
     end
 
-    it 'shows link to collection title and disabled remove button' do
-      subject
-      expect(rendered).to have_link(document.title.first)
-      expect(rendered).to have_button("Remove", disabled: true)
+    context 'and user can edit the parent collection' do
+      before do
+        allow(view).to receive(:can?).with(:edit, document.id).and_return(true)
+      end
+
+      it 'shows link to collection title and active remove button' do
+        subject
+        expect(rendered).to have_link(document.title.first)
+        expect(rendered).to have_button("Remove")
+      end
+
+      it "renders the proper data attributes on list element" do
+        expect(subject).to have_selector(:css, 'li[data-post-url="/dashboard/collections/123/remove_parent/999"]')
+        expect(subject).to have_selector(:css, 'li[data-id="123"]')
+        expect(subject).to have_selector(:css, 'li[data-parent-id="999"]')
+      end
+    end
+
+    context 'and user cannot edit the parent collection' do
+      before do
+        allow(view).to receive(:can?).with(:edit, document.id).and_return(false)
+      end
+
+      it 'shows link to collection title and active remove link' do
+        subject
+        expect(rendered).to have_link(document.title.first)
+        expect(rendered).to have_link("Remove")
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #3009 

This PR establishes the following rules.

While viewing the child collection’s show page…
* if the user does not have edit access to the child collection, do not show the Remove button for parent collections
* if the user has edit access to the child collection, always show the Remove button for parent collections
  * if the user has edit access to the parent, Remove button shows confirmation modal allowing the parent to be removed
  * if the user does not have edit access to the parent, Remove button shows modal telling the user they do not have sufficient permissions
