### PR TITLE
Set Work permissions and visibility when using `create_work` transaction

### DIFF
--- a/app/services/hyrax/visibility_intention_applicator.rb
+++ b/app/services/hyrax/visibility_intention_applicator.rb
@@ -23,17 +23,17 @@ module Hyrax
     end
 
     ##
-    # @param [Object] obj an object; this probably needs to be leasable,
+    # @param [Object] model an object; this probably needs to be leasable,
     #   embargoable, has visibility, and an AdminSet/PermissionTemplate.
-    def apply_to(obj)
+    def apply_to(model:)
       if intention.wants_embargo?
         raise InvalidIntentionError unless intention.valid_embargo?
-        obj.apply_embargo(*intention.embargo_params)
+        model.apply_embargo(*intention.embargo_params)
       elsif intention.wants_lease?
         raise InvalidIntentionError unless intention.valid_lease?
-        obj.apply_lease(*intention.lease_params)
+        model.apply_lease(*intention.lease_params)
       else
-        obj.visibility = intention.visibility
+        model.visibility = intention.visibility
       end
     end
     alias to apply_to

--- a/app/services/hyrax/visibility_intention_applicator.rb
+++ b/app/services/hyrax/visibility_intention_applicator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # Applies a `VisibilityIntention` to a repository object.
+  class VisibilityIntentionApplicator
+    ##
+    # @!attribute [rw] intention
+    #   @return [VisibilityIntention]
+    attr_accessor :intention
+
+    ##
+    # @param [VisibilityIntention] intention
+    def initialize(intention:)
+      self.intention = intention
+    end
+
+    ##
+    # @param [VisibilityIntention] intention
+    #
+    # @return [VisibilityIntentionApplicator]
+    def self.apply(intention)
+      new(intention: intention)
+    end
+
+    ##
+    # @param [Object] obj an object; this probably needs to be leasable,
+    #   embargoable, has visibility, and an AdminSet/PermissionTemplate.
+    def apply_to(obj)
+      if intention.wants_embargo?
+        raise InvalidIntentionError unless intention.valid_embargo?
+        obj.apply_embargo(*intention.embargo_params)
+      elsif intention.wants_lease?
+        raise InvalidIntentionError unless intention.valid_lease?
+        obj.apply_lease(*intention.lease_params)
+      else
+        obj.visibility = intention.visibility
+      end
+    end
+    alias to apply_to
+
+    class InvalidIntentionError < ArgumentError; end
+  end
+end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -20,6 +20,7 @@ module Hyrax
     class Container
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/destroy_work'
+      require 'hyrax/transactions/steps/apply_collection_permission_template'
       require 'hyrax/transactions/steps/apply_permission_template'
       require 'hyrax/transactions/steps/apply_visibility'
       require 'hyrax/transactions/steps/destroy_work'
@@ -32,7 +33,13 @@ module Hyrax
 
       extend Dry::Container::Mixin
 
+      # Disable BlockLength rule for DSL code
+      # rubocop:disable Metrics/BlockLength
       namespace 'work' do |ops|
+        ops.register 'apply_collection_permission_template' do
+          Steps::ApplyCollectionPermissionTemplate.new
+        end
+
         ops.register 'apply_permission_template' do
           Steps::ApplyPermissionTemplate.new
         end
@@ -70,6 +77,7 @@ module Hyrax
           Steps::SetUploadedDate.new
         end
       end
+      # rubocop:enable Metrics/BlockLength
     end
   end
 end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -21,6 +21,7 @@ module Hyrax
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/destroy_work'
       require 'hyrax/transactions/steps/apply_permission_template'
+      require 'hyrax/transactions/steps/apply_visibility'
       require 'hyrax/transactions/steps/destroy_work'
       require 'hyrax/transactions/steps/ensure_admin_set'
       require 'hyrax/transactions/steps/ensure_permission_template'
@@ -36,8 +37,13 @@ module Hyrax
           Steps::ApplyPermissionTemplate.new
         end
 
