### PR TITLE
Replace construct query

### DIFF
--- a/app/models/concerns/hyrax/collection_nesting.rb
+++ b/app/models/concerns/hyrax/collection_nesting.rb
@@ -43,7 +43,7 @@ module Hyrax
     end
 
     def find_children_of(destroyed_id:)
-      Hyrax::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: destroyed_id))
+      Hyrax::SolrService.query(Hyrax::SolrQueryBuilderService.construct_query(member_of_collection_ids_ssim: destroyed_id))
     end
 
     # Only models which include Hyrax::CollectionNesting will respond to this method.

--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -26,7 +26,7 @@ module Hyrax
       def show_only_other_collections_of_the_same_collection_type(solr_parameters)
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += [
-          "-" +  Hyrax::SolrQueryBuilderService.construct_query_for_ids([limit_ids]),
+          "-" + Hyrax::SolrQueryBuilderService.construct_query_for_ids([limit_ids]),
           Hyrax::SolrQueryBuilderService.construct_query(Collection.collection_type_gid_document_field_name => @collection.collection_type_gid)
         ]
         solr_parameters[:fq] += limit_clause if limit_clause # add limits to prevent illegal nesting arrangements

--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -25,10 +25,9 @@ module Hyrax
 
       def show_only_other_collections_of_the_same_collection_type(solr_parameters)
         solr_parameters[:fq] ||= []
-        query = Hyrax::SolrQueryBuilderService.construct_query_for_ids([limit_ids])
         solr_parameters[:fq] += [
-          "-" + query,
-          ActiveFedora::SolrQueryBuilder.construct_query(Collection.collection_type_gid_document_field_name => @collection.collection_type_gid)
+          "-" +  Hyrax::SolrQueryBuilderService.construct_query_for_ids([limit_ids]),
+          Hyrax::SolrQueryBuilderService.construct_query(Collection.collection_type_gid_document_field_name => @collection.collection_type_gid)
         ]
         solr_parameters[:fq] += limit_clause if limit_clause # add limits to prevent illegal nesting arrangements
       end

--- a/app/search_builders/hyrax/my/find_works_search_builder.rb
+++ b/app/search_builders/hyrax/my/find_works_search_builder.rb
@@ -14,7 +14,7 @@ class Hyrax::My::FindWorksSearchBuilder < Hyrax::My::SearchBuilder
 
   def filter_on_title(solr_parameters)
     solr_parameters[:fq] ||= []
-    solr_parameters[:fq] += [ActiveFedora::SolrQueryBuilder.construct_query(title_tesim: @q)]
+    solr_parameters[:fq] += [Hyrax::SolrQueryBuilderService.construct_query(title_tesim: @q)]
   end
 
   def show_only_other_works(solr_parameters)
@@ -31,7 +31,7 @@ class Hyrax::My::FindWorksSearchBuilder < Hyrax::My::SearchBuilder
   def show_only_works_not_parent(solr_parameters)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq]  += [
-      "-" + ActiveFedora::SolrQueryBuilder.construct_query(member_ids_ssim: @id)
+      "-" + Hyrax::SolrQueryBuilderService.construct_query(member_ids_ssim: @id)
     ]
   end
 

--- a/app/services/hyrax/adapters/nesting_index_adapter.rb
+++ b/app/services/hyrax/adapters/nesting_index_adapter.rb
@@ -157,7 +157,7 @@ module Hyrax
       # @todo What is the appropriate suffix to apply to the solr_field_name?
       def self.raw_child_solr_documents_of(parent_document:)
         # query Solr for all of the documents included as a member_of_collection parent. Or up to 10000 of them.
-        child_query = ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: parent_document.id)
+        child_query = Hyrax::SolrQueryBuilderService.construct_query(member_of_collection_ids_ssim: parent_document.id)
         Hyrax::SolrService.query(child_query, rows: 10_000.to_i)
       end
       private_class_method :raw_child_solr_documents_of

--- a/app/services/hyrax/solr_query_builder_service.rb
+++ b/app/services/hyrax/solr_query_builder_service.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  # Methods in this class are from ActiveFedora::SolrQueryBuilder
+  # Methods in this class are from/based on ActiveFedora::SolrQueryBuilder
   class SolrQueryBuilderService
     class << self
       # Construct a solr query for a list of ids
@@ -9,7 +9,7 @@ module Hyrax
       def construct_query_for_ids(id_array)
         ids = id_array.reject(&:blank?)
         return "id:NEVER_USE_THIS_ID" if ids.empty?
-        "{!terms f=id}#{ids.join(',')}"
+        "{!terms f=#{Hyrax.config.id_field}}#{ids.join(',')}"
       end
 
       # Construct a solr query from a list of pairs (e.g. [field name, values])

