### PR TITLE
Fixes #3243 - Added logic to collection name/link display in collection view page.

### DIFF
--- a/app/actors/hyrax/actors/create_with_files_ordered_members_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_ordered_members_actor.rb
@@ -1,5 +1,37 @@
 module Hyrax
   module Actors
+    # When adding member FileSets to a Work, Hyrax saves
+    #   and reloads the work for each new member FileSet.
+    #   This can significantly slow down ingest for Works
+    #   with many member FileSets. The saving and reloading
+    #   happens in FileSetActor#attach_to_work.
+    #
+    # This is a 'swappable' alternative approach. It will
+    #   be of most value to Hyrax applications dealing with
+    #   works with many filesets. Anecdotally, a work with
+    #   600 filesets can be processed in ~15 mins versus
+    #   > 3 hours with the standard approach.
+    #
+    # The tradeoff is that the ordered members are now added in a
+    #   single step after the creation of all the FileSets, thus
+    #   introducing a slight risk of orphan filesets if the upload
+    #   fails before the addition of the ordered members. This
+    #   has not been observed in practice.
+    #
+    # Swapping out the actors can be achieved thus:
+    #
+    # In `config/initializers/hyrax.rb`:
+    # ```
+    # Hyrax::CurationConcern.actor_factory.swap(Hyrax::Actors::CreateWithFilesActor,
+    #   Hyrax::Actors::CreateWithFilesOrderedMembersActor)
+    # ```
+    # Alternatively, in `config/application.rb`:
+    # ```
+    # config.to_prepare
+    #   Hyrax::CurationConcern.actor_factory.swap(Hyrax::Actors::CreateWithFilesActor,
+    #     Hyrax::Actors::CreateWithFilesOrderedMembersActor)
+    # end
+    # ```
     # Creates a work and attaches files to the work
     class CreateWithFilesOrderedMembersActor < CreateWithFilesActor
       # @return [TrueClass]

--- a/app/actors/hyrax/actors/create_with_remote_files_ordered_members_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_ordered_members_actor.rb
@@ -1,5 +1,38 @@
 module Hyrax
   module Actors
+    # When adding member FileSets to a Work, Hyrax saves
+    #   and reloads the work for each new member FileSet.
+    #   This can significantly slow down ingest for Works
+    #   with many member FileSets. The saving and reloading
+    #   happens in FileSetActor#attach_to_work.
+    #
+    # This is a 'swappable' alternative approach. It will
+    #   be of most value to Hyrax applications dealing with
+    #   works with many filesets. Anecdotally, a 600 fileset
+    #   can be processed in ~15 mins versus >3 hours
+    #   with the standard approach.
+    #
+    # The tradeoff is that the ordered members are now added in a
+    #   single step after the creation of all the FileSets, thus
+    #   introducing a slight risk of orphan filesets if the upload
+    #   fails before the addition of the ordered members. This
+    #   has not been observed in practice.
+    #
+    # Swapping out the actors can be achieved thus:
+    #
+    # In `config/initializers/hyrax.rb`:
+    # ```
+    # Hyrax::CurationConcern.actor_factory.swap(Hyrax::Actors::CreateWithFilesActor,
+    #   Hyrax::Actors::CreateWithRemoteFilesOrderedMembersActor)
+    # ```
+    # Alternatively, in `config/application.rb`:
+    # ```
+    # config.to_prepare
+    #   Hyrax::CurationConcern.actor_factory.swap(Hyrax::Actors::CreateWithFilesActor,
+    #     Hyrax::Actors::CreateWithRemoteFilesOrderedMembersActor)
+    # end
+    # ```
+    #
     # If there is a key `:remote_files' in the attributes, it attaches the files at the specified URIs
     # to the work. e.g.:
     #     attributes[:remote_files] = filenames.map do |name|

--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -20,6 +20,19 @@ module Hyrax
       content_tag :span, safe_join([t('hyrax.collection.is_part_of'), ': '] + collection_links)
     end
 