+<<<<<<< HEAD
         ops.register 'destroy_work' do
           Steps::DestroyWork.new
+=======
+        ops.register 'apply_visibility' do
+          Steps::ApplyVisibility.new
+>>>>>>> Apply visibility, embargo, and lease when creating transactionally
         end
 
         ops.register 'ensure_admin_set' do

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -44,13 +44,12 @@ module Hyrax
           Steps::ApplyPermissionTemplate.new
         end
 
-<<<<<<< HEAD
-        ops.register 'destroy_work' do
-          Steps::DestroyWork.new
-=======
         ops.register 'apply_visibility' do
           Steps::ApplyVisibility.new
->>>>>>> Apply visibility, embargo, and lease when creating transactionally
+        end
+
+        ops.register 'destroy_work' do
+          Steps::DestroyWork.new
         end
 
         ops.register 'ensure_admin_set' do

--- a/lib/hyrax/transactions/create_work.rb
+++ b/lib/hyrax/transactions/create_work.rb
@@ -34,17 +34,21 @@ module Hyrax
     #
     # @see https://dry-rb.org/gems/dry-transaction/
     #
-    # @todo add collection membership handling
-    # @todo add handling for collection permissions (see: `ApplyPermissionTemplateActor`)
+    # @todo add collection membership handling (@see CollectionsMembershipActor)
+    # @todo set depositor (@see BaseActor)
+    # @todo initialize workflow after save (@see BaseActor)
     # @todo add to parent works post-save (see: 'AddToWorkActor`)
     # @todo attach files (see: 'CreateWithFilesActor`, `CreateWithRemoteFilesActor`
     # @todo validate PermissionTemplate against visibility, lease, and embargo (see: `InterpretVisibilityActor`)
+    # @todo add locking/transactionality. Just do better than the Actor Stack
+    # @todo add support for proxy deposit (see: TransferRequestActor)
     class CreateWork
       include Dry::Transaction(container: Hyrax::Transactions::Container)
 
       step :set_default_admin_set,     with: 'work.set_default_admin_set'
       step :ensure_admin_set,          with: 'work.ensure_admin_set'
       step :apply_permission_template, with: 'work.apply_permission_template'
+      step :apply_collection_template, with: 'work.apply_collection_permission_template'
       step :apply_visibility,          with: 'work.apply_visibility'
       step :set_modified_date,         with: 'work.set_modified_date'
       step :set_uploaded_date,         with: 'work.set_uploaded_date'

--- a/lib/hyrax/transactions/create_work.rb
+++ b/lib/hyrax/transactions/create_work.rb
@@ -33,12 +33,19 @@ module Hyrax
     #     .or { |error| handle_error(error) }
     #
     # @see https://dry-rb.org/gems/dry-transaction/
+    #
+    # @todo add collection membership handling
+    # @todo add handling for collection permissions (see: `ApplyPermissionTemplateActor`)
+    # @todo add to parent works post-save (see: 'AddToWorkActor`)
+    # @todo attach files (see: 'CreateWithFilesActor`, `CreateWithRemoteFilesActor`
+    # @todo validate PermissionTemplate against visibility, lease, and embargo (see: `InterpretVisibilityActor`)
     class CreateWork
       include Dry::Transaction(container: Hyrax::Transactions::Container)
 
       step :set_default_admin_set,     with: 'work.set_default_admin_set'
       step :ensure_admin_set,          with: 'work.ensure_admin_set'
       step :apply_permission_template, with: 'work.apply_permission_template'
+      step :apply_visibility,          with: 'work.apply_visibility'
       step :set_modified_date,         with: 'work.set_modified_date'
       step :set_uploaded_date,         with: 'work.set_uploaded_date'
       step :save_work,                 with: 'work.save_work'

