### PR TITLE
remove turbolinks false

### DIFF
--- a/app/views/hyrax/admin/collection_types/index.html.erb
+++ b/app/views/hyrax/admin/collection_types/index.html.erb
@@ -34,7 +34,7 @@
              <tr>
                <td><%= collection_type.title %></td>
                <td>
-                 <%= link_to hyrax.edit_admin_collection_type_path(collection_type), class: 'btn btn-primary btn-sm', data: { turbolinks: false } do %>
+                 <%= link_to hyrax.edit_admin_collection_type_path(collection_type), class: 'btn btn-primary btn-sm' do %>
                   <%= t('helpers.action.edit') %>
                  <% end %>
                  <% unless collection_type.admin_set? || collection_type.user_collection? %>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,6 +1,6 @@
 <div class="show-actions">
   <% if Hyrax.config.analytics? %>
-    <%= link_to "Analytics", presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
+    <%= link_to "Analytics", presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
   <% end %>
   <% if presenter.editor? %>
       <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
@@ -44,5 +44,3 @@
   <span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>
 <!-- Render Modals -->
   <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>
-
-

--- a/app/views/hyrax/dashboard/_index_partials/_transfers.html.erb
+++ b/app/views/hyrax/dashboard/_index_partials/_transfers.html.erb
@@ -3,7 +3,7 @@
     <h4><%= t("hyrax.dashboard.transfers_sent") %></h4>
   </div>
   <div class="col-xs-12 col-sm-3 transfer_link">
-    <%= link_to hyrax.my_works_path, data: { turbolinks: false } do %>
+    <%= link_to hyrax.my_works_path do %>
         <%= t("hyrax.dashboard.transfer_works_link") %>
     <% end %>
   </div>

--- a/app/views/hyrax/dashboard/collections/_edit_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_edit_actions.html.erb
@@ -3,6 +3,5 @@
   <%= link_to t('hyrax.collection.actions.add_existing_works.label'),
               hyrax.my_works_path(add_works_to_collection: @form.id),
               title: t('hyrax.collection.actions.add_existing_works.desc'),
-              class: 'btn btn-default',
-              data: { turbolinks: false } %>
+              class: 'btn btn-default' %>
 </div>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -97,7 +97,7 @@
 
       <div class="panel-footer">
         <% if @collection.persisted? %>
