### PR TITLE
Consolidate dependency on ActiveFedora::Base.logger

### DIFF
--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -58,6 +58,6 @@ class FixityCheckJob < Hyrax::ApplicationJob
     end
 
     def logger
-      ActiveFedora::Base.logger
+      Hyrax.logger
     end
 end

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -46,6 +46,12 @@ module Hyrax
     @config
   end
 
+  ##
+  # @return [Logger]
+  def self.logger
+    @logger ||= ActiveFedora::Base.logger
+  end
+
   def self.primary_work_type
     Hyrax::WorkRelation::DummyModel.primary_concern
   end

--- a/lib/hyrax/arkivo/create_subscription_job.rb
+++ b/lib/hyrax/arkivo/create_subscription_job.rb
@@ -22,7 +22,7 @@ module Hyrax
       private
 
         def logger
-          ActiveFedora::Base.logger
+          Hyrax.logger
         end
 
         def validate_user!

--- a/lib/hyrax/redis_event_store.rb
+++ b/lib/hyrax/redis_event_store.rb
@@ -15,7 +15,7 @@ module Hyrax
         nil
       end
 
-      delegate :logger, to: ActiveFedora::Base
+      delegate :logger, to: Hyrax
 
       def instance
         if Redis.current.is_a? Redis::Namespace

--- a/spec/lib/hyrax_spec.rb
+++ b/spec/lib/hyrax_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Hyrax do
+  describe '.logger' do
+    it 'is a Logger' do
+      expect(described_class.logger).to respond_to :log
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ::SolrDocument, type: :model do
       let(:attributes) { { 'date_uploaded_dtsi' => 'Test' } }
 
       it "logs parse errors" do
-        expect(ActiveFedora::Base.logger).to receive(:info).with(/Unable to parse date.*/)
+        expect(Hyrax.logger).to receive(:info).with(/Unable to parse date.*/)
         subject
       end
     end
@@ -59,7 +59,7 @@ RSpec.describe ::SolrDocument, type: :model do
       let(:attributes) { { 'system_create_dtsi' => 'Test' } }
 
       it "logs parse errors" do
-        expect(ActiveFedora::Base.logger).to receive(:info).with(/Unable to parse date.*/)
+        expect(Hyrax.logger).to receive(:info).with(/Unable to parse date.*/)
         subject
       end
     end


### PR DESCRIPTION
This dependency was hard coded in a number of places. This moves it to a single place where it can more easily be overridden. 

This is a (very small) part of a larger program to clarify and isolate the extent of our `ActiveFedora` dependencies.

Changes proposed in this pull request:
* Add a `Hyrax.logger`, setting it to `ActiveFedora::Base.logger`.
* Depend on `Hyrax.logger` instead of `ActiveFedora::Base.logger` throughout.

@samvera/hyrax-code-reviewers
