### PR TITLE
Make stalebot comment explicit about days of inactivity

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,7 +11,7 @@ staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
+  activity for 30 days. It will be closed if no further activity occurs within 14 days. Thank you
   for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
The stalebot comment currently says it will be closed if there isn't any more activity but doesn't say how long it will wait.  This change makes it explicit so one can know how long until it closes the PR (14 days).  This PR also makes it explicit how long it took for the PR to become stale (30 days).  A downside to this explicitness is that if we ever decide to change those time lengths then we'd have to update this message at the same time.

@samvera/hyrax-code-reviewers
