### PR TITLE
Changes default terms text in template to ordered list

### DIFF
--- a/app/views/hyrax/content_blocks/templates/terms.html.erb
+++ b/app/views/hyrax/content_blocks/templates/terms.html.erb
@@ -1,62 +1,62 @@
 <h1>Terms of Use for <%= ApplicationController.helpers.application_name %></h1>
 
-<p>
-1.  <strong>General:</strong> The Site is maintained by the <%= ApplicationController.helpers.institution_name_full %> Libraries and <%= ApplicationController.helpers.institution_name_full %> Information Technology Services (ITS), in support of our mission to disseminate information and research to scholars, educators and the public. As used in these Terms of Use, the terms "we, "us," and "our" refer to the Libraries, ITS, and <%= ApplicationController.helpers.institution_name_full %> ("<%= ApplicationController.helpers.institution_name %>"). Use of <%= ApplicationController.helpers.application_name %> (the Site and its contents) is subject to the following terms and conditions and all applicable laws. By using the Site or any of its content, you accept and agree to be bound by these Terms of Use and all applicable laws. If any of these Terms of Use are unacceptable to you, do not use the Site.
-</p>
-
-<p>
-2. <strong>Changes to Terms of Use Are Binding:</strong> We may change these Terms of Use from time-to-time without advance notice. Your use of the Site or any of its content after any changes have been made will constitute your agreement on a prospective basis to the modified Terms of Use and all of the changes. Accordingly, you should read these Terms of Use from time-to-time for any changes.
-</p>
-
-<p>
-3. <strong>Copyright and Use of <%= ApplicationController.helpers.application_name %> Content:</strong> The Site includes text, images, graphics, information, articles, multi-media objects, scholarly projects and other works protected by copyright, trademark and other laws ("Content").  Some of the Content on this site may include materials from older published works that have passed into the "public domain" under U.S. copyright law.  Where such information is known, it is included specifically in the metadata associated with each item of Content.  However, the Site itself and most of the materials held as Content on the Site are protected by copyright and other laws.  These materials have been deposited to enable teaching, research, and other non-profit educational activities.  Unless otherwise specified in the metadata attached to an item of Content, you may use the Site and the Content only for non-commercial, research, educational, or related academic purposes.  Further, you have the responsibility to make your own assessment of the copyright or other legal concerns that might affect your use of <%= ApplicationController.helpers.application_name %> content and to assume personal responsibility for your uses of Content.
-</p>
-
-<p>
-4. <strong>Special Permissions:</strong> <%= ApplicationController.helpers.application_name %> does not have the authority to grant or deny special permissions to use images or other Content found on the site beyond those uses that are specifically described in these Terms of Use or as noted specifically on individual items of Content.  <%= ApplicationController.helpers.application_name %> staff are not able to undertake copyright investigations on behalf of Site users.
-</p>
-
-<p>
-5. <strong><%= ApplicationController.helpers.application_name %> Access Levels:</strong> Where possible, <%= ApplicationController.helpers.application_name %> makes its Content available to the general public. However, some of the Content on this Site has been made available only to <%= ApplicationController.helpers.institution_name %> community users or other user subgroups by the depositor.  Such Content cannot be used, downloaded, or distributed outside the <%= ApplicationController.helpers.institution_name %> community (or subgroup identified) without the specific permission of the depositor.
-</p>
-
-<p>
-6. <strong>Use of <%= ApplicationController.helpers.application_name %> Site and Content:</strong> Unless otherwise specified in the metadata attached to an item, Content that has been made accessible to the general public may be used for non-commercial, research, educational, or related academic purposes only.  Such uses include personal study, distribution to students, research and scholarship (including computational research uses such as data and text-mining, citation-extraction, or cross-referencing) as long as you do not sell the Content or sell advertising on any page on which the Content is displayed.  If you make an item of Content available to others, you shall do so in accordance with the terms of the rights granted pursuant to the particular item of Content, or at a minimum, you will retain with the Content its title, the name of the author(s), a reference to these Terms of Use, any copyright notice included on the original, and any metadata associated with the original. You may not use a facsimile of the published version of an article that may be posted in <%= ApplicationController.helpers.application_name %> under these open access terms, unless the publisher so permits.  You will not make any translation, adaptation or other derivative work of an item of Content except as authorized under U.S. law. You may not sublicense or otherwise transfer your rights in an item of Content, unless specifically authorized by the copyright license granted to the item of Content and will only make Content  available to others for use by them under these Terms of Use.  Links on the Site to third-party web sites are provided solely as a convenience to you. We do not approve or endorse the content of linked third-party sites, and you agree that we will have no responsibility or liability in connection with your use of any linked third-party sites. Nothing in these Terms of Use or on the Site will be construed as granting you any right or license to use any trademarks, service marks or logos displayed on the Site. You agree not to use or register any name, logo or insignia of <%= ApplicationController.helpers.institution_name_full %> or any of its subdivisions for any purpose except with our prior written approval and in accordance with any restrictions required by us.
-</p>
-
-<p>
-7. <strong>Fair Use and Other Lawful Uses:</strong> Nothing in these Terms of Use is intended to restrict or limit you from making uses of Content  that, in the absence of rights granted hereunder, would not infringe or violate anyone's copyright, trademark or other rights.  To the extent permitted by law, adaptation of <%= ApplicationController.helpers.application_name %> Content to enable use and access by persons with disabilities is encouraged.
-</p>
-
-<p>
-8. <strong>Reserved Rights; Obtaining Permissions:</strong> All rights in the Site and the Content that are not expressly granted are reserved. You agree to use the Site and the Content only in ways that comply with copyright and all other applicable laws, as well as with these Terms of Use, and that do not infringe or violate anyone's rights. If you wish to make any use of the Content that requires authorization under copyright, trademark or other rights, you agree to obtain all necessary permissions. You are responsible for determining whether permission is needed to make any use of the Content that you wish to make.
-</p>
-
-<p>
-9. <strong>Disclaimer of Warranties:</strong> THE SITE AND THE CONTENT ARE PROVIDED "AS IS." TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, WE DISCLAIM ALL WARRANTIES OF ANY KIND (EXPRESS, IMPLIED OR OTHERWISE) REGARDING THE SITE OR THE CONTENT, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OWNERSHIP, AND NON-INFRINGEMENT. WE MAKE NO WARRANTY ABOUT THE ACCURACY, RELIABILITY, COMPLETENESS, TIMELINESS, SUFFICIENCY OR QUALITY OF THE SITE OR THE CONTENT, NOR THAT ANY PARTICULAR CONTENT WILL CONTINUE TO BE MADE AVAILABLE. WE DO NOT APPROVE OR ENDORSE ANY POSTED MATERIAL OR CONTENT PROVIDED BY OTHERS, INCLUDING <%= ApplicationController.helpers.institution_name.upcase %> AUTHORS. WE DO NOT WARRANT THAT THE SITE WILL OPERATE WITHOUT ERROR OR INTERRUPTION, OR THAT THE SITE OR ITS SERVER ARE FREE OF COMPUTER VIRUSES OR OTHER HARMFUL MATERIALS.
-</p>
-
-<p>
-10. <strong>Limitations of Liability and Remedies:</strong> WE MAKE THE SITE AND THE CONTENT AVAILABLE FREE OF CHARGE. YOUR USE OF THE SITE AND THE CONTENT IS AT YOUR OWN SOLE RISK. IN NO EVENT SHALL WE BE LIABLE TO YOU, IN CONTRACT, TORT OR OTHERWISE, FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY OR OTHER DAMAGES OF ANY KIND ARISING OUT OF OR RELATING TO THE SITE OR THE CONTENT, OR YOUR USE OF THE SITE OR THE CONTENT, OR ANY THIRD PARTY RIGHTS IN THE CONTENT, EVEN IF THE SITE OR CONTENT IS DEFECTIVE OR WE ARE NEGLIGENT OR OTHERWISE AT FAULT, AND REGARDLESS WHETHER WE ARE ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THE FOREGOING LIMITATIONS SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW.
-</p>
-
-<p>
-11. <strong>Indemnity:</strong> You agree to indemnify and hold harmless <%= ApplicationController.helpers.institution_name_full %> and its trustees, officers, fellows, students, employees and agents, from and against all claims, actions, suits, damages, liabilities and costs (including, without limitation, reasonable legal fees) arising from or relating to your use of the Site or any of the Content or your failure to comply with any provision of these Terms of Use.
-</p>
-
-<p>
-12.  <strong>Communications:</strong>
-<ul>
+<ol>
   <li>
