### PR TITLE
revert build job to always build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
 
     - run:
         name: Generate test app
-        command: (git diff --name-only master | grep -qG 'generators\/hyrax') && bundle exec rake engine_cart:generate || true
+        command: (git diff --name-only master | grep -qG 'generators\/hyrax') || bundle exec rake engine_cart:generate
 
     - save_cache:
         key: v1-test-app-{{ checksum "template.rb" }}--{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
The `.internal_test_app` doesn’t exist in the circle ci cache, so while the build step is ignored the tests won’t work because the .internal_test_app doesn’t exist. 

Will follow-up with a ticket describing the problem and the future need for improvement.