### PR TITLE
Allow i18n via data properties like on all the other fields

### DIFF
--- a/app/assets/javascripts/hyrax/editor/controlled_vocabulary.es6
+++ b/app/assets/javascripts/hyrax/editor/controlled_vocabulary.es6
@@ -27,7 +27,7 @@ export default class ControlledVocabulary extends FieldManager {
 
         labelControls:      true,
       }
-      super(element, options)
+      super(element, $.extend({}, options, $(element).data()))
       this.paramKey = paramKey
       this.fieldName = this.element.data('fieldName')
       this.searchUrl = this.element.data('autocompleteUrl')


### PR DESCRIPTION
Fixes #3461; supersedes #3555.

On all fields except "location" (based_near), the "add another" button can be internationalized by data properties.

``` ruby
data: { 'autocomplete-url' => "/authorities/search/geonames",
                                    'field-name' => key,
                                    "add-text": t(".add_another"),
                                    "remove-text":  t(".remove")}
```
This attributes are merged into default options in hydra-editor's manage_repeating_fields.js
`var options = $.extend({}, DEFAULTS, $this.data(), typeof option == 'object' && option);`
But based near does not take them into account.

Changes proposed in this pull request:

You can override default options in ControlledVocabulary like in hydra-editor's manage_repeating_fields.js.

Guidance for testing, such as acceptance criteria or new user interface behaviors:

* customize 'add text' and 'remove text' in app/views/records/edit_fields/_based_near.html.erb
```ruby
data:
    {
     "add-text": t("my_key_for_add"),"remove-text": t("my_key_for_remove")
    }
```
* Observe the result in the form label

h/t @j-dornbusch

@samvera/hyrax-code-reviewers

Fixes #issuenumber ; refs #issuenumber

Present tense short summary (50 characters or less)

More detailed description, if necessary. Try to be as descriptive as you can: even if you think that the PR content is obvious, it may not be obvious to others. Include tracebacks if helpful, and be sure to call out any bits of the PR that may be work-in-progress.

Description can have multiple paragraphs and you can use code examples inside:

``` ruby
class PostsController
  def index
    respond_with Post.limit(10)
  end
end
```

Changes proposed in this pull request:
*
*
*

Guidance for testing, such as acceptance criteria or new user interface behaviors:
*
*
*

@samvera/hyrax-code-reviewers
