### PR TITLE
Make Admin Set Participants tab layout match Collections Sharing tab …

### DIFF
--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -401,22 +401,8 @@ button.branding-banner-remove:hover {
   .section-add-sharing {
     padding-bottom: 40px;
 
-    .form-inline {
-      label {
-        padding-right: 5px;
-        text-align: right;
-        width: 100px;
-      }
-
-      input,
-      select,
-      .select2-container {
-        width: 200px;
-      }
-
-      .btn {
-        width: 75px;
-      }
+    .sharing-row-form {
+      margin-bottom: $padding-large-vertical;
     }
   }
 

--- a/app/assets/stylesheets/hyrax/_file-listing.scss
+++ b/app/assets/stylesheets/hyrax/_file-listing.scss
@@ -97,8 +97,7 @@ h4 .small {
   text-decoration: none;
 }
 
-input.batch_document_selector,
-input.disabled {
+input.batch_document_selector {
   margin: 10px 10px 2px 10px;
   padding: 0px;
 }

--- a/app/views/hyrax/admin/admin_sets/_form_participant_table.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_participant_table.html.erb
@@ -16,9 +16,9 @@
                           <td><%= g.agent_type.titleize %></td>
                           <td>
                             <% if g.admin_group? && g.access == Hyrax::PermissionTemplateAccess::MANAGE %>
-                              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
+                              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
                             <% else %>
-                              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-danger' %>
+                              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger' %>
                             <% end %>
                           </td>
                         </tr>

--- a/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
@@ -1,68 +1,73 @@
           <div id="participants" class="tab-pane">
-            <div class="panel panel-default labels">
+            <div class="panel panel-default labels edit-sharing-tab">
               <div class="panel-body">
-                <h2><%= t('.add_participants') %></h2>
-                <% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
-                <%= simple_form_for @form.permission_template,
-                                    url: [hyrax, :admin, @form, :permission_template],
-                                    html: { id: 'group-participants-form' } do |f| %>
-                  <div class="clearfix spacer">
-                  <%= f.fields_for 'access_grants_attributes',
-                                   f.object.access_grants.build(agent_type: 'group'),
-                                   index: 0 do |builder| %>
-                    <div class="form-inline">
-                      <label class="col-md-2 col-xs-4 control-label"><%= t('.add_group') %></label>
+                <section class="section-add-sharing clearfix">
+                  <h3><%= t('.add_participants') %></h3>
+                  <% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
+                  <div class="sharing-row-form">
+                    <%= simple_form_for @form.permission_template,
+                        url: [hyrax, :admin, @form, :permission_template],
+                        html: { id: 'group-participants-form', class: 'form-inline' } do |f| %>
 
-                      <div class="col-md-10 col-xs-8 form-group">
-                        <%= builder.hidden_field :agent_type %>
-                        <%= builder.text_field :agent_id,
-                                         placeholder: "Search for a group...",
-                                         class: 'form-control' %>
-                        as
-                        <%= builder.select :access,
-                                     access_options,
-                                     { prompt: "Select a role..." },
-                                     class: 'form-control' %>
-
-                                   <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
-                      </div>
-                    </div>
-                  <% end %>
-                  </div>
-                <% end %>
-
-                <%= simple_form_for @form.permission_template,
-                                    url: [hyrax, :admin, @form, :permission_template],
-                                    html: { id: 'user-participants-form' } do |f| %>
-                  <%= f.fields_for 'access_grants_attributes',
-                                   f.object.access_grants.build(agent_type: 'user'),
-                                   index: 0 do |builder| %>
-                    <div class="form-inline add-users">
-                      <label class="col-md-2 col-xs-4 control-label"><%= t('.add_user') %></label>
-
-                      <div class="col-md-10 col-xs-8 form-group">
-                        <%= builder.hidden_field :agent_type %>
-                        <%= builder.text_field :agent_id,
-                                         placeholder: "Search for a user..." %>
-                        as
-                        <%= builder.select :access,
-                                     access_options,
-                                     { prompt: "Select a role..." },
-                                     class: 'form-control' %>
-
+                        <%= f.fields_for 'access_grants_attributes',
+                            f.object.access_grants.build(agent_type: 'group'),
+                            index: 0 do |builder| %>
+                          <div class="form-group">
+                            <label><%= t('.add_group') %></label>
+                            <%= builder.hidden_field :agent_type %>
+                            <%= builder.text_field :agent_id,
+                                placeholder: "Search for a group...",
+                                class: 'form-control' %>
+                          </div>
+                          <div class="form-group">
+                            <label>as</label>
+                            <%= builder.select :access,
+                                access_options,
+                                { prompt: "Select a role..." },
+                                class: 'form-control' %>
+                          </div>
+                        <% end %>
                         <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
-                        <p class="help-block"><%= t('hyrax.admin.admin_sets.form.note') %></p>
-                      </div>
-                    </div>
-                  <% end %>
-                <% end %>
 
-                <fieldset class="admin-set-participants">
+                    <% end %>
+                  </div>
+
+                  <div class="sharing-row-form">
+                    <%= simple_form_for @form.permission_template,
+                        url: [hyrax, :admin, @form, :permission_template],
+                        html: { id: 'user-participants-form', class: 'form-inline add-users' } do |f| %>
+
+                      <%= f.fields_for 'access_grants_attributes',
+                                      f.object.access_grants.build(agent_type: 'user'),
+                                      index: 0 do |builder| %>
+                        <div class="form-group">
+                          <label><%= t('.add_user') %></label>
+                          <%= builder.hidden_field :agent_type %>
+                          <%= builder.text_field :agent_id,
+                                            placeholder: "Search for a user..." %>
+                        </div>
+                        <div class="form-group">
+                          <label>as</label>
+                          <%= builder.select :access,
+                                      access_options,
+                                      { prompt: "Select a role..." },
+                                      class: 'form-control' %>
+                        </div>
+                      <% end %>
+                      <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
+                    <% end %>
+                  </div>
+
+                  <p class="help-block"><%= t('hyrax.admin.admin_sets.form.note') %></p>
+                </section>
+
+                <fieldset class="admin-set-participants section-collection-sharing">
                   <legend><%= t(".current_participants") %></legend>
                   <%= render 'form_participant_table', access: 'managers', filter: :manage? %>
                   <%= render 'form_participant_table', access: 'depositors', filter: :deposit? %>
                   <%= render 'form_participant_table', access: 'viewers', filter: :view? %>
                 </fieldset>
-              </div>
+
+              </div><!-- /.panel-body -->
             </div>
           </div>

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -1,85 +1,83 @@
 <% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
 
 <div id="participants" class="tab-pane">
-  <div class="panel panel-default labels edit-sharing-tab">
-    <div class="panel-body">
+  <div class="edit-sharing-tab">
+    <section class="section-add-sharing">
+      <p><%= t('.note') %></p>
+      <h3><%= t('.add_sharing') %></h3>
 
-      <section class="section-add-sharing">
-        <p><%= t('.note') %></p>
-        <h3><%= t('.add_sharing') %></h3>
+      <!-- Add group form -->
+      <div class="form-add-sharing-wrapper" data-id="<%= @form.id %>">
+        <%= simple_form_for @form.permission_template,
+                            url: [hyrax, :dashboard, @form, :permission_template],
+                            html: { id: 'group-participants-form' } do |f| %>
 
-        <!-- Add group form -->
-        <div class="form-add-sharing-wrapper" data-id="<%= @form.id %>">
-          <%= simple_form_for @form.permission_template,
-                              url: [hyrax, :dashboard, @form, :permission_template],
-                              html: { id: 'group-participants-form' } do |f| %>
-            <div class="clearfix spacer">
-              <%= f.fields_for 'access_grants_attributes',
-                               f.object.access_grants.build(agent_type: 'group'),
-                               index: 0 do |builder| %>
+          <div class="form-inline add-sharing-form sharing-row-form">
+            <%= f.fields_for 'access_grants_attributes',
+                              f.object.access_grants.build(agent_type: 'group'),
+                              index: 0 do |builder| %>
 
-                <div class="form-inline add-sharing-form">
-                  <label class="col-md-2 col-xs-4 control-label"><%= t('.add_group') %>:</label>
-                  <div class="col-md-10 col-xs-8 form-group">
-                    <%= builder.hidden_field :agent_type %>
-                    <%= builder.text_field :agent_id,
-                                           placeholder: "Search for a group...",
-                                           class: 'form-control search-input' %>
-                    as
-                    <%= builder.select :access,
-                                       access_options,
-                                       { prompt: "Select a role..." },
-                                       class: 'form-control' %>
-
-                    <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button', :disabled => true %>
-                  </div>
-                </div>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-
-        <!-- Add user form -->
-        <div class="form-add-sharing-wrapper" data-id="<%= @form.id %>">
-          <%= simple_form_for @form.permission_template,
-                              url: [hyrax, :dashboard, @form, :permission_template],
-                              html: { id: 'user-participants-form' } do |f| %>
-            <div class="clearfix spacer">
-
-              <%= f.fields_for 'access_grants_attributes',
-                               f.object.access_grants.build(agent_type: 'user'),
-                               index: 0 do |builder| %>
-
-              <div class="form-inline add-users">
-                <label class="col-md-2 col-xs-4 control-label"><%= t('.add_user') %>:</label>
-                <div class="col-md-10 col-xs-8 form-group">
-                  <%= builder.hidden_field :agent_type %>
-                  <%= builder.text_field :agent_id,
-                                         placeholder: "Search for a user..." %>
-                  as
-                  <%= builder.select :access,
-                                     access_options,
-                                     { prompt: "Select a role..." },
-                                     class: 'form-control' %>
-
-                  <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button', :disabled => true %>
-                </div>
+              <div class="form-group">
+                <label><%= t('.add_group') %>:</label>
+                <%= builder.hidden_field :agent_type %>
+                <%= builder.text_field :agent_id,
+                                        placeholder: "Search for a group...",
+                                        class: 'form-control search-input' %>
               </div>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
+              <div class="form-group">
+                <label>as</label>
+                <%= builder.select :access,
+                                      access_options,
+                                      { prompt: "Select a role..." },
+                                      class: 'form-control' %>
+              </div>
+            <% end %>
+            <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button', :disabled => true %>
 
-        <p class="help-block"><%= t('hyrax.admin.admin_sets.form.note') %></p>
-      </section>
+          </div><!-- /.form-inline -->
+        <% end %>
+      </div>
 
-      <section class="section-collection-sharing">
-        <legend><%= t(".current_shared") %></legend>
-        <%= render 'form_share_table', access: 'managers', filter: :manage? %>
-        <%= render 'form_share_table', access: 'depositors', filter: :deposit? %>
-        <%= render 'form_share_table', access: 'viewers', filter: :view? %>
-      </section>
+      <!-- Add user form -->
+      <div class="form-add-sharing-wrapper" data-id="<%= @form.id %>">
+        <%= simple_form_for @form.permission_template,
+                            url: [hyrax, :dashboard, @form, :permission_template],
+                            html: { id: 'user-participants-form' } do |f| %>
 
-    </div>
+          <div class="form-inline sharing-row-form add-users">
+            <%= f.fields_for 'access_grants_attributes',
+                              f.object.access_grants.build(agent_type: 'user'),
+                              index: 0 do |builder| %>
+
+              <div class="form-group">
+                <label><%= t('.add_user') %>:</label>
+                <%= builder.hidden_field :agent_type %>
+                <%= builder.text_field :agent_id,
+                                        placeholder: "Search for a user..." %>
+              </div>
+              <div class="form-group">
+                <label>as</label>
+                <%= builder.select :access,
+                                    access_options,
+                                    { prompt: "Select a role..." },
+                                    class: 'form-control' %>
+              </div>
+            <% end %>
+
+            <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button', :disabled => true %>
+
+          </div> <!-- /.form-inline -->
+        <% end %>
+      </div>
+
+      <p class="help-block"><%= t('hyrax.admin.admin_sets.form.note') %></p>
+    </section>
+
+    <section class="section-collection-sharing">
+      <legend><%= t(".current_shared") %></legend>
+      <%= render 'form_share_table', access: 'managers', filter: :manage? %>
+      <%= render 'form_share_table', access: 'depositors', filter: :deposit? %>
+      <%= render 'form_share_table', access: 'viewers', filter: :view? %>
+    </section>
   </div>
 </div>


### PR DESCRIPTION
…layout.  Also update the add users and add group forms to use Bootstrap inline-forms with cleaner markup

Fixes #3365 

Cleans up the UI / layout of Admin Set Participants tab view, to match Collections Sharing tab view.   Also cleans up the Bootstrap `form-inline` markup to better follow Bootstrap convention.

#### After
![admin-set-participants-tab-updated](https://user-images.githubusercontent.com/3020266/48097005-52074e80-e1de-11e8-920b-2c80b22d055a.png)

#### Before
![admin-set-participants-tab](https://user-images.githubusercontent.com/3020266/48097061-72370d80-e1de-11e8-903c-d34ef07f4e3a.png)

@samvera/hyrax-code-reviewers
