### PR TITLE
Change radio buttons into autocomplete field for add works to collect…

### DIFF
--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -1,3 +1,5 @@
+var autocompleteModule = require('hyrax/autocomplete');
+
 Blacklight.onLoad(function () {
 
   /**
@@ -182,10 +184,17 @@ Blacklight.onLoad(function () {
   $('[data-behavior="updates-collection"]').on('click', function() {
       var string_to_replace = "collection_replace_id",
         form = $(this).closest("form"),
-        collection_id = $(".collection-selector:checked")[0].value;
+        collection_id = $('#member_of_collection_ids')[0].value;
 
       form[0].action = form[0].action.replace(string_to_replace, collection_id);
       form.append('<input type="hidden" value="add" name="collection[members]"></input>');
+  });
+
+  // Initializes the autocomplete element for the add to collection modal
+  $('#collection-list-container').on('show.bs.modal', function() {
+    var inputField = $('#member_of_collection_ids');
+    var autocomplete = new autocompleteModule();
+    autocomplete.setup(inputField, inputField.data('autocomplete'), inputField.data('autocompleteUrl'));
   });
 
   // Display access deny for edit request.

--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -56,6 +56,7 @@ module Hyrax
         @empty_batch = batch.empty?
         @all_checked = (count_on_page == @document_list.count)
         @add_works_to_collection = params.fetch(:add_works_to_collection, '')
+        @add_works_to_collection_label = params.fetch(:add_works_to_collection_label, '')
       end
 
       def query_solr

--- a/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
@@ -13,12 +13,17 @@
               <fieldset>
                 <legend><%= t("hyrax.collection.select_form.select_heading") %></legend>
               <ul>
-                <% user_collections.sort { |c1,c2| c2[CatalogController.uploaded_field] <=> c1[CatalogController.uploaded_field] }.each_with_index do |collection,index| %>
-                  <li>
-                    <% selected = (collection.id == @add_works_to_collection) || (@add_works_to_collection.blank? && index == 0) %>
-                    <%= radio_button_tag(:id, collection.id, selected, class: "collection-selector") %>
-                    <%= label_tag(:collection, collection.title_or_label, for: "id_#{collection.id}") %>
-                  </li>
+                <% if @add_works_to_collection %>
+                  <%= text_field_tag 'member_of_collection_label', @add_works_to_collection_label, disabled: true %>
+                  <%= hidden_field_tag 'member_of_collection_ids', @add_works_to_collection %>
+                <% else %>
+                  <%= text_field_tag 'member_of_collection_ids', nil,
+                              prompt: :translate,
+                              data: {
+                                placeholder: t('simple_form.placeholders.defaults.member_of_collection_ids'),
+                                autocomplete: 'collection',
+                                'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/collections?access=deposit'
+                              } %>
                 <% end %>
               </ul>
               </fieldset>

--- a/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div>
       <%= link_to t('hyrax.collection.actions.add_existing_works.label'),
-                  hyrax.my_works_path(add_works_to_collection: presenter.id),
+                  hyrax.my_works_path(add_works_to_collection: presenter.id, add_works_to_collection_label: presenter.title),
                   title: t('hyrax.collection.actions.add_existing_works.desc'),
                   class: 'btn btn-link side-arrows',
                   data: { turbolinks: false } %>

--- a/spec/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'hyrax/dashboard/collections/_form_for_select_collection.html.erb
     end
   end
 
-  let(:doc) { Nokogiri::HTML(rendered) }
+  let(:page) { Capybara::Node::Simple.new(rendered) }
 
   before do
     # Stub route because view specs don't handle engine routes
@@ -27,29 +27,21 @@ RSpec.describe 'hyrax/dashboard/collections/_form_for_select_collection.html.erb
     allow(view).to receive(:user_collections).and_return(solr_collections)
   end
 
-  it "sorts the collections" do
+  it "uses autocomplete" do
     render
-    collection_ids = doc.xpath("//input[@class='collection-selector']/@id").map(&:to_s)
-    expect(collection_ids).to eql(["id_1237", "id_1234", "id_1235", "id_1236"])
-    expect(rendered).to have_selector("label", text: 'Title 1')
-    expect(rendered).not_to have_selector("label", text: "[\"Title 1\"]")
+    expect(page).to have_selector('input[data-autocomplete-url="/authorities/search/collections?access=deposit"]')
   end
 
-  it "selects the right collection when instructed to do so" do
-    assign(:add_works_to_collection, collections[2][:id])
-    render
-    expect(rendered).not_to have_selector "#id_#{collections[0][:id]}[checked='checked']"
-    expect(rendered).not_to have_selector "#id_#{collections[1][:id]}[checked='checked']"
-    expect(rendered).not_to have_selector "#id_#{collections[3][:id]}[checked='checked']"
-    expect(rendered).to have_selector "#id_#{collections[2][:id]}[checked='checked']"
-  end
+  context 'when a collection is specified' do
+    let(:collection_id) { collections[2][:id] }
+    let(:collection_label) { collections[2]["title_tesim"] }
 
-  it "selects the first collection when nothing else specified" do
-    # first when sorted by create date, so not index 0
-    render
-    expect(rendered).not_to have_selector "#id_#{collections[0][:id]}[checked='checked']"
-    expect(rendered).not_to have_selector "#id_#{collections[1][:id]}[checked='checked']"
-    expect(rendered).not_to have_selector "#id_#{collections[2][:id]}[checked='checked']"
-    expect(rendered).to have_selector "#id_#{collections[3][:id]}[checked='checked']"
+    it "selects the right collection when instructed to do so" do
+      assign(:add_works_to_collection, collection_id)
+      assign(:add_works_to_collection_label, collection_label)
+      render
+      expect(page).to have_selector "#member_of_collection_ids[value=\"#{collection_id}\"]", visible: false
+      expect(page).to have_selector "#member_of_collection_label", text: collection_label
+    end
   end
 end

--- a/spec/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'hyrax/dashboard/collections/_show_add_items_actions.html.erb', type: :view do
-  let(:presenter) { double('Hyrax::CollectionPresenter', solr_document: solr_document, id: '123') }
+  let(:presenter) { double('Hyrax::CollectionPresenter', solr_document: solr_document, id: '123', title: 'Collection 1') }
   let(:solr_document) { double('Solr Document') }
   let(:can_deposit) { true }
 
@@ -14,7 +14,8 @@ RSpec.describe 'hyrax/dashboard/collections/_show_add_items_actions.html.erb', t
 
     it 'renders add_existing_works_to_collection link' do
       render
-      expect(rendered).to have_css(".btn[href='#{hyrax.my_works_path(add_works_to_collection: presenter.id)}']")
+      expect(rendered).to have_css(".btn[href='#{hyrax.my_works_path(add_works_to_collection: presenter.id,
+                                                                     add_works_to_collection_label: presenter.title)}']")
     end
     it 'renders add_new_work_to_collection link' do
       render
@@ -26,7 +27,8 @@ RSpec.describe 'hyrax/dashboard/collections/_show_add_items_actions.html.erb', t
 
     it 'does not render add_works_to_collection link' do
       render
-      expect(rendered).not_to have_css(".actions-controls-collections .btn[href='#{hyrax.my_works_path(add_works_to_collection: presenter.id)}']")
+      expect(rendered).not_to have_css(".actions-controls-collections .btn[href='#{hyrax.my_works_path(add_works_to_collection: presenter.id,
+                                                                                                       add_works_to_collection_label: presenter.title)}']")
     end
   end
 


### PR DESCRIPTION
…ion modal.

It was easiest to remove the ability for the user to select a different collection when adding existing works to a collection from the collection view page.  This makes the modal act like a confirmation dialog since the user has already selected a collection when they initiated the process.  The collection title is added as a query param instead of doing a lookup when rendering the page or via AJAX.

Co-authored-by: Brian Keese <bkeese@indiana.edu>

Backports #3027 

@samvera/hyrax-code-reviewers
