### PR TITLE
Upgrade to capybara-maleficent 0.3

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -82,7 +82,7 @@ SUMMARY
 
   # temporary pin to 2.17 due to failures caused in 2.18.0
   spec.add_development_dependency "capybara", '~> 2.4', '< 2.18.0'
-  spec.add_development_dependency 'capybara-maleficent', '~> 0.3'
+  spec.add_development_dependency 'capybara-maleficent', '~> 0.3.0'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
   spec.add_development_dependency 'engine_cart', '~> 2.0'
   spec.add_development_dependency "equivalent-xml", '~> 0.5'

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -82,7 +82,7 @@ SUMMARY
 
   # temporary pin to 2.17 due to failures caused in 2.18.0
   spec.add_development_dependency "capybara", '~> 2.4', '< 2.18.0'
-  spec.add_development_dependency 'capybara-maleficent', '~> 0.2'
+  spec.add_development_dependency 'capybara-maleficent', '~> 0.3'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
   spec.add_development_dependency 'engine_cart', '~> 2.0'
   spec.add_development_dependency "equivalent-xml", '~> 0.5'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,7 +49,7 @@ unless ENV['SKIP_MALEFICENT']
   # Wrap Capybara matchers with sleep intervals to reduce fragility of specs.
   require 'capybara/maleficent/spindle'
 
-  Capybara::Maleficent.config do |c|
+  Capybara::Maleficent.configure do |c|
     # Quieting down maleficent's logging
     logger = Logger.new(STDOUT)
     logger.level = Logger::INFO


### PR DESCRIPTION
Capybara-maleficent 0.3 was released yesterday to include a change needed for #3314, but it included a change in its API which is breaking the build.  This PR completes the upgrade and bumps the dependency in the gemspec.

@samvera/hyrax-code-reviewers
