### PR TITLE
Place the content above facets in the search results view for accessi…

### DIFF
--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,7 +1,7 @@
-<div id="sidebar" class="col-md-3 col-sm-4">
-  <%= render 'search_sidebar' %>
+<div id="content" class="col-md-9 col-md-push-3 col-sm-8 col-sm-push-4">
+    <%= render 'search_results' %>
 </div>
 
-<div id="content" class="col-md-9 col-sm-8">
-    <%= render 'search_results' %>
+<div id="sidebar" class="col-md-3 col-md-pull-9 col-sm-4 col-sm-pull-8">
+  <%= render 'search_sidebar' %>
 </div>


### PR DESCRIPTION
…bility purpose, however keep the facets on the left visually in the UI

Fixes #1266 

Placed the content above facets in the search results view's code for accessibility purpose.  Via Bootstrap class styling, the facets sidebar will continue to visually appear on the left.

@samvera/hyrax-code-reviewers
