### PR TITLE
Add `ApplyPermissionTemplate` to the `CreateWork` transaction

### DIFF
--- a/app/actors/hyrax/actors/apply_permission_template_actor.rb
+++ b/app/actors/hyrax/actors/apply_permission_template_actor.rb
@@ -31,10 +31,8 @@ module Hyrax
         end
 
         def set_curation_concern_access(env, template)
-          env.curation_concern.edit_users += template.agent_ids_for(agent_type: 'user', access: 'manage')
-          env.curation_concern.edit_groups += template.agent_ids_for(agent_type: 'group', access: 'manage')
-          env.curation_concern.read_users += template.agent_ids_for(agent_type: 'user', access: 'view')
-          env.curation_concern.read_groups += template.agent_ids_for(agent_type: 'group', access: 'view')
+          PermissionTemplateApplicator
+            .apply(template).to(model: env.curation_concern)
         end
     end
   end

--- a/app/services/hyrax/permission_template_applicator.rb
+++ b/app/services/hyrax/permission_template_applicator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # Applies a `PermissionTemplate` to a given model object by adding the
+  # template's manage and view users to the model's permissions.
+  #
+  # @example applying a template
+  #   applicator = PermissionTemplateApplicator.new(template: my_template)
+  #   applicator.apply_to(work)
+  #
+  # @example applying a template with fluent chaining syntax
+  #   PermissionTemplateApplicator.apply(my_template).to work
+  #
+  # @since 2.4.0
+  class PermissionTemplateApplicator
+    ##
+    # @!attribute [rw] template
+    #   @return [Hyrax::PermissionTemplate]
+    attr_accessor :template
+
+    ##
+    # @param template [Hyrax::PermissionTemplate]
+    def initialize(template:)
+      self.template = template
+    end
+
+    ##
+    # @param template [Hyrax::PermissionTemplate]
+    #
+    # @return [PermissionTemplateApplicator]
+    def self.apply(template)
+      new(template: template)
+    end
+
+    ##
+    # @param model [Hydra::PCDM::Object, Hydra::PCDM::Collection]
+    # @return [Boolean] true if the permissions have been successfully applied
+    def apply_to(model:)
+      model.edit_groups += template.agent_ids_for(agent_type: 'group', access: 'manage')
+      model.edit_users  += template.agent_ids_for(agent_type: 'user',  access: 'manage')
+      model.read_groups += template.agent_ids_for(agent_type: 'group', access: 'view')
+      model.read_users  += template.agent_ids_for(agent_type: 'user',  access: 'view')
+
+      true
+    end
+    alias to apply_to
+  end
+end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -19,6 +19,7 @@ module Hyrax
     # @see https://dry-rb.org/gems/dry-container/
     class Container
       require 'hyrax/transactions/create_work'
+      require 'hyrax/transactions/steps/apply_permission_template'
       require 'hyrax/transactions/steps/ensure_admin_set'
       require 'hyrax/transactions/steps/ensure_permission_template'
       require 'hyrax/transactions/steps/save_work'
@@ -29,6 +30,10 @@ module Hyrax
       extend Dry::Container::Mixin
 
       namespace 'work' do |ops|
+        ops.register 'apply_permission_template' do
+          Steps::ApplyPermissionTemplate.new
+        end
+
         ops.register 'ensure_admin_set' do
           Steps::EnsureAdminSet.new
         end

--- a/lib/hyrax/transactions/create_work.rb
+++ b/lib/hyrax/transactions/create_work.rb
@@ -36,12 +36,12 @@ module Hyrax
     class CreateWork
       include Dry::Transaction(container: Hyrax::Transactions::Container)
 
-      step :set_default_admin_set,      with: 'work.set_default_admin_set'
-      step :ensure_admin_set,           with: 'work.ensure_admin_set'
-      step :ensure_permission_template, with: 'work.ensure_permission_template'
-      step :set_modified_date,          with: 'work.set_modified_date'
-      step :set_uploaded_date,          with: 'work.set_uploaded_date'
-      step :save_work,                  with: 'work.save_work'
+      step :set_default_admin_set,     with: 'work.set_default_admin_set'
+      step :ensure_admin_set,          with: 'work.ensure_admin_set'
+      step :apply_permission_template, with: 'work.apply_permission_template'
+      step :set_modified_date,         with: 'work.set_modified_date'
+      step :set_uploaded_date,         with: 'work.set_uploaded_date'
+      step :save_work,                 with: 'work.save_work'
     end
   end
 end

