### PR TITLE
Ports the Solr indexing functionality from ActiveFedora, implementing

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -25,6 +25,20 @@ Metrics/AbcSize:
   Exclude:
     - 'app/indexers/hyrax/file_set_indexer.rb'
     - 'app/services/hyrax/workflow/permission_query.rb'
+    - 'app/services/hyrax/indexing/solr_mapper.rb'
+    - 'app/services/hyrax/indexing/field_mapper.rb'
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'app/services/hyrax/indexing/solr_mapper.rb'
+    - 'app/services/hyrax/indexing/field_mapper.rb'
+    - 'app/services/hyrax/indexing/suffix.rb'
+
+Metrics/LineLength:
+  Exclude:
+    - 'app/services/hyrax/indexing/solr_mapper.rb'
+    - 'app/services/hyrax/indexing/descriptor.rb'
+    - 'app/services/hyrax/indexing/suffix.rb'
 
 Metrics/ModuleLength:
   Exclude:
@@ -46,13 +60,19 @@ Metrics/MethodLength:
     - 'app/services/hyrax/workflow/permission_query.rb'
     - 'lib/generators/hyrax/install_generator.rb'
     - 'lib/hyrax/rails/routes.rb'
+    - 'app/services/hyrax/indexing/solr_mapper.rb'
+    - 'app/services/hyrax/indexing/field_mapper.rb'
+    - 'app/services/hyrax/indexing/suffix.rb'
     - 'spec/support/**/*'
 
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'app/services/hyrax/indexing/solr_mapper.rb'
+    - 'app/services/hyrax/indexing/field_mapper.rb'
 
 Naming/PredicateName:
   Exclude:
     - 'app/helpers/hyrax/collections_helper.rb'
-
 
 # TODO: remove when https://github.com/bbatsov/rubocop/issues/4539 is fixed
 Style/FormatStringToken:

--- a/app/indexers/hyrax/collection_indexer.rb
+++ b/app/indexers/hyrax/collection_indexer.rb
@@ -2,7 +2,7 @@ module Hyrax
   class CollectionIndexer < Hydra::PCDM::CollectionIndexer
     include Hyrax::IndexesThumbnails
 
-    STORED_LONG = ActiveFedora::Indexing::Descriptor.new(:long, :stored)
+    STORED_LONG = Hyrax::Indexing::Descriptor.new(:long, :stored)
 
     self.thumbnail_path_service = Hyrax::CollectionThumbnailPathService
 

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -2,7 +2,7 @@ module Hyrax
   class FileSetIndexer < ActiveFedora::IndexingService
     include Hyrax::IndexesThumbnails
     include Hyrax::IndexesBasicMetadata
-    STORED_LONG = ActiveFedora::Indexing::Descriptor.new(:long, :stored)
+    STORED_LONG = Hyrax::Indexing::Descriptor.new(:long, :stored)
 
     def generate_solr_document
       super.tap do |solr_doc|

--- a/app/indexers/hyrax/indexes_workflow.rb
+++ b/app/indexers/hyrax/indexes_workflow.rb
@@ -1,6 +1,6 @@
 module Hyrax
   module IndexesWorkflow
-    STORED_BOOL = ActiveFedora::Indexing::Descriptor.new(:boolean, :stored, :indexed)
+    STORED_BOOL = Hyrax::Indexing::Descriptor.new(:boolean, :stored, :indexed)
 
     mattr_accessor :suppressed_field, instance_writer: false do
       Hyrax.config.index_field_mapper.solr_name('suppressed', STORED_BOOL)

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -81,7 +81,7 @@ module Hyrax
         attribute :thumbnail_path, Solr::String, CatalogController.blacklight_config.index.thumbnail_field
         attribute :label, Solr::String, solr_name('label')
         attribute :file_format, Solr::String, solr_name('file_format')
-        attribute :suppressed?, Solr::String, solr_name('suppressed', ActiveFedora::Indexing::Descriptor.new(:boolean, :stored, :indexed))
+        attribute :suppressed?, Solr::String, solr_name('suppressed', Hyrax::Indexing::Descriptor.new(:boolean, :stored, :indexed))
 
         attribute :date_modified, Solr::Date, solr_name('date_modified', :stored_sortable, type: :date)
         attribute :date_uploaded, Solr::Date, solr_name('date_uploaded', :stored_sortable, type: :date)

