### PR TITLE
Update dashboard collection list item thumbnails to not overlap width…

### DIFF
--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -209,11 +209,13 @@ button.branding-banner-remove:hover {
     display: flex;
 
     .thumbnail-wrapper {
-      width: 50px;
+      flex: 0 0 64px;
+      margin-right: 10px;
+      overflow-x: hidden;
 
       > img {
-        height: 30px;
-        width: auto;
+        height: auto;
+        max-width: 64px;
       }
     }
 

--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -29,10 +29,10 @@ $admin-panel-border-color: #dedede !default;
   .media-body {
     width: 18vw;
   }
+}
 
-  .works-list-batch-checkbox-label-text {
-    margin: 0 5px;
-  }
+.batch-checkbox-label-text {
+  margin: 0 5px;
 }
 
 body.dashboard {

--- a/app/views/hyrax/batch_edits/_check_all.html.erb
+++ b/app/views/hyrax/batch_edits/_check_all.html.erb
@@ -1,7 +1,7 @@
 <div class="dropdown batch_document_selector_all">
   <label class="centerizer">
     <%= check_box_tag 'check_all', 'yes', @all_checked, disabled: @disable_select_all %>
-    <span class="works-list-batch-checkbox-label-text">
+    <span class="batch-checkbox-label-text">
       <%= t("hyrax.dashboard.my.action.select") %>
     </span>
     <% if !@disable_select_all %>


### PR DESCRIPTION
… into the title.  Also updated to have thumbnails be the same size as thumbnails in Works list view

Fixes #3430 

This fix will prevent a collection thumbnail from overlapping into the title to it's right.  Previously `height` was a fixed style on the thumbnail, but now it's adjusted to a `max-width`, which will retain the positioning within the table row, and also keep the thumbnail image at its original scale.

This also updates the Collections list thumbnails to be the same size as the Works list thumbnails.  

Note this does increase the height of the rows some.  If keeping the Collection list items rows compact is a priority, then the alternative would be to place an `overflow` style on the element wrapper for the Collection thumbnail, which would 'cut off' part of the thumbnail.   If any interest in this, let me know and I can adjust.

#### Updated
![collections-list-thumbs](https://user-images.githubusercontent.com/3020266/49166990-16056c00-f2fa-11e8-9850-6df81cc74202.png)

#### Original
![collections-list-thumbs-original](https://user-images.githubusercontent.com/3020266/49166997-1a318980-f2fa-11e8-97ee-f9d838b09f4e.png)


@samvera/hyrax-code-reviewers
