### PR TITLE
Generate riiif 2.0

### DIFF
--- a/lib/generators/hyrax/riiif_generator.rb
+++ b/lib/generators/hyrax/riiif_generator.rb
@@ -16,7 +16,7 @@ class Hyrax::RiiifGenerator < Rails::Generators::Base
   end
 
   def add_to_gemfile
-    gem 'riiif', '~> 1.1'
+    gem 'riiif', '~> 2.0'
 
     Bundler.with_clean_env do
       run "bundle install"


### PR DESCRIPTION
I don't believe this is backwards incompatible, because it doesn't force a version change, it only generates the 2.0 version when you run the generator and typically you only do that once.