### PR TITLE
Change SingleUseLink itemId and downloadKey from camel to snake case

### DIFF
--- a/app/controllers/hyrax/single_use_links_controller.rb
+++ b/app/controllers/hyrax/single_use_links_controller.rb
@@ -18,22 +18,22 @@ module Hyrax
     end
 
     def create_download
-      @su = SingleUseLink.create itemId: params[:id], path: hyrax.download_path(id: params[:id])
-      render plain: hyrax.download_single_use_link_url(@su.downloadKey)
+      @su = SingleUseLink.create item_id: params[:id], path: hyrax.download_path(id: params[:id])
+      render plain: hyrax.download_single_use_link_url(@su.download_key)
     end
 
     def create_show
-      @su = SingleUseLink.create(itemId: params[:id], path: asset_show_path)
-      render plain: hyrax.show_single_use_link_url(@su.downloadKey)
+      @su = SingleUseLink.create(item_id: params[:id], path: asset_show_path)
+      render plain: hyrax.show_single_use_link_url(@su.download_key)
     end
 
     def index
-      links = SingleUseLink.where(itemId: params[:id]).map { |link| show_presenter.new(link) }
+      links = SingleUseLink.where(item_id: params[:id]).map { |link| show_presenter.new(link) }
       render partial: 'hyrax/file_sets/single_use_link_rows', locals: { single_use_links: links }
     end
 
     def destroy
-      SingleUseLink.find_by_downloadKey(params[:link_id]).destroy
+      SingleUseLink.find_by_download_key(params[:link_id]).destroy
       head :ok
     end
 

--- a/app/controllers/hyrax/single_use_links_viewer_controller.rb
+++ b/app/controllers/hyrax/single_use_links_viewer_controller.rb
@@ -18,7 +18,7 @@ module Hyrax
     end
 
     def show
-      _, document_list = search_results(id: single_use_link.itemId)
+      _, document_list = search_results(id: single_use_link.item_id)
       curation_concern = document_list.first
 
       # Authorize using SingleUseLinksViewerController::Ability
@@ -30,7 +30,7 @@ module Hyrax
 
       # create a dowload link that is single use for the user since we do not just want to show metadata we want to access it too
       @su = single_use_link.create_for_path hyrax.download_path(curation_concern.id)
-      @download_link = hyrax.download_single_use_link_path(@su.downloadKey)
+      @download_link = hyrax.download_single_use_link_path(@su.download_key)
     end
 
     private
@@ -51,7 +51,7 @@ module Hyrax
       end
 
       def single_use_link
-        @single_use_link ||= SingleUseLink.find_by_downloadKey!(params[:id])
+        @single_use_link ||= SingleUseLink.find_by_download_key!(params[:id])
       end
 
       def not_found_exception
@@ -59,7 +59,7 @@ module Hyrax
       end
 
       def asset
-        @asset ||= ActiveFedora::Base.find(single_use_link.itemId)
+        @asset ||= ActiveFedora::Base.find(single_use_link.item_id)
       end
 
       def current_ability
@@ -88,7 +88,7 @@ module Hyrax
 
           @single_use_link = single_use_link
           can :read, [ActiveFedora::Base, ::SolrDocument] do |obj|
-            single_use_link.valid? && single_use_link.itemId == obj.id && single_use_link.destroy!
+            single_use_link.valid? && single_use_link.item_id == obj.id && single_use_link.destroy!
           end
         end
       end

--- a/app/models/single_use_link.rb
+++ b/app/models/single_use_link.rb
@@ -2,10 +2,13 @@ class SingleUseLink < ActiveRecord::Base
   validate :expiration_date_cannot_be_in_the_past
   validate :cannot_be_destroyed
 
+  alias_attribute :downloadKey, :download_key
+  alias_attribute :itemId, :item_id
+
   after_initialize :set_defaults
 
   def create_for_path(path)
-    self.class.create(itemId: itemId, path: path)
+    self.class.create(item_id: item_id, path: path)
   end
 
   def expired?
@@ -13,7 +16,7 @@ class SingleUseLink < ActiveRecord::Base
   end
 
   def to_param
-    downloadKey
+    download_key
   end
 
   private
@@ -29,6 +32,6 @@ class SingleUseLink < ActiveRecord::Base
     def set_defaults
       return unless new_record?
       self.expires ||= DateTime.current.advance(hours: 24)
-      self.downloadKey ||= (Digest::SHA2.new << rand(1_000_000_000).to_s).to_s
+      self.download_key ||= (Digest::SHA2.new << rand(1_000_000_000).to_s).to_s
     end
 end

--- a/app/models/single_use_link.rb
+++ b/app/models/single_use_link.rb
@@ -7,6 +7,28 @@ class SingleUseLink < ActiveRecord::Base
 
   after_initialize :set_defaults
 
