### PR TITLE
Use flipper status for all work's children

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -90,6 +90,10 @@ module Hyrax
                                                               presenter_args: current_ability).first
     end
 
+    def user_can_perform_any_action?
+      current_ability.can?(:edit, id) || current_ability.can?(:destroy, id) || current_ability.can?(:download, id)
+    end
+
     private
 
       def link_presenter_class

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -155,8 +155,8 @@ module Hyrax
 
     delegate :member_presenters, :file_set_presenters, :work_presenters, to: :member_presenter_factory
 
-    def exclude_unauthorized_file_sets
-      member_presenters.delete_if { |m| m.is_a?(Hyrax::FileSetPresenter) && !current_ability.can?(:read, m.id) }
+    def exclude_unauthorized_members
+      member_presenters.delete_if { |m| !current_ability.can?(:read, m.id) }
     end
 
     def manifest_url

--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -1,5 +1,5 @@
 <h2><%= t('.header') %></h2>
-<%  members = Flipflop.hide_private_files? ? presenter.exclude_unauthorized_file_sets : presenter.member_presenters %>
+<%  members = Flipflop.hide_private_items? ? presenter.exclude_unauthorized_members : presenter.member_presenters %>
 <% if members.present? %>
   <table class="table table-striped related-files">
     <thead>
@@ -17,4 +17,6 @@
   </table>
 <% elsif can? :edit, presenter.id %>
     <div class="alert alert-warning" role="alert"><%= t('.empty', type: presenter.human_readable_type) %></div>
+<% else %>
+  <div class="alert alert-warning" role="alert"><%= t('.unauthorized', type: presenter.human_readable_type) %></div>
 <% end %>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,42 +1,44 @@
-<div class="btn-group">
+<% if file_set.user_can_perform_any_action? %>
+  <div class="btn-group">
 
-  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true">
-    <span class="sr-only">Press to </span>
-    Select an action
-    <span class="caret" aria-hidden="true"></span>
-  </button>
+    <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true">
+      <span class="sr-only">Press to </span>
+      <%= t('.header') %>
+      <span class="caret" aria-hidden="true"></span>
+    </button>
 
-  <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= file_set.id %>">
-  <% if can?(:edit, file_set.id) %>
-    <li role="menuitem" tabindex="-1">
-      <%= link_to 'Edit', edit_polymorphic_path([main_app, file_set]),
-        { title: "Edit #{file_set}" } %>
-    </li>
+    <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= file_set.id %>">
+    <% if can?(:edit, file_set.id) %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to t('.edit'), edit_polymorphic_path([main_app, file_set]),
+          { title: t('.edit_title', file_set: file_set) } %>
+      </li>
 
-    <li role="menuitem" tabindex="-1">
-      <%= link_to 'Versions',  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
-        { title: "Display previous versions" } %>
-    </li>
-  <% end %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to t('.versions'),  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
+          { title: t('.versions_title') } %>
+      </li>
+    <% end %>
 
-  <% if can?(:destroy, file_set.id) %>
-    <li role="menuitem" tabindex="-1">
-      <%= link_to 'Delete', polymorphic_path([main_app, file_set]),
-        method: :delete, title: "Delete #{file_set}",
-        data: {confirm: "Deleting #{file_set} from #{application_name} is permanent. Click OK to delete this from #{application_name}, or Cancel to cancel this operation"} %>
-    </li>
-  <% end %>
+    <% if can?(:destroy, file_set.id) %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to t('.delete'), polymorphic_path([main_app, file_set]),
+          method: :delete, title: t('.delete_title', file_set: file_set),
+          data: { confirm: t('.delete_confirm', file_set: file_set, application_name: application_name) } %>
+      </li>
+    <% end %>
 
