### PR TITLE
Snappy test app boot times via bootsnap

### DIFF
--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -4,3 +4,5 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
 end
+
+gem 'bootsnap', require: false

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -5,6 +5,12 @@ class TestAppGenerator < Rails::Generators::Base
   # so the following path gets us to /path/to/hyrax/spec/test_app_templates/
   source_root File.expand_path('../../../../spec/test_app_templates/', __FILE__)
 
+  def require_bootsnap
+    inject_into_file 'config/boot.rb', after: "require 'bundler/setup' # Set up gems listed in the Gemfile.\n" do
+      "require 'bootsnap/setup'\n"
+    end
+  end
+
   def install_engine
     generate 'hyrax:install', '-f'
   end


### PR DESCRIPTION
Refs #3424.

I'm seeing the a freshly built internal test app loading @jcoyne's `benchmark.rb` go from
```
real	0m28.512s
user	0m11.314s
sys	0m10.303s
```
to
```
real	0m6.960s
user	0m3.389s
sys	0m0.865s
```
when adding `bootsnap` to the internal test app's Gemfile and requiring it in `config/boot.rb`.

This PR adds bootsnap to the internal test app which decreases boot times significantly for rspec and other commands.  Future work would be to add documentation to advise adding `bootsnap` to Hyrax-based apps.  Once Hyrax becomes compatible with rails 5.2, we may have to make some of these proposed changes conditional since `bootsnap` comes default in a generated rails 5.2 app.

@samvera/hyrax-code-reviewers