### PR TITLE
Extends Wings::ActiveFedoraConverter in order to normalize values passed to the ActiveFedora::Base constructor (should scalar values need to be Arrays)

### DIFF
--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Wings::Valkyrie::Persister do
       expect(output.depositor).to be_nil
     end
 
-    xit "stores created_at/updated_at" do
+    it "stores created_at/updated_at" do
       book = persister.save(resource: resource_class.new)
       book.title = "test"
       book = persister.save(resource: book)


### PR DESCRIPTION
Resolves #3664 