### PR TITLE
Hide cancel upload button when file upload(s) are finished

### DIFF
--- a/app/assets/javascripts/hyrax/save_work/save_work_control.es6
+++ b/app/assets/javascripts/hyrax/save_work/save_work_control.es6
@@ -92,6 +92,20 @@ export default class SaveWorkControl {
     this.preventSubmit()
     this.watchMultivaluedFields()
     this.formChanged()
+    this.addFileUploadEventListeners();
+  }
+
+  addFileUploadEventListeners() {
+    let $uploadsEl = this.uploads.element;
+    const $cancelBtn = this.uploads.form.find('#file-upload-cancel-btn');
+
+    $uploadsEl.bind('fileuploadstart', () => {
+      $cancelBtn.removeClass('hidden');
+    });
+
+    $uploadsEl.bind('fileuploadstop', () => {
+      $cancelBtn.addClass('hidden');
+    });
   }
 
   preventSubmit() {

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -32,7 +32,7 @@
                     <%= t('hyrax.upload.browse_everything.browse_files_button') %>
                   <% end %>
                 <% end %>
-                <button type="reset" class="btn btn-warning cancel hidden">
+                <button type="reset" id="file-upload-cancel-btn" class="btn btn-warning cancel hidden">
                     <span class="glyphicon glyphicon-ban-circle"></span>
                     <span>Cancel upload</span>
                 </button>


### PR DESCRIPTION
Fixes #494 

Hide the "Cancel Upload" button when file(s) are finished uploading.

@samvera/hyrax-code-reviewers
