### PR TITLE
honor ability on workflow unavailable page

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -206,7 +206,7 @@ module Hyrax
 
       def document_not_found!
         doc = ::SolrDocument.find(params[:id])
-        raise WorkflowAuthorizationException if doc.suppressed?
+        raise WorkflowAuthorizationException if doc.suppressed? && current_ability.can?(:read, doc)
         raise CanCan::AccessDenied.new(nil, :show)
       end
 


### PR DESCRIPTION
Fixes #3104

* For suppressed works unavailable due to workflow, don't show even the minimal unavailable page to the user unless they have read access. 

@samvera/hyrax-code-reviewers
