### PR TITLE
Setup initial work creation transaction

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -43,6 +43,7 @@ SUMMARY
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'dry-equalizer', '~> 0.2'
   spec.add_dependency 'dry-struct', '~> 0.1'
+  spec.add_dependency 'dry-transaction', '~> 0.11'
   spec.add_dependency 'dry-validation', '~> 0.9'
   spec.add_dependency 'flipflop', '~> 2.3'
   # Pin more tightly because 0.x gems are potentially unstable

--- a/lib/hyrax/transactions.rb
+++ b/lib/hyrax/transactions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/container'
+
+module Hyrax
+  module Transactions
+  end
+end

--- a/lib/hyrax/transactions.rb
+++ b/lib/hyrax/transactions.rb
@@ -2,6 +2,22 @@
 require 'hyrax/transactions/container'
 
 module Hyrax
+  ##
+  # This is a parent module for DRY Transaction classes handling Hyrax
+  # processes. Especially: transactions and steps for creating, updating, and
+  # destroying PCDM Objects are located here. Loading this module provides an
+  # easy way to load the full suite of transactions included for these purposes.
+  #
+  # @note These uses of `dry-transaction` are currently experimental
+  #   replacements for actor stack behavior. They are not loaded during normal
+  #   execution in a stock Hyrax application.
+  #
+  # @since 2.4.0
+  #
+  # @example
+  #   require 'hyrax/transactions'
+  #
+  # @see https://dry-rb.org/gems/dry-transaction/
   module Transactions
   end
 end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require "dry/transaction"
+require "dry/transaction/operation"
+
+module Hyrax
+  module Transactions
+    class Container
+      require 'hyrax/transactions/create_work'
+      require 'hyrax/transactions/steps/ensure_admin_set'
+      require 'hyrax/transactions/steps/ensure_permission_template'
+      require 'hyrax/transactions/steps/save_work'
+      require 'hyrax/transactions/steps/set_default_admin_set'
+      require 'hyrax/transactions/steps/set_modified_date'
+      require 'hyrax/transactions/steps/set_uploaded_date'
+
+      extend Dry::Container::Mixin
+
+      namespace 'work' do |ops|
+        ops.register 'ensure_admin_set' do
+          Steps::EnsureAdminSet.new
+        end
+
+        ops.register 'ensure_permission_template' do
+          Steps::EnsurePermissionTemplate.new
+        end
+
+        ops.register 'save_work' do
+          Steps::SaveWork.new
+        end
+
+        ops.register 'set_default_admin_set' do
+          Steps::SetDefaultAdminSet.new
+        end
+
+        ops.register 'set_modified_date' do
+          Steps::SetModifiedDate.new
+        end
+
+        ops.register 'set_uploaded_date' do
+          Steps::SetUploadedDate.new
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -4,6 +4,19 @@ require "dry/transaction/operation"
 
 module Hyrax
   module Transactions
+    ##
+    # Provides a container for transaction steps related to creating, updating,
+    # and destroying PCDM Objects in Hyrax.
+    #
+    # In advanced use, the container could provide runtime dependency injection
+    # for particular step code. For the basic case, users can consider it as
+    # providing namespaceing and resolution for steps (as used in
+    # `Hyrax::Transaction::CreateWork`; e.g.
+    # `step :save_work, with: 'work.save_work'`).
+    #
+    # @since 2.4.0
+    #
+    # @see https://dry-rb.org/gems/dry-container/
     class Container
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/steps/ensure_admin_set'

--- a/lib/hyrax/transactions/create_work.rb
+++ b/lib/hyrax/transactions/create_work.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    class CreateWork
+      include Dry::Transaction(container: Hyrax::Transactions::Container)
+
+      step :set_default_admin_set,      with: 'work.set_default_admin_set'
+      step :ensure_admin_set,           with: 'work.ensure_admin_set'
+      step :ensure_permission_template, with: 'work.ensure_permission_template'
+      step :set_modified_date,          with: 'work.set_modified_date'
+      step :set_uploaded_date,          with: 'work.set_uploaded_date'
+      step :save_work,                  with: 'work.save_work'
+    end
+  end
+end

