### PR TITLE
Add Display Name to Workflow Roles management page

### DIFF
--- a/app/views/hyrax/admin/workflow_roles/index.html.erb
+++ b/app/views/hyrax/admin/workflow_roles/index.html.erb
@@ -26,15 +26,17 @@
         <h2 class="panel-title h2"><%= t('.current_roles') %></h3>
       </div>
       <div class="panel-body">
-        <table class="table table-striped">
+        <table class="table table-striped datatable">
           <thead>
+            <th><%= t('.header.name') %></th>
             <th><%= t('.header.user') %></th>
             <th><%= t('.header.roles') %></th>
           </thead>
           <tbody>
           <% @presenter.users.each do |user| %>
             <tr>
-              <td><%= user.user_key %></td>
+              <td data-sort="<%= user.name %>"><%= user.name %></td>
+              <td data-sort="<%= user.user_key %>"><%= user.user_key %></td>
               <% agent_presenter = @presenter.presenter_for(user) %>
               <% if agent_presenter && agent_presenter.responsibilities_present? %>
                 <td>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -314,6 +314,7 @@ de:
           delete:
             confirm: Sind Sie sich sicher?
           header:
+            name: Name
             roles: Rollen
             user: Benutzer
           new_role: Rolle zuweisen

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -314,6 +314,7 @@ en:
           delete:
             confirm: Are you sure?
           header:
+            name: Name
             roles: Roles
             user: User
           new_role: Assign Role

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -314,6 +314,7 @@ es:
           delete:
             confirm: "¿Estás seguro?"
           header:
+            name: Nombre
             roles: Roles
             user: Usuario
           new_role: Asignar Rol

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -314,6 +314,7 @@ fr:
           delete:
             confirm: Êtes-vous sûr?
           header:
+            name: Nom
             roles: Les rôles
             user: Utilisateur
           new_role: Attribuer un rôle

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -314,6 +314,7 @@ it:
           delete:
             confirm: Sei sicuro?
           header:
+            name: Nome
             roles: ruoli
             user: Utente
           new_role: Assegna ruolo

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -314,6 +314,7 @@ pt-BR:
           delete:
             confirm: Você tem certeza?
           header:
+            name: Nome
             roles: Roles
             user: Do utilizador
           new_role: Atribuir papel

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -314,6 +314,7 @@ zh:
           delete:
             confirm: 您肯定要删除?
           header:
+            name: 名称
             roles: 角色
             user: 用户
           new_role: '授予角色:'


### PR DESCRIPTION
Adding the display name to the workflow roles page makes it
more user friendly for repository admins.

Also, add the ability to sort by Display Name or User Key. 

Fixes https://github.com/curationexperts/laevigata/issues/1173 (we could just fix this locally, but we thought others might want this improvement too).

@samvera/hyrax-code-reviewers
