### PR TITLE
refer to the Valkyrie::ID instead of Wings::Valkyrie::ID

### DIFF
--- a/lib/wings/resource_factory.rb
+++ b/lib/wings/resource_factory.rb
@@ -77,7 +77,7 @@ module Wings
       klass = @@resource_class_cache.fetch(pcdm_object) do
         self.class.to_valkyrie_resource_class(klass: pcdm_object.class)
       end
-      klass.new(alternate_ids: [Valkyrie::ID.new(pcdm_object.id)], **attributes)
+      klass.new(alternate_ids: [::Valkyrie::ID.new(pcdm_object.id)], **attributes)
     end
 
     class ActiveFedoraResource < Valkyrie::Resource


### PR DESCRIPTION
adding metadata adapter namespaced with valkyrie causes this reference to fail

@no-reply
