### PR TITLE
Sanitize activity log

### DIFF
--- a/app/views/hyrax/users/_activity_log.html.erb
+++ b/app/views/hyrax/users/_activity_log.html.erb
@@ -9,7 +9,7 @@
   <% events.each do |event| %>
     <% next if event[:action].blank? or event[:timestamp].blank? %>
     <tr>
-      <td><%= event[:action] %></td>
+      <td><%= sanitize event[:action] %></td>
       <% time = Time.zone.at(event[:timestamp].to_i) %>
       <td data-sort="<%= time.getutc.iso8601(5) %>">
         <relative-time datetime="<%= time.getutc.iso8601 %>" title="<%= time.to_formatted_s(:standard) %>">


### PR DESCRIPTION
The activity log unsually contains links, so we need to call the sanitize helper
to avoid displaying the links as escaped HTML text.

This bug was introduced in c01c356508459d6 and v2.2.2.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Ensure the user activity log shows active hyperlinks, rather than raw html

![user_act](https://user-images.githubusercontent.com/1361776/45181341-0a127e00-b1d3-11e8-91d1-021a4f6fdb57.png)

@samvera/hyrax-code-reviewers
