### PR TITLE
Update breadcrumbs for accessiblity standards

### DIFF
--- a/app/assets/stylesheets/hyrax/_breadcrumbs.scss
+++ b/app/assets/stylesheets/hyrax/_breadcrumbs.scss
@@ -1,0 +1,25 @@
+.breadcrumb {
+  border: 1px solid $admin-panel-border-color;
+  border-radius: 3px;
+  margin-top: 0.5em;
+  padding: 0.8em 1em;
+
+  ol {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+  }
+
+  li {
+    display: inline;
+
+    +::before {
+      border-right: 0.1em solid #ccc;
+      content: '';
+      display: inline-block;
+      height: 0.8em;
+      margin: 0 0.5em;
+      transform: rotate(15deg);
+    }
+  }
+}

--- a/app/assets/stylesheets/hyrax/_hyrax.scss
+++ b/app/assets/stylesheets/hyrax/_hyrax.scss
@@ -9,7 +9,7 @@
         'hyrax/fixedsticky', 'hyrax/file_upload', 'hyrax/representative-media',
         'hyrax/footer', 'hyrax/select_work_type', 'hyrax/users', 'hyrax/dashboard',
         'hyrax/sidebar', 'hyrax/controlled_vocabulary', 'hyrax/accessibility',
-        'hyrax/recent', 'hyrax/viewer';
+        'hyrax/recent', 'hyrax/viewer', 'hyrax/breadcrumbs';
 @import 'typeahead';
 @import 'sharing_buttons';
 

--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -41,11 +41,6 @@ body.dashboard {
 }
 
 .dashboard {
-  .breadcrumb {
-    border: 1px solid $admin-panel-border-color;
-    margin-top: 0.5em;
-  }
-
   .count-display {
     font-size: 1.1em;
   }

--- a/app/builders/hyrax/bootstrap_breadcrumbs_builder.rb
+++ b/app/builders/hyrax/bootstrap_breadcrumbs_builder.rb
@@ -11,16 +11,22 @@ class Hyrax::BootstrapBreadcrumbsBuilder < BreadcrumbsOnRails::Breadcrumbs::Buil
   def render
     return "" if @elements.blank?
 
-    @context.content_tag(:ul, class: 'breadcrumb') do
-      safe_join(@elements.uniq.collect { |e| render_element(e) })
+    @context.content_tag(:nav, breadcrumbs_options) do
+      @context.content_tag(:ol) do
+        safe_join(@elements.uniq.collect { |e| render_element(e) })
+      end
     end
   end
 
   def render_element(element)
-    html_class = 'active' if @context.current_page?(compute_path(element))
+    html_class = 'active' if @context.current_page?(compute_path(element)) || element.options["aria-current"] == "page"
 
     @context.content_tag(:li, class: html_class) do
-      @context.link_to_unless_current(@context.truncate(compute_name(element), length: 30, separator: ' '), compute_path(element), element.options)
+      @context.link_to_unless(html_class == 'active', @context.truncate(compute_name(element), length: 30, separator: ' '), compute_path(element), element.options)
     end
+  end
+
+  def breadcrumbs_options
+    { class: 'breadcrumb', role: "region", "aria-label" => "Breadcrumb" }
   end
 end

--- a/app/controllers/concerns/hyrax/breadcrumbs_for_collections.rb
+++ b/app/controllers/concerns/hyrax/breadcrumbs_for_collections.rb
@@ -14,10 +14,14 @@ module Hyrax
     def add_breadcrumb_for_action
       case action_name
       when 'edit'.freeze
-        add_breadcrumb I18n.t("hyrax.collection.browse_view"), collection_path(params["id"])
+        add_breadcrumb I18n.t("hyrax.collection.browse_view"), collection_path(params["id"]), mark_active_action
       when 'show'.freeze
-        add_breadcrumb presenter.to_s, polymorphic_path(presenter)
+        add_breadcrumb presenter.to_s, polymorphic_path(presenter), mark_active_action
       end
+    end
+
+    def mark_active_action
+      { "aria-current" => "page" }
     end
   end
 end

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Hyrax::CollectionsController do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
           get :show, params: { id: collection }
           expect(response).to be_successful
         end
@@ -117,7 +117,7 @@ RSpec.describe Hyrax::CollectionsController do
       it "sets breadcrumbs" do
         expect(controller).not_to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         expect(controller).not_to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
         get :show, params: { id: collection }
         expect(response).to be_successful
       end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
           get :show, params: { id: collection }
           expect(response).to be_successful
         end
@@ -457,7 +457,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.browse_view"), collection_path(collection.id, locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.browse_view"), collection_path(collection.id, locale: 'en'), "aria-current" => "page")
         get :edit, params: { id: collection }
         expect(response).to be_successful
       end


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/3068

Wrap breadcrumbs in <nav> tag with appropriate labels.
Make actions for collection show & edit breadcrumbs inactive.
Adjust collections specs for { "aria-current" => "page" } expectation.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Wrap all breadcrumbs in `<nav class="breadcrumb" role="region" aria-label="breadcrumbs">`
* Mark all action breadcrumbs with `<li class="active">` and ensure there is no link.

@samvera/hyrax-code-reviewers
