### PR TITLE
[wings] Refactor `id_field` for Hyrax configuratability

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -97,8 +97,8 @@ module Hyrax
 
       def fetch_parent_presenter
         ids = ActiveFedora::SolrService.query("{!field f=member_ids_ssim}#{id}",
-                                              fl: ActiveFedora.id_field)
-                                       .map { |x| x.fetch(ActiveFedora.id_field) }
+                                              fl: Hyrax.config.id_field)
+                                       .map { |x| x.fetch(Hyrax.config.id_field) }
         Hyrax::PresenterFactory.build_for(ids: ids,
                                           presenter_class: WorkShowPresenter,
                                           presenter_args: current_ability).first

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -55,9 +55,9 @@ module Hyrax
         @file_set_ids ||= begin
                             ActiveFedora::SolrService.query("{!field f=has_model_ssim}FileSet",
                                                             rows: 10_000,
-                                                            fl: ActiveFedora.id_field,
+                                                            fl: Hyrax.config.id_field,
                                                             fq: "{!join from=ordered_targets_ssim to=id}id:\"#{id}/list_source\"")
-                                                     .flat_map { |x| x.fetch(ActiveFedora.id_field, []) }
+                                                     .flat_map { |x| x.fetch(Hyrax.config.id_field, []) }
                           end
       end
 

--- a/app/search_builders/hyrax/catalog_search_builder.rb
+++ b/app/search_builders/hyrax/catalog_search_builder.rb
@@ -79,6 +79,6 @@ class Hyrax::CatalogSearchBuilder < Hyrax::SearchBuilder
 
     # join from file id to work relationship solrized file_set_ids_ssim
     def join_for_works_from_files
-      "{!join from=#{ActiveFedora.id_field} to=file_set_ids_ssim}#{dismax_query}"
+      "{!join from=#{Hyrax.config.id_field} to=file_set_ids_ssim}#{dismax_query}"
     end
 end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -388,6 +388,11 @@ module Hyrax
       @cache_path ||= ->() { Rails.root + 'tmp' + 'uploads' + 'cache' }
     end
 
+    attr_writer :id_field
+    def id_field
+      @id_field || ActiveFedora.id_field
+    end
+
     # Enable IIIF image service. This is required to use the
     # IIIF viewer enabled show page
     #


### PR DESCRIPTION
Isolate the dependency on `ActiveFedora#id_field` to a configuration. The
implementation in ActiveFedora uses `SOLR_DOCUMENT_ID` if present, and
`ActiveFedora.index_field_mapper.id_field` otherwise.

A next step could be to remove the `ActiveFedora.id_field` call in favor of a
reimplementation of that behavior, referencing `Hyrax.config.index_field_mapper`
instead of ActiveFedora's version.

Related to #3798.

@samvera/hyrax-code-reviewers
