### PR TITLE
make home icon accessible

### DIFF
--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,4 +1,4 @@
 <a id="logo" class="navbar-brand" href="<%= hyrax.root_path %>" data-no-turbolink="true">
-  <span class="glyphicon glyphicon-globe"></span>
+  <span class="glyphicon glyphicon-globe" role="img" aria-label="<%= application_name %>"></span>
   <span class="institution_name"><%= application_name %></span>
 </a>


### PR DESCRIPTION
Fixes #2979

* Adds `role="img" aria-label="txt"` to the `span` containing the background image used for the logo. From what I can tell this is best practice for making background images accessible. 

@samvera/hyrax-code-reviewers
