### PR TITLE
Sanitize output from iiif_manifest gem

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -218,7 +218,7 @@ module Hyrax
       Hyrax.config.iiif_metadata_fields.each do |field|
         metadata << {
           'label' => I18n.t("simple_form.labels.defaults.#{field}"),
-          'value' => Array.wrap(send(field))
+          'value' => Array.wrap(send(field).map { |f| Loofah.fragment(f.to_s).scrub!(:whitewash).to_s })
         }
       end
       metadata

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -618,5 +618,14 @@ RSpec.describe Hyrax::GenericWorksController do
       get :manifest, params: { id: work, format: :html }
       expect(response.body).to eq "{\"test\":\"manifest\"}"
     end
+
+    describe "when there are html tags in the labels or description" do
+      let(:manifest_factory) { double(to_h: { label: "The title<img src=xx:x onerror=eval('\x61ler\x74(1)') />", description: ["Some description <script>something</script> here..."] }) }
+
+      it "sanitizes the labels and description" do
+        get :manifest, params: { id: work, format: :json }
+        expect(response.body).to include "{\"label\":\"The title\\u003cimg\\u003e\",\"description\":[\"Some description  here...\"]}"
+      end
+    end
   end
 end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -531,6 +531,16 @@ RSpec.describe Hyrax::WorkShowPresenter do
         expect(subject[0]['label']).to eq('Title')
         expect(subject[0]['value']).to include('Test title', 'Another test title')
       end
+
+      context "when there are html tags in the metadata" do
+        before do
+          work.title = ["The title<img src=xx:x onerror=eval('\x61ler\x74(1)') />", 'Another test title']
+        end
+
+        it "sanitizes the metadata values" do
+          expect(subject[0]['value']).to include('The title<img>', 'Another test title')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
refs #3187 
refs #3232 

Per @no-reply - sanitize the output from the `iiif_manifest` gem before presenting the manifest to address vulnerability no. 4 in #3187 

@samvera/hyrax-code-reviewers
