### PR TITLE
Fix JSON API for collections

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -25,6 +25,7 @@ module Hyrax
     end
 
     def show
+      @curation_concern ||= ActiveFedora::Base.find(params[:id])
       presenter
       query_collection_members
     end

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       expect(page).not_to have_content(work2.title.first)
     end
 
+    it "returns json results" do
+      visit "/collections/#{collection.id}.json"
+      expect(page).to have_http_status(:success)
+      json = JSON.parse(page.body)
+      expect(json['id']).to eq collection.id
+      expect(json['title']).to match_array collection.title
+    end
+
     context "with a non-nestable collection type" do
       let(:collection) do
         build(:public_collection_lw, user: user, description: ['collection description'], collection_type_settings: :not_nestable, with_solr_document: true, with_permission_template: true)


### PR DESCRIPTION
Fixes #3202 

Fix the json api issue to return a valid json to an HTTP request to any collection page with .json extension.

Here's the screen shot.

![collection_json](https://user-images.githubusercontent.com/1864660/45323132-1bbf9280-b4ff-11e8-8a38-b5eab23eab9d.png)

@samvera/hyrax-code-reviewers
