### PR TITLE
Don't crash when a work has no depositor

### DIFF
--- a/app/search_builders/hyrax/filter_suppressed_with_roles.rb
+++ b/app/search_builders/hyrax/filter_suppressed_with_roles.rb
@@ -31,7 +31,11 @@ module Hyrax
       end
 
       def depositor?
-        current_work[DepositSearchBuilder.depositor_field].first == current_ability.current_user.user_key
+        depositors = current_work[DepositSearchBuilder.depositor_field]
+
+        return false if depositors.nil?
+
+        depositors.first == current_ability.current_user.user_key
       end
   end
 end


### PR DESCRIPTION
A work with no
depositor (e.g. https://nurax.curationexperts.com/concern/generic_works/5425k968s)
in its solr document would previously fail on `NoMethodError`.

The tests for the search builders are heavily stubbed, and are in need of a
significant refactor. Since the existing test avoid calling this method, I'm not
adding a test for it here.

@samvera/hyrax-code-reviewers
