### PR TITLE
authorize adminset resource before extra validation and provide better redirect

### DIFF
--- a/app/models/concerns/hyrax/ability/admin_set_ability.rb
+++ b/app/models/concerns/hyrax/ability/admin_set_ability.rb
@@ -9,7 +9,7 @@ module Hyrax
           can :view_admin_show_any, AdminSet
         else
           can :manage_any, AdminSet if Hyrax::Collections::PermissionsService.can_manage_any_admin_set?(ability: self)
-          can :create_any, AdminSet if Hyrax::CollectionTypes::PermissionsService.can_create_admin_set_collection_type?(ability: self)
+          can [:create_any, :create], AdminSet if Hyrax::CollectionTypes::PermissionsService.can_create_admin_set_collection_type?(ability: self)
           can :view_admin_show_any, AdminSet if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_admin_set?(ability: self)
 
           can [:edit, :update, :destroy], AdminSet do |admin_set| # for test by solr_doc, see solr_document_ability.rb

--- a/spec/abilities/admin_set_ability_spec.rb
+++ b/spec/abilities/admin_set_ability_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'AdminSetAbility' do
       is_expected.to be_able_to(:manage, AdminSet)
       is_expected.to be_able_to(:manage_any, AdminSet)
       is_expected.to be_able_to(:create_any, AdminSet)
+      is_expected.to be_able_to(:create, AdminSet)
       is_expected.to be_able_to(:view_admin_show_any, AdminSet)
       is_expected.to be_able_to(:edit, admin_set)
       is_expected.to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
@@ -72,6 +73,7 @@ RSpec.describe 'AdminSetAbility' do
     it 'denies manage ability' do
       is_expected.not_to be_able_to(:manage, AdminSet)
       is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
+      is_expected.not_to be_able_to(:create, AdminSet)
     end
   end
 
@@ -100,6 +102,7 @@ RSpec.describe 'AdminSetAbility' do
       is_expected.not_to be_able_to(:manage, AdminSet)
       is_expected.not_to be_able_to(:manage_any, AdminSet)
       is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
+      is_expected.not_to be_able_to(:create, AdminSet)
       is_expected.not_to be_able_to(:edit, admin_set)
       is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:update, admin_set)
@@ -133,6 +136,7 @@ RSpec.describe 'AdminSetAbility' do
       is_expected.not_to be_able_to(:manage, AdminSet)
       is_expected.not_to be_able_to(:manage_any, AdminSet)
       is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
+      is_expected.not_to be_able_to(:create, AdminSet)
       is_expected.not_to be_able_to(:edit, admin_set)
       is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:update, admin_set)
@@ -154,6 +158,7 @@ RSpec.describe 'AdminSetAbility' do
       is_expected.not_to be_able_to(:manage, AdminSet)
       is_expected.not_to be_able_to(:manage_any, AdminSet)
       is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
+      is_expected.not_to be_able_to(:create, AdminSet)
       is_expected.not_to be_able_to(:view_admin_show_any, AdminSet)
       is_expected.not_to be_able_to(:edit, admin_set)
       is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb


### PR DESCRIPTION
Related to Issue #2004, PR #3056, PR #3059

* moves `load_and_authorize_resource` before extra validation
* rescues access denied exceptions and forwards to home page if user is already logged in or to login page if they are not.  This is consistent with how other controllers handle this type of exception.
* tighten up ensure_manager! to check for manage access to the current admin set instead of any admin set