### PR TITLE
[refactor] Invert dependencies for `AdminStatsPresenter`

### DIFF
--- a/app/controllers/concerns/hyrax/admin/stats_behavior.rb
+++ b/app/controllers/concerns/hyrax/admin/stats_behavior.rb
@@ -1,20 +1,44 @@
 module Hyrax
   module Admin
+    ##
+    # @example using a custom presenter and stats services
+    #   class MyStatsController < ApplicationController
+    #     include Hyrax::Admin::StatsBehavior
+    #
+    #     self.admin_stats_presenter = MyCustomStatsPresenter
+    #     self.admin_stats_services = { by_depositor:      CustomDepositorService,
+    #                                   depositor_summary: CustomSummaryService }
+    #     # see AdminStatsPresenter#initialize for supported services
+    #   end
+    #
     module StatsBehavior
       extend ActiveSupport::Concern
       included do
         with_themed_layout 'dashboard'
+
+        class_attribute :admin_stats_presenter, :admin_stats_services
+        self.admin_stats_presenter = AdminStatsPresenter
+        self.admin_stats_services  = {}
       end
 
       def show
         authorize! :read, Hyrax::Statistics
         stats_filters = params.fetch(:stats_filters, {})
         limit = params.fetch(:limit, "5").to_i
-        @presenter = AdminStatsPresenter.new(stats_filters, limit)
+        @presenter = build_presenter(stats_filters, limit)
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
         add_breadcrumb t(:'hyrax.admin.sidebar.statistics'), hyrax.admin_stats_path
       end
+
+      private
+
+        def build_presenter(stats_filters, limit)
+          presenter_class = self.class.admin_stats_presenter
+          services_opts   = self.class.admin_stats_services
+
+          presenter_class.new(stats_filters, limit, **services_opts)
+        end
     end
   end
 end

--- a/app/presenters/hyrax/admin_stats_presenter.rb
+++ b/app/presenters/hyrax/admin_stats_presenter.rb
@@ -2,10 +2,49 @@ module Hyrax
   class AdminStatsPresenter
     attr_reader :limit, :stats_filters
 
-    def initialize(stats_filters, limit)
+    ##
+    # @!attribute [rw] by_depositor
+    #   @return [#query]
+    # @!attribute [rw] by_format
+    #   @return [#query]
+    # @!attribute [rw] depositor_summary
+    #   @return [#depositors]
+    # @!attribute [rw] system_stats
+    #   @return [#recent_users]
+    # @!attribute [rw] works_counter
+    #   @return [#by_permission]
+    attr_accessor :by_depositor, :by_format, :depositor_summary, :system_stats,
+                  :works_counter
+
+    # Long parameter lists (especially optional) are preferred to hard-coded
+    # dependencies. Further refactors may be desirable.
+    #
+    # rubocop:disable Metrics/ParameterLists
+
+    ##
+    # @param stats_filters     [Hash<Symbol, Object>]
+    # @param limit             [FixNum]
+    # @param by_depositor      [#query]
+    # @param by_format         [#query]
+    # @param depositor_summary [#depositors]
+    # @param system_stats      [#recent_users]
+    # @param works_counter     [#by_permission]
+    def initialize(stats_filters, limit,
+                   by_depositor:      Hyrax::Statistics::Works::ByDepositor,
+                   by_format:         Hyrax::Statistics::FileSets::ByFormat,
+                   depositor_summary: Hyrax::Statistics::Depositors::Summary,
+                   system_stats:      Hyrax::Statistics::SystemStats,
+                   works_counter:     Hyrax::Statistics::Works::Count)
       @stats_filters = stats_filters
       @limit = limit
+
+      self.by_depositor      = by_depositor
+      self.by_format         = by_format
+      self.depositor_summary = depositor_summary
+      self.system_stats      = system_stats
+      self.works_counter     = works_counter
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def start_date
       @start_date ||= extract_date_from_stats_filters(key: :start_date, as_of: :beginning_of_day)
@@ -26,29 +65,36 @@ module Hyrax
 
     # @see Hyrax::Statistics::Depositors::Summary
     def depositors
