### PR TITLE
fix current logic error in displaying/hiding feature/unfeature buttons

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -9,11 +9,11 @@
     <% if presenter.work_featurable? %>
       <%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
           data: { behavior: 'feature' },
-          class: presenter.display_unfeature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+          class: presenter.display_feature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
 
       <%= link_to t('.unfeature'), hyrax.featured_work_path(presenter, format: :json),
           data: { behavior: 'unfeature' },
-          class: presenter.display_feature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+          class: presenter.display_unfeature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
     <% end %>
     <% if Hyrax.config.analytics? %>
       <%= link_to t('.analytics'), presenter.stats_path, id: 'stats', class: 'btn btn-default' %>


### PR DESCRIPTION
Fixes #3169 

The current implementation of showing/hiding feature/unfeature buttons seems to be incorrect. 

e.g. for feature button:

<%= link_to "Feature", hyrax.featured_work_path(presenter, format: :json),
          data: { behavior: 'feature' },
          class: presenter.display_unfeature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>

It says, "if display_unfeature_link returns true, then hide feature button, OTHERWISE, show feature button". While display_unfeature_link returns false, it doesn't necessarily mean feature button needs to be shown.  For example, when 5 works have been featured already, both feature/unfeature buttons should be hidden for new objects. Therefore, to make it simple and working:

<%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
          data: { behavior: 'feature' },
          class: presenter.display_feature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>

@samvera/hyrax-code-reviewers
