### PR TITLE
Fix Work Show spec failure

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -10,23 +10,20 @@
       <% end %>
       <% if presenter.valid_child_concerns.length > 0 %>
         <div class="btn-group">
-          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Attach Child <span class="caret"></span>
-          </button>
-
-          <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
-          <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
-              class: 'btn btn-default submits-batches submits-batches-add',
-              data: { toggle: "modal", target: "#collection-list-container" } %>
-
-          <ul class="dropdown-menu">
-            <% presenter.valid_child_concerns.each do |concern| %>
-              <li>
-                <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
-              </li>
-            <% end %>
-          </ul>
+          <button type="button" class="btn btn-default dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Attach Child <span class="caret"></span></button>
+            <ul class="dropdown-menu">
+              <% presenter.valid_child_concerns.each do |concern| %>
+                <li>
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                </li>
+              <% end %>
+            </ul>
         </div>
+        <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+        <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+            class: 'btn btn-default submits-batches submits-batches-add',
+            data: { toggle: "modal", target: "#collection-list-container" } %>
       <% end %>
   <% end %>
   <% if presenter.work_featurable? %>


### PR DESCRIPTION
Work show actions had buttons overlapped with nonstandard html. This seemed to cause the spec to fail locally. (The TRAVIS failure re Issue #3038 still applies). This only solves the local build failure.

@samvera/hyrax-code-reviewers
