### PR TITLE
Add support for Ruby 2.6; drop 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Note here that the following commands assume you're setting up Hyrax in a develo
 
 First, you'll need a working Ruby installation. You can install this via your operating system's package manager -- you are likely to get farther with OSX, Linux, or UNIX than Windows but your mileage may vary -- but we recommend using a Ruby version manager such as [RVM](https://rvm.io/) or [rbenv](https://github.com/sstephenson/rbenv).
 
-Hyrax supports Ruby 2.3, 2.4 and 2.5. When starting a new project, we recommend using the latest Ruby 2.5 version.
+Hyrax supports Ruby 2.4, 2.5, and 2.6. When starting a new project, we recommend using the latest Ruby 2.6 version.
 
 ## Redis
 


### PR DESCRIPTION
Adds support for Ruby 2.6, which is in the build matrix as of #3565.

Ruby 2.3 falls out of its security maintenance phase on the 31st of this
month. That will likely predate the 3.0.0 release, meaning support should be
dropped in that release. This removes it in anticipation of that.

This is really just a README update, documenting official support policy.

@samvera/hyrax-code-reviewers
