### PR TITLE
Downgrades the Valkyrie dependency to 1.6.x releases

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -78,7 +78,7 @@ SUMMARY
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
-  spec.add_dependency 'valkyrie', '~> 2.0.0.RC7'
+  spec.add_dependency 'valkyrie', '~> 2.0.0.RC5'
 
   # temporary pin to 2.17 due to failures caused in 2.18.0
   spec.add_development_dependency "capybara", '~> 2.4', '< 2.18.0'

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -78,7 +78,7 @@ SUMMARY
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
-  spec.add_dependency 'valkyrie', '~> 2.0.0.RC5'
+  spec.add_dependency 'valkyrie', '~> 1.6'
 
   # temporary pin to 2.17 due to failures caused in 2.18.0
   spec.add_development_dependency "capybara", '~> 2.4', '< 2.18.0'


### PR DESCRIPTION
Using Valkyrie release 2.0.0RC5 due to Rails dependency issues arising in the build process.  Please see the errors for https://circleci.com/gh/samvera/hyrax/4000?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link