### PR TITLE
[wings] Add Hyrax finder interface

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -25,7 +25,7 @@ module Hyrax
     end
 
     def show
-      @curation_concern ||= ActiveFedora::Base.find(params[:id])
+      @curation_concern ||= Hyrax::ActiveFedoraFinder.find(params[:id])
       presenter
       query_collection_members
     end

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -202,7 +202,7 @@ module Hyrax
         end
 
         def link_parent_collection(parent_id)
-          parent = ActiveFedora::Base.find(parent_id)
+          parent = Hyrax::ActiveFedoraFinder.find(parent_id)
           Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent, child: @collection)
         end
 
@@ -375,7 +375,7 @@ module Hyrax
 
         def remove_members_from_collection
           batch.each do |pid|
-            work = ActiveFedora::Base.find(pid)
+            work = Hyrax::ActiveFedoraFinder.find(pid)
             work.member_of_collections.delete @collection
             work.save!
           end

--- a/app/controllers/hyrax/permissions_controller.rb
+++ b/app/controllers/hyrax/permissions_controller.rb
@@ -28,7 +28,7 @@ module Hyrax
     end
 
     def curation_concern
-      @curation_concern ||= ActiveFedora::Base.find(params[:id])
+      @curation_concern ||= Hyrax::ActiveFedoraFinder.find(params[:id])
     end
   end
 end

--- a/app/controllers/hyrax/single_use_links_viewer_controller.rb
+++ b/app/controllers/hyrax/single_use_links_viewer_controller.rb
@@ -59,7 +59,7 @@ module Hyrax
       end
 
       def asset
-        @asset ||= ActiveFedora::Base.find(single_use_link.item_id)
+        @asset ||= Hyrax::ActiveFedoraFinder.find(single_use_link.item_id)
       end
 
       def current_ability

--- a/app/controllers/hyrax/workflow_actions_controller.rb
+++ b/app/controllers/hyrax/workflow_actions_controller.rb
@@ -16,7 +16,7 @@ module Hyrax
     private
 
       def curation_concern
-        @curation_concern ||= ActiveFedora::Base.find(params[:id])
+        @curation_concern ||= Hyrax::ActiveFedoraFinder.find(params[:id])
       end
 
       def workflow_action_form

--- a/app/forms/hyrax/forms/batch_edit_form.rb
+++ b/app/forms/hyrax/forms/batch_edit_form.rb
@@ -64,7 +64,7 @@ module Hyrax
         def initialize_combined_fields
           # For each of the files in the batch, set the attributes to be the concatenation of all the attributes
           batch_document_ids.each_with_object({}) do |doc_id, combined_attributes|
-            work = ActiveFedora::Base.find(doc_id)
+            work = Hyrax::ActiveFedoraFinder.find(doc_id)
             terms.each do |field|
               combined_attributes[field] ||= []
               combined_attributes[field] = (combined_attributes[field] + work[field].to_a).uniq

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -54,7 +54,7 @@ module Hyrax
     #       add_member_objects using the member_of_collections relationship.  Deprecate?
     def add_members(new_member_ids)
       return if new_member_ids.blank?
-      members << ActiveFedora::Base.find(new_member_ids)
+      members << Hyrax::ActiveFedoraFinder.find(new_member_ids)
     end
 
     # Add member objects by adding this collection to the objects' member_of_collection association.
@@ -63,7 +63,7 @@ module Hyrax
     #                   lib/wings/models/concerns/collection_behavior.rb
     def add_member_objects(new_member_ids)
       Array(new_member_ids).collect do |member_id|
-        member = ActiveFedora::Base.find(member_id)
+        member = Hyrax::ActiveFedoraFinder.find(member_id)
         message = Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
         if message
           member.errors.add(:collections, message)
@@ -79,7 +79,7 @@ module Hyrax
     # Valkyrie Version: Wings::CollectionBehavior#child_collections_and_works aliased to #member_objects
     #                   lib/wings/models/concerns/collection_behavior.rb
     def member_objects
-      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}")
+      Hyrax::ActiveFedoraFinder.where("member_of_collection_ids_ssim:#{id}")
     end
 
     # Use this query to get the ids of the member objects (since the containment

--- a/app/services/hyrax/active_fedora_finder.rb
+++ b/app/services/hyrax/active_fedora_finder.rb
@@ -26,12 +26,13 @@ module Hyrax
     #
     # @return [ActiveFedora::Base]
     def find(id)
-      # resource = resource_finder.find(id.to_s)
+      resource = @resource_finder.find(id.to_s)
 
-      # Wings::ActiveFedoraConverter
-      #   .new(resource: resource)
-      #   .convert
-      ActiveFedora::Base.find(id)
+      Wings::ActiveFedoraConverter
+        .new(resource: resource)
+        .convert
+    rescue Valkyrie::Persistence::ObjectNotFoundError => err
+      raise ActiveFedora::ObjectNotFoundError, err.message
     end
   end
 end

--- a/app/services/hyrax/active_fedora_finder.rb
+++ b/app/services/hyrax/active_fedora_finder.rb
@@ -1,0 +1,37 @@
+module Hyrax
+  ##
+  # Finds `ActiveFedora::Base` resources by id.
+  #
+  # Replaces `ActiveFedora::Base.find`, with a query-side interface like that of
+  # `ResourceFinder`. The response is an ActiveFedora model.
+  #
+  # The `query_service` provided at initialization is for interface
+  # compatibility only; this class provides no guarantee that the provided query
+  # service will be used to execute the query.
+  class ActiveFedoraFinder
+    ##
+    # @!attribute [r] query_service
+    #   @return [#find_by]
+    attr_reader :query_service
+
+    ##
+    # @param query_service [#find_by]
+    def initialize(query_service: Valkyrie.config.metadata_adapter.query_service)
+      @query_service   = query_service
+      @resource_finder = ResourceFinder.new(query_service: query_service)
+    end
+
+    ##
+    # @param id [#to_s]
+    #
+    # @return [ActiveFedora::Base]
+    def find(id)
+      # resource = resource_finder.find(id.to_s)
+
+      # Wings::ActiveFedoraConverter
+      #   .new(resource: resource)
+      #   .convert
+      ActiveFedora::Base.find(id)
+    end
+  end
+end

