### PR TITLE
Extract `VisibilityIntention` class from `InterpretVisibilityActor`

### DIFF
--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -205,16 +205,12 @@ module Hyrax
         def apply_lease(env, intention)
           return true unless intention.wants_lease?
           env.curation_concern.apply_lease(*intention.lease_params)
-          return unless env.curation_concern.lease
-          env.curation_concern.lease.save # see https://github.com/samvera/hydra-head/issues/226
         end
 
         # If they want an embargo, we can assume it's valid
         def apply_embargo(env, intention)
           return true unless intention.wants_embargo?
           env.curation_concern.apply_embargo(*intention.embargo_params)
-          return unless env.curation_concern.embargo
-          env.curation_concern.embargo.save # see https://github.com/samvera/hydra-head/issues/226
         end
     end
   end

--- a/app/services/hyrax/visibility_intention.rb
+++ b/app/services/hyrax/visibility_intention.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # Provides tools for interpreting form input as a visibility.
+  #
+  # @since 3.0.0
+  class VisibilityIntention
+    PUBLIC          = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    PRIVATE         = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    LEASE_REQUEST   = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE
+    EMBARGO_REQUEST = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
+
+    ##
+    # @!attribute [rw] after
+    #   @return [String] the visibility requested after the embargo/lease release
+    # @!attribute [rw] during
+    #   @return [String] the visibility requested while the embargo/lease is in effect
+    # @!attribute [rw] release_date
+    #   @return [String]
+    # @!attribute [rw] visibility
+    #   @return [String]
+    attr_accessor :after, :during, :release_date, :visibility
+
+    ##
+    # @param [String] after
+    # @param [String] during
+    # @param [String] release_date
+    # @param [String] visibility
+    def initialize(visibility: PRIVATE, release_date: nil, during: nil, after: nil)
+      self.after        = after
+      self.during       = during
+      self.release_date = release_date
+      self.visibility   = visibility
+    end
+
+    ##
+    # @return [Array] the parameters for the requested embargo
+    def embargo_params
+      return []           unless wants_embargo?
+      raise ArgumentError unless valid_embargo?
+
+      [release_date, (during || PRIVATE), (after || PUBLIC)]
+    end
+
+    ##
+    # @return [Array] the parameters for the requested embargo
+    def lease_params
+      return []           unless wants_lease?
+      raise ArgumentError unless valid_lease?
+
+      [release_date, (during || PUBLIC), (after || PRIVATE)]
+    end
+
+    ##
+    # @return [Boolean]
+    def valid_embargo?
+      wants_embargo? && release_date.present?
+    end
+
+    ##
+    # @return [Boolean]
+    def wants_embargo?
+      visibility == EMBARGO_REQUEST
+    end
+
+    ##
+    # @return [Boolean]
+    def valid_lease?
+      wants_lease? && release_date.present?
+    end
+
+    ##
+    # @return [Boolean]
+    def wants_lease?
+      visibility == LEASE_REQUEST
+    end
+  end
+end

--- a/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
+++ b/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
           expect(curation_concern.visibility_during_embargo).to eq 'authenticated'
           expect(curation_concern.visibility_after_embargo).to eq 'open'
           expect(curation_concern.visibility).to eq 'authenticated'
+          expect(curation_concern.reload).to be_under_embargo
         end
       end
 
@@ -429,6 +430,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
           expect(curation_concern.visibility_during_lease).to eq 'open'
           expect(curation_concern.visibility_after_lease).to eq 'restricted'
           expect(curation_concern.visibility).to eq 'open'
+          expect(curation_concern.reload.lease).not_to be_new_record
         end
       end
 

