### PR TITLE
Visibility component close collapsable only inside save widget on page load

### DIFF
--- a/app/assets/javascripts/hyrax/save_work/visibility_component.es6
+++ b/app/assets/javascripts/hyrax/save_work/visibility_component.es6
@@ -8,7 +8,7 @@ export default class VisibilityComponent {
     this.element = element
     this.adminSetWidget = adminSetWidget
     this.form = element.closest('form')
-    $('#savewidget .collapse').collapse({ toggle: false })
+      this.element.find('.collapse').collapse({ toggle: false })
     element.find("[type='radio']").on('change', () => { this.showForm() })
     // Ensure any disabled options are re-enabled when form submits
     this.form.on('submit', () => { this.enableAllOptions() })
@@ -22,7 +22,7 @@ export default class VisibilityComponent {
 
   // Collapse all Visibility sub-options
   collapseAll() {
-    $('#savewidget .collapse').collapse('hide');
+      this.element.find('.collapse').collapse('hide');
   }
 
   // Open the selected Visibility's sub-options, collapsing all others
@@ -33,8 +33,8 @@ export default class VisibilityComponent {
 
     if(target) {
       // Show the target suboption and hide all others
-      $('#savewidget .collapse' + target).collapse('show');
-      $('#savewidget .collapse:not(' + target + ')').collapse('hide');
+        this.element.find('.collapse' + target).collapse('show');
+        this.element.find('.collapse:not(' + target + ')').collapse('hide');
     }
     else {
       this.collapseAll()

--- a/app/assets/javascripts/hyrax/save_work/visibility_component.es6
+++ b/app/assets/javascripts/hyrax/save_work/visibility_component.es6
@@ -8,7 +8,7 @@ export default class VisibilityComponent {
     this.element = element
     this.adminSetWidget = adminSetWidget
     this.form = element.closest('form')
-    $('.collapse').collapse({ toggle: false })
+    $('#savewidget .collapse').collapse({ toggle: false })
     element.find("[type='radio']").on('change', () => { this.showForm() })
     // Ensure any disabled options are re-enabled when form submits
     this.form.on('submit', () => { this.enableAllOptions() })
@@ -22,7 +22,7 @@ export default class VisibilityComponent {
 
   // Collapse all Visibility sub-options
   collapseAll() {
-    $('.collapse').collapse('hide');
+    $('#savewidget .collapse').collapse('hide');
   }
 
   // Open the selected Visibility's sub-options, collapsing all others
@@ -33,8 +33,8 @@ export default class VisibilityComponent {
 
     if(target) {
       // Show the target suboption and hide all others
-      $('.collapse' + target).collapse('show');
-      $('.collapse:not(' + target + ')').collapse('hide');
+      $('#savewidget .collapse' + target).collapse('show');
+      $('#savewidget .collapse:not(' + target + ')').collapse('hide');
     }
     else {
       this.collapseAll()


### PR DESCRIPTION
Fixes #3093  ;
Modify visibility component to limit the scope for closing collapsable containers within # SaveWidget only.


Changes proposed in this pull request:
* limit scope for closing collapse content within save widget only

@samvera/hyrax-code-reviewers
