### PR TITLE
Add work item pagination

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -192,7 +192,9 @@ module Hyrax
       end
 
       def curation_concern_from_search_results
-        search_result_document(params)
+        search_params = params
+        search_params.delete :page
+        search_result_document(search_params)
       end
 
       # Only returns unsuppressed documents the user has read access to

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -36,17 +36,17 @@ module Hyrax
       @work_presenters ||= member_presenters(ordered_ids - file_set_ids, work_presenter_class)
     end
 
-    private
+    # TODO: Extract this to ActiveFedora::Aggregations::ListSource
+    def ordered_ids
+      @ordered_ids ||= begin
+                         ActiveFedora::SolrService.query("proxy_in_ssi:#{id}",
+                                                         rows: 10_000,
+                                                         fl: "ordered_targets_ssim")
+                                                  .flat_map { |x| x.fetch("ordered_targets_ssim", []) }
+                       end
+    end
 
-      # TODO: Extract this to ActiveFedora::Aggregations::ListSource
-      def ordered_ids
-        @ordered_ids ||= begin
-                           ActiveFedora::SolrService.query("proxy_in_ssi:#{id}",
-                                                           rows: 10_000,
-                                                           fl: "ordered_targets_ssim")
-                                                    .flat_map { |x| x.fetch("ordered_targets_ssim", []) }
-                         end
-      end
+    private
 
       # These are the file sets that belong to this work, but not necessarily
       # in order.

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -69,7 +69,7 @@ module Hyrax
       return nil if representative_id.blank?
       @representative_presenter ||=
         begin
-          result = member_presenters([representative_id]).first
+          result = member_presenters_for([representative_id]).first
           return nil if result.try(:id) == id
           if result.respond_to?(:representative_presenter)
             result.representative_presenter
@@ -153,10 +153,22 @@ module Hyrax
       solr_document.to_model
     end
 
-    delegate :member_presenters, :file_set_presenters, :work_presenters, to: :member_presenter_factory
+    delegate :member_presenters, :ordered_ids, :file_set_presenters, :work_presenters, to: :member_presenter_factory
 
-    def exclude_unauthorized_members
-      member_presenters.delete_if { |m| !current_ability.can?(:read, m.id) }
+    # @return [Array] list to display with Kaminari pagination
+    def list_of_item_ids_to_display
+      paginated_item_list(page_array: authorized_item_ids)
+    end
+
+    # @param [Array<String>] ids a list of ids to build presenters for
+    # @return [Array<presenter_class>] presenters for the array of ids (not filtered by class)
+    def member_presenters_for(an_array_of_ids)
+      member_presenters(an_array_of_ids)
+    end
+
+    # @return [Integer] total number of pages of viewable items
+    def total_pages
+      (total_items.to_f / rows_from_params.to_f).ceil
     end
 
     def manifest_url
@@ -193,6 +205,33 @@ module Hyrax
     end
 
     private
+
+      # list of item ids to display is based on ordered_ids
+      def authorized_item_ids
+        @member_item_list_ids ||= begin
+          items = ordered_ids
+          items.delete_if { |m| !current_ability.can?(:read, m) } if Flipflop.hide_private_items?
+          items
+        end
+      end
+
+      # Uses kaminari to paginate an array to avoid need for solr documents for items here
+      def paginated_item_list(page_array:)
+        Kaminari.paginate_array(page_array, total_count: page_array.size).page(current_page).per(rows_from_params)
+      end
+
+      def total_items
+        authorized_item_ids.size
+      end
+
+      def rows_from_params
+        request.params[:rows].nil? ? 10 : request.params[:rows].to_i
+      end
+
+      def current_page
+        page = request.params[:page].nil? ? 1 : request.params[:page].to_i
+        page > total_pages ? total_pages : page
+      end
 
       def manifest_helper
         @manifest_helper ||= ManifestHelper.new(request.base_url)

--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -1,5 +1,6 @@
 <h2><%= t('.header') %></h2>
-<%  members = Flipflop.hide_private_items? ? presenter.exclude_unauthorized_members : presenter.member_presenters %>
+<%  array_of_ids = presenter.list_of_item_ids_to_display %>
+<%  members = presenter.member_presenters_for(array_of_ids) %>
 <% if members.present? %>
   <table class="table table-striped related-files">
     <thead>
