### PR TITLE
Backport/remaining

### DIFF
--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -52,6 +52,12 @@ ul.tabular {
 .work-type {
   margin-bottom: 18px;
   margin-top: -8px;
+  .panel-body {
+    .work_description,
+    li.attribute {
+      word-break: break-word;
+    }
+  }
 }
 
 .panel-workflow {

--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -4,7 +4,8 @@
   }
 }
 
-.no-preview, .social-media {
+.no-preview,
+.social-media {
   padding: $panel-body-padding;
 }
 
@@ -17,7 +18,8 @@ header > h1 .label {
   padding: $panel-body-padding;
 }
 
-.relationships, .attributes {
+.relationships,
+.attributes {
   tbody th {
     width: 20%;
   }
@@ -52,6 +54,7 @@ ul.tabular {
 .work-type {
   margin-bottom: 18px;
   margin-top: -8px;
+
   .panel-body {
     .work_description,
     li.attribute {

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -10,12 +10,8 @@ class ImportUrlJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
   before_enqueue do |job|
+    operation = job.arguments[1]
     operation.pending_job(job)
-  end
-
-  # Retrieves the operation for the job
-  def operation
-    arguments.reduce(:merge).fetch(:operation)
   end
 
   # @param [FileSet] file_set

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -8,6 +8,7 @@ require 'browse_everything/retriever'
 # and CreateWithRemoteFilesActor when files are located in some other service.
 class ImportUrlJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
+  attr_reader :file_set, :operation
 
   before_enqueue do |job|
     operation = job.arguments[1]
@@ -20,6 +21,14 @@ class ImportUrlJob < Hyrax::ApplicationJob
     operation.performing!
     user = User.find_by_user_key(file_set.depositor)
     uri = URI(file_set.import_url)
+    @file_set = file_set
+    @operation = operation
+
+    unless HTTParty.head(file_set.import_url).success?
+      send_error('Expired URL')
+      return false
+    end
+
     # @todo Use Hydra::Works::AddExternalFileToFileSet instead of manually
     #       copying the file here. This will be gnarly.
     copy_remote_file(uri, headers) do |f|
@@ -29,13 +38,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
       # FileSetActor operates synchronously so that this tempfile is available.
       # If asynchronous, the job might be invoked on a machine that did not have this temp file on its file system!
       # NOTE: The return status may be successful even if the content never attaches.
-      if Hyrax::Actors::FileSetActor.new(file_set, user).create_content(f, from_url: true)
-        operation.success!
-      else
-        # send message to user on download failure
-        Hyrax.config.callback.run(:after_import_url_failure, file_set, user)
-        operation.fail!(file_set.errors.full_messages.join(' '))
-      end
+      log_import_status(uri, f, user)
     end
   end
 
@@ -53,14 +56,47 @@ class ImportUrlJob < Hyrax::ApplicationJob
       Rails.logger.debug("ImportUrlJob: Copying <#{uri}> to #{dir}")
 
       File.open(File.join(dir, filename), 'wb') do |f|
-        retriever = BrowseEverything::Retriever.new
-        uri_spec = { 'url' => uri }.merge(headers)
-        retriever.retrieve(uri_spec) do |chunk|
-          f.write(chunk)
+        begin
+          write_file(uri, f, headers)
+          yield f
+        rescue StandardError => e
+          send_error(e.message)
         end
-        f.rewind
-        yield f
       end
       Rails.logger.debug("ImportUrlJob: Closing #{File.join(dir, filename)}")
+    end
+
+    # Send message to user on download failure
+    # @param filename [String] the filename of the file to download
+    # @param error_message [String] the download error message
+    def send_error(error_message)
+      user = User.find_by_user_key(file_set.depositor)
+      @file_set.errors.add('Error:', error_message)
+      Hyrax.config.callback.run(:after_import_url_failure, @file_set, user)
+      @operation.fail!(@file_set.errors.full_messages.join(' '))
+    end
+
+    # Write file to the stream
+    # @param uri [URI] the uri of the file to download
+    # @param f [IO] the stream to write to
+    def write_file(uri, f, headers)
+      retriever = BrowseEverything::Retriever.new
+      uri_spec = { 'url' => uri }.merge(headers)
+      retriever.retrieve(uri_spec) do |chunk|
+        f.write(chunk)
+      end
+      f.rewind
+    end
+
+    # Set the import operation status
+    # @param uri [URI] the uri of the file to download
+    # @param f [IO] the stream to write to
+    # @param user [User]
+    def log_import_status(uri, f, user)
+      if Hyrax::Actors::FileSetActor.new(@file_set, user).create_content(f, from_url: true)
+        operation.success!
+      else
+        send_error(uri.path, nil)
+      end
     end
 end

--- a/app/models/concerns/hyrax/ability/admin_set_ability.rb
+++ b/app/models/concerns/hyrax/ability/admin_set_ability.rb
@@ -9,7 +9,7 @@ module Hyrax
           can :view_admin_show_any, AdminSet
         else
           can :manage_any, AdminSet if Hyrax::Collections::PermissionsService.can_manage_any_admin_set?(ability: self)
-          can :create_any, AdminSet if Hyrax::CollectionTypes::PermissionsService.can_create_admin_set_collection_type?(ability: self)
+          can [:create_any, :create], AdminSet if Hyrax::CollectionTypes::PermissionsService.can_create_admin_set_collection_type?(ability: self)
           can :view_admin_show_any, AdminSet if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_admin_set?(ability: self)
 
           can [:edit, :update, :destroy], AdminSet do |admin_set| # for test by solr_doc, see solr_document_ability.rb

--- a/spec/abilities/admin_set_ability_spec.rb
+++ b/spec/abilities/admin_set_ability_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'AdminSetAbility' do
       is_expected.to be_able_to(:manage, AdminSet)
       is_expected.to be_able_to(:manage_any, AdminSet)
       is_expected.to be_able_to(:create_any, AdminSet)
+      is_expected.to be_able_to(:create, AdminSet)
       is_expected.to be_able_to(:view_admin_show_any, AdminSet)
       is_expected.to be_able_to(:edit, admin_set)
       is_expected.to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
@@ -72,6 +73,7 @@ RSpec.describe 'AdminSetAbility' do
     it 'denies manage ability' do
       is_expected.not_to be_able_to(:manage, AdminSet)
       is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
+      is_expected.not_to be_able_to(:create, AdminSet)
     end
   end
 
@@ -100,6 +102,7 @@ RSpec.describe 'AdminSetAbility' do
       is_expected.not_to be_able_to(:manage, AdminSet)
       is_expected.not_to be_able_to(:manage_any, AdminSet)
       is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
+      is_expected.not_to be_able_to(:create, AdminSet)
       is_expected.not_to be_able_to(:edit, admin_set)
       is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:update, admin_set)
@@ -133,6 +136,7 @@ RSpec.describe 'AdminSetAbility' do
       is_expected.not_to be_able_to(:manage, AdminSet)
       is_expected.not_to be_able_to(:manage_any, AdminSet)
       is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
+      is_expected.not_to be_able_to(:create, AdminSet)
       is_expected.not_to be_able_to(:edit, admin_set)
       is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
       is_expected.not_to be_able_to(:update, admin_set)
@@ -154,6 +158,7 @@ RSpec.describe 'AdminSetAbility' do
       is_expected.not_to be_able_to(:manage, AdminSet)
       is_expected.not_to be_able_to(:manage_any, AdminSet)
       is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
+      is_expected.not_to be_able_to(:create, AdminSet)
       is_expected.not_to be_able_to(:view_admin_show_any, AdminSet)
       is_expected.not_to be_able_to(:edit, admin_set)
       is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe ImportUrlJob do
   let(:operation) { create(:operation) }
   let(:actor) { instance_double(Hyrax::Actors::FileSetActor, create_content: true) }
 
+  let(:mock_retriever) { double }
+  let(:inbox) { user.mailbox.inbox }
+
   before do
     allow(Hyrax::Actors::FileSetActor).to receive(:new).with(file_set, user).and_return(actor)
 
@@ -26,6 +29,9 @@ RSpec.describe ImportUrlJob do
     stub_request(:get, "http://example.org#{file_hash}").to_return(
       body: File.open(File.expand_path(file_path, __FILE__)).read, status: 200, headers: response_headers
     )
+
+    allow(BrowseEverything::Retriever).to receive(:new).and_return(mock_retriever)
+    allow(mock_retriever).to receive(:retrieve)
   end
 
   context 'before enqueueing the job' do
@@ -86,6 +92,40 @@ RSpec.describe ImportUrlJob do
       # import job should not override the title set another process
       file = FileSet.find(file_set_id)
       expect(file.title).to eq(['File One'])
+    end
+  end
+
+  context 'when the remote file is unavailable' do
+    before do
+      response_headers = { 'Content-Type' => 'image/png', 'Content-Length' => File.size(File.expand_path(file_path, __FILE__)) }
+
+      stub_request(:head, "http://example.org#{file_hash}").to_return(
+        body: "", status: 404, headers: response_headers
+      )
+    end
+
+    it 'sends error message' do
+      expect(operation).to receive(:fail!)
+      expect(file_set.original_file).to be_nil
+      described_class.perform_now(file_set, operation)
+      expect(inbox.count).to eq(1)
+      last_message = inbox[0].last_message
+      expect(last_message.subject).to eq('File Import Error')
+      expect(last_message.body).to eq("Error: Expired URL")
+    end
+  end
+
+  context 'when retrieval fails' do
+    before { allow(mock_retriever).to receive(:retrieve).and_raise(StandardError, 'Timeout') }
+
+    it 'sends error message' do
+      expect(operation).to receive(:fail!)
+      expect(file_set.original_file).to be_nil
+      described_class.perform_now(file_set, operation)
+      expect(inbox.count).to eq(1)
+      last_message = inbox[0].last_message
+      expect(last_message.subject).to eq('File Import Error')
+      expect(last_message.body).to eq("Error: Timeout")
     end
   end
 end

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe ImportUrlJob do
     )
   end
 
+  context 'before enqueueing the job' do
+    before do
+      file_set.id = 'fsid123'
+    end
+
+    describe '.operation' do
+      it 'fetches the operation' do
+        described_class.perform_later(file_set, operation)
+        expect { subject.operation.to eq Hyrax::Operation }
+      end
+    end
+  end
+
   context 'after running the job' do
     let!(:tmpdir) { Rails.root.join("tmp/spec/#{Process.pid}") }
 


### PR DESCRIPTION
Fixes #3046, #1235, #2976, #2004; ref #3056, #3059 

**Backports the following PRs from master to rc2_bugfix**

PR #3062 - gets operation from job arguments before enqueueing (fixing issue #3046)
PR #2821 - Check http status and notify user that the download failed for Import (fixing issue #1235)
PR #2977 - breaks very long metadata field values on show page (fixing issue #2976 )
PR #3066 - authorize adminset resource before extra validation and provide better redirect   (fixing issue #2004, PR #3056, PR #3059, https://github.com/curationexperts/nurax/issues/121, https://github.com/curationexperts/nurax/issues/200 (dup of 122), ref https://github.com/curationexperts/nurax/issues/191)

