### PR TITLE
define Hyrax::ObjectNotFoundError

### DIFF
--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -18,7 +18,7 @@ module Hyrax
         # For derivatives stored on the local file system
         send_local_content
       else
-        raise ActiveFedora::ObjectNotFoundError
+        raise Hyrax::ObjectNotFoundError
       end
     end
 

--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -30,31 +30,31 @@ module Hyrax
 
     # A bit of an analogue for a `belongs_to :source_model` as it crosses from Fedora to the DB
     # @return [AdminSet | Collection]
-    # @raise [ActiveFedora::ObjectNotFoundError] when neither an AdminSet or Collection is found
+    # @raise [Hyrax::ObjectNotFoundError] when neither an AdminSet or Collection is found
     def source_model
       admin_set
-    rescue ActiveFedora::ObjectNotFoundError
+    rescue Hyrax::ObjectNotFoundError
       collection
     end
 
     # A bit of an analogue for a `belongs_to :admin_set` as it crosses from Fedora to the DB
     # @return [AdminSet]
-    # @raise [ActiveFedora::ObjectNotFoundError] when the we cannot find the AdminSet
+    # @raise [Hyrax::ObjectNotFoundError] when the we cannot find the AdminSet
     def admin_set
       return AdminSet.find(source_id) if AdminSet.exists?(source_id)
-      raise ActiveFedora::ObjectNotFoundError
+      raise Hyrax::ObjectNotFoundError
     rescue ActiveFedora::ActiveFedoraError # TODO: remove the rescue when active_fedora issue #1276 is fixed
-      raise ActiveFedora::ObjectNotFoundError
+      raise Hyrax::ObjectNotFoundError
     end
 
     # A bit of an analogue for a `belongs_to :collection` as it crosses from Fedora to the DB
     # @return [Collection]
-    # @raise [ActiveFedora::ObjectNotFoundError] when the we cannot find the Collection
+    # @raise [Hyrax::ObjectNotFoundError] when the we cannot find the Collection
     def collection
       return Collection.find(source_id) if Collection.exists?(source_id)
-      raise ActiveFedora::ObjectNotFoundError
+      raise Hyrax::ObjectNotFoundError
     rescue ActiveFedora::ActiveFedoraError # TODO: remove the rescue when active_fedora issue #1276 is fixed
-      raise ActiveFedora::ObjectNotFoundError
+      raise Hyrax::ObjectNotFoundError
     end
 
     # Valid Release Period values

--- a/app/services/hyrax/graph_exporter.rb
+++ b/app/services/hyrax/graph_exporter.rb
@@ -20,7 +20,7 @@ module Hyrax
       end
     rescue Ldp::NotFound
       # this error is handled with a 404 page.
-      raise ActiveFedora::ObjectNotFoundError
+      raise Hyrax::ObjectNotFoundError
     end
 
     private

--- a/app/services/hyrax/thumbnail_path_service.rb
+++ b/app/services/hyrax/thumbnail_path_service.rb
@@ -24,7 +24,7 @@ module Hyrax
         def fetch_thumbnail(object)
           return object if object.thumbnail_id == object.id
           Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: object.thumbnail_id)
-        rescue Valkyrie::Persistence::ObjectNotFoundError
+        rescue Hyrax::ObjectNotFoundError
           Rails.logger.error("Couldn't find thumbnail #{object.thumbnail_id} for #{object.id}")
           nil
         end

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -29,7 +29,8 @@ module Hyrax
 
     config.action_dispatch.rescue_responses.merge!(
       "ActiveFedora::ObjectNotFoundError" =>     :not_found, # We can remove this when we use ActiveFedora 11.2
-      "Blacklight::Exceptions::RecordNotFound" => :not_found
+      "Blacklight::Exceptions::RecordNotFound" => :not_found,
+      "Hyrax::ObjectNotFoundError" => :not_found
     )
 
     config.before_initialize do

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -30,6 +30,7 @@ module Hyrax
     config.action_dispatch.rescue_responses.merge!(
       "ActiveFedora::ObjectNotFoundError" =>     :not_found, # We can remove this when we use ActiveFedora 11.2
       "Blacklight::Exceptions::RecordNotFound" => :not_found,
+      "Valkyrie::ObjectNotFoundError" => :not_found,
       "Hyrax::ObjectNotFoundError" => :not_found
     )
 

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -30,7 +30,7 @@ module Hyrax
     config.action_dispatch.rescue_responses.merge!(
       "ActiveFedora::ObjectNotFoundError" =>     :not_found, # We can remove this when we use ActiveFedora 11.2
       "Blacklight::Exceptions::RecordNotFound" => :not_found,
-      "Valkyrie::ObjectNotFoundError" => :not_found,
+      "Valkyrie::Persistence::ObjectNotFoundError" => :not_found,
       "Hyrax::ObjectNotFoundError" => :not_found
     )
 

--- a/lib/hyrax/errors.rb
+++ b/lib/hyrax/errors.rb
@@ -8,4 +8,6 @@ module Hyrax
   class WorkflowAuthorizationException < HyraxError; end
 
   class SingleUseError < HyraxError; end