--- a/lib/hyrax/transactions/steps/apply_collection_permission_template.rb
+++ b/lib/hyrax/transactions/steps/apply_collection_permission_template.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # A `dry-transcation` step that applies permission templates for a set of
+      # collections on a given work.
+      #
+      # @since 3.0.0
+      class ApplyCollectionPermissionTemplate
+        include Dry::Transaction::Operation
+
+        ##
+        # @param [Hyrax::WorkBehavior] work
+        # @param [Array<#permision_template>] collections  a list of collections for which
+        #   permission templates should be applied
+        #
+        # @return [Dry::Monads::Result]
+        def call(work, collections: [])
+          collections.each do |collection|
+            template = Hyrax::PermissionTemplate.find_by!(source_id: collection.id)
+            Hyrax::PermissionTemplateApplicator.apply(template).to(model: work)
+          end
+
+          Success(work)
+        rescue ActiveRecord::RecordNotFound => err
+          Failure(err)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/apply_permission_template.rb
+++ b/lib/hyrax/transactions/steps/apply_permission_template.rb
@@ -3,7 +3,8 @@ module Hyrax
   module Transactions
     module Steps
       ##
-      # A `dry-transcation` step that applies a permission template.
+      # A `dry-transcation` step that applies a permission template for a given
+      # work's AdminSet.
       #
       # @since 2.4.0
       class ApplyPermissionTemplate

--- a/lib/hyrax/transactions/steps/apply_visibility.rb
+++ b/lib/hyrax/transactions/steps/apply_visibility.rb
@@ -27,7 +27,7 @@ module Hyrax
                                                      during:       during,
                                                      after:        after)
 
-          Hyrax::VisibilityIntentionApplicator.apply(intention).to(work)
+          Hyrax::VisibilityIntentionApplicator.apply(intention).to(model: work)
 
           Success(work)
         rescue Hyrax::VisibilityIntentionApplicator::InvalidIntentionError => err

--- a/lib/hyrax/transactions/steps/apply_visibility.rb
+++ b/lib/hyrax/transactions/steps/apply_visibility.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # A `dry-transaction` step that interprets visibility/lease/embargo from
+      # passed arguments.
+      #
+      # @since 3.0.0
+      class ApplyVisibility
+        include Dry::Transaction::Operation
+
+        ##
+        # @param [Hyrax::WorkBehavior] work
+        # @param [String] visibility
+        # @param [String] release_date
+        # @param [String] during
+        # @param [String] after
+        #
+        # @return [Dry::Monads::Result] `Failure` if there is no
+        #   `PermissionTemplate` for the input; `Success(input)`, otherwise.
+        def call(work, visibility: nil, release_date: nil, during: nil, after: nil)
+          return Success(work) unless visibility.present?
+
+          intention = Hyrax::VisibilityIntention.new(visibility:   visibility,
+                                                     release_date: release_date,
+                                                     during:       during,
+                                                     after:        after)
+
+          Hyrax::VisibilityIntentionApplicator.apply(intention).to(work)
+
+          Success(work)
+        rescue Hyrax::VisibilityIntentionApplicator::InvalidIntentionError => err
+          Failure(err)
+        end
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/create_work_spec.rb
+++ b/spec/hyrax/transactions/create_work_spec.rb
@@ -83,6 +83,34 @@ RSpec.describe Hyrax::Transactions::CreateWork do
     end
   end
 
+  context 'when requesting a lease' do
+    let(:after)     { 'restricted' }
+    let(:during)    { 'open' }
+    let(:end_date)  { (Time.zone.today + 2).to_s }
+    let(:request)   { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE }
+    let(:step_args) { { apply_visibility: [visibility: request, release_date: end_date, during: during, after: after] } }
+
+    it 'sets the lease' do
+      expect { transaction.with_step_args(step_args).call(work) }
+        .to change { work.lease }
+        .to be_a_lease_matching(release_date: end_date, during: during, after: after)
+    end
+  end
+
+  context 'when requesting an embargo' do
+    let(:after)     { 'open' }
+    let(:during)    { 'restricted' }
+    let(:end_date)  { (Time.zone.today + 2).to_s }
+    let(:request)   { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO }
+    let(:step_args) { { apply_visibility: [visibility: request, release_date: end_date, during: during, after: after] } }
+
+    it 'sets the embargo' do
+      expect { transaction.with_step_args(step_args).call(work) }
+        .to change { work.embargo }
+        .to be_an_embargo_matching(release_date: end_date, during: during, after: after)
+    end
+  end
+
   context 'with an admin set' do
     let(:admin_set) { AdminSet.find(template.source_id) }
     let(:template)  { create(:permission_template, with_admin_set: true) }

