### PR TITLE
setup infrastructure for including pcdm/works methods

### DIFF
--- a/lib/wings/hydra/pcdm/models/concerns/collection_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/collection_valkyrie_behavior.rb
@@ -1,0 +1,27 @@
+require 'wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior'
+
+module Wings
+  module Pcdm
+    module CollectionValkyrieBehavior
+      extend ActiveSupport::Concern
+
+      included do
+        include Wings::Pcdm::PcdmValkyrieBehavior
+      end
+
+      ##
+      # @return [Boolean] whether this instance is a PCDM Object.
+      def pcdm_object?
+        false
+      end
+
+      ##
+      # @return [Boolean] whether this instance is a PCDM Collection.
+      def pcdm_collection?
+        true
+      end
+
+      # TODO: Add translated methods
+    end
+  end
+end

--- a/lib/wings/hydra/pcdm/models/concerns/object_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/object_valkyrie_behavior.rb
@@ -1,0 +1,27 @@
+require 'wings/active_fedora_converter'
+
+module Wings
+  module Pcdm
+    module ObjectValkyrieBehavior
+      extend ActiveSupport::Concern
+
+      included do
+        include Wings::Pcdm::PcdmValkyrieBehavior
+      end
+
+      ##
+      # @return [Boolean] whether this instance is a PCDM Object.
+      def pcdm_object?
+        true
+      end
+
+      ##
+      # @return [Boolean] whether this instance is a PCDM Collection.
+      def pcdm_collection?
+        false
+      end
+
+      # TODO: Add translated methods
+    end
+  end
+end

--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -1,22 +1,24 @@
 require 'wings/active_fedora_converter'
 
 module Wings
-  module PcdmValkyrieBehavior
-    ##
-    # Gives the subset of #members that are PCDM objects
-    # @return [Enumerable<ActiveFedora::Base> | Enumerable<Valkyrie::Resource>] an enumerable over the members
-    #   that are PCDM objects
-    def objects(valkyrie: false)
-      af_objects = Wings::ActiveFedoraConverter.new(resource: self).convert.objects
-      return af_objects unless valkyrie
-      af_objects.map(&:valkyrie_resource)
-    end
+  module Pcdm
+    module PcdmValkyrieBehavior
+      ##
+      # Gives the subset of #members that are PCDM objects
+      # @return [Enumerable<PCDM::ObjectBehavior>] an enumerable over the members
+      #   that are PCDM objects
+      def objects(valkyrie: false)
+        af_objects = Wings::ActiveFedoraConverter.new(resource: self).convert.objects
+        return af_objects unless valkyrie
+        af_objects.map(&:valkyrie_resource)
+      end
 
-    ##
-    # Gives a subset of #member_ids, where all elements are PCDM objects.
-    # @return [Enumerable<String> | Enumerable<Valkyrie::ID] the object ids
-    def object_ids(valkyrie: false)
-      objects(valkyrie: valkyrie).map(&:id)
+      ##
+      # Gives a subset of #member_ids, where all elements are PCDM objects.
+      # @return [Enumerable<String> | Enumerable<Valkyrie::ID] the object ids
+      def object_ids(valkyrie: false)
+        objects(valkyrie: valkyrie).map(&:id)
+      end
     end
   end
 end

--- a/lib/wings/hydra/works/models/concerns/collection_valkyrie_behavior.rb
+++ b/lib/wings/hydra/works/models/concerns/collection_valkyrie_behavior.rb
@@ -1,0 +1,30 @@
+require 'wings/hydra/pcdm/models/concerns/collection_valkyrie_behavior'
+
+module Wings
+  module Works
+    module CollectionValkyrieBehavior
+      extend ActiveSupport::Concern
+
+      included do
+        include Wings::Pcdm::CollectionValkyrieBehavior
+      end
+
+      # @return [Boolean] whether this instance is a Hydra::Works Collection.
+      def collection?
+        true
+      end
+
+      # @return [Boolean] whether this instance is a Hydra::Works Generic Work.
+      def work?
+        false
+      end
+
+      # @return [Boolean] whether this instance is a Hydra::Works::FileSet.
+      def file_set?
+        false
+      end
+
+      # TODO: Add translated methods
+    end
+  end
+end