+
+  class ObjectNotFoundError < HyraxError; end
 end

--- a/lib/hyrax/errors.rb
+++ b/lib/hyrax/errors.rb
@@ -1,4 +1,6 @@
 module Hyrax
+  require 'active_fedora/errors'
+
   # Generic Hyrax exception class.
   class HyraxError < StandardError; end
 

--- a/lib/hyrax/errors.rb
+++ b/lib/hyrax/errors.rb
@@ -9,5 +9,5 @@ module Hyrax
 
   class SingleUseError < HyraxError; end
 
-  class ObjectNotFoundError < HyraxError; end
+  class ObjectNotFoundError < ActiveFedora::ObjectNotFoundError; end
 end

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -25,7 +25,7 @@ module Wings
       # Find a record using a Valkyrie ID, and map it to a Valkyrie Resource
       # @param [Valkyrie::ID, String] id
       # @return [Valkyrie::Resource]
-      # @raise [Valkyrie::Persistence::ObjectNotFoundError]
+      # @raise [Hyrax::ObjectNotFoundError]
       def find_by(id:)
         find_by_alternate_identifier(alternate_identifier: id)
       end
@@ -80,15 +80,15 @@ module Wings
       # @param [Valkyrie::ID, String] id
       # @param [boolean] optionally return ActiveFedora object/errors
       # @return [Valkyrie::Resource]
-      # @raise [Valkyrie::Persistence::ObjectNotFoundError]
+      # @raise [Hyrax::ObjectNotFoundError]
       def find_by_alternate_identifier(alternate_identifier:, use_valkyrie: true)
         alternate_identifier = ::Valkyrie::ID.new(alternate_identifier.to_s) if alternate_identifier.is_a?(String)
         validate_id(alternate_identifier)
         object = ::ActiveFedora::Base.find(alternate_identifier.to_s)
         return object if use_valkyrie == false
         resource_factory.to_resource(object: object)
-      rescue ::ActiveFedora::ObjectNotFoundError, Ldp::Gone => e
-        raise use_valkyrie == true ? ::Valkyrie::Persistence::ObjectNotFoundError : e
+      rescue ActiveFedora::ObjectNotFoundError, Ldp::Gone => e
+        raise Hyrax::ObjectNotFoundError
       end
 
       # Find all members of a given resource, and map to Valkyrie Resources

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -87,7 +87,7 @@ module Wings
         object = ::ActiveFedora::Base.find(alternate_identifier.to_s)
         return object if use_valkyrie == false
         resource_factory.to_resource(object: object)
-      rescue ActiveFedora::ObjectNotFoundError, Ldp::Gone => e
+      rescue ActiveFedora::ObjectNotFoundError, Ldp::Gone
         raise Hyrax::ObjectNotFoundError
       end
 

--- a/spec/controllers/hyrax/api/items_controller_spec.rb
+++ b/spec/controllers/hyrax/api/items_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Hyrax::API::ItemsController, type: :controller do
 
       before do
         allow(Hyrax::WorkRelation).to receive(:new).and_return(relation)
-        allow(relation).to receive(:find).with(default_work.id).and_raise(ActiveFedora::ObjectNotFoundError)
+        allow(relation).to receive(:find).with(default_work.id).and_raise(Hyrax::ObjectNotFoundError)
         get :show, params: { format: :json, id: default_work.id, token: token }
       end
 
@@ -231,7 +231,7 @@ RSpec.describe Hyrax::API::ItemsController, type: :controller do
       before do
         allow(Hyrax::WorkRelation).to receive(:new).and_return(relation)
         allow(relation).to receive(:find).with(gw.id) do
-          raise(ActiveFedora::ObjectNotFoundError)
+          raise(Hyrax::ObjectNotFoundError)
         end
         put :update, params: { id: gw.id, format: :json }, body: put_item
       end
@@ -368,7 +368,7 @@ RSpec.describe Hyrax::API::ItemsController, type: :controller do
       before do
         # Mock ActiveFedora
         allow(Hyrax::WorkRelation).to receive(:new).and_return(relation)
-        allow(relation).to receive(:find).with(not_found_id).and_raise(ActiveFedora::ObjectNotFoundError)
+        allow(relation).to receive(:find).with(not_found_id).and_raise(Hyrax::ObjectNotFoundError)
         delete :destroy, params: { format: :json, id: not_found_id, token: token }
       end
 

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Hyrax::DownloadsController do
           it "raises an error if the requested file does not exist" do
             expect do
               get :show, params: { id: file_set, file: 'thumbnail' }
-            end.to raise_error ActiveFedora::ObjectNotFoundError
+            end.to raise_error Hyrax::ObjectNotFoundError
           end
         end
       end
@@ -129,7 +129,7 @@ RSpec.describe Hyrax::DownloadsController do
       it "raises an error if the requested association does not exist" do
         expect do
           get :show, params: { id: file_set, file: 'non-existant' }
