### PR TITLE
Remove `Hyrax::Actors::TransactionalRequest` from default middleware 

### DIFF
--- a/app/services/hyrax/default_middleware_stack.rb
+++ b/app/services/hyrax/default_middleware_stack.rb
@@ -3,10 +3,6 @@ module Hyrax
     # rubocop:disable Metrics/MethodLength
     def self.build_stack
       ActionDispatch::MiddlewareStack.new.tap do |middleware|
-        # Wrap everything in a database transaction, if the save of the resource
-        # fails then roll back any database AdminSetChangeSet
-        middleware.use Hyrax::Actors::TransactionalRequest
-
         # Ensure you are mutating the most recent version
         middleware.use Hyrax::Actors::OptimisticLockValidator
 

--- a/spec/features/actor_stack_spec.rb
+++ b/spec/features/actor_stack_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+# Integration tests for the full midddleware stack
+RSpec.describe Hyrax::DefaultMiddlewareStack, :clean_repo do
+  subject(:actor)  { stack.build(Hyrax::Actors::Terminator.new) }
+  let(:ability)    { ::Ability.new(user) }
+  let(:attributes) { {} }
+  let(:stack)      { described_class.build_stack }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:user)       { FactoryBot.create(:user) }
+  let(:work)       { FactoryBot.build(:work) }
+  let(:env)        { Hyrax::Actors::Environment.new(work, ability, attributes) }
+
+  let(:delayed_failure_actor) do
+    Class.new(Hyrax::Actors::AbstractActor) do
+      def create(env)
+        next_actor.create(env) && raise('ALWAYS RAISE')
+      end
+    end
+  end
+
+  describe '#create' do
+    it 'persists the work' do
+      expect { actor.create(env) }
+        .to change { work.persisted? }
+        .to true
+    end
+
+    context 'when failing on the way back up the actor stack' do
+      before { stack.insert_before(Hyrax::Actors::ModelActor, delayed_failure_actor) }
+
+      before(:context) do
+        Hyrax.config.enable_noids = true
+        # we need to mint once to set the `rand` database column and
+        # make minter behavior predictable
+        ::Noid::Rails.config.minter_class.new.mint
+      end
+
+      after(:context) { Hyrax.config.enable_noids = false }
+
+      it 'leaves a valid minter state', :aggregate_failures do
+        expect { actor.create(env) }.to raise_error 'ALWAYS RAISE'
+
+        expect(GenericWork.new.assign_id).not_to eq work.id
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/curation_concern_spec.rb
+++ b/spec/services/hyrax/curation_concern_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hyrax::CurationConcern do
   describe ".actor" do
     subject { described_class.actor }
 
-    it { is_expected.to be_kind_of Hyrax::Actors::TransactionalRequest }
+    it { is_expected.to be_kind_of Hyrax::Actors::AbstractActor }
   end
 
   describe ".actor_factory" do

--- a/spec/services/hyrax/default_middleware_stack_spec.rb
+++ b/spec/services/hyrax/default_middleware_stack_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Hyrax::DefaultMiddlewareStack do
 
     it "has the correct stack frames" do
       expect(subject.middlewares).to eq [
-        Hyrax::Actors::TransactionalRequest,
         Hyrax::Actors::OptimisticLockValidator,
         Hyrax::Actors::CreateWithRemoteFilesActor,
         Hyrax::Actors::CreateWithFilesActor,
@@ -30,7 +29,7 @@ RSpec.describe Hyrax::DefaultMiddlewareStack do
 
   describe 'Hyrax::CurationConcern.actor' do
     it "calls the Hyrax::ActorFactory" do
-      expect(Hyrax::CurationConcern.actor).to be_instance_of Hyrax::Actors::TransactionalRequest
+      expect(Hyrax::CurationConcern.actor).to be_instance_of Hyrax::Actors::OptimisticLockValidator
     end
   end
 end


### PR DESCRIPTION
The actor stack involves writing to several diffrent persistence layers; at
least:

  - ActiveRecord
  - ActiveFedora (Fedora/Solr)
  - ActiveJob

The transactionality provided by `Hyrax::Actors::TransactionalRequest` addresses
only one of these (ActiveRecord). Routinely, failures in the actor stack that
trigger transaction rollback there lead to broken states across the various data
stores.

Additionally, this rollback is not triggered for the main documented failure API
for the stack (returning `false`). Rollback only happens when uncaught errors
are propagated to the top of the stack.

Since this middleware is problematic and doesn't have a clear documented use
case, this proposes its removal.

Fixes #3128.

@samvera/hyrax-code-reviewers
