### PR TITLE
Fixing German translation "admin set" into collection integration

### DIFF
--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -698,7 +698,7 @@ de:
           select_none: Nichts ausgewählt
           transfer: Besitz der Arbeit übertragen
           unhighlight: Hervorhebung der Arbeit entfernen
-          view_admin_set: Admin-Set anzeigen
+          view_admin_set: Sammlung anzeigen
           view_collection: Sammlung anzeigen
           work_confirmation: Das Löschen einer Arbeit aus %{application_name} ist dauerhaft. Klicken Sie auf OK, um diese Arbeit aus %{application_name} zu löschen, oder auf Abbrechen, um diesen Vorgang abzubrechen
         collection_list:


### PR DESCRIPTION
Testing 2.1.0rc2 

Changes proposed in this pull request:
* Fixing the German translation upon integration of Admin-Sets into collection

@samvera/hyrax-code-reviewers