--- a/lib/hyrax/transactions/create_work.rb
+++ b/lib/hyrax/transactions/create_work.rb
@@ -1,6 +1,38 @@
 # frozen_string_literal: true
 module Hyrax
   module Transactions
+    ##
+    # A transaction for creating a Work ready for use in Hyrax. Handles
+    # ensuring admin sets and permission templates are present, and setting
+    # system managed dates prior to save.
+    #
+    # @note This is an experimental replacement for the actor stack's `#create`
+    #   stack. In time, we hope this will have feature parity with that stack,
+    #   along with improved architecture, error handling, readability, and
+    #   customizability. While this develops, please provide feedback.
+    #
+    # @since 2.4.0
+    #
+    # @example Creating a work transactionally
+    #   work   = MyWork.new(title: ['Comet in Moominland'])
+    #   result = Hyrax::Transactions::CreateWork.call(work)
+    #   result.success? => true
+    #
+    # @example Handling errors with procedural style
+    #   work   = MyWork.new # invalid work (no title)
+    #   result = Hyrax::Transactions::CreateWork.call(work)
+    #   result.success? => false
+    #
+    #   result.failure # => failure description or object
+    #
+    # @example Handling errors with `#or`
+    #   work   = MyWork.new # invalid work (no title)
+    #
+    #   Hyrax::Transactions::CreateWork
+    #     .call(work)
+    #     .or { |error| handle_error(error) }
+    #
+    # @see https://dry-rb.org/gems/dry-transaction/
     class CreateWork
       include Dry::Transaction(container: Hyrax::Transactions::Container)
 

--- a/lib/hyrax/transactions/steps/ensure_admin_set.rb
+++ b/lib/hyrax/transactions/steps/ensure_admin_set.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      class EnsureAdminSet
+        include Dry::Transaction::Operation
+
+        def call(work)
+          work.admin_set_id ? Success(work) : Failure(:no_admin_set_id)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/ensure_admin_set.rb
+++ b/lib/hyrax/transactions/steps/ensure_admin_set.rb
@@ -2,9 +2,18 @@
 module Hyrax
   module Transactions
     module Steps
+      ##
+      # A `dry-transaction` step that ensures the input `work` has an AdminSet.
+      #
+      # @since 2.4.0
       class EnsureAdminSet
         include Dry::Transaction::Operation
 
+        ##
+        # @param [Hyrax::WorkBehavior] work
+        #
+        # @return [Dry::Monads::Result] `Failure` if there is no `AdminSet` for
+        #   the input; `Success(input)`, otherwise.
         def call(work)
           work.admin_set_id ? Success(work) : Failure(:no_admin_set_id)
         end

--- a/lib/hyrax/transactions/steps/ensure_permission_template.rb
+++ b/lib/hyrax/transactions/steps/ensure_permission_template.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      class EnsurePermissionTemplate
+        include Dry::Transaction::Operation
+
+        def call(work)
+          return Failure(:no_permission_template) unless
+            Hyrax::PermissionTemplate.find_by(source_id: work.admin_set&.id)
+
+          Success(work)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/ensure_permission_template.rb
+++ b/lib/hyrax/transactions/steps/ensure_permission_template.rb
@@ -2,9 +2,19 @@
 module Hyrax
   module Transactions
     module Steps
+      ##
+      # A `dry-transaction` step that ensures the input `work` has a permission
+      # template.
+      #
+      # @since 2.4.0
       class EnsurePermissionTemplate
         include Dry::Transaction::Operation
 
+        ##
+        # @param [Hyrax::WorkBehavior] work
+        #
+        # @return [Dry::Monads::Result] `Failure` if there is no
+        #   `PermissionTemplate` for the input; `Success(input)`, otherwise.
         def call(work)
           return Failure(:no_permission_template) unless
             Hyrax::PermissionTemplate.find_by(source_id: work.admin_set&.id)

