### PR TITLE
Don't blindly mark flash strings HTML safe

### DIFF
--- a/app/views/_flash_msg.html.erb
+++ b/app/views/_flash_msg.html.erb
@@ -2,7 +2,7 @@
   <% if flash[type].present? %>
     <div class="alert <%= flash_dom_class %> alert-dismissable" role="alert">
       <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-      <%= safe_join(Array.wrap(flash[type]), tag(:br)) %>
+      <%= sanitize Array.wrap(flash[type]).join(tag(:br)) %>
     </div>
     <% flash.delete(type) %>
   <% end %>

--- a/app/views/_flash_msg.html.erb
+++ b/app/views/_flash_msg.html.erb
@@ -2,7 +2,7 @@
   <% if flash[type].present? %>
     <div class="alert <%= flash_dom_class %> alert-dismissable" role="alert">
       <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-      <%= safe_join(Array.wrap(flash[type]).map(&:html_safe), tag(:br)) %>
+      <%= safe_join(Array.wrap(flash[type]), tag(:br)) %>
     </div>
     <% flash.delete(type) %>
   <% end %>


### PR DESCRIPTION
This view partial had originally marked all of the strings it received as `#html_safe`, effectively trusting all content. Using sanitize essentially does the opposite: distrusting all flash message content. Any tags or attributes not in the whitelist (https://github.com/flavorjones/loofah/blob/master/lib/loofah/html5/whitelist.rb) will be removed, regardless of the source.

This seems like the best solution, since flash messages are serialized as strings, so the providers cannot give us carefully constructed `#html_safe` strings. In general, flash messages shouldn't require markup more complex than basic formatting and links.

Fixes #3228
Connected to #3187

Changes proposed in this pull request:
* Remove `map(&:html_safe)`!!!
* Call `sanitize` on flash messages

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Verify that this fixes *Vulnerability 2* in #3187.

@samvera/hyrax-code-reviewers
