### PR TITLE
when downloading from Box, use label for filename 

### DIFF
--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -62,7 +62,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
     # @param uri [URI] the uri of the file to download
     # @yield [IO] the stream to write to
     def copy_remote_file(uri, headers = {})
-      filename = File.basename(uri.path)
+      filename = file_set.label
       dir = Dir.mktmpdir
       Rails.logger.debug("ImportUrlJob: Copying <#{uri}> to #{dir}")
 

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -3,10 +3,11 @@ RSpec.describe ImportUrlJob do
 
   let(:file_path) { fixture_path + '/world.png' }
   let(:file_hash) { '/673467823498723948237462429793840923582' }
+  let(:file_name) { 'world.png' }
 
   let(:file_set) do
     FileSet.new(import_url: "http://example.org#{file_hash}",
-                label: file_path) do |f|
+                label: file_name) do |f|
       f.apply_depositor_metadata(user.user_key)
     end
   end
@@ -74,7 +75,7 @@ RSpec.describe ImportUrlJob do
 
     it 'leaves the temp directory in place' do
       described_class.perform_now(file_set, operation)
-      expect(File.exist?(File.join(tmpdir, file_hash))).to be true
+      expect(File.exist?(File.join(tmpdir, file_name))).to be true
     end
   end
 


### PR DESCRIPTION
Fixes #1684

Presently when downloading from Box, the file(s) downloaded take(s) on the name "download".  By setting the filename to the label in file_set, this is remedied.  

Guidance for testing, such as acceptance criteria or new user interface behaviors:

* When testing this on local, you will have to create an app for box.  From this page https://developer.box.com/docs/authenticate-with-developer-token go to the link to "developer console" .  There, create an app and in the config section for your new app, you will be able to get the client_id and client_secrete which you will have to update .internal_test_app/config/browse_everything_providers.yml  with.

<img width="992" alt="Screen Shot 2019-03-26 at 3 51 00 PM" src="https://user-images.githubusercontent.com/11095558/55028916-44acfe00-4fdf-11e9-8e26-f268370cd978.png">

* Either create a new work or Edit an existing work.  
* Select the "Files" tab
* Select the button "Add cloud files..."
* Select a few files from Box
* Save the work.
* Go the the work page and try to download the files you just uploaded from Box.
* The files you downloaded should have the appropriate filename 

@samvera/hyrax-code-reviewers
