### PR TITLE
Index versioned file URI for IIIF, improve thumbnail cache behavior.

### DIFF
--- a/app/controllers/concerns/hyrax/local_file_downloads_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/local_file_downloads_controller_behavior.rb
@@ -29,6 +29,7 @@ module Hyrax
       end
 
       def send_local_file_contents
+        return unless stale?(last_modified: local_file_last_modified, template: false)
         self.status = 200
         prepare_local_file_headers
         # For derivatives stored on the local file system
@@ -65,7 +66,7 @@ module Hyrax
         response.headers['Content-Type'] = local_file_mime_type
         response.headers['Content-Length'] ||= local_file_size.to_s
         # Prevent Rack::ETag from calculating a digest over body
-        response.headers['Last-Modified'] = local_file_last_modified.utc.strftime("%a, %d %b %Y %T GMT")
+        response.headers['Last-Modified'] ||= local_file_last_modified.httpdate
         self.content_type = local_file_mime_type
       end
 

--- a/app/controllers/concerns/hyrax/local_file_downloads_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/local_file_downloads_controller_behavior.rb
@@ -66,7 +66,7 @@ module Hyrax
         response.headers['Content-Type'] = local_file_mime_type
         response.headers['Content-Length'] ||= local_file_size.to_s
         # Prevent Rack::ETag from calculating a digest over body
-        response.headers['Last-Modified'] ||= local_file_last_modified.httpdate
+        response.headers['Last-Modified'] = local_file_last_modified.httpdate
         self.content_type = local_file_mime_type
       end
 

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -42,11 +42,7 @@ module Hyrax
 
       def original_file_id
         return unless object.original_file
-        if object.original_file.versions.present?
-          ActiveFedora::File.uri_to_id(object.current_content_version_uri)
-        else
-          object.original_file.id
-        end
+        Hyrax::VersioningService.versioned_file_id object.original_file
       end
 
       def file_format

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -28,11 +28,21 @@ module Hyrax
         solr_doc['sample_rate_tesim']       = object.sample_rate
         solr_doc['original_checksum_tesim'] = object.original_checksum
         solr_doc['alpha_channels_ssi']      = object.alpha_channels
+        solr_doc['current_file_version_ssi'] = latest_version_id
         solr_doc['original_file_id_ssi']    = original_file_id
       end
     end
 
     private
+
+      def latest_version_id
+        return unless object.original_file.present?
+        if object.original_file.versions.present?
+          ActiveFedora::File.uri_to_id(object.current_content_version_uri)
+        else
+          ActiveFedora::File.uri_to_id(object.original_file.uri)
+        end
+      end
 
       def digest_from_content
         return unless object.original_file

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -28,7 +28,6 @@ module Hyrax
         solr_doc['sample_rate_tesim']       = object.sample_rate
         solr_doc['original_checksum_tesim'] = object.original_checksum
         solr_doc['alpha_channels_ssi']      = object.alpha_channels
-        solr_doc['current_file_version_ssi'] = latest_version_id
         solr_doc['original_file_id_ssi']    = original_file_id
       end
     end

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -35,15 +35,6 @@ module Hyrax
 
     private
 
-      def latest_version_id
-        return unless object.original_file.present?
-        if object.original_file.versions.present?
-          ActiveFedora::File.uri_to_id(object.current_content_version_uri)
-        else
-          ActiveFedora::File.uri_to_id(object.original_file.uri)
-        end
-      end
-
       def digest_from_content
         return unless object.original_file
         object.original_file.digest.first.to_s
@@ -51,7 +42,11 @@ module Hyrax
 
       def original_file_id
         return unless object.original_file
-        object.original_file.id
+        if object.original_file.versions.present?
+          ActiveFedora::File.uri_to_id(object.current_content_version_uri)
+        else
+          object.original_file.id
+        end
       end
 
       def file_format

--- a/app/models/concerns/hyrax/solr_document/characterization.rb
+++ b/app/models/concerns/hyrax/solr_document/characterization.rb
@@ -103,7 +103,7 @@ module Hyrax
       end
 
       def alpha_channels
