### PR TITLE
add member_of, in_collections, and in_collection_ids methods for valkyrie resources

### DIFF
--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -15,6 +15,14 @@ module Wings
         #           Since member_ids is all that keeps these in wings, how can we do that here?
       end
 
+      # TODO: Methods requiring further investigation...
+      #   #type_validator class method
+      #   #ancestor?
+
+      # TODO: Should these method NOT USED BY HYRAX be converted...
+      #   #related_object_ids
+      #   #related_objects
+
       ##
       # @return [Enumerable<ActiveFedora::Base> | Enumerable<Valkyrie::Resource>] an enumerable over the parent collections
       def parent_collections(valkyrie: false)
@@ -30,27 +38,74 @@ module Wings
         return member_of_collection_ids if valkyrie
         member_of_collection_ids.map(&:id)
       end
+      # alias member_of_collection_ids child_object_ids # TODO: Cannot alias in this way because member_of_collection_ids method is already defined thru the attribute definition.
 
       ##
       # Gives the subset of #members that are PCDM objects
       # @return [Enumerable<ActiveFedora::Base> | Enumerable<Valkyrie::Resource>] an enumerable over the members
       #   that are PCDM objects
+      # NOTE: A collection could be added to members, but for Hyrax collections are stored using member_of_collection_ids.
+      #       As long as this rule holds, then members and ordered_members are equivalent to objects/child_objects.
+      # TODO: Do we want to support members separate from child_objects (see NOTE)
       def child_objects(valkyrie: false)
         af_objects = Wings::ActiveFedoraConverter.new(resource: self).convert.objects
         return af_objects unless valkyrie
         af_objects.map(&:valkyrie_resource)
       end
       alias objects child_objects
+      alias ordered_objects child_objects
       alias members child_objects
       alias ordered_members child_objects
 
       ##
       # Gives a subset of #member_ids, where all elements are PCDM objects.
       # @return [Enumerable<String> | Enumerable<Valkyrie::ID] the object ids
+      # NOTE: A collection could be added to member_ids, but for Hyrax collections are stored using member_of_collection_ids.
+      #       As long as this rule holds, then member_ids and ordered_member_ids are equivalent to object_ids/child_object_ids.
+      # TODO: Do we want to support member_ids separate from child_objects (see NOTE)
       def child_object_ids(valkyrie: false)
         child_objects(valkyrie: valkyrie).map(&:id)
       end
       alias object_ids child_object_ids
+      alias ordered_object_ids child_object_ids
+      # alias member_ids child_object_ids # TODO: Cannot alias in this way because member_ids method is already defined thru the attribute definition.
+      alias ordered_members_ids child_object_ids
+
+      ##
+      # @return [Enumerable<ActiveFedora::Base> | Enumerable<Valkyrie::Resource>] the collections the
+      #    collection or object is a member of.
+      # NOTE: For Hyrax, member_of_collection_ids is used to hold the parent collections.
+      #       members is used to hold the child works and child filesets.  This method looks
+      #       in solr for the members relationship and infers a member_of relationship through
+      #       a solr query by looking for all parents that have self's id in their members list.
+      def member_of(valkyrie: false)
+        af_id = valkyrie ? id : id.id
+        return [] if af_id.nil?
+        af_parents = Wings::ActiveFedoraConverter.new(resource: self).convert.member_of
+        return af_parents unless valkyrie
+        af_parents.map(&:valkyrie_resource)
+      end
+
+      # @return [Enumerable<ActiveFedora::Base> | Enumerable<Valkyrie::Resource>] the collections the
+      #   object is a member of.
+      # TODO: This is using the member_of method which uses the members relationship.  That should
+      #       never return any collections since they are stored using the member_of_collection
+      #       relationship.  But this method is called in characterize_job.rb and collection_indexer.rb.
+      #       It could be that these are no-ops because nothing is ever returned, but more exploration
+      #       is needed to determine this.
+      def in_collections(valkyrie: false)
+        member_of(valkyrie: valkyrie).select(&:pcdm_collection?).to_a
+      end
+
+      # @return [Enumerable<String> | Enumerable<Valkyrie::ID] ids for collections the object is a member of
+      # TODO: This is using the member_of method which uses the members relationship.  That should
+      #       never return any collections since they are stored using the member_of_collection
+      #       relationship.  But this method is called in base_actor.rb #destroy.
+      #       It could be that these are no-ops because nothing is ever returned, but more exploration
+      #       is needed to determine this.
+      def in_collection_ids(valkyrie: false)
+        in_collections(valkyrie: valkyrie).map(&:id)
+      end
     end
   end
 end

