### PR TITLE
[wings] Inline `ActiveFedora::SolrService` to `Hyrax` namespace

### DIFF
--- a/app/actors/hyrax/actors/cleanup_file_sets_actor.rb
+++ b/app/actors/hyrax/actors/cleanup_file_sets_actor.rb
@@ -22,7 +22,7 @@ module Hyrax
           curation_concern.list_source.destroy
           # Remove Work from Solr after it was removed from Fedora so that the
           # in_objects lookup does not break when FileSets are destroyed.
-          ActiveFedora::SolrService.delete(curation_concern.id)
+          Hyrax::SolrService.delete(curation_concern.id)
           fs.each(&:destroy)
         end
     end

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -83,7 +83,7 @@ module Hyrax
         # we pass the parent_id through a hidden field in the form and link the two after the create.
         link_parent_collection(params[:parent_id]) unless params[:parent_id].nil?
         respond_to do |format|
-          ActiveFedora::SolrService.instance.conn.commit
+          Hyrax::SolrService.instance.conn.commit
           format.html { redirect_to edit_dashboard_collection_path(@collection), notice: t('hyrax.dashboard.my.action.collection_create_success') }
           format.json { render json: @collection, status: :created, location: dashboard_collection_path(@collection) }
         end

--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -75,7 +75,7 @@ module Hyrax
                                       .joins(:permission_template)
                                       .pluck('DISTINCT source_id')
         query = "_query_:\"{!raw f=has_model_ssim}AdminSet\" AND {!terms f=id}#{ids.join(',')}"
-        ActiveFedora::SolrService.count(query).positive?
+        Hyrax::SolrService.count(query).positive?
       end
 
       # This overrides hydra-head, (and restores the method from blacklight-access-controls)

--- a/app/models/concerns/hyrax/collection_nesting.rb
+++ b/app/models/concerns/hyrax/collection_nesting.rb
@@ -43,7 +43,7 @@ module Hyrax
     end
 
     def find_children_of(destroyed_id:)
-      ActiveFedora::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: destroyed_id))
+      Hyrax::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: destroyed_id))
     end
 
     # Only models which include Hyrax::CollectionNesting will respond to this method.

--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -7,7 +7,7 @@ module Hyrax
     end
 
     def total_items
-      ActiveFedora::SolrService.count("{!field f=isPartOf_ssim}#{id}")
+      Hyrax::SolrService.count("{!field f=isPartOf_ssim}#{id}")
     end
 
     def total_viewable_items

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -96,9 +96,8 @@ module Hyrax
       end
 
       def fetch_parent_presenter
-        ids = ActiveFedora::SolrService.query("{!field f=member_ids_ssim}#{id}",
-                                              fl: Hyrax.config.id_field)
-                                       .map { |x| x.fetch(Hyrax.config.id_field) }
+        ids = Hyrax::SolrService.query("{!field f=member_ids_ssim}#{id}", fl: Hyrax.config.id_field)
+                                .map { |x| x.fetch(Hyrax.config.id_field) }
         Hyrax::PresenterFactory.build_for(ids: ids,
                                           presenter_class: WorkShowPresenter,
                                           presenter_args: current_ability).first

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -39,10 +39,10 @@ module Hyrax
     # TODO: Extract this to ActiveFedora::Aggregations::ListSource
     def ordered_ids
       @ordered_ids ||= begin
-                         ActiveFedora::SolrService.query("proxy_in_ssi:#{id}",
-                                                         rows: 10_000,
-                                                         fl: "ordered_targets_ssim")
-                                                  .flat_map { |x| x.fetch("ordered_targets_ssim", []) }
+                         Hyrax::SolrService.query("proxy_in_ssi:#{id}",
+                                                  rows: 10_000,
+                                                  fl:   "ordered_targets_ssim")
+                                           .flat_map { |x| x.fetch("ordered_targets_ssim", []) }
                        end
     end
 
@@ -53,11 +53,11 @@ module Hyrax
       # Arbitrarily maxed at 10 thousand; had to specify rows due to solr's default of 10
       def file_set_ids
         @file_set_ids ||= begin
