### PR TITLE
add navigator services to find child members for various model parts

### DIFF
--- a/lib/wings/navigators/child_collections_navigator.rb
+++ b/lib/wings/navigators/child_collections_navigator.rb
@@ -1,0 +1,35 @@
+# Navigate from a resource to the child collections in the resource.
+module Wings
+  class ChildCollectionsNavigator
+    # Define the queries that can be fulfilled by this navigator.
+    def self.queries
+      [:find_child_collections, :find_child_collection_ids]
+    end
+
+    attr_reader :query_service
+
+    def initialize(query_service:)
+      @query_service = query_service
+    end
+
+    # Find child collections of a given resource, and map to Valkyrie Resources
+    # @param [Valkyrie::Resource]
+    # @return [Array<Valkyrie::Resource>]
+    # TODO: By storing all children in a single relationship, it requires that the full resource be constructed for all children
+    #       and then selecting only the children of a particular type to return.
+    def find_child_collections(resource:)
+      query_service.find_members(resource: resource).select(&:collection?)
+    end
+
+    # Find the ids of child collections of a given resource, and map to Valkyrie Resources
+    # @param [Valkyrie::Resource]
+    # @return [Array<Valkyrie::ID>]
+    # TODO: By storing all children in a single relationship, it requires that the full resource be constructed for all children
+    #       and then selecting only the children of a particular type.  If we stored collections in a collections relationship and
+    #       works in a works relationship, then a request for IDs would return all ids from the relationship and not instantiate
+    #       any resources.
+    def find_child_collection_ids(resource:)
+      find_child_collections(resource: resource).map(&:id)
+    end
+  end
+end

--- a/lib/wings/navigators/child_filesets_navigator.rb
+++ b/lib/wings/navigators/child_filesets_navigator.rb
@@ -1,0 +1,35 @@
+# Navigate from a resource to the child filesets in the resource.
+module Wings
+  class ChildFilesetsNavigator
+    # Define the queries that can be fulfilled by this navigator.
+    def self.queries
+      [:find_child_filesets, :find_child_fileset_ids]
+    end
+
+    attr_reader :query_service
+
+    def initialize(query_service:)
+      @query_service = query_service
+    end
+
+    # Find child filesets of a given resource, and map to Valkyrie Resources
+    # @param [Valkyrie::Resource]
+    # @return [Array<Valkyrie::Resource>]
+    # TODO: By storing all children in a single relationship, it requires that the full resource be constructed for all children
+    #       and then selecting only the children of a particular type to return.
+    def find_child_filesets(resource:)
+      query_service.find_members(resource: resource).select(&:file_set?)
+    end
+
+    # Find the ids of child filesets of a given resource, and map to Valkyrie Resources
+    # @param [Valkyrie::Resource]
+    # @return [Array<Valkyrie::ID>]
+    # TODO: By storing all children in a single relationship, it requires that the full resource be constructed for all children
+    #       and then selecting only the children of a particular type.  If we stored works in a works relationship and filesets
+    #       in a filesets relationship, then a request for IDs would return all ids from the relationship and not instantiate
+    #       any resources.
+    def find_child_fileset_ids(resource:)
+      find_child_filesets(resource: resource).map(&:id)
+    end
+  end
+end

--- a/lib/wings/navigators/child_works_navigator.rb
+++ b/lib/wings/navigators/child_works_navigator.rb
@@ -1,0 +1,35 @@
+# Navigate from a resource to the child works in the resource.
+module Wings
+  class ChildWorksNavigator
+    # Define the queries that can be fulfilled by this navigator.
+    def self.queries
+      [:find_child_works, :find_child_work_ids]
+    end
+
+    attr_reader :query_service
+
+    def initialize(query_service:)
+      @query_service = query_service
+    end
+
+    # Find child works of a given resource, and map to Valkyrie Resources
+    # @param [Valkyrie::Resource]
+    # @return [Array<Valkyrie::Resource>]
+    # TODO: By storing all children in a single relationship, it requires that the full resource be constructed for all children
+    #       and then selecting only the children of a particular type to return.
+    def find_child_works(resource:)
+      query_service.find_members(resource: resource).select(&:work?)
+    end
+
+    # Find the ids of child works of a given resource, and map to Valkyrie Resources
+    # @param [Valkyrie::Resource]
+    # @return [Array<Valkyrie::ID>]
+    # TODO: By storing all children in a single relationship, it requires that the full resource be constructed for all children
+    #       and then selecting only the children of a particular type.  If we stored works in a works relationship and filesets
+    #       in a filesets relationship, then a request for IDs would return all ids from the relationship and not instantiate
+    #       any resources.
+    def find_child_work_ids(resource:)
+      find_child_works(resource: resource).map(&:id)
+    end
+  end
+end

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -89,17 +89,11 @@ module Wings
       # @param [Valkyrie::ResourceClass]
       # @return [Array<Valkyrie::Resource>]
       def find_members(resource:, model: nil)
