### PR TITLE
Replace ActiveFedora::Base.find

### DIFF
--- a/app/actors/hyrax/actors/add_to_work_actor.rb
+++ b/app/actors/hyrax/actors/add_to_work_actor.rb
@@ -30,7 +30,7 @@ module Hyrax
 
         def cleanup_ids_to_remove_from_curation_concern(env, new_work_ids)
           (env.curation_concern.in_works_ids - new_work_ids).each do |old_id|
-            work = ::ActiveFedora::Base.find(old_id)
+            work = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: old_id, use_valkyrie: false)
             work.ordered_members.delete(env.curation_concern)
             work.members.delete(env.curation_concern)
             work.save!
@@ -40,7 +40,7 @@ module Hyrax
         def add_new_work_ids_not_already_in_curation_concern(env, new_work_ids)
           # add to new so long as the depositor for the parent and child matches, otherwise inject an error
           (new_work_ids - env.curation_concern.in_works_ids).each do |work_id|
-            work = ::ActiveFedora::Base.find(work_id)
+            work = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: work_id, use_valkyrie: false)
             if can_edit_both_works?(env, work)
               work.ordered_members << env.curation_concern
               work.save!

--- a/app/actors/hyrax/actors/apply_order_actor.rb
+++ b/app/actors/hyrax/actors/apply_order_actor.rb
@@ -27,7 +27,7 @@ module Hyrax
         # @see Hyrax::Actors::AddToWorkActor for duplication
         def cleanup_ids_to_remove_from_curation_concern(curation_concern, ordered_member_ids)
           (curation_concern.ordered_member_ids - ordered_member_ids).each do |old_id|
-            work = ::ActiveFedora::Base.find(old_id)
+            work = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: old_id, use_valkyrie: false)
             curation_concern.ordered_members.delete(work)
             curation_concern.members.delete(work)
           end
@@ -35,7 +35,7 @@ module Hyrax
 
         def add_new_work_ids_not_already_in_curation_concern(env, ordered_member_ids)
           (ordered_member_ids - env.curation_concern.ordered_member_ids).each do |work_id|
-            work = ::ActiveFedora::Base.find(work_id)
+            work = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: work_id, use_valkyrie: false)
             if can_edit_both_works?(env, work)
               env.curation_concern.ordered_members << work
               env.curation_concern.save!

--- a/app/actors/hyrax/actors/attach_members_actor.rb
+++ b/app/actors/hyrax/actors/attach_members_actor.rb
@@ -43,14 +43,14 @@ module Hyrax
         # Adds the item to the ordered members so that it displays in the items
         # along side the FileSets on the show page
         def add(env, id)
-          member = ActiveFedora::Base.find(id)
+          member = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false)
           return unless env.current_ability.can?(:edit, member)
           env.curation_concern.ordered_members << member
         end
 
         # Remove the object from the members set and the ordered members list
         def remove(curation_concern, id)
-          member = ActiveFedora::Base.find(id)
+          member = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false)
           curation_concern.ordered_members.delete(member)
           curation_concern.members.delete(member)
         end

--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -25,7 +25,7 @@ module Hyrax
     end
 
     def show
-      @curation_concern ||= ActiveFedora::Base.find(params[:id])
+      @curation_concern ||= Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: params[:id], use_valkyrie: false)
       presenter
       query_collection_members
     end

--- a/app/controllers/hyrax/batch_edits_controller.rb
+++ b/app/controllers/hyrax/batch_edits_controller.rb
@@ -38,7 +38,7 @@ module Hyrax
 
     def destroy_collection
       batch.each do |doc_id|
-        obj = ActiveFedora::Base.find(doc_id, cast: true)
+        obj = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false)
         obj.destroy
       end
       flash[:notice] = "Batch delete complete"
@@ -60,7 +60,7 @@ module Hyrax
       case params["update_type"]
       when "update"
         batch.each do |doc_id|
-          update_document(ActiveFedora::Base.find(doc_id))
+          update_document(Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false))
         end
         flash[:notice] = "Batch update complete"
         after_update
@@ -82,7 +82,7 @@ module Hyrax
       end
 
       def destroy_batch
-        batch.each { |id| ActiveFedora::Base.find(id).destroy }
+        batch.each { |id| Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false).destroy }
         after_update
       end
 

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -202,7 +202,7 @@ module Hyrax
         end
 
         def link_parent_collection(parent_id)
-          parent = ActiveFedora::Base.find(parent_id)
+          parent = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: parent_id, use_valkyrie: false)
           Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent, child: @collection)
         end
 
@@ -375,7 +375,7 @@ module Hyrax
 
         def remove_members_from_collection
           batch.each do |pid|
-            work = ActiveFedora::Base.find(pid)
+            work = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: pid, use_valkyrie: false)
             work.member_of_collections.delete @collection
             work.save!
           end

--- a/app/controllers/hyrax/permissions_controller.rb
+++ b/app/controllers/hyrax/permissions_controller.rb
@@ -28,7 +28,7 @@ module Hyrax
     end
 
     def curation_concern
