### PR TITLE
Backport/fixes from master

### DIFF
--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -6,12 +6,27 @@ module Hyrax::Controller
 
     # Adds Hydra behaviors into the application controller
     include Hydra::Controller::ControllerBehavior
+    helper_method :create_work_presenter
     before_action :set_locale
   end
 
   # Provide a place for Devise to send the user to after signing in
   def user_root_path
     hyrax.dashboard_path
+  end
+
+  ##
+  # @deprecated this helper is no longer used by Hyrax; if you need access to
+  #   this presenter on every page, you may need to readd it manually.
+  #
+  # A presenter for selecting a work type to create this is needed here because
+  # the selector is in the header on every page.
+  def create_work_presenter
+    Deprecation.warn(self, "The `create_work_presenter` helper is deprecated " \
+                           "for removal in Hyrax 3.0. The work selector has " \
+                           "been removed the masthead in Hyrax 2.1.")
+
+    Hyrax::SelectTypeListPresenter.new(current_user)
   end
 
   # Ensure that the locale choice is persistent across requests

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -257,6 +257,14 @@ module Hyrax
       content_tag(:span, "", class: [Hyrax::ModelIcon.css_class_for(Collection), "collection-icon-search"])
     end
 
+    def collection_title_by_id(id)
+      solr_docs = controller.repository.find(id).docs
+      return nil if solr_docs.empty?
+      solr_field = solr_docs.first[Solrizer.solr_name("title", :stored_searchable)]
+      return nil if solr_field.nil?
+      solr_field.first
+    end
+
     private
 
       def user_agent

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -225,7 +225,7 @@ module Hyrax
       end
 
       def rows_from_params
-        request.params[:rows].nil? ? 10 : request.params[:rows].to_i
+        request.params[:rows].nil? ? Hyrax.config.show_work_item_rows : request.params[:rows].to_i
       end
 
       def current_page

--- a/app/search_builders/hyrax/catalog_search_builder.rb
+++ b/app/search_builders/hyrax/catalog_search_builder.rb
@@ -2,7 +2,8 @@ class Hyrax::CatalogSearchBuilder < Hyrax::SearchBuilder
   self.default_processor_chain += [
     :add_access_controls_to_solr_params,
     :show_works_or_works_that_contain_files,
-    :show_only_active_records
+    :show_only_active_records,
+    :filter_collection_facet_for_access
   ]
 
   # show both works that match the query and works that contain files that match the query
@@ -17,6 +18,18 @@ class Hyrax::CatalogSearchBuilder < Hyrax::SearchBuilder
   def show_only_active_records(solr_parameters)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] << '-suppressed_bsi:true'
+  end
+
+  # only return facet counts for collections that this user has access to see
+  def filter_collection_facet_for_access(solr_parameters)
+    return if current_ability.admin?
+
+    collection_ids = Hyrax::Collections::PermissionsService.collection_ids_for_view(ability: current_ability).map { |id| "^#{id}$" }
+    solr_parameters['f.member_of_collection_ids_ssim.facet.matches'] = if collection_ids.present?
+                                                                         collection_ids.join('|')
+                                                                       else
+                                                                         "^$"
+                                                                       end
   end
 
   private

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -99,6 +99,19 @@ module Hyrax
 
       # @api public
       #
+      # IDs of collections which the user can view.
+      #
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Array<String>] IDs of collections into which the user can view
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.collection_ids_for_view(ability:)
+        collection_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE,
+                                                           Hyrax::PermissionTemplateAccess::DEPOSIT,
+                                                           Hyrax::PermissionTemplateAccess::VIEW])
+      end
+
+      # @api public
+      #
       # Determine if the given user has permissions to view the admin show page for at least one collection
       #
       # @param ability [Ability] the ability coming from cancan ability check

--- a/lib/generators/hyrax/templates/catalog_controller.rb
+++ b/lib/generators/hyrax/templates/catalog_controller.rb
@@ -44,7 +44,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("based_near_label", :facetable), limit: 5
     config.add_facet_field solr_name("publisher", :facetable), limit: 5
     config.add_facet_field solr_name("file_format", :facetable), limit: 5
