### PR TITLE
Fix ordering of headlines on Dashboard landing page

### DIFF
--- a/app/views/hyrax/admin/collection_types/index.html.erb
+++ b/app/views/hyrax/admin/collection_types/index.html.erb
@@ -21,7 +21,7 @@
         <%= t('.more_toggle_content_html') %>
       </div>
 
-      <h3>Current Collection Types</h3>
+      <h2>Current Collection Types</h2>
       <table class="table collection-types-table">
          <thead>
            <tr>

--- a/app/views/hyrax/dashboard/_admin_sets.html.erb
+++ b/app/views/hyrax/dashboard/_admin_sets.html.erb
@@ -2,7 +2,7 @@
   <div class="col-md-12">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title"><%= t('.title') %></h3>
+        <h2 class="panel-title"><%= t('.title') %></h2>
         <div><%= t('.subtitle') %></div>
       </div>
       <div class="panel-body">

--- a/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
+++ b/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="row">
     <div class="col-xs-6 proxy-search">
-      <h4><%= t("hyrax.dashboard.authorize_proxies") %></h4>
+      <h2><%= t("hyrax.dashboard.authorize_proxies") %></h2>
       <div class="form-group">
         <label for="user"><%= t("hyrax.dashboard.proxy_user") %></label>
         <%= hidden_field_tag :user, nil, data: { grantor: current_user.to_param } %>
@@ -15,7 +15,7 @@
     </div>
 
     <div class="col-xs-6">
-      <h4><%= t("hyrax.dashboard.current_proxies") %></h4>
+      <h2><%= t("hyrax.dashboard.current_proxies") %></h2>
       <table class="table table-condensed table-striped" id="authorizedProxies">
         <tbody>
         <% user.can_receive_deposits_from.each do |depositor| %>


### PR DESCRIPTION
Fixes #1961 

This fixes the noted accessibility issue of using header elements which are out of order in page flow.  For example:
```
<h1>Header</h1>
<h3>Jumps to This, bad for accessibility</h3>
```

Here are a few screenshots of what the fixes look like, which visually look odd (at least to me), since the `<h1>` and `<h2>` elements have been styled to be the same size.  

![headers-in-order](https://user-images.githubusercontent.com/3020266/45301200-126e0000-b4d6-11e8-835a-3922384c17e5.png)

![headers-in-order2](https://user-images.githubusercontent.com/3020266/45301199-126e0000-b4d6-11e8-9ff3-5b920ae7a889.png)

@no-reply @vantuyls @jcoyne Perhaps some future work for this group could be establishing a better consistency in the UI for how we're handling page titles, sub-titles, and so forth.  Maybe go through the whole site and just clean it up and make consistent.  I'd volunteer for this.

@samvera/hyrax-code-reviewers
