### PR TITLE
Ensures that code coverage analysis is run for CircleCI builds

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,28 +1,25 @@
 ENV["RAILS_ENV"] ||= 'test'
 require "bundler/setup"
 
-def coverage_needed?
-  ENV['COVERAGE'] || ENV['TRAVIS']
-end
-
 def ci_build?
-  ENV['TRAVIS'] || ENV['CIRCLE']
+  ENV['CI']
 end
 
-if coverage_needed?
-  require 'simplecov'
-  require 'coveralls'
-  SimpleCov.root(File.expand_path('../..', __FILE__))
-  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-  SimpleCov.start('rails') do
-    add_filter '/.internal_test_app'
-    add_filter '/lib/generators'
-    add_filter '/spec'
-    add_filter '/tasks'
-    add_filter '/lib/hyrax/version.rb'
-    add_filter '/lib/hyrax/engine.rb'
-  end
-  SimpleCov.command_name 'spec'
+require 'simplecov'
+require 'coveralls'
+Coveralls.wear!
+SimpleCov.root(File.expand_path('../..', __FILE__))
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  Coveralls::SimpleCov::Formatter,
+  SimpleCov::Formatter::HTMLFormatter
+]
+SimpleCov.start('rails') do
+  add_filter '/.internal_test_app'
+  add_filter '/lib/generators'
+  add_filter '/spec'
+  add_filter '/tasks'
+  add_filter '/lib/hyrax/version.rb'
+  add_filter '/lib/hyrax/engine.rb'
 end
 
 require 'factory_bot'


### PR DESCRIPTION
I don't believe that CircleCI is submitting code coverage analysis reports to Coveralls: https://coveralls.io/github/samvera/hyrax

This should restore the reporting and ensure that HTML-formatted coverage reports are generated when the RSpec test suites are run on development environments,