### PR TITLE
TransactionalRequest removal backport

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     # - image: circleci/postgres:9.4
 
     working_directory: ~/repo
-    parallelism: 2
+    parallelism: 4
 
     environment:
       RAILS_ENV: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,19 +59,11 @@ jobs:
         - v1-internal-test-app-{{ .Branch }}
         - v1-internal-test-app-
 
-    # Download and cache dependencies
-    - restore_cache:
-        keys:
-        - v1-dependencies-{{ .Branch }}-{{ checksum "./.internal_test_app/.generated_engine_cart" }}
-        - v1-dependencies-{{ .Branch }}
-        - v1-dependencies-
-
     - run:
         name: Install dependencies
         command: |
           gem update --system
           gem update bundler
-          bundle config path $CIRCLE_WORKING_DIRECTORY/vendor/bundle
           bundle install
 
     - run:
@@ -107,10 +99,6 @@ jobs:
         name: Clean dependencies
         command: bundle clean
 
-    - save_cache:
-        paths:
-        - ./vendor/bundle
-        key: v1-dependencies-{{ .Branch }}-{{ checksum "./.internal_test_app/.generated_engine_cart" }}
 
     # collect reports
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,11 +90,6 @@ jobs:
         key: v1-internal-test-app-{{ .Branch }}-{{ checksum "./.internal_test_app/.generated_engine_cart" }}
 
     - run:
-        name: Start headless Chrome
-        command: google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost
-        background: true
-
-    - run:
         name: Load config into SolrCloud
         command: |
           cd .internal_test_app/solr/config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,11 +95,6 @@ jobs:
           mkdir /tmp/test-results
           bundle exec rspec $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
 
-    - run:
-        name: Clean dependencies
-        command: bundle clean
-
-
     # collect reports
     - store_test_results:
         path: /tmp/test-results

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: required
 dist: trusty
 
 addons:
-  chrome: stable
+  apt:
+    packages:
+      - chromium-chromedriver
 cache:
   bundler: true
 
@@ -31,3 +33,4 @@ services:
   - redis-server
 before_script:
   - jdk_switcher use oraclejdk8
+  - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,14 @@
 source 'https://rubygems.org'
 
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
 # Please see hyrax.gemspec for dependency information.
 gemspec
+
+gem 'hydra-head', github: 'samvera/hydra-head', branch: 'no-extra-acls'
 
 group :development, :test do
   gem 'coveralls', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+# Please see hyrax.gemspec for dependency information.
+gemspec
+
 group :development, :test do
   gem 'coveralls', require: false
   gem 'i18n-tasks'

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,5 @@
 source 'https://rubygems.org'
 
-git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-  "https://github.com/#{repo_name}.git"
-end
-
-# Please see hyrax.gemspec for dependency information.
-gemspec
-
-gem 'hydra-head', github: 'samvera/hydra-head', branch: 'master'
-
 group :development, :test do
   gem 'coveralls', require: false
   gem 'i18n-tasks'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 # Please see hyrax.gemspec for dependency information.
 gemspec
 
-gem 'hydra-head', github: 'samvera/hydra-head', branch: 'no-extra-acls'
+gem 'hydra-head', github: 'samvera/hydra-head', branch: 'master'
 
 group :development, :test do
   gem 'coveralls', require: false

--- a/app/actors/hyrax/actors/transactional_request.rb
+++ b/app/actors/hyrax/actors/transactional_request.rb
@@ -1,24 +1,24 @@
 module Hyrax
   module Actors
-    # Wrap the stack in a database transaction.
-    # This will roll back any database actions (particularly workflow) if there
+    # Used to wrap the stack in a database transaction.
+    # This would have rolled back any database actions (particularly workflow) if there
     # is an error elsewhere in the actor stack.
+    # This was problematic, is removed in v3.0, and is currently a no-op
+    # Backport of https://github.com/samvera/hyrax/pull/3482
     class TransactionalRequest < Actors::AbstractActor
+      # rubocop:disable Rails/Delegate
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if create was successful
       def create(env)
-        ActiveRecord::Base.transaction do
-          next_actor.create(env)
-        end
+        next_actor.create(env)
       end
 
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if update was successful
       def update(env)
-        ActiveRecord::Base.transaction do
-          next_actor.update(env)
-        end
+        next_actor.update(env)
       end
+      # rubocop:enable Rails/Delegate
     end
   end
 end

--- a/app/services/hyrax/default_middleware_stack.rb
+++ b/app/services/hyrax/default_middleware_stack.rb
@@ -3,6 +3,12 @@ module Hyrax
     # rubocop:disable Metrics/MethodLength
     def self.build_stack
       ActionDispatch::MiddlewareStack.new.tap do |middleware|
+        # Used to wrap everything in a database transaction, if the save of the resource
+        # failed then rolled back any database AdminSetChangeSet
+        # This was problematic, is removed in v3.0, and is currently a no-op
+        # Backport of https://github.com/samvera/hyrax/pull/3482
+        middleware.use Hyrax::Actors::TransactionalRequest
+
         # Ensure you are mutating the most recent version
         middleware.use Hyrax::Actors::OptimisticLockValidator
 

--- a/app/services/hyrax/default_middleware_stack.rb
+++ b/app/services/hyrax/default_middleware_stack.rb
@@ -3,10 +3,6 @@ module Hyrax
     # rubocop:disable Metrics/MethodLength
     def self.build_stack
       ActionDispatch::MiddlewareStack.new.tap do |middleware|
-        # Wrap everything in a database transaction, if the save of the resource
-        # fails then roll back any database AdminSetChangeSet
-        middleware.use Hyrax::Actors::TransactionalRequest
-
         # Ensure you are mutating the most recent version
         middleware.use Hyrax::Actors::OptimisticLockValidator
 

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -85,7 +85,7 @@ SUMMARY
   spec.add_development_dependency 'capybara-maleficent', '~> 0.3.0'
   spec.add_development_dependency 'chromedriver-helper', '~> 2.1'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
-  spec.add_development_dependency 'engine_cart', '~> 2.0'
+  spec.add_development_dependency 'engine_cart', '~> 2.2'
   spec.add_development_dependency "equivalent-xml", '~> 0.5'
   spec.add_development_dependency "factory_bot", '~> 4.4'
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.5', '>= 0.5.1'

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -83,6 +83,7 @@ SUMMARY
   # temporary pin to 2.17 due to failures caused in 2.18.0
   spec.add_development_dependency "capybara", '~> 2.4', '< 2.18.0'
   spec.add_development_dependency 'capybara-maleficent', '~> 0.3.0'
+  spec.add_development_dependency 'chromedriver-helper', '~> 2.1'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
   spec.add_development_dependency 'engine_cart', '~> 2.0'
   spec.add_development_dependency "equivalent-xml", '~> 0.5'
@@ -112,8 +113,4 @@ SUMMARY
   # simple_form 3.5.1 broke hydra-editor for certain model types;
   #   see: https://github.com/plataformatec/simple_form/issues/1549
   spec.add_dependency 'simple_form', '~> 3.2', '<= 3.5.0'
-  # chromedriver-helper 2.0 broke the chromedriver used by capybara
-  #   see: https://github.com/flavorjones/chromedriver-helper/issues/62
-  #        and https://github.com/flavorjones/chromedriver-helper/issues/57
-  spec.add_development_dependency 'chromedriver-helper', '< 2.0'
 end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -51,7 +51,7 @@ SUMMARY
   spec.add_dependency 'font-awesome-rails', '~> 4.2'
   spec.add_dependency 'hydra-derivatives', '~> 3.3'
   spec.add_dependency 'hydra-editor', '>= 3.3', '< 5.0'
-  spec.add_dependency 'hydra-head', '>= 10.5.0'
+  spec.add_dependency 'hydra-head', '>= 10.6.1'
   spec.add_dependency 'hydra-works', '>= 0.16', '< 2.0'
   spec.add_dependency 'iiif_manifest', '>= 0.3', '< 0.6'
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4'

--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'CollectionAbility' do
   end
 
   context 'when user has no special access' do