-      @depositors ||= Hyrax::Statistics::Depositors::Summary.depositors(start_date: start_date, end_date: end_date)
+      @depositors ||=
+        depositor_summary.depositors(start_date: start_date, end_date: end_date)
     end
 
     # @see Hyrax::Statistics::SystemStats.recent_users
     def recent_users
-      @recent_users ||= Hyrax::Statistics::SystemStats.recent_users(limit: limit, start_date: start_date, end_date: end_date)
+      @recent_users ||=
+        system_stats.recent_users(limit:      limit,
+                                  start_date: start_date,
+                                  end_date:   end_date)
     end
 
     # @see Hyrax::Statistics::Works::ByDepositor
     def active_users
-      @active_users ||= Hyrax::Statistics::Works::ByDepositor.query(limit: limit)
+      @active_users ||= by_depositor.query(limit: limit)
     end
 
     # @see Hyrax::Statistics::FileSets::ByFormat
     def top_formats
-      @top_formats ||= Hyrax::Statistics::FileSets::ByFormat.query(limit: limit)
+      @top_formats ||= by_format.query(limit: limit)
     end
 
     # @see Hyrax::Statistics::Works::Count
     def works_count
-      @works_count ||= Hyrax::Statistics::Works::Count.by_permission(start_date: start_date, end_date: end_date)
+      @works_count ||=
+        works_counter.by_permission(start_date: start_date, end_date: end_date)
     end
 
+    ##
+    # @return [String]
     def date_filter_string
       if start_date.blank?
         "unfiltered"

--- a/spec/controllers/hyrax/admin/stats_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/stats_controller_spec.rb
@@ -21,10 +21,40 @@ RSpec.describe Hyrax::Admin::StatsController, type: :controller do
       end
 
       it 'allows an authorized user to view the page' do
-        expect(Hyrax::AdminStatsPresenter).to receive(:new).with(expected_params, 5).and_call_original
         get :show
+
         expect(response).to be_success
         expect(assigns[:presenter]).to be_kind_of Hyrax::AdminStatsPresenter
+        expect(assigns[:presenter])
+          .to have_attributes(limit: 5, stats_filters: {})
+      end
+
+      context 'with a custom presenter' do
+        let(:presenter_class) { Class.new(Hyrax::AdminStatsPresenter) }
+
+        before { described_class.admin_stats_presenter = presenter_class }
+
+        it 'allows an authorized user to view the page' do
+          get :show
+
+          expect(assigns[:presenter]).to be_kind_of presenter_class
+          expect(assigns[:presenter])
+            .to have_attributes(limit: 5, stats_filters: {})
+        end
+      end
+
+      context 'with custom stats services' do
+        let(:by_depositor_class) { Class.new(Hyrax::Statistics::Works::ByDepositor) }
+        let(:service_config)     { { by_depositor: by_depositor_class } }
+
+        before { described_class.admin_stats_services = service_config }
+
+        it 'allows an authorized user to view the page' do
+          get :show
+
+          expect(assigns[:presenter])
+            .to have_attributes(by_depositor: by_depositor_class)
+        end
       end
     end
   end

--- a/spec/presenters/hyrax/admin_stats_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_stats_presenter_spec.rb
@@ -16,12 +16,40 @@ RSpec.describe Hyrax::AdminStatsPresenter do
       expect(Hyrax::Statistics::Works::ByDepositor).to receive(:query).with(limit: limit).and_return(:query_response)
       expect(service.active_users).to eq(:query_response)
     end
+
+    context 'with alternatate class' do
+      subject(:service) do
+        described_class.new(filters, limit, by_depositor: by_depositor_class)
+      end
+
+      let(:by_depositor_class) { spy('ByDepositor') }
+
+      it 'retrieves active_users from the class' do
+        service.active_users
+
+        expect(by_depositor_class).to have_received(:query).with(limit: limit)
+      end
+    end
   end
 
   describe "#top_formats" do
     it 'delegates to Hyrax::Statistics::FileSets::ByFormat.query' do
       expect(Hyrax::Statistics::FileSets::ByFormat).to receive(:query).with(limit: limit).and_return(:query_response)
       expect(service.top_formats).to eq(:query_response)