--- a/spec/hyrax/transactions/create_work_spec.rb
+++ b/spec/hyrax/transactions/create_work_spec.rb
@@ -180,4 +180,44 @@ RSpec.describe Hyrax::Transactions::CreateWork do
       end
     end
   end
+
+  context 'when inheriting permissions from a collection' do
+    let(:manage_groups) { ['edit_group_1', 'edit_group_2'] }
+    let(:manage_users)  { create_list(:user, 2) }
+    let(:view_groups)   { ['read_group_1', 'read_group_2'] }
+    let(:view_users)    { create_list(:user, 2) }
+    let(:collection)    { create(:collection_lw, with_permission_template: permissions) }
+    let(:step_args)     { { apply_collection_template: [collections: [collection]] } }
+
+    let(:permissions) do
+      { manage_groups: manage_groups,
+        manage_users:  manage_users,
+        view_groups:   view_groups,
+        view_users:    view_users }
+    end
+
+    it 'assigns edit groups from template' do
+      expect { transaction.with_step_args(step_args).call(work) }
+        .to change { work.edit_groups }
+        .to include(*manage_groups)
+    end
+
+    it 'assigns edit users from template' do
+      expect { transaction.with_step_args(step_args).call(work) }
+        .to change { work.edit_users }
+        .to include(*manage_users.map(&:user_key))
+    end
+
+    it 'assigns read groups from template' do
+      expect { transaction.with_step_args(step_args).call(work) }
+        .to change { work.read_groups }
+        .to include(*view_groups)
+    end
+
+    it 'assigns read users from template' do
+      expect { transaction.with_step_args(step_args).call(work) }
+        .to change { work.read_users }
+        .to include(*view_users.map(&:user_key))
+    end
+  end
 end

