### PR TITLE
add wings to file_set_actor

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -7,9 +7,10 @@ module Hyrax
       include Lockable
       attr_reader :file_set, :user, :attributes
 
-      def initialize(file_set, user)
+      def initialize(file_set, user, use_valkyrie: false)
         @file_set = file_set
         @user = user
+        @use_valkyrie = use_valkyrie
       end
 
       # @!group Asynchronous Operations
@@ -23,7 +24,7 @@ module Hyrax
         # If the file set doesn't have a title or label assigned, set a default.
         file_set.label ||= label_for(file)
         file_set.title = [file_set.label] if file_set.title.blank?
-        return false unless save(file_set, use_valkyrie: false) # Need to save to get an id
+        return false unless save(file_set, use_valkyrie: @use_valkyrie) # Need to save to get an id
         if from_url
           # If ingesting from URL, don't spawn an IngestJob; instead
           # reach into the FileActor and run the ingest with the file instance in
@@ -75,13 +76,13 @@ module Hyrax
           # Ensure we have an up-to-date copy of the members association, so that we append to the end of the list.
           work = reload(work) unless work.new_record?
           file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
-          save(file_set, use_valkyrie: false)
+          save(file_set, use_valkyrie: @use_valkyrie)
           work.ordered_members << file_set
           work.representative = file_set if work.representative_id.blank?
           work.thumbnail = file_set if work.thumbnail_id.blank?
           # Save the work so the association between the work and the file_set is persisted (head_id)
           # NOTE: the work may not be valid, in which case this save doesn't do anything.
-          save(work, use_valkyrie: false)
+          save(work, use_valkyrie: @use_valkyrie)
           Hyrax.config.callback.run(:after_create_fileset, file_set, user)
         end
       end
@@ -162,10 +163,10 @@ module Hyrax
           work.thumbnail = nil if work.thumbnail_id == file_set.id
           work.representative = nil if work.representative_id == file_set.id
           work.rendering_ids -= [file_set.id]
-          save(work, use_valkyrie: false)
+          save(work, use_valkyrie: @use_valkyrie)
         end
 
-        def save(af_object, use_valkyrie: false)
+        def save(af_object, use_valkyrie: @use_valkyrie)
           af_object.save unless use_valkyrie
 
           adapter = Hyrax.config.valkyrie_metadata_adapter

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -23,7 +23,7 @@ module Hyrax
         # If the file set doesn't have a title or label assigned, set a default.
         file_set.label ||= label_for(file)
         file_set.title = [file_set.label] if file_set.title.blank?
-        return false unless save(file_set) # Need to save to get an id
+        return false unless save(file_set, use_valkyrie: false) # Need to save to get an id
         if from_url
           # If ingesting from URL, don't spawn an IngestJob; instead
           # reach into the FileActor and run the ingest with the file instance in
@@ -75,13 +75,13 @@ module Hyrax
           # Ensure we have an up-to-date copy of the members association, so that we append to the end of the list.
           work = reload(work) unless work.new_record?
           file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
-          save(file_set)
+          save(file_set, use_valkyrie: false)
           work.ordered_members << file_set
           work.representative = file_set if work.representative_id.blank?
           work.thumbnail = file_set if work.thumbnail_id.blank?
           # Save the work so the association between the work and the file_set is persisted (head_id)
           # NOTE: the work may not be valid, in which case this save doesn't do anything.
-          save(work)
+          save(work, use_valkyrie: false)
           Hyrax.config.callback.run(:after_create_fileset, file_set, user)
         end
       end
@@ -162,7 +162,7 @@ module Hyrax
           work.thumbnail = nil if work.thumbnail_id == file_set.id
           work.representative = nil if work.representative_id == file_set.id
           work.rendering_ids -= [file_set.id]
-          save(work)
+          save(work, use_valkyrie: false)
         end
 
         def save(af_object, use_valkyrie: false)

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -74,7 +74,7 @@ module Hyrax
       def attach_to_work(work, file_set_params = {})
         acquire_lock_for(work.id) do
           # Ensure we have an up-to-date copy of the members association, so that we append to the end of the list.
-          work = reload(work) unless work.new_record?
+          work.reload unless work.new_record?
           file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
           save(file_set, use_valkyrie: @use_valkyrie)
           work.ordered_members << file_set