+    def render_other_collection_links(solr_doc, collection_id)
+      collection_list = Hyrax::CollectionMemberService.run(solr_doc, controller.current_ability)
+      return if collection_list.empty?
+      links = collection_list.select { |collection| collection.id != collection_id }.map { |collection| link_to collection.title_or_label, hyrax.collection_path(collection.id) }
+      return if links.empty?
+      collection_links = []
+      links.each_with_index do |link, n|
+        collection_links << link
+        collection_links << ', ' unless links[n + 1].nil?
+      end
+      content_tag :span, safe_join([t('hyrax.collection.also_belongs_to'), ': '] + collection_links)
+    end
+
     ##
     # Append a collection_type_id to the existing querystring (whether or not it has pre-existing params)
     # @return [String] the original url with and added collection_type_id param

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -11,6 +11,7 @@ module Hyrax
     include Hyrax::CollectionsHelper
     include Hyrax::ChartsHelper
     include Hyrax::DashboardHelperBehavior
+    include Hyrax::IiifHelper
 
     # Which translations are available for the user to select
     # @return [Hash<String,String>] locale abbreviations as keys and flags as values

--- a/app/helpers/hyrax/iiif_helper.rb
+++ b/app/helpers/hyrax/iiif_helper.rb
@@ -1,0 +1,12 @@
+module Hyrax
+  module IiifHelper
+    def iiif_viewer_display(work_presenter, locals = {})
+      render iiif_viewer_display_partial(work_presenter),
+             locals.merge(presenter: work_presenter)
+    end
+
+    def iiif_viewer_display_partial(work_presenter)
+      'hyrax/base/iiif_viewers/' + work_presenter.iiif_viewer.to_s
+    end
+  end
+end

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -64,6 +64,12 @@ module Hyrax
         members_include_viewable_image?
     end
 
+    # Override this method to declare a different iiif viewer for your work type
+    # @return [Symbol] the name of the IIIF viewer partial to render
+    def iiif_viewer
+      :universal_viewer
+    end
+
     # @return FileSetPresenter presenter for the representative FileSets
     def representative_presenter
       return nil if representative_id.blank?

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -67,8 +67,19 @@ module Hyrax
     alias universal_viewer? iiif_viewer?
     deprecation_deprecate universal_viewer?: "use iiif_viewer? instead"
 
-    # Override this method to declare a different iiif viewer for your work type
     # @return [Symbol] the name of the IIIF viewer partial to render
+    # @example A work presenter with a custom iiif viewer
+    #   module Hyrax
+    #     class GenericWorkPresenter < Hyrax::WorkShowPresenter
+    #       def iiif_viewer
+    #         :my_iiif_viewer
+    #       end
+    #     end
+    #   end
+    #
+    #   Custom iiif viewer partial at app/views/hyrax/base/iiif_viewers/_my_iiif_viewer.html.erb
+    #   <h3>My IIIF Viewer!</h3>
+    #   <a href=<%= main_app.polymorphic_url([main_app, :manifest, presenter], { locale: nil }) %>>Manifest</a>
     def iiif_viewer
       :universal_viewer
     end

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -55,14 +55,17 @@ module Hyrax
       Hyrax::Engine.routes.url_helpers.download_url(representative_presenter, host: request.host)
     end
 
-    # @return [Boolean] render the UniversalViewer
-    def universal_viewer?
+    # @return [Boolean] render a IIIF viewer
+    def iiif_viewer?
       representative_id.present? &&
         representative_presenter.present? &&
         representative_presenter.image? &&
         Hyrax.config.iiif_image_server? &&
         members_include_viewable_image?
     end
+
+    alias universal_viewer? iiif_viewer?
+    deprecation_deprecate universal_viewer?: "use iiif_viewer? instead"
 
     # Override this method to declare a different iiif viewer for your work type
     # @return [Symbol] the name of the IIIF viewer partial to render

--- a/app/views/hyrax/admin/collection_types/_form_settings.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_settings.html.erb
@@ -29,7 +29,7 @@
             APPLY TO NEW WORKS
           </label>
         </div>
-        <p class="help-block">t('simple_form.hints.collection_type.share_applies_to_new_works')</p>
+        <p class="help-block">When new works are created directly in the collection, grant sharing users and groups permissions for the new work according to their collection roles.</p>
       </div>
     </div>
     <p><%= f.input :allow_multiple_membership, as: :boolean, disabled: f.object.all_settings_disabled? %></p>

--- a/app/views/hyrax/admin/collection_types/_form_settings.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form_settings.html.erb
@@ -29,7 +29,7 @@
             APPLY TO NEW WORKS
           </label>
         </div>
