### PR TITLE
use explicit utf-8 character for German Guillemets'

### DIFF
--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -149,7 +149,7 @@ de:
             title: Freigabe
             varies:
               any: Dem Deponenten erlauben, sich zu entscheiden
-              between: Zwischen &ldquor;jetzt&ldquo; und
+              between: Zwischen „jetzt“ und
               description: 'Variabel - Deponenten können den Freigabedatum für eine einzelne Arbeit festlegen:'
               embargo:
                 1yr: 1 Jahr nach Deponierung
@@ -423,7 +423,7 @@ de:
       items:
         actions: Aktionen
         date_uploaded: Datum Hochgeladen
-        empty: Diese %{type} hat keine Dateien zugeordnet. Klicken Sie auf &ldquor;Bearbeiten&ldquo;, um weitere Dateien hinzuzufügen.
+        empty: Diese %{type} hat keine Dateien zugeordnet. Klicken Sie auf „Bearbeiten“, um weitere Dateien hinzuzufügen.
         header: Artikel
         thumbnail: Miniaturansicht
         title: Titel
@@ -437,7 +437,7 @@ de:
       share_with:
         definition_heading: Berechtigungsdefinitionen
         definitions_html: "<strong>Ansicht / Download: Auf</strong> diese Datei (sowohl Inhalte als auch Metadaten) kann innerhalb von %{application_name} zugegriffen werden. <br /> <strong>Bearbeiten:</strong> Diese Datei (sowohl Inhalte als auch Metadaten) kann bearbeitet werden. Sie dürfen diese Berechtigung nur Benutzern und / oder Gruppen von %{institution_name} erteilen."
-        share_with_html: Sie können den Zugriff &ldquor;Ansicht / Download&ldquo; oder &ldquor;Bearbeiten&ldquo; für bestimmte Benutzer und / oder Gruppen auf Dateien gewähren. Geben Sie nacheinander einen gültigen %{account_name} ein, wählen Sie die Zugriffsebene für diesen Benutzer und klicken Sie auf + Hinzufügen.
+        share_with_html: Sie können den Zugriff „Ansicht / Download“ oder „Bearbeiten“ für bestimmte Benutzer und / oder Gruppen auf Dateien gewähren. Geben Sie nacheinander einen gültigen %{account_name} ein, wählen Sie die Zugriffsebene für diesen Benutzer und klicken Sie auf + Hinzufügen.
       show:
         items: Objekte
         last_modified: Zuletzt geändert
@@ -926,7 +926,7 @@ de:
         save: Speichern
         title: Titel
       groups_description:
-        description_html: Die Liste der Gruppen in der Auswahlliste mit der Bezeichnung &ldquor;Wählen Sie eine Gruppe aus&ldquo; zeigt ihnen jene Benutzer administrierten Gruppen an, bei denen Sie Mitglied sind. Sie können eine bestimmte Gruppe auswählen und eine Zugriffsebene für eine Datei innerhalb von %{application_name} zuweisen, ähnlich wie das Hinzufügen von Benutzerzugriffsebenen.
+        description_html: Die Liste der Gruppen in der Auswahlliste mit der Bezeichnung „Wählen Sie eine Gruppe aus“ zeigt ihnen jene Benutzer administrierten Gruppen an, bei denen Sie Mitglied sind. Sie können eine bestimmte Gruppe auswählen und eine Zugriffsebene für eine Datei innerhalb von %{application_name} zuweisen, ähnlich wie das Hinzufügen von Benutzerzugriffsebenen.
       permission:
         save: Speichern
       permission_form:
@@ -935,7 +935,7 @@ de:
         enter: Geben Sie %{account_label} ein (einzeln)
         header: Berechtigungen
         optional: "(wahlweise)"
-        save_note_html: Berechtigungen werden <strong>nicht</strong> gespeichert, bis die Schaltfläche &ldquor;Speichern&ldquo; am unteren Rand der Seite gedrückt wird.
+        save_note_html: Berechtigungen werden <strong>nicht</strong> gespeichert, bis die Schaltfläche „Speichern“ am unteren Rand der Seite gedrückt wird.
         select_group: Wählen Sie eine Gruppe aus
         share_with: Teilen mit
         table_title_access: Zugriffsebene
@@ -1177,8 +1177,8 @@ de:
         confirm: Sind Sie sicher, dass Sie das Eigentum an dieser Arbeit an einen anderen Benutzer übertragen möchten? Klicken Sie auf OK, um zu übertragen oder auf Abbrechen, um zur Transfer-Seite zurückzukehren
         header: Eigentum übertragen
         placeholder: Suche nach einem Benutzer
