### PR TITLE
implement #object_ids from pcdm_behavior

### DIFF
--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -4,12 +4,19 @@ module Wings
   module PcdmValkyrieBehavior
     ##
     # Gives the subset of #members that are PCDM objects
-    # @return [Enumerable<PCDM::ObjectBehavior>] an enumerable over the members
+    # @return [Enumerable<ActiveFedora::Base> | Enumerable<Valkyrie::Resource>] an enumerable over the members
     #   that are PCDM objects
     def objects(valkyrie: false)
       af_objects = Wings::ActiveFedoraConverter.new(resource: self).convert.objects
       return af_objects unless valkyrie
       af_objects.map(&:valkyrie_resource)
+    end
+
+    ##
+    # Gives a subset of #member_ids, where all elements are PCDM objects.
+    # @return [Enumerable<String> | Enumerable<Valkyrie::ID] the object ids
+    def object_ids(valkyrie: false)
+      objects(valkyrie: valkyrie).map(&:id)
     end
   end
 end

--- a/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
@@ -5,46 +5,75 @@ require 'wings/model_transformer'
 RSpec.describe Wings::PcdmValkyrieBehavior do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 
-  context 'for PCDM & Hydra-Works models', :clean_repo do
-    let(:collection1) { build(:public_collection_lw, id: 'col1', title: ['Collection 1']) }
-    let(:collection2) { build(:public_collection_lw, id: 'col2', title: ['Collection 2']) }
-    let(:collection3) { build(:public_collection_lw, id: 'col3', title: ['Collection 3']) }
-    let(:work1)       { build(:work, id: 'wk1', title: ['Work 1']) }
-    let(:work2)       { build(:work, id: 'wk2', title: ['Work 2']) }
-    let(:work3)       { build(:work, id: 'wk3', title: ['Work 3']) }
-    let(:fileset1)    { build(:file_set, id: 'fs1', title: ['Fileset 1']) }
-    let(:fileset2)    { build(:file_set, id: 'fs2', title: ['Fileset 2']) }
+  let(:collection1) { build(:public_collection_lw, id: 'col1', title: ['Collection 1']) }
+  let(:collection2) { build(:public_collection_lw, id: 'col2', title: ['Collection 2']) }
+  let(:collection3) { build(:public_collection_lw, id: 'col3', title: ['Collection 3']) }
+  let(:work1)       { build(:work, id: 'wk1', title: ['Work 1']) }
+  let(:work2)       { build(:work, id: 'wk2', title: ['Work 2']) }
+  let(:work3)       { build(:work, id: 'wk3', title: ['Work 3']) }
+  let(:fileset1)    { build(:file_set, id: 'fs1', title: ['Fileset 1']) }
+  let(:fileset2)    { build(:file_set, id: 'fs2', title: ['Fileset 2']) }
 
-    describe '#objects on valkyrie resource' do
-      let(:pcdm_object) { collection1 }
+  describe '#objects on valkyrie resource' do
+    let(:pcdm_object) { collection1 }
 
-      before do
-        collection1.members = [work1, work2, collection2, collection3]
-        collection1.save!
-      end
+    before do
+      collection1.members = [work1, work2, collection2, collection3]
+      collection1.save!
+    end
 
-      context 'when valkyrie resources requested' do
-        it 'returns works only as valkyrie resources through pcdm_valkyrie_behavior' do
-          resources = subject.build.objects(valkyrie: true)
-          expect(resources.size).to eq 2
-          expect(resources.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
-        end
+    context 'when valkyrie resources requested' do
+      it 'returns works only as valkyrie resources through pcdm_valkyrie_behavior' do
+        resources = subject.build.objects(valkyrie: true)
+        expect(resources.size).to eq 2
+        expect(resources.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
       end
-      context 'when active fedora objects requested' do
-        it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
-          af_objects = subject.build.objects
-          expect(af_objects.size).to eq 2
-          expect(af_objects.first.pcdm_object?).to be true
-          expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
-        end
+    end
+    context 'when active fedora objects requested' do
+      it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
+        af_objects = subject.build.objects(valkyrie: false)
+        expect(af_objects.size).to eq 2
+        expect(af_objects.first.pcdm_object?).to be true
+        expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
       end
-      context 'when return type is not specified' do
-        it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
-          af_objects = subject.build.objects
-          expect(af_objects.size).to eq 2
-          expect(af_objects.first.pcdm_object?).to be true
-          expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
-        end
+    end
+    context 'when return type is not specified' do
+      it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
+        af_objects = subject.build.objects
+        expect(af_objects.size).to eq 2
+        expect(af_objects.first.pcdm_object?).to be true
+        expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
+      end
+    end
+  end
+
+  describe '#object_ids on valkyrie resource' do
+    let(:pcdm_object) { collection1 }
+
+    before do
+      collection1.members = [work1, work2, collection2, collection3]
+      collection1.save!
+    end
+
+    context 'when valkyrie resources requested' do
+      it 'returns works only as valkyrie resources through pcdm_valkyrie_behavior' do
+        resource_ids = subject.build.object_ids(valkyrie: true)
+        expect(resource_ids.size).to eq 2
+        expect(resource_ids).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
+      end
+    end
+    context 'when active fedora objects requested' do
+      it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
+        af_object_ids = subject.build.object_ids(valkyrie: false)
+        expect(af_object_ids.size).to eq 2
+        expect(af_object_ids.to_a).to match_array [work1.id, work2.id]
+      end
+    end
+    context 'when return type is not specified' do
+      it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
+        af_object_ids = subject.build.object_ids
+        expect(af_object_ids.size).to eq 2
+        expect(af_object_ids.to_a).to match_array [work1.id, work2.id]
       end
     end
   end


### PR DESCRIPTION
refs #3585

Implements #object_ids under wings such that it will return ActiveFedora object ids (default) or Valkyrie resource ids.  This continues to use ActiveFedora to get the set of objects, so more work is required for this to be fully valkyrized.

### Usage:

```
af_object_ids = valkyrie_resource.object_ids
valkyrie_resource_ids = valkyrie_resource.object_ids(valkyrie: true)
```
