### PR TITLE
Clean up Valkyrie Resource Factory and add Value Mapper

### DIFF
--- a/lib/wings/resource_factory.rb
+++ b/lib/wings/resource_factory.rb
@@ -30,7 +30,7 @@ module Wings
     end
 
     def self.to_valkyrie_resource_class(klass:)
-      Class.new(::Valkyrie::Resource) do
+      Class.new(ActiveFedoraResource) do
         # Based on Valkyrie implementation, we call Class.to_s to define
         # the internal resource.
         @to_s = klass.to_s
@@ -56,7 +56,11 @@ module Wings
         self.class.to_valkyrie_resource_class(klass: pcdm_object.class)
       end
 
-      klass.new(id: pcdm_object.id, **attributes)
+      klass.new(alternate_ids: [Valkyrie::ID.new(pcdm_object.id)], **attributes)
+    end
+
+    class ActiveFedoraResource < Valkyrie::Resource
+      attribute :alternate_ids, Valkyrie::Types::Array
     end
 
     private

--- a/lib/wings/resource_factory.rb
+++ b/lib/wings/resource_factory.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'wings/value_mapper'
+
 module Wings
   # we really want a class var here. maybe we could use a singleton instead?
   # rubocop:disable Style/ClassVars
@@ -67,18 +69,7 @@ module Wings
 
       def attributes
         pcdm_object.attributes.each_with_object({}) do |(name, values), mem|
-          mem[name.to_sym] = normalize_values(values)
-        end
-      end
-
-      def normalize_values(values)
-        case values
-        when ActiveTriples::Resource
-          values.to_term
-        when ActiveTriples::Relation
-          values.map { |val| normalize_values(val) }
-        else
-          values
+          mem[name.to_sym] = ValueMapper.for(values).result
         end
       end
   end

--- a/lib/wings/value_mapper.rb
+++ b/lib/wings/value_mapper.rb
@@ -1,0 +1,28 @@
+module Wings
+  class ValueMapper < ::Valkyrie::ValueMapper
+  end
+
+  class ResourceMapper < ValueMapper
+    ValueMapper.register(self)
+
+    def self.handles?(value)
+      value.respond_to?(:term?) && value.term?
+    end
+
+    def result
+      value.to_term
+    end
+  end
+
+  class EnumerableMapper < ValueMapper
+    ValueMapper.register(self)
+
+    def self.handles?(value)
+      value.is_a?(Enumerable)
+    end
+
+    def result
+      value.map { |v| calling_mapper.for(v).result }
+    end
+  end
+end

--- a/spec/wings/resource_factory_spec.rb
+++ b/spec/wings/resource_factory_spec.rb
@@ -40,10 +40,9 @@ RSpec.describe Wings::ResourceFactory do
   end
 
   # TODO: extract to Valkyrie?
-  define :have_a_valkyrie_id_of do |expected_id_str|
+  define :have_a_valkyrie_alternate_id_of do |expected_id_str|
     match do |valkyrie_resource|
-      expect(valkyrie_resource.id).to be_a Valkyrie::ID
-      valkyrie_resource.id.id == expected_id_str
+      valkyrie_resource.alternate_ids.map(&:id).include?(expected_id_str)
     end
   end
 
@@ -87,7 +86,7 @@ RSpec.describe Wings::ResourceFactory do
     end
 
     it 'has the id of the pcdm_object' do
-      expect(factory.build).to have_a_valkyrie_id_of work.id
+      expect(factory.build).to have_a_valkyrie_alternate_id_of work.id
     end
 
     it 'has attributes matching the pcdm_object' do
@@ -101,7 +100,7 @@ RSpec.describe Wings::ResourceFactory do
     it 'round trips attributes' do
       persister.save(resource: factory.build)
 
-      expect(adapter.query_service.find_by(id: work.id))
+      expect(adapter.query_service.find_by_alternate_identifier(alternate_identifier: work.id))
         .to have_attributes title: work.title,
                             date_created: work.date_created,
                             depositor: work.depositor,

--- a/spec/wings/resource_factory_spec.rb
+++ b/spec/wings/resource_factory_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe Wings::ResourceFactory do
       depositor: 'user1',
       description: ['a description'],
       import_url: uris.first,
-      related_url: uris
+      publisher: [false],
+      related_url: uris,
+      source: [1.125, :moomin]
     }
   end
 
@@ -105,7 +107,9 @@ RSpec.describe Wings::ResourceFactory do
                             depositor: work.depositor,
                             description: work.description,
                             import_url: work.import_url,
-                            related_url: work.related_url
+                            publisher: work.publisher,
+                            related_url: work.related_url,
+                            source: work.source
     end
   end
 end

--- a/spec/wings/value_mapper_spec.rb
+++ b/spec/wings/value_mapper_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'wings/value_mapper'
+
+RSpec.describe Wings::ValueMapper do
+  subject(:mapper) { described_class.for(value) }
+  let(:value)      { 'a value' }
+  let(:uri)        { RDF::URI('http://example.com/moomin') }
+
+  describe '.for' do
+    it 'returns a value mapper' do
+      expect(described_class.for(value)).to be_a described_class
+    end
+  end
+
+  describe '.result' do
+    it 'returns the value by default' do
+      expect(mapper.result).to eq value
+    end
+
+    context 'with an ActiveTriples::RDFSource URI value' do
+      let(:value) { ActiveTriples::Resource.new(uri) }
+
+      it 'casts to the RDF term' do
+        expect(mapper.result).to eq uri
+      end
+    end
+
+    context 'with an ActiveTriples::RDFSource bnode value' do
+      let(:value) { ActiveTriples::Resource.new(node) }
+      let(:node)  { RDF::Node.new }
+
+      it 'somehow manages to map the node?'
+    end
+
+    context 'with an ActiveTriples::Relation value' do
+      let(:value)       { work.source }
+      let(:work)        { GenericWork.new(source: cast_values) }
+      let(:cast_values) { ['moomin', 1.125, :moomin, Time.now.utc, false, uri] }
+
+      it 'casts internal values' do
+        expect(mapper.result).to contain_exactly(*cast_values)
+      end
+    end
+
+    context 'with a URI value'
+    context 'with a blank node value'
+    context 'with a boolean value'
+    context 'with a date value'
+    context 'with a numeric value'
+
+    context 'with an enumerable value' do
+      let(:value) { ['a value'] }
+
+      it 'maps internal values' do
+        expect(mapper.result).to eq value
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a second batch of Valkyrie setup.

The factory is updated to handle typed data using the `Valkyrie::Mapper` interface; tests are added for numeric data, booleans, and symbols/tokens, as well as enumerables of URIs.

AF/Hyrax identifiers are shifted to use Valkyrie's `alternate_identifier` feature. This is motivated by Valkyrie adapters overwriting the `id` attribute silently. This can be problematic if we're counting on that `id` to match the one used by `ActiveFedora`, so the `alternate_id` gives us a safe alternative.

Support for defined reflections is also added to the factory, with preliminary testing for complex relationships.

@samvera/hyrax-code-reviewers
