### PR TITLE
generate test app or return true for job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
 
     - run:
         name: Generate test app
-        command: (git diff --name-only master | grep -qiG 'generators\/hyrax') && bundle exec rake engine_cart:generate
+        command: (git diff --name-only master | grep -qG 'generators\/hyrax') && bundle exec rake engine_cart:generate || true
 
     - save_cache:
         key: v1-test-app-{{ checksum "template.rb" }}--{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
Fixes CircleCI build job failing. Command greps changed file names to find files in `*generators/hyrax*` and uses engine_cart to build if files are found, otherwise it returns `true` for a successful exit status code.  