### PR TITLE
Expand Support for "inactive" Authority Terms

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -201,7 +201,7 @@ module Hyrax
     # @param [Hash] options from blacklight helper_method invocation. Maps license URIs to links with labels.
     # @return [ActiveSupport::SafeBuffer] license links, html_safe
     def license_links(options)
-      service = Hyrax::LicenseService.new
+      service = Hyrax.config.license_service_class.new
       to_sentence(options[:value].map { |right| link_to service.label(right), right })
     end
 
@@ -209,7 +209,7 @@ module Hyrax
     # @param [Hash] options from blacklight helper_method invocation. Maps rights statement URIs to links with labels.
     # @return [ActiveSupport::SafeBuffer] rights statement links, html_safe
     def rights_statement_links(options)
-      service = Hyrax::RightsStatementService.new
+      service = Hyrax.config.rights_statement_service_class.new
       to_sentence(options[:value].map { |right| link_to service.label(right), right })
     end
 

--- a/app/services/hyrax/license_service.rb
+++ b/app/services/hyrax/license_service.rb
@@ -4,13 +4,5 @@ module Hyrax
     def initialize(_authority_name = nil)
       super('licenses')
     end
-
-    def include_current_value(value, _index, render_options, html_options)
-      unless value.blank? || active?(value)
-        html_options[:class] << ' force-select'
-        render_options += [[label(value), value]]
-      end
-      [render_options, html_options]
-    end
   end
 end

--- a/app/services/hyrax/license_service.rb
+++ b/app/services/hyrax/license_service.rb
@@ -1,7 +1,7 @@
 module Hyrax
   # Provide select options for the license (dcterms:rights) field
   class LicenseService < QaSelectService
-    def initialize
+    def initialize(_authority_name = nil)
       super('licenses')
     end
 

--- a/app/services/hyrax/qa_select_service.rb
+++ b/app/services/hyrax/qa_select_service.rb
@@ -49,5 +49,22 @@ module Hyrax
     def active_elements
       authority.all.select { |e| e.fetch('active') }
     end
+
+    ##
+    # A helper for adding the current value to a form dropdown when
+    # @note this was extracted from LicenseService for more general use.
+    #
+    # @todo find a better home for this! This was initially inlined to the
+    #   service from a helper module in
+    #   https://github.com/samvera/curation_concerns/pull/986. It seems odd
+    #   that this service knows about HTML rendering details. Maybe a factory
+    #   is an appropriate next step?
+    def include_current_value(value, _index, render_options, html_options)
+      unless value.blank? || active?(value)
+        html_options[:class] << ' force-select'
+        render_options += [[label(value) { value }, value]]
+      end
+      [render_options, html_options]
+    end
   end
 end

--- a/app/services/hyrax/qa_select_service.rb
+++ b/app/services/hyrax/qa_select_service.rb
@@ -8,16 +8,23 @@ module Hyrax
       @authority = Qa::Authorities::Local.subauthority_for(authority_name)
     end
 
+    ##
+    # @return [Array<String, #to_s>]
     def select_all_options
       authority.all.map do |element|
         [element[:label], element[:id]]
       end
     end
 
+    # @return [Array<String, #to_s>]
     def select_active_options
       active_elements.map { |e| [e[:label], e[:id]] }
     end
 
+    ##
+    # @return [Boolean] whether the key is active
+    #
+    # @raise [KeyError] when the key has no `active:` status
     def active?(id)
       authority.find(id).fetch('active')
     end
@@ -35,6 +42,10 @@ module Hyrax
       authority.find(id).fetch('term', &block)
     end
 
+    ##
+    # @return [Enumerable<Hash>]
+    #
+    # @raise [KeyError] when no 'term' value is present for the id
     def active_elements
       authority.all.select { |e| e.fetch('active') }
     end

--- a/app/services/hyrax/rights_statement_service.rb
+++ b/app/services/hyrax/rights_statement_service.rb
@@ -1,7 +1,7 @@
 module Hyrax
   # Provide select options for the copyright status (edm:rights) field
   class RightsStatementService < QaSelectService
-    def initialize
+    def initialize(_authority_name = nil)
       super('rights_statements')
     end
   end

--- a/app/services/hyrax/tolerant_select_service.rb
+++ b/app/services/hyrax/tolerant_select_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # A more tolerant `QaSelectService`. This service treats terms with no
+  # `active:` property as active terms, instead of erroring with `eKeyError`.
+  class TolerantSelectService < QaSelectService
+    ##
+    # @return [Boolean] indicates whether the term is active;
+    #   false if the term is inactive or does not exist; defaults to true when
+    #   no key is given
+    def active?(id)
+      authority.find(id)&.fetch('active', true)
+    end
+
+    ##
+    # @return [Enumerable<Hash>]
+    #
+    # @raise [KeyError] when no 'term' value is present for the id
+    def active_elements
+      authority.all.select { |e| e.fetch('active', true) }
+    end
+  end
+end

