### PR TITLE
WIP: Download from S3 if Needed During File Processing

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -230,6 +230,9 @@ module Hyrax
 
         def add_new_banner(uploaded_file_ids)
           f = uploaded_files(uploaded_file_ids).first
+          if f.file_url.match(/^http/)
+            f.file.download!(f.file_url)
+          end
           banner_info = CollectionBrandingInfo.new(
             collection_id: @collection.id,
             filename: File.split(f.file_url).last,
@@ -255,6 +258,9 @@ module Hyrax
 
         def create_logo_info(uploaded_file_id, alttext, linkurl)
           file = uploaded_files(uploaded_file_id)
+          if file.file_url.match(/^http/)
+            file.file.download!(file.file_url)
+          end
           logo_info = CollectionBrandingInfo.new(
             collection_id: @collection.id,
             filename: File.split(file.file_url).last,


### PR DESCRIPTION
Logo and branding fail if S3 is used for file uploads. Since all of CarrierWave settings get changed in this case, all file uploaders have to handle the idea that the files may be on S3. 

Fixes #3475

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* I'm not sure how to write a test spec for this issue and would love to hear any suggestions about the right way to approach this.
* To manually test this code - set carrierwave initializer to 

```
require 'carrierwave'

if Settings.s3.upload_bucket
  CarrierWave.configure do |config|
    # config.fog_provider = 'fog/aws' # we use carrierwave-aws instead of fog now
    # config.fog_credentials = {
    #   provider: 'AWS',
    #   use_iam_profile: true
    # }
    config.storage = :aws
    config.aws_bucket = Settings.s3.upload_bucket
    config.aws_acl = 'bucket-owner-full-control'
  end
end
```

@samvera/hyrax-code-reviewers