### PR TITLE
[wings] Refactor for configurable `ActiveFedora.index_field_mapper`

### DIFF
--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -44,6 +44,6 @@ class Hyrax::HomepageController < ApplicationController
     end
 
     def sort_field
-      "#{ActiveFedora.index_field_mapper.solr_name('date_uploaded', :stored_sortable, type: :date)} desc"
+      "#{Hyrax.config.index_field_mapper.solr_name('date_uploaded', :stored_sortable, type: :date)} desc"
     end
 end

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -89,7 +89,7 @@ module Hyrax
     # @return [ActiveSupport::SafeBuffer] the html_safe link
     def link_to_facet_list(values, solr_field, empty_message = "No value entered", separator = ", ")
       return empty_message if values.blank?
-      facet_field = ActiveFedora.index_field_mapper.solr_name(solr_field, :facetable)
+      facet_field = Hyrax.config.index_field_mapper.solr_name(solr_field, :facetable)
       safe_join(values.map { |item| link_to_facet(item, facet_field) }, separator)
     end
 
@@ -261,7 +261,7 @@ module Hyrax
     def collection_title_by_id(id)
       solr_docs = controller.repository.find(id).docs
       return nil if solr_docs.empty?
-      solr_field = solr_docs.first[ActiveFedora.index_field_mapper.solr_name("title", :stored_searchable)]
+      solr_field = solr_docs.first[Hyrax.config.index_field_mapper.solr_name("title", :stored_searchable)]
       return nil if solr_field.nil?
       solr_field.first
     end
@@ -307,7 +307,7 @@ module Hyrax
       def search_state_with_facets(params, facet = {})
         state = Blacklight::SearchState.new(params, CatalogController.blacklight_config)
         return state.params if facet.none?