-    let!(:collection) { create(:collection, id: 'as', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { build(:collection_lw, id: 'as', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     it 'denies all abilities' do # rubocop:disable RSpec/ExampleLength

--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'CollectionAbility' do
   end
 
   context 'when user has no special access' do
-    let!(:collection) { build(:collection_lw, id: 'as', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { create(:collection_lw, id: 'as', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     it 'denies all abilities' do # rubocop:disable RSpec/ExampleLength

--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'CollectionAbility' do
 
   context 'when admin user' do
     let(:user) { FactoryBot.create(:admin) }
-    let!(:collection) { create(:collection, id: 'col_au', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { build(:collection_lw, id: 'col_au', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     it 'allows all abilities' do # rubocop:disable RSpec/ExampleLength
@@ -34,7 +34,7 @@ RSpec.describe 'CollectionAbility' do
   end
 
   context 'when collection manager' do
-    let!(:collection) { create(:collection, id: 'col_mu', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { build(:collection_lw, id: 'col_mu', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do
@@ -69,7 +69,7 @@ RSpec.describe 'CollectionAbility' do
   end
 
   context 'when collection depositor' do
-    let!(:collection) { create(:collection, id: 'col_du', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { build(:collection_lw, id: 'col_du', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do
@@ -104,7 +104,7 @@ RSpec.describe 'CollectionAbility' do
   end
 
   context 'when collection viewer' do
-    let!(:collection) { create(:collection, id: 'col_vu', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { build(:collection_lw, id: 'col_vu', with_permission_template: true, collection_type_gid: collection_type_gid) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do

--- a/spec/abilities/permission_template_ability_spec.rb
+++ b/spec/abilities/permission_template_ability_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'PermissionTemplateAbility' do
   let(:current_user) { user }
   let(:collection_type_gid) { create(:collection_type).gid }
 
-  let!(:collection) { create(:collection, with_permission_template: true, collection_type_gid: collection_type_gid) }
+  let!(:collection) { build(:collection_lw, with_permission_template: true, collection_type_gid: collection_type_gid) }
   let(:permission_template) { collection.permission_template }
   let!(:permission_template_access) do
     create(:permission_template_access,

--- a/spec/abilities/permission_template_ability_spec.rb
+++ b/spec/abilities/permission_template_ability_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'PermissionTemplateAbility' do
   let(:current_user) { user }
   let(:collection_type_gid) { create(:collection_type).gid }
 
-  let!(:collection) { build(:collection_lw, with_permission_template: true, collection_type_gid: collection_type_gid) }
+  let!(:collection) { create(:collection_lw, with_permission_template: true, collection_type_gid: collection_type_gid) }
   let(:permission_template) { collection.permission_template }
   let!(:permission_template_access) do
     create(:permission_template_access,

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
 
     context "updates env" do
       let!(:collection_type) { create(:collection_type) }
-      let!(:collection) { build(:collection_lw, collection_type_gid: collection_type.gid, with_permission_template: true) }
+      let!(:collection) { create(:collection_lw, collection_type_gid: collection_type.gid, with_permission_template: true) }
 
       subject(:middleware) do
         stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
@@ -205,7 +205,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
         end
 
         context "when more than one collection" do
-          let(:collection2) { build(:collection_lw, with_permission_template: true) }
+          let(:collection2) { create(:collection_lw, with_permission_template: true) }
           let(:attributes) do
             {
               member_of_collections_attributes: {

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
   end
 
   describe 'the next actor' do
-    let(:collection) { create(:collection, create_access: true) }
+    let(:collection) { build(:collection_lw, with_permission_template: true) }
     let(:attributes) do
       {
         member_of_collections_attributes: { '0' => { id: '123' } },
@@ -68,7 +68,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
     end
 
     context "when work is in user's own collection and destroy is passed" do
-      let(:collection) { create(:collection, user: user, title: ['A good title'], create_access: true) }
+      let(:collection) { build(:collection_lw, user: user, title: ['A good title'], with_permission_template: true) }
       let(:attributes) do
         { member_of_collections_attributes: { '0' => { id: collection.id, _destroy: 'true' } } }
       end
@@ -86,7 +86,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
 
     context "when work is in another user's collection" do
       let(:other_user) { create(:user) }
-      let(:other_collection) { create(:collection, user: other_user, title: ['A good title'], create_access: true) }
+      let(:other_collection) { build(:collection_lw, user: other_user, title: ['A good title'], with_permission_template: true) }
 
       before do
         curation_concern.member_of_collections = [other_collection]
@@ -172,7 +172,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
 
     context "updates env" do
       let!(:collection_type) { create(:collection_type) }
-      let!(:collection) { create(:collection, collection_type_gid: collection_type.gid, create_access: true) }
+      let!(:collection) { build(:collection_lw, collection_type_gid: collection_type.gid, with_permission_template: true) }
 
       subject(:middleware) do
         stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
@@ -205,7 +205,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
         end
 
         context "when more than one collection" do
-          let(:collection2) { create(:collection, create_access: true) }
+          let(:collection2) { build(:collection_lw, with_permission_template: true) }
           let(:attributes) do
             {
               member_of_collections_attributes: {

--- a/spec/actors/hyrax/actors/transactional_request_spec.rb
+++ b/spec/actors/hyrax/actors/transactional_request_spec.rb
@@ -35,10 +35,12 @@ RSpec.describe Hyrax::Actors::TransactionalRequest do
 
     subject { middleware.create(env) }
 
-    it "rolls back any database changes" do
+    # Note that this test changed behavior with the
+    # backport of https://github.com/samvera/hyrax/pull/3482
+    it "does NOT roll back any database changes" do
       expect do
         expect { subject }.to raise_error 'boom'
-      end.not_to change { User.count } # Note the above good actor creates a user
+      end.to change { User.count } # Note the above good actor creates a user
     end
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CatalogController, type: :controller do
     end
 
     context 'with collections' do
-      let(:collection) { create(:public_collection, keyword: ['rocks']) }
+      let(:collection) { create(:public_collection_lw, keyword: ['rocks']) }
       let(:objects) { [collection, rocks, clouds] }
 
       it 'finds collections' do

--- a/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller, clean
       end
 
       context "when collections exist of this type" do
-        let!(:collection) { create(:collection, collection_type_gid: collection_type_to_destroy.gid) }
+        let!(:collection) { create(:collection_lw, collection_type_gid: collection_type_to_destroy.gid) }
 
         it "doesn't delete the collection type or collection" do
           delete :destroy, params: { id: collection_type_to_destroy }

--- a/spec/controllers/hyrax/batch_edits_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_edits_controller_spec.rb
@@ -174,15 +174,15 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
     let(:user) { create(:user) }
 
     let(:collection1) do
-      create(:public_collection, title: ["My First Collection"],
-                                 description: ["My incredibly detailed description of the collection"],
-                                 user: user)
+      create(:public_collection_lw, title: ["My First Collection"],
+                                    description: ["My incredibly detailed description of the collection"],
+                                    user: user)
     end
 
     let(:collection2) do
-      create(:public_collection, title: ["My Other Collection"],
-                                 description: ["My incredibly detailed description of the other collection"],
-                                 user: user)
+      create(:public_collection_lw, title: ["My Other Collection"],
+                                    description: ["My incredibly detailed description of the other collection"],
+                                    user: user)
     end
 
     let!(:work1) { create(:work, title: ["First of the Assets"], member_of_collections: [collection1], user: user) }
@@ -204,9 +204,9 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
       let(:user2) { create(:user) }
 
       let(:collection3) do
-        create(:public_collection, title: ["User2's Collection"],
-                                   description: ["Collection created by user2"],
-                                   user: user2)
+        create(:public_collection_lw, title: ["User2's Collection"],
+                                      description: ["Collection created by user2"],
+                                      user: user2)
       end
 
       before do

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Hyrax::CollectionsController do
   let(:other) { build(:user) }
 
   let(:collection) do
-    create(:public_collection, title: ["My collection"],
-                               description: ["My incredibly detailed description of the collection"],
-                               user: user)
+    create(:public_collection_lw, title: ["My collection"],
+                                  description: ["My incredibly detailed description of the collection"],
+                                  user: user)
   end
 
   let(:asset1)         { create(:work, title: ["First of the Assets"], user: user) }

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Hyrax::CollectionsController do
   let(:asset1)         { create(:work, title: ["First of the Assets"], user: user) }
   let(:asset2)         { create(:work, title: ["Second of the Assets"], user: user) }
   let(:asset3)         { create(:work, title: ["Third of the Assets"], user: user) }
-  let(:asset4)         { create(:collection, title: ["First subcollection"], user: user) }
-  let(:asset5)         { create(:collection, title: ["Second subcollection"], user: user) }
+  let(:asset4)         { build(:collection_lw, title: ["First subcollection"], user: user) }
+  let(:asset5)         { build(:collection_lw, title: ["Second subcollection"], user: user) }
   let(:unowned_asset)  { create(:work, user: other) }
 
   let(:collection_attrs) do

--- a/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
@@ -10,20 +10,23 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
   let(:work_5_read) { create(:work, id: 'work-5-read', title: ["Other's work with read access"], user: other, read_users: [user]) }
   let(:work_6_noaccess) { create(:work, id: 'work-6-no_access', title: ["Other's work with no access"], user: other) }
 
-  let(:coll_1_own) { create(:private_collection, id: 'col-1-own', title: ['User created'], user: user, create_access: true) }
+  let(:coll_1_own) { create(:private_collection_lw, id: 'col-1-own', title: ['User created'], user: user, with_permission_template: true) }
   let(:coll_2_mgr) do
-    create(:private_collection, id: 'col-2-mgr', title: ['User has manage access'], user: other,
-                                with_permission_template: { manage_users: [user] }, create_access: true)
+    create(:private_collection_lw, id: 'col-2-mgr', title: ['User has manage access'], user: other,
+                                   with_permission_template: { manage_users: [user] })
   end
   let(:coll_3_dep) do
-    create(:private_collection, id: 'col-3-dep', title: ['User has deposit access'], user: other,
-                                with_permission_template: { deposit_users: [user] }, create_access: true)
+    create(:private_collection_lw, id: 'col-3-dep', title: ['User has deposit access'], user: other,
+                                   with_permission_template: { deposit_users: [user] })
   end
   let(:coll_4_view) do
-    create(:private_collection, id: 'col-4-dep', title: ['User has view access'], user: other,
-                                with_permission_template: { view_users: [user] }, create_access: true)
+    create(:private_collection_lw, id: 'col-4-dep', title: ['User has view access'], user: other,
+                                   with_permission_template: { view_users: [user] })
   end
-  let(:coll_5_noaccess) { create(:private_collection, id: 'col-5-no_access', title: ['Other user created'], user: other, create_access: true) }
+  let(:coll_5_noaccess) do
+    create(:private_collection_lw, id: 'col-5-no_access', title: ['Other user created'],
+                                   user: other, with_permission_template: true)
+  end
 
   describe '#update_members' do
     context 'when user created the collection' do
@@ -95,7 +98,7 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
       end
 
       context 'and user adds a subcollection' do
-        let(:parent_collection) { create(:private_collection, id: 'pcol', title: ['User created another'], user: user, create_access: true) }
+        let(:parent_collection) { create(:private_collection_lw, id: 'pcol', title: ['User created another'], user: user, with_permission_template: true) }
 
         it 'adds collection user created' do
           expect do
@@ -209,8 +212,8 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
 
       context 'and user adds a subcollection' do
         let(:parent_collection) do
-          create(:private_collection, id: 'pcol-mgr', title: ['User has manage access to another'], user: other,
-                                      with_permission_template: { manage_users: [user] }, create_access: true)
+          create(:private_collection_lw, id: 'pcol-mgr', title: ['User has manage access to another'], user: other,
+                                         with_permission_template: { manage_users: [user] })
         end
 
         it 'adds collection user created' do
@@ -325,8 +328,8 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
 
       context 'and user adds a subcollection' do
         let(:parent_collection) do
-          create(:private_collection, id: 'pcol-dep', title: ['User has deposit access to another'], user: other,
-                                      with_permission_template: { deposit_users: [user] }, create_access: true)
+          create(:private_collection_lw, id: 'pcol-dep', title: ['User has deposit access to another'], user: other,
+                                         with_permission_template: { deposit_users: [user] })
         end
 
         it 'adds collection user created' do

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
     end
 
     context "when params includes parent_id" do
-      let(:parent_collection) { create(:collection, title: ['Parent']) }
+      let(:parent_collection) { create(:collection_lw, title: ['Parent']) }
 
       it "creates a collection as a subcollection of parent" do
         parent_collection
@@ -189,7 +189,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       let(:asset1) { create(:generic_work, user: user) }
       let(:asset2) { create(:generic_work, user: user) }
       let(:asset3) { create(:generic_work, user: user) }
-      let(:collection2) { create(:collection, title: ['Some Collection'], user: user) }
+      let(:collection2) { create(:collection_lw, title: ['Some Collection'], user: user) }
 
       before do
         [asset1, asset2, asset3].each do |asset|

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   let(:collection_type_gid) { create(:user_collection_type).gid }
 
   let(:collection) do
-    create(:public_collection, title: ["My collection"],
-                               description: ["My incredibly detailed description of the collection"],
-                               user: user)
+    create(:public_collection_lw, title: ["My collection"],
+                                  description: ["My incredibly detailed description of the collection"],
+                                  user: user)
   end
 
   let(:asset1)         { create(:work, title: ["First of the Assets"], user: user) }

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   let(:asset1)         { create(:work, title: ["First of the Assets"], user: user) }
   let(:asset2)         { create(:work, title: ["Second of the Assets"], user: user) }
   let(:asset3)         { create(:work, title: ["Third of the Assets"], user: user) }
-  let(:asset4)         { create(:collection, title: ["First subcollection"], user: user) }
-  let(:asset5)         { create(:collection, title: ["Second subcollection"], user: user) }
+  let(:asset4)         { build(:collection_lw, title: ["First subcollection"], user: user) }
+  let(:asset5)         { build(:collection_lw, title: ["Second subcollection"], user: user) }
   let(:unowned_asset)  { create(:work, user: other) }
 
   let(:collection_attrs) do
@@ -233,7 +233,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
     end
 
     context "when update fails" do
-      let(:collection) { create(:collection, id: '12345') }
+      let(:collection) { build(:collection_lw, id: '12345') }
       let(:repository) { instance_double(Blacklight::Solr::Repository, search: result) }
       let(:result) { double(documents: [], total: 0) }
 

--- a/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
   routes { Hyrax::Engine.routes }
   let(:child_id) { 'child1' }
   let(:child) { instance_double(Collection, title: ["Awesome Child"]) }
-  let(:parent) { create(:collection, id: 'parent1', collection_type_settings: :nestable, title: ["Uncool Parent"]) }
+  let(:parent) { create(:collection_lw, id: 'parent1', collection_type_settings: :nestable, title: ["Uncool Parent"]) }
 
   describe '#blacklight_config' do
     subject { controller.blacklight_config }

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -534,7 +534,7 @@ RSpec.describe Hyrax::GenericWorksController do
 
   describe '#destroy' do
     let(:work_to_be_deleted) { create(:private_generic_work, user: user) }
-    let(:parent_collection) { create(:collection) }
+    let(:parent_collection) { build(:collection_lw) }
 
     it 'deletes the work' do
       delete :destroy, params: { id: work_to_be_deleted }

--- a/spec/controllers/hyrax/my/shares_controller_spec.rb
+++ b/spec/controllers/hyrax/my/shares_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::My::SharesController, type: :controller do
       let!(:shared_with_me)           { create(:work, user: other_user, edit_users: [user, other_user]) }
       let!(:read_shared_with_me)      { create(:work, user: other_user, read_users: [user, other_user]) }
       let!(:shared_with_someone_else) { create(:work, user: other_user, edit_users: [someone_else, other_user]) }
-      let!(:my_collection)            { create(:public_collection, user: user) }
+      let!(:my_collection)            { create(:public_collection_lw, user: user) }
 
       it "responds with success" do
         get :index

--- a/spec/features/actor_stack_spec.rb
+++ b/spec/features/actor_stack_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+# Integration tests for the full midddleware stack
+RSpec.describe Hyrax::DefaultMiddlewareStack, :clean_repo do
+  subject(:actor)  { stack.build(Hyrax::Actors::Terminator.new) }
+  let(:ability)    { ::Ability.new(user) }
+  let(:attributes) { {} }
+  let(:stack)      { described_class.build_stack }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:user)       { FactoryBot.create(:user) }
+  let(:work)       { FactoryBot.build(:work) }
+  let(:env)        { Hyrax::Actors::Environment.new(work, ability, attributes) }
+
+  let(:delayed_failure_actor) do
+    Class.new(Hyrax::Actors::AbstractActor) do
+      def create(env)
+        next_actor.create(env) && raise('ALWAYS RAISE')
+      end
+    end
+  end
+
+  describe '#create' do
+    it 'persists the work' do
+      expect { actor.create(env) }
+        .to change { work.persisted? }
+        .to true
+    end
+
+    context 'when failing on the way back up the actor stack' do
+      before { stack.insert_before(Hyrax::Actors::ModelActor, delayed_failure_actor) }
+
+      before(:context) do
+        Hyrax.config.enable_noids = true
+        # we need to mint once to set the `rand` database column and
+        # make minter behavior predictable
+        ::Noid::Rails.config.minter_class.new.mint
+      end
+
+      after(:context) { Hyrax.config.enable_noids = false }
+
+      it 'leaves a valid minter state', :aggregate_failures do
+        expect { actor.create(env) }.to raise_error 'ALWAYS RAISE'
+
+        expect(GenericWork.new.assign_id).not_to eq work.id
+      end
+    end
+  end
+end

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'catalog searching', type: :feature do
   end
 
   context 'with public works and private collections', clean_repo: true do
-    let!(:collection) { create(:private_collection) }
+    let!(:collection) { build(:private_collection_lw) }
 
     let!(:jills_work) do
       create(:public_work, title: ["Jill's Research"], keyword: ['jills_keyword'], member_of_collections: [collection])

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'catalog searching', type: :feature do
       create(:public_work, title: ["Jack's Research"], keyword: ['jacks_keyword', 'shared_keyword'])
     end
 
-    let!(:collection) { create(:public_collection, keyword: ['collection_keyword', 'shared_keyword']) }
+    let!(:collection) { create(:public_collection_lw, keyword: ['collection_keyword', 'shared_keyword']) }
 
     it 'performing a search' do
       within('#search-form-header') do

--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
   end
 
   describe 'when both collections support multiple membership' do
-    let(:old_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_1.gid, title: ['OldCollectionTitle']) }
+    let(:old_collection) { build(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_1.gid, title: ['OldCollectionTitle']) }
     let!(:work) { create(:generic_work, user: admin_user, member_of_collections: [old_collection], title: ['The highly valued work that everyone wants in their collection']) }
 
     context 'and are of different types' do
@@ -56,7 +56,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
   end
 
   describe 'when both collections require single membership' do
-    let(:old_collection) { create(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_1.gid, title: ['OldCollectionTitle']) }
+    let(:old_collection) { build(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_1.gid, title: ['OldCollectionTitle']) }
     let!(:work) do
       create(:generic_work,
              user: admin_user,

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
       sign_in user
     end
-    let(:collection) { create(:named_collection, user: user) }
+    let(:collection) { create(:named_collection_lw, user: user) }
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       visit "/collections/#{collection.id}"
@@ -112,7 +112,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
       sign_in user
     end
-    let(:collection) { create(:named_collection, user: user) }
+    let(:collection) { create(:named_collection_lw, user: user) }
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       visit "/collections/#{collection.id}"

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -1,17 +1,17 @@
 RSpec.describe 'collection', type: :feature, clean_repo: true do
   let(:user) { create(:user) }
 
-  let(:collection1) { create(:public_collection, user: user) }
-  let(:collection2) { create(:public_collection, user: user) }
+  let(:collection1) { create(:public_collection_lw, user: user) }
+  let(:collection2) { create(:public_collection_lw, user: user) }
 
   describe 'collection show page' do
     let(:collection) do
-      create(:public_collection, user: user, description: ['collection description'], collection_type_settings: :nestable)
+      create(:public_collection_lw, user: user, description: ['collection description'], collection_type_settings: :nestable)
     end
     let!(:work1) { create(:work, title: ["King Louie"], member_of_collections: [collection], user: user) }
     let!(:work2) { create(:work, title: ["King Kong"], member_of_collections: [collection], user: user) }
-    let!(:col1) { create(:public_collection, title: ["Sub-collection 1"], member_of_collections: [collection], user: user) }
-    let!(:col2) { create(:public_collection, title: ["Sub-collection 2"], member_of_collections: [collection], user: user) }
+    let!(:col1) { create(:public_collection_lw, title: ["Sub-collection 1"], member_of_collections: [collection], user: user) }
+    let!(:col2) { create(:public_collection_lw, title: ["Sub-collection 2"], member_of_collections: [collection], user: user) }
 
     before do
       sign_in user

--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
     end
 
     context 'when collections exist of this type' do
-      let!(:collection1) { create(:public_collection, user: build(:user), collection_type_gid: exhibit_collection_type.gid) }
+      let!(:collection1) { create(:public_collection_lw, user: build(:user), collection_type_gid: exhibit_collection_type.gid) }
 
       before do
         exhibit_collection_type
@@ -352,7 +352,7 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
 
     context 'when collections exist of this type' do
       let!(:not_empty_collection_type) { create(:collection_type, title: 'Not Empty Type', creator_user: admin_user) }
-      let!(:collection1) { create(:public_collection, user: admin_user, collection_type_gid: not_empty_collection_type.gid) }
+      let!(:collection1) { create(:public_collection_lw, user: admin_user, collection_type_gid: not_empty_collection_type.gid) }
       let(:deny_delete_modal_text) do
         'You cannot delete this collection type because one or more collections of this type have already been created. ' \
         'To delete this collection type, first ensure that all collections of this type have been deleted.'

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   # Setting Title on admin sets to avoid false positive matches with collections.
   let(:admin_set_a) { create(:admin_set, creator: [admin_user.user_key], title: ['Set A'], with_permission_template: true) }
   let(:admin_set_b) { create(:admin_set, creator: [user.user_key], title: ['Set B'], edit_users: [user.user_key], with_permission_template: true) }
-  let(:collection1) { create(:public_collection, user: user, collection_type_gid: collection_type.gid, create_access: true) }
-  let(:collection2) { create(:public_collection, user: user, collection_type_gid: collection_type.gid, create_access: true) }
-  let(:collection3) { create(:public_collection, user: admin_user, collection_type_gid: collection_type.gid, create_access: true) }
-  let(:collection4) { create(:public_collection, user: admin_user, collection_type_gid: user_collection_type.gid, create_access: true) }
+  let(:collection1) { create(:public_collection_lw, user: user, collection_type_gid: collection_type.gid, with_permission_template: true) }
+  let(:collection2) { create(:public_collection_lw, user: user, collection_type_gid: collection_type.gid, with_permission_template: true) }
+  let(:collection3) { create(:public_collection_lw, user: admin_user, collection_type_gid: collection_type.gid, with_permission_template: true) }
+  let(:collection4) { create(:public_collection_lw, user: admin_user, collection_type_gid: user_collection_type.gid, with_permission_template: true) }
 
   describe 'Your Collections tab' do
     context 'when non-admin user' do
@@ -328,8 +328,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   end
 
   describe 'delete collection' do
-    let!(:empty_collection) { create(:public_collection, title: ['Empty Collection'], user: user, create_access: true) }
-    let!(:collection) { create(:public_collection, title: ['Collection with Work'], user: user, create_access: true) }
+    let!(:empty_collection) { create(:public_collection_lw, title: ['Empty Collection'], user: user, with_permission_template: true) }
+    let!(:collection) { create(:public_collection_lw, title: ['Collection with Work'], user: user, with_permission_template: true) }
     let!(:admin_user) { create(:admin) }
     let!(:empty_adminset) { create(:admin_set, title: ['Empty Admin Set'], creator: [admin_user.user_key], with_permission_template: true) }
     let!(:adminset) { create(:admin_set, title: ['Admin Set with Work'], creator: [admin_user.user_key], with_permission_template: true) }
@@ -564,7 +564,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
   describe 'collection show page' do
     let(:collection) do
-      create(:public_collection, user: user, description: ['collection description'], create_access: true)
+      build(:public_collection_lw, user: user, description: ['collection description'], with_permission_template: true)
     end
     let!(:work1) { create(:work, title: ["King Louie"], member_of_collections: [collection], user: user) }
     let!(:work2) { create(:work, title: ["King Kong"], member_of_collections: [collection], user: user) }
@@ -707,7 +707,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
       sign_in user
     end
-    let(:collection) { create(:named_collection, user: user, create_access: true) }
+    let(:collection) { create(:named_collection_lw, user: user, with_permission_template: true) }
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       visit '/dashboard/my/collections'
@@ -762,7 +762,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   end
 
   describe 'edit collection' do
-    let(:collection) { create(:named_collection, user: user, create_access: true) }
+    let(:collection) { build(:named_collection_lw, user: user, with_permission_template: true) }
     let!(:work1) { create(:work, title: ["King Louie"], member_of_collections: [collection], user: user) }
     let!(:work2) { create(:work, title: ["King Kong"], member_of_collections: [collection], user: user) }
 
@@ -856,8 +856,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       context 'with brandable set' do
-        let(:brandable_collection_id) { create(:collection, user: user, collection_type_settings: [:brandable], create_access: true).id }
-        let(:not_brandable_collection_id) { create(:collection, user: user, collection_type_settings: [:not_brandable], create_access: true).id }
+        let(:brandable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:brandable], with_permission_template: true).id }
+        let(:not_brandable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:not_brandable], with_permission_template: true).id }
 
         it 'to true, it shows Branding tab' do
           visit "/dashboard/collections/#{brandable_collection_id}/edit"
@@ -871,8 +871,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       context 'with discoverable set' do
-        let(:discoverable_collection_id) { create(:collection, user: user, collection_type_settings: [:discoverable], create_access: true).id }
-        let(:not_discoverable_collection_id) { create(:collection, user: user, collection_type_settings: [:not_discoverable], create_access: true).id }
+        let(:discoverable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:discoverable], with_permission_template: true).id }
+        let(:not_discoverable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:not_discoverable], with_permission_template: true).id }
 
         it 'to true, it shows Discovery tab' do
           visit "/dashboard/collections/#{discoverable_collection_id}/edit"
@@ -886,8 +886,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       context 'with sharable set' do
-        let(:sharable_collection_id) { create(:collection, user: user, collection_type_settings: [:sharable], create_access: true).id }
-        let(:not_sharable_collection_id) { create(:collection, user: user, collection_type_settings: [:not_sharable], create_access: true).id }
+        let(:sharable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:sharable], with_permission_template: true).id }
+        let(:not_sharable_collection_id) { create(:collection_lw, user: user, collection_type_settings: [:not_sharable], with_permission_template: true).id }
 
         it 'to true, it shows Sharable tab' do
           visit "/dashboard/collections/#{sharable_collection_id}/edit"

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'searching' do
   end
 
   let!(:collection) do
-    create(:public_collection, title: ['collection title abc'], description: [subject_value], user: user, members: [work])
+    create(:public_collection_lw, title: ['collection title abc'], description: [subject_value], user: user, members: [work])
   end
 
   context "as a public user", :clean_repo do

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -53,11 +53,14 @@ RSpec.describe "work show view" do
     it "allows adding work to a collection", clean_repo: true, js: true do
       optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
       click_button "Add to collection" # opens the modal
-      select_member_of_collection(collection)
+      # Really ensure that this Collection model is persisted
+      Collection.all.map(&:destroy!)
+      persisted_collection = create(:collection_lw, user: user, collection_type_gid: multi_membership_type_1.gid)
+      select_member_of_collection(persisted_collection)
       click_button 'Save changes'
 
       # forwards to collection show page
-      expect(page).to have_content collection.title.first
+      expect(page).to have_content persisted_collection.title.first
       expect(page).to have_content work.title.first
       expect(page).to have_selector '.alert-success', text: 'Collection was successfully updated.'
     end

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
     subject { form.permission_template }
 
     context "when the PermissionTemplate doesn't exist" do
-      let(:model) { create(:collection) }
+      let(:model) { build(:collection_lw) }
 
       it "gets created" do
         expect(subject).to be_instance_of Hyrax::Forms::PermissionTemplateForm
@@ -185,7 +185,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
     context "when the PermissionTemplate exists" do
       let(:form) { described_class.new(model, ability, repository) }
       let(:permission_template) { Hyrax::PermissionTemplate.find_by(source_id: model.id) }
-      let(:model) { create(:collection, with_permission_template: true) }
+      let(:model) { build(:collection_lw, with_permission_template: true) }
 
       it "uses the existing template" do
         expect(subject).to be_instance_of Hyrax::Forms::PermissionTemplateForm

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
     end
   end
 
-  let(:collection) { build(:collection) }
+  let(:collection) { build(:collection_lw) }
   let(:ability) { Ability.new(create(:user)) }
   let(:repository) { double }
   let(:form) { described_class.new(collection, ability, repository) }
@@ -74,8 +74,8 @@ RSpec.describe Hyrax::Forms::CollectionForm do
   end
 
   context "nested relationships" do
-    let(:child_collection) { build(:collection) }
-    let(:parent_collection) { build(:collection) }
+    let(:child_collection) { build(:collection_lw) }
+    let(:parent_collection) { build(:collection_lw) }
     let(:service_object) { double(available_member_subcollections: double(documents: [child_collection])) }
 
     before do

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
   let(:form) { described_class.new(permission_template) }
   let(:today) { Time.zone.today }
   let(:admin_set) { create(:admin_set) }
-  let(:collection) { create(:collection) }
+  let(:collection) { build(:collection_lw) }
 
   subject { form }
 

--- a/spec/indexers/hyrax/collection_indexer_spec.rb
+++ b/spec/indexers/hyrax/collection_indexer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Hyrax::CollectionIndexer do
   let(:indexer) { described_class.new(collection) }
-  let(:collection) { build(:collection) }
+  let(:collection) { build(:collection_lw) }
   let(:col1id) { 'col1' }
   let(:col2id) { 'col2' }
   let(:col1title) { 'col1 title' }

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CharacterizeJob do
 
   context "when the file set's work is in a collection" do
     let(:work)       { build(:generic_work) }
-    let(:collection) { build(:collection) }
+    let(:collection) { build(:collection_lw) }
 
     before do
       allow(file_set).to receive(:parent).and_return(work)

--- a/spec/lib/hyrax/resource_sync/change_list_writer_spec.rb
+++ b/spec/lib/hyrax/resource_sync/change_list_writer_spec.rb
@@ -10,6 +10,27 @@ RSpec.describe Hyrax::ResourceSync::ChangeListWriter, :clean_repo do
     described_class.new(resource_host: 'example.com',
                         capability_list_url: capability_list)
   end
+  let(:namespaces) do
+    {
+      'rs' => "http://www.openarchives.org/rs/terms/",
+      'x' => sitemap
+    }
+  end
+  let(:capability_element) { xml.xpath('//rs:ln/@href', 'rs' => "http://www.openarchives.org/rs/terms/") }
+  # The creation and modified dates are used in order to determine whether or
+  # not the status is "created" or "updated"
+  # This avoids any potential delays/conflicts when testing against Solr and
+  # Fedora within the testing environment
+  # @see Hyrax::ResourceSync::ChangeListWriter#build_resource
+  let(:file_set_status) do
+    file_set.create_date.to_i == file_set.modified_date.to_i ? 'created' : 'updated'
+  end
+  let(:public_work_status) do
+    public_work.create_date.to_i == public_work.modified_date.to_i ? 'created' : 'updated'
+  end
+  let(:public_collection_status) do
+    public_collection.create_date.to_i == public_collection.modified_date.to_i ? 'created' : 'updated'
+  end
 
   subject { instance.write }
 
@@ -25,40 +46,33 @@ RSpec.describe Hyrax::ResourceSync::ChangeListWriter, :clean_repo do
       create(:private_collection)
       create(:work)
 
-      # Sleep in between to ensure modified dates are different
       public_collection
-      sleep(1)
       public_work
-      sleep(1)
       file_set
     end
 
     it "has a list of resources" do
-      capability = xml.xpath('//rs:ln/@href', 'rs' => "http://www.openarchives.org/rs/terms/").text
-      expect(capability).to eq capability_list
-
-      expect(location(1)).to eq "http://example.com/concern/file_sets/#{file_set.id}"
-      expect(change(1)).to eq "created"
-
-      expect(location(2)).to eq "http://example.com/concern/generic_works/#{public_work.id}"
-      expect(change(2)).to eq "created"
-
-      expect(location(3)).to eq "http://example.com/collections/#{public_collection.id}"
-      expect(change(3)).to eq "created"
+      expect(capability_element.text).to eq capability_list
+      locations = location_elements(namespaces).map(&:text)
+      expect(locations).to include "http://example.com/concern/file_sets/#{file_set.id}"
+      expect(locations).to include "http://example.com/concern/generic_works/#{public_work.id}"
+      expect(locations).to include "http://example.com/collections/#{public_collection.id}"
+      changed = changed_elements(namespaces).map(&:value)
+      expect(changed).to match_array([public_collection_status, public_work_status, file_set_status])
 
       expect(url_list.count).to eq 3
     end
   end
 
-  def change(n)
-    query(n, 'rs:md/@change', 'rs' => "http://www.openarchives.org/rs/terms/")
+  def changed_elements(namespaces = {})
+    query("rs:md/@change", namespaces)
   end
 
-  def location(n)
-    query(n, 'x:loc')
+  def location_elements(namespaces = {})
+    query("x:loc", namespaces)
   end
 
-  def query(n, part, ns = {})
-    xml.xpath("//x:url[#{n}]/#{part}", ns.merge('x' => sitemap)).text
+  def query(part, ns = {})
+    xml.xpath("//x:url/#{part}", ns)
   end
 end

--- a/spec/lib/hyrax/resource_sync/change_list_writer_spec.rb
+++ b/spec/lib/hyrax/resource_sync/change_list_writer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Hyrax::ResourceSync::ChangeListWriter, :clean_repo do
   context "when resources exist" do
     before do
       # These private items should not show up.
-      create(:private_collection)
+      build(:private_collection_lw)
       create(:work)
 
       public_collection

--- a/spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb
+++ b/spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Hyrax::ResourceSync::ResourceListWriter, :clean_repo do
   let(:sitemap) { 'http://www.sitemaps.org/schemas/sitemap/0.9' }
-  let!(:private_collection) { create(:private_collection) }
+  let!(:private_collection) { build(:private_collection_lw) }
   let!(:public_collection) { create(:public_collection) }
   let!(:public_work) { create(:public_generic_work) }
   let!(:private_work) { create(:work) }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -318,8 +318,8 @@ RSpec.describe Collection, type: :model do
   end
 
   describe '#update_nested_collection_relationship_indices', :with_nested_reindexing do
-    it 'will be called after save' do
-      expect(Samvera::NestingIndexer).to receive(:reindex_relationships).with(id: kind_of(String), extent: kind_of(String))
+    it 'will be called once for the Collection resource and once for the nested ACL permission resource' do
+      expect(Samvera::NestingIndexer).to receive(:reindex_relationships).exactly(2).times.with(id: kind_of(String), extent: kind_of(String))
       collection.save!
     end
   end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Collection, type: :model do
   end
 
   describe "#members_objects", clean_repo: true do
-    let(:collection) { create(:collection) }
+    let(:collection) { create(:collection_lw) }
 
     it "is empty by default" do
       expect(collection.member_objects).to match_array []
@@ -185,7 +185,7 @@ RSpec.describe Collection, type: :model do
 
   describe '.after_destroy' do
     it 'will destroy the associated permission template' do
-      collection = create(:collection, with_permission_template: true)
+      collection = build(:collection_lw, with_permission_template: true)
       expect { collection.destroy }.to change { Hyrax::PermissionTemplate.count }.by(-1)
     end
   end
@@ -193,7 +193,7 @@ RSpec.describe Collection, type: :model do
   describe '#reset_access_controls!' do
     let!(:user) { build(:user) }
     let(:collection_type) { create(:collection_type) }
-    let!(:collection) { create(:collection, user: user, collection_type_gid: collection_type.gid) }
+    let!(:collection) { build(:collection_lw, user: user, collection_type_gid: collection_type.gid) }
     let!(:permission_template) { build(:permission_template) }
 
     before do
@@ -236,20 +236,20 @@ RSpec.describe Collection, type: :model do
 
     describe 'permission template' do
       it 'will be created when with_permission_template is true' do
-        expect { create(:collection, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       end
 
       it 'will be created when with_permission_template is set to attributes identifying access' do
-        expect { create(:collection, with_permission_template: { manage_users: [user] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
-        expect { create(:collection, with_permission_template: { manage_users: [user], deposit_users: [user] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, with_permission_template: { manage_users: [user] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, with_permission_template: { manage_users: [user], deposit_users: [user] }) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       end
 
       it 'will be created when create_access is true' do
-        expect { create(:collection, create_access: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, create_access: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       end
 
       it 'will not be created by default' do
-        expect { create(:collection) }.not_to change { Hyrax::PermissionTemplate.count }
+        expect { build(:collection_lw) }.not_to change { Hyrax::PermissionTemplate.count }
       end
     end
 
@@ -264,11 +264,11 @@ RSpec.describe Collection, type: :model do
       end
 
       it 'will be created when create_access is true' do
-        expect { create(:collection, user: user, create_access: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { build(:collection_lw, user: user, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       end
 
       it 'will not be created by default' do
-        expect { create(:collection) }.not_to change { Hyrax::PermissionTemplateAccess.count }
+        expect { build(:collection_lw) }.not_to change { Hyrax::PermissionTemplateAccess.count }
       end
     end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe Collection, type: :model do
       end
 
       it 'will be created when create_access is true' do
-        expect { build(:collection_lw, create_access: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect { create(:collection_lw, with_permission_template: true) }.to change { Hyrax::PermissionTemplate.count }.by(1)
       end
 
       it 'will not be created by default' do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Collection, type: :model do
-  let(:collection) { build(:public_collection) }
+  let(:collection) { build(:public_collection_lw) }
 
   it "has open visibility" do
     expect(collection.read_groups).to eq ['public']
@@ -15,7 +15,7 @@ RSpec.describe Collection, type: :model do
 
   describe "#to_solr" do
     let(:user) { build(:user) }
-    let(:collection) { build(:collection, user: user, title: ['A good title']) }
+    let(:collection) { build(:collection_lw, user: user, title: ['A good title']) }
 
     let(:solr_document) { collection.to_solr }
 
@@ -80,7 +80,7 @@ RSpec.describe Collection, type: :model do
   end
 
   describe "#destroy", clean_repo: true do
-    let(:collection) { build(:collection) }
+    let(:collection) { build(:collection_lw) }
     let(:work1) { create(:work) }
 
     before do
@@ -130,7 +130,7 @@ RSpec.describe Collection, type: :model do
   end
 
   describe '#collection_type_gid=' do
-    let(:collection) { build(:collection) }
+    let(:collection) { build(:collection_lw) }
     let(:collection_type) { create(:collection_type) }
 
     it 'sets gid' do
@@ -170,7 +170,7 @@ RSpec.describe Collection, type: :model do
   end
 
   describe 'collection type delegated methods' do
-    subject { build(:collection) }
+    subject { build(:collection_lw) }
 
     it { is_expected.to delegate_method(:nestable?).to(:collection_type) }
     it { is_expected.to delegate_method(:discoverable?).to(:collection_type) }
@@ -293,7 +293,7 @@ RSpec.describe Collection, type: :model do
 
       context 'when building a collection' do
         let(:coll123) do
-          build(:collection,
+          build(:collection_lw,
                 id: 'Collection123',
                 collection_type_gid: collection_type.gid,
                 with_nesting_attributes:

--- a/spec/models/concerns/hyrax/collection_nesting_spec.rb
+++ b/spec/models/concerns/hyrax/collection_nesting_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Hyrax::CollectionNesting do
     end
 
     let(:user) { create(:user) }
-    let!(:collection) { create(:collection, collection_type_settings: [:nestable]) }
-    let!(:child_collection) { create(:collection, collection_type_settings: [:nestable]) }
+    let!(:collection) { build(:collection_lw, collection_type_settings: [:nestable]) }
+    let!(:child_collection) { create(:collection_lw, collection_type_settings: [:nestable]) }
     let(:extent) { Hyrax::Adapters::NestingIndexAdapter::FULL_REINDEX }
 
     before do

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   describe "collections" do
-    let!(:collection) { create(:collection, collection_type_gid: collection_type.gid.to_s) }
+    let!(:collection) { create(:collection_lw, collection_type_gid: collection_type.gid.to_s) }
     let(:collection_type) { create(:collection_type) }
 
     it 'returns collections of this collection type' do
@@ -151,7 +151,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     let(:collection_type) { create(:collection_type) }
 
     it 'returns true if there are any collections of this collection type' do
-      create(:collection, collection_type_gid: collection_type.gid.to_s)
+      create(:collection_lw, collection_type_gid: collection_type.gid.to_s)
       expect(collection_type).to have_collections
     end
     it 'returns false if there are not any collections of this collection type' do

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::CollectionPresenter do
   end
 
   let(:collection) do
-    build(:collection,
+    build(:collection_lw,
           id: 'adc12v',
           description: ['a nice collection'],
           based_near: ['Over there'],
@@ -61,7 +61,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     let(:collection_type) { create(:collection_type) }
 
     describe 'when solr_document#collection_type_gid exists' do
-      let(:collection) { build(:collection, collection_type_gid: collection_type.gid) }
+      let(:collection) { build(:collection_lw, collection_type_gid: collection_type.gid) }
       let(:solr_doc) { SolrDocument.new(collection.to_solr) }
 
       it 'finds the collection type based on the solr_document#collection_type_gid if one exists' do
@@ -173,7 +173,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context "collection with private collection" do
-      let!(:work) { create(:private_collection, member_of_collections: [collection]) }
+      let!(:work) { create(:private_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 0 }
     end
@@ -185,14 +185,14 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context "collection with public collection" do
-      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 1 }
     end
 
     context "collection with public work and sub-collection" do
       let!(:work) { create(:public_work, member_of_collections: [collection]) }
-      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 2 }
     end
@@ -232,7 +232,7 @@ RSpec.describe Hyrax::CollectionPresenter do
 
     context "collection with public work and sub-collection" do
       let!(:work) { create(:public_work, member_of_collections: [collection]) }
-      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 1 }
     end
@@ -259,20 +259,20 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context "collection with private collection" do
-      let!(:subcollection) { create(:private_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:private_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 0 }
     end
 
     context "collection with public collection" do
-      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 1 }
     end
 
     context "collection with public work and sub-collection" do
       let!(:work) { create(:public_work, member_of_collections: [collection]) }
-      let!(:subcollection) { create(:public_collection, member_of_collections: [collection]) }
+      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 1 }
     end
@@ -310,8 +310,8 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context('when parent_collections is has collections') do
-      let(:collection1) { build(:collection, title: ['col1']) }
-      let(:collection2) { build(:collection, title: ['col2']) }
+      let(:collection1) { build(:collection_lw, title: ['col1']) }
+      let(:collection2) { build(:collection_lw, title: ['col2']) }
       let!(:parent_docs) { [collection1, collection2] }
 
       before do

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context "collection with private collection" do
-      let!(:work) { create(:private_collection_lw, member_of_collections: [collection]) }
+      let!(:work) { build(:private_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 0 }
     end
@@ -259,7 +259,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
 
     context "collection with private collection" do
-      let!(:subcollection) { create(:private_collection_lw, member_of_collections: [collection]) }
+      let!(:subcollection) { build(:private_collection_lw, member_of_collections: [collection]) }
 
       it { is_expected.to eq 0 }
     end

--- a/spec/search_builders/hyrax/collection_member_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_member_search_builder_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Hyrax::CollectionMemberSearchBuilder do
   let(:context) { double("context", blacklight_config: CatalogController.blacklight_config) }
   let(:solr_params) { { fq: [] } }
   let(:include_models) { :both }
-  let(:collection) { build(:collection, id: '12345') }
+  let(:collection) { build(:collection_lw, id: '12345') }
   let(:builder) { described_class.new(scope: context, collection: collection, search_includes_models: include_models) }
 
   describe ".default_processor_chain" do

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Hyrax::CollectionSearchBuilder do
 
     context 'when access is :deposit' do
       let(:access) { "deposit" }
-      let!(:collection) { create(:collection, with_permission_template: attributes) }
+      let!(:collection) { create(:collection_lw, with_permission_template: attributes) }
 
       context 'and user has access' do
         let(:attributes) { { deposit_users: [user.user_key] } }

--- a/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Hyrax::Dashboard::NestedCollectionsSearchBuilder do
 
     context 'when access is :deposit' do
       let(:access) { "deposit" }
-      let!(:collection) { create(:collection, with_permission_template: attributes) }
+      let!(:collection) { build(:collection_lw, with_permission_template: attributes) }
 
       context 'and user has access' do
         let(:attributes) { { deposit_users: [user.user_key] } }

--- a/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Hyrax::Dashboard::NestedCollectionsSearchBuilder do
 
     context 'when access is :deposit' do
       let(:access) { "deposit" }
-      let!(:collection) { build(:collection_lw, with_permission_template: attributes) }
+      let!(:collection) { create(:collection_lw, with_permission_template: attributes) }
 
       context 'and user has access' do
         let(:attributes) { { deposit_users: [user.user_key] } }

--- a/spec/search_builders/hyrax/work_relation_spec.rb
+++ b/spec/search_builders/hyrax/work_relation_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Hyrax::WorkRelation, :clean_repo do
   let!(:work) { create(:generic_work) }
   let!(:file_set) { create(:file_set) }
-  let!(:collection) { create(:collection) }
+  let!(:collection) { build(:collection_lw) }
 
   it 'has works and not collections or file sets' do
     expect(subject).to eq [work]

--- a/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
+++ b/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
 
   describe '.each_perservation_document_id_and_parent_ids', clean_repo: true do
     let!(:nested_parent) { build(:collection_lw, member_of_collections: []) }
-    let!(:nested_with_parent) { create(:collection, member_of_collections: [nested_parent]) }
+    let!(:nested_with_parent) { create(:collection_lw, member_of_collections: [nested_parent]) }
     let!(:work) { create(:generic_work) }
     let(:count_of_items) { ActiveFedora::Base.descendant_uris(ActiveFedora.fedora.base_uri, exclude_uri: true).count }
 

--- a/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
+++ b/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
   end
 
   describe '.each_perservation_document_id_and_parent_ids', clean_repo: true do
-    let!(:nested_parent) { create(:collection, member_of_collections: []) }
+    let!(:nested_parent) { build(:collection_lw, member_of_collections: []) }
     let!(:nested_with_parent) { create(:collection, member_of_collections: [nested_parent]) }
     let!(:work) { create(:generic_work) }
     let(:count_of_items) { ActiveFedora::Base.descendant_uris(ActiveFedora.fedora.base_uri, exclude_uri: true).count }

--- a/spec/services/hyrax/collections/collection_member_service_spec.rb
+++ b/spec/services/hyrax/collections/collection_member_service_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe Hyrax::Collections::CollectionMemberService, clean_repo: true do
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
   let(:current_ability) { instance_double(Ability, admin?: true) }
-  let!(:nestable_collection) { create(:public_collection, collection_type_settings: [:nestable]) }
+  let!(:nestable_collection) { create(:public_collection_lw, collection_type_settings: [:nestable]) }
   let(:scope) { double('Scope', current_ability: current_ability, repository: repository, blacklight_config: blacklight_config, collection: nestable_collection) }
-  let!(:subcollection) { create(:public_collection, member_of_collections: [nestable_collection], collection_type_settings: [:nestable]) }
+  let!(:subcollection) { create(:public_collection_lw, member_of_collections: [nestable_collection], collection_type_settings: [:nestable]) }
   let(:builder) { described_class.new(scope: scope, collection: nestable_collection, params: { "id" => nestable_collection.id.to_s }) }
 
   let!(:work1) { create(:generic_work, member_of_collections: [nestable_collection]) }

--- a/spec/services/hyrax/collections/migration_service_spec.rb
+++ b/spec/services/hyrax/collections/migration_service_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
 
   describe ".migrate_all_collections" do
     context 'when legacy collections are found (e.g. collections created before Hyrax 2.1.0)' do
-      let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true) }
-      let!(:col_vu) { build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
-      let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], do_save: true) }
-      let!(:col_mu) { build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
-      let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
+      let!(:col_none) { build(:typeless_collection, user: user, edit_users: [user.user_key], do_save: true) }
+      let!(:col_vu) { build(:typeless_collection, user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
+      let!(:col_vg) { build(:typeless_collection, user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], do_save: true) }
+      let!(:col_mu) { build(:typeless_collection, user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
+      let!(:col_mg) { build(:typeless_collection, user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
 
       it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
         Collection.all.each do |col|
@@ -158,11 +158,11 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
 
       context "and collection wasn't migrated at all" do
-        let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true) }
-        let!(:col_vu) { build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
-        let!(:col_vg) { build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], do_save: true) }
-        let!(:col_mu) { build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
-        let!(:col_mg) { build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
+        let!(:col_none) { build(:typeless_collection_lw, user: user, edit_users: [user.user_key], read_users: [], do_save: true) }
+        let!(:col_vu) { build(:typeless_collection_lw, user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], do_save: true) }
+        let!(:col_vg) { build(:typeless_collection_lw, user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], do_save: true) }
+        let!(:col_mu) { build(:typeless_collection_lw, user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], do_save: true) }
+        let!(:col_mg) { build(:typeless_collection_lw, user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
 
         it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
           Collection.all.each do |col|
@@ -212,21 +212,21 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       end
 
       context "and collection type gid isn't set but permission template exists with access set" do
-        let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true, with_permission_template: true) }
+        let!(:col_none) { build(:typeless_collection, user: user, edit_users: [user.user_key], do_save: true, with_permission_template: true) }
         let!(:col_vu) do
-          build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_vg) do
-          build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mu) do
-          build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key],
+          build(:typeless_collection, user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mg) do
-          build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'],
                                       do_save: true, with_permission_template: true)
         end
 
@@ -276,21 +276,21 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       end
 
       context "and collection type gid isn't set and permission template exists with access not set" do
-        let!(:col_none) { build(:typeless_collection, id: 'col_none', user: user, edit_users: [user.user_key], do_save: true, with_permission_template: true) }
+        let!(:col_none) { build(:typeless_collection, user: user, edit_users: [user.user_key], do_save: true, with_permission_template: true) }
         let!(:col_vu) do
-          build(:typeless_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_vg) do
-          build(:typeless_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mu) do
-          build(:typeless_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key],
+          build(:typeless_collection, user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key],
                                       do_save: true, with_permission_template: true)
         end
         let!(:col_mg) do
-          build(:typeless_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'],
+          build(:typeless_collection, user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'],
                                       do_save: true, with_permission_template: true)
         end
 

--- a/spec/services/hyrax/collections/migration_service_spec.rb
+++ b/spec/services/hyrax/collections/migration_service_spec.rb
@@ -322,8 +322,8 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
 
     context 'when newer collections are found (e.g. collections created at or after Hyrax 2.1.0)' do
       let!(:collection) do
-        create(:collection, id: 'col_newer', user: user, with_permission_template: true, collection_type_settings: [:discoverable],
-                            edit_users: [user.user_key], create_access: true)
+        build(:collection_lw, id: 'col_newer', user: user, with_permission_template: true, collection_type_settings: [:discoverable],
+                              edit_users: [user.user_key])
       end
       let!(:permission_template) { collection.permission_template }
       let!(:collection_type_gid) { collection.collection_type_gid }

--- a/spec/services/hyrax/collections/migration_service_spec.rb
+++ b/spec/services/hyrax/collections/migration_service_spec.rb
@@ -185,11 +185,11 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       end
 
       context "and collection type gid is set but permission template doesn't exist" do
-        let!(:col_none) { create(:user_collection, id: 'col_none', user: user, edit_users: [user.user_key], collection_type_gid: default_gid) }
-        let!(:col_vu) { create(:user_collection, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], collection_type_gid: default_gid) }
-        let!(:col_vg) { create(:user_collection, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], collection_type_gid: default_gid) }
-        let!(:col_mu) { create(:user_collection, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], collection_type_gid: default_gid) }
-        let!(:col_mg) { create(:user_collection, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], collection_type_gid: default_gid) }
+        let!(:col_none) { build(:user_collection_lw, id: 'col_none', user: user, edit_users: [user.user_key], collection_type_gid: default_gid) }
+        let!(:col_vu) { build(:user_collection_lw, id: 'col_vu', user: user, edit_users: [user.user_key], read_users: [reader1.user_key, reader2.user_key], collection_type_gid: default_gid) }
+        let!(:col_vg) { build(:user_collection_lw, id: 'col_vg', user: user, edit_users: [user.user_key], read_groups: ['read_group_1', 'read_group_2'], collection_type_gid: default_gid) }
+        let!(:col_mu) { build(:user_collection_lw, id: 'col_mu', user: user, edit_users: [user.user_key, editor1.user_key, editor2.user_key], collection_type_gid: default_gid) }
+        let!(:col_mg) { build(:user_collection_lw, id: 'col_mg', user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], collection_type_gid: default_gid) }
 
         it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
           Collection.all.each do |col|

--- a/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Hyrax::Collections::NestedCollectionPersistenceService, with_nested_reindexing: true do
-  let(:parent) { create(:collection) }
+  let(:parent) { build(:collection_lw) }
   let(:child) { create(:collection) }
 
   describe '.persist_nested_collection_for' do

--- a/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
@@ -153,57 +153,57 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
 
         # using create option here because permission template is required for testing :deposit access
         let(:coll_a) do
-          create(:public_collection,
-                 id: 'Collection_A',
-                 collection_type_gid: collection_type.gid,
-                 user: user,
-                 create_access: true)
+          build(:public_collection_lw,
+                id: 'Collection_A',
+                collection_type_gid: collection_type.gid,
+                user: user,
+                with_permission_template: true)
         end
         let(:coll_b) do
-          create(:public_collection,
-                 id: 'Collection_B',
-                 collection_type_gid: collection_type.gid,
-                 user: user,
-                 create_access: true,
-                 member_of_collections: [coll_a])
+          build(:public_collection_lw,
+                id: 'Collection_B',
+                collection_type_gid: collection_type.gid,
+                user: user,
+                with_permission_template: true,
+                member_of_collections: [coll_a])
         end
         let(:coll_c) do
-          create(:public_collection,
-                 id: 'Collection_C',
-                 collection_type_gid: collection_type.gid,
-                 user: user,
-                 create_access: true,
-                 member_of_collections: [coll_b])
+          build(:public_collection_lw,
+                id: 'Collection_C',
+                collection_type_gid: collection_type.gid,
+                user: user,
+                with_permission_template: true,
+                member_of_collections: [coll_b])
         end
         let(:coll_d) do
-          create(:public_collection,
-                 id: 'Collection_D',
-                 collection_type_gid: collection_type.gid,
-                 user: user,
-                 create_access: true,
-                 member_of_collections: [coll_c])
+          build(:public_collection_lw,
+                id: 'Collection_D',
+                collection_type_gid: collection_type.gid,
+                user: user,
+                with_permission_template: true,
+                member_of_collections: [coll_c])
         end
         let(:coll_e) do
-          create(:public_collection,
+          create(:public_collection_lw,
                  id: 'Collection_E',
                  collection_type_gid: collection_type.gid,
                  user: user,
-                 create_access: true,
+                 with_permission_template: true,
                  member_of_collections: [coll_d])
         end
         let(:another) do
-          create(:public_collection,
+          create(:public_collection_lw,
                  id: 'Another_One',
                  collection_type_gid: collection_type.gid,
                  user: user,
-                 create_access: true)
+                 with_permission_template: true)
         end
         let(:wrong) do
-          create(:public_collection,
-                 id: 'Wrong_Type',
-                 collection_type_gid: another_collection_type.gid,
-                 user: user,
-                 create_access: true)
+          build(:public_collection_lw,
+                id: 'Wrong_Type',
+                collection_type_gid: another_collection_type.gid,
+                user: user,
+                with_permission_template: true)
         end
 
         before do
@@ -245,18 +245,18 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
       describe 'and are of the same collection type', with_nested_reindexing: true do
         # using create option here because permission template is required for testing :deposit access
         let!(:parent) do
-          create(:public_collection,
+          create(:public_collection_lw,
                  id: 'Parent_Collecton',
                  collection_type_gid: collection_type.gid,
                  user: user,
-                 create_access: true)
+                 with_permission_template: true)
         end
         let!(:child) do
-          create(:public_collection,
+          create(:public_collection_lw,
                  id: 'Child_Collection',
                  collection_type_gid: collection_type.gid,
                  user: user,
-                 create_access: true)
+                 with_permission_template: true)
         end
 
         it { is_expected.to eq(true) }

--- a/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   describe 'nesting attributes object', with_nested_reindexing: true do
     let(:user) { create(:user) }
     let!(:parent) { build(:collection_lw, id: 'Parent_Coll', collection_type_gid: collection_type.gid, user: user) }
-    let!(:child) { create(:user_collection, id: 'Child_Coll', collection_type_gid: collection_type.gid, user: user) }
+    let!(:child) { create(:user_collection_lw, id: 'Child_Coll', collection_type_gid: collection_type.gid, user: user) }
     let(:nesting_attributes) { Hyrax::Collections::NestedCollectionQueryService::NestingAttributes.new(id: child.id, scope: scope) }
 
     before do

--- a/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
 
   describe 'nesting attributes object', with_nested_reindexing: true do
     let(:user) { create(:user) }
-    let!(:parent) { create(:collection, id: 'Parent_Coll', collection_type_gid: collection_type.gid, user: user) }
+    let!(:parent) { build(:collection_lw, id: 'Parent_Coll', collection_type_gid: collection_type.gid, user: user) }
     let!(:child) { create(:user_collection, id: 'Child_Coll', collection_type_gid: collection_type.gid, user: user) }
     let(:nesting_attributes) { Hyrax::Collections::NestedCollectionQueryService::NestingAttributes.new(id: child.id, scope: scope) }
 

--- a/spec/services/hyrax/curation_concern_spec.rb
+++ b/spec/services/hyrax/curation_concern_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hyrax::CurationConcern do
   describe ".actor" do
     subject { described_class.actor }
 
-    it { is_expected.to be_kind_of Hyrax::Actors::TransactionalRequest }
+    it { is_expected.to be_kind_of Hyrax::Actors::AbstractActor }
   end
 
   describe ".actor_factory" do

--- a/spec/services/hyrax/curation_concern_spec.rb
+++ b/spec/services/hyrax/curation_concern_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hyrax::CurationConcern do
   describe ".actor" do
     subject { described_class.actor }
 
-    it { is_expected.to be_kind_of Hyrax::Actors::AbstractActor }
+    it { is_expected.to be_kind_of Hyrax::Actors::TransactionalRequest }
   end
 
   describe ".actor_factory" do

--- a/spec/services/hyrax/default_middleware_stack_spec.rb
+++ b/spec/services/hyrax/default_middleware_stack_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Hyrax::DefaultMiddlewareStack do
 
     it "has the correct stack frames" do
       expect(subject.middlewares).to eq [
-        Hyrax::Actors::TransactionalRequest,
         Hyrax::Actors::OptimisticLockValidator,
         Hyrax::Actors::CreateWithRemoteFilesActor,
         Hyrax::Actors::CreateWithFilesActor,
@@ -30,7 +29,7 @@ RSpec.describe Hyrax::DefaultMiddlewareStack do
 
   describe 'Hyrax::CurationConcern.actor' do
     it "calls the Hyrax::ActorFactory" do
-      expect(Hyrax::CurationConcern.actor).to be_instance_of Hyrax::Actors::TransactionalRequest
+      expect(Hyrax::CurationConcern.actor).to be_instance_of Hyrax::Actors::OptimisticLockValidator
     end
   end
 end

--- a/spec/services/hyrax/default_middleware_stack_spec.rb
+++ b/spec/services/hyrax/default_middleware_stack_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Hyrax::DefaultMiddlewareStack do
 
     it "has the correct stack frames" do
       expect(subject.middlewares).to eq [
+        Hyrax::Actors::TransactionalRequest,
         Hyrax::Actors::OptimisticLockValidator,
         Hyrax::Actors::CreateWithRemoteFilesActor,
         Hyrax::Actors::CreateWithFilesActor,
@@ -29,7 +30,7 @@ RSpec.describe Hyrax::DefaultMiddlewareStack do
 
   describe 'Hyrax::CurationConcern.actor' do
     it "calls the Hyrax::ActorFactory" do
-      expect(Hyrax::CurationConcern.actor).to be_instance_of Hyrax::Actors::OptimisticLockValidator
+      expect(Hyrax::CurationConcern.actor).to be_instance_of Hyrax::Actors::TransactionalRequest
     end
   end
 end

--- a/spec/services/hyrax/statistics/depositors/summary_spec.rb
+++ b/spec/services/hyrax/statistics/depositors/summary_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Hyrax::Statistics::Depositors::Summary, :clean_repo do
   let(:end_date) { nil }
   let!(:work1) { create(:work, user: user1) }
   let!(:work2) { create(:work, user: user2) }
-  let!(:collection1) { create(:public_collection, user: user1) }
+  let!(:collection1) { create(:public_collection_lw, user: user1) }
   let(:service) { described_class.new(start_date, end_date) }
 
   before do

--- a/spec/services/hyrax/statistics/works/by_resource_type_spec.rb
+++ b/spec/services/hyrax/statistics/works/by_resource_type_spec.rb
@@ -1,12 +1,19 @@
 RSpec.describe Hyrax::Statistics::Works::ByResourceType do
   let(:service) { described_class.new }
+  let(:user) { create(:user) }
 
   describe "#query", :clean_repo do
     before do
-      create(:generic_work, resource_type: ['Conference Proceeding'])
-      create(:generic_work, resource_type: ['Conference Proceeding'])
-      create(:generic_work, resource_type: ['Image'])
-      create(:generic_work, resource_type: ['Journal'])
+      # Creating factories here led to failures found within
+      # https://travis-ci.org/samvera/hyrax/jobs/454752377
+      # One should be able to invoke create(:generic_work)...
+      # ...however, there are difficulties here which relate to the "terms"
+      # requestHandler
+      # @see https://github.com/samvera/hyrax/issues/3491
+      GenericWork.create(title: ['test'], resource_type: ['Conference Proceeding']).save!
+      GenericWork.create(title: ['test'], resource_type: ['Conference Proceeding']).save!
+      GenericWork.create(title: ['test'], resource_type: ['Image']).save!
+      GenericWork.create(title: ['test'], resource_type: ['Journal']).save!
     end
 
     subject { service.query }

--- a/spec/support/selectors.rb
+++ b/spec/support/selectors.rb
@@ -43,7 +43,16 @@ module Selectors
     def select_member_of_collection(collection)
       find('#s2id_member_of_collection_ids').click
       find('.select2-input').set(collection.title.first)
-      sleep 10
+      # Crude way of waiting for the AJAX response
+      select2_results = []
+      time_elapsed = 0
+      while select2_results.empty? && time_elapsed < 30
+        begin_time = Time.now.to_f
+        doc = Nokogiri::XML.parse(page.body)
+        select2_results = doc.xpath('//html:li[contains(@class,"select2-result")]', html: 'http://www.w3.org/1999/xhtml')
+        end_time = Time.now.to_f
+        time_elapsed += end_time - begin_time
+      end
       expect(page).to have_css('.select2-result')
       within ".select2-result" do
         find("span", text: collection.title.first).click

--- a/template.rb
+++ b/template.rb
@@ -1,3 +1,5 @@
+# Hack for https://github.com/rails/rails/issues/35153
+gsub_file 'Gemfile', /^gem ["']sqlite3["']$/, 'gem "sqlite3", "~> 1.3.0"'
 gem 'hyrax', '2.4.1'
 run 'bundle install'
 generate 'hyrax:install', '-f'


### PR DESCRIPTION
Backwards-compatible backport of #3482 for Hyrax 2.x.

I backported all of the CI and test suite related changes except the circleci workflows since it seemed like it was a bigger merge.

@samvera/hyrax-code-reviewers