### PR TITLE
Restoring the gemspec statement in the Gemfile and uses chromium-chromedriver on Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: required
 dist: trusty
 
 addons:
-  chrome: stable
+  apt:
+    packages:
+      - chromium-chromedriver
 cache:
   bundler: true
 
@@ -31,3 +33,4 @@ services:
   - redis-server
 before_script:
   - jdk_switcher use oraclejdk8
+  - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+# Please see hyrax.gemspec for dependency information.
+gemspec
+
 group :development, :test do
   gem 'coveralls', require: false
   gem 'i18n-tasks'


### PR DESCRIPTION
This should restored builds to passing on Travis CI