--- a/spec/hyrax/transactions/steps/apply_collection_permission_template_spec.rb
+++ b/spec/hyrax/transactions/steps/apply_collection_permission_template_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::ApplyCollectionPermissionTemplate do
+  subject(:step) { described_class.new }
+  let(:work)     { build(:generic_work) }
+
+  it 'is a success' do
+    expect(step.call(work)).to be_success
+  end
+
+  context 'when collection has no template' do
+    let(:collection) { double(Collection, id: 'fake_id') }
+
+    it 'is a failure' do
+      expect(step.call(work, collections: [collection])).to be_failure
+    end
+  end
+
+  context 'with permission template' do
+    let(:manage_groups) { ['edit_group_1', 'edit_group_2'] }
+    let(:manage_users)  { create_list(:user, 2) }
+    let(:view_groups)   { ['read_group_1', 'read_group_2'] }
+    let(:view_users)    { create_list(:user, 2) }
+    let(:collection)    { create(:collection_lw, with_permission_template: permissions) }
+
+    let(:permissions) do
+      { manage_groups: manage_groups,
+        manage_users:  manage_users,
+        view_groups:   view_groups,
+        view_users:    view_users }
+    end
+
+    it 'assigns edit users from template' do
+      expect { step.call(work, collections: [collection]) }
+        .to change { work.edit_users }
+        .to include(*manage_users.map(&:user_key))
+    end
+
+    it 'assigns edit groups from template' do
+      expect { step.call(work, collections: [collection]) }
+        .to change { work.edit_groups }
+        .to include(*manage_groups)
+    end
+
+    it 'assigns read users from template' do
+      expect { step.call(work, collections: [collection]) }
+        .to change { work.read_users }
+        .to include(*view_users.map(&:user_key))
+    end
+
+    it 'assigns read groups from template' do
+      expect { step.call(work, collections: [collection]) }
+        .to change { work.read_groups }
+        .to include(*view_groups)
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/apply_visibility_spec.rb
+++ b/spec/hyrax/transactions/steps/apply_visibility_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::ApplyVisibility do
+  subject(:step) { described_class.new }
+  let(:work)     { build(:generic_work) }
+
+  describe '#call' do
+    it 'is a success' do
+      expect(step.call(work)).to be_success
+    end
+
+    context 'without a visibility' do
+      it 'retains the existing visibility' do
+        expect { step.call(work) }
+          .not_to change { work.visibility }
+      end
+    end
+
+    context 'when setting visibility explictly' do
+      let(:visibility) { 'open' }
+
+      it 'applies the custom visibility embargo' do
+        expect { step.call(work, visibility: visibility) }
+          .to change { work.visibility }
+          .to visibility
+      end
+    end
+
+    context 'when setting a lease' do
+      let(:visibility) { 'lease' }
+      let(:end_date)   { (Time.zone.now + 2).to_s }
+      let(:after)      { 'restricted' }
+      let(:during)     { 'open' }
+      let(:opts) do
+        { visibility:   visibility,
+          release_date: end_date,
+          after:        after,
+          during:       during }
+      end
+
+      it 'interprets and applies the lease' do
+        expect { step.call(work, **opts) }
+          .to change { work.lease }
+          .to be_a_lease_matching(release_date: end_date, during: during, after: after)
+      end
+
+      context 'with missing end date' do
+        it 'is a failure' do
+          expect(step.call(work, visibility: visibility)).to be_failure
+        end
+      end
+    end
+
+    context 'when setting an embargo' do
+      let(:visibility) { 'embargo' }
+      let(:end_date)   { (Time.zone.now + 2).to_s }
+      let(:after)      { 'open' }
+      let(:during)     { 'restricted' }
+
+      let(:opts) do
+        { visibility:   visibility,
+          release_date: end_date,
+          after:        after,
+          during:       during }
+      end
+
+      it 'interprets and applies the embargo' do
+        expect { step.call(work, **opts) }
+          .to change { work.embargo }
+          .to be_an_embargo_matching(release_date: end_date, during: during, after: after)
+      end
+
+      context 'with missing end date' do
+        it 'is a failure' do
+          expect(step.call(work, visibility: visibility)).to be_failure
+        end
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/visibility_intention_applicator_spec.rb
+++ b/spec/services/hyrax/visibility_intention_applicator_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::VisibilityIntentionApplicator do
+  subject(:applicator) { described_class.new(intention: intention) }
+  let(:work)           { build(:work) }
+
+  let(:intention) do
+    instance_double(Hyrax::VisibilityIntention,
+                    'wants_embargo?': false,
+                    'wants_lease?':   false,
+                    visibility:       Hyrax::VisibilityIntention::PUBLIC)
+  end
+
+  describe '#apply' do
+    it 'initializes with intention' do
+      expect(described_class.apply(intention))
+        .to have_attributes(intention: intention)
+    end
+  end
+
+  describe '#apply_to' do
+    it 'applies simple visibility' do
+      expect { applicator.apply_to(work) }
+        .to change { work.visibility }
+        .to Hyrax::VisibilityIntention::PUBLIC
+    end
+
+    context 'when applying an embargo' do
+      let(:after)    { Hyrax::VisibilityIntention::PUBLIC }
+      let(:params)   { [end_date, during, after] }
+      let(:end_date) { (Time.zone.now + 2).to_s }
+      let(:during)   { Hyrax::VisibilityIntention::PRIVATE }
+
+      let(:intention) do
+        instance_double(Hyrax::VisibilityIntention,
+                        'wants_embargo?': true,
+                        'wants_lease?':   false,
+                        'valid_embargo?': true,
+                        embargo_params:   params)
+      end
+
+      it 'applies an embargo' do
+        expect { applicator.apply_to(work) }
+          .to change { work.embargo }
+          .to be_an_embargo_matching(release_date: end_date, during: during, after: after)
+      end
+    end
+
+    context 'when applying a lease' do
+      let(:after)    { Hyrax::VisibilityIntention::PUBLIC }
+      let(:during)   { Hyrax::VisibilityIntention::PRIVATE }
+      let(:params)   { [end_date, during, after] }
+      let(:end_date) { (Time.zone.now + 2).to_s }
+
+      let(:intention) do
+        instance_double(Hyrax::VisibilityIntention,
+                        'wants_embargo?': false,
+                        'wants_lease?':   true,
+                        'valid_lease?':   true,
+                        lease_params:     params)
+      end
+
+      it 'applies an lease' do
+        expect { applicator.apply_to(work) }
+          .to change { work.lease }
+          .to be_a_lease_matching(release_date: end_date, during: during, after: after)
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/visibility_intention_applicator_spec.rb
+++ b/spec/services/hyrax/visibility_intention_applicator_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::VisibilityIntentionApplicator do
 
   describe '#apply_to' do
     it 'applies simple visibility' do
