### PR TITLE
[wings] Introduce a converter actor for reworking the actor stack

### DIFF
--- a/app/actors/hyrax/actors/active_fedora_to_valkyrie.rb
+++ b/app/actors/hyrax/actors/active_fedora_to_valkyrie.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Actors
+    ##
+    # Casts `env.curation_concern` from a `ActiveFedora::Base` model to a
+    # `Valkyrie::Resource` resource.
+    #
+    # If the curation concern is not an `ActiveFedora::Base` this is a
+    # no-op.
+    #
+    # This can be used in conjunction with `ValkyrieToActiveFedora` to create a
+    # vertical boundary in the actor stack between actors that deal with
+    # `ActiveFedora` models and those that work on `Valkyrie::Resource` objects.
+    #
+    # @example defining a stack using both ActiveFedora and Valkyrie actors
+    #   stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+    #     middleware.use ActorThatUsesActiveFedora
+    #     middleware.use AnotherActorThatUsesActiveFedora
+    #     middleware.use ValkyrieToActiveFedora # casts on the way up
+    #     middleware.use ActiveFedoraToValkyrie # casts on the way down
+    #     middleware.use ActorThatUsesValkyrie
+    #     middleware.use AnotherActorThatUsesValkyrie
+    #   end
+    #
+    #   actor = stack.build(Hyrax::Actors::Terminator.new)
+    #
+    # @see ValkyrieToActiveFedora
+    class ActiveFedoraToValkyrie < AbstractActor
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true
+      def create(env)
+        cast(env) && next_actor.create(env)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true
+      def update(env)
+        cast(env) && next_actor.update(env)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true
+      def destroy(env)
+        cast(env) && next_actor.destroy(env)
+      end
+
+      private
+
+        def cast(env)
+          return true unless env.curation_concern.is_a? ActiveFedora::Base
+
+          env.curation_concern = env.curation_concern.valkyrie_resource
+
+          true
+        end
+    end
+  end
+end

--- a/app/actors/hyrax/actors/valkyrie_to_active_fedora.rb
+++ b/app/actors/hyrax/actors/valkyrie_to_active_fedora.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Actors
+    ##
+    # Casts `env.curation_concern` from a `Valkyrie::Resource` to an
+    # `ActiveFedora::Base` model.
+    #
+    # If the curation concern is not a `Valkyrie::Resource` this is a
+    # no-op.
+    #
+    # This can be used in conjunction with `ActiveFedoraToValkyrie` to create a
+    # vertical boundary in the actor stack between actors that deal with
+    # `ActiveFedora` models and those that work on `Valkyrie::Resource` objects.
+    #
+    # @example defining a stack using both ActiveFedora and Valkyrie actors
+    #   stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+    #     middleware.use ActorThatUsesActiveFedora
+    #     middleware.use AnotherActorThatUsesActiveFedora
+    #     middleware.use ValkyrieToActiveFedora # casts on the way up
+    #     middleware.use ActiveFedoraToValkyrie # casts on the way down
+    #     middleware.use ActorThatUsesValkyrie
+    #     middleware.use AnotherActorThatUsesValkyrie
+    #   end
+    #
+    #   actor = stack.build(Hyrax::Actors::Terminator.new)
+    #
+    # @see ValkyrieToActiveFedora
+    class ValkyrieToActiveFedora < AbstractActor
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true
+      def create(env)
+        next_actor.create(env) && cast(env)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true
+      def update(env)
+        next_actor.update(env) && cast(env)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true
+      def destroy(env)
+        next_actor.destroy(env) && cast(env)
+      end
+
+      private
+
+        def cast(env)
+          return true unless env.curation_concern.is_a? Valkyrie::Resource
+
+          env.curation_concern =
+            Wings::ActiveFedoraConverter.convert(resource: env.curation_concern)
+
+          true
+        end
+    end
+  end
+end

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -23,6 +23,14 @@ module Wings
     end
 
     ##
+    # @params [Valkyrie::Resource] resource
+    #
+    # @return [ActiveFedora::Base]
+    def self.convert(resource:)
+      new(resource: resource).convert
+    end
+
+    ##
     # @!attribute [rw] resource
     #   @return [Valkyrie::Resource]
     attr_accessor :resource

