### PR TITLE
Implement find_members in query_service

### DIFF
--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -77,6 +77,24 @@ module Wings
         raise ::Valkyrie::Persistence::ObjectNotFoundError
       end
 
+      # Find all members of a given resource, and map to Valkyrie Resources
+      # @param [Valkyrie::Resource]
+      # @param [Valkyrie::ResourceClass]
+      # @return [Array<Valkyrie::Resource>]
+      def find_members(resource:, model: nil)
+        find_model = model.internal_resource.constantize if model
+        member_list = resource_factory.from_resource(resource: resource).try(:members)
+        return [] unless member_list
+        if model
+          member_list = member_list.select do |obj|
+            obj.class == find_model
+          end
+        end
+        member_list.map do |obj|
+          resource_factory.to_resource(object: obj)
+        end
+      end
+
       # Constructs a Valkyrie::Persistence::CustomQueryContainer using this query service
       # @return [Valkyrie::Persistence::CustomQueryContainer]
       def custom_queries

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -93,6 +93,7 @@ module Wings
         member_list.map do |obj|
           resource_factory.to_resource(object: obj)
         end
+      end
 
       # Find the Valkyrie Resources referenced by another Valkyrie Resource
       # @param [<Valkyrie::Resource>]

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -249,6 +249,9 @@ RSpec.describe Wings::Valkyrie::QueryService do
         it "returns an empty array" do
           expect(subject.to_a).to eq []
         end
+      end
+    end
+  end
 
   describe ".find_references_by" do
     context "when the property is unordered" do

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Wings::Valkyrie::QueryService do
   before do
     class Book < ActiveFedora::Base
       property :title, predicate: ::RDF::Vocab::DC.title, multiple: true
+      include Hyrax::WorkBehavior
     end
     class Image < ActiveFedora::Base
       property :title, predicate: ::RDF::Vocab::DC.title, multiple: true
@@ -36,6 +37,7 @@ RSpec.describe Wings::Valkyrie::QueryService do
     expect(subject).to respond_to(:find_all_of_model).with_keywords(:model)
     expect(subject).to respond_to(:find_many_by_ids).with_keywords(:ids)
     expect(subject).to respond_to(:find_by_alternate_identifier).with_keywords(:alternate_identifier)
+    expect(subject).to respond_to(:find_members).with_keywords(:resource)
   end
 
   describe ".find_by" do
@@ -170,6 +172,81 @@ RSpec.describe Wings::Valkyrie::QueryService do
     it "removes duplicates" do
       found = query_service.find_many_by_ids(ids: [resource.id, resource2.id, resource.id])
       expect(found.map(&:id)).to contain_exactly resource.id, resource2.id
+    end
+  end
+
+  describe ".find_members" do
+    context "without filtering by model" do
+      let(:af_resource_class) { GenericWork }
+      subject { query_service.find_members(resource: parent) }
+
+      context "when the object has members" do
+        let!(:child1) { persister.save(resource: resource_class.new(title: ['Child 1'])) }
+        let!(:child2) { persister.save(resource: resource_class.new(title: ['Child 2'])) }
+        let(:parent) { persister.save(resource: resource_class.new(title: ['Parent'], member_ids: [child2.id, child1.id])) }
+
+        it "returns all a resource's members in order" do
+          expect(subject.map(&:id).to_a).to eq [child2.id, child1.id]
+        end
+
+        context "when something is member more than once" do
+          let(:parent) { persister.save(resource: resource_class.new(title: ['Parent'], member_ids: [child1.id, child2.id, child1.id])) }
+          xit "includes duplicates" do
+            expect(subject.map(&:id).to_a).to eq [child1.id, child2.id, child1.id]
+          end
+        end
+      end
+
+      context "when there's no resource ID" do
+        let(:parent) { resource_class.new(title: ['Parent']) }
+
+        it "doesn't error" do
+          expect(subject).not_to eq nil
+          expect(subject.to_a).to eq []
+        end
+      end
+
+      context "when there are no members" do
+        let(:parent) { persister.save(resource: resource_class.new(title: ['Parent'])) }
+
+        it "returns an empty array" do
+          expect(subject.to_a).to eq []
+        end
+      end
+
+      context "when the model doesn't have member_ids" do
+        let(:parent) { persister.save(resource: image_resource_class.new) }
+
+        it "returns an empty array" do
+          expect(subject.to_a).to eq []
+        end
+      end
+    end
+
+    context "filtering by model" do
+      subject { query_service.find_members(resource: parent, model: resource_class) }
+      let(:gw_resource_class) { GenericWork }
+      let(:parent_resource_class) { Wings::ModelTransformer.to_valkyrie_resource_class(klass: gw_resource_class) }
+
+      context "when the object has members" do
+        let(:child1) { persister.save(resource: resource_class.new(title: ['Child 1'])) }
+        let(:child2) { persister.save(resource: parent_resource_class.new(title: ['Child 2'])) }
+        let(:child3) { persister.save(resource: resource_class.new(title: ['Child 3'])) }
+        let(:parent) { persister.save(resource: parent_resource_class.new(title: ['Parent'], member_ids: [child3.id, child2.id, child1.id])) }
+
+        it "returns all a resource's members in order" do
+          expect(subject.map(&:id).to_a).to eq [child3.id, child1.id]
+        end
+      end
+
+      context "when there are no members that match the filter" do
+        let(:child2) { persister.save(resource: parent_resource_class.new(title: ['Child 2'])) }
+        let(:parent) { persister.save(resource: parent_resource_class.new(title: ['Parent'], member_ids: [child2.id])) }
+
+        it "returns an empty array" do
+          expect(subject.to_a).to eq []
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/3622

Implement `find_members` in query service, using PCDM method `members` on the active_fedora object.

@samvera/hyrax-code-reviewers
