### PR TITLE
add access rights metadata to a work.

### DIFF
--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -22,7 +22,7 @@ module Hyrax
       attr_reader :agreement_accepted
 
       self.terms = [:title, :creator, :contributor, :description, :abstract,
-                    :keyword, :license, :rights_statement, :rights_notes, :publisher, :date_created,
+                    :keyword, :license, :rights_statement, :access_right, :rights_notes, :publisher, :date_created,
                     :subject, :language, :identifier, :based_near, :related_url,
                     :representative_id, :thumbnail_id, :rendering_ids, :files,
                     :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,

--- a/app/indexers/hyrax/basic_metadata_indexer.rb
+++ b/app/indexers/hyrax/basic_metadata_indexer.rb
@@ -3,7 +3,7 @@ module Hyrax
   class BasicMetadataIndexer < ActiveFedora::RDF::IndexingService
     class_attribute :stored_and_facetable_fields, :stored_fields, :symbol_fields
     self.stored_and_facetable_fields = %i[resource_type creator contributor keyword publisher subject language based_near]
-    self.stored_fields = %i[description abstract license rights_statement rights_notes date_created identifier related_url bibliographic_citation source]
+    self.stored_fields = %i[description abstract license rights_statement rights_notes access_right date_created identifier related_url bibliographic_citation source]
     self.symbol_fields = %i[import_url]
 
     private

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -24,6 +24,7 @@ module Hyrax
 
       # This is for the rights statement
       property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
+      property :access_right, predicate: ::RDF::Vocab::DC.accessRights
       property :publisher, predicate: ::RDF::Vocab::DC11.publisher
       property :date_created, predicate: ::RDF::Vocab::DC.created
       property :subject, predicate: ::RDF::Vocab::DC11.subject

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -68,6 +68,7 @@ module Hyrax
         attribute :date_created, Solr::Array, solr_name('date_created')
         attribute :rights_statement, Solr::Array, solr_name('rights_statement')
         attribute :rights_notes, Solr::Array, solr_name('rights_notes')
+        attribute :access_right, Solr::Array, solr_name('access_right')
 
         attribute :mime_type, Solr::String, solr_name('mime_type', :stored_sortable)
         attribute :workflow_state, Solr::String, solr_name('workflow_state_name', :symbol)

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -15,7 +15,7 @@ module Hyrax
 
     # delegate fields from Hyrax::Works::Metadata to solr_document
     delegate :based_near_label, :related_url, :depositor, :identifier, :resource_type,
-             :keyword, :itemtype, :admin_set, :rights_notes, :abstract, to: :solr_document
+             :keyword, :itemtype, :admin_set, :rights_notes, :access_right, :abstract, to: :solr_document
 
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -14,4 +14,5 @@
 <%= presenter.attribute_to_html(:source, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_notes, html_dl: true) %>
+<%= presenter.attribute_to_html(:access_right, html_dl: true) %>
 <%= presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>

--- a/app/views/records/edit_fields/_access_right.html.erb
+++ b/app/views/records/edit_fields/_access_right.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.multiple? key %>
+  <%= f.input :access_right, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input :access_right, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
+<% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1290,6 +1290,7 @@ en:
         title: ''
       defaults:
         abstract: A brief summary of a research article, thesis, review, conference proceeding, or any in-depth analysis of a particular subject.
+        access_right: Contains information about who can access the resource or an indication of its security status.
         based_near: A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>.
         contributor: A person or group you want to recognize for playing a role in the creation of the work, but not the primary role.
         creator: The person or group responsible for the work. Usually this is the author of the content. Personal names should be entered with the last name first, e.g. &quot;Smith, John.&quot;.
@@ -1323,6 +1324,7 @@ en:
         share_applies_to_new_works: APPLY TO NEW WORKS
         title: Type name
       defaults:
+        access_right: Access Rights
         abstract: Abstract
         admin_set_id: Administrative Set
         based_near: Location

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Hyrax::Forms::BatchUploadForm do
                          :keyword,
                          :license,
                          :rights_statement,
+                         :access_right,
                          :rights_notes,
                          :publisher,
                          :date_created,

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -111,22 +111,27 @@ RSpec.describe Hyrax::Forms::WorkForm do
         source: ['related'],
         rights_statement: 'http://rightsstatements.org/vocab/InC-EDU/1.0/',
         rights_notes: ['Notes on the rights'],
-        license: ['http://creativecommons.org/licenses/by/3.0/us/']
+        license: ['http://creativecommons.org/licenses/by/3.0/us/'],
+        access_right: ['Only accessible via login.']
       }
     end
 
     subject { described_class.model_attributes(params) }
 
-    it 'permits parameters' do
+    it 'permits metadata parameters' do
       expect(subject['title']).to eq ['foo']
       expect(subject['description']).to be_empty
       expect(subject['abstract']).to be_empty
       expect(subject['visibility']).to eq 'open'
+      expect(subject['keyword']).to eq ['penguin']
+      expect(subject['source']).to eq ['related']
+    end
+
+    it 'permits rights parameters' do
       expect(subject['license']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
       expect(subject['rights_statement']).to eq 'http://rightsstatements.org/vocab/InC-EDU/1.0/'
       expect(subject['rights_notes']).to eq ['Notes on the rights']
-      expect(subject['keyword']).to eq ['penguin']
-      expect(subject['source']).to eq ['related']
+      expect(subject['access_right']).to eq ['Only accessible via login.']
     end
 
     it 'excludes non-permitted params' do


### PR DESCRIPTION
Fixes #3295

Adds access rights as a metadata to a work.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a work and verify that access right is listed in metadata
* Enter a couple of values for access rights
* Save work
* Verify that access rights shows up on the work show page
* Edit the just created work, and change the value of the access rights
* Save the work
* Verify that the access rights just edited values changed in the work show page

@samvera/hyrax-code-reviewers
