### PR TITLE
Lock unauthorized permissions from update

### DIFF
--- a/app/services/hyrax/edit_permissions_service.rb
+++ b/app/services/hyrax/edit_permissions_service.rb
@@ -1,0 +1,112 @@
+module Hyrax
+  class EditPermissionsService
+    # Encapsulates the logic to determine which object permissions may be edited by a given user
+    #  - user is permitted to update any work permissions coming ONLY from collections they manage
+    #  - user is not permitted to update a work permission if it comes from a collection they do not manage, even if also from a managed collection
+    #  - user is permitted to update only non-manager permissions from any Collections
+    #  - user is permitted to update any non-collection permissions
+    attr_reader :depositor, :unauthorized_collection_managers
+
+    # @param [Object] GenericWorkForm (if called for object) or GenericWork (if called for file set)
+    # @param [Ability] user's current_ability
+    def initialize(object:, ability:)
+      @object = object
+      @ability = ability
+      @depositor = object.depositor
+      unauthorized = manager_permissions_to_block
+      @unauthorized_managers = unauthorized.unauthorized_managers
+      @unauthorized_collection_managers = unauthorized.unauthorized_collection_managers
+    end
+
+    # @param [Hash] one set of permission fields for object {:name, :access}
+    # @return [Boolean] true if user cannot edit the given permissions
+    def cannot_edit_permissions?(permission_hash)
+      @unauthorized_managers.include?(permission_hash[:name]) && permission_hash[:access] == "edit"
+    end
+
+    # @param [Hash] one set of permission fields for object {:name, :access}
+    # @return [Boolean] true if given permissions are one of fixed exclusions
+    def excluded_permission?(permission_hash)
+      exclude_from_display.include? permission_hash[:name].downcase
+    end
+
+    private
+
+      # Fixed set of users & groups to exclude from "editable" section of display
+      def exclude_from_display
+        [::Ability.public_group_name, ::Ability.registered_group_name, ::Ability.admin_group_name, @depositor]
+      end
+
+      BlockedPermissions = Struct.new(:unauthorized_managers, :unauthorized_collection_managers)
+
+      # find all of the other managers of collections which a user cannot manage
+      #
+      #   Process used:
+      #   - find all of the work's collections which a user can manage
+      #   - find all of the work's collections (of a type which shares permissions) that a user cannot manage
+      #   - find all of the managers of these collections the user cannot manage
+      #   This gives us the manager permissions the user is not authorized to update.
+      #
+      # @return [Struct] BlockedPermissions
+      #   - unauthorized_managers [Array] ids of managers of all collections
+      #   - unauthorized_collection_managers [Array hashes] manager ids & collection_ids [{:name, :id}]
+      def manager_permissions_to_block
+        unauthorized_managers = []
+        unauthorized_collection_managers = []
+        if object_unauthorized_collection_ids.any?
+          object_unauthorized_collection_ids.each do |id|
+            Hyrax::PermissionTemplate.find_by(source_id: id).access_grants.each do |grant|
+              if grant.access == "manage"
+                unauthorized_managers << grant.agent_id
+                unauthorized_collection_managers += Array.wrap({ name: grant.agent_id }.merge(id: id))
+              end
+            end
+          end
+        end
+        BlockedPermissions.new(unauthorized_managers, unauthorized_collection_managers)
+      end
+
+      # find all of the work's collections a user can manage
+      # @return [Array] of collection ids
+      def object_managed_collection_ids
+        @object_managed_collection_ids ||= object_member_of & managed_collection_ids
+      end
+
+      # find all of the work's collections a user cannot manage
+      # note: if the collection type doesn't include "sharing_applies_to_new_works", we don't limit access
+      # @return [Array] of collection ids with limited access
+      def object_unauthorized_collection_ids
+        @object_unauthorized_collection_ids ||= begin
+          limited_access = []
+          unauthorized_collection_ids = object_member_of - object_managed_collection_ids
+          if unauthorized_collection_ids.any?
+            unauthorized_collection_ids.each do |id|
+              collection = ActiveFedora::Base.find(id)
+              limited_access << id if (collection.instance_of? AdminSet) || collection.share_applies_to_new_works?
+            end
+          end
+          limited_access
+        end
+      end
+
+      # find all of the collection ids an object is a member of
+      # @return [Array] array of collection ids
+      def object_member_of
+        @object_member_of ||= begin
+          belongs_to = []
+          # get all of work's collection ids from the form
+          @object.member_of_collections.each do |collection|
+            belongs_to << collection.id
+          end
+          belongs_to << @object.admin_set_id unless @object.admin_set_id.empty?
+          belongs_to
+        end
+      end
+
+      # The list of all collections this user has manage rights on
+      # @return [Array] array of all collection ids that user can manage
+      def managed_collection_ids
+        Hyrax::Collections::PermissionsService.source_ids_for_manage(ability: @ability)
+      end
+  end
+end

