### PR TITLE
add abstract metadata to work

### DIFF
--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -21,7 +21,7 @@ module Hyrax
 
       attr_reader :agreement_accepted
 
-      self.terms = [:title, :creator, :contributor, :description,
+      self.terms = [:title, :creator, :contributor, :description, :abstract,
                     :keyword, :license, :rights_statement, :rights_notes, :publisher, :date_created,
                     :subject, :language, :identifier, :based_near, :related_url,
                     :representative_id, :thumbnail_id, :rendering_ids, :files,

--- a/app/indexers/hyrax/basic_metadata_indexer.rb
+++ b/app/indexers/hyrax/basic_metadata_indexer.rb
@@ -3,7 +3,7 @@ module Hyrax
   class BasicMetadataIndexer < ActiveFedora::RDF::IndexingService
     class_attribute :stored_and_facetable_fields, :stored_fields, :symbol_fields
     self.stored_and_facetable_fields = %i[resource_type creator contributor keyword publisher subject language based_near]
-    self.stored_fields = %i[description license rights_statement rights_notes date_created identifier related_url bibliographic_citation source]
+    self.stored_fields = %i[description abstract license rights_statement rights_notes date_created identifier related_url bibliographic_citation source]
     self.symbol_fields = %i[import_url]
 
     private

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -15,6 +15,7 @@ module Hyrax
       property :creator, predicate: ::RDF::Vocab::DC11.creator
       property :contributor, predicate: ::RDF::Vocab::DC11.contributor
       property :description, predicate: ::RDF::Vocab::DC11.description
+      property :abstract, predicate: ::RDF::Vocab::DC.abstract
       property :keyword, predicate: ::RDF::Vocab::DC11.relation
       # Used for a license
       property :license, predicate: ::RDF::Vocab::DC.rights

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -56,6 +56,7 @@ module Hyrax
         attribute :admin_set, Solr::Array, solr_name('admin_set')
         attribute :member_of_collection_ids, Solr::Array, solr_name('member_of_collection_ids', :symbol)
         attribute :description, Solr::Array, solr_name('description')
+        attribute :abstract, Solr::Array, solr_name('abstract')
         attribute :title, Solr::Array, solr_name('title')
         attribute :contributor, Solr::Array, solr_name('contributor')
         attribute :subject, Solr::Array, solr_name('subject')

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -15,7 +15,7 @@ module Hyrax
 
     # delegate fields from Hyrax::Works::Metadata to solr_document
     delegate :based_near_label, :related_url, :depositor, :identifier, :resource_type,
-             :keyword, :itemtype, :admin_set, :rights_notes, to: :solr_document
+             :keyword, :itemtype, :admin_set, :rights_notes, :abstract, to: :solr_document
 
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,3 +1,4 @@
+<%= presenter.attribute_to_html(:abstract, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_modified, label: t('hyrax.base.show.last_modified'), html_dl: true) %>
 <%= presenter.attribute_to_html(:creator, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted, html_dl: true) %>

--- a/app/views/records/edit_fields/_abstract.html.erb
+++ b/app/views/records/edit_fields/_abstract.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.multiple? key %>
+  <%= f.input :abstract, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input :abstract, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
+<% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1289,6 +1289,7 @@ en:
         share_applies_to_new_works: When new works are created directly in the collection, grant sharing users and groups permissions for the new work according to their collection roles.
         title: ''
       defaults:
+        abstract: A brief summary of a research article, thesis, review, conference proceeding, or any in-depth analysis of a particular subject.
         based_near: A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>.
         contributor: A person or group you want to recognize for playing a role in the creation of the work, but not the primary role.
         creator: The person or group responsible for the work. Usually this is the author of the content. Personal names should be entered with the last name first, e.g. &quot;Smith, John.&quot;.
@@ -1322,6 +1323,7 @@ en:
         share_applies_to_new_works: APPLY TO NEW WORKS
         title: Type name
       defaults:
+        abstract: Abstract
         admin_set_id: Administrative Set
         based_near: Location
         creator: Creator

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Hyrax::Forms::BatchUploadForm do
       is_expected.to eq [:creator,
                          :contributor,
                          :description,
+                         :abstract,
                          :keyword,
                          :license,
                          :rights_statement,

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
       {
         title: ['foo'],
         description: [''],
+        abstract: [''],
         visibility: 'open',
         parent_id: '123',
         representative_id: '456',
@@ -119,6 +120,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
     it 'permits parameters' do
       expect(subject['title']).to eq ['foo']
       expect(subject['description']).to be_empty
+      expect(subject['abstract']).to be_empty
       expect(subject['visibility']).to eq 'open'
       expect(subject['license']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
       expect(subject['rights_statement']).to eq 'http://rightsstatements.org/vocab/InC-EDU/1.0/'
@@ -170,6 +172,12 @@ RSpec.describe Hyrax::Forms::WorkForm do
   describe "initialized fields" do
     context "for :description" do
       subject { form[:description] }
+
+      it { is_expected.to eq [''] }
+    end
+
+    context "for :abstract" do
+      subject { form[:abstract] }
 
       it { is_expected.to eq [''] }
     end


### PR DESCRIPTION
Fixes #3297

This PR is to add abstract metadata to a work.  I made abstract NOT required, repeatable, and a textarea.  I also used this as the hint for the metadata:

* A brief summary of a research article, thesis, review, conference proceeding, or any in-depth analysis of a particular subject.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a work, and enter an abstract in the metadata section.
* After saving the work, verify the abstract shows up.
* Edit an existing work, and change the abstract text.
* Verify the change was saved.

@samvera/hyrax-code-reviewers
