### PR TITLE
HYRAX-#3293 - Map license to dcterms:license

### DIFF
--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -20,7 +20,7 @@ module Hyrax
       property :abstract, predicate: ::RDF::Vocab::DC.abstract
       property :keyword, predicate: ::RDF::Vocab::SCHEMA.keywords
       # Used for a license
-      property :license, predicate: ::RDF::Vocab::DC.rights
+      property :license, predicate: ::RDF::URI.new('http://dublincore.org/documents/dcmi-terms/#terms-license'), multiple: true
 
       property :rights_notes, predicate: ::RDF::URI.new('http://purl.org/dc/elements/1.1/rights'), multiple: true
 

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -38,6 +38,7 @@ namespace :hyrax do
     # Migrate any orphan fedora data from the first to the second predicate
     task migrate_keyword_predicate: :environment do
       Hyrax::Works::MigrationService.migrate_predicate(::RDF::Vocab::DC11.relation, ::RDF::Vocab::SCHEMA.keywords)
+      Hyrax::Works::MigrationService.migrate_predicate(::RDF::Vocab::DC.rights, ::RDF::URI.new('http://dublincore.org/documents/dcmi-terms/#terms-license'))
     end
   end
 end

--- a/spec/services/hyrax/works/migration_service_spec.rb
+++ b/spec/services/hyrax/works/migration_service_spec.rb
@@ -2,19 +2,29 @@
 RSpec.describe Hyrax::Works::MigrationService, clean_repo: true do
   let(:predicate_from) { ::RDF::Vocab::DC11.description }
   let(:predicate_to) { ::RDF::Vocab::SCHEMA.description }
+  let(:predicate_from2) { ::RDF::Vocab::DC.rights }
+  let(:predicate_to2) { ::RDF::URI.new('http://dublincore.org/documents/dcmi-terms/#terms-license') }
 
   describe "#migrate_predicate" do
-    it "uses DC description by default" do
-      @work = GenericWork.create(title: ["War and Peace"], description: ["war", "peace"])
+    it "uses DC description and terms-license license by default" do
+      @work = GenericWork.create( title: ["War and Peace"],
+                                  description: ["war", "peace"],
+                                  license: ["the_license_string"] )
       expect(@work.ldp_source.content).to include("http://purl.org/dc/elements/1.1/description")
+      expect(@work.ldp_source.content).to include( predicate_to2.to_s )
     end
 
     it "updates to use SCHEMA description" do
-      @work = GenericWork.create(title: ["War and Peace"], description: ["war", "peace"])
+      @work = GenericWork.create( title: ["War and Peace"],
+                                  description: ["war", "peace"],
+                                  license: ["the_license_string"] )
       described_class.migrate_predicate(predicate_from, predicate_to)
+      described_class.migrate_predicate(predicate_from2, predicate_to2)
       @work.reload
       expect(@work.ldp_source.content).to include("http://schema.org/description")
       expect(@work.ldp_source.content).not_to include("http://purl.org/dc/elements/1.1/description")
+      expect(@work.ldp_source.content).to include( predicate_to2.to_s )
+      expect(@work.ldp_source.content).not_to include( predicate_from2.to_s )
     end
   end
 end

--- a/spec/services/hyrax/works/migration_service_spec.rb
+++ b/spec/services/hyrax/works/migration_service_spec.rb
@@ -7,24 +7,22 @@ RSpec.describe Hyrax::Works::MigrationService, clean_repo: true do
 
   describe "#migrate_predicate" do
     it "uses DC description and terms-license license by default" do
-      @work = GenericWork.create( title: ["War and Peace"],
-                                  description: ["war", "peace"],
-                                  license: ["the_license_string"] )
+      @work = GenericWork.create(title: ["War and Peace"], description: ["war", "peace"],
+                                 license: ["the_license_string"])
       expect(@work.ldp_source.content).to include("http://purl.org/dc/elements/1.1/description")
-      expect(@work.ldp_source.content).to include( predicate_to2.to_s )
+      expect(@work.ldp_source.content).to include(predicate_to2.to_s)
     end
 
     it "updates to use SCHEMA description" do
-      @work = GenericWork.create( title: ["War and Peace"],
-                                  description: ["war", "peace"],
-                                  license: ["the_license_string"] )
+      @work = GenericWork.create(title: ["War and Peace"], description: ["war", "peace"],
+                                 license: ["the_license_string"])
       described_class.migrate_predicate(predicate_from, predicate_to)
       described_class.migrate_predicate(predicate_from2, predicate_to2)
       @work.reload
       expect(@work.ldp_source.content).to include("http://schema.org/description")
       expect(@work.ldp_source.content).not_to include("http://purl.org/dc/elements/1.1/description")
-      expect(@work.ldp_source.content).to include( predicate_to2.to_s )
-      expect(@work.ldp_source.content).not_to include( predicate_from2.to_s )
+      expect(@work.ldp_source.content).to include(predicate_to2.to_s)
+      expect(@work.ldp_source.content).not_to include(predicate_from2.to_s)
     end
   end
 end


### PR DESCRIPTION
Fixes HYRAX-#3293

Change the basic meta data for `license` to the url pointing to the `dcterms:license`