+    end
+
+    context 'with alternatate class' do
+      subject(:service) do
+        described_class.new(filters, limit, by_format: by_format)
+      end
+
+      let(:by_format) { spy('ByFormat') }
+
+      it 'retrieves formats from the class' do
+        service.top_formats
+
+        expect(by_format).to have_received(:query).with(limit: limit)
+      end
     end
   end
 
@@ -30,6 +58,19 @@ RSpec.describe Hyrax::AdminStatsPresenter do
       expect(Hyrax::Statistics::Works::Count).to receive(:by_permission).with(start_date: service.start_date, end_date: service.end_date).and_return(:query_response)
       expect(service.works_count).to eq(:query_response)
     end
+
+    context 'with alternatate class' do
+      subject(:service)   { described_class.new(filters, limit, works_counter: works_counter) }
+      let(:works_counter) { spy('Works::Count') }
+
+      it 'retrieves count from the class' do
+        service.works_count
+
+        expect(works_counter)
+          .to have_received(:by_permission)
+          .with(start_date: service.start_date, end_date: service.end_date)
+      end
+    end
   end
 
   describe "#depositors" do
@@ -37,12 +78,44 @@ RSpec.describe Hyrax::AdminStatsPresenter do
       expect(Hyrax::Statistics::Depositors::Summary).to receive(:depositors).with(start_date: service.start_date, end_date: service.end_date).and_return(:query_response)
       expect(service.depositors).to eq(:query_response)
     end
+
+    context 'with alternatate class' do
+      subject(:service) do
+        described_class.new(filters, limit, depositor_summary: summary_class)
+      end
+
+      let(:summary_class) { spy('depositor summary class') }
+
+      it 'retrieves depositors from the class' do
+        service.depositors
+
+        expect(summary_class)
+          .to have_received(:depositors)
+          .with(start_date: service.start_date, end_date: service.end_date)
+      end
+    end
   end
 
   describe "#recent_users" do
     it 'delegates to Hyrax::Statistics::SystemStats.recent_users' do
       expect(Hyrax::Statistics::SystemStats).to receive(:recent_users).with(limit: limit, start_date: service.start_date, end_date: service.end_date).and_return(:query_response)
       expect(service.recent_users).to eq(:query_response)
+    end
+
+    context 'with alternatate class' do
+      subject(:service) do
+        described_class.new(filters, limit, system_stats: system_stats)
+      end
+
+      let(:system_stats) { spy('SystemStats') }
+
+      it 'retrieves users from the class' do
+        service.recent_users
+
+        expect(system_stats)
+          .to have_received(:recent_users)
+          .with(limit: limit, start_date: service.start_date, end_date: service.end_date)
+      end
     end
   end
 


### PR DESCRIPTION
This is a straight refactor to invert the previously hard coded dependencies in
`AdminStatsPresenter`. This allows callers to inject stats services with custom
behavior.

This is particularly motivated by the eager failure behavior of
`Hyrax::Statistics::Depositors::Summary`, which raises an error in the case
that a work has been saved with a `depositor` that can't be found (e.g. the
depositor's user_key has changed, or a depositor string has been saved that does
not have a matching record in the application). Since we don't enforce integrity
of reference for depostor strings, an option for a more fault tolerant stats
service seems desirable. This opens the presenter to that change.

We disable the method parameter size rubocop rule for the `#initialize` method,
since having many optional parameters in an intializer seems like a step forward
from having many hard coded dependencies. Further changes to reduce the
parameter list may be worth exploring.

Lastly, we add class variables to the stats behavior mixin allowing custom presenters
and service options in client code.

Changes proposed in this pull request:
* Invert dependencies in `AdminStatsPresenter`
* Add `admin_stats_presenter` and `admin_stats_services` class variables to the `Admin::StatsBehavior` controller mixin.

@samvera/hyrax-code-reviewers
