### PR TITLE
Code Refactor for Spec Tests Creating Collections

### DIFF
--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Collection, type: :model do
-  let(:collection) { build(:public_collection) }
+  let(:collection) { build(:public_collection_lw) }
 
   it "has open visibility" do
     expect(collection.read_groups).to eq ['public']
@@ -15,7 +15,7 @@ RSpec.describe Collection, type: :model do
 
   describe "#to_solr" do
     let(:user) { build(:user) }
-    let(:collection) { build(:collection, user: user, title: ['A good title']) }
+    let(:collection) { build(:collection_lw, user: user, title: ['A good title']) }
 
     let(:solr_document) { collection.to_solr }
 
@@ -80,7 +80,7 @@ RSpec.describe Collection, type: :model do
   end
 
   describe "#destroy", clean_repo: true do
-    let(:collection) { build(:collection) }
+    let(:collection) { build(:collection_lw) }
     let(:work1) { create(:work) }
 
     before do
@@ -130,7 +130,7 @@ RSpec.describe Collection, type: :model do
   end
 
   describe '#collection_type_gid=' do
-    let(:collection) { build(:collection) }
+    let(:collection) { build(:collection_lw) }
     let(:collection_type) { create(:collection_type) }
 
     it 'sets gid' do
@@ -170,7 +170,7 @@ RSpec.describe Collection, type: :model do
   end
 
   describe 'collection type delegated methods' do
-    subject { build(:collection) }
+    subject { build(:collection_lw) }
 
     it { is_expected.to delegate_method(:nestable?).to(:collection_type) }
     it { is_expected.to delegate_method(:discoverable?).to(:collection_type) }
@@ -293,7 +293,7 @@ RSpec.describe Collection, type: :model do
 
       context 'when building a collection' do
         let(:coll123) do
-          build(:collection,
+          build(:collection_lw,
                 id: 'Collection123',
                 collection_type_gid: collection_type.gid,
                 with_nesting_attributes:

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::CollectionPresenter do
   end
 
   let(:collection) do
-    build(:collection,
+    build(:collection_lw,
           id: 'adc12v',
           description: ['a nice collection'],
           based_near: ['Over there'],
@@ -61,7 +61,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     let(:collection_type) { create(:collection_type) }
 
     describe 'when solr_document#collection_type_gid exists' do
-      let(:collection) { build(:collection, collection_type_gid: collection_type.gid) }
+      let(:collection) { build(:collection_lw, collection_type_gid: collection_type.gid) }
       let(:solr_doc) { SolrDocument.new(collection.to_solr) }
 
       it 'finds the collection type based on the solr_document#collection_type_gid if one exists' do
@@ -173,7 +173,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context "collection with private collection" do
-      let!(:work) { create(:private_collection, member_of_collections: [collection]) }
+      let!(:work) { create(:private_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 0 }
     end
@@ -185,14 +185,14 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context "collection with public collection" do
-      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 1 }
     end
 
     context "collection with public work and sub-collection" do
       let!(:work) { create(:public_work, member_of_collections: [collection]) }
-      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 2 }
     end
@@ -232,7 +232,7 @@ RSpec.describe Hyrax::CollectionPresenter do
 
     context "collection with public work and sub-collection" do
       let!(:work) { create(:public_work, member_of_collections: [collection]) }
-      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 1 }
     end
@@ -259,20 +259,20 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context "collection with private collection" do
-      let!(:subcollection) { create(:private_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:private_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 0 }
     end
 
     context "collection with public collection" do
-      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 1 }
     end
 
     context "collection with public work and sub-collection" do
       let!(:work) { create(:public_work, member_of_collections: [collection]) }
-      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 1 }
     end
@@ -310,8 +310,8 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context('when parent_collections is has collections') do
-      let(:collection1) { build(:collection, title: ['col1']) }
-      let(:collection2) { build(:collection, title: ['col2']) }
+      let(:collection1) { build(:collection_lw, title: ['col1']) }
+      let(:collection2) { build(:collection_lw, title: ['col2']) }
       let!(:parent_docs) { [collection1, collection2] }
 
       before do

--- a/spec/search_builders/hyrax/collection_member_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_member_search_builder_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Hyrax::CollectionMemberSearchBuilder do
   let(:context) { double("context", blacklight_config: CatalogController.blacklight_config) }
   let(:solr_params) { { fq: [] } }
   let(:include_models) { :both }
-  let(:collection) { build(:collection, id: '12345') }
+  let(:collection) { build(:collection_lw, id: '12345') }
   let(:builder) { described_class.new(scope: context, collection: collection, search_includes_models: include_models) }
 
   describe ".default_processor_chain" do


### PR DESCRIPTION
Replaces collection, public, and private collection with new collection_lw, public_collection_lw, private_collection_lw

refs #2940 

Present tense short summary (50 characters or less)

Refactoring tests to use build instead of create and the new way for building collection


Changes proposed in this pull request:
* swap create for build
* use the new collection_lw


@samvera/hyrax-code-reviewers
