### PR TITLE
Persister stores created & updated dates

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -46,6 +46,8 @@ module Wings
       attrs.delete(:new_record)
       attrs.delete(:id)
       attrs.delete(:alternate_ids)
+      attrs.delete(:created_at)
+      attrs.delete(:updated_at)
 
       attrs.compact
     end

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -172,6 +172,8 @@ module Wings
           next unless pcdm_object.respond_to? attr_name
           mem[attr_name.to_sym] = ValueMapper.for(pcdm_object.public_send(attr_name)).result
         end
+                                .merge(created_at: pcdm_object.try(:create_date),
+                                       updated_at: pcdm_object.try(:modified_date))
       end
   end
   # rubocop:enable Style/ClassVars

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Wings::Valkyrie::Persister do
     expect(saved.id).not_to be_blank
   end
 
-  xit "stores created_at/updated_at" do
+  it "stores created_at/updated_at" do
     book = persister.save(resource: resource)
     book.title = ["test"]
     book = persister.save(resource: book)
@@ -48,13 +48,12 @@ RSpec.describe Wings::Valkyrie::Persister do
   xit "can override default id generation with a provided id" do
     id = SecureRandom.uuid
     book = persister.save(resource: resource_class.new(id: id, title: ['Foo']))
-    reloaded = query_service.find_by(id: book.id)
-    expect(reloaded.id).to eq Valkyrie::ID.new(id)
-    expect(reloaded).to be_persisted
-    expect(reloaded.created_at).not_to be_blank
-    expect(reloaded.updated_at).not_to be_blank
-    expect(reloaded.created_at).not_to be_kind_of Array
-    expect(reloaded.updated_at).not_to be_kind_of Array
+    expect(book.id).to eq Valkyrie::ID.new(id)
+    expect(book).to be_persisted
+    expect(book.created_at).not_to be_blank
+    expect(book.updated_at).not_to be_blank
+    expect(book.created_at).not_to be_kind_of Array
+    expect(book.updated_at).not_to be_kind_of Array
   end
 
   it "doesn't override a resource that already has an ID" do


### PR DESCRIPTION
Update model_transformer and active_fedora_converter to handle created
and updated dates.

Co-authored-by: Anna Headley hackmastera <anna.headley@gmail.com>

Fixes #3644 


@samvera/hyrax-code-reviewers