--- a/app/views/hyrax/base/_currently_shared.html.erb
+++ b/app/views/hyrax/base/_currently_shared.html.erb
@@ -1,0 +1,66 @@
+<%#
+# form object.class = SimpleForm::FormBuilder
+#   For works (i.e. GenericWork):
+#   - form object.object = Hyrax::GenericWorkForm
+#   - form object.object.model = GenericWork
+#   - use the work itself
+#   For file_sets:
+#   - form object.object.class = FileSet
+#   - use work the file_set is in
+#   No other object types are supported by this view. %>
+<% if f.object.respond_to?(:model) && f.object.model.work?
+  object_acting_upon = f.object
+elsif f.object.file_set?
+  object_acting_upon = f.object.in_works.first
+end %>
+
+<% permission_service = Hyrax::EditPermissionsService.new(object: object_acting_upon, ability: current_ability) %>
+<% depositor = permission_service.depositor %>
+
+<h2><%= t('.currently_sharing') %></h2>
+
+<table class="table table-bordered">
+  <tr>
+    <th><%= t('.table_title_user') %></th>
+    <th><div class="col-sm-10"><%= t('.table_title_access') %></div></th>
+  </tr>
+  <tr id="file_permissions">
+    <td>
+      <%= label_tag :owner_access, class: "control-label" do %>
+        Depositor (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
+      <% end %>
+    </td>
+    <td>
+    <div class="col-sm-10">
+      <%= Hyrax.config.owner_permission_levels.keys[0] %>
+    </div>
+    </td>
+  </tr>
+  <%= f.fields_for :permissions do |permission_fields| %>
+    <% perm_hash = permission_fields.object.to_hash %>
+    <% next if permission_service.excluded_permission?(perm_hash) %>
+    <% cannot_edit_perms = permission_service.cannot_edit_permissions?(perm_hash) %>
+    <tr>
+      <td>
+        <%= permission_fields.label :agent_name, class: "control-label" do %>
+          <%= user_display_name_and_key(perm_hash[:name]) %>
+          <% permission_service.unauthorized_collection_managers.select {|mgrs| mgrs[:name] == perm_hash[:name] }.each do |coll| %>
+            <br />Access granted via collection <%= coll[:id] %>
+          <% end %>
+        <% end %>
+      </td>
+      <td>
+        <div class="col-sm-10">
+        <% if cannot_edit_perms %>
+          <%= Hyrax.config.permission_levels.key(perm_hash[:access]) %>
+        <% else %>
+          <%= permission_fields.select :access, Hyrax.config.permission_levels, {}, class: 'form-control select_perm' %>
+        <% end %>
+        </div>
+        <% if !cannot_edit_perms %>
+          <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">&times;</button>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/hyrax/base/_form_share.html.erb
+++ b/app/views/hyrax/base/_form_share.html.erb
@@ -1,8 +1,6 @@
 <p><%= t('.directions') %></p>
 <h2><%= t('.add_sharing') %></h2>
 
-<% depositor = f.object.depositor %>
-
 <div class="alert alert-info hidden" id="save_perm_note">Permissions are
   <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
 
@@ -48,39 +46,11 @@
   </div>
 </fieldset>
 
-<h2><%= t('.currently_sharing') %></h2>
-
-<table class="table">
-  <tr id="file_permissions">
-    <td width="20%">
-      <%= Hyrax.config.owner_permission_levels.keys[0] %>
-    </td>
-    <td width="60%">
-      <%= label_tag :owner_access, class: "control-label" do %>
-        Depositor (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
-      <% end %>
-    </td>
-  </tr>
-  <%= f.fields_for :permissions do |permission_fields| %>
-    <%# skip the public, registered, and depositor perms as they are displayed first at the top %>
-    <% next if ['public', 'registered', depositor].include? permission_fields.object.agent_name.downcase %>
-    <tr>
-      <td>
-        <%= permission_fields.select :access, Hyrax.config.permission_levels, {}, class: 'form-control select_perm' %>
-      </td>
-      <td>
-        <%= permission_fields.label :agent_name, class: "control-label" do %>
-          <%= user_display_name_and_key(permission_fields.object.agent_name) %>
-        <% end %>
-        <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">&times;</button>
-      </td>
-    </tr>
-  <% end %>
-</table>
+<%= render 'currently_shared', f: f %>
 
 <script type="text/x-tmpl" id="tmpl-work-grant">
-<tr>
-  <td>{%= o.accessLabel %}</td>
-  <td><label class="control-label">{%= o.name %}</label> <button class="btn close">&times;</button></td>
-</tr>
+  <tr>
+    <td><label class="control-label">{%= o.name %}</label></td>
+    <td><div class="col-sm-10">{%= o.accessLabel %}<button class="btn close">&times;</button></div></td>
+  </tr>
 </script>

--- a/app/views/hyrax/batch_edits/_currently_shared.html.erb
+++ b/app/views/hyrax/batch_edits/_currently_shared.html.erb
@@ -1,0 +1,8 @@
+<h2><%= t('.share_batch_with') %></h2>
+
+<table class="table table-bordered">
+  <tr id="file_permissions">
+    <th  width="65%"><%= t('.table_title_user') %></th>
+    <th><div class="col-sm-10"><%= t('.table_title_access') %></div></th>
+  </tr>
+</table>

--- a/app/views/hyrax/file_sets/_permission_form.html.erb
+++ b/app/views/hyrax/file_sets/_permission_form.html.erb
@@ -65,37 +65,8 @@
   </div>
 </div>
 
-<table class="table table-bordered">
-  <tr>
-    <th width="60%"><%= t('.table_title_user') %></th>
-    <th width="40%"><%= t('.table_title_access') %></th>
-  </tr>
-  <tr id="file_permissions">
-    <td>
-      <%= label_tag :owner_access, class: "control-label" do %>
-        <%= t('.depositor') %> (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
-      <% end %>
-    </td>
-    <td>
-      <%= Hyrax.config.owner_permission_levels.keys[0] %>
-    </td>
-  </tr>
-  <%= f.fields_for :permissions do |permission_fields| %>
-    <%# skip the public, registered, and depositor perms as they are displayed first at the top %>
-    <% next if ['public', 'registered', depositor].include? permission_fields.object.agent_name.downcase %>
-    <tr>
-      <td><%= permission_fields.label :agent_name, class: "control-label" do %>
-        <%= user_display_name_and_key(permission_fields.object.agent_name) %>
-      <% end %></td>
-      <td>
-        <div class="col-sm-8">
-          <%= permission_fields.select :access, Hyrax.config.permission_levels, {}, class: 'form-control select_perm' %>
-        </div>
-        <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">X</button>
-      </td>
-    </tr>
-  <% end %>
-</table>
+<%= render 'currently_shared', f: f %>
+
 <script type="text/x-tmpl" id="tmpl-file-set-grant">
 <tr>
   <td><label class="control-label">{%= o.name %}</label></td>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -348,6 +348,10 @@ en:
     base:
       citations:
         header: 'Citations:'
+      currently_shared:
+        currently_sharing: Currently Shared With
+        table_title_access: Access Level
+        table_title_user: Person/Group
       file_manager:
         back_to: Back to
         toolbar: Toolbar
@@ -416,7 +420,6 @@ en:
         legend_html: Representative Media
       form_share:
         add_sharing: Add Sharing
-        currently_sharing: Currently Shared With
         directions: Regardless of the visibility settings for this work, you can also share it with other users and groups.
       form_thumbnail:
         help_html: Select the file to be used as the thumbnail for this work.
@@ -462,6 +465,10 @@ en:
         resource_type: You may select multiple types to apply to all files
         title: Filename will be the default title. Please provide a more meaningful title, and filenames will still be preserved by the system.
     batch_edits:
+      currently_shared:
+        share_batch_with: Share Batch With
+        table_title_access: Access Level
+        table_title_user: Person/Group
       delete_selected:
         button_label: Delete Selected
     batch_uploads:
@@ -930,8 +937,6 @@ en:
         save_note_html: Permissions are <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.
         select_group: Select a group
         share_with: Share With
-        table_title_access: Access Level
-        table_title_user: Person/Group
         user_search: Search for a user
       show_actions:
         analytics: Analytics

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
   let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
   let!(:workflow) { create(:workflow, allows_access_grant: true, active: true, permission_template_id: permission_template.id) }
 
-  let!(:work1)       { create(:public_work, admin_set_id: admin_set.id, user: current_user, members: [file_set]) }
+  let!(:work1)       { create(:public_work, admin_set_id: admin_set.id, user: current_user, ordered_members: [file_set]) }
   let!(:work2)       { create(:public_work, admin_set_id: admin_set.id, user: current_user) }
   let!(:file_set)    { create(:file_set) }
 

--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
   end
 
   describe 'when both collections require single membership' do
-    let(:old_collection) { build(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_1.gid, title: ['OldCollectionTitle']) }
+    let(:old_collection) { build(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_1.gid, title: ['OldCollectionTitle'], with_permission_template: true) }
     let!(:work) do
       create(:generic_work,
              user: admin_user,

--- a/spec/features/edit_file_spec.rb
+++ b/spec/features/edit_file_spec.rb
@@ -1,7 +1,10 @@
 RSpec.describe "Editing a file:", type: :feature do
   let(:user) { create(:user) }
+  let(:admin_set) { create(:admin_set) }
+  let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
+  let!(:workflow) { create(:workflow, allows_access_grant: true, active: true, permission_template_id: permission_template.id) }
   let(:file_title) { 'Some kind of title' }
-  let(:work) { build(:work, user: user) }
+  let(:work) { build(:work, user: user, admin_set_id: admin_set.id) }
   let(:file_set) { create(:file_set, user: user, title: [file_title]) }
   let(:file) { File.open(fixture_path + '/world.png') }
 

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe 'Editing a work', type: :feature do
     work.ordered_members << create(:file_set, user: user, title: ['ABC123xyz'])
     work.read_groups = []
     work.save!
+
+    create(:permission_template_access,
+           :deposit,
+           permission_template: create(:permission_template, source_id: default_admin_set.id, with_admin_set: true, with_active_workflow: true),
+           agent_type: 'user',
+           agent_id: user.user_key)
+    create(:permission_template_access,
+           :deposit,
+           permission_template: create(:permission_template, source_id: another_admin_set.id, with_admin_set: true, with_active_workflow: true),
+           agent_type: 'user',
+           agent_id: user.user_key)
   end
 
   context 'when the user changes permissions' do
@@ -39,19 +50,6 @@ RSpec.describe 'Editing a work', type: :feature do
   end
 
   context 'when form loads' do
-    before do
-      create(:permission_template_access,
-             :deposit,
-             permission_template: create(:permission_template, source_id: default_admin_set.id, with_admin_set: true, with_active_workflow: true),
-             agent_type: 'user',
-             agent_id: user.user_key)
-      create(:permission_template_access,
-             :deposit,
-             permission_template: create(:permission_template, source_id: another_admin_set.id, with_admin_set: true, with_active_workflow: true),
-             agent_type: 'user',
-             agent_id: user.user_key)
-    end
-
     it 'selects admin set already assigned' do
       visit edit_hyrax_generic_work_path(work)
       click_link "Relationships" # switch tab

--- a/spec/services/hyrax/edit_permissions_service_spec.rb
+++ b/spec/services/hyrax/edit_permissions_service_spec.rb
@@ -1,0 +1,147 @@
+RSpec.describe Hyrax::EditPermissionsService do
+  let(:my_user) { create(:user) }
+  let(:ability) { Ability.new(my_user) }
+  # build users for testing
+  let(:mgr1) { build(:user) }
+  let(:mgr2) { build(:user) }
+  let(:mgr3) { build(:user) }
+  let(:mgr4) { build(:user) }
+  let(:mgr5) { build(:user) }
+  let(:vw1) { build(:user) }
+  let(:vw2) { build(:user) }
+  let(:vw3) { build(:user) }
+  let(:vw4) { build(:user) }
+  let(:coll_creator) { build(:user) }
+
+  # build collections for testing
+  # my_user has no manage rights to admin_set
+  let(:admin_set) do
+    build(:adminset_lw,
+          id: 'default_admin_set',
+          user: coll_creator,
+          with_permission_template: { manage_users: [mgr1], view_users: [vw1] })
+  end
+  # my_user has manage rights to this collection
+  let(:sharable_coll1) do
+    build(:collection_lw,
+          id: 'sharable_coll1',
+          user: coll_creator,
+          collection_type_settings: [:sharable],
+          with_permission_template: { manage_users: [mgr2, my_user], view_users: [vw2] })
+  end
+  # my_user has no manage rights to this collection
+  let(:sharable_coll2) do
+    build(:collection_lw,
+          id: 'sharable_coll2',
+          user: coll_creator,
+          collection_type_settings: [:sharable],
+          with_permission_template: { manage_users: [mgr3], view_users: [vw3] })
+  end
+  # non-sharable collections do not impact the permissions of the works
+  let(:nonsharable_collection) do
+    build(:collection_lw,
+          id: 'nonsharable_coll',
+          user: coll_creator,
+          collection_type_settings: [:not_sharable],
+          with_permission_template: { manage_users: [mgr4], view_users: [vw4] })
+  end
+
+  # @note: We are using multiple collections only in order to test the complex situations
+  # all at once. Collection permissions are explicitly added onto the work here because
+  # multi-membership at the time of creation prevents sharing of permissions to the work.
+  # However, since we don't know which work's permissions were actually inherited from a
+  # sharable collection, we have to assume they all need to be restricted.
+  # build work for testing:
+  let(:generic_work) do
+    build(:generic_work,
+          user: my_user,
+          edit_users: [mgr2, mgr3, mgr4, mgr5],
+          read_users: [vw2, vw3, vw4],
+          visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE,
+          member_of_collections: [sharable_coll1, sharable_coll2, nonsharable_collection],
+          admin_set: admin_set)
+  end
+
+  let(:work_permission_service) { described_class.new(object: generic_work, ability: ability) }
+
+  # defined for expectations
+  let(:admin_set_manager) { Hash[id: admin_set.id, name: mgr1.user_key] }
+  let(:admin_set_creator) { Hash[id: admin_set.id, name: coll_creator.user_key] }
+  let(:sharable_coll1_manager) { Hash[id: sharable_coll1.id, name: mgr2.user_key] }
+  let(:sharable_coll1_creator) { Hash[id: sharable_coll1.id, name: coll_creator.user_key] }
+  let(:sharable_coll2_manager) { Hash[id: sharable_coll2.id, name: mgr3.user_key] }
+  let(:sharable_coll2_creator) { Hash[id: sharable_coll2.id, name: coll_creator.user_key] }
+  let(:sharable_coll2_viewer) { Hash[id: sharable_coll2.id, name: vw3.user_key] }
+  let(:nonsharable_coll_manager) { Hash[id: nonsharable_collection.id, name: mgr4.user_key] }
+  let(:nonsharable_coll_creator) { Hash[id: nonsharable_collection.id, name: coll_creator.user_key] }
+
+  before do
+    allow(ActiveFedora::Base).to receive(:find).with(admin_set.id).and_return(admin_set)
+    allow(ActiveFedora::Base).to receive(:find).with(sharable_coll1.id).and_return(sharable_coll1)
+    allow(ActiveFedora::Base).to receive(:find).with(sharable_coll2.id).and_return(sharable_coll2)
+    allow(ActiveFedora::Base).to receive(:find).with(nonsharable_collection.id).and_return(nonsharable_collection)
+  end
+
+  describe '#initialize' do
+    let(:subject) { work_permission_service }
+
+    it 'responds to #depositor and #unauthorized_collection_managers' do
+      expect(subject).to respond_to(:depositor)
+      expect(subject).to respond_to(:unauthorized_collection_managers)
+      expect(subject.depositor).to eq(my_user.user_key)
+    end
+  end
+
+  describe '#cannot_edit_permissions?' do
+    let(:subject) { work_permission_service }
+
+    context 'validating which collection managers user may manage' do
+      it 'allows user to change managers from authorized collection' do
+        expect(subject.unauthorized_collection_managers).not_to include(sharable_coll1_manager)
+        expect(subject.cannot_edit_permissions?(Hash[name: mgr2.name, type: 'person', access: 'edit'])).to eq false
+      end
+
+      it 'restricts user from changing managers from unauthorized collections' do
+        expect(subject.unauthorized_collection_managers).to include(admin_set_manager, admin_set_creator, sharable_coll2_manager, sharable_coll2_creator)
+        expect(subject.cannot_edit_permissions?(Hash[name: mgr1.name, type: 'person', access: 'edit'])).to eq true
+        expect(subject.cannot_edit_permissions?(Hash[name: mgr3.name, type: 'person', access: 'edit'])).to eq true
+      end
+
+      it 'restricts user from changing managers which are in both authorized & unauthorized collections' do
+        expect(subject.unauthorized_collection_managers).not_to include(sharable_coll1_creator)
+        expect(subject.cannot_edit_permissions?(Hash[name: coll_creator.name, type: 'person', access: 'edit'])).to eq true
+      end
+
+      it 'allows user to change managers not from sharable collections' do
+        expect(subject.unauthorized_collection_managers).not_to include(nonsharable_coll_manager)
+        expect(subject.cannot_edit_permissions?(Hash[name: mgr4.name, type: 'person', access: 'edit'])).to eq false
+        expect(subject.cannot_edit_permissions?(Hash[name: mgr5.name, type: 'person', access: 'edit'])).to eq false
+      end
+
+      it 'allows user to change non-manager permissions an unauthorized collection' do
+        expect(subject.unauthorized_collection_managers).not_to include(sharable_coll2_viewer)
+        expect(subject.cannot_edit_permissions?(Hash[name: vw3.name, type: 'person', access: 'read'])).to eq false
+      end
+    end
+  end
+
+  describe '#excluded_permission?' do
+    let(:subject) { work_permission_service.excluded_permission?(permission_hash) }
+
+    context 'for an excluded permission' do
+      let(:permission_hash) { Hash[name: my_user.name, type: 'person', access: 'edit'] }
+
+      it 'returns true' do
+        expect(subject).to eq true
+      end
+    end
+
+    context 'for an allowed permission' do
+      let(:permission_hash) { Hash[name: mgr1.name, type: 'person', access: 'edit'] }
+
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+  end
+end

--- a/spec/views/hyrax/base/_currently_shared.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_currently_shared.html.erb_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe 'hyrax/base/_currently_shared.html.erb', type: :view do
+  let(:user) { stub_model(User) }
+  let(:work) do
+    stub_model(GenericWork, id: '456')
+  end
+  # let(:admin_set) { stub_model(AdminSet, id: '789') }
+  let(:file_set) do
+    stub_model(FileSet, id: '123',
+                        depositor: 'bob',
+                        resource_type: ['Dataset'], in_works: [work])
+  end
+  let(:file_set_form) do
+    view.simple_form_for(file_set, url: '/update') do |fs_form|
+      return fs_form
+    end
+  end
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(view).to receive(:f).and_return(file_set_form)
+    allow(work).to receive(:depositor).and_return(user)
+    allow(file_set).to receive(:permissions).and_return(permissions)
+    allow(work).to receive(:member_of_collections).and_return([])
+    allow(work).to receive(:admin_set_id).and_return([])
+    render
+  end
+
+  context "it displays the form" do
+    let(:permissions) { [] }
+
+    it "draws the permissions form without error" do
+      # actual testing of who gets what permission access is done in the EditPermissionsService
+      expect(rendered).to have_content("Depositor")
+    end
+  end
+end

--- a/spec/views/hyrax/base/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form.html.erb_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
     allow(form).to receive(:permissions).and_return([])
     allow(form).to receive(:visibility).and_return('public')
     stub_template 'hyrax/base/_form_files.html.erb' => 'files'
+    stub_template 'hyrax/base/_currently_shared.html.erb' => 'shared'
   end
 
   context "for a new object" do

--- a/spec/views/hyrax/file_sets/_permission_form.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_permission_form.html.erb_spec.rb
@@ -13,32 +13,15 @@ RSpec.describe 'hyrax/file_sets/_permission_form.html.erb', type: :view do
 
   before do
     allow(controller).to receive(:current_user).and_return(stub_model(User))
-    allow(file_set).to receive(:permissions).and_return(permissions)
     allow(view).to receive(:f).and_return(form)
     view.lookup_context.prefixes.push 'hyrax/base'
+    stub_template "_currently_shared.html.erb" => "<span class='base-currently-shared'>base/currently_shared</span>"
     view.extend Hyrax::PermissionsHelper
     render
   end
 
-  context "without additional users" do
-    let(:permissions) { [] }
-
-    it "draws the permissions form without error" do
-      expect(rendered).to have_css("input#new_user_name_skel")
-      expect(rendered).not_to have_css("button.remove_perm")
-    end
-  end
-
-  context "with additional users" do
-    let(:depositor_permission) { Hydra::AccessControls::Permission.new(id: '123', name: 'bob', type: 'person', access: 'edit') }
-    let(:public_permission) { Hydra::AccessControls::Permission.new(id: '124', name: 'public', type: 'group', access: 'read') }
-    let(:other_permission) { Hydra::AccessControls::Permission.new(id: '125', name: 'joe@example.com', type: 'person', access: 'edit') }
-    let(:permissions) { [depositor_permission, public_permission, other_permission] }
-
-    it "draws the permissions form without error" do
-      expect(rendered).to have_css("input#new_user_name_skel")
-      expect(rendered).to have_css("button.remove_perm", count: 1) # depositor and public should be filtered out
-      expect(rendered).to have_css("button.remove_perm[data-index='2']")
-    end
+  it "draws the permissions form without error" do
+    expect(rendered).to have_css("input#new_user_name_skel")
+    expect(rendered).to have_content("base/currently_shared")
   end
 end


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/3166

### Allowed permission maintenance:
- user is permitted to update any work permissions coming from collections they manage
- user is permitted to update non-manager permissions from any Collections
- user is permitted to update non-collection permissions 

### Process used:
- find all of the work's collections a user can manage
- find all of the work's collections a user cannot manage
- find all of the other managers of collections a user can manage
- find all of the other managers of collections a user cannot manage who are not also managers in collections that the user CAN manage.

This gives us the permissions the user is not authorized to update. The shared partial, `currently_shared.html.erb` embeds all of the above logic and uses it to display all of the work or file set's permissions in either a fixed or editable format. The new shared partial results in a slight reformat of the display of these permissions, as there were previously minor differences between the two displays.

Additionally, a new partial was created for batch edit, as the above rules cannot be enforced at a batch level. Dealing with batch editing sharing issues is beyond the scope of this issue.

@samvera/hyrax-code-reviewers
