### PR TITLE
Replaces create collection with build collection_lw (part 2)

### DIFF
--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'CollectionAbility' do
 
   context 'when admin user' do
     let(:user) { FactoryBot.create(:admin) }
-    let!(:collection) { create(:collection, id: 'col_au', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { build(:collection_lw, id: 'col_au', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     it 'allows all abilities' do # rubocop:disable RSpec/ExampleLength
@@ -34,7 +34,7 @@ RSpec.describe 'CollectionAbility' do
   end
 
   context 'when collection manager' do
-    let!(:collection) { create(:collection, id: 'col_mu', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { build(:collection_lw, id: 'col_mu', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do
@@ -69,7 +69,7 @@ RSpec.describe 'CollectionAbility' do
   end
 
   context 'when collection depositor' do
-    let!(:collection) { create(:collection, id: 'col_du', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { build(:collection_lw, id: 'col_du', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do
@@ -104,7 +104,7 @@ RSpec.describe 'CollectionAbility' do
   end
 
   context 'when collection viewer' do
-    let!(:collection) { create(:collection, id: 'col_vu', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { build(:collection_lw, id: 'col_vu', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Hyrax::CollectionsController do
   let(:asset1)         { create(:work, title: ["First of the Assets"], user: user) }
   let(:asset2)         { create(:work, title: ["Second of the Assets"], user: user) }
   let(:asset3)         { create(:work, title: ["Third of the Assets"], user: user) }
-  let(:asset4)         { create(:collection, title: ["First subcollection"], user: user) }
-  let(:asset5)         { create(:collection, title: ["Second subcollection"], user: user) }
+  let(:asset4)         { build(:collection_lw, title: ["First subcollection"], user: user) }
+  let(:asset5)         { build(:collection_lw, title: ["Second subcollection"], user: user) }
   let(:unowned_asset)  { create(:work, user: other) }
 
   let(:collection_attrs) do

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   let(:asset1)         { create(:work, title: ["First of the Assets"], user: user) }
   let(:asset2)         { create(:work, title: ["Second of the Assets"], user: user) }
   let(:asset3)         { create(:work, title: ["Third of the Assets"], user: user) }
-  let(:asset4)         { create(:collection, title: ["First subcollection"], user: user) }
-  let(:asset5)         { create(:collection, title: ["Second subcollection"], user: user) }
+  let(:asset4)         { build(:collection_lw, title: ["First subcollection"], user: user) }
+  let(:asset5)         { build(:collection_lw, title: ["Second subcollection"], user: user) }
   let(:unowned_asset)  { create(:work, user: other) }
 
   let(:collection_attrs) do
@@ -233,7 +233,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
     end
 
     context "when update fails" do
-      let(:collection) { create(:collection, id: '12345') }
+      let(:collection) { build(:collection_lw, id: '12345') }
       let(:repository) { instance_double(Blacklight::Solr::Repository, search: result) }
       let(:result) { double(documents: [], total: 0) }
 

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -534,7 +534,7 @@ RSpec.describe Hyrax::GenericWorksController do
 
   describe '#destroy' do
     let(:work_to_be_deleted) { create(:private_generic_work, user: user) }
-    let(:parent_collection) { create(:collection) }
+    let(:parent_collection) { build(:collection_lw) }
 
     it 'deletes the work' do
       delete :destroy, params: { id: work_to_be_deleted }

--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
   end
 
   describe 'when both collections support multiple membership' do
-    let(:old_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_1.gid, title: ['OldCollectionTitle']) }
+    let(:old_collection) { build(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_1.gid, title: ['OldCollectionTitle']) }
     let!(:work) { create(:generic_work, user: admin_user, member_of_collections: [old_collection], title: ['The highly valued work that everyone wants in their collection']) }
 
     context 'and are of different types' do
@@ -56,7 +56,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
   end
 
   describe 'when both collections require single membership' do
-    let(:old_collection) { create(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_1.gid, title: ['OldCollectionTitle']) }
+    let(:old_collection) { build(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_1.gid, title: ['OldCollectionTitle']) }
     let!(:work) do
       create(:generic_work,
              user: admin_user,

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
     end
   end
 
-  let(:collection) { build(:collection) }
+  let(:collection) { build(:collection_lw) }
   let(:ability) { Ability.new(create(:user)) }
   let(:repository) { double }
   let(:form) { described_class.new(collection, ability, repository) }
@@ -74,8 +74,8 @@ RSpec.describe Hyrax::Forms::CollectionForm do
   end
 
   context "nested relationships" do
-    let(:child_collection) { build(:collection) }
-    let(:parent_collection) { build(:collection) }
+    let(:child_collection) { build(:collection_lw) }
+    let(:parent_collection) { build(:collection_lw) }
     let(:service_object) { double(available_member_subcollections: double(documents: [child_collection])) }
 
     before do

--- a/spec/indexers/hyrax/collection_indexer_spec.rb
+++ b/spec/indexers/hyrax/collection_indexer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Hyrax::CollectionIndexer do
   let(:indexer) { described_class.new(collection) }
-  let(:collection) { build(:collection) }
+  let(:collection) { build(:collection_lw) }
   let(:col1id) { 'col1' }
   let(:col2id) { 'col2' }
   let(:col1title) { 'col1 title' }

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CharacterizeJob do
 
   context "when the file set's work is in a collection" do
     let(:work)       { build(:generic_work) }
-    let(:collection) { build(:collection) }
+    let(:collection) { build(:collection_lw) }
 
     before do
       allow(file_set).to receive(:parent).and_return(work)


### PR DESCRIPTION
Replaces create with build for better performance with the collection_lw factory.

refs #2940 

Present tense short summary (50 characters or less)

Working in small branches to update the spec tests to use the light weight collection factory

Changes proposed in this pull request:
* replaces `create` with `build` where it can be done
* updates `collection` with `collection_lw`1


@samvera/hyrax-code-reviewers