-                            ActiveFedora::SolrService.query("{!field f=has_model_ssim}FileSet",
-                                                            rows: 10_000,
-                                                            fl: Hyrax.config.id_field,
-                                                            fq: "{!join from=ordered_targets_ssim to=id}id:\"#{id}/list_source\"")
-                                                     .flat_map { |x| x.fetch(Hyrax.config.id_field, []) }
+                            Hyrax::SolrService.query("{!field f=has_model_ssim}FileSet",
+                                                     rows: 10_000,
+                                                     fl:   ActiveFedora.id_field,
+                                                     fq:   "{!join from=ordered_targets_ssim to=id}id:\"#{id}/list_source\"")
+                                              .flat_map { |x| x.fetch(Hyrax.config.id_field, []) }
                           end
       end
 

--- a/app/presenters/hyrax/presenter_factory.rb
+++ b/app/presenters/hyrax/presenter_factory.rb
@@ -58,7 +58,7 @@ module Hyrax
       def query(query, args = {})
         args[:q] = query
         args[:qt] = 'standard'
-        conn = ActiveFedora::SolrService.instance.conn
+        conn = Hyrax::SolrService.instance.conn
         result = conn.post('select', data: args)
         result.fetch('response').fetch('docs')
       end

--- a/app/search_builders/hyrax/my/find_works_search_builder.rb
+++ b/app/search_builders/hyrax/my/find_works_search_builder.rb
@@ -25,7 +25,7 @@ class Hyrax::My::FindWorksSearchBuilder < Hyrax::My::SearchBuilder
   end
 
   def show_only_works_not_child(solr_parameters)
-    ids = ActiveFedora::SolrService.query("{!field f=id}#{@id}", fl: "member_ids_ssim", rows: 10_000).flat_map { |x| x.fetch("member_ids_ssim", []) }
+    ids = Hyrax::SolrService.query("{!field f=id}#{@id}", fl: "member_ids_ssim", rows: 10_000).flat_map { |x| x.fetch("member_ids_ssim", []) }
     solr_parameters[:fq] ||= []
     solr_parameters[:fq]  += [
       "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids(ids)

--- a/app/services/hyrax/adapters/nesting_index_adapter.rb
+++ b/app/services/hyrax/adapters/nesting_index_adapter.rb
@@ -57,7 +57,7 @@ module Hyrax
             yield(id, parent_ids) if parent_ids.empty?
           else
             Rails.logger.info "Re-indexing via to_solr ... #{id}"
-            ActiveFedora::SolrService.add(object.to_solr, commit: true)
+            Hyrax::SolrService.add(object.to_solr, commit: true)
           end
         end
       end
@@ -97,7 +97,7 @@ module Hyrax
         solr_doc[solr_field_name_for_storing_parent_ids] = parent_ids
         solr_doc[solr_field_name_for_storing_pathnames] = pathnames
         solr_doc[solr_field_name_for_deepest_nested_depth] = depth
-        ActiveFedora::SolrService.add(solr_doc, commit: true)
+        Hyrax::SolrService.add(solr_doc, commit: true)
         solr_doc
       end
 
@@ -132,7 +132,7 @@ module Hyrax
       # @api private
       def self.find_solr_document_by(id:)
         query = ActiveFedora::SolrQueryBuilder.construct_query_for_ids([id])
-        document = ActiveFedora::SolrService.query(query, rows: 1).first
+        document = Hyrax::SolrService.query(query, rows: 1).first
         document = ActiveFedora::Base.find(id).to_solr if document.nil?
         raise "Unable to find SolrDocument with ID=#{id}" if document.nil?
         document
@@ -158,7 +158,7 @@ module Hyrax
       def self.raw_child_solr_documents_of(parent_document:)
         # query Solr for all of the documents included as a member_of_collection parent. Or up to 10000 of them.
         child_query = ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: parent_document.id)
-        ActiveFedora::SolrService.query(child_query, rows: 10_000.to_i)
+        Hyrax::SolrService.query(child_query, rows: 10_000.to_i)
       end
       private_class_method :raw_child_solr_documents_of
 

