### PR TITLE
Restructures the Wings::ModelTransformer in order to dynamically define classes for Valkyrie::Resources

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -16,6 +16,7 @@ Metrics/ClassLength:
     - 'lib/generators/hyrax/templates/catalog_controller.rb'
     - 'lib/generators/hyrax/install_generator.rb'
     - 'lib/hyrax/configuration.rb'
+    - 'lib/wings/model_transformer.rb'
 
 Metrics/ParameterLists:
   Exclude:

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -497,7 +497,7 @@ module Hyrax
     attr_writer :translate_id_to_uri
     def translate_id_to_uri
       @translate_id_to_uri ||= lambda do |id|
-        "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{::Noid::Rails.treeify(id)}"
+        "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{::Noid::Rails.treeify(id.to_s)}"
       end
     end
 

--- a/lib/wings/active_fedora_attributes.rb
+++ b/lib/wings/active_fedora_attributes.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'wings/converter_value_mapper'
+
+module Wings
+  # This needs to be reconciled with AttributeTransformer
+  class ActiveFedoraAttributes
+    attr_reader :attributes
+
+    # Constructor
+    # @param attributes [Hash]
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    # Transforms attribues from Valkyrie Resources for ActiveFedora Models
+    # @return [Hash]
+    def result
+      Hash[
+        filtered_attributes.map do |value|
+          ConverterValueMapper.for(value).result
+        end.select(&:present?)
+      ]
+    end
+
+    private
+
+      # Filter for attributes which cannot be passed to ActiveFedora constructor
+      # or attribute mutator methods
+      # @return [Hash]
+      # rubocop:disable Metrics/MethodLength
+      def filtered_attributes
+        # avoid reflections for now; `*_ids` can't be passed as attributes.
+        # handling for reflections needs to happen in future work
+        attrs = attributes.reject { |k, _| k.to_s.end_with? '_ids' }
+
+        attrs.delete(:internal_resource)
+        attrs.delete(:new_record)
+        attrs.delete(:id)
+        attrs.delete(:alternate_ids)
+        attrs.delete(:created_at)
+        attrs.delete(:updated_at)
+        attrs.delete(:member_ids)
+        attrs.delete(:read_groups)
+        attrs.delete(:read_users)
+        attrs.delete(:edit_groups)
+        attrs.delete(:edit_users)
+
+        embargo_id         = attrs.delete(:embargo_id)
+        attrs[:embargo_id] = embargo_id.to_s unless embargo_id.nil? || embargo_id.empty?
+        lease_id          = attrs.delete(:lease_id)
+        attrs[:lease_id]  = lease_id.to_s unless lease_id.nil? || lease_id.empty?
+        attrs.compact
+      end
+    # rubocop:enable Metrics/MethodLength
+  end
+end

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -67,7 +67,7 @@ module Wings
     def id
       id_attr = resource[:id]
       return id_attr.to_s if id_attr.present? && id_attr.is_a?(::Valkyrie::ID) && !id_attr.blank?
-      return "" unless resource.respond_to?(:alternate_ids)
+      return "" unless resource.respond_to?(:alternate_ids) && !resource.alternate_ids.nil?
       resource.alternate_ids.first.to_s
     end
 
@@ -78,7 +78,7 @@ module Wings
         # TODO: It would be better to find a way to add the members without resuming all the member AF objects
         ordered_members = []
         resource.member_ids.each do |valkyrie_id|
-          ordered_members << ActiveFedora::Base.find(valkyrie_id.id)
+          ordered_members << ActiveFedora::Base.find(valkyrie_id.to_s)
         end
         af_object.ordered_members = ordered_members
       end

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'wings/resource_transformer'
 
 require 'wings/converter_value_mapper'
 
@@ -15,6 +16,8 @@ module Wings
   # @note the `Valkyrie::Resource` object passed to this class **must** have an
   #   `#internal_resource` mapping it to an `ActiveFedora::Base` class.
   class ActiveFedoraConverter
+    class NestedResource < ::Wings::NestedResource; end
+
     ##
     # Accesses the Class implemented for handling resource attributes
     # @return [Class]
@@ -46,19 +49,14 @@ module Wings
     ##
     # @return [ActiveFedora::Base]
     def convert
-      active_fedora_class.new(normal_attributes).tap do |af_object|
+      ResourceTransformer.for(resource).tap do |af_object|
         af_object.id = id unless id.empty?
         apply_depositor_to(af_object)
         add_access_control_attributes(af_object)
