### PR TITLE
Orders members when converting to AF objects.

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -163,7 +163,7 @@ module Wings
       def convert_members(af_object)
         return unless resource.respond_to?(:member_ids) && resource.member_ids
         # TODO: It would be better to find a way to add the members without resuming all the member AF objects
-        resource.member_ids.each { |valkyrie_id| af_object.members << ActiveFedora::Base.find(valkyrie_id.id) }
+        resource.member_ids.each { |valkyrie_id| af_object.ordered_members << ActiveFedora::Base.find(valkyrie_id.id) }
       end
 
       def convert_member_of_collections(af_object)

--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -127,6 +127,22 @@ module Wings
       def respond_to_missing?(_name, _include_private = false)
         true
       end
+
+      # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
+      # @return [Enumerable<Hydra::Works::Work>] The works this work contains
+      # NOTE: This method avoids using the Hydra::Works version of parent_works because of Issue #361
+      def parent_works(valkyrie: false)
+        af_child = Wings::ActiveFedoraConverter.new(resource: self).convert
+        af_parents = af_child.member_of_works
+        return af_parents unless valkyrie
+        af_parents.map(&:valkyrie_resource)
+      end
+
+      # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
+      # @return [Enumerable<String> | Enumerable<Valkerie::ID] The ids of the file sets this work contains
+      def parent_work_ids(valkyrie: false)
+        parent_works(valkyrie: valkyrie).map(&:id)
+      end
     end
   end
 end

--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -139,7 +139,7 @@ module Wings
       end
 
       # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
-      # @return [Enumerable<String> | Enumerable<Valkerie::ID>] The ids of the works this work is contained in
+      # @return [Enumerable<String> | Enumerable<Valkyrie::ID>] The ids of the works this work is contained in
       def parent_work_ids(valkyrie: false)
         parent_works(valkyrie: valkyrie).map(&:id)
       end

--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -139,7 +139,7 @@ module Wings
       end
 
       # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
-      # @return [Enumerable<String> | Enumerable<Valkerie::ID] The ids of the file sets this work contains
+      # @return [Enumerable<String> | Enumerable<Valkyrie::ID>] The ids of the file sets this work contains
       def parent_work_ids(valkyrie: false)
         parent_works(valkyrie: valkyrie).map(&:id)
       end

--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -129,7 +129,7 @@ module Wings
       end
 
       # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
-      # @return [Enumerable<Hydra::Works::Work>] The works this work contains
+      # @return [Enumerable<Hydra::Works::Work>] The works this work is contained in
       # NOTE: This method avoids using the Hydra::Works version of parent_works because of Issue #361
       def parent_works(valkyrie: false)
         af_child = Wings::ActiveFedoraConverter.new(resource: self).convert
@@ -139,7 +139,7 @@ module Wings
       end
 
       # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
-      # @return [Enumerable<String> | Enumerable<Valkyrie::ID>] The ids of the file sets this work contains
+      # @return [Enumerable<String> | Enumerable<Valkerie::ID>] The ids of the works this work is contained in
       def parent_work_ids(valkyrie: false)
         parent_works(valkyrie: valkyrie).map(&:id)
       end

--- a/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
+++ b/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
@@ -24,18 +24,6 @@ module Wings
         false
       end
 
-      # # @param valkyrie [Boolean] Should the returned resources be Valkyrie or AF objects?
-      # # @return [Enumerable<Hydra::Works::Work>] The works this work is in
-      # def parent_works(valkyrie: false)
-      #   parent_objects(valkyrie: valkyrie).select(&:work?)
-      # end
-      #
-      # # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
-      # # @return [Enumerable<String> | Enumerable<Valkerie::ID] The ids of the works this work is in
-      # def parent_work_ids(valkyrie: false)
-      #   parent_works(valkyrie: valkyrie).map(&:id)
-      # end
-
       # @param valkyrie [Boolean] Should the returned resources be Valkyrie or AF objects?
       # @return [Enumerable<Hydra::Works::Work>] The works this work contains
       def child_works(valkyrie: false)

