### PR TITLE
Add select all dropdown to collections page

### DIFF
--- a/app/helpers/hyrax/batch_edits_helper.rb
+++ b/app/helpers/hyrax/batch_edits_helper.rb
@@ -9,7 +9,6 @@ module Hyrax
     # Displays a "check all" button with a dropdown that has "Select None"
     # and "Select current page" actions
     def render_check_all
-      return if params[:controller] == "hyrax/my/collections"
       render 'hyrax/batch_edits/check_all'
     end
   end

--- a/app/views/hyrax/my/collections/_default_group.html.erb
+++ b/app/views/hyrax/my/collections/_default_group.html.erb
@@ -2,15 +2,7 @@
   <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
   <thead>
   <tr>
-    <th class="check-all text-left">
-      <label for="check_all" class="sr-only">
-        <%= t("hyrax.dashboard.my.sr.check_all_label") %>
-      </label>
-      <label class="centerizer">
-        <input type="checkbox" class="check-all-checkbox" name="check_all" id="check_all" value="yes" />
-        <%= t("hyrax.dashboard.my.action.select") %>
-      </label>
-    </th>
+    <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>
     <th><%= t("hyrax.dashboard.my.heading.type") %></th>
     <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>

--- a/spec/helpers/hyrax/batch_edits_helper_spec.rb
+++ b/spec/helpers/hyrax/batch_edits_helper_spec.rb
@@ -40,8 +40,10 @@ RSpec.describe Hyrax::BatchEditsHelper, type: :helper do
     context "with my collections" do
       let(:controller_path) { "hyrax/my/collections" }
 
-      it "does not show the check all dropdown" do
-        expect(subject).to be_nil
+      it "show the check all dropdown" do
+        expect(subject).to have_css("span.caret")
+        expect(subject).to have_content t("hyrax.dashboard.my.action.select_all")
+        expect(subject).to have_content t("hyrax.dashboard.my.action.select_none")
       end
     end
 


### PR DESCRIPTION
Fixes #2852 

Add select all dropdown to collections page like works page for consistency.

Here's the screen shot
![collectionselectdropdown](https://user-images.githubusercontent.com/1864660/45831295-d2680380-bcb3-11e8-813a-99f55e8d5c98.png)

@samvera/hyrax-code-reviewers