@@ -15,6 +16,13 @@
       <%= render partial: 'member', collection: members %>
     </tbody>
   </table>
+  <div class="row">
+    <% if presenter.total_pages > 1 %>
+        <div class="row record-padding col-md-9">
+          <%= paginate array_of_ids, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
+        </div><!-- /pager -->
+    <% end %>
+  </div>
 <% elsif can? :edit, presenter.id %>
     <div class="alert alert-warning" role="alert"><%= t('.empty', type: presenter.human_readable_type) %></div>
 <% else %>

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe Hyrax::WorkShowPresenter do
   it { is_expected.to delegate_method(:resource_type).to(:solr_document) }
   it { is_expected.to delegate_method(:keyword).to(:solr_document) }
   it { is_expected.to delegate_method(:itemtype).to(:solr_document) }
+  it { is_expected.to delegate_method(:member_presenters).to(:member_presenter_factory) }
+  it { is_expected.to delegate_method(:ordered_ids).to(:member_presenter_factory) }
 
   describe "#model_name" do
     subject { presenter.model_name }
@@ -224,13 +226,86 @@ RSpec.describe Hyrax::WorkShowPresenter do
     end
   end
 
-  describe "exclude_unauthorized_members" do
+  describe "#member_presenters_for" do
     let(:obj) { create(:work_with_file_and_work) }
     let(:attributes) { obj.to_solr }
-    let(:ability) { double Ability, can?: false }
+    let(:items) { presenter.ordered_ids }
+    let(:subject) { presenter.member_presenters_for(items) }
 
-    it 'filters out unauthorized members' do
-      expect(presenter.exclude_unauthorized_members.count).to eq 0
+    it "returns appropriate classes for each item" do
+      expect(subject.size).to eq 2
+      expect(subject.first).to be_instance_of(Hyrax::FileSetPresenter)
+      expect(subject.last).to be_instance_of(described_class)
+    end
+  end
+
+  describe "#list_of_item_ids_to_display" do
+    let(:subject) { presenter.list_of_item_ids_to_display }
+    let(:items_list) { ['item0', 'item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7', 'item8', 'item9'] }
+    let(:rows) { 10 }
+    let(:page) { 1 }
+    let(:ability) { double "Ability" }
+    let(:current_ability) { ability }
+
+    before do
+      allow(presenter).to receive(:ordered_ids).and_return(items_list)
+      allow(current_ability).to receive(:can?).with(:read, 'item0').and_return true
+      allow(current_ability).to receive(:can?).with(:read, 'item1').and_return false
+      allow(current_ability).to receive(:can?).with(:read, 'item2').and_return true
+      allow(current_ability).to receive(:can?).with(:read, 'item3').and_return false
+      allow(current_ability).to receive(:can?).with(:read, 'item4').and_return true
+      allow(current_ability).to receive(:can?).with(:read, 'item5').and_return true
+      allow(current_ability).to receive(:can?).with(:read, 'item6').and_return false
+      allow(current_ability).to receive(:can?).with(:read, 'item7').and_return true
+      allow(current_ability).to receive(:can?).with(:read, 'item8').and_return false
+      allow(current_ability).to receive(:can?).with(:read, 'item9').and_return true
+      allow(presenter).to receive(:rows_from_params).and_return(rows)
+      allow(presenter).to receive(:current_page).and_return(page)
+      allow(Flipflop).to receive(:hide_private_items?).and_return(answer)
+    end
+
+    context 'when hiding private items' do
+      let(:answer) { true }
+
+      it "returns viewable items" do
+        expect(subject.size).to eq 6
+        expect(subject).to be_instance_of(Kaminari::PaginatableArray)
+        expect(subject).to include("item0", "item2", "item4", "item5", "item7", "item9")
+      end
+    end
+    context 'when including private items' do
+      let(:answer) { false }
+
+      it "returns appropriate items" do
+        expect(subject.size).to eq 10
+        expect(subject).to be_instance_of(Kaminari::PaginatableArray)
+        expect(subject).to eq(items_list)
+      end
+    end
+    context 'with pagination' do
+      let(:rows) { 3 }
+      let(:page) { 2 }
+
+      let(:answer) { true }
+      it 'partitions the item list and excluding hidden items' do
+        expect(subject).to eq(['item5', 'item7', 'item9'])
+      end
+    end
+  end
+
+  describe "#total_pages" do
+    let(:subject) { presenter.total_pages }
+    let(:items) { 17 }
+    let(:rows) { 4 }
+
+    before do
+      allow(Flipflop).to receive(:hide_private_items?).and_return(false)
+      allow(presenter).to receive(:total_items).and_return(items)
+      allow(presenter).to receive(:rows_from_params).and_return(rows)
+    end
+
+    it 'calculates number of pages from items and rows' do
+      expect(subject).to eq(5)
     end
   end
 

