### PR TITLE
Remove XSS vulnerability from `confirm_access` page

### DIFF
--- a/app/views/hyrax/permissions/confirm_access.html.erb
+++ b/app/views/hyrax/permissions/confirm_access.html.erb
@@ -3,7 +3,7 @@
     <h4>Apply changes to contents?<h4>
   </div>
   <div class="panel-body">
-      <%= I18n.t("hyrax.upload.change_access_message_html", curation_concern: curation_concern).html_safe %>
+      <%= I18n.t("hyrax.upload.change_access_message_html", curation_concern: curation_concern) %>
   </div>
   <div class="form-actions panel-footer">
     <%= button_to I18n.t("hyrax.upload.change_access_yes_message"), hyrax.copy_access_permission_path(curation_concern), class: 'btn btn-primary' %>


### PR DESCRIPTION
This string was marked `#html_safe` even though it included user input. For now,
we remove that mark to remove the vulnerability and accept the unpleasant
formatting consequences.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Confirm that this addresses **Vulnerability 3** in #3187 

Connected to #3187.

@samvera/hyrax-code-reviewers
