### PR TITLE
Mark tests that were optional in Travis as optional in CircleCI

### DIFF
--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
       let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_2.gid, title: ['NewCollectionTitle']) }
 
       it 'then the work is added to both collections' do
-        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ENV['TRAVIS']
+        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
         # Add to second multi-membership collection of a different type
         visit '/dashboard/my/works'
         check 'check_all'
@@ -38,7 +38,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
       let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_1.gid, title: ['NewCollectionTitle']) }
 
       it 'then the work is added to both collections' do
-        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ENV['TRAVIS']
+        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
         # Add to second multi-membership collection of a different type
         visit '/dashboard/my/works'
         check 'check_all'
@@ -70,7 +70,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
       let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_2.gid, title: ['NewCollectionTitle']) }
 
       it 'then the work is added to both collections' do
-        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ENV['TRAVIS']
+        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
         # Add to second single-membership collection of a different type
         visit '/dashboard/my/works'
         check 'check_all'
@@ -91,7 +91,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
 
       context 'then the work fails to add to the second collection' do
         it 'from the dashboard->works batch add to collection' do
-          optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ENV['TRAVIS']
+          optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
           # Attempt to add to second single-membership collection of the same type
           visit '/dashboard/my/works'
           check 'check_all'
@@ -165,7 +165,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
       let!(:new_collection) { old_collection }
 
       it 'then the add is treated as a success' do
-        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ENV['TRAVIS']
+        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
         # Re-add to same multi-membership collection
         visit '/dashboard/my/works'
         check 'check_all'
@@ -186,7 +186,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
       let!(:new_collection) { old_collection }
 
       it 'then the add is treated as a success' do
-        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ENV['TRAVIS']
+        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
         # Re-add to same single-membership collection
         visit '/dashboard/my/works'
         check 'check_all'

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "display a work as its owner" do
     end
 
     it "add work to a collection", clean_repo: true, js: true do
-      optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ENV['TRAVIS']
+      optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
       click_button "Add to collection" # opens the modal
       select_member_of_collection(collection)
       click_button 'Save changes'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,10 @@ def coverage_needed?
   ENV['COVERAGE'] || ENV['TRAVIS']
 end
 
+def ci_build?
+  ENV['TRAVIS'] || ENV['CIRCLE']
+end
+
 if coverage_needed?
   require 'simplecov'
   require 'coveralls'
@@ -60,7 +64,7 @@ require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 
 require 'i18n/debug' if ENV['I18N_DEBUG']
-require 'byebug' unless ENV['TRAVIS']
+require 'byebug' unless ci_build?
 
 # @note In January 2018, TravisCI disabled Chrome sandboxing in its Linux
 #       container build environments to mitigate Meltdown/Spectre
@@ -141,7 +145,7 @@ RSpec.configure do |config|
   config.include Shoulda::Matchers::ActiveRecord, type: :model
   config.include Shoulda::Matchers::ActiveModel, type: :form
   config.include Shoulda::Callback::Matchers::ActiveModel
-  config.full_backtrace = true if ENV['TRAVIS']
+  config.full_backtrace = true if ci_build?
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
Some tests are marked optional in CI due to capybara/jquery issues. These are mostly due to https://github.com/samvera/hyrax/issues/3038.

This introduces a `ci_build?` helper for RSpec and makes it `true` when`ENV['CIRCLE']` is set.

@samvera/hyrax-code-reviewers
