### PR TITLE
Correct German from google translate for versions 2.1.0 through 2.3.1

### DIFF
--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -860,16 +860,16 @@ de:
         versions: Versionen
       form:
         attach_to: An %{parent} anhängen
-        cancel: Stornieren
-        save: sparen
+        cancel: Abbrechen
+        save: Speichern
         title: Titel
       groups_description:
         description_html: Die Liste der Gruppen in der Auswahlliste mit der Bezeichnung &ldquor; Wählen Sie eine Gruppe aus &ldquor; zeigt ihnen jene Benutzer administrierten Gruppen an, bei denen Sie Mitglied sind. Sie können eine bestimmte Gruppe auswählen und eine Zugriffsebene für eine Datei innerhalb von %{application_name} zuweisen, ähnlich wie das Hinzufügen von Benutzerzugriffsebenen.
       permission:
-        save: sparen
+        save: Speichern
       permission_form:
         applied_to: "(gilt für alle gerade hochgeladenen Dateien)"
-        depositor: Einzahler
+        depositor: Deponent
         enter: Geben Sie %{account_label} ein (einzeln)
         header: Berechtigungen
         optional: "(wahlweise)"
@@ -884,7 +884,7 @@ de:
         header: Versionen
         restore: Vorherige Version wiederherstellen
         restore_from: Wiederherstellen von
-        save: Revision speichern
+        save: Überarbeitete Version speichern
         upload: Neue Version hochladen
     help:
       header: Benutzer-Support


### PR DESCRIPTION
Fixes #3034 and #3227 (via  [commit b3c1c69 ](https://github.com/samvera/hyrax/pull/3227/commits/b3c1c690ba4b9ec20c93b5dcbff94e4f2dff625b))

Changes proposed in this pull request:
* Fixing Gtranslators guess 


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* native speaker 

@samvera/hyrax-code-reviewers
