### PR TITLE
Stop using deprecated static attributes

### DIFF
--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
 
     transient do
       # false, true, or Hash with keys for permission_template
-      with_permission_template false
+      with_permission_template { false }
     end
   end
 end

--- a/spec/factories/admin_sets_lw.rb
+++ b/spec/factories/admin_sets_lw.rb
@@ -58,8 +58,8 @@ FactoryBot.define do
     transient do
       user { create(:user) }
 
-      with_permission_template false
-      with_solr_document false
+      with_permission_template { false }
+      with_solr_document { false }
     end
     sequence(:title) { |n| ["Collection Title #{n}"] }
 
@@ -87,10 +87,10 @@ FactoryBot.define do
             manage_groups: [::Ability.admin_group_name]
           }
         end
-        with_solr_document true
+        with_solr_document { true }
       end
-      id AdminSet::DEFAULT_ID
-      title AdminSet::DEFAULT_TITLE
+      id { AdminSet::DEFAULT_ID }
+      title { AdminSet::DEFAULT_TITLE }
     end
   end
 
@@ -99,8 +99,8 @@ FactoryBot.define do
     # Do not use with create because the save will cause the solr grants to be created.
     transient do
       user { create(:user) }
-      with_permission_template true
-      with_solr_document true
+      with_permission_template { true }
+      with_solr_document { true }
     end
 
     sequence(:title) { |n| ["No Solr Grant Admin Set Title #{n}"] }

--- a/spec/factories/api_items.rb
+++ b/spec/factories/api_items.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :post_item, class: Hash do
     skip_create
 
