### PR TITLE
allow tabbing to reach "Add files..." and "Add folder..."

### DIFF
--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -13,17 +13,23 @@
           <div class="row">
             <div class="col-xs-12">
                 <!-- The fileinput-button span is used to style the file input field as button -->
-                <span id="addfiles" class="btn btn-success fileinput-button">
-                    <span class="glyphicon glyphicon-plus"></span>
-                    <span><%=  t(".add_files") %></span>
-                    <input type="file" name="files[]" multiple />
-                </span>
+                <!-- The a tag and the tabIndex="-1" is used to allow tabbing on page to work -->
+                <a href="#" onclick="return false;">
+                    <span id="addfiles" class="btn btn-success fileinput-button">
+                        <span class="glyphicon glyphicon-plus"></span>
+                        <span><%=  t(".add_files") %></span>
+                        <input tabIndex="-1" type="file" name="files[]" multiple />
+                    </span>
+                </a>
                 <!-- The fileinput-button span is used to style the file input field as button -->
-                <span id="addfolder" class="btn btn-success fileinput-button">
-                    <span class="glyphicon glyphicon-plus"></span>
-                    <span><%=  t(".add_folder") %></span>
-                    <input type="file" name="files[]" multiple directory webkitdirectory />
-                </span>
+                <!-- The a tag and the tabIndex="-1" is used to allow tabbing on page to work -->
+                <a href="#" onclick="return false;">
+                    <span id="addfolder" class="btn btn-success fileinput-button">
+                        <span class="glyphicon glyphicon-plus"></span>
+                        <span><%=  t(".add_folder") %></span>
+                        <input tabIndex="-1" type="file" name="files[]" multiple directory webkitdirectory />
+                    </span>
+                </a>
                 <% if Hyrax.config.browse_everything? %>
                   <%= button_tag(type: 'button', class: 'btn btn-success', id: "browse-btn",
                     'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,


### PR DESCRIPTION
Fixes #3451

This change allows tabbing to reach the "Add files..." and the "Add folder..." buttons on the page where the user uploads files for a work.  Because of the way these buttons are created using an input within a span that has  opacity set to 0, when the user tabs to the input, the input ( which thanks to the span looks like a button ) was not highlighting.  Increasing the opacity number exposed the input, but the button did not look right ( it displayed unwanted text ).  The other solution might have been to convert these inputs to buttons, but that would make things perhaps too complicated.  By setting the tabIndex="-1" for the inputs and adding the `a` tag, the desired effect was achieved.


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to the dashboard.
* Select to Add a new work
* Go to the Tab where you upload files.
* tab within the page, you should see the "Add files..." and "Add folder..." buttons highlight.

@samvera/hyrax-code-reviewers
