### PR TITLE
Move permissions inheriting earlier in block before other jobs are enqueued...

### DIFF
--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -12,10 +12,10 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
     metadata = visibility_attributes(work_attributes)
     uploaded_files.each do |uploaded_file|
       actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
+      actor.file_set.permissions_attributes = work_permissions
       actor.create_metadata(metadata)
       actor.create_content(uploaded_file)
       actor.attach_to_work(work)
-      actor.file_set.permissions_attributes = work_permissions
       uploaded_file.update(file_set_uri: actor.file_set.uri)
     end
   end


### PR DESCRIPTION
…to workaround timing bug where the file set's access_controls fedora object persists but isn't included when the file set is indexed.  This issue (#3076) wasn't manifested locally until switching to sidekiq.  My guess is that when the AttachFilesToWorkJob ran last (or close to last) it was running into this issue with the access_controls not getting indexed but when other jobs that save the file set ran last it was getting reindexed with the access_controls.  This PR moves the copying of the permissions to before other jobs are enqueued to hopefully allow for multiple saves/indexes with the access_controls set.

Fixes #3076.

@samvera/hyrax-code-reviewers
