### PR TITLE
Fix homepage controller random spec failure

### DIFF
--- a/spec/controllers/hyrax/homepage_controller_spec.rb
+++ b/spec/controllers/hyrax/homepage_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Hyrax::HomepageController, type: :controller do
       end
     end
 
-    context "with a document not created this second" do
+    context "with a document not created this second", clean_repo: true do
       before do
         gw3 = GenericWork.new(title: ['Test 3 Document'], read_groups: ['public'])
         gw3.apply_depositor_metadata('mjg36')
@@ -60,7 +60,8 @@ RSpec.describe Hyrax::HomepageController, type: :controller do
         old_to_solr = gw3.method(:to_solr)
         allow(gw3).to receive(:to_solr) do
           old_to_solr.call.merge(
-            Solrizer.solr_name('system_create', :stored_sortable, type: :date) => 1.day.ago.iso8601
+            Solrizer.solr_name('system_create', :stored_sortable, type: :date) => 1.day.ago.iso8601,
+            Solrizer.solr_name('date_uploaded', :stored_sortable, type: :date) => 1.day.ago.iso8601
           )
         end
         gw3.save


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/3206
This spec was failing randomly, apparently because the search results are looking for solr field `date_uploaded_dtsi`. This was not consistently being loaded, so the array of 4 recent works returned here could include solr docs with no uploaded date. However the repo was also not being cleaned before running the spec, so other data could result in a comparison of nil to an actual value as it tried to do the sort.

It might be ideal to have more solr docs added for this spec, or even better, figure out where in the specs solr docs are being written without `date_uploaded`, but this is the first step toward a useful spec (i.e. it actually can find the GenericWork that is being created for the spec and it doesn't fail!)

@samvera/hyrax-code-reviewers
