### PR TITLE
Display creator on Review Submissions dashboard

### DIFF
--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -34,7 +34,7 @@
                           <%= link_to document, [main_app, document] %>
                         </td>
                         <td>
-                          <%= document.depositor %>
+                          <%= safe_join(document.creator, tag(:br)) %>
                         </td>
                         <td>
                           <%= document.date_modified %>


### PR DESCRIPTION
We should consistently display the object creator
on both tabs of the Review Submissions form.
This PR makes the behavior consistent.

Before:
![review_submissions_depositor](https://user-images.githubusercontent.com/65608/43278824-292dd902-90da-11e8-85c9-fecfaa0a4373.png)

After (now it matches what's on the Published tab):
![after](https://user-images.githubusercontent.com/65608/43278850-37bd22e8-90da-11e8-951c-2072f9d39712.png)

@samvera/hyrax-code-reviewers
