### PR TITLE
implement #objects from pcdm_behavior

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -44,7 +44,10 @@ module Wings
     ##
     # @return [ActiveFedora::Base]
     def convert
-      resource.internal_resource.new(attributes).tap { |obj| obj.id = id unless id.empty? }
+      resource.internal_resource.new(attributes).tap do |obj|
+        obj.id = id unless id.empty?
+        resource.member_ids.each { |valkyrie_id| obj.members << ActiveFedora::Base.find(valkyrie_id.id) } if resource.respond_to? :member_ids
+      end
     end
 
     ##

--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -1,0 +1,15 @@
+require 'wings/active_fedora_converter'
+
+module Wings
+  module PcdmValkyrieBehavior
+    ##
+    # Gives the subset of #members that are PCDM objects
+    # @return [Enumerable<PCDM::ObjectBehavior>] an enumerable over the members
+    #   that are PCDM objects
+    def objects(valkyrie: false)
+      af_objects = Wings::ActiveFedoraConverter.new(resource: self).convert.objects
+      return af_objects unless valkyrie
+      af_objects.map(&:valkyrie_resource)
+    end
+  end
+end

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'wings/value_mapper'
+require 'wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior'
 
 module Wings
   #
@@ -81,6 +82,8 @@ module Wings
     #   results in long methods
     def self.to_valkyrie_resource_class(klass:)
       Class.new(ActiveFedoraResource) do
+        include Wings::PcdmValkyrieBehavior
+
         # Based on Valkyrie implementation, we call Class.to_s to define
         # the internal resource.
         @internal_resource = klass

--- a/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/model_transformer'
+
+RSpec.describe Wings::PcdmValkyrieBehavior do
+  subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
+
+  context 'for PCDM & Hydra-Works models', :clean_repo do
+    let(:collection1) { build(:public_collection_lw, id: 'col1', title: ['Collection 1']) }
+    let(:collection2) { build(:public_collection_lw, id: 'col2', title: ['Collection 2']) }
+    let(:collection3) { build(:public_collection_lw, id: 'col3', title: ['Collection 3']) }
+    let(:work1)       { build(:work, id: 'wk1', title: ['Work 1']) }
+    let(:work2)       { build(:work, id: 'wk2', title: ['Work 2']) }
+    let(:work3)       { build(:work, id: 'wk3', title: ['Work 3']) }
+    let(:fileset1)    { build(:file_set, id: 'fs1', title: ['Fileset 1']) }
+    let(:fileset2)    { build(:file_set, id: 'fs2', title: ['Fileset 2']) }
+
+    describe '#objects on valkyrie resource' do
+      let(:pcdm_object) { collection1 }
+
+      before do
+        collection1.members = [work1, work2, collection2, collection3]
+        collection1.save!
+      end
+
+      context 'when valkyrie resources requested' do
+        it 'returns works only as valkyrie resources through pcdm_valkyrie_behavior' do
+          resources = subject.build.objects(valkyrie: true)
+          expect(resources.size).to eq 2
+          expect(resources.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
+        end
+      end
+      context 'when active fedora objects requested' do
+        it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
+          af_objects = subject.build.objects
+          expect(af_objects.size).to eq 2
+          expect(af_objects.first.pcdm_object?).to be true
+          expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
+        end
+      end
+      context 'when return type is not specified' do
+        it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
+          af_objects = subject.build.objects
+          expect(af_objects.size).to eq 2
+          expect(af_objects.first.pcdm_object?).to be true
+          expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
+        end
+      end
+    end
+  end
+end

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+require 'wings_helper'
 require 'wings/model_transformer'
 
 RSpec.describe Wings::ModelTransformer do
@@ -172,7 +172,7 @@ RSpec.describe Wings::ModelTransformer do
           .to have_attributes title: book.title,
                               contributor: book.contributor,
                               description: book.description
-        expect_ids_to_match(subject.build.page_ids, ['pg1', 'pg2'])
+        expect(subject.build.page_ids).to match_valkyrie_ids_with_active_fedora_ids(['pg1', 'pg2'])
       end
     end
   end
@@ -191,6 +191,7 @@ RSpec.describe Wings::ModelTransformer do
       context 'for parent collection' do
         before do
           collection1.members = [work1, work2, collection2, collection3]
+          # collection1.vmembers = [work1.id, work2.id, collection2.id, collection3.id]
           collection1.save!
         end
 
@@ -207,7 +208,7 @@ RSpec.describe Wings::ModelTransformer do
         it 'has attributes for the PCDM model' do
           expect(subject.build)
             .to have_attributes title: collection1.title
-          expect_ids_to_match(subject.build.member_ids, [work1.id, work2.id, collection2.id, collection3.id])
+          expect(subject.build.member_ids).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id, collection2.id, collection3.id])
         end
       end
 
@@ -230,7 +231,7 @@ RSpec.describe Wings::ModelTransformer do
         it 'has attributes matching the active_fedora_object' do
           expect(subject.build)
             .to have_attributes title: collection3.title
-          expect_ids_to_match(subject.build.member_of_collection_ids, ['col1', 'col2'])
+          expect(subject.build.member_of_collection_ids).to match_valkyrie_ids_with_active_fedora_ids(['col1', 'col2'])
         end
       end
 
@@ -253,7 +254,7 @@ RSpec.describe Wings::ModelTransformer do
         it 'has attributes matching the active_fedora_object' do
           expect(subject.build)
             .to have_attributes title: work1.title
-          expect_ids_to_match(subject.build.member_of_collection_ids, ['col1', 'col2'])
+          expect(subject.build.member_of_collection_ids).to match_valkyrie_ids_with_active_fedora_ids(['col1', 'col2'])
         end
       end
 
@@ -276,13 +277,9 @@ RSpec.describe Wings::ModelTransformer do
         it 'has attributes matching the active_fedora_object' do
           expect(subject.build)
             .to have_attributes title: work1.title
-          expect_ids_to_match(subject.build.member_ids, [work2.id, work3.id, fileset1.id, fileset2.id])
+          expect(subject.build.member_ids).to match_valkyrie_ids_with_active_fedora_ids([work2.id, work3.id, fileset1.id, fileset2.id])
         end
       end
     end
-  end
-
-  def expect_ids_to_match(valkyrie_ids, expected_ids)
-    expect(valkyrie_ids.map(&:id)).to match_array expected_ids
   end
 end

--- a/spec/wings/support/matchers/match_valkyrie_ids_with_af_ids.rb
+++ b/spec/wings/support/matchers/match_valkyrie_ids_with_af_ids.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :match_valkyrie_ids_with_active_fedora_ids do |_active_fedora_ids|
+  match do |valkyrie_ids|
+    contain_exactly(valkyrie_ids.map(&:id))
+  end
+end

--- a/spec/wings_helper.rb
+++ b/spec/wings_helper.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+require 'wings'
+
+Dir[File.expand_path(File.join(File.dirname(__FILE__), 'wings', 'support', 'matchers', '**', '*.rb'))].each { |f| require f }


### PR DESCRIPTION
returns either AF objects or Valkyrie resources

Fixes #3585

Implements #objects under wings such that it will return ActiveFedora objects (default) or Valkyrie resources.  This continues to use ActiveFedora to get the set of objects, so more work is required for this to be fully valkyrized.

### Usage:

```
af_objects = valkyrie_resource.objects
valkyrie_resources = valkyrie_resource.objects(valkyrie: true)
```