--- a/spec/views/hyrax/base/_items.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_items.html.erb_spec.rb
@@ -1,11 +1,17 @@
 RSpec.describe 'hyrax/base/_items.html.erb', type: :view do
   let(:ability) { double }
-  let(:presenter) { double(:presenter, member_presenters: member_presenters, id: 'the-id', human_readable_type: 'Thing') }
+  let(:request) { double "request", params: params }
+  let(:params) { ActionController::Parameters.new(rows: 10) }
 
   context 'when children are not present' do
-    let(:member_presenters) { [] }
+    let(:member_list) { [] }
+    let(:presenter) { double(:presenter, list_of_items_to_display: member_list, member_presenters_for: member_list, id: 'the-id', human_readable_type: 'Thing') }
 
-    context 'and the current user edit the presenter' do
+    before do
+      expect(presenter).to receive(:list_of_item_ids_to_display).and_return(member_list)
+    end
+
+    context 'and the current user can edit the presenter' do
       it 'renders an alert' do
         expect(view).to receive(:can?).with(:edit, presenter.id).and_return(true)
         render 'hyrax/base/items', presenter: presenter
@@ -25,35 +31,23 @@ RSpec.describe 'hyrax/base/_items.html.erb', type: :view do
     let(:child1) { double('Thing1', id: 'Thing 1', title: 'Title 1') }
     let(:child2) { double('Thing2', id: 'Thing 2', title: 'Title 2') }
     let(:child3) { double('Thing3', id: 'Thing 3', title: 'Title 3') }
-    let(:member_presenters) { [child1, child2, child3] }
-    let(:authorized_presenters) { [child1, child3] }
+    let(:member_list) { [child1, child2, child3] }
     let(:solr_document) { double('Solr Doc', id: 'the-id') }
     let(:presenter) { Hyrax::WorkShowPresenter.new(solr_document, ability, request) }
 
     before do
       stub_template 'hyrax/base/_member.html.erb' => '<%= member %>'
       expect(Flipflop).to receive(:hide_private_items?).and_return(:flipflop)
-      expect(presenter).to receive(:member_presenters).and_return(member_presenters)
-      expect(ability).to receive(:can?).with(:read, child1.id).and_return true
-      expect(ability).to receive(:can?).with(:read, child2.id).and_return false
-      expect(ability).to receive(:can?).with(:read, child3.id).and_return true
+      allow(presenter).to receive(:list_of_item_ids_to_display).and_return(member_list)
+      allow(presenter).to receive(:member_presenters_for).with(member_list).and_return(member_list)
+      allow(ability).to receive(:can?).with(:read, child1.id).and_return true
+      allow(ability).to receive(:can?).with(:read, child2.id).and_return false
+      allow(ability).to receive(:can?).with(:read, child3.id).and_return true
     end
 
-    context 'and hide_private_items is on' do
-      let(:flip_flop) { true }
-
-      it "displays only authorized children" do
-        render 'hyrax/base/items', presenter: presenter
-        expect(rendered).to have_css('tbody', text: authorized_presenters.join)
-      end
-    end
-    context 'and hide_private_items is off' do
-      let(:flip_flop) { false }
-
-      it "displays all children" do
-        render 'hyrax/base/items', presenter: presenter
-        expect(rendered).to have_css('tbody', text: member_presenters.join)
-      end
+    it "displays children" do
+      render 'hyrax/base/items', presenter: presenter
+      expect(rendered).to have_css('tbody')
     end
   end
 end


### PR DESCRIPTION
Fixes #3078

- Added a basic pagination render to the items partial.
- Added methods to Work Show Presenter to support page and rows
  params for items, and to paginate the array of items being displayed.

@samvera/hyrax-code-reviewers
