### PR TITLE
Don't show trackable fields if Devise trackable isn't installed

### DIFF
--- a/app/presenters/hyrax/admin/users_presenter.rb
+++ b/app/presenters/hyrax/admin/users_presenter.rb
@@ -20,6 +20,12 @@ module Hyrax
         user.last_sign_in_at || user.created_at
       end
 
+      # return [Boolean] true if the devise trackable module is enabled.
+      def show_last_access?
+        return @show_last_access unless @show_last_access.nil?
+        @show_last_access = ::User.devise_modules.include?(:trackable)
+      end
+
       private
 
         # Returns a list of users excluding the system users and guest_users

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -15,7 +15,9 @@
             <th></th>
             <th><%= t('.id_label') %></th>
             <th><%= t('.role_label') %></th>
-            <th><%= t('.access_label') %></th>
+            <% if @presenter.show_last_access? %>
+              <th><%= t('.access_label') %></th>
+            <% end %>
           </tr>
         </thead>
         <tbody>
@@ -32,12 +34,14 @@
                     <% end %>
                   </ul>
               </td>
-              <td>
-                <%# in the case that a user is created who never signs in, this is necessary %>
-                <relative-time datetime="<%= @presenter.last_accessed(user).getutc.iso8601 %>" title="<%= @presenter.last_accessed(user).to_formatted_s(:standard) %>">
-                  <%= @presenter.last_accessed(user).to_formatted_s(:long_ordinal) %>
-                </relative-time>
-              </td>
+              <% if @presenter.show_last_access? %>
+                <td>
+                  <%# in the case that a user is created who never signs in, this is necessary %>
+                  <relative-time datetime="<%= @presenter.last_accessed(user).getutc.iso8601 %>" title="<%= @presenter.last_accessed(user).to_formatted_s(:standard) %>">
+                    <%= @presenter.last_accessed(user).to_formatted_s(:long_ordinal) %>
+                  </relative-time>
+                </td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/spec/presenters/hyrax/admin/users_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin/users_presenter_spec.rb
@@ -29,4 +29,20 @@ RSpec.describe Hyrax::Admin::UsersPresenter do
       end
     end
   end
+
+  describe 'show_last_access?' do
+    before do
+      allow(User).to receive(:devise_modules).and_return(modules)
+    end
+    subject { instance.show_last_access? }
+    context 'when devise trackable is installed' do
+      let(:modules) { [:trackable] }
+      it { is_expected.to be true }
+    end
+
+    context 'when devise trackable is not installed' do
+      let(:modules) { [:rememberable] }
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/views/hyrax/admin/users/index.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/users/index.html.erb_spec.rb
@@ -3,19 +3,43 @@ RSpec.describe 'hyrax/admin/users/index.html.erb', type: :view do
   let(:users) { [] }
 
   before do
-    (1..4).each { |i| users << build(:user, display_name: "user#{i}", email: "email#{i}@example.com", last_sign_in_at: Time.zone.now - 15.minutes, created_at: Time.zone.now - 3.days) }
+    (1..4).each { |i| users << build(:user, display_name: "user#{i}", email: "email#{i}@example.com", created_at: Time.zone.now - 3.days) }
     allow(presenter).to receive(:users).and_return(users)
     assign(:presenter, presenter)
+    allow(presenter).to receive(:show_last_access?).and_return(show_last_access)
   end
 
-  it "draws user list with all users" do
+  let(:page) do
     render
-    page = Capybara::Node::Simple.new(rendered)
-    expect(page).to have_content("Username")
-    expect(page).to have_content("Roles")
-    expect(page).to have_content("Last access")
-    (1..4).each do |i|
-      expect(page).to have_content("email#{i}@example.com")
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  context 'when show_last_access? is true' do
+    let(:show_last_access) { true }
+    before do
+      allow(presenter).to receive(:last_accessed).and_return(Time.zone.now - 3.days)
+    end
+
+    it 'draws user list with all users' do
+      expect(page).to have_content("Username")
+      expect(page).to have_content("Roles")
+      expect(page).to have_content("Last access")
+      (1..4).each do |i|
+        expect(page).to have_content("email#{i}@example.com")
+      end
+    end
+  end
+
+  context 'when show_last_access? is false' do
+    let(:show_last_access) { false }
+
+    it 'draws user list with all users' do
+      expect(page).to have_content("Username")
+      expect(page).to have_content("Roles")
+      expect(page).not_to have_content("Last access")
+      (1..4).each do |i|
+        expect(page).to have_content("email#{i}@example.com")
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #3210
