### PR TITLE
[wings] Avoid double setting visibility in Wings converter

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -34,7 +34,7 @@ module Wings
     end
 
     ##
-    # Accesses and parses the attributes from the resource through ConvetrerValueMapper
+    # Accesses and parses the attributes from the resource through ConverterValueMapper
     # @return [Hash]
     def attributes
       @attribs ||= begin

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -34,7 +34,7 @@ module Wings
     end
 
     ##
-    # Accesses and parses the attributes from the resource through ConverterValueMapper
+    # Accesses and parses the attributes from the resource through ConvetrerValueMapper
     # @return [Hash]
     def attributes
       @attribs ||= begin
@@ -149,7 +149,6 @@ module Wings
 
       # Add attributes from resource which aren't AF properties into af_object
       def add_access_control_attributes(af_object)
-        af_object.visibility = attributes[:visibility] unless attributes[:visibility].blank?
         af_object.read_users = attributes[:read_users] unless attributes[:read_users].blank?
         af_object.edit_users = attributes[:edit_users] unless attributes[:edit_users].blank?
         af_object.read_groups = attributes[:read_groups] unless attributes[:read_groups].blank?

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -178,7 +178,6 @@ module Wings
 
     class ActiveFedoraResource < ::Valkyrie::Resource
       attribute :alternate_ids, ::Valkyrie::Types::Array
-      attribute :visibility,    ::Valkyrie::Types::Symbol
     end
 
     class AttributeTransformer

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -60,16 +60,33 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       end
     end
 
-    context 'with a generic work that has open visibility' do
+    context 'when specifying visibility' do
       let(:attributes) do
         FactoryBot.attributes_for(:generic_work)
       end
-      before do
-        work.visibility = "open"
-      end
+
+      let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+
+      before { work.visibility = visibility }
 
       it 'sets the visibility' do
-        expect(converter.convert).to have_attributes(visibility: work.visibility)
+        expect(converter.convert).to have_attributes(visibility: visibility)
+      end
+
+      context 'when restricted' do
+        let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+
+        it 'sets the visibility' do
+          expect(converter.convert).to have_attributes(visibility: visibility)
+        end
+      end
+
+      context 'when private' do
+        let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+
+        it 'sets the visibility' do
+          expect(converter.convert).to have_attributes(visibility: visibility)
+        end
       end
     end
 


### PR DESCRIPTION
`#visibility` in `Hydra::AccessControls` is a projection on the ACLs. Since the
converter sets the ACL users and groups manually, there's no need to set
`visibility` separately; doing so may complicate special cases like embargo and
lease.

This is a non-functional change, isolated to Wings.

@samvera/hyrax-code-reviewers