--- a/app/services/hyrax/admin_set_service.rb
+++ b/app/services/hyrax/admin_set_service.rb
@@ -30,8 +30,8 @@ module Hyrax
       admin_sets = search_results(access)
       ids = admin_sets.map(&:id).join(',')
       query = "{!terms f=#{join_field}}#{ids}"
-      results = ActiveFedora::SolrService.instance.conn.get(
-        ActiveFedora::SolrService.select_path,
+      results = Hyrax::SolrService.instance.conn.get(
+        Hyrax::SolrService.select_path,
         params: { fq: query,
                   rows: 0,
                   'facet.field' => join_field }
@@ -57,8 +57,8 @@ module Hyrax
         file_counts = Hash.new(0)
         admin_sets.each do |admin_set|
           query = "{!join from=file_set_ids_ssim to=id}isPartOf_ssim:#{admin_set.id}"
-          file_results = ActiveFedora::SolrService.instance.conn.get(
-            ActiveFedora::SolrService.select_path,
+          file_results = Hyrax::SolrService.instance.conn.get(
+            Hyrax::SolrService.select_path,
             params: { fq: [query, "has_model_ssim:FileSet"],
                       rows: 0 }
           )

--- a/app/services/hyrax/admin_set_service.rb
+++ b/app/services/hyrax/admin_set_service.rb
@@ -31,7 +31,7 @@ module Hyrax
       ids = admin_sets.map(&:id).join(',')
       query = "{!terms f=#{join_field}}#{ids}"
       results = Hyrax::SolrService.instance.conn.get(
-        Hyrax::SolrService.select_path,
+        Hyrax.config.solr_select_path,
         params: { fq: query,
                   rows: 0,
                   'facet.field' => join_field }
@@ -58,7 +58,7 @@ module Hyrax
         admin_sets.each do |admin_set|
           query = "{!join from=file_set_ids_ssim to=id}isPartOf_ssim:#{admin_set.id}"
           file_results = Hyrax::SolrService.instance.conn.get(
-            Hyrax::SolrService.select_path,
+            Hyrax.config.solr_select_path,
             params: { fq: [query, "has_model_ssim:FileSet"],
                       rows: 0 }
           )

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -29,7 +29,7 @@ module Hyrax
                   "_query_:\"{!raw f=has_model_ssim}Collection\""
                 end
         query += " AND #{id_clause}"
-        ActiveFedora::SolrService.query(query, fl: 'id', rows: ids.count).map { |hit| hit['id'] }
+        Hyrax::SolrService.query(query, fl: 'id', rows: ids.count).map { |hit| hit['id'] }
       end
       private_class_method :filter_source
 

--- a/app/services/hyrax/solr_service.rb
+++ b/app/services/hyrax/solr_service.rb
@@ -4,7 +4,16 @@ module Hyrax
   #
   # This class replaces `ActiveFedora::SolrService`, which is deprecated for
   # internal use.
-  class SolrService < ActiveFedora::SolrService
+  class SolrService
+    extend Forwardable
+
+    def_delegators :@old_service, :add, :commit, :count, :delete, :get, :instance, :post, :query
+    def_delegators :instance, :conn
+
+    def initialize
+      @old_service = ActiveFedora::SolrService
+    end
+
     class << self
       ##
       # We don't implement `.select_path` instead configuring this at the Hyrax
@@ -13,6 +22,8 @@ module Hyrax
         raise NotImplementedError, 'This method is not available on this subclass.' \
                                    'Use `Hyrax.config.solr_select_path` instead'
       end
+
+      delegate :add, :commit, :count, :delete, :get, :instance, :post, :query, to: :new
     end
   end
 end

--- a/app/services/hyrax/solr_service.rb
+++ b/app/services/hyrax/solr_service.rb
@@ -1,0 +1,6 @@
+module Hyrax
+  ##
+  # Supports a range of basic Solr interactions
+  class SolrService < ActiveFedora::SolrService
+  end
+end

--- a/app/services/hyrax/solr_service.rb
+++ b/app/services/hyrax/solr_service.rb
@@ -1,6 +1,18 @@
 module Hyrax
   ##
-  # Supports a range of basic Solr interactions
+  # Supports a range of basic Solr interactions.
+  #
+  # This class replaces `ActiveFedora::SolrService`, which is deprecated for
+  # internal use.
   class SolrService < ActiveFedora::SolrService
+    class << self
+      ##
+      # We don't implement `.select_path` instead configuring this at the Hyrax
+      # level
+      def select_path
+        raise NotImplementedError, 'This method is not available on this subclass.' \
+                                   'Use `Hyrax.config.solr_select_path` instead'
+      end
+    end
   end
 end

--- a/app/services/hyrax/statistics/term_query.rb
+++ b/app/services/hyrax/statistics/term_query.rb
@@ -65,7 +65,7 @@ module Hyrax
       private
 
         def solr_connection
-          ActiveFedora::SolrService.instance.conn
+          Hyrax::SolrService.instance.conn
         end
     end
   end

--- a/app/services/hyrax/work_query_service.rb
+++ b/app/services/hyrax/work_query_service.rb
@@ -4,7 +4,7 @@ module Hyrax
   # @see ProxyDepositRequest
   # @see Hyrax::WorkRelation
   # @see SolrDocument
-  # @see ActiveFedora::SolrService
+  # @see Hyrax::SolrService
   # @see ActiveFedora::SolrQueryBuilder
   # @note This was extracted from the ProxyDepositRequest, which was coordinating lots of effort. It was also an ActiveRecord object that required lots of Fedora/Solr interactions.
   class WorkQueryService
@@ -48,7 +48,7 @@ module Hyrax
       end
 
       def solr_response
-        @solr_response ||= ActiveFedora::SolrService.get(query)
+        @solr_response ||= Hyrax::SolrService.get(query)
       end
 
       def query

--- a/lib/generators/hyrax/templates/config/initializers/riiif.rb
+++ b/lib/generators/hyrax/templates/config/initializers/riiif.rb
@@ -6,7 +6,7 @@ Riiif::Image.info_service = lambda do |id, _file|
 
   # Capture everything before the first slash
   fs_id = id.sub(/\A([^\/]*)\/.*/, '\1')
-  resp = ActiveFedora::SolrService.get("id:#{fs_id}")
+  resp = Hyrax::SolrService.get("id:#{fs_id}")
   doc = resp['response']['docs'].first
   raise "Unable to find solr document with id:#{fs_id}" unless doc
   { height: doc['height_is'], width: doc['width_is'], format: doc['mime_type_ssi'] }

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -543,6 +543,11 @@ module Hyrax
       ->(id:, extent:) { Samvera::NestingIndexer.reindex_relationships(id: id, extent: extent) }
     end
 
+    attr_writer :solr_select_path
+    def solr_select_path
+      @solr_select_path ||= ActiveFedora.solr_config.fetch(:select_path, 'select')
+    end
+
     private
 
       # @param [Symbol, #to_s] model_name - symbol representing the model

--- a/lib/wings/valkyrie/persister.rb
+++ b/lib/wings/valkyrie/persister.rb
@@ -50,8 +50,8 @@ module Wings
 
       # Deletes all resources from Fedora and Solr
       def wipe!
-        ActiveFedora::SolrService.instance.conn.delete_by_query("*:*")
-        ActiveFedora::SolrService.instance.conn.commit
+        Hyrax::SolrService.instance.conn.delete_by_query("*:*")
+        Hyrax::SolrService.instance.conn.commit
         ActiveFedora::Cleaner.clean!
       end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe CatalogController, type: :controller do
     end
 
     before do
-      objects.each { |obj| ActiveFedora::SolrService.add(obj.to_solr) }
-      ActiveFedora::SolrService.commit
+      objects.each { |obj| Hyrax::SolrService.add(obj.to_solr) }
+      Hyrax::SolrService.commit
     end
 
     context 'with a non-work file' do

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         }
 
         expect(assigns[:collection].member_objects).to eq [asset1]
-        asset_results = ActiveFedora::SolrService.instance.conn.get "select", params: { fq: ["id:\"#{asset1.id}\""], fl: ['id', Hyrax.config.index_field_mapper.solr_name(:collection)] }
+        asset_results = Hyrax::SolrService.instance.conn.get "select", params: { fq: ["id:\"#{asset1.id}\""], fl: ['id', Hyrax.config.index_field_mapper.solr_name(:collection)] }
         expect(asset_results["response"]["numFound"]).to eq 1
         doc = asset_results["response"]["docs"].first
         expect(doc["id"]).to eq asset1.id

--- a/spec/factories/admin_sets_lw.rb
+++ b/spec/factories/admin_sets_lw.rb
@@ -187,7 +187,7 @@ FactoryBot.define do
     # @param [Class] evaluator holding the transient properties for the current build/creation process
     def self.process_with_solr_document(adminset, evaluator, creator_only = false)
       return unless creator_only || evaluator.with_solr_document
-      ActiveFedora::SolrService.add(solr_document_with_permissions(adminset, evaluator, creator_only), commit: true)
+      Hyrax::SolrService.add(solr_document_with_permissions(adminset, evaluator, creator_only), commit: true)
     end
 
     # Return the admin set's solr document with permissions added, such that...

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -302,7 +302,7 @@ FactoryBot.define do
     def self.process_with_solr_document(collection, evaluator)
       return unless evaluator.with_solr_document
       return if evaluator.with_nesting_attributes.present? && collection.nestable? # will create the solr document there instead
-      ActiveFedora::SolrService.add(solr_document_with_permissions(collection, evaluator), commit: true)
+      Hyrax::SolrService.add(solr_document_with_permissions(collection, evaluator), commit: true)
     end
 
     # Return the collection's solr document with permissions added, such that...

--- a/spec/factory_tests/adminsets_factory_spec.rb
+++ b/spec/factory_tests/adminsets_factory_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'AdminSets Factory' do # rubocop:disable RSpec/DescribeClass
       context 'true' do
         let(:adminset) { build(:adminset_lw, with_solr_document: true) }
 
-        subject { ActiveFedora::SolrService.get("id:#{adminset.id}")["response"]["docs"].first }
+        subject { Hyrax::SolrService.get("id:#{adminset.id}")["response"]["docs"].first }
 
         it 'will create a solr document' do
           expect(subject["id"]).to eq adminset.id
@@ -53,7 +53,7 @@ RSpec.describe 'AdminSets Factory' do # rubocop:disable RSpec/DescribeClass
                                                           view_users: [user_vw] })
         end
 
-        subject { ActiveFedora::SolrService.get("id:#{adminset.id}")["response"]["docs"].first }
+        subject { Hyrax::SolrService.get("id:#{adminset.id}")["response"]["docs"].first }
 
         it 'will created a solr document' do
           expect(subject["id"]).to eq adminset.id
@@ -79,7 +79,7 @@ RSpec.describe 'AdminSets Factory' do # rubocop:disable RSpec/DescribeClass
 
   describe 'default_adminset' do
     let(:default_adminset) { build(:default_adminset) }
-    let(:solrdoc) { ActiveFedora::SolrService.get("id:#{default_adminset.id}")["response"]["docs"].first }
+    let(:solrdoc) { Hyrax::SolrService.get("id:#{default_adminset.id}")["response"]["docs"].first }
     let(:permission_template) { default_adminset.permission_template }
 
     it 'will create the default adminset with expected metadata' do
@@ -111,7 +111,7 @@ RSpec.describe 'AdminSets Factory' do # rubocop:disable RSpec/DescribeClass
         view_users: [user_vw] }
     end
     let(:legacy_adminset) { build(:no_solr_grants_adminset, user: user, with_permission_template: permissions) }