-        end.to raise_error ActiveFedora::ObjectNotFoundError
+        end.to raise_error Hyrax::ObjectNotFoundError
       end
     end
   end

--- a/spec/models/hyrax/permission_template_spec.rb
+++ b/spec/models/hyrax/permission_template_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::PermissionTemplate, :clean_repo do
       end
       it 'will not persist an AdminSet when false (or not given)' do
         permission_template = create(:permission_template, with_admin_set: false)
-        expect { permission_template.admin_set }.to raise_error(ActiveFedora::ObjectNotFoundError)
+        expect { permission_template.admin_set }.to raise_error(Hyrax::ObjectNotFoundError)
       end
     end
 
@@ -29,7 +29,7 @@ RSpec.describe Hyrax::PermissionTemplate, :clean_repo do
       end
       it 'will not persist an Collection when false (or not given)' do
         permission_template = create(:permission_template, with_collection: false)
-        expect { permission_template.collection }.to raise_error(ActiveFedora::ObjectNotFoundError)
+        expect { permission_template.collection }.to raise_error(Hyrax::ObjectNotFoundError)
       end
     end
 

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Wings::Valkyrie::Persister do
     it "can delete objects" do
       persisted = persister.save(resource: resource)
       persister.delete(resource: persisted)
-      expect { query_service.find_by(id: persisted.id) }.to raise_error ::Valkyrie::Persistence::ObjectNotFoundError
+      expect { query_service.find_by(id: persisted.id) }.to raise_error Hyrax::ObjectNotFoundError
     end
 
     it "can delete all objects" do
@@ -350,7 +350,7 @@ RSpec.describe Wings::Valkyrie::Persister do
     it "can delete objects" do
       persisted = persister.save(resource: resource)
       persister.delete(resource: persisted)
-      expect { query_service.find_by(id: persisted.id) }.to raise_error ::Valkyrie::Persistence::ObjectNotFoundError
+      expect { query_service.find_by(id: persisted.id) }.to raise_error Hyrax::ObjectNotFoundError
     end
 
     it "can delete all objects" do

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Wings::Valkyrie::QueryService do
       expect(found).to be_persisted
     end
 
-    it "returns a Valkyrie::Persistence::ObjectNotFoundError for a non-found ID" do
-      expect { query_service.find_by(id: ::Valkyrie::ID.new("123123123")) }.to raise_error ::Valkyrie::Persistence::ObjectNotFoundError
+    it "returns a Hyrax::ObjectNotFoundError for a non-found ID" do
+      expect { query_service.find_by(id: ::Valkyrie::ID.new("123123123")) }.to raise_error Hyrax::ObjectNotFoundError
     end
 
     it 'raises an error if the id is not a Valkyrie::ID or a string' do
@@ -126,13 +126,13 @@ RSpec.describe Wings::Valkyrie::QueryService do
     # Not a use case that Hyrax has; everything has to have an alternate_id
     #   We can't make this test pass because we can't persist an object without
     #   an alternate_id
-    xit 'raises a Valkyrie::Persistence::ObjectNotFoundError when persisted objects do not have alternate_ids' do
+    xit 'raises a Hyrax::ObjectNotFoundError when persisted objects do not have alternate_ids' do
       persister.save(resource: SecondResource.new)
-      expect { query_service.find_by_alternate_identifier(alternate_identifier: Valkyrie::ID.new("123123123")) }.to raise_error ::Valkyrie::Persistence::ObjectNotFoundError
+      expect { query_service.find_by_alternate_identifier(alternate_identifier: Valkyrie::ID.new("123123123")) }.to raise_error Hyrax::ObjectNotFoundError
     end
 
-    it "raises a Valkyrie::Persistence::ObjectNotFoundError for a non-found alternate identifier" do
-      expect { query_service.find_by_alternate_identifier(alternate_identifier: Valkyrie::ID.new("123123123")) }.to raise_error ::Valkyrie::Persistence::ObjectNotFoundError
+    it "raises a Hyrax::ObjectNotFoundError for a non-found alternate identifier" do
+      expect { query_service.find_by_alternate_identifier(alternate_identifier: Valkyrie::ID.new("123123123")) }.to raise_error Hyrax::ObjectNotFoundError
     end
 
     it 'raises an error if the alternate identifier is not a Valkyrie::ID or a string' do
@@ -167,7 +167,7 @@ RSpec.describe Wings::Valkyrie::QueryService do
       end
 
       it 'returns an ActiveFedora error' do
-        expect { query_service.find_by_alternate_identifier(alternate_identifier: Valkyrie::ID.new("123123123"), use_valkyrie: false) }.to raise_error ::ActiveFedora::ObjectNotFoundError
+        expect { query_service.find_by_alternate_identifier(alternate_identifier: Valkyrie::ID.new("123123123"), use_valkyrie: false) }.to raise_error ActiveFedora::ObjectNotFoundError
       end
     end
   end


### PR DESCRIPTION
Fixes #3823

Adds Hyrax::ObjectNotFoundError for use instead of ActiveFedora::ObjectNotFoundError.
