### PR TITLE
[WIP] Fix Universal Viewer embed code

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -127,7 +127,10 @@ module Hyrax
 
     def manifest
       headers['Access-Control-Allow-Origin'] = '*'
-      render json: manifest_builder.to_h
+      respond_to do |wants|
+        wants.json { render json: manifest_builder.to_h }
+        wants.html { render json: manifest_builder.to_h }
+      end
     end
 
     private

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -2,7 +2,7 @@
   <% if defined?(viewer) && viewer %>
     <%= PulUvRails::UniversalViewer.script_tag %>
     <div class="viewer-wrapper">
-      <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter], { locale: nil } %>"></div>
+      <div class="uv viewer" data-uri="<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>"></div>
     </div>
   <% else %>
     <%= media_display presenter.representative_presenter %>

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -609,8 +609,13 @@ RSpec.describe Hyrax::GenericWorksController do
         .and_return(manifest_factory)
     end
 
-    it "produces a manifest" do
+    it "produces a manifest for a json request" do
       get :manifest, params: { id: work, format: :json }
+      expect(response.body).to eq "{\"test\":\"manifest\"}"
+    end
+
+    it "produces a manifest for a html request" do
+      get :manifest, params: { id: work, format: :html }
       expect(response.body).to eq "{\"test\":\"manifest\"}"
     end
   end

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "display a work as its owner" do
       end
 
       # IIIF manifest does not include locale query param
-      expect(find('div.viewer:first')['data-uri']).to eq "/concern/generic_works/#{work.id}/manifest"
+      expect(find('div.viewer:first')['data-uri']).to eq "http://www.example.com/concern/generic_works/#{work.id}/manifest"
     end
 
     it "add work to a collection", clean_repo: true, js: true do


### PR DESCRIPTION
UV data-uri needs full URI otherwise the embed code won't work on other sites

Also, external sites will make a standard get request to the manifest, so we need to return the json manifest for both a json and html request
