### PR TITLE
[wings] Introduce a Hyrax::IndexingService to replace the AF class

### DIFF
--- a/app/indexers/hyrax/work_indexer.rb
+++ b/app/indexers/hyrax/work_indexer.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  class WorkIndexer < ActiveFedora::IndexingService
+  class WorkIndexer < Hyrax::IndexingService
     include Hyrax::IndexesThumbnails
     include Hyrax::IndexesWorkflow
 

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -15,6 +15,7 @@ require 'browse-everything'
 require 'hydra/works'
 require 'hyrax/engine'
 require 'hyrax/version'
+require 'hyrax/indexing_service'
 require 'hyrax/inflections'
 require 'kaminari_route_prefix'
 

--- a/lib/hyrax/indexing_service.rb
+++ b/lib/hyrax/indexing_service.rb
@@ -1,0 +1,4 @@
+module Hyrax
+  class IndexingService < ActiveFedora::IndexingService
+  end
+end


### PR DESCRIPTION
For now, this service subclasses the ActiveFedora version, but can be used
throughout the local codebase, allowing us to deprecate direct inheritance of
`ActiveFedora::IndexingService`, and any of its features that we would prefer
not to support going forward.

Connected to #3800.

@samvera/hyrax-code-reviewers
