### PR TITLE
Deprecate `Solrizer::Common` methods

### DIFF
--- a/app/models/concerns/hyrax/work_behavior.rb
+++ b/app/models/concerns/hyrax/work_behavior.rb
@@ -45,6 +45,15 @@ module Hyrax
           "hyrax/#{collection}/#{element}".freeze
         end
       end
+
+      ##
+      # @deprecated Solrizer::Common will be removed in 3.0.0
+      def create_and_insert_terms(*)
+        Deprecation.warn(self, 'Solrizer::Common methods will be removed ' \
+                               'from WorkBehavior in Hyrax 3.0.0')
+
+        super
+      end
     end
   end
 end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -4,6 +4,13 @@ RSpec.describe GenericWork do
     expect(subject.title).to eq ['foo']
   end
 
+  describe '.create_and_insert_terms' do
+    it 'is deprecated' do
+      expect(Deprecation).to receive(:warn)
+      described_class.create_and_insert_terms(:base, :value, [], {})
+    end
+  end
+
   describe '#active_workflow' do
     it 'leverages "Sipity::Workflow.find_active_workflow_for"' do
       expect(Sipity::Workflow).to receive(:find_active_workflow_for)


### PR DESCRIPTION
Solizer is unsupported, and `Common` is removed from `WorkBehavior` in #3399.

@samvera/hyrax-code-reviewers
