### PR TITLE
add  _id attrs to wings roundtrip

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -30,7 +30,7 @@ module Wings
       attributes = ActiveFedoraAttributes.new(resource.attributes).result
       active_fedora_class.new(attributes).tap do |af_object|
         af_object.id = id unless id.empty?
-        af_object.visibility = attributes[:visibility]
+        af_object.visibility = attributes[:visibility] unless attributes[:visibility].blank?
         convert_members(af_object)
         convert_member_of_collections(af_object)
       end

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -69,11 +69,11 @@ module Wings
         attrs.delete(:created_at)
         attrs.delete(:updated_at)
         attrs.delete(:member_ids)
-
-        embargo_id         = attrs.delete(:embargo_id)
-        attrs[:embargo_id] = embargo_id.to_s unless embargo_id.nil? || embargo_id.empty?
-        lease_id          = attrs.delete(:lease_id)
-        attrs[:lease_id]  = lease_id.to_s unless lease_id.nil? || lease_id.empty?
+        # remove reflection id attributes and reinsert as strings
+        attrs.select { |k| k.to_s.end_with? '_id' }.each_key do |k|
+          val = attrs.delete(k)
+          attrs[k] = val.to_s unless val.blank?
+        end
         attrs.compact
       end
     end

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -30,6 +30,7 @@ module Wings
       attributes = ActiveFedoraAttributes.new(resource.attributes).result
       active_fedora_class.new(attributes).tap do |af_object|
         af_object.id = id unless id.empty?
+        af_object.visibility = attributes[:visibility]
         convert_members(af_object)
         convert_member_of_collections(af_object)
       end

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -166,13 +166,14 @@ module Wings
       end
     end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
 
-    class ActiveFedoraResource < ::Valkyrie::Resource
-      attribute :alternate_ids, ::Valkyrie::Types::Array
-      attribute :embargo_id,    ::Valkyrie::Types::ID
-      attribute :lease_id,      ::Valkyrie::Types::ID
-      attribute :visibility,    ::Valkyrie::Types::Symbol
+    class ActiveFedoraResource <    ::Valkyrie::Resource
+      attribute :alternate_ids,     ::Valkyrie::Types::Array
+      attribute :embargo_id,        ::Valkyrie::Types::ID
+      attribute :lease_id,          ::Valkyrie::Types::ID
+      attribute :representative_id, ::Valkyrie::Types::ID
+      attribute :thumbnail_id,      ::Valkyrie::Types::ID
+      attribute :visibility,        ::Valkyrie::Types::Symbol
     end
 
     class AttributeTransformer
@@ -195,12 +196,15 @@ module Wings
           pcdm_object.attributes.keys +
           self.class.relationship_keys_for(reflections: pcdm_object.reflections)
         AttributeTransformer.run(pcdm_object, all_keys)
-                            .merge(created_at: pcdm_object.try(:create_date),
-                                   updated_at: pcdm_object.try(:modified_date),
-                                   embargo_id: pcdm_object.try(:embargo)&.id,
-                                   lease_id:   pcdm_object.try(:lease)&.id,
-                                   visibility: pcdm_object.try(:visibility))
+                            .merge(created_at:        pcdm_object.try(:create_date),
+                                   updated_at:        pcdm_object.try(:modified_date),
+                                   embargo_id:        pcdm_object.try(:embargo)&.id,
+                                   lease_id:          pcdm_object.try(:lease)&.id,
+                                   representative_id: pcdm_object.try(:representative)&.id,
+                                   thumbnail_id:      pcdm_object.try(:thumbnail)&.id,
+                                   visibility:        pcdm_object.try(:visibility))
       end
   end
   # rubocop:enable Style/ClassVars
+  # rubocop:enable Metrics/AbcSize
 end

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -197,13 +197,13 @@ module Wings
           pcdm_object.attributes.keys +
           self.class.relationship_keys_for(reflections: pcdm_object.reflections)
         AttributeTransformer.run(pcdm_object, all_keys)
-                            .merge active_fedora_resource_reflection_ids
+                            .merge active_fedora_resource_attribute_ids
           .merge(created_at: pcdm_object.try(:create_date),
                  updated_at: pcdm_object.try(:modified_date),
                  visibility: pcdm_object.try(:visibility))
       end
 
-      def active_fedora_resource_reflection_ids
+      def active_fedora_resource_attribute_ids
         ActiveFedoraResource.fields.select { |k| k.to_s.end_with? '_id' }.each_with_object({}) do |k, mem|
           mem[k] = pcdm_object.try(k)
         end

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -166,6 +166,7 @@ module Wings
       end
     end
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     class ActiveFedoraResource <    ::Valkyrie::Resource
       attribute :alternate_ids,     ::Valkyrie::Types::Array
@@ -196,15 +197,17 @@ module Wings
           pcdm_object.attributes.keys +
           self.class.relationship_keys_for(reflections: pcdm_object.reflections)
         AttributeTransformer.run(pcdm_object, all_keys)
-                            .merge(created_at:        pcdm_object.try(:create_date),
-                                   updated_at:        pcdm_object.try(:modified_date),
-                                   embargo_id:        pcdm_object.try(:embargo)&.id,
-                                   lease_id:          pcdm_object.try(:lease)&.id,
-                                   representative_id: pcdm_object.try(:representative)&.id,
-                                   thumbnail_id:      pcdm_object.try(:thumbnail)&.id,
-                                   visibility:        pcdm_object.try(:visibility))
+                            .merge active_fedora_resource_reflection_ids
+          .merge(created_at: pcdm_object.try(:create_date),
+                 updated_at: pcdm_object.try(:modified_date),
+                 visibility: pcdm_object.try(:visibility))
+      end
+
+      def active_fedora_resource_reflection_ids
+        ActiveFedoraResource.fields.select { |k| k.to_s.end_with? '_id' }.each_with_object({}) do |k, mem|
+          mem[k] = pcdm_object.try(k)
+        end
       end
   end
   # rubocop:enable Style/ClassVars
-  # rubocop:enable Metrics/AbcSize
 end


### PR DESCRIPTION
refs #3604

Add representative_id and thumbnail_id from object reflections to the list of attributes in the ModelTransformer following the current syntax (currently contains embargo_id and lease_id); their presence is tested in file_set_actor_spec.
Adds reflection ids if they contain values in ActiveFedoraConverter