### PR TITLE
Make indexing not require existing solr doc

### DIFF
--- a/app/services/hyrax/adapters/nesting_index_adapter.rb
+++ b/app/services/hyrax/adapters/nesting_index_adapter.rb
@@ -133,6 +133,7 @@ module Hyrax
       def self.find_solr_document_by(id:)
         query = ActiveFedora::SolrQueryBuilder.construct_query_for_ids([id])
         document = ActiveFedora::SolrService.query(query, rows: 1).first
+        document = ActiveFedora::Base.find(id).to_solr if document.nil?
         raise "Unable to find SolrDocument with ID=#{id}" if document.nil?
         document
       end

--- a/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
+++ b/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
@@ -38,12 +38,16 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
   describe '.find_index_document_by' do
     subject { described_class.find_index_document_by(id: id) }
 
-    context 'with a not found id ' do
+    context 'with id not in solr, it builds from Fedora' do
       let(:id) { 'so-very-missing-no-document-here' }
+      let(:document) { double("Document", id: id, fetch: nil) }
+      let(:object) { double("Object_to_reindex", id: id, to_solr: document) }
 
-      it 'raises RuntimeError' do
-        expect { subject }.to raise_error(RuntimeError)
+      before do
+        allow(ActiveFedora::Base).to receive(:find).with(id).and_return(object)
       end
+
+      it { is_expected.to be_a(Samvera::NestingIndexer::Documents::IndexDocument) }
     end
 
     context 'with a found id' do


### PR DESCRIPTION
When reindexing everything with no existing index, the nesting indexer
will create a "solr document" from the data in Fedora to allow the
full indexing to occur, rather than just throwing an error.

Fixes https://github.com/samvera/hyrax/issues/3037

Backport PR #3047 from master to rc1