### PR TITLE
Switch to webdrivers and pin chromedriver to 72

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -105,6 +105,7 @@ SUMMARY
   spec.add_development_dependency 'bixby', '~> 1.0.0'
   spec.add_development_dependency 'shoulda-callback-matchers', '~> 1.1.1'
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
+  spec.add_development_dependency 'webdrivers', '~> 3.0'
   spec.add_development_dependency 'webmock'
 
   ########################################################

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,7 @@ require 'rspec/active_model/mocks'
 require 'capybara/rspec'
 require 'capybara/rails'
 require 'selenium-webdriver'
-require 'chromedriver-helper'
+require 'webdrivers'
 require 'equivalent-xml'
 require 'equivalent-xml/rspec_matchers'
 require 'database_cleaner'
@@ -62,7 +62,7 @@ end
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 
 require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow_localhost: true, allow: 'chromedriver.storage.googleapis.com')
 
 require 'i18n/debug' if ENV['I18N_DEBUG']
 require 'byebug' unless ci_build?
@@ -82,6 +82,9 @@ end
 
 Capybara.default_driver = :rack_test # This is a faster driver
 Capybara.javascript_driver = :selenium_chrome_headless_sandboxless # This is slower
+
+# FIXME: Pin to older version of chromedriver to avoid issue with clicking non-visible elements
+Webdrivers::Chromedriver.version = '72.0.3626.69'
 
 ActiveJob::Base.queue_adapter = :test
 
@@ -192,11 +195,11 @@ RSpec.configure do |config|
 
   config.before(:each, type: :view) do
     initialize_controller_helpers(view)
-    WebMock.disable_net_connect!(allow_localhost: false)
+    WebMock.disable_net_connect!(allow_localhost: false, allow: 'chromedriver.storage.googleapis.com')
   end
 
   config.after(:each, type: :view) do
-    WebMock.disable_net_connect!(allow_localhost: true)
+    WebMock.disable_net_connect!(allow_localhost: true, allow: 'chromedriver.storage.googleapis.com')
   end
 
   config.before(:all, type: :feature) do


### PR DESCRIPTION
This is to deal with failing circleci builds due to an update in chrome/chromedriver.  `webdrivers` is supported and more stable than `chromedriver-helper`.  The pin to `chromedriver` 72 is to temporarily workaround two failing tests that occur because elements aren't visible/clickable at specific points:

```
Failure/Error: click_link('Sharing')

Selenium::WebDriver::Error::WebDriverError:
  element click intercepted: Element <a href="#sharing" role="tab" data-toggle="tab" aria-expanded="true">...</a> is not clickable at point (613, 21). Other element would receive the click: <span class="hidden-xs">...</span>
    (Session info: headless chrome=74.0.3729.131)
    (Driver info: chromedriver=74.0.3729.6 (255758eccf3d244491b8a1317aa76e1ce10d57e9-refs/branch-heads/3729@{#29}),platform=Linux 4.15.0-1035-aws x86_64)
./spec/features/dashboard/collection_spec.rb:903:in `block (6 levels) in <main>'
```
```
Failure/Error: click_link 'Marketing Text'

Selenium::WebDriver::Error::WebDriverError:
  element click intercepted: Element <a href="#marketing" role="tab" data-toggle="tab" class="nav-safety-confirm">...</a> is not clickable at point (503, 192). Other element would receive the click: <div class="modal fade" id="nav-safety-modal" tabindex="-1" role="dialog" dirtydata="false" style="display: block; padding-right: 15px;">...</div>
    (Session info: headless chrome=74.0.3729.131)
    (Driver info: chromedriver=74.0.3729.6 (255758eccf3d244491b8a1317aa76e1ce10d57e9-refs/branch-heads/3729@{#29}),platform=Linux 4.15.0-1035-aws x86_64)
./spec/features/edit_content_block_admin_spec.rb:58:in `block (3 levels) in <main>'
```

@jrochkind ran into similar issues and had a JS scrolling based workaround. (https://groups.google.com/forum/#!msg/chromedriver-users/0Pu-TPvlu18/5qnLM55PDQAJ)

@samvera/hyrax-code-reviewers
