### PR TITLE
warn user that he can't make himself a proxy.

### DIFF
--- a/app/assets/javascripts/hyrax/proxy_rights.js
+++ b/app/assets/javascripts/hyrax/proxy_rights.js
@@ -16,7 +16,11 @@
         dataType: 'json',
         data: {grantee_id: user_key},
         success: function (data) {
-          if (data.name !== undefined) {
+          if (data.name === "FAILURE") {
+            $('#proxy-deny-modal').modal('show');
+            return;
+          }
+          else if (data.name !== undefined) {
             row = rowTemplate(data);
             $('#authorizedProxies tbody', $container).append(row);
             if (settings.afterAdd)

--- a/app/views/hyrax/depositors/_modal_proxy_deny.html.erb
+++ b/app/views/hyrax/depositors/_modal_proxy_deny.html.erb
@@ -1,0 +1,14 @@
+<div class="modal fade" id="proxy-deny-modal" tabindex="-1" role="dialog" aria-labelledby="proxy-deny-label">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <form class="proxy-deny-modal-form">
+        <div class="modal-body">
+          <p><%= t('hyrax.dashboard.proxy_add_deny') %></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-dismiss="modal"><%= t('helpers.action.close') %></button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/depositors/index.html.erb
+++ b/app/views/hyrax/depositors/index.html.erb
@@ -10,4 +10,7 @@
       </div>
     </div>
   </div>
+
+<%= render 'modal_proxy_deny' %>
+
 </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -807,6 +807,7 @@ en:
       no_transfer_requests: You haven't received any work transfer requests
       no_transfers: You haven't transferred any work
       proxy_activity: Proxy Activity
+      proxy_add_deny: You cannot make yourself a proxy
       proxy_delete: Delete Proxy
       proxy_help: Select a user who can deposit works on your behalf. Both you and your proxy will be able to make changes to these works. You can revoke a proxy by clicking the Delete Proxy button. To revoke their ability to edit a work they previously submitted, remove them from the Sharing tab on each work.
       proxy_user: Proxy User

--- a/spec/controllers/hyrax/depositors_controller_spec.rb
+++ b/spec/controllers/hyrax/depositors_controller_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe Hyrax::DepositorsController do
           post :create, params: grant_proxy_params.merge(grantee_id: user.user_key)
         end
 
-        it 'does not add the user, and returns a 200, with empty response body' do
+        it 'does not add the user, and returns a 200, with a failure json' do
           expect { redundant_request_to_grant_proxy }.to change { ProxyDepositRights.count }.by(0)
           expect(response).to be_success
-          expect(response.body).to be_blank
+          expect(response.body).to have_content "{\"name\":\"FAILURE\"}"
         end
 
         it 'does not send a message to the user' do

--- a/spec/features/proxy_spec.rb
+++ b/spec/features/proxy_spec.rb
@@ -21,5 +21,26 @@ RSpec.describe 'proxy', type: :feature do
       expect(page).to have_css('td.depositor-name', text: second_user.user_key)
       expect(page).to have_link('Delete Proxy')
     end
+
+    it "try to make yourself a proxy" do
+      sign_in user
+      click_link "Your activity"
+      within 'div#proxy_management' do
+        click_link "Manage Proxies"
+      end
+      expect(first("td.depositor-name")).to be_nil
+
+      # BEGIN create_proxy_using_partial
+      find('a.select2-choice').click
+      find(".select2-input").set(user.user_key)
+      expect(page).to have_css("div.select2-result-label")
+      find("div.select2-result-label").click
+      # END create_proxy_using_partial
+
+      within('#proxy-deny-modal') do
+        expect(page).to have_content "You cannot make yourself a proxy"
+        click_button('Close')
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #3710

If user logged in tries to make himself a proxy, don't allow this, and put out an alert letting him know that she/he can't do that.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Login and go to the Manage Proxy page
* Assign some other user to be a proxy
* Verify that user shows up in the list shown at the right of the page
* Assign yourself as a proxy
* Verify that you get an Alert letting you know that is not permitted.

@samvera/hyrax-code-reviewers