--- a/spec/actors/hyrax/actors/active_fedora_to_valkyrie_spec.rb
+++ b/spec/actors/hyrax/actors/active_fedora_to_valkyrie_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Actors::ActiveFedoraToValkyrie do
+  let(:ability)    { :FAKE_ABILITY }
+  let(:attrs)      { {} }
+  let(:env)        { Hyrax::Actors::Environment.new(work, ability, attrs) }
+  let(:spy)        { middleware.next_actor }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:work)       { FactoryBot.build(:work) }
+
+  subject(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+      middleware.use FakeActor
+    end
+
+    stack.build(terminator)
+  end
+
+  shared_examples 'casts to Valkyrie' do |method|
+    it 'returns true' do
+      expect(middleware.public_send(method, env)).to be true
+    end
+
+    it 'casts to Valkyrie' do
+      expect { middleware.public_send(method, env) }
+        .to change { env.curation_concern }
+        .to be_a Valkyrie::Resource
+    end
+
+    context 'when concern is not an ActiveFedora::Base' do
+      let(:work) { :FAKE_WORK }
+
+      it 'is a no-op' do
+        expect { middleware.public_send(method, env) }
+          .not_to change { env.curation_concern }
+      end
+    end
+  end
+
+  describe '#create' do
+    include_examples 'casts to Valkyrie', :create
+
+    it 'calls create on next actor' do
+      expect { middleware.create(env) }
+        .to change { spy.created }
+        .from be_falsey
+    end
+  end
+
+  describe '#update' do
+    include_examples 'casts to Valkyrie', :update
+
+    it 'calls update on next actor' do
+      expect { middleware.update(env) }
+        .to change { spy.updated }
+        .from be_falsey
+    end
+  end
+
+  describe '#destroy' do
+    include_examples 'casts to Valkyrie', :destroy
+
+    it 'calls update on next actor' do
+      expect { middleware.destroy(env) }
+        .to change { spy.destroyed }
+        .from be_falsey
+    end
+  end
+end

--- a/spec/actors/hyrax/actors/valkyrie_to_active_fedora_spec.rb
+++ b/spec/actors/hyrax/actors/valkyrie_to_active_fedora_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Actors::ValkyrieToActiveFedora do
+  let(:ability)    { :FAKE_ABILITY }
+  let(:attrs)      { {} }
+  let(:env)        { Hyrax::Actors::Environment.new(work, ability, attrs) }
+  let(:spy)        { middleware.next_actor }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:work)       { FactoryBot.build(:work).valkyrie_resource }
+
+  subject(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+      middleware.use FakeActor
+    end
+
+    stack.build(terminator)
+  end
+
+  shared_examples 'casts to ActiveFedora' do |method|
+    it 'returns true' do
+      expect(middleware.public_send(method, env)).to be true
+    end
+
+    it 'casts to ActiveFedora' do
+      expect { middleware.public_send(method, env) }
+        .to change { env.curation_concern }
+        .to be_a GenericWork
+    end
+
+    context 'when concern is not a valkyrie resource' do
+      let(:work) { :FAKE_WORK }
+
+      it 'is a no-op' do
+        expect { middleware.public_send(method, env) }
+          .not_to change { env.curation_concern }
+      end
+    end
+  end
+
+  describe '#create' do
+    include_examples 'casts to ActiveFedora', :create
+
+    it 'calls create on next actor' do
+      expect { middleware.create(env) }
+        .to change { spy.created }
+        .from be_falsey
+    end
+  end
+
+  describe '#update' do
+    include_examples 'casts to ActiveFedora', :update
+
+    it 'calls update on next actor' do
+      expect { middleware.update(env) }
+        .to change { spy.updated }
+        .from be_falsey
+    end
+  end
+
+  describe '#destroy' do
+    include_examples 'casts to ActiveFedora', :destroy
+
+    it 'calls update on next actor' do
+      expect { middleware.destroy(env) }
+        .to change { spy.destroyed }
+        .from be_falsey
+    end
+  end
+end

--- a/spec/support/fakes/fake_actor.rb
+++ b/spec/support/fakes/fake_actor.rb
@@ -1,0 +1,21 @@
+class FakeActor < Hyrax::Actors::AbstractActor
+  attr_accessor :created, :destroyed, :updated
+
+  def create(env)
+    self.created = env
+
+    true
+  end
+
+  def destroy(env)
+    self.destroyed = env
+
+    true
+  end
+
+  def update(env)
+    self.updated = env
+
+    true
+  end
+end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
   let(:resource)      { work.valkyrie_resource }
   let(:work)          { GenericWork.new(attributes) }
 
+  describe '.convert' do
+    it 'returns the ActiveFedora model' do
+      expect(described_class.convert(resource: resource)).to eq work
+    end
+  end
+
   describe '#convert' do
     it 'returns the ActiveFedora model' do
       expect(converter.convert).to eq work


### PR DESCRIPTION
These are support actors, designed to create a boundary in the stack between
actors that handle valkyrie resources, and code that uses ActiveFedora.

By using both actors adjacent to each other anywhere in the actor stack, a two
way conversion can be achieved. Actors below the boundary will accept Valkyrie
resources as their `env.curation_concern` input and can be designed to act only
on Valkyrie objects. Actors above the boundary can continue to work with
ActiveFedora models.

Alternatively, these actors may be used independantly, to swap input/output for
a specific actor.

The idea is that this boundary can begin at the bottom of the stack, and actors
can be reworked or replaced to move the boundary up the stack.

@samvera/hyrax-code-reviewers
