### PR TITLE
Use the original file's width and height instead of assuming 640x480

### DIFF
--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -21,8 +21,8 @@ module Hyrax
       )
       # @see https://github.com/samvera-labs/iiif_manifest
       IIIFManifest::DisplayImage.new(url,
-                                     width: 640,
-                                     height: 480,
+                                     width: original_file.width,
+                                     height: original_file.height,
                                      iiif_endpoint: iiif_endpoint(original_file.id))
     end
 


### PR DESCRIPTION
@joelakes noticed that UV embedded in Hyrax was giving download image size options that didn't match the proportions of the original file.  This PR uses the original file's measurements which allows UV to offer sensible download sizes.

@samvera/hyrax-code-reviewers
