### PR TITLE
Use `i18n` keys for hard coded string values in Collection Type

### DIFF
--- a/app/views/hyrax/admin/collection_types/_form_settings.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_settings.html.erb
@@ -29,7 +29,7 @@
             APPLY TO NEW WORKS
           </label>
         </div>
-        <p class="help-block">When new works are created directly in the collection, grant sharing users and groups permissions for the new work according to their collection roles.</p>
+        <p class="help-block">t('simple_form.hints.collection_type.share_applies_to_new_works')</p>
       </div>
     </div>
     <p><%= f.input :allow_multiple_membership, as: :boolean, disabled: f.object.all_settings_disabled? %></p>

--- a/app/views/hyrax/admin/collection_types/index.html.erb
+++ b/app/views/hyrax/admin/collection_types/index.html.erb
@@ -21,7 +21,7 @@
         <%= t('.more_toggle_content_html') %>
       </div>
 
-      <h2>Current Collection Types</h2>
+      <h2>t('.header')</h2>
       <table class="table collection-types-table">
          <thead>
            <tr>


### PR DESCRIPTION
These hard coded string values already have corresponding `i18n` keys. Using them improves internationalization of the UI.

@samvera/hyrax-code-reviewers