+        af_object.visibility = resource.attributes[:visibility] unless resource.attributes[:visibility].blank?
         convert_members(af_object)
         convert_member_of_collections(af_object)
       end
-    end
-
-    def active_fedora_class
-      klass = resource.internal_resource.constantize
-      return klass if klass <= ActiveFedora::Base
-      DefaultWork
     end
 
     ##
@@ -71,37 +69,6 @@ module Wings
       return id_attr.to_s if id_attr.present? && id_attr.is_a?(::Valkyrie::ID) && !id_attr.blank?
       return "" unless resource.respond_to?(:alternate_ids)
       resource.alternate_ids.first.to_s
-    end
-
-    # A dummy work class for valkyrie resources that don't have corresponding
-    # hyrax ActiveFedora::Base models.
-    #
-    # A possible improvement would be to dynamically generate properties based
-    # on what's found in the resource.
-    class DefaultWork < ActiveFedora::Base
-      include Hyrax::WorkBehavior
-      property :ordered_authors, predicate: ::RDF::Vocab::DC.creator
-      property :ordered_nested, predicate: ::RDF::URI("http://example.com/ordered_nested")
-      property :nested_resource, predicate: ::RDF::URI("http://example.com/nested_resource"), class_name: "Wings::ActiveFedoraConverter::NestedResource"
-      include ::Hyrax::BasicMetadata
-      accepts_nested_attributes_for :nested_resource
-
-      # self.indexer = <%= class_name %>Indexer
-    end
-
-    class NestedResource < ActiveTriples::Resource
-      property :title, predicate: ::RDF::Vocab::DC.title
-      property :ordered_authors, predicate: ::RDF::Vocab::DC.creator
-      property :ordered_nested, predicate: ::RDF::URI("http://example.com/ordered_nested")
-      def initialize(uri = RDF::Node.new, _parent = ActiveTriples::Resource.new)
-        uri = if uri.try(:node?)
-                RDF::URI("#nested_resource_#{uri.to_s.gsub('_:', '')}")
-              elsif uri.to_s.include?('#')
-                RDF::URI(uri)
-              end
-        super
-      end
-      include ::Hyrax::BasicMetadata
     end
 
     private

--- a/lib/wings/model_value_mapper.rb
+++ b/lib/wings/model_value_mapper.rb
@@ -7,12 +7,12 @@ module Wings
   #
   # This top level matcher has registered several internal mappers which handle
   # indivdual value types from the source data.
-  class TransformerValueMapper < ::Valkyrie::ValueMapper; end
+  class ModelValueMapper < ::Valkyrie::ValueMapper; end
 
   class NestedResourceMapper < ::Valkyrie::ValueMapper
     # needs to register before the ResourceMapper or it will use that one
     # instead
-    TransformerValueMapper.register(self)
+    ModelValueMapper.register(self)
 
     def self.handles?(value)
       value.is_a? Wings::ActiveFedoraConverter::NestedResource
@@ -38,7 +38,7 @@ module Wings
   #
   # @see RDF::Term
   class ResourceMapper < ::Valkyrie::ValueMapper
-    TransformerValueMapper.register(self)
+    ModelValueMapper.register(self)
 
     ##
     # @param value [Object]
@@ -61,7 +61,7 @@ module Wings
   #
   # @note a common value type this mapper handles is `ActiveTriples::Relation`
   class EnumerableMapper < ::Valkyrie::ValueMapper
-    TransformerValueMapper.register(self)
+    ModelValueMapper.register(self)
 
     ##
     # @param value [Object]

--- a/lib/wings/nested_resource.rb
+++ b/lib/wings/nested_resource.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Wings
+  class NestedResource < ActiveTriples::Resource
+    include ::Hyrax::BasicMetadata
+    property :title, predicate: ::RDF::Vocab::DC.title
+    property :ordered_authors, predicate: ::RDF::Vocab::DC.creator
+    property :ordered_nested, predicate: ::RDF::URI("http://example.com/ordered_nested")
+
+    def self.build_fragment_uri(uri)
+      uri_id = uri.to_s.gsub('_:', '')
+      ::RDF::URI("#nested_resource_#{uri_id}")
+    end
+
+    def initialize(uri = ::RDF::Node.new, _parent = ActiveTriples::Resource.new)
+      uri = if uri.try(:node?)
+              self.class.build_fragment_uri(uri)
+            elsif uri.to_s.include?('#')
+              ::RDF::URI(uri)
+            end
+      super
+    end
+  end
+end