--- a/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
+++ b/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
@@ -24,17 +24,17 @@ module Wings
         false
       end
 
-      # @param valkyrie [Boolean] Should the returned resources be Valkyrie or AF objects?
-      # @return [Enumerable<Hydra::Works::Work>] The works this work is in
-      def parent_works(valkyrie: false)
-        parent_objects(valkyrie: valkyrie).select(&:work?)
-      end
-
-      # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
-      # @return [Enumerable<String> | Enumerable<Valkerie::ID] The ids of the works this work is in
-      def parent_work_ids(valkyrie: false)
-        parent_works(valkyrie: valkyrie).map(&:id)
-      end
+      # # @param valkyrie [Boolean] Should the returned resources be Valkyrie or AF objects?
+      # # @return [Enumerable<Hydra::Works::Work>] The works this work is in
+      # def parent_works(valkyrie: false)
+      #   parent_objects(valkyrie: valkyrie).select(&:work?)
+      # end
+      #
+      # # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
+      # # @return [Enumerable<String> | Enumerable<Valkerie::ID] The ids of the works this work is in
+      # def parent_work_ids(valkyrie: false)
+      #   parent_works(valkyrie: valkyrie).map(&:id)
+      # end
 
       # @param valkyrie [Boolean] Should the returned resources be Valkyrie or AF objects?
       # @return [Enumerable<Hydra::Works::Work>] The works this work contains

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -49,10 +49,12 @@ module Wings
     #
     # @return [Array<Symbol>]
     def self.relationship_keys_for(reflections:)
-      reflections
-        .keys
-        .reject { |k| k.to_s.include?('id') }
-        .map { |k| k.to_s.singularize + '_ids' }
+      relationships = reflections
+                      .keys
+                      .reject { |k| k.to_s.include?('id') }
+                      .map { |k| k.to_s.singularize + '_ids' }
+      relationships.delete(:member_ids) # Remove here.  Members will be extracted as ordered_members in attributes method.
+      relationships
     end
 
     ##
@@ -199,7 +201,8 @@ module Wings
                                    updated_at: pcdm_object.try(:modified_date),
                                    embargo_id: pcdm_object.try(:embargo)&.id,
                                    lease_id:   pcdm_object.try(:lease)&.id,
-                                   visibility: pcdm_object.try(:visibility))
+                                   visibility: pcdm_object.try(:visibility),
+                                   member_ids: pcdm_object.try(:ordered_member_ids)) # We want members in order, so extract from ordered_members.
       end
   end
   # rubocop:enable Style/ClassVars

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'wings'
 require 'wings/active_fedora_converter'
 
-RSpec.describe Wings::ActiveFedoraConverter do
+RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
   subject(:converter) { described_class.new(resource: resource) }
   let(:adapter)       { Valkyrie::Persistence::Memory::MetadataAdapter.new }
   let(:attributes)    { { id: id } }

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -79,11 +79,11 @@ RSpec.describe Wings::ActiveFedoraConverter do
         end
 
         it 'converts member_of_collection_ids back to af_object' do
-          expect(converter.convert.members.map(&:id)).to match_array [work2.id, work3.id]
+          expect(converter.convert.members.map(&:id)).to match_array [work3.id, work2.id]
         end
 
         it 'preserves order across conversion' do
-          expect(converter.convert.ordered_member_ids).to match_array [work2.id, work3.id]
+          expect(converter.convert.ordered_member_ids).to eq [work2.id, work3.id]
         end
       end
     end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
         let(:work3)       { build(:work, id: 'wk3', title: ['Work 3']) }
 
         before do
-          work1.members = [work2, work3]
+          work1.ordered_members = [work2, work3]
           work1.save!
         end
 

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe Wings::ActiveFedoraConverter do
         it 'converts member_of_collection_ids back to af_object' do
           expect(converter.convert.members.map(&:id)).to match_array [work2.id, work3.id]
         end
