### PR TITLE
Use Valkyrie when creating objects through the `BaseActor` 

### DIFF
--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -19,7 +19,7 @@ module Hyrax
         apply_creation_data_to_curation_concern(env)
         apply_save_data_to_curation_concern(env)
 
-        save(env, use_valkyrie: false) &&
+        save(env, use_valkyrie: true) &&
           next_actor.create(env) &&
           run_callbacks(:after_create_concern, env)
       end

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -66,7 +66,7 @@ module Wings
          :updated_at, :member_ids]
           .map { |key| attrs.delete(key) }
 
-        [:admin_set_id, :embargo_id, :lease_id]
+        [:admin_set_id, :embargo_id, :lease_id, :access_control_id]
           .map { |name| stringify_id_field(attrs, name: name) }
 
         attrs.compact

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -62,20 +62,22 @@ module Wings
         # handling for reflections needs to happen in future work
         attrs = attributes.reject { |k, _| k.to_s.end_with? '_ids' }
 
-        attrs.delete(:internal_resource)
-        attrs.delete(:new_record)
-        attrs.delete(:id)
-        attrs.delete(:alternate_ids)
-        attrs.delete(:created_at)
-        attrs.delete(:updated_at)
-        attrs.delete(:member_ids)
+        [:internal_resource, :new_record, :id, :alternate_ids, :created_at,
+         :updated_at, :member_ids]
+          .map { |key| attrs.delete(key) }
 
-        embargo_id         = attrs.delete(:embargo_id)
-        attrs[:embargo_id] = embargo_id.to_s unless embargo_id.nil? || embargo_id.empty?
-        lease_id          = attrs.delete(:lease_id)
-        attrs[:lease_id]  = lease_id.to_s unless lease_id.nil? || lease_id.empty?
+        [:admin_set_id, :embargo_id, :lease_id]
+          .map { |name| stringify_id_field(attrs, name: name) }
+
         attrs.compact
       end
+
+      private
+
+        def stringify_id_field(attrs, name:)
+          value       = attrs.delete(name)
+          attrs[name] = value.to_s unless value.nil? || value.empty?
+        end
     end
 
     ##

--- a/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
+++ b/lib/wings/hydra/works/models/concerns/work_valkyrie_behavior.rb
@@ -30,6 +30,8 @@ module Wings
         child_objects(valkyrie: valkyrie).select(&:work?)
       end
       alias works child_works
+      alias member_works child_works
+      alias member_objects child_works
 
       # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
       # @return [Enumerable<String> | Enumerable<Valkerie::ID] The ids of the works this work contains
@@ -37,6 +39,8 @@ module Wings
         child_works(valkyrie: valkyrie).map(&:id)
       end
       alias work_ids child_work_ids
+      alias member_work_ids child_work_ids
+      alias member_object_ids child_work_ids
 
       # @param valkyrie [Boolean] Should the returned resources be Valkyrie or AF objects?
       # @return [Enumerable<Hydra::Works::FileSet>] The file sets this work contains

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -53,7 +53,10 @@ module Wings
                       .keys
                       .reject { |k| k.to_s.include?('id') }
                       .map { |k| k.to_s.singularize + '_ids' }
-      relationships.delete(:member_ids) # Remove here.  Members will be extracted as ordered_members in attributes method.
+      # Remove here.  Members will be extracted as ordered_members in attributes method.
+      relationships.delete(:member_ids)
+
+      relationships.delete('admin_set_ids')
       relationships
     end
 
@@ -171,6 +174,7 @@ module Wings
     # rubocop:enable Metrics/AbcSize
 
     class ActiveFedoraResource < ::Valkyrie::Resource
+      attribute :admin_set_id,  ::Valkyrie::Types::ID
       attribute :alternate_ids, ::Valkyrie::Types::Array
       attribute :embargo_id,    ::Valkyrie::Types::ID
       attribute :lease_id,      ::Valkyrie::Types::ID
@@ -197,12 +201,13 @@ module Wings
           pcdm_object.attributes.keys +
           self.class.relationship_keys_for(reflections: pcdm_object.reflections)
         AttributeTransformer.run(pcdm_object, all_keys)
-                            .merge(created_at: pcdm_object.try(:create_date),
-                                   updated_at: pcdm_object.try(:modified_date),
-                                   embargo_id: pcdm_object.try(:embargo)&.id,
-                                   lease_id:   pcdm_object.try(:lease)&.id,
-                                   visibility: pcdm_object.try(:visibility),
-                                   member_ids: pcdm_object.try(:ordered_member_ids)) # We want members in order, so extract from ordered_members.
+                            .merge(created_at:   pcdm_object.try(:create_date),
+                                   updated_at:   pcdm_object.try(:modified_date),
+                                   admin_set_id: pcdm_object.try(:admin_set_id),
+                                   embargo_id:   pcdm_object.try(:embargo)&.id,
+                                   lease_id:     pcdm_object.try(:lease)&.id,
+                                   visibility:   pcdm_object.try(:visibility),
+                                   member_ids:   pcdm_object.try(:ordered_member_ids)) # We want members in order, so extract from ordered_members.
       end
   end
   # rubocop:enable Style/ClassVars

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -197,20 +197,22 @@ module Wings
         ::Noid::Rails.config.minter_class.new.mint
       end
 