-        state.add_facet_params(ActiveFedora.index_field_mapper.solr_name(facet.keys.first, :facetable),
+        state.add_facet_params(Hyrax.config.index_field_mapper.solr_name(facet.keys.first, :facetable),
                                facet.values.first)
       end
 

--- a/app/indexers/hyrax/admin_set_indexer.rb
+++ b/app/indexers/hyrax/admin_set_indexer.rb
@@ -7,7 +7,7 @@ module Hyrax
     def generate_solr_document
       super.tap do |solr_doc|
         # Makes Admin Sets show under the "Admin Sets" tab
-        ActiveFedora.index_field_mapper.set_field(solr_doc, 'generic_type', 'Admin Set', :facetable)
+        Hyrax.config.index_field_mapper.set_field(solr_doc, 'generic_type', 'Admin Set', :facetable)
       end
     end
   end

--- a/app/indexers/hyrax/collection_indexer.rb
+++ b/app/indexers/hyrax/collection_indexer.rb
@@ -11,9 +11,9 @@ module Hyrax
     def generate_solr_document
       super.tap do |solr_doc|
         # Makes Collections show under the "Collections" tab
-        ActiveFedora.index_field_mapper.set_field(solr_doc, 'generic_type', 'Collection', :facetable)
+        Hyrax.config.index_field_mapper.set_field(solr_doc, 'generic_type', 'Collection', :facetable)
         # Index the size of the collection in bytes
-        solr_doc[ActiveFedora.index_field_mapper.solr_name(:bytes, STORED_LONG)] = object.bytes
+        solr_doc[Hyrax.config.index_field_mapper.solr_name(:bytes, STORED_LONG)] = object.bytes
         solr_doc['visibility_ssi'] = object.visibility
 
         object.in_collections.each do |col|

--- a/app/indexers/hyrax/indexes_workflow.rb
+++ b/app/indexers/hyrax/indexes_workflow.rb
@@ -3,7 +3,7 @@ module Hyrax
     STORED_BOOL = ActiveFedora::Indexing::Descriptor.new(:boolean, :stored, :indexed)
 
     mattr_accessor :suppressed_field, instance_writer: false do
-      ActiveFedora.index_field_mapper.solr_name('suppressed', STORED_BOOL)
+      Hyrax.config.index_field_mapper.solr_name('suppressed', STORED_BOOL)
     end
 
     # Adds thumbnail indexing to the solr document
@@ -31,11 +31,11 @@ module Hyrax
     end
 
     def workflow_state_name_field
-      @workflow_state_name_field ||= ActiveFedora.index_field_mapper.solr_name('workflow_state_name', :symbol)
+      @workflow_state_name_field ||= Hyrax.config.index_field_mapper.solr_name('workflow_state_name', :symbol)
     end
 
     def workflow_role_field
-      @workflow_role_field ||= ActiveFedora.index_field_mapper.solr_name('actionable_workflow_roles', :symbol)
+      @workflow_role_field ||= Hyrax.config.index_field_mapper.solr_name('actionable_workflow_roles', :symbol)
     end
 
     def workflow_roles(entity)

--- a/app/indexers/hyrax/work_indexer.rb
+++ b/app/indexers/hyrax/work_indexer.rb
@@ -9,7 +9,7 @@ module Hyrax
         solr_doc['member_ids_ssim'] = object.member_ids
         solr_doc['member_of_collections_ssim']    = object.member_of_collections.map(&:first_title)
         solr_doc['member_of_collection_ids_ssim'] = object.member_of_collections.map(&:id)
-        ActiveFedora.index_field_mapper.set_field(solr_doc, 'generic_type', 'Work', :facetable)
+        Hyrax.config.index_field_mapper.set_field(solr_doc, 'generic_type', 'Work', :facetable)
 
         # This enables us to return a Work when we have a FileSet that matches
         # the search query.  While at the same time allowing us not to return Collections

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -106,7 +106,7 @@ module Hyrax
       end
 
       def collection_type_gid_document_field_name
-        ActiveFedora.index_field_mapper.solr_name('collection_type_gid', *index_collection_type_gid_as)
+        Hyrax.config.index_field_mapper.solr_name('collection_type_gid', *index_collection_type_gid_as)
       end
     end
 
@@ -181,12 +181,12 @@ module Hyrax
       # Field name to look up when locating the size of each file in Solr.
       # Override for your own installation if using something different
       def file_size_field
-        ActiveFedora.index_field_mapper.solr_name(:file_size, Hyrax::FileSetIndexer::STORED_LONG)
+        Hyrax.config.index_field_mapper.solr_name(:file_size, Hyrax::FileSetIndexer::STORED_LONG)
       end
 
       # Solr field name works use to index member ids
       def member_ids_field
-        ActiveFedora.index_field_mapper.solr_name('member_ids', :symbol)
+        Hyrax.config.index_field_mapper.solr_name('member_ids', :symbol)
       end
 
       def destroy_permission_template

--- a/app/models/concerns/hyrax/file_set/querying.rb
+++ b/app/models/concerns/hyrax/file_set/querying.rb
@@ -5,7 +5,7 @@ module Hyrax
 
       module ClassMethods
         def where_digest_is(digest_string)
-          where ActiveFedora.index_field_mapper.solr_name('digest', :symbol) => urnify(digest_string)
+          where Hyrax.config.index_field_mapper.solr_name('digest', :symbol) => urnify(digest_string)
         end
 
         def urnify(digest_string)

--- a/app/models/concerns/hyrax/human_readable_type.rb
+++ b/app/models/concerns/hyrax/human_readable_type.rb
@@ -22,8 +22,8 @@ module Hyrax
 
     def to_solr(solr_doc = {})
       super(solr_doc).tap do |doc|
-        doc[ActiveFedora.index_field_mapper.solr_name('human_readable_type', :facetable)] = human_readable_type
-        doc[ActiveFedora.index_field_mapper.solr_name('human_readable_type', :stored_searchable)] = human_readable_type
+        doc[Hyrax.config.index_field_mapper.solr_name('human_readable_type', :facetable)] = human_readable_type
+        doc[Hyrax.config.index_field_mapper.solr_name('human_readable_type', :stored_searchable)] = human_readable_type
       end
     end
   end

--- a/app/models/concerns/hyrax/solr_document/characterization.rb
+++ b/app/models/concerns/hyrax/solr_document/characterization.rb
@@ -3,27 +3,27 @@ module Hyrax
     # TODO: aside from height and width, I don't think any of these other terms are indexed by default. - Justin 3/2016
     module Characterization
       def byte_order
-        self[ActiveFedora.index_field_mapper.solr_name("byte_order")]
+        self[Hyrax.config.index_field_mapper.solr_name("byte_order")]
       end
 
       def capture_device
-        self[ActiveFedora.index_field_mapper.solr_name("capture_device")]
+        self[Hyrax.config.index_field_mapper.solr_name("capture_device")]
       end
 
       def color_map
-        self[ActiveFedora.index_field_mapper.solr_name("color_map")]
+        self[Hyrax.config.index_field_mapper.solr_name("color_map")]
       end
 
       def color_space
-        self[ActiveFedora.index_field_mapper.solr_name("color_space")]
+        self[Hyrax.config.index_field_mapper.solr_name("color_space")]
       end
 
       def compression
-        self[ActiveFedora.index_field_mapper.solr_name("compression")]
+        self[Hyrax.config.index_field_mapper.solr_name("compression")]
       end
 
       def gps_timestamp
-        self[ActiveFedora.index_field_mapper.solr_name("gps_timestamp")]
+        self[Hyrax.config.index_field_mapper.solr_name("gps_timestamp")]
       end
 
       def height
@@ -31,31 +31,31 @@ module Hyrax
       end
 
       def image_producer
-        self[ActiveFedora.index_field_mapper.solr_name("image_producer")]
+        self[Hyrax.config.index_field_mapper.solr_name("image_producer")]
       end
 
       def latitude
-        self[ActiveFedora.index_field_mapper.solr_name("latitude")]
+        self[Hyrax.config.index_field_mapper.solr_name("latitude")]
       end
 
       def longitude
-        self[ActiveFedora.index_field_mapper.solr_name("longitude")]
+        self[Hyrax.config.index_field_mapper.solr_name("longitude")]
       end
 
       def orientation
-        self[ActiveFedora.index_field_mapper.solr_name("orientation")]
+        self[Hyrax.config.index_field_mapper.solr_name("orientation")]
       end
 
       def profile_name
-        self[ActiveFedora.index_field_mapper.solr_name("profile_name")]
+        self[Hyrax.config.index_field_mapper.solr_name("profile_name")]
       end
 
       def profile_version
-        self[ActiveFedora.index_field_mapper.solr_name("profile_version")]
+        self[Hyrax.config.index_field_mapper.solr_name("profile_version")]
       end
 
       def scanning_software
-        self[ActiveFedora.index_field_mapper.solr_name("scanning_software")]
+        self[Hyrax.config.index_field_mapper.solr_name("scanning_software")]
       end
 
       def width
@@ -63,43 +63,43 @@ module Hyrax
       end
 
       def format_label
-        self[ActiveFedora.index_field_mapper.solr_name("format_label")]
+        self[Hyrax.config.index_field_mapper.solr_name("format_label")]
       end
 
       def file_size
-        self[ActiveFedora.index_field_mapper.solr_name("file_size")]
+        self[Hyrax.config.index_field_mapper.solr_name("file_size")]
       end
 
       def filename
-        self[ActiveFedora.index_field_mapper.solr_name("filename")]
+        self[Hyrax.config.index_field_mapper.solr_name("filename")]
       end
 
       def well_formed
-        self[ActiveFedora.index_field_mapper.solr_name("well_formed")]
+        self[Hyrax.config.index_field_mapper.solr_name("well_formed")]
       end
 
       def page_count
-        self[ActiveFedora.index_field_mapper.solr_name("page_count")]
+        self[Hyrax.config.index_field_mapper.solr_name("page_count")]
       end
 
       def file_title
-        self[ActiveFedora.index_field_mapper.solr_name("file_title")]
+        self[Hyrax.config.index_field_mapper.solr_name("file_title")]
       end
 
       def duration
-        self[ActiveFedora.index_field_mapper.solr_name("duration")]
+        self[Hyrax.config.index_field_mapper.solr_name("duration")]
       end
 
       def sample_rate
-        self[ActiveFedora.index_field_mapper.solr_name("sample_rate")]
+        self[Hyrax.config.index_field_mapper.solr_name("sample_rate")]
       end
 
       def last_modified
-        self[ActiveFedora.index_field_mapper.solr_name("last_modified")]
+        self[Hyrax.config.index_field_mapper.solr_name("last_modified")]
       end
 
       def original_checksum
-        self[ActiveFedora.index_field_mapper.solr_name("original_checksum")]
+        self[Hyrax.config.index_field_mapper.solr_name("original_checksum")]
       end
     end
   end

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -10,7 +10,7 @@ module Hyrax
         end
 
         def solr_name(*args)
-          ActiveFedora.index_field_mapper.solr_name(*args)
+          Hyrax.config.index_field_mapper.solr_name(*args)
         end
       end
 

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -71,11 +71,11 @@ module Hyrax
 
     # Method to return the ActiveFedora model
     def hydra_model
-      first(ActiveFedora.index_field_mapper.solr_name('has_model', :symbol)).constantize
+      first(Hyrax.config.index_field_mapper.solr_name('has_model', :symbol)).constantize
     end
 
     def depositor(default = '')
-      val = first(ActiveFedora.index_field_mapper.solr_name('depositor'))
+      val = first(Hyrax.config.index_field_mapper.solr_name('depositor'))
       val.present? ? val : default
     end
 
@@ -85,7 +85,7 @@ module Hyrax
                    else
                      :stored_searchable
                    end
-      fetch(ActiveFedora.index_field_mapper.solr_name('creator', descriptor), [])
+      fetch(Hyrax.config.index_field_mapper.solr_name('creator', descriptor), [])
     end
 
     def visibility

--- a/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
@@ -12,7 +12,7 @@ module Hyrax
         end
 
         def search_field
-          ERB::Util.h(ActiveFedora.index_field_mapper.solr_name(options.fetch(:search_field, field), :facetable, type: :string))
+          ERB::Util.h(Hyrax.config.index_field_mapper.solr_name(options.fetch(:search_field, field), :facetable, type: :string))
         end
     end
   end

--- a/app/search_builders/hyrax/collection_search_builder.rb
+++ b/app/search_builders/hyrax/collection_search_builder.rb
@@ -19,7 +19,7 @@ module Hyrax
 
     # @return [String] Solr field name indicating default sort order
     def sort_field
-      ActiveFedora.index_field_mapper.solr_name('title', :sortable)
+      Hyrax.config.index_field_mapper.solr_name('title', :sortable)
     end
 
     # This overrides the models in FilterByType

--- a/app/search_builders/hyrax/deposit_search_builder.rb
+++ b/app/search_builders/hyrax/deposit_search_builder.rb
@@ -17,7 +17,7 @@ module Hyrax
     end
 
     def self.depositor_field
-      @depositor_field ||= ActiveFedora.index_field_mapper.solr_name('depositor', :symbol).freeze
+      @depositor_field ||= Hyrax.config.index_field_mapper.solr_name('depositor', :symbol).freeze
     end
 
     private

--- a/app/services/hyrax/statistics/file_sets/by_format.rb
+++ b/app/services/hyrax/statistics/file_sets/by_format.rb
@@ -6,7 +6,7 @@ module Hyrax
 
           # Returns 'file_format_sim'
           def index_key
-            ActiveFedora.index_field_mapper.solr_name('file_format', :facetable)
+            Hyrax.config.index_field_mapper.solr_name('file_format', :facetable)
           end
       end
     end

--- a/app/services/hyrax/statistics/works/by_resource_type.rb
+++ b/app/services/hyrax/statistics/works/by_resource_type.rb
@@ -5,7 +5,7 @@ module Hyrax
         private
 
           def index_key
-            ActiveFedora.index_field_mapper.solr_name("resource_type", :facetable)
+            Hyrax.config.index_field_mapper.solr_name("resource_type", :facetable)
           end
       end
     end

--- a/app/views/records/show_fields/_based_near.html.erb
+++ b/app/views/records/show_fields/_based_near.html.erb
@@ -1,6 +1,6 @@
 <% record.based_near.each do |bn| %>
   <span itemprop="contentLocation" itemscope itemtype="http://schema.org/Place">
-    <span itemprop="name"><%= link_to_facet(bn, ActiveFedora.index_field_mapper.solr_name("based_near", :facetable)) %></span>
+    <span itemprop="name"><%= link_to_facet(bn, Hyrax.config.index_field_mapper.solr_name("based_near", :facetable)) %></span>
   </span>
   <br />
 <% end %>

--- a/app/views/records/show_fields/_creator.html.erb
+++ b/app/views/records/show_fields/_creator.html.erb
@@ -1,6 +1,6 @@
 <% record.creator.each do |creator| %>
 <span itemprop="creator" itemscope itemtype="http://schema.org/Person">
-  <span itemprop="name"><%= link_to_facet(creator, ActiveFedora.index_field_mapper.solr_name("creator", :facetable)) %></span>
+  <span itemprop="name"><%= link_to_facet(creator, Hyrax.config.index_field_mapper.solr_name("creator", :facetable)) %></span>
 </span>
 <br />
 <% end %>

--- a/app/views/records/show_fields/_keyword.html.erb
+++ b/app/views/records/show_fields/_keyword.html.erb
@@ -1,3 +1,3 @@
 <% record.keyword.each do |t| %>
-  <span itemprop="keywords"><%= link_to_facet(t, ActiveFedora.index_field_mapper.solr_name("keyword", :facetable)) %></span><br />
+  <span itemprop="keywords"><%= link_to_facet(t, Hyrax.config.index_field_mapper.solr_name("keyword", :facetable)) %></span><br />
 <% end %>

--- a/app/views/records/show_fields/_language.html.erb
+++ b/app/views/records/show_fields/_language.html.erb
@@ -1,3 +1,3 @@
 <% record.language.each do |lang| %>
-  <span itemprop="inLanguage"><%= link_to_facet(lang, ActiveFedora.index_field_mapper.solr_name("language", :facetable)) %></span><br />
+  <span itemprop="inLanguage"><%= link_to_facet(lang, Hyrax.config.index_field_mapper.solr_name("language", :facetable)) %></span><br />
 <% end %>

--- a/app/views/records/show_fields/_publisher.html.erb
+++ b/app/views/records/show_fields/_publisher.html.erb
@@ -1,6 +1,6 @@
 <% record.publisher.each do |pub| %>
   <span itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
-    <span itemprop="name"><%= link_to_facet(pub, ActiveFedora.index_field_mapper.solr_name("publisher", :facetable)) %></span>
+    <span itemprop="name"><%= link_to_facet(pub, Hyrax.config.index_field_mapper.solr_name("publisher", :facetable)) %></span>
         </span>
   <br />
 <% end %>

--- a/app/views/records/show_fields/_resource_type.html.erb
+++ b/app/views/records/show_fields/_resource_type.html.erb
@@ -1,3 +1,3 @@
 <% record.resource_type.each do |rtype| %>
-  <%= link_to_facet(rtype, ActiveFedora.index_field_mapper.solr_name("resource_type", :facetable)) %><br />
+  <%= link_to_facet(rtype, Hyrax.config.index_field_mapper.solr_name("resource_type", :facetable)) %><br />
 <% end %>

--- a/app/views/records/show_fields/_subject.html.erb
+++ b/app/views/records/show_fields/_subject.html.erb
@@ -1,6 +1,6 @@
 <% record.subject.each do |sub| %>
   <span itemprop="about" itemscope itemtype="http://schema.org/Thing">
-    <span itemprop="name"><%= link_to_facet(sub, ActiveFedora.index_field_mapper.solr_name("subject", :facetable)) %></span>
+    <span itemprop="name"><%= link_to_facet(sub, Hyrax.config.index_field_mapper.solr_name("subject", :facetable)) %></span>
   </span>
   <br />
 <% end %>

--- a/config/initializers/samvera-nesting_indexer_initializer.rb
+++ b/config/initializers/samvera-nesting_indexer_initializer.rb
@@ -9,8 +9,8 @@ Samvera::NestingIndexer.configure do |config|
   # C1 <- C2 <- C3 <- W1
   config.maximum_nesting_depth = 5
   config.adapter = Hyrax::Adapters::NestingIndexAdapter
-  config.solr_field_name_for_storing_parent_ids = ActiveFedora.index_field_mapper.solr_name('nesting_collection__parent_ids', :symbol)
-  config.solr_field_name_for_storing_ancestors =  ActiveFedora.index_field_mapper.solr_name('nesting_collection__ancestors', :symbol)
-  config.solr_field_name_for_storing_pathnames =  ActiveFedora.index_field_mapper.solr_name('nesting_collection__pathnames', :symbol)
+  config.solr_field_name_for_storing_parent_ids = Hyrax.config.index_field_mapper.solr_name('nesting_collection__parent_ids', :symbol)
+  config.solr_field_name_for_storing_ancestors =  Hyrax.config.index_field_mapper.solr_name('nesting_collection__ancestors', :symbol)
+  config.solr_field_name_for_storing_pathnames =  Hyrax.config.index_field_mapper.solr_name('nesting_collection__pathnames', :symbol)
   config.solr_field_name_for_deepest_nested_depth = 'nesting_collection__deepest_nested_depth_isi'
 end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -450,6 +450,11 @@ module Hyrax
     end
     attr_writer :iiif_metadata_fields
 
+    attr_writer :index_field_mapper
+    def index_field_mapper
+      @index_field_mapper ||= ActiveFedora.index_field_mapper
+    end
+
     # Should a button with "Share my work" show on the front page to users who are not logged in?
     attr_writer :display_share_button_when_not_logged_in
     def display_share_button_when_not_logged_in?

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         }
 
         expect(assigns[:collection].member_objects).to eq [asset1]