@@ -175,18 +175,6 @@ module Hyrax
           true
         rescue StandardError
           false
-        end
-
-        # Per the comment in attach_to_work, reload is needed to ensure that associations
-        # are up-to-date.
-        def reload(af_object)
-          return af_object unless af_object.persisted?
-
-          adapter = Hyrax.config.valkyrie_metadata_adapter
-          resource = adapter.query_service.find_by(id: af_object.id)
-          af_object.clear_association_cache
-          af_object.association_cache.merge! adapter.resource_factory.from_resource(resource: resource).association_cache
-          af_object
         end
 
         def file_set_destroy

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -167,7 +167,7 @@ module Hyrax
         end
 
         def save(af_object, use_valkyrie: @use_valkyrie)
-          af_object.save unless use_valkyrie
+          return af_object.save unless use_valkyrie
 
           adapter = Hyrax.config.valkyrie_metadata_adapter
           resource = adapter.persister.save(resource: af_object.valkyrie_resource)

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -182,6 +182,7 @@ module Hyrax
 
           adapter = Hyrax.config.valkyrie_metadata_adapter
           adapter.persister.delete(resource: file_set.valkyrie_resource)
+          file_set.instance_variable_set(:@destroyed, true)
         end
       # rubocop:enable Metrics/ClassLength
       # rubocop:enable Metrics/AbcSize

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -170,8 +170,7 @@ module Hyrax
           return af_object.save unless use_valkyrie
 
           adapter = Hyrax.config.valkyrie_metadata_adapter
-          resource = adapter.persister.save(resource: af_object.valkyrie_resource)
-          Wings::ActiveFedoraConverter.new(resource: resource).convert
+          adapter.persister.save(resource: af_object.valkyrie_resource)
           true
         rescue StandardError
           false

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -105,7 +105,7 @@ module Hyrax
 
       def destroy
         unlink_from_work
-        file_set_destroy
+        file_set_destroy(use_valkyrie: @use_valkyrie)
         Hyrax.config.callback.run(:after_destroy, file_set.id, user)
       end
 
@@ -177,7 +177,9 @@ module Hyrax
           false
         end
 
-        def file_set_destroy
+        def file_set_destroy(use_valkyrie: @use_valkyrie)
+          return file_set.destroy unless use_valkyrie
+
           adapter = Hyrax.config.valkyrie_metadata_adapter
           adapter.persister.delete(resource: file_set.valkyrie_resource)
         end

--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -45,3 +45,17 @@ Valkyrie::StorageAdapter.register(
   :active_fedora
 )
 Valkyrie.config.storage_adapter = :active_fedora
+
+# if we've messed up handling the @destroyed flag, still raise the correct error
+class ActiveFedora::Base
+  def reload
+    super
+  rescue Ldp::Gone => err
+    Rails.logger.info("Tried to reload an object that has been destroyed; " \
+                      "this is probably due to mismanagement of the object's " \
+                      "@destroyed variable, which should prevent us from " \
+                      "sending Fedora requests for objects that have been " \
+                      "destroyed in-memory: #{err.message}")
+    raise ActiveFedora::ObjectNotFoundError
+  end
+end

--- a/lib/wings/valkyrie/persister.rb
+++ b/lib/wings/valkyrie/persister.rb
@@ -49,9 +49,9 @@ module Wings
       # @param [Valkyrie::Resource] resource
       # @return [Valkyrie::Resource] the deleted resource
       def delete(resource:)
-        af_object = ActiveFedora::Base.new
-        af_object.id = resource.alternate_ids.first.to_s
-        af_object.delete
+        af_object = resource_factory.from_resource(resource: resource)
+        af_object.destroy!
+        af_object
       end
 
       # Deletes all resources from Fedora and Solr

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     end
   end
 
-
   describe "creating metadata, content and attaching to a work" do
     let(:work) { create(:generic_work) }
     let(:date_today) { DateTime.current }
@@ -243,7 +242,6 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     end
   end
 
-
   describe "#destroy" do
     [true, false].each do |use_valkyrie|
       context "when use_valkyrie = #{use_valkyrie}" do