-    let(:solrdoc) { ActiveFedora::SolrService.get("id:#{legacy_adminset.id}")["response"]["docs"].first }
+    let(:solrdoc) { Hyrax::SolrService.get("id:#{legacy_adminset.id}")["response"]["docs"].first }
 
     it 'will create a permission template with all access' do
       expect { build(:no_solr_grants_adminset, user: user, with_permission_template: permissions) }

--- a/spec/factory_tests/collections_factory_spec.rb
+++ b/spec/factory_tests/collections_factory_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Collections Factory' do # rubocop:disable RSpec/DescribeClass
       context 'true' do
         let(:col) { build(:collection_lw, with_solr_document: true) }
 
-        subject { ActiveFedora::SolrService.get("id:#{col.id}")["response"]["docs"].first }
+        subject { Hyrax::SolrService.get("id:#{col.id}")["response"]["docs"].first }
 
         it 'will create a solr document' do
           expect(subject["id"]).to eq col.id
@@ -85,7 +85,7 @@ RSpec.describe 'Collections Factory' do # rubocop:disable RSpec/DescribeClass
                                                             view_users: [user_vw] })
         end
 
-        subject { ActiveFedora::SolrService.get("id:#{col.id}")["response"]["docs"].first }
+        subject { Hyrax::SolrService.get("id:#{col.id}")["response"]["docs"].first }
 
         it 'will create a solr document' do
           expect(subject["id"]).to eq col.id
