### PR TITLE
3376 collections show page refactor

### DIFF
--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -292,6 +292,11 @@ button.branding-banner-remove:hover {
     margin-top: $padding-large-vertical * 4;
   }
 
+  .collections-search-results-headline {
+    margin-bottom: $padding-large-vertical * 2;
+    margin-top: $padding-large-vertical * 4;
+  }
+
   // Works section
   .works-wrapper {
     > div:first-of-type {

--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -127,14 +127,6 @@ button.branding-banner-remove:hover {
   text-decoration: underline;
 }
 
-.dashboard .collections-wrapper {
-  .panel {
-    .panel-title {
-      font-weight: 300;
-    }
-  }
-}
-
 // Styles wrapped in a selector class initially intended
 // for the Collections index list page
 .collections-wrapper {
@@ -262,13 +254,6 @@ button.branding-banner-remove:hover {
       }
     }
   }
-
-  .side-arrows::after {
-    content: "»";
-    font-size: 18px;
-    line-height: 1;
-    padding-left: 3px;
-  }
 }
 
 // Admin show page
@@ -291,51 +276,6 @@ button.branding-banner-remove:hover {
     }
   }
 
-  // This class wraps the collection title row, which includes labels plus show action buttons
-  .collection-title-row-wrapper {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-
-    @media (max-width: 992px) {
-      display: block;
-    }
-
-    .collection-title-row-content {
-      align-items: center;
-      display: flex;
-
-      @media (max-width: 992px) {
-        display: block;
-        margin-bottom: 10px;
-      }
-
-      .label {
-        margin-left: 5px;
-      }
-
-      @media (max-width: 768px) {
-        .btn {
-          display: block;
-          margin: 0 0 5px;
-          width: 100%;
-        }
-      }
-    }
-
-    .collection-title {
-      display: inline-block;
-      margin: 0;
-      padding-right: 5px;
-
-      // Wraps each collection title text, and helpful when there are multiple titles
-      span {
-        display: block;
-        padding-bottom: 5px;
-      }
-    }
-  }
-
   .collection-description-wrapper {
     section {
       margin-bottom: 30px;
@@ -348,7 +288,8 @@ button.branding-banner-remove:hover {
 
   // Search collections section
   .collections-search-wrapper {
-    border: 0;
+    margin-bottom: $padding-large-vertical;
+    margin-top: $padding-large-vertical * 4;
   }
 
   // Works section

--- a/app/assets/stylesheets/hyrax/_hyrax.scss
+++ b/app/assets/stylesheets/hyrax/_hyrax.scss
@@ -1,15 +1,15 @@
 @import 'hydra-editor/multi_value_fields';
 @import 'hyrax/variables', 'hyrax/file_sets', 'hyrax/settings', 'hyrax/header',
-  'hyrax/styles', 'hyrax/file-listing', 'hyrax/browse_everything_overrides',
-  'hyrax/nestable', 'hyrax/collections', 'hyrax/collection_types',
-  'hyrax/batch-edit', 'hyrax/home-page', 'hyrax/featured', 'hyrax/usage-stats',
-  'hyrax/catalog', 'hyrax/buttons', 'hyrax/tinymce', 'hyrax/proxy-rights',
-  'hyrax/file-show', 'hyrax/work-show', 'hyrax/modal', 'hyrax/forms',
-  'hyrax/form', 'hyrax/file_manager', 'hyrax/form-progress', 'hyrax/positioning',
-  'hyrax/fixedsticky', 'hyrax/file_upload', 'hyrax/representative-media',
-  'hyrax/footer', 'hyrax/select_work_type', 'hyrax/users', 'hyrax/dashboard',
-  'hyrax/sidebar', 'hyrax/controlled_vocabulary', 'hyrax/accessibility',
-  'hyrax/recent', 'hyrax/viewer', 'hyrax/breadcrumbs';
+'hyrax/styles', 'hyrax/file-listing', 'hyrax/browse_everything_overrides',
+        'hyrax/nestable', 'hyrax/collections', 'hyrax/collection_types', 'hyrax/batch-edit',
+        'hyrax/home-page', 'hyrax/featured', 'hyrax/usage-stats', 'hyrax/catalog',
+        'hyrax/buttons', 'hyrax/tinymce', 'hyrax/proxy-rights', 'hyrax/file-show',
+        'hyrax/work-show', 'hyrax/modal', 'hyrax/forms', 'hyrax/form',
+        'hyrax/file_manager', 'hyrax/form-progress', 'hyrax/positioning',
+        'hyrax/fixedsticky', 'hyrax/file_upload', 'hyrax/representative-media',
+        'hyrax/footer', 'hyrax/select_work_type', 'hyrax/users', 'hyrax/dashboard',
+        'hyrax/sidebar', 'hyrax/controlled_vocabulary', 'hyrax/accessibility',
+        'hyrax/recent', 'hyrax/viewer', 'hyrax/breadcrumbs', 'hyrax/layout';
 @import 'typeahead';
 @import 'sharing_buttons';
 

--- a/app/assets/stylesheets/hyrax/_layout.scss
+++ b/app/assets/stylesheets/hyrax/_layout.scss
@@ -1,0 +1,45 @@
+// Button row which sits below the title, and above panel content for a page
+.button-row-top-two-column {
+  margin-bottom: $padding-large-vertical;
+  margin-top: $padding-large-vertical;
+
+  @media screen and (max-width: 767px) {
+    > div {
+      text-align: center;
+
+      &:first-child {
+        padding-bottom: $padding-small-vertical;
+      }
+    }
+  }
+}
+
+.item-title {
+  margin-bottom: $padding-large-vertical * 2;
+}
+
+.item-type-tag {
+  color: #808080;
+  font-size: 24px;
+  font-weight: 500;
+  margin-bottom: $padding-large-vertical;
+  margin-top: $padding-large-vertical * 2;
+}
+
+.title-with-badges {
+  align-items: center;
+  display: flex;
+
+  h1,
+  h2 {
+    margin: 0;
+  }
+
+  .label {
+    margin-left: 5px;
+
+    &:first-of-type {
+      margin-left: 10px;
+    }
+  }
+}

--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -46,14 +46,6 @@ ul.tabular {
   }
 }
 
-.work-type-tag {
-  color: #808080;
-  font-size: 24px;
-  font-weight: 500;
-  margin-bottom: $padding-large-vertical;
-  margin-top: $padding-large-vertical * 2;
-}
-
 .work-type {
   margin-bottom: 18px;
   margin-top: -8px;
@@ -64,44 +56,10 @@ ul.tabular {
       word-break: break-word;
     }
   }
-
-  // Button row which sits below the title, and above panel content for a page
-  .button-row-top-two-column {
-    margin-bottom: $padding-large-vertical;
-    margin-top: $padding-large-vertical;
-
-    @media screen and (max-width: 767px) {
-      > div {
-        text-align: center;
-
-        &:first-child {
-          padding-bottom: $padding-small-vertical;
-        }
-      }
-    }
-  }
 }
 
 .work-title-wrapper {
   margin-bottom: $padding-large-vertical * 2;
-
-  .title-with-badges {
-    align-items: center;
-    display: flex;
-
-    h1,
-    h2 {
-      margin: 0;
-    }
-
-    .label {
-      margin-left: 5px;
-
-      &:first-of-type {
-        margin-left: 10px;
-      }
-    }
-  }
 }
 
 .panel-workflow {

--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -220,28 +220,28 @@ body.dashboard {
   }
 
   .panel {
-    border: 1px solid $admin-panel-border-color;
-    float: left;
-    width: 100%;
+    // border: 1px solid $admin-panel-border-color;
+    // float: left;
+    // width: 100%;
 
     .panel-heading,
     .panel-footer,
     .panel-body,
     .list-group-item {
-      float: left;
-      width: 100%;
+      // float: left;
+      // width: 100%;
     }
 
     .panel-title {
-      color: $title-text-color;
-      display: block;
-      font-size: 18px;
-      font-weight: 600;
-      line-height: 30px;
+      // color: $title-text-color;
+      // display: block;
+      // font-size: 18px;
+      // font-weight: 600;
+      // line-height: 30px;
 
-      &.h2 {
-        font-size: 22px;
-      }
+      // &.h2 {
+      //   font-size: 22px;
+      // }
     }
   }
 

--- a/app/views/hyrax/base/_work_type.html.erb
+++ b/app/views/hyrax/base/_work_type.html.erb
@@ -1,4 +1,4 @@
-<div class="work-type-tag">
+<div class="item-type-tag">
   <span class="<%= Hyrax::ModelIcon.css_class_for(presenter.model) %>" aria-hidden="true"></span>
   <%= presenter.human_readable_type %>
 </div>

--- a/app/views/hyrax/dashboard/collections/_collection_title.html.erb
+++ b/app/views/hyrax/dashboard/collections/_collection_title.html.erb
@@ -1,23 +1,16 @@
-<% id = presenter.id %>
+<section class="item-title">
 
-<section class="collection-title-row-wrapper"
-  data-source="my"
-  data-id="<%= id %>"
-  data-colls-hash="<%= presenter.available_parent_collections(scope: controller) %>"
-  data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
-  data-post-delete-url="<%= hyrax.dashboard_collection_path(id) %>">
+  <% presenter.title.each_with_index do |title, index| %>
+    <% if index == 0 %>
+      <div class="title-with-badges">
+        <h2><%= title %></h2>
+        <%= presenter.permission_badge %>
+        <%= presenter.collection_type_badge %>
+      </div>
+    <% else %>
+      <h2><%= title %></h2>
+    <% end %>
+  <% end %>
 
-    <div class="collection-title-row-content">
-      <h3 class="collection-title">
-        <% # List multiple titles %>
-        <% presenter.title.each_with_index do |title, index| %>
-          <span><%= title %></span>
-        <% end %>
-      </h3>
-      <%= presenter.permission_badge %>
-      <%= presenter.collection_type_badge %>
-    </div>
-    <div class="collection-title-row-content">
-      <%= render 'show_actions', presenter: presenter %>
-    </div>
 </section>
+

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -1,28 +1,28 @@
 <h2 class="sr-only"><%= t('hyrax.collection.actions.header') %></h2>
-<% if can? :edit, presenter.solr_document %>
-    <%= link_to t('hyrax.collection.actions.edit.label'),
-                hyrax.edit_dashboard_collection_path(presenter),
-                title: t('hyrax.collection.actions.edit.desc'),
-                class: 'btn btn-primary' %>
-<% end %>
 
-<% if presenter.collection_type_is_nestable? && presenter.user_can_nest_collection? %>
-<!-- The user should have deposit access to the parent and read access to the child (the collection we are already showing, so no test is necessary). -->
-    <%= button_tag '',
-                  class: 'btn btn-primary add-to-collection',
-                  title: t("hyrax.collection.actions.nested_subcollection.desc"),
-                  type: 'button',
-                  data: { nestable: presenter.collection_type_is_nestable?,
-                          hasaccess: true } do %>
-                  <%= t('hyrax.collection.actions.nested_subcollection.button_label') %>
-                <% end %>
-<% end %>
+<div class="row button-row-top-two-column">
+    <div class="col-sm-8">
+        <% unless has_collection_search_parameters? %>
+            <%= render 'show_add_items_actions', presenter: presenter %>
+        <% end %>
+    </div>
+    <div class="col-sm-4 text-right">
+        <% if can? :edit, presenter.solr_document %>
+            <%= link_to hyrax.edit_dashboard_collection_path(presenter),
+                        title: t('hyrax.collection.actions.edit.desc'),
+                        class: 'btn btn-default' do %>
+                <%= t('hyrax.collection.actions.edit.label') %>
+            <% end %>
+        <% end %>
+        <% if can? :destroy, presenter.solr_document %>
+            <%= link_to hyrax.dashboard_collection_path(presenter),
+                        title: t('hyrax.collection.actions.delete.desc'),
+                        class: 'btn btn-danger',
+                        data: { confirm: t('hyrax.collection.actions.delete.confirmation'),
+                                method: :delete } do %>
+                <%= t('hyrax.collection.actions.delete.label') %>
+            <% end %>
+        <% end %>
+    </div>
+</div>
 
-<% if can? :destroy, presenter.solr_document %>
-    <%= link_to t('hyrax.collection.actions.delete.label'),
-                hyrax.dashboard_collection_path(presenter),
-                title: t('hyrax.collection.actions.delete.desc'),
-                class: 'btn btn-danger',
-                data: { confirm: t('hyrax.collection.actions.delete.confirmation'),
-                        method: :delete } %>
-<% end %>

--- a/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
@@ -1,24 +1,22 @@
 <h2 class="sr-only"><%= t('hyrax.collection.actions.header') %></h2>
-<div class="text-right">
-  <% if can? :deposit, presenter.solr_document %>
-    <div>
-      <% if @presenter.create_many_work_types? %>
-        <%= link_to t('hyrax.collection.actions.add_new_work.label'),
-                    '#',
-                    title: t('hyrax.collection.actions.add_new_work.desc'),
-                    data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single', add_works_to_collection: presenter.id },
-                    class: 'btn btn-primary deposit-new-work-through-collection' %>
-      <% else # simple link to the first work type %>
-        <%= link_to t('hyrax.collection.actions.add_new_work.label'),
-                    new_polymorphic_path([main_app, @presenter.first_work_type], add_works_to_collection: presenter.id),
-                    class: 'btn btn-primary' %>
+<% if can? :deposit, presenter.solr_document %>
+    <%= link_to hyrax.my_works_path(add_works_to_collection: presenter.id, add_works_to_collection_label: presenter.title),
+                title: t('hyrax.collection.actions.add_existing_works.desc'),
+                class: 'btn btn-primary' do %>
+      <span class="glyphicon glyphicon-import" aria-hidden="true"></span> <%= t('hyrax.collection.actions.add_existing_works.label') %>
+    <% end %>
+
+    <% if @presenter.create_many_work_types? %>
+      <%= link_to '#',
+                  title: t('hyrax.collection.actions.add_new_work.desc'),
+                  data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single', add_works_to_collection: presenter.id },
+                  class: 'btn btn-default deposit-new-work-through-collection' do %>
+        <%= t('hyrax.collection.actions.add_new_work.label') %>
       <% end %>
-    </div>
-    <div>
-      <%= link_to t('hyrax.collection.actions.add_existing_works.label'),
-                  hyrax.my_works_path(add_works_to_collection: presenter.id, add_works_to_collection_label: presenter.title),
-                  title: t('hyrax.collection.actions.add_existing_works.desc'),
-                  class: 'btn btn-link side-arrows' %>
-    </div>
+    <% else # simple link to the first work type %>
+      <%= link_to t('hyrax.collection.actions.add_new_work.label'),
+                  new_polymorphic_path([main_app, @presenter.first_work_type], add_works_to_collection: presenter.id),
+                  class: 'btn btn-default' %>
+    <% end %>
+
   <% end %>
-</div>

--- a/app/views/hyrax/dashboard/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_descriptions.html.erb
@@ -1,4 +1,4 @@
-<h2 class="sr-only">Descriptions</h2>
+<h3 class="sr-only">Descriptions</h3>
 <dl class="dl-horizontal metadata-collections">
   <% present_terms(@presenter, @presenter.terms_with_values) do |r, term| %>
       <dt><%= r.label(term) %></dt>

--- a/app/views/hyrax/dashboard/collections/_show_subcollection_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_subcollection_actions.html.erb
@@ -2,25 +2,22 @@
   <!-- The user should have deposit access to the parent (the collection we are showing) and read access to the child -->
   <% if presenter.user_can_nest_collection? %>
     <div class="text-right">
-      <div>
-        <div class="sr-only"><% t('hyrax.collection.actions.nest_collections.desc') %></div>
-        <%= button_tag t('hyrax.collection.actions.nest_collections.button_label'),
-              class: 'btn btn-primary add-subcollection',
-              title: t('hyrax.collection.actions.nest_collections.desc'),
-              data: { nestable: true,
-                      hasaccess: true,
-                      presenter_id: presenter.id } %>
-      </div>
-      <div>
-        <!-- The user should must have the ability to create a new collection of parent's type -->
-        <% if presenter.user_can_create_new_nest_collection? %>
-          <div class="sr-only"><% t('hyrax.collection.actions.add_new_nested_collection.desc') %></div>
-          <%= link_to t('hyrax.collection.actions.add_new_nested_collection.label'),
-            hyrax.dashboard_create_subcollection_under_path(parent_id: presenter.id),
-            title: t('hyrax.collection.actions.add_new_nested_collection.desc'),
-            class: 'btn btn-link side-arrows' %>
-        <% end %>
-      </div>
+      <div class="sr-only"><% t('hyrax.collection.actions.nest_collections.desc') %></div>
+      <%= button_tag t('hyrax.collection.actions.nest_collections.button_label'),
+            class: 'btn btn-default add-subcollection',
+            title: t('hyrax.collection.actions.nest_collections.desc'),
+            data: { nestable: true,
+                    hasaccess: true,
+                    presenter_id: presenter.id } %>
+
+      <!-- The user should must have the ability to create a new collection of parent's type -->
+      <% if presenter.user_can_create_new_nest_collection? %>
+        <div class="sr-only"><% t('hyrax.collection.actions.add_new_nested_collection.desc') %></div>
+        <%= link_to t('hyrax.collection.actions.add_new_nested_collection.label'),
+          hyrax.dashboard_create_subcollection_under_path(parent_id: presenter.id),
+          title: t('hyrax.collection.actions.add_new_nested_collection.desc'),
+          class: 'btn btn-default' %>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -4,92 +4,117 @@
   <h1><span class="fa fa-file" aria-hidden="true"></span> <%= t('.header') %></h1>
 <% end %>
 
+<% id = @presenter.id %>
 <div class="collections-wrapper">
-  <section class="panel panel-default collections-panel-wrapper admin-show-page">
-    <div class="panel-heading">
-      <%= render 'collection_title', presenter: @presenter %>
-    </div>
+  <section class="admin-show-page"
+    data-source="my"
+    data-id="<%= id %>"
+    data-colls-hash="<%= @presenter.available_parent_collections(scope: controller) %>"
+    data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
+    data-post-delete-url="<%= hyrax.dashboard_collection_path(id) %>"
+  >
 
-    <div class="panel-body">
-      <section>
+    <%= render 'collection_title', presenter: @presenter %>
+    <%= render 'show_actions', presenter: @presenter %>
+
+    <div class="panel panel-default">
+      <div class="panel-body">
         <div itemscope itemtype="http://schema.org/CollectionPage" class="row collection">
           <div class="col-sm-3 text-center">
               <%= render 'hyrax/collections/media_display', presenter: @presenter %>
               <%= link_to t('.public_view_label'), collection_path(id: @presenter.id) %>
           </div>
-          <div class="col-sm-9 collection-description-wrapper">
-            <!-- Parent Collection(s) -->
-            <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
-                <h4><%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)</h4>
-                <section id="parent-collections-wrapper" class="parent-collections-wrapper">
-                  <%= render 'hyrax/dashboard/collections/show_parent_collections', presenter: @presenter %>
-                </section>
-            <% end %>
+          <div class="col-sm-8 col-sm-offset-1 collection-description-wrapper">
 
             <!-- Collection Description(s) -->
-            <section>
+            <div>
               <%= render 'hyrax/collections/collection_description', presenter: @presenter %>
-            </section>
+            </div>
 
             <% unless has_collection_search_parameters? %>
               <%= render 'show_descriptions' %>
             <% end %>
+
           </div>
         </div>
-      </section>
-
-      <!-- Search results label -->
-
-      <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
-          <div class="hyc-blacklight hyc-bl-title">
-            <h2>
-              <% if has_collection_search_parameters? %>
-                  <%= t('hyrax.dashboard.collections.show.search_results') %>
+      </div>
+      <div class="panel-footer text-right">
+        <%# Add this collection within another collection button %>
+        <% if @presenter.collection_type_is_nestable? && @presenter.user_can_nest_collection? %>
+        <!-- The user should have deposit access to the parent and read access to the child (the collection we are already showing, so no test is necessary). -->
+            <%= button_tag '',
+              class: 'btn btn-default add-to-collection',
+              title: t("hyrax.collection.actions.nested_subcollection.desc"),
+              type: 'button',
+              data: { nestable: @presenter.collection_type_is_nestable?,
+                      hasaccess: true } do %>
+              <%= t('hyrax.collection.actions.nested_subcollection.modal_title') %>
               <% end %>
-            </h2>
-          </div>
-      <% end %>
-
-      <!-- Search bar -->
-      <section class="collections-search-wrapper">
-        <div class="row">
-          <div class="col-sm-8">
-            <%# TODO: leaving this as it was causes rerouting to the public show page. needs work %>
-            <%= render 'hyrax/collections/search_form', presenter: @presenter, url: hyrax.dashboard_collection_path(@presenter.id) %>
-          </div>
-        </div>
-      </section>
-
-      <!-- Subcollections -->
-      <% if @presenter.collection_type_is_nestable? %>
-        <section id="sub-collections-wrapper" class="sub-collections-wrapper">
-          <h4><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h4>
-          <div class="row">
-            <div class="col-md-7">
-              <%= render 'subcollection_list', id: @presenter.id, collection: @subcollection_docs %>
-            </div>
-            <% unless has_collection_search_parameters? %>
-              <div class="col-md-5">
-                <%= render 'show_subcollection_actions', presenter: @presenter %>
-              </div>
-            <% end %>
-          </div>
-        </section>
-      <% end %>
-
-      <!-- Works -->
-      <section class="works-wrapper">
-        <h4><%= t('.item_count') %> (<%= @members_count %>)</h4>
-        <% unless has_collection_search_parameters? %>
-          <%= render 'show_add_items_actions', presenter: @presenter %>
         <% end %>
+      </div>
+    </div>
 
+    <!-- Parent Collection(s) -->
+    <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title"><%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)</h3>
+        </div>
+        <div id="parent-collections-wrapper" class="panel-body parent-collections-wrapper">
+          <%= render 'hyrax/dashboard/collections/show_parent_collections', presenter: @presenter %>
+        </div>
+      </div>
+    <% end %>
+
+    <!-- Search bar -->
+    <div class="collections-search-wrapper">
+      <div class="row">
+        <div class="col-lg-6 col-lg-offset-3">
+          <%# TODO: leaving this as it was causes rerouting to the public show page. needs work %>
+          <%= render 'hyrax/collections/search_form', presenter: @presenter, url: hyrax.dashboard_collection_path(@presenter.id) %>
+        </div>
+      </div>
+    </div>
+
+    <!-- Search results label -->
+    <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
+      <% if has_collection_search_parameters? %>
+        <h3>
+          <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+          <%= t('hyrax.dashboard.collections.show.search_results') %>
+        </h3>
+    <% end %>
+    <% end %>
+
+    <!-- Subcollections -->
+    <% if @presenter.collection_type_is_nestable? %>
+      <div id="sub-collections-wrapper" class="panel panel-default sub-collections-wrapper">
+        <div class="panel-heading">
+          <h3 class="panel-title"><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h3>
+        </div>
+        <div class="panel-body">
+          <%= render 'subcollection_list', id: @presenter.id, collection: @subcollection_docs %>
+        </div>
+        <% unless has_collection_search_parameters? %>
+          <div class="panel-footer">
+            <%= render 'show_subcollection_actions', presenter: @presenter %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <!-- Works -->
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title"><%= t('.item_count') %> (<%= @members_count %>)</h3>
+      </div>
+      <div class="panel-body">
         <%= render 'sort_and_per_page', collection: @presenter %>
         <%= render_document_index @member_docs %>
         <%= render 'hyrax/collections/paginate' %>
-      </section>
+      </div>
+    </div>
 
-    </div><!-- /panel-body -->
   </section><!-- /collections-panel-wrapper -->
 </div><!-- /collections-wrapper -->
 

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -66,25 +66,25 @@
       </div>
     <% end %>
 
-    <!-- Search bar -->
     <div class="collections-search-wrapper">
+      <!-- Search results headline -->
+      <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
+        <% if has_collection_search_parameters? %>
+          <h3 class="collections-search-results-headline">
+            <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+            <%= t('hyrax.dashboard.collections.show.search_results') %>
+          </h3>
+        <% end %>
+      <% end %>
+
+      <!-- Search bar -->
       <div class="row">
-        <div class="col-lg-6 col-lg-offset-3">
+        <div class="col-lg-9">
           <%# TODO: leaving this as it was causes rerouting to the public show page. needs work %>
           <%= render 'hyrax/collections/search_form', presenter: @presenter, url: hyrax.dashboard_collection_path(@presenter.id) %>
         </div>
       </div>
     </div>
-
-    <!-- Search results label -->
-    <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
-      <% if has_collection_search_parameters? %>
-        <h3>
-          <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
-          <%= t('hyrax.dashboard.collections.show.search_results') %>
-        </h3>
-    <% end %>
-    <% end %>
 
     <!-- Subcollections -->
     <% if @presenter.collection_type_is_nestable? %>

--- a/app/views/hyrax/my/collections/index.html.erb
+++ b/app/views/hyrax/my/collections/index.html.erb
@@ -39,7 +39,7 @@
   </section>
 
   <%# Collections list %>
-  <div class="panel panel-default collections-panel-wrapper">
+  <div class="panel panel-default">
     <div class="panel-heading">
       <% if  current_page?(hyrax.my_collections_path(locale: nil)) %>
         <span class="count-display"><%= I18n.t('hyrax.my.count.collections.you_own', total_count: @response.total_count).html_safe %></span>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -474,7 +474,7 @@ en:
           label: Edit collection
         header: Actions
         nest_collections:
-          button_label: Add a subcollection
+          button_label: Add existing collection as subcollection
           desc: Nest other collections within this Collection
           label: Add existing collections to this collection
           modal_title: Add a Subcollection to Collection
@@ -482,7 +482,7 @@ en:
         nested_subcollection:
           button_label: Add to collection
           desc: Add existing collections to this collection
-          modal_title: Add this Collection Within Another Collection
+          modal_title: Add this collection within another collection
           select_label: Select collection
       browse_view: Browse View
       document_list:
@@ -511,7 +511,7 @@ en:
         default_description: A User Collection can be created by any user to organize their works.
     collections:
       search_form:
-        button_label: Go
+        button_label: Search
         label: Search Collection %{title}
         placeholder: Search subcollections and works in this collection
       show:

--- a/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
@@ -33,35 +33,6 @@ RSpec.describe 'hyrax/dashboard/collections/_show_actions.html.erb', type: :view
     end
   end
 
-  describe 'nesting the collection within another collection' do
-    context 'with nestable collection' do
-      it 'renders add parent collection link' do
-        allow(presenter).to receive(:collection_type_is_nestable?).and_return true
-        allow(presenter).to receive(:user_can_nest_collection?).and_return true
-
-        render
-        expect(rendered).to have_button('Add existing collections to this collection')
-      end
-    end
-
-    context 'with nestable collection but without permissions' do
-      it 'does not render add parent collection link' do
-        allow(presenter).to receive(:collection_type_is_nestable?).and_return true
-        allow(presenter).to receive(:user_can_nest_collection?).and_return false
-
-        render
-        expect(rendered).not_to have_button('Add existing collections to this collection')
-      end
-    end
-
-    context 'with non-nestable collection' do
-      it 'does not render add parent collection link' do
-        render
-        expect(rendered).not_to have_button('Nest this collection')
-      end
-    end
-  end
-
   describe 'when user can destroy the document' do
     it 'renders a link to destroy the document' do
       render

--- a/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe 'hyrax/dashboard/collections/_show_actions.html.erb', type: :view
 
     allow(view).to receive(:can?).with(:edit, solr_document).and_return(can_edit)
     allow(view).to receive(:can?).with(:destroy, solr_document).and_return(can_destroy)
+
+    stub_template '_show_add_items_actions.html.erb' => '<div class="stubbed-actions">THE ADD ITEMS ACTIONS</div>'
   end
 
   describe 'when user can edit the document' do

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -60,6 +60,35 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     expect(rendered).not_to have_text('Search Results within this Collection')
   end
 
+  describe 'nesting the collection within another collection' do
+    context 'with nestable collection' do
+      it 'renders add parent collection link' do
+        allow(presenter).to receive(:collection_type_is_nestable?).and_return true
+        allow(presenter).to receive(:user_can_nest_collection?).and_return true
+
+        render
+        expect(rendered).to have_button('Add existing collections to this collection')
+      end
+    end
+
+    context 'with nestable collection but without permissions' do
+      it 'does not render add parent collection link' do
+        allow(presenter).to receive(:collection_type_is_nestable?).and_return true
+        allow(presenter).to receive(:user_can_nest_collection?).and_return false
+
+        render
+        expect(rendered).not_to have_button('Add existing collections to this collection')
+      end
+    end
+
+    context 'with non-nestable collection' do
+      it 'does not render add parent collection link' do
+        render
+        expect(rendered).not_to have_button('Nest this collection')
+      end
+    end
+  end
+
   context 'with a not-nested collection_type' do
     before do
       allow(presenter).to receive(:subcollection_count).and_return(0)

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     allow(view).to receive(:can?).with(:destroy, document).and_return(true)
     allow(view).to receive(:current_ability).and_return(ability)
     allow(ability).to receive(:current_user).and_return(user)
+    allow(ability).to receive(:can?).with(:deposit, document).and_return(true)
 
     allow(Collection).to receive(:find).with(document.id).and_return(collection)
 
@@ -42,7 +43,6 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     # This is tested ./spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
     stub_template '_show_actions.html.erb' => '<div class="stubbed-actions">THE COLLECTION ACTIONS</div>'
     stub_template '_show_subcollection_actions.html.erb' => '<div class="stubbed-actions">THE SUBCOLLECTION ACTIONS</div>'
-    stub_template '_show_add_items_actions.html.erb' => '<div class="stubbed-actions">THE ADD ITEMS ACTIONS</div>'
     stub_template '_show_parent_collections.html.erb' => '<div class="stubbed-actions">THE PARENT COLLECTIONS LIST</div>'
     stub_template '_subcollection_list.html.erb' => '<div class="stubbed-actions">THE SUB-COLLECTIONS LIST</div>'
     stub_template 'hyrax/collections/_paginate.html.erb' => 'paginate'
@@ -56,7 +56,6 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     # Making sure that we are verifying that the _show_actions.html.erb is rendering
     expect(rendered).to have_css('.stubbed-actions', text: 'THE COLLECTION ACTIONS')
     expect(rendered).to have_css('.stubbed-actions', text: 'THE SUBCOLLECTION ACTIONS')
-    expect(rendered).to have_css('.stubbed-actions', text: 'THE ADD ITEMS ACTIONS')
     expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
     expect(rendered).not_to have_text('Search Results within this Collection')
   end
@@ -71,7 +70,6 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
       # Making sure that we are verifying that the _show_actions.html.erb is rendering
       expect(rendered).to have_css('.stubbed-actions', text: 'THE COLLECTION ACTIONS')
       expect(rendered).to have_css('.stubbed-actions', text: 'THE SUBCOLLECTION ACTIONS')
-      expect(rendered).to have_css('.stubbed-actions', text: 'THE ADD ITEMS ACTIONS')
       expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
       expect(rendered).not_to have_text('Search Results within this Collection')
     end
@@ -94,7 +92,6 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
         expect(rendered).to have_text('Search Results within this Collection')
         expect(rendered).to have_css('.stubbed-actions', text: 'THE COLLECTION ACTIONS')
         expect(rendered).not_to have_css('.stubbed-actions', text: 'THE SUBCOLLECTION ACTIONS')
-        expect(rendered).not_to have_css('.stubbed-actions', text: 'THE ADD ITEMS ACTIONS')
       end
     end
 
@@ -109,7 +106,6 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
         expect(rendered).to have_text('Search Results within this Collection')
         expect(rendered).to have_css('.stubbed-actions', text: 'THE COLLECTION ACTIONS')
         expect(rendered).not_to have_css('.stubbed-actions', text: 'THE SUBCOLLECTION ACTIONS')
-        expect(rendered).not_to have_css('.stubbed-actions', text: 'THE ADD ITEMS ACTIONS')
       end
     end
   end


### PR DESCRIPTION
Fixes #3376 

Follows the same pattern of grouping page data as in the Works show page.   Using Bootstrap panels as a way to organize page data.

##### After
![collections-show-pr](https://user-images.githubusercontent.com/3020266/49103198-57394580-f240-11e8-90fc-5bb7d59aacad.png)

##### After (with search)
![collections-show-with-search-pr](https://user-images.githubusercontent.com/3020266/49103207-5acccc80-f240-11e8-9c5b-70261763d21b.png)

##### Before
![collections-show-original](https://user-images.githubusercontent.com/3020266/49103539-39b8ab80-f241-11e8-980e-a721224ce195.png)


@samvera/hyrax-code-reviewers
