### PR TITLE
Allow support for SolrWrapper 2.x

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -94,7 +94,7 @@ SUMMARY
   spec.add_development_dependency 'rspec-its', '~> 1.1'
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency "selenium-webdriver"
-  spec.add_development_dependency 'solr_wrapper', '~> 1.1'
+  spec.add_development_dependency 'solr_wrapper', '>= 1.1', '< 3.0'
   spec.add_development_dependency 'i18n-debug' if ENV['I18N_DEBUG']
   spec.add_development_dependency 'i18n_yaml_sorter' unless ENV['TRAVIS']
   spec.add_development_dependency 'rails-controller-testing', '~> 1'


### PR DESCRIPTION
SolrWrapper 2.0 was released in
https://github.com/cbeer/solr_wrapper/commit/4c412aba182a33c28fddf77736f86d7c8c304102.

This deals with changes in apache's checksum publishing practices. We keep
support for 1.0 for backwards compatibility, though some downstream adopters may
find they need to upgrade to keep SolrWrapper working.

Changes proposed in this pull request:
* Support SolrWrapper 2.x; fixes current Hyrax build.

@samvera/hyrax-code-reviewers
