### PR TITLE
[wings] persist embargo/lease data when embargo/lease_id isn't set

### DIFF
--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -214,7 +214,8 @@ module Wings
       def additional_attributes
         { created_at: pcdm_object.try(:create_date),
           updated_at: pcdm_object.try(:modified_date),
-          visibility: pcdm_object.try(:visibility),
+          embargo_id: pcdm_object.try(:embargo)&.id || pcdm_object.try(:embargo_id),
+          lease_id:   pcdm_object.try(:lease)&.id   || pcdm_object.try(:lease_id),
           read_groups: pcdm_object.try(:read_groups),
           read_users: pcdm_object.try(:read_users),
           edit_groups: pcdm_object.try(:edit_groups),

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -143,6 +143,26 @@ RSpec.describe Wings::ModelTransformer do
         expect(subject.build.lease_id.to_s).to eq work.lease.id
       end
     end
+
+    context 'with newly saved embargo' do
+      let(:work) { FactoryBot.build(:embargoed_work) }
+
+      it 'has the correct embargo id' do
+        work.embargo.save
+
+        expect(subject.build.embargo_id.to_s).to eq work.embargo.id
+      end
+    end
+
+    context 'with newly saved lease' do
+      let(:work) { FactoryBot.build(:leased_work) }
+
+      it 'has the correct lease id' do
+        work.lease.save
+
+        expect(subject.build.lease_id.to_s).to eq work.lease.id
+      end
+    end
   end
 
   context 'with _id attributes' do
@@ -157,16 +177,6 @@ RSpec.describe Wings::ModelTransformer do
       expect(resource[:thumbnail_id].to_s).to eq(work.thumbnail_id)
       expect(resource[:access_control_id].to_s).to eq(work.access_control_id)
       expect(resource[:admin_set_id].to_s).to eq(work.admin_set_id)
-    end
-  end
-
-  context 'with a generic work that has open visibility' do
-    before do
-      work.visibility = "open"
-    end
-
-    it 'sets the visibility' do
-      expect(subject.build.visibility).to eq(work.visibility)
     end
   end
 


### PR DESCRIPTION
When an embargo or lease is saved in an `ActiveFedora::Base`'s `#embargo` or
`#lease` field, but the `#embargo_id` or `#lease_id` isn't set, we should still
retain the embargo/lease when converting. This supports the pattern for
embargo/lease management that's actually in use for existing AF code. Hopefully,
supporting it will make writing transition code easier.

Visibility is dropped from the `#additional_attributes` to ease integration with
other open branches. The visibility set here is a no-op, already, so whatever
order we choose to remove it should be fine.

Expands the internal behavior of Wings.

@samvera/hyrax-code-reviewers
