### PR TITLE
Deduplicate exported graphs for nested works

### DIFF
--- a/app/services/hyrax/graph_exporter.rb
+++ b/app/services/hyrax/graph_exporter.rb
@@ -51,6 +51,8 @@ module Hyrax
       end
 
       def subresource_replacer(resource_id, parent_klass)
+        return subject_replacer(parent_klass, resource_id) unless resource_id.include?('/')
+
         parent_id, local = resource_id.split('/', 2)
 
         if @visited_subresources.add?(resource_id)
@@ -73,7 +75,10 @@ module Hyrax
                     end
         routes = Rails.application.routes.url_helpers
         builder = ActionDispatch::Routing::PolymorphicRoutes::HelperMethodBuilder
-        builder.polymorphic_method routes, route_key, nil, :url, id: resource_id, host: hostname, anchor: anchor
+        resource_id = RDF::URI(resource_id)
+        new_uri = RDF::URI(builder.polymorphic_method(routes, route_key, nil, :url, id: resource_id.path, host: hostname, anchor: anchor))
+        new_uri.fragment = resource_id.fragment
+        new_uri
       end
 
       def object_replacer(id, _graph)

--- a/spec/services/hyrax/graph_exporter_spec.rb
+++ b/spec/services/hyrax/graph_exporter_spec.rb
@@ -36,5 +36,23 @@ RSpec.describe Hyrax::GraphExporter do
         expect { subject }.to raise_error ActiveFedora::ObjectNotFoundError
       end
     end
+
+    context 'with a nested work' do
+      let(:work) do
+        NamespacedWorks::NestedWork
+          .create(title: ['Comet in Moominland'],
+                  created_attributes: [{ start: DateTime.now.utc - 1, finish: DateTime.now.utc },
+                                       { start: DateTime.now.utc - 2, finish: DateTime.now.utc }])
+      end
+
+      it 'includes each nested resources once' do
+        resource_fragments = work.created.map { |ts| ts.rdf_subject.fragment }
+        mapped_fragments   = subject.query(predicate: RDF.type, object: RDF::Vocab::EDM.TimeSpan)
+                                    .subjects
+                                    .map(&:fragment)
+
+        expect(mapped_fragments).to contain_exactly(*resource_fragments)
+      end
+    end
   end
 end


### PR DESCRIPTION
Nested works with hash URIs were previously assumed to be list elements in the
graph exporter for the work presenter. This class is meant to faithfully
replace uris and expand scope of a Fedora resource, but for hash URI's it ended
up refectching and reincluding the base graph using a different replacement
rule.

In the patched version we only follow links when the resource id has a `/`. We
still assume these uris are list elements (which may be wrong). We also fix a
bug where hash URIs got URL encoded, turning hashes into `"%23"`.

Fixes #3103

@samvera/hyrax-code-reviewers
