### PR TITLE
Remove ActiveFedora 11.5.2 guard

### DIFF
--- a/app/indexers/hyrax/repository_reindexer.rb
+++ b/app/indexers/hyrax/repository_reindexer.rb
@@ -1,6 +1,5 @@
 require 'active_fedora/base'
 require 'active_fedora/version'
-raise "Verify this override is still needed for non 11.5.2 versions" unless ActiveFedora::VERSION == '11.5.2'
 
 module Hyrax
   module RepositoryReindexer


### PR DESCRIPTION
This guard artificially breaks Hyrax for explictly supported `ActiveFedora`
versions. When `ActiveFedora` 11.5.3 was released recently, this started hitting
us when `bundle update` runs.

@samvera/hyrax-code-reviewers