--- a/app/services/hyrax/solr_query_builder_service.rb
+++ b/app/services/hyrax/solr_query_builder_service.rb
@@ -1,14 +1,71 @@
 module Hyrax
+  # Methods in this class are from ActiveFedora::SolrQueryBuilder
   class SolrQueryBuilderService
-    # Extracted from ActiveFedora::SolrQueryBuilder
-    # Construct a solr query for a list of ids
-    # This is used to get a solr response based on the list of ids in an object's RELS-EXT relationhsips
-    # If the id_array is empty, defaults to a query of "id:NEVER_USE_THIS_ID", which will return an empty solr response
-    # @param [Array] id_array the ids that you want included in the query
-    def self.construct_query_for_ids(id_array)
-      ids = id_array.reject(&:blank?)
-      return "id:NEVER_USE_THIS_ID" if ids.empty?
-      "{!terms f=id}#{ids.join(',')}"
+    class << self
+      # Construct a solr query for a list of ids
+      # This is used to get a solr response based on the list of ids in an object's RELS-EXT relationhsips
+      # If the id_array is empty, defaults to a query of "id:NEVER_USE_THIS_ID", which will return an empty solr response
+      # @param [Array] id_array the ids that you want included in the query
+      def construct_query_for_ids(id_array)
+        ids = id_array.reject(&:blank?)
+        return "id:NEVER_USE_THIS_ID" if ids.empty?
+        "{!terms f=id}#{ids.join(',')}"
+      end
+
+      # Construct a solr query from a list of pairs (e.g. [field name, values])
+      # @param [Array<Array>] field_pairs a list of pairs of property name and values
+      # @param [String] join_with ('AND') the value we're joining the clauses with
+      # @param [String] type ('field') The type of query to run. Either 'raw' or 'field'
+      # @return [String] a solr query
+      # @example
+      #   construct_query([['library_id_ssim', '123'], ['owner_ssim', 'Fred']])
+      #   # => "_query_:\"{!field f=library_id_ssim}123\" AND _query_:\"{!field f=owner_ssim}Fred\""
+      def construct_query(field_pairs, join_with = default_join_with, type = 'field'.freeze)
+        clauses = pairs_to_clauses(field_pairs, type)
+        return "" if clauses.count.zero?
+        return clauses.first if clauses.count == 1
+        "(#{clauses.join(join_with)})"
+      end
+
+      def default_join_with
+        ' AND '
+      end
+
+      private
+
+        # @param [Array<Array>] pairs a list of (key, value) pairs. The value itself may
+        # @param [String] type  The type of query to run. Either 'raw' or 'field'
+        # @return [Array] a list of solr clauses
+        def pairs_to_clauses(pairs, type)
+          pairs.flat_map do |field, value|
+            condition_to_clauses(field, value, type)
+          end
+        end
+
+        # @param [String] field
+        # @param [String, Array<String>] values
+        # @param [String] type The type of query to run. Either 'raw' or 'field'
+        # @return [Array<String>]
+        def condition_to_clauses(field, values, type)
+          values = Array(values)
+          values << nil if values.empty?
+          values.map do |value|
+            if value.present?
+              query_clause(type, field, value)
+            else
+              # Check that the field is not present. In SQL: "WHERE field IS NULL"
+              "-#{field}:[* TO *]"
+            end
+          end
+        end
+
+        # Create a raw query clause suitable for sending to solr as an fq element
+        # @param [String] type The type of query to run. Either 'raw' or 'field'
+        # @param [String] key
+        # @param [String] value
+        def query_clause(type, key, value)
+          "_query_:\"{!#{type} f=#{key}}#{value.gsub('"', '\"')}\""
+        end
     end
   end
 end

--- a/spec/services/hyrax/solr_query_builder_service_spec.rb
+++ b/spec/services/hyrax/solr_query_builder_service_spec.rb
@@ -9,4 +9,9 @@ RSpec.describe Hyrax::SolrQueryBuilderService do
       expect(described_class.construct_query_for_ids([""])).to eq "id:NEVER_USE_THIS_ID"
     end
   end
+  describe "construct_query" do
+    it "generates a query clause" do
+      expect(described_class.construct_query('id' => "my:_ID1_")).to eq '_query_:"{!field f=id}my:_ID1_"'
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3793 

similar to #3825, this extracts the  construct_query method from ActiveFedora::SolrQueryBuilder and places it in Hyrax::SolrQueryBuilderService, and then fixes 4 calls; brings over the spec; fixes a hard coded arg in the construct_query_for_ids method.
