### PR TITLE
Move license attribute row from _metadata partial to _attribute_rows …

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -12,4 +12,4 @@
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:source, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
-
+<%= presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -1,6 +1,5 @@
-<dl class="work-show <%= dom_class(presenter) %>" <%= presenter.microdata_type_to_html %>> 
+<dl class="work-show <%= dom_class(presenter) %>" <%= presenter.microdata_type_to_html %>>
     <%= render 'attribute_rows', presenter: presenter %>
     <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date, html_dl: true) %>
     <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date, html_dl: true) %>
-    <%= presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>
- </dl> 
+ </dl>


### PR DESCRIPTION
…partial

Fixes #394 

This PR attempts to fix "Move rights rows from _metadata to _attribute_rows", but see issue https://github.com/samvera/hyrax/issues/394 for needed clarification of what's the acceptance criteria for this issue.   It's not clear to me.

@samvera/hyrax-code-reviewers