-        self[ActiveFedora.index_field_mapper.solr_name("alpha_channels")]
+        self["alpha_channels_ssi"]
       end
     end
   end

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -77,6 +77,7 @@ module Hyrax
         attribute :label, Solr::String, "label_tesim"
         attribute :file_format, Solr::String, "file_format_tesim"
         attribute :suppressed?, Solr::String, "suppressed_bsi"
+        attribute :current_file_version, Solr::String, "current_file_version_ssi"
         attribute :date_modified, Solr::Date, "date_modified_dtsi"
         attribute :date_uploaded, Solr::Date, "date_uploaded_dtsi"
         attribute :create_date, Solr::Date, "system_create_dtsi"

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -77,7 +77,7 @@ module Hyrax
         attribute :label, Solr::String, "label_tesim"
         attribute :file_format, Solr::String, "file_format_tesim"
         attribute :suppressed?, Solr::String, "suppressed_bsi"
-        attribute :current_file_version, Solr::String, "current_file_version_ssi"
+        attribute :original_file_id, Solr::String, "original_file_id_ssi"
         attribute :date_modified, Solr::Date, "date_modified_dtsi"
         attribute :date_uploaded, Solr::Date, "date_uploaded_dtsi"
         attribute :create_date, Solr::Date, "system_create_dtsi"

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -12,7 +12,7 @@ module Hyrax
     def display_image
       return nil unless ::FileSet.exists?(id) && solr_document.image? && current_ability.can?(:read, id)
 
-      latest_file_id = current_file_version || unindexed_current_file_version
+      latest_file_id = original_file_id || unindexed_current_file_version
 
       return nil unless latest_file_id
 

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -54,7 +54,7 @@ module Hyrax
         result = original_file_id
         if result.blank?
           Rails.logger.warn "original_file_id for #{id} not found, falling back to Fedora."
-          result = ActiveFedora::File.uri_to_id(::FileSet.find(id).current_content_version_uri)
+          result = Hyrax::VersioningService.versioned_file_id ::FileSet.find(id).original_file
         end
         result
       end

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -11,21 +11,27 @@ module Hyrax
     # @return [IIIFManifest::DisplayImage] the display image required by the manifest builder.
     def display_image
       return nil unless ::FileSet.exists?(id) && solr_document.image? && current_ability.can?(:read, id)
-      # @todo this is slow, find a better way (perhaps index iiif url):
-      original_file = ::FileSet.find(id).original_file
+
+      latest_file_id = current_file_version || unindexed_current_file_version
+
+      return nil unless latest_file_id
 
       url = Hyrax.config.iiif_image_url_builder.call(
-        original_file.id,
+        latest_file_id,
         request.base_url,
         Hyrax.config.iiif_image_size_default,
         format: image_format(original_file.alpha_channels)
       )
+
+      # @todo this is slow, find a better way (perhaps index iiif url):
+      original_file = ::FileSet.find(id).original_file
+
       # @see https://github.com/samvera-labs/iiif_manifest
       IIIFManifest::DisplayImage.new(url,
                                      format: image_format(original_file.alpha_channels),
                                      width: original_file.width,
                                      height: original_file.height,
-                                     iiif_endpoint: iiif_endpoint(original_file.id))
+                                     iiif_endpoint: iiif_endpoint(latest_file_id))
     end
 
     private
@@ -40,6 +46,11 @@ module Hyrax
 
       def image_format(channels)
         channels.find { |c| c.include?('rgba') }.nil? ? 'jpg' : 'png'
+      end
+
+      def unindexed_current_file_version
+        Rails.logger.warn "Indexed current_file_version for #{id} not found, falling back to Fedora."
+        ActiveFedora::File.uri_to_id(::FileSet.find(id).current_content_version_uri)
       end
   end
 end

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -58,6 +58,5 @@ module Hyrax
         end
         result
       end
-    end
   end
 end

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -42,12 +42,7 @@ module Hyrax
       end
 
       def image_format(channels)
