### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+The Samvera community is dedicated to providing a welcoming and
+positive experience for all its members, whether they are at a formal
+gathering, in a social setting, or taking part in activities online.
+The Samvera community welcomes participation from people all over the
+world and these members bring with them a wide variety of
+professional, personal and social backgrounds; whatever these may be,
+we treat colleagues with dignity and respect.
+
+Community members communicate primarily in English, though for many of
+them this is not their native language. We therefore strive to express
+ourselves simply and clearly remembering that unnecessary use of
+jargon and slang will be a barrier to understanding for many of our
+colleagues.  We are sensitive to the fact that the international
+nature of the community means that we span many different social norms
+around language and behaviour and we strive to conduct ourselves,
+online and in person, in ways that are unlikely to cause offence.
+
+Samvera conversations are often information-rich and intended to
+generate discussion and debate.  We discuss ideas from a standpoint of
+mutual respect and reasoned argument.
+
+Community members work together to promote a respectful and safe
+community. In the event that someone’s conduct is causing offence or
+distress, Samvera has a detailed
+[Anti-Harassment Policy and Protocol](https://wiki.duraspace.org/display/samvera/Anti-Harassment+Policy)
+which can be applied to address the problem. The first step in dealing
+with any serious misconduct is to contact a local meeting organizer,
+the
+[Samvera community helpers](https://wiki.duraspace.org/display/samvera/Samvera+Community+Helpers)
+([email](mailto:helpers@samvera.org)), a community member you
+trust, or the
+[Samvera Steering Group](https://wiki.duraspace.org/display/samvera/Samvera+Steering+Group+membership)
+immediately; at Samvera events, these people can be identified by
+distinctive name badges. The
+[Policy and Protocol](https://wiki.duraspace.org/display/samvera/Anti-Harassment+Policy)
+should be consulted for fuller details.


### PR DESCRIPTION
The samvera community code of conduct should be in the repository, as it applies to activity related to contributing to this project.

@samvera/hyrax-code-reviewers
