### PR TITLE
Make CreateWithRemoteFilesOrderedMembersActor thread safe

### DIFF
--- a/app/actors/hyrax/actors/create_with_remote_files_ordered_members_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_ordered_members_actor.rb
@@ -42,13 +42,11 @@ module Hyrax
     # Browse everything may also return a local file. And although it's in the
     # url property, it may have spaces, and not be a valid URI.
     class CreateWithRemoteFilesOrderedMembersActor < CreateWithRemoteFilesActor
-      attr_reader :ordered_members
-
       # @param [HashWithIndifferentAccess] remote_files
       # @return [TrueClass]
       def attach_files(env, remote_files)
         return true unless remote_files
-        @ordered_members = env.curation_concern.ordered_members.to_a
+        env.store(self, :ordered_members, env.curation_concern.ordered_members.to_a)
         remote_files.each do |file_info|
           next if file_info.blank? || file_info[:url].blank?
           # Escape any space characters, so that this is a legal URI
@@ -60,7 +58,7 @@ module Hyrax
           auth_header = file_info.fetch(:auth_header, {})
           create_file_from_url(env, uri, file_info[:file_name], auth_header)
         end
-        add_ordered_members(env.user, env.curation_concern)
+        add_ordered_members(env)
         true
       end
 
@@ -72,7 +70,7 @@ module Hyrax
           actor.create_metadata(visibility: env.curation_concern.visibility)
           actor.attach_to_work(env.curation_concern)
           fs.save!
-          ordered_members << fs
+          env.retrieve(self, :ordered_members) << fs
           if uri.scheme == 'file'
             # Turn any %20 into spaces.
             file_path = CGI.unescape(uri.path)
@@ -84,9 +82,9 @@ module Hyrax
       end
 
       # Add all file_sets as ordered_members in a single action
-      def add_ordered_members(user, work)
-        actor = Hyrax::Actors::OrderedMembersActor.new(ordered_members, user)
-        actor.attach_ordered_members_to_work(work)
+      def add_ordered_members(env)
+        actor = Hyrax::Actors::OrderedMembersActor.new(env.retrieve(self, :ordered_members), env.user)
+        actor.attach_ordered_members_to_work(env.curation_concern)
       end
 
       class_attribute :file_set_actor_class

--- a/app/actors/hyrax/actors/environment.rb
+++ b/app/actors/hyrax/actors/environment.rb
@@ -8,6 +8,7 @@ module Hyrax
         @curation_concern = curation_concern
         @current_ability = current_ability
         @attributes = attributes.to_h.with_indifferent_access
+        @actor_storage = {}
       end
 
       attr_reader :curation_concern, :current_ability, :attributes
@@ -16,6 +17,20 @@ module Hyrax
       def user
         current_ability.current_user
       end
+
+      def store(actor, key, value)
+        store_for(actor)[key] = value
+      end
+
+      def retrieve(actor, key)
+        store_for(actor)[key]
+      end
+
+      private
+
+        def store_for(actor)
+          @actor_storage[actor] ||= {}
+        end
     end
   end
 end

--- a/spec/actors/hyrax/actors/create_with_remote_files_ordered_members_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_remote_files_ordered_members_actor_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe Hyrax::Actors::CreateWithRemoteFilesOrderedMembersActor do
+  let(:null_operation) { class_double('Hyrax::Operation').as_null_object }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:actor) { stack.build(terminator) }
   let(:stack) do
@@ -9,41 +10,44 @@ RSpec.describe Hyrax::Actors::CreateWithRemoteFilesOrderedMembersActor do
   let(:user) { create(:user) }
   let(:ability) { Ability.new(user) }
   let(:work) { create(:generic_work, user: user) }
-  let(:url1) { "https://dl.dropbox.com/fake/blah-blah.filepicker-demo.txt.txt" }
-  let(:url2) { "https://dl.dropbox.com/fake/blah-blah.Getting%20Started.pdf" }
+  let(:urls) { ["https://dl.dropbox.com/fake/blah-blah.filepicker-demo.txt.txt", "https://dl.dropbox.com/fake/blah-blah.Getting%20Started.pdf"] }
+  let(:filenames) { ['filepicker-demo.txt.txt', 'Getting%20Started.pdf'] }
 
   let(:remote_files) do
