### PR TITLE
prevent tabbing from moving page up.

### DIFF
--- a/app/assets/stylesheets/hyrax/_users.scss
+++ b/app/assets/stylesheets/hyrax/_users.scss
@@ -13,3 +13,14 @@
     margin-top: $padding-small-vertical;
   }
 }
+
+.activity-display {
+  max-height: 100%;
+  overflow: scroll;
+  padding-bottom: 300px;
+  position: fixed;
+
+  .activity-date {
+    padding-right: 130px;
+  }
+}

--- a/app/views/hyrax/users/_activity_log.html.erb
+++ b/app/views/hyrax/users/_activity_log.html.erb
@@ -1,22 +1,25 @@
-<table id="activity" class="table table-striped table-bordered">
-  <thead>
-    <tr>
-      <th>User Activity</th>
-      <th>Date</th>
-    </tr>
-  </thead>
-  <tbody>
-  <% events.each do |event| %>
-    <% next if event[:action].blank? or event[:timestamp].blank? %>
-    <tr>
-      <td class="ensure-wrapped"><%= sanitize event[:action] %></td>
-      <% time = Time.zone.at(event[:timestamp].to_i) %>
-      <td data-sort="<%= time.getutc.iso8601(5) %>">
-        <relative-time datetime="<%= time.getutc.iso8601 %>" title="<%= time.to_formatted_s(:standard) %>">
-          <%= time.to_formatted_s(:long_ordinal) %>
-        </relative-time>
-      </td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>
+<div  class="activity-display">
+  <table id="activity" class="table table-striped table-bordered">
+    <thead>
+      <tr>
+        <th>User Activity</th>
+        <th class="activity-date">Date</th>
+      </tr>
+    </thead>
+    <tbody>
+    <% events.each do |event| %>
+      <% next if event[:action].blank? or event[:timestamp].blank? %>
+      <tr>
+        <td class="ensure-wrapped"><%= sanitize event[:action] %></td>
+        <% time = Time.zone.at(event[:timestamp].to_i) %>
+        <td data-sort="<%= time.getutc.iso8601(5) %>">
+          <relative-time datetime="<%= time.getutc.iso8601 %>" title="<%= time.to_formatted_s(:standard) %>">
+            <%= time.to_formatted_s(:long_ordinal) %>
+          </relative-time>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
+


### PR DESCRIPTION
Fixes #3696 3402

When in this page https://nurax-dev.curationexperts.com/users/gamtest7@test-dot-org

you should be able to tab from Highlighted to Activity without the page position changing.  Before this change, when moving to Activity tab, the page would slide up and  the header of the page would be out of view.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to the users page 
* Move around from one tab to the other
* Confirm that the page position does not change and that you can scroll down the table presented in the Activities tab.

@samvera/hyrax-code-reviewers
