### PR TITLE
add clean_repo to model tests

### DIFF
--- a/spec/wings/hydra/pcdm/models/concerns/collection_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/collection_valkyrie_behavior_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/model_transformer'
 
-RSpec.describe Wings::Pcdm::CollectionValkyrieBehavior do
+RSpec.describe Wings::Pcdm::CollectionValkyrieBehavior, :clean_repo do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 
   let(:collection1) { build(:public_collection_lw, id: 'col1', title: ['Collection 1']) }

--- a/spec/wings/hydra/pcdm/models/concerns/object_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/object_valkyrie_behavior_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/model_transformer'
 
-RSpec.describe Wings::Pcdm::ObjectValkyrieBehavior do
+RSpec.describe Wings::Pcdm::ObjectValkyrieBehavior, :clean_repo do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 
   let(:work1)       { build(:work, id: 'wk1', title: ['Work 1']) }

--- a/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/model_transformer'
 
-RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior do
+RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior, :clean_repo do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 
   let(:resource) { subject.build }

--- a/spec/wings/hydra/works/models/concerns/collection_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/works/models/concerns/collection_valkyrie_behavior_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/model_transformer'
 
-RSpec.describe Wings::Works::CollectionValkyrieBehavior do
+RSpec.describe Wings::Works::CollectionValkyrieBehavior, :clean_repo do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 
   let(:collection1) { build(:public_collection_lw, id: 'col1', title: ['Collection 1']) }

--- a/spec/wings/hydra/works/models/concerns/work_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/works/models/concerns/work_valkyrie_behavior_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/model_transformer'
 
-RSpec.describe Wings::Works::WorkValkyrieBehavior do
+RSpec.describe Wings::Works::WorkValkyrieBehavior, :clean_repo do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 
   let(:resource) { subject.build }


### PR DESCRIPTION
Some tests were getting back more objects when retrieving through relationships because objects created in other tests are bleeding over.  The solution is to add `:clean_repo` to the `RSpec.describe` statement to clean out fedora before the tests run.

Example:

```
RSpec.describe Wings::Pcdm::PcdmValkyrieBehavior, :clean_repo do
```