-        sr_only_description: Wählen Sie einen Benutzer aus, um &ldquor;%{work_title}&ldquo; zu senden, fügen Sie optionale Kommentare hinzu und drücken Sie dann Übertragung.
-        title: Übertragung des Eigentums von &ldquor;%{work_title}&ldquo;
+        sr_only_description: Wählen Sie einen Benutzer aus, um „%{work_title}“ zu senden, fügen Sie optionale Kommentare hinzu und drücken Sie dann Übertragung.
+        title: Übertragung des Eigentums von „%{work_title}“
     upload:
       alert:
         contact_href_text: Kontakt Formular
@@ -1233,7 +1233,7 @@ de:
         warning_html: '<p> <strong>Bitte beachten Sie</strong>, dass Inhalt, der für die gesamte Öffentlichkeit sichtbar ist (d.h. das Markieren dieses als %{label}), als Publikation angesehen werden kann und somit folgende Schritte negativ beeinflussen könnte: </p><ul><li> Patentieren Ihrer Arbeit </li><li> Veröffentlichen Ihrer Arbeit in einer Zeitschrift. </li></ul><p> Überprüfen Sie <a href="http://www.sherpa.ac.uk/romeo/">SHERPA / RoMEO</a> für weitere Informationen über Urheberrechtsrichtlinien des Herausgebers. </p>'
       open_title_attr: Ändern Sie die Sichtbarkeit dieser Ressource
       restricted:
-        note_html: Nur Benutzer und / oder Gruppen, denen im Abschnitt &ldquor;Freigeben&ldquo; einen bestimmten Zugriff gewährt wurde.
+        note_html: Nur Benutzer und / oder Gruppen, denen im Abschnitt „Freigeben“ einen bestimmten Zugriff gewährt wurde.
         text: Privat
       restricted_title_attr: Ändern Sie die Sichtbarkeit dieser Ressource
     workflow:
@@ -1269,12 +1269,12 @@ de:
   simple_form:
     hints:
       admin_set:
-        description: Eine kurze übergreifende Beschreibung, die für alle in diesem Admin-Set gesammelten Arbeiten gilt. Zum Beispiel,  &ldquor;Thesen und ergänzende Dateien, welche von den Absolventen der Geowissenschaften erstellt wurden.&ldquo;
+        description: Eine kurze übergreifende Beschreibung, die für alle in diesem Admin-Set gesammelten Arbeiten gilt. Zum Beispiel,  „Thesen und ergänzende Dateien, welche von den Absolventen der Geowissenschaften erstellt wurden.“
         title: Ein Name zur erleichterten Identifizierung des Admin-Sets und zur Unterscheidung von anderen Admin-Sets im Repositorium.
       collection:
         based_near: Ein Ortsname im Zusammenhang mit der Sammlung, wie die Website der Veröffentlichung, oder die Stadt, Staat oder Land, welches Inhalt der Sammlung sind. Ruft die Seite <a href='http://www.geonames.org'> GeoNames Web Service </a> auf.
         contributor: Eine Person oder Gruppe, die Sie für eine Rolle bei der Erstellung der Sammlung kenntlich machen wollen, die aber nicht die primäre Rolle besitzen.
-        creator: Die Person oder Gruppe, welche verantwortlich für die Sammlung ist. In der Regel ist dies der Autor des Inhalts. Persönliche Namen sollten zuerst mit dem Nachnamen eingegeben werden, z.B. &ldquor;Smith, John&ldquo;.
+        creator: Die Person oder Gruppe, welche verantwortlich für die Sammlung ist. In der Regel ist dies der Autor des Inhalts. Persönliche Namen sollten zuerst mit dem Nachnamen eingegeben werden, z.B. „Smith, John“.
         date_created: Das Datum, an dem die Sammlung erstellt wurde.
         description: Freitextnoten über die Sammlung. Beispiel hierfür sind Kurzfassungen (Abstracts) eines wissenschaftlichen Aufsatzes in Zeitschriftenartikeln.
         identifier: Eine eindeutige Kennung, der die Sammlung identifiziert. Ein Beispiel wäre ein DOI für einen Zeitschriftenartikel oder eine ISBN- oder OCLC-Nummer für ein Buch.
