### PR TITLE
fix circleci config to match masters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,9 +129,3 @@ workflows:
           requires:
             - build
             - lint
-      - test:
-          name: "ruby2-6-2"
-          ruby_version: "2.6.2"
-          requires:
-            - build
-            - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,195 +1,137 @@
-# Ruby CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-ruby/ for more details
-#
 version: 2.1
-executors:
-  ruby:
-    docker:
-      - image: circleci/ruby:2.5.3
-    working_directory: ~/hyrax
-    environment:
-      BUNDLE_PATH: vendor/bundle
-      BUNDLE_JOBS: 4
-      BUNDLE_RETRY: 3
-
+orbs:
+  samvera: samvera/circleci-orb@0
 jobs:
   bundle:
-    executor: ruby
+    parameters:
+      ruby_version:
+        type: string
+        default: 2.5.5
+      bundler_version:
+        type: string
+        default: 1.17.3
+      rails_version:
+        type: string
+        default: '5.2.2'
+    executor:
+      name: 'samvera/ruby'
+      ruby_version: << parameters.ruby_version >>
+    resource_class: medium+
+    environment:
+      RAILS_VERSION: << parameters.rails_version >>
+      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
     steps:
-    - restore_cache:
-        keys:
-        - v1-source-{{ .Branch }}-{{ .Revision }}
-        - v1-source-{{ .Branch }}-
-        - v1-source-
-
-    - checkout
-
-    - save_cache:
-        key: v1-source-{{ .Branch }}-{{ .Revision }}
-        paths:
-        - ".git"
-
-    - restore_cache:
-        keys:
-        - v1-bundle-{{ checksum "Gemfile" }}--{{ checksum "hyrax.gemspec" }}
-        - v1-bundle
-
-    - run:
-        name: Install dependencies
-        command: bundle check || bundle install
-
-    - save_cache:
-        key: v1-bundle-{{ checksum "Gemfile.lock" }}--{{ checksum "hyrax.gemspec" }}
-        paths:
-        - ~/hyrax/vendor/bundle
-
-    - persist_to_workspace:
-        root: ~/
-        paths:
-        - hyrax/*
-        - hyrax/**/*
+      - samvera/cached_checkout
+      - samvera/bundle_for_gem:
+          ruby_version: << parameters.ruby_version >>
+          bundler_version: << parameters.bundler_version >>
+          project: hyrax
+      - persist_to_workspace:
+          root: ~/
+          paths:
+          - project/*
+          - project/**/*
 
   lint:
-    executor: ruby
+    parameters:
+      ruby_version:
+        type: string
+        default: 2.5.5
+    executor:
+      name: 'samvera/ruby'
+      ruby_version: << parameters.ruby_version >>
+    resource_class: medium+
     steps:
-    - attach_workspace:
-        at: ~/
-
-    - run:
-        name: Call Rubocop
-        command: bundle exec rubocop
+      - attach_workspace:
+          at: ~/
+      - samvera/rubocop
 
   build:
-    docker:
-    - image: circleci/ruby:2.5.3-node
-
-    working_directory: ~/hyrax
-
+    parameters:
+      ruby_version:
+        type: string
+        default: 2.5.5
+      bundler_version:
+        type: string
+        default: 1.17.3
+      rails_version:
+        type: string
+        default: '5.2.2'
+    executor:
+      name: 'samvera/ruby'
+      ruby_version: << parameters.ruby_version >>
+    resource_class: medium+
     environment:
-      BUNDLE_PATH: vendor/bundle
-      BUNDLE_JOBS: 4
-      BUNDLE_RETRY: 3
-      RAILS_ENV: test
-      RACK_ENV: test
-      FCREPO_TEST_PORT: 8080/fcrepo
+      RAILS_VERSION: << parameters.rails_version >>
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
       ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-action-cable --skip-coffee --skip-puma --skip-test
-      SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
-      COVERALLS_PARALLEL: true
-
     steps:
-    - attach_workspace:
-        at: ~/
-
-    # Update to the latest release of Chrome
-    - run: wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-    - run: sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-    - run: sudo apt-get update && sudo apt-get -y install google-chrome-stable
-
-    - restore_cache:
-        keys:
-        - v1-test-app-{{ checksum "template.rb" }}--{{ checksum "Gemfile.lock" }}
-
-    - run:
-        name: Check dependencies
-        command: bundle check || bundle install
-
-    - run:
-        name: Generate test app
-        command: (git diff --name-only master | grep -qG 'generators\/hyrax') || bundle exec rake engine_cart:generate
-
-    - run:
-        name: Ensure test app dependencies are installed
-        command: |
-          cd .internal_test_app
-          bundle check || bundle install
-
-    - save_cache:
-        key: v1-test-app-{{ checksum "template.rb" }}--{{ checksum "Gemfile.lock" }}
-        paths:
-        - ".internal_test_app"
-
-    - persist_to_workspace:
-        root: ~/
-        paths:
-        - hyrax/*
-        - hyrax/**/*
+      - attach_workspace:
+          at: ~/
+      - samvera/engine_cart_generate:
+          cache_key: v1-internal-test-app-{{ checksum "hyrax.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/hyrax/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
+      - samvera/bundle_for_gem:
+          ruby_version: << parameters.ruby_version >>
+          bundler_version: << parameters.bundler_version >>
+          project: hyrax
+      - persist_to_workspace:
+          root: ~/
+          paths:
+          - project/*
+          - project/**/*
 
   test:
-    docker:
-    - image: circleci/ruby:2.5.3-node-browsers-legacy
-    - image: circleci/redis:4
-    - image: ualbertalib/docker-fcrepo4:4.7
-      environment:
-        CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC"
-    - image: solr:7-alpine
-      command: bin/solr -cloud -noprompt -f -p 8985
-
-    working_directory: ~/hyrax
-    parallelism: 4
-
+    parameters:
+      ruby_version:
+        type: string
+        default: 2.5.5
+      bundler_version:
+        type: string
+        default: 1.17.3
+    executor:
+      name: 'samvera/ruby_fcrepo_solr_redis'
+      ruby_version: << parameters.ruby_version >>
+    resource_class: medium+
+    parallelism: 10
     environment:
-      BUNDLE_PATH: vendor/bundle
-      BUNDLE_JOBS: 4
-      BUNDLE_RETRY: 3
-      RAILS_ENV: test
-      RACK_ENV: test
-      FCREPO_TEST_PORT: 8080/fcrepo
-      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-      ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-action-cable --skip-coffee --skip-puma --skip-test
-      SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
       COVERALLS_PARALLEL: true
-
     steps:
-    - attach_workspace:
-        at: ~/
-
-    - run:
-        name: Ensure top-level Gemfile.lock is valid
-        command: bundle check || bundle install
-
-    - run:
-        name: Uninstall chromedriver Gems
-        command: gem uninstall -ax chromedriver-helper
-
-    - run:
-        name: Install chromedriver Gems
-        command: gem install chromedriver-helper
-
-    - run:
-        name: Load config into solr
-        command: |
-          cd .internal_test_app/solr/config
-          zip -1 -r solr_hyrax_config.zip ./*
-          curl -H "Content-type:application/octet-stream" --data-binary @solr_hyrax_config.zip "http://localhost:8985/solr/admin/configs?action=UPLOAD&name=hyrax"
-          curl -H 'Content-type: application/json' http://localhost:8985/api/collections/ -d '{create: {name: hydra-test, config: hyrax, numShards: 1}}'
-
-    - run:
-        name: Run rspec in parallel
-        command: |
-          mkdir /tmp/test-results
-          bundle exec rspec $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-
-    # collect reports
-    - store_test_results:
-        path: /tmp/test-results
-    - store_artifacts:
-        path: /tmp/test-results
-        destination: test-results
+      - attach_workspace:
+          at: ~/
+      - samvera/install_solr_core:
+          solr_config_path: .internal_test_app/solr/config
+      # Rerun bundler in case this is a different ruby version than bundle and build steps
+      - samvera/bundle_for_gem:
+          ruby_version: << parameters.ruby_version >>
+          bundler_version: << parameters.bundler_version >>
+          project: hyrax
+      - samvera/parallel_rspec
 
 workflows:
   version: 2
   ci:
     jobs:
-      - bundle
+      - bundle:
+          ruby_version: "2.5.5"
+          rails_version: "5.1.7"
       - lint:
+          ruby_version: "2.5.5"
           requires:
             - bundle
       - build:
+          ruby_version: "2.5.5"
+          rails_version: "5.1.7"
           requires:
             - bundle
       - test:
+          name: "ruby2-5-5"
+          ruby_version: "2.5.5"
+          requires:
+            - build
+            - lint
+      - test:
+          name: "ruby2-6-2"
+          ruby_version: "2.6.2"
           requires:
             - build
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,3 +129,9 @@ workflows:
           requires:
             - build
             - lint
+      - test:
+          name: "ruby2-6-2"
+          ruby_version: "2.6.2"
+          requires:
+            - build
+            - lint

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -105,6 +105,7 @@ SUMMARY
   spec.add_development_dependency 'bixby', '~> 1.0.0'
   spec.add_development_dependency 'shoulda-callback-matchers', '~> 1.1.1'
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
+  spec.add_development_dependency 'webdrivers', '~> 3.0'
   spec.add_development_dependency 'webmock'
 
   ########################################################

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,7 @@ require 'rspec/active_model/mocks'
 require 'capybara/rspec'
 require 'capybara/rails'
 require 'selenium-webdriver'
-require 'chromedriver-helper'
+require 'webdrivers'
 require 'equivalent-xml'
 require 'equivalent-xml/rspec_matchers'
 require 'database_cleaner'
@@ -62,7 +62,7 @@ end
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 
 require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow_localhost: true, allow: 'chromedriver.storage.googleapis.com')
 
 require 'i18n/debug' if ENV['I18N_DEBUG']
 require 'byebug' unless ci_build?
@@ -82,6 +82,10 @@ end
 
 Capybara.default_driver = :rack_test # This is a faster driver
 Capybara.javascript_driver = :selenium_chrome_headless_sandboxless # This is slower
+
+# FIXME: Pin to older version of chromedriver to avoid issue with clicking
+# non-visible elements
+Webdrivers::Chromedriver.version = '72.0.3626.69'
 
 ActiveJob::Base.queue_adapter = :test
 
@@ -192,11 +196,11 @@ RSpec.configure do |config|
 
   config.before(:each, type: :view) do
     initialize_controller_helpers(view)
-    WebMock.disable_net_connect!(allow_localhost: false)
+    WebMock.disable_net_connect!(allow_localhost: false, allow: 'chromedriver.storage.googleapis.com')
   end
 
   config.after(:each, type: :view) do
-    WebMock.disable_net_connect!(allow_localhost: true)
+    WebMock.disable_net_connect!(allow_localhost: true, allow: 'chromedriver.storage.googleapis.com')
   end
 
   config.before(:all, type: :feature) do


### PR DESCRIPTION
Fixes CircleCI failing on 2.x-stable branch due to chrome driver

Circle CI config continues to evolve and along the way solved the chrome driver issue. This backports that code from master to the 2.x branch.

Changes proposed in this pull request:
* updates .circle/config to match master

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* [best lawyer voice] if the CI don't loose you must approve!