--- a/app/services/hyrax/indexing.rb
+++ b/app/services/hyrax/indexing.rb
@@ -1,0 +1,26 @@
+module Hyrax
+  # Mix in this module to update Solr on save.
+  # Assign a new indexer at the class level where this is mixed in
+  #   (or define an #indexing_service method)
+  #   to change the document contents sent to solr
+  #
+  # Example indexing services are:
+  # @see ActiveFedora::IndexingService
+  # @see ActiveFedora::RDF::IndexingService
+  module Indexing
+    extend ActiveSupport::Concern
+    extend ActiveSupport::Autoload
+
+    class InvalidIndexDescriptor < StandardError; end
+    class UnknownIndexMacro < StandardError; end
+
+    eager_autoload do
+      autoload :Suffix
+      autoload :Descriptor
+      autoload :StringDescriptor
+      autoload :DefaultDescriptors
+      autoload :FieldMapper
+      autoload :Solr
+    end
+  end
+end

--- a/app/services/hyrax/indexing.rb
+++ b/app/services/hyrax/indexing.rb
@@ -11,7 +11,7 @@ module Hyrax
     extend ActiveSupport::Concern
     extend ActiveSupport::Autoload
 
-    class InvalidIndexDescriptor < StandardError; end
+    class InvalidIndexDescriptor < RuntimeError; end
     class UnknownIndexMacro < StandardError; end
 
     eager_autoload do

--- a/app/services/hyrax/indexing/default_descriptors.rb
+++ b/app/services/hyrax/indexing/default_descriptors.rb
@@ -1,0 +1,130 @@
+module Hyrax
+  module Indexing
+    extend ActiveSupport::Concern
+
+    class DefaultDescriptors
+      # The suffix produced depends on the type parameter -- produces suffixes:
+      #  _tesim - for strings or text fields
+      #  _dtsim - for dates
+      #  _isim - for integers
+      def self.stored_searchable
+        @stored_searchable ||= Descriptor.new(stored_searchable_field_definition, converter: searchable_converter, requires_type: true)
+      end
+
+      # The suffix produced depends on the type parameter -- produces suffixes:
+      #  _teim - for strings or text fields
+      #  _dtim - for dates
+      #  _iim - for integers
+      def self.searchable
+        @searchable ||= Descriptor.new(searchable_field_definition, converter: searchable_converter, requires_type: true)
+      end
+
+      # Takes fields which are stored as strings, but we want indexed as dates.  (e.g. "November 6th, 2012")
+      # produces suffixes:
+      #  _dtsim - for dates
+      def self.dateable
+        @dateable ||= Descriptor.new(:date, :stored, :indexed, :multivalued, converter: dateable_converter)
+      end
+
+      # Produces _sim suffix
+      def self.facetable
+        @facetable ||= Descriptor.new(:string, :indexed, :multivalued)
+      end
+
+      # Produces _ssim suffix
+      # This is useful for when you only want to match whole words, such as user/group names from the the rightsMetadata datastream
+      def self.symbol
+        @symbol ||= Descriptor.new(:string, :stored, :indexed, :multivalued)
+      end
+
+      # The suffix produced depends on the type parameter -- produces suffixes:
+      #  _tei - for text fields
+      #  _si - for strings
+      #  _dti - for dates
+      #  _ii - for integers
+      def self.sortable
+        @sortable ||= Descriptor.new(sortable_field_definition, converter: searchable_converter, requires_type: true)
+      end
+
+      # Fields that are both stored and sortable
+      # Produces _ssi suffix if field_type is string
+      # Produces _dtsi suffix if field_type is date
+      def self.stored_sortable
+        @stored_sortable ||= Descriptor.new(->(field_type) { [field_type, :stored, :indexed] }, converter: searchable_converter)
+      end
+
+      # Produces _ssm suffix
+      def self.displayable
+        @displayable ||= Descriptor.new(:string, :stored, :multivalued)
+      end
+
+      # Produces _tim suffix (used to be _unstem)
+      def self.unstemmed_searchable
+        @unstemmed_searchable ||= Descriptor.new(:text, :indexed, :multivalued)
+      end
+
+      def self.simple
+        @simple ||= Descriptor.new(->(field_type) { [field_type, :indexed] })
+      end
+
+      class << self
+        def searchable_field_definition
+          lambda do |type|
+            type = :text_en if [:string, :text].include?(type) # for backwards compatibility with old solr schema
+            vals = [type, :indexed, :multivalued]
+            vals
+          end
+        end
+
+        def stored_searchable_field_definition
+          lambda do |type|
+            type = :text_en if [:string, :text].include?(type) # for backwards compatibility with old solr schema
+            if type == :boolean
+              [type, :indexed, :stored]
+            else
+              [type, :indexed, :stored, :multivalued]
+            end
+          end
+        end
+
+        def sortable_field_definition
+          lambda do |type|
+            vals = [type, :indexed]
+            vals
+          end
+        end
+
+        def searchable_converter
+          lambda do |type|
+            case type
+            when :date, :time
+              ->(val) { iso8601_date(val) }
+            end
+          end
+        end
+
+        def dateable_converter
+          lambda do |_type|
+            lambda do |val|
+              begin
+                iso8601_date(Date.parse(val))
+              rescue ArgumentError
+                nil
+              end
+            end
+          end
+        end
+
+        def iso8601_date(value)
+          if value.is_a?(Date) || value.is_a?(Time)
+            DateTime.parse(value.to_s).to_time.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+          elsif !value.empty?
+            DateTime.parse(value).to_time.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+          end
+        rescue ArgumentError
+          raise ArgumentError, "Unable to parse `#{value}' as a date-time object"
+        end
+      end
+    end
+  end
+end