-    config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5, label: 'Collections'
+    config.add_facet_field solr_name('member_of_collection_ids', :symbol), limit: 5, label: 'Collections', helper_method: :collection_title_by_id
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -116,6 +116,10 @@ Hyrax.config do |config|
   # The default is true.
   # config.work_requires_files = true
 
+  # How many rows of items should appear on the work show view?
+  # The default is 10
+  # config.show_work_item_rows = 10
+
   # Enable IIIF image service. This is required to use the
   # UniversalViewer-ified show page
   #

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -340,6 +340,11 @@ module Hyrax
       @work_requires_files
     end
 
+    attr_writer :show_work_item_rows
+    def show_work_item_rows
+      @show_work_item_rows ||= 10 # rows on show view
+    end
+
     attr_writer :batch_user_key
     def batch_user_key
       @batch_user_key ||= 'batchuser@example.com'

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -366,4 +366,34 @@ RSpec.describe HyraxHelper, type: :helper do
       expect(helper.banner_image).to eq(Hyrax.config.banner_image)
     end
   end
+
+  describe "#collection_title_by_id" do
+    let(:solr_doc) { double(id: "abcd12345") }
+    let(:bad_solr_doc) { double(id: "efgh67890") }
+    let(:solr_response) { double(docs: [solr_doc]) }
+    let(:bad_solr_response) { double(docs: [bad_solr_doc]) }
+    let(:empty_solr_response) { double(docs: []) }
+    let(:repository) { double }
+
+    before do
+      allow(controller).to receive(:repository).and_return(repository)
+      allow(solr_doc).to receive(:[]).with("title_tesim").and_return(["Collection of Awesomeness"])
+      allow(bad_solr_doc).to receive(:[]).with("title_tesim").and_return(nil)
+      allow(repository).to receive(:find).with("abcd12345").and_return(solr_response)
+      allow(repository).to receive(:find).with("efgh67890").and_return(bad_solr_response)
+      allow(repository).to receive(:find).with("bad-id").and_return(empty_solr_response)
+    end
+
+    it "returns the first title of the collection" do
+      expect(helper.collection_title_by_id("abcd12345")).to eq "Collection of Awesomeness"
+    end
+
+    it "returns nil if collection doesn't have title_tesim field" do
+      expect(helper.collection_title_by_id("efgh67890")).to eq nil
+    end
+
+    it "returns nil if collection not found" do
+      expect(helper.collection_title_by_id("bad-id")).to eq nil
+    end
+  end
 end

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:rights_statement_service_class=) }
   it { is_expected.to respond_to(:redis_namespace) }
   it { is_expected.to respond_to(:subject_prefix) }
+  it { is_expected.to respond_to(:show_work_item_rows) }
   it { is_expected.to respond_to(:translate_id_to_uri) }
   it { is_expected.to respond_to(:translate_uri_to_id) }
   it { is_expected.to respond_to(:upload_path) }

--- a/spec/services/hyrax/collections/permissions_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_service_spec.rb
@@ -299,6 +299,20 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       end
     end
 
+    describe '.collection_ids_for_view' do
+      it 'returns collection ids where user has view access' do
+        expect(described_class.collection_ids_for_view(ability: ability)).to match_array [col_du.id, col_dg.id, col_mu.id, col_mg.id, col_vu.id, col_vg.id]
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user2) }
+
+        it 'returns empty array' do
+          expect(described_class.collection_ids_for_view(ability: ability)).to match_array []
+        end
+      end
+    end
+
     describe '.can_manage_any_collection?' do
       it 'returns true when user has manage access to at least one collection' do
         expect(described_class.can_manage_any_collection?(ability: ability)).to be true


### PR DESCRIPTION
Backport PRs from master to rc3_bugfix

PR #3102 - Switch to using member_of_collection_ids_ssim to power collection facet
PR #3100 - Make work item rows shown configurable
PR #3097 - Reinstate the `create_work_presenter` and deprecate it

