### PR TITLE
Assign file_set permissions from work

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -54,7 +54,7 @@ module Hyrax
       # @param [Hash] file_set_params specifying the visibility, lease and/or embargo of the file set.
       #   Without visibility, embargo_release_date or lease_expiration_date, visibility will be copied from the parent.
       def create_metadata(file_set_params = {})
-        file_set.apply_depositor_metadata(user)
+        file_set.depositor = depositor_id(user)
         now = TimeService.time_in_utc
         file_set.date_uploaded = now
         file_set.date_modified = now
@@ -142,6 +142,11 @@ module Hyrax
 
         def assign_visibility?(file_set_params = {})
           !((file_set_params || {}).keys.map(&:to_s) & %w[visibility embargo_release_date lease_expiration_date]).empty?
+        end
+
+        # replaces file_set.apply_depositor_metadata(user)from hydra-access-controls so depositor doesn't automatically get edit access
+        def depositor_id(depositor)
+          depositor.respond_to?(:user_key) ? depositor.user_key : depositor
         end
 
         # Must clear the fileset from the thumbnail_id, representative_id and rendering_ids fields on the work

--- a/app/search_builders/hyrax/my/works_search_builder.rb
+++ b/app/search_builders/hyrax/my/works_search_builder.rb
@@ -7,7 +7,8 @@ module Hyrax
     # We remove the access controls filter, because some of the works a user has
     # deposited may have gone through a workflow which has removed their ability
     # to edit the work.
-    self.default_processor_chain -= [:add_access_controls_to_solr_params]
+    # We remove the active works filter, so a depositor can see submitted works in any state.
+    self.default_processor_chain -= [:only_active_works, :add_access_controls_to_solr_params]
 
     def only_works?
       true

--- a/lib/generators/hyrax/templates/mediated_deposit_workflow.json.erb
+++ b/lib/generators/hyrax/templates/mediated_deposit_workflow.json.erb
@@ -18,6 +18,7 @@
                         }
                     ],
                     "methods": [
+                        "Hyrax::Workflow::GrantReadToDepositor",
                         "Hyrax::Workflow::DeactivateObject"
                     ]
                 }, {

--- a/spec/search_builders/hyrax/my/works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/works_search_builder_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Hyrax::My::WorksSearchBuilder do
 
     it "filters works that we are the depositor of" do
       expect(subject).to eq ["{!terms f=has_model_ssim}GenericWork",
-                             "-suppressed_bsi:true",
                              "depositor"]
     end
   end
@@ -44,7 +43,6 @@ RSpec.describe Hyrax::My::WorksSearchBuilder do
         :add_group_config_to_solr,
         :add_facet_paging_to_solr,
         :filter_models,
-        :only_active_works,
         :show_only_resources_deposited_by_current_user
       ]
     end


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/1421

Remove depositor's edit access to file sets, as previously
assigned via hydra-access-controls. This allows the workflow to control
whether the depositor gets access in the work, and assigns permissions
to the file_sets accordingly.

Modify my/works_search_builder to include works of all states on the
dashboard views for works.

## Changes

- After creating a work using `mediated_deposit_workflow`, depositor will see the work's show page. Edit option will not be available on either work or its file sets while work is pending review.
- Works in pending review status will appear to the depositor and viewers on the dashboard views: Depositor will see works on the my works list, Viewers will see works on the managed works list. Both will see works on the Admin Set show page's list of works.

@samvera/hyrax-code-reviewers
