### PR TITLE
Add support for `simple_form` 3.5.1 and later

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -101,11 +101,4 @@ SUMMARY
   spec.add_development_dependency 'shoulda-callback-matchers', '~> 1.1.1'
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
   spec.add_development_dependency 'webmock'
-
-  ########################################################
-  # Temporarily pinned dependencies. INCLUDE EXPLANATIONS.
-  #
-  # simple_form 3.5.1 broke hydra-editor for certain model types;
-  #   see: https://github.com/plataformatec/simple_form/issues/1549
-  spec.add_dependency 'simple_form', '~> 3.2', '<= 3.5.0'
 end


### PR DESCRIPTION
The pin was initally introduced in #2663. `hydra-editor` now handles pinning of
`simple_form` versions (see: https://github.com/samvera/hydra-editor/pull/143)
on its 3.x series. We support newer versions of `simple_form` via `hydra-editor`
4.x (see: https://github.com/samvera/hydra-editor/pull/145).

Fixes #2665.

@samvera/hyrax-code-reviewers
