### PR TITLE
Allow support for `active-fedora` 12

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -31,7 +31,8 @@ SUMMARY
   # http://guides.rubyonrails.org/maintenance_policy.html
   spec.add_dependency 'rails', '~> 5.0'
 
-  spec.add_dependency 'active-fedora', '~> 11.5', '>= 11.5.2'
+  spec.add_dependency 'active-fedora', '>= 11.5.2', '< 13'
+  spec.add_dependency 'solrizer', '>= 3.4', '< 5'
   spec.add_dependency 'almond-rails', '~> 0.1'
   spec.add_dependency 'awesome_nested_set', '~> 3.1'
   spec.add_dependency 'blacklight', '~> 6.14'

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -70,6 +70,7 @@ module Hyrax
       require 'dry/struct'
       require 'dry/equalizer'
       require 'dry/validation'
+      require 'solrizer'
     end
 
     initializer 'routing' do


### PR DESCRIPTION
Expand support for `ActiveFedora` to allow use of 12.x releases. This brings us
up to date on current releases.

We explictly add a `Solrizer` dependency, which has been removed from
`ActiveFedora` and inlined to `ActiveFedora::Indexing`. Adding this explictly
retains existing behavior for downstream users. We should remove internal
references to `Solrizer` soon, and remove the dependency altogether on the next
major release.

@samvera/hyrax-code-reviewers