--- a/app/services/hyrax/indexing/descriptor.rb
+++ b/app/services/hyrax/indexing/descriptor.rb
@@ -1,0 +1,44 @@
+module Hyrax
+  module Indexing
+    class Descriptor
+      attr_reader :index_type
+      def initialize(*args)
+        if args.last.is_a? Hash
+          opts = args.pop
+          @converter = opts[:converter]
+          @type_required = opts[:requires_type]
+        end
+        @index_type = args
+        raise InvalidIndexDescriptor, "Invalid index type passed to Sorizer.solr_name.  It should be an array like [:string, :indexed, :stored, :multivalued]. You provided: `#{@index_type}'" unless index_type.is_a? Array
+      end
+
+      def name_and_converter(field_name, args = nil)
+        args ||= {}
+        field_type = args[:type]
+        if type_required?
+          raise ArgumentError, "Must provide a :type argument when index_type is `#{self}' for #{field_name}" unless field_type
+        end
+        [field_name.to_s + suffix(field_type), converter(field_type)]
+      end
+
+      def type_required?
+        @type_required
+      end
+
+      def evaluate_suffix(field_type)
+        Suffix.new(index_type.first.is_a?(Proc) ? index_type.first.call(field_type) : index_type.dup)
+      end
+
+      protected
+
+        # Suffix can be overridden if you want a different method of grabbing the suffix
+        def suffix(field_type)
+          evaluate_suffix(field_type).to_s
+        end
+
+        def converter(field_type)
+          @converter&.call(field_type)
+        end
+    end
+  end
+end

