### PR TITLE
Active fedora converter members

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -108,12 +108,15 @@ module Wings
 
       def convert_members(af_object)
         return unless resource.respond_to?(:member_ids) && resource.member_ids
+        return if af_object.ordered_members.ids == resource.member_ids
         # TODO: It would be better to find a way to add the members without resuming all the member AF objects
-        ordered_members = []
+        temp_object = af_object.class.new
         resource.member_ids.each do |valkyrie_id|
-          ordered_members << ActiveFedora::Base.find(valkyrie_id.id)
+          temp_object.ordered_members << ActiveFedora::Base.find(valkyrie_id.id)
         end
-        af_object.ordered_members = ordered_members
+        temp_object.id = resource.alternate_ids.first.to_s if resource.respond_to?(:alternate_ids) && resource.alternate_ids
+        af_object.ordered_member_proxies.association.replace temp_object.ordered_member_proxies.association.to_a
+        af_object
       end
 
       def convert_member_of_collections(af_object)

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -111,7 +111,7 @@ module Wings
         # TODO: It would be better to find a way to add the members without resuming all the member AF objects
         temp_object = assemble_members(af_object)
         af_object.ordered_member_proxies.association.replace temp_object.ordered_member_proxies.association.to_a
-        af_object.members.proxy_association.target.concat temp_object.members.proxy_association.target
+        af_object.members.proxy_association.target.replace temp_object.members.proxy_association.target
         af_object
       end
 

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -107,7 +107,7 @@ module Wings
     private
 
       def convert_members(af_object)
-        return unless resource.respond_to?(:member_ids) && !resource.member_ids.blank?
+        return unless resource.respond_to?(:member_ids) && resource.member_ids.present?
         # TODO: It would be better to find a way to add the members without resuming all the member AF objects
         temp_object = assemble_members(af_object)
         af_object.ordered_member_proxies.association.replace temp_object.ordered_member_proxies.association.to_a

--- a/lib/wings/valkyrie/persister.rb
+++ b/lib/wings/valkyrie/persister.rb
@@ -20,6 +20,7 @@ module Wings
       def save(resource:)
         return save_file(file_node: resource) if resource.is_a? Wings::FileNode
         af_object = resource_factory.from_resource(resource: resource)
+        af_object.ordered_member_proxies.association.owner.save if af_object.respond_to? :ordered_member_proxies
         af_object.save!
         resource_factory.to_resource(object: af_object)
       rescue ActiveFedora::RecordInvalid => err

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
           work1.save!
         end
 
-        xit 'converts member_of_collection_ids back to af_object' do
+        it 'converts member_of_collection_ids back to af_object' do
           expect(converter.convert.members.map(&:id)).to match_array [work3.id, work2.id]
         end
 

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -124,12 +124,16 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
           work1.save!
         end
 
-        it 'converts member_of_collection_ids back to af_object' do
+        xit 'converts member_of_collection_ids back to af_object' do
           expect(converter.convert.members.map(&:id)).to match_array [work3.id, work2.id]
         end
 
         it 'preserves order across conversion' do
           expect(converter.convert.ordered_member_ids).to eq [work2.id, work3.id]
+        end
+
+        it 'does not change the proxy count' do
+          expect { converter.convert }.not_to change { ActiveFedora::Aggregation::Proxy.count }
         end
       end
     end


### PR DESCRIPTION
Fixes #3756 

In ActiveFedoraConverter, setting the members in an ActiveFedora object being assembled from a Valkyrie Resource increases the object's proxy count each time the converter runs. Although the current code looks as though it ought to avoid increasing the member count maintained by ActiveFedora, ActiveFedora behaves as if items are being added.

This additional code adds the members to a temporary object and then copies from the temp object's proxy_association for ordered_members and members to the ActiveFedora object being assembled.
