### PR TITLE
adds child collections to pcdm valkyrie

### DIFF
--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -1,4 +1,5 @@
 require 'wings/active_fedora_converter'
+require 'wings/navigators/child_collections_navigator'
 
 module Wings
   module Pcdm
@@ -39,6 +40,23 @@ module Wings
         member_of_collection_ids.map(&:id)
       end
       # alias member_of_collection_ids child_object_ids # TODO: Cannot alias in this way because member_of_collection_ids method is already defined thru the attribute definition.
+
+      ##
+      # @return [Enumerable<ActiveFedora::Base> | Enumerable<Valkyrie::Resource>] an enumerable over the child collections
+      def child_collections(valkyrie: false)
+        @child_collections_navigator ||= ChildCollectionsNavigator.new(query_service: ::Valkyrie.config.metadata_adapter.query_service)
+        resources = @child_collections_navigator.find_child_collections(resource: self)
+        return resources if valkyrie
+        resources.map { |r| Wings::ActiveFedoraConverter.new(resource: r).convert }
+      end
+      alias collections child_collections
+
+      ##
+      # @return [Enumerable<String> | Enumerable<Valkyrie::ID] the child collection ids
+      def child_collection_ids(valkyrie: false)
+        child_collections(valkyrie: valkyrie).map(&:id)
+      end
+      alias collection_ids child_collection_ids
 
       ##
       # Gives the subset of #members that are PCDM objects

--- a/lib/wings/navigators/child_collections_navigator.rb
+++ b/lib/wings/navigators/child_collections_navigator.rb
@@ -18,7 +18,7 @@ module Wings
     # TODO: By storing all children in a single relationship, it requires that the full resource be constructed for all children
     #       and then selecting only the children of a particular type to return.
     def find_child_collections(resource:)
-      query_service.find_members(resource: resource).select(&:collection?)
+      query_service.find_inverse_references_by(resource: resource, property: :member_of_collection_ids).select(&:collection?)
     end
 
     # Find the ids of child collections of a given resource, and map to Valkyrie Resources

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -117,7 +117,7 @@ module Wings
       #   other resources.
       # @param property [Symbol] The property which, on other resources, is
       #   referencing the given `resource`. Note: the property needs to be
-      #   indexed as a `*_ssim` field
+      #   indexed as a `*_ssim` field and indexing either ActiveFedora IDs or full URIs
       # @raise [ArgumentError] Raised when the ID is not in the persistence backend.
       # @return [Array<Valkyrie::Resource>] All resources in the persistence backend
       #   which have the ID of the given `resource` in their `property` property. Not
@@ -127,7 +127,7 @@ module Wings
         id ||= resource.alternate_ids.first
         raise ArgumentError, "Resource has no id; is it persisted?" unless id
         uri = ActiveFedora::Base.id_to_uri(id.to_s)
-        ActiveFedora::Base.where("#{property}_ssim: \"#{uri}\"").map do |obj|
+        ActiveFedora::Base.where("+(#{property}_ssim: \"#{uri}\" OR #{property}_ssim: \"#{id}\")").map do |obj|
           resource_factory.to_resource(object: obj)
         end
       end

--- a/spec/wings/hydra/pcdm/models/concerns/collection_valkyrie_behavior_spec.rb
+++ b/spec/wings/hydra/pcdm/models/concerns/collection_valkyrie_behavior_spec.rb
@@ -6,14 +6,28 @@ RSpec.describe Wings::Pcdm::CollectionValkyrieBehavior, :clean_repo do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 
   let(:collection1) { build(:public_collection_lw, id: 'col1', title: ['Collection 1']) }
+  let(:collection2) { build(:public_collection_lw, id: 'col2', title: ['Collection 2']) }
+  let(:collection3) { build(:public_collection_lw, id: 'col3', title: ['Collection 3']) }
+  let(:pcdm_object) { collection1 }
+  let(:resource) { subject.build }
+
+  before do
+    collection2.member_of_collections = [collection1]
+    collection2.save!
+    collection3.member_of_collections = [collection1]
+    collection3.save!
+  end
 
   describe 'type check methods on valkyrie resource' do
-    let(:pcdm_object) { collection1 }
-    let(:resource) { subject.build }
+    it { expect(resource.pcdm_collection?).to be true }
+    it { expect(resource.pcdm_object?).to be false }
+  end
 
-    it 'returns appropriate response from type check methods' do
-      expect(resource.pcdm_collection?).to be true
-      expect(resource.pcdm_object?).to be false
-    end
+  describe '#collection_ids' do
+    it { expect(resource.collection_ids).to eq([collection2.id, collection3.id]) }
+  end
+
+  describe '#collections' do
+    it { expect(resource.collections).to eq([collection2, collection3]) }
   end
 end


### PR DESCRIPTION
fixes #3595
fixes #3597 

This makes use of the query_service to find inverse references, all collections having `member_of_collection_ids` including the target collection being queried. This facilitates identifying all "Child Collections" of a collection. 