### PR TITLE
Add a method to indicate enabled status of save button based on valid…

### DIFF
--- a/app/assets/javascripts/hyrax/save_work/save_work_control.es6
+++ b/app/assets/javascripts/hyrax/save_work/save_work_control.es6
@@ -108,13 +108,18 @@ export default class SaveWorkControl {
 
   // Called when a file has been uploaded, the deposit agreement is clicked or a form field has had text entered.
   formStateChanged() {
-    this.saveButton.prop("disabled", !this.isValid());
+    this.saveButton.prop("disabled", !this.isSaveButtonEnabled);
   }
 
   // called when a new field has been added to the form.
   formChanged() {
     this.requiredFields.reload();
     this.formStateChanged();
+  }
+
+  // Indicates whether the "Save" button should be enabled: a valid form and no uploads in progress
+  get isSaveButtonEnabled() {
+    return this.isValid() && !this.uploads.inProgress;
   }
 
   isValid() {

--- a/spec/javascripts/save_work_spec.js
+++ b/spec/javascripts/save_work_spec.js
@@ -173,6 +173,56 @@ describe("SaveWorkControl", function() {
 
   });
 
+  describe('isSaveButtonEnabled helper method', function() {
+    const form_id = 'new_generic_work';
+    let buildTarget = function(form_id) {
+      let buildFixture = function(id) {
+        return setFixtures(
+          `<form id="${id}">
+            <aside id="form-progress">
+              <ul>
+                <li id="required-metadata"></li>
+                <li id="required-files"></li>
+                <li id="required-agreement"></li>
+              </ul>
+              <input type="checkbox" name="agreement" id="agreement" value="1" required="required" checked="checked" />
+              <input type="submit">
+            </aside>
+          </form>`
+        );
+      };
+      target = new SaveWorkControl(buildFixture(form_id).find('#form-progress'));
+      return target;
+    };
+
+    describe('returns a boolean value of', function() {
+      beforeEach(function() {
+        target = buildTarget(form_id);
+        target.uploads = {
+          hasFiles: true,
+          hasFileRequirement: true,
+          // mock current uploads getter value
+          inProgress: false
+        };
+      });
+
+      it('true when the form is valid and there are no in progress uploads', () => {
+        expect(target.isSaveButtonEnabled).toBeTruthy();
+      });
+      
+      it('false when required files have not been added to the form', () => {
+        target.uploads.hasFiles = false;
+        expect(target.isSaveButtonEnabled).toBeFalsy();
+      });
+
+      it('false when file uploads are still in progress', () => {
+        target.uploads.inProgress = true;
+        expect(target.isSaveButtonEnabled).toBeFalsy();
+      });
+    });
+  });
+
+
   describe("on submit", function() {
     var target;
     beforeEach(function() {


### PR DESCRIPTION
… form state and no file uploads currently in progress.

Fixes #380 

This PR introduces a new method, `isSaveButtonEnabled` on the `SaveWorkControl` class, which expands the check for enabled status on the form Save button.   It checks against any current file uploads in progress.

I went the route of hooking into the existing pattern this form uses for checking file upload status based on the `inProgress` method in `UploadedFiles.es6`, instead of the the jQuery File Upload events which probably could be also consumed to arrive at a similar state:
https://github.com/blueimp/jQuery-File-Upload/wiki/Options#callback-options


@samvera/hyrax-code-reviewers