--- a/spec/services/hyrax/visibility_intention_spec.rb
+++ b/spec/services/hyrax/visibility_intention_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::VisibilityIntention do
+  subject(:intention) { described_class.new(attributes) }
+  let(:attributes)    { {} }
+
+  describe '#embargo_params' do
+    it 'is empty when no embargo is requested' do
+      expect(intention.embargo_params).to be_empty
+    end
+
+    context 'when an embargo is requested with no release date' do
+      let(:attributes) { { visibility: described_class::EMBARGO_REQUEST } }
+
+      it 'raises an error' do
+        expect { intention.embargo_params }.to raise_error ArgumentError
+      end
+    end
+
+    context 'when an embargo is requested with valid release date' do
+      let(:attributes) do
+        { visibility: described_class::EMBARGO_REQUEST, release_date: date }
+      end
+
+      let(:date) { Time.zone.today }
+
+      it 'builds private -> public embargo' do
+        expect(intention.embargo_params).to eq [date, described_class::PRIVATE, described_class::PUBLIC]
+      end
+    end
+
+    context 'when an embargo is requested with specific visibilities' do
+      let(:attributes) do
+        { visibility:   described_class::EMBARGO_REQUEST,
+          release_date: date,
+          after:       after,
+          during:      during }
+      end
+
+      let(:after)  { 'custom_after_embargo_visibility' }
+      let(:date)   { Time.zone.today }
+      let(:during) { 'custom_during_embargo_visibility' }
+
+      it 'builds private -> public embargo' do
+        expect(intention.embargo_params).to eq [date, during, after]
+      end
+    end
+  end
+
+  describe '#lease_params' do
+    it 'is empty when no lease is requested' do
+      expect(intention.lease_params).to be_empty
+    end
+
+    context 'when an lease is requested with no release date' do
+      let(:attributes) { { visibility: described_class::LEASE_REQUEST } }
+
+      it 'raises an error' do
+        expect { intention.lease_params }.to raise_error ArgumentError
+      end
+    end
+
+    context 'when lease embargo is requested with valid release date' do
+      let(:attributes) do
+        { visibility: described_class::LEASE_REQUEST, release_date: date }
+      end
+
+      let(:date) { Time.zone.today }
+
+      it 'builds public -> private lease' do
+        expect(intention.lease_params).to eq [date, described_class::PUBLIC, described_class::PRIVATE]
+      end
+    end
+
+    context 'when an lease is requested with specific visibilities' do
+      let(:attributes) do
+        { visibility: described_class::LEASE_REQUEST,
+          release_date: date,
+          after:       after,
+          during:      during }
+      end
+
+      let(:after)  { 'custom_after_lease_visibility' }
+      let(:date)   { Time.zone.today }
+      let(:during) { 'custom_during_lease_visibility' }
+
+      it 'builds private -> public embargo' do
+        expect(intention.lease_params).to eq [date, during, after]
+      end
+    end
+  end
+
+  describe '#valid_embargo?' do
+    it 'is false by default' do
+      expect(intention.valid_embargo?).to be_falsey
+    end
+
+    context 'when an embargo is requested with no release date' do
+      let(:attributes) { { visibility: described_class::EMBARGO_REQUEST } }
+
+      it 'is false' do
+        expect(intention.valid_embargo?).to be_falsey
+      end
+    end
+
+    context 'when an embargo is requested with valid release date' do
+      let(:attributes) do
+        { visibility: described_class::EMBARGO_REQUEST, release_date: Time.zone.now.to_s }
+      end
+
+      it 'is true' do
+        expect(intention.valid_embargo?).to be_truthy
+      end
+    end
+  end
+
+  describe '#wants_embargo?' do
+    it 'is false by default' do
+      expect(intention.wants_embargo?).to be_falsey
+    end
+
+    context 'when an embargo is requested' do
+      let(:attributes) { { visibility: described_class::EMBARGO_REQUEST } }
+
+      it 'is true' do
+        expect(intention.wants_embargo?).to be_truthy
+      end
+    end
+  end
+
+  describe '#wants_lease?' do
+    it 'is false by default' do
+      expect(intention.wants_lease?).to be_falsey
+    end
+
+    context 'when a lease is requested' do
+      let(:attributes) { { visibility: described_class::LEASE_REQUEST } }
+
+      it 'is true' do
+        expect(intention.wants_lease?).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
This logic is reasonably complex and reusable, but was previously hidden away in
a nested namespace. The reusable parts of the logic are extracted to a class
with a slightly simplified interface. The existing `Intention` class now
inherits `VisibilityIntention` and adds parameter sanitization (which doesn't
quite seem to fit in the extracted class).

This is a straight refactor with added unit tests for the new class. The
intention is to reuse this behavior in `hyrax/transactions`.

@samvera/hyrax-code-reviewers
