### PR TITLE
Replace construct query for rel

### DIFF
--- a/app/search_builders/hyrax/abstract_type_relation.rb
+++ b/app/search_builders/hyrax/abstract_type_relation.rb
@@ -14,7 +14,7 @@ module Hyrax
 
     def search_model_clause
       clauses = allowable_types.map do |k|
-        ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: k.to_s)
+        Hyrax::SolrQueryBuilderService.construct_query_for_rel(has_model: k.to_s)
       end
       # empty array returns nil, AF finder method handles it properly, see hyrax issue #2844
       clauses.size <= 1 ? clauses.first : "(#{clauses.join(' OR ')})"

--- a/app/search_builders/hyrax/dashboard/collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/collections_search_builder.rb
@@ -17,8 +17,8 @@ module Hyrax
       def show_only_managed_collections_for_non_admins(solr_parameters)
         return if current_ability.admin?
         clauses = [
-          '-' + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key),
-          '-' + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::AdminSet.to_s, creator: current_user_key)
+          '-' + Hyrax::SolrQueryBuilderService.construct_query_for_rel(depositor: current_user_key),
+          '-' + Hyrax::SolrQueryBuilderService.construct_query_for_rel(has_model: ::AdminSet.to_s, creator: current_user_key)
         ]
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += ["(#{clauses.join(' OR ')})"]

--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -114,7 +114,7 @@ module Hyrax
 
         def exclude_if_already_parent
           # 2) Exclude any of Collection F's direct children
-          "-" + ActiveFedora::SolrQueryBuilder.construct_query(Samvera::NestingIndexer.configuration.solr_field_name_for_storing_parent_ids => @collection.id)
+          "-" + Hyrax::SolrQueryBuilderService.construct_query(Samvera::NestingIndexer.configuration.solr_field_name_for_storing_parent_ids => @collection.id)
         end
     end
   end

--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -26,7 +26,7 @@ module Hyrax
       def show_only_other_collections_of_the_same_collection_type(solr_parameters)
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += [
-          "-" + Hyrax::SolrQueryBuilderService.construct_query_for_ids([limit_ids]),
+          "-" + Hyrax::SolrQueryBuilderService.construct_query_for_ids(limit_ids),
           Hyrax::SolrQueryBuilderService.construct_query(Collection.collection_type_gid_document_field_name => @collection.collection_type_gid)
         ]
         solr_parameters[:fq] += limit_clause if limit_clause # add limits to prevent illegal nesting arrangements

--- a/app/search_builders/hyrax/dashboard/works_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/works_search_builder.rb
@@ -11,7 +11,7 @@ module Hyrax
       def show_only_managed_works_for_non_admins(solr_parameters)
         return if current_ability.admin?
         solr_parameters[:fq] ||= []
-        solr_parameters[:fq] << '-' + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key)
+        solr_parameters[:fq] << '-' + Hyrax::SolrQueryBuilderService.construct_query_for_rel(depositor: current_user_key)
       end
     end
   end

--- a/app/search_builders/hyrax/my/collections_search_builder.rb
+++ b/app/search_builders/hyrax/my/collections_search_builder.rb
@@ -10,8 +10,8 @@ class Hyrax::My::CollectionsSearchBuilder < ::SearchBuilder
   # @param [Hash] solr_parameters
   def show_only_collections_deposited_by_current_user(solr_parameters)
     clauses = [
-      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key),
-      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::AdminSet.to_s, creator: current_user_key)
+      Hyrax::SolrQueryBuilderService.construct_query_for_rel(depositor: current_user_key),
+      Hyrax::SolrQueryBuilderService.construct_query_for_rel(has_model: ::AdminSet.to_s, creator: current_user_key)
     ]
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] += ["(#{clauses.join(' OR ')})"]

--- a/app/search_builders/hyrax/my/search_builder.rb
+++ b/app/search_builders/hyrax/my/search_builder.rb
@@ -13,7 +13,7 @@ module Hyrax
       def show_only_resources_deposited_by_current_user(solr_parameters)
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += [
-          ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key)
+          Hyrax::SolrQueryBuilderService.construct_query_for_rel(depositor: current_user_key)
         ]
       end
     end

--- a/app/search_builders/hyrax/my/shares_search_builder.rb
+++ b/app/search_builders/hyrax/my/shares_search_builder.rb
@@ -7,7 +7,7 @@ class Hyrax::My::SharesSearchBuilder < Hyrax::SearchBuilder
   def show_only_shared_files(solr_parameters)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] += [
-      "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key)
+      "-" + Hyrax::SolrQueryBuilderService.construct_query_for_rel(depositor: current_user_key)
     ]
   end
 end

