### PR TITLE
Integrating changes into Hyrax 3.0.0 for supporting BrowseEverything 1.0.x releases

### DIFF
--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -64,7 +64,8 @@ module Hyrax
         # Generic utility for creating FileSet from a URL
         # Used in to import files using URLs from a file picker like browse_everything
         def create_file_from_url(env, uri, file_name, auth_header = {})
-          ::FileSet.new(import_url: uri.to_s, label: file_name) do |fs|
+          import_url = URI.decode_www_form_component(uri.to_s)
+          ::FileSet.new(import_url: import_url, label: file_name) do |fs|
             actor = Hyrax::Actors::FileSetActor.new(fs, env.user)
             actor.create_metadata(visibility: env.curation_concern.visibility)
             actor.attach_to_work(env.curation_concern)

--- a/app/jobs/ingest_local_file_job.rb
+++ b/app/jobs/ingest_local_file_job.rb
@@ -14,9 +14,9 @@ class IngestLocalFileJob < Hyrax::ApplicationJob
     else
       Hyrax.config.callback.run(:after_import_local_file_failure, file_set, user, path)
     end
-  rescue SystemCallError => error
+  rescue SystemCallError
     # This is generic in order to handle Errno constants raised when accessing files
     # @see https://ruby-doc.org/core-2.5.3/Errno.html
-    send_error(error.message)
+    Hyrax.config.callback.run(:after_import_local_file_failure, file_set, user, path)
   end
 end

--- a/app/jobs/ingest_local_file_job.rb
+++ b/app/jobs/ingest_local_file_job.rb
@@ -14,5 +14,9 @@ class IngestLocalFileJob < Hyrax::ApplicationJob
     else
       Hyrax.config.callback.run(:after_import_local_file_failure, file_set, user, path)
     end
+  rescue SystemCallError => error
+    # This is generic in order to handle Errno constants raised when accessing files
+    # @see https://ruby-doc.org/core-2.5.3/Errno.html
+    send_error(error.message)
   end
 end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -37,8 +37,7 @@ SUMMARY
   spec.add_dependency 'blacklight', '~> 6.14'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
-  # Pin browse-everything to stable version
-  spec.add_dependency 'browse-everything', '< 0.16'
+  spec.add_dependency 'browse-everything', '~> 1.0'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'dry-equalizer', '~> 0.2'

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -37,7 +37,7 @@ SUMMARY
   spec.add_dependency 'blacklight', '~> 6.14'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
-  spec.add_dependency 'browse-everything', '~> 1.0'
+  spec.add_dependency 'browse-everything', '< 2.0'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'dry-equalizer', '~> 0.2'

--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -38,6 +38,7 @@ module Hyrax
       say_status('info', '[Hyrax] GENERATING HYDRA-HEAD', :blue)
       generate 'hydra:head -f'
       generate "hyrax:models#{options[:force] ? ' -f' : ''}"
+      generate 'browse_everything:config'
     end
 
     def replace_blacklight_layout

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -189,7 +189,10 @@ module Hyrax
     def whitelisted_ingest_dirs
       @whitelisted_ingest_dirs ||= \
         if defined? BrowseEverything
-          Array.wrap(BrowseEverything.config['file_system'].try(:[], :home)).compact
+          file_system_dirs = Array.wrap(BrowseEverything.config['file_system'].try(:[], :home)).compact
+          # Include the Rails tmp directory for cases where the BrowseEverything provider is required to download the file to a temporary directory first
+          tmp_dir = [Rails.root.join('tmp').to_s]
+          file_system_dirs + tmp_dir
         else
           []
         end

--- a/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
@@ -44,6 +44,20 @@ RSpec.describe Hyrax::Actors::CreateWithRemoteFilesActor do
     end
   end
 