+
+        it 'preserves order across conversion' do
+          expect(converter.convert.ordered_member_ids).to match_array [work2.id, work3.id]
+        end
       end
     end
   end

--- a/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior, :clean_repo do
     let(:parent_work_resource) { resource }
 
     before do
-      work1.members = [work2, work3, fileset1, fileset2]
+      work1.ordered_members = [work2, work3, fileset1, fileset2]
       work1.save!
     end
 
@@ -111,7 +111,7 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior, :clean_repo do
     let(:parent_work_resource) { resource }
 
     before do
-      work1.members = [work2, work3, fileset1, fileset2]
+      work1.ordered_members = [work2, work3, fileset1, fileset2]
       work1.save!
     end
 
@@ -147,7 +147,7 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior, :clean_repo do
     let(:pcdm_object) { collection1 }
 
     before do
-      collection1.members = [work1, work2, collection2, collection3]
+      collection1.ordered_members = [work1, work2, collection2, collection3]
       collection1.save!
     end
 
@@ -181,7 +181,7 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior, :clean_repo do
     let(:pcdm_object) { collection1 }
 
     before do
-      collection1.members = [work1, work2, collection2, collection3]
+      collection1.ordered_members = [work1, work2, collection2, collection3]
       collection1.save!
     end
 
@@ -213,8 +213,8 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior, :clean_repo do
     let(:child_resource) { resource }
 
     before do
-      work1.members = [work3, fileset1]
-      work2.members = [work3, fileset2]
+      work1.ordered_members = [work3, fileset1]
+      work2.ordered_members = [work3, fileset2]
       work1.save!
       work2.save!
     end
@@ -254,9 +254,9 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior, :clean_repo do
     let(:child_resource) { resource }
 
     before do
-      collection1.members = [work1, collection3]
-      collection2.members = [work1, work2]
-      work3.members = [work1]
+      collection1.ordered_members = [work1, collection3]
+      collection2.ordered_members = [work1, work2]
+      work3.ordered_members = [work1]
       collection1.save!
       collection2.save!
     end
@@ -296,9 +296,9 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior, :clean_repo do
     let(:child_resource) { resource }
 
     before do
-      collection1.members = [work1, collection3]
-      collection2.members = [work1, work2]
-      work3.members = [work1]
+      collection1.ordered_members = [work1, collection3]
+      collection2.ordered_members = [work1, work2]
+      work3.ordered_members = [work1]
       collection1.save!
       collection2.save!
       work3.save!

--- a/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
@@ -330,4 +330,69 @@ RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior, :clean_repo do
       expect { resource.a_missing_method }.to raise_error NoMethodError
     end
   end
