### PR TITLE
Circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,62 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+    # specify the version you desire here
+    - image: circleci/ruby:2.5.1-node-browsers
+      environment:
+        RAILS_ENV: test
+        RACK_ENV: test
+        NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+        ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-action-cable --skip-coffee --skip-puma --skip-test
+        SPEC_OPTS: --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - image: circleci/redis:4
+    # - image: yinlinchen/fcrepo4-docker:4.7.5
+    # - image: solr:7
+
+    # Specify service dependencies here if necessary
+    # CircleCI maintains a library of pre-built images
+    # documented at https://circleci.com/docs/2.0/circleci-images/
+    # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    steps:
+    - checkout
+
+    # Download and cache dependencies
+    - restore_cache:
+        keys:
+        - v1-dependencies-{{ checksum "Gemfile.lock" }}
+        # fallback to using the latest cache if no exact match is found
+        - v1-dependencies-
+
+    - run:
+        name: install dependencies
+        command: |
+          bundle check || bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+    - save_cache:
+        paths:
+        - ./vendor/bundle
+        key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+
+    # run tests!
+    - run:
+        name: run tests
+        command: |
+          mkdir /tmp/test-results
+          TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+
+          bundle exec rake ci
+
+    # collect reports
+    - store_test_results:
+        path: /tmp/test-results
+    - store_artifacts:
+        path: /tmp/test-results
+        destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
       environment:
         RAILS_ENV: test
         RACK_ENV: test
+        BUNDLE_JOBS: 4
+        BUNDLE_RETRY: 3
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true
         ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-action-cable --skip-coffee --skip-puma --skip-test
         SPEC_OPTS: --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
@@ -26,24 +28,31 @@ jobs:
     working_directory: ~/repo
 
     steps:
+    - run:
+        name: Setup Interpolated ENV Variables
+        command: |
+          echo 'export BUNDLE_PATH="$CIRCLE_WORKING_DIR/vendor/bundle"' >> $BASH_ENV
+
     - checkout
 
     # Download and cache dependencies
     - restore_cache:
         keys:
-        - v1-dependencies-{{ checksum "Gemfile.lock" }}
-        # fallback to using the latest cache if no exact match is found
         - v1-dependencies-
 
     - run:
         name: install dependencies
         command: |
-          bundle check || bundle install --jobs=4 --retry=3 --path vendor/bundle
+          gem update bundler
+          bundle update
+          bundle exec rake engine_cart:generate
 
     - save_cache:
         paths:
+        - ./Gemfile.lock
         - ./vendor/bundle
-        key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+        - ./.internal_test_app
+        key: v1-dependencies-{{ checksum "./.internal_test_app/.generated_engine_cart" }}
 
     # run tests!
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ version: 2
 jobs:
   build:
     docker:
-    # specify the version you desire here
-    - image: circleci/ruby:2.5.1-node-browsers
+    # legacy needed for phantomjs
+    - image: circleci/ruby:2.5.1-node-browsers-legacy
       environment:
         RAILS_ENV: test
         RACK_ENV: test
@@ -31,7 +31,7 @@ jobs:
     - run:
         name: Setup Interpolated ENV Variables
         command: |
-          echo 'export BUNDLE_PATH="$CIRCLE_WORKING_DIR/vendor/bundle"' >> $BASH_ENV
+          echo 'export BUNDLE_PATH="$CIRCLE_WORKING_DIRECTORY/vendor/bundle"' >> $BASH_ENV
 
     - checkout
 
@@ -54,9 +54,13 @@ jobs:
         - ./.internal_test_app
         key: v1-dependencies-{{ checksum "./.internal_test_app/.generated_engine_cart" }}
 
-    # run tests!
     - run:
-        name: run tests
+        name: Start headless Chrome
+        command: google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost
+        background: true
+
+    - run:
+        name: Run tests
         command: |
           mkdir /tmp/test-results
           TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -94,6 +94,7 @@ SUMMARY
   spec.add_development_dependency 'rspec-activemodel-mocks', '~> 1.0'
   spec.add_development_dependency 'rspec-its', '~> 1.1'
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
+  spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency "selenium-webdriver"
   spec.add_development_dependency 'solr_wrapper', '>= 1.1', '< 3.0'
   spec.add_development_dependency 'i18n-debug' if ENV['I18N_DEBUG']


### PR DESCRIPTION
Fixes #3277 

Adds a basic but passing CircleCI config. The internal_test_app is setup to be cached and rely on engine_cart to determine if it needs to be rebuilt.

Further enhancements might include running specs in parallel and using secondary service containers in place of fcrepo_wrapper and solr_wrapper. 