### PR TITLE
Implement "find_all" for Wings::Valkyrie::QueryService

### DIFF
--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -24,6 +24,18 @@ module Wings
         raise ::Valkyrie::Persistence::ObjectNotFoundError
       end
 
+      # Find all work/collection records, and map to Valkyrie Resources
+      # @return [Array<Valkyrie::Resource>]
+      def find_all
+        klasses = Hyrax.config.curation_concerns.append(::Collection)
+        objects = ::ActiveFedora::Base.all.select do |object|
+          klasses.include? object.class
+        end
+        objects.map do |id|
+          resource_factory.to_resource(object: id)
+        end
+      end
+
       # Constructs a Valkyrie::Persistence::CustomQueryContainer using this query service
       # @return [Valkyrie::Persistence::CustomQueryContainer]
       def custom_queries

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Wings::Valkyrie::QueryService do
   it 'responds to expected methods' do
     expect(subject).to respond_to(:find_by).with_keywords(:id)
     expect(subject).to respond_to(:resource_factory)
+    expect(subject).to respond_to(:find_all).with(0).arguments
   end
 
   describe ".find_by" do
@@ -47,6 +48,20 @@ RSpec.describe Wings::Valkyrie::QueryService do
 
     it 'raises an error if the id is not a Valkyrie::ID or a string' do
       expect { query_service.find_by(id: 123) }.to raise_error ArgumentError
+    end
+  end
+
+  describe ".find_all", clean_repo: true do
+    before do
+      allow(Hyrax.config).to receive(:curation_concerns).and_return(Hyrax.config.curation_concerns.append(::Collection).append(af_resource_class))
+    end
+
+    it "returns all created resources and no access control objects" do
+      work = create(:generic_work)
+      resource1 = persister.save(resource: resource_class.new)
+      resource2 = persister.save(resource: resource_class.new)
+
+      expect(query_service.find_all.map(&:id)).to contain_exactly resource1.id, resource2.id, Valkyrie::ID.new(work.id)
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/3581

In order to use the Valkyrie shared specs, the Active Fedora adapter needs to support all of the required queries.

This PR implements the `find_all` query.