--- a/lib/wings/resource_transformer.rb
+++ b/lib/wings/resource_transformer.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'wings/converter_value_mapper'
+require 'wings/active_fedora_attributes'
+
+module Wings
+  class PCDMObjectClassCache
+    include Singleton
+
+    ##
+    # @!attribute [r] cache
+    #   @return [Hash<Class, Class>]
+    attr_reader :cache
+
+    def initialize
+      @cache = {}
+    end
+
+    ##
+    # @param key [Class] the ActiveFedora class to map
+    #
+    # @return [Class]
+    def fetch(key)
+      @cache.fetch(key) do
+        @cache[key] = yield
+      end
+    end
+  end
+
+  # This needs to be reconciled with ActiveFedoraAttributes
+  class AttributeTransformer
+    def self.value_mapper_class
+      ConverterValueMapper
+    end
+
+    def self.run(obj, keys)
+      keys.each_with_object({}) do |attr_name, mem|
+        next unless obj.respond_to? attr_name
+        mem[attr_name.to_sym] = value_mapper_class.for(obj.public_send(attr_name)).result
+      end
+    end
+  end
+
+  class DefaultWork < ActiveFedora::Base
+    include Hyrax::WorkBehavior
+    property :ordered_authors, predicate: ::RDF::Vocab::DC.creator
+    property :ordered_nested, predicate: ::RDF::URI("http://example.com/ordered_nested")
+    property :nested_resource, predicate: ::RDF::URI("http://example.com/nested_resource"), class_name: "Wings::ActiveFedoraConverter::NestedResource"
+    accepts_nested_attributes_for :nested_resource
+
+    include ::Hyrax::BasicMetadata
+  end
+
+  class ResourceTransformer
+    # Construct an ActiveFedora Model from a Valkyrie Resource
+    # @param valkyrie_resource [Valkyrie::Resource]
+    # @return [ActiveFedora::Base]
+    def self.for(valkyrie_resource)
+      new(valkyrie_resource: valkyrie_resource).build
+    end
+
+    def self.class_namespace
+      Wings::ResourceTransformer
+    end
+
+    def self.class_in_namespace?(class_name)
+      namespaced = class_name.split("::")
+      class_name.include?(class_namespace.to_s) && class_namespace.constants.include?(namespaced.last.to_sym)
+    end
+
+    def self.active_fedora_model?(class_name)
+      klass = class_name.constantize
+      klass.ancestors.include?(ActiveFedora::Base)
+    end
+
+    # Dynamically define the Class for the new ActiveFedora Model
+    # @param resource [Valkyrie::Resource]
+    # @return [Class]
+    def self.to_active_fedora_class(resource:)
+      return resource.internal_resource.constantize if const_defined?(resource.internal_resource) && class_in_namespace?(resource.internal_resource) || active_fedora_model?(resource.internal_resource)
+
+      class_namespace.class_eval <<-CODE
+        class #{resource.internal_resource} < Wings::DefaultWork; end
+      CODE
+
+      "#{class_namespace}::#{resource.internal_resource}".constantize
+    end
+
+    # Retrieve the Class for the Valkyrie Resource being transformed
+    # (Abstract and only delegates to a method supporting the transformation to
+    # an ActiveFedora Model)
+    # @param resource [Valkyrie::Resource]
+    # @return [Class]
+    def self.to_pcdm_object_class(resource:)
+      to_active_fedora_class(resource: resource)
+    end
+
+    ##
+    # @!attribute [rw] valkyrie_resource
+    #   @return [Valkyrie::Resource]
+    attr_accessor :valkyrie_resource
+
+    ##
+    # Constructor
+    # @param valkyrie_resource [Valkyrie::Resource]
+    def initialize(valkyrie_resource:)
+      self.valkyrie_resource = valkyrie_resource
+    end
+
+    # Factory
+    # Constructs the ActiveFedora Model object using a dynamically-defined child
+    # class derived from ActiveFedora::Base
+    # @return [ActiveFedora::Base]
+    def build
+      klass.new(**attributes)
+    end
+
+    private
+
+      def klass
+        @klass ||= PCDMObjectClassCache.instance.fetch(valkyrie_resource) do
+          self.class.to_pcdm_object_class(resource: valkyrie_resource)
+        end
+      end
+
+      # Transform the attributes from the Valkyrie Resource
+      # @return [Hash]
+      def transformed_attributes
+        new_attributes = ActiveFedoraAttributes.new(valkyrie_resource.attributes)
+        new_attributes.result
+      end
+
+      def normalized_attributes
+        # This normalizes for cases where scalar values are passed to multiple
+        # values for the construction of ActiveFedora Models
+        normalized = {}
+        transformed_attributes.each_pair do |attrib, value|
+          property = klass.properties[attrib.to_s]
+          # This handles some cases where the attributes do not directly map to
+          # a RDF property value
+          normalized[attrib] = value
+          next if property.nil?
+          normalized[attrib] = Array.wrap(value) if property.multiple?
+        end
+        normalized
+      end
+
+      alias attributes normalized_attributes
+  end
+end

