### PR TITLE
Remove conditional from user partial in favor of `User#display_name`

### DIFF
--- a/app/views/hyrax/users/_user.html.erb
+++ b/app/views/hyrax/users/_user.html.erb
@@ -2,10 +2,7 @@
   <div class="panel-heading">
     <%= image_tag user.avatar.url(:thumb), width: 100 if user.avatar.present? %>
     <h3>
-      <% if user.name != user.user_key %>
-        <%= user.name %><br />
-      <% end %>
-      <%= user.user_key %>
+      <%= user.name %>
     </h3>
   </div>
 


### PR DESCRIPTION
`User#name` already handles this logic in a cleanly overridable way. It's also a
bit nicer since it avoids repeated access and comparison on `#name` and `#user_key`.

The goal is: display a nice displayable name when its available; display the
`#user_key` as a fall back.

This should behave as a straight refactor except when `#display_name` is customized. The assumption is that in this case, using `#display_name` is desirable.

@samvera/hyrax-code-reviewers
