### PR TITLE
Don't allow XSS on title in Chicago Formatter

### DIFF
--- a/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
@@ -13,11 +13,11 @@ module Hyrax
           text = "<span class=\"citation-author\">#{text}</span>" if text.present?
           # Get Pub Date
           pub_date = setup_pub_date(work)
-          text << " #{pub_date}." unless pub_date.nil?
+          text << " #{whitewash(pub_date)}." unless pub_date.nil?
 
           text << format_title(work.to_s)
           pub_info = setup_pub_info(work, false)
-          text << " #{pub_info}." if pub_info.present?
+          text << " #{whitewash(pub_info)}." if pub_info.present?
           text.html_safe
         end
 
@@ -36,7 +36,7 @@ module Hyrax
           # if for some reason the first author ended with a comma
           text.gsub!(',,', ',')
           text << "." unless text =~ /\.$/
-          text
+          whitewash(text)
         end
         # rubocop:enable Metrics/MethodLength
 
@@ -46,9 +46,15 @@ module Hyrax
           return "" if title_info.blank?
           title_text = chicago_citation_title(title_info)
           title_text << '.' unless title_text =~ /\.$/
-          title_text = Loofah.fragment(title_text).scrub!(:whitewash).to_s
+          title_text = whitewash(title_text)
           " <i class=\"citation-title\">#{title_text}</i>"
         end
+
+        private
+
+          def whitewash(text)
+            Loofah.fragment(text.to_s).scrub!(:whitewash).to_s
+          end
       end
     end
   end

--- a/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
@@ -46,6 +46,7 @@ module Hyrax
           return "" if title_info.blank?
           title_text = chicago_citation_title(title_info)
           title_text << '.' unless title_text =~ /\.$/
+          title_text = Loofah.fragment(title_text).scrub!(:whitewash).to_s
           " <i class=\"citation-title\">#{title_text}</i>"
         end
       end

--- a/spec/helpers/hyrax/citations_behaviors/formatters/chicago_formatter_spec.rb
+++ b/spec/helpers/hyrax/citations_behaviors/formatters/chicago_formatter_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Hyrax::CitationsBehaviors::Formatters::ChicagoFormatter do
+  subject(:formatter) { described_class.new(:no_context) }
+
+  let(:presenter) { Hyrax::WorkShowPresenter.new(SolrDocument.new(work.to_solr), :no_ability) }
+  let(:work)      { build(:generic_work, title: ['<ScrIPt>prompt("Confirm Password")</sCRIpt>']) }
+
+  it 'sanitizes input' do
+    expect(formatter.format(presenter)).not_to include 'prompt'
+  end
+end


### PR DESCRIPTION
There's probably a larger fix related to forms here, but the chicago formatter
needn't be so permissive.

Related to #3187.

Acceptance: Check XSS referenced in #3187, **Vulnerability 1**

@samvera/hyrax-code-reviewers
