### PR TITLE
define member_object_ids for valkyrie resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,3 +345,4 @@ This software has been developed by and is brought to you by the Samvera communi
 [Samvera website](http://samvera.org/).
 
 ![Samvera Logo](https://wiki.duraspace.org/download/thumbnails/87459292/samvera-fall-font2-200w.png?version=1&modificationDate=1498550535816&api=v2)
+ 

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -50,6 +50,8 @@ module Hyrax
     end
 
     # Add members using the members association.
+    # TODO: Confirm if this is ever used.  I believe all relationships are done through
+    #       add_member_objects using the member_of_collections relationship.  Deprecate?
     def add_members(new_member_ids)
       return if new_member_ids.blank?
       members << ActiveFedora::Base.find(new_member_ids)
@@ -78,6 +80,15 @@ module Hyrax
     #                   lib/wings/models/concerns/collection_behavior.rb
     def member_objects
       ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}")
+    end
+
+    # Use this query to get the ids of the member objects (since the containment
+    # association has been flipped)
+    # Valkyrie Version: Wings::CollectionBehavior#child_collections_and_works_ids aliased to #member_object_ids
+    #                   lib/wings/models/concerns/collection_behavior.rb
+    def member_object_ids
+      return [] unless id
+      member_objects.map(&:id)
     end
 
     def to_s
@@ -111,13 +122,6 @@ module Hyrax
 
       # One query per member_id because Solr is not a relational database
       member_object_ids.collect { |work_id| size_for_work(work_id) }.sum
-    end
-
-    # Use this query to get the ids of the member objects (since the containment
-    # association has been flipped)
-    def member_object_ids
-      return [] unless id
-      ActiveFedora::Base.search_with_conditions("member_of_collection_ids_ssim:#{id}").map(&:id)
     end
 
     # @api public

--- a/lib/wings/models/concerns/collection_behavior.rb
+++ b/lib/wings/models/concerns/collection_behavior.rb
@@ -27,5 +27,12 @@ module Wings
       af_collections_and_works.map(&:valkyrie_resource)
     end
     alias member_objects child_collections_and_works
+
+    ##
+    # @return [Enumerable<ActiveFedora::Base> | Enumerable<Valkyrie::Resource>] an enumerable over the children of this collection
+    def child_collections_and_works_ids(valkyrie: false)
+      child_collections_and_works(valkyrie: valkyrie).map(&:id)
+    end
+    alias member_object_ids child_collections_and_works_ids
   end
 end

--- a/spec/wings/models/concerns/collection_behavior_spec.rb
+++ b/spec/wings/models/concerns/collection_behavior_spec.rb
@@ -81,4 +81,40 @@ RSpec.describe Wings::CollectionBehavior do
       end
     end
   end
+
+  describe '#child_collections_and_works_ids' do
+    let(:pcdm_object) { collection1 }
+    let(:parent_collection_resource) { resource }
+
+    before do
+      collection2.member_of_collections = [collection1]
+      collection3.member_of_collections = [collection1]
+      work1.member_of_collections = [collection1]
+      work2.member_of_collections = [collection1]
+      collection2.save!
+      collection3.save!
+      work1.save!
+      work2.save!
+      collection1.save!
+    end
+
+    context 'when valkyrie resources requested' do
+      it 'returns ids of works only as valkyrie resources through pcdm_valkyrie_behavior' do
+        resource_ids = parent_collection_resource.child_collections_and_works_ids(valkyrie: true)
+        expect(resource_ids).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id, collection2.id, collection3.id])
+      end
+    end
+    context 'when active fedora objects requested' do
+      it 'returns ids of works only as fedora objects through pcdm_valkyrie_behavior' do
+        af_object_ids = parent_collection_resource.child_collections_and_works_ids(valkyrie: false)
+        expect(af_object_ids.to_a).to match_array [work1.id, work2.id, collection2.id, collection3.id]
+      end
+    end
+    context 'when return type is not specified' do
+      it 'returns ids of works only as fedora objects through pcdm_valkyrie_behavior' do
+        af_object_ids = parent_collection_resource.child_collections_and_works_ids
+        expect(af_object_ids.to_a).to match_array [work1.id, work2.id, collection2.id, collection3.id]
+      end
+    end
+  end
 end


### PR DESCRIPTION
refs #3651

Adds member_object_ids aliased to child_collections_and_works_ids supporting this method for Valkyrie Resources.