### PR TITLE
Display collections without descriptions

### DIFF
--- a/app/views/hyrax/collections/_collection_description.erb
+++ b/app/views/hyrax/collections/_collection_description.erb
@@ -1,3 +1,3 @@
-<% presenter.description.each do |description| %>
+<% presenter&.description&.each do |description| %>
   <%= simple_format(auto_link(description)) %>
 <% end %>


### PR DESCRIPTION
`CollectionPresenter#description` is delegated to `#solr_document`, which can return `nil`. When we display the collection, we try to call `#each`, which gives `NoMethodError` in the `nil` case.

Using the safe access operator `&.` avoids this bug and allows display of Collections and AdminSets without any descriptions.

Connected to #2575.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a collection with no description;
* Visit the collection show page and ensure there is no error.

@samvera/hyrax-code-reviewers
