### PR TITLE
Extract more strings for i18n

### DIFF
--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -249,11 +249,13 @@ Blacklight.onLoad(function () {
     var tableRows = $('#documents table.collections-list-table tbody tr');
     var checkbox = null;
     var numRowsSelected = false;
+    var $modal = $('#selected-collections-delete-modal');
+    var $deleteWordingTarget = $modal.find('.pluralized');
     var deleteWording = {
-      plural: 'these collections',
-      singular: 'this collection'
+      plural: $modal.data("pluralForm"),
+      singular: $modal.data("singularForm")
     };
-    var $deleteWordingTarget = $('#selected-collections-delete-modal .pluralized');
+    console.log(deleteWording);
 
     var canDeleteAll = true;
     var selectedInputs = $('#documents table.collections-list-table tbody tr')
@@ -277,7 +279,7 @@ Blacklight.onLoad(function () {
       } else {
         $deleteWordingTarget.text(deleteWording.singular);
       }
-      $('#selected-collections-delete-modal').modal('show');
+      $modal.modal('show');
     }
   });
 

--- a/app/assets/javascripts/hyrax/collections.js
+++ b/app/assets/javascripts/hyrax/collections.js
@@ -255,7 +255,6 @@ Blacklight.onLoad(function () {
       plural: $modal.data("pluralForm"),
       singular: $modal.data("singularForm")
     };
-    console.log(deleteWording);
 
     var canDeleteAll = true;
     var selectedInputs = $('#documents table.collections-list-table tbody tr')

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -48,7 +48,7 @@ module Hyrax
     def destroy
       parent = curation_concern.parent
       actor.destroy
-      redirect_to [main_app, parent], notice: 'The file has been deleted.'
+      redirect_to [main_app, parent], notice: view_context.t('hyrax.file_sets.asset_deleted_flash.message')
     end
 
     # PATCH /concern/file_sets/:id
@@ -95,7 +95,7 @@ module Hyrax
       def after_update_response
         respond_to do |wants|
           wants.html do
-            redirect_to [main_app, curation_concern], notice: "The file #{view_context.link_to(curation_concern, [main_app, curation_concern])} has been updated."
+            redirect_to [main_app, curation_concern], notice: view_context.t('hyrax.file_sets.asset_updated_flash.message', link_to_file: view_context.link_to(curation_concern, [main_app, curation_concern]))
           end
           wants.json do
             @presenter = show_presenter.new(curation_concern, current_ability)

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -95,7 +95,8 @@ module Hyrax
       def after_update_response
         respond_to do |wants|
           wants.html do
-            redirect_to [main_app, curation_concern], notice: view_context.t('hyrax.file_sets.asset_updated_flash.message', link_to_file: view_context.link_to(curation_concern, [main_app, curation_concern]))
+            link_to_file = view_context.link_to(curation_concern, [main_app, curation_concern])
+            redirect_to [main_app, curation_concern], notice: view_context.t('hyrax.file_sets.asset_updated_flash.message', link_to_file: link_to_file)
           end
           wants.json do
             @presenter = show_presenter.new(curation_concern, current_ability)

--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -88,7 +88,7 @@ class ProxyDepositRequest < ActiveRecord::Base
 
     def send_request_transfer_message_as_part_of_create
       user_link = link_to(sending_user.name, Hyrax::Engine.routes.url_helpers.user_path(sending_user))
-      transfer_link = link_to('transfer requests', Hyrax::Engine.routes.url_helpers.transfers_path)
+      transfer_link = link_to( I18n.t('hyrax.notifications.proxy_deposit_request.transfer_on_create.transfer_link_label'), Hyrax::Engine.routes.url_helpers.transfers_path)
       message = I18n.t('hyrax.notifications.proxy_deposit_request.transfer_on_create.message', user_link: user_link,
                                                                                                transfer_link: transfer_link)
       Hyrax::MessengerService.deliver(::User.batch_user, receiving_user, message,

--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -88,7 +88,7 @@ class ProxyDepositRequest < ActiveRecord::Base
 
     def send_request_transfer_message_as_part_of_create
       user_link = link_to(sending_user.name, Hyrax::Engine.routes.url_helpers.user_path(sending_user))
-      transfer_link = link_to( I18n.t('hyrax.notifications.proxy_deposit_request.transfer_on_create.transfer_link_label'), Hyrax::Engine.routes.url_helpers.transfers_path)
+      transfer_link = link_to(I18n.t('hyrax.notifications.proxy_deposit_request.transfer_on_create.transfer_link_label'), Hyrax::Engine.routes.url_helpers.transfers_path)
       message = I18n.t('hyrax.notifications.proxy_deposit_request.transfer_on_create.message', user_link: user_link,
                                                                                                transfer_link: transfer_link)
       Hyrax::MessengerService.deliver(::User.batch_user, receiving_user, message,

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -39,7 +39,7 @@
             </ul>
         </div>
       <% end %>
-      <%= link_to t('.delete'), [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
+      <%= link_to t('.delete'), [main_app, presenter], class: 'btn btn-danger', data: { confirm: t('.confirm_delete', work_type: presenter.human_readable_type) }, method: :delete %>
     <% end %>
   </div>
 </div>

--- a/app/views/hyrax/file_sets/_asset_deleted_flash.html.erb
+++ b/app/views/hyrax/file_sets/_asset_deleted_flash.html.erb
@@ -1,1 +1,1 @@
-The file has been deleted.
+<%=t('.message') %>

--- a/app/views/hyrax/file_sets/_asset_saved_flash.html.erb
+++ b/app/views/hyrax/file_sets/_asset_saved_flash.html.erb
@@ -1,9 +1,8 @@
-The file(s)
 <%=
   total_shown = 20
-  file_sets.first(total_shown)
-           .map { |fs| link_to(fs, file_set_url(fs)) }
-           .tap { |fs| fs << '...' if file_sets.length > total_shown }
-           .join(', ')
+  saved_files = file_sets.first(total_shown)
+  .map { |fs| link_to(fs, file_set_url(fs)) }
+  .tap { |fs| fs << '...' if file_sets.length > total_shown }
+  .join(', ')
 %>
- have been saved.
+<%=t('.message', files: saved_files, count:file_sets.count) %>

--- a/app/views/hyrax/file_sets/_asset_updated_flash.html.erb
+++ b/app/views/hyrax/file_sets/_asset_updated_flash.html.erb
@@ -1,1 +1,2 @@
-The file <%= link_to(file_set, hyrax.file_set_url(file_set)) %> has been updated.
+<% link_to_file = link_to(file_set, hyrax.file_set_url(file_set)) %>
+<%= t('.message', link_to_file: link_to_file) %>

--- a/app/views/hyrax/my/collections/_modal_delete_selected_collections.html.erb
+++ b/app/views/hyrax/my/collections/_modal_delete_selected_collections.html.erb
@@ -1,4 +1,7 @@
-<div class="modal fade" id="selected-collections-delete-modal" tabindex="-1" role="dialog" aria-labelledby="delete-collection-label">
+<div class="modal fade" id="selected-collections-delete-modal"
+     data-plural-form="<%= t('hyrax.dashboard.my.action.collections_confirmation_plural') %>"
+     data-singular-form="<%= t('hyrax.dashboard.my.action.collections_confirmation_singular') %>"
+     tabindex="-1" role="dialog" aria-labelledby="delete-collection-label">
   <div class="modal-dialog">
     <div class="modal-content">
         <div class="modal-body">

--- a/app/views/hyrax/permissions/confirm_access.html.erb
+++ b/app/views/hyrax/permissions/confirm_access.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default permissions-confirm">
   <div class="panel-heading">
-    <h4>Apply changes to contents?<h4>
+    <h4><%= I18n.t("hyrax.upload.change_access_title_html") %><h4>
   </div>
   <div class="panel-body">
       <%= sanitize I18n.t("hyrax.upload.change_access_message_html", curation_concern: curation_concern) %>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -730,6 +730,8 @@ de:
           collection_update_success: Die Sammlung wurde erfolgreich aktualisiert.
           collections_confirmation_html: "<span class='pluralized'>Diese Sammlung</span> löschen , wird permanent <span class='pluralized'>diese Sammlung</span> aus dem Repository entfernen. Elemente in <span class='pluralized'>dieser Sammlung</span> verbleiben im Repository. Möchten Sie <span class='pluralized'>diese Sammlung</span> wirklich löschen?"
           collections_confirmation_no_items_html: Möchten Sie diese Sammlung wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
+          collections_confirmation_plural: diese Sammlungen
+          collections_confirmation_singular: diese Sammlung
           delete_admin_set: Sammlung löschen
           delete_admin_set_deny: Dieses Sammlung ist als Admin-Set definiert und nicht leer. Um dieses Admin-Set zu löschen, müssen Sie zunächst alle Elemente aus dem Admin-Set entfernen (löschen oder in eine andere Admin-Set-Sammlung verschieben).
           delete_collection: Sammlung löschen

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -905,6 +905,14 @@ de:
         header: Wählen Sie eine Aktion
         versions: Versionen
         versions_title: Vorherige Versionen anzeigen
+      asset_deleted_flash:
+        message: Die Datei wurde gelöscht.
+      asset_saved_flash:
+        message:
+          one: Die Datei %{saved_files} gespeichert wurden.
+          other: Die Dateien %{saved_files} gespeichert wurden.
+      asset_updated_flash:
+        message: Die Datei %{link_to_file} wurde aktualisiert.
       edit:
         descriptions: Beschreibungen
         header: Bearbeite %{file_set}

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -1082,6 +1082,7 @@ de:
         transfer_on_create:
           message: "%{user_link} möchte eine Arbeit an Sie übertragen. Überprüfen Sie alle %{transfer_link}"
           subject: Antrag auf Änderung des Eigentums
+          transfer_link_label: transfer-Anfragen
         transfer_on_update:
           comments: 'Kommentare: %{receiver_comment}'
           message: Ihre Übertragungsanforderung lautete %{status}.

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -445,6 +445,7 @@ de:
       show_actions:
         analytics: Analytics
         attach_child: Untergeordnete Arbeit hinzufügen
+        confirm_delete: Löschen %{work_type} ?
         delete: Löschen
         edit: Bearbeiten
         feature: Hervorheben
@@ -1182,6 +1183,7 @@ de:
       change_access_flash_message: Aktualisierung der Dateiberechtigungen. Dies kann ein paar Minuten dauern. Sie können Ihren Browser aktualisieren oder später zu diesem Datensatz zurückkehren, um die aktualisierten Dateizugriffsberechtigungen zu sehen.
       change_access_message_html: "<p> Sie haben die <i>Zugriffsberechtigung</i> auf die Arbeit <i>%{curation_concern} geändert</i> , so dass sie anderen Benutzern oder Gruppen zum Ansehen oder Bearbeiten zugänglich ist. </p><p> Möchten Sie alle Dateien in der Arbeit ändern, damit diese die selben Berechtigungen für Benutzer, Gruppen und Sichtbarkeit zu haben? </p>"
       change_access_no_message: Nein. Ich werde es manuell aktualisieren.
+      change_access_title_html: Änderungen an Inhalt?
       change_access_yes_message: Ja bitte.
       change_permissions_message_html: "<p> Sie haben die Berechtigungen für diese %{curation_concern_human_readable_type}, <i>%{curation_concern} geändert</i> , so dass es sichtbar für <b>%{visibility_badge}</b> . </p><p> Möchten Sie alle Dateien im %{curation_concern_human_readable_type} auch auf <b>%{visibility_badge} ändern</b> ? </p>"
       local_ingest:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -451,7 +451,7 @@ en:
       show_actions:
         analytics: Analytics
         attach_child: Attach Child
-        confirm_delete: Delete this %{work_type}
+        confirm_delete: Delete this %{work_type}?
         delete: Delete
         edit: Edit
         feature: Feature

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -451,6 +451,7 @@ en:
       show_actions:
         analytics: Analytics
         attach_child: Attach Child
+        confirm_delete: Delete this %{work_type}
         delete: Delete
         edit: Edit
         feature: Feature
@@ -1188,6 +1189,7 @@ en:
       change_access_flash_message: Updating file access levels. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file access levels.
       change_access_message_html: "<p>You have changed the access level on work <i>%{curation_concern}</i>, making it accessible to other users or groups to view or edit.</p><p>Would you like change all of the files within the work to have the same access users, groups and visibility as well?</p>"
       change_access_no_message: No. I'll update it manually.
+      change_access_title_html: Apply changes to contents?
       change_access_yes_message: Yes please.
       change_permissions_message_html: "<p>You have changed the permissions on this %{curation_concern_human_readable_type}, <i>%{curation_concern}</i>, making it visible to <b>%{visibility_badge}</b>.</p><p>Would you like change all of the files within the %{curation_concern_human_readable_type} to <b>%{visibility_badge}</b> as well?</p>"
       local_ingest:
@@ -1327,8 +1329,8 @@ en:
         share_applies_to_new_works: APPLY TO NEW WORKS
         title: Type name
       defaults:
-        access_right: Access Rights
         abstract: Abstract
+        access_right: Access Rights
         admin_set_id: Administrative Set
         based_near: Location
         creator: Creator

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -911,6 +911,14 @@ en:
         header: Select an action
         versions: Versions
         versions_title: Display previous versions
+      asset_deleted_flash:
+        message: The file has been deleted.
+      asset_saved_flash:
+        message:
+          one: The file %{saved_files} has been saved.
+          other: The files %{saved_files} have been saved.
+      asset_updated_flash:
+        message: The file %{link_to_file} has been updated.
       edit:
         descriptions: Descriptions
         header: Edit %{file_set}

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -736,6 +736,8 @@ en:
           collection_update_success: Collection was successfully updated.
           collections_confirmation_html: Deleting <span class='pluralized'>this collection</span> will permanently remove <span class='pluralized'>this collection</span> from the repository.  Items in <span class='pluralized'>this collection</span> will remain in the repository.  Are you sure you want to delete <span class='pluralized'>this collection</span>?
           collections_confirmation_no_items_html: Are you sure you want to delete this collection? This action cannot be undone.
+          collections_confirmation_plural: these collections
+          collections_confirmation_singular: this collection
           delete_admin_set: Delete collection
           delete_admin_set_deny: This collection is defined as Admin Set and is not empty. To delete this Admin Set, you must first remove (delete or move to another Admin Set collection) all items from the Admin Set.
           delete_collection: Delete collection

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1088,6 +1088,7 @@ en:
         transfer_on_create:
           message: "%{user_link} wants to transfer a work to you. Review all %{transfer_link}"
           subject: Ownership Change Request
+          transfer_link_label: transfer requests
         transfer_on_update:
           comments: 'Comments: %{receiver_comment}'
           message: Your transfer request was %{status}.

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -964,6 +964,14 @@ es:
         delete_this: Eliminar este %{type}
         edit_this: Editar este %{type}
         confirm_delete_this: Eliminar este %{type}?
+      asset_deleted_flash:
+        message: El archivo ha sido eliminado.
+      asset_saved_flash:
+        message:
+          one: El archivo %{saved_files} ha sido guardado.
+          other: Los archivos %{saved_files} se han salvado.
+      asset_updated_flash:
+        message: El archivo %{link_to_file} ha sido actualizado.
     help:
       header: Soporte al Usuario
       override_text: Utilice app/views/static/help.html.erb para anular este archivo

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1089,6 +1089,7 @@ es:
         transfer_on_create:
           message: "%{user_link} quiere transferirte un trabajo. Revisar todos los %{transfer_link}"
           subject: Solicitud de cambio de propiedad
+          transfer_link_label: las solicitudes de transferencia
         transfer_on_update:
           comments: 'Comentarios: %{receiver_comment}'
           message: Su solicitud de transferencia fue %{status}.

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -735,6 +735,8 @@ es:
           collection_update_success: La colección fue actualizada con éxito.
           collections_confirmation_html: Eliminar <span class='pluralized'>esta colección</span> eliminará permanentemente <span class='pluralized'>esta colección</span> del repositorio. Los elementos de <span class='pluralized'>esta colección</span> permanecerán en el repositorio. ¿Seguro que quieres eliminar <span class='pluralized'>esta colección</span> ?
           collections_confirmation_no_items_html: "¿Seguro que quieres eliminar esta colección? Esta acción no se puede deshacer."
+          collections_confirmation_plural: estas colecciones
+          collections_confirmation_singular: esta colección
           delete_admin_set: Eliminar colección
           delete_admin_set_deny: Esta colección se define como Admin Set y no está vacía. Para eliminar este conjunto de administración, primero debe eliminar (eliminar o mover a otra colección del conjunto de administración) todos los elementos del conjunto de administración.
           delete_collection: Borrar Colección

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -450,6 +450,7 @@ es:
       show_actions:
         analytics: Analíticas
         attach_child: Adjuntar Niño
+        confirm_delete: Eliminar este %{work_type} ?
         delete: Eliminar
         edit: Editar
         feature: Función
@@ -1189,6 +1190,7 @@ es:
       change_access_flash_message: Actualizando los niveles de acceso. Esto puede tomar unos minutos. Quizás quiera actualizar su navegador o regresar a este registro posteriormente para ver los niveles de acceso.
       change_access_message_html: "<p>Ha cambiado los permisos de acceso en el trabajo <i>%{curation_concern}</i>, haciéndolo accesible a otros usuarios o grupos para ver o editar.</p><p>¿Le gustaría también cambiar todos los archivos dentro del mismo trabajo para que tengan los mismos usuarios de acceso, grupos y visibilidad?</p>"
       change_access_no_message: No. Los actualizaré automáticamente.
+      change_access_title_html: Aplicar los cambios a los contenidos?
       change_access_yes_message: Sí, por favor.
       change_permissions_message_html: "<p>Ha cambiado los permisos en %{curation_concern_human_readable_type}, <i>%{curation_concern}</i>, haciéndolo visible para <b>%{visibility_badge}</b>.</p><p>¿Le gustaría también cambiar todos los archivos dentro de %{curation_concern_human_readable_type} a <b>%{visibility_badge}</b> también?</p>"
       local_ingest:

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -1090,8 +1090,9 @@ fr:
         subject: Erreur d'importation de fichier
       proxy_deposit_request:
         transfer_on_create:
-          message: "%{user_link} souhaite vous transférer une œuvre. Voir tous les %{transfer_link}"
+          message: "%{user_link} souhaite vous transférer une œuvre. Voir toutes les %{transfer_link}"
           subject: Demande de changement de propriété
+          transfer_link_label: les demandes de transfert
         transfer_on_update:
           comments: 'Commentaires: %{receiver_comment}'
           message: Votre demande de transfert était %{status}.

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -915,6 +915,14 @@ fr:
         header: Sélectionnez une action
         versions: Versions
         versions_title: Afficher les versions précédentes
+      asset_deleted_flash:
+        message: Le fichier a été supprimé.
+      asset_saved_flash:
+        message:
+          one: Le fichier %{saved_files} a été enregistré.
+          other: Les fichiers %{saved_files} ont été enregistrés.
+      asset_updated_flash:
+        message: Le fichier %{link_to_file} a été mis à jour.
       edit:
         descriptions: Les descriptions
         header: Modifier %{file_set}

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -740,6 +740,8 @@ fr:
           collection_update_success: La collection a été mise à jour avec succès.
           collections_confirmation_html: La suppression de <span class='pluralized'>cette collection</span> supprimera définitivement <span class='pluralized'>cette collection</span> du référentiel. Les éléments de <span class='pluralized'>cette collection</span> resteront dans le référentiel. Êtes-vous sûr de vouloir supprimer <span class='pluralized'>cette collection</span> ?
           collections_confirmation_no_items_html: Êtes-vous sûr de vouloir supprimer cette collection? Cette action ne peut pas être annulée.
+          collections_confirmation_plural: ces collections
+          collections_confirmation_singular: cette collection
           delete_admin_set: Supprimer la collection
           delete_admin_set_deny: Cette collection est définie en tant que jeu d'administration et n'est pas vide. Pour supprimer cet ensemble d'administration, vous devez d'abord supprimer (supprimer ou déplacer vers une autre collection d'ensembles d'administration) tous les éléments du jeu d'administration.
           delete_collection: Supprimer la collection

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -455,6 +455,7 @@ fr:
       show_actions:
         analytics: Statistiques
         attach_child: Insérer un travail enfant
+        confirm_delete: Supprimer ce %{work_type} ?
         delete: Supprimer
         edit: Modifier
         feature: Mettre à la une
@@ -1192,6 +1193,7 @@ fr:
       change_access_flash_message: Mise à jour des niveaux d'accès aux fichiers. Cela peut prendre quelques minutes. Vous voudrez peut-être rafraîchir votre navigateur ou revenir à cet enregistrement plus tard pour voir les niveaux d'accès aux fichiers mis à jour.
       change_access_message_html: "<p> Vous avez modifié le niveau d'accès au travail <i>%{curation_concern}</i> , ce qui le rend accessible à d'autres utilisateurs ou groupes pour afficher ou modifier. </p><p> Voulez-vous changer tous les fichiers dans le travail pour avoir le même accès utilisateurs, groupes et visibilité? </p>"
       change_access_no_message: Non. Je vais le mettre à jour manuellement.
+      change_access_title_html: Appliquer les modifications au contenu ?
       change_access_yes_message: Oui s'il vous plaît.
       change_permissions_message_html: "<p> Vous avez modifié les autorisations sur ce %{curation_concern_human_readable_type}, <i>%{curation_concern}</i> , ce qui le rend visible pour <b>%{visibility_badge}</b> . </p><p> Voulez-vous changer tous les fichiers dans %{curation_concern_human_readable_type} à <b>%{visibility_badge}</b> aussi? </p>"
       local_ingest:

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -910,6 +910,14 @@ it:
         header: Seleziona un'azione
         versions: versioni
         versions_title: Mostra le versioni precedenti
+      asset_deleted_flash:
+        message: Il file è stato eliminato.
+      asset_saved_flash:
+        message:
+          one: Il file %{saved_files} è stato salvato.
+          other: Il file %{saved_files} sono stati salvati.
+      asset_updated_flash:
+        message: Il file %{link_to_file} è stata aggiornata.
       edit:
         descriptions: descrizioni
         header: Modifica %{file_set}

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -735,6 +735,8 @@ it:
           collection_update_success: La raccolta è stata aggiornata con successo.
           collections_confirmation_html: L'eliminazione di <span class='pluralized'>questa raccolta</span> rimuove definitivamente <span class='pluralized'>questa raccolta</span> dal repository. Gli articoli di <span class='pluralized'>questa raccolta</span> rimarranno nel repository. Sei sicuro di voler eliminare <span class='pluralized'>questa raccolta</span> ?
           collections_confirmation_no_items_html: Sei sicuro di voler eliminare questa raccolta? Questa azione non può essere annullata.
+          collections_confirmation_plural: queste collezioni
+          collections_confirmation_singular: questa collezione
           delete_admin_set: Elimina raccolta
           delete_admin_set_deny: Questa raccolta è definita come Imposta amministratore e non è vuota. Per eliminare questo set di amministrazione, devi prima rimuovere (eliminare o spostare in un'altra raccolta di un gruppo di amministratori) tutti gli elementi dal set di amministrazione.
           delete_collection: Elimina raccolta

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -450,6 +450,7 @@ it:
       show_actions:
         analytics: Analytics
         attach_child: Allegare Bambino
+        confirm_delete: Eliminare questo %{work_type} ?
         delete: Eliminare
         edit: Modifica
         feature: Funzione
@@ -1187,6 +1188,7 @@ it:
       change_access_flash_message: Aggiornamento dei livelli di accesso ai file. Questo potrebbe richiedere alcuni minuti. Potresti voler aggiornare il tuo browser o tornare a questo disco in un secondo momento per vedere i livelli di accesso ai file aggiornati.
       change_access_message_html: "<p> Hai <i>modificato</i> il livello di accesso sul lavoro <i>%{curation_concern}</i> , rendendolo accessibile ad altri utenti o gruppi per visualizzare o modificare. </p><p> Vuoi cambiare tutti i file all'interno del lavoro per avere gli stessi utenti di accesso, i gruppi e la visibilità? </p>"
       change_access_no_message: No. Lo aggiornerò manualmente.
+      change_access_title_html: Applicare le modifiche al contenuto?
       change_access_yes_message: Sì grazie.
       change_permissions_message_html: "<p> Hai modificato le autorizzazioni di questo %{curation_concern_human_readable_type}, <i>%{curation_concern}</i> , <i>rendendolo</i> visibile a <b>%{visibility_badge}</b> . </p><p> Vuoi cambiare tutti i file all'interno di <b>%{curation_concern_human_readable_type}</b> anche <b>%{visibility_badge}</b> ? </p>"
       local_ingest:

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -1087,6 +1087,7 @@ it:
         transfer_on_create:
           message: "%{user_link} vuole trasferirti un lavoro. Revisione di tutto %{transfer_link}"
           subject: Richiesta di modifica della proprietà
+          transfer_link_label: le richieste di trasferimento
         transfer_on_update:
           comments: 'Commenti: %{receiver_comment}'
           message: La tua richiesta di trasferimento era %{status}.

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -1082,6 +1082,7 @@ pt-BR:
         transfer_on_create:
           message: "%{user_link} quer transferir um trabalho para você. Revisão de todos %{transfer_link}"
           subject: Pedido de Alteração de Propriedade
+          transfer_link_label: pedidos de transferência de
         transfer_on_update:
           comments: 'Comentários: %{receiver_comment}'
           message: Seu pedido de transferência foi %{status}.

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -445,6 +445,7 @@ pt-BR:
       show_actions:
         analytics: O Analytics
         attach_child: Anexar Criança
+        confirm_delete: Eliminar esta %{work_type} ?
         delete: Apagar
         edit: Editar
         feature: Recurso
@@ -1182,6 +1183,7 @@ pt-BR:
       change_access_flash_message: Atualizando os níveis de acesso do arquivo. Isto pode levar alguns minutos. Você pode recarregar seu navegador ou retornar a este registro mais tarde para ver os níveis de acesso do arquivo atualizados.
       change_access_message_html: "<p>Você alterou o nível de acesso na obra <i> %{curation_concern}</i> , possibilitando seu acesso e edição por outros usuários ou grupos. </p><p> Você quer que todos os arquivos da obra tenham os mesmos usuários, grupos e permissões de acesso? </p>"
       change_access_no_message: Não. Vou fazer atualizações manualmente.
+      change_access_title_html: Aplicar alterações a conteúdo?
       change_access_yes_message: Sim, por favor.
       change_permissions_message_html: "<p> Você alterou as permissões neste %{curation_concern_human_readable_type}, <i>%{curation_concern}</i> , tornando-o accessível para <b>%{visibility_badge}</b> . </p><p> Você gostaria de mudar todos os arquivos do %{curation_concern_human_readable_type} para <b> %{visibility_badge}</b> também? </p>"
       local_ingest:

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -905,6 +905,14 @@ pt-BR:
         header: Selecione uma ação
         versions: Versões
         versions_title: Exibir versões anteriores
+      asset_deleted_flash:
+        message: O arquivo foi excluído.
+      asset_saved_flash:
+        message:
+          one: O arquivo %{saved_files} tiver sido salvo.
+          other: Os arquivos %{saved_files} ter sido salvo.
+      asset_updated_flash:
+        message: O arquivo %{link_to_file} foi atualizado.
       edit:
         descriptions: Descrições
         header: Editar %{file_set}

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -730,6 +730,8 @@ pt-BR:
           collection_update_success: A coleção foi atualizada com sucesso.
           collections_confirmation_html: A eliminação <span class='pluralized'>desta coleção</span> a removerá permanentemente do repositório. Os itens <span class='pluralized'>desta coleção</span> permanecerão no repositório. Tem certeza de que deseja eliminar <span class='pluralized'>esta coleção</span> ?
           collections_confirmation_no_items_html: Tem certeza de que deseja eliminar esta coleção? Essa ação não pode ser revertida.
+          collections_confirmation_plural: essas coleções
+          collections_confirmation_singular: esta coleção
           delete_admin_set: Eliminar coleção
           delete_admin_set_deny: Esta coleção é definida como Conjunto Administrativo e não está vazia. Para eliminar este conjunto administrativo, primeiro você deve remover (eliminar ou mover para outro conjunto administrativo) todos os itens nele contidos.
           delete_collection: Eliminar coleção

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -1085,6 +1085,7 @@ zh:
         transfer_on_create:
           message: "%{user_link}想要将作品转移给你。查看所有%{transfer_link}"
           subject: 所有权变更请求
+          transfer_link_label: 转移请求
         transfer_on_update:
           comments: 评论：%{receiver_comment}
           message: 您的转移请求是%{status}。

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -733,6 +733,8 @@ zh:
           collection_update_success: 收集已成功更新。
           collections_confirmation_html: 删除<span class='pluralized'>这个集合</span>将永久地从存储库中删除<span class='pluralized'>这个集合</span> 。 <span class='pluralized'>此集合中的</span>项目将保留在存储库中。你确定要删除<span class='pluralized'>这个集合</span>吗？
           collections_confirmation_no_items_html: 你确定要删除这个集合吗？此操作无法撤消。
+          collections_confirmation_plural: 这些集合
+          collections_confirmation_singular: 此集合
           delete_admin_set: 删除集合
           delete_admin_set_deny: 这个集合被定义为Admin Set并且不是空的。要删除此管理员设置，您必须先删除（删除或移动到另一个管理员设置集合）管理员设置中的所有项目。
           delete_collection: 删除收藏集

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -448,6 +448,7 @@ zh:
       show_actions:
         analytics: 分析
         attach_child: 附上的孩子
+        confirm_delete: 删除这一%{work_type}
         delete: 删除
         edit: 编辑
         feature: 功能
@@ -1185,6 +1186,7 @@ zh:
       change_access_flash_message: 更新文件访问级别。 稍等片刻。 您可能需要刷新浏览器或稍后回访查询该文件访问级别是否更新。
       change_access_message_html: "<p>您改变了其他用户或群组对作品阅览或编辑的访问级别 <i>%{curation_concern}</i> </p><p>您需要对作品内所有文件的用户或群组的访问级别和公开度做同样的改变吗</p>"
       change_access_no_message: 不用。 我会手动更新。
+      change_access_title_html: 申请更改的内容吗？
       change_access_yes_message: 是的, 请做同样的更新。
       change_permissions_message_html: "<p>您改变了对%{curation_concern_human_readable_type}, <i>%{curation_concern}</i>的权限，使它对<b>%{visibility_badge}</b>公开。</p><p> 您需要对%{curation_concern_human_readable_type}中所有文件对<b>%{visibility_badge}</b>的权限做同样的改变吗？</p>"
       local_ingest:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -908,6 +908,14 @@ zh:
         header: 选择一个动作
         versions: 版本
         versions_title: 显示以前的版本
+      asset_deleted_flash:
+        message: 该文件已经被删除。
+      asset_saved_flash:
+        message:
+          one: 该文件%{saved_files}已经保存。
+          other: 该文件%{saved_files}已经保存。
+      asset_updated_flash:
+        message: 该文件%{link_to_file}已经更新。
       edit:
         descriptions: 说明
         header: 编辑%{file_set}


### PR DESCRIPTION
A few strings extracted for i18n, mostly confirmation messages.
The same strings were present in dedicated flash message templates ( app/views/hyrax/file_sets/_asset_deleted_flash.html.erb,  app/views/hyrax/file_sets/_asset_saved_flash.html.erb) and in controllers : it is difficult to understand the reason. I think that templates are never used without being sure. I translated both.
String concatenation in  app/assets/javascripts/hyrax/collections.js is not a robust solution: the syntax varies from one language to another. We have no idea of the result in Chinese. I only translated the part that was left in English but it would be necessary to change the whole approach.

@samvera/hyrax-code-reviewers
