### PR TITLE
Hides user list by default

### DIFF
--- a/app/controllers/hyrax/users_controller.rb
+++ b/app/controllers/hyrax/users_controller.rb
@@ -6,6 +6,7 @@ module Hyrax
     helper Hyrax::TrophyHelper
 
     def index
+      authenticate_user! if Flipflop.hide_users_list?
       @users = search(params[:uq])
     end
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -38,4 +38,8 @@ Flipflop.configure do
   feature :hide_private_items,
           default: false,
           description: "Do not show the private items."
+
+  feature :hide_users_list,
+          default: true,
+          description: "Do not show users list unless user has authenticated."
 end

--- a/spec/controllers/hyrax/users_controller_spec.rb
+++ b/spec/controllers/hyrax/users_controller_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Hyrax::UsersController, type: :controller do
     let!(:u1) { create(:user) }
     let!(:u2) { create(:user) }
 
+    before do
+      allow(Flipflop).to receive(:hide_users_list?).and_return(false)
+    end
+
     describe "requesting html" do
       before do
         # These user types are excluded:
@@ -87,6 +91,60 @@ RSpec.describe Hyrax::UsersController, type: :controller do
         expect(assigns[:users]).to include(u3)
         expect(assigns[:users]).not_to include(u1, u2)
         u3.destroy
+      end
+    end
+  end
+
+  describe 'user list access' do
+    context 'with hide_users_list?=enabled' do
+      before do
+        allow(Flipflop).to receive(:hide_users_list?).and_return(true)
+      end
+
+      describe 'with registered user' do
+        it 'renders the user list' do
+          get :index
+          expect(response.code).to eq '200'
+          expect(response).to render_template(:index)
+        end
+
+        it 'does return .json results' do
+          get :index, params: { format: :json }
+          expect(response).to be_successful
+        end
+      end
+
+      describe 'with unauthenticated user' do
+        before do
+          sign_out user
+        end
+
+        it 'does not render the user list' do
+          get :index
+          expect(flash[:alert]).to eq 'You need to sign in or sign up before continuing.'
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to('/users/sign_in')
+        end
+
+        it 'does not return .json results' do
+          get :index, params: { format: :json }
+          expect(response).not_to be_successful
+        end
+      end
+    end
+
+    context 'with hide_users_list?=disabled' do
+      before do
+        sign_out user
+        allow(Flipflop).to receive(:hide_users_list?).and_return(false)
+      end
+
+      describe 'with unauthenticated user' do
+        it 'renders the user list' do
+          get :index
+          expect(response.code).to eq '200'
+          expect(response).to render_template(:index)
+        end
       end
     end
   end

--- a/spec/models/flipflop_spec.rb
+++ b/spec/models/flipflop_spec.rb
@@ -38,4 +38,12 @@ RSpec.describe Flipflop do
       is_expected.to be false
     end
   end
+
+  describe "hide_users_list?" do
+    subject { described_class.hide_users_list? }
+
+    it "defaults to true" do
+      is_expected.to be true
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3112 

* add a flipper for public vs. authenticated user index; default authenticated

Note that this PR does not implement the second requirement: "add config for role authentication; default :admin" because the select2 dropdown functionality used in several places (collections edit sharing tab, transfer work ownership) requires access to the users list functionality by non-admin registered users. 


@samvera/hyrax-code-reviewers
