### PR TITLE
Handle `nil` responses from `CollectionPresenter#description`

### DIFF
--- a/app/views/hyrax/collections/_list_collections.html.erb
+++ b/app/views/hyrax/collections/_list_collections.html.erb
@@ -37,7 +37,7 @@
   <td colspan="6">
     <dl class="expanded-details row">
       <dt class="col-xs-3 col-lg-2"><%= t("hyrax.dashboard.my.collection_list.description") %></dt>
-      <dd class="col-xs-9 col-lg-10"><%= collection_presenter.description.first %></dd>
+      <dd class="col-xs-9 col-lg-10"><%= collection_presenter.description&.first %></dd>
       <dt class="col-xs-3 col-lg-2"><%= t("hyrax.dashboard.my.collection_list.edit_access") %></dt>
       <dd class="col-xs-9 col-lg-10">
       <% if collection_presenter.edit_groups.present? %>

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -40,7 +40,7 @@
       <div class="expanded-details">
         <p>
           <strong><%= t("hyrax.dashboard.my.collection_list.description") %></strong>
-          <br /><%= collection_presenter.description.first %>
+          <br /><%= collection_presenter.description&.first %>
         </p>
         <p>
           <strong><%= t("hyrax.dashboard.my.collection_list.edit_access") %></strong>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -42,7 +42,7 @@
       <div class="expanded-details">
         <p>
           <strong><%= t("hyrax.dashboard.my.collection_list.description") %></strong>
-          <br /><%= collection_presenter.description.first %>
+          <br /><%= collection_presenter.description&.first %>
         </p>
         <p>
           <strong><%= t("hyrax.dashboard.my.collection_list.edit_access") %></strong>


### PR DESCRIPTION
`CollectionPresenter` (and other presenter classes) can return `nil` when
delegating to `#solr_document`. This happens particularly when either the model
does not have a matching property or the indexer fails to index it.

Since `Collection` is not guaranteed to have a `:description` (it's not in
`CoreMetadata`), we need to handle the `nil` case whereever we rely on
`CollectionPresenter#description` in our views. Particularly: apps generated by
Hyrax 1.x do not index `:description` by default, and always return `nil` from
this method.

Changes proposed in this pull request:
* Use safe call syntax (`&.`) when calling `CollectionPresenter#description`

@samvera/hyrax-code-reviewers
