### PR TITLE
Lock Devise to pre-4.5.0

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -60,6 +60,8 @@ EOF
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4'
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
   spec.add_dependency 'clipboard-rails', '~> 1.5'
+  # Devise 4.5 removes the 'trackable' module, which we depend on
+  spec.add_dependency 'devise', '<= 4.4.99'
   spec.add_dependency 'rails_autolink', '~> 1.1'
   spec.add_dependency 'active_fedora-noid', '~> 2.0', '>= 2.0.2'
   spec.add_dependency 'awesome_nested_set', '~> 3.1'

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -80,7 +80,7 @@ EOF
   spec.add_development_dependency 'engine_cart', '~> 1.2'
   spec.add_development_dependency 'mida', '~> 0.3'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
-  spec.add_development_dependency 'solr_wrapper', '~> 1.1'
+  spec.add_development_dependency 'solr_wrapper', '>= 1.1', '< 3.0'
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.5', '>= 0.5.1'
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'rspec-its', '~> 1.1'

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
         actor.attach_to_work(work)
         expect(work.representative).to eq(file_set)
         expect(work.thumbnail).to eq(file_set)
-        expect { work.reload }.not_to change { [work.representative, work.thumbnail] }
+        expect { work.reload }.not_to change { [work.representative.id, work.thumbnail.id] }
       end
     end
 


### PR DESCRIPTION
evise 4.5.0 removes 'trackable', which is a dependency of Hyrax. Hyrax 2.2+ simply removes the dependant features when the module is not present.

Backported fix for #3210

@samvera/hyrax-code-reviewers
