### PR TITLE
IIIF viewer choice

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -11,6 +11,7 @@ module Hyrax
     include Hyrax::CollectionsHelper
     include Hyrax::ChartsHelper
     include Hyrax::DashboardHelperBehavior
+    include Hyrax::IiifHelper
 
     # Which translations are available for the user to select
     # @return [Hash<String,String>] locale abbreviations as keys and flags as values

--- a/app/helpers/hyrax/iiif_helper.rb
+++ b/app/helpers/hyrax/iiif_helper.rb
@@ -1,0 +1,12 @@
+module Hyrax
+  module IiifHelper
+    def iiif_viewer_display(work_presenter, locals = {})
+      render iiif_viewer_display_partial(work_presenter),
+             locals.merge(presenter: work_presenter)
+    end
+
+    def iiif_viewer_display_partial(work_presenter)
+      'hyrax/base/iiif_viewers/' + work_presenter.iiif_viewer.to_s
+    end
+  end
+end

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -64,6 +64,12 @@ module Hyrax
         members_include_viewable_image?
     end
 
+    # Override this method to declare a different iiif viewer for your work type
+    # @return [Symbol] the name of the IIIF viewer partial to render
+    def iiif_viewer
+      :universal_viewer
+    end
+
     # @return FileSetPresenter presenter for the representative FileSets
     def representative_presenter
       return nil if representative_id.blank?

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -67,8 +67,19 @@ module Hyrax
     alias universal_viewer? iiif_viewer?
     deprecation_deprecate universal_viewer?: "use iiif_viewer? instead"
 
-    # Override this method to declare a different iiif viewer for your work type
     # @return [Symbol] the name of the IIIF viewer partial to render
+    # @example A work presenter with a custom iiif viewer
+    #   module Hyrax
+    #     class GenericWorkPresenter < Hyrax::WorkShowPresenter
+    #       def iiif_viewer
+    #         :my_iiif_viewer
+    #       end
+    #     end
+    #   end
+    #
+    #   Custom iiif viewer partial at app/views/hyrax/base/iiif_viewers/_my_iiif_viewer.html.erb
+    #   <h3>My IIIF Viewer!</h3>
+    #   <a href=<%= main_app.polymorphic_url([main_app, :manifest, presenter], { locale: nil }) %>>Manifest</a>
     def iiif_viewer
       :universal_viewer
     end

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -55,14 +55,17 @@ module Hyrax
       Hyrax::Engine.routes.url_helpers.download_url(representative_presenter, host: request.host)
     end
 
-    # @return [Boolean] render the UniversalViewer
-    def universal_viewer?
+    # @return [Boolean] render a IIIF viewer
+    def iiif_viewer?
       representative_id.present? &&
         representative_presenter.present? &&
         representative_presenter.image? &&
         Hyrax.config.iiif_image_server? &&
         members_include_viewable_image?
     end
+
+    alias universal_viewer? iiif_viewer?
+    deprecation_deprecate universal_viewer?: "use iiif_viewer? instead"
 
     # Override this method to declare a different iiif viewer for your work type
     # @return [Symbol] the name of the IIIF viewer partial to render

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,9 +1,6 @@
 <% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
   <% if defined?(viewer) && viewer %>
-    <%= PulUvRails::UniversalViewer.script_tag %>
-    <div class="viewer-wrapper">
-      <div class="uv viewer" data-uri="<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>"></div>
-    </div>
+    <%= iiif_viewer_display presenter %>
   <% else %>
     <%= media_display presenter.representative_presenter %>
   <% end %>

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -1,0 +1,4 @@
+<%= PulUvRails::UniversalViewer.script_tag %>
+<div class="viewer-wrapper">
+  <div class="uv viewer" data-uri="<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>"></div>
+</div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -15,13 +15,13 @@
       <div class="panel-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <% if @presenter.universal_viewer? %>
+          <% if @presenter.iiif_viewer? %>
             <div class="col-sm-12">
               <%= render 'representative_media', presenter: @presenter, viewer: true %>
             </div>
           <% end %>
           <div class="col-sm-3 text-center">
-            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
+            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
             <%= render 'citations', presenter: @presenter %>
             <%= render 'social_media' %>
           </div>

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -121,7 +121,7 @@ Hyrax.config do |config|
   # config.show_work_item_rows = 10
 
   # Enable IIIF image service. This is required to use the
-  # UniversalViewer-ified show page
+  # IIIF viewer enabled show page
   #
   # If you have run the riiif generator, an embedded riiif service
   # will be used to deliver images via IIIF. If you have not, you will

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -367,7 +367,7 @@ module Hyrax
     end
 
     # Enable IIIF image service. This is required to use the
