### PR TITLE
Replace construct query for ids

### DIFF
--- a/app/presenters/hyrax/trophy_presenter.rb
+++ b/app/presenters/hyrax/trophy_presenter.rb
@@ -13,7 +13,7 @@ module Hyrax
     # @return [Array<TrophyPresenter>] a list of all the trophy presenters for the user
     def self.find_by_user(user)
       work_ids = user.trophies.pluck(:work_id)
-      query = ActiveFedora::SolrQueryBuilder.construct_query_for_ids(work_ids)
+      query = Hyrax::SolrQueryBuilderService.construct_query_for_ids(work_ids)
       results = Hyrax::WorkRelation.new.search_with_conditions(query)
       results.map { |result| TrophyPresenter.new(document_model.new(result)) }
     rescue RSolr::Error::ConnectionRefused

--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -25,8 +25,9 @@ module Hyrax
 
       def show_only_other_collections_of_the_same_collection_type(solr_parameters)
         solr_parameters[:fq] ||= []
+        query = Hyrax::SolrQueryBuilderService.construct_query_for_ids([limit_ids])
         solr_parameters[:fq] += [
-          "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids(limit_ids),
+          "-" + query,
           ActiveFedora::SolrQueryBuilder.construct_query(Collection.collection_type_gid_document_field_name => @collection.collection_type_gid)
         ]
         solr_parameters[:fq] += limit_clause if limit_clause # add limits to prevent illegal nesting arrangements

--- a/app/search_builders/hyrax/my/find_works_search_builder.rb
+++ b/app/search_builders/hyrax/my/find_works_search_builder.rb
@@ -19,17 +19,13 @@ class Hyrax::My::FindWorksSearchBuilder < Hyrax::My::SearchBuilder
 
   def show_only_other_works(solr_parameters)
     solr_parameters[:fq] ||= []
-    solr_parameters[:fq] += [
-      "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids([@id])
-    ]
+    solr_parameters[:fq] += ["-#{Hyrax::SolrQueryBuilderService.construct_query_for_ids([@id])}"]
   end
 
   def show_only_works_not_child(solr_parameters)
     ids = Hyrax::SolrService.query("{!field f=id}#{@id}", fl: "member_ids_ssim", rows: 10_000).flat_map { |x| x.fetch("member_ids_ssim", []) }
     solr_parameters[:fq] ||= []
-    solr_parameters[:fq]  += [
-      "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids(ids)
-    ]
+    solr_parameters[:fq] += ["-#{Hyrax::SolrQueryBuilderService.construct_query_for_ids([ids])}"]
   end
 
   def show_only_works_not_parent(solr_parameters)

--- a/app/search_builders/hyrax/my/highlights_search_builder.rb
+++ b/app/search_builders/hyrax/my/highlights_search_builder.rb
@@ -7,8 +7,6 @@ class Hyrax::My::HighlightsSearchBuilder < Hyrax::SearchBuilder
   def show_only_highlighted_works(solr_parameters)
     ids = scope.current_user.trophies.pluck(:work_id)
     solr_parameters[:fq] ||= []
-    solr_parameters[:fq] += [
-      ActiveFedora::SolrQueryBuilder.construct_query_for_ids(ids)
-    ]
+    solr_parameters[:fq] += [Hyrax::SolrQueryBuilderService.construct_query_for_ids([ids])]
   end
 end

--- a/app/search_builders/hyrax/nested_collections_parent_search_builder.rb
+++ b/app/search_builders/hyrax/nested_collections_parent_search_builder.rb
@@ -15,7 +15,7 @@ module Hyrax
     # Filters the query to only include the parent collections
     def parent_collections_only(solr_parameters)
       solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << ActiveFedora::SolrQueryBuilder.construct_query_for_ids(child.member_of_collection_ids)
+      solr_parameters[:fq] += [Hyrax::SolrQueryBuilderService.construct_query_for_ids(child.member_of_collection_ids)]
     end
     self.default_processor_chain += [:parent_collections_only]
 

--- a/app/search_builders/hyrax/parent_collection_search_builder.rb
+++ b/app/search_builders/hyrax/parent_collection_search_builder.rb
@@ -6,7 +6,7 @@ module Hyrax
     # include filters into the query to only include the collections containing this item
     def include_item_ids(solr_parameters)
       solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << ActiveFedora::SolrQueryBuilder.construct_query_for_ids(item.member_of_collection_ids)
+      solr_parameters[:fq] += [Hyrax::SolrQueryBuilderService.construct_query_for_ids([item.member_of_collection_ids])]
     end
   end
 end

--- a/app/services/hyrax/adapters/nesting_index_adapter.rb
+++ b/app/services/hyrax/adapters/nesting_index_adapter.rb
@@ -131,7 +131,7 @@ module Hyrax
 
       # @api private
       def self.find_solr_document_by(id:)
-        query = ActiveFedora::SolrQueryBuilder.construct_query_for_ids([id])
+        query = Hyrax::SolrQueryBuilderService.construct_query_for_ids([id])
         document = Hyrax::SolrService.query(query, rows: 1).first
         document = ActiveFedora::Base.find(id).to_solr if document.nil?
         raise "Unable to find SolrDocument with ID=#{id}" if document.nil?

