### PR TITLE
Add missing translations for filter dropdowns on work and collection dashboard index views

### DIFF
--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -18,9 +18,11 @@ de:
       fields:
         facet:
           admin_set_sim: Sammlung
+          collection_type_gid_ssim: Sammlungsart
           member_of_collections_ssim: Sammlung
           resource_type_sim: Ressourcentyp
           suppressed_bsi: Status
+          visibility_ssi: Sichtbarkeit
         show:
           admin_set: 'Im Admin-Set:'
           based_near_label: Ort

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -18,9 +18,11 @@ en:
       fields:
         facet:
           admin_set_sim: Admin Set
+          collection_type_gid_ssim: Collection Type
           member_of_collections_ssim: Collection
           resource_type_sim: Resource type
           suppressed_bsi: Status
+          visibility_ssi: Visibility
         show:
           admin_set: 'In Administrative Set:'
           based_near_label: Location

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -18,9 +18,11 @@ es:
       fields:
         facet:
           admin_set_sim: Colección
+          collection_type_gid_ssim: Tipo de colección
           member_of_collections_ssim: Colección
           resource_type_sim: Tipo de recurso
           suppressed_bsi: Estado
+          visibility_ssi: Visibilidad
         show:
           admin_set: 'En Conjunto Administrativo:'
           based_near_label: Ubicación

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -18,9 +18,11 @@ fr:
       fields:
         facet:
           admin_set_sim: Collection
+          collection_type_gid_ssim: Type de collection
           member_of_collections_ssim: Collection
           resource_type_sim: Type de ressource
           suppressed_bsi: Statut
+          visibility_ssi: Visibilité
         show:
           admin_set: 'Dans l''ensemble administratif:'
           based_near_label: Emplacement

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -18,9 +18,11 @@ it:
       fields:
         facet:
           admin_set_sim: Collezione
+          collection_type_gid_ssim: Tipo di raccolta
           member_of_collections_ssim: Collezione
           resource_type_sim: Tipo di risorsa
           suppressed_bsi: Stato
+          visibility_ssi: Visibilità
         show:
           admin_set: 'In Impostazione amministrativa:'
           based_near_label: luogo

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -18,9 +18,11 @@ pt-BR:
       fields:
         facet:
           admin_set_sim: Conjunto Administrativo
+          collection_type_gid_ssim: Tipo de Coleção
           member_of_collections_ssim: Coleção
           resource_type_sim: Tipo de recurso
           suppressed_bsi: Status
+          visibility_ssi: Acesso
         show:
           admin_set: 'No conjunto administrativo:'
           based_near_label: Localização

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -18,9 +18,11 @@ zh:
       fields:
         facet:
           admin_set_sim: 集
+          collection_type_gid_ssim: 集合类型
           member_of_collections_ssim: 采集
           resource_type_sim: 资源类型
           suppressed_bsi: 状况
+          visibility_ssi: 公开度
         show:
           admin_set: '管理集内:'
           based_near_label: 地点


### PR DESCRIPTION
Shea Van Schuyver and Adam Malantonio mentioned in slack that these two translations on the work and collection dashboard indexes were missing.  This PR adds the two in all of the existing locales using values from `hyrax.dashboard.my.heading`.

Screenshots showing these issues:
<img width="393" alt="Screen Shot 2019-04-26 at 4 03 54 PM" src="https://user-images.githubusercontent.com/1053603/56833723-4a476f00-683d-11e9-81d5-2b4f1172089e.png">
<img width="393" alt="Screen Shot 2019-04-26 at 4 04 23 PM" src="https://user-images.githubusercontent.com/1053603/56833724-4ddaf600-683d-11e9-996f-11e1a4086b8b.png">

@samvera/hyrax-code-reviewers