--- a/lib/wings/hydra/works/models/concerns/file_set_valkyrie_behavior.rb
+++ b/lib/wings/hydra/works/models/concerns/file_set_valkyrie_behavior.rb
@@ -1,0 +1,30 @@
+require 'wings/hydra/pcdm/models/concerns/object_valkyrie_behavior'
+
+module Wings
+  module Works
+    module FileSetValkyrieBehavior
+      extend ActiveSupport::Concern
+
+      included do
+        include Wings::Pcdm::ObjectValkyrieBehavior
+      end
+
+      # @return [Boolean] whether this instance is a Hydra::Works Collection.
+      def collection?
+        false
+      end
+
+      # @return [Boolean] whether this instance is a Hydra::Works Generic Work.
+      def work?
+        false
+      end
+
+      # @return [Boolean] whether this instance is a Hydra::Works::FileSet.
+      def file_set?
+        true
+      end
+
+      # TODO: Add translated methods
+    end
+  end
+end

--- a/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
+++ b/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
@@ -1,0 +1,30 @@
+require 'wings/hydra/pcdm/models/concerns/object_valkyrie_behavior'
+
+module Wings
+  module Works
+    module WorkValkyrieBehavior
+      extend ActiveSupport::Concern
+
+      included do
+        include Wings::Pcdm::ObjectValkyrieBehavior
+      end
+
+      # @return [Boolean] whether this instance is a Hydra::Works Collection.
+      def collection?
+        false
+      end
+
+      # @return [Boolean] whether this instance is a Hydra::Works Generic Work.
+      def work?
+        true
+      end
+
+      # @return [Boolean] whether this instance is a Hydra::Works::FileSet.
+      def file_set?
+        false
+      end
+
+      # TODO: Add translated methods
+    end
+  end
+end

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'wings/value_mapper'
-require 'wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior'
+require 'wings/hydra/works/models/concerns/collection_valkyrie_behavior'
+require 'wings/hydra/works/models/concerns/work_valkyrie_behavior'
+require 'wings/hydra/works/models/concerns/file_set_valkyrie_behavior'
 
 module Wings
   #
@@ -78,11 +80,13 @@ module Wings
     # @return [Class] a dyamically generated `Valkyrie::Resource` subclass
     #   mirroring the provided `ActiveFedora` model
     #
-    # rubocop:disable Metrics/MethodLength because metaprogramming a class
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize because metaprogramming a class
     #   results in long methods
     def self.to_valkyrie_resource_class(klass:)
       Class.new(ActiveFedoraResource) do
-        include Wings::PcdmValkyrieBehavior
+        include Wings::Works::CollectionValkyrieBehavior if klass.included_modules.include?(Hyrax::CollectionBehavior)
+        include Wings::Works::WorkValkyrieBehavior if klass.included_modules.include?(Hyrax::WorkBehavior)
+        include Wings::Works::FileSetValkyrieBehavior if klass.included_modules.include?(Hyrax::FileSetBehavior)
 
         # Based on Valkyrie implementation, we call Class.to_s to define
         # the internal resource.
@@ -113,7 +117,7 @@ module Wings
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     ##
     # @param pcdm_object [ActiveFedora::Base]

--- a/spec/wings/hydra/pcdm/models/concerns/collection_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/collection_valkyrie_behavior_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/model_transformer'
+
+RSpec.describe Wings::Pcdm::CollectionValkyrieBehavior do
+  subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
+
+  let(:collection1) { build(:public_collection_lw, id: 'col1', title: ['Collection 1']) }
+
+  describe 'type check methods on valkyrie resource' do
+    let(:pcdm_object) { collection1 }
+    let(:resource) { subject.build }
+
+    it 'returns appropriate response from type check methods' do
+      expect(resource.pcdm_collection?).to be true
+      expect(resource.pcdm_object?).to be false
+    end
+  end
+end

--- a/spec/wings/hydra/pcdm/models/concerns/object_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/object_valkyrie_behavior_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/model_transformer'
+
+RSpec.describe Wings::Pcdm::ObjectValkyrieBehavior do
+  subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
+
+  let(:work1)       { build(:work, id: 'wk1', title: ['Work 1']) }
+
+  describe 'type check methods on valkyrie resource' do
+    let(:pcdm_object) { work1 }
+    let(:resource) { subject.build }
+
+    it 'returns appropriate response from type check methods' do
+      expect(resource.pcdm_collection?).to be false
+      expect(resource.pcdm_object?).to be true
+    end
+  end
+end

