### PR TITLE
Make Single-Use Links more accessible.

### DIFF
--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -9,9 +9,6 @@
       <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter],
                   class: 'btn btn-danger', data: { confirm: "Delete this #{@presenter.human_readable_type}?" },
                   method: :delete %>
-      <%= link_to t('hyrax.single_use_links.button'),
-                  hyrax.generate_download_single_use_link_path(@presenter),
-                  class: 'btn btn-default generate-single-use-link' %>
   <% end %>
 
   <%= render 'social_media' %>

--- a/app/views/hyrax/file_sets/_single_use_links.html.erb
+++ b/app/views/hyrax/file_sets/_single_use_links.html.erb
@@ -8,3 +8,8 @@
     <% end %>
   </tbody>
 </table>
+<div class="form_actions">
+  <%= link_to t('hyrax.single_use_links.button'),
+              hyrax.generate_download_single_use_link_path(presenter),
+              class: 'btn btn-default generate-single-use-link' %>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1021,7 +1021,7 @@ en:
       name: Work
     share_button: Share Your Work
     single_use_links:
-      button: Single-Use Link to File
+      button: Create Single-Use Link
       copy:
         button: Copy
         tooltip: Copied!

--- a/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe 'hyrax/file_sets/_show_actions.html.erb', type: :view do
     it 'renders actions for the user' do
       expect(page).to have_link("Edit This File")
       expect(page).to have_link("Delete This File")
-      expect(page).to have_link("Single-Use Link to File")
     end
   end
 end

--- a/spec/views/hyrax/file_sets/_single_use_links.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_single_use_links.html.erb_spec.rb
@@ -27,5 +27,9 @@ RSpec.describe 'hyrax/file_sets/_single_use_links.html.erb', type: :view do
     it "renders a table with links" do
       expect(rendered).to include("Link sha2ha expires in 23 hours")
     end
+
+    it "renders the single use link button" do
+      expect(rendered).to have_link("Create Single-Use Link")
+    end
   end
 end


### PR DESCRIPTION
Fixes #1201  ; refs https://github.com/psu-stewardship/scholarsphere/commit/0063155497e7b092557f289a03dc902dbd6ae179

Moving the the button that adds Single-use links to the area underneath where they are added to help users see the changes that are occurring.


Screenshots for after changes:
<img width="388" alt="after-no-links" src="https://user-images.githubusercontent.com/2430784/42659442-25c887d8-85dd-11e8-80f5-bd4c7c4ff22c.png">

<img width="397" alt="after-w-links" src="https://user-images.githubusercontent.com/2430784/42659448-2b5afadc-85dd-11e8-99c3-6c2e4238009d.png">

@samvera/hyrax-code-reviewers
