### PR TITLE
Parallelism can be extended to 4 containers on free CircleCI 2.0 accounts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
     # - image: circleci/postgres:9.4
 
     working_directory: ~/repo
-    parallelism: 2
+    parallelism: 4
 
     environment:
       RAILS_ENV: test


### PR DESCRIPTION
samvera/hyrax currently has up to 4 containers available: https://circleci.com/gh/samvera/hyrax/edit#parallel-builds
