### PR TITLE
Fixes #3243 - Added logic to collection name/link display in collection view page.

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -20,6 +20,19 @@ module Hyrax
       content_tag :span, safe_join([t('hyrax.collection.is_part_of'), ': '] + collection_links)
     end
 
+    def render_other_collection_links(solr_doc, collection_id)
+      collection_list = Hyrax::CollectionMemberService.run(solr_doc, controller.current_ability)
+      return if collection_list.empty?
+      links = collection_list.select { |collection| collection.id != collection_id }.map { |collection| link_to collection.title_or_label, hyrax.collection_path(collection.id) }
+      return if links.empty?
+      collection_links = []
+      links.each_with_index do |link, n|
+        collection_links << link
+        collection_links << ', ' unless links[n + 1].nil?
+      end
+      content_tag :span, safe_join([t('hyrax.collection.also_belongs_to'), ': '] + collection_links)
+    end
+
     ##
     # Append a collection_type_id to the existing querystring (whether or not it has pre-existing params)
     # @return [String] the original url with and added collection_type_id param

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -14,7 +14,7 @@
         <p class="media-heading">
           <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
         </p>
-        <%= render_collection_links(document) %>
+        <%= render_other_collection_links(document, @presenter.id) %>
       </div>
     </div>
   </td>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -15,7 +15,7 @@
           <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
           <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></i></a>
         </p>
-        <%= render_collection_links(document) %>
+        <%= render_other_collection_links(document, @presenter.id) %>
       </div>
     </div>
   </td>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -492,6 +492,7 @@ de:
         additional_fields: Zusätzliche Felder
         description: Beschreibungen
       is_part_of: Ist ein Teil von
+      also_belongs_to: Diese Arbeit gehört auch zu
       select_form:
         close: Schließen
         create: Sammlung erstellen

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -491,6 +491,7 @@ en:
         additional_fields: Additional fields
         description: Descriptions
       is_part_of: Is part of
+      also_belongs_to: This work also belongs to 
       select_form:
         close: Close
         create: Save

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -490,6 +490,7 @@ es:
         additional_fields: Campos adicionales
         description: Descripciones
       is_part_of: Es parte de
+      also_belongs_to: Este trabajo también pertenece a
       select_form:
         close: Cerrar
         create: Crear Colección

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -491,6 +491,7 @@ fr:
         additional_fields: Champs supplémentaires
         description: Descriptions
       is_part_of: Fait partie de
+      also_belongs_to: Ce travail appartient aussi à
       select_form:
         close: Fermer
         create: Créer une collection

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -490,6 +490,7 @@ it:
         additional_fields: Campi aggiuntivi
         description: descrizioni
       is_part_of: È parte di
+      also_belongs_to: Anche questo lavoro appartiene a
       select_form:
         close: Vicino
         create: Crea collezione

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -485,6 +485,7 @@ pt-BR:
         additional_fields: Campos adicionais
         description: Descrições
       is_part_of: É parte de
+      also_belongs_to: Este trabalho também pertence a
       select_form:
         close: Fechar
         create: Salvar

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -488,6 +488,7 @@ zh:
         additional_fields: 额外字段
         description: 描述
       is_part_of: 是一部分
+      also_belongs_to: 这项工作也属于
       select_form:
         close: 关闭
         create: 创建收藏集

--- a/spec/views/hyrax/collections/_show_document_list_row.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_document_list_row.html.erb_spec.rb
@@ -15,15 +15,16 @@ RSpec.describe 'hyrax/collections/_show_document_list_row.html.erb', type: :view
   context 'when not logged in' do
     before do
       view.blacklight_config = Blacklight::Configuration.new
+      assign(:presenter, collection)
       allow(view).to receive(:current_user).and_return(nil)
       allow(work).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
       allow(work).to receive(:edit_people).and_return([])
-      allow(view).to receive(:render_collection_links).and_return("collections: #{collection.title}")
+      allow(view).to receive(:render_other_collection_links).and_return([])
     end
 
     it "renders collections links" do
       render('hyrax/collections/show_document_list_row.html.erb', document: work)
-      expect(rendered).to have_content 'My awesome collection'
+      expect(rendered).not_to have_content 'My awesome collection'
     end
 
     it "renders works" do

--- a/spec/views/hyrax/dashboard/collections/_show_document_list_row.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_document_list_row.html.erb_spec.rb
@@ -15,15 +15,16 @@ RSpec.describe 'hyrax/dashboard/collections/_show_document_list_row.html.erb', t
   context 'when not logged in' do
     before do
       view.blacklight_config = Blacklight::Configuration.new
+      assign(:presenter, collection)
       allow(view).to receive(:current_user).and_return(nil)
       allow(work).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
       allow(work).to receive(:edit_people).and_return([])
-      allow(view).to receive(:render_collection_links).and_return("collections: #{collection.title}")
+      allow(view).to receive(:render_other_collection_links).and_return([])
     end
 
     it "renders collections links" do
       render('show_document_list_row', document: work)
-      expect(rendered).to have_content 'My awesome collection'
+      expect(rendered).not_to have_content 'My awesome collection'
     end
 
     it "renders works" do


### PR DESCRIPTION
Fixes #3243 ; refs #3243

Based on the comments from https://github.com/samvera/hyrax/issues/3243#issuecomment-429105965,  The following logic is added:

If the work only belongs to the collection you are currently viewing - don't show the collection name/link after the work.
If the work belongs to more than one collection - show the other collection name/link but not the collection currently viewing after the work.

Here is the screenshots after changes:
Only belongs to the collection you are currently viewing:
![screen shot 2018-11-05 at 2 41 11 pm](https://user-images.githubusercontent.com/2432753/48278570-c4587880-e402-11e8-8051-5041c2be906d.png)

Belongs to more than one collection:
![screen shot 2018-11-05 at 2 40 35 pm](https://user-images.githubusercontent.com/2432753/48278632-f10c9000-e402-11e8-9761-6fffc6fb7c77.png)


@samvera/hyrax-code-reviewers