-  <% if can?(:download, file_set.id) %>
-    <li role="menuitem" tabindex="-1">
-      <%= link_to 'Download',
-                  hyrax.download_path(file_set),
-                  title: "Download #{file_set.to_s.inspect}",
-                  target: "_blank",
-                  id: "file_download",
-                  data: { label: file_set.id } %>
-    </li>
-  <% end %>
+    <% if can?(:download, file_set.id) %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to t('.download'),
+                    hyrax.download_path(file_set),
+                    title: t('.download_title', file_set: file_set),
+                    target: "_blank",
+                    id: "file_download",
+                    data: { label: file_set.id } %>
+      </li>
+    <% end %>
 
-  </ul>
-</div>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? %>
+<% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/config/features.rb
+++ b/config/features.rb
@@ -35,7 +35,7 @@ Flipflop.configure do
           default: false,
           description: "Display new reporting features. *Very Experimental*"
 
-  feature :hide_private_files,
+  feature :hide_private_items,
           default: false,
-          description: "Do not show the private files."
+          description: "Do not show the private items."
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -413,6 +413,7 @@ en:
         header: Items
         thumbnail: Thumbnail
         title: Title
+        unauthorized: There are no publicly available items in this %{type}.
         visibility: Visibility
       relationships:
         empty: This %{type} is not currently in any collections.
@@ -830,6 +831,17 @@ en:
           pdf_link: Download PDF
           video_link: Download video
     file_sets:
+      actions:
+        delete: Delete
+        delete_confirm: Deleting %{file_set} from %{application_name} is permanent. Click OK to delete this from %{application_name}, or Cancel to cancel this operation
+        delete_title: Delete %{file_set}
+        download: Download
+        download_title: Download %{file_set}
+        edit: Edit
+        edit_title: Edit %{file_set}
+        header: Select an action
+        versions: Versions
+        versions_title: Display previous versions
       groups_description:
         description_html: The list of groups in the drop-down marked "Select a group" is a list of User Managed Groups that you are a member of.  You may select a specific group and assign an access level for a file within %{application_name}, similarly to adding user access levels.
     help:

--- a/spec/models/flipflop_spec.rb
+++ b/spec/models/flipflop_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Flipflop do
     end
   end
 
-  describe "hide_private_files?" do
-    subject { described_class.hide_private_files? }
+  describe "hide_private_items?" do
+    subject { described_class.hide_private_items? }
 
     it "defaults to false" do
       is_expected.to be false

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -55,6 +55,30 @@ RSpec.describe Hyrax::FileSetPresenter do
     it { is_expected.to be false }
   end
 
