### PR TITLE
Add Rails 5.2 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ env:
   # It should be sufficient to test only the latest of the patch versions for a minor version, they
   # should be compatible across patch versions (only bug fixes are released in patch versions).
   matrix:
-    - "RAILS_VERSION=5.1.4"
-    - "RAILS_VERSION=5.0.6"
+    - "RAILS_VERSION=5.2.0"
+    - "RAILS_VERSION=5.1.6"
 
 services:
   - redis-server


### PR DESCRIPTION
Rails 5.0.x is no longer supported. Drop it from the build matrix and replace it with 5.2.

@samvera/hyrax-code-reviewers
