### PR TITLE
 Use `sanitize` helper instead of `#html_safe`

### DIFF
--- a/app/views/hyrax/batch_edits/edit.html.erb
+++ b/app/views/hyrax/batch_edits/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="scrollx scrolly fileHeight"> <!-- original values -->
   <h3> <b>Changes will be applied to: (<%= @form.names.size %> works) </b></h3>
-   <%= @form.names.join(", ").html_safe %>
+   <%= sanitize @form.names.join(", ") %>
 </div> <!-- /original values -->
 
 <div>

--- a/app/views/hyrax/dashboard/collections/_flash_msg.html.erb
+++ b/app/views/hyrax/dashboard/collections/_flash_msg.html.erb
@@ -2,7 +2,7 @@
   <% if flash[type].present? %>
     <div class="alert <%= flash_dom_class %> alert-dismissable" role="alert">
       <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-      <%= safe_join(Array.wrap(flash[type]).map(&:html_safe), '<br/>'.html_safe) %>
+      <%= sanitize Array.wrap(flash[type]).join(tag(:br)) %>
     </div>
     <% flash.delete(type) %>
   <% end %>

--- a/app/views/hyrax/file_sets/_extra_fields_modal.html.erb
+++ b/app/views/hyrax/file_sets/_extra_fields_modal.html.erb
@@ -11,7 +11,7 @@
         <h2 id="extraFieldsModal_<%= name %>_Label">Additional <%= label %>(s)</h2>
       </div>
       <div class="modal-body">
-        <%= values.join("<br />").html_safe %>
+        <%= sanitize values.join("<br />") %>
       </div>
       <div class="modal-footer">
         <button class="btn btn-primary" data-dismiss="modal">Close</button>

--- a/app/views/hyrax/file_sets/_show_characterization_details.html.erb
+++ b/app/views/hyrax/file_sets/_show_characterization_details.html.erb
@@ -1,7 +1,7 @@
 <% @presenter.characterization_metadata.keys.each do |term| %>
   <div>
     <% additional_values = @presenter.secondary_characterization_values(term) %>
-    <%= @presenter.label_for_term(term) %>: <%= @presenter.primary_characterization_values(term).join("<br />").html_safe %>
+    <%= @presenter.label_for_term(term) %>: <%= sanitize @presenter.primary_characterization_values(term).join("<br />") %>
     <% unless additional_values.empty? %>
       <%= render partial: "extra_fields_modal", locals: { name: term, values: additional_values } %>
     <% end %>

--- a/app/views/hyrax/notifications/_notifications.html.erb
+++ b/app/views/hyrax/notifications/_notifications.html.erb
@@ -17,8 +17,8 @@
                 <%= msg.last_message.created_at.to_formatted_s(:long_ordinal) %>
               </relative-time>
             </td>
-            <td><%= msg.last_message.subject.html_safe %></td>
-            <td><%= msg.last_message.body.html_safe %></td>
+            <td><%= sanitize msg.last_message.subject %></td>
+            <td><%= sanitize msg.last_message.body %></td>
             <td>
               <%= link_to hyrax.notification_path(msg.id),
                       class: "itemicon itemtrash",

--- a/app/views/hyrax/permissions/confirm_access.html.erb
+++ b/app/views/hyrax/permissions/confirm_access.html.erb
@@ -3,7 +3,7 @@
     <h4>Apply changes to contents?<h4>
   </div>
   <div class="panel-body">
-      <%= I18n.t("hyrax.upload.change_access_message_html", curation_concern: curation_concern) %>
+      <%= sanitize I18n.t("hyrax.upload.change_access_message_html", curation_concern: curation_concern) %>
   </div>
   <div class="form-actions panel-footer">
     <%= button_to I18n.t("hyrax.upload.change_access_yes_message"), hyrax.copy_access_permission_path(curation_concern), class: 'btn btn-primary' %>

--- a/app/views/hyrax/stats/file.html.erb
+++ b/app/views/hyrax/stats/file.html.erb
@@ -2,7 +2,7 @@
 <script>
 //<![CDATA[
 
-  var hyrax_item_stats = <%= @stats.to_flot.to_json.html_safe %>;
+  var hyrax_item_stats = <%= raw json_escape @stats.to_flot.to_json %>;
 
 //]]>
 </script>

--- a/app/views/hyrax/stats/work.html.erb
+++ b/app/views/hyrax/stats/work.html.erb
@@ -2,7 +2,7 @@
 <script>
 //<![CDATA[
 
-  var hyrax_item_stats = <%= @stats.to_flot.to_json.html_safe %>;
+  var hyrax_item_stats = <%= raw json_escape @stats.to_flot.to_json %>;
 
 //]]>
 </script>

--- a/app/views/hyrax/users/_activity_log.html.erb
+++ b/app/views/hyrax/users/_activity_log.html.erb
@@ -9,7 +9,7 @@
   <% events.each do |event| %>
     <% next if event[:action].blank? or event[:timestamp].blank? %>
     <tr>
-      <td><%= event[:action].html_safe %></td>
+      <td><%= event[:action] %></td>
       <% time = Time.zone.at(event[:timestamp].to_i) %>
       <td data-sort="<%= time.getutc.iso8601(5) %>">
         <relative-time datetime="<%= time.getutc.iso8601 %>" title="<%= time.to_formatted_s(:standard) %>">


### PR DESCRIPTION
Marking unknown strings as `#html_safe` in a view is not safe. This fixes many
instances of this, in favor of using the `sanitize` helper.

Related to #3187; #3229.

Guidance for testing:
* Visit affected pages and ensure formatting remains correct. It's possible that the switch from `html_safe` impacts details of certain markup.
* Especially watch out for any issues with:
  * Batch edit
  * FileSet metadata/characterization views
  * Notifications
  * User activity

@samvera/hyrax-code-reviewers
