### PR TITLE
input form has title as single entry, but the title def stays multiple

### DIFF
--- a/app/forms/hyrax/forms/admin_set_form.rb
+++ b/app/forms/hyrax/forms/admin_set_form.rb
@@ -7,6 +7,14 @@ module Hyrax
       # Cast any array values on the model to scalars.
       def [](key)
         return super if key == :thumbnail_id
+        if key == :title
+          @attributes["title"].each do |value|
+            @attributes["alt_title"] << value
+          end
+          @attributes["alt_title"].delete(@attributes["alt_title"].sort.first) unless @attributes["alt_title"].empty?
+          return @attributes["title"].sort.first unless @attributes["title"].empty?
+          return ""
+        end
         super.first
       end
 

--- a/app/indexers/hyrax/basic_metadata_indexer.rb
+++ b/app/indexers/hyrax/basic_metadata_indexer.rb
@@ -3,7 +3,7 @@ module Hyrax
   class BasicMetadataIndexer < ActiveFedora::RDF::IndexingService
     class_attribute :stored_and_facetable_fields, :stored_fields, :symbol_fields
     self.stored_and_facetable_fields = %i[resource_type creator contributor keyword publisher subject language based_near]
-    self.stored_fields = %i[description abstract license rights_statement rights_notes access_right date_created identifier related_url bibliographic_citation source]
+    self.stored_fields = %i[alt_title description abstract license rights_statement rights_notes access_right date_created identifier related_url bibliographic_citation source]
     self.symbol_fields = %i[import_url]
 
     private

--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -31,6 +31,11 @@ class AdminSet < ActiveFedora::Base
   property :title, predicate: ::RDF::Vocab::DC.title do |index|
     index.as :stored_searchable, :facetable
   end
+
+  property :alt_title, predicate: ::RDF::Vocab::DC.alternative do |index|
+    index.as :stored_searchable
+  end
+
   property :description, predicate: ::RDF::Vocab::DC.description do |index|
     index.as :stored_searchable
   end

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -6,6 +6,8 @@ module Hyrax
     extend ActiveSupport::Concern
 
     included do
+      property :alt_title, predicate: ::RDF::Vocab::DC.alternative
+
       property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false
 
       property :relative_path, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#relativePath'), multiple: false

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -44,6 +44,7 @@ module Hyrax
       end
 
       included do
+        attribute :alt_title, Solr::Array, solr_name('alt_title')
         attribute :identifier, Solr::Array, solr_name('identifier')
         attribute :based_near, Solr::Array, solr_name('based_near')
         attribute :based_near_label, Solr::Array, solr_name('based_near_label')

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -39,7 +39,7 @@ module Hyrax
     delegate :title, :date_created, :description,
              :creator, :contributor, :subject, :publisher, :language, :embargo_release_date,
              :lease_expiration_date, :license, :source, :rights_statement, :thumbnail_id, :representative_id,
-             :rendering_ids, :member_of_collection_ids, to: :solr_document
+             :rendering_ids, :member_of_collection_ids, :alt_title, to: :solr_document
 
     def workflow
       @workflow ||= WorkflowPresenter.new(solr_document, current_ability)

--- a/app/views/hyrax/dashboard/collections/edit.html.erb
+++ b/app/views/hyrax/dashboard/collections/edit.html.erb
@@ -1,7 +1,7 @@
-<% provide :page_title, construct_page_title( t('.header', type_title: @collection.collection_type.title, title: @form.title.first) ) %>
+<% provide :page_title, construct_page_title( t('.header', type_title: @collection.collection_type.title, title: @form.title) ) %>
 
 <% provide :page_header do %>
-  <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t('.header', type_title: @collection.collection_type.title, title: @form.title.first) %></h1>
+  <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t('.header', type_title: @collection.collection_type.title, title: @form.title) %></h1>
 <% end %>
 
 <div class="row">

--- a/app/views/records/edit_fields/_alt_title.html.erb
+++ b/app/views/records/edit_fields/_alt_title.html.erb
@@ -1,0 +1,3 @@
+<% f.object.alt_title.each do |value| %>
+  <%= f.hidden_field :alt_title, multiple: true, value: value.to_s  %>
+<% end %>

--- a/app/views/records/edit_fields/_title.html.erb
+++ b/app/views/records/edit_fields/_title.html.erb
@@ -1,0 +1,1 @@
+<%= f.input :title, required: f.object.required?(:title) %>

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -244,7 +244,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         click_on('Create collection')
 
         expect(page).to have_selector('h1', text: 'New User Collection')
-        expect(page).to have_selector "input.collection_title.multi_value"
 
         click_link('Additional fields')
         expect(page).to have_selector "input.collection_creator.multi_value"
@@ -275,7 +274,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       it 'makes a new collection' do
         click_link "New Collection"
         expect(page).to have_selector('h1', text: 'New User Collection')
-        expect(page).to have_selector "input.collection_title.multi_value"
 
         click_link('Additional fields')
         expect(page).to have_selector "input.collection_creator.multi_value"
@@ -335,7 +333,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
     let!(:adminset) { create(:admin_set, title: ['Admin Set with Work'], creator: [admin_user.user_key], with_permission_template: true) }
     let!(:work) { create(:work, title: ["King Louie"], admin_set: adminset, member_of_collections: [collection], user: user) }
 
-    # check table row has appropriate data attributes added
+    # Check table row has appropriate data attributes added
     def check_tr_data_attributes(id, type)
       url_fragment = get_url_fragment(type)
       expect(page).to have_selector("tr[data-id='#{id}'][data-colls-hash]")
@@ -343,7 +341,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       expect(page).to have_selector("tr[data-post-delete-url='/#{url_fragment}/#{id}?locale=en']")
     end
 