--- a/lib/hyrax/transactions/steps/apply_permission_template.rb
+++ b/lib/hyrax/transactions/steps/apply_permission_template.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # A `dry-transcation` step that applies a permission template.
+      #
+      # @since 2.4.0
+      class ApplyPermissionTemplate
+        include Dry::Transaction::Operation
+
+        ##
+        # @param [Hyrax::WorkBehavior] work
+        #
+        # @return [Dry::Monads::Result]
+        def call(work)
+          return Failure(:missing_permission) unless
+            (template = work&.admin_set&.permission_template)
+
+          Hyrax::PermissionTemplateApplicator.apply(template).to(model: work)
+
+          Success(work)
+        rescue ActiveRecord::RecordNotFound => err
+          Failure(err)
+        end
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/apply_permission_template_spec.rb
+++ b/spec/hyrax/transactions/steps/apply_permission_template_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::ApplyPermissionTemplate do
+  subject(:step) { described_class.new }
+  let(:work)     { build(:generic_work) }
+
+  context 'without an admin_set' do
+    it 'is a failure' do
+      expect(step.call(work)).to be_failure
+    end
+  end
+
+  context 'with an admin_set' do
+    let(:work)      { build(:generic_work, admin_set: admin_set) }
+    let(:admin_set) { create(:admin_set, with_permission_template: true) }
+
+    it 'is a success' do
+      expect(step.call(work)).to be_success
+    end
+
+    context 'with users and groups' do
+      let(:admin_set)     { AdminSet.find(template.source_id) }
+      let(:manage_groups) { ['edit_group_1', 'edit_group_2'] }
+      let(:manage_users)  { create_list(:user, 2) }
+      let(:view_groups)   { ['read_group_1', 'read_group_2'] }
+      let(:view_users)    { create_list(:user, 2) }
+
+      let(:template) do
+        create(:permission_template,
+               with_admin_set: true,
+               manage_groups: manage_groups,
+               manage_users:  manage_users,
+               view_groups:   view_groups,
+               view_users:    view_users)
+      end
+
+      it 'assigns edit users from template' do
+        expect { step.call(work) }
+          .to change { work.edit_users }
+          .to include(*manage_users.map(&:user_key))
+      end
+
+      it 'assigns edit groups from template' do
+        expect { step.call(work) }
+          .to change { work.edit_groups }
+          .to include(*manage_groups)
+      end
+
+      it 'assigns read users from template' do
+        expect { step.call(work) }
+          .to change { work.read_users }
+          .to include(*view_users.map(&:user_key))
+      end
+
+      it 'assigns read groups from template' do
+        expect { step.call(work) }
+          .to change { work.read_groups }
+          .to include(*view_groups)
+      end
+    end
+
+    context 'missing PermissionTemplate' do
+      let(:admin_set) { create(:admin_set, with_permission_template: false) }
+
+      it 'is a failure' do
+        expect(step.call(work)).to be_failure
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/permission_template_applicator_spec.rb
+++ b/spec/services/hyrax/permission_template_applicator_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe Hyrax::PermissionTemplateApplicator do
+  subject(:applicator) { described_class.new(template: template) }
+  let(:manage_groups)  { ['edit_group_1', 'edit_group_2'] }
+  let(:manage_users)   { ['moomin', 'snork'] }
+  let(:template)       { :not_a_template }
+  let(:view_groups)    { ['read_group_1', 'read_group_2'] }
+  let(:view_users)     { ['snufkin', 'too-ticky'] }
+  let(:work)           { build(:work) }
+
+  describe '.apply' do
+    it 'initializes with template' do
+      expect(described_class.apply(template))
+        .to have_attributes(template: template)
+    end
+  end
+
+  describe '#apply_to' do
+    let(:template) do
+      create(:permission_template,
+             manage_groups: manage_groups,
+             manage_users:  manage_users,
+             view_groups:   view_groups,
+             view_users:    view_users)
+    end
+
+    it 'applies edit groups' do
+      edit_after_application = work.edit_groups + manage_groups
+
+      expect { applicator.apply_to(model: work) }
+        .to change { work.edit_groups }
+        .to contain_exactly(*edit_after_application)
+    end
+
+    it 'applies edit users' do
+      edit_after_application = work.edit_users + manage_users
+
+      expect { applicator.apply_to(model: work) }
+        .to change { work.edit_users }
+        .to contain_exactly(*edit_after_application)
+    end
+
+    it 'applies read groups' do
+      read_after_application = work.read_groups + view_groups
+
+      expect { applicator.apply_to(model: work) }
+        .to change { work.read_groups }
+        .to contain_exactly(*read_after_application)
+    end
+
+    it 'applies read users' do
+      read_after_application = work.read_users + view_users
+
+      expect { applicator.apply_to(model: work) }
+        .to change { work.read_users }
+        .to contain_exactly(*read_after_application)
+    end
+  end
+
+  describe '#template' do
+    let(:new_template) { :not_another_template }
+
+    it 'has a template attribute' do
+      expect { applicator.template = new_template }
+        .to change { applicator.template }
+        .from(template)
+        .to new_template
+    end
+  end
+end


### PR DESCRIPTION
Replaces the `:ensure_permission_template` step with an
`:apply_permission_template` step.

The new step uses a `PermissionTemplateApplicator` (extracted from
`ApplyPermissionTemplateActor`) to set model permissions based on the
`AdminSet` permission template. Collection permissions are ignored so far.

This still achieves the goal of the old `:ensure_permission_template` by
entering the error path when a permission template is missing. The extra access
needed to separately 'ensure' is avoided by the replacement.

@samvera/hyrax-code-reviewers
