### PR TITLE
Remove direct dependency on `ActiveFedora.id_field`

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -390,7 +390,7 @@ module Hyrax
 
     attr_writer :id_field
     def id_field
-      @id_field || ActiveFedora.id_field
+      @id_field || index_field_mapper.id_field
     end
 
     # Enable IIIF image service. This is required to use the


### PR DESCRIPTION
The `ActiveFedora.id_field` implementation passes through to the configured
`index_field_mapper`. Relying on that to configure our `id_field` for Solr
removes direct dependencies on `ActiveFedora.id_field` from the codebase.

There is also a reference to `SOLR_DOCUMENT_ID` in the original `id_field`
implementation. I can't find other references to this in current stack code, so
I think it's legacy cruft and propose to remove it from Hyrax with only a minor
note in the release notes for 3.0.0.

Closes #3798.

@samvera/hyrax-code-reviewers
