### PR TITLE
Recover rolled back minter state on actor stack failure

### DIFF
--- a/app/actors/hyrax/actors/transactional_request.rb
+++ b/app/actors/hyrax/actors/transactional_request.rb
@@ -10,6 +10,10 @@ module Hyrax
         ActiveRecord::Base.transaction do
           next_actor.create(env)
         end
+      rescue StandardError => err
+        # note that this does not catch explicit `ActiveRecord::Rollback` calls.
+        env.curation_concern.ensure_valid_minter_state
+        raise err
       end
 
       # @param [Hyrax::Actors::Environment] env

--- a/app/services/hyrax/noid.rb
+++ b/app/services/hyrax/noid.rb
@@ -8,6 +8,22 @@ module Hyrax
       service.mint if Hyrax.config.enable_noids?
     end
 
+    ##
+    # Mints ids until one of them isn't in use in the Fedora backend
+    #
+    # @note this uses up an identifier from the minter which won't ever be
+    #   assigned to an object
+    #
+    # @return [Boolean] true if we have successfully re-established a valid
+    #   minter state
+    def ensure_valid_minter_state
+      return true unless Hyrax.config.enable_noids?
+
+      loop { break unless ActiveFedora::Base.exists?(service.mint) }
+
+      true
+    end
+
     private
 
       def service

--- a/spec/features/actor_stack_spec.rb
+++ b/spec/features/actor_stack_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+# Integration tests for the full midddleware stack
+RSpec.describe Hyrax::DefaultMiddlewareStack, :clean_repo do
+  subject(:actor)  { stack.build(Hyrax::Actors::Terminator.new) }
+  let(:ability)    { ::Ability.new(user) }
+  let(:attributes) { {} }
+  let(:stack)      { described_class.build_stack }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:user)       { FactoryBot.create(:user) }
+  let(:work)       { FactoryBot.build(:work) }
+  let(:env)        { Hyrax::Actors::Environment.new(work, ability, attributes) }
+
+  let(:delayed_failure_actor) do
+    Class.new(Hyrax::Actors::AbstractActor) do
+      def create(env)
+        next_actor.create(env) && raise
+      end
+    end
+  end
+
+  describe '#create' do
+    it 'persists the work' do
+      expect { actor.create(env) }
+        .to change { work.persisted? }
+        .to true
+    end
+
+    context 'when failing on the way back up the actor stack' do
+      before { stack.insert_before(Hyrax::Actors::ModelActor, delayed_failure_actor) }
+
+      before(:context) do
+        Hyrax.config.enable_noids = true
+        # we need to mint once to set the `rand` database column and
+        # make minter behavior predictable
+        ::Noid::Rails.config.minter_class.new.mint
+      end
+
+      after(:context) { Hyrax.config.enable_noids = false }
+
+      it 'leaves a valid minter state' do
+        begin; actor.create(env); rescue; end
+
+        expect(GenericWork.new.assign_id).not_to eq work.id
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the actor stack fails, a database transaction rolls back. When the DB-based
NOID minter is in use, this rolls back the minter state. However, it does *not*
roll back any objects actually created by ActiveFedora in the process of running
the stack. This leads lagged minter state, and a perpetual `Ldp::Conflict`
blocking creation of further objects.

Rather than keeping this lagged minter state, we can catch any errors raised
through the transaction, and update the minter state. To do this, we mint ids
and send HEAD requests to Fedora until we can find an id that does not already
have a Fedora object. This first valid id is wasted, but future mints are
unblocked.

This process only runs in cases where an error has been raised by the
transactions. This is mostly an effective time to remediate, except two caveats:

  - Explict raises of `ActiveRecord::Rollback` are eaten by the transaction, so
    won't recover. Actors, therefore, should not explictly rollback; this is
    probably an anti-pattern to begin with.
  - When an error is raised, but no ActiveFedora objects have been created, we
    are over-eager and end up running the recovery code and wasting the test
    id.

Related to #3128.

@samvera/hyrax-code-reviewers
