### PR TITLE
Remove datatables class from All Works display table, which was causi…

### DIFF
--- a/app/views/hyrax/dashboard/works/_default_group.html.erb
+++ b/app/views/hyrax/dashboard/works/_default_group.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-striped works-list datatable">
+<table class="table table-striped works-list">
   <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
   <thead>
     <tr>


### PR DESCRIPTION
…ng double search and pagination

Fixes #3306 

This removes the double search and pagination which was appearing in Works "All Items" page.

**After:**

![works-regular-search-pagination](https://user-images.githubusercontent.com/3020266/46365314-e14c9f80-c63d-11e8-80c5-ea30d9aff067.png)

**Before:**

![works-extra-search-pagination](https://user-images.githubusercontent.com/3020266/46365324-e7db1700-c63d-11e8-8ab9-3866a5832609.png)

@samvera/hyrax-code-reviewers