-      expect { applicator.apply_to(work) }
+      expect { applicator.apply_to(model: work) }
         .to change { work.visibility }
         .to Hyrax::VisibilityIntention::PUBLIC
     end
@@ -39,7 +39,7 @@ RSpec.describe Hyrax::VisibilityIntentionApplicator do
       end
 
       it 'applies an embargo' do
-        expect { applicator.apply_to(work) }
+        expect { applicator.apply_to(model: work) }
           .to change { work.embargo }
           .to be_an_embargo_matching(release_date: end_date, during: during, after: after)
       end
@@ -60,7 +60,7 @@ RSpec.describe Hyrax::VisibilityIntentionApplicator do
       end
 
       it 'applies an lease' do
-        expect { applicator.apply_to(work) }
+        expect { applicator.apply_to(model: work) }
           .to change { work.lease }
           .to be_a_lease_matching(release_date: end_date, during: during, after: after)
       end

--- a/spec/support/matchers/embargo.rb
+++ b/spec/support/matchers/embargo.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :be_an_embargo_matching do |embargo_args|
+  match do |embargo|
+    (embargo.visibility_after_embargo == embargo_args[:after]) &&
+      (embargo.visibility_during_embargo == embargo_args[:during]) &&
+      embargo.embargo_release_date.to_s.start_with?(embargo_args[:release_date][0..9])
+  end
+end

--- a/spec/support/matchers/lease.rb
+++ b/spec/support/matchers/lease.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :be_a_lease_matching do |lease_args|
+  match do |lease|
+    (lease.visibility_after_lease == lease_args[:after]) &&
+      (lease.visibility_during_lease == lease_args[:during]) &&
+      lease.lease_expiration_date.to_s.start_with?(lease_args[:release_date][0..9])
+  end
+end


### PR DESCRIPTION
Applies visibility, embargo, and lease when creating transactionally; duplicating the core behavior of `InterpretVisibilityActor`, allowing users of transactional creation to pass in appropriate visibility arguments to achieve embargo, lease, or just custom visibility.

Existing behavior, where simple visibility can be set on a work before a transaction begins, remains.

Several details of the `InterpretVisibilityActor` remain unimplemented. For instance, we don't check visibility/embargo/lease against a `PermissionTemplate`. It's not immediately clear whether these features should be re-added in the transactional context. It appears they cause silent/unrecoverable failures in the Actor Stack context; if so, the status quo is that clients responsible for not running afoul of them.

----

Also applies `PermissionTemplate` based on collection. The AdminSet permission template is already applied in a separate step.

The actor stack has a complex way of handling Collection templates, split across the `CollectionsMembershipActor` and the `ApplyPermissionTemplateActor`, see especially: `CollectionsMembershipActor#extract_collection_id`.

Rather than reproduce this logic, we expect callers to the `create_work` transaction to simply tell us which collections we should apply a permission template for. This allows different user input to specify how collection membership should effect permissions, even allowing multiple templates to be
applied (which is not possible in the actor stack's approach).

@samvera/hyrax-code-reviewers