-        <p class="help-block">When new works are created directly in the collection, grant sharing users and groups permissions for the new work according to their collection roles.</p>
+        <p class="help-block"><%= t('simple_form.hints.collection_type.share_applies_to_new_works') %></p>
       </div>
     </div>
     <p><%= f.input :allow_multiple_membership, as: :boolean, disabled: f.object.all_settings_disabled? %></p>

--- a/app/views/hyrax/admin/collection_types/index.html.erb
+++ b/app/views/hyrax/admin/collection_types/index.html.erb
@@ -21,7 +21,7 @@
         <%= t('.more_toggle_content_html') %>
       </div>
 
-      <h2>Current Collection Types</h2>
+      <h2><%= t('.header') %></h2>
       <table class="table collection-types-table">
          <thead>
            <tr>

--- a/app/views/hyrax/admin/collection_types/index.html.erb
+++ b/app/views/hyrax/admin/collection_types/index.html.erb
@@ -21,7 +21,7 @@
         <%= t('.more_toggle_content_html') %>
       </div>
 
-      <h2>t('.header')</h2>
+      <h2>Current Collection Types</h2>
       <table class="table collection-types-table">
          <thead>
            <tr>

--- a/app/views/hyrax/base/_form_rendering.html.erb
+++ b/app/views/hyrax/base/_form_rendering.html.erb
@@ -4,11 +4,13 @@
       <legend>
         <%= t("hyrax.base.form_rendering.legend_html") %>
       </legend>
-      <p><%= t("hyrax.base.form_rendering.help_html") %></p>
-      <%= f.select :rendering_ids,
-                   f.object.select_files,
-                   { include_blank: true },
-                   { class: 'form-control', multiple: true } %>
+      <div class="form-group">
+        <span class="help-block"><%= t("hyrax.base.form_rendering.help_html") %></span>
+        <%= f.select :rendering_ids,
+                    f.object.select_files,
+                    { include_blank: true },
+                    { class: 'form-control', multiple: true } %>
+      </div>
     </fieldset>
   </div>
 </div>

--- a/app/views/hyrax/base/_form_representative.html.erb
+++ b/app/views/hyrax/base/_form_representative.html.erb
@@ -4,8 +4,10 @@
         <legend>
           <%= t("hyrax.base.form_representative.legend_html") %>
         </legend>
-        <p><%= t("hyrax.base.form_representative.help_html") %></p>
-        <%= f.select :representative_id, @form.select_files, {}, { class: 'form-control' } %>
+        <div class="form-group">
+          <span class="help-block"><%= t("hyrax.base.form_representative.help_html") %></span>
+          <%= f.select :representative_id, @form.select_files, {}, { class: 'form-control' } %>
+        </div>
       </fieldset>
     </div>
   </div>

--- a/app/views/hyrax/base/_form_thumbnail.html.erb
+++ b/app/views/hyrax/base/_form_thumbnail.html.erb
@@ -4,8 +4,10 @@
         <legend>
           <%= t("hyrax.base.form_thumbnail.legend_html") %>
         </legend>
-        <p><%= t("hyrax.base.form_thumbnail.help_html") %></p>
-        <%= f.select :thumbnail_id, @form.select_files, {}, { class: 'form-control' } %>
+        <div class="form-group">
+          <span class="help-block"><%= t("hyrax.base.form_thumbnail.help_html") %></span>
+          <%= f.select :thumbnail_id, @form.select_files, {}, { class: 'form-control' } %>
+        </div>
       </fieldset>
     </div>
   </div>

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,9 +1,6 @@
 <% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
   <% if defined?(viewer) && viewer %>
-    <%= PulUvRails::UniversalViewer.script_tag %>
-    <div class="viewer-wrapper">
-      <div class="uv viewer" data-uri="<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>"></div>
-    </div>
+    <%= iiif_viewer_display presenter %>
   <% else %>
     <%= media_display presenter.representative_presenter %>
   <% end %>

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -1,0 +1,4 @@
+<%= PulUvRails::UniversalViewer.script_tag %>
+<div class="viewer-wrapper">
+  <div class="uv viewer" data-uri="<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>"></div>
+</div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -15,13 +15,13 @@
       <div class="panel-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <% if @presenter.universal_viewer? %>
+          <% if @presenter.iiif_viewer? %>
             <div class="col-sm-12">
               <%= render 'representative_media', presenter: @presenter, viewer: true %>
             </div>
           <% end %>
           <div class="col-sm-3 text-center">
