### PR TITLE
Wrap top bar navigation components in a <header> tag for better acces…

### DIFF
--- a/app/assets/stylesheets/hyrax/_header.scss
+++ b/app/assets/stylesheets/hyrax/_header.scss
@@ -6,6 +6,10 @@
   z-index: $zindex-navbar + 1;
 }
 
+header > .navbar {
+  margin-bottom: 0;
+}
+
 .navbar + .navbar,
 .navbar + .image-masthead {
   margin-top: -1 * $navbar-margin-bottom;

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,18 +1,21 @@
-<nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation">
-  <div class="container-fluid">
-    <!-- Brand and toggle get grouped for better mobile display -->
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-      <%= render '/logo' %>
-    </div>
+<header>
+  <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation">
+    <div class="container-fluid">
+      <!-- Brand and toggle get grouped for better mobile display -->
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <%= render '/logo' %>
+      </div>
 
-    <div class="collapse navbar-collapse" id="top-navbar-collapse">
-      <%= render '/user_util_links' %>
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <%= render '/user_util_links' %>
+      </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</header>
+


### PR DESCRIPTION
…sibility

Fixes #3082 

Wraps top bar navigation components in a `<header>` tag for better accessibility.

<img width="1299" alt="home-page-header" src="https://user-images.githubusercontent.com/3020266/45305033-12263280-b4df-11e8-9dd5-3e574a1141e7.png">


@samvera/hyrax-code-reviewers
