### PR TITLE
Remove second occurrence of :height

### DIFF
--- a/app/presenters/hyrax/characterization_behavior.rb
+++ b/app/presenters/hyrax/characterization_behavior.rb
@@ -5,7 +5,7 @@ module Hyrax
     class_methods do
       def characterization_terms
         [
-          :byte_order, :compression, :height, :width, :height, :color_space,
+          :byte_order, :compression, :height, :width, :color_space,
           :profile_name, :profile_version, :orientation, :color_map, :image_producer,
           :capture_device, :scanning_software, :gps_timestamp, :latitude, :longitude,
           :file_format, :file_title, :page_count, :duration, :sample_rate,


### PR DESCRIPTION
Fixes #3719 

Remove second occurrence of :height 

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* No app behavior should change.

@samvera/hyrax-code-reviewers