+  # rubocop:disable Naming/MethodName
+  def downloadKey
+    Deprecation.warn(self, 'The #downloadKey attribute is deprecated. Use #download_key instead.')
+    download_key
+  end
+
+  def downloadKey=(val)
+    Deprecation.warn(self, 'The #downloadKey attribute is deprecated. Use #download_key instead.')
+    self.download_key = val
+  end
+
+  def itemId
+    Deprecation.warn(self, 'The #itemId attribute is deprecated. Use #item_id instead.')
+    item_id
+  end
+
+  def itemId=(val)
+    Deprecation.warn(self, 'The #itemId attribute is deprecated. Use #item_id instead.')
+    self.item_id = val
+  end
+  # rubocop:enable Naming/MethodName
+
   def create_for_path(path)
     self.class.create(item_id: item_id, path: path)
   end

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -33,7 +33,7 @@ module Hyrax
              to: :solr_document
 
     def single_use_links
-      @single_use_links ||= SingleUseLink.where(itemId: id).map { |link| link_presenter_class.new(link) }
+      @single_use_links ||= SingleUseLink.where(item_id: id).map { |link| link_presenter_class.new(link) }
     end
 
     # The title of the webpage that shows this FileSet.

--- a/app/presenters/hyrax/single_use_link_presenter.rb
+++ b/app/presenters/hyrax/single_use_link_presenter.rb
@@ -4,7 +4,7 @@ module Hyrax
 
     attr_reader :link
 
-    delegate :downloadKey, :expired?, :to_param, to: :link
+    delegate :download_key, :expired?, :to_param, to: :link
 
     # @param link [SingleUseLink]
     def initialize(link)
@@ -20,7 +20,7 @@ module Hyrax
     end
 
     def short_key
-      link.downloadKey.first(6)
+      link.download_key.first(6)
     end
 
     def link_type

--- a/app/views/hyrax/file_sets/_single_use_link_rows.html.erb
+++ b/app/views/hyrax/file_sets/_single_use_link_rows.html.erb
@@ -6,7 +6,7 @@
     </td>
     <td>
       <button class="btn btn-xs btn-default copy-single-use-link"
-              data-clipboard-text="<%= hyrax.send(presenter.url_helper, presenter.downloadKey) %>"
+              data-clipboard-text="<%= hyrax.send(presenter.url_helper, presenter.download_key) %>"
               data-toggle="tooltip" data-placement="bottom"
               title="<%= t('hyrax.single_use_links.copy.tooltip') %>">
         <%= t('hyrax.single_use_links.copy.button') %>

--- a/lib/generators/hyrax/templates/db/migrate/20180612002029_update_single_use_links_column_names.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20180612002029_update_single_use_links_column_names.rb.erb
@@ -1,0 +1,6 @@
+class UpdateSingleUseLinksColumnNames < ActiveRecord::Migration<%= migration_version %>
+  def change
+    rename_column :single_use_links, :downloadKey, :download_key
+    rename_column :single_use_links, :itemId, :item_id
+  end
+end

--- a/spec/controllers/hyrax/single_use_links_viewer_controller_spec.rb
+++ b/spec/controllers/hyrax/single_use_links_viewer_controller_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe Hyrax::SingleUseLinksViewerController do
 
   describe "retrieval links" do
     let :show_link do
-      SingleUseLink.create itemId: file.id, path: Rails.application.routes.url_helpers.hyrax_file_set_path(id: file, locale: 'en')
+      SingleUseLink.create item_id: file.id, path: Rails.application.routes.url_helpers.hyrax_file_set_path(id: file, locale: 'en')
     end
 
     let :download_link do
       Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :original_file)
-      SingleUseLink.create itemId: file.id, path: Hyrax::Engine.routes.url_helpers.download_path(id: file, locale: 'en')
+      SingleUseLink.create item_id: file.id, path: Hyrax::Engine.routes.url_helpers.download_path(id: file, locale: 'en')
     end
 
-    let(:show_link_hash) { show_link.downloadKey }
-    let(:download_link_hash) { download_link.downloadKey }
+    let(:show_link_hash) { show_link.download_key }
+    let(:download_link_hash) { download_link.download_key }
 
     describe "GET 'download'" do
       let(:expected_content) { ActiveFedora::Base.find(file.id).original_file.content }
@@ -26,11 +26,11 @@ RSpec.describe Hyrax::SingleUseLinksViewerController do
         get :download, params: { id: download_link_hash }
         expect(response.body).to eq expected_content
         expect(response).to be_success
-        expect { SingleUseLink.find_by_downloadKey!(download_link_hash) }.to raise_error ActiveRecord::RecordNotFound
+        expect { SingleUseLink.find_by_download_key!(download_link_hash) }.to raise_error ActiveRecord::RecordNotFound
       end
 
       context "when the key is not found" do
-        before { SingleUseLink.find_by_downloadKey!(download_link_hash).destroy }
+        before { SingleUseLink.find_by_download_key!(download_link_hash).destroy }
 
         it "returns 404" do
           get :download, params: { id: download_link_hash }
@@ -44,11 +44,11 @@ RSpec.describe Hyrax::SingleUseLinksViewerController do
         get 'show', params: { id: show_link_hash }
         expect(response).to be_success
         expect(assigns[:presenter].id).to eq file.id
-        expect { SingleUseLink.find_by_downloadKey!(show_link_hash) }.to raise_error ActiveRecord::RecordNotFound
+        expect { SingleUseLink.find_by_download_key!(show_link_hash) }.to raise_error ActiveRecord::RecordNotFound
       end
 
       context "when the key is not found" do
-        before { SingleUseLink.find_by_downloadKey!(show_link_hash).destroy }
+        before { SingleUseLink.find_by_download_key!(show_link_hash).destroy }
         it "returns 404" do
           get :show, params: { id: show_link_hash }
           expect(response).to render_template("hyrax/single_use_links_viewer/single_use_error", "layouts/error")

--- a/spec/factories/single_use_links.rb
+++ b/spec/factories/single_use_links.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :single_use_link do
     factory :show_link do
-      itemId { 'fs-id' }
-      path { '/concerns/generic_work/1234' }
+      item_id { 'fs-id' }
+      path    { '/concerns/generic_work/1234' }
     end
 
     factory :download_link do
-      itemId { 'fs-id' }
-      path { '/downloads/1234' }
+      item_id { 'fs-id' }
+      path    { '/downloads/1234' }
     end
   end
 end

--- a/spec/models/single_use_link_spec.rb
+++ b/spec/models/single_use_link_spec.rb
@@ -5,6 +5,20 @@ RSpec.describe SingleUseLink do
     let(:hash) { "sha2hash#{DateTime.current.to_f}" }
     let(:path) { '/foo/file/99999' }
 
+    subject { described_class.new item_id: '99999', path: path }
+
+    it "creates link" do
+      expect(Digest::SHA2).to receive(:new).and_return(hash)
+      expect(subject.download_key).to eq hash
+      expect(subject.item_id).to eq '99999'
+      expect(subject.path).to eq path
+    end
+  end
+
+  describe "attribute aliases" do
+    let(:hash) { "sha2hash#{DateTime.current.to_f}" }
+    let(:path) { '/foo/file/99999' }
+
     subject { described_class.new itemId: '99999', path: path }
 
     it "creates link" do

--- a/spec/presenters/hyrax/single_use_link_presenter_spec.rb
+++ b/spec/presenters/hyrax/single_use_link_presenter_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Hyrax::SingleUseLinkPresenter do
     end
 
     describe "#short_key" do
-      its(:short_key) { is_expected.to eq(link.downloadKey.first(6)) }
+      its(:short_key) { is_expected.to eq(link.download_key.first(6)) }
     end
 
     describe "delegated methods" do
-      its(:downloadKey) { is_expected.to eq(link.downloadKey) }
+      its(:download_key) { is_expected.to eq(link.download_key) }
       its(:expired?)    { is_expected.to eq(link.expired?) }
       its(:to_param)    { is_expected.to eq(link.to_param) }
     end

--- a/spec/views/hyrax/file_sets/_single_use_links.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_single_use_links.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'hyrax/file_sets/_single_use_links.html.erb', type: :view do
   end
 
   context "with single use links" do
-    let(:link)           { SingleUseLink.create(itemId: "1234", downloadKey: "sha2hashb") }
+    let(:link)           { SingleUseLink.create(item_id: "1234", download_key: "sha2hashb") }
     let(:link_presenter) { Hyrax::SingleUseLinkPresenter.new(link) }
 
     before do


### PR DESCRIPTION
PostgreSQL, by default, doesn't handle camelCase column names very well, so let's not use them.

This PR renames two database columns, both in `single_use_links`: `itemId` -> `item_id` and `downloadKey` -> `download_key`. This is because PostgreSQL is case insensitive by default, but not _totally_ case insensitive. Creating `itemId` turns it into `itemid` but in such a way that it does not recognize `itemId` in queries.

Ideally, this would be fixed in the `pg` gem, but they have enough compatibility and versioning issues going on right now that I think avoiding capital letters in column names is the safest bet.

Changes proposed in this pull request:
* Rename `itemId` to `item_id`
* Rename `downloadKey` to `download_key`
* Change all references to them throughout the codebase
* Add `alias_attribute` statements to the `SingleUseLink` model to allow the camelCase attribute names to continue to work

@samvera/hyrax-code-reviewers