--- a/lib/hyrax/transactions/steps/save_work.rb
+++ b/lib/hyrax/transactions/steps/save_work.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      class SaveWork
+        include Dry::Transaction::Operation
+
+        def call(work)
+          work.save ? Success(work) : Failure(:not_saved)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/save_work.rb
+++ b/lib/hyrax/transactions/steps/save_work.rb
@@ -1,11 +1,23 @@
 # frozen_string_literal: true
 module Hyrax
   module Transactions
-    ##
-    # A `dry-transaction` step that saves an input work.
-    #
-    # @since 2.4.0
     module Steps
+      ##
+      # A `dry-transaction` step that saves an input work.
+      #
+      # @example saving a work
+      #   step = Hyrax::Transactions::Steps::SaveWork.new
+      #   work = MyWork.new(title: ['Comet in Moominland'])
+      #
+      #   step.call(work) # => Success
+      #
+      # @example handling error cases
+      #   step = Hyrax::Transactions::Steps::SaveWork.new
+      #   work = MyWork.new(title: [:invalid_title])
+      #
+      #   step.call(work).or { |err| puts err.messages }
+      #
+      # @since 2.4.0
       class SaveWork
         include Dry::Transaction::Operation
 
@@ -15,7 +27,7 @@ module Hyrax
         # @return [Dry::Monads::Result] `Failure` if the work fails to save;
         #   `Success(input)`, otherwise.
         def call(work)
-          work.save ? Success(work) : Failure(:not_saved)
+          work.save ? Success(work) : Failure(work.errors)
         end
       end
     end

--- a/lib/hyrax/transactions/steps/save_work.rb
+++ b/lib/hyrax/transactions/steps/save_work.rb
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 module Hyrax
   module Transactions
+    ##
+    # A `dry-transaction` step that saves an input work.
+    #
+    # @since 2.4.0
     module Steps
       class SaveWork
         include Dry::Transaction::Operation
 
+        ##
+        # @param [Hyrax::WorkBehavior] work
+        #
+        # @return [Dry::Monads::Result] `Failure` if the work fails to save;
+        #   `Success(input)`, otherwise.
         def call(work)
           work.save ? Success(work) : Failure(:not_saved)
         end

--- a/lib/hyrax/transactions/steps/set_default_admin_set.rb
+++ b/lib/hyrax/transactions/steps/set_default_admin_set.rb
@@ -2,9 +2,17 @@
 module Hyrax
   module Transactions
     module Steps
+      ##
+      # A `dry-transaction` step that sets the `AdminSet` for an input work to
+      # the default admin set, if none is already set. Creates the default
+      # admin set if it doesn't already exist.
       class SetDefaultAdminSet
         include Dry::Transaction::Operation
 
+        ##
+        # @param [Hyrax::WorkBehavior] work
+        #
+        # @return [Dry::Monads::Result]
         def call(work)
           work.admin_set ||=
             AdminSet.find(AdminSet.find_or_create_default_admin_set_id)

--- a/lib/hyrax/transactions/steps/set_default_admin_set.rb
+++ b/lib/hyrax/transactions/steps/set_default_admin_set.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      class SetDefaultAdminSet
+        include Dry::Transaction::Operation
+
+        def call(work)
+          work.admin_set ||=
+            AdminSet.find(AdminSet.find_or_create_default_admin_set_id)
+
+          Success(work)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/set_modified_date.rb
+++ b/lib/hyrax/transactions/steps/set_modified_date.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      class SetModifiedDate
+        include Dry::Transaction::Operation
+
+        def call(work)
+          work.date_modified = Hyrax::TimeService.time_in_utc
+
+          Success(work)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/set_modified_date.rb
+++ b/lib/hyrax/transactions/steps/set_modified_date.rb
@@ -2,9 +2,18 @@
 module Hyrax
   module Transactions
     module Steps
+      ##
+      # A `dry-transaction` step that sets the modified date to now for an
+      # input work.
+      #
+      # @since 2.4.0
       class SetModifiedDate
         include Dry::Transaction::Operation
 
+        ##
+        # @param [Hyrax::WorkBehavior] work
+        #
+        # @return [Dry::Monads::Result]
         def call(work)
           work.date_modified = Hyrax::TimeService.time_in_utc
 