+      # rubocop:disable Metrics/AbcSize
       def attributes
         all_keys =
           pcdm_object.attributes.keys +
           self.class.relationship_keys_for(reflections: pcdm_object.reflections)
         AttributeTransformer.run(pcdm_object, all_keys)
-                            .merge(created_at:   pcdm_object.try(:create_date),
-                                   updated_at:   pcdm_object.try(:modified_date),
-                                   admin_set_id: pcdm_object.try(:admin_set_id),
-                                   embargo_id:   pcdm_object.try(:embargo)&.id,
+                            .merge(created_at:          pcdm_object.try(:create_date),
+                                   updated_at:          pcdm_object.try(:modified_date),
+                                   admin_set_id:        pcdm_object.try(:admin_set_id),
+                                   embargo_id:          pcdm_object.try(:embargo)&.id,
                                    access_control_id:   pcdm_object.try(:access_control_id),
-                                   lease_id:     pcdm_object.try(:lease)&.id,
-                                   visibility:   pcdm_object.try(:visibility),
-                                   member_ids:   pcdm_object.try(:ordered_member_ids)) # We want members in order, so extract from ordered_members.
+                                   lease_id:            pcdm_object.try(:lease)&.id,
+                                   visibility:          pcdm_object.try(:visibility),
+                                   member_ids:          pcdm_object.try(:ordered_member_ids)) # We want members in order, so extract from ordered_members.
       end
+    # rubocop:enable Metrics/AbcSize
   end
   # rubocop:enable Style/ClassVars
 end

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -178,7 +178,8 @@ module Wings
       attribute :alternate_ids, ::Valkyrie::Types::Array
       attribute :embargo_id,    ::Valkyrie::Types::ID
       attribute :lease_id,      ::Valkyrie::Types::ID
-      attribute :visibility,    ::Valkyrie::Types::Symbol
+      attribute :access_control_id, ::Valkyrie::Types::ID
+      attribute :visibility, ::Valkyrie::Types::Symbol
     end
 
     class AttributeTransformer
@@ -205,6 +206,7 @@ module Wings
                                    updated_at:   pcdm_object.try(:modified_date),
                                    admin_set_id: pcdm_object.try(:admin_set_id),
                                    embargo_id:   pcdm_object.try(:embargo)&.id,
+                                   access_control_id:   pcdm_object.try(:access_control_id),
                                    lease_id:     pcdm_object.try(:lease)&.id,
                                    visibility:   pcdm_object.try(:visibility),
                                    member_ids:   pcdm_object.try(:ordered_member_ids)) # We want members in order, so extract from ordered_members.

--- a/spec/actors/hyrax/actors/generic_work_actor_spec.rb
+++ b/spec/actors/hyrax/actors/generic_work_actor_spec.rb
@@ -90,6 +90,15 @@ RSpec.describe Hyrax::Actors::GenericWorkActor do
         end
       end
 
+      context 'with an admin_set' do
+        let(:curation_concern) { build(:generic_work, admin_set: admin_set, user: user) }
+
+        it 'assigns the admin_set' do
+          expect(middleware.create(env)).to be true
+          expect(curation_concern.reload.admin_set).to eq admin_set
+        end
+      end
+
       context 'with in_work_ids' do
         let(:parent) { create(:generic_work, user: user) }
         let(:attributes) do

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       it 'populates reflections'
     end
 
+    context 'with an admin_set' do
+      let(:admin_set) { FactoryBot.create(:admin_set) }
+      let(:work)      { FactoryBot.create(:work, admin_set: admin_set) }
+
+      it 'repopulates the admin_set' do
+        expect(converter.convert).to have_attributes(admin_set_id: work.admin_set_id)
+      end
+    end
+
     context 'with an embargo' do
       let(:work) { FactoryBot.create(:embargoed_work) }
 

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -117,6 +117,13 @@ RSpec.describe Wings::ModelTransformer do
                             source: work.source
     end
 
+    it 'has an admin set id matching the pcdm object' do
+      work.admin_set = admin_set = create(:admin_set)
+
+      expect(factory.build)
+        .to have_attributes admin_set_id: Valkyrie::ID.new(admin_set.id)
+    end
+
     context 'without an existing id' do
       let(:id)        { nil }
       let(:minted_id) { 'bobross' }


### PR DESCRIPTION
Turn on valkyrie in `BaseActor#create`. This is the first use of Valkyrie in live code!

To achieve this, we need support for admin sets in Wings: `admin_set_id` needs to be retained when casting from `ActiveFedora` to `Valkyrie`. Support for that is added through changes to the `ModelTransformer` and `ActiveFedoraConverter`.

A minor refactor in `ActiveFedoraConverter` reduces duplicate code that was expanding somewhat through this work.

Changes proposed in this pull request:
* Use valkyrie in production!

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* This should be a non-functional change.

@samvera/hyrax-code-reviewers