@@ -309,7 +307,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
         context 'with representative and thumbnail' do
           it 'does not (re)assign them' do
             allow(work).to receive(:thumbnail_id).and_return('ab123c78h')
-             allow(work).to receive(:representative_id).and_return('zz365c78h')
+            allow(work).to receive(:representative_id).and_return('zz365c78h')
             expect(work).not_to receive(:representative=)
             expect(work).not_to receive(:thumbnail=)
             actor.attach_to_work(work)

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -28,109 +28,120 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     end
   end
 
-  describe 'creating metadata, content and attaching to a work' do
+
+  describe "creating metadata, content and attaching to a work" do
     let(:work) { create(:generic_work) }
     let(:date_today) { DateTime.current }
 
-    subject { file_set.reload }
+    [true, false].each do |use_valkyrie|
+      context "when use_valkyrie = #{use_valkyrie}" do
+        subject { file_set.reload }
 
-    before do
-      allow(DateTime).to receive(:current).and_return(date_today)
-      allow(actor).to receive(:acquire_lock_for).and_yield
-      actor.create_metadata
-      actor.create_content(file)
-      actor.attach_to_work(work)
-    end
+        before do
+          actor.instance_variable_set("@use_valkyrie", use_valkyrie)
+          allow(DateTime).to receive(:current).and_return(date_today)
+          allow(actor).to receive(:acquire_lock_for).and_yield
+          actor.create_metadata
+          actor.create_content(file)
+          actor.attach_to_work(work)
+        end
 
-    context 'when a work is provided' do
-      it 'adds the FileSet to the parent work' do
-        expect(subject.parents).to eq [work]
-        expect(work.reload.file_sets).to include(subject)
+        context 'when a work is provided' do
+          it 'adds the FileSet to the parent work' do
+            expect(subject.parents).to eq [work]
+            expect(work.reload.file_sets).to include(subject)
 
-        # Confirming that date_uploaded and date_modified were set
-        expect(subject.date_uploaded).to eq date_today.utc
-        expect(subject.date_modified).to eq date_today.utc
-        expect(subject.depositor).to eq user.email
+            # Confirming that date_uploaded and date_modified were set
+            expect(subject.date_uploaded).to eq date_today.utc
+            expect(subject.date_modified).to eq date_today.utc
+            expect(subject.depositor).to eq user.email
 
-        # Confirm that embargo/lease are not set.
-        expect(subject).not_to be_under_embargo
-        expect(subject).not_to be_active_lease
-        expect(subject.visibility).to eq 'restricted'
-      end
-    end
-  end
-
-  describe '#create_content' do
-    before do
-      expect(JobIoWrapper).to receive(:create_with_varied_file_handling!).with(any_args).and_return(JobIoWrapper.new)
-      expect(IngestJob).to receive(:perform_later).with(JobIoWrapper)
-    end
-
-    it 'calls ingest_file' do
-      actor.create_content(file)
-    end
-
-    context 'when an alternative relationship is specified' do
-      let(:relation) { :remastered }
-
-      it 'calls ingest_file' do
-        actor.create_content(file, :remastered)
-      end
-    end
-
-    context 'using ::File' do
-      let(:file) { local_file }
-
-      before { actor.create_content(local_file) }
-
-      it 'sets the label and title' do
-        expect(file_set.label).to eq(File.basename(local_file))
-        expect(file_set.title).to eq([File.basename(local_file)])
-      end
-
-      it 'gets the mime_type from original_file' do
-        expect(file_set.mime_type).to eq('image/png')
-      end
-    end
-
-    context 'when file_set.title is empty and file_set.label is not' do
-      let(:long_name) do
-        'an absurdly long title that goes on way to long and messes up the display of the page which should not need ' \
-          'to be this big in order to show this impossibly long, long, long, oh so long string'
-      end
-      let(:short_name) { 'Nice Short Name' }
-
-      before do
-        allow(file_set).to receive(:label).and_return(short_name)
-        actor.create_content(file)
-      end
-
-      subject { file_set.title }
-
-      it { is_expected.to match_array [short_name] }
-    end
-
-    context 'when a label is already specified' do
-      let(:label) { 'test_file.png' }
-      let(:file_set) do
-        FileSet.new do |f|
-          f.apply_depositor_metadata(user.user_key)
-          f.label = label
+            # Confirm that embargo/lease are not set.
+            expect(subject).not_to be_under_embargo
+            expect(subject).not_to be_active_lease
+            expect(subject.visibility).to eq 'restricted'
+          end
         end
       end