--- a/app/services/hyrax/persist_directly_contained_output_file_service.rb
+++ b/app/services/hyrax/persist_directly_contained_output_file_service.rb
@@ -24,7 +24,7 @@ module Hyrax
     def self.retrieve_file_set(directives)
       uri = URI(directives.fetch(:url))
       raise ArgumentError, "#{uri} is not an http(s) uri" unless uri.is_a?(URI::HTTP)
-      ActiveFedora::Base.find(ActiveFedora::Base.uri_to_id(uri.to_s))
+      Hyrax::ActiveFedoraFinder.find(ActiveFedora::Base.uri_to_id(uri.to_s))
     end
     private_class_method :retrieve_file_set
 

--- a/app/services/hyrax/resource_finder.rb
+++ b/app/services/hyrax/resource_finder.rb
@@ -1,0 +1,25 @@
+module Hyrax
+  ##
+  # Finds Resources using the configured query service
+  class ResourceFinder
+    ##
+    # @!attribute [r] query_service
+    #   @return [#find_by]
+    attr_reader :query_service
+
+    ##
+    # @param query_service [#find_by]
+    def initialize(query_service: Valkyrie.config.metadata_adapter.query_service)
+      @query_service = query_service
+    end
+
+    ##
+    # @param id [String]
+    #
+    # @return [Valkyrie::Resource]
+    # @raise  [Valkyrie::Persistence::ObjectNotFoundError]
+    def find(id)
+      query_service.find_by(id: Valkyrie::ID.new(id))
+    end
+  end
+end

--- a/app/services/hyrax/thumbnail_path_service.rb
+++ b/app/services/hyrax/thumbnail_path_service.rb
@@ -22,7 +22,7 @@ module Hyrax
 
         def fetch_thumbnail(object)
           return object if object.thumbnail_id == object.id
-          ::ActiveFedora::Base.find(object.thumbnail_id)
+          Hyrax::ActiveFedoraFinder.find(object.thumbnail_id)
         rescue ActiveFedora::ObjectNotFoundError
           Rails.logger.error("Couldn't find thumbnail #{object.thumbnail_id} for #{object.id}")
           nil

--- a/app/services/hyrax/workflow/deposited_notification.rb
+++ b/app/services/hyrax/workflow/deposited_notification.rb
@@ -13,7 +13,7 @@ module Hyrax
         end
 
         def users_to_notify
-          user_key = ActiveFedora::Base.find(work_id).depositor
+          user_key = Hyrax::ActiveFedoraFinder.find(work_id).depositor
           super << ::User.find_by(email: user_key)
         end
     end

--- a/spec/services/hyrax/active_fedora_finder_spec.rb
+++ b/spec/services/hyrax/active_fedora_finder_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Hyrax::ActiveFedoraFinder do
+  subject(:finder) { described_class.new }
+
+  describe '.new' do
+    let(:query_service) { :FAKE_QUERY_SERVICE }
+
+    it 'sets the query service' do
+      expect(described_class.new(query_service: query_service))
+        .to have_attributes query_service: query_service
+    end
+  end
+
+  describe '#find' do
+    context 'when resource does not exist' do
+      it 'raises object not found' do
+        expect { finder.find('a_completely_fake_id') }
+          .to raise_error ActiveFedora::ObjectNotFoundError
+      end
+    end
+
+    context 'when resource is present' do
+      let(:id)   { work.id }
+      let(:work) { FactoryBot.create(:work) }
+
+      it 'finds the resource' do
+        expect(finder.find(id)).to eq work
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/resource_finder_spec.rb
+++ b/spec/services/hyrax/resource_finder_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Hyrax::ResourceFinder do
+  subject(:finder) { described_class.new }
+
+  describe '.new' do
+    let(:query_service) { :FAKE_QUERY_SERVICE }
+
+    it 'sets the query service' do
+      expect(described_class.new(query_service: query_service))
+        .to have_attributes query_service: query_service
+    end
+  end
+
+  describe '#find' do
+    context 'when resource does not exist' do
+      it 'raises object not found' do
+        expect { finder.find('a_completely_fake_id') }
+          .to raise_error Valkyrie::Persistence::ObjectNotFoundError
+      end
+    end
+
+    context 'when resource is present' do
+      let(:id)   { work.id }
+      let(:work) { FactoryBot.create(:work) }
+
+      it 'finds the resource' do
+        expect(finder.find(id)).to have_attributes id: Valkyrie::ID.new(id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This interface replaces `ActiveFedora::Base.find` in a way that can support a
clean changeover to Valkyrie.

Existing calls to `ActiveFedora::Base.find` can be swapped for
`Hyrax::ActiveFedoraFinder.find` calls. This class returns the same types, and
raises the same errors as the `AF::Base` version. That can later be swapped for
`Hyrax::ResourceFinder`, which is a light wrapper around
`Valkyrie` `#find_by`.

Some consideration was given to using a Valkyrie custom query, but since the
end-goal for this particular swap is to bundle a globally configured
query adapter and its existing `find_by` method, there seemed to be little
point.

Related to #3790.

@samvera/hyrax-code-reviewers