--- a/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/model_transformer'
 
-RSpec.describe Wings::PcdmValkyrieBehavior do
+RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 
   let(:collection1) { build(:public_collection_lw, id: 'col1', title: ['Collection 1']) }
@@ -26,6 +26,7 @@ RSpec.describe Wings::PcdmValkyrieBehavior do
       it 'returns works only as valkyrie resources through pcdm_valkyrie_behavior' do
         resources = subject.build.objects(valkyrie: true)
         expect(resources.size).to eq 2
+        expect(resources.first.pcdm_object?).to be true
         expect(resources.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
       end
     end
@@ -56,21 +57,21 @@ RSpec.describe Wings::PcdmValkyrieBehavior do
     end
 
     context 'when valkyrie resources requested' do
-      it 'returns works only as valkyrie resources through pcdm_valkyrie_behavior' do
+      it 'returns ids of works only as valkyrie resources through pcdm_valkyrie_behavior' do
         resource_ids = subject.build.object_ids(valkyrie: true)
         expect(resource_ids.size).to eq 2
         expect(resource_ids).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
       end
     end
     context 'when active fedora objects requested' do
-      it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns ids of works only as fedora objects through pcdm_valkyrie_behavior' do
         af_object_ids = subject.build.object_ids(valkyrie: false)
         expect(af_object_ids.size).to eq 2
         expect(af_object_ids.to_a).to match_array [work1.id, work2.id]
       end
     end
     context 'when return type is not specified' do
-      it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns ids of works only as fedora objects through pcdm_valkyrie_behavior' do
         af_object_ids = subject.build.object_ids
         expect(af_object_ids.size).to eq 2
         expect(af_object_ids.to_a).to match_array [work1.id, work2.id]

--- a/spec/wings/hydra/works/models/concerns/collection_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/works/models/concerns/collection_valkyrie_behavior_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/model_transformer'
+
+RSpec.describe Wings::Works::CollectionValkyrieBehavior do
+  subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
+
+  let(:collection1) { build(:public_collection_lw, id: 'col1', title: ['Collection 1']) }
+
+  describe 'type check methods on valkyrie resource' do
+    let(:pcdm_object) { collection1 }
+    let(:resource) { subject.build }
+
+    it 'returns appropriate response from type check methods' do
+      expect(resource.pcdm_collection?).to be true
+      expect(resource.pcdm_object?).to be false
+      expect(resource.collection?).to be true
+      expect(resource.work?).to be false
+      expect(resource.file_set?).to be false
+    end
+  end
+end

--- a/spec/wings/hydra/works/models/concerns/file_set_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/works/models/concerns/file_set_valkyrie_behavior_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/model_transformer'
+
+RSpec.describe Wings::Works::FileSetValkyrieBehavior do
+  subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
+
+  let(:fileset1) { build(:file_set, id: 'fs1', title: ['Fileset 1']) }
+
+  describe 'type check methods on valkyrie resource' do
+    let(:pcdm_object) { fileset1 }
+    let(:resource) { subject.build }
+
+    it 'returns appropriate response from type check methods' do
+      expect(resource.pcdm_collection?).to be false
+      expect(resource.pcdm_object?).to be true
+      expect(resource.collection?).to be false
+      expect(resource.work?).to be false
+      expect(resource.file_set?).to be true
+    end
+  end
+end

--- a/spec/wings/hydra/works/models/concerns/work_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/works/models/concerns/work_valkyrie_behavior_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/model_transformer'
+
+RSpec.describe Wings::Works::WorkValkyrieBehavior do
+  subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
+
+  let(:work1) { build(:work, id: 'wk1', title: ['Work 1']) }
+
+  describe 'type check methods on valkyrie resource' do
+    let(:pcdm_object) { work1 }
+    let(:resource) { subject.build }
+
+    it 'returns appropriate response from type check methods' do
+      expect(resource.pcdm_collection?).to be false
+      expect(resource.pcdm_object?).to be true
+      expect(resource.collection?).to be false
+      expect(resource.work?).to be true
+      expect(resource.file_set?).to be false
+    end
+  end
+end


### PR DESCRIPTION
Adds infrastructure for all the pcdm/works model behaviors.  Includes type checking tests (e.g. pcdm_collection?, pcdm_object?, collection?, work?, file_set?).  Adds tests for all these methods for each behavior model.