### PR TITLE
Handles WebMock explicitly after every test suite

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -210,6 +210,11 @@ RSpec.configure do |config|
 
   config.after do
     DatabaseCleaner.clean
+    # This is disabled in order to avoid occasional failures where DELETE
+    # requests to the Selenium server are treated as network requests which
+    # should be forbidden by WebMock
+    # @see https://github.com/samvera/hyrax/issues/3514
+    WebMock.disable!
   end
 
   # If true, the base class of anonymous controllers will be inferred

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -206,15 +206,21 @@ RSpec.configure do |config|
     # Precompile the assets to prevent these issues.
     visit "/assets/application.css"
     visit "/assets/application.js"
+    # This is enabled in order to avoid occasional failures where DELETE
+    # requests to the Selenium server are treated as network requests which
+    # should be forbidden by WebMock
+    # @see https://github.com/samvera/hyrax/issues/3514
+    WebMock.enable!
+  end
+
+  config.after(:all, type: :feature) do
+    # This is disabled in order to avoid the aforementioned Capybara/Selenium
+    # failures
+    WebMock.disable!
   end
 
   config.after do
     DatabaseCleaner.clean
-    # This is disabled in order to avoid occasional failures where DELETE
-    # requests to the Selenium server are treated as network requests which
-    # should be forbidden by WebMock
-    # @see https://github.com/samvera/hyrax/issues/3514
-    WebMock.disable!
   end
 
   # If true, the base class of anonymous controllers will be inferred


### PR DESCRIPTION
Refs #3514.  I'm failing to reproduce the referenced error:
```
Real HTTP connections are disabled. Unregistered request: DELETE http://127.0.0.1:9515/session/9ef6d523fe031915926103945ee42944 with headers {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json; charset=UTF-8', 'User-Agent'=>'selenium/3.141.0 (ruby linux)'} (WebMock::NetConnectNotAllowedError)

You can stub this request with the following snippet:

stub_request(:delete, "http://127.0.0.1:9515/session/9ef6d523fe031915926103945ee42944").
  with(
    headers: {
	  'Accept'=>'application/json',
	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
	  'Content-Type'=>'application/json; charset=UTF-8',
	  'User-Agent'=>'selenium/3.141.0 (ruby linux)'
    }).
  to_return(status: 200, body: "", headers: {})
```
...in my local environment, however this change should hopefully address this and does not appear to break any of the tests.  Assuming that this error no longer occurs after a given period of time, #3514 should be considered to be resolved by this.