### PR TITLE
Integrates hydra-head updates in order to ensure that ACL resources are not persisted when Works/Collections are only built

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,14 @@
 source 'https://rubygems.org'
 
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
 # Please see hyrax.gemspec for dependency information.
 gemspec
+
+gem 'hydra-head', github: 'samvera/hydra-head', branch: 'no-extra-acls'
 
 group :development, :test do
   gem 'coveralls', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,5 @@
 source 'https://rubygems.org'
 
-git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-  "https://github.com/#{repo_name}.git"
-end
-
-# Please see hyrax.gemspec for dependency information.
-gemspec
-
-gem 'hydra-head', github: 'samvera/hydra-head', branch: 'master'
-
 group :development, :test do
   gem 'coveralls', require: false
   gem 'i18n-tasks'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 # Please see hyrax.gemspec for dependency information.
 gemspec
 
-gem 'hydra-head', github: 'samvera/hydra-head', branch: 'no-extra-acls'
+gem 'hydra-head', github: 'samvera/hydra-head', branch: 'master'
 
 group :development, :test do
   gem 'coveralls', require: false

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -51,7 +51,7 @@ SUMMARY
   spec.add_dependency 'font-awesome-rails', '~> 4.2'
   spec.add_dependency 'hydra-derivatives', '~> 3.3'
   spec.add_dependency 'hydra-editor', '>= 3.3', '< 5.0'
-  spec.add_dependency 'hydra-head', '>= 10.5.0'
+  spec.add_dependency 'hydra-head', '>= 10.6.1'
   spec.add_dependency 'hydra-works', '>= 0.16', '< 2.0'
   spec.add_dependency 'iiif_manifest', '>= 0.3', '< 0.6'
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4'

--- a/spec/lib/hyrax/resource_sync/change_list_writer_spec.rb
+++ b/spec/lib/hyrax/resource_sync/change_list_writer_spec.rb
@@ -10,6 +10,27 @@ RSpec.describe Hyrax::ResourceSync::ChangeListWriter, :clean_repo do
     described_class.new(resource_host: 'example.com',
                         capability_list_url: capability_list)
   end
+  let(:namespaces) do
+    {
+      'rs' => "http://www.openarchives.org/rs/terms/",
+      'x' => sitemap
+    }
+  end
+  let(:capability_element) { xml.xpath('//rs:ln/@href', 'rs' => "http://www.openarchives.org/rs/terms/") }
+  # The creation and modified dates are used in order to determine whether or
+  # not the status is "created" or "updated"
+  # This avoids any potential delays/conflicts when testing against Solr and
+  # Fedora within the testing environment
+  # @see Hyrax::ResourceSync::ChangeListWriter#build_resource
+  let(:file_set_status) do
+    file_set.create_date.to_i == file_set.modified_date.to_i ? 'created' : 'updated'
+  end
+  let(:public_work_status) do
+    public_work.create_date.to_i == public_work.modified_date.to_i ? 'created' : 'updated'
+  end
+  let(:public_collection_status) do
+    public_collection.create_date.to_i == public_collection.modified_date.to_i ? 'created' : 'updated'
+  end
 
   subject { instance.write }
 
@@ -25,40 +46,33 @@ RSpec.describe Hyrax::ResourceSync::ChangeListWriter, :clean_repo do
       build(:private_collection_lw)
       create(:work)
 
-      # Sleep in between to ensure modified dates are different
       public_collection
-      sleep(1)
       public_work
-      sleep(1)
       file_set
     end
 
     it "has a list of resources" do
-      capability = xml.xpath('//rs:ln/@href', 'rs' => "http://www.openarchives.org/rs/terms/").text
-      expect(capability).to eq capability_list
-
-      expect(location(1)).to eq "http://example.com/concern/file_sets/#{file_set.id}"
-      expect(change(1)).to eq "created"
-
-      expect(location(2)).to eq "http://example.com/concern/generic_works/#{public_work.id}"
-      expect(change(2)).to eq "created"
-
-      expect(location(3)).to eq "http://example.com/collections/#{public_collection.id}"
-      expect(change(3)).to eq "created"
+      expect(capability_element.text).to eq capability_list
+      locations = location_elements(namespaces).map(&:text)
+      expect(locations).to include "http://example.com/concern/file_sets/#{file_set.id}"
+      expect(locations).to include "http://example.com/concern/generic_works/#{public_work.id}"
+      expect(locations).to include "http://example.com/collections/#{public_collection.id}"
+      changed = changed_elements(namespaces).map(&:value)
+      expect(changed).to match_array([public_collection_status, public_work_status, file_set_status])
 
       expect(url_list.count).to eq 3
     end
   end
 
-  def change(n)
-    query(n, 'rs:md/@change', 'rs' => "http://www.openarchives.org/rs/terms/")
+  def changed_elements(namespaces = {})
+    query("rs:md/@change", namespaces)
   end
 
-  def location(n)
-    query(n, 'x:loc')
+  def location_elements(namespaces = {})
+    query("x:loc", namespaces)
   end
 