@@ -1283,7 +1283,7 @@ de:
         license: Lizenz- und Verbreitungsinformationen für den Zugang zur Sammlung. Wählen Sie aus der mitgelieferten Auswahlliste aus.
         publisher: Die Person oder Gruppe, die die Sammlung zur Verfügung stellt. Im Allgemeinen ist das die Institution.
         related_url: Ein Link zu einer Website oder anderen spezifischen Inhalten (Audio, Video, PDF Dokument) im Zusammenhang mit der Sammlung. Ein Beispiel ist die URL eines Forschungsprojektes, aus dem die Sammlung abgeleitet wurde.
-        resource_type: Vordefinierte Kategorien, um die Art des hochgeladenen Inhalts zu beschreiben, wie beispielsweise &ldquor;Artikel&ldquo; oder &ldquor;Datensatz&ldquo;. Es können mehr als ein Typ ausgewählt werden.
+        resource_type: Vordefinierte Kategorien, um die Art des hochgeladenen Inhalts zu beschreiben, wie beispielsweise „Artikel“ oder „Datensatz“. Es können mehr als ein Typ ausgewählt werden.
         subject: Überschriften oder Indexbegriffe, die beschreiben, was die Sammlung betrifft; Diese müssen sich an ein bestehendes Vokabular anpassen.
         title: Ein Name, der bei der Identifizierung einer Sammlung hilft.
       collection_type:
@@ -1301,7 +1301,7 @@ de:
       defaults:
         based_near: Ein Ortsname in Bezug auf die Arbeit, wie ihre Website der Veröffentlichung, oder die Stadt, Staat oder Land die Inhalt der Arbeit sind. Ruft die Seite <a href='http://www.geonames.org'> GeoNames Web Service </a> auf.
         contributor: Eine Person oder Gruppe, die Sie für eine Rolle bei der Schaffung der Arbeit kenntlich machen wollen, aber nicht die primäre Rolle besitzen.
-        creator: Die Person oder Gruppe, welche verantwortlich für die Arbeit ist. In der Regel ist dies der Autor des Inhalts. Persönliche Namen sollten zuerst mit dem Nachnamen eingegeben werden, z.B. &ldquor;Smith, John&ldquo;.
+        creator: Die Person oder Gruppe, welche verantwortlich für die Arbeit ist. In der Regel ist dies der Autor des Inhalts. Persönliche Namen sollten zuerst mit dem Nachnamen eingegeben werden, z.B. „Smith, John“.
         date_created: Das Datum, an dem die Arbeit erstellt wurde.
         description: Freitextnoten über die Arbeit. Beispiel hierfür sind Kurzfassungen (Abstracts) eines wissenschaftlichen Aufsatzes in Zeitschriftenartikeln.
         identifier: Eine eindeutige Kennung, der die Arbeit identifiziert. Ein Beispiel wäre ein DOI für einen Zeitschriftenartikel oder eine ISBN- oder OCLC-Nummer für ein Buch.
@@ -1310,7 +1310,7 @@ de:
         license: Lizenz- und Verbreitungsinformationen für den Zugang zur Arbeit. Wählen Sie aus der mitgelieferten Dropdown-Liste aus.
         publisher: Die Person oder Gruppe, die die Arbeit zur Verfügung stellt. Im Allgemeinen ist das die Institution.
         related_url: Ein Link zu einer Website oder anderen spezifischen Inhalten (Audio, Video, PDF-Dokument) im Zusammenhang mit der Arbeit. Ein Beispiel ist die URL eines Forschungsprojekts, aus dem die Arbeit abgeleitet wurde.
-        resource_type: Vordefinierte Kategorien, um die Art des hochgeladenen Inhalts zu beschreiben, wie beispielsweise &ldquor;Artikel&ldquo; oder &ldquor;Datensatz&ldquo;. Es können mehr als ein Typ ausgewählt werden.
+        resource_type: Vordefinierte Kategorien, um die Art des hochgeladenen Inhalts zu beschreiben, wie beispielsweise „Artikel“ oder „Datensatz“. Es können mehr als ein Typ ausgewählt werden.
         rights_notes: Enthält Informationen zu den in und über der Ressource gehaltenen Rechten.
         subject: Überschriften oder Indexbegriffe, die beschreiben, worum es bei der Arbeit geht; Diese müssen sich an ein bestehendes Vokabular anpassen.
         title: Ein Titel, um bei der Identifizierung einer Arbeit zu helfen.


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/3421

Guillemets are preferred in German. 
Changes proposed in this pull request:
* This PR uses utf-8 characters in the i18n translation string. (see #3421 )

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* see https://github.com/samvera/hyrax/issues/3421

@samvera/hyrax-code-reviewers