--- a/lib/hyrax/transactions/steps/set_uploaded_date.rb
+++ b/lib/hyrax/transactions/steps/set_uploaded_date.rb
@@ -2,6 +2,11 @@
 module Hyrax
   module Transactions
     module Steps
+      ##
+      # A `dry-transaction` step that sets the uploaded date to now for an
+      # input work.
+      #
+      # @since 2.4.0
       class SetUploadedDate
         include Dry::Transaction::Operation
 

--- a/lib/hyrax/transactions/steps/set_uploaded_date.rb
+++ b/lib/hyrax/transactions/steps/set_uploaded_date.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      class SetUploadedDate
+        include Dry::Transaction::Operation
+
+        ##
+        # @note the current implementation sets the uploaded date to
+        #   `#date_modified` if it exists, falling back on the current datetime.
+        #
+        # @param [Hyrax::WorkBehavior] work
+        #
+        # @return [Dry::Monads::Result]
+        def call(work)
+          work.date_uploaded =
+            work.date_modified || Hyrax::TimeService.time_in_utc
+          Success(work)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :work, aliases: [:generic_work, :private_generic_work], class: GenericWork do
     transient do
@@ -32,6 +34,10 @@ FactoryBot.define do
 
     trait :public do
       visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    end
+
+    factory :invalid_generic_work do
+      title nil
     end
 
     factory :private_work do

--- a/spec/hyrax/transactions/create_work_spec.rb
+++ b/spec/hyrax/transactions/create_work_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::CreateWork do
+  subject(:transaction) { described_class.new }
+  let(:work)            { build(:generic_work) }
+  let(:xmas)            { DateTime.parse('2018-12-25 11:30').iso8601 }
+
+  before do
+    Hyrax::PermissionTemplate
+      .find_or_create_by(source_id: AdminSet.find_or_create_default_admin_set_id)
+  end
+
+  describe '#call' do
+    context 'with an invalid work' do
+      let(:work) { build(:invalid_generic_work) }
+
+      it 'is a failure' do
+        expect(transaction.call(work)).to be_failure
+      end
+
+      it 'does not save the work' do
+        expect { transaction.call(work) }.not_to change { work.new_record? }.from true
+      end
+    end
+
+    it 'is a success' do
+      expect(transaction.call(work)).to be_success
+    end
+
+    it 'persists the work' do
+      expect { transaction.call(work) }
+        .to change { work.persisted? }
+        .to true
+    end
+
+    it 'sets visibility to restricted by default' do
+      expect { transaction.call(work) }
+        .not_to change { work.visibility }
+        .from Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+
+    it 'sets the default admin set' do
+      expect { transaction.call(work) }
+        .to change { work.admin_set&.id }
+        .to AdminSet.find_or_create_default_admin_set_id
+    end
+
+    it 'sets the modified time using Hyrax::TimeService' do
+      allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(xmas)
+
+      expect { transaction.call(work) }.to change { work.date_modified }.to xmas
+    end
+
+    it 'sets the created time using Hyrax::TimeService' do
+      allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(xmas)
+
+      expect { transaction.call(work) }.to change { work.date_uploaded }.to xmas
+    end
+  end
+
+  context 'with an admin set' do
+    let(:admin_set) { create(:admin_set, with_permission_template: true) }
+    let(:work)      { build(:generic_work, admin_set: admin_set) }
+
+    context 'without a permission template' do
+      let(:admin_set) { create(:admin_set, with_permission_template: false) }
+
+      it 'is a failure' do
+        expect(transaction.call(work)).to be_failure
+      end
+
+      it 'is does not persist the work' do
+        expect { transaction.call(work) }
+          .not_to change { work.persisted? }
+          .from false
+      end
+    end
+
+    it 'is a success' do
+      expect(transaction.call(work)).to be_success
+    end
+
+    it 'retains the set admin set' do
+      expect { transaction.call(work) }
+        .not_to change { work.admin_set&.id }
+        .from admin_set.id
+    end
+  end
+end

--- a/spec/hyrax/transactions/create_work_spec.rb
+++ b/spec/hyrax/transactions/create_work_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Hyrax::Transactions::CreateWork do
       it 'does not save the work' do
         expect { transaction.call(work) }.not_to change { work.new_record? }.from true
       end