-        asset_results = ActiveFedora::SolrService.instance.conn.get "select", params: { fq: ["id:\"#{asset1.id}\""], fl: ['id', ActiveFedora.index_field_mapper.solr_name(:collection)] }
+        asset_results = ActiveFedora::SolrService.instance.conn.get "select", params: { fq: ["id:\"#{asset1.id}\""], fl: ['id', Hyrax.config.index_field_mapper.solr_name(:collection)] }
         expect(asset_results["response"]["numFound"]).to eq 1
         doc = asset_results["response"]["docs"].first
         expect(doc["id"]).to eq asset1.id

--- a/spec/controllers/hyrax/homepage_controller_spec.rb
+++ b/spec/controllers/hyrax/homepage_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Hyrax::HomepageController, type: :controller do
     it "includes only GenericWork objects in recent documents" do
       get :index
       assigns(:recent_documents).each do |doc|
-        expect(doc[ActiveFedora.index_field_mapper.solr_name("has_model", :symbol)]).to eql ["GenericWork"]
+        expect(doc[Hyrax.config.index_field_mapper.solr_name("has_model", :symbol)]).to eql ["GenericWork"]
       end
     end
 
@@ -60,8 +60,8 @@ RSpec.describe Hyrax::HomepageController, type: :controller do
         old_to_solr = gw3.method(:to_solr)
         allow(gw3).to receive(:to_solr) do
           old_to_solr.call.merge(
-            ActiveFedora.index_field_mapper.solr_name('system_create', :stored_sortable, type: :date) => 1.day.ago.iso8601,
-            ActiveFedora.index_field_mapper.solr_name('date_uploaded', :stored_sortable, type: :date) => 1.day.ago.iso8601
+            Hyrax.config.index_field_mapper.solr_name('system_create', :stored_sortable, type: :date) => 1.day.ago.iso8601,
+            Hyrax.config.index_field_mapper.solr_name('date_uploaded', :stored_sortable, type: :date) => 1.day.ago.iso8601
           )
         end
         gw3.save