-      @curation_concern ||= ActiveFedora::Base.find(params[:id])
+      @curation_concern ||= Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: params[:id], use_valkyrie: false)
     end
   end
 end

--- a/app/controllers/hyrax/single_use_links_viewer_controller.rb
+++ b/app/controllers/hyrax/single_use_links_viewer_controller.rb
@@ -59,7 +59,7 @@ module Hyrax
       end
 
       def asset
-        @asset ||= ActiveFedora::Base.find(single_use_link.item_id)
+        @asset ||= Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: single_use_link.item_id, use_valkyrie: false)
       end
 
       def current_ability

--- a/app/controllers/hyrax/workflow_actions_controller.rb
+++ b/app/controllers/hyrax/workflow_actions_controller.rb
@@ -16,7 +16,7 @@ module Hyrax
     private
 
       def curation_concern
-        @curation_concern ||= ActiveFedora::Base.find(params[:id])
+        @curation_concern ||= Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: params[:id], use_valkyrie: false)
       end
 
       def workflow_action_form

--- a/app/forms/hyrax/forms/batch_edit_form.rb
+++ b/app/forms/hyrax/forms/batch_edit_form.rb
@@ -64,7 +64,7 @@ module Hyrax
         def initialize_combined_fields
           # For each of the files in the batch, set the attributes to be the concatenation of all the attributes
           batch_document_ids.each_with_object({}) do |doc_id, combined_attributes|
-            work = ActiveFedora::Base.find(doc_id)
+            work = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false)
             terms.each do |field|
               combined_attributes[field] ||= []
               combined_attributes[field] = (combined_attributes[field] + work[field].to_a).uniq

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -63,7 +63,7 @@ module Hyrax
     #                   lib/wings/models/concerns/collection_behavior.rb
     def add_member_objects(new_member_ids)
       Array(new_member_ids).collect do |member_id|
-        member = ActiveFedora::Base.find(member_id)
+        member = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: member_id, use_valkyrie: false)
         message = Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
         if message
           member.errors.add(:collections, message)

--- a/app/services/hyrax/persist_directly_contained_output_file_service.rb
+++ b/app/services/hyrax/persist_directly_contained_output_file_service.rb
@@ -24,7 +24,7 @@ module Hyrax
     def self.retrieve_file_set(directives)
       uri = URI(directives.fetch(:url))
       raise ArgumentError, "#{uri} is not an http(s) uri" unless uri.is_a?(URI::HTTP)
-      ActiveFedora::Base.find(ActiveFedora::Base.uri_to_id(uri.to_s))
+      Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: ActiveFedora::Base.uri_to_id(uri.to_s), use_valkyrie: false)
     end
     private_class_method :retrieve_file_set
 

--- a/app/services/hyrax/thumbnail_path_service.rb
+++ b/app/services/hyrax/thumbnail_path_service.rb
@@ -22,7 +22,7 @@ module Hyrax
 
         def fetch_thumbnail(object)
           return object if object.thumbnail_id == object.id
-          ::ActiveFedora::Base.find(object.thumbnail_id)
+          Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: object.thumbnail_id, use_valkyrie: false)
         rescue ActiveFedora::ObjectNotFoundError
           Rails.logger.error("Couldn't find thumbnail #{object.thumbnail_id} for #{object.id}")
           nil

--- a/app/services/hyrax/workflow/deposited_notification.rb
+++ b/app/services/hyrax/workflow/deposited_notification.rb
@@ -13,7 +13,7 @@ module Hyrax
         end
 
         def users_to_notify
-          user_key = ActiveFedora::Base.find(work_id).depositor
+          user_key = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: work_id, use_valkyrie: false).depositor
           super << ::User.find_by(email: user_key)
         end
     end

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -87,8 +87,8 @@ module Wings
         object = ::ActiveFedora::Base.find(alternate_identifier.to_s)
         return object if use_valkyrie == false
         resource_factory.to_resource(object: object)
-        rescue ::ActiveFedora::ObjectNotFoundError, Ldp::Gone => e
-          raise use_valkyrie == true ? ::Valkyrie::Persistence::ObjectNotFoundError : e
+      rescue ::ActiveFedora::ObjectNotFoundError, Ldp::Gone => e
+        raise use_valkyrie == true ? ::Valkyrie::Persistence::ObjectNotFoundError : e
       end
 
       # Find all members of a given resource, and map to Valkyrie Resources

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -76,12 +76,19 @@ module Wings
         resources
       end
 
-      def find_by_alternate_identifier(alternate_identifier:)
+      # Find a record using an alternate ID, and map it to a Valkyrie Resource
+      # @param [Valkyrie::ID, String] id
+      # @param [boolean] optionally return ActiveFedora object/errors
+      # @return [Valkyrie::Resource]
+      # @raise [Valkyrie::Persistence::ObjectNotFoundError]
+      def find_by_alternate_identifier(alternate_identifier:, use_valkyrie: true)
         alternate_identifier = ::Valkyrie::ID.new(alternate_identifier.to_s) if alternate_identifier.is_a?(String)
         validate_id(alternate_identifier)
