### PR TITLE
center headings in work listed in dashboard.

### DIFF
--- a/app/views/hyrax/dashboard/works/_default_group.html.erb
+++ b/app/views/hyrax/dashboard/works/_default_group.html.erb
@@ -4,10 +4,10 @@
     <tr>
       <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
       <th><%= t("hyrax.dashboard.my.heading.title") %></th>
-      <th class="date"><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
-      <th><%= t("blacklight.search.fields.facet.suppressed_bsi") %></th>
-      <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
-      <th><%= t("hyrax.dashboard.my.heading.action") %></th>
+      <th class="date text-center"><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
+      <th class="text-center"><%= t("blacklight.search.fields.facet.suppressed_bsi") %></th>
+      <th class="text-center"><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+      <th class="text-center"><%= t("hyrax.dashboard.my.heading.action") %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/hyrax/dashboard/works/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/works/_list_works.html.erb
@@ -28,7 +28,7 @@
   </td>
 
   <td class='text-center'><%= document.date_uploaded %></td>
-  <td class='workflow-state'><%= presenter.workflow.state_label %></td>
+  <td class='workflow-state text-center'><%= presenter.workflow.state_label %></td>
   <td class='text-center'><%= render_visibility_link document %></td>
 
   <td class='text-center'>

--- a/app/views/hyrax/my/works/_default_group.html.erb
+++ b/app/views/hyrax/my/works/_default_group.html.erb
@@ -4,10 +4,10 @@
   <tr>
     <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>
-    <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
-    <th><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
-    <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
-    <th><%= t("hyrax.dashboard.my.heading.action") %></th>
+    <th class='text-center'><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
+    <th class='text-center'><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
+    <th class='text-center'><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+    <th class='text-center'><%= t("hyrax.dashboard.my.heading.action") %></th>
   </tr>
   </thead>
   <tbody>

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -29,12 +29,12 @@
     </div>
   </td>
 
-  <td class="date"><%= document.date_uploaded %></td>
+  <td class="date text-center"><%= document.date_uploaded %></td>
   <td class='text-center'>
     <span class="fa <%= current_user.trophies.where(work_id: document.id).exists? ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>" aria-hidden="true"></span></td>
-  <td><%= render_visibility_link document %></td>
+  <td class='text-center'><%= render_visibility_link document %></td>
 
-  <td>
+  <td class='text-center'>
     <%= render 'work_action_menu', document: document %>
   </td>
 </tr>


### PR DESCRIPTION
Fixes #3721

This PR address the headers and values listed on the dashboard for works.  Many values were not centered.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to dashboard/my/works page
* Verify that the headers of the table and values are centered, with the exception of the 1st 2 columns
* Got to dashboard/works page
* Verify that the headers of the table and values are centered, with the exception of the 1st 2 columns

@samvera/hyrax-code-reviewers