-      let(:actor) { described_class.new(file_set, user) }
+    end
+  end
 
-      before do
-        actor.create_content(file)
-      end
+  describe "#create_content" do
+    [true, false].each do |use_valkyrie|
+      context "when use_valkyrie = #{use_valkyrie}" do
+        before do
+          expect(JobIoWrapper).to receive(:create_with_varied_file_handling!).with(any_args).and_return(JobIoWrapper.new)
+          expect(IngestJob).to receive(:perform_later).with(JobIoWrapper)
+          actor.instance_variable_set("@use_valkyrie", use_valkyrie)
+        end
 
-      it "retains the object's original label" do
-        expect(file_set.label).to eql(label)
+        it 'calls ingest_file' do
+          actor.create_content(file)
+        end
+
+        context 'when an alternative relationship is specified' do
+          let(:relation) { :remastered }
+
+          it 'calls ingest_file' do
+            actor.create_content(file, :remastered)
+          end
+        end
+
+        context 'using ::File' do
+          let(:file) { local_file }
+
+          before { actor.create_content(local_file) }
+
+          it 'sets the label and title' do
+            expect(file_set.label).to eq(File.basename(local_file))
+            expect(file_set.title).to eq([File.basename(local_file)])
+          end
+
+          it 'gets the mime_type from original_file' do
+            expect(file_set.mime_type).to eq('image/png')
+          end
+        end
+
+        context 'when file_set.title is empty and file_set.label is not' do
+          let(:long_name) do
+            'an absurdly long title that goes on way to long and messes up the display of the page which should not need ' \
+            'to be this big in order to show this impossibly long, long, long, oh so long string'
+          end
+          let(:short_name) { 'Nice Short Name' }
+
+          before do
+            allow(file_set).to receive(:label).and_return(short_name)
+            actor.create_content(file)
+          end
+
+          subject { file_set.title }
+
+          it { is_expected.to match_array [short_name] }
+        end
+
+        context 'when a label is already specified' do
+          let(:label) { 'test_file.png' }
+          let(:file_set) do
+            FileSet.new do |f|
+              f.apply_depositor_metadata(user.user_key)
+              f.label = label
+            end
+          end
+          let(:actor) { described_class.new(file_set, user) }
+
+          before do
+            actor.create_content(file)
+          end
+
+          it "retains the object's original label" do
+            expect(file_set.label).to eql(label)
+          end
+        end
       end
     end
   end
 
-  describe '#create_content when from_url is true' do
+  describe "#create_content when from_url is true" do
     before do
       expect(JobIoWrapper).to receive(:create_with_varied_file_handling!).with(any_args).once.and_call_original
     end
@@ -141,67 +152,73 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       expect(InheritPermissionsJob).to have_been_enqueued
     end
 
-    context 'when an alternative relationship is specified' do
-      before do
-        # Relationship must be declared before being used. Inject it here.
-        FileSet.class_eval do
-          directly_contains_one :remastered, through: :files, type: ::RDF::URI("http://otherpcdm.example.org/use#Remastered"), class_name: 'Hydra::PCDM::File'
+    [true, false].each do |use_valkyrie|
+      context "when use_valkyrie = #{use_valkyrie}" do
+        before  { actor.instance_variable_set("@use_valkyrie", use_valkyrie) }
+
+        context 'when an alternative relationship is specified' do
+          before do
+            # Relationship must be declared before being used. Inject it here.
+            FileSet.class_eval do
+              directly_contains_one :remastered, through: :files, type: ::RDF::URI("http://otherpcdm.example.org/use#Remastered"), class_name: 'Hydra::PCDM::File'
+            end
+          end
+
+          it 'calls ingest_file' do
+            actor.create_content(file, :remastered, from_url: true)
+          end
         end
-      end
 
-      it 'calls ingest_file' do
-        actor.create_content(file, :remastered, from_url: true)
-      end
-    end
+        context 'using ::File' do
+          let(:file) { local_file }
 
-    context 'using ::File' do
-      let(:file) { local_file }
+          before { actor.create_content(local_file, from_url: true) }
 