-  def query(n, part, ns = {})
-    xml.xpath("//x:url[#{n}]/#{part}", ns.merge('x' => sitemap)).text
+  def query(part, ns = {})
+    xml.xpath("//x:url/#{part}", ns)
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -318,8 +318,8 @@ RSpec.describe Collection, type: :model do
   end
 
   describe '#update_nested_collection_relationship_indices', :with_nested_reindexing do
-    it 'will be called after save' do
-      expect(Samvera::NestingIndexer).to receive(:reindex_relationships).with(id: kind_of(String), extent: kind_of(String))
+    it 'will be called once for the Collection resource and once for the nested ACL permission resource' do
+      expect(Samvera::NestingIndexer).to receive(:reindex_relationships).exactly(2).times.with(id: kind_of(String), extent: kind_of(String))
       collection.save!
     end
   end

--- a/spec/services/hyrax/collections/migration_service_spec.rb
+++ b/spec/services/hyrax/collections/migration_service_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
 
   describe ".migrate_all_collections" do
     context 'when legacy collections are found (e.g. collections created before Hyrax 2.1.0)' do
-      let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true) }
-      let!(:col_vu) { build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
-      let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], do_save: true) }
-      let!(:col_mu) { build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
-      let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
+      let!(:col_none) { build(:typeless_collection, user: user, edit_users: [user.user_key], do_save: true) }
+      let!(:col_vu) { build(:typeless_collection, user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
+      let!(:col_vg) { build(:typeless_collection, user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], do_save: true) }
+      let!(:col_mu) { build(:typeless_collection, user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
+      let!(:col_mg) { build(:typeless_collection, user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
 
       it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
         Collection.all.each do |col|
@@ -158,11 +158,11 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
 
       context "and collection wasn't migrated at all" do
-        let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true) }
-        let!(:col_vu) { build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
-        let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], do_save: true) }
-        let!(:col_mu) { build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
-        let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
+        let!(:col_none) { build(:typeless_collection_lw, user: user, edit_users: [user.user_key], read_users: [], do_save: true) }
+        let!(:col_vu) { build(:typeless_collection_lw, user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
+        let!(:col_vg) { build(:typeless_collection_lw, user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], do_save: true) }
+        let!(:col_mu) { build(:typeless_collection_lw, user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
+        let!(:col_mg) { build(:typeless_collection_lw, user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
 
         it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
           Collection.all.each do |col|
@@ -212,21 +212,21 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       end
 
       context "and collection type gid isn't set but permission template exists with access set" do
-        let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true, with_permission_template: true) }
+        let!(:col_none) { build(:typeless_collection, user: user, edit_users: [user.user_key], do_save: true, with_permission_template: true) }
         let!(:col_vu) do
-          build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_vg) do
-          build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mu) do
-          build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key],
+          build(:typeless_collection, user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mg) do
-          build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'],
                                       do_save: true, with_permission_template: true)
         end
 
@@ -276,21 +276,21 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       end
 
       context "and collection type gid isn't set and permission template exists with access not set" do
-        let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true, with_permission_template: true) }
+        let!(:col_none) { build(:typeless_collection, user: user, edit_users: [user.user_key], do_save: true, with_permission_template: true) }
         let!(:col_vu) do
-          build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_vg) do
-          build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mu) do
-          build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key],
+          build(:typeless_collection, user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mg) do
-          build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'],
                                       do_save: true, with_permission_template: true)
         end
 

--- a/spec/services/hyrax/statistics/works/by_resource_type_spec.rb
+++ b/spec/services/hyrax/statistics/works/by_resource_type_spec.rb
@@ -1,12 +1,19 @@
 RSpec.describe Hyrax::Statistics::Works::ByResourceType do
   let(:service) { described_class.new }
+  let(:user) { create(:user) }
 
   describe "#query", :clean_repo do
     before do
-      create(:generic_work, resource_type: ['Conference Proceeding'])
-      create(:generic_work, resource_type: ['Conference Proceeding'])
-      create(:generic_work, resource_type: ['Image'])
-      create(:generic_work, resource_type: ['Journal'])
+      # Creating factories here led to failures found within
+      # https://travis-ci.org/samvera/hyrax/jobs/454752377
+      # One should be able to invoke create(:generic_work)...
+      # ...however, there are difficulties here which relate to the "terms"
+      # requestHandler
+      # @see https://github.com/samvera/hyrax/issues/3491
+      GenericWork.create(title: ['test'], resource_type: ['Conference Proceeding']).save!
+      GenericWork.create(title: ['test'], resource_type: ['Conference Proceeding']).save!
+      GenericWork.create(title: ['test'], resource_type: ['Image']).save!
+      GenericWork.create(title: ['test'], resource_type: ['Journal']).save!
     end
 
     subject { service.query }


### PR DESCRIPTION
Deprecates  https://github.com/samvera/hyrax/compare/hydra-head-469; Please see https://github.com/samvera/hydra-head/pull/469 for reference