-A. Copyright Complaints: We respect the intellectual property rights of others. If you believe your copyright has been violated on the Site, please notify us through <%= ApplicationController.helpers.institution_name %>'s designated agent under the Digital Millennium Copyright Act (see 17 U.S.C. Â&sect;512(c)(3).</li>
-  <li> B. Other Site Issues: Please direct all other communications to <a href="<%= Hyrax::Engine.routes.url_helpers.contact_path %>">contact form</a>.</ul>
-</ul>
-</p>
+    <strong>General:</strong> The Site is maintained by the <%= ApplicationController.helpers.institution_name_full %> Libraries and <%= ApplicationController.helpers.institution_name_full %> Information Technology Services (ITS), in support of our mission to disseminate information and research to scholars, educators and the public. As used in these Terms of Use, the terms "we, "us," and "our" refer to the Libraries, ITS, and <%= ApplicationController.helpers.institution_name_full %> ("<%= ApplicationController.helpers.institution_name %>"). Use of <%= ApplicationController.helpers.application_name %> (the Site and its contents) is subject to the following terms and conditions and all applicable laws. By using the Site or any of its content, you accept and agree to be bound by these Terms of Use and all applicable laws. If any of these Terms of Use are unacceptable to you, do not use the Site.
+  </li>
 
-<p>
-13. <strong>Applicable Law and Jurisdiction; Access from Outside the Commonwealth of Pennsylvania:</strong> The Site is controlled and operated from our facilities in and around University Park, PA. These Terms of Use, and any claim or dispute that arises from or relates to your use of the Site or the Content, will be governed by the laws of Pennsylvania, without regard to its conflicts of laws principles. You agree that all such claims and disputes will be heard and resolved exclusively in the courts of Centre County, Pennsylvania. You consent to the personal jurisdiction of such courts over you for this purpose, and waive and agree not to assert any objection to such proceedings in such courts (including any defense or objection of lack of proper jurisdiction or venue or inconvenience of forum). If you choose to access our website from locations other than Pennsylvania, you will be responsible for compliance with all local laws of those other locations.
-</p>
+  <li>
+    <strong>Changes to Terms of Use Are Binding:</strong> We may change these Terms of Use from time-to-time without advance notice. Your use of the Site or any of its content after any changes have been made will constitute your agreement on a prospective basis to the modified Terms of Use and all of the changes. Accordingly, you should read these Terms of Use from time-to-time for any changes.
+  </li>
 
