### PR TITLE
Configure Circle CI to run as a "workflow"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,116 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
+executors:
+  ruby:
+    docker:
+      - image: circleci/ruby:2.5.3
+    working_directory: ~/hyrax
+    environment:
+      BUNDLE_PATH: vendor/bundle
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
+
 jobs:
+  bundle:
+    executor: ruby
+    steps:
+    - restore_cache:
+        keys:
+        - v1-source-{{ .Branch }}-{{ .Revision }}
+        - v1-source-{{ .Branch }}-
+        - v1-source-
+
+    - checkout
+
+    - save_cache:
+        key: v1-source-{{ .Branch }}-{{ .Revision }}
+        paths:
+        - ".git"
+
+    - restore_cache:
+        keys:
+        - v1-bundle-{{ checksum "Gemfile" }}--{{ checksum "hyrax.gemspec" }}
+        - v1-bundle
+
+    - run:
+        name: Install dependencies
+        command: bundle check || bundle install
+
+    - save_cache:
+        key: v1-bundle-{{ checksum "Gemfile.lock" }}--{{ checksum "hyrax.gemspec" }}
+        paths:
+        - ~/hyrax/vendor/bundle
+
+    - persist_to_workspace:
+        root: ~/
+        paths:
+        - hyrax/*
+        - hyrax/**/*
+
+  lint:
+    executor: ruby
+    steps:
+    - attach_workspace:
+        at: ~/
+
+    - run:
+        name: Call Rubocop
+        command: bundle exec rubocop
+
   build:
+    docker:
+    - image: circleci/ruby:2.5.3-node
+
+    working_directory: ~/hyrax
+
+    environment:
+      BUNDLE_PATH: vendor/bundle
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
+      RAILS_ENV: test
+      RACK_ENV: test
+      FCREPO_TEST_PORT: 8080/fcrepo
+      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+      ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-action-cable --skip-coffee --skip-puma --skip-test
+      SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+      COVERALLS_PARALLEL: true
+
+    steps:
+    - attach_workspace:
+        at: ~/
+
+    - restore_cache:
+        keys:
+        - v1-test-app-{{ checksum "template.rb" }}
+
+    - run:
+        name: Check dependencies
+        command: bundle check || bundle install
+
+    - run:
+        name: Generate test app
+        command: (git diff --name-only master | grep -qG 'generators\/hyrax') || bundle exec rake engine_cart:generate
+
+    - run:
+        name: Ensure test app dependencies are installed
+        command: |
+          cd .internal_test_app
+          bundle check || bundle install
+
+    - save_cache:
+        key: v1-test-app-{{ .Branch }}-{{ .Revision }}
+        paths:
+        - ".internal_test_app"
+
+    - persist_to_workspace:
+        root: ~/
+        paths:
+        - hyrax/*
+        - hyrax/**/*
+
+  test:
     docker:
     - image: circleci/ruby:2.5.3-node-browsers-legacy
     - image: circleci/redis:4
@@ -14,74 +121,31 @@ jobs:
     - image: solr:7-alpine
       command: bin/solr -cloud -noprompt -f -p 8985
 
-    # Specify service dependencies here if necessary
-    # CircleCI maintains a library of pre-built images
-    # documented at https://circleci.com/docs/2.0/circleci-images/
-    # - image: circleci/postgres:9.4
-
-    working_directory: ~/repo
+    working_directory: ~/hyrax
     parallelism: 4
 
     environment:
+      BUNDLE_PATH: vendor/bundle
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
       RAILS_ENV: test
       RACK_ENV: test
       FCREPO_TEST_PORT: 8080/fcrepo
-      BUNDLE_JOBS: 4
-      BUNDLE_RETRY: 3
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
       ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-action-cable --skip-coffee --skip-puma --skip-test
       SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
       COVERALLS_PARALLEL: true
 
     steps:
-    - restore_cache:
-        keys:
-        - source-v1-{{ .Branch }}-{{ .Revision }}
-        - source-v1-{{ .Branch }}-
-        - source-v1-
-
-    - checkout
-
-    - save_cache:
-        key: source-v1-{{ .Branch }}-{{ .Revision }}
-        paths:
-        - ".git"
-
-    # BUNDLE_PATH is unset to allow for `bundle config path` to take precedence.
-    - run:
-        name: Extra environment setup
-        command: |
-          echo 'unset BUNDLE_PATH' >> $BASH_ENV
-
-    - restore_cache:
-        keys:
-        - v1-internal-test-app-{{ .Branch }}
-        - v1-internal-test-app-
+    - attach_workspace:
+        at: ~/
 
     - run:
-        name: Install dependencies
-        command: |
-          gem update --system
-          gem update bundler
-          bundle install
+        name: Ensure top-level Gemfile.lock is valid
+        command: bundle check || bundle install
 
     - run:
-        name: Call Rubocop
-        command: bundle exec rubocop
-
-    - run:
-        name: Generate test app, ensure top-level Gemfile.lock is valid
-        command: |
-          bundle exec rake engine_cart:generate
-          bundle install
-
-    - save_cache:
-        paths:
-        - ./.internal_test_app
-        key: v1-internal-test-app-{{ .Branch }}-{{ checksum "./.internal_test_app/.generated_engine_cart" }}
-
-    - run:
-        name: Load config into SolrCloud
+        name: Load config into solr
         command: |
           cd .internal_test_app/solr/config
           zip -1 -r solr_hyrax_config.zip ./*
@@ -100,3 +164,19 @@ jobs:
     - store_artifacts:
         path: /tmp/test-results
         destination: test-results
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - bundle
+      - lint:
+          requires:
+            - bundle
+      - build:
+          requires:
+            - bundle
+      - test:
+          requires:
+            - build
+            - lint


### PR DESCRIPTION
Circle CI supports "workflow" pipelines. This is an initial configuration that
breaks our prior Circle setup down into a workflow to avoid duplication of
work.

The jobs included in the workflow are as follows:

  - `bundle`: this checks out code and installs the `hyrax` level dependencies.
  The output of this step is cached to avoid duplicating work across workflow
  runs, and persists to the workflow's workspace for use by other jobs within
  this workflow run.
  - `build`: generates the Engine Cart application for use by the test suite.
  This depends on the `bundle` job. The output also persisted into the
  workspace.
  - `lint`: runs `rubocop`. This is broken into a separate job so it can run in
  parallel with `build`.
  - `test`: runs `rspec` using the output of `bundle` and `build`. This job is
  configured to run in 4x parallelism, and only after `build` and `lint` have
  succeeded.

A next step might be to fan the workflow out further to include build/test
processes covering supported versions of Ruby and Rails.

@samvera/hyrax-code-reviewers
