### PR TITLE
Configure Circle CI to run as a "workflow"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,14 +83,14 @@ jobs:
     - run:
         name: Generate test app
         command: |
-          bundle exec rails new ~/test_app
+          bundle exec rails new ~/test_app -m template.rb
           cd ~/test_app
 
     - run:
         name: Setup Gemfile dependencies
         command: |
           sed -i -- "s/gem 'sqlite3'/gem 'sqlite3', '< 1.4.0'/g" ~/test_app/Gemfile
-          echo "gem 'hyrax', path: '../hyrax'" >> ~/test_app/Gemfile
+          sed -i -- "s/gem 'hyrax', .*/gem 'hyrax', path: '..\/hyrax/g" ~/test_app/Gemfile
 
     - run:
         name: Install app dependencies
@@ -102,7 +102,6 @@ jobs:
         name: Install Hyrax
         command: |
           cd ~/test_app
-          ./bin/rails g hyrax:install -f
           bundle exec rake db:migrate
           bundle exec rake hyrax:default_collection_types:create
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,18 +97,12 @@ jobs:
         command: |
           cd ~/test_app
           bundle install --path ./vendor/bundle --binstubs ./vendor/bin
-          bundle show --paths
-          ruby -v
 
     - run:
         name: Install Hyrax
         command: |
           cd ~/test_app
-          ruby -v
-          bundle exec ruby -v
-          bundle exec rake -T
-          bundle exec ./vendor/bin/rails --version
-          bundle exec ./vendor/bin/rails g hyrax:install -f
+          bundle exec ./bin/rails g hyrax:install -f
           bundle exec rake db:migrate
           bundle exec rake hyrax:default_collection_types:create
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
         name: Install Hyrax
         command: |
           cd ~/test_app
-          bundle exec ./bin/rails g hyrax:install -f
+          ./bin/rails g hyrax:install -f
           bundle exec rake db:migrate
           bundle exec rake hyrax:default_collection_types:create
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,16 +98,9 @@ jobs:
           cd ~/test_app
           bundle install --path ./vendor/bundle --binstubs ./vendor/bin
 
-    - run:
-        name: Install Hyrax
-        command: |
-          cd ~/test_app
-          bundle exec rake db:migrate
-          bundle exec rake hyrax:default_collection_types:create
-
   test:
     docker:
-    - image: circleci/ruby:2.5.3
+    - image: circleci/ruby:2.5-node-browsers
     - image: circleci/redis:4
     - image: ualbertalib/docker-fcrepo4:4.7
       environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 executors:
   ruby:
     docker:
-      - image: circleci/ruby:2.5.3
+      - image: ruby:2.5
     working_directory: ~/hyrax
     environment:
       BUNDLE_PATH: ~/bundle
@@ -55,7 +55,7 @@ jobs:
 
   build:
     docker:
-    - image: circleci/ruby:2.5.3-node-browsers-legacy
+    - image: circleci/ruby:2.5-node-browsers
     - image: circleci/redis:4
     - image: ualbertalib/docker-fcrepo4:4.7
       environment:
@@ -73,7 +73,6 @@ jobs:
       RACK_ENV: test
       FCREPO_TEST_PORT: 8080/fcrepo
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-      ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-action-cable --skip-coffee --skip-puma --skip-test
       SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
       COVERALLS_PARALLEL: true
 
@@ -82,22 +81,40 @@ jobs:
         at: ~/
 
     - run:
-        name: Generate test app, ensure top-level Gemfile.lock is valid
+        name: Generate test app
         command: |
-          bundle exec rake engine_cart:generate
-          bundle check || bundle install
+          bundle exec rails new ~/test_app
+          cd ~/test_app
 
-    - persist_to_workspace:
-        root: ~/
-        paths:
-        - hyrax/*
-        - hyrax/**/*
-        - bundle/*
-        - bundle/**/*
+    - run:
+        name: Setup Gemfile dependencies
+        command: |
+          sed -i -- "s/gem 'sqlite3'/gem 'sqlite3', '< 1.4.0'/g" ~/test_app/Gemfile
+          echo "gem 'hyrax', path: '../hyrax'" >> ~/test_app/Gemfile
+
+    - run:
+        name: Install app dependencies
+        command: |
+          cd ~/test_app
+          bundle install --path ./vendor/bundle --binstubs ./vendor/bin
+          bundle show --paths
+          ruby -v
+
+    - run:
+        name: Install Hyrax
+        command: |
+          cd ~/test_app
+          ruby -v
+          bundle exec ruby -v
+          bundle exec rake -T
+          bundle exec ./vendor/bin/rails --version
+          bundle exec ./vendor/bin/rails g hyrax:install -f
+          bundle exec rake db:migrate
+          bundle exec rake hyrax:default_collection_types:create
 
   test:
     docker:
-    - image: circleci/ruby:2.5.3-node-browsers-legacy
+    - image: circleci/ruby:2.5.3
     - image: circleci/redis:4
     - image: ualbertalib/docker-fcrepo4:4.7
       environment:
@@ -127,7 +144,7 @@ jobs:
     - run:
         name: Load config into SolrCloud
         command: |