--- a/app/services/hyrax/indexing/field_mapper.rb
+++ b/app/services/hyrax/indexing/field_mapper.rb
@@ -1,0 +1,158 @@
+module Hyrax
+  module Indexing
+    extend ActiveSupport::Concern
+
+    class FieldMapper
+      class_attribute :id_field, :descriptors
+      # set defaults
+      self.id_field = 'id'
+      self.descriptors = [DefaultDescriptors]
+
+      # @api
+      # @params [Hash] doc the hash to insert the value into
+      # @params [String] name the name of the field (without the suffix)
+      # @params [String,Date] value the value to be inserted
+      # @params [Array,Hash] indexer_args the arguments that find the indexer
+      # @returns [Hash] doc the document that was provided with the new field (replacing any field with the same name)
+      def set_field(doc, name, value, *indexer_args)
+        # adding defaults indexer
+        indexer_args = [:stored_searchable] if indexer_args.empty?
+        doc.merge! solr_names_and_values(name, value, indexer_args)
+        doc
+      end
+
+      # @api
+      # Given a field name, index_type, etc., returns the corresponding Solr name.
+      # TODO field type is the input format, maybe we could just detect that?
+      # See https://github.com/samvera/active_fedora/issues/1338
+      # @param [String] field_name the ruby (term) name which will get a suffix appended to become a Solr field name
+      # @param opts - index_type is only needed if the FieldDescriptor requires it (e.g. :searcahble)
+      # @return [String] name of the solr field, based on the params
+      def solr_name(field_name, *opts)
+        index_type, args = if opts.first.is_a? Hash
+                             [:stored_searchable, opts.first]
+                           elsif opts.empty?
+                             [:stored_searchable, { type: :text }]
+                           else
+                             [opts[0], opts[1] || { type: :string }]
+                           end
+
+        descriptor = indexer(index_type)
+        names = descriptor.name_and_converter(field_name, args)
+        names.first
+      end
+
+      # Given a field name-value pair, a data type, and an array of index types, returns a hash of
+      # mapped names and values. The values in the hash are _arrays_, and may contain multiple values.
+      def solr_names_and_values(field_name, field_value, index_types)
+        return {} if field_value.nil?
+
+        # Determine the set of index types
+        index_types = Array(index_types)
+        index_types.uniq!
+        index_types.dup.each do |index_type|
+          if index_type.to_s =~ /^not_(.*)/
+            index_types.delete index_type # not_foo
+            index_types.delete Regexp.last_match(1).to_sym # foo
+          end
+        end
+
+        # Map names and values
+
+        results = {}
+
+        # Time seems to extend enumerable, so wrap it so we don't interate over each of its elements.
+        field_value = [field_value] if field_value.is_a? Time
+
+        index_types.each do |index_type|
+          Array(field_value).each do |single_value|
+            # Get mapping for field
+            descriptor = indexer(index_type)
+            data_type = extract_type(single_value)
+            name, _converter = descriptor.name_and_converter(field_name, type: data_type)
+            next unless name
+
+            # Is there a custom converter?
+            # TODO instead of a custom converter, look for input data type and output data type. Create a few methods that can do that cast.
+            # See https://github.com/samvera/active_fedora/issues/1339
+
+            # The converter requires that the Descriptor be constructed with the
+            # :converter option
+            # value = if converter
+            #           if converter.arity == 1
+            #             converter.call(single_value)
+            #           else
+            #             converter.call(single_value, field_name)
+            #           end
+            #         elsif data_type == :boolean
+            #           single_value
+            #         else
+            #           single_value.to_s
+            #         end
+            value = if data_type == :boolean
+                      single_value
+                    else
+                      single_value.to_s
+                    end
+
+            # Add mapped name & value, unless it's a duplicate
+            if descriptor.evaluate_suffix(data_type).multivalued?
+              values = (results[name] ||= [])
+              values << value unless value.nil? || values.include?(value)
+            else
+              Hyrax.logger.warn "Setting #{name} to `#{value}', but it already had `#{results[name]}'" if results[name]
+              results[name] = value
+            end
+          end
+        end
+
+        results
+      end
+
+      private
+
+        # @param [Symbol, String, Descriptor] index_type is a Descriptor, a symbol that references a method that returns a Descriptor, or a string which will be used as the suffix.
+        # @return [Descriptor]
+        def indexer(index_type)
+          index_type = case index_type
+                       when Symbol
+                         index_type_macro(index_type)
+                       when String
+                         StringDescriptor.new(index_type)
+                       when Descriptor
+                         index_type
+                       else
+                         raise InvalidIndexDescriptor, "#{index_type.class} is not a valid indexer_type. Use a String, Symbol or Descriptor."
+                       end
+
+          raise InvalidIndexDescriptor, "index type should be an Descriptor, you passed: #{index_type.class}" unless index_type.is_a?(Descriptor)
+          index_type
+        end
+
+        # @param index_type [Symbol]
+        # search through the descriptors (class attribute) until a module is found that responds to index_type, then call it.
+        def index_type_macro(index_type)
+          klass = self.class.descriptors.find { |descriptor_klass| descriptor_klass.respond_to? index_type }
+
+          raise UnknownIndexMacro, "Unable to find `#{index_type}' in #{self.class.descriptors}" if klass.nil?
+
+          klass.send(index_type)
+        end
+
+        def extract_type(value)
+          case value
+          when NilClass
+            nil
+          when Integer # In ruby < 2.4, Fixnum extends Integer
+            :integer
+          when DateTime
+            :time
+          when TrueClass, FalseClass
+            :boolean
+          else
+            value.class.to_s.underscore.to_sym
+          end
+        end
+    end
+  end
+end