-        resource_factory.to_resource(object: ::ActiveFedora::Base.find(alternate_identifier.to_s))
-      rescue ::ActiveFedora::ObjectNotFoundError, Ldp::Gone
-        raise ::Valkyrie::Persistence::ObjectNotFoundError
+        object = ::ActiveFedora::Base.find(alternate_identifier.to_s)
+        return object if use_valkyrie == false
+        resource_factory.to_resource(object: object)
+        rescue ::ActiveFedora::ObjectNotFoundError, Ldp::Gone => e
+          raise use_valkyrie == true ? ::Valkyrie::Persistence::ObjectNotFoundError : e
       end
 
       # Find all members of a given resource, and map to Valkyrie Resources

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       let(:work_v1) { create(:generic_work) } # this version of the work has no members
 
       before do # another version of the same work is saved with a member
-        work_v2 = ActiveFedora::Base.find(work_v1.id)
+        work_v2 = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: work_v1.id, use_valkyrie: false)
         work_v2.ordered_members << create(:file_set)
         work_v2.save!
       end

--- a/spec/actors/hyrax/actors/ordered_members_actor_spec.rb
+++ b/spec/actors/hyrax/actors/ordered_members_actor_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::Actors::OrderedMembersActor do
       let(:work_v1) { create(:generic_work) } # this version of the work has no members
 
       before do # another version of the same work is saved with a member
-        work_v2 = ActiveFedora::Base.find(work_v1.id)
+        work_v2 = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: work_v1.id, use_valkyrie: false)
         work_v2.ordered_members << create(:file_set)
         work_v2.save!
       end

--- a/spec/controllers/hyrax/single_use_links_viewer_controller_spec.rb
+++ b/spec/controllers/hyrax/single_use_links_viewer_controller_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe Hyrax::SingleUseLinksViewerController do
     let(:download_link_hash) { download_link.download_key }
 
     describe "GET 'download'" do
-      let(:expected_content) { ActiveFedora::Base.find(file.id).original_file.content }
-
+      let(:expected_content) { Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: file.id, use_valkyrie: false).original_file.content }
       it "downloads the file and deletes the link from the database" do
         expect(controller).to receive(:send_file_headers!).with(filename: 'world.png', disposition: 'attachment', type: 'image/png')
         get :download, params: { id: download_link_hash }

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Creating a new Work', :js, :workflow do
+RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
   let(:user) { create(:user) }
   let!(:ability) { ::Ability.new(user) }
   let(:file1) { File.open(fixture_path + '/world.png') }

--- a/spec/features/static_pages_spec.rb
+++ b/spec/features/static_pages_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "The static pages" do
+RSpec.describe "The static pages", :clean_repo do
   it do
     visit root_path
     click_link "About"

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "work show view" do
     end
 
     it "allows adding work to a collection", clean_repo: true, js: true do
-      optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
+      # optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
       click_button "Add to collection" # opens the modal
       # Really ensure that this Collection model is persisted
       Collection.all.map(&:destroy!)
@@ -64,6 +64,7 @@ RSpec.describe "work show view" do
       click_button 'Save changes'
 
       # forwards to collection show page
+      sleep 5
       expect(page).to have_content persisted_collection.title.first
       expect(page).to have_content work.title.first
       expect(page).to have_selector '.alert-success', text: 'Collection was successfully updated.'
@@ -107,12 +108,13 @@ RSpec.describe "work show view" do
     end
 
     it "allows adding work to a collection", clean_repo: true, js: true do
-      optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
+      # optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
       click_button "Add to collection" # opens the modal
       select_member_of_collection(collection)
       click_button 'Save changes'
 
       # forwards to collection show page
+      sleep 5
       expect(page).to have_content collection.title.first
       expect(page).to have_content work.title.first
       expect(page).to have_selector '.alert-success', text: 'Collection was successfully updated.'

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -152,6 +152,24 @@ RSpec.describe Wings::Valkyrie::QueryService do
       expect(found.id).to eq resource.id
       expect(found).to be_persisted
     end
+
+    context 'when use_valkyrie: false' do
+      it 'returns an ActiveFedora object' do
+        resource = resource_class.new
+        resource.alternate_ids = [Valkyrie::ID.new('p9s0xfj')]
+        resource = persister.save(resource: resource)
+        id = resource.alternate_ids.first
+
+        found = query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false)
+        expect(found.id).to eq resource.id.id
+        expect(found).to be_persisted
+        expect(found).to be_a(ActiveFedora::Base)
+      end
+
+      it 'returns an ActiveFedora error' do
+        expect { query_service.find_by_alternate_identifier(alternate_identifier: Valkyrie::ID.new("123123123"), use_valkyrie: false) }.to raise_error ::ActiveFedora::ObjectNotFoundError
+      end
+    end
   end
 
   describe ".find_many_by_ids" do


### PR DESCRIPTION
references https://github.com/samvera/hyrax/issues/3790

Replace the majority of direct calls to ActiveFedora::Base.find with calls to Valkyrie query service find_by_alternate_identifier.

Note: Does not address following cases:
* find is using a batch of ids rather than a single id
* nesting index adapter

@samvera/hyrax-code-reviewers