+  describe "#user_can_perform_any_action?" do
+    subject { presenter.user_can_perform_any_action? }
+    let(:current_ability) { ability }
+
+    context 'when user can perform at least 1 action' do
+      before do
+        expect(current_ability).to receive(:can?).with(:edit, presenter.id).and_return false
+        expect(current_ability).to receive(:can?).with(:destroy, presenter.id).and_return false
+        expect(current_ability).to receive(:can?).with(:download, presenter.id).and_return true
+      end
+
+      it { is_expected.to be true }
+    end
+    context 'when user cannot perform any action' do
+      before do
+        expect(current_ability).to receive(:can?).with(:edit, presenter.id).and_return false
+        expect(current_ability).to receive(:can?).with(:destroy, presenter.id).and_return false
+        expect(current_ability).to receive(:can?).with(:download, presenter.id).and_return false
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe "properties delegated to solr_document" do
     let(:solr_properties) do
       ["date_uploaded", "title_or_label",

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -224,6 +224,16 @@ RSpec.describe Hyrax::WorkShowPresenter do
     end
   end
 
+  describe "exclude_unauthorized_members" do
+    let(:obj) { create(:work_with_file_and_work) }
+    let(:attributes) { obj.to_solr }
+    let(:ability) { double Ability, can?: false }
+
+    it 'filters out unauthorized members' do
+      expect(presenter.exclude_unauthorized_members.count).to eq 0
+    end
+  end
+
   describe "#file_set_presenters" do
     let(:obj) { create(:work_with_ordered_files) }
     let(:attributes) { obj.to_solr }

--- a/spec/views/hyrax/base/_items.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_items.html.erb_spec.rb
@@ -9,72 +9,50 @@ RSpec.describe 'hyrax/base/_items.html.erb', type: :view do
       it 'renders an alert' do
         expect(view).to receive(:can?).with(:edit, presenter.id).and_return(true)
         render 'hyrax/base/items', presenter: presenter
-        expect(rendered).to have_css('.alert-warning[role=alert]')
+        expect(rendered).to have_css('.alert-warning[role=alert]', text: 'This Thing has no files associated with it. Click "edit" to add more files.')
       end
     end
     context 'and the current user cannot edit the presenter' do
-      it 'does not render an alert' do
+      it 'renders an alert' do
         expect(view).to receive(:can?).with(:edit, presenter.id).and_return(false)
         render 'hyrax/base/items', presenter: presenter
-        expect(rendered).not_to have_css('.alert-warning[role=alert]')
+        expect(rendered).to have_css('.alert-warning[role=alert]', text: "There are no publicly available items in this Thing.")
       end
     end
   end
 
-  context "when children are present" do
-    let(:member_presenters) { ['Thing One', 'Thing Two'] }
-
-    before do
-      stub_template 'hyrax/base/_member.html.erb' => '<%= member %>'
-    end
-    it "links to child work" do
-      render 'hyrax/base/items', presenter: presenter
-      expect(rendered).to have_css('tbody', text: member_presenters.join)
-    end
-  end
-
-  context "when file set members are present" do
-    let(:user) { create(:user) }
-    let(:ability) { Ability.new(user) }
-    let(:file1) { create(:file_set, :public) }
-    let(:file2) { create(:file_set) }
-
-    let(:solr_document) { SolrDocument.new(attributes) }
+  context 'when children are present' do
+    let(:child1) { double('Thing1', id: 'Thing 1', title: 'Title 1') }
+    let(:child2) { double('Thing2', id: 'Thing 2', title: 'Title 2') }
+    let(:child3) { double('Thing3', id: 'Thing 3', title: 'Title 3') }
+    let(:member_presenters) { [child1, child2, child3] }
+    let(:authorized_presenters) { [child1, child3] }
+    let(:solr_document) { double('Solr Doc', id: 'the-id') }
     let(:presenter) { Hyrax::WorkShowPresenter.new(solr_document, ability, request) }
 
     before do
       stub_template 'hyrax/base/_member.html.erb' => '<%= member %>'
+      expect(Flipflop).to receive(:hide_private_items?).and_return(:flipflop)
+      expect(presenter).to receive(:member_presenters).and_return(member_presenters)
+      expect(ability).to receive(:can?).with(:read, child1.id).and_return true
+      expect(ability).to receive(:can?).with(:read, child2.id).and_return false
+      expect(ability).to receive(:can?).with(:read, child3.id).and_return true
     end
 
-    context "and a public file set" do
-      let(:attributes) { create(:public_work, ordered_members: [file1]).to_solr }
+    context 'and hide_private_items is on' do
+      let(:flip_flop) { true }
 
-      it "show the link for the file set" do
-        expect(Flipflop).to receive(:hide_private_files?).and_return(true)
+      it "displays only authorized children" do
         render 'hyrax/base/items', presenter: presenter
-        expect(rendered).to have_content presenter.member_presenters.first.link_name
+        expect(rendered).to have_css('tbody', text: authorized_presenters.join)
       end
     end
+    context 'and hide_private_items is off' do
+      let(:flip_flop) { false }
 
-    context "and a private file set" do
-      let(:attributes) { create(:public_work, ordered_members: [file2]).to_solr }
-
-      it "won't show the link to the file set" do
-        expect(Flipflop).to receive(:hide_private_files?).and_return(true)
-        expect(view).to receive(:can?).with(:edit, presenter.id).and_return(false)
+      it "displays all children" do
         render 'hyrax/base/items', presenter: presenter
-        expect(rendered).not_to have_content presenter.member_presenters.first.link_name
-      end
-    end
-
-    context "with public and private file sets" do
-      let(:attributes) { create(:public_work, ordered_members: [file1, file2]).to_solr }
-
-      it "only show the link to the file set that users have permission to see" do
-        expect(Flipflop).to receive(:hide_private_files?).and_return(true)
-        render 'hyrax/base/items', presenter: presenter
-        expect(rendered).to have_content presenter.member_presenters.first.link_name
-        expect(rendered).not_to have_content presenter.member_presenters[1].link_name
+        expect(rendered).to have_css('tbody', text: member_presenters.join)
       end
     end
   end

--- a/spec/views/hyrax/base/_member.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_member.html.erb_spec.rb
@@ -38,6 +38,6 @@ RSpec.describe 'hyrax/base/_member.html.erb' do
     expect(rendered).to have_selector "a[title=\"Edit My File\"][href='#{edit_polymorphic_path(presenter)}']", text: 'Edit'
     expect(rendered).to have_selector "a[title=\"Delete My File\"][data-method='delete'][href='#{polymorphic_path(presenter)}']", text: 'Delete'
     expect(rendered).to have_link('Download')
-    expect(rendered).to have_selector "a[title='Download \"My File\"'][href='#{hyrax.download_path(presenter)}']", text: 'Download'
+    expect(rendered).to have_selector "a[title='Download My File'][href='#{hyrax.download_path(presenter)}']", text: 'Download'
   end
 end

--- a/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
@@ -1,15 +1,36 @@
 RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
-  let(:file_set) { stub_model(FileSet) }
+  let(:solr_document) { double("Solr Doc", id: 'file_set_id') }
+  let(:user) { build(:user) }
+  let(:ability) { Ability.new(user) }
+  let(:file_set) { Hyrax::FileSetPresenter.new(solr_document, ability) }
 
-  before do
-    allow(view).to receive(:can?).with(:edit, file_set.id).and_return(false)
-    allow(view).to receive(:can?).with(:destroy, file_set.id).and_return(false)
-    allow(view).to receive(:can?).with(:download, file_set.id).and_return(true)
-    render 'hyrax/file_sets/actions', file_set: file_set
+  context 'with download permission' do
+    before do
+      allow(file_set).to receive(:user_can_perform_any_action?).and_return(true)
+      allow(view).to receive(:can?).with(:edit, file_set.id).and_return(false)
+      allow(view).to receive(:can?).with(:destroy, file_set.id).and_return(false)
+      allow(view).to receive(:can?).with(:download, file_set.id).and_return(true)
+      render 'hyrax/file_sets/actions', file_set: file_set
+    end
+
+    it "includes google analytics data in the download link" do
+      expect(rendered).to have_css('a#file_download')
+      expect(rendered).to have_selector("a[data-label=\"#{file_set.id}\"]")
+    end
   end
 
-  it "includes google analytics data in the download link" do
-    expect(rendered).to have_css('a#file_download')
-    expect(rendered).to have_selector("a[data-label=\"#{file_set.id}\"]")
+  context 'with no permission' do
+    let(:current_ability) { ability }
+
+    before do
+      allow(current_ability).to receive(:can?).with(:edit, file_set.id).and_return(false)
+      allow(current_ability).to receive(:can?).with(:destroy, file_set.id).and_return(false)
+      allow(current_ability).to receive(:can?).with(:download, file_set.id).and_return(false)
+      render 'hyrax/file_sets/actions', file_set: file_set
+    end
+
+    it "renders nothing" do
+      expect(rendered).to eq('')
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/3063

Additionally:
- Adds internalization to work's actions.
- Checks for download ability before displaying download link on work's show view.
- Tightens up specs for hide_private_items? flipper to avoid building objects unnecessarily.

Backport of PR #3064 from master to rc2_bugfix branch
