### PR TITLE
[WIP] Lock unauthorized permissions from update

### DIFF
--- a/app/views/hyrax/base/_currently_shared.html.erb
+++ b/app/views/hyrax/base/_currently_shared.html.erb
@@ -1,0 +1,97 @@
+<%# ================================================================= %>
+<%# Lock unauthorized permissions from update:
+    - user is permitted to update any work permissions coming from collections they manage
+    - user is permitted to update non-manager permissions from any Collections
+    - user is permitted to update non-collection permissions
+    Process used:
+    - find all of the work's collections a user can manage
+    - find all of the work's collections a user cannot manage
+    - find all of the other managers of collections a user can manage
+    - find all of the other managers of collections a user cannot manage who are not also managers in collections that the user CAN manage.
+    This gives us the permissions the user is not authorized to update.
+%>
+
+<%# get all of work's or file_set's collection ids %>
+<% object_acting_upon =  f.object.respond_to?(:work?) ? f.object.in_works.first : f.object %>
+<% work_member_of = object_acting_upon.member_of_collection_ids + Array.wrap(object_acting_upon.admin_set_id) %>
+
+<%# get work's collection ids which the user manages %>
+<% managed_collection_ids = Hyrax::Collections::PermissionsService.source_ids_for_manage(ability: current_ability) %>
+<% work_managed_collection_ids = work_member_of & managed_collection_ids %>
+<% work_unauthorized_collection_ids = work_member_of - work_managed_collection_ids %>
+
+<%# authorized collection managers %>
+<% authorized_mgrs = [] %>
+<% authorized_collection_mgrs = [] %>
+<% work_managed_collection_ids.each do |id| %>
+  <% Hyrax::PermissionTemplate.find_by(source_id: id).access_grants.each do |grant| %>
+    <% if grant.access == "manage" %>
+      <% authorized_mgrs << grant.agent_id %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%# unauthorized collection managers %>
+<% unauthorized_mgrs = [] %>
+<% unauthorized_collection_mgrs = [] %>
+<% work_unauthorized_collection_ids.each do |id| %>
+  <% Hyrax::PermissionTemplate.find_by(source_id: id).access_grants.each do |grant| %>
+    <% if grant.access == "manage" && (!authorized_mgrs.include? grant.agent_id) %>
+      <% unauthorized_mgrs << grant.agent_id %>
+      <% unauthorized_collection_mgrs += Array.wrap({name: grant.agent_id}.merge({id: id})) %>
+    <% end %>
+  <% end %>
+<% end %>
+<%# ================================================================= %>
+
+<% depositor = f.object.depositor %>
+<%# omit the public, registered, admin, and depositor permissions from the display %>
+<% exclude_from_display = [::Ability.public_group_name, ::Ability.registered_group_name, ::Ability.admin_group_name, depositor] %>
+
+<h2><%= t('hyrax.base.form_share.currently_sharing') %></h2>
+
+<table class="table table-bordered">
+  <tr>
+    <th><%= t('.table_title_user') %></th>
+    <th><div class="col-sm-10"><%= t('.table_title_access') %></div></th>
+  </tr>
+  <tr id="file_permissions">
+    <td>
+      <%= label_tag :owner_access, class: "control-label" do %>
+        Depositor (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
+      <% end %>
+    </td>
+    <td>
+    <div class="col-sm-10">
+      <%= Hyrax.config.owner_permission_levels.keys[0] %>
+    </div>
+    </td>
+  </tr>
+  <%= f.fields_for :permissions do |permission_fields| %>
+    <% perm_hash = permission_fields.object.to_hash %>
+    <% next if exclude_from_display.include? perm_hash[:name].downcase %>
+    <% cannot_edit_perms = (unauthorized_mgrs.include? perm_hash[:name]) && perm_hash[:access] == "edit" %>
+    <tr>
+      <td>
+        <%= permission_fields.label :agent_name, class: "control-label" do %>
+          <%= user_display_name_and_key(perm_hash[:name]) %>
+          <% unauthorized_collection_mgrs.select {|mgrs| mgrs[:name] == perm_hash[:name] }.each do |coll| %>
+            <br />Access granted via collection <%= coll[:id] %>
+          <% end %>
+        <% end %>
+      </td>
+      <td>
+        <div class="col-sm-10">
+        <% if cannot_edit_perms %>
+          <%= Hyrax.config.permission_levels.key(perm_hash[:access]) %>
+        <% else %>
+          <%= permission_fields.select :access, Hyrax.config.permission_levels, {}, class: 'form-control select_perm' %>
+        <% end %>
+        </div>
+        <% if !cannot_edit_perms %>
+          <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">&times;</button>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/hyrax/base/_form_share.html.erb
+++ b/app/views/hyrax/base/_form_share.html.erb
@@ -1,8 +1,6 @@
 <p><%= t('.directions') %></p>
 <h2><%= t('.add_sharing') %></h2>
 
-<% depositor = f.object.depositor %>
-
 <div class="alert alert-info hidden" id="save_perm_note">Permissions are
   <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
 
@@ -48,39 +46,11 @@
   </div>
 </fieldset>
 
-<h2><%= t('.currently_sharing') %></h2>
-
-<table class="table">
-  <tr id="file_permissions">
-    <td width="20%">
-      <%= Hyrax.config.owner_permission_levels.keys[0] %>
-    </td>
-    <td width="60%">
-      <%= label_tag :owner_access, class: "control-label" do %>
-        Depositor (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
-      <% end %>
-    </td>
-  </tr>
-  <%= f.fields_for :permissions do |permission_fields| %>
-    <%# skip the public, registered, and depositor perms as they are displayed first at the top %>
-    <% next if ['public', 'registered', depositor].include? permission_fields.object.agent_name.downcase %>
-    <tr>
-      <td>
-        <%= permission_fields.select :access, Hyrax.config.permission_levels, {}, class: 'form-control select_perm' %>
-      </td>
-      <td>
-        <%= permission_fields.label :agent_name, class: "control-label" do %>
-          <%= user_display_name_and_key(permission_fields.object.agent_name) %>
-        <% end %>
-        <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">&times;</button>
-      </td>
-    </tr>
-  <% end %>
-</table>
+<%= render 'currently_shared', f: f %>
 
 <script type="text/x-tmpl" id="tmpl-work-grant">
 <tr>
-  <td>{%= o.accessLabel %}</td>
   <td><label class="control-label">{%= o.name %}</label> <button class="btn close">&times;</button></td>
+  <td>{%= o.accessLabel %}</td>
 </tr>
 </script>

--- a/app/views/hyrax/file_sets/_permission_form.html.erb
+++ b/app/views/hyrax/file_sets/_permission_form.html.erb
@@ -65,37 +65,8 @@
   </div>
 </div>
 
-<table class="table table-bordered">
-  <tr>
-    <th width="60%"><%= t('.table_title_user') %></th>
-    <th width="40%"><%= t('.table_title_access') %></th>
-  </tr>
-  <tr id="file_permissions">
-    <td>
-      <%= label_tag :owner_access, class: "control-label" do %>
-        <%= t('.depositor') %> (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
-      <% end %>
-    </td>
-    <td>
-      <%= Hyrax.config.owner_permission_levels.keys[0] %>
-    </td>
-  </tr>
-  <%= f.fields_for :permissions do |permission_fields| %>
-    <%# skip the public, registered, and depositor perms as they are displayed first at the top %>
-    <% next if ['public', 'registered', depositor].include? permission_fields.object.agent_name.downcase %>
-    <tr>
-      <td><%= permission_fields.label :agent_name, class: "control-label" do %>
-        <%= user_display_name_and_key(permission_fields.object.agent_name) %>
-      <% end %></td>
-      <td>
-        <div class="col-sm-8">
-          <%= permission_fields.select :access, Hyrax.config.permission_levels, {}, class: 'form-control select_perm' %>
-        </div>
-        <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">X</button>
-      </td>
-    </tr>
-  <% end %>
-</table>
+<%= render 'currently_shared', f: f %>
+
 <script type="text/x-tmpl" id="tmpl-file-set-grant">
 <tr>
   <td><label class="control-label">{%= o.name %}</label></td>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -348,6 +348,9 @@ en:
     base:
       citations:
         header: 'Citations:'
+      currently_shared:
+        table_title_access: Access Level
+        table_title_user: Person/Group
       form_child_work_relationships:
         actions:
           remove: Remove from this work
@@ -875,8 +878,6 @@ en:
         save_note_html: Permissions are <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.
         select_group: Select a group
         share_with: Share With
-        table_title_access: Access Level
-        table_title_user: Person/Group
         user_search: Search for a user
       versioning:
         current: Current Version


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/3166

## Details:

- user is permitted to update any work permissions coming from collections they manage
- user is permitted to update work permissions which are non-manager permissions from any collections work belongs to
- user is permitted to update work permissions which are not related to its collections

Process used:
- find all of the work's collections a user can manage
- find all of the work's collections a user cannot manage
- find all of the other managers of collections a user can manage
- find all of the other managers of collections a user cannot manage who are not also managers in collections that the user CAN manage.

This gives us the permissions the user is not authorized to update. 

Permission logic was moved into a new shared partial `currently_shared.html.erb` which embeds all of the above logic and uses it to display all of the work or file set's permissions in either a fixed or editable format.

The new shared partial results in a slight reformat of the display of these permissions, as there were previously minor differences between the two displays.

### Work Permissions View
![screen shot 2018-09-13 at 2 45 02 pm](https://user-images.githubusercontent.com/17851674/45509016-5ece6f80-b764-11e8-9790-4b57e631b67f.png)

### File Set Permissions View
![screen shot 2018-09-13 at 2 44 53 pm](https://user-images.githubusercontent.com/17851674/45509022-6130c980-b764-11e8-9676-7a065dd9ca84.png)

@samvera/hyrax-code-reviewers