-            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
+            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
             <%= render 'citations', presenter: @presenter %>
             <%= render 'social_media' %>
           </div>

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -14,7 +14,7 @@
         <p class="media-heading">
           <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
         </p>
-        <%= render_collection_links(document) %>
+        <%= render_other_collection_links(document, @presenter.id) %>
       </div>
     </div>
   </td>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -15,7 +15,7 @@
           <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
           <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></i></a>
         </p>
-        <%= render_collection_links(document) %>
+        <%= render_other_collection_links(document, @presenter.id) %>
       </div>
     </div>
   </td>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -492,6 +492,7 @@ de:
         additional_fields: Zusätzliche Felder
         description: Beschreibungen
       is_part_of: Ist ein Teil von
+      also_belongs_to: Diese Arbeit gehört auch zu
       select_form:
         close: Schließen
         create: Sammlung erstellen

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -491,6 +491,7 @@ en:
         additional_fields: Additional fields
         description: Descriptions
       is_part_of: Is part of
+      also_belongs_to: This work also belongs to 
       select_form:
         close: Close
         create: Save

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -490,6 +490,7 @@ es:
         additional_fields: Campos adicionales
         description: Descripciones
       is_part_of: Es parte de
+      also_belongs_to: Este trabajo también pertenece a
       select_form:
         close: Cerrar
         create: Crear Colección

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -491,6 +491,7 @@ fr:
         additional_fields: Champs supplémentaires
         description: Descriptions
       is_part_of: Fait partie de
+      also_belongs_to: Ce travail appartient aussi à
       select_form:
         close: Fermer
         create: Créer une collection

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -490,6 +490,7 @@ it:
         additional_fields: Campi aggiuntivi
         description: descrizioni
       is_part_of: È parte di
+      also_belongs_to: Anche questo lavoro appartiene a
       select_form:
         close: Vicino
         create: Crea collezione

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -485,6 +485,7 @@ pt-BR:
         additional_fields: Campos adicionais
         description: Descrições
       is_part_of: É parte de
+      also_belongs_to: Este trabalho também pertence a
       select_form:
         close: Fechar
         create: Salvar

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -488,6 +488,7 @@ zh:
         additional_fields: 额外字段
         description: 描述
       is_part_of: 是一部分
+      also_belongs_to: 这项工作也属于
       select_form:
         close: 关闭
         create: 创建收藏集

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -121,7 +121,7 @@ Hyrax.config do |config|
   # config.show_work_item_rows = 10
 
   # Enable IIIF image service. This is required to use the
-  # UniversalViewer-ified show page
+  # IIIF viewer enabled show page
   #
   # If you have run the riiif generator, an embedded riiif service
   # will be used to deliver images via IIIF. If you have not, you will

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -367,7 +367,7 @@ module Hyrax
     end
 
     # Enable IIIF image service. This is required to use the
-    # UniversalViewer-enabled show page
+    # IIIF viewer enabled show page
     #
     # If you have run the hyrax:riiif generator, an embedded riiif service
     # will be used to deliver images via IIIF. If you have not, you will

--- a/spec/helpers/hyrax/iiif_helper_spec.rb
+++ b/spec/helpers/hyrax/iiif_helper_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe Hyrax::IiifHelper, type: :helper do
+  let(:solr_document) { SolrDocument.new }
+  let(:request) { double }
+  let(:ability) { nil }
+  let(:presenter) { Hyrax::WorkShowPresenter.new(solr_document, ability, request) }
+  let(:uv_partial_path) { 'hyrax/base/iiif_viewers/universal_viewer' }
+
+  describe '#iiif_viewer_display' do
+    before do
+      allow(helper).to receive(:iiif_viewer_display_partial).with(presenter)
+                                                            .and_return(uv_partial_path)
+    end
+
+    it "renders a partial" do
+      expect(helper).to receive(:render)
+        .with(uv_partial_path, presenter: presenter)
+      helper.iiif_viewer_display(presenter)
+    end
+
+    it "takes options" do
+      expect(helper).to receive(:render)
+        .with(uv_partial_path, presenter: presenter, transcript_id: '123')
+      helper.iiif_viewer_display(presenter, transcript_id: '123')
+    end
+  end
+
+  describe '#iiif_viewer_display_partial' do
+    subject { helper.iiif_viewer_display_partial(presenter) }
+
+    it 'defaults to universal viewer' do
+      expect(subject).to eq uv_partial_path
+    end
+
+    context "with #iiif_viewer override" do
+      let(:iiif_viewer) { :mirador }
+
+      before do
+        allow(presenter).to receive(:iiif_viewer).and_return(iiif_viewer)
+      end
+
+      it { is_expected.to eq 'hyrax/base/iiif_viewers/mirador' }
+    end
+  end
+end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -569,4 +569,12 @@ RSpec.describe Hyrax::WorkShowPresenter do
       end
     end
   end
