### PR TITLE
convert valkyrie member_of_collection_ids to AF member_of_collections objects

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -27,9 +27,10 @@ module Wings
     ##
     # @return [ActiveFedora::Base]
     def convert
-      active_fedora_class.new(attributes).tap do |obj|
-        obj.id = id unless id.empty?
-        resource.member_ids.each { |valkyrie_id| obj.members << ActiveFedora::Base.find(valkyrie_id.id) } if resource.respond_to?(:member_ids) && resource.member_ids
+      active_fedora_class.new(attributes).tap do |af_object|
+        af_object.id = id unless id.empty?
+        convert_members(af_object)
+        convert_member_of_collections(af_object)
       end
     end
 
@@ -97,5 +98,19 @@ module Wings
       end
       include ::Hyrax::BasicMetadata
     end
+
+    private
+
+      def convert_members(af_object)
+        return unless resource.respond_to?(:member_ids) && resource.member_ids
+        # TODO: It would be better to find a way to add the members without resuming all the member AF objects
+        resource.member_ids.each { |valkyrie_id| af_object.members << ActiveFedora::Base.find(valkyrie_id.id) }
+      end
+
+      def convert_member_of_collections(af_object)
+        return unless resource.respond_to?(:member_of_collection_ids) && resource.member_of_collection_ids
+        # TODO: It would be better to find a way to set the parent collections without resuming all the collection AF objects
+        resource.member_of_collection_ids.each { |valkyrie_id| af_object.member_of_collections << ActiveFedora::Base.find(valkyrie_id.id) }
+      end
   end
 end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -43,5 +43,45 @@ RSpec.describe Wings::ActiveFedoraConverter do
         expect(converter.convert).to have_attributes(lease_id: work.lease_id)
       end
     end
+
+    context 'with relationships' do
+      subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
+
+      let(:resource) { subject.build }
+
+      context 'for member_of_collections' do
+        let(:pcdm_object) { collection1 }
+
+        let(:collection1) { build(:public_collection_lw, id: 'col1', title: ['Collection 1']) }
+        let(:collection2) { build(:public_collection_lw, id: 'col2', title: ['Collection 2']) }
+        let(:collection3) { build(:public_collection_lw, id: 'col3', title: ['Collection 3']) }
+
+        before do
+          collection1.member_of_collections = [collection2, collection3]
+          collection1.save!
+        end
+
+        it 'converts member_of_collection_ids back to af_object' do
+          expect(converter.convert.member_of_collections.map(&:id)).to match_array [collection2.id, collection3.id]
+        end
+      end
+
+      context 'for members' do
+        let(:pcdm_object) { work1 }
+
+        let(:work1)       { build(:work, id: 'wk1', title: ['Work 1']) }
+        let(:work2)       { build(:work, id: 'wk2', title: ['Work 2']) }
+        let(:work3)       { build(:work, id: 'wk3', title: ['Work 3']) }
+
+        before do
+          work1.members = [work2, work3]
+          work1.save!
+        end
+
+        it 'converts member_of_collection_ids back to af_object' do
+          expect(converter.convert.members.map(&:id)).to match_array [work2.id, work3.id]
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes an issue where member_of_collections was converted to the valkyrie resource but not back to the af_object.