@@ -102,7 +102,7 @@ RSpec.describe 'Collections Factory' do # rubocop:disable RSpec/DescribeClass
       let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
       let(:current_ability) { instance_double(Ability, admin?: true) }
       let(:scope) { double('Scope', can?: true, current_ability: current_ability, repository: repository, blacklight_config: blacklight_config) }
-      let(:solr_doc) { ActiveFedora::SolrService.get("id:#{col.id}")["response"]["docs"].first }
+      let(:solr_doc) { Hyrax::SolrService.get("id:#{col.id}")["response"]["docs"].first }
       let(:nesting_attributes) do
         Hyrax::Collections::NestedCollectionQueryService::NestingAttributes.new(id: col.id, scope: scope)
       end

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           "nesting_collection__parent_ids_ssim" => [collection.id],
           "edit_access_person_ssim" => [user.user_key] }
       end
-      ActiveFedora::SolrService.add(docs, commit: true)
+      Hyrax::SolrService.add(docs, commit: true)
 
       sign_in user
     end
@@ -108,7 +108,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           "nesting_collection__parent_ids_ssim" => [collection.id],
           "edit_access_person_ssim" => [user.user_key] }
       end
-      ActiveFedora::SolrService.add(docs, commit: true)
+      Hyrax::SolrService.add(docs, commit: true)
 
       sign_in user
     end

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -700,7 +700,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           "nesting_collection__parent_ids_ssim" => [collection.id],
           "edit_access_person_ssim" => [user.user_key] }
       end
