### PR TITLE
make sure when depositing by proxy that user gets rights over files.

### DIFF
--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -8,7 +8,8 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
     validate_files!(uploaded_files)
     depositor = proxy_or_depositor(work)
     user = User.find_by_user_key(depositor)
-    work_permissions = work.permissions.map(&:to_hash)
+
+    work, work_permissions = create_permissions work, depositor
     metadata = visibility_attributes(work_attributes)
     uploaded_files.each do |uploaded_file|
       next if uploaded_file.file_set_uri.present?
@@ -23,6 +24,13 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
   end
 
   private
+
+    def create_permissions(work, depositor)
+      work.edit_users += [depositor]
+      work.edit_users = work.edit_users.dup
+      work_permissions = work.permissions.map(&:to_hash)
+      [work, work_permissions]
+    end
 
     # The attributes used for visibility - sent as initial params to created FileSets.
     def visibility_attributes(attributes)

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -97,6 +97,17 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       sign_in second_user
       click_link 'Works'
       expect(page).to have_content "My Test Work"
+
+      # check that user can get to the files
+      click_link "My Test Work"
+      click_link "image.jp2"
+      expect(page).to have_content "image.jp2"
+
+      visit '/dashboard'
+      click_link 'Works'
+      click_link "My Test Work"
+      click_link "jp2_fits.xml"
+      expect(page).to have_content "jp2_fits.xml"
     end
   end
 


### PR DESCRIPTION
Fixes #3416
Present tense short summary (50 characters or less)

With this change the files get the right permissions applied to it, so that not only the proxy depositor, but the user that granted the proxy deposit rights have access to edit the files.


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create two users, and make on proxy to the other.
* So let user1 be a proxy for user2
* Deposit as user1 on behalf of user2 a work with a couple of files
* Make sure user1 and user2 both have access to edit the files.

@samvera/hyrax-code-reviewers
