### PR TITLE
Make file upload buttons tab accessible

### DIFF
--- a/app/assets/stylesheets/hyrax/_accessibility.scss
+++ b/app/assets/stylesheets/hyrax/_accessibility.scss
@@ -35,3 +35,20 @@
   width: auto;
   z-index: 1005;
 }
+
+// Makes file upload buttons tab focusable
+.hidden-file-input {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+}
+
+/* Colors taken from Bootstrap's focus */
+input.hidden-file-input:focus + label {
+  outline: #66afe9 auto 5px;
+  outline: -webkit-focus-ring-color auto 5px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+}

--- a/app/assets/stylesheets/hyrax/_accessibility.scss
+++ b/app/assets/stylesheets/hyrax/_accessibility.scss
@@ -38,17 +38,17 @@
 
 // Makes file upload buttons tab focusable
 .hidden-file-input {
-  position: absolute !important;
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
   clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute !important;
+  width: 1px;
 }
 
-/* Colors taken from Bootstrap's focus */
+// Colors taken from Bootstrap's focus
 input.hidden-file-input:focus + label {
-  outline: #66afe9 auto 5px;
-  outline: -webkit-focus-ring-color auto 5px;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  outline: #66afe9 auto 5px;
+  outline: -webkit-focus-ring-color auto 5px;
 }

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -1,4 +1,5 @@
 class IngestJob < Hyrax::ApplicationJob
+  include Sidekiq::Worker
   queue_as Hyrax.config.ingest_queue_name
 
   after_perform do |job|
@@ -13,6 +14,7 @@ class IngestJob < Hyrax::ApplicationJob
   # @see 'config/initializers/hyrax_callbacks.rb'
   # rubocop:disable Lint/UnusedMethodArgument
   def perform(wrapper, notification: false)
+    logger.debug "Help #{hash.inspect}"
     wrapper.ingest_file
   end
 end

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -12,18 +12,14 @@
         <div class="fileupload-buttonbar">
           <div class="row">
             <div class="col-xs-12">
-                <!-- The fileinput-button span is used to style the file input field as button -->
-                <span id="addfiles" class="btn btn-success fileinput-button">
-                    <span class="glyphicon glyphicon-plus"></span>
-                    <span>Add files...</span>
-                    <input type="file" name="files[]" multiple />
-                </span>
-                <!-- The fileinput-button span is used to style the file input field as button -->
-                <span id="addfolder" class="btn btn-success fileinput-button">
-                    <span class="glyphicon glyphicon-plus"></span>
-                    <span>Add folder...</span>
-                    <input type="file" name="files[]" multiple directory webkitdirectory />
-                </span>
+              <!-- The fileinput-button span is used to style the file input field as button -->
+              <input type="file" id="addFiles" name="files[]" class="hidden-file-input" multiple>
+              <label for="addFiles" class=" btn btn-success fileinput-button"><span class="glyphicon glyphicon-plus"></span> Add files...</label>
+
+              <!-- The fileinput-button span is used to style the file input field as button -->
+              <input type="file" id="addFolder" name="files[]" class="hidden-file-input" multiple directory webkitdirectory>
+              <label for="addFolder" class=" btn btn-success fileinput-button"><span class="glyphicon glyphicon-plus"></span> Add folder...</label>
+
                 <% if Hyrax.config.browse_everything? %>
                   <%= button_tag(type: 'button', class: 'btn btn-success', id: "browse-btn",
                     'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,


### PR DESCRIPTION
Make file upload buttons tab accessible without breaking file uploads in FF

Fixes #1246 ; without causing the issue experienced here #3214

@samvera/hyrax-code-reviewers
