### PR TITLE
Test with non-legacy image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
 
   test:
     docker:
-    - image: circleci/ruby:2.5.3-node-browsers-legacy
+    - image: circleci/ruby:2.5.3-node-browsers
     - image: circleci/redis:4
     - image: ualbertalib/docker-fcrepo4:4.7
       environment:


### PR DESCRIPTION
Builds for hyrax master as well as 2.x-stable are failing due to a chromedriver issue even though nothing appears to have changed.  `chromedriver-helper`, `selenium-webdriver`, and the circleci docker image all look the same as when the build was passing.
This PR tries switching to the non-legacy circleci docker image to see if it works.