### PR TITLE
Allows Hyrax to use prerelease versions of Valkyrie.

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -78,7 +78,7 @@ SUMMARY
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
-  spec.add_dependency 'valkyrie', '~> 2.0.0-rc3'
+  spec.add_dependency 'valkyrie', '~> 2.0.0.RC7'
 
   # temporary pin to 2.17 due to failures caused in 2.18.0
   spec.add_development_dependency "capybara", '~> 2.4', '< 2.18.0'


### PR DESCRIPTION
After 2.0.0rc2 was yanked, the specification for Valkyrie in the gemspec could not be satisfied.