### PR TITLE
Fix flaky collection type spec

### DIFF
--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -372,6 +372,7 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
           expect(page).to have_content(deny_delete_modal_text)
           click_link('View collections of this type')
         end
+        sleep 3
 
         # forwards to Dashboard -> Collections -> All Collections
         within('li.active') do


### PR DESCRIPTION
References https://github.com/samvera/hyrax/issues/3192 to fix collection type spec error at line 366.

The modal click often took too long, and the capybara sleep statement doesn't get triggered until it passes `within('li.active')`. Adding a 3 second sleep seems to be enough for the new page to load.

Note: This PR does not close issue 3192

@samvera/hyrax-code-reviewers
