### PR TITLE
[Backport] Remove ActiveFedora 11.5.2 guard

### DIFF
--- a/app/indexers/hyrax/repository_reindexer.rb
+++ b/app/indexers/hyrax/repository_reindexer.rb
@@ -1,6 +1,5 @@
 require 'active_fedora/base'
 require 'active_fedora/version'
-raise "Verify this override is still needed for non 11.5.2 versions" unless ActiveFedora::VERSION == '11.5.2'
 
 module Hyrax
   module RepositoryReindexer

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -79,7 +79,6 @@ SUMMARY
   # temporary pin to 2.17 due to failures caused in 2.18.0
   spec.add_development_dependency "capybara", '~> 2.4', '< 2.18.0'
   spec.add_development_dependency 'capybara-maleficent', '~> 0.2'
-  spec.add_development_dependency "chromedriver-helper"
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
   spec.add_development_dependency 'engine_cart', '~> 2.0'
   spec.add_development_dependency "equivalent-xml", '~> 0.5'
@@ -108,4 +107,8 @@ SUMMARY
   # simple_form 3.5.1 broke hydra-editor for certain model types;
   #   see: https://github.com/plataformatec/simple_form/issues/1549
   spec.add_dependency 'simple_form', '~> 3.2', '<= 3.5.0'
+  # chromedriver-helper 2.0 broke the chromedriver used by capybara
+  #   see: https://github.com/flavorjones/chromedriver-helper/issues/62
+  #        and https://github.com/flavorjones/chromedriver-helper/issues/57
+  spec.add_development_dependency 'chromedriver-helper', '< 2.0'
 end


### PR DESCRIPTION
This guard artificially breaks Hyrax for explictly supported `ActiveFedora`
versions. When `ActiveFedora` 11.5.3 was released recently, this started hitting
us when `bundle update` runs.

@samvera/hyrax-code-reviewers
