### PR TITLE
add rights notes metadata to work.

### DIFF
--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -22,7 +22,7 @@ module Hyrax
       attr_reader :agreement_accepted
 
       self.terms = [:title, :creator, :contributor, :description,
-                    :keyword, :license, :rights_statement, :publisher, :date_created,
+                    :keyword, :license, :rights_statement, :rights_notes, :publisher, :date_created,
                     :subject, :language, :identifier, :based_near, :related_url,
                     :representative_id, :thumbnail_id, :rendering_ids, :files,
                     :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,

--- a/app/indexers/hyrax/basic_metadata_indexer.rb
+++ b/app/indexers/hyrax/basic_metadata_indexer.rb
@@ -3,7 +3,7 @@ module Hyrax
   class BasicMetadataIndexer < ActiveFedora::RDF::IndexingService
     class_attribute :stored_and_facetable_fields, :stored_fields, :symbol_fields
     self.stored_and_facetable_fields = %i[resource_type creator contributor keyword publisher subject language based_near]
-    self.stored_fields = %i[description license rights_statement date_created identifier related_url bibliographic_citation source]
+    self.stored_fields = %i[description license rights_statement rights_notes date_created identifier related_url bibliographic_citation source]
     self.symbol_fields = %i[import_url]
 
     private

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -19,6 +19,8 @@ module Hyrax
       # Used for a license
       property :license, predicate: ::RDF::Vocab::DC.rights
 
+      property :rights_notes, predicate: ::RDF::URI.new('http://purl.org/dc/elements/1.1/rights'), multiple: true
+
       # This is for the rights statement
       property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
       property :publisher, predicate: ::RDF::Vocab::DC11.publisher

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -66,6 +66,7 @@ module Hyrax
         attribute :source, Solr::Array, solr_name('source')
         attribute :date_created, Solr::Array, solr_name('date_created')
         attribute :rights_statement, Solr::Array, solr_name('rights_statement')
+        attribute :rights_notes, Solr::Array, solr_name('rights_notes')
 
         attribute :mime_type, Solr::String, solr_name('mime_type', :stored_sortable)
         attribute :workflow_state, Solr::String, solr_name('workflow_state_name', :symbol)

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -15,7 +15,7 @@ module Hyrax
 
     # delegate fields from Hyrax::Works::Metadata to solr_document
     delegate :based_near_label, :related_url, :depositor, :identifier, :resource_type,
-             :keyword, :itemtype, :admin_set, to: :solr_document
+             :keyword, :itemtype, :admin_set, :rights_notes, to: :solr_document
 
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -12,4 +12,5 @@
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:source, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
+<%= presenter.attribute_to_html(:rights_notes, html_dl: true) %>
 <%= presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1258,6 +1258,7 @@ en:
         publisher: The person or group making the work available. Generally this is the institution.
         related_url: A link to a website or other specific content (audio, video, PDF document) related to the work. An example is the URL of a research project from which the work was derived.
         resource_type: Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected.
+        rights_notes: Contains information about rights held in and over the resource.
         subject: Headings or index terms describing what the work is about; these do need to conform to an existing vocabulary.
         title: A name to aid in identifying a work.
     labels:
@@ -1290,6 +1291,7 @@ en:
         license: License
         member_of_collection_ids: Add to collection
         related_url: Related URL
+        rights_notes: Rights notes
         rights_statement: Rights statement
         title: Title
         visibility_after_embargo: then open it up to

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Hyrax::Forms::BatchUploadForm do
                          :keyword,
                          :license,
                          :rights_statement,
+                         :rights_notes,
                          :publisher,
                          :date_created,
                          :subject,

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
         keyword: ['penguin'],
         source: ['related'],
         rights_statement: 'http://rightsstatements.org/vocab/InC-EDU/1.0/',
+        rights_notes: ['Notes on the rights'],
         license: ['http://creativecommons.org/licenses/by/3.0/us/']
       }
     end
@@ -121,6 +122,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
       expect(subject['visibility']).to eq 'open'
       expect(subject['license']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
       expect(subject['rights_statement']).to eq 'http://rightsstatements.org/vocab/InC-EDU/1.0/'
+      expect(subject['rights_notes']).to eq ['Notes on the rights']
       expect(subject['keyword']).to eq ['penguin']
       expect(subject['source']).to eq ['related']
     end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
   it { is_expected.to delegate_method(:date_modified).to(:solr_document) }
   it { is_expected.to delegate_method(:date_uploaded).to(:solr_document) }
   it { is_expected.to delegate_method(:rights_statement).to(:solr_document) }
+  it { is_expected.to delegate_method(:rights_notes).to(:solr_document) }
 
   it { is_expected.to delegate_method(:based_near_label).to(:solr_document) }
   it { is_expected.to delegate_method(:related_url).to(:solr_document) }

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
                      description_tesim: ['Lorem ipsum lorem ipsum.'],
                      keyword_tesim: ['bacon', 'sausage', 'eggs'],
                      rights_statement_tesim: ['http://example.org/rs/1'],
+                     rights_notes_tesim: ['Notes on the rights'],
                      date_created_tesim: ['1984-01-02'])
   end
 


### PR DESCRIPTION
Fixes #3294

Added the "Rights notes" metadata to work.

Changes proposed in this pull request:

Added the :rights_notes metadata to a work and placed it in the "Additional fields" section, joust below license.  You will also see this metadata (if it exists) in the work page.

Guidance for testing:

1. Create a work and be sure to enter something for Rights notes.
2.  Save the work.
3. From the home page hit "Go" and go to the work display page. Make sure the Rights notes you entered is in the page.
4. Edit the work.  Make sure you see the Rights notes metadata and then also change the metadata and make sure the change sticks.


@samvera/hyrax-code-reviewers