+
+      it 'gives useful errors' do
+        expect(transaction.call(work).failure).to eq work.errors
+      end
     end
 
     it 'is a success' do

--- a/spec/hyrax/transactions/create_work_spec.rb
+++ b/spec/hyrax/transactions/create_work_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe Hyrax::Transactions::CreateWork do
     end
   end
 
+  context 'when visibility is set' do
+    let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+
+    before { work.visibility = visibility }
+
+    it 'keeps the visibility' do
+      expect { transaction.call(work) }
+        .not_to change { work.visibility }
+        .from visibility
+    end
+  end
+
   context 'with an admin set' do
     let(:admin_set) { create(:admin_set, with_permission_template: true) }
     let(:work)      { build(:generic_work, admin_set: admin_set) }

--- a/spec/hyrax/transactions/steps/ensure_admin_set_spec.rb
+++ b/spec/hyrax/transactions/steps/ensure_admin_set_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::EnsureAdminSet do
+  subject(:step) { described_class.new }
+  let(:work)     { build(:generic_work) }
+
+  describe '#call' do
+    context 'without an admin set' do
+      it 'is a failure' do
+        expect(step.call(work)).to be_failure
+      end
+    end
+
+    context 'with an admin set' do
+      let(:admin_set) { create(:admin_set) }
+      let(:work)      { build(:generic_work, admin_set_id: admin_set.id) }
+
+      it 'is a success' do
+        expect(step.call(work)).to be_success
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/ensure_admin_set_spec.rb
+++ b/spec/hyrax/transactions/steps/ensure_admin_set_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hyrax::Transactions::Steps::EnsureAdminSet do
   describe '#call' do
     context 'without an admin set' do
       it 'is a failure' do
-        expect(step.call(work)).to be_failure
+        expect(step.call(work).failure).to eq :no_admin_set_id
       end
     end
 

--- a/spec/hyrax/transactions/steps/ensure_permission_template_spec.rb
+++ b/spec/hyrax/transactions/steps/ensure_permission_template_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::EnsurePermissionTemplate do
+  subject(:step) { described_class.new }
+  let(:work)     { build(:generic_work) }
+
+  describe '#call' do
+    context 'without an admin_set' do
+      it 'is a failure' do
+        expect(step.call(work)).to be_failure
+      end
+    end
+
+    context 'with an admin_set' do
+      let(:work)      { build(:generic_work, admin_set: admin_set) }
+      let(:admin_set) { create(:admin_set, with_permission_template: true) }
+
+      it 'is success' do
+        expect(step.call(work)).to be_success
+      end
+
+      context 'missing PermissionTemplate' do
+        let(:admin_set) { create(:admin_set, with_permission_template: false) }
+
+        it 'fails with missing template' do
+          expect(step.call(work)).to be_failure
+        end
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/ensure_permission_template_spec.rb
+++ b/spec/hyrax/transactions/steps/ensure_permission_template_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hyrax::Transactions::Steps::EnsurePermissionTemplate do
   describe '#call' do
     context 'without an admin_set' do
       it 'is a failure' do
-        expect(step.call(work)).to be_failure
+        expect(step.call(work).failure).to eq :no_permission_template
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::Transactions::Steps::EnsurePermissionTemplate do
         let(:admin_set) { create(:admin_set, with_permission_template: false) }
 
         it 'fails with missing template' do
-          expect(step.call(work)).to be_failure
+          expect(step.call(work).failure).to eq :no_permission_template
         end
       end
     end

--- a/spec/hyrax/transactions/steps/save_work_spec.rb
+++ b/spec/hyrax/transactions/steps/save_work_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::SaveWork do
+  subject(:step) { described_class.new }
+  let(:work)     { build(:generic_work) }
+
+  describe '#call' do
+    it 'is success' do
+      expect(step.call(work)).to be_success
+    end
+
+    it 'persists the work' do
+      expect { step.call(work) }
+        .to change { work.persisted? }
+        .to true
+    end
+
+    context 'if the work is invalid' do
+      let(:work) { build(:invalid_generic_work) }
+
+      it 'returns failure' do
+        expect(step.call(work)).to be_failure
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/save_work_spec.rb
+++ b/spec/hyrax/transactions/steps/save_work_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Hyrax::Transactions::Steps::SaveWork do
       it 'returns failure' do
         expect(step.call(work)).to be_failure
       end