--- a/lib/wings/resource_transformer.rb
+++ b/lib/wings/resource_transformer.rb
@@ -79,11 +79,17 @@ module Wings
     def self.to_active_fedora_class(resource:)
       return resource.internal_resource.constantize if const_defined?(resource.internal_resource) && class_in_namespace?(resource.internal_resource) || active_fedora_model?(resource.internal_resource)
 
+      # This handles cases where there might be an ActiveFedora Model defined in
+      # the global namespace
+      class_name = resource.internal_resource.split("::").last
+      return class_name.constantize if const_defined?(class_name) && active_fedora_model?(class_name)
+
+      namespaced_class_name = "#{class_namespace}::#{class_name}"
       class_namespace.class_eval <<-CODE
-        class #{resource.internal_resource} < Wings::DefaultWork; end
+        class #{namespaced_class_name} < Wings::DefaultWork; end
       CODE
 
-      "#{class_namespace}::#{resource.internal_resource}".constantize
+      namespaced_class_name.to_s.constantize
     end
 
     # Retrieve the Class for the Valkyrie Resource being transformed

--- a/lib/wings/resource_transformer.rb
+++ b/lib/wings/resource_transformer.rb
@@ -118,7 +118,14 @@ module Wings
     # class derived from ActiveFedora::Base
     # @return [ActiveFedora::Base]
     def build
-      klass.new(**attributes)
+      built = klass.new(**attributes)
+
+      # Permissions are handled separately by hydra-access-controls
+      built.read_users = valkyrie_resource.attributes.fetch(:read_users, [])
+      built.read_groups = valkyrie_resource.attributes.fetch(:read_groups, [])
+      built.edit_users = valkyrie_resource.attributes.fetch(:edit_users, [])
+      built.edit_groups = valkyrie_resource.attributes.fetch(:edit_groups, [])
+      built
     end
 
     private

--- a/lib/wings/valkyrie/persister.rb
+++ b/lib/wings/valkyrie/persister.rb
@@ -43,6 +43,8 @@ module Wings
       # @param [Valkyrie::Resource] resource
       # @return [Valkyrie::Resource] the deleted resource
       def delete(resource:)
+        return unless resource.respond_to?(:alternate_ids) && !resource.alternate_ids.empty?
+
         af_object = ActiveFedora::Base.new
         af_object.id = resource.alternate_ids.first.to_s
         af_object.delete

--- a/spec/wings/model_value_mapper_spec.rb
+++ b/spec/wings/model_value_mapper_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require 'spec_helper'
-require 'wings/transformer_value_mapper'
+require 'wings/model_value_mapper'
 
-RSpec.describe Wings::TransformerValueMapper do
+RSpec.describe Wings::ModelValueMapper do
   subject(:mapper) { described_class.for(value) }
   let(:value)      { 'a value' }
   let(:uri)        { RDF::URI('http://example.com/moomin') }

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe Wings::Valkyrie::Persister do
         attribute :title
         attribute :author
         attribute :member_ids
+        attribute :alternate_ids
         attribute :nested_resource
         attribute :depositor, Valkyrie::Types::String.optional
         attribute :ordered_authors, Valkyrie::Types::Array.of(Valkyrie::Types::Anything).meta(ordered: true)
@@ -359,9 +360,9 @@ RSpec.describe Wings::Valkyrie::Persister do
     # not sure how to fix this one. When a resource wasn't ever in AF, it is persisted as
     # internal_resource="Wings::ActiveFedoraConverter::DefaultWork"
     # so the CustomResource defined above will not be persisted as such.
-    xit "can find that resource again" do
-      id = persister.save(resource: resource).id
-      item = query_service.find_by(id: id)
+    it "can find that resource again" do
+      persisted = persister.save(resource: resource)
+      item = query_service.find_by(id: persisted.id)
       expect(item).to be_kind_of resource_class
     end
 

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -201,39 +201,56 @@ RSpec.describe Wings::Valkyrie::Persister do
       expect(reloaded.title).to contain_exactly custom_rdf
     end
 
