### PR TITLE
Resolves RSpec issues for CircleCI tests against 2.x releases

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -108,6 +108,7 @@ EOF
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'i18n-debug' if ENV['I18N_DEBUG']
   spec.add_development_dependency 'i18n_yaml_sorter' unless ENV['TRAVIS']
+  spec.add_development_dependency 'chromedriver-helper', '~> 2.1'
 
   ########################################################
   # Temporarily pinned dependencies. INCLUDE EXPLANATIONS.
@@ -117,8 +118,4 @@ EOF
   spec.add_dependency 'simple_form', '~> 3.2', '<= 3.5.0'
   # parser 2.5.0.0 broke local and Travis rubocop checks due to a change in parsing
   spec.add_development_dependency 'parser', '< 2.5'
-  # chromedriver-helper 2.0 broke the chromedriver used by capybara
-  #   see: https://github.com/flavorjones/chromedriver-helper/issues/62
-  #        and https://github.com/flavorjones/chromedriver-helper/issues/57
-  spec.add_development_dependency 'chromedriver-helper', '< 2.0'
 end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -86,7 +86,7 @@ EOF
   spec.add_development_dependency 'rspec-its', '~> 1.1'
   spec.add_development_dependency 'rspec-activemodel-mocks', '~> 1.0'
   spec.add_development_dependency "capybara", '~> 2.4'
-  spec.add_development_dependency 'capybara-maleficent', '~> 0.2'
+  spec.add_development_dependency 'capybara-maleficent', '0.2'
   spec.add_development_dependency "selenium-webdriver"
   spec.add_development_dependency "factory_bot_rails", '~> 4.4'
   spec.add_development_dependency "equivalent-xml", '~> 0.5'
@@ -109,6 +109,7 @@ EOF
   spec.add_development_dependency 'i18n-debug' if ENV['I18N_DEBUG']
   spec.add_development_dependency 'i18n_yaml_sorter' unless ENV['TRAVIS']
   spec.add_development_dependency 'chromedriver-helper', '~> 2.1'
+  spec.add_development_dependency 'rspec_junit_formatter'
 
   ########################################################
   # Temporarily pinned dependencies. INCLUDE EXPLANATIONS.


### PR DESCRIPTION
Resolves RSpec issues for CircleCI 2.x releases (please see the failures in https://circleci.com/gh/samvera/hyrax/1484) by addressing the following:
- Updates `chromedriver-helper` to 2.1.0
- Locks `capybara-maleficent` to release 0.2.0
- Ensures that `rspec_junit_formatter` is installed