### PR TITLE
Fixes #3210 Restores devise trackable module.

### DIFF
--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -107,6 +107,12 @@ module Hyrax
       end
     end
 
+    def inject_devise_trackable
+      inject_into_file 'app/models/user.rb', after: /\s*devise :database_authenticatable, :registerable,\s*\n/ do
+        "         :trackable,\n"
+      end
+    end
+
     # Add behaviors to the application controller
     def inject_hyrax_application_controller_behavior
       file_path = "app/controllers/application_controller.rb"

--- a/lib/generators/hyrax/templates/db/migrate/20180817154400_add_trackable_to_users.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20180817154400_add_trackable_to_users.rb.erb
@@ -1,0 +1,11 @@
+class AddTrackableToUsers < ActiveRecord::Migration<%= migration_version %>
+  def change
+    change_table :users do |t|
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3210 

Restores devise trackable module to fix the test suite.

Devise removed the trackable module from their generator, breaking our test app and newly generated hyrax applications. This restores the trackable module in the User model and db migration. 

We may want to consider if removing our dependence on the trackable module is desirable.

Changes proposed in this pull request:
* Manually insert the trackable modules into the devise setup in the User model when installing hyrax.
* Add a migration duplicating the trackable db columns previously added by the default devise migrations.

@samvera/hyrax-code-reviewers
