### PR TITLE
Add `DestroyWork` transaction, and make it destroy the a work

### DIFF
--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -19,7 +19,9 @@ module Hyrax
     # @see https://dry-rb.org/gems/dry-container/
     class Container
       require 'hyrax/transactions/create_work'
+      require 'hyrax/transactions/destroy_work'
       require 'hyrax/transactions/steps/apply_permission_template'
+      require 'hyrax/transactions/steps/destroy_work'
       require 'hyrax/transactions/steps/ensure_admin_set'
       require 'hyrax/transactions/steps/ensure_permission_template'
       require 'hyrax/transactions/steps/save_work'
@@ -32,6 +34,10 @@ module Hyrax
       namespace 'work' do |ops|
         ops.register 'apply_permission_template' do
           Steps::ApplyPermissionTemplate.new
+        end
+
+        ops.register 'destroy_work' do
+          Steps::DestroyWork.new
         end
 
         ops.register 'ensure_admin_set' do

--- a/lib/hyrax/transactions/destroy_work.rb
+++ b/lib/hyrax/transactions/destroy_work.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    ##
+    # A transaction for destroying a Hyrax Work.
+    #
+    # @note This is an experimental replacement for the actor stack's `#destroy`
+    #   stack. In time, we hope this will have feature parity with that stack,
+    #   along with improved architecture, error handling, readability, and
+    #   customizability. While this develops, please provide feedback.
+    #
+    # @since 3.0.0
+    #
+    # @see https://dry-rb.org/gems/dry-transaction/
+    class DestroyWork
+      include Dry::Transaction(container: Hyrax::Transactions::Container)
+
+      step :destroy_work, with: 'work.destroy_work'
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/destroy_work.rb
+++ b/lib/hyrax/transactions/steps/destroy_work.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # A `dry-transcation` step that destroys a Work.
+      #
+      # @since 3.0.0
+      class DestroyWork
+        include Dry::Transaction::Operation
+
+        ##
+        # @param [Hyrax::WorkBehavior] work
+        #
+        # @return [Dry::Monads::Result]
+        def call(work)
+          work.destroy! && Success(work)
+        rescue => err
+          Failure(err)
+        end
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/destroy_work_spec.rb
+++ b/spec/hyrax/transactions/destroy_work_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::DestroyWork do
+  subject(:transaction) { described_class.new }
+  let(:work)            { create(:generic_work) }
+
+  describe '#call' do
+    it 'is a success' do
+      expect(transaction.call(work)).to be_success
+    end
+
+    it 'destroys the work' do
+      expect { transaction.call(work) }
+        .to change { work.persisted? }
+        .from(true)
+        .to false
+    end
+
+    context 'with an unsaved work' do
+      let(:work) { build(:generic_work) }
+
+      it 'is a success' do
+        expect(transaction.call(work)).to be_success
+      end
+
+      it 'leaves the work unpersisted' do
+        expect { transaction.call(work) }
+          .not_to change { work.persisted? }
+          .from false
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/destroy_work_spec.rb
+++ b/spec/hyrax/transactions/steps/destroy_work_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::DestroyWork do
+  subject(:step) { described_class.new }
+  let(:work)     { build(:generic_work) }
+
+  it 'is a success' do
+    expect(step.call(work)).to be_success
+  end
+
+  context 'with an existing work' do
+    let(:work) { create(:generic_work) }
+
+    it 'destroys the work' do
+      expect { step.call(work) }
+        .to change { work.persisted? }
+        .from(true)
+        .to false
+    end
+
+    context 'when destruction fails for an unknown reason' do
+      let(:message) { 'moomin message' }
+
+      before { allow(work).to receive(:destroy).and_raise(message) }
+
+      it 'is a failure' do
+        expect(step.call(work).failure).to have_attributes(message: message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a first step to replacing the `#destroy` stack in the Actor Stack.

A `DestroyWork` transaction is added. It's sole current operation is to destroy
the work if it is persisted. When the work is not persisted, we return a
`Success`; errors are caught and wrapped in a `Failure`.

@samvera/hyrax-code-reviewers
