### PR TITLE
Create derivatives job reload

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -1,3 +1,4 @@
+require 'wings/services/active_fedora_reloader_service'
 module Hyrax
   module Actors
     # Actions are decoupled from controller logic so that they may be called from a controller or a background job.
@@ -71,7 +72,7 @@ module Hyrax
       def attach_to_work(work, file_set_params = {})
         acquire_lock_for(work.id) do
           # Ensure we have an up-to-date copy of the members association, so that we append to the end of the list.
-          work.reload unless work.new_record?
+          Wings::ActiveFedoraReloaderService.reload(work) unless work.new_record?
           file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
           work.ordered_members << file_set
           work.representative = file_set if work.representative_id.blank?

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -25,9 +25,9 @@ class CreateDerivativesJob < Hyrax::ApplicationJob
   end
 
   def reload(af_object)
-    adapter = Hyrax.config.valkyrie_metadata_adapter
     return af_object unless af_object.persisted?
 
+    adapter = Hyrax.config.valkyrie_metadata_adapter
     resource = adapter.query_service.find_by(id: af_object.id)
     af_object.clear_association_cache
     af_object.association_cache.merge! adapter.resource_factory.from_resource(resource: resource).association_cache

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -1,4 +1,4 @@
-require 'wings'
+require 'wings/services/active_fedora_reloader_service'
 class CreateDerivativesJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
@@ -12,7 +12,7 @@ class CreateDerivativesJob < Hyrax::ApplicationJob
     file_set.create_derivatives(filename)
 
     # Reload from Fedora and reindex for thumbnail and extracted text
-    file_set = reload(file_set)
+    file_set = Wings::ActiveFedoraReloaderService.reload(file_set)
     file_set.update_index
     file_set.parent.update_index if parent_needs_reindex?(file_set)
   end
@@ -22,15 +22,5 @@ class CreateDerivativesJob < Hyrax::ApplicationJob
   def parent_needs_reindex?(file_set)
     return false unless file_set.parent
     file_set.parent.thumbnail_id == file_set.id
-  end
-
-  def reload(af_object)
-    return af_object unless af_object.persisted?
-
-    adapter = Hyrax.config.valkyrie_metadata_adapter
-    resource = adapter.query_service.find_by(id: af_object.id)
-    af_object.clear_association_cache
-    af_object.association_cache.merge! adapter.resource_factory.from_resource(resource: resource).association_cache
-    af_object
   end
 end

--- a/lib/wings/services/active_fedora_reloader_service.rb
+++ b/lib/wings/services/active_fedora_reloader_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Wings
+  class ActiveFedoraReloaderService
+  ##
+  # For replacing calls to reload on ActiveFedora objects
+  #
+
+    def self.reload(af_object)
+      return af_object unless af_object.persisted?
+
+      adapter = Hyrax.config.valkyrie_metadata_adapter
+      resource = adapter.query_service.find_by(id: af_object.id)
+      af_object.clear_association_cache
+      retrieved_object = adapter.resource_factory.from_resource(resource: resource)
+      af_object.association_cache.merge! retrieved_object.association_cache
+      af_object.ldp_source.graph.clear!
+      af_object.ldp_source.graph << retrieved_object.ldp_source.graph
+      af_object
+    end
+  end
+end

--- a/lib/wings/services/active_fedora_reloader_service.rb
+++ b/lib/wings/services/active_fedora_reloader_service.rb
@@ -2,9 +2,7 @@
 
 module Wings
   class ActiveFedoraReloaderService
-  ##
-  # For replacing calls to reload on ActiveFedora objects
-  #
+    # For replacing calls to reload on ActiveFedora objects
 
     def self.reload(af_object)
       return af_object unless af_object.persisted?

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -295,11 +295,13 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       before do # another version of the same work is saved with a member
         work_v2 = ActiveFedora::Base.find(work_v1.id)
         work_v2.ordered_members << create(:file_set)
+        work_v2.description = ["3 kittens"]
         work_v2.save!
       end
 
       it "writes to the most up to date version" do
         actor.attach_to_work(work_v1)
+        expect(work_v1.description).to eq ["3 kittens"]
         expect(work_v1.members.size).to eq 2
       end
     end

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe CreateDerivativesJob do
     context "with a file name" do
       it 'calls create_derivatives and save on a file set' do
         expect(Hydra::Derivatives::AudioDerivatives).to receive(:create)
-        expect(file_set).to receive(:reload)
         expect(file_set).to receive(:update_index)
         described_class.perform_now(file_set, file.id)
       end
@@ -44,7 +43,6 @@ RSpec.describe CreateDerivativesJob do
         let(:parent) { GenericWork.new(thumbnail_id: id) }
 
         it 'updates the index of the parent object' do
-          expect(file_set).to receive(:reload)
           expect(parent).to receive(:update_index)
           described_class.perform_now(file_set, file.id)
         end
@@ -54,7 +52,6 @@ RSpec.describe CreateDerivativesJob do
         let(:parent) { GenericWork.new }
 
         it "doesn't update the parent's index" do
-          expect(file_set).to receive(:reload)
           expect(parent).not_to receive(:update_index)
           described_class.perform_now(file_set, file.id)
         end

--- a/spec/wings/services/active_fedora_reloader_service_spec.rb
+++ b/spec/wings/services/active_fedora_reloader_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/services/active_fedora_reloader_service'
+
+RSpec.describe Wings::ActiveFedoraReloaderService do
+  let(:af_object) { create(:generic_work) }
+  let(:child_work) { create(:generic_work) }
+
+  before do
+    work_copy = ActiveFedora::Base.find(af_object.id)
+    work_copy.description = ["3 Crumpets and a Teacake"]
+    work_copy.ordered_members << child_work
+    work_copy.save!
+  end
+
+  describe '#reload' do
+    it 'updates the associations for the object' do
+      expect(described_class.reload(af_object).members).to eq [child_work]
+    end
+    it 'updates the metadata' do
+      expect(described_class.reload(af_object).description).to eq ["3 Crumpets and a Teacake"]
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3604 (together with PR #3742)

Adds a reload method using wings; uses the same code as in PR#3742 file_set_actor#reload.
Removes from the spec the expectation that file_set will receive reload.