### PR TITLE
Refactor `Wings::Valkyrie::ResourceFactory` to use a converter class

### DIFF
--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -11,5 +11,6 @@ require 'wings/model_transformer'
 require 'wings/resource_factory'
 require 'wings/valkyrizable'
 require 'wings/valkyrie_monkey_patch'
+require 'wings/valkyrie/resource_factory'
 
 ActiveFedora::Base.include Wings::Valkyrizable

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Wings
+  class ActiveFedoraConverter
+    ##
+    # @!attribute [rw] resource
+    #   @return [Valkyrie::Resource]
+    attr_accessor :resource
+
+    ##
+    # @param [Valkyrie::Resource]
+    def initialize(resource:)
+      @resource = resource
+    end
+
+    ##
+    # @return [Hash<Symbol, Object>]
+    def attributes
+      attrs = resource.attributes
+
+      # avoid reflections for now; `*_ids` can't be passed as attributes.
+      # handling for reflections needs to happen in future work
+      attrs = attrs.reject { |k, _| k.to_s.end_with? '_ids' }
+
+      attrs.delete(:internal_resource)
+      attrs.delete(:new_record)
+      attrs.delete(:id)
+      attrs.delete(:alternate_ids)
+
+      attrs[:id] = id unless id.empty?
+      attrs.compact
+    end
+
+    ##
+    # @return [ActiveFedora::Base]
+    def convert
+      resource.internal_resource.new(attributes)
+    end
+
+    ##
+    # @return [String]
+    def id
+      resource.alternate_ids.first.to_s
+    end
+  end
+end

--- a/lib/wings/valkyrie/resource_factory.rb
+++ b/lib/wings/valkyrie/resource_factory.rb
@@ -1,64 +1,39 @@
 # frozen_string_literal: true
 
+require 'wings/active_fedora_converter'
+
 module Wings
   module Valkyrie
     class ResourceFactory
+      ##
+      # @!attribute [r] adapter
+      #   @return [MetadataAdapter]
       attr_reader :adapter
+
       delegate :id, to: :adapter, prefix: true
 
+      ##
       # @param [MetadataAdapter] adapter
       def initialize(adapter:)
         @adapter = adapter
       end
 
-      # @param object [ActiveFedora::Base] AF
-      #   record to be converted.
+      ##
+      # @param object [ActiveFedora::Base] AF record to be converted.
+      #
       # @return [Valkyrie::Resource] Model representation of the AF record.
       def to_resource(object:)
         object.valkyrie_resource
       end
 
+      ##
       # @param resource [Valkyrie::Resource] Model to be converted to ActiveRecord.
+      #
       # @return [ActiveFedora::Base] ActiveFedora
       #   resource for the Valkyrie resource.
       def from_resource(resource:)
-        # af_object = resource.fedora_model.new(af_attributes(resource))
-
-        # hack
-        af_object = GenericWork.new(af_attributes(resource))
-        # end of hack
-
-        afid = af_id(resource)
-        af_object.id = afid unless afid.empty?
-        af_object
+        ActiveFedoraConverter.new(resource: resource).convert
       end
-
-      private
-
-        def af_attributes(resource)
-          hash = resource.to_h
-          hash.delete(:internal_resource)
-          hash.delete(:new_record)
-          hash.delete(:id)
-          hash.delete(:alternate_ids)
-          # Deal with these later
-          hash.delete(:created_at)
-          hash.delete(:updated_at)
-          hash.compact
-        end
-
-        def af_id(resource)
-          resource.id.to_s
-        end
-
-        def translate_resource(resource)
-          hash = resource.to_h
-          hash.delete(:internal_resource)
-          hash.delete(:new_record)
-          hash.delete(:id)
-
-          resource.fedora_model.new(hash.compact)
-        end
     end
   end
 end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'wings'
+require 'wings/active_fedora_converter'
+
+RSpec.describe Wings::ActiveFedoraConverter do
+  subject(:converter) { described_class.new(resource: resource) }
+  let(:adapter)       { Valkyrie::Persistence::Memory::MetadataAdapter.new }
+  let(:attributes)    { { id: id } }
+  let(:id)            { 'moomin_id' }
+  let(:resource)      { work.valkyrie_resource }
+  let(:work)          { GenericWork.new(attributes) }
+
+  describe '#convert' do
+    it 'returns the ActiveFedora model' do
+      expect(converter.convert).to eq work
+    end
+
+    context 'with attributes' do
+      let(:attributes) do
+        FactoryBot.attributes_for(:generic_work)
+      end
+
+      it 'repopulates the attributes' do
+        expect(converter.convert).to have_attributes(attributes)
+      end
+
+      it 'populates reflections'
+    end
+  end
+end

--- a/spec/wings/valkyrie/resource_factory_spec.rb
+++ b/spec/wings/valkyrie/resource_factory_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'wings'
+
+RSpec.describe Wings::Valkyrie::ResourceFactory do
+  subject(:factory) { described_class.new(adapter: adapter) }
+  let(:adapter)     { Valkyrie::Persistence::Memory::MetadataAdapter.new }
+  let(:work)        { GenericWork.new }
+
+  describe '#to_resource' do
+    it 'returns a valkyrie_resource for the object' do
+      expect(factory.to_resource(object: work)).to be_a Valkyrie::Resource
+    end
+  end
+
+  describe '#from_resource' do
+    let(:resource) { work.valkyrie_resource }
+
+    it 'returns an ActiveFedora object' do
+      expect(factory.from_resource(resource: resource)).to be_a GenericWork
+    end
+
+    context 'with a FileSet' do
+      let(:resource) { file_set.valkyrie_resource }
+      let(:file_set) { FileSet.new }
+
+      it 'returns an ActiveFedora object' do
+        expect(factory.from_resource(resource: resource)).to be_a FileSet
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduces `Wings::ActiveFedoraConverter` and uses it in the
`ResourceFactory`. The converter knows how to get an id and attributes to build
an AF model for a given `ValkyrieResource`.

It currently counts on `#internal_resource` being present, and assumes that the
id is the first entry in `#alternate_ids`. We may need to revisit either of
these assumptions later.

@samvera/hyrax-code-reviewers