-    # check data attributes have been transferred from table row to the modal
+    # Check data attributes have been transferred from table row to the modal
     def check_modal_data_attributes(id, type)
       url_fragment = get_url_fragment(type)
       expect(page).to have_selector("div[data-id='#{id}']")

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe Hyrax::Forms::BatchUploadForm do
     subject { form.terms }
 
     it do
-      is_expected.to eq [:creator,
+      is_expected.to eq [:alt_title,
+                         :creator,
                          :contributor,
                          :description,
                          :abstract,

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -3,7 +3,8 @@ RSpec.describe Hyrax::Forms::CollectionForm do
     subject { described_class.terms }
 
     it do
-      is_expected.to eq [:resource_type,
+      is_expected.to eq [:alt_title,
+                         :resource_type,
                          :title,
                          :creator,
                          :contributor,
@@ -40,6 +41,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
 
     it do
       is_expected.to eq [
+        :alt_title,
         :creator,
         :contributor,
         :keyword,
@@ -127,7 +129,8 @@ RSpec.describe Hyrax::Forms::CollectionForm do
     subject { described_class.build_permitted_params }
 
     it do
-      is_expected.to eq [{ resource_type: [] },
+      is_expected.to eq [{ alt_title: [] },
+                         { resource_type: [] },
                          { title: [] },
                          { creator: [] },
                          { contributor: [] },

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
     let(:params) { ActionController::Parameters.new(attributes) }
     let(:attributes) do
       {
-        title: ['foo'],
+        title: ['aaa', 'bbb', 'ccc'],
         description: [''],
         abstract: [''],
         visibility: 'open',
@@ -118,8 +118,8 @@ RSpec.describe Hyrax::Forms::WorkForm do
 
     subject { described_class.model_attributes(params) }
 
-    it 'permits metadata parameters' do
-      expect(subject['title']).to eq ['foo']
+    it 'permits parameters' do
+      expect(subject['title']).to eq ['aaa', 'bbb', 'ccc']
       expect(subject['description']).to be_empty
       expect(subject['abstract']).to be_empty
       expect(subject['visibility']).to eq 'open'

--- a/spec/forms/hyrax/generic_work_form_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Hyrax::GenericWorkForm do
       end
 
       it 'removes blank parameters' do
-        expect(subject['title']).to be_empty
+        expect(subject['title']).to eq ['']
         expect(subject['description']).to be_empty
         expect(subject['license']).to be_empty
         expect(subject['keyword']).to be_empty

--- a/spec/views/records/edit_fields/_alt_title.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_alt_title.html.erb_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe 'records/edit_fields/_title.html.erb', type: :view do
+  let(:work) { GenericWork.new }
+  let(:form) { Hyrax::GenericWorkForm.new(work, nil, controller) }
+
+  let(:form_template) do
+    %(
+      <%= simple_form_for [main_app, @form] do |f| %>
+        <%= render "records/edit_fields/alt_title", f: f, key: 'description' %>
+      <% end %>
+    )
+  end
+
+  before do
+    work.title = ["bbb", "aaa", "ccc"]
+    work.alt_title = []
+    assign(:form, form)
+  end
+
+  context "when there are 3 titles" do
+    it 'hides the last 2 after alphabetizing all 3 titles' do
+      render inline: form_template
+      expect(rendered).to have_selector('input[type="hidden"][value="bbb"]', visible: false)
+      expect(rendered).to have_selector('input[type="hidden"][value="ccc"]', visible: false)
+    end
+  end
+end

--- a/spec/views/records/edit_fields/_title.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_title.html.erb_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe 'records/edit_fields/_title.html.erb', type: :view do
+  let(:work) { GenericWork.new }
+  let(:form) { Hyrax::GenericWorkForm.new(work, nil, controller) }
+
+  let(:form_template) do
+    %(
+      <%= simple_form_for [main_app, @form] do |f| %>
+        <%= render "records/edit_fields/title", f: f, key: 'description' %>
+      <% end %>
+    )
+  end
+
+  before do
+    work.title = ["ccc", "bbb", "aaa"]
+    assign(:form, form)
+  end
+
+  context "when there are 3 titles" do
+    it 'displays the first after alphabetizing the list' do
+      render inline: form_template
+      expect(rendered).to have_selector('input[class="form-control string required"][value="aaa"]')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3299

Title will now be displayed as a single entry in the work form.  It remains defined as a multiple ( array ), but in the edit form, it is treated as a single.  In cases where a work has more than one title, the titles are sorted alphabetically and the 1st in the list is displayed on the edit form.  User collections and admin sets presently display only a single title, but because there is a lot of overlap in the form processing of works and collections, the work form and admin form processing had to change too.  

In cases of multiple titles, in order to store values not being displayed on the form, a new metadata type called alt_title was created.  This metadata is never displayed but is used during the processing of the form to store the titles not being displayed by the form and then when the form is saved, saving these titles back in the title metadata.

Guidance for testing, such as acceptance criteria or new user interface behaviors:

* Create a work, and see that you are only given one entry for title.  
* Enter the title, and remaining required fields and upload one file.
* Save the work.
* Verify that the correct title is  displayed on the work page
* Edit the work and change the title.
* Verify that the correct title is displayed on the work page.
* Repeat this for another type of work, User collection, and Admin Set.

Testing multiple titles for a work:

* Create a work, and see that you are only given one entry for title.  
* Enter the title, and remaining required fields and upload one file.
* Save the work.
* Using Rails console add a few more titles to the work.
* Verify that the correct title is  displayed on the work page
* Edit the work and notice that the 1st title based on the alphabetization of the titles is displayed.
* Change the title.
* Verify that the correct titles are displayed on the work page with the changed title and the other titles.


@samvera/hyrax-code-reviewers