-<p>
-14. <strong>Termination:</strong> The permissions granted to you will terminate automatically upon any breach by you of these Terms of Use.  If we take down or otherwise cease to make a work available as an item of Content, the permission granted to you hereunder to use that Content thereafter will terminate at that time. <%= ApplicationController.helpers.application_name %> is maintained as a scholarly and educational resource by <%= ApplicationController.helpers.institution_name %> which may be modified or terminated by the University in its sole discretion.
-</p>
+  <li>
+    <strong>Copyright and Use of <%= ApplicationController.helpers.application_name %> Content:</strong> The Site includes text, images, graphics, information, articles, multi-media objects, scholarly projects and other works protected by copyright, trademark and other laws ("Content").  Some of the Content on this site may include materials from older published works that have passed into the "public domain" under U.S. copyright law.  Where such information is known, it is included specifically in the metadata associated with each item of Content.  However, the Site itself and most of the materials held as Content on the Site are protected by copyright and other laws.  These materials have been deposited to enable teaching, research, and other non-profit educational activities.  Unless otherwise specified in the metadata attached to an item of Content, you may use the Site and the Content only for non-commercial, research, educational, or related academic purposes.  Further, you have the responsibility to make your own assessment of the copyright or other legal concerns that might affect your use of <%= ApplicationController.helpers.application_name %> content and to assume personal responsibility for your uses of Content.
+  </li>
+
+  <li>
+    <strong>Special Permissions:</strong> <%= ApplicationController.helpers.application_name %> does not have the authority to grant or deny special permissions to use images or other Content found on the site beyond those uses that are specifically described in these Terms of Use or as noted specifically on individual items of Content.  <%= ApplicationController.helpers.application_name %> staff are not able to undertake copyright investigations on behalf of Site users.
+  </li>
+
+  <li>
+    <strong><%= ApplicationController.helpers.application_name %> Access Levels:</strong> Where possible, <%= ApplicationController.helpers.application_name %> makes its Content available to the general public. However, some of the Content on this Site has been made available only to <%= ApplicationController.helpers.institution_name %> community users or other user subgroups by the depositor.  Such Content cannot be used, downloaded, or distributed outside the <%= ApplicationController.helpers.institution_name %> community (or subgroup identified) without the specific permission of the depositor.
+  </li>
+
+  <li>
+    <strong>Use of <%= ApplicationController.helpers.application_name %> Site and Content:</strong> Unless otherwise specified in the metadata attached to an item, Content that has been made accessible to the general public may be used for non-commercial, research, educational, or related academic purposes only.  Such uses include personal study, distribution to students, research and scholarship (including computational research uses such as data and text-mining, citation-extraction, or cross-referencing) as long as you do not sell the Content or sell advertising on any page on which the Content is displayed.  If you make an item of Content available to others, you shall do so in accordance with the terms of the rights granted pursuant to the particular item of Content, or at a minimum, you will retain with the Content its title, the name of the author(s), a reference to these Terms of Use, any copyright notice included on the original, and any metadata associated with the original. You may not use a facsimile of the published version of an article that may be posted in <%= ApplicationController.helpers.application_name %> under these open access terms, unless the publisher so permits.  You will not make any translation, adaptation or other derivative work of an item of Content except as authorized under U.S. law. You may not sublicense or otherwise transfer your rights in an item of Content, unless specifically authorized by the copyright license granted to the item of Content and will only make Content  available to others for use by them under these Terms of Use.  Links on the Site to third-party web sites are provided solely as a convenience to you. We do not approve or endorse the content of linked third-party sites, and you agree that we will have no responsibility or liability in connection with your use of any linked third-party sites. Nothing in these Terms of Use or on the Site will be construed as granting you any right or license to use any trademarks, service marks or logos displayed on the Site. You agree not to use or register any name, logo or insignia of <%= ApplicationController.helpers.institution_name_full %> or any of its subdivisions for any purpose except with our prior written approval and in accordance with any restrictions required by us.
+  </li>
+
+  <li>
+    <strong>Fair Use and Other Lawful Uses:</strong> Nothing in these Terms of Use is intended to restrict or limit you from making uses of Content  that, in the absence of rights granted hereunder, would not infringe or violate anyone's copyright, trademark or other rights.  To the extent permitted by law, adaptation of <%= ApplicationController.helpers.application_name %> Content to enable use and access by persons with disabilities is encouraged.
+  </li>
+
+  <li>
+    <strong>Reserved Rights; Obtaining Permissions:</strong> All rights in the Site and the Content that are not expressly granted are reserved. You agree to use the Site and the Content only in ways that comply with copyright and all other applicable laws, as well as with these Terms of Use, and that do not infringe or violate anyone's rights. If you wish to make any use of the Content that requires authorization under copyright, trademark or other rights, you agree to obtain all necessary permissions. You are responsible for determining whether permission is needed to make any use of the Content that you wish to make.
+  </li>
+
+  <li>
+    <strong>Disclaimer of Warranties:</strong> THE SITE AND THE CONTENT ARE PROVIDED "AS IS." TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, WE DISCLAIM ALL WARRANTIES OF ANY KIND (EXPRESS, IMPLIED OR OTHERWISE) REGARDING THE SITE OR THE CONTENT, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OWNERSHIP, AND NON-INFRINGEMENT. WE MAKE NO WARRANTY ABOUT THE ACCURACY, RELIABILITY, COMPLETENESS, TIMELINESS, SUFFICIENCY OR QUALITY OF THE SITE OR THE CONTENT, NOR THAT ANY PARTICULAR CONTENT WILL CONTINUE TO BE MADE AVAILABLE. WE DO NOT APPROVE OR ENDORSE ANY POSTED MATERIAL OR CONTENT PROVIDED BY OTHERS, INCLUDING <%= ApplicationController.helpers.institution_name.upcase %> AUTHORS. WE DO NOT WARRANT THAT THE SITE WILL OPERATE WITHOUT ERROR OR INTERRUPTION, OR THAT THE SITE OR ITS SERVER ARE FREE OF COMPUTER VIRUSES OR OTHER HARMFUL MATERIALS.
+  </li>
+
+  <li>
+    <strong>Limitations of Liability and Remedies:</strong> WE MAKE THE SITE AND THE CONTENT AVAILABLE FREE OF CHARGE. YOUR USE OF THE SITE AND THE CONTENT IS AT YOUR OWN SOLE RISK. IN NO EVENT SHALL WE BE LIABLE TO YOU, IN CONTRACT, TORT OR OTHERWISE, FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY OR OTHER DAMAGES OF ANY KIND ARISING OUT OF OR RELATING TO THE SITE OR THE CONTENT, OR YOUR USE OF THE SITE OR THE CONTENT, OR ANY THIRD PARTY RIGHTS IN THE CONTENT, EVEN IF THE SITE OR CONTENT IS DEFECTIVE OR WE ARE NEGLIGENT OR OTHERWISE AT FAULT, AND REGARDLESS WHETHER WE ARE ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THE FOREGOING LIMITATIONS SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW.
+  </li>
+
+  <li>
+    <strong>Indemnity:</strong> You agree to indemnify and hold harmless <%= ApplicationController.helpers.institution_name_full %> and its trustees, officers, fellows, students, employees and agents, from and against all claims, actions, suits, damages, liabilities and costs (including, without limitation, reasonable legal fees) arising from or relating to your use of the Site or any of the Content or your failure to comply with any provision of these Terms of Use.
+  </li>
+
+  <li>
+    <strong>Communications:</strong>
+    <ol type="A">
+      <li>Copyright Complaints: We respect the intellectual property rights of others. If you believe your copyright has been violated on the Site, please notify us through <%= ApplicationController.helpers.institution_name %>'s designated agent under the Digital Millennium Copyright Act (see 17 U.S.C. Â&sect;512(c)(3).</li>
+      <li>Other Site Issues: Please direct all other communications to <a href="<%= Hyrax::Engine.routes.url_helpers.contact_path %>">contact form</a>.
+    </ol>
+  </li>
+
+  <li>
+    <strong>Applicable Law and Jurisdiction; Access from Outside the Commonwealth of Pennsylvania:</strong> The Site is controlled and operated from our facilities in and around University Park, PA. These Terms of Use, and any claim or dispute that arises from or relates to your use of the Site or the Content, will be governed by the laws of Pennsylvania, without regard to its conflicts of laws principles. You agree that all such claims and disputes will be heard and resolved exclusively in the courts of Centre County, Pennsylvania. You consent to the personal jurisdiction of such courts over you for this purpose, and waive and agree not to assert any objection to such proceedings in such courts (including any defense or objection of lack of proper jurisdiction or venue or inconvenience of forum). If you choose to access our website from locations other than Pennsylvania, you will be responsible for compliance with all local laws of those other locations.</li>
+
+  <li>
+    <strong>Termination:</strong> The permissions granted to you will terminate automatically upon any breach by you of these Terms of Use.  If we take down or otherwise cease to make a work available as an item of Content, the permission granted to you hereunder to use that Content thereafter will terminate at that time. <%= ApplicationController.helpers.application_name %> is maintained as a scholarly and educational resource by <%= ApplicationController.helpers.institution_name %> which may be modified or terminated by the University in its sole discretion.
+  </li>
+</ol>


### PR DESCRIPTION
Fixes #2983 

* Uses ordered list tags in markup rather than `<p>` in the generator template for the Terms of Use page.

Note: This changes the markup for the terms in the generator template, which is populated in the database (one time only) on first terms access. After that, the text is editable by users. So, for testing, you may not see changes unless db is cleared.


@samvera/hyrax-code-reviewers