-      before { actor.create_content(local_file, from_url: true) }
+          it 'sets the label and title' do
+            expect(file_set.label).to eq(File.basename(local_file))
+            expect(file_set.title).to eq([File.basename(local_file)])
+          end
 
-      it 'sets the label and title' do
-        expect(file_set.label).to eq(File.basename(local_file))
-        expect(file_set.title).to eq([File.basename(local_file)])
-      end
-
-      it 'gets the mime_type from original_file' do
-        expect(file_set.mime_type).to eq('image/png')
-      end
-    end
-
-    context 'when file_set.title is empty and file_set.label is not' do
-      let(:long_name) do
-        'an absurdly long title that goes on way to long and messes up the display of the page which should not need ' \
-        'to be this big in order to show this impossibly long, long, long, oh so long string'
-      end
-      let(:short_name) { 'Nice Short Name' }
-
-      before do
-        allow(file_set).to receive(:label).and_return(short_name)
-        actor.create_content(file, from_url: true)
-      end
-
-      subject { file_set.title }
-
-      it { is_expected.to match_array [short_name] }
-    end
-
-    context 'when a label is already specified' do
-      let(:label) { 'test_file.png' }
-      let(:file_set) do
-        FileSet.new do |f|
-          f.apply_depositor_metadata(user.user_key)
-          f.label = label
+          it 'gets the mime_type from original_file' do
+            expect(file_set.mime_type).to eq('image/png')
+          end
         end
-      end
-      let(:actor) { described_class.new(file_set, user) }
 
-      before do
-        actor.create_content(file, from_url: true)
-      end
+        context 'when file_set.title is empty and file_set.label is not' do
+          let(:long_name) do
+            'an absurdly long title that goes on way to long and messes up the display of the page which should not need ' \
+            'to be this big in order to show this impossibly long, long, long, oh so long string'
+          end
+          let(:short_name) { 'Nice Short Name' }
 
-      it "retains the object's original label" do
-        expect(file_set.label).to eql(label)
+          before do
+            allow(file_set).to receive(:label).and_return(short_name)
+            actor.create_content(file, from_url: true)
+          end
+
+          subject { file_set.title }
+
+          it { is_expected.to match_array [short_name] }
+        end
+
+        context 'when a label is already specified' do
+          let(:label) { 'test_file.png' }
+          let(:file_set) do
+            FileSet.new do |f|
+              f.apply_depositor_metadata(user.user_key)
+              f.label = label
+            end
+          end
+          let(:actor) { described_class.new(file_set, user) }
+
+          before do
+            actor.create_content(file, from_url: true)
+          end
+
+          it "retains the object's original label" do
+            expect(file_set.label).to eql(label)
+          end
+        end
       end
     end
   end
@@ -226,34 +243,41 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     end
   end
 
+
   describe "#destroy" do
-    it "destroys the object" do
-      actor.destroy
-      expect { file_set.reload }.to raise_error Ldp::Gone
-    end
+    [true, false].each do |use_valkyrie|
+      context "when use_valkyrie = #{use_valkyrie}" do
+        before { actor.instance_variable_set("@use_valkyrie", use_valkyrie) }
 
-    context "representative, renderings and thumbnail of a work" do
-      let!(:work) do
-        work = create(:generic_work)
-        # this is not part of a block on the create, since the work must be saved
-        # before the representative can be assigned
-        work.ordered_members << file_set
-        work.representative = file_set
-        work.thumbnail = file_set
-        work.renderings = [file_set]
-        work.save
-        work
-      end
+        it "destroys the object" do
+          actor.destroy
+          expect { file_set.reload }.to raise_error Ldp::Gone
+        end
 
