### PR TITLE
enforces only to use wings adapter for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
 
     - run:
         name: Generate test app
-        command: (git diff --name-only master | grep -qG 'generators\/hyrax') || bundle exec rake engine_cart:generate
+        command: (git diff --name-only master | grep -qiG 'generators\/hyrax') || bundle exec rake engine_cart:generate
 
     - run:
         name: Ensure test app dependencies are installed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
 
     - run:
         name: Generate test app
-        command: (git diff --name-only master | grep -qiG 'generators\/hyrax') || bundle exec rake engine_cart:generate
+        command: (git diff --name-only master | grep -qiG 'generators\/hyrax') && bundle exec rake engine_cart:generate
 
     - run:
         name: Ensure test app dependencies are installed

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -1,5 +1,4 @@
 Hyrax.config do |config|
-
   # The MetadataAdapter to use when persisting resources with Valkyrie.
   # NOTE: Until Hyrax has been reworked to be Valkyrie-native, the default
   #       metadata adapter supported is :wings_adapter.

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -1,4 +1,5 @@
 Hyrax.config do |config|
+
   # The MetadataAdapter to use when persisting resources with Valkyrie.
   # NOTE: Until Hyrax has been reworked to be Valkyrie-native, the default
   #       metadata adapter supported is :wings_adapter.

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -1,4 +1,16 @@
 Hyrax.config do |config|
+  # The MetadataAdapter to use when persisting resources with Valkyrie.
+  # NOTE: Until Hyrax has been reworked to be Valkyrie-native, the default
+  #       metadata adapter supported is :wings_adapter.
+  # @see lib/wings
+  # @see https://github.com/samvera-labs/valkyrie
+  # config.valkyrie_metadata_adapter = :wings_adapter
+
+  # The StorageAdapter to use when persisting resources with Valkyrie
+  # @see lib/wings
+  # @see https://github.com/samvera-labs/valkyrie
+  # config.valkyrie_storage_adapter = :fedora
+
   # Register roles that are expected by your implementation.
   # @see Hyrax::RoleRegistry for additional details.
   # @note there are magical roles as defined in Hyrax::RoleRegistry::MAGIC_ROLES

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -227,9 +227,13 @@ module Hyrax
     # @see lib/wings
     # @see https://github.com/samvera-labs/valkyrie
     def valkyrie_metadata_adapter
-      Valkyrie::MetadataAdapter.find(@valkyrie_metadata_adapter || :wings_adapter)
+      Valkyrie::MetadataAdapter.find(@valkyrie_metadata_adapter)
     end
-    attr_writer :valkyrie_metadata_adapter
+
+    def valkyrie_metadata_adapter=(adapter)
+      raise StandardError, "Hyrax currently only supports :wings_adapter as the configured valkyrie_metadata_adapter." unless adapter == :wings_adapter
+      @valkyrie_metadata_adapter = adapter
+    end
 
     # The StorageAdapter to use when persisting resources with Valkyrie
     #

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -227,7 +227,7 @@ module Hyrax
     # @see lib/wings
     # @see https://github.com/samvera-labs/valkyrie
     def valkyrie_metadata_adapter
-      Valkyrie::MetadataAdapter.find(@valkyrie_metadata_adapter)
+      Valkyrie::MetadataAdapter.find(@valkyrie_metadata_adapter || :wings_adapter)
     end
 
     def valkyrie_metadata_adapter=(adapter)

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -86,4 +86,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:whitelisted_ingest_dirs) }
   it { is_expected.to respond_to(:whitelisted_ingest_dirs=) }
   it { is_expected.to respond_to(:work_requires_files?) }
+
+  # Can be removed when Hyrax has support and established pattern for using non-Wings adapter
+  it { expect { subject.valkyrie_metadata_adapter = :bobross }.to raise_error(StandardError) }
+  it { expect { subject.valkyrie_metadata_adapter = :wings_adapter }.not_to raise_error(StandardError) }
 end


### PR DESCRIPTION
Fixes #3654 

Circle CI configuration change notes;
- Originally if any files in the PR changed `hyrax/generators` then the internal test app wouldn't be generated. Changed to be the inverse, so that the internal test app is forced to be rebuilt when any generator file had changes. 
- Because Circle CI is configured to cache the internal test app directory, it should be restored and functional across test suite runs until a PR includes changes to a `hyrax/generators` file. 
