### PR TITLE
Update browse-everything and use BrowseEverything::Retriever.can_retrieve?

### DIFF
--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -24,7 +24,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
     @file_set = file_set
     @operation = operation
 
-    unless can_retrieve?(uri)
+    unless BrowseEverything::Retriever.can_retrieve?(uri)
       send_error('Expired URL')
       return false
     end
@@ -43,17 +43,6 @@ class ImportUrlJob < Hyrax::ApplicationJob
   end
 
   private
-
-    # The previous strategy of using only a HEAD request to check the validity of a
-    # remote URL fails for Amazon S3 pre-signed URLs. S3 URLs are generated for a single
-    # verb only (in this case, GET), and will return a 403 Forbidden response if any
-    # other verb is used. The workaround is to issue a GET request instead, with a
-    # Range: header requesting only the first byte. The successful response status
-    # code is 206 instead of 200, but that is enough to satisfy the #success? method.
-    # @param uri [URI] the uri of the file to be downloaded
-    def can_retrieve?(uri)
-      HTTParty.get(uri, headers: { Range: 'bytes=0-0' }).success?
-    end
 
     # Download file from uri, yields a block with a file in a temporary directory.
     # It is important that the file on disk has the same file name as the URL,

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -37,7 +37,7 @@ SUMMARY
   spec.add_dependency 'blacklight', '~> 6.14'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
-  spec.add_dependency 'browse-everything', '>= 0.10.5'
+  spec.add_dependency 'browse-everything', '>= 0.16.0'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'dry-equalizer', '~> 0.2'


### PR DESCRIPTION
Updates browse-everything to latest release `0.16.0` which:
  - Replaces `HTTParty` dependency with `Typhoeus` for improved download handling
  - Implements `BrowseEverything::Retriever.can_retrieve?` allowing removal of `ImportUrlJob#can_retrieve?`