### PR TITLE
Reduce the number, but increase the size, of RSpec containers in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
 
     working_directory: ~/hyrax
     resource_class: medium+
-    parallelism: 10
+    parallelism: 6
 
     environment: &spec_env
       BUNDLE_PATH: vendor/bundle
@@ -186,7 +186,7 @@ jobs:
 
     resource_class: medium+
     working_directory: ~/hyrax
-    parallelism: 10
+    parallelism: 6
     environment: *spec_env
     steps:       *run_specs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
       command: bin/solr -cloud -noprompt -f -p 8985
 
     working_directory: ~/hyrax
-    resource_class: medium+
+    resource_class: large
     parallelism: 6
 
     environment: &spec_env
@@ -184,7 +184,7 @@ jobs:
     - image: solr:7-alpine
       command: bin/solr -cloud -noprompt -f -p 8985
 
-    resource_class: medium+
+    resource_class: large
     working_directory: ~/hyrax
     parallelism: 6
     environment: *spec_env


### PR DESCRIPTION
It turns out that using a larger container for the rspec runs reduces the build time significantly. We drop the parallelism a bit, since 10x didn't seem to be helping much more than 6x.

@samvera/hyrax-code-reviewers
