### PR TITLE
Adds a translated version of #child_work_ids

### DIFF
--- a/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
+++ b/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
@@ -24,12 +24,10 @@ module Wings
         false
       end
 
-      # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
-      # @return [Enumerable<PCDM::Object>] The works this work is contains
+      # @param valkyrie [Boolean] Should the returned resources be Valkyrie or AF objects?
+      # @return [Enumerable<Hydra::Works::Work>] The works this work contains
       def child_works(valkyrie: false)
-        af_works = child_objects(valkyrie: false).select(&:work?)
-        return af_works unless valkyrie
-        af_works.map(&:valkyrie_resource)
+        child_objects(valkyrie: valkyrie).select(&:work?)
       end
       alias works child_works
 

--- a/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
+++ b/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
@@ -33,6 +33,13 @@ module Wings
       end
       alias works child_works
 
+      # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
+      # @return [Enumerable<String> | Enumerable<Valkerie::ID] The ids of the works this work contains
+      def child_work_ids(valkyrie: false)
+        child_works(valkyrie: valkyrie).map(&:id)
+      end
+      alias work_ids child_work_ids
+
       # TODO: Add translated methods
     end
   end

--- a/spec/wings/hydra/works/models/concerns/work_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/works/models/concerns/work_valkyrie_behavior_spec.rb
@@ -59,4 +59,35 @@ RSpec.describe Wings::Works::WorkValkyrieBehavior do
       end
     end
   end
+
+  describe '#child_work_ids' do
+    let(:pcdm_object) { work1 }
+    let(:work) { resource }
+
+    before do
+      work1.members = [work2, work3, fileset1, fileset2]
+      work1.save!
+    end
+
+    context 'when return type is not specified' do
+      it 'returns AF ids for child works only' do
+        af_object_ids = work.child_work_ids
+        expect(af_object_ids).to match_array [work2.id, work3.id]
+      end
+    end
+
+    context 'when active fedora objects are requested' do
+      it 'returns AF ids for child works only' do
+        af_object_ids = work.child_work_ids(valkyrie: false)
+        expect(af_object_ids).to match_array [work2.id, work3.id]
+      end
+    end
+
+    context 'when valkyrie objects are requested' do
+      it 'returns Valkyrie ids for child works only' do
+        resource_ids = work.child_work_ids(valkyrie: true)
+        expect(resource_ids).to match_valkyrie_ids_with_active_fedora_ids([work2.id, work3.id])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This method is aliased to #work_ids as well, following the pattern from #child works.