### PR TITLE
Wings add attrs roundtrip

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -71,10 +71,11 @@ module Wings
         attrs.delete(:updated_at)
         attrs.delete(:member_ids)
 
-        embargo_id         = attrs.delete(:embargo_id)
-        attrs[:embargo_id] = embargo_id.to_s unless embargo_id.nil? || embargo_id.empty?
-        lease_id          = attrs.delete(:lease_id)
-        attrs[:lease_id]  = lease_id.to_s unless lease_id.nil? || lease_id.empty?
+        # remove reflection id attributes and reinsert as strings
+        attrs.select { |k| k.to_s.end_with? '_id' }.each_key do |k|
+          val = attrs.delete(k)
+          attrs[k] = val.to_s unless val.blank?
+        end
         attrs.compact
       end
     end

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -30,6 +30,7 @@ module Wings
       attributes = ActiveFedoraAttributes.new(resource.attributes).result
       active_fedora_class.new(attributes).tap do |af_object|
         af_object.id = id unless id.empty?
+        af_object.visibility = attributes[:visibility] unless attributes[:visibility].blank?
         convert_members(af_object)
         convert_member_of_collections(af_object)
       end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -60,6 +60,19 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       end
     end
 
+    context 'with a generic work that has open visibility' do
+      let(:attributes) do
+        FactoryBot.attributes_for(:generic_work)
+      end
+      before do
+        work.visibility = "open"
+      end
+
+      it 'sets the visibility' do
+        expect(converter.convert).to have_attributes(visibility: work.visibility)
+      end
+    end
+
     context 'with relationships' do
       subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -44,6 +44,22 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       end
     end
 
+    context 'with a generic work with _id attributes' do
+      let(:work) { FactoryBot.create(:work_with_representative_file, with_admin_set: true) }
+      before do
+        work.thumbnail_id = work.representative_id
+      end
+
+      it 'repopulates the _id attributes' do
+        expect(converter.convert).to have_attributes(
+          representative_id: work.representative_id,
+          thumbnail_id: work.thumbnail_id,
+          access_control_id: work.access_control_id,
+          admin_set_id: work.admin_set_id
+        )
+      end
+    end
+
     context 'with relationships' do
       subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -145,6 +145,21 @@ RSpec.describe Wings::ModelTransformer do
     end
   end
 
+  context 'with _id attributes' do
+    let(:work) { FactoryBot.create(:work_with_representative_file, with_admin_set: true) }
+    before do
+      work.thumbnail_id = work.representative_id
+    end
+
+    it 'repopulates the _id attributes' do
+      resource = subject.build
+      expect(resource[:representative_id].to_s).to eq(work.representative_id)
+      expect(resource[:thumbnail_id].to_s).to eq(work.thumbnail_id)
+      expect(resource[:access_control_id].to_s).to eq(work.access_control_id)
+      expect(resource[:admin_set_id].to_s).to eq(work.admin_set_id)
+    end
+  end
+
   context 'with relationship properties' do
     let(:pcdm_object) { book }
     let(:id)          { 'moomin123' }

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -160,6 +160,16 @@ RSpec.describe Wings::ModelTransformer do
     end
   end
 
+  context 'with a generic work that has open visibility' do
+    before do
+      work.visibility = "open"
+    end
+
+    it 'sets the visibility' do
+      expect(subject.build.visibility).to eq(work.visibility)
+    end
+  end
+
   context 'with relationship properties' do
     let(:pcdm_object) { book }
     let(:id)          { 'moomin123' }


### PR DESCRIPTION
refs #3604 

This adds _id attributes from the object reflections to the roundtrip wings conversion, the presence of which are tested in file_set_actor_spec. Also sets visibility in ActiveFedoraConverter when the property is present in the attributes saved in the resource.





