### PR TITLE
Backport of #3164 - Collection Thumbnails don't show in search results

### DIFF
--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,3 +1,4 @@
 <div class="col-md-2">
-  <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-search" aria-hidden="true"></span>
-</div>
+  <%= render_thumbnail_tag document, {}, suppress_link: true %>
+</div> 
+

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'searching' do
       expect(page).to have_content('Search Results')
       expect(page).to have_content "Toothbrush"
       expect(page).to have_content('collection title abc')
-      expect(page).to have_css("span.collection-icon-search")
+      expect(page).to have_selector("//img")
 
       expect(page.body).to include "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=taco&amp;locale=en\">taco</a></span>"
       expect(page.body).to include "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=mustache&amp;locale=en\">mustache</a></span>"

--- a/spec/views/catalog/_thumbnail_list_collection.html.erb_spec.rb
+++ b/spec/views/catalog/_thumbnail_list_collection.html.erb_spec.rb
@@ -1,10 +1,43 @@
 RSpec.describe 'catalog/_thumbnail_list_collection.html.erb', type: :view do
-  before do
-    stub_template 'catalog/_thumbnail_list_collection.html.erb' => '<div class="col-sm-3"><span class="fa fa-cubes collection-icon-search"></span></div>'
-    render
+  context "When the collection thumbnail is attached" do
+    let(:attributes) do
+      { id: "xxx",
+        "has_model_ssim": ["Collection"],
+        "title_tesim": ["Collection Title"],
+        "description_tesim": ["Collection Description"],
+        "system_modified_dtsi": 'date',
+        "thumbnail_path_ss": '/xxx/yyy?file=thumbnail' }
+    end
+    let(:doc) { SolrDocument.new(attributes) }
+    let(:current_ability) { Ability.new(build(:user)) }
+
+    before do
+      render 'catalog/thumbnail_list_collection', document: doc
+    end
+
+    it 'displays the collection thumbnail in the search results' do
+      expect(rendered).to include '/xxx/yyy?file=thumbnail'
+    end
   end
 
-  it 'displays the collection icon in the search results' do
-    expect(rendered).to match '<div class="col-sm-3"><span class="fa fa-cubes collection-icon-search"></span></div>'
+  context "When the collection thumbnail is not attached" do
+    let(:attributes) do
+      { id: "xxx",
+        "has_model_ssim": ["Collection"],
+        "title_tesim": ["Collection Title"],
+        "description_tesim": ["Collection Description"],
+        "system_modified_dtsi": 'date',
+        "thumbnail_path_ss" => Hyrax::CollectionIndexer.thumbnail_path_service.default_image }
+    end
+    let(:doc) { SolrDocument.new(attributes) }
+    let(:current_ability) { Ability.new(build(:user)) }
+
+    before do
+      render 'catalog/thumbnail_list_collection', document: doc
+    end
+
+    it 'displays the collection icon in the search results' do
+      expect(rendered).to include '/assets/collection-'
+    end
   end
 end


### PR DESCRIPTION
This is a backport of https://github.com/samvera/hyrax/pull/3291
I would like to have this bug fixed in a 2.4.2 release, please.

@samvera/hyrax-code-reviewers
