### PR TITLE
aria-expanded attribute always present on dropdowns

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -11,7 +11,7 @@
         <%= t('hyrax.search.button.html') %>
       </button>
       <% if current_user %>
-        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
           <span data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
           <span class="caret"></span>
         </button>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,7 +1,7 @@
 <% if file_set.user_can_perform_any_action? %>
   <div class="btn-group">
 
-    <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true">
+    <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
       <span class="sr-only">Press to </span>
       <%= t('.header') %>
       <span class="caret" aria-hidden="true"></span>


### PR DESCRIPTION
Fixes #2985 

* fixes issue where the `aria-expanded` attribute is only present after the dropdown is clicked

Note that the last two are not addressed in this PR. Will open separate issues in the Blacklight project to see if they can be addressed there.
* "Limit your search" menu items (Blacklight)
* "Sort by" and "Per page" select dropdown

@samvera/hyrax-code-reviewers
