### PR TITLE
Wrap long file names in fileset and work show page

### DIFF
--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -18,12 +18,11 @@ header > h1 .label {
   padding: $panel-body-padding;
 }
 
-.attribute-filename,
-header h1,
-td:first-child {
+.ensure-wrapped {
   word-break: break-all;
 }
 
+.relationships,
 .attributes {
   tbody th {
     width: 20%;

--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -20,7 +20,7 @@ header > h1 .label {
 
 .attribute-filename,
 header h1,
-#activity td:first-child {
+td:first-child {
   word-break: break-all;
 }
 

--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -18,7 +18,12 @@ header > h1 .label {
   padding: $panel-body-padding;
 }
 
-.relationships,
+.attribute-filename,
+header h1,
+#activity td:first-child {
+  word-break: break-all;
+}
+
 .attributes {
   tbody th {
     width: 20%;

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -2,7 +2,7 @@
   <td class="thumbnail">
     <%= render_thumbnail_tag member %>
   </td>
-  <td class="attribute attribute-filename"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
+  <td class="attribute attribute-filename ensure-wrapped"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
   <td class="attribute attribute-date_uploaded"><%= member.try(:date_uploaded) %></td>
   <td class="attribute attribute-permission"><%= member.permission_badge %></td>
   <td>

--- a/app/views/hyrax/file_sets/_file_set_title.erb
+++ b/app/views/hyrax/file_sets/_file_set_title.erb
@@ -1,9 +1,9 @@
 <% presenter.title.each_with_index do |title, index| %>
     <% if index == 0 %>
-        <h1>
+        <h1 class="ensure-wrapped">
             <%= title %> <%= presenter.permission_badge %>
         </h1>
     <% else %>
-        <h1><%= title %></h1>
+        <h1 class="ensure-wrapped"><%= title %></h1>
     <% end %>
 <% end %>

--- a/app/views/hyrax/users/_activity_log.html.erb
+++ b/app/views/hyrax/users/_activity_log.html.erb
@@ -9,7 +9,7 @@
   <% events.each do |event| %>
     <% next if event[:action].blank? or event[:timestamp].blank? %>
     <tr>
-      <td><%= sanitize event[:action] %></td>
+      <td class="ensure-wrapped"><%= sanitize event[:action] %></td>
       <% time = Time.zone.at(event[:timestamp].to_i) %>
       <td data-sort="<%= time.getutc.iso8601(5) %>">
         <relative-time datetime="<%= time.getutc.iso8601 %>" title="<%= time.to_formatted_s(:standard) %>">


### PR DESCRIPTION
Fixes #1275

Wrap long file names without spaces fit the layout.

Here's the screen shot of before and after the change

Before
![beforewrapfilename](https://user-images.githubusercontent.com/1864660/46897839-fd202480-ce39-11e8-868a-120301c788e3.png)
![beforefileset](https://user-images.githubusercontent.com/1864660/46897842-03160580-ce3a-11e8-9818-8e4621c3cab8.png)

After
![afterwrapfilename](https://user-images.githubusercontent.com/1864660/46897847-0c9f6d80-ce3a-11e8-89f0-d87ad3cbe836.png)
![afterfileset](https://user-images.githubusercontent.com/1864660/46897855-10cb8b00-ce3a-11e8-832e-14d3078f2a24.png)


@samvera/hyrax-code-reviewers
