### PR TITLE
Require hyrax/search_state

### DIFF
--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -1,3 +1,5 @@
+require 'hyrax/search_state'
+
 module Hyrax::Controller
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
When attempting to set the admin_set_create_service for the AdminSetsController in the hyrax initializer, you get an uninitialized constant error for Hyrax::SearchState.  It is required in an initializer within the Hyrax engine but for some reason that hasn't been loaded by this point in the hyrax initializer.  This commit makes the dependency explicit by requiring the load of search state here when Hyrax::Controller is used.

@samvera/hyrax-code-reviewers
