### PR TITLE
present a confirmation when moving between tabs in collection edit.

### DIFF
--- a/app/assets/javascripts/hyrax/admin/collection_type/settings.es6
+++ b/app/assets/javascripts/hyrax/admin/collection_type/settings.es6
@@ -13,6 +13,15 @@ export default class {
     // Watch for changes to "sharable" checkbox
     $("#collection_type_sharable").on('change', () => { this.sharableChanged() })
     this.sharableChanged()
+
+    // Watch for changes to the tab, and alert user that changes need to be saved.
+    $('.panel-default li.coll-panel').on('click', function() {
+      if(!confirm('It is best to "Save changes" before moving to another tab, or your changes may be lost.  Do you want to change tab?')){
+        event.preventDefault();
+        return false;
+      }
+    })
+
   }
 
   // Based on the "sharable" checked/unchecked, enable/disable adjust share_applies_to_new_works checkbox

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -1,21 +1,21 @@
 <div class="panel panel-default tabs" id="collection-edit-controls">
   <ul class="nav nav-tabs" role="tablist">
-    <li class="active">
+    <li class="coll-panel active">
       <a href="#description" role="tab" data-toggle="tab"><%= t('.tabs.description') %></a>
     </li>
     <% if @form.persisted? %>
       <% if @collection.brandable? %>
-      <li>
+      <li class="coll-panel">
         <a href="#branding" role="tab" data-toggle="tab"><%= t('.tabs.branding') %></a>
       </li>
       <% end %>
       <% if @collection.discoverable? %>
-      <li>
+      <li class="coll-panel">
         <a href="#discovery" role="tab" data-toggle="tab"><%= t('.tabs.discovery') %></a>
       </li>
       <% end %>
       <% if @collection.sharable? %>
-      <li>
+      <li class="coll-panel">
         <a href="#sharing" role="tab" data-toggle="tab"><%= t('.tabs.sharing') %></a>
       </li>
       <% end %>

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -897,10 +897,18 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
             visit "/dashboard/collections/#{sharable_collection_id}/edit"
             expect(page).to have_link('Sharing', href: '#sharing')
             click_link('Sharing')
+
+            expect(page.driver.browser.switch_to.alert.text).to have_content 'It is best to "Save changes" before moving to another tab, or your changes may be lost.  Do you want to change tab?'
+            page.driver.browser.switch_to.alert.accept
+
             expect(page).to have_selector(".form-inline.add-users .select2-container")
             select_user(user2, 'Depositor')
             click_button('Save')
             click_link('Sharing')
+
+            expect(page.driver.browser.switch_to.alert.text).to have_content 'It is best to "Save changes" before moving to another tab, or your changes may be lost.  Do you want to change tab?'
+            page.driver.browser.switch_to.alert.accept
+
             expect(page).to have_selector('td', text: user2.user_key)
           end
         end


### PR DESCRIPTION
Fixes #3454;

If a user is editing a collection and makes some changes on one of the tabs and does not select the "Save changes" button  at the bottom of the pages, the user is at risk for losing his/her changes.  If he/she for example goes to the Sharing tab and starts selecting users and groups to share with, he/she will lose  the changes from previous tabs.  The safest thing to do is to "Save changes" on each tab and then move on to the next tab.

With this change a confirmation question is generated to remind the user to save his/her changes as the user switches from tab to tab.

@samvera/hyrax-code-reviewers