-        channels.find { |c| c.include?('rgba') }.nil? ? 'jpg' : 'png'
-      end
-
-      def unindexed_current_file_version
-        Rails.logger.warn "Indexed current_file_version for #{id} not found, falling back to Fedora."
-        ActiveFedora::File.uri_to_id(::FileSet.find(id).current_content_version_uri)
+        channels&.include?('rgba') ? 'png' : 'jpg'
       end
 
       def lookup_original_file_id

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -20,14 +20,14 @@ module Hyrax
         latest_file_id,
         request.base_url,
         Hyrax.config.iiif_image_size_default,
-        format: image_format(solr_document[:alpha_channels_ssi])
+        format: image_format(alpha_channels)
       )
 
       # @see https://github.com/samvera-labs/iiif_manifest
       IIIFManifest::DisplayImage.new(url,
-                                     format: image_format(solr_document[:alpha_channels_ssi]),
-                                     width: solr_document[:width_is],
-                                     height: solr_document[:height_is],
+                                     format: image_format(alpha_channels),
+                                     width: width,
+                                     height: height,
                                      iiif_endpoint: iiif_endpoint(latest_file_id))
     end
 

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -30,6 +30,7 @@ module Hyrax
              :embargo_release_date, :lease_expiration_date,
              :depositor, :keyword, :title_or_label, :keyword,
              :date_created, :date_modified, :itemtype,
+             :current_file_version,
              to: :solr_document
 
     def single_use_links

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -30,7 +30,7 @@ module Hyrax
              :embargo_release_date, :lease_expiration_date,
              :depositor, :keyword, :title_or_label, :keyword,
              :date_created, :date_modified, :itemtype,
-             :current_file_version,
+             :original_file_id,
              to: :solr_document
 
     def single_use_links

--- a/app/services/hyrax/versioning_service.rb
+++ b/app/services/hyrax/versioning_service.rb
@@ -16,6 +16,16 @@ module Hyrax
         file.versions.last
       end
 
+      # @param [ActiveFedora::File | Hyrax::FileMetadata] content
+      def versioned_file_id(file)
+        versions = file.versions.all
+        if versions.present?
+          ActiveFedora::File.uri_to_id versions.last.uri
+        else
+          file.id
+        end
+      end
+
       # Record the version committer of the last version
       # @param [ActiveFedora::File | Hyrax::FileMetadata] content
       # @param [User, String] user_key

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -74,6 +74,15 @@ RSpec.describe Hyrax::DownloadsController do
             get :show, params: { id: file_set, file: 'thumbnail' }
           end
 
+          it 'sends 304 response when client has valid cached data' do
+            get :show, params: { id: file_set, file: 'thumbnail' }
+            expect(response).to have_http_status :success
+            request.env['HTTP_IF_MODIFIED_SINCE'] = response.headers['Last-Modified']
+            request.env['HTTP_IF_NONE_MATCH'] = response.headers['ETag']
+            get :show, params: { id: file_set, file: 'thumbnail' }
+            expect(response).to have_http_status :not_modified
+          end
+
           context "stream" do
             it "head request" do
               request.env["HTTP_RANGE"] = 'bytes=0-15'

--- a/spec/indexers/hyrax/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/file_set_indexer_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Hyrax::FileSetIndexer do
 
   let(:resource_version) do
     ActiveFedora::VersionsGraph::ResourceVersion.new.tap do |v|
-      v.uri = 'http://test.example/rest/example/foo123/files/1001/fcr:versions/version1'
+      v.uri = "http://test.example/rest/example/foo123/files/#{mock_file.id}/fcr:versions/version1"
       v.label = 'version1'
       v.created = '2019-08-07T06:05:43.210Z'
     end

--- a/spec/indexers/hyrax/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/file_set_indexer_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Hyrax::FileSetIndexer do
 
     context "when original_file is not versioned" do
       before do