-      ActiveFedora::SolrService.add(docs, commit: true)
+      Hyrax::SolrService.add(docs, commit: true)
 
       sign_in user
     end

--- a/spec/helpers/hyrax/collections_helper_spec.rb
+++ b/spec/helpers/hyrax/collections_helper_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe Hyrax::CollectionsHelper do
       let!(:work_doc) { SolrDocument.new(id: '123', title_tesim: ['My GenericWork'], member_of_collection_ids_ssim: coll_ids) }
 
       before do
-        ActiveFedora::SolrService.add(coll1_attrs)
-        ActiveFedora::SolrService.add(coll2_attrs)
-        ActiveFedora::SolrService.commit
+        Hyrax::SolrService.add(coll1_attrs)
+        Hyrax::SolrService.add(coll2_attrs)
+        Hyrax::SolrService.commit
       end
 
       it 'renders a list of links to the collections' do
@@ -59,8 +59,8 @@ RSpec.describe Hyrax::CollectionsHelper do
       let!(:work_doc) { SolrDocument.new(id: '123', title_tesim: ['My GenericWork'], member_of_collection_ids_ssim: coll_ids) }
 
       before do
-        ActiveFedora::SolrService.add(coll1_attrs)
-        ActiveFedora::SolrService.commit
+        Hyrax::SolrService.add(coll1_attrs)
+        Hyrax::SolrService.commit
       end
 
       it 'renders nothing' do
@@ -76,9 +76,9 @@ RSpec.describe Hyrax::CollectionsHelper do
       let!(:work_doc) { SolrDocument.new(id: '123', title_tesim: ['My GenericWork'], member_of_collection_ids_ssim: coll_ids) }
 
       before do
-        ActiveFedora::SolrService.add(coll1_attrs)
-        ActiveFedora::SolrService.add(coll2_attrs)
-        ActiveFedora::SolrService.commit
+        Hyrax::SolrService.add(coll1_attrs)
+        Hyrax::SolrService.add(coll2_attrs)
+        Hyrax::SolrService.commit
       end
 
       it 'renders a list of links to the collections' do

