### PR TITLE
Allow #show view for work types that aren't returned in search results.

### DIFF
--- a/app/search_builders/hyrax/single_result.rb
+++ b/app/search_builders/hyrax/single_result.rb
@@ -4,6 +4,7 @@ module Hyrax
 
     included do
       self.default_processor_chain += [:find_one]
+      self.default_processor_chain.delete :filter_models
     end
 
     def find_one(solr_parameters)

--- a/spec/search_builders/hyrax/single_admin_set_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/single_admin_set_search_builder_spec.rb
@@ -7,14 +7,7 @@ RSpec.describe Hyrax::SingleAdminSetSearchBuilder do
   let(:builder) { described_class.new(context) }
 
   describe "#query" do
-    before do
-      expect(builder).to receive(:find_one)
-    end
     subject { builder.with(id: '123').query.fetch('fq') }
-
-    it do
-      is_expected.to match_array ["",
-                                  "{!terms f=has_model_ssim}AdminSet"]
-    end
+    it { is_expected.to match_array ["", "{!raw f=id}123"] }
   end
 end

--- a/spec/search_builders/hyrax/work_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/work_search_builder_spec.rb
@@ -35,9 +35,8 @@ RSpec.describe Hyrax::WorkSearchBuilder do
       context "and the current user has a role" do
         let(:roles) { [double] }
 
-        it "filters for id, access, suppressed and type" do
+        it "filters for id and access" do
           expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                      "{!terms f=has_model_ssim}GenericWork,Collection",
                                       "{!raw f=id}123abc"]
         end
       end
@@ -49,9 +48,8 @@ RSpec.describe Hyrax::WorkSearchBuilder do
             allow(builder).to receive(:depositor?).and_return(false)
           end
 
-          it "filters for id, access, suppressed and type" do
+          it "filters for id, access, and suppressed" do
             expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                        "{!terms f=has_model_ssim}GenericWork,Collection",
                                         "-suppressed_bsi:true",
                                         "{!raw f=id}123abc"]
           end
@@ -62,9 +60,8 @@ RSpec.describe Hyrax::WorkSearchBuilder do
             allow(builder).to receive(:depositor?).and_return(true)
           end
 
-          it "filters for id, access, suppressed and type" do
+          it "filters for id and access" do
             expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                        "{!terms f=has_model_ssim}GenericWork,Collection",
                                         "{!raw f=id}123abc"]
           end
         end
@@ -82,9 +79,8 @@ RSpec.describe Hyrax::WorkSearchBuilder do
           allow(builder).to receive(:depositor?).and_return(false)
         end
 
-        it "filters for id, access, suppressed and type" do
+        it "filters for id, access, and suppressed" do
           expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                      "{!terms f=has_model_ssim}GenericWork,Collection",
                                       "-suppressed_bsi:true",
                                       "{!raw f=id}123abc"]
         end
@@ -95,9 +91,8 @@ RSpec.describe Hyrax::WorkSearchBuilder do
           allow(builder).to receive(:depositor?).and_return(true)
         end
 
-        it "filters for id, access, suppressed and type" do
+        it "filters for id and access" do
           expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                      "{!terms f=has_model_ssim}GenericWork,Collection",
                                       "{!raw f=id}123abc"]
         end
       end


### PR DESCRIPTION
The `#show` view for instances of work types that aren't returned from
`SearchBuilder#models` was showing an Unauthorized page.

This change removes `:filter_models` from the default processor chain when doing a search to return
a single record for the `#show` view of a given work type.

Fixes #3174.

@samvera/hyrax-code-reviewers
