### PR TITLE
[refactor] Don't depend on `Hyrax::WorkRelation` from the top level

### DIFF
--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -47,6 +47,6 @@ module Hyrax
   end
 
   def self.primary_work_type
-    Hyrax::WorkRelation::DummyModel.primary_concern
+    config.curation_concerns.first
   end
 end


### PR DESCRIPTION
The `Hyrax` module had a hard dependency on `Hyrax::WorkRelation::DummyModel`, which relied in turn on `Hyrax.config`. This reaching back and forth across layers is confusing and unnecessary. Instead, `Hyrax` can get its `.primary_work_type` from closer to home.

Changes proposed in this pull request:
* Change the `Hyrax.primary_work_type` implementation to retrieve directly from `.config` instead of an obscure downstream module.

@samvera/hyrax-code-reviewers
