### PR TITLE
Update file upload buttons to be keyboard tab accessible

### DIFF
--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -13,17 +13,17 @@
           <div class="row">
             <div class="col-xs-12">
                 <!-- The fileinput-button span is used to style the file input field as button -->
-                <span id="addfiles" class="btn btn-success fileinput-button">
+                <button id="addfiles" class="btn btn-success fileinput-button">
                     <span class="glyphicon glyphicon-plus"></span>
                     <span>Add files...</span>
-                    <input type="file" name="files[]" multiple />
-                </span>
+                    <input type="file" name="files[]" tabindex="-1" aria-hidden="true" multiple />
+                </button>
                 <!-- The fileinput-button span is used to style the file input field as button -->
-                <span id="addfolder" class="btn btn-success fileinput-button">
+                <button id="addfolder" class="btn btn-success fileinput-button">
                     <span class="glyphicon glyphicon-plus"></span>
                     <span>Add folder...</span>
-                    <input type="file" name="files[]" multiple directory webkitdirectory />
-                </span>
+                    <input type="file" name="files[]" tabindex="-1" aria-hidden="true" multiple directory webkitdirectory />
+                </button>
                 <% if Hyrax.config.browse_everything? %>
                   <%= button_tag(type: 'button', class: 'btn btn-success', id: "browse-btn",
                     'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,

--- a/app/views/hyrax/dashboard/collections/_form_branding.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_branding.html.erb
@@ -13,11 +13,11 @@
     <div class="row fileupload-buttonbar">
       <div class="col-xs-4">
         <!-- The fileinput-button span is used to style the file input field as button -->
-        <span class="btn btn-success fileinput-button">
+        <button class="btn btn-success fileinput-button">
           <span class="glyphicon glyphicon-plus"></span>
           <span>Choose File</span>
-          <input type="file" name="files[]" single />
-        </span>
+          <input type="file" name="files[]" tabindex="-1" aria-hidden="true" single />
+        </button>
       </div> <!-- end col-xs-4 -->
 
       <!-- The global progress state -->
@@ -90,11 +90,11 @@
     <div class="row fileupload-buttonbar">
       <div class="col-xs-4">
         <!-- The fileinput-button span is used to style the file input field as button -->
-        <span class="btn btn-success fileinput-button">
+        <button class="btn btn-success fileinput-button">
           <span class="glyphicon glyphicon-plus"></span>
           <span>Choose File</span>
-          <input type="file" name="files[]" single />
-        </span>
+          <input type="file" name="files[]" tabindex="-1" aria-hidden="true" single />
+        </button>
       </div> <!-- end col-xs-4 -->
 
       <!-- The global progress state -->

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
     it "allows on-behalf-of batch deposit", :js do
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
-      within('span#addfiles') do
+      within('button#addfiles') do
         # two arbitrary files that aren't actually related, but should be
         # small enough to require minimal processessing.
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/small_file.txt", visible: false)

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
       expect(page).to have_content "Add folder"
-      within('span#addfiles') do
+      within('button#addfiles') do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
@@ -71,7 +71,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
     it "allows on-behalf-of deposit" do
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
-      within('span#addfiles') do
+      within('button#addfiles') do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
@@ -113,7 +113,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
 
     it 'updates the required file check status' do
       click_link "Files" # switch to the Files tab
-      within('span#addfiles') do
+      within('button#addfiles') do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
       end
       expect(page).to have_css('ul li#required-files.complete', text: 'Add files')

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -671,7 +671,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         # add required file
         click_link "Files" # switch tab
-        within('span#addfiles') do
+        within('button#addfiles') do
           attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         end
         # set required metadata


### PR DESCRIPTION
Fixes #1246 

Updates the file upload buttons to be `<button>` elements instead of `<span>`s.  This enables keyboard tabbing through the buttons in document flow, to improve accessibility.  

@samvera/hyrax-code-reviewers

![work-file-upload-focused-button](https://user-images.githubusercontent.com/3020266/43793652-d4cf7f34-9a41-11e8-9384-4135d76ca448.png)