--- a/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
+++ b/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::DashboardHelperBehavior, type: :helper do
   end
 
   describe "#number_of_works" do
-    let(:conn) { ActiveFedora::SolrService.instance.conn }
+    let(:conn) { Hyrax::SolrService.instance.conn }
     let(:user1) { User.new(email: "abc@test") }
     let(:user2) { User.new(email: "abc@test.123") }
 
@@ -32,7 +32,7 @@ RSpec.describe Hyrax::DashboardHelperBehavior, type: :helper do
   end
 
   describe "#number_of_files" do
-    let(:conn) { ActiveFedora::SolrService.instance.conn }
+    let(:conn) { Hyrax::SolrService.instance.conn }
     let(:user1) { User.new(email: "abc@test") }
     let(:user2) { User.new(email: "abc@test.123") }
 
@@ -46,7 +46,7 @@ RSpec.describe Hyrax::DashboardHelperBehavior, type: :helper do
   end
 
   describe "#number_of_collections" do
-    let(:conn) { ActiveFedora::SolrService.instance.conn }
+    let(:conn) { Hyrax::SolrService.instance.conn }
     let(:user1) { User.new(email: "abc@test") }
     let(:user2) { User.new(email: "abc@test.123") }
 

--- a/spec/presenters/hyrax/presenter_factory_spec.rb
+++ b/spec/presenters/hyrax/presenter_factory_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Hyrax::PresenterFactory do
     let(:presenter_class) { Hyrax::FileSetPresenter }
 
     before do
-      allow(ActiveFedora::SolrService.instance.conn).to receive(:post)
+      allow(Hyrax::SolrService.instance.conn).to receive(:post)
         .with('select', data: { q: "{!terms f=id}12,13", rows: 1000, qt: 'standard' })
         .and_return('response' => { 'docs' => results })
     end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
 
     context "solr query" do
       before do
-        expect(ActiveFedora::SolrService).to receive(:query).twice.with(anything, hash_including(rows: 10_000)).and_return([])
+        expect(Hyrax::SolrService).to receive(:query).twice.with(anything, hash_including(rows: 10_000)).and_return([])
       end
 
       it "requests >10 rows" do

--- a/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
 
     it "is successful" do
       subject
-      ids = ActiveFedora::SolrService.query("{!field f=id}#{work.id}", fl: "member_ids_ssim").flat_map { |x| x.fetch("member_ids_ssim", []) }
+      ids = Hyrax::SolrService.query("{!field f=id}#{work.id}", fl: "member_ids_ssim").flat_map { |x| x.fetch("member_ids_ssim", []) }
       expect(solr_params[:fq]).to eq ["-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids([ids])]
     end
   end

--- a/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
+++ b/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
       let(:document) { { id: id } }
 
       before do
-        ActiveFedora::SolrService.delete(id)
-        ActiveFedora::SolrService.add(document, commit: true)
+        Hyrax::SolrService.delete(id)
+        Hyrax::SolrService.add(document, commit: true)
       end
 
       it { is_expected.to be_a(Samvera::NestingIndexer::Documents::IndexDocument) }
@@ -72,7 +72,7 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
     it 'uses direct add to Solr on non-nested objects but yields the document and parent_ids to allow nesting logic to fire' do
       # The two collections and the work are handled via the nesting indexer.
       # we expect remaining repository objects to reindex via to_solr.
-      expect(ActiveFedora::SolrService).to receive(:add).exactly(count_of_items - 3).times
+      expect(Hyrax::SolrService).to receive(:add).exactly(count_of_items - 3).times
       yielded = []
       described_class.each_perservation_document_id_and_parent_ids do |document_id, parent_ids|
         yielded << [document_id, parent_ids]
@@ -110,7 +110,7 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
 
     before do
       ([parent] + children + not_my_children).each do |doc|
-        ActiveFedora::SolrService.add(doc, commit: true)
+        Hyrax::SolrService.add(doc, commit: true)
       end
     end
 
@@ -145,7 +145,7 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
 
   describe '.write_nesting_document_to_index_layer' do
     let(:work) { create(:work) }
-    let(:query_for_works_solr_document) { ->(id:) { ActiveFedora::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query_for_ids([id])).first } }
+    let(:query_for_works_solr_document) { ->(id:) { Hyrax::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query_for_ids([id])).first } }
 
     # rubocop:disable RSpec/ExampleLength
     it 'will append parent_ids, ancestors, pathnames, and deepest_nested_depth to the SOLR document' do

