### PR TITLE
Add method_missing to catch any unconverted methods

### DIFF
--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -106,6 +106,26 @@ module Wings
       def in_collection_ids(valkyrie: false)
         in_collections(valkyrie: valkyrie).map(&:id)
       end
+
+      ##
+      # Any method not implemented is sent to the ActiveFedora version of the resource.
+      def method_missing(name, *args, &block)
+        # TODO: Remove the puts and this method when all methods are valkyrized
+        af_object = Wings::ActiveFedoraConverter.new(resource: self).convert
+        unless af_object.respond_to? name
+          Rails.logger.warn "#{af_object.class} does not respond to method #{name}"
+          super
+        end
+        Rails.logger.info "Calling through Method Missing with name: #{name}    args: #{args}   block_given? #{block_given?}"
+        args.delete_if { |arg| arg.is_a?(Hash) && arg.key?(:valkyrie) }
+        return af_object.send(name, args, block) if block_given?
+        return af_object.send(name, args) if args.present?
+        af_object.send(name)
+      end
+
+      def respond_to_missing?(_name, _include_private = false)
+        true
+      end
     end
   end
 end

--- a/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
@@ -323,4 +323,11 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior do
       end
     end
   end
+
+  describe '#missing_method' do
+    let!(:pcdm_object) { collection1 }
+    it 'raises NoMethodError when neither the resource nor the active fedora object respond to the method' do
+      expect { resource.a_missing_method }.to raise_error NoMethodError
+    end
+  end
 end

--- a/spec/wings/hydra/works/models/concerns/file_set_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/works/models/concerns/file_set_valkyrie_behavior_spec.rb
@@ -2,14 +2,17 @@
 require 'wings_helper'
 require 'wings/model_transformer'
 
-RSpec.describe Wings::Works::FileSetValkyrieBehavior do
+RSpec.describe Wings::Works::FileSetValkyrieBehavior, :clean_repo do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 
+  let(:resource) { subject.build }
+
+  let(:work1)    { build(:work, id: 'wk1', title: ['Work 1']) }
+  let(:work2)    { build(:work, id: 'wk2', title: ['Work 2']) }
   let(:fileset1) { build(:file_set, id: 'fs1', title: ['Fileset 1']) }
 
   describe 'type check methods on valkyrie resource' do
     let(:pcdm_object) { fileset1 }
-    let(:resource) { subject.build }
 
     it 'returns appropriate response from type check methods' do
       expect(resource.pcdm_collection?).to be false
@@ -17,6 +20,73 @@ RSpec.describe Wings::Works::FileSetValkyrieBehavior do
       expect(resource.collection?).to be false
       expect(resource.work?).to be false
       expect(resource.file_set?).to be true
+    end
+  end
+
+  describe '#parent_works' do
+    let(:pcdm_object) { fileset1 }
+    let(:child_file_set_resource) { resource }
+
+    before do
+      work1.members = [fileset1]
+      work2.members = [fileset1]
+      work1.save!
+      work2.save!
+    end
+
+    context 'when valkyrie resources requested' do
+      it 'returns parent works as valkyrie resources through file_set_valkyrie_behavior' do
+        pending "TODO: Implementation of this method for valkyrie"
+        resources = child_file_set_resource.parent_works(valkyrie: true)
+        expect(resources.map(&:work?)).to all(be true)
+        expect(resources.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
+      end
+    end
+    context 'when active fedora objects requested' do
+      it 'returns parent works as fedora objects through file_set_valkyrie_behavior' do
+        af_objects = child_file_set_resource.parent_works(valkyrie: false)
+        expect(af_objects.map(&:work?)).to all(be true)
+        expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
+      end
+    end
+    context 'when return type is not specified' do
+      it 'returns parent works as fedora objects through file_set_valkyrie_behavior' do
+        af_objects = child_file_set_resource.parent_works
+        expect(af_objects.map(&:work?)).to all(be true)
+        expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
+      end
+    end
+  end
+
+  describe '#parent_work_ids' do
+    let(:pcdm_object) { fileset1 }
+    let(:child_file_set_resource) { resource }
+
+    before do
+      work1.members = [fileset1]
+      work2.members = [fileset1]
+      work1.save!
+      work2.save!
+    end
+
+    context 'when valkyrie resources requested' do
+      it 'returns parent works as valkyrie resources through file_set_valkyrie_behavior' do
+        pending "TODO: Implementation of this method for valkyrie"
+        resource_ids = child_file_set_resource.parent_work_ids(valkyrie: true)
+        expect(resource_ids).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
+      end
+    end
+    context 'when active fedora objects requested' do
+      it 'returns parent works as fedora objects through file_set_valkyrie_behavior' do
+        af_object_ids = child_file_set_resource.parent_work_ids(valkyrie: false)
+        expect(af_object_ids).to match_array [work1.id, work2.id]
+      end
+    end
+    context 'when return type is not specified' do
+      it 'returns parent works as fedora objects through file_set_valkyrie_behavior' do
+        af_object_ids = child_file_set_resource.parent_work_ids
+        expect(af_object_ids).to match_array [work1.id, work2.id]
+      end
     end
   end
 end


### PR DESCRIPTION
NOTE: This will allow methods to function by calling the AF version of the method on the converted resource.  It does not handle the case where you want to pass in Valkyrie resource/id and receive back Valkyrie resource/id.

The function of this is a catch all during the conversion process.

