### PR TITLE
Switch to using member_of_collection_ids_ssim to power collection facet

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -257,6 +257,14 @@ module Hyrax
       content_tag(:span, "", class: [Hyrax::ModelIcon.css_class_for(Collection), "collection-icon-search"])
     end
 
+    def collection_title_by_id(id)
+      solr_docs = controller.repository.find(id).docs
+      return nil if solr_docs.empty?
+      solr_field = solr_docs.first[Solrizer.solr_name("title", :stored_searchable)]
+      return nil if solr_field.nil?
+      solr_field.first
+    end
+
     private
 
       def user_agent

--- a/app/search_builders/hyrax/catalog_search_builder.rb
+++ b/app/search_builders/hyrax/catalog_search_builder.rb
@@ -2,7 +2,8 @@ class Hyrax::CatalogSearchBuilder < Hyrax::SearchBuilder
   self.default_processor_chain += [
     :add_access_controls_to_solr_params,
     :show_works_or_works_that_contain_files,
-    :show_only_active_records
+    :show_only_active_records,
+    :filter_collection_facet_for_access
   ]
 
   # show both works that match the query and works that contain files that match the query
@@ -17,6 +18,18 @@ class Hyrax::CatalogSearchBuilder < Hyrax::SearchBuilder
   def show_only_active_records(solr_parameters)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] << '-suppressed_bsi:true'
+  end
+
+  # only return facet counts for collections that this user has access to see
+  def filter_collection_facet_for_access(solr_parameters)
+    return if current_ability.admin?
+
+    collection_ids = Hyrax::Collections::PermissionsService.collection_ids_for_view(ability: current_ability).map { |id| "^#{id}$" }
+    solr_parameters['f.member_of_collection_ids_ssim.facet.matches'] = if collection_ids.present?
+                                                                         collection_ids.join('|')
+                                                                       else
+                                                                         "^$"
+                                                                       end
   end
 
   private

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -99,6 +99,19 @@ module Hyrax
 
       # @api public
       #
+      # IDs of collections which the user can view.
+      #
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Array<String>] IDs of collections into which the user can view
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.collection_ids_for_view(ability:)
+        collection_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE,
+                                                           Hyrax::PermissionTemplateAccess::DEPOSIT,
+                                                           Hyrax::PermissionTemplateAccess::VIEW])
+      end
+
+      # @api public
+      #
       # Determine if the given user has permissions to view the admin show page for at least one collection
       #
       # @param ability [Ability] the ability coming from cancan ability check

--- a/lib/generators/hyrax/templates/catalog_controller.rb
+++ b/lib/generators/hyrax/templates/catalog_controller.rb
@@ -44,7 +44,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("based_near_label", :facetable), limit: 5
     config.add_facet_field solr_name("publisher", :facetable), limit: 5
     config.add_facet_field solr_name("file_format", :facetable), limit: 5
-    config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5, label: 'Collections'
+    config.add_facet_field solr_name('member_of_collection_ids', :symbol), limit: 5, label: 'Collections', helper_method: :collection_title_by_id
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -366,4 +366,34 @@ RSpec.describe HyraxHelper, type: :helper do
       expect(helper.banner_image).to eq(Hyrax.config.banner_image)
     end
   end
+
+  describe "#collection_title_by_id" do
+    let(:solr_doc) { double(id: "abcd12345") }
+    let(:bad_solr_doc) { double(id: "efgh67890") }
+    let(:solr_response) { double(docs: [solr_doc]) }
+    let(:bad_solr_response) { double(docs: [bad_solr_doc]) }
+    let(:empty_solr_response) { double(docs: []) }
+    let(:repository) { double }
+
+    before do
+      allow(controller).to receive(:repository).and_return(repository)
+      allow(solr_doc).to receive(:[]).with("title_tesim").and_return(["Collection of Awesomeness"])
+      allow(bad_solr_doc).to receive(:[]).with("title_tesim").and_return(nil)
+      allow(repository).to receive(:find).with("abcd12345").and_return(solr_response)
+      allow(repository).to receive(:find).with("efgh67890").and_return(bad_solr_response)
+      allow(repository).to receive(:find).with("bad-id").and_return(empty_solr_response)
+    end
+
+    it "returns the first title of the collection" do
+      expect(helper.collection_title_by_id("abcd12345")).to eq "Collection of Awesomeness"
+    end
+
+    it "returns nil if collection doesn't have title_tesim field" do
+      expect(helper.collection_title_by_id("efgh67890")).to eq nil
+    end
+
+    it "returns nil if collection not found" do
+      expect(helper.collection_title_by_id("bad-id")).to eq nil
+    end
+  end
 end

--- a/spec/services/hyrax/collections/permissions_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_service_spec.rb
@@ -299,6 +299,20 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       end
     end
 
+    describe '.collection_ids_for_view' do
+      it 'returns collection ids where user has view access' do
+        expect(described_class.collection_ids_for_view(ability: ability)).to match_array [col_du.id, col_dg.id, col_mu.id, col_mg.id, col_vu.id, col_vg.id]
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user2) }
+
+        it 'returns empty array' do
+          expect(described_class.collection_ids_for_view(ability: ability)).to match_array []
+        end
+      end
+    end
+
     describe '.can_manage_any_collection?' do
       it 'returns true when user has manage access to at least one collection' do
         expect(described_class.can_manage_any_collection?(ability: ability)).to be true


### PR DESCRIPTION
…and filter values based upon a whitelist of collections that the user has access to read then resolve these ids to human readable names using a helper method.

Fixes #3092 .

This will need to be tested with many different roles and scenarios.

I'm a bit concerned that this isn't backwards compatible and has a pretty big cost of 6 additional solr queries per catalog search.  But I think this does show a way to do this.


@samvera/hyrax-code-reviewers
