### PR TITLE
Add mime_type to the Riiif info_service

### DIFF
--- a/lib/generators/hyrax/templates/config/initializers/riiif.rb
+++ b/lib/generators/hyrax/templates/config/initializers/riiif.rb
@@ -9,7 +9,7 @@ Riiif::Image.info_service = lambda do |id, _file|
   resp = ActiveFedora::SolrService.get("id:#{fs_id}")
   doc = resp['response']['docs'].first
   raise "Unable to find solr document with id:#{fs_id}" unless doc
-  { height: doc['height_is'], width: doc['width_is'] }
+  { height: doc['height_is'], width: doc['width_is'], format: doc['mime_type_ssi'] }
 end
 
 Riiif::Image.file_resolver.id_to_uri = lambda do |id|


### PR DESCRIPTION
Part of the fix for #3422;  This [Riiif PR](https://github.com/curationexperts/riiif/pull/125) provides the other part of the fix

In order to deal with #3422 we need the mime_type to be passed with the Riiif::Image.info_service

In Riiif we can then filter by png and then deal with the problematic alpha channel, reported in [riiif#124](https://github.com/curationexperts/riiif/issues/124)

Changes proposed in this pull request:
* add mime_type to the response for `Riiif::Image.info_service`

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* call `Riiif::Image.info_service.call(file_set_id, nil)` with an image file_set id

@samvera/hyrax-code-reviewers
