### PR TITLE
Extending Selectors::Dashboard#select_member_of_collection in order to prevent select2 in feature tests from failing

### DIFF
--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -53,11 +53,14 @@ RSpec.describe "work show view" do
     it "allows adding work to a collection", clean_repo: true, js: true do
       optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
       click_button "Add to collection" # opens the modal
-      select_member_of_collection(collection)
+      # Really ensure that this Collection model is persisted
+      Collection.all.map(&:destroy!)
+      persisted_collection = create(:collection_lw, user: user, collection_type_gid: multi_membership_type_1.gid)
+      select_member_of_collection(persisted_collection)
       click_button 'Save changes'
 
       # forwards to collection show page
-      expect(page).to have_content collection.title.first
+      expect(page).to have_content persisted_collection.title.first
       expect(page).to have_content work.title.first
       expect(page).to have_selector '.alert-success', text: 'Collection was successfully updated.'
     end

--- a/spec/support/selectors.rb
+++ b/spec/support/selectors.rb
@@ -43,7 +43,16 @@ module Selectors
     def select_member_of_collection(collection)
       find('#s2id_member_of_collection_ids').click
       find('.select2-input').set(collection.title.first)
-      sleep 10
+      # Crude way of waiting for the AJAX response
+      select2_results = []
+      time_elapsed = 0
+      while select2_results.empty? && time_elapsed < 30
+        begin_time = Time.now.to_f
+        doc = Nokogiri::XML.parse(page.body)
+        select2_results = doc.xpath('//html:li[contains(@class,"select2-result")]', html: 'http://www.w3.org/1999/xhtml')
+        end_time = Time.now.to_f
+        time_elapsed += end_time - begin_time
+      end
       expect(page).to have_css('.select2-result')
       within ".select2-result" do
         find("span", text: collection.title.first).click


### PR DESCRIPTION
Refs #3038.  This should progress towards resolving this issue, but I would prefer to delay closing the issue until all can be certain that the affected tests no longer fail.

@samvera/hyrax-code-reviewers