--- a/app/services/hyrax/indexing/solr.rb
+++ b/app/services/hyrax/indexing/solr.rb
@@ -1,0 +1,10 @@
+
+module Hyrax
+  module Indexing
+    class Solr
+      def self.index_field_mapper
+        @index_field_mapper ||= FieldMapper.new
+      end
+    end
+  end
+end

--- a/app/services/hyrax/indexing/string_descriptor.rb
+++ b/app/services/hyrax/indexing/string_descriptor.rb
@@ -1,0 +1,13 @@
+module Hyrax
+  module Indexing
+    class StringDescriptor < Descriptor
+      def initialize(suffix)
+        @suffix = suffix
+      end
+
+      def suffix(_field_type)
+        '_' + @suffix
+      end
+    end
+  end
+end

--- a/app/services/hyrax/indexing/suffix.rb
+++ b/app/services/hyrax/indexing/suffix.rb
@@ -64,6 +64,8 @@ module Hyrax
                                                      'b'
                                                    when :long
                                                      'lt'
+                                                   when :float, :big_decimal
+                                                     'f'
                                                    else
                                                      raise InvalidIndexDescriptor, "Invalid datatype `#{type.inspect}'. Must be one of: :date, :time, :text, :text_en, :string, :symbol, :integer, :boolean"
                                                    end

--- a/app/services/hyrax/indexing/suffix.rb
+++ b/app/services/hyrax/indexing/suffix.rb
@@ -1,0 +1,81 @@
+module Hyrax
+  module Indexing
+    class Suffix
+      def initialize(*fields)
+        @fields = fields.flatten
+      end
+
+      def multivalued?
+        field? :multivalued
+      end
+
+      def stored?
+        field? :stored
+      end
+
+      def indexed?
+        field? :indexed
+      end
+
+      def field?(f)
+        (f.to_sym == :type) || @fields.include?(f.to_sym)
+      end
+
+      def data_type
+        @fields.first
+      end
+
+      def to_s
+        raise InvalidIndexDescriptor, "Missing datatype for #{@fields}" unless data_type
+
+        field_suffix = [config.suffix_delimiter]
+
+        config.fields.select { |f| field? f }.each do |f|
+          key = :"#{f}_suffix"
+          field_suffix << if config.send(key).is_a? Proc
+                            config.send(key).call(@fields)
+                          else
+                            config.send(key)
+                          end
+        end
+
+        field_suffix.join
+      end
+
+      def self.config
+        # TODO: `:symbol' usage ought to be deprecated
+        # See https://github.com/samvera/active_fedora/issues/1334
+        @config ||= OpenStruct.new fields: [:type, :stored, :indexed, :multivalued],
+                                   suffix_delimiter: '_',
+                                   type_suffix: (lambda do |fields|
+                                                   type = fields.first
+                                                   case type
+                                                   when :string, :symbol
+                                                     's'
+                                                   when :text
+                                                     't'
+                                                   when :text_en
+                                                     'te'
+                                                   when :date, :time
+                                                     'dt'
+                                                   when :integer
+                                                     'i'
+                                                   when :boolean
+                                                     'b'
+                                                   when :long
+                                                     'lt'
+                                                   else
+                                                     raise InvalidIndexDescriptor, "Invalid datatype `#{type.inspect}'. Must be one of: :date, :time, :text, :text_en, :string, :symbol, :integer, :boolean"
+                                                   end
+                                                 end),
+                                   stored_suffix: 's',
+                                   indexed_suffix: 'i',
+                                   multivalued_suffix: 'm'
+      end
+
+      def config
+        @config ||= self.class.config.dup
+      end
+    end
+  end
+end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -457,7 +457,7 @@ module Hyrax
 
     attr_writer :index_field_mapper
     def index_field_mapper
-      @index_field_mapper ||= ActiveFedora.index_field_mapper
+      @index_field_mapper ||= Hyrax::Indexing::Solr.index_field_mapper
     end
 
     # Should a button with "Share my work" show on the front page to users who are not logged in?

