### PR TITLE
Wrap filter options in a fieldset element, using a legend for screen …

### DIFF
--- a/app/views/hyrax/my/_facet_layout.html.erb
+++ b/app/views/hyrax/my/_facet_layout.html.erb
@@ -1,7 +1,8 @@
-<div class="btn-group">
+<fieldset class="btn-group">
+  <legend class="sr-only"><%= facet_field_label(facet_field.field) %></legend>
   <button class="btn btn-default dropdown-toggle" type="button" id="<%= facet_field.field.parameterize %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" aria-controls="<%= facet_field.field.parameterize + '-dropdown-options' %>">
     <%= facet_field_label(facet_field.field) %>
     <span class="caret"></span>
   </button>
   <%= yield %>
-</div>
+</fieldset>


### PR DESCRIPTION
…readers to aid accessibility

Fixes #3131 
Wraps the filter options in Works and Collections list pages with a `<fieldset>` element, and use `<legend>` for screen readers to better aid in accessibility.

@samvera/hyrax-code-reviewers
