### PR TITLE
Use solr image based on openjdk:8 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     - image: ualbertalib/docker-fcrepo4:4.7
       environment:
         CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC"
-    - image: solr:7
+    - image: solr:7-alpine
       command: bin/solr -cloud -noprompt -f -p 8985
 
     # Specify service dependencies here if necessary


### PR DESCRIPTION
…to workaround build failure with openjdk:10.

There appears to be an issue with openjdk 10 that is affecting lucene when used in docker. Using the official solr:7 docker image was resulting in errors similar to those mentioned here: https://discuss.elastic.co/t/mergeexception-due-to-illegal-state-in-perfieldpostingsformat-es-6-3-0/138650/6

solr:7-alpine is still based on openjdk 8 (for now) and appears to workaround the issue.