### PR TITLE
Wrap thread code in rails reloader to avoid circular load issue

### DIFF
--- a/spec/actors/hyrax/actors/create_with_remote_files_ordered_members_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_remote_files_ordered_members_actor_spec.rb
@@ -39,15 +39,19 @@ RSpec.describe Hyrax::Actors::CreateWithRemoteFilesOrderedMembersActor do
     let(:work2) { create(:generic_work, user: user) }
     let(:environments) { [environment, Hyrax::Actors::Environment.new(work2, ability, attributes)] }
 
+    # rubocop:disable RSpec/ExampleLength
     it "attaches the correct FileSets to the correct works in the correct order" do
       expect(ImportUrlJob).to receive(:perform_later).with(FileSet, null_operation, {}).exactly(4).times
       threads = environments.collect do |env|
         Thread.new do
-          expect(actor.create(env)).to be true
-          expect(env.curation_concern.ordered_members.to_a.collect(&:label)).to eq(filenames)
+          Rails.application.reloader.wrap do
+            expect(actor.create(env)).to be true
+            expect(env.curation_concern.ordered_members.to_a.collect(&:label)).to eq(filenames)
+          end
         end
       end
       threads.each(&:join)
     end
+    # rubocop:enable RSpec/ExampleLength
   end
 end


### PR DESCRIPTION
This PR takes the suggestion in https://github.com/rails/rails/issues/30350 to wrap the code in a Rails reloader in order to fix autoload issues that were hit in [this CircleCI build](https://circleci.com/gh/samvera/hyrax/977#tests/containers/1).  I was able to reproduce the errors locally by running this one failing test.

In support of #3535.

@samvera/hyrax-code-reviewers