+
+      it 'gives errors about the work' do
+        expect(step.call(work).failure).to eq work.errors
+      end
     end
   end
 end

--- a/spec/hyrax/transactions/steps/set_default_admin_set_spec.rb
+++ b/spec/hyrax/transactions/steps/set_default_admin_set_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::SetDefaultAdminSet do
+  subject(:step) { described_class.new }
+  let(:work)     { build(:generic_work) }
+
+  describe '#call' do
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+
+    it 'is success' do
+      expect(step.call(work)).to be_success
+    end
+
+    it 'sets the default admin_set' do
+      expect { step.call(work) }
+        .to change { work.admin_set&.id }
+        .from(nil)
+        .to(admin_set_id)
+    end
+
+    context 'when the work has an admin_set' do
+      let(:admin_set) { create(:admin_set) }
+      let(:work)      { build(:generic_work, admin_set: admin_set) }
+
+      it 'is success' do
+        expect(step.call(work)).to be_success
+      end
+
+      it 'does not change the admin_set' do
+        expect { step.call(work) }
+          .not_to change { work.admin_set&.id }
+          .from(admin_set.id)
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/set_modified_date_spec.rb
+++ b/spec/hyrax/transactions/steps/set_modified_date_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::SetModifiedDate do
+  subject(:step) { described_class.new }
+  let(:work)     { build(:generic_work) }
+
+  let(:xmas)     { DateTime.parse('2018-12-25 11:30').iso8601 }
+
+  before { allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(xmas) }
+
+  describe '#call' do
+    it 'is success' do
+      expect(step.call(work)).to be_success
+    end
+
+    it 'sets the modified date' do
+      expect { step.call(work) }.to change { work.date_modified }.to xmas
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/set_uploaded_date_spec.rb
+++ b/spec/hyrax/transactions/steps/set_uploaded_date_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::SetUploadedDate do
+  subject(:step) { described_class.new }
+  let(:work)     { build(:generic_work) }
+  let(:xmas)     { DateTime.parse('2018-12-25 11:30').iso8601 }
+
+  before { allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(xmas) }
+
+  describe '#call' do
+    it 'is success' do
+      expect(step.call(work)).to be_success
+    end
+
+    it 'sets the uploaded date' do
+      expect { step.call(work) }.to change { work.date_uploaded }.to xmas
+    end
+
+    context 'when a modified date exists' do
+      let(:work)      { build(:generic_work, date_modified: xmas_past) }
+      let(:xmas_past) { DateTime.parse('2009-12-25 11:30').iso8601 }
+
+      it 'sets the uploaded date to the modified date' do
+        expect { step.call(work) }
+          .to change { work.date_uploaded }
+          .to work.date_modified
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the first chunk of an experimental Actor Stack replacement based on DRY Transactions. The philosophy of this replacement is to ensure that create/update/delete steps remain extensible but are granular (single responsibility), stateless, reusable, and safe under error conditions.

We begin by introducing a `CreateWork` transaction that handles a few of the basic steps involved in preparing a work for save:

  - `SetDefaultAdminSet`
  - `EnsureAdminSet` (fail if no AdminSet is present)
  - `EnsurePermissionTemplate` (fail if no PermissionTemplate is presesnt)
  - `SetModifiedDate`
  - `SetUploadedDate`
  - `SaveWork`

These steps are defined individually, and organized under the `CreateWork` transaction. They do not yet represent a full replacement of the behavior in the `#create` branch of the default Actor Stack. Instead, they are intended to grow in this direction.

Later work will provide the option for adopters to use a transaction like this one in place of the Actor Stack.

**This is a non-functional change**. It introduces code that may be used by adopters, but otherwise won't ever be loaded or executed.

@samvera/hyrax-code-reviewers
