### PR TITLE
Add labels to search form inputs for improved accessibility

### DIFF
--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -164,3 +164,10 @@ form.button-to {
   margin-bottom: 0;
   padding: 7px 15px;
 }
+
+.search-form {
+
+  .form-group {
+    margin: 0;
+  }
+}

--- a/app/assets/stylesheets/hyrax/_header.scss
+++ b/app/assets/stylesheets/hyrax/_header.scss
@@ -17,6 +17,10 @@ header > .navbar {
 
 .searchbar-right {
   margin-right: 0;
+
+  label {
+    color: #ffffff;
+  }
 }
 
 // We need these ancestor selectors to override Bootstrap and push

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container-fluid">
     <div class="row">
-      <ul class="nav navbar-nav col-sm-5 col-md-6">
+      <ul class="nav navbar-nav col-sm-5">
         <li <%= 'class=active' if current_page?(hyrax.root_path) %>>
           <%= link_to t(:'hyrax.controls.home'), hyrax.root_path, aria: current_page?(hyrax.root_path) ? {current: 'page'} : nil %></li>
         <li <%= 'class=active' if current_page?(hyrax.about_path) %>>
@@ -11,7 +11,7 @@
         <li <%= 'class=active' if current_page?(hyrax.contact_path) %>>
           <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
       </ul><!-- /.nav -->
-      <div class="searchbar-right navbar-right col-sm-7 col-md-6">
+      <div class="searchbar-right navbar-right col-sm-7">
         <%= render partial: 'catalog/search_form' %>
       </div>
     </div>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,40 +1,45 @@
-<%= form_tag search_form_action, method: :get, id: "search-form-header", role: "search" do %>
+<%= form_tag search_form_action, method: :get, class: "form-horizontal search-form", id: "search-form-header", role: "search" do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <%= hidden_field_tag :search_field, 'all_fields' %>
-  <div class="input-group">
+  <div class="form-group">
 
-    <label class="sr-only" for="search-field-header"><%= t("hyrax.search.form.q.label", application_name: application_name) %></label>
-    <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+    <label class="control-label col-sm-3" for="search-field-header">
+      <%= t("hyrax.search.form.q.label", application_name: application_name) %>
+    </label>
 
-    <div class="input-group-btn">
-      <button type="submit" class="btn btn-primary" id="search-submit-header">
-        <%= t('hyrax.search.button.html') %>
-      </button>
-      <% if current_user %>
-        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
+    <div class="input-group">
+      <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
-          <span class="sr-only" data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
-          <span aria-hidden="true"><%= t("hyrax.search.form.option.all.label_short") %></span>
-          <span class="caret"></span>
+      <div class="input-group-btn">
+        <button type="submit" class="btn btn-primary" id="search-submit-header">
+          <%= t('hyrax.search.button.html') %>
         </button>
+        <% if current_user %>
+          <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
 
-        <ul class="dropdown-menu pull-right">
-          <li>
-            <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
-                data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
-          </li>
-          <li>
-            <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#",
-                data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
-          </li>
-          <li>
-            <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
-                data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
-          </li>
-        <% end %>
+            <span class="sr-only" data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
+            <span aria-hidden="true"><%= t("hyrax.search.form.option.all.label_short") %></span>
+            <span class="caret"></span>
+          </button>
 
-      </ul>
-    </div><!-- /.input-group-btn -->
+          <ul class="dropdown-menu pull-right">
+            <li>
+              <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
+                  data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
+            </li>
+            <li>
+              <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#",
+                  data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
+            </li>
+            <li>
+              <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
+                  data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
+            </li>
+          <% end %>
 
-  </div><!-- /.input-group -->
+        </ul>
+      </div><!-- /.input-group-btn -->
+    </div><!-- /.input-group -->
+    
+  </div><!-- /.form-group -->
 <% end %>

--- a/app/views/hyrax/my/_search_form.html.erb
+++ b/app/views/hyrax/my/_search_form.html.erb
@@ -1,14 +1,19 @@
-<%= form_tag search_action_url, method: :get, class: "search-query-form", role: "search" do %>
+<%= form_tag search_action_url, method: :get, class: "search-query-form form-horizontal search-form", role: "search" do %>
+
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
-  <div class="input-group">
+  <div class="form-group">
+    <label class="control-label col-sm-3" for="search-field-header">
+      <%= t("hyrax.search.form.q.label", application_name: application_name) %>
+    </label>
 
-    <label class="sr-only" for="search-field-header"><%= t("hyrax.search.form.q.label", application_name: application_name) %></label>
-    <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+    <div class="input-group">
+      <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
-    <div class="input-group-btn">
-      <button type="submit" class="btn btn-primary" id="search-submit-header">
-        <%= t('hyrax.search.button.html') %>
-      </button>
-    </div>
-  </div>
+      <div class="input-group-btn">
+        <button type="submit" class="btn btn-primary" id="search-submit-header">
+          <%= t('hyrax.search.button.html') %>
+        </button>
+      </div>
+    </div><!-- /.input-group -->
+  </div><!-- /.form-group -->
 <% end %>

--- a/app/views/hyrax/my/_search_header.html.erb
+++ b/app/views/hyrax/my/_search_header.html.erb
@@ -4,10 +4,10 @@
 <%= render 'constraints' %>
 
 <div class="row">
-  <div class="col-sm-5 col-md-6">
+  <div class="col-sm-5">
     <%= render 'hyrax/my/sort_and_per_page' %>
   </div>
-  <div class="col-sm-7 col-md-6">
+  <div class="col-sm-7">
     <%= render 'search_form' %>
   </div>
 </div>


### PR DESCRIPTION
Fixes #3129 

Adds visible (not just screen reader only) form labels to search inputs.  See discussion on #3129 for more info.
![home-search-label](https://user-images.githubusercontent.com/3020266/45441994-60c20100-b686-11e8-9207-ebe2e786ff14.png)

![work-collection-search-label-mobile](https://user-images.githubusercontent.com/3020266/45441992-60c20100-b686-11e8-9426-708f639f7229.png)

![work-collection-search-label](https://user-images.githubusercontent.com/3020266/45441993-60c20100-b686-11e8-9b9b-8644ddedc433.png)

@samvera/hyrax-code-reviewers
