### PR TITLE
Add find_many_by_ids to wings query_service

### DIFF
--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -53,14 +53,14 @@ module Wings
       # @param [Array<Valkyrie::ID, String>] ids
       # @return [Array<Valkyrie::Resource>]
       def find_many_by_ids(ids:)
-        ids = ids.uniq
-        ids.map do |id|
-          begin
-            find_by(id: id)
-          rescue ::Valkyrie::Persistence::ObjectNotFoundError
-            nil
-          end
-        end.compact
+        ids.each do |id|
+          id = ::Valkyrie::ID.new(id.to_s) if id.is_a?(String)
+          validate_id(id)
+        end
+        ids = ids.uniq.map(&:to_s)
+        ActiveFedora::Base.where("id: (#{ids.join(' OR ')})").map do |obj|
+          resource_factory.to_resource(object: obj)
+        end
       end
 
       # Constructs a Valkyrie::Persistence::CustomQueryContainer using this query service

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -49,6 +49,9 @@ module Wings
         end
       end
 
+      # Find an array of record using Valkyrie IDs, and map them to Valkyrie Resources
+      # @param [Array<Valkyrie::ID, String>] ids
+      # @return [Array<Valkyrie::Resource>]
       def find_many_by_ids(ids:)
         ids = ids.uniq
         ids.map do |id|

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -49,6 +49,17 @@ module Wings
         end
       end
 
+      def find_many_by_ids(ids:)
+        ids = ids.uniq
+        ids.map do |id|
+          begin
+            find_by(id: id)
+          rescue ::Valkyrie::Persistence::ObjectNotFoundError
+            nil
+          end
+        end.compact
+      end
+
       # Constructs a Valkyrie::Persistence::CustomQueryContainer using this query service
       # @return [Valkyrie::Persistence::CustomQueryContainer]
       def custom_queries


### PR DESCRIPTION
This is a naive implementation, which valkyrie uses in its fedora
adapter. Another implementation was explored, using https://github.com/samvera/active_fedora/blob/master/lib/active_fedora/relation/finder_methods.rb#L94, but that returns SolrHit objects which we believe we'd need to call ActiveFedora.find over, anyway.

fixes #3614