### PR TITLE
Shot in the dark for build failures

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -210,6 +210,7 @@ RSpec.configure do |config|
 
   config.after do
     DatabaseCleaner.clean
+    true
   end
 
   # If true, the base class of anonymous controllers will be inferred
@@ -232,6 +233,7 @@ RSpec.configure do |config|
     Warden.test_reset!
     Capybara.reset_sessions!
     page.driver.reset!
+    true
   end
 
   config.include Capybara::RSpecMatchers, type: :input
@@ -290,5 +292,6 @@ RSpec.configure do |config|
 
     ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = false
     ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
+    true
   end
 end

--- a/spec/support/optional_example.rb
+++ b/spec/support/optional_example.rb
@@ -6,6 +6,7 @@ module OptionalExample
         example.display_exception = nil
         example.execution_result.pending_exception = ex
       end
+      true
     end
   end
 


### PR DESCRIPTION
In conversation with Chris, RSpec sometimes reports 0 errors, but
the suite returns a non-zero shell response. The CI tool, then
interprets the non-zero response as a failure to build.

My thinking is that the after blocks of rspec may be returning false
for the last run in the suite, and that is interpretted as a non-zero.
This would be sad panda if that were the case, but hey, maybe.

This is very much a stab in the dark.