### PR TITLE
Refer to the Valkyrie::ID instead of Wings::Valkyrie::ID

### DIFF
--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -82,11 +82,11 @@ module Wings
       klass = @@resource_class_cache.fetch(pcdm_object) do
         self.class.to_valkyrie_resource_class(klass: pcdm_object.class)
       end
-      klass.new(alternate_ids: [Valkyrie::ID.new(pcdm_object.id)], **attributes)
+      klass.new(alternate_ids: [::Valkyrie::ID.new(pcdm_object.id)], **attributes)
     end
 
-    class ActiveFedoraResource < Valkyrie::Resource
-      attribute :alternate_ids, Valkyrie::Types::Array
+    class ActiveFedoraResource < ::Valkyrie::Resource
+      attribute :alternate_ids, ::Valkyrie::Types::Array
     end
 
     private


### PR DESCRIPTION
The introduction of `Wings::Valkyrie` means we need to be very specific about
namespacing for references to classes and modules in `Valkyrie`.

@samvera/hyrax-code-reviewers