-          <%= f.submit t(:'hyrax.collection.select_form.update'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "update_submit", name: "update_collection", data: { turbolinks: false } %>
+          <%= f.submit t(:'hyrax.collection.select_form.update'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "update_submit", name: "update_collection" %>
           <%= link_to t(:'helpers.action.cancel'), hyrax.dashboard_collection_path(@collection), class: 'btn btn-link' %>
         <% else %>
           <%= f.submit t(:'hyrax.collection.select_form.create'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "create_submit", name: "create_collection" %>

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -3,8 +3,7 @@
     <%= link_to t('hyrax.collection.actions.edit.label'),
                 hyrax.edit_dashboard_collection_path(presenter),
                 title: t('hyrax.collection.actions.edit.desc'),
-                class: 'btn btn-primary',
-                data: { turbolinks: false } %>
+                class: 'btn btn-primary' %>
 <% end %>
 
 <% if presenter.collection_type_is_nestable? && presenter.user_can_nest_collection? %>

--- a/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
@@ -18,8 +18,7 @@
       <%= link_to t('hyrax.collection.actions.add_existing_works.label'),
                   hyrax.my_works_path(add_works_to_collection: presenter.id, add_works_to_collection_label: presenter.title),
                   title: t('hyrax.collection.actions.add_existing_works.desc'),
-                  class: 'btn btn-link side-arrows',
-                  data: { turbolinks: false } %>
+                  class: 'btn btn-link side-arrows' %>
     </div>
   <% end %>
 </div>

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -6,7 +6,6 @@
   <% end %>
 
   <%= menu.nav_link(hyrax.my_works_path,
-                    also_active_for: hyrax.dashboard_works_path,
-                    data: { turbolinks: false }) do %>
+                    also_active_for: hyrax.dashboard_works_path) do %>
     <span class="fa fa-file"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
   <% end %>

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -1,6 +1,6 @@
 <div class="form-actions">
   <% if Hyrax.config.analytics? %>
-    <%= link_to "Analytics", @presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
+    <%= link_to "Analytics", @presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
   <% end %>
 
   <% if @presenter.editor? %>

--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -8,7 +8,7 @@
       </audio>
       <%= link_to t('hyrax.file_set.show.downloadable_content.audio_link'),
                   hyrax.download_path(file_set),
-                  data: { turbolinks: false, label: file_set.id },
+                  data: { label: file_set.id },
                   target: :_blank,
                   id: "file_download" %>
     </div>

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -7,7 +7,7 @@
                     role: "presentation" %>
       <%= link_to t('hyrax.file_set.show.downloadable_content.image_link'),
                   hyrax.download_path(file_set),
-                  data: { turbolinks: false, label: file_set.id },
+                  data: { label: file_set.id },
                   target: :_blank,
                   id: "file_download" %>
     </div>

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -7,7 +7,6 @@
                     role: "presentation" %>
       <%= link_to t('hyrax.file_set.show.downloadable_content.office_link'),
                   hyrax.download_path(file_set),
-                  data: { turbolinks: false },
                   target: :_blank,
                   id: "file_download",
                   data: { label: file_set.id } %>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -7,7 +7,6 @@
                     role: "presentation" %>
       <%= link_to t('hyrax.file_set.show.downloadable_content.pdf_link'),
                   hyrax.download_path(file_set),
-                  data: { turbolinks: false },
                   target: :_blank,
                   id: "file_download",
                   data: { label: file_set.id } %>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -8,7 +8,7 @@
       </video>
       <%= link_to t('hyrax.file_set.show.downloadable_content.video_link'),
                   hyrax.download_path(file_set),
-                  data: { turbolinks: false, label: file_set.id },
+                  data: { label: file_set.id },
                   target: :_blank,
                   id: "file_download" %>
     </div>

--- a/app/views/hyrax/my/works/_batch_actions.html.erb
+++ b/app/views/hyrax/my/works/_batch_actions.html.erb
@@ -9,6 +9,6 @@
     <%= batch_delete %>
     <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
         class: 'btn btn-primary submits-batches submits-batches-add',
-        data: { toggle: "modal", target: "#collection-list-container", turbolinks: false } %>
+        data: { toggle: "modal", target: "#collection-list-container" } %>
   </div>
 </div>

--- a/app/views/hyrax/my/works/_tabs.html.erb
+++ b/app/views/hyrax/my/works/_tabs.html.erb
@@ -1,8 +1,8 @@
-<ul class="nav nav-tabs" id="my_nav" role="navigation">	
+<ul class="nav nav-tabs" id="my_nav" role="navigation">
   <li<%= ' class="active"'.html_safe if current_page?(hyrax.dashboard_works_path(locale: nil)) %>>
-    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.works"), hyrax.dashboard_works_path, data: { turbolinks: false } %>
+    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.works"), hyrax.dashboard_works_path %>
   </li>
   <li<%= ' class="active"'.html_safe if current_page?(hyrax.my_works_path(locale: nil)) %>>
-    <%= link_to t('hyrax.dashboard.my.your_works'), hyrax.my_works_path, data: { turbolinks: false } %>
+    <%= link_to t('hyrax.dashboard.my.your_works'), hyrax.my_works_path %>
   </li>
 </ul>

--- a/app/views/hyrax/single_use_links_viewer/show.html.erb
+++ b/app/views/hyrax/single_use_links_viewer/show.html.erb
@@ -2,7 +2,7 @@
   <h1 class="lower"><%= @presenter %></h1>
     <h2 class="non lower">Actions</h2>
     <p>
-      <%= link_to "Download (can only be used once)", @download_link, target: :_blank, data: { turbolinks: false } %>
+      <%= link_to "Download (can only be used once)", @download_link, target: :_blank %>
     </p>
   <h2> Descriptions:</h2>
 

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -7,7 +7,7 @@
 
   <body>
     <div class="skip-to-content">
-      <%= link_to "Skip to Content", "#skip-to-content", data: { turbolinks: false } %>
+      <%= link_to "Skip to Content", "#skip-to-content" %>
     </div>
     <%= render '/masthead' %>
     <%= content_for(:navbar) %>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -7,7 +7,7 @@
 
   <body class="dashboard">
     <div class="skip-to-content">
-      <%= link_to "Skip to Content", "#skip-to-content", data: { turbolinks: false } %>
+      <%= link_to "Skip to Content", "#skip-to-content" %>
     </div>
     <%= render '/masthead' %>
     <%= content_for(:navbar) %>

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -631,14 +631,14 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       it "preselects the collection we are adding works to and adds the selected works" do
         visit "/dashboard/collections/#{collection1.id}"
         click_link 'Add existing works'
-        first('input#check_all').click
+        find('input#check_all').click
         click_button "Add to collection"
         expect(page).to have_selector "#member_of_collection_ids[value=\"#{collection1.id}\"]", visible: false
         expect(page).to have_selector "#member_of_collection_label[value=\"#{collection1.title.first}\"]"
 
         visit "/dashboard/collections/#{collection2.id}"
         click_link 'Add existing works'
-        first('input#check_all').click
+        find('input#check_all').click
         click_button "Add to collection"
         expect(page).to have_selector "#member_of_collection_ids[value=\"#{collection2.id}\"]", visible: false
         expect(page).to have_selector "#member_of_collection_label[value=\"#{collection2.title.first}\"]"

--- a/spec/views/hyrax/single_use_links_viewer/show.html.erb_spec.rb
+++ b/spec/views/hyrax/single_use_links_viewer/show.html.erb_spec.rb
@@ -14,8 +14,4 @@ RSpec.describe 'hyrax/single_use_links_viewer/show.html.erb' do
   it "contains a download link" do
     expect(rendered).to have_selector "a[href^='/single_use_link/download/']"
   end
-
-  it "has turbolinks disabled in the download link" do
-    expect(rendered).to have_selector "a[data-turbolinks^='false'][href^='/single_use_link/download/']"
-  end
 end


### PR DESCRIPTION
Fixes #2881 

* Removes all instances of `data: {  turbolinks: false }` which were added as workaround to CSRF Exception which PR #2875  addressed.

@samvera/hyrax-code-reviewers