-    xit "can handle Date RDF properties" do
+    it "can handle Date RDF properties" do
       date_rdf = RDF::Literal.new(Date.current)
       book = persister.save(resource: resource_class.new(title: [date_rdf]))
       reloaded = query_service.find_by(id: book.id)
-      expect(reloaded.title).to contain_exactly date_rdf
+      persisted_date_rdf = RDF::Literal(reloaded.title.first)
+      expect(persisted_date_rdf).to eq date_rdf
     end
 
-    xit "can handle DateTime RDF properties" do
+    it "can handle DateTime RDF properties" do
       datetime_rdf = RDF::Literal.new(DateTime.current)
       book = persister.save(resource: resource_class.new(title: [datetime_rdf]))
       reloaded = query_service.find_by(id: book.id)
-      expect(reloaded.title).to contain_exactly datetime_rdf
+      # Because ActiveFedora uses ActiveTriples::Relation to manage underlying
+      # attributes, the attribute values are consistently persisted as
+      # RDF::Literal types within the RDF graph store
+      #
+      # Unless classes interfacing with the ActiveFedora expect to deal
+      # exclusively with RDF::Literal objects, adopters must explicitly recast
+      # the attribute values into RDF::Literals after the Valkyrie::Resource is
+      # constructed from the persisted ActiveFedora Model
+      persisted_datetime_rdf = RDF::Literal(reloaded.title.first)
+      expect(persisted_datetime_rdf).to eq datetime_rdf
     end
 
-    xit "can handle Decimal RDF properties" do
+    # This is failing given that indexing floats in Solr are not supported by
+    # ActiveFedora
+    it "can handle Decimal RDF properties" do
       decimal_rdf = RDF::Literal.new(BigDecimal(5.5, 10))
       book = persister.save(resource: resource_class.new(title: [decimal_rdf]))
       reloaded = query_service.find_by(id: book.id)
-      expect(reloaded.title).to contain_exactly decimal_rdf
+      persisted_rdf = RDF::Literal(reloaded.title.first)
+      expect(persisted_rdf).to eq decimal_rdf
     end
 
-    xit "can handle Double RDF properties" do
+    # This is failing given that indexing floats in Solr are not supported by
+    # ActiveFedora
+    it "can handle Double RDF properties" do
       double_rdf = RDF::Literal.new(5.5)
       book = persister.save(resource: resource_class.new(title: [double_rdf]))
       reloaded = query_service.find_by(id: book.id)
-      expect(reloaded.title).to contain_exactly double_rdf
+      persisted_rdf = RDF::Literal(reloaded.title.first)
+      expect(persisted_rdf).to eq double_rdf
     end
 
-    xit "can handle Integer RDF properties" do
+    it "can handle Integer RDF properties" do
       int_rdf = RDF::Literal.new(17)
       book = persister.save(resource: resource_class.new(title: [int_rdf]))
       reloaded = query_service.find_by(id: book.id)
-      expect(reloaded.title).to contain_exactly int_rdf
+      persisted_rdf = RDF::Literal(reloaded.title.first)
+      expect(persisted_rdf).to eq int_rdf
     end
 
     it "can handle language-typed RDF properties" do
@@ -243,11 +260,12 @@ RSpec.describe Wings::Valkyrie::Persister do
       expect(reloaded.title).to contain_exactly "Test1", language_rdf
     end
 
-    xit "can handle Time RDF properties" do
+    it "can handle Time RDF properties" do
       time_rdf = RDF::Literal.new(Time.current)
       book = persister.save(resource: resource_class.new(title: [time_rdf]))
       reloaded = query_service.find_by(id: book.id)
-      expect(reloaded.title).to contain_exactly time_rdf
+      persisted_time_rdf = RDF::Literal.new(reloaded.title.first)
+      expect(DateTime.parse(persisted_time_rdf.value).utc).to eq DateTime.parse(time_rdf.value).utc
     end
 
     #  https://github.com/samvera-labs/valkyrie/wiki/Supported-Data-Types

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Wings::Valkyrie::Persister do
         include Hyrax::CoreMetadata
         include Hydra::WithDepositor
         property :title, predicate: ::RDF::Vocab::DC.title, multiple: true
+        # property :read_users, predicate:
+        # property :read_groups
+        # property :edit_users
+        # property :edit_groups
       end
     end
 


### PR DESCRIPTION
Previously these were generated just as anonymous `Class` instances, and this is currently blocked by #3738.  Resolves #3671 