### PR TITLE
Replaced test code keyword 'derp' with 'penguin'

### DIFF
--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
         parent_id: '123',
         representative_id: '456',
         thumbnail_id: '789',
-        keyword: ['derp'],
+        keyword: ['penguin'],
         source: ['related'],
         rights_statement: 'http://rightsstatements.org/vocab/InC-EDU/1.0/',
         license: ['http://creativecommons.org/licenses/by/3.0/us/']
@@ -121,7 +121,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
       expect(subject['visibility']).to eq 'open'
       expect(subject['license']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
       expect(subject['rights_statement']).to eq 'http://rightsstatements.org/vocab/InC-EDU/1.0/'
-      expect(subject['keyword']).to eq ['derp']
+      expect(subject['keyword']).to eq ['penguin']
       expect(subject['source']).to eq ['related']
     end
 

--- a/spec/forms/hyrax/generic_work_form_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Hyrax::GenericWorkForm do
         representative_id: '456',
         rendering_ids: [file_set.id],
         thumbnail_id: '789',
-        keyword: ['derp'],
+        keyword: ['penguin'],
         license: ['http://creativecommons.org/licenses/by/3.0/us/'],
         member_of_collection_ids: ['123456', 'abcdef']
       )
@@ -72,7 +72,7 @@ RSpec.describe Hyrax::GenericWorkForm do
       expect(subject['description']).to be_empty
       expect(subject['visibility']).to eq 'open'
       expect(subject['license']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
-      expect(subject['keyword']).to eq ['derp']
+      expect(subject['keyword']).to eq ['penguin']
       expect(subject['member_of_collection_ids']).to eq ['123456', 'abcdef']
       expect(subject['rendering_ids']).to eq [file_set.id]
     end


### PR DESCRIPTION
The term "derp" is often used to make fun of intellectual disability. Replacing with "penguin," because the penguin paradigm was the first wholesome thing I could think of.

@samvera/hyrax-code-reviewers
