### PR TITLE
Make Works dashboard sortable

### DIFF
--- a/app/views/hyrax/dashboard/works/_default_group.html.erb
+++ b/app/views/hyrax/dashboard/works/_default_group.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-striped works-list">
+<table class="table table-striped works-list datatable">
   <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
   <thead>
     <tr>


### PR DESCRIPTION
Add a datatable class to the table of works on the Works controller. This improves usability
for collections with lots of items.
![datatable](https://user-images.githubusercontent.com/65608/43290052-d231f068-90fa-11e8-901d-28e91ed2c74b.png)

@samvera/hyrax-code-reviewers