--- a/spec/services/hyrax/indexing/default_descriptors_spec.rb
+++ b/spec/services/hyrax/indexing/default_descriptors_spec.rb
@@ -1,0 +1,85 @@
+
+RSpec.describe Hyrax::Indexing::DefaultDescriptors do
+  describe ".searchable" do
+    subject(:descriptor) { described_class.searchable }
+
+    it "constructs a Descriptor object" do
+      expect(descriptor).to be_a Hyrax::Indexing::Descriptor
+    end
+  end
+
+  describe ".dateable" do
+    subject(:descriptor) { described_class.dateable }
+
+    it "constructs a Descriptor object" do
+      expect(descriptor).to be_a Hyrax::Indexing::Descriptor
+    end
+  end
+
+  describe ".displayable" do
+    subject(:descriptor) { described_class.displayable }
+
+    it "constructs a Descriptor object" do
+      expect(descriptor).to be_a Hyrax::Indexing::Descriptor
+    end
+  end
+
+  describe ".unstemmed_searchable" do
+    subject(:descriptor) { described_class.unstemmed_searchable }
+
+    it "constructs a Descriptor object" do
+      expect(descriptor).to be_a Hyrax::Indexing::Descriptor
+    end
+  end
+
+  describe ".simple" do
+    subject(:descriptor) { described_class.simple }
+
+    it "constructs a Descriptor object" do
+      expect(descriptor).to be_a Hyrax::Indexing::Descriptor
+    end
+  end
+
+  describe ".searchable_field_definition" do
+    it "generates field definitions from field types" do
+      expect(described_class.searchable_field_definition.call(:boolean)).to eq([:boolean, :indexed, :multivalued])
+      expect(described_class.searchable_field_definition.call(:text)).to eq([:text_en, :indexed, :multivalued])
+    end
+  end
+
+  describe ".stored_searchable_field_definition" do
+    it "generates field definitions from field types" do
+      expect(described_class.stored_searchable_field_definition.call(:boolean)).to eq([:boolean, :indexed, :stored])
+      expect(described_class.stored_searchable_field_definition.call(:text)).to eq([:text_en, :indexed, :stored, :multivalued])
+      expect(described_class.stored_searchable_field_definition.call(:date)).to eq([:date, :indexed, :stored, :multivalued])
+    end
+  end
+
+  describe ".iso8601_date" do
+    it "generates a timestamp from a date or time object" do
+      new_date = Date.new
+      # rubocop:disable Rails/Date
+      expect(described_class.iso8601_date(new_date)).to eq new_date.to_time.strftime('%Y-%m-%dT%H:%M:%SZ')
+      # rubocop:enable Rails/Date
+
+      new_time = Time.new.utc
+      expect(described_class.iso8601_date(new_time)).to eq new_time.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+      expect(described_class.iso8601_date("01/01/1970")).to eq "1970-01-01T00:00:00Z"
+    end
+
+    it "raises an error if a non-date and non-time object is passed" do
+      expect { described_class.iso8601_date("test") }.to raise_error(ArgumentError, "Unable to parse `test' as a date-time object")
+    end
+  end
+
+  describe ".dateable_converter" do
+    it "generates a timestamp from a date or time object" do
+      expect(described_class.dateable_converter.call(:noop).call("01/01/1970")).to eq "1970-01-01T00:00:00Z"
+    end
+
+    it "returns nil if a non-date and non-time object is passed" do
+      expect(described_class.dateable_converter.call(:noop).call("test")).to be nil
+    end
+  end
+end

--- a/spec/services/hyrax/indexing/descriptor_spec.rb
+++ b/spec/services/hyrax/indexing/descriptor_spec.rb
@@ -1,0 +1,24 @@
+
+RSpec.describe Hyrax::Indexing::Descriptor do
+  subject(:descriptor) { described_class.new(*args) }
+  let(:args) do
+    [
+      {
+        converter: nil,
+        requires_type: true
+      }
+    ]
+  end
+
+  describe '#name_and_converter' do
+    it 'generates the values for indexing field values into Solr' do
+      expect { descriptor.name_and_converter(:subject) }.to raise_error(ArgumentError, "Must provide a :type argument when index_type is `#{descriptor}' for subject")
+    end
+  end
+
+  describe '#type_required?' do
+    it 'determines if this type of descriptor is required for indexing' do
+      expect(descriptor.type_required?).to be true
+    end
+  end
+end

--- a/spec/services/hyrax/indexing/field_mapper_spec.rb
+++ b/spec/services/hyrax/indexing/field_mapper_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Hyrax::Indexing::FieldMapper do
       end
     end
 
