### PR TITLE
[WIP] Addresses browse-everything 1.0.0rc2 compatibility issues

### DIFF
--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -64,7 +64,8 @@ module Hyrax
         # Generic utility for creating FileSet from a URL
         # Used in to import files using URLs from a file picker like browse_everything
         def create_file_from_url(env, uri, file_name, auth_header = {})
-          ::FileSet.new(import_url: uri.to_s, label: file_name) do |fs|
+          import_url = URI.decode_www_form_component(uri.to_s)
+          ::FileSet.new(import_url: import_url, label: file_name) do |fs|
             actor = Hyrax::Actors::FileSetActor.new(fs, env.user)
             actor.create_metadata(visibility: env.curation_concern.visibility)
             actor.attach_to_work(env.curation_concern)

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -21,17 +21,18 @@ class ImportUrlJob < Hyrax::ApplicationJob
     operation.performing!
     user = User.find_by_user_key(file_set.depositor)
     uri = URI(file_set.import_url)
+    name = file_set.label
     @file_set = file_set
     @operation = operation
 
-    unless can_retrieve?(uri)
+    unless BrowseEverything::Retriever.can_retrieve?(uri, headers)
       send_error('Expired URL')
       return false
     end
 
     # @todo Use Hydra::Works::AddExternalFileToFileSet instead of manually
     #       copying the file here. This will be gnarly.
-    copy_remote_file(uri, headers) do |f|
+    copy_remote_file(uri, name, headers) do |f|
       # reload the FileSet once the data is copied since this is a long running task
       file_set.reload
 
@@ -44,25 +45,16 @@ class ImportUrlJob < Hyrax::ApplicationJob
 
   private
 
-    # The previous strategy of using only a HEAD request to check the validity of a
-    # remote URL fails for Amazon S3 pre-signed URLs. S3 URLs are generated for a single
-    # verb only (in this case, GET), and will return a 403 Forbidden response if any
-    # other verb is used. The workaround is to issue a GET request instead, with a
-    # Range: header requesting only the first byte. The successful response status
-    # code is 206 instead of 200, but that is enough to satisfy the #success? method.
-    # @param uri [URI] the uri of the file to be downloaded
-    def can_retrieve?(uri)
-      HTTParty.get(uri, headers: { Range: 'bytes=0-0' }).success?
-    end
-
     # Download file from uri, yields a block with a file in a temporary directory.
     # It is important that the file on disk has the same file name as the URL,
     # because when the file in added into Fedora the file name will get persisted in the
     # metadata.
     # @param uri [URI] the uri of the file to download
+    # @param name [String] the human-readable name of the file
+    # @param headers [Hash] the HTTP headers for the GET request (these may contain an authentication token)
     # @yield [IO] the stream to write to
-    def copy_remote_file(uri, headers = {})
-      filename = File.basename(uri.path)
+    def copy_remote_file(uri, name, headers = {})
+      filename = File.basename(name)
       dir = Dir.mktmpdir
       Rails.logger.debug("ImportUrlJob: Copying <#{uri}> to #{dir}")
 
@@ -92,7 +84,8 @@ class ImportUrlJob < Hyrax::ApplicationJob
     # @param f [IO] the stream to write to
     def write_file(uri, f, headers)
       retriever = BrowseEverything::Retriever.new
-      uri_spec = { 'url' => uri }.merge(headers)
+      uri_spec = ActiveSupport::HashWithIndifferentAccess.new(url: uri, headers: headers)
+
       retriever.retrieve(uri_spec) do |chunk|
         f.write(chunk)
       end

--- a/app/jobs/ingest_local_file_job.rb
+++ b/app/jobs/ingest_local_file_job.rb
@@ -14,5 +14,9 @@ class IngestLocalFileJob < Hyrax::ApplicationJob
     else
       Hyrax.config.callback.run(:after_import_local_file_failure, file_set, user, path)
     end
+  rescue SystemCallError => error
+    # This is generic in order to handle Errno constants raised when accessing files
+    # @see https://ruby-doc.org/core-2.5.3/Errno.html
+    send_error(error.message)
   end
 end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -1,3 +1,4 @@
+# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hyrax/version'
@@ -37,8 +38,7 @@ SUMMARY
   spec.add_dependency 'blacklight', '~> 6.14'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
-  # Pin browse-everything to stable version
-  spec.add_dependency 'browse-everything', '< 0.16'
+  spec.add_dependency 'browse-everything', '1.0.0rc2'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'dry-equalizer', '~> 0.2'

--- a/lib/generators/hyrax/config_generator.rb
+++ b/lib/generators/hyrax/config_generator.rb
@@ -49,6 +49,10 @@ class Hyrax::ConfigGenerator < Rails::Generators::Base
     copy_file 'config/tinymce.yml'
   end
 
+  def configure_browse_everything
+    copy_file 'config/browse_everything_providers.yml'
+  end
+
   def inject_i18n
     copy_file 'config/locales/hyrax.en.yml'
     copy_file 'config/locales/hyrax.es.yml'

--- a/lib/generators/hyrax/templates/config/browse_everything_providers.yml
+++ b/lib/generators/hyrax/templates/config/browse_everything_providers.yml
@@ -1,0 +1,21 @@
+#
+# To make browse-everything aware of a provider, uncomment the info for that provider and add your API key information.
+# The file_system provider can be a path to any directory on the server where your application is running.
+#
+# dropbox:
+#   client_id: YOUR_DROPBOX_APP_KEY
+#   client_secret: YOUR_DROPBOX_APP_SECRET
+# box:
+#   client_id: YOUR_BOX_CLIENT_ID
+#   client_secret: YOUR_BOX_CLIENT_SECRET
+# google_drive:
+#   client_id: YOUR_GOOGLE_API_CLIENT_ID
+#   client_secret: YOUR_GOOGLE_API_CLIENT_SECRET
+# s3:
+#   bucket: YOUR_AWS_S3_BUCKET
+#   response_type: signed_url # set to :public_url for public urls or :s3_uri for an s3://BUCKET/KEY uri
+#   expires_in: 14400 # for signed_url response_type, number of seconds url will be valid for.
+#   app_key: YOUR_AWS_S3_KEY       # :app_key, :app_secret, and :region can be specified
+#   app_secret: YOUR_AWS_S3_SECRET # explicitly here, or left out to use system-configured
+#   region: YOUR_AWS_S3_REGION     # defaults.
+#   See https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/


### PR DESCRIPTION
Fixes #1852

This aims to address compatibility issues with the latest release candidate for 1.0.0 of the `browse-everything` Gem which I've discovered affect the behavior of `ImportUrlJob` (as well as related functionality for retrieving resources from cloud service providers).

Changes proposed in this pull request:

* Handling HTTP GET parameter encoding issues (e. g. `X-Amz-Credential`) in `CreateWithRemoteFilesActor#create_file_from_url`
* Ensuring that `BrowseEverything::Retriever.can_retrieve?` is used within `ImportUrlJob`
* Handles errors encountered at the file system level when using `IngestLocalFileJob` to read from a file buffer
* Ensures that filenames are preserved using `FileSet#label` within `ImportUrlJob#copy_remote_file`

@samvera/hyrax-code-reviewers