### PR TITLE
Run rspec at 4x parallelism in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
       command: bin/solr -cloud -noprompt -f -p 8985
 
     working_directory: ~/hyrax
-    parallelism: 2
+    parallelism: 4
 
     environment: &spec_env
       BUNDLE_PATH: vendor/bundle
@@ -188,7 +188,7 @@ jobs:
       command: bin/solr -cloud -noprompt -f -p 8985
 
     working_directory: ~/hyrax
-    parallelism: 2
+    parallelism: 4
     environment: *spec_env
     steps:       *run_specs
 


### PR DESCRIPTION
We had turned down parallelism because we had fewer Circle containers than we
needed. Now we have 15, and can afford to play with the settings.

@samvera/hyrax-code-reviewers