+  context "with source URIs that are remote and contain encoded parameters" do
+    let(:url1) { "https://dl.dropbox.com/fake/file?param1=%28example%29&param2=%5Bexample2%5D" }
+
+    before do
+      allow(::FileSet).to receive(:new).and_call_original
+    end
+
+    it "preserves the encoded parameters in the URIs" do
+      expect(ImportUrlJob).to receive(:perform_later).with(FileSet, Hyrax::Operation, {}).twice
+      expect(actor.create(environment)).to be true
+      expect(::FileSet).to have_received(:new).with(import_url: "https://dl.dropbox.com/fake/file?param1=%28example%29&param2=%5Bexample2%5D", label: "filepicker-demo.txt.txt")
+    end
+  end
+
   context "with source uris that are remote bearing auth headers" do
     let(:remote_files) do
       [{ url: url1,

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe ImportUrlJob do
 
     it 'leaves the temp directory in place' do
       described_class.perform_now(file_set, operation)
+      file_name = File.basename(file_set.label)
       expect(File.exist?(File.join(tmpdir, file_name))).to be true
     end
   end

--- a/spec/jobs/ingest_local_file_job_spec.rb
+++ b/spec/jobs/ingest_local_file_job_spec.rb
@@ -3,6 +3,9 @@ RSpec.describe IngestLocalFileJob do
 
   let(:file_set) { FileSet.new }
   let(:actor) { double }
+  let(:path) do
+    File.join(fixture_path, 'world.png')
+  end
 
   before do
     allow(Hyrax::Actors::FileSetActor).to receive(:new).with(file_set, user).and_return(actor)
@@ -11,6 +14,27 @@ RSpec.describe IngestLocalFileJob do
   it 'has attached a file' do
     expect(FileUtils).not_to receive(:rm)
     expect(actor).to receive(:create_content).and_return(true)
-    described_class.perform_now(file_set, File.join(fixture_path, 'world.png'), user)
+    described_class.perform_now(file_set, path, user)
+  end
+
+  context 'when an error is encountered when trying to save the file to disk' do
+    let(:callback) do
+      instance_double(Hyrax::Callbacks::Registry)
+    end
+    let(:config) do
+      instance_double(Hyrax::Configuration)
+    end
+
+    before do
+      allow(callback).to receive(:run)
+      allow(config).to receive(:callback).and_return(callback)
+      allow(Hyrax).to receive(:config).and_return(config)
+      allow(actor).to receive(:create_content).and_raise(SystemCallError, "example file system error")
+      described_class.perform_now(file_set, path, user)
+    end
+
+    it "invokes the file failure callback" do
+      expect(callback).to have_received(:run).with(:after_import_local_file_failure, file_set, user, path)
+    end
   end
 end

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Hyrax::Configuration do
-  subject { described_class.new }
+  subject(:configuration) { described_class.new }
 
   describe '#register_roles' do
     it 'yields a RoleRegistry' do
@@ -82,4 +82,10 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:whitelisted_ingest_dirs) }
   it { is_expected.to respond_to(:whitelisted_ingest_dirs=) }
   it { is_expected.to respond_to(:work_requires_files?) }
+
+  describe "#whitelisted_ingest_dirs" do
+    it "provides the Rails tmp directory for temporary downloads for cloud files" do
+      expect(configuration.whitelisted_ingest_dirs).to include(Rails.root.join('tmp').to_s)
+    end
+  end
 end


### PR DESCRIPTION
This addresses the following in order to support integrating 1.0.0 and later 1.0.x releases of [browse-everything:](https://github.com/samvera/browse-everything)
- Ensures that HTTP headers are passed in requests to determine if cloud resources are available
- Ensures that HTTP GET request parameters are decoded when requesting cloud resources
- Ensures that FileSet labels are used when ingesting files which are temporarily downloaded from cloud service providers (this approach is currently used by at least one browse-everything driver)
- Ensures that the Rails `tmp` directory is whitelisted for file uploads (this is where the aforementioned downloaded files are placed)
- Ensures that the `browse_everything:config` generator is run for new Hyrax instances (otherwise errors are raised for a missing BE configuration file)

Please note that this is a WIP given that https://github.com/samvera/browse-everything/pull/270/files should be merged (and a 1.0.1 version released) in order to handle errors raised when the directory for the File System driver does not exist.