### PR TITLE
Allow readonly works to be added to collections

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -133,7 +133,7 @@ module Hyrax
     private
 
       def user_collections
-        collections_service.search_results(:deposit) if presenter.editor?
+        collections_service.search_results(:deposit)
       end
 
       def collections_service

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -204,6 +204,13 @@ module Hyrax
       metadata
     end
 
+    # determine if the user can add this work to a collection
+    # @param collections <Collections> list of collections to which this user can deposit
+    # @return true if the user can deposit to at least one collection OR if the user can create a collection; otherwise, false
+    def show_deposit_for?(collections:)
+      collections.present? || current_ability.can?(:create_any, Collection)
+    end
+
     private
 
       # list of item ids to display is based on ordered_ids

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -20,11 +20,13 @@
               <% end %>
             </ul>
         </div>
-        <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
-        <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
-            class: 'btn btn-default submits-batches submits-batches-add',
-            data: { toggle: "modal", target: "#collection-list-container" } %>
       <% end %>
+  <% end %>
+  <% if presenter.show_deposit_for?(collections: @user_collections) %>
+      <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+      <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+                     class: 'btn btn-default submits-batches submits-batches-add',
+                     data: { toggle: "modal", target: "#collection-list-container" } %>
   <% end %>
   <% if presenter.work_featurable? %>
       <%= link_to "Feature", hyrax.featured_work_path(presenter, format: :json),

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -533,4 +533,40 @@ RSpec.describe Hyrax::WorkShowPresenter do
       end
     end
   end
+
+  describe "#show_deposit_for?" do
+    subject { presenter }
+
+    context "when user has depositable collections" do
+      let(:user_collections) { double }
+
+      it "returns true" do
+        expect(subject.show_deposit_for?(collections: user_collections)).to be true
+      end
+    end
+
+    context "when user does not have depositable collections" do
+      let(:user_collections) { nil }
+
+      context "and user can create a collection" do
+        before do
+          allow(ability).to receive(:can?).with(:create_any, Collection).and_return(true)
+        end
+
+        it "returns true" do
+          expect(subject.show_deposit_for?(collections: user_collections)).to be true
+        end
+      end
+
+      context "and user can NOT create a collection" do
+        before do
+          allow(ability).to receive(:can?).with(:create_any, Collection).and_return(false)
+        end
+
+        it "returns false" do
+          expect(subject.show_deposit_for?(collections: user_collections)).to be false
+        end
+      end
+    end
+  end
 end

--- a/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'hyrax/base/_show_actions.html.erb', type: :view do
 
   context "as an unregistered user" do
     before do
+      allow(presenter).to receive(:show_deposit_for?).with(anything).and_return(false)
       allow(presenter).to receive(:editor?).and_return(false)
       render 'hyrax/base/show_actions.html.erb', presenter: presenter
     end
@@ -25,6 +26,7 @@ RSpec.describe 'hyrax/base/_show_actions.html.erb', type: :view do
 
   context "as an editor" do
     before do
+      allow(presenter).to receive(:show_deposit_for?).with(anything).and_return(true)
       allow(presenter).to receive(:editor?).and_return(true)
     end
     context "when the work does not contain children" do
@@ -72,6 +74,75 @@ RSpec.describe 'hyrax/base/_show_actions.html.erb', type: :view do
       end
       it "creates a link to add child work" do
         expect(rendered).to have_link 'Attach Generic Work', href: "/concern/parent/#{presenter.id}/generic_works/new"
+      end
+    end
+  end
+
+  context "when user CAN deposit to at least one collection" do
+    before do
+      allow(presenter).to receive(:show_deposit_for?).with(anything).and_return(true)
+      allow(presenter).to receive(:member_presenters).and_return([])
+    end
+
+    context "and user is editor" do
+      before do
+        allow(presenter).to receive(:editor?).and_return(true)
+        render 'hyrax/base/show_actions.html.erb', presenter: presenter
+      end
+
+      it "shows editor related buttons" do
+        expect(rendered).not_to have_link 'File Manager'
+        expect(rendered).to have_link 'Edit'
+        expect(rendered).to have_link 'Delete'
+        expect(rendered).to have_button 'Add to collection'
+      end
+    end
+
+    context "and user is viewer" do
+      before do
+        allow(presenter).to receive(:editor?).and_return(false)
+        render 'hyrax/base/show_actions.html.erb', presenter: presenter
+      end
+      it "shows only Add to collection link" do
+        expect(rendered).not_to have_link 'File Manager'
+        expect(rendered).not_to have_link 'Edit'
+        expect(rendered).not_to have_link 'Delete'
+        expect(rendered).to have_button 'Add to collection'
+      end
+    end
+  end
+
+  context "when user can NOT deposit to any collections" do
+    before do
+      allow(presenter).to receive(:show_deposit_for?).with(anything).and_return(false)
+      allow(presenter).to receive(:member_presenters).and_return([])
+    end
+
+    context "and user is editor" do
+      before do
+        allow(presenter).to receive(:editor?).and_return(true)
+        render 'hyrax/base/show_actions.html.erb', presenter: presenter
+      end
+
+      it "shows editor related buttons" do
+        expect(rendered).not_to have_link 'File Manager'
+        expect(rendered).to have_link 'Edit'
+        expect(rendered).to have_link 'Delete'
+        expect(rendered).not_to have_button 'Add to collection'
+      end
+    end
+
+    context "and user is viewer" do
+      before do
+        allow(presenter).to receive(:editor?).and_return(false)
+        render 'hyrax/base/show_actions.html.erb', presenter: presenter
+      end
+
+      it "shows only Add to collection link" do
+        expect(rendered).not_to have_link 'File Manager'
+        expect(rendered).not_to have_link 'Edit'
+        expect(rendered).not_to have_link 'Delete'
+        expect(rendered).not_to have_button 'Add to collection'
       end
     end
   end


### PR DESCRIPTION
Fixes #3323

Allow logged in users to add read-only works to collections.  This supports the exhibit building use case as described in issue #3323.

## Backward Compatibility Analysis

### Public API
* 0 public methods changed
* 1 public method added to work_show_presenter

### UI Behavior
impacts work show page only
* behavior for editors of the work is unchanged
* behavior for viewers of the work - now will show the Add to Collection button if the user can deposit to at least one collection or can create a collection

## Guidance for testing, such as acceptance criteria or new user interface behaviors:
* As editor of the work, see Add to Collection button.
* As a logged in viewer of the work, see Add to Collection button IFF the viewer can deposit in at least one collection OR can create a new collection
* As a non-logged in user viewing the work, do NOT see the Add to Collection button

@samvera/hyrax-code-reviewers
