### PR TITLE
Remove `Solrizer::Common` from `WorkBehavior`

### DIFF
--- a/app/models/concerns/hyrax/work_behavior.rb
+++ b/app/models/concerns/hyrax/work_behavior.rb
@@ -7,7 +7,6 @@ module Hyrax
     include Permissions
     include Serializers
     include Hydra::WithDepositor
-    include Solrizer::Common
     include HasRepresentative
     include HasRendering
     include WithFileSets

--- a/spec/models/hyrax/work_behavior_spec.rb
+++ b/spec/models/hyrax/work_behavior_spec.rb
@@ -10,14 +10,13 @@ RSpec.describe Hyrax::WorkBehavior do
 
   subject { EssentialWork.new }
 
-  it 'mixes together all the goodness' do
+  it 'mixes together some junk' do
     expect(subject.class.ancestors).to include(::Hyrax::WithFileSets,
                                                ::Hyrax::HumanReadableType,
                                                Hyrax::Noid,
                                                Hyrax::Serializers,
                                                Hydra::WithDepositor,
                                                Hydra::AccessControls::Embargoable,
-                                               Solrizer::Common,
                                                Hyrax::Suppressible,
                                                Hyrax::CollectionNesting)
   end


### PR DESCRIPTION
`Solrizer` is unsupported. This is part of the process of removing it.

@samvera/hyrax-code-reviewers