--- a/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
+++ b/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
@@ -62,13 +62,13 @@ RSpec.describe Hyrax::DashboardHelperBehavior, type: :helper do
   def create_models(model, user1, user2)
     # deposited by the first user
     3.times do |t|
-      conn.add id: "199#{t}", ActiveFedora.index_field_mapper.solr_name('depositor', :stored_searchable) => user1.user_key, "has_model_ssim" => [model],
-               ActiveFedora.index_field_mapper.solr_name('depositor', :symbol) => user1.user_key
+      conn.add id: "199#{t}", Hyrax.config.index_field_mapper.solr_name('depositor', :stored_searchable) => user1.user_key, "has_model_ssim" => [model],
+               Hyrax.config.index_field_mapper.solr_name('depositor', :symbol) => user1.user_key
     end
 
     # deposited by the second user, but editable by the first
-    conn.add id: "1994", ActiveFedora.index_field_mapper.solr_name('depositor', :stored_searchable) => user2.user_key, "has_model_ssim" => [model],
-             ActiveFedora.index_field_mapper.solr_name('depositor', :symbol) => user2.user_key, "edit_access_person_ssim" => user1.user_key
+    conn.add id: "1994", Hyrax.config.index_field_mapper.solr_name('depositor', :stored_searchable) => user2.user_key, "has_model_ssim" => [model],
+             Hyrax.config.index_field_mapper.solr_name('depositor', :symbol) => user2.user_key, "edit_access_person_ssim" => user1.user_key
     conn.commit
   end
 end

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe HyraxHelper, type: :helper do
     subject { helper.link_to_each_facet_field(options) }
 
     context "with helper_facet and default separator" do