+    # rubocop:disable RSpec/ExampleLength
     it 'generates pairs of Solr field names and values' do
       expect(field_mapper.solr_names_and_values('subject', '社会生物学', [:stored_searchable])).to eq('subject_tesim' => ['社会生物学'])
       expect(field_mapper.solr_names_and_values('subject', '社会生物学', [:stored_searchable, :sortable])).to eq("subject_si" => "社会生物学", "subject_tesim" => ["社会生物学"])
@@ -30,6 +31,11 @@ RSpec.describe Hyrax::Indexing::FieldMapper do
       current_date_time = DateTime.current
       expect(field_mapper.solr_names_and_values('creation_date', current_date_time, [:stored_searchable])).to eq("creation_date_dtsim" => [current_date_time.strftime('%Y-%m-%dT%H:%M:%S%:z')])
       expect(field_mapper.solr_names_and_values('publicly_accessible', true, [:stored_searchable])).to eq("publicly_accessible_bsi" => true)
+      expect(field_mapper.solr_names_and_values('my_number', (6.022140857 * 10**23).to_f, [:displayable, :searchable])).to eq(
+        "my_number_ssm" => ["6.0221408569999995e+23"],
+        "my_number_fim" => ["6.0221408569999995e+23"]
+      )
     end
+    # rubocop:enable RSpec/ExampleLength
   end
 end

--- a/spec/services/hyrax/indexing/field_mapper_spec.rb
+++ b/spec/services/hyrax/indexing/field_mapper_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Hyrax::Indexing::FieldMapper do
+  subject(:field_mapper) { described_class.new }
+
+  describe "#solr_name" do
+    it "generates Solr field names" do
+      expect(field_mapper.solr_name('creation_date', type: :date)).to eq('creation_date_dtsim')
+      expect(field_mapper.solr_name('description')).to eq('description_tesim')
+      expect(field_mapper.solr_name('abstract', :stored_searchable, type: :text)).to eq('abstract_tesim')
+      expect(field_mapper.solr_name('abstract', 'stored_searchable')).to eq('abstract_stored_searchable')
+      expect { field_mapper.solr_name('abstract', Date.current) }.to raise_error(Hyrax::Indexing::InvalidIndexDescriptor, 'Date is not a valid indexer_type. Use a String, Symbol or Descriptor.')
+      expect(field_mapper.solr_name('subject', :stored_searchable)).to eq('subject_tesim')
+    end
+  end
+
+  describe '#solr_names_and_values' do
+    context 'with duplicate names and values provided' do
+      it 'logs a warning' do
+        allow(Hyrax.logger).to receive(:warn)
+        expect(field_mapper.solr_names_and_values('subject', ['社会生物学', '社会生物学'], [:sortable])).to eq("subject_si" => "社会生物学")
+        expect(Hyrax.logger).to have_received(:warn).with("Setting subject_si to `社会生物学', but it already had `社会生物学'")
+      end
+    end
+
+    it 'generates pairs of Solr field names and values' do
+      expect(field_mapper.solr_names_and_values('subject', '社会生物学', [:stored_searchable])).to eq('subject_tesim' => ['社会生物学'])
+      expect(field_mapper.solr_names_and_values('subject', '社会生物学', [:stored_searchable, :sortable])).to eq("subject_si" => "社会生物学", "subject_tesim" => ["社会生物学"])
+      expect(field_mapper.solr_names_and_values('subject', '社会生物学', [:not_stored_sortable, :sortable])).to eq("subject_si" => "社会生物学")
+      expect(field_mapper.solr_names_and_values('subject', 'Habitat conservation', [:stored_searchable])).to eq("subject_tesim" => ["Habitat conservation"])
+      expect(field_mapper.solr_names_and_values('serial_number', 123_456_789, [:stored_searchable])).to eq("serial_number_isim" => ["123456789"])
+      current_date_time = DateTime.current
+      expect(field_mapper.solr_names_and_values('creation_date', current_date_time, [:stored_searchable])).to eq("creation_date_dtsim" => [current_date_time.strftime('%Y-%m-%dT%H:%M:%S%:z')])
+      expect(field_mapper.solr_names_and_values('publicly_accessible', true, [:stored_searchable])).to eq("publicly_accessible_bsi" => true)
+    end
+  end
+end

--- a/spec/services/hyrax/indexing/solr_spec.rb
+++ b/spec/services/hyrax/indexing/solr_spec.rb
@@ -1,0 +1,8 @@
+
+RSpec.describe Hyrax::Indexing::Solr do
+  describe ".index_field_mapper" do
+    it "constructs a new FieldMapper object" do
+      expect(described_class.index_field_mapper).to be_a Hyrax::Indexing::FieldMapper
+    end
+  end
+end

