### PR TITLE
allow viewers and depositors to view admin set’s admin show page

### DIFF
--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -2,7 +2,8 @@ module Hyrax
   class Admin::AdminSetsController < ApplicationController
     include Hyrax::CollectionsControllerBehavior
 
-    before_action :ensure_manager!
+    before_action :ensure_manager!, except: [:show]
+    before_action :ensure_viewer!, only: [:show]
     load_and_authorize_resource
 
     with_themed_layout 'dashboard'
@@ -95,6 +96,12 @@ module Hyrax
         # Even though the user can view this admin set, they may not be able to view
         # it on the admin page.
         authorize! :manage_any, AdminSet
+      end
+
+      def ensure_viewer!
+        # Even though the user can view this admin set, they may not be able to view
+        # it on the admin page if access is granted as a public or registered user only.
+        authorize! :view_admin_show, @admin_set
       end
 
       def create_admin_set

--- a/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
@@ -18,14 +18,47 @@ RSpec.describe Hyrax::Admin::AdminSetsController do
     end
 
     describe "#show" do
-      context "a public admin set" do
+      before do
+        sign_in user
+        controller.instance_variable_set(:@admin_set, admin_set)
+      end
+
+      context "when user has access through public group" do
         # Even though the user can view this admin set, the should not be able to view
         # it on the admin page.
-        let(:admin_set) { create(:admin_set, read_groups: ['public']) }
+        let(:admin_set) { create(:adminset_lw, with_solr_document: true, with_permission_template: { view_groups: ['public'] }) }
 
         it 'is unauthorized' do
           get :show, params: { id: admin_set }
           expect(response).to be_redirect
+        end
+      end
+
+      context "when user has access through registered group" do
+        # Even though the user can view this admin set, the should not be able to view
+        # it on the admin page.
+        let(:admin_set) { create(:adminset_lw, with_solr_document: true, with_permission_template: { view_groups: ['registered'] }) }
+
+        it 'is unauthorized' do
+          get :show, params: { id: admin_set }
+          expect(response).to be_redirect
+        end
+      end
+
+      context "when user is directly granted view access" do
+        # Even though the user can view this admin set, the should not be able to view
+        # it on the admin page.
+        let(:admin_set) { create(:adminset_lw, with_solr_document: true, with_permission_template: { view_users: [user.user_key] }) }
+
+        before do
+          create(:work, :public, admin_set: admin_set)
+        end
+
+        it 'defines a presenter' do
+          get :show, params: { id: admin_set }
+          expect(response).to be_success
+          expect(assigns[:presenter]).to be_kind_of Hyrax::AdminSetPresenter
+          expect(assigns[:presenter].id).to eq admin_set.id
         end
       end
     end

--- a/spec/services/hyrax/collections/permissions_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_service_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe Hyrax::Collections::PermissionsService do
 
       subject { described_class }
 
-      it ".can_deposit_in_collection? returns true" do
+      it '.can_deposit_in_collection? returns true' do
         expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
       end
-      it ".can_view_admin_show_for_collection? returns true" do
+      it '.can_view_admin_show_for_collection? returns true' do
         expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
       end
     end
@@ -46,10 +46,10 @@ RSpec.describe Hyrax::Collections::PermissionsService do
 
       subject { described_class }
 
-      it ".can_deposit_in_collection? returns true" do
+      it '.can_deposit_in_collection? returns true' do
         expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
       end
-      it ".can_view_admin_show_for_collection? returns true" do
+      it '.can_view_admin_show_for_collection? returns true' do
         expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
       end
     end
@@ -66,21 +66,105 @@ RSpec.describe Hyrax::Collections::PermissionsService do
 
       subject { described_class }
 
-      it ".can_deposit_in_collection? returns true" do
+      it '.can_deposit_in_collection? returns false' do
         expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
       end
-      it ".can_view_admin_show_for_collection? returns true" do
+      it '.can_view_admin_show_for_collection? returns true' do
         expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
+      end
+    end
+
+    context 'when deposit user' do
+      context 'thru membership in public group' do
+        before do
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return(['public'])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
+        end
+
+        subject { described_class }
+
+        it '.can_deposit_in_collection? returns true' do
+          expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
+        end
+        it '.can_view_admin_show_for_collection? returns false' do
+          expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
+      end
+
+      context 'thru membership in registered group' do
+        before do
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return(['registered'])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
+        end
+
+        subject { described_class }
+
+        it '.can_deposit_in_collection? returns true' do
+          expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
+        end
+        it '.can_view_admin_show_for_collection? returns false' do
+          expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
+      end
+    end
+
+    context 'when view user' do
+      context 'thru membership in public group' do
+        before do
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return(['public'])
+        end
+
+        subject { described_class }
+
+        it '.can_deposit_in_collection? returns false' do
+          expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
+        it '.can_view_admin_show_for_collection? returns false' do
+          expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
+      end
+
+      context 'thru membership in registered group' do
+        before do
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'view').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'manage').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'deposit').and_return([])
+          allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return(['registered'])
+        end
+
+        subject { described_class }
+
+        it '.can_deposit_in_collection? returns false' do
+          expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
+        it '.can_view_admin_show_for_collection? returns false' do
+          expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
       end
     end
 
     context 'when user without access' do
       subject { described_class }
 
-      it ".can_deposit_in_collection? returns true" do
+      it '.can_deposit_in_collection? returns false' do
         expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
       end
-      it ".can_view_admin_show_for_collection? returns true" do
+      it '.can_view_admin_show_for_collection? returns false' do
         expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
       end
     end


### PR DESCRIPTION
This excludes viewers and depositors who have access only by being in the public or registered groups.

Backport PR #3056 from master to rc2_bugfix