### PR TITLE
Upgrade browse-everything to latest version

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -37,7 +37,7 @@ SUMMARY
   spec.add_dependency 'blacklight', '~> 6.14'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
-  spec.add_dependency 'browse-everything', '>= 0.16.0'
+  spec.add_dependency 'browse-everything', '>= 0.16.1'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'dry-equalizer', '~> 0.2'


### PR DESCRIPTION
Using the browse-everything gem version 0.16.0
makes Hyrax undeployable (and, presumably,
also breaks the browse-everything functionality)
for those who have a browse-everything config
file that contains symbols. Since Hyrax
has always shipped with such a
config file, this would presumably affect
many users of the software.

The fix is to upgrade to 0.16.1, which again allows
symbols in the config file.

Many thanks to @mbklein for the quick turnaround on 
diagnosing the problem and getting a new version of 
browse-everything released. 

Fixes #3180 

@samvera/hyrax-code-reviewers