--- a/spec/services/hyrax/indexing/string_descriptor_spec.rb
+++ b/spec/services/hyrax/indexing/string_descriptor_spec.rb
@@ -1,0 +1,11 @@
+
+RSpec.describe Hyrax::Indexing::StringDescriptor do
+  subject(:string_descriptor) { described_class.new(suffix) }
+  let(:suffix) { 'tesim' }
+
+  describe '#suffix' do
+    it 'generates the suffix for the field' do
+      expect(string_descriptor.suffix(:string)).to eq('_tesim')
+    end
+  end
+end

--- a/spec/services/hyrax/indexing/suffix_spec.rb
+++ b/spec/services/hyrax/indexing/suffix_spec.rb
@@ -1,0 +1,69 @@
+
+RSpec.describe Hyrax::Indexing::Suffix do
+  subject(:suffix) { described_class.new(*fields) }
+  let(:fields) do
+    [
+      :type,
+      :stored,
+      :indexed,
+      :multivalued
+    ]
+  end
+
+  describe '#multivalued?' do
+    it 'determines if a suffix is multivalued' do
+      expect(suffix.multivalued?).to be true
+    end
+  end
+
+  describe '#stored?' do
+    it 'determines if a suffix indicates that a Solr field should have its value stored' do
+      expect(suffix.stored?).to be true
+    end
+  end
+
+  describe '#indexed?' do
+    it 'determines if a suffix indicates that a Solr field should have its value indexed' do
+      expect(suffix.indexed?).to be true
+    end
+  end
+
+  describe '#field?' do
+    it 'determines if a metadata field is used in the suffix' do
+      expect(suffix.field?(:type)).to be true
+      expect(suffix.field?(:stored)).to be true
+    end
+  end
+
+  describe '#data_type' do
+    it 'accesses the data type for the suffix' do
+      expect(suffix.data_type).to eq(:type)
+    end
+  end
+
+  describe '#config' do
+    # rubocop:disable RSpec/ExampleLength
+    it 'accesses the generated configuration' do
+      expect(suffix.config).to be_an OpenStruct
+      expect(suffix.config.fields).to eq(fields)
+      expect(suffix.config.suffix_delimiter).to eq('_')
+      expect(suffix.config.stored_suffix).to eq('s')
+      expect(suffix.config.indexed_suffix).to eq('i')
+      expect(suffix.config.multivalued_suffix).to eq('m')
+
+      type_suffix = suffix.config.type_suffix
+      expect(type_suffix.call([:string])).to eq('s')
+      expect(type_suffix.call([:symbol])).to eq('s')
+      expect(type_suffix.call([:text])).to eq('t')
+      expect(type_suffix.call([:text_en])).to eq('te')
+      expect(type_suffix.call([:date])).to eq('dt')
+      expect(type_suffix.call([:time])).to eq('dt')
+      expect(type_suffix.call([:integer])).to eq('i')
+      expect(type_suffix.call([:boolean])).to eq('b')
+      expect(type_suffix.call([:long])).to eq('lt')
+      expect { type_suffix.call([:foo]) }.to raise_error(Hyrax::Indexing::InvalidIndexDescriptor,
+                                                         "Invalid datatype `:foo'. Must be one of: :date, :time, :text, :text_en, :string, :symbol, :integer, :boolean")
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,12 @@
 ENV["RAILS_ENV"] ||= 'test'
 require "bundler/setup"
 
+def coverage_needed?
+  ENV['COVERAGE'] || ENV['TRAVIS']
+end
+
 def ci_build?
-  ENV['CI']
+  ENV['TRAVIS'] || ENV['CIRCLE']
 end
 
 require 'simplecov'


### PR DESCRIPTION
Ports the Solr indexing functionality from ActiveFedora, implementing the `Hyrax::Indexing Module`, as well as:
- `Hyrax::Indexing::Descriptor`
- `Hyrax::Indexing::DefaultDescriptors`
- `Hyrax::Indexing::Suffix`
- `Hyrax::Indexing::FieldMapper, Hyrax::Indexing::Solr`
- `Hyrax::Indexing::StringDescriptor`

Resolves #3794 