-        allow(version_graph).to receive(:fedora_versions) { [] }
+        allow(version_graph).to receive(:fedora_versions).and_return([])
       end
 
       it "does not have version info indexed" do

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe Hyrax::FileSetPresenter do
        "subject", "language", "license", "format_label", "file_size",
        "height", "width", "filename", "well_formed", "page_count",
        "file_title", "last_modified", "original_checksum", "mime_type",
+       "duration", "sample_rate", "current_file_version"]
        "duration", "sample_rate", "alpha_channels"]
     end
 
@@ -305,11 +306,15 @@ RSpec.describe Hyrax::FileSetPresenter do
   end
 
   describe 'IIIF integration' do
+    def uri_segment_escape(uri)
+      ActionDispatch::Journey::Router::Utils.escape_segment(uri)
+    end
+
     let(:file_set) { create(:file_set) }
     let(:solr_document) { SolrDocument.new(file_set.to_solr) }
     let(:request) { double(base_url: 'http://test.host') }
     let(:presenter) { described_class.new(solr_document, ability, request) }
-    let(:id) { CGI.escape(file_set.original_file.id) }
+    let(:id) { ActiveFedora::File.uri_to_id(file_set.original_file.versions.last.uri) }
     let(:read_permission) { true }
 
     before do
@@ -345,7 +350,7 @@ RSpec.describe Hyrax::FileSetPresenter do
           end
 
           it { is_expected.to be_instance_of IIIFManifest::DisplayImage }
-          its(:url) { is_expected.to eq "http://test.host/images/#{id}/full/600,/0/default.jpg" }
+          its(:url) { is_expected.to eq "http://test.host/images/#{uri_segment_escape(id)}/full/600,/0/default.jpg" }
 
           context 'with custom image size default' do
             let(:custom_image_size) { '666,' }
@@ -358,7 +363,7 @@ RSpec.describe Hyrax::FileSetPresenter do
             end
 
             it { is_expected.to be_instance_of IIIFManifest::DisplayImage }
-            its(:url) { is_expected.to eq "http://test.host/images/#{id}/full/#{custom_image_size}/0/default.jpg" }
+            its(:url) { is_expected.to eq "http://test.host/images/#{uri_segment_escape(id)}/full/#{custom_image_size}/0/default.jpg" }
           end
 
           context 'with custom image url builder' do
@@ -388,7 +393,7 @@ RSpec.describe Hyrax::FileSetPresenter do
     end
 
     describe "#iiif_endpoint" do
-      subject { presenter.send(:iiif_endpoint, file_set.original_file.id) }
+      subject { presenter.send(:iiif_endpoint, id) }
 
       before do
         allow(Hyrax.config).to receive(:iiif_image_server?).and_return(riiif_enabled)
@@ -399,7 +404,7 @@ RSpec.describe Hyrax::FileSetPresenter do
       context 'with iiif_image_server enabled' do
         let(:riiif_enabled) { true }
 
-        its(:url) { is_expected.to eq "http://test.host/images/#{id}" }
+        its(:url) { is_expected.to eq "http://test.host/images/#{uri_segment_escape(id)}" }
         its(:profile) { is_expected.to eq 'http://iiif.io/api/image/2/level2.json' }
 
         context 'with a custom iiif image profile' do

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe Hyrax::FileSetPresenter do
        "subject", "language", "license", "format_label", "file_size",
        "height", "width", "filename", "well_formed", "page_count",
        "file_title", "last_modified", "original_checksum", "mime_type",
-       "duration", "sample_rate", "current_file_version"]
-       "duration", "sample_rate", "alpha_channels"]
+       "duration", "sample_rate", "alpha_channels",
+       "original_file_id", "current_file_version"]
     end
 
     it "delegates to the solr_document" do

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -86,8 +86,7 @@ RSpec.describe Hyrax::FileSetPresenter do
        "subject", "language", "license", "format_label", "file_size",
        "height", "width", "filename", "well_formed", "page_count",
        "file_title", "last_modified", "original_checksum", "mime_type",
