### PR TITLE
Remove `bundle clean` from the CircleCI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,11 +94,6 @@ jobs:
           mkdir /tmp/test-results
           bundle exec rspec $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
 
-    - run:
-        name: Clean dependencies
-        command: bundle clean
-
-
     # collect reports
     - store_test_results:
         path: /tmp/test-results


### PR DESCRIPTION
These are no longer needed when the bundle dependencies are not cached, and prevent build failures such as https://circleci.com/gh/jrgriffiniii/hyrax/27
