### PR TITLE
Fix FileSet comparision issue in spec

### DIFF
--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
         actor.attach_to_work(work)
         expect(work.representative).to eq(file_set)
         expect(work.thumbnail).to eq(file_set)
-        expect { work.reload }.not_to change { [work.representative, work.thumbnail] }
+        expect { work.reload }.not_to change { [work.representative.id, work.thumbnail.id] }
       end
     end
 


### PR DESCRIPTION
This test is failing because of a dependency issue(?). It used to reliably
compare `FileSet` instances, but now reliabily treats identical instances
different. Comparing the ids is adequate for test purposes.

Did FileSet equality change? Does it need to change back?

@samvera/hyrax-code-reviewers