-       "duration", "sample_rate", "alpha_channels",
-       "original_file_id", "current_file_version"]
+       "duration", "sample_rate", "alpha_channels", "original_file_id"]
     end
 
     it "delegates to the solr_document" do

--- a/spec/services/hyrax/versioning_service_spec.rb
+++ b/spec/services/hyrax/versioning_service_spec.rb
@@ -1,26 +1,46 @@
 RSpec.describe Hyrax::VersioningService do
-  describe '#latest_version_of' do
-    let(:user) { build(:user) }
-    let(:file) { create(:file_set) }
+  let(:user) { build(:user) }
+  let(:file) { create(:file_set) }
 
-    before do
-      # Add the original_file (this service  creates a version after saving when you call it with versioning: true)
-      Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :original_file, versioning: true)
+  before do
+    # Add the original_file (this service  creates a version after saving when you call it with versioning: true)
+    Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :original_file, versioning: true)
+  end
+
+  describe '#versioned_file_id' do
+    subject { described_class.versioned_file_id file.original_file }
+
+    context 'without version data' do
+      before do
+        allow(file.original_file).to receive(:has_versions?) { false }
+      end
+      it { is_expected.to eq file.original_file.id }
     end
 
-    describe 'latest_version_of' do
-      subject { described_class.latest_version_of(file.original_file).label }
+    context 'with one version' do
+      it { is_expected.to eq "#{file.original_file.id}/fcr:versions/version1" }
+    end
 
-      context 'with one version' do
-        it { is_expected.to eq 'version1' }
+    context 'with two versions' do
+      before do
+        file.original_file.create_version
       end
+      it { is_expected.to eq "#{file.original_file.id}/fcr:versions/version2" }
+    end
+  end
 
-      context 'with two versions' do
-        before do
-          file.original_file.create_version
-        end
-        it { is_expected.to eq 'version2' }
+  describe '#latest_version_of' do
+    subject { described_class.latest_version_of(file.original_file).label }
+
+    context 'with one version' do
+      it { is_expected.to eq 'version1' }
+    end
+
+    context 'with two versions' do
+      before do
+        file.original_file.create_version
       end
+      it { is_expected.to eq 'version2' }
     end
   end
 end

--- a/spec/services/hyrax/versioning_service_spec.rb
+++ b/spec/services/hyrax/versioning_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hyrax::VersioningService do
 
     context 'without version data' do
       before do
-        allow(file.original_file).to receive(:has_versions?) { false }
+        allow(file.original_file).to receive(:has_versions?).and_return(false)
       end
       it { is_expected.to eq file.original_file.id }
     end

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -21,7 +21,7 @@ module Hyrax
                  duration:          opts.fetch(:duration, []),
                  sample_rate:       opts.fetch(:sample_rate, []),
                  versions:          opts.fetch(:versions, []),
-                 uri:               opts.fetch(:versions, []))
+                 uri:               opts.fetch(:uri, []))
     end
   end
 end

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -20,8 +20,7 @@ module Hyrax
                  digest:            opts.fetch(:digest, []),
                  duration:          opts.fetch(:duration, []),
                  sample_rate:       opts.fetch(:sample_rate, []),
-                 versions:          opts.fetch(:versions, []),
-                 uri:               opts.fetch(:uri, []))
+                 versions:          opts.fetch(:versions, []))
     end
   end
 end

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -19,7 +19,9 @@ module Hyrax
                  alpha_channels:    opts.fetch(:alpha_channels, []),
                  digest:            opts.fetch(:digest, []),
                  duration:          opts.fetch(:duration, []),
-                 sample_rate:       opts.fetch(:sample_rate, []))
+                 sample_rate:       opts.fetch(:sample_rate, []),
+                 versions:          opts.fetch(:versions, []),
+                 uri:               opts.fetch(:versions, []))
     end
   end
 end


### PR DESCRIPTION
Fixes #2910 
Use versioned URI for IIIF image requests, and instruct browser to check for new versions of thumbnails. 

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Upload a new version of a file in a fileset
* Work show page should show new version in UV and a matching thumbnail.

@samvera/hyrax-code-reviewers
