### PR TITLE
Adding internal_resource to ResourceFactory results

### DIFF
--- a/spec/wings/resource_factory_spec.rb
+++ b/spec/wings/resource_factory_spec.rb
@@ -67,6 +67,9 @@ RSpec.describe Wings::ResourceFactory do
         it 'has a to_s instance that delegates to the given klass' do
           expect(subject.to_s).to eq(GenericWork.to_s)
         end
+        it 'has a internal_resource instance that is the given klass' do
+          expect(subject.internal_resource).to eq(GenericWork)
+        end
       end
     end
     context 'when given a non-ActiveFedora class' do


### PR DESCRIPTION
In reading the Valkyrie documentation, we need to persist a meaningful
"symbol" (e.g. class name) for the internal resource. This is necessary
so that when we retrieve via Valkyrie, we map the given "symbol" to its
corresponding Valkyrie::Resource.

@samvera/hyrax-code-reviewers
