### PR TITLE
[DO NOT MERGE] [WIP] Resolves issues with a proposed browse-everything 1.0.0 release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ else
   end
 end
 # END ENGINE_CART BLOCK
+gem 'browse-everything', github: 'jrgriffiniii/browse-everything', branch: '1.0.0'
 # rubocop:enable Bundler/DuplicatedGem
 
 eval_gemfile File.expand_path('spec/test_app_templates/Gemfile.extra', File.dirname(__FILE__)) unless File.exist?(file)

--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -64,7 +64,8 @@ module Hyrax
         # Generic utility for creating FileSet from a URL
         # Used in to import files using URLs from a file picker like browse_everything
         def create_file_from_url(env, uri, file_name, auth_header = {})
-          ::FileSet.new(import_url: uri.to_s, label: file_name) do |fs|
+          import_url = URI.decode_www_form_component(uri.to_s)
+          ::FileSet.new(import_url: import_url, label: file_name) do |fs|
             actor = Hyrax::Actors::FileSetActor.new(fs, env.user)
             actor.create_metadata(visibility: env.curation_concern.visibility)
             actor.attach_to_work(env.curation_concern)

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -1,3 +1,4 @@
+# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hyrax/version'
@@ -38,7 +39,6 @@ SUMMARY
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
   # Pin browse-everything to stable version
-  spec.add_dependency 'browse-everything', '< 0.16'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'dry-equalizer', '~> 0.2'

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -4,3 +4,5 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
 end
+
+gem 'browse-everything', github: 'jrgriffiniii/browse-everything', branch: '1.0.0'


### PR DESCRIPTION
After testing with a pull request for releasing 1.0.0 of browse-everything (https://github.com/samvera/browse-everything/pull/243), the following bugs are addressed:

* Handling HTTP GET parameter encoding issues (e. g. X-Amz-Credential) in CreateWithRemoteFilesActor#create_file_from_url
* Replacing HTTParty with Typhoeus in ImportUrlJob

**Once this has been updated upstream, this PR will be rebased to use the 1.0.0 release from RubyGems**

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Users should be able to use browse-everything release 1.0.0 to upload files from cloud storage providers from Dropbox, Google Drive, and Amazon S3
