### PR TITLE
[wings] Use valkyrie for the initial save in `BaseActor`

### DIFF
--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -19,7 +19,7 @@ module Hyrax
         apply_creation_data_to_curation_concern(env)
         apply_save_data_to_curation_concern(env)
 
-        save(env, use_valkyrie: false) &&
+        save(env, use_valkyrie: true) &&
           next_actor.create(env) &&
           run_callbacks(:after_create_concern, env)
       end


### PR DESCRIPTION
When we first create a Work using the actor stack, the `BaseActor#create` method
is called to save the work. Where we previously used ActiveFedora to service the
actual Fedora API requests carrying out that save, this routes those requests
through Valkyrie, via the `wings` adapter.

Fixes #3572.

@samvera/hyrax-code-reviewers