--- a/spec/services/hyrax/admin_set_service_spec.rb
+++ b/spec/services/hyrax/admin_set_service_spec.rb
@@ -124,9 +124,9 @@ RSpec.describe Hyrax::AdminSetService do
       all_objects = []
       all_objects << works << admin_sets << file_sets
       all_objects.each do |obj|
-        ActiveFedora::SolrService.add(obj)
+        Hyrax::SolrService.add(obj)
       end
-      ActiveFedora::SolrService.commit
+      Hyrax::SolrService.commit
     end
 
     context "when there are works and files in the admin set" do

--- a/spec/services/hyrax/embargo_service_spec.rb
+++ b/spec/services/hyrax/embargo_service_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Hyrax::EmbargoService do
     end
 
     before do
-      ActiveFedora::SolrService.add(attributes)
-      ActiveFedora::SolrService.commit
+      Hyrax::SolrService.add(attributes)
+      Hyrax::SolrService.commit
     end
 
     it 'returns all assets with embargo history set' do

--- a/spec/services/hyrax/solr_service_spec.rb
+++ b/spec/services/hyrax/solr_service_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe Hyrax::SolrService do
+  describe '.select_path' do
+    it 'raises NotImplementedError' do
+      expect { described_class.select_path }.to raise_error NotImplementedError
+    end
+  end
+end

--- a/spec/services/hyrax/workflow/status_list_service_spec.rb
+++ b/spec/services/hyrax/workflow/status_list_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hyrax::Workflow::StatusListService do
     let(:results) { service.each.to_a }
 
     before do
-      ActiveFedora::SolrService.add([document, ability], commit: true)
+      Hyrax::SolrService.add([document, ability], commit: true)
     end
 
     context "when user has roles" do
@@ -46,11 +46,11 @@ RSpec.describe Hyrax::Workflow::StatusListService do
         let(:mock_response) { { 'response' => { 'docs' => [{}, {}, {}] } } }
 
         it 'queries Solr via HTTP POST method' do
-          allow(ActiveFedora::SolrService).to receive(:post).and_return(mock_response)
-          allow(ActiveFedora::SolrService).to receive(:get)
+          allow(Hyrax::SolrService).to receive(:post).and_return(mock_response)
+          allow(Hyrax::SolrService).to receive(:get)
           service.send(:search_solr)
-          expect(ActiveFedora::SolrService).to have_received(:post)
-          expect(ActiveFedora::SolrService).not_to have_received(:get)
+          expect(Hyrax::SolrService).to have_received(:post)
+          expect(Hyrax::SolrService).not_to have_received(:get)
         end
       end
     end

--- a/spec/services/hyrax/workflow/status_list_service_spec.rb
+++ b/spec/services/hyrax/workflow/status_list_service_spec.rb
@@ -41,18 +41,6 @@ RSpec.describe Hyrax::Workflow::StatusListService do
         expect(results.first.to_s).to eq 'Hey dood!'
         expect(results.first.workflow_state).to eq 'initial'
       end
-
-      describe '#search_solr' do
-        let(:mock_response) { { 'response' => { 'docs' => [{}, {}, {}] } } }
-
-        it 'queries Solr via HTTP POST method' do
-          allow(Hyrax::SolrService).to receive(:post).and_return(mock_response)
-          allow(Hyrax::SolrService).to receive(:get)
-          service.send(:search_solr)
-          expect(Hyrax::SolrService).to have_received(:post)
-          expect(Hyrax::SolrService).not_to have_received(:get)
-        end
-      end
     end
 
     context "when user doesn't have roles" do


### PR DESCRIPTION
This is a first step toward removing the `ActiveFedora::SolrService` dependency
by replacing it with a `Hyrax` version. We add an empty subclass, and use it
throughout the codebase.

Related to #3801.

@samvera/hyrax-code-reviewers
