### PR TITLE
Fixes #1248 Move homepage thumbnails inside their title link.

### DIFF
--- a/app/assets/stylesheets/hyrax/_featured.scss
+++ b/app/assets/stylesheets/hyrax/_featured.scss
@@ -18,6 +18,8 @@ ol#featured_works {
 
   img {
     width: 90px;
+    float: left;
+    padding-right: 1em;
   }
 
   .main {
@@ -27,6 +29,10 @@ ol#featured_works {
   .featured-label {
     color: $gray;
     font-weight: bold;
+  }
+
+  .featured-field {
+    padding-left: 90px;
   }
 }
 

--- a/app/assets/stylesheets/hyrax/_recent.scss
+++ b/app/assets/stylesheets/hyrax/_recent.scss
@@ -17,10 +17,16 @@
 
   img {
     width: 90px;
+    float: left;
+    padding-right: 1em;
   }
 
   .recent-label {
     color: $gray;
     font-weight: bold;
+  }
+
+  .recent-field {
+    padding-left: 90px;
   }
 }

--- a/app/views/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/hyrax/homepage/_explore_collections.html.erb
@@ -4,13 +4,11 @@
       <tr>
         <td>
           <div class="media">
-            <%= link_to [hyrax, collection], class: 'media-left', 'aria-hidden' => true do %>
-              <%= render_thumbnail_tag collection, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
-            <% end %>
             <div class="media-body">
               <div class="media-heading">
                 <%= link_to [hyrax, collection] do %>
-                  <%= collection.title_or_label %>
+                  <%= render_thumbnail_tag(collection, { class: 'hidden-xs file_listing_thumbnail' },
+                                           { suppress_link: true }) + collection.title_or_label %>
                 <% end %>
               </div>
             </div>

--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -1,12 +1,16 @@
 <div>
   <div class="featured-item-title">
     <span class="sr-only"><%= t('hyrax.homepage.featured_works.document.title_label') %></span>
-    <h3><%= link_to featured.title.first, [main_app, featured] %></h3>
+    <h3>
+      <%= link_to [main_app, featured] do %>
+        <%= render_thumbnail_tag(featured, {width: 90}, {suppress_link: true}) + featured.title.first %>
+      <% end %>
+    </h3>
   </div>
-  <div class="featured-item-depositor">
+  <div class="featured-field featured-item-depositor">
     <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.depositor_label') %>:</span> <%= link_to_profile featured.depositor(t('hyrax.homepage.featured_works.document.depositor_missing')) %>
   </div>
-  <div class="featured-item-keywords">
+  <div class="featured-field featured-item-keywords">
     <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.keyword_label') %>:</span> <%= link_to_facet_list(featured.keyword, 'keyword', t('hyrax.homepage.featured_works.document.keyword_missing')) %>
   </div>
 </div>

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -1,16 +1,16 @@
 <li class="recent-item">
     <div class="row">
-      <div class="col-sm-2">
-        <%= link_to [main_app, recent_document] do %>
-          <%= render_thumbnail_tag recent_document, suppress_link: true %>
-        <% end %>
-      </div>
-      <div class="col-sm-10">
-        <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span><h3><%= link_to recent_document.to_s, [main_app, recent_document] %></h3>
-        <p>
+      <div class="col-sm-12">
+        <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
+        <h3>
+          <%= link_to [main_app, recent_document] do %>
+            <%= render_thumbnail_tag(recent_document, {width: 90}, {suppress_link: true}) + recent_document.to_s %>
+          <% end %>
+        </h3>
+        <p class="recent-field">
           <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.depositor_label') %>:</span> <%= link_to_profile recent_document.depositor(t('hyrax.homepage.recently_uploaded.document.depositor_missing')) %>
         </p>
-        <p>
+        <p class="recent-field">
           <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.keyword_label') %>:</span> <%= link_to_facet_list(recent_document.keyword, 'keyword', t('hyrax.homepage.recently_uploaded.document.keyword_missing')).html_safe %>
         </p>
       </div>

--- a/app/views/hyrax/homepage/_sortable_featured.html.erb
+++ b/app/views/hyrax/homepage/_sortable_featured.html.erb
@@ -5,12 +5,7 @@
     <%= f.hidden_field :id %>
     <%= f.hidden_field :order, data: { property: "order" } %>
     <div class="main row">
-      <div class="col-sm-3">
-        <%= link_to [main_app, presenter] do %>
-          <%= render_thumbnail_tag presenter, width: 90 %>
-        <% end %>
-      </div>
-      <div class="col-sm-9">
+      <div class="col-sm-12">
         <% if can? :destroy, FeaturedWork %>
           <h3 class="pull-right">
             <%= link_to hyrax.featured_work_path(presenter, format: :json),

--- a/spec/views/hyrax/homepage/_featured_works.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/_featured_works.html.erb_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "hyrax/homepage/_featured_works.html.erb", type: :view do
 
     before do
       allow(view).to receive(:can?).with(:update, FeaturedWork).and_return(false)
-      allow(view).to receive(:render_thumbnail_tag).with(presenter)
+      allow(view).to receive(:render_thumbnail_tag).with(presenter, any_args).and_return("thumbnail")
       allow(list).to receive(:empty?).and_return(false)
       allow(list).to receive(:featured_works).and_return([featured_work])
       allow(featured_work).to receive(:presenter).and_return(presenter)


### PR DESCRIPTION
Fixes #1248 

Moves thumbnails on the homepage to be inside the respective title hyperlink for improved a11y.