### PR TITLE
namespace call to route helper path collection_path

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -11,7 +11,7 @@ module Hyrax
     def render_collection_links(solr_doc)
       collection_list = Hyrax::CollectionMemberService.run(solr_doc, controller.current_ability)
       return if collection_list.empty?
-      links = collection_list.map { |collection| link_to collection.title_or_label, collection_path(collection.id) }
+      links = collection_list.map { |collection| link_to collection.title_or_label, hyrax.collection_path(collection.id) }
       collection_links = []
       links.each_with_index do |link, n|
         collection_links << link


### PR DESCRIPTION
Fixes #3113

Add `hyrax` namespace to call to `collection_path`.

@samvera/hyrax-code-reviewers
