### PR TITLE
Add checkbox label to table header for checkbox column in Work and Co…

### DIFF
--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -154,10 +154,16 @@ button.branding-banner-remove:hover {
     td {
       text-align: center;
       vertical-align: top;
+      padding: 8px 2px;
 
+      &:nth-child(1),
       &:nth-child(2) {
         text-align: left;
       }
+    }
+
+    .check-all-checkbox {
+      margin-right: 5px !important;
     }
 
     .modal {

--- a/app/assets/stylesheets/hyrax/_file-listing.scss
+++ b/app/assets/stylesheets/hyrax/_file-listing.scss
@@ -109,6 +109,11 @@ input#check_all {
 
 .check-all {
   white-space: nowrap;
+
+  label {
+    margin: 0;
+  }
+
   .caret {
     margin-left: 0;
   }

--- a/app/assets/stylesheets/hyrax/_styles.scss
+++ b/app/assets/stylesheets/hyrax/_styles.scss
@@ -56,3 +56,9 @@ label.disabled {
   text-decoration:underline;
   background-color:#0088CC;
 }
+
+// Vertically center child elements
+.centerizer {
+  align-items: center;
+  display: flex;
+}

--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -29,6 +29,10 @@ $admin-panel-border-color: #dedede !default;
   .media-body {
     width: 18vw;
   }
+
+  .works-list-batch-checkbox-label-text {
+    margin: 0 5px;
+  }
 }
 
 body.dashboard {

--- a/app/views/hyrax/batch_edits/_check_all.html.erb
+++ b/app/views/hyrax/batch_edits/_check_all.html.erb
@@ -1,9 +1,17 @@
 <div class="dropdown batch_document_selector_all">
-  <%= check_box_tag 'check_all', 'yes', @all_checked, disabled: @disable_select_all %>
-  <% if !@disable_select_all %>
-    <a class="dropdown-toggle" data-toggle="dropdown" href="#"><span class="sr-only">Select to access selection options</span><span class="caret"></span></a>
-    <ul class="dropdown-menu">
-      <%= render "batch_edits_actions" %>
-    </ul>
-  <% end %>
+  <label class="centerizer">
+    <%= check_box_tag 'check_all', 'yes', @all_checked, disabled: @disable_select_all %>
+    <span class="works-list-batch-checkbox-label-text">
+      <%= t("hyrax.dashboard.my.action.select") %>
+    </span>
+    <% if !@disable_select_all %>
+      <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+        <span class="sr-only">Select to access selection options</span>
+        <span class="caret"></span>
+      </a>
+      <ul class="dropdown-menu">
+        <%= render "batch_edits_actions" %>
+      </ul>
+    <% end %>
+  </label>
 </div>

--- a/app/views/hyrax/dashboard/collections/_default_group.html.erb
+++ b/app/views/hyrax/dashboard/collections/_default_group.html.erb
@@ -3,8 +3,13 @@
   <thead>
   <tr>
     <th class="check-all">
-      <label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label>
-      <input type="checkbox" name="check_all" id="check_all" value="yes" />
+      <label for="check_all" class="sr-only"
+        ><%= t("hyrax.dashboard.my.sr.check_all_label") %>
+      </label>
+      <label class="centerizer">
+        <input type="checkbox" class="check-all-checkbox" name="check_all" id="check_all" value="yes" />
+        <%= t("hyrax.dashboard.my.action.select") %>
+      </label>
     </th>
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>
     <% if !current_ability.admin? %>

--- a/app/views/hyrax/my/collections/_default_group.html.erb
+++ b/app/views/hyrax/my/collections/_default_group.html.erb
@@ -2,9 +2,14 @@
   <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
   <thead>
   <tr>
-    <th class="check-all">
-      <label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label>
-      <input type="checkbox" name="check_all" id="check_all" value="yes" />
+    <th class="check-all text-left">
+      <label for="check_all" class="sr-only">
+        <%= t("hyrax.dashboard.my.sr.check_all_label") %>
+      </label>
+      <label class="centerizer">
+        <input type="checkbox" class="check-all-checkbox" name="check_all" id="check_all" value="yes" />
+        <%= t("hyrax.dashboard.my.action.select") %>
+      </label>
     </th>
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>
     <th><%= t("hyrax.dashboard.my.heading.type") %></th>


### PR DESCRIPTION
…llection listings pages

Fixes #126 

Add a label to the checkbox table header for checkbox column in Works and Collections listing pages.  There was no text specified for the label in the issue, so until someone has a better option, for now "Select" is the checkbox label.

Also cleaned up the layout of the Collections listing table headers a bit, reducing the header horizontal padding to get all header text on one line (at least for English language).

**Screenshot after:**

![works-list-page-checkbox-label-after](https://user-images.githubusercontent.com/3020266/43005432-78a23b22-8bf8-11e8-9c88-f563c4e20379.png)

Screenshot before:

![works-list-page-checkbox-label-before](https://user-images.githubusercontent.com/3020266/43005493-a8a04d0a-8bf8-11e8-9d72-dd9611f23d41.png)


@samvera/hyrax-code-reviewers