--- a/app/services/hyrax/solr_query_builder_service.rb
+++ b/app/services/hyrax/solr_query_builder_service.rb
@@ -1,0 +1,13 @@
+module Hyrax
+  class SolrQueryBuilderService
+      # Construct a solr query for a list of ids
+      # This is used to get a solr response based on the list of ids in an object's RELS-EXT relationhsips
+      # If the id_array is empty, defaults to a query of "id:NEVER_USE_THIS_ID", which will return an empty solr response
+      # @param [Array] id_array the ids that you want included in the query
+      def self.construct_query_for_ids(id_array)
+        ids = id_array.reject(&:blank?)
+        return "id:NEVER_USE_THIS_ID" if ids.empty?
+        "{!terms f=id}#{ids.join(',')}"
+      end
+  end
+end

--- a/app/services/hyrax/solr_query_builder_service.rb
+++ b/app/services/hyrax/solr_query_builder_service.rb
@@ -1,13 +1,13 @@
 module Hyrax
   class SolrQueryBuilderService
-      # Construct a solr query for a list of ids
-      # This is used to get a solr response based on the list of ids in an object's RELS-EXT relationhsips
-      # If the id_array is empty, defaults to a query of "id:NEVER_USE_THIS_ID", which will return an empty solr response
-      # @param [Array] id_array the ids that you want included in the query
-      def self.construct_query_for_ids(id_array)
-        ids = id_array.reject(&:blank?)
-        return "id:NEVER_USE_THIS_ID" if ids.empty?
-        "{!terms f=id}#{ids.join(',')}"
-      end
+    # Construct a solr query for a list of ids
+    # This is used to get a solr response based on the list of ids in an object's RELS-EXT relationhsips
+    # If the id_array is empty, defaults to a query of "id:NEVER_USE_THIS_ID", which will return an empty solr response
+    # @param [Array] id_array the ids that you want included in the query
+    def self.construct_query_for_ids(id_array)
+      ids = id_array.reject(&:blank?)
+      return "id:NEVER_USE_THIS_ID" if ids.empty?
+      "{!terms f=id}#{ids.join(',')}"
+    end
   end
 end

--- a/app/services/hyrax/solr_query_builder_service.rb
+++ b/app/services/hyrax/solr_query_builder_service.rb
@@ -1,5 +1,6 @@
 module Hyrax
   class SolrQueryBuilderService
+    # Extracted from ActiveFedora::SolrQueryBuilder
     # Construct a solr query for a list of ids
     # This is used to get a solr response based on the list of ids in an object's RELS-EXT relationhsips
     # If the id_array is empty, defaults to a query of "id:NEVER_USE_THIS_ID", which will return an empty solr response

--- a/app/services/hyrax/work_query_service.rb
+++ b/app/services/hyrax/work_query_service.rb
@@ -52,7 +52,7 @@ module Hyrax
       end
 
       def query
-        ActiveFedora::SolrQueryBuilder.construct_query_for_ids([id])
+        Hyrax::SolrQueryBuilderService.construct_query_for_ids([id])
       end
   end
 end

--- a/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
 
     it "is successful" do
       subject
-      expect(solr_params[:fq]).to eq ["-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids([work.id])]
+      expect(solr_params[:fq]).to eq ["-" + Hyrax::SolrQueryBuilderService.construct_query_for_ids([work.id])]
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
     it "is successful" do
       subject
       ids = Hyrax::SolrService.query("{!field f=id}#{work.id}", fl: "member_ids_ssim").flat_map { |x| x.fetch("member_ids_ssim", []) }
-      expect(solr_params[:fq]).to eq ["-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids([ids])]
+      expect(solr_params[:fq]).to eq ["-" + Hyrax::SolrQueryBuilderService.construct_query_for_ids([ids])]
     end
   end
 

--- a/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
+++ b/spec/services/hyrax/adapters/nesting_index_adapter_spec.rb
@@ -145,8 +145,7 @@ RSpec.describe Hyrax::Adapters::NestingIndexAdapter do
 
   describe '.write_nesting_document_to_index_layer' do
     let(:work) { create(:work) }
-    let(:query_for_works_solr_document) { ->(id:) { Hyrax::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query_for_ids([id])).first } }
-
+    let(:query_for_works_solr_document) { ->(id:) { Hyrax::SolrService.query(Hyrax::SolrQueryBuilderService.construct_query_for_ids([id])).first } }
     # rubocop:disable RSpec/ExampleLength
     it 'will append parent_ids, ancestors, pathnames, and deepest_nested_depth to the SOLR document' do
       previous_solr_keys = work.to_solr.keys

--- a/spec/services/hyrax/solr_query_builder_service_spec.rb
+++ b/spec/services/hyrax/solr_query_builder_service_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe Hyrax::SolrQueryBuilderService do
+  describe '#construct_query_for_ids' do
+    it "generates a useable solr query from an array of Fedora ids" do
+      expect(described_class.construct_query_for_ids(["my:_ID1_", "my:_ID2_", "my:_ID3_"])).to eq '{!terms f=id}my:_ID1_,my:_ID2_,my:_ID3_'
+    end
+    it "returns a valid solr query even if given an empty array as input" do
+      expect(described_class.construct_query_for_ids([""])).to eq "id:NEVER_USE_THIS_ID"
+    end
+  end
+end
+

--- a/spec/services/hyrax/solr_query_builder_service_spec.rb
+++ b/spec/services/hyrax/solr_query_builder_service_spec.rb
@@ -10,4 +10,3 @@ RSpec.describe Hyrax::SolrQueryBuilderService do
     end
   end
 end
-


### PR DESCRIPTION
Fixes #3792 

Extracts construct_query_for_ids from ActiveFedora::SolrQueryBuilder and places it in a Hyrax::SolrQueryBuilderService.  Changes 8 calls to ActiveFedora to the Hyrax service, as well as two calls in specs. Also brings over the associated spec.
Part of the work to remove ActiveFedora calls from Hyrax. 
