### PR TITLE
Relabel the links for private child works from 'File'

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -116,7 +116,7 @@ module Hyrax
     end
 
     def link_name
-      current_ability.can?(:read, id) ? to_s : 'File'
+      current_ability.can?(:read, id) ? to_s : 'Private'
     end
 
     def export_as_nt


### PR DESCRIPTION
"File" isn't an accurate description of a work. When a child work isn't readable, just list it as "Private" instead.

@samvera/hyrax-code-reviewers