-    # UniversalViewer-enabled show page
+    # IIIF viewer enabled show page
     #
     # If you have run the hyrax:riiif generator, an embedded riiif service
     # will be used to deliver images via IIIF. If you have not, you will

--- a/spec/helpers/hyrax/iiif_helper_spec.rb
+++ b/spec/helpers/hyrax/iiif_helper_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe Hyrax::IiifHelper, type: :helper do
+  let(:solr_document) { SolrDocument.new }
+  let(:request) { double }
+  let(:ability) { nil }
+  let(:presenter) { Hyrax::WorkShowPresenter.new(solr_document, ability, request) }
+  let(:uv_partial_path) { 'hyrax/base/iiif_viewers/universal_viewer' }
+
+  describe '#iiif_viewer_display' do
+    before do
+      allow(helper).to receive(:iiif_viewer_display_partial).with(presenter)
+                                                            .and_return(uv_partial_path)
+    end
+
+    it "renders a partial" do
+      expect(helper).to receive(:render)
+        .with(uv_partial_path, presenter: presenter)
+      helper.iiif_viewer_display(presenter)
+    end
+
+    it "takes options" do
+      expect(helper).to receive(:render)
+        .with(uv_partial_path, presenter: presenter, transcript_id: '123')
+      helper.iiif_viewer_display(presenter, transcript_id: '123')
+    end
+  end
+
+  describe '#iiif_viewer_display_partial' do
+    subject { helper.iiif_viewer_display_partial(presenter) }
+
+    it 'defaults to universal viewer' do
+      expect(subject).to eq uv_partial_path
+    end
+
+    context "with #iiif_viewer override" do
+      let(:iiif_viewer) { :mirador }
+
+      before do
+        allow(presenter).to receive(:iiif_viewer).and_return(iiif_viewer)
+      end
+
+      it { is_expected.to eq 'hyrax/base/iiif_viewers/mirador' }
+    end
+  end
+end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -569,4 +569,12 @@ RSpec.describe Hyrax::WorkShowPresenter do
       end
     end
   end
+
+  describe '#iiif_viewer' do
+    subject { presenter.iiif_viewer }
+
+    it 'defaults to universal viewer' do
+      expect(subject).to be :universal_viewer
+    end
+  end
 end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
     it { is_expected.to eq 'http://example.org/concern/generic_works/888888/manifest' }
   end
 
-  describe '#universal_viewer?' do
+  describe '#iiif_viewer?' do
     let(:id_present) { false }
     let(:representative_presenter) { double('representative', present?: false) }
     let(:image_boolean) { false }
@@ -64,7 +64,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
       allow(Hyrax.config).to receive(:iiif_image_server?).and_return(iiif_enabled)
     end
 
-    subject { presenter.universal_viewer? }
+    subject { presenter.iiif_viewer? }
 
     context 'with no representative_id' do
       it { is_expected.to be false }

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
     expect(page).to have_content 'Foobar'
   end
 
-  describe 'UniversalViewer integration' do
+  describe 'IIIF viewer integration' do
     before do
-      allow(presenter).to receive(:universal_viewer?).and_return(viewer_enabled)
+      allow(presenter).to receive(:iiif_viewer?).and_return(viewer_enabled)
       render template: 'hyrax/base/show.html.erb'
     end
 


### PR DESCRIPTION
Pulls in work from https://github.com/samvera-labs/hyrax-iiif_av to generalize the IIIF viewer support to any IIIF viewer and not assuming Universal Viewer.  In the future other viewers could be added to core Hyrax but this PR at least allows a downstream app the ability to customize the IIIF view partial without overriding.  This is helpful for more experimental viewers like the Avalon react player for IIIF Presentation 3.0 AV manifests.  Possible documentation for how to use a custom IIIF viewer is below.

This PR has some view partial changes so I'd hope that it would be considered for Hyrax 3.0.

@samvera/hyrax-code-reviewers


# Adding a custom IIIF viewer

Create a new file in your Hyrax app at `app/views/hyrax/base/iiif_viewers/_my_iiif_viewer.html.erb`:
```
<h3>My IIIF Viewer!</h3>
<a href=<%= main_app.polymorphic_path([main_app, :manifest, presenter], { locale: nil }) %>>Manifest</a>
```

Override `#iiif_viewer` in your work presenter `app/presenters/hyrax/generic_work_presenter.rb`:
```
def iiif_viewer
  :my_iiif_viewer
end
```

