### PR TITLE
Don't set visibility unnecessarily in generic work factories

### DIFF
--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -23,7 +23,6 @@ FactoryBot.define do
     end
 
     title { ["Test title"] }
-    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
@@ -36,7 +35,8 @@ FactoryBot.define do
     end
 
     factory :private_work do
-      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+      # private is default
+      # visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :registered_generic_work do


### PR DESCRIPTION
Setting (or accessinge) visibility creates Fedora ACL objects, even before the
related objects exist. Avoiding eager calls to `#visibility` should improve
performance of the test suite.

Connected to #3255

@samvera/hyrax-code-reviewers
