### PR TITLE
Make the <title> tag for File Set items consistent with Works items, …

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -38,7 +38,7 @@ module Hyrax
 
     # The title of the webpage that shows this FileSet.
     def page_title
-      first_title
+      "#{human_readable_type} | #{title.first} | ID: #{id} | #{I18n.t('hyrax.product_name')}"
     end
 
     # The first title assertion

--- a/app/views/hyrax/admin/admin_sets/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_sort_and_per_page.html.erb
@@ -1,5 +1,5 @@
 <% if show_pagination? %>
-  <div id="sortAndPerPage" class="sort-pagination" class="clearfix">
+  <div id="sortAndPerPage" class="sort-pagination clearfix">
     <%= render partial: "paginate_compact", object: @response %>
   </div>
 <% end %>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -1,3 +1,4 @@
+<% provide :page_title, @presenter.page_title %>
 <div class="container-fluid">
   <div class="row">
     <div class="col-xs-12 col-sm-4">


### PR DESCRIPTION
…for improved accessibility

Fixes #1283 

Updates the `<title>` tag on File Set pages to match the pattern in a Works page.  It will now read, for example as: 

`<title>File | sample-star-struck.jpg | ID: ng451h485 | Hyrax</title>`

@samvera/hyrax-code-reviewers