-      it "removes representative, renderings, thumbnail, and the proxy association" do
-        gw = GenericWork.find(work.id)
-        expect(gw.representative_id).to eq(file_set.id)
-        expect(gw.thumbnail_id).to eq(file_set.id)
-        expect { actor.destroy }.to change { ActiveFedora::Aggregation::Proxy.count }.by(-1)
-        gw.reload
-        expect(gw.representative_id).to be_nil
-        expect(gw.thumbnail_id).to be_nil
-        expect(gw.rendering_ids).to eq([])
+        context "representative, renderings and thumbnail of a work" do
+          let!(:work) do
+            work = create(:generic_work)
+            # this is not part of a block on the create, since the work must be saved
+            # before the representative can be assigned
+            work.ordered_members << file_set
+            work.representative = file_set
+            work.thumbnail = file_set
+            work.renderings = [file_set]
+            work.save
+            work
+          end
+
+          it "removes representative, renderings, thumbnail, and the proxy association" do
+            gw = GenericWork.find(work.id)
+            expect(gw.representative_id).to eq(file_set.id)
+            expect(gw.thumbnail_id).to eq(file_set.id)
+            expect { actor.destroy }.to change { ActiveFedora::Aggregation::Proxy.count }.by(-1)
+            gw.reload
+            expect(gw.representative_id).to be_nil
+            expect(gw.thumbnail_id).to be_nil
+            expect(gw.rendering_ids).to eq([])
+          end
+        end
       end
     end
   end
@@ -261,51 +285,54 @@ RSpec.describe Hyrax::Actors::FileSetActor do
   describe "#attach_to_work" do
     let(:work) { build(:public_generic_work) }
 
-    before do
-      allow(actor).to receive(:acquire_lock_for).and_yield
-    end
+    [true, false].each do |use_valkyrie|
+      context "when use_valkyrie = #{use_valkyrie}" do
+        before do
+          actor.instance_variable_set("@use_valkyrie", use_valkyrie)
+          allow(actor).to receive(:acquire_lock_for).and_yield
+        end
 
-    it 'copies file_set visibility from the parent' do
-      actor.attach_to_work(work)
-      expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-    end
+        it 'copies file_set visibility from the parent' do
+          actor.attach_to_work(work)
+          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        end
 
-    context 'without representative and thumbnail' do
-      it 'assigns them (with persistence)' do
-        actor.attach_to_work(work)
-        expect(work.representative).to eq(file_set)
-        expect(work.thumbnail).to eq(file_set)
-        expect { work.reload }.not_to change { [work.representative.id, work.thumbnail.id] }
-      end
-    end
+        context 'without representative and thumbnail' do
+          it 'assigns them (with persistence)' do
+            actor.attach_to_work(work)
+            expect(work.representative).to eq(file_set)
+            expect(work.thumbnail).to eq(file_set)
+            expect { work.reload }.not_to change { [work.representative.id, work.thumbnail.id] }
+          end
+        end
 
-    context 'with representative and thumbnail' do
-      it 'does not (re)assign them' do
-        allow(work).to receive(:thumbnail_id).and_return('ab123c78h')
-        allow(work).to receive(:representative_id).and_return('zz365c78h')
-        expect(work).not_to receive(:representative=)
-        expect(work).not_to receive(:thumbnail=)
-        actor.attach_to_work(work)
-      end
-    end
+        context 'with representative and thumbnail' do
+          it 'does not (re)assign them' do
+            allow(work).to receive(:thumbnail_id).and_return('ab123c78h')
+             allow(work).to receive(:representative_id).and_return('zz365c78h')
+            expect(work).not_to receive(:representative=)
+            expect(work).not_to receive(:thumbnail=)
+            actor.attach_to_work(work)
+          end
+        end
 
-    context 'with multiple versions' do
-      let(:work_v1) { create(:generic_work) } # this version of the work has no members
-      let(:coll) { create(:collection, title: ['Cats on Roombas']) }
+        context 'with multiple versions' do
+          let(:work_v1) { create(:generic_work) } # this version of the work has no members
+          let(:coll) { create(:collection, title: ['Cats on Roombas']) }
 
-      before do # another version of the same work is saved with a member
-        work_v2 = ActiveFedora::Base.find(work_v1.id)
-        work_v2.ordered_members << create(:file_set)
-        work_v2.description = ["3 kittens"]
-        work_v2.member_of_collections = [coll]
-        work_v2.save!
-      end
+          before do # another version of the same work is saved with a member
+            work_v2 = ActiveFedora::Base.find(work_v1.id)
+            work_v2.ordered_members << create(:file_set)
+            work_v2.member_of_collections = [coll]
+            work_v2.save!
+          end
 