+
+  describe '#iiif_viewer' do
+    subject { presenter.iiif_viewer }
+
+    it 'defaults to universal viewer' do
+      expect(subject).to be :universal_viewer
+    end
+  end
 end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
     it { is_expected.to eq 'http://example.org/concern/generic_works/888888/manifest' }
   end
 
-  describe '#universal_viewer?' do
+  describe '#iiif_viewer?' do
     let(:id_present) { false }
     let(:representative_presenter) { double('representative', present?: false) }
     let(:image_boolean) { false }
@@ -64,7 +64,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
       allow(Hyrax.config).to receive(:iiif_image_server?).and_return(iiif_enabled)
     end
 
-    subject { presenter.universal_viewer? }
+    subject { presenter.iiif_viewer? }
 
     context 'with no representative_id' do
       it { is_expected.to be false }

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
     expect(page).to have_content 'Foobar'
   end
 
-  describe 'UniversalViewer integration' do
+  describe 'IIIF viewer integration' do
     before do
-      allow(presenter).to receive(:universal_viewer?).and_return(viewer_enabled)
+      allow(presenter).to receive(:iiif_viewer?).and_return(viewer_enabled)
       render template: 'hyrax/base/show.html.erb'
     end
 

--- a/spec/views/hyrax/collections/_show_document_list_row.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_document_list_row.html.erb_spec.rb
@@ -15,15 +15,16 @@ RSpec.describe 'hyrax/collections/_show_document_list_row.html.erb', type: :view
   context 'when not logged in' do
     before do
       view.blacklight_config = Blacklight::Configuration.new
+      assign(:presenter, collection)
       allow(view).to receive(:current_user).and_return(nil)
       allow(work).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
       allow(work).to receive(:edit_people).and_return([])
-      allow(view).to receive(:render_collection_links).and_return("collections: #{collection.title}")
+      allow(view).to receive(:render_other_collection_links).and_return([])
     end
 
     it "renders collections links" do
       render('hyrax/collections/show_document_list_row.html.erb', document: work)
-      expect(rendered).to have_content 'My awesome collection'
+      expect(rendered).not_to have_content 'My awesome collection'
     end
 
     it "renders works" do

--- a/spec/views/hyrax/dashboard/collections/_show_document_list_row.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_document_list_row.html.erb_spec.rb
@@ -15,15 +15,16 @@ RSpec.describe 'hyrax/dashboard/collections/_show_document_list_row.html.erb', t
   context 'when not logged in' do
     before do
       view.blacklight_config = Blacklight::Configuration.new
+      assign(:presenter, collection)
       allow(view).to receive(:current_user).and_return(nil)
       allow(work).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
       allow(work).to receive(:edit_people).and_return([])
-      allow(view).to receive(:render_collection_links).and_return("collections: #{collection.title}")
+      allow(view).to receive(:render_other_collection_links).and_return([])
     end
 
     it "renders collections links" do
       render('show_document_list_row', document: work)
-      expect(rendered).to have_content 'My awesome collection'
+      expect(rendered).not_to have_content 'My awesome collection'
     end
 
     it "renders works" do


### PR DESCRIPTION
Fixes #3243 ; refs #3243

Based on the comments from https://github.com/samvera/hyrax/issues/3243#issuecomment-429105965,  The following logic is added:
If the work only belongs to the collection you are currently viewing - don't show the collection name/link after the work.
If the work belongs to more than one collection - show the other collection name/link but not the collection currently viewing after the work.

Here is the screenshots after changes:
Only belongs to the collection you are currently viewing:
![screen shot 2018-11-05 at 2 41 11 pm](https://user-images.githubusercontent.com/2432753/48278570-c4587880-e402-11e8-8051-5041c2be906d.png)

Belongs to more than one collection:
![screen shot 2018-11-05 at 2 40 35 pm](https://user-images.githubusercontent.com/2432753/48278632-f10c9000-e402-11e8-9761-6fffc6fb7c77.png)


@samvera/hyrax-code-reviewers
