### PR TITLE
Use polymorphic_url instead of _path for UV data-uri

### DIFF
--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -2,7 +2,7 @@
   <% if defined?(viewer) && viewer %>
     <%= PulUvRails::UniversalViewer.script_tag %>
     <div class="viewer-wrapper">
-      <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter], { locale: nil } %>"></div>
+      <div class="uv viewer" data-uri="<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>"></div>
     </div>
   <% else %>
     <%= media_display presenter.representative_presenter %>

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "display a work as its owner" do
       end
 
       # IIIF manifest does not include locale query param
-      expect(find('div.viewer:first')['data-uri']).to eq "/concern/generic_works/#{work.id}/manifest"
+      expect(find('div.viewer:first')['data-uri']).to eq "http://www.example.com/concern/generic_works/#{work.id}/manifest"
     end
 
     it "add work to a collection", clean_repo: true, js: true do


### PR DESCRIPTION
UV data-uri needs full URI otherwise the embed code won't work on other sites

replaces #3341 (problems with travis build)