### PR TITLE
Include fcr:version in IIIF image URI

### DIFF
--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -13,9 +13,10 @@ module Hyrax
       return nil unless ::FileSet.exists?(id) && solr_document.image? && current_ability.can?(:read, id)
       # @todo this is slow, find a better way (perhaps index iiif url):
       original_file = ::FileSet.find(id).original_file
+      latest_file_id = original_file.has_versions? ? ActiveFedora::File.uri_to_id(original_file.versions.last.uri) : original_file.id
 
       url = Hyrax.config.iiif_image_url_builder.call(
-        original_file.id,
+        latest_file_id,
         request.base_url,
         Hyrax.config.iiif_image_size_default
       )
@@ -23,7 +24,7 @@ module Hyrax
       IIIFManifest::DisplayImage.new(url,
                                      width: 640,
                                      height: 480,
-                                     iiif_endpoint: iiif_endpoint(original_file.id))
+                                     iiif_endpoint: iiif_endpoint(latest_file_id))
     end
 
     private


### PR DESCRIPTION
Fixes #2910 

Include fcr:version in IIIF image URI so the cached file's hashed filename created by riiif is version specific.
Use Rails' URI escape library (instead of CGI) in the spec because colon is handled differently.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a work with an image file.
* Add a new visually distinct version of the image file.
* Verify the universal viewer displays the new version on the work show page.

@samvera/hyrax-code-reviewers