-          cd .internal_test_app/solr/config
+          cd ~/test_app/solr/config
           zip -1 -r solr_hyrax_config.zip ./*
           curl -H "Content-type:application/octet-stream" --data-binary @solr_hyrax_config.zip "http://localhost:8985/solr/admin/configs?action=UPLOAD&name=hyrax"
           curl -H 'Content-type: application/json' http://localhost:8985/api/collections/ -d '{create: {name: hydra-test, config: hyrax, numShards: 1}}'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
         name: Setup Gemfile dependencies
         command: |
           sed -i -- "s/gem 'sqlite3'/gem 'sqlite3', '< 1.4.0'/g" ~/test_app/Gemfile
-          sed -i -- "s/gem 'hyrax', .*/gem 'hyrax', path: '..\/hyrax/g" ~/test_app/Gemfile
+          sed -i -- "s/gem 'hyrax', .*/gem 'hyrax', path: '..\/hyrax'/g" ~/test_app/Gemfile
 
     - run:
         name: Install app dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,16 @@ jobs:
           cd ~/test_app
           bundle install --path ./vendor/bundle --binstubs ./vendor/bin
 
+    - persist_to_workspace:
+        root: ~/
+        paths:
+        - hyrax/*
+        - hyrax/**/*
+        - bundle/*
+        - bundle/**/*
+        - test_app/*
+        - test_app/**/*
+
   test:
     docker:
     - image: circleci/ruby:2.5-node-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,57 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
+executors:
+  ruby:
+    docker:
+      - image: circleci/ruby:2.5.3
+    working_directory: ~/hyrax
+    environment:
+      BUNDLE_PATH: ~/bundle
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
+
 jobs:
+  bundle:
+    executor: ruby
+    steps:
+    - restore_cache:
+        keys:
+        - source-v1-{{ .Branch }}-{{ .Revision }}
+        - source-v1-{{ .Branch }}-
+        - source-v1-
+
+    - checkout
+
+    - run:
+        name: Install dependencies
+        command: bundle check || bundle install
+
+    - save_cache:
+        key: source-v1-{{ .Branch }}-{{ .Revision }}
+        paths:
+        - ".git"
+        - ~/bundle
+
+    - persist_to_workspace:
+        root: ~/
+        paths:
+        - hyrax/*
+        - hyrax/**/*
+        - bundle/*
+        - bundle/**/*
+
+  lint:
+    executor: ruby
+    steps:
+    - attach_workspace:
+        at: ~/
+
+    - run:
+        name: Call Rubocop
+        command: bundle exec rubocop
+
   build:
     docker:
     - image: circleci/ruby:2.5.3-node-browsers-legacy
@@ -14,71 +63,66 @@ jobs:
     - image: solr:7-alpine
       command: bin/solr -cloud -noprompt -f -p 8985
 
-    # Specify service dependencies here if necessary
-    # CircleCI maintains a library of pre-built images
-    # documented at https://circleci.com/docs/2.0/circleci-images/
-    # - image: circleci/postgres:9.4
-
-    working_directory: ~/repo
-    parallelism: 4
+    working_directory: ~/hyrax
 
     environment:
+      BUNDLE_PATH: ~/bundle
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
       RAILS_ENV: test
       RACK_ENV: test
       FCREPO_TEST_PORT: 8080/fcrepo
-      BUNDLE_JOBS: 4
-      BUNDLE_RETRY: 3
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
       ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-action-cable --skip-coffee --skip-puma --skip-test
       SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
       COVERALLS_PARALLEL: true
 
     steps:
-    - restore_cache:
-        keys:
-        - source-v1-{{ .Branch }}-{{ .Revision }}
-        - source-v1-{{ .Branch }}-
-        - source-v1-
-
-    - checkout
-
-    - save_cache:
-        key: source-v1-{{ .Branch }}-{{ .Revision }}
-        paths:
-        - ".git"
-
-    # BUNDLE_PATH is unset to allow for `bundle config path` to take precedence.
-    - run:
-        name: Extra environment setup
-        command: |
-          echo 'unset BUNDLE_PATH' >> $BASH_ENV
-
-    - restore_cache:
-        keys:
-        - v1-internal-test-app-{{ .Branch }}
-        - v1-internal-test-app-
-
-    - run:
-        name: Install dependencies
-        command: |
-          gem update --system
-          gem update bundler
-          bundle install
-
-    - run:
-        name: Call Rubocop
-        command: bundle exec rubocop
+    - attach_workspace:
+        at: ~/
 
     - run:
         name: Generate test app, ensure top-level Gemfile.lock is valid
         command: |
           bundle exec rake engine_cart:generate
-          bundle install
+          bundle check || bundle install
 
-    - save_cache:
+    - persist_to_workspace:
+        root: ~/
         paths:
-        - ./.internal_test_app
-        key: v1-internal-test-app-{{ .Branch }}-{{ checksum "./.internal_test_app/.generated_engine_cart" }}
+        - hyrax/*
+        - hyrax/**/*
+        - bundle/*
+        - bundle/**/*
+
+  test:
+    docker:
+    - image: circleci/ruby:2.5.3-node-browsers-legacy
+    - image: circleci/redis:4
+    - image: ualbertalib/docker-fcrepo4:4.7
+      environment:
+        CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC"
+    - image: solr:7-alpine
+      command: bin/solr -cloud -noprompt -f -p 8985
+
+    working_directory: ~/hyrax
+    parallelism: 4
+
+    environment:
+      BUNDLE_PATH: ~/bundle
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
+      RAILS_ENV: test
+      RACK_ENV: test
+      FCREPO_TEST_PORT: 8080/fcrepo
+      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+      ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-action-cable --skip-coffee --skip-puma --skip-test
+      SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+      COVERALLS_PARALLEL: true
+
+    steps:
+    - attach_workspace:
+        at: ~/
 
     - run:
         name: Load config into SolrCloud
@@ -100,3 +144,19 @@ jobs:
     - store_artifacts:
         path: /tmp/test-results
         destination: test-results
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - bundle
+      - lint:
+          requires:
+            - bundle
+      - build:
+          requires:
+            - bundle
+      - test:
+          requires:
+            - build
+            - lint

--- a/.engine_cart.yml
+++ b/.engine_cart.yml
@@ -1,1 +1,0 @@
-rails_options: "<%= '--skip-listen' if ENV.fetch('RAILS_VERSION', '') < '5.0' %>"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -169,13 +169,8 @@ RSpec.configure do |config|
       DatabaseCleaner.start
     end
 
-    if example.metadata[:type] == :view
-      # View tests should not hit any services. This ensures the tests are unit
-      # testing only the views and run fast.
-      WebMock.disable_net_connect!(allow_localhost: false)
-    else
-      WebMock.disable_net_connect!(allow_localhost: true)
-    end
+    WebMock.disable_net_connect!(allow_localhost: true)
+
     # using :workflow is preferable to :clean_repo, use the former if possible
     # It's important that this comes after DatabaseCleaner.start
     ensure_deposit_available_for(user) if example.metadata[:workflow]
@@ -195,7 +190,19 @@ RSpec.configure do |config|
   end
 
   config.include(ControllerLevelHelpers, type: :view)
-  config.before(:each, type: :view) { initialize_controller_helpers(view) }
+
+  config.before(:each, type: :view) do
+    # View tests should not hit any services. This ensures the tests are unit
+    # testing only the views and run fast.
+    WebMock.disable_net_connect!(allow_localhost: false)
+
+    initialize_controller_helpers(view)
+  end
+
+  config.after(:each, type: :view) do
+    # reset webmock to allow localhost connections
+    WebMock.disable_net_connect!(allow_localhost: true)
+  end
 
   config.before(:all, type: :feature) do
     # Assets take a long time to compile. This causes two problems:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -169,8 +169,13 @@ RSpec.configure do |config|
       DatabaseCleaner.start
     end
 
-    WebMock.disable_net_connect!(allow_localhost: true)
-
+    if example.metadata[:type] == :view
+      # View tests should not hit any services. This ensures the tests are unit
+      # testing only the views and run fast.
+      WebMock.disable_net_connect!(allow_localhost: false)
+    else
+      WebMock.disable_net_connect!(allow_localhost: true)
+    end
     # using :workflow is preferable to :clean_repo, use the former if possible
     # It's important that this comes after DatabaseCleaner.start
     ensure_deposit_available_for(user) if example.metadata[:workflow]
@@ -190,19 +195,7 @@ RSpec.configure do |config|
   end
 
   config.include(ControllerLevelHelpers, type: :view)
-
-  config.before(:each, type: :view) do
-    # View tests should not hit any services. This ensures the tests are unit
-    # testing only the views and run fast.
-    WebMock.disable_net_connect!(allow_localhost: false)
-
-    initialize_controller_helpers(view)
-  end
-
-  config.after(:each, type: :view) do
-    # reset webmock to allow localhost connections
-    WebMock.disable_net_connect!(allow_localhost: true)
-  end
+  config.before(:each, type: :view) { initialize_controller_helpers(view) }
 
   config.before(:all, type: :feature) do
     # Assets take a long time to compile. This causes two problems:


### PR DESCRIPTION
Circle CI supports "workflow" pipelines. This is an initial configuration that
breaks our prior Circle setup down into a workflow to avoid duplication of
work.

The jobs included in the workflow are as follows:

  - `bundle`: this checks out code and installs the `hyrax` level dependencies.
  The output of this step is cached to avoid duplicating work across workflow
  runs, and persists to the workflow's workspace for use by other jobs within
  this workflow run.
  - `build`: generates the Engine Cart application for use by the test suite.
  This depends on the `bundle` job. The output also persisted into the
  workspace.
  - `lint`: runs `rubocop`. This is broken into a separate job so it can run in
  parallel with `build`.
  - `test`: runs `rspec` using the output of `bundle` and `build`. This job is
  configured to run in 4x parallelism, and only after `build` and `lint` have
  succeeded.

A next step might be to fan the workflow out further to include build/test
processes covering supported versions of Ruby and Rails.

This is a CI configuration change, and does not impact any production code.

@samvera/hyrax-code-reviewers
