### PR TITLE
Fix bcrypt missing on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,8 @@ jobs:
     - run:
         name: install dependencies
         command: |
-          gem update bundler
-          bundle update
+          gem update --system
+          bundle install
           bundle exec rake engine_cart:generate
 
     - save_cache:


### PR DESCRIPTION
This should fix the bcrypt missing error in CircleCI