### PR TITLE
New Collection Factory Methods in Spec Tests

### DIFF
--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'CollectionAbility' do
   end
 
   context 'when user has no special access' do
-    let!(:collection) { create(:collection, id: 'as', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { build(:collection_lw, id: 'as', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     it 'denies all abilities' do # rubocop:disable RSpec/ExampleLength

--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'CollectionAbility' do
   end
 
   context 'when user has no special access' do
-    let!(:collection) { build(:collection_lw, id: 'as', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { create(:collection_lw, id: 'as', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     it 'denies all abilities' do # rubocop:disable RSpec/ExampleLength

--- a/spec/abilities/permission_template_ability_spec.rb
+++ b/spec/abilities/permission_template_ability_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'PermissionTemplateAbility' do
   let(:current_user) { user }
   let(:collection_type_gid) { create(:collection_type).gid }
 
-  let!(:collection) { create(:collection, with_permission_template: true, collection_type_gid: collection_type_gid) }
+  let!(:collection) { build(:collection_lw, with_permission_template: true, collection_type_gid: collection_type_gid) }
   let(:permission_template) { collection.permission_template }
   let!(:permission_template_access) do
     create(:permission_template_access,

--- a/spec/abilities/permission_template_ability_spec.rb
+++ b/spec/abilities/permission_template_ability_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'PermissionTemplateAbility' do
   let(:current_user) { user }
   let(:collection_type_gid) { create(:collection_type).gid }
 
-  let!(:collection) { build(:collection_lw, with_permission_template: true, collection_type_gid: collection_type_gid) }
+  let!(:collection) { create(:collection_lw, with_permission_template: true, collection_type_gid: collection_type_gid) }
   let(:permission_template) { collection.permission_template }
   let!(:permission_template_access) do
     create(:permission_template_access,

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
   end
 
   describe 'the next actor' do
-    let(:collection) { create(:collection, create_access: true) }
+    let(:collection) { build(:collection_lw, with_permission_template: true) }
     let(:attributes) do
       {
         member_of_collections_attributes: { '0' => { id: '123' } },
@@ -68,7 +68,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
     end
 
     context "when work is in user's own collection and destroy is passed" do
-      let(:collection) { create(:collection, user: user, title: ['A good title'], create_access: true) }
+      let(:collection) { build(:collection_lw, user: user, title: ['A good title'], with_permission_template: true) }
       let(:attributes) do
         { member_of_collections_attributes: { '0' => { id: collection.id, _destroy: 'true' } } }
       end
@@ -86,7 +86,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
 
     context "when work is in another user's collection" do
       let(:other_user) { create(:user) }
-      let(:other_collection) { create(:collection, user: other_user, title: ['A good title'], create_access: true) }
+      let(:other_collection) { build(:collection_lw, user: other_user, title: ['A good title'], with_permission_template: true) }
 
       before do
         curation_concern.member_of_collections = [other_collection]
@@ -102,7 +102,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
 
     context "updates env" do
       let!(:collection_type) { create(:collection_type) }
-      let!(:collection) { create(:collection, collection_type_gid: collection_type.gid, create_access: true) }
+      let!(:collection) { build(:collection_lw, collection_type_gid: collection_type.gid, with_permission_template: true) }
 
       subject(:middleware) do
         stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
@@ -135,7 +135,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
         end
 
         context "when more than one collection" do
-          let(:collection2) { create(:collection, create_access: true) }
+          let(:collection2) { build(:collection_lw, with_permission_template: true) }
           let(:attributes) do
             {
               member_of_collections_attributes: {

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
 
     context "updates env" do
       let!(:collection_type) { create(:collection_type) }
-      let!(:collection) { build(:collection_lw, collection_type_gid: collection_type.gid, with_permission_template: true) }
+      let!(:collection) { create(:collection_lw, collection_type_gid: collection_type.gid, with_permission_template: true) }
 
       subject(:middleware) do
         stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
@@ -135,7 +135,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
         end
 
         context "when more than one collection" do
-          let(:collection2) { build(:collection_lw, with_permission_template: true) }
+          let(:collection2) { create(:collection_lw, with_permission_template: true) }
           let(:attributes) do
             {
               member_of_collections_attributes: {

--- a/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller, clean
       end
 
       context "when collections exist of this type" do
-        let!(:collection) { create(:collection, collection_type_gid: collection_type_to_destroy.gid) }
+        let!(:collection) { create(:collection_lw, collection_type_gid: collection_type_to_destroy.gid) }
 
         it "doesn't delete the collection type or collection" do
           delete :destroy, params: { id: collection_type_to_destroy }

--- a/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
@@ -10,20 +10,23 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
   let(:work_5_read) { create(:work, id: 'work-5-read', title: ["Other's work with read access"], user: other, read_users: [user]) }
   let(:work_6_noaccess) { create(:work, id: 'work-6-no_access', title: ["Other's work with no access"], user: other) }
 
-  let(:coll_1_own) { create(:private_collection, id: 'col-1-own', title: ['User created'], user: user, create_access: true) }
+  let(:coll_1_own) { create(:private_collection_lw, id: 'col-1-own', title: ['User created'], user: user, with_permission_template: true) }
   let(:coll_2_mgr) do
-    create(:private_collection, id: 'col-2-mgr', title: ['User has manage access'], user: other,
-                                with_permission_template: { manage_users: [user] }, create_access: true)
+    create(:private_collection_lw, id: 'col-2-mgr', title: ['User has manage access'], user: other,
+                                   with_permission_template: { manage_users: [user] })
   end
   let(:coll_3_dep) do
-    create(:private_collection, id: 'col-3-dep', title: ['User has deposit access'], user: other,
-                                with_permission_template: { deposit_users: [user] }, create_access: true)
+    create(:private_collection_lw, id: 'col-3-dep', title: ['User has deposit access'], user: other,
+                                   with_permission_template: { deposit_users: [user] })
   end
   let(:coll_4_view) do
-    create(:private_collection, id: 'col-4-dep', title: ['User has view access'], user: other,
-                                with_permission_template: { view_users: [user] }, create_access: true)
+    create(:private_collection_lw, id: 'col-4-dep', title: ['User has view access'], user: other,
+                                   with_permission_template: { view_users: [user] })
   end
-  let(:coll_5_noaccess) { create(:private_collection, id: 'col-5-no_access', title: ['Other user created'], user: other, create_access: true) }
+  let(:coll_5_noaccess) do
+    create(:private_collection_lw, id: 'col-5-no_access', title: ['Other user created'],
+                                   user: other, with_permission_template: true)
+  end
 
   describe '#update_members' do
     context 'when user created the collection' do
@@ -95,7 +98,7 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
       end
 
       context 'and user adds a subcollection' do
-        let(:parent_collection) { create(:private_collection, id: 'pcol', title: ['User created another'], user: user, create_access: true) }
+        let(:parent_collection) { create(:private_collection_lw, id: 'pcol', title: ['User created another'], user: user, with_permission_template: true) }
 
         it 'adds collection user created' do
           expect do
@@ -209,8 +212,8 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
 
       context 'and user adds a subcollection' do
         let(:parent_collection) do
-          create(:private_collection, id: 'pcol-mgr', title: ['User has manage access to another'], user: other,
-                                      with_permission_template: { manage_users: [user] }, create_access: true)
+          create(:private_collection_lw, id: 'pcol-mgr', title: ['User has manage access to another'], user: other,
+                                         with_permission_template: { manage_users: [user] })
         end
 
         it 'adds collection user created' do
@@ -325,8 +328,8 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
 
       context 'and user adds a subcollection' do
         let(:parent_collection) do
-          create(:private_collection, id: 'pcol-dep', title: ['User has deposit access to another'], user: other,
-                                      with_permission_template: { deposit_users: [user] }, create_access: true)
+          create(:private_collection_lw, id: 'pcol-dep', title: ['User has deposit access to another'], user: other,
+                                         with_permission_template: { deposit_users: [user] })
         end
 
         it 'adds collection user created' do

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
     end
 
     context "when params includes parent_id" do
-      let(:parent_collection) { create(:collection, title: ['Parent']) }
+      let(:parent_collection) { create(:collection_lw, title: ['Parent']) }
 
       it "creates a collection as a subcollection of parent" do
         parent_collection
@@ -189,7 +189,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       let(:asset1) { create(:generic_work, user: user) }
       let(:asset2) { create(:generic_work, user: user) }
       let(:asset3) { create(:generic_work, user: user) }
-      let(:collection2) { create(:collection, title: ['Some Collection'], user: user) }
+      let(:collection2) { create(:collection_lw, title: ['Some Collection'], user: user) }
 
       before do
         [asset1, asset2, asset3].each do |asset|

--- a/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
   routes { Hyrax::Engine.routes }
   let(:child_id) { 'child1' }
   let(:child) { instance_double(Collection, title: ["Awesome Child"]) }
-  let(:parent) { create(:collection, id: 'parent1', collection_type_settings: :nestable, title: ["Uncool Parent"]) }
+  let(:parent) { create(:collection_lw, id: 'parent1', collection_type_settings: :nestable, title: ["Uncool Parent"]) }
 
   describe '#blacklight_config' do
     subject { controller.blacklight_config }

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
       sign_in user
     end
-    let(:collection) { create(:named_collection, user: user) }
+    let(:collection) { create(:named_collection_lw, user: user) }
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       visit "/collections/#{collection.id}"
@@ -112,7 +112,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
       sign_in user
     end
-    let(:collection) { create(:named_collection, user: user) }
+    let(:collection) { create(:named_collection_lw, user: user) }
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       visit "/collections/#{collection.id}"

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   # Setting Title on admin sets to avoid false positive matches with collections.
   let(:admin_set_a) { create(:admin_set, creator: [admin_user.user_key], title: ['Set A'], with_permission_template: true) }
   let(:admin_set_b) { create(:admin_set, creator: [user.user_key], title: ['Set B'], edit_users: [user.user_key], with_permission_template: true) }
-  let(:collection1) { create(:public_collection, user: user, collection_type_gid: collection_type.gid, create_access: true) }
-  let(:collection2) { create(:public_collection, user: user, collection_type_gid: collection_type.gid, create_access: true) }
-  let(:collection3) { create(:public_collection, user: admin_user, collection_type_gid: collection_type.gid, create_access: true) }
-  let(:collection4) { create(:public_collection, user: admin_user, collection_type_gid: user_collection_type.gid, create_access: true) }
+  let(:collection1) { create(:public_collection_lw, user: user, collection_type_gid: collection_type.gid, with_permission_template: true) }
+  let(:collection2) { create(:public_collection_lw, user: user, collection_type_gid: collection_type.gid, with_permission_template: true) }
+  let(:collection3) { create(:public_collection_lw, user: admin_user, collection_type_gid: collection_type.gid, with_permission_template: true) }
+  let(:collection4) { create(:public_collection_lw, user: admin_user, collection_type_gid: user_collection_type.gid, with_permission_template: true) }
 
   describe 'Your Collections tab' do
     context 'when non-admin user' do
@@ -328,8 +328,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   end
 
   describe 'delete collection' do
-    let!(:empty_collection) { create(:public_collection, title: ['Empty Collection'], user: user, create_access: true) }
-    let!(:collection) { create(:public_collection, title: ['Collection with Work'], user: user, create_access: true) }
+    let!(:empty_collection) { create(:public_collection_lw, title: ['Empty Collection'], user: user, with_permission_template: true) }
+    let!(:collection) { create(:public_collection_lw, title: ['Collection with Work'], user: user, with_permission_template: true) }
     let!(:admin_user) { create(:admin) }
     let!(:empty_adminset) { create(:admin_set, title: ['Empty Admin Set'], creator: [admin_user.user_key], with_permission_template: true) }
     let!(:adminset) { create(:admin_set, title: ['Admin Set with Work'], creator: [admin_user.user_key], with_permission_template: true) }
@@ -564,7 +564,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
   describe 'collection show page' do
     let(:collection) do
-      create(:public_collection, user: user, description: ['collection description'], create_access: true)
+      build(:public_collection_lw, user: user, description: ['collection description'], with_permission_template: true)
     end
     let!(:work1) { create(:work, title: ["King Louie"], member_of_collections: [collection], user: user) }
     let!(:work2) { create(:work, title: ["King Kong"], member_of_collections: [collection], user: user) }
@@ -707,7 +707,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
       sign_in user
     end
-    let(:collection) { create(:named_collection, user: user, create_access: true) }
+    let(:collection) { create(:named_collection_lw, user: user, with_permission_template: true) }
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       visit '/dashboard/my/collections'
@@ -762,7 +762,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   end
 
   describe 'edit collection' do
-    let(:collection) { create(:named_collection, user: user, create_access: true) }
+    let(:collection) { build(:named_collection_lw, user: user, with_permission_template: true) }
     let!(:work1) { create(:work, title: ["King Louie"], member_of_collections: [collection], user: user) }
     let!(:work2) { create(:work, title: ["King Kong"], member_of_collections: [collection], user: user) }
 
@@ -856,8 +856,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       context 'with brandable set' do
-        let(:brandable_collection_id) { create(:collection, user: user, collection_type_settings: [:brandable], create_access: true).id }
-        let(:not_brandable_collection_id) { create(:collection, user: user, collection_type_settings: [:not_brandable], create_access: true).id }
+        let(:brandable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:brandable], with_permission_template: true).id }
+        let(:not_brandable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:not_brandable], with_permission_template: true).id }
 
         it 'to true, it shows Branding tab' do
           visit "/dashboard/collections/#{brandable_collection_id}/edit"
@@ -871,8 +871,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       context 'with discoverable set' do
-        let(:discoverable_collection_id) { create(:collection, user: user, collection_type_settings: [:discoverable], create_access: true).id }
-        let(:not_discoverable_collection_id) { create(:collection, user: user, collection_type_settings: [:not_discoverable], create_access: true).id }
+        let(:discoverable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:discoverable], with_permission_template: true).id }
+        let(:not_discoverable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:not_discoverable], with_permission_template: true).id }
 
         it 'to true, it shows Discovery tab' do
           visit "/dashboard/collections/#{discoverable_collection_id}/edit"
@@ -886,8 +886,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       context 'with sharable set' do
-        let(:sharable_collection_id) { create(:collection, user: user, collection_type_settings: [:sharable], create_access: true).id }
-        let(:not_sharable_collection_id) { create(:collection, user: user, collection_type_settings: [:not_sharable], create_access: true).id }
+        let(:sharable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:sharable], with_permission_template: true).id }
+        let(:not_sharable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:not_sharable], with_permission_template: true).id }
 
         it 'to true, it shows Sharable tab' do
           visit "/dashboard/collections/#{sharable_collection_id}/edit"

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Collection, type: :model do
   end
 
   describe "#members_objects", clean_repo: true do
-    let(:collection) { create(:collection) }
+    let(:collection) { create(:collection_lw) }
 
     it "is empty by default" do
       expect(collection.member_objects).to match_array []
@@ -185,7 +185,7 @@ RSpec.describe Collection, type: :model do
 
   describe '.after_destroy' do
     it 'will destroy the associated permission template' do
-      collection = create(:collection, with_permission_template: true)
+      collection = build(:collection_lw, with_permission_template: true)
       expect { collection.destroy }.to change { Hyrax::PermissionTemplate.count }.by(-1)
     end
   end
@@ -193,7 +193,7 @@ RSpec.describe Collection, type: :model do
   describe '#reset_access_controls!' do
     let!(:user) { build(:user) }
     let(:collection_type) { create(:collection_type) }
-    let!(:collection) { create(:collection, user: user, collection_type_gid: collection_type.gid) }
+    let!(:collection) { build(:collection_lw, user: user, collection_type_gid: collection_type.gid) }
     let!(:permission_template) { build(:permission_template) }
 
     before do
@@ -236,20 +236,20 @@ RSpec.describe Collection, type: :model do
 
     describe 'permission template' do
       it 'will be created when with_permission_template is true' do
-        expect { create(:collection, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       end
 
       it 'will be created when with_permission_template is set to attributes identifying access' do
-        expect { create(:collection, with_permission_template: { manage_users: [user] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
-        expect { create(:collection, with_permission_template: { manage_users: [user], deposit_users: [user] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, with_permission_template: { manage_users: [user] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, with_permission_template: { manage_users: [user], deposit_users: [user] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       end
 
       it 'will be created when create_access is true' do
-        expect { create(:collection, create_access: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, create_access: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       end
 
       it 'will not be created by default' do
-        expect { create(:collection) }.not_to change { Hyrax::PermissionTemplate.count }
+        expect { build(:collection_lw) }.not_to change { Hyrax::PermissionTemplate.count }
       end
     end
 
@@ -264,11 +264,11 @@ RSpec.describe Collection, type: :model do
       end
 
       it 'will be created when create_access is true' do
-        expect { create(:collection, user: user, create_access: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, user: user, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       end
 
       it 'will not be created by default' do
-        expect { create(:collection) }.not_to change { Hyrax::PermissionTemplateAccess.count }
+        expect { build(:collection_lw) }.not_to change { Hyrax::PermissionTemplateAccess.count }
       end
     end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe Collection, type: :model do
       end
 
       it 'will be created when create_access is true' do
-        expect { build(:collection_lw, create_access: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { create(:collection_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       end
 
       it 'will not be created by default' do

--- a/spec/models/concerns/hyrax/collection_nesting_spec.rb
+++ b/spec/models/concerns/hyrax/collection_nesting_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Hyrax::CollectionNesting do
     end
 
     let(:user) { create(:user) }
-    let!(:collection) { create(:collection, collection_type_settings: [:nestable]) }
-    let!(:child_collection) { create(:collection, collection_type_settings: [:nestable]) }
+    let!(:collection) { build(:collection_lw, collection_type_settings: [:nestable]) }
+    let!(:child_collection) { create(:collection_lw, collection_type_settings: [:nestable]) }
     let(:extent) { Hyrax::Adapters::NestingIndexAdapter::FULL_REINDEX }
 
     before do

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   describe "collections" do
-    let!(:collection) { create(:collection, collection_type_gid: collection_type.gid.to_s) }
+    let!(:collection) { create(:collection_lw, collection_type_gid: collection_type.gid.to_s) }
     let(:collection_type) { create(:collection_type) }
 
     it 'returns collections of this collection type' do
@@ -151,7 +151,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     let(:collection_type) { create(:collection_type) }
 
     it 'returns true if there are any collections of this collection type' do
-      create(:collection, collection_type_gid: collection_type.gid.to_s)
+      create(:collection_lw, collection_type_gid: collection_type.gid.to_s)
       expect(collection_type).to have_collections
     end
     it 'returns false if there are not any collections of this collection type' do

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Hyrax::CollectionSearchBuilder do
 
     context 'when access is :deposit' do
       let(:access) { "deposit" }
-      let!(:collection) { create(:collection, with_permission_template: attributes) }
+      let!(:collection) { create(:collection_lw, with_permission_template: attributes) }
 
       context 'and user has access' do
         let(:attributes) { { deposit_users: [user.user_key] } }

--- a/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Hyrax::Dashboard::NestedCollectionsSearchBuilder do
 
     context 'when access is :deposit' do
       let(:access) { "deposit" }
-      let!(:collection) { create(:collection, with_permission_template: attributes) }
+      let!(:collection) { build(:collection_lw, with_permission_template: attributes) }
 
       context 'and user has access' do
         let(:attributes) { { deposit_users: [user.user_key] } }

--- a/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Hyrax::Dashboard::NestedCollectionsSearchBuilder do
 
     context 'when access is :deposit' do
       let(:access) { "deposit" }
-      let!(:collection) { build(:collection_lw, with_permission_template: attributes) }
+      let!(:collection) { create(:collection_lw, with_permission_template: attributes) }
 
       context 'and user has access' do
         let(:attributes) { { deposit_users: [user.user_key] } }

--- a/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
+++ b/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
 
   describe '.each_perservation_document_id_and_parent_ids', clean_repo: true do
     let!(:nested_parent) { build(:collection_lw, member_of_collections: []) }
-    let!(:nested_with_parent) { create(:collection, member_of_collections: [nested_parent]) }
+    let!(:nested_with_parent) { create(:collection_lw, member_of_collections: [nested_parent]) }
     let!(:work) { create(:generic_work) }
     let(:count_of_items) { ActiveFedora::Base.descendant_uris(ActiveFedora.fedora.base_uri, exclude_uri: true).count }
 

--- a/spec/services/hyrax/collections/migration_service_spec.rb
+++ b/spec/services/hyrax/collections/migration_service_spec.rb
@@ -322,8 +322,8 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
 
     context 'when newer collections are found (e.g. collections created at or after Hyrax 2.1.0)' do
       let!(:collection) do
-        create(:collection, id: 'col_newer', user: user, with_permission_template: true, collection_type_settings: [:discoverable],
-                            edit_users: [user.user_key], create_access: true)
+        build(:collection_lw, id: 'col_newer', user: user, with_permission_template: true, collection_type_settings: [:discoverable],
+                              edit_users: [user.user_key])
       end
       let!(:permission_template) { collection.permission_template }
       let!(:collection_type_gid) { collection.collection_type_gid }

--- a/spec/services/hyrax/collections/migration_service_spec.rb
+++ b/spec/services/hyrax/collections/migration_service_spec.rb
@@ -185,11 +185,11 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       end
 
       context "and collection type gid is set but permission template doesn't exist" do
-        let!(:col_none) { create(:user_collection, id: 'col_none', user: user, edit_users: [user.user_key], collection_type_gid: default_gid) }
-        let!(:col_vu) { create(:user_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], collection_type_gid: default_gid) }
-        let!(:col_vg) { create(:user_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], collection_type_gid: default_gid) }
-        let!(:col_mu) { create(:user_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], collection_type_gid: default_gid) }
-        let!(:col_mg) { create(:user_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], collection_type_gid: default_gid) }
+        let!(:col_none) { build(:user_collection_lw, id: 'col_none', user: user, edit_users: [user.user_key], collection_type_gid: default_gid) }
+        let!(:col_vu) { build(:user_collection_lw, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], collection_type_gid: default_gid) }
+        let!(:col_vg) { build(:user_collection_lw, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], collection_type_gid: default_gid) }
+        let!(:col_mu) { build(:user_collection_lw, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], collection_type_gid: default_gid) }
+        let!(:col_mg) { build(:user_collection_lw, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], collection_type_gid: default_gid) }
 
         it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
           Collection.all.each do |col|

--- a/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
@@ -153,57 +153,57 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
 
         # using create option here because permission template is required for testing :deposit access
         let(:coll_a) do
-          create(:public_collection,
-                 id: 'Collection_A',
-                 collection_type_gid: collection_type.gid,
-                 user: user,
-                 create_access: true)
+          build(:public_collection_lw,
+                id: 'Collection_A',
+                collection_type_gid: collection_type.gid,
+                user: user,
+                with_permission_template: true)
         end
         let(:coll_b) do
-          create(:public_collection,
-                 id: 'Collection_B',
-                 collection_type_gid: collection_type.gid,
-                 user: user,
-                 create_access: true,
-                 member_of_collections: [coll_a])
+          build(:public_collection_lw,
+                id: 'Collection_B',
+                collection_type_gid: collection_type.gid,
+                user: user,
+                with_permission_template: true,
+                member_of_collections: [coll_a])
         end
         let(:coll_c) do
-          create(:public_collection,
-                 id: 'Collection_C',
-                 collection_type_gid: collection_type.gid,
-                 user: user,
-                 create_access: true,
-                 member_of_collections: [coll_b])
+          build(:public_collection_lw,
+                id: 'Collection_C',
+                collection_type_gid: collection_type.gid,
+                user: user,
+                with_permission_template: true,
+                member_of_collections: [coll_b])
         end
         let(:coll_d) do
-          create(:public_collection,
-                 id: 'Collection_D',
-                 collection_type_gid: collection_type.gid,
-                 user: user,
-                 create_access: true,
-                 member_of_collections: [coll_c])
+          build(:public_collection_lw,
+                id: 'Collection_D',
+                collection_type_gid: collection_type.gid,
+                user: user,
+                with_permission_template: true,
+                member_of_collections: [coll_c])
         end
         let(:coll_e) do
-          create(:public_collection,
+          create(:public_collection_lw,
                  id: 'Collection_E',
                  collection_type_gid: collection_type.gid,
                  user: user,
-                 create_access: true,
+                 with_permission_template: true,
                  member_of_collections: [coll_d])
         end
         let(:another) do
-          create(:public_collection,
+          create(:public_collection_lw,
                  id: 'Another_One',
                  collection_type_gid: collection_type.gid,
                  user: user,
-                 create_access: true)
+                 with_permission_template: true)
         end
         let(:wrong) do
-          create(:public_collection,
-                 id: 'Wrong_Type',
-                 collection_type_gid: another_collection_type.gid,
-                 user: user,
-                 create_access: true)
+          build(:public_collection_lw,
+                id: 'Wrong_Type',
+                collection_type_gid: another_collection_type.gid,
+                user: user,
+                with_permission_template: true)
         end
 
         before do
@@ -245,18 +245,18 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
       describe 'and are of the same collection type', with_nested_reindexing: true do
         # using create option here because permission template is required for testing :deposit access
         let!(:parent) do
-          create(:public_collection,
+          create(:public_collection_lw,
                  id: 'Parent_Collecton',
                  collection_type_gid: collection_type.gid,
                  user: user,
-                 create_access: true)
+                 with_permission_template: true)
         end
         let!(:child) do
-          create(:public_collection,
+          create(:public_collection_lw,
                  id: 'Child_Collection',
                  collection_type_gid: collection_type.gid,
                  user: user,
-                 create_access: true)
+                 with_permission_template: true)
         end
 
         it { is_expected.to eq(true) }

--- a/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   describe 'nesting attributes object', with_nested_reindexing: true do
     let(:user) { create(:user) }
     let!(:parent) { build(:collection_lw, id: 'Parent_Coll', collection_type_gid: collection_type.gid, user: user) }
-    let!(:child) { create(:user_collection, id: 'Child_Coll', collection_type_gid: collection_type.gid, user: user) }
+    let!(:child) { create(:user_collection_lw, id: 'Child_Coll', collection_type_gid: collection_type.gid, user: user) }
     let(:nesting_attributes) { Hyrax::Collections::NestedCollectionQueryService::NestingAttributes.new(id: child.id, scope: scope) }
 
     before do


### PR DESCRIPTION
refs #2940 

Present tense short summary (50 characters or less)

This is an extension of the previous PRs from a sprint week to tackle updating the use of the old collection factory and `create` for the new factories and using `build` where possible. 

Previous PRs
- #3483 
- #3487 
- #3488 
- #3490 


Changes proposed in this pull request:
* swaps `create` for `build`
* updates factory methods to use `collection_lw` or `public_collection_lw` etc.
* replaces `create_access: true` with `with_permission_template_true` where it can be done



@samvera/hyrax-code-reviewers
