### PR TITLE
Hide deposit agreement progress when disabled

### DIFF
--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -11,7 +11,7 @@
           <% if Hyrax.config.work_requires_files? %>
             <li class="incomplete" id="required-files"><%= t('.required_files') %></li>
           <% end %>
-          <% if Flipflop.active_deposit_agreement_acceptance? %>
+          <% if Flipflop.show_deposit_agreement? && Flipflop.active_deposit_agreement_acceptance? %>
             <li class="incomplete" id="required-agreement"><%= t('.required_agreement') %></li>
           <% end %>
         </ul>

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -99,6 +99,17 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
         expect(page).not_to have_link 'Deposit Agreement', href: '/agreement'
       end
     end
+
+    context "with active deposit acceptance but no show deposit agreement" do
+      before do
+        allow(Flipflop).to receive(:show_deposit_agreement?).and_return(false)
+        allow(Flipflop).to receive(:active_deposit_agreement_acceptance?)
+          .and_return(true)
+      end
+      it "does not display the deposit agreement in the requirements" do
+        expect(page).not_to have_selector("#required-agreement")
+      end
+    end
   end
 
   context "when the work has been saved before" do


### PR DESCRIPTION
Fixes #1102

* Don't show the Deposit Agreement in the Requirements checklist if the Show Deposit Agreement setting is off.

@samvera/hyrax-code-reviewers