+
+  describe '#parent_works' do
+    let(:pcdm_object) { work3 }
+    let(:child_work_resource) { resource }
+
+    before do
+      work1.ordered_members = [work3]
+      work2.ordered_members = [work3]
+      work1.save!
+      work2.save!
+    end
+
+    context 'when valkyrie resources requested' do
+      it 'returns parent works as valkyrie resources through pcdm_valkyrie_behavior' do
+        resources = child_work_resource.parent_works(valkyrie: true)
+        expect(resources.map(&:work?)).to all(be true)
+        expect(resources.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
+      end
+    end
+    context 'when active fedora objects requested' do
+      it 'returns parent works as fedora objects through pcdm_valkyrie_behavior' do
+        af_objects = child_work_resource.parent_works(valkyrie: false)
+        expect(af_objects.map(&:work?)).to all(be true)
+        expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
+      end
+    end
+    context 'when return type is not specified' do
+      it 'returns parent works as fedora objects through pcdm_valkyrie_behavior' do
+        af_objects = child_work_resource.parent_works
+        expect(af_objects.map(&:work?)).to all(be true)
+        expect(af_objects.map(&:id)).to match_array [work1.id, work2.id]
+      end
+    end
+  end
+
+  describe '#parent_work_ids' do
+    let(:pcdm_object) { work3 }
+    let(:child_work_resource) { resource }
+
+    before do
+      work1.ordered_members = [work3]
+      work2.ordered_members = [work3]
+      work1.save!
+      work2.save!
+    end
+
+    context 'when valkyrie resources requested' do
+      it 'returns parent works as valkyrie resources through pcdm_valkyrie_behavior' do
+        resource_ids = child_work_resource.parent_work_ids(valkyrie: true)
+        expect(resource_ids).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
+      end
+    end
+    context 'when active fedora objects requested' do
+      it 'returns parent works as fedora objects through pcdm_valkyrie_behavior' do
+        af_object_ids = child_work_resource.parent_work_ids(valkyrie: false)
+        expect(af_object_ids).to match_array [work1.id, work2.id]
+      end
+    end
+    context 'when return type is not specified' do
+      it 'returns parent works as fedora objects through pcdm_valkyrie_behavior' do
+        af_object_ids = child_work_resource.parent_work_ids
+        expect(af_object_ids).to match_array [work1.id, work2.id]
+      end
+    end
+  end
 end

--- a/spec/wings/hydra/works/models/concerns/file_set_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/works/models/concerns/file_set_valkyrie_behavior_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Wings::Works::FileSetValkyrieBehavior, :clean_repo do
     let(:child_file_set_resource) { resource }
 
     before do
-      work1.members = [fileset1]
-      work2.members = [fileset1]
+      work1.ordered_members = [fileset1]
+      work2.ordered_members = [fileset1]
       work1.save!
       work2.save!
     end
@@ -63,8 +63,8 @@ RSpec.describe Wings::Works::FileSetValkyrieBehavior, :clean_repo do
     let(:child_file_set_resource) { resource }
 
     before do
-      work1.members = [fileset1]
-      work2.members = [fileset1]
+      work1.ordered_members = [fileset1]
+      work2.ordered_members = [fileset1]
       work1.save!
       work2.save!
     end

--- a/spec/wings/hydra/works/models/concerns/file_set_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/works/models/concerns/file_set_valkyrie_behavior_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe Wings::Works::FileSetValkyrieBehavior, :clean_repo do
 
     context 'when valkyrie resources requested' do
       it 'returns parent works as valkyrie resources through file_set_valkyrie_behavior' do
-        pending "TODO: Implementation of this method for valkyrie"
         resources = child_file_set_resource.parent_works(valkyrie: true)
         expect(resources.map(&:work?)).to all(be true)
         expect(resources.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
@@ -71,7 +70,6 @@ RSpec.describe Wings::Works::FileSetValkyrieBehavior, :clean_repo do
 
     context 'when valkyrie resources requested' do
       it 'returns parent works as valkyrie resources through file_set_valkyrie_behavior' do
-        pending "TODO: Implementation of this method for valkyrie"
         resource_ids = child_file_set_resource.parent_work_ids(valkyrie: true)
         expect(resource_ids).to match_valkyrie_ids_with_active_fedora_ids([work1.id, work2.id])
       end

--- a/spec/wings/hydra/works/models/concerns/work_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/works/models/concerns/work_valkyrie_behavior_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Wings::Works::WorkValkyrieBehavior, :clean_repo do
     work4.save!
     work5.ordered_members << work1
     work5.save!
-    work1.members = [work2, work3, fileset1, fileset2]
+    work1.ordered_members = [work2, work3, fileset1, fileset2]
     work1.save!
   end
 


### PR DESCRIPTION
Adding members via `#members=` does not add the member to the ordered relation, so that after a save, `#member_ids` contains objects, but `#ordered_member_ids` is empty. Since many parts of the code use `#ordered_members`, the converter should order the members.