### PR TITLE
Use [* TO *] to work with old and new versions of AF and Solr

### DIFF
--- a/app/search_builders/hyrax/embargo_search_builder.rb
+++ b/app/search_builders/hyrax/embargo_search_builder.rb
@@ -14,7 +14,7 @@ module Hyrax
 
     def only_active_embargoes(solr_params)
       solr_params[:fq] ||= []
-      solr_params[:fq] = 'embargo_release_date_dtsi:*'
+      solr_params[:fq] = 'embargo_release_date_dtsi:[* TO *]'
     end
   end
 end

--- a/app/search_builders/hyrax/lease_search_builder.rb
+++ b/app/search_builders/hyrax/lease_search_builder.rb
@@ -14,7 +14,7 @@ module Hyrax
 
     def only_active_leases(solr_params)
       solr_params[:fq] ||= []
-      solr_params[:fq] = 'lease_expiration_date_dtsi:*'
+      solr_params[:fq] = 'lease_expiration_date_dtsi:[* TO *]'
     end
   end
 end


### PR DESCRIPTION
ActiveFedora 12.1.0 brings a new solr schema which switches from the deprecated solr.TrieDateField (to be removed in solr 8) to solr.DatePointField.  While the TrieDateField allowed queries like `date_dtsi:*`, DatePointField only allows single value and range queries so this example query needs to change to `date_dtsi:[* TO *]`.  Luckily the latter also works in TrieDateField.  This PR updates both the  embargo and lease search builders to use the `[* TO *]` query to work with both types of solr fields.

This fixes the tests that were blocking https://github.com/samvera/hyrax/pull/3541

@samvera/hyrax-code-reviewers
