### PR TITLE
Reinstate the `create_work_presenter` and deprecate it

### DIFF
--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -6,12 +6,27 @@ module Hyrax::Controller
 
     # Adds Hydra behaviors into the application controller
     include Hydra::Controller::ControllerBehavior
+    helper_method :create_work_presenter
     before_action :set_locale
   end
 
   # Provide a place for Devise to send the user to after signing in
   def user_root_path
     hyrax.dashboard_path
+  end
+
+  ##
+  # @deprecated this helper is no longer used by Hyrax; if you need access to
+  #   this presenter on every page, you may need to readd it manually.
+  #
+  # A presenter for selecting a work type to create this is needed here because
+  # the selector is in the header on every page.
+  def create_work_presenter
+    Deprecation.warn(self, "The `create_work_presenter` helper is deprecated " \
+                           "for removal in Hyrax 3.0. The work selector has " \
+                           "been removed the masthead in Hyrax 2.1.")
+
+    Hyrax::SelectTypeListPresenter.new(current_user)
   end
 
   # Ensure that the locale choice is persistent across requests


### PR DESCRIPTION
Removal of this method broke upgrades to 2.1 for several
adopters. https://github.com/samvera/hyrax/wiki/Troubleshooting-Migration-from-2.0.x-to-2.1.0#error-on-overridden-home-page

Reinstating it and deprecating explictly will be nicer during upgrades.

@samvera/hyrax-code-reviewers