--- a/app/services/hyrax/solr_query_builder_service.rb
+++ b/app/services/hyrax/solr_query_builder_service.rb
@@ -12,6 +12,19 @@ module Hyrax
         "{!terms f=#{Hyrax.config.id_field}}#{ids.join(',')}"
       end
 
+      # Create a raw query with a clause for each key, value
+      # @param [Hash, Array<Array<String>>] field_pairs key is the predicate, value is the target_uri
+      # @param [String] join_with ('AND') the value we're joining the clauses with
+      # @example
+      #   construct_query_for_rel [[:has_model, "ComplexCollection"], [:has_model, "ActiveFedora_Base"]], 'OR'
+      #   # => _query_:"{!raw f=has_model_ssim}ComplexCollection" OR _query_:"{!raw f=has_model_ssim}ActiveFedora_Base"
+      #
+      #   construct_query_for_rel [[Book._reflect_on_association(:library), "foo/bar/baz"]]
+      def construct_query_for_rel(field_pairs, join_with = default_join_with)
+        field_pairs = field_pairs.to_a if field_pairs.is_a? Hash
+        construct_query(property_values_to_solr(field_pairs), join_with, 'raw'.freeze)
+      end
+
       # Construct a solr query from a list of pairs (e.g. [field name, values])
       # @param [Array<Array>] field_pairs a list of pairs of property name and values
       # @param [String] join_with ('AND') the value we're joining the clauses with
@@ -56,6 +69,30 @@ module Hyrax
               # Check that the field is not present. In SQL: "WHERE field IS NULL"
               "-#{field}:[* TO *]"
             end
+          end
+        end
+
+        # Given a list of pairs (e.g. [field name, values]), convert the field names
+        # to solr names
+        # @param [Array<Array>] pairs a list of pairs of property name and values
+        # @return [Hash] map of solr fields to values
+        # @example
+        #   property_values_to_solr([['library_id', '123'], ['owner', 'Fred']])
+        #   # => [['library_id_ssim', '123'], ['owner_ssim', 'Fred']]
+        def property_values_to_solr(pairs)
+          pairs.map do |(property, value)|
+            [solr_field(property), value]
+          end
+        end
+
+        # @param [String, ActiveFedora::Relation] field
+        # @return [String] the corresponding solr field for the string
+        def solr_field(field)
+          # solr_key is a property of ActiveFedora::Reflection
+          if field.respond_to? :solr_key
+            field.solr_key
+          else
+            Hyrax.config.index_field_mapper.solr_name(field, :symbol)
           end
         end
 

--- a/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
 
     it "is successful" do
       subject
-      expect(solr_params[:fq]).to eq [ActiveFedora::SolrQueryBuilder.construct_query(title_tesim: q)]
+      expect(solr_params[:fq]).to eq [Hyrax::SolrQueryBuilderService.construct_query(title_tesim: q)]
     end
   end
 
@@ -48,7 +48,7 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
 
     it "is successful" do
       subject
-      expect(solr_params[:fq]).to eq ["-" + ActiveFedora::SolrQueryBuilder.construct_query(member_ids_ssim: work.id)]
+      expect(solr_params[:fq]).to eq ["-" + Hyrax::SolrQueryBuilderService.construct_query(member_ids_ssim: work.id)]
     end
   end
 

--- a/spec/search_builders/hyrax/my/shares_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/shares_search_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::My::SharesSearchBuilder do
     # This prevents any generated classes from interfering with this test:
     allow(builder).to receive(:work_classes).and_return([GenericWork])
 
-    allow(ActiveFedora::SolrQueryBuilder).to receive(:construct_query_for_rel)
+    allow(Hyrax::SolrQueryBuilderService).to receive(:construct_query_for_rel)
       .with(depositor: me.user_key)
       .and_return("depositor")
   end

--- a/spec/search_builders/hyrax/my/works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/works_search_builder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::My::WorksSearchBuilder do
       # This prevents any generated classes from interfering with this test:
       allow(builder).to receive(:work_classes).and_return([GenericWork])
 
-      allow(ActiveFedora::SolrQueryBuilder).to receive(:construct_query_for_rel)
+      allow(Hyrax::SolrQueryBuilderService).to receive(:construct_query_for_rel)
         .with(depositor: me.user_key)
         .and_return("depositor")
     end


### PR DESCRIPTION
Fixes #3791

Similar to #3793 and #3792, extracts construct_query_for_rel from ActiveFedora::SolrQueryBuilder and places in Hyrax::SolrQueryBuilderService.

Requires additional methods from the original class and workarounds to avoid using ActiveFedora::Reflection::AssociationReflection and ActiveFedora.index_field_mapper. Replaces calls for the original method (and some calls to construct_query that should have been caught in 3793).
Part of the work to remove calls to ActiveFedora from Hyrax.