-    token 'mock_token'
+    token { 'mock_token' }
 
     metadata do
       {

--- a/spec/factories/collection_branding_infos.rb
+++ b/spec/factories/collection_branding_infos.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :collection_branding_info do
-    collection_id "1"
-    role "banner"
-    local_path "/fake/path/to/banner.png"
-    alt_text "This is the banner"
-    target_url "http://example.com/"
-    height ""
-    width ""
+    collection_id { "1" }
+    role { "banner" }
+    local_path { "/fake/path/to/banner.png" }
+    alt_text { "This is the banner" }
+    target_url { "http://example.com/" }
+    height { "" }
+    width { "" }
   end
 end

--- a/spec/factories/collection_type_participants.rb
+++ b/spec/factories/collection_type_participants.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :collection_type_participant, class: Hyrax::CollectionTypeParticipant do
     association :hyrax_collection_type, factory: :collection_type
     sequence(:agent_id) { |n| "user#{n}@example.com" }
-    agent_type  'user'
-    access      Hyrax::CollectionTypeParticipant::MANAGE_ACCESS
+    agent_type  { 'user' }
+    access      { Hyrax::CollectionTypeParticipant::MANAGE_ACCESS }
   end
 end

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -3,22 +3,22 @@ FactoryBot.define do
     sequence(:title) { |n| "Collection Type #{n}" }
     sequence(:machine_id) { |n| "title_#{n}" }
 
-    description 'Collection type with all options'
-    nestable true
-    discoverable true
-    sharable true
-    brandable true
-    share_applies_to_new_works true
-    allow_multiple_membership true
-    require_membership false
-    assigns_workflow false
-    assigns_visibility false
+    description { 'Collection type with all options' }
+    nestable { true }
+    discoverable { true }
+    sharable { true }
+    brandable { true }
+    share_applies_to_new_works { true }
+    allow_multiple_membership { true }
+    require_membership { false }
+    assigns_workflow { false }
+    assigns_visibility { false }
 
     transient do
-      creator_user nil
-      creator_group nil
-      manager_user nil
-      manager_group nil
+      creator_user { nil }
+      creator_group { nil }
+      manager_user { nil }
+      manager_group { nil }
     end
 
     after(:create) do |collection_type, evaluator|
@@ -56,50 +56,50 @@ FactoryBot.define do
     end
 
     trait :nestable do
-      nestable true
+      nestable { true }
     end
 
     trait :not_nestable do
-      nestable false
+      nestable { false }
     end
 
     trait :discoverable do
-      discoverable true
+      discoverable { true }
     end
 
     trait :not_discoverable do
-      discoverable false
+      discoverable { false }
     end
 
     trait :brandable do
-      brandable true
+      brandable { true }
     end
 
     trait :not_brandable do
-      brandable false
+      brandable { false }
     end
 
     trait :sharable do
-      sharable true
-      share_applies_to_new_works true
+      sharable { true }
+      share_applies_to_new_works { true }
     end
 
     trait :sharable_no_work_permissions do
-      sharable true
-      share_applies_to_new_works false
+      sharable { true }
+      share_applies_to_new_works { false }
     end
 
     trait :not_sharable do
-      sharable false
-      share_applies_to_new_works false
+      sharable { false }
+      share_applies_to_new_works { false }
     end
 
     trait :allow_multiple_membership do
-      allow_multiple_membership true
+      allow_multiple_membership { true }
     end
 
     trait :not_allow_multiple_membership do
-      allow_multiple_membership false
+      allow_multiple_membership { false }
     end
   end
 

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -102,10 +102,10 @@ FactoryBot.define do
     transient do
       user { create(:user) }
 
-      collection_type_settings nil
-      with_permission_template false
-      with_nesting_attributes nil
-      with_solr_document false
+      collection_type_settings { nil }
+      with_permission_template { false }
+      with_nesting_attributes { nil }
+      with_solr_document { false }
     end
     sequence(:title) { |n| ["Collection Title #{n}"] }
 
@@ -130,32 +130,32 @@ FactoryBot.define do
     factory :public_collection_lw, traits: [:public_lw]
 
     factory :private_collection_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :institution_collection_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
     end
 
     factory :named_collection_lw do
-      title ['collection title']
-      description ['collection description']
+      title { ['collection title'] }
+      description { ['collection description'] }
     end
 
     trait :public_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     trait :private_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     trait :institution_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
     end
 
     trait :public_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
   end
 
@@ -179,8 +179,8 @@ FactoryBot.define do
     #   col.save(validate: false)
     transient do
       user { create(:user) }
-      with_permission_template false
-      do_save false
+      with_permission_template { false }
+      do_save { false }
     end
 
     sequence(:title) { |n| ["Typeless Collection Title #{n}"] }

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -20,10 +20,10 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # allow defaulting to default user collection
-      collection_type_settings nil
-      with_permission_template false
-      create_access false
-      with_nesting_attributes nil
+      collection_type_settings { nil }
+      with_permission_template { false }
+      create_access { false }
+      with_nesting_attributes { nil }
     end
     sequence(:title) { |n| ["Collection Title #{n}"] }
 
@@ -66,20 +66,20 @@ FactoryBot.define do
     factory :public_collection, traits: [:public]
 
     trait :public do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_collection do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :institution_collection do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
     end
 
     factory :named_collection do
-      title ['collection title']
-      description ['collection description']
+      title { ['collection title'] }
+      description { ['collection description'] }
     end
   end
 
@@ -103,9 +103,9 @@ FactoryBot.define do
     #   col.save(validate: false)
     transient do
       user { create(:user) }
-      with_permission_template false
-      create_access false
-      do_save false
+      with_permission_template { false }
+      create_access { false }
+      do_save { false }
     end
 
     sequence(:title) { |n| ["Typeless Collection Title #{n}"] }

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :file_set do
     transient do
       user { create(:user) }
-      content nil
+      content { nil }
     end
     after(:build) do |fs, evaluator|
       fs.apply_depositor_metadata evaluator.user.user_key
@@ -13,11 +13,11 @@ FactoryBot.define do
     end
 
     trait :public do
-      read_groups ["public"]
+      read_groups { ["public"] }
     end
 
     trait :registered do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :file_with_work do

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # Set to true (or a hash) if you want to create an admin set
-      with_admin_set false
+      with_admin_set { false }
     end
 
     # It is reasonable to assume that a work has an admin set; However, we don't want to
@@ -22,8 +22,8 @@ FactoryBot.define do
       work.save! if work.member_of_collections.present?
     end
 
-    title ["Test title"]
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    title { ["Test title"] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
@@ -32,15 +32,15 @@ FactoryBot.define do
     factory :public_generic_work, aliases: [:public_work], traits: [:public]
 
     trait :public do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_work do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :registered_generic_work do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :work_with_one_file do
@@ -100,7 +100,7 @@ FactoryBot.define do
       # let(:work) { create(:embargoed_work, with_embargo_attributes: embargo_attributes) }
 
       transient do
-        with_embargo_attributes false
+        with_embargo_attributes { false }
         embargo_date { Date.tomorrow.to_s }
         current_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
         future_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
@@ -147,7 +147,7 @@ FactoryBot.define do
       # let(:work) { create(:leased_work, with_lease_attributes: lease_attributes) }
 
       transient do
-        with_lease_attributes false
+        with_lease_attributes { false }
         lease_date { Date.tomorrow.to_s }
         current_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
         future_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
@@ -184,7 +184,7 @@ FactoryBot.define do
 
   # Doesn't set up any edit_users
   factory :work_without_access, class: GenericWork do
-    title ['Test title']
+    title { ['Test title'] }
     depositor { create(:user).user_key }
   end
 end

--- a/spec/factories/operations.rb
+++ b/spec/factories/operations.rb
@@ -1,21 +1,21 @@
 FactoryBot.define do
   factory :operation, class: Hyrax::Operation do
-    operation_type "Test operation"
+    operation_type { "Test operation" }
 
     trait :failing do
-      status Hyrax::Operation::FAILURE
+      status { Hyrax::Operation::FAILURE }
     end
 
     trait :pending do
-      status Hyrax::Operation::PENDING
+      status { Hyrax::Operation::PENDING }
     end
 
     trait :successful do
-      status Hyrax::Operation::SUCCESS
+      status { Hyrax::Operation::SUCCESS }
     end
 
     factory :batch_create_operation, class: Hyrax::BatchCreateOperation do
-      operation_type "Batch Create"
+      operation_type { "Batch Create" }
     end
   end
 end

--- a/spec/factories/permission_template_accesses.rb
+++ b/spec/factories/permission_template_accesses.rb
@@ -2,15 +2,15 @@ FactoryBot.define do
   factory :permission_template_access, class: Hyrax::PermissionTemplateAccess do
     permission_template
     trait :manage do
-      access 'manage'
+      access { 'manage' }
     end
 
     trait :deposit do
-      access 'deposit'
+      access { 'deposit' }
     end
 
     trait :view do
-      access 'view'
+      access { 'view' }
     end
   end
 end

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -52,16 +52,16 @@ FactoryBot.define do
     end
 
     transient do
-      with_admin_set false
-      with_collection false
-      with_workflows false
-      with_active_workflow false
-      manage_users nil
-      manage_groups nil
-      deposit_users nil
-      deposit_groups nil
-      view_users nil
-      view_groups nil
+      with_admin_set { false }
+      with_collection { false }
+      with_workflows { false }
+      with_active_workflow { false }
+      manage_users { nil }
+      manage_groups { nil }
+      deposit_users { nil }
+      deposit_groups { nil }
+      view_users { nil }
+      view_groups { nil }
     end
   end
 

--- a/spec/factories/single_use_links.rb
+++ b/spec/factories/single_use_links.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :single_use_link do
     factory :show_link do
-      itemId 'fs-id'
-      path '/concerns/generic_work/1234'
+      itemId { 'fs-id' }
+      path { '/concerns/generic_work/1234' }
     end
 
     factory :download_link do
-      itemId 'fs-id'
-      path '/downloads/1234'
+      itemId { 'fs-id' }
+      path { '/downloads/1234' }
     end
   end
 end

--- a/spec/factories/sipity_entities.rb
+++ b/spec/factories/sipity_entities.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :sipity_entity, class: Sipity::Entity do
-    proxy_for_global_id 'gid://internal/Mock/1'
+    proxy_for_global_id { 'gid://internal/Mock/1' }
     workflow { workflow_state.workflow }
     workflow_state
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
-    password 'password'
+    password { 'password' }
 
     transient do
       # Allow for custom groups when a user is instantiated.
       # @example create(:user, groups: 'avacado')
-      groups []
+      groups { [] }
     end
 
     # TODO: Register the groups for the given user key such that we can remove the following from other specs:
@@ -22,7 +22,7 @@ FactoryBot.define do
     end
 
     factory :admin do
-      groups ['admin']
+      groups { ['admin'] }
     end
 
     factory :user_with_mail do
@@ -46,7 +46,7 @@ FactoryBot.define do
   end
 
   trait :guest do
-    guest true
+    guest { true }
   end
 end
 

--- a/spec/factories/workflow_actions.rb
+++ b/spec/factories/workflow_actions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :workflow_action, class: Sipity::WorkflowAction do
     workflow
-    name 'submit'
+    name { 'submit' }
   end
 end

--- a/spec/factories/workflow_states.rb
+++ b/spec/factories/workflow_states.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :workflow_state, class: Sipity::WorkflowState do
     workflow
-    name 'initial'
+    name { 'initial' }
   end
 end


### PR DESCRIPTION
This avoids the warnings like this:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:
with_permission_template { false }
To automatically update from static attributes to dynamic ones,
install rubocop-rspec and run:
rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct
```