### PR TITLE
Add aria-expanded and aria-controls to button dropdown combos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ tmp
 *.log
 *~
 
+## Xray Rails
+.xrayconfig.yml
+
 #redis snapshot db
 dump.rdb
 

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -5,14 +5,14 @@
       <%= render_notifications(user: current_user) %>
     </li>
     <li class="dropdown">
-      <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false} do %>
+      <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false, controls: 'user-util-links' } do %>
         <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
         <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
         <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
         <span class="fa fa-user" aria-hidden="true"></span>
         <span class="caret"></span>
       <% end %>
-      <ul class="dropdown-menu dropdown-menu-right" role="menu">
+      <ul id="user-util-links" class="dropdown-menu dropdown-menu-right" role="menu">
         <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
 
         <li class="divider"></li>

--- a/app/views/hyrax/my/_admin_set_action_menu.html.erb
+++ b/app/views/hyrax/my/_admin_set_action_menu.html.erb
@@ -1,10 +1,12 @@
 <% id = admin_set_presenter.id %>
+<% ul_id = 'admin-set-action-dropdown-ul-' + id %>
+
 <div class="btn-group">
-  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= id %>" aria-haspopup="true">
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
     <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
     <%= t("hyrax.dashboard.my.action.select") %> <span class="caret" aria-hidden="true"></span>
   </button>
-  <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= id %>">
+  <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= id %>">
     <li role="menuitem" tabindex="-1">
       <%= link_to hyrax.admin_admin_set_path(id),
                   class: 'itemicon itemedit',

--- a/app/views/hyrax/my/_collection_action_menu.html.erb
+++ b/app/views/hyrax/my/_collection_action_menu.html.erb
@@ -1,12 +1,13 @@
 <% id = collection_presenter.id %>
-<div class="btn-group">
+<% ul_id = 'collection-action-dropdown-ul-' + id %>
 
-  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= id %>" aria-haspopup="true">
+<div class="btn-group">
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
     <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
     <%= t("hyrax.dashboard.my.action.select") %> <span class="caret" aria-hidden="true"></span>
   </button>
 
-  <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= id %>">
+  <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= id %>">
     <li role="menuitem" tabindex="-1">
       <%= link_to hyrax.dashboard_collection_path(id),
                   class: 'itemicon itemedit',

--- a/app/views/hyrax/my/_facet_layout.html.erb
+++ b/app/views/hyrax/my/_facet_layout.html.erb
@@ -1,5 +1,5 @@
 <div class="btn-group">
-  <button class="btn btn-default dropdown-toggle" type="button" id="<%= facet_field.field.parameterize %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+  <button class="btn btn-default dropdown-toggle" type="button" id="<%= facet_field.field.parameterize %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" aria-controls="<%= facet_field.field.parameterize + '-dropdown-options' %>">
     <%= facet_field_label(facet_field.field) %>
     <span class="caret"></span>
   </button>

--- a/app/views/hyrax/my/_facet_limit.html.erb
+++ b/app/views/hyrax/my/_facet_limit.html.erb
@@ -1,7 +1,7 @@
   <%# This template is used to render the initial facet list (#index action)
       and a paginated facet list in a modal (#facet action). The `dropdown-menu`
       class in only necessary for the former and causes display issues in the latter. -%>
-  <ul class="<%= 'dropdown-menu ' if action_name == 'index' %>facet-values" aria-labelledby="<%= facet_field.field.parameterize %>">
+  <ul id="<%= facet_field.field.parameterize + '-dropdown-options' %>" class="<%= 'dropdown-menu ' if action_name == 'index' %>facet-values" aria-labelledby="<%= facet_field.field.parameterize %>">
     <% paginator = facet_paginator(facet_field, display_facet) %>
     <%= render_facet_limit_list paginator, facet_field.key %>
 

--- a/app/views/hyrax/my/_facet_pivot.html.erb
+++ b/app/views/hyrax/my/_facet_pivot.html.erb
@@ -1,5 +1,5 @@
 <% if !subfacet ||= false %>
-  <ul class="dropdown-menu pivot-facet list-unstyled">
+  <ul class="dropdown-menu pivot-facet list-unstyled" id="<%= facet_field.field.parameterize + '-dropdown-options' %>">
 <% end %>
 
   <% display_facet.items.each do |item| -%>

--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -1,12 +1,14 @@
+<% ul_id = 'admin-set-action-dropdown-ul-' + document.id %>
+
 <div class="btn-group">
 
-  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= document.id %>" aria-haspopup="true">
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= document.id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
     <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
     <%= t("hyrax.dashboard.my.action.select") %>
     <span class="caret" aria-hidden="true"></span>
   </button>
 
-  <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
+  <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
 
     <% if can? :edit, document.id %>
       <li role="menuitem" tabindex="-1">

--- a/app/views/shared/_locale_picker.html.erb
+++ b/app/views/shared/_locale_picker.html.erb
@@ -1,10 +1,10 @@
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" aria-controls="language-dropdown-menu">
         <span class="sr-only"><%= t('hyrax.toolbar.language_switch') %></span>
         <span title="<%= t('hyrax.toolbar.language_switch') %>"><%= available_translations[I18n.locale.to_s] %></span>
         <b class="caret"></b>
     </a>
-    <ul class="dropdown-menu" role="menu">
+    <ul id="language-dropdown-menu" class="dropdown-menu" role="menu">
         <li role="presentation" class="dropdown-header"><%= t('hyrax.toolbar.language_switch') %></li>
         <li role="presentation" class="divider"></li>
         <% available_translations.each do |language, label| %>


### PR DESCRIPTION
Fixes #3043 

Add `aria-expanded="..."` and `aria-controls="..."` attributes to controlling buttons for dropdown menus.  Also added necessary `id` attributes to `<ul>` wrapper elements where necessary.  This is all to improve screen reader ability and improve accessibility.

@samvera/hyrax-code-reviewers
