### PR TITLE
Rework class docs, reorganize ModelTransformer

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -2,7 +2,7 @@
 
 module Wings
   ##
-  # Converts `ValkyrieResource` objects to legacy `ActiveFedora::Base` objects.
+  # Converts `Valkyrie::Resource` objects to legacy `ActiveFedora::Base` objects.
   #
   # @example
   #   work     = GenericWork.new(title: ['Comet in Moominland'])
@@ -25,6 +25,15 @@ module Wings
     end
 
     ##
+    # @return [ActiveFedora::Base]
+    def convert
+      resource.internal_resource.new(attributes).tap do |obj|
+        obj.id = id unless id.empty?
+        resource.member_ids.each { |valkyrie_id| obj.members << ActiveFedora::Base.find(valkyrie_id.id) } if resource.respond_to? :member_ids
+      end
+    end
+
+    ##
     # @return [Hash<Symbol, Object>]
     def attributes
       attrs = resource.attributes
@@ -39,15 +48,6 @@ module Wings
       attrs.delete(:alternate_ids)
 
       attrs.compact
-    end
-
-    ##
-    # @return [ActiveFedora::Base]
-    def convert
-      resource.internal_resource.new(attributes).tap do |obj|
-        obj.id = id unless id.empty?
-        resource.member_ids.each { |valkyrie_id| obj.members << ActiveFedora::Base.find(valkyrie_id.id) } if resource.respond_to? :member_ids
-      end
     end
 
     ##

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -6,10 +6,15 @@ require 'wings/hydra/works/models/concerns/work_valkyrie_behavior'
 require 'wings/hydra/works/models/concerns/file_set_valkyrie_behavior'
 
 module Wings
+  ##
+  # Transforms ActiveFedora models or objects into Valkyrie::Resource models or
+  # objects
   #
-  # This class is responsible for coordinating the transformation of a PCDM
-  # Model (be it the class or an instance of the class) to a [Valkyrie::Resource](https://github.com/samvera-labs/valkyrie/blob/master/lib/valkyrie/resource.rb).
-  # for the given PCDM model.
+  # @see https://github.com/samvera-labs/valkyrie/blob/master/lib/valkyrie/resource.rb
+  #
+  # Similar to an orm_converter class in other valkyrie persisters. Also used by
+  # the Valkyrizable mixin to make AF objects able to return their
+  # Valkyrie::Resource representation.
   #
   # @example getting a valkyrie resource
   #   work     = GenericWork.new(id: 'an_identifier')
@@ -18,6 +23,39 @@ module Wings
   #   resource.alternate_ids # => [#<Valkyrie::ID:0x... id: 'an_identifier'>]
   #
   class ModelTransformer
+    ##
+    # @!attribute [rw] pcdm_object
+    #   @return [ActiveFedora::Base]
+    attr_accessor :pcdm_object
+
+    ##
+    # @param pcdm_object [ActiveFedora::Base]
+    def initialize(pcdm_object:)
+      self.pcdm_object = pcdm_object
+    end
+
+    ##
+    # Factory
+    #
+    # @param pcdm_object [ActiveFedora::Base]
+    #
+    # @return [::Valkyrie::Resource] a resource mirroiring `pcdm_object`
+    def self.for(pcdm_object)
+      new(pcdm_object: pcdm_object).build
+    end
+
+    ##
+    # Builds a `Valkyrie::Resource` equivalent to the `pcdm_object`
+    #
+    # @return [::Valkyrie::Resource] a resource mirroiring `pcdm_object`
+    def build
+      klass = @@resource_class_cache.fetch(pcdm_object) do
+        self.class.to_valkyrie_resource_class(klass: pcdm_object.class)
+      end
+      pcdm_object.id = minted_id if pcdm_object.id.nil?
+      klass.new(alternate_ids: [::Valkyrie::ID.new(pcdm_object.id)], **attributes)
+    end
+
     ##
     # Caches dynamically generated `Valkyrie::Resource` subclasses mapped from
     # legacy `ActiveFedora` model classes.
@@ -53,11 +91,6 @@ module Wings
     # we really want a class var here. maybe we could use a singleton instead?
     # rubocop:disable Style/ClassVars
     @@resource_class_cache = ResourceClassCache.new
-
-    ##
-    # @!attribute [rw] pcdm_object
-    #   @return [ActiveFedora::Base]
-    attr_accessor :pcdm_object
 
     ##
     # @note The method signature is to conform to Valkyrie's method signature
@@ -118,32 +151,6 @@ module Wings
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
-
-    ##
-    # @param pcdm_object [ActiveFedora::Base]
-    def initialize(pcdm_object:)
-      self.pcdm_object = pcdm_object
-    end
-
-    ##
-    # @param pcdm_object [ActiveFedora::Base]
-    #
-    # @return [::Valkyrie::Resource] a resource mirroiring `pcdm_object`
-    def self.for(pcdm_object)
-      new(pcdm_object: pcdm_object).build
-    end
-
-    ##
-    # Builds a `Valkyrie::Resource` equivalent to the `pcdm_object`
-    #
-    # @return [::Valkyrie::Resource] a resource mirroiring `pcdm_object`
-    def build
-      klass = @@resource_class_cache.fetch(pcdm_object) do
-        self.class.to_valkyrie_resource_class(klass: pcdm_object.class)
-      end
-      pcdm_object.id = minted_id if pcdm_object.id.nil?
-      klass.new(alternate_ids: [::Valkyrie::ID.new(pcdm_object.id)], **attributes)
-    end
 
     class ActiveFedoraResource < ::Valkyrie::Resource
       attribute :alternate_ids, ::Valkyrie::Types::Array


### PR DESCRIPTION
Moved factory / conversion methods closer to the top. Hopefully this
will accentuate the way ModelTransformer and ActiveFedoraConverter
compliment one another.

closes #3633