--- a/app/views/records/edit_fields/_license.html.erb
+++ b/app/views/records/edit_fields/_license.html.erb
@@ -1,4 +1,4 @@
-<% license_service = Hyrax::LicenseService.new %>
+<% license_service = Hyrax.config.license_service_class.new %>
 <%= f.input :license, as: :multi_value_select,
     collection: license_service.select_active_options,
     include_blank: true,

--- a/app/views/records/edit_fields/_rights_statement.html.erb
+++ b/app/views/records/edit_fields/_rights_statement.html.erb
@@ -1,4 +1,4 @@
-<% rights_statements = Hyrax::RightsStatementService.new %>
+<% rights_statements = Hyrax.config.rights_statement_service_class.new %>
 <%= f.input :rights_statement,
     collection: rights_statements.select_active_options,
     include_blank: true,

--- a/app/views/records/edit_fields/_rights_statement.html.erb
+++ b/app/views/records/edit_fields/_rights_statement.html.erb
@@ -2,4 +2,5 @@
 <%= f.input :rights_statement,
     collection: rights_statements.select_active_options,
     include_blank: true,
+    item_helper: rights_statements.method(:include_current_value),
     input_html: { class: 'form-control' } %>

--- a/spec/services/hyrax/qa_select_service_spec.rb
+++ b/spec/services/hyrax/qa_select_service_spec.rb
@@ -1,21 +1,4 @@
 RSpec.describe Hyrax::QaSelectService do
-  let(:authority) do
-    # Implementing an ActiveRecord interface as required for this spec
-    Class.new do
-      def initialize(map)
-        @map = map
-      end
-
-      def all
-        @map
-      end
-
-      def find(id)
-        @map.detect { |item| item[:id] == id }
-      end
-    end
-    # rubocop:enable RSpec/InstanceVariable
-  end
   let(:authority_map) do
     [
       HashWithIndifferentAccess.new(term: 'Active Label', label: 'Active Label', id: 'active-id', active: true),
@@ -23,6 +6,8 @@ RSpec.describe Hyrax::QaSelectService do
       HashWithIndifferentAccess.new(label: 'Active No Term', id: 'active-no-term-id', active: true)
     ]
   end
+
+  let(:authority) { FakeAuthority }
   let(:authority_name) { 'respect_my' }
   let(:qa_select_service) { described_class.new(authority_name) }
 

--- a/spec/services/hyrax/qa_select_service_spec.rb
+++ b/spec/services/hyrax/qa_select_service_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe Hyrax::QaSelectService do
     it 'will be Array of Arrays<label, id>' do
       expect(subject).to eq([['Active Label', 'active-id'], ['Active No Term', 'active-no-term-id']])
     end
+
+    context 'when a key has no active property' do
+      let(:no_state) { HashWithIndifferentAccess.new(term: 'term', label: 'label', id: 'no-state') }
+
+      before { authority_map << no_state }
+
+      it 'raises KeyError' do
+        expect { subject }.to raise_error(KeyError)
+      end
+    end
   end
 
   describe '#label' do

--- a/spec/services/hyrax/qa_select_service_spec.rb
+++ b/spec/services/hyrax/qa_select_service_spec.rb
@@ -78,4 +78,32 @@ RSpec.describe Hyrax::QaSelectService do
       end
     end
   end
+
+  describe '#include_current_value' do
+    let(:render_opts) { [] }
+    let(:html_opts)   { { class: 'moomin' } }
+
+    let(:authority_map) do
+      [
+        HashWithIndifferentAccess.new(term: 'Active Label', label: 'Active Label', id: 'active-id', active: true),
+        HashWithIndifferentAccess.new(term: 'Inactive Label', label: 'Inactive Label', id: 'inactive-id', active: false),
+        HashWithIndifferentAccess.new(label: 'Inactive No Term', id: 'inactive-no-term-id', active: false)
+      ]
+    end
+
+    it 'adds an inactive current value' do
+      expect(qa_select_service.include_current_value('inactive-id', :idx, render_opts, html_opts))
+        .to eq [[['Inactive Label', 'inactive-id']], { class: 'moomin force-select' }]
+    end
+
+    it 'adds an inactive current value with fallback label' do
+      expect(qa_select_service.include_current_value('inactive-no-term-id', :idx, render_opts, html_opts))
+        .to eq [[['inactive-no-term-id', 'inactive-no-term-id']], { class: 'moomin force-select' }]
+    end
+
+    it 'does not add an active current value' do
+      expect(qa_select_service.include_current_value('active-id', :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
+  end
 end

--- a/spec/services/hyrax/tolerant_select_service_spec.rb
+++ b/spec/services/hyrax/tolerant_select_service_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe Hyrax::TolerantSelectService do
+  subject(:select_service) { described_class.new(authority_name) }
+
+  let(:authority) { FakeAuthority }
+  let(:authority_name) { 'fake_authority' }
+  let(:authority_map) { [] }
+
+  before do
+    allow(Qa::Authorities::Local)
+      .to receive(:subauthority_for)
+      .with(authority_name)
+      .and_return(authority.new(authority_map))
+  end
+
+  shared_context 'with terms' do
+    let(:authority_map) do
+      [HashWithIndifferentAccess.new(term: 'Active Label', label: 'Active Label', id: 'active-id', active: true),
+       HashWithIndifferentAccess.new(term: 'Inactive Label', label: 'Inactive Label', id: 'inactive-id', active: false),
+       HashWithIndifferentAccess.new(label: 'Active No Term', id: 'active-no-term-id', active: true),
+       HashWithIndifferentAccess.new(term: 'No Active Flag Term', label: 'No Active Flag Label', id: 'no-active-flag-id')]
+    end
+  end
+
+  describe '#active?' do
+    it 'is false for missing id' do
+      expect(select_service.active?('fake_id')).to be_falsey
+    end
+
+    context 'with terms' do
+      include_context 'with terms'
+
+      it 'is true for an active term' do
+        expect(select_service.active?('active-id')).to be true
+      end
+
+      it 'is false for an inactive term' do
+        expect(select_service.active?('inactive-id')).to be_falsey
+      end
+
+      it 'defaults to true for a term with no flag' do
+        expect(select_service.active?('no-active-flag-id')).to be true
+      end
+    end
+  end
+
+  describe '#select_all_options' do
+    it 'is empty' do
+      expect(select_service.select_all_options).to be_empty
+    end
+
+    context 'with terms' do
+      include_context 'with terms'
+
+      it 'contains all labels and ids' do
+        expect(select_service.select_all_options)
+          .to contain_exactly(['Active Label', 'active-id'],
+                              ['Inactive Label', 'inactive-id'],
+                              ['Active No Term', 'active-no-term-id'],
+                              ['No Active Flag Label', 'no-active-flag-id'])
+      end
+    end
+  end
+
+  describe '#select_active_options' do
+    it 'is empty' do
+      expect(select_service.select_active_options).to be_empty
+    end
+
+    context 'with terms' do
+      include_context 'with terms'
+
+      it 'contains active labels and ids' do
+        expect(select_service.select_active_options)
+          .to contain_exactly(['Active Label', 'active-id'],
+                              ['Active No Term', 'active-no-term-id'],
+                              ['No Active Flag Label', 'no-active-flag-id'])
+      end
+    end
+  end
+end

--- a/spec/support/fakes/fake_authority.rb
+++ b/spec/support/fakes/fake_authority.rb
@@ -1,0 +1,13 @@
+class FakeAuthority
+  def initialize(map)
+    @map = map
+  end
+
+  def all
+    @map
+  end
+
+  def find(id)
+    @map.detect { |item| item[:id] == id }
+  end
+end


### PR DESCRIPTION
Questioning Authority allows for an [(optional) active/inactive](https://github.com/samvera/questioning_authority/#list-of-id-and-term-keys-and-optionally-active-key) flag on authority terms. This makes it easier to remove existing keys from vocabularies after they have been used in item metadata. Hyrax previously supported inactive keys for the License terms only.

The Hyrax `QaSelectService` fails with `KeyError` when checking `#active?` or listing `#select_active_options` when this key is not included. This appears to be by design (it's explicitly tested) but is undesirable. We introduce an experimental `TolerantSelectService` to provide a more tolerant option. Downstream users may wish to configure their authority select services to use this parent class.

Additionally, this refactors the existing classes and add support for `#include_current_value` to the `RightsStatementService`, eventually adding use of that helper to the form field for rights statement.

The work supporting this significantly expands support for inactive fields in downstream applications.

The Resource Type vocabulary remains without support for inactive terms. Since vocabulary doesn't use the main `QaSelectService`, I treated it as out of scope for this PR and am intending to address it in follow-up work.

Changes proposed in this pull request:
* Add support for inactive authorities to `RightsStatementService` and associated views.

In support of this:
* Move `#include_current_value` helper to the parent `QaSelectService` for use across authority services.
* Use the Hyrax configured authority service classes in place of hard coded ones; the default classes are unchanged.
* Add experimental `TolerantSelectService` which is forgiving of missing `active:` keys. The existing service fails if downstream users do not include the key.
* Small refactors to existing services (e.g. comply with [Liskov](https://en.wikipedia.org/wiki/Liskov_substitution_principle) in initializer arguments) and specs.
* Minor inline documentation improvements.

@samvera/hyrax-code-reviewers