+        return [] unless resource.respond_to?(:member_ids) && resource.member_ids.present?
+        all_members = find_many_by_ids(ids: resource.member_ids)
+        return all_members unless model
         find_model = model.internal_resource.constantize if model
-        member_list = resource_factory.from_resource(resource: resource).try(:members)
-        return [] unless member_list
-        if model
-          member_list = member_list.select do |obj|
-            obj.class == find_model
-          end
-        end
-        member_list.map do |obj|
-          resource_factory.to_resource(object: obj)
-        end
+        all_members.select { |member_resource| member_resource.internal_resource.constantize == find_model }
       end
 
       # Find the Valkyrie Resources referenced by another Valkyrie Resource

--- a/spec/wings/navigators/child_collections_navigator_spec.rb
+++ b/spec/wings/navigators/child_collections_navigator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/model_transformer'
+require 'wings/navigators/child_collections_navigator'
+
+RSpec.describe Wings::ChildCollectionsNavigator, :clean_repo do
+  subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
+
+  let(:resource) { subject.build }
+
+  let(:adapter) { Wings::Valkyrie::MetadataAdapter.new }
+  let(:query_service) { Wings::Valkyrie::QueryService.new(adapter: adapter) }
+  let(:navigator) { described_class.new(query_service: query_service) }
+
+  let(:collection1)    { build(:collection, id: 'col1', title: ['Collection 1']) }
+  let(:collection2)    { build(:collection, id: 'col2', title: ['Child Collection 1']) }
+  let(:collection3)    { build(:collection, id: 'col3', title: ['Child Collection 2']) }
+  let(:work1) { build(:work, id: 'wk1', title: ['Child Work 1']) }
+  let(:work2) { build(:work, id: 'wk2', title: ['Child Work 2']) }
+
+  describe '#find_child_collections' do
+    let(:pcdm_object) { collection1 }
+    let(:collection1_resource) { resource }
+
+    before do
+      collection1.members = [collection2, collection3, work1, work2]
+      collection1.save!
+    end
+
+    it 'returns only child collections as Valkyrie resources' do
+      child_collections = navigator.find_child_collections(resource: collection1_resource)
+      expect(child_collections.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([collection2.id, collection3.id])
+    end
+  end
+
+  describe '#find_child_collection_ids' do
+    let(:pcdm_object) { collection1 }
+    let(:collection1_resource) { resource }
+
+    before do
+      collection1.members = [collection2, collection3, work1, work2]
+      collection1.save!
+    end
+
+    it 'returns Valkyrie ids for child collections only' do
+      child_collections = navigator.find_child_collections(resource: collection1_resource)
+      expect(child_collections.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([collection2.id, collection3.id])
+    end
+  end
+end

--- a/spec/wings/navigators/child_filesets_navigator_spec.rb
+++ b/spec/wings/navigators/child_filesets_navigator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/model_transformer'
+require 'wings/navigators/child_filesets_navigator'
+
+RSpec.describe Wings::ChildFilesetsNavigator, :clean_repo do
+  subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
+
+  let(:resource) { subject.build }
+
+  let(:adapter) { Wings::Valkyrie::MetadataAdapter.new }
+  let(:query_service) { Wings::Valkyrie::QueryService.new(adapter: adapter) }
+  let(:navigator) { described_class.new(query_service: query_service) }
+
+  let(:work1)    { build(:work, id: 'wk1', title: ['Work 1']) }
+  let(:work2)    { build(:work, id: 'wk2', title: ['Child Work 1']) }
+  let(:work3)    { build(:work, id: 'wk3', title: ['Child Work 2']) }
+  let(:fileset1) { build(:file_set, id: 'fs1', title: ['Child File Set 1']) }
+  let(:fileset2) { build(:file_set, id: 'fs2', title: ['Child File Set 2']) }
+
+  describe '#find_child_filesets' do
+    let(:pcdm_object) { work1 }
+    let(:work1_resource) { resource }
+
+    before do
+      work1.members = [work2, work3, fileset1, fileset2]
+      work1.save!
+    end
+
+    it 'returns only child filesets as Valkyrie resources' do
+      child_filesets = navigator.find_child_filesets(resource: work1_resource)
+      expect(child_filesets.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([fileset1.id, fileset2.id])
+    end
+  end
+
+  describe '#find_child_fileset_ids' do
+    let(:pcdm_object) { work1 }
+    let(:work1_resource) { resource }
+
+    before do
+      work1.members = [work2, work3, fileset1, fileset2]
+      work1.save!
+    end
+
+    it 'returns Valkyrie ids for child filesets only' do
+      child_fileset_ids = navigator.find_child_fileset_ids(resource: work1_resource)
+      expect(child_fileset_ids).to match_valkyrie_ids_with_active_fedora_ids([fileset1.id, fileset2.id])
+    end
+  end
+end

--- a/spec/wings/navigators/child_works_navigator_spec.rb
+++ b/spec/wings/navigators/child_works_navigator_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/model_transformer'
+require 'wings/navigators/child_works_navigator'
+
+RSpec.describe Wings::ChildWorksNavigator, :clean_repo do
+  subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
+
+  let(:resource) { subject.build }
+
+  let(:adapter) { Wings::Valkyrie::MetadataAdapter.new }
+  let(:query_service) { Wings::Valkyrie::QueryService.new(adapter: adapter) }
+  let(:navigator) { described_class.new(query_service: query_service) }
+
+  let(:collection1)    { build(:collection, id: 'col1', title: ['Collection 1']) }
+  let(:collection2)    { build(:collection, id: 'col2', title: ['Child Collection 1']) }
+  let(:collection3)    { build(:collection, id: 'col3', title: ['Child Collection 2']) }
+  let(:work1)    { build(:work, id: 'wk1', title: ['Work 1']) }
+  let(:work2)    { build(:work, id: 'wk2', title: ['Child Work 1']) }
+  let(:work3)    { build(:work, id: 'wk3', title: ['Child Work 2']) }
+  let(:fileset1) { build(:file_set, id: 'fs1', title: ['Child File Set 1']) }
+  let(:fileset2) { build(:file_set, id: 'fs2', title: ['Child File Set 2']) }
+
+  describe '#find_child_works' do
+    context 'on a collection' do
+      let(:pcdm_object) { collection1 }
+      let(:collection1_resource) { resource }
+
+      before do
+        collection1.members = [collection2, collection3, work2, work1]
+        collection1.save!
+      end
+
+      it 'returns only child works as Valkyrie resources' do
+        child_works = navigator.find_child_works(resource: collection1_resource)
+        expect(child_works.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([work2.id, work1.id])
+      end
+    end
+
+    context 'on a work' do
+      let(:pcdm_object) { work1 }
+      let(:work1_resource) { resource }
+
+      before do
+        work1.members = [work2, work3, fileset1, fileset2]
+        work1.save!
+      end
+
+      it 'returns only child works as Valkyrie resources' do
+        child_works = navigator.find_child_works(resource: work1_resource)
+        expect(child_works.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([work2.id, work3.id])
+      end
+    end
+  end
+
+  describe '#find_child_work_ids' do
+    context 'on a collection' do
+      let(:pcdm_object) { collection1 }
+      let(:collection1_resource) { resource }
+
+      before do
+        collection1.members = [collection2, collection3, work2, work1]
+        collection1.save!
+      end
+
+      it 'returns Valkyrie ids for child works only' do
+        child_work_ids = navigator.find_child_work_ids(resource: collection1_resource)
+        expect(child_work_ids).to match_valkyrie_ids_with_active_fedora_ids([work2.id, work1.id])
+      end
+    end
+
+    context 'on a work' do
+      let(:pcdm_object) { work1 }
+      let(:work1_resource) { resource }
+
+      before do
+        work1.members = [work2, work3, fileset1, fileset2]
+        work1.save!
+      end
+
+      it 'returns Valkyrie ids for child works only' do
+        child_work_ids = navigator.find_child_work_ids(resource: work1_resource)
+        expect(child_work_ids).to match_valkyrie_ids_with_active_fedora_ids([work2.id, work3.id])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3713

* find_child_collections/collection_ids
* find_child_works/work_ids
* find_child_filesets/fileset_ids

These use the query service methods to get members.  As the query service moves to pure valkyrie, these methods will become pure valkyrie without any changes.

----
*Design Question*

Right now, all children are stored in a single members relationship.  Because of this, to get_works, you instantiate all member resources and then keep only the work resources.

A more efficient approach would be to have work members and fileset members.  Then you can get only works or only filesets.  Additionally, in this approach, if you only want ids, you won’t have to instantiate any resources to get just work ids or just fileset ids.