-    [{ url: url1,
-       expires: "2014-03-31T20:37:36.214Z",
-       file_name: "filepicker-demo.txt.txt" },
-     { url: url2,
-       expires: "2014-03-31T20:37:36.731Z",
-       file_name: "Getting+Started.pdf" }]
+    urls.collect.with_index do |url, index|
+      { url: url, expires: "2014-03-31T20:37:36.214Z", file_name: filenames[index] }
+    end
   end
+
   let(:attributes) { { remote_files: remote_files } }
   let(:environment) { Hyrax::Actors::Environment.new(work, ability, attributes) }
 
   before do
+    allow(Hyrax::Operation).to receive(:create!).and_return(null_operation)
     allow(terminator).to receive(:create).and_return(true)
   end
 
   context "with two file_sets" do
-    let(:remote_files) do
-      [{ url: url1,
-         expires: "2014-03-31T20:37:36.214Z",
-         file_name: "filepicker-demo.txt.txt" },
-       { url: url2,
-         expires: "2014-03-31T20:37:36.731Z",
-         file_name: "Getting+Started.pdf" }]
-    end
-
     it "attaches files and passes ordered_members to OrderedMembersActor in correct order" do
-      expect(Hyrax::Actors::OrderedMembersActor).to receive(:new).with([FileSet, FileSet], user).and_return(Hyrax::Actors::OrderedMembersActor)
-      expect(Hyrax::Actors::OrderedMembersActor).to receive(:attach_ordered_members_to_work).with(work)
-      expect(ImportUrlJob).to receive(:perform_later).with(FileSet, Hyrax::Operation, {}).twice
+      expect(ImportUrlJob).to receive(:perform_later).with(FileSet, null_operation, {}).twice
       expect(actor.create(environment)).to be true
-      expect(actor.ordered_members.first.label).to eq('filepicker-demo.txt.txt')
-      expect(actor.ordered_members.last.label).to eq('Getting+Started.pdf')
+      expect(work.ordered_members.to_a.collect(&:label)).to eq(filenames)
+    end
+  end
+
+  context "with two environments processed by the same actor instance simultaneously" do
+    let(:work2) { create(:generic_work, user: user) }
+    let(:environments) { [environment, Hyrax::Actors::Environment.new(work2, ability, attributes)] }
+
+    it "attaches the correct FileSets to the correct works in the correct order" do
+      expect(ImportUrlJob).to receive(:perform_later).with(FileSet, null_operation, {}).exactly(4).times
+      threads = environments.collect do |env|
+        Thread.new do
+          expect(actor.create(env)).to be true
+          expect(env.curation_concern.ordered_members.to_a.collect(&:label)).to eq(filenames)
+        end
+      end
+      threads.each(&:join)
     end
   end
 end


### PR DESCRIPTION
*Summary:* Prevents instance variable collisions in the `CreateWithRemoteFilesOrderedMembersActor`

*Detailed Description*: Since `ActionDispatch::MiddlewareStack` reuses specific middlewares from a pool at runtime, individual middlewares (such as actors) should not count on having mutable instance variables. In this case, that manifested through the `@ordered_members` accumulator on the `CreateWithRemoteFilesOrderedMembersActor` actor, which ended up with a jumble of unrelated file sets under heavy ingest load (such as a batch ingest operation).

Changes proposed in this pull request:
* Add thread-safe `store` and `retrieve` methods to the environment that gets passed around among actors.
* Use environment storage instead of instance variables in the `CreateWithRemoteFilesOrderedMembersActor` actor.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* There isn't a great way to test this live without throwing a few hundred multi-fileset works at it in a single batch. I did add a threaded spec test that fails on the existing master branch and passes on this commit.

@samvera/hyrax-code-reviewers