### PR TITLE
Replace Private Collection factory Method with New Light Weight Method

### DIFF
--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'catalog searching', type: :feature do
   end
 
   context 'with public works and private collections', clean_repo: true do
-    let!(:collection) { create(:private_collection) }
+    let!(:collection) { build(:private_collection_lw) }
 
     let!(:jills_work) do
       create(:public_work, title: ["Jill's Research"], keyword: ['jills_keyword'], member_of_collections: [collection])

--- a/spec/lib/hyrax/resource_sync/change_list_writer_spec.rb
+++ b/spec/lib/hyrax/resource_sync/change_list_writer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Hyrax::ResourceSync::ChangeListWriter, :clean_repo do
   context "when resources exist" do
     before do
       # These private items should not show up.
-      create(:private_collection)
+      build(:private_collection_lw)
       create(:work)
 
       # Sleep in between to ensure modified dates are different

--- a/spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb
+++ b/spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Hyrax::ResourceSync::ResourceListWriter, :clean_repo do
   let(:sitemap) { 'http://www.sitemaps.org/schemas/sitemap/0.9' }
-  let!(:private_collection) { create(:private_collection) }
+  let!(:private_collection) { build(:private_collection_lw) }
   let!(:public_collection) { create(:public_collection) }
   let!(:public_work) { create(:public_generic_work) }
   let!(:private_work) { create(:work) }

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context "collection with private collection" do
-      let!(:work) { create(:private_collection_lw, member_of_collections: [collection]) }
+      let!(:work) { build(:private_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 0 }
     end
@@ -259,7 +259,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context "collection with private collection" do
-      let!(:subcollection) { create(:private_collection_lw, member_of_collections: [collection]) }
+      let!(:subcollection) { build(:private_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 0 }
     end


### PR DESCRIPTION
Updates the references to private_collection and replaces it with the new factory private_collection_lw.

refs #2940 

Present tense short summary (50 characters or less)

Replacing the old collections factory methods with the new light weight methods in the spec tests. Worked through the building of private collections instead of creating them.

Changes proposed in this pull request:
* swap create for build
* replace `private_collection` with `private_collection_lw`


@samvera/hyrax-code-reviewers
