### PR TITLE
Use a one-byte GET request instead of a HEAD request to check the validity of a remote URL

### DIFF
--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -24,7 +24,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
     @file_set = file_set
     @operation = operation
 
-    unless HTTParty.get(file_set.import_url, headers: { Range: 'bytes=0-0' }).success?
+    unless can_retrieve?(uri)
       send_error('Expired URL')
       return false
     end
@@ -43,6 +43,17 @@ class ImportUrlJob < Hyrax::ApplicationJob
   end
 
   private
+
+    # The previous strategy of using only a HEAD request to check the validity of a
+    # remote URL fails for Amazon S3 pre-signed URLs. S3 URLs are generated for a single
+    # verb only (in this case, GET), and will return a 403 Forbidden response if any
+    # other verb is used. The workaround is to issue a GET request instead, with a
+    # Range: header requesting only the first byte. The successful response status
+    # code is 206 instead of 200, but that is enough to satisfy the #success? method.
+    # @param uri [URI] the uri of the file to be downloaded
+    def can_retrieve?(uri)
+      HTTParty.get(uri, headers: { Range: 'bytes=0-0' }).success?
+    end
 
     # Download file from uri, yields a block with a file in a temporary directory.
     # It is important that the file on disk has the same file name as the URL,

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -24,7 +24,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
     @file_set = file_set
     @operation = operation
 
-    unless HTTParty.head(file_set.import_url).success?
+    unless HTTParty.get(file_set.import_url, headers: { Range: 'bytes=0-0' }).success?
       send_error('Expired URL')
       return false
     end

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe ImportUrlJob do
   context 'when the remote file is unavailable' do
     before do
       stub_request(:get, "http://example.org#{file_hash}").with(headers: { 'Range' => 'bytes=0-0' }).to_return(
-        body: '', status: 406, headers: { }
+        body: '', status: 406, headers: {}
       )
     end
 

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -20,10 +20,14 @@ RSpec.describe ImportUrlJob do
   before do
     allow(Hyrax::Actors::FileSetActor).to receive(:new).with(file_set, user).and_return(actor)
 
-    response_headers = { 'Content-Type' => 'image/png', 'Content-Length' => File.size(File.expand_path(file_path, __FILE__)) }
+    response_headers = {
+      'Content-Type' => 'image/png',
+      'Content-Length' => 1,
+      'Content-Range' => "0-0/#{File.size(File.expand_path(file_path, __FILE__))}"
+    }
 
-    stub_request(:head, "http://example.org#{file_hash}").to_return(
-      body: "", status: 200, headers: response_headers
+    stub_request(:get, "http://example.org#{file_hash}").with(headers: { 'Range' => 'bytes=0-0' }).to_return(
+      body: File.open(File.expand_path(file_path, __FILE__)).read(1), status: 206, headers: response_headers
     )
 
     stub_request(:get, "http://example.org#{file_hash}").to_return(
@@ -97,10 +101,8 @@ RSpec.describe ImportUrlJob do
 
   context 'when the remote file is unavailable' do
     before do
-      response_headers = { 'Content-Type' => 'image/png', 'Content-Length' => File.size(File.expand_path(file_path, __FILE__)) }
-
-      stub_request(:head, "http://example.org#{file_hash}").to_return(
-        body: "", status: 404, headers: response_headers
+      stub_request(:get, "http://example.org#{file_hash}").with(headers: { 'Range' => 'bytes=0-0' }).to_return(
+        body: '', status: 406, headers: { }
       )
     end
 


### PR DESCRIPTION
The current strategy of using a `HEAD` request to check remote URLs fails for Amazon S3 pre-signed URLs. S3 URLs are generated for a single verb only (in this case, `GET`), and will return a `403 Forbidden` response if any other verb is used.

The lack of `HEAD` support for pre-signed `GET` URLs is an old and unresolved topic on the AWS support forums. I don't see them fixing this any time soon, if at all.

This is not an optimal solution, as it depends on the remote server being configured to satisfy byte range requests. I think it's safe to assume that the cloud providers we support all do so.

Changes proposed in this pull request:
* Change `ImportUrlJob` to issue a `GET` request for bytes 0-0 instead of a `HEAD`.
* Alter the `ImportUrlJob` specs to stub that range request instead of the head request.

@samvera/hyrax-code-reviewers