--- a/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
@@ -28,21 +28,21 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior do
     context 'when valkyrie resources requested' do
       it 'returns parent collections as valkyrie resources through pcdm_valkyrie_behavior' do
         resources = child_collection_resource.parent_collections(valkyrie: true)
-        expect(resources.first.pcdm_collection?).to be true
+        expect(resources.map(&:pcdm_collection?)).to all(be true)
         expect(resources.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([collection2.id, collection3.id])
       end
     end
     context 'when active fedora objects requested' do
-      it 'returns parent collections as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns parent collections as active fedora objects through pcdm_valkyrie_behavior' do
         af_objects = child_collection_resource.parent_collections(valkyrie: false)
-        expect(af_objects.first.pcdm_collection?).to be true
+        expect(af_objects.map(&:pcdm_collection?)).to all(be true)
         expect(af_objects.map(&:id)).to match_array [collection2.id, collection3.id]
       end
     end
     context 'when return type is not specified' do
-      it 'returns parent collections as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns parent collections as active fedora objects through pcdm_valkyrie_behavior' do
         af_objects = child_collection_resource.parent_collections
-        expect(af_objects.first.pcdm_collection?).to be true
+        expect(af_objects.map(&:pcdm_collection?)).to all(be true)
         expect(af_objects.map(&:id)).to match_array [collection2.id, collection3.id]
       end
     end
@@ -64,13 +64,13 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior do
       end
     end
     context 'when active fedora objects requested' do
-      it 'returns ids of parent collections as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns ids of parent collections as active fedora objects through pcdm_valkyrie_behavior' do
         af_object_ids = child_collection_resource.parent_collection_ids(valkyrie: false)
         expect(af_object_ids.to_a).to match_array [collection2.id, collection3.id]
       end
     end
     context 'when return type is not specified' do
-      it 'returns ids of parent collections as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns ids of parent collections as active fedora objects through pcdm_valkyrie_behavior' do
         af_object_ids = child_collection_resource.parent_collection_ids
         expect(af_object_ids.to_a).to match_array [collection2.id, collection3.id]
       end
@@ -93,13 +93,13 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior do
       end
     end
     context 'when active fedora objects requested' do
-      it 'returns parent collections as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns parent collections as active fedora objects through pcdm_valkyrie_behavior' do
         af_objects = parent_work_resource.members(valkyrie: false)
         expect(af_objects.map(&:id)).to match_array [work2.id, work3.id, fileset1.id, fileset2.id]
       end
     end
     context 'when return type is not specified' do
-      it 'returns parent collections as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns parent collections as active fedora objects through pcdm_valkyrie_behavior' do
         af_objects = parent_work_resource.members
         expect(af_objects.map(&:id)).to match_array [work2.id, work3.id, fileset1.id, fileset2.id]
       end
@@ -130,13 +130,13 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior do
     #   end
     # end
     # context 'when active fedora objects requested' do
-    #   it 'returns ids of parent collections as fedora objects through pcdm_valkyrie_behavior' do
+    #   it 'returns ids of parent collections as active fedora objects through pcdm_valkyrie_behavior' do
     #     af_object_ids = parent_work_resource.member_ids(valkyrie: false)
     #     expect(af_object_ids.to_a).to match_array [work2.id, work3.id, fileset1.id, fileset2.id]
     #   end
     # end
     # context 'when return type is not specified' do
-    #   it 'returns ids of parent collections as fedora objects through pcdm_valkyrie_behavior' do
+    #   it 'returns ids of parent collections as active fedora objects through pcdm_valkyrie_behavior' do
     #     af_object_ids = parent_work_resource.member_ids
     #     expect(af_object_ids.to_a).to match_array [work2.id, work3.id, fileset1.id, fileset2.id]
     #   end
@@ -155,23 +155,23 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior do
       it 'returns works only as valkyrie resources through pcdm_valkyrie_behavior' do
         resources = resource.child_objects(valkyrie: true)
         expect(resources.size).to eq 2
-        expect(resources.first.pcdm_object?).to be true
+        expect(resources.map(&:pcdm_object?)).to all(be true)
         expect(resources.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
       end
     end
     context 'when active fedora objects requested' do
-      it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns works only as active fedora objects through pcdm_valkyrie_behavior' do
         af_objects = resource.child_objects(valkyrie: false)
         expect(af_objects.size).to eq 2
-        expect(af_objects.first.pcdm_object?).to be true
+        expect(af_objects.map(&:pcdm_object?)).to all(be true)
         expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
       end
     end
     context 'when return type is not specified' do
-      it 'returns works only as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns works only as active fedora objects through pcdm_valkyrie_behavior' do
         af_objects = resource.child_objects
         expect(af_objects.size).to eq 2
-        expect(af_objects.first.pcdm_object?).to be true
+        expect(af_objects.map(&:pcdm_object?)).to all(be true)
         expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
       end
     end
@@ -193,17 +193,133 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior do
       end
     end
     context 'when active fedora objects requested' do
-      it 'returns ids of works only as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns ids of works only as active fedora objects through pcdm_valkyrie_behavior' do
         af_object_ids = resource.child_object_ids(valkyrie: false)
         expect(af_object_ids.size).to eq 2
         expect(af_object_ids.to_a).to match_array [work1.id, work2.id]
       end
     end
     context 'when return type is not specified' do
-      it 'returns ids of works only as fedora objects through pcdm_valkyrie_behavior' do
+      it 'returns ids of works only as active fedora objects through pcdm_valkyrie_behavior' do
         af_object_ids = resource.child_object_ids
         expect(af_object_ids.size).to eq 2
         expect(af_object_ids.to_a).to match_array [work1.id, work2.id]
+      end
+    end
+  end
+
+  describe '#member_of' do
+    let(:pcdm_object) { work3 }
+    let(:child_resource) { resource }
+
+    before do
+      work1.members = [work3, fileset1]
+      work2.members = [work3, fileset2]
+      work1.save!
+      work2.save!
+    end
+
+    context 'when valkyrie resources requested' do
+      it 'returns works only as valkyrie resources through pcdm_valkyrie_behavior' do
+        resources = child_resource.member_of(valkyrie: true)
+        expect(resources.size).to eq 2
+        expect(resources.map(&:pcdm_object?)).to all(be true)
+        expect(resources.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
+      end
+    end
+    context 'when active fedora objects requested' do
+      it 'returns works only as active fedora objects through pcdm_valkyrie_behavior' do
+        af_objects = child_resource.member_of(valkyrie: false)
+        expect(af_objects.size).to eq 2
+        expect(af_objects.map(&:pcdm_object?)).to all(be true)
+        expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
+      end
+    end
+    context 'when return type is not specified' do
+      it 'returns works only as active fedora objects through pcdm_valkyrie_behavior' do
+        af_objects = child_resource.member_of
+        expect(af_objects.size).to eq 2
+        expect(af_objects.map(&:pcdm_object?)).to all(be true)
+        expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
+      end
+    end
+  end
+
+  describe '#in_collections' do
+    # TODO: This test is misleading.  Hyrax does not use the members relationship for tracking members of a collection.
+    #       It uses the member_of_collections relationship.  Use of members here is only to test the in_collections
+    #       method from PCDM which is used in 2 places in Hyrax.  It is likely that the 2 places this is used never gets
+    #       any collections and use of this method is a no-op.  But that needs to be confirmed before this can be deprecated.
+    let(:pcdm_object) { work1 }
+    let(:child_resource) { resource }
+
+    before do
+      collection1.members = [work1, collection3]
+      collection2.members = [work1, work2]
+      work3.members = [work1]
+      collection1.save!
+      collection2.save!
+    end
+
+    context 'when valkyrie resources requested' do
+      it 'returns collections only as valkyrie resources through pcdm_valkyrie_behavior' do
+        resources = child_resource.in_collections(valkyrie: true)
+        expect(resources.size).to eq 2
+        expect(resources.map(&:pcdm_collection?)).to all(be true)
+        expect(resources.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([collection1.id, collection2.id])
+      end
+    end
+    context 'when active fedora objects requested' do
+      it 'returns collections only as active fedora objects through pcdm_valkyrie_behavior' do
+        af_objects = child_resource.in_collections(valkyrie: false)
+        expect(af_objects.size).to eq 2
+        expect(af_objects.map(&:pcdm_collection?)).to all(be true)
+        expect(af_objects.map(&:id)).to match_array [collection1.id, collection2.id]
+      end
+    end
+    context 'when return type is not specified' do
+      it 'returns collections only as active fedora objects through pcdm_valkyrie_behavior' do
+        af_objects = child_resource.in_collections
+        expect(af_objects.size).to eq 2
+        expect(af_objects.map(&:pcdm_collection?)).to all(be true)
+        expect(af_objects.map(&:id)).to match_array [collection1.id, collection2.id]
+      end
+    end
+  end
+
+  describe '#in_collection_ids' do
+    # TODO: This test is misleading.  Hyrax does not use the members relationship for tracking members of a collection.
+    #       It uses the member_of_collections relationship.  Use of members here is only to test the in_collection_ids
+    #       method from PCDM which is used in 1 place in Hyrax.  It is likely that the place this is used never gets
+    #       any collections and use of this method is a no-op.  But that needs to be confirmed before this can be deprecated.
+    let(:pcdm_object) { work1 }
+    let(:child_resource) { resource }
+
+    before do
+      collection1.members = [work1, collection3]
+      collection2.members = [work1, work2]
+      work3.members = [work1]
+      collection1.save!
+      collection2.save!
+      work3.save!
+    end
+
+    context 'when valkyrie resources requested' do
+      it 'returns collection ids only as valkyrie resource ids through pcdm_valkyrie_behavior' do
+        resource_ids = child_resource.in_collection_ids(valkyrie: true)
+        expect(resource_ids).to match_valkyrie_ids_with_active_fedora_ids([collection1.id, collection2.id])
+      end
+    end
+    context 'when active fedora objects requested' do
+      it 'returns collection ids only as active fedora object ids through pcdm_valkyrie_behavior' do
+        af_object_ids = child_resource.in_collection_ids(valkyrie: false)
+        expect(af_object_ids).to match_array [collection1.id, collection2.id]
+      end
+    end
+    context 'when return type is not specified' do
+      it 'returns collection ids only as active fedora object ids through pcdm_valkyrie_behavior' do
+        af_object_ids = child_resource.in_collection_ids
+        expect(af_object_ids).to match_array [collection1.id, collection2.id]
       end
     end
   end


### PR DESCRIPTION
Fixes #3577

#member_of uses solr to find all objects that have the current object as a child using the members relationship.  #in_collections and #in_collection_ids use #member_of with the intent of finding parent collections. But parent collections in Hyrax are tracked using the member_of_collections relationship.  As a consequence, these two methods in Hyrax are expected to always return an empty array.  

`in_collections` is called from `characterize_job.rb` and `collection_index.rb`
`in_collection_ids` is called from `base_actor.rb #destroy`