-      let(:options) { { config: { helper_facet: ActiveFedora.index_field_mapper.solr_name("document_types", :facetable).to_sym }, value: ["Imaging > Object Photography"] } }
+      let(:options) { { config: { helper_facet: Hyrax.config.index_field_mapper.solr_name("document_types", :facetable).to_sym }, value: ["Imaging > Object Photography"] } }
 
       it do
         is_expected.to eq("<a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Imaging\">" \
@@ -127,7 +127,7 @@ RSpec.describe HyraxHelper, type: :helper do
     end
 
     context "with helper_facet and optional separator" do
-      let(:options) { { config: { helper_facet: ActiveFedora.index_field_mapper.solr_name("document_types", :facetable).to_sym, separator: " : " }, value: ["Imaging : Object Photography"] } }
+      let(:options) { { config: { helper_facet: Hyrax.config.index_field_mapper.solr_name("document_types", :facetable).to_sym, separator: " : " }, value: ["Imaging : Object Photography"] } }
 
       it do
         is_expected.to eq("<a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Imaging\">" \
@@ -138,7 +138,7 @@ RSpec.describe HyraxHelper, type: :helper do
 
     context "with :output_separator" do
       let(:options) do
-        { config: { helper_facet: ActiveFedora.index_field_mapper.solr_name("document_types", :facetable).to_sym, output_separator: ' ~ ', separator: ":" }, value: ["Imaging : Object Photography"] }
+        { config: { helper_facet: Hyrax.config.index_field_mapper.solr_name("document_types", :facetable).to_sym, output_separator: ' ~ ', separator: ":" }, value: ["Imaging : Object Photography"] }
       end
 
       it do
@@ -150,7 +150,7 @@ RSpec.describe HyraxHelper, type: :helper do
 
     context "with :no_spaces_around_separator" do
       let(:options) do
-        { config: { helper_facet: ActiveFedora.index_field_mapper.solr_name("document_types", :facetable).to_sym, output_separator: '~', separator: ":" }, value: ["Imaging : Object Photography"] }
+        { config: { helper_facet: Hyrax.config.index_field_mapper.solr_name("document_types", :facetable).to_sym, output_separator: '~', separator: ":" }, value: ["Imaging : Object Photography"] }
       end
 
       it do

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -487,8 +487,8 @@ RSpec.describe FileSet do
     end
 
     let(:depositor) { 'jcoyne' }
-    let(:depositor_key) { ActiveFedora.index_field_mapper.solr_name('depositor') }
-    let(:title_key) { ActiveFedora.index_field_mapper.solr_name('title', :stored_searchable, type: :string) }
+    let(:depositor_key) { Hyrax.config.index_field_mapper.solr_name('depositor') }
+    let(:title_key) { Hyrax.config.index_field_mapper.solr_name('title', :stored_searchable, type: :string) }
     let(:title) { ['abc123'] }
     let(:no_terms) { described_class.find(subject.id).to_solr }
     let(:terms) do

--- a/spec/views/hyrax/base/_attributes.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attributes.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'hyrax/base/_attributes.html.erb' do
   let(:solr_document) { SolrDocument.new(attributes) }
   let(:attributes) do
     {
-      ActiveFedora.index_field_mapper.solr_name('has_model', :symbol) => ["GenericWork"],
+      Hyrax.config.index_field_mapper.solr_name('has_model', :symbol) => ["GenericWork"],
       subject_tesim: subject,
       contributor_tesim: contributor,
       creator_tesim: creator,


### PR DESCRIPTION
We want to remove the dependency on `ActiveFedora.index_field_mapper` as part of
the wings work. As a first step to that, we add support for a configurable
mapper, setting it to the existing mapper by default.

Related to #3794.

@samvera/hyrax-code-reviewers
