### PR TITLE
A whole sentence ("To create a separate work for each of the files, g…

### DIFF
--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -16,7 +16,7 @@
   <% end %>
   <% if Flipflop.batch_upload? && f.object.new_record? %>
     <% provide :metadata_tab do %>
-      <p class="switch-upload-type">To create a separate work for each of the files, go to <%= link_to "Batch upload", hyrax.new_batch_upload_path %></p>
+      <p class="switch-upload-type"><%= t(".create_separate_work_for_each_file") %> <%= link_to t(".batch_upload"), hyrax.new_batch_upload_path %></p>
     <% end %>
   <% end %>
   <%= render 'hyrax/base/guts4form', f: f %>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -348,6 +348,9 @@ de:
     base:
       citations:
         header: 'Zitate:'
+      form:
+        batch_upload: batch upload
+        create_separate_work_for_each_file: Um eine separate Arbeit für jede Datei zu erstellen, gehen Sie zu
       form_child_work_relationships:
         actions:
           remove: Diese Arbeit entfernen

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -348,6 +348,9 @@ en:
     base:
       citations:
         header: 'Citations:'
+      form:
+        batch_upload: batch upload
+        create_separate_work_for_each_file: To create a separate work for each of the files, go to
       form_child_work_relationships:
         actions:
           remove: Remove from this work

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -348,6 +348,9 @@ es:
     base:
       citations:
         header: 'Citaciones:'
+      form:
+        batch_upload: carga por lotes
+        create_separate_work_for_each_file: Para crear un trabajo separado para cada uno de los archivos, vaya a
       form_child_work_relationships:
         actions:
           remove: Eliminar de este trabajo

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -348,6 +348,9 @@ fr:
     base:
       citations:
         header: 'Citations:'
+      form:
+        batch_upload: l'import par lot
+        create_separate_work_for_each_file: Pour créer un travail distinct par fichier, utilisez
       form_child_work_relationships:
         actions:
           remove: Supprimer de ce travail

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -348,6 +348,9 @@ it:
     base:
       citations:
         header: 'citazioni:'
+      form:
+        batch_upload: caricamento in gruppo
+        create_separate_work_for_each_file: Per creare un'opera separata per ciascuno dei file, vai a
       form_child_work_relationships:
         actions:
           remove: Rimuovi da questo lavoro

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -348,6 +348,9 @@ pt-BR:
     base:
       citations:
         header: 'Citações:'
+      form:
+        batch_upload: upload em lote
+        create_separate_work_for_each_file: Para criar um trabalho separado para cada um dos arquivos, vá para
       form_child_work_relationships:
         actions:
           remove: Remover desta obra

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -348,6 +348,9 @@ zh:
     base:
       citations:
         header: '引文:'
+      form:
+        batch_upload: 批量上传
+        create_separate_work_for_each_file: 要为每个文件创建单独的工作，请转到
       form_child_work_relationships:
         actions:
           remove: 从这个工作中删除


### PR DESCRIPTION
…o to...") was not translated.

It was impossible for us  to translate in french the sentence "To create a separate work for each of the files, go to batch upload" : it is written in plain english in an erb file, and Rails i18n mechanism is not called.
Translations other than french and english were automatically  generated through Google translate. They're probably not suitable.

@samvera/hyrax-code-reviewers
