### PR TITLE
Allow use of 0.5 version of iiif_manifest

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -52,7 +52,7 @@ SUMMARY
   spec.add_dependency 'hydra-editor', '>= 3.3', '< 5.0'
   spec.add_dependency 'hydra-head', '>= 10.5.0'
   spec.add_dependency 'hydra-works', '>= 0.16', '< 2.0'
-  spec.add_dependency 'iiif_manifest', '>= 0.3', '< 0.5'
+  spec.add_dependency 'iiif_manifest', '>= 0.3', '< 0.6'
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4'
   spec.add_dependency 'jquery-ui-rails', '~> 6.0'
   spec.add_dependency 'json-schema' # for Arkivo


### PR DESCRIPTION
`iiif_manifest` 0.5 was just released and I need support for it for `hyrax-iiif_av`

@samvera/hyrax-code-reviewers