-      it "writes to the most up to date version" do
-        actor.attach_to_work(work_v1)
-        expect(work_v1.ordered_members.ids.size).to eq 2
-        expect(work_v1.member_of_collections).to eq([coll])
-        expect(work_v1.description).to eq(["3 kittens"])
+          it "writes to the most up to date version" do
+            actor.attach_to_work(work_v1)
+            expect(work_v1.ordered_members.ids.size).to eq 2
+            expect(work_v1.member_of_collections).to eq([coll])
+          end
+        end
       end
     end
   end
@@ -332,21 +359,26 @@ RSpec.describe Hyrax::Actors::FileSetActor do
     end
   end
 
-  describe '#revert_content', perform_enqueued: [IngestJob] do
+  describe "#revert_content", perform_enqueued: [IngestJob] do
     let(:file_set) { create(:file_set, user: user) }
     let(:file1)    { "small_file.txt" }
     let(:version1) { "version1" }
     let(:restored_content) { file_set.reload.original_file }
 
-    before do
-      actor.create_content(fixture_file_upload(file1))
-      actor.create_content(fixture_file_upload('hyrax_generic_stub.txt'))
-      actor.file_set.reload
-    end
+    [true, false].each do |use_valkyrie|
+      context "when use_valkyrie = #{use_valkyrie}" do
+        before do
+          actor.instance_variable_set("@use_valkyrie", use_valkyrie)
+          actor.create_content(fixture_file_upload(file1))
+          actor.create_content(fixture_file_upload('hyrax_generic_stub.txt'))
+          actor.file_set.reload
+        end
 
-    it "restores the first versions's content and metadata" do
-      actor.revert_content(version1)
-      expect(restored_content.original_name).to eq file1
+        it "restores the first versions's content and metadata" do
+          actor.revert_content(version1)
+          expect(restored_content.original_name).to eq file1
+        end
+      end
     end
   end
 end

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -250,12 +250,13 @@ RSpec.describe Hyrax::Actors::FileSetActor do
         expect { file_set.reload }.to raise_error ActiveFedora::ObjectNotFoundError
       end
     end
+
     context "when use_valkyrie = true" do
       before { actor.instance_variable_set("@use_valkyrie", true) }
 
       it "destroys the object" do
         actor.destroy
-        expect { file_set.reload }.to raise_error Ldp::Gone
+        expect { file_set.reload }.to raise_error ActiveFedora::ObjectNotFoundError
       end
     end
 

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -243,14 +243,25 @@ RSpec.describe Hyrax::Actors::FileSetActor do
   end
 
   describe "#destroy" do
+    context "when use_valkyrie = false" do
+      before { actor.instance_variable_set("@use_valkyrie", false) }
+      it "destroys the object" do
+        actor.destroy
+        expect { file_set.reload }.to raise_error ActiveFedora::ObjectNotFoundError
+      end
+    end
+    context "when use_valkyrie = true" do
+      before { actor.instance_variable_set("@use_valkyrie", true) }
+
+      it "destroys the object" do
+        actor.destroy
+        expect { file_set.reload }.to raise_error Ldp::Gone
+      end
+    end
+
     [true, false].each do |use_valkyrie|
       context "when use_valkyrie = #{use_valkyrie}" do
         before { actor.instance_variable_set("@use_valkyrie", use_valkyrie) }
-
-        it "destroys the object" do
-          actor.destroy
-          expect { file_set.reload }.to raise_error Ldp::Gone
-        end
 
         context "representative, renderings and thumbnail of a work" do
           let!(:work) do


### PR DESCRIPTION
refs #3604 #3568

Adds reload and destroy methods that go through the Wings module instead of directly using ActiveFedora methods. Similarly adds a save method which is currently still WIP and blocked from being used.

In order to correctly maintain the ActiveFedora::Aggregation::Proxy.count, this also changes the persister to use destroy! rather than delete, and operates on the found object.

One of the tests for actor.destroy uses the ActiveFedora reload and looks for an exception that is raised by AF reload when object.destroyed? returns true. Since the Wings conversion process requires that the destroy operation happen on another copy of the object, the original object.destroyed? returns false, and therefore, a different exception is raised by AF reload. Since this test's function seems to be confirming that the object was indeed destroyed after actor.destroy, the spec is changed to accept the Ldp::Gone exception.
