### PR TITLE
Ensure locale is preserved when following links with urls generated outside of controller context.

### DIFF
--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -24,7 +24,7 @@ module Hyrax
     end
 
     def show_path
-      Hyrax::Engine.routes.url_helpers.admin_admin_set_path(id)
+      Hyrax::Engine.routes.url_helpers.admin_admin_set_path(id, locale: I18n.locale)
     end
 
     def available_parent_collections(*)

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -104,7 +104,7 @@ module Hyrax
     end
 
     def show_path
-      Hyrax::Engine.routes.url_helpers.dashboard_collection_path(id)
+      Hyrax::Engine.routes.url_helpers.dashboard_collection_path(id, locale: I18n.locale)
     end
 
     def banner_file

--- a/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
@@ -8,7 +8,7 @@ module Hyrax
         end
 
         def search_path(value)
-          Rails.application.routes.url_helpers.search_catalog_path(:"f[#{search_field}][]" => value)
+          Rails.application.routes.url_helpers.search_catalog_path(:"f[#{search_field}][]" => value, locale: I18n.locale)
         end
 
         def search_field

--- a/app/renderers/hyrax/renderers/linked_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/linked_attribute_renderer.rb
@@ -9,7 +9,7 @@ module Hyrax
 
         def search_path(value)
           Rails.application.routes.url_helpers.search_catalog_path(
-            search_field: search_field, q: ERB::Util.h(value)
+            search_field: search_field, q: ERB::Util.h(value), locale: I18n.locale
           )
         end
 

--- a/spec/presenters/hyrax/admin_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_presenter_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Hyrax::AdminSetPresenter do
 
     subject { presenter.show_path }
 
-    it { is_expected.to eq "/admin/admin_sets/#{admin_set.id}" }
+    it { is_expected.to eq "/admin/admin_sets/#{admin_set.id}?locale=en" }
   end
 
   describe '#managed_access' do

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Hyrax::CollectionPresenter do
   describe '#show_path' do
     subject { presenter.show_path }
 
-    it { is_expected.to eq "/dashboard/collections/#{solr_doc.id}" }
+    it { is_expected.to eq "/dashboard/collections/#{solr_doc.id}?locale=en" }
   end
 
   describe "banner_file" do

--- a/spec/renderers/hyrax/renderers/faceted_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/faceted_attribute_renderer_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Hyrax::Renderers::FacetedAttributeRenderer do
       %(
       <tr><th>Name</th>
       <td><ul class='tabular'>
-      <li class="attribute attribute-name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Bob">Bob</a></li>
-      <li class="attribute attribute-name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Jessica">Jessica</a></li>
+      <li class="attribute attribute-name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Bob&locale=en">Bob</a></li>
+      <li class="attribute attribute-name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Jessica&locale=en">Jessica</a></li>
       </ul></td></tr>
     )
     end
@@ -28,7 +28,7 @@ RSpec.describe Hyrax::Renderers::FacetedAttributeRenderer do
       let(:rendered_link_query) { URI.parse(rendered_link['href']).query }
 
       it "escapes content properly" do
-        expect(rendered_link_query).to eq "#{CGI.escape('f[name_sim][]')}=#{CGI.escape('John & Bob')}"
+        expect(rendered_link_query).to eq "#{CGI.escape('f[name_sim][]')}=#{CGI.escape('John & Bob')}&locale=en"
       end
     end
   end

--- a/spec/renderers/hyrax/renderers/linked_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/linked_attribute_renderer_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Hyrax::Renderers::LinkedAttributeRenderer do
     let(:tr_content) do
       "<tr><th>Name</th>\n" \
        "<td><ul class='tabular'>" \
-       "<li class=\"attribute attribute-name\"><a href=\"/catalog?q=Bob&amp;search_field=name\">Bob</a></li>\n" \
-       "<li class=\"attribute attribute-name\"><a href=\"/catalog?q=Jessica&amp;search_field=name\">Jessica</a></li>\n" \
+       "<li class=\"attribute attribute-name\"><a href=\"/catalog?locale=en&q=Bob&amp;search_field=name\">Bob</a></li>\n" \
+       "<li class=\"attribute attribute-name\"><a href=\"/catalog?locale=en&q=Jessica&amp;search_field=name\">Jessica</a></li>\n" \
        "</ul></td></tr>"
     end
 

--- a/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
       expect(rendered).to have_selector("tr#document_#{id}")
       check_tr_data_attributes
       expect(rendered).to have_selector("tr[data-post-delete-url='/dashboard/collections/#{id}']")
-      expect(rendered).to have_link 'Collection Title', href: hyrax.dashboard_collection_path(id)
+      expect(rendered).to have_link 'Collection Title', href: hyrax.dashboard_collection_path(id, locale: I18n.locale)
       expect(rendered).to have_link 'Edit collection', href: hyrax.edit_dashboard_collection_path(id)
       expect(rendered).to have_link 'Delete collection'
       expect(rendered).to have_link 'Add to collection'


### PR DESCRIPTION
Fixes #3075.

This PR fixes all places that are the same scenario:
- Links to collections and admin sets on the collections dashboard
- Metadata values on the show page which link to searches
- ~Links to user profiles (like on featured works on the homepage)~
- ~Link to contact page on default terms of use page (might not actually work but shouldn't hurt)~

Not fixed in this PR are links embedded within notification messages.

@samvera/hyrax-code-reviewers
