### PR TITLE
Normalize Valkyrie configuration

### DIFF
--- a/app/actors/hyrax/actors/add_to_work_actor.rb
+++ b/app/actors/hyrax/actors/add_to_work_actor.rb
@@ -42,7 +42,7 @@ module Hyrax
 
         def cleanup_ids_to_remove_from_curation_concern(env, new_work_ids)
           (env.curation_concern.in_works_ids - new_work_ids).each do |old_id|
-            work = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: old_id, use_valkyrie: false)
+            work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: old_id, use_valkyrie: false)
             work.ordered_members.delete(env.curation_concern)
             work.members.delete(env.curation_concern)
             work.save!

--- a/app/actors/hyrax/actors/apply_order_actor.rb
+++ b/app/actors/hyrax/actors/apply_order_actor.rb
@@ -27,7 +27,7 @@ module Hyrax
         # @see Hyrax::Actors::AddToWorkActor for duplication
         def cleanup_ids_to_remove_from_curation_concern(curation_concern, ordered_member_ids)
           (curation_concern.ordered_member_ids - ordered_member_ids).each do |old_id|
-            work = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: old_id, use_valkyrie: false)
+            work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: old_id, use_valkyrie: false)
             curation_concern.ordered_members.delete(work)
             curation_concern.members.delete(work)
           end
@@ -35,7 +35,7 @@ module Hyrax
 
         def add_new_work_ids_not_already_in_curation_concern(env, ordered_member_ids)
           (ordered_member_ids - env.curation_concern.ordered_member_ids).each do |work_id|
-            work = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: work_id, use_valkyrie: false)
+            work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: work_id, use_valkyrie: false)
             if can_edit_both_works?(env, work)
               env.curation_concern.ordered_members << work
               env.curation_concern.save!

--- a/app/actors/hyrax/actors/attach_members_actor.rb
+++ b/app/actors/hyrax/actors/attach_members_actor.rb
@@ -43,14 +43,14 @@ module Hyrax
         # Adds the item to the ordered members so that it displays in the items
         # along side the FileSets on the show page
         def add(env, id)
-          member = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false)
+          member = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false)
           return unless env.current_ability.can?(:edit, member)
           env.curation_concern.ordered_members << member
         end
 
         # Remove the object from the members set and the ordered members list
         def remove(curation_concern, id)
-          member = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false)
+          member = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false)
           curation_concern.ordered_members.delete(member)
           curation_concern.members.delete(member)
         end

--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -73,10 +73,9 @@ module Hyrax
           env.curation_concern.embargo&.save
           env.curation_concern.lease&.save
 
-          adapter  = Valkyrie.config.metadata_adapter
-          resource = adapter.persister.save(resource: env.curation_concern.valkyrie_resource)
+          resource = Hyrax.persister.save(resource: env.curation_concern.valkyrie_resource)
 
-          env.curation_concern = adapter.resource_factory.from_resource(resource: resource)
+          env.curation_concern = Hyrax.metadata_adapter.resource_factory.from_resource(resource: resource)
         rescue Wings::Valkyrie::Persister::FailedSaveError => _err
           # for now, just hit the validation error again
           # later we should capture the _err.obj and pass it back

--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -73,7 +73,7 @@ module Hyrax
           env.curation_concern.embargo&.save
           env.curation_concern.lease&.save
 
-          adapter  = Hyrax.config.valkyrie_metadata_adapter
+          adapter  = Valkyrie.config.metadata_adapter
           resource = adapter.persister.save(resource: env.curation_concern.valkyrie_resource)
 
           env.curation_concern = adapter.resource_factory.from_resource(resource: resource)

--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -91,10 +91,8 @@ module Hyrax
         end
 
         def node_builder
-          storage_adapter = Valkyrie.config.storage_adapter
-          persister = Valkyrie.config.metadata_adapter.persister # TODO: Explore why valkyrie6 branch used indexing_persister adapter for this
-          Wings::FileNodeBuilder.new(storage_adapter: storage_adapter,
-                                     persister: persister)
+          Wings::FileNodeBuilder.new(storage_adapter: Hyrax.storage_adapter,
+                                     persister:       Hyrax.persister)
         end
 
         def normalize_relation(relation, use_valkyrie: false)

--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -25,7 +25,7 @@ module Hyrax
     end
 
     def show
-      @curation_concern ||= Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: params[:id], use_valkyrie: false)
+      @curation_concern ||= Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id], use_valkyrie: false)
       presenter
       query_collection_members
     end

--- a/app/controllers/hyrax/batch_edits_controller.rb
+++ b/app/controllers/hyrax/batch_edits_controller.rb
@@ -38,7 +38,7 @@ module Hyrax
 
     def destroy_collection
       batch.each do |doc_id|
-        obj = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false)
+        obj = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false)
         obj.destroy
       end
       flash[:notice] = "Batch delete complete"
@@ -60,7 +60,7 @@ module Hyrax
       case params["update_type"]
       when "update"
         batch.each do |doc_id|
-          update_document(Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false))
+          update_document(Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false))
         end
         flash[:notice] = "Batch update complete"
         after_update
@@ -82,7 +82,7 @@ module Hyrax
       end
 
       def destroy_batch
-        batch.each { |id| Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false).destroy }
+        batch.each { |id| Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false).destroy }
         after_update
       end
 

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -202,7 +202,7 @@ module Hyrax
         end
 
         def link_parent_collection(parent_id)
-          parent = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: parent_id, use_valkyrie: false)
+          parent = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: parent_id, use_valkyrie: false)
           Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent, child: @collection)
         end
 
@@ -375,7 +375,7 @@ module Hyrax
 
         def remove_members_from_collection
           batch.each do |pid|
-            work = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: pid, use_valkyrie: false)
+            work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: pid, use_valkyrie: false)
             work.member_of_collections.delete @collection
             work.save!
           end

--- a/app/controllers/hyrax/permissions_controller.rb
+++ b/app/controllers/hyrax/permissions_controller.rb
@@ -28,7 +28,7 @@ module Hyrax
     end
 
     def curation_concern
-      @curation_concern ||= Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: params[:id], use_valkyrie: false)
+      @curation_concern ||= Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id], use_valkyrie: false)
     end
   end
 end

--- a/app/controllers/hyrax/single_use_links_viewer_controller.rb
+++ b/app/controllers/hyrax/single_use_links_viewer_controller.rb
@@ -59,7 +59,7 @@ module Hyrax
       end
 
       def asset
-        @asset ||= Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: single_use_link.item_id, use_valkyrie: false)
+        @asset ||= Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: single_use_link.item_id, use_valkyrie: false)
       end
 
       def current_ability

--- a/app/controllers/hyrax/workflow_actions_controller.rb
+++ b/app/controllers/hyrax/workflow_actions_controller.rb
@@ -16,7 +16,7 @@ module Hyrax
     private
 
       def curation_concern
-        @curation_concern ||= Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: params[:id], use_valkyrie: false)
+        @curation_concern ||= Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id], use_valkyrie: false)
       end
 
       def workflow_action_form

--- a/app/forms/hyrax/forms/batch_edit_form.rb
+++ b/app/forms/hyrax/forms/batch_edit_form.rb
@@ -64,7 +64,7 @@ module Hyrax
         def initialize_combined_fields
           # For each of the files in the batch, set the attributes to be the concatenation of all the attributes
           batch_document_ids.each_with_object({}) do |doc_id, combined_attributes|
-            work = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false)
+            work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false)
             terms.each do |field|
               combined_attributes[field] ||= []
               combined_attributes[field] = (combined_attributes[field] + work[field].to_a).uniq

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -63,7 +63,7 @@ module Hyrax
     #                   lib/wings/models/concerns/collection_behavior.rb
     def add_member_objects(new_member_ids)
       Array(new_member_ids).collect do |member_id|
-        member = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: member_id, use_valkyrie: false)
+        member = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: member_id, use_valkyrie: false)
         message = Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
         if message
           member.errors.add(:collections, message)

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -67,9 +67,8 @@ class JobIoWrapper < ApplicationRecord
 
   def file_set(use_valkyrie: false)
     return FileSet.find(file_set_id) unless use_valkyrie
-    adapter = Valkyrie.config.metadata_adapter
-    query_service = Wings::Valkyrie::QueryService.new(adapter: adapter)
-    query_service.find_by(id: Valkyrie::ID.new(file_set_id))
+
+    Hyrax.query_service.find_by(id: Valkyrie::ID.new(file_set_id))
     # TODO: At least temporarily, should this return the valkyrie resource version of the fileset or the active fedora fileset?
   end
 

--- a/app/services/hyrax/persist_directly_contained_output_file_service.rb
+++ b/app/services/hyrax/persist_directly_contained_output_file_service.rb
@@ -24,7 +24,7 @@ module Hyrax
     def self.retrieve_file_set(directives)
       uri = URI(directives.fetch(:url))
       raise ArgumentError, "#{uri} is not an http(s) uri" unless uri.is_a?(URI::HTTP)
-      Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: ActiveFedora::Base.uri_to_id(uri.to_s), use_valkyrie: false)
+      Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: ActiveFedora::Base.uri_to_id(uri.to_s), use_valkyrie: false)
     end
     private_class_method :retrieve_file_set
 

--- a/app/services/hyrax/thumbnail_path_service.rb
+++ b/app/services/hyrax/thumbnail_path_service.rb
@@ -23,8 +23,7 @@ module Hyrax
 
         def fetch_thumbnail(object)
           return object if object.thumbnail_id == object.id
-          service = Valkyrie.config.metadata_adapter.query_service
-          service.find_by_alternate_identifier(alternate_identifier: object.thumbnail_id)
+          Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: object.thumbnail_id)
         rescue Valkyrie::Persistence::ObjectNotFoundError
           Rails.logger.error("Couldn't find thumbnail #{object.thumbnail_id} for #{object.id}")
           nil

--- a/app/services/hyrax/workflow/deposited_notification.rb
+++ b/app/services/hyrax/workflow/deposited_notification.rb
@@ -13,7 +13,7 @@ module Hyrax
         end
 
         def users_to_notify
-          user_key = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: work_id, use_valkyrie: false).depositor
+          user_key = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: work_id, use_valkyrie: false).depositor
           super << ::User.find_by(email: user_key)
         end
     end

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -1,16 +1,4 @@
 Hyrax.config do |config|
-  # The MetadataAdapter to use when persisting resources with Valkyrie.
-  # NOTE: Until Hyrax has been reworked to be Valkyrie-native, the default
-  #       metadata adapter supported is :wings_adapter.
-  # @see lib/wings
-  # @see https://github.com/samvera-labs/valkyrie
-  # config.valkyrie_metadata_adapter = :wings_adapter
-
-  # The StorageAdapter to use when persisting resources with Valkyrie
-  # @see lib/wings
-  # @see https://github.com/samvera-labs/valkyrie
-  # config.valkyrie_storage_adapter = :fedora
-
   # Register roles that are expected by your implementation.
   # @see Hyrax::RoleRegistry for additional details.
   # @note there are magical roles as defined in Hyrax::RoleRegistry::MAGIC_ROLES

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -55,4 +55,20 @@ module Hyrax
   def self.primary_work_type
     config.curation_concerns.first
   end
+
+  def self.persister
+    metadata_adapter.persister
+  end
+
+  def self.metadata_adapter
+    Valkyrie.config.metadata_adapter
+  end
+
+  def self.storage_adapter
+    Valkyrie.config.storage_adapter
+  end
+
+  def self.query_service
+    metadata_adapter.query_service
+  end
 end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -222,28 +222,6 @@ module Hyrax
       registered_curation_concern_types.map(&:constantize)
     end
 
-    # The MetadataAdapter to use when persisting resources with Valkyrie
-    #
-    # @see lib/wings
-    # @see https://github.com/samvera-labs/valkyrie
-    def valkyrie_metadata_adapter
-      Valkyrie::MetadataAdapter.find(@valkyrie_metadata_adapter || :wings_adapter)
-    end
-
-    def valkyrie_metadata_adapter=(adapter)
-      raise StandardError, "Hyrax currently only supports :wings_adapter as the configured valkyrie_metadata_adapter." unless adapter == :wings_adapter
-      @valkyrie_metadata_adapter = adapter
-    end
-
-    # The StorageAdapter to use when persisting resources with Valkyrie
-    #
-    # @see lib/wings
-    # @see https://github.com/samvera-labs/valkyrie
-    def valkyrie_storage_adapter
-      Valkyrie::StorageAdapter.find(@valkyrie_storage_adapter || :fedora)
-    end
-    attr_writer :valkyrie_storage_adapter
-
     # A configuration point for changing the behavior of the license service.
     #
     # @!attribute [w] license_service_class

--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -45,7 +45,7 @@ module Wings
       # @return [Enumerable<ActiveFedora::Base> | Enumerable<Valkyrie::Resource>] an enumerable over the child collections
       # @todo There is no guarantee to collection ordering until Hyrax is fully valkyrie-native, see issue 3784
       def child_collections(valkyrie: false)
-        @child_collections_navigator ||= ChildCollectionsNavigator.new(query_service: ::Valkyrie.config.metadata_adapter.query_service)
+        @child_collections_navigator ||= ChildCollectionsNavigator.new(query_service: Hyrax.query_service)
         resources = @child_collections_navigator.find_child_collections(resource: self)
         return resources if valkyrie
         resources.map { |r| Wings::ActiveFedoraConverter.new(resource: r).convert }

--- a/lib/wings/models/file_node.rb
+++ b/lib/wings/models/file_node.rb
@@ -132,7 +132,7 @@ module Wings
     end
 
     def versions
-      query_service = Wings::Valkyrie::QueryService.new(adapter: ::Valkyrie.config.metadata_adapter)
+      query_service = Wings::Valkyrie::QueryService.new(adapter: Hyrax.metadata_adapter)
       query_service.find_members(resource: self, model: Wings::FileNode).to_a
     end
   end

--- a/lib/wings/services/id_converter_service.rb
+++ b/lib/wings/services/id_converter_service.rb
@@ -3,8 +3,7 @@
 module Wings
   class IdConverterService
     def self.convert_to_active_fedora_ids(valkyrie_ids)
-      metadata_adapter = Valkyrie.config.metadata_adapter
-      resources = valkyrie_ids.map { |id| metadata_adapter.query_service.find_by(id: id) }
+      resources = valkyrie_ids.map { |id| Hyrax.query_service.find_by(id: id) }
       resources.map { |resource| resource.id.id } # TODO: What if id.id is empty?
     end
 

--- a/lib/wings/services/id_converter_service.rb
+++ b/lib/wings/services/id_converter_service.rb
@@ -3,7 +3,7 @@
 module Wings
   class IdConverterService
     def self.convert_to_active_fedora_ids(valkyrie_ids)
-      metadata_adapter = Hyrax.config.valkyrie_metadata_adapter
+      metadata_adapter = Valkyrie.config.metadata_adapter
       resources = valkyrie_ids.map { |id| metadata_adapter.query_service.find_by(id: id) }
       resources.map { |resource| resource.id.id } # TODO: What if id.id is empty?
     end

--- a/lib/wings/valkyrie/storage/active_fedora.rb
+++ b/lib/wings/valkyrie/storage/active_fedora.rb
@@ -21,8 +21,7 @@ module Wings::Storage
 
       def file_set(file_node)
         file_set_id = file_node.file_set_id
-        query_service = Valkyrie.config.metadata_adapter.query_service
-        query_service.find_by(id: file_set_id)
+        Hyrax.query_service.find_by(id: file_set_id)
       end
   end
 end

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe Hyrax::Actors::FileActor do
     let(:fixture)  { fixture_file_upload('/world.png', 'image/png') }
     let(:huf) { Hyrax::UploadedFile.new(user: user, file: fixture) }
     let(:io) { JobIoWrapper.new(file_set_id: file_set.id, user: user, uploaded_file: huf, path: huf.uploader.path) }
-    let(:storage_adapter) { Valkyrie.config.storage_adapter }
-    let(:metadata_adapter) { Valkyrie.config.metadata_adapter }
+    let(:storage_adapter) { Hyrax.storage_adapter }
+    let(:metadata_adapter) { Hyrax.metadata_adapter }
     let(:persister) { metadata_adapter.persister }
     let(:query_service) { Wings::Valkyrie::QueryService.new(adapter: metadata_adapter) }
     let(:file_node) do
@@ -188,7 +188,7 @@ RSpec.describe Hyrax::Actors::FileActor do
       let(:io2) { JobIoWrapper.new(file_set_id: file_set.id, user: user2, uploaded_file: huf2, path: huf2.uploader.path) }
       let(:user2) { create(:user) }
       let(:actor2) { described_class.new(file_set, relation, user2) }
-      let(:adapter) { Valkyrie.config.metadata_adapter }
+      let(:adapter) { Hyrax.metadata_adapter }
       let(:query_service) { Wings::Valkyrie::QueryService.new(adapter: adapter) }
       let(:versions) do
         reloaded = query_service.find_by(id: file_set.id)

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
       let(:work_v1) { create(:generic_work) } # this version of the work has no members
 
       before do # another version of the same work is saved with a member
-        work_v2 = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: work_v1.id, use_valkyrie: false)
+        work_v2 = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: work_v1.id, use_valkyrie: false)
         work_v2.ordered_members << create(:file_set)
         work_v2.save!
       end

--- a/spec/actors/hyrax/actors/ordered_members_actor_spec.rb
+++ b/spec/actors/hyrax/actors/ordered_members_actor_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::Actors::OrderedMembersActor do
       let(:work_v1) { create(:generic_work) } # this version of the work has no members
 
       before do # another version of the same work is saved with a member
-        work_v2 = Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: work_v1.id, use_valkyrie: false)
+        work_v2 = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: work_v1.id, use_valkyrie: false)
         work_v2.ordered_members << create(:file_set)
         work_v2.save!
       end

--- a/spec/controllers/hyrax/single_use_links_viewer_controller_spec.rb
+++ b/spec/controllers/hyrax/single_use_links_viewer_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::SingleUseLinksViewerController do
     let(:download_link_hash) { download_link.download_key }
 
     describe "GET 'download'" do
-      let(:expected_content) { Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: file.id, use_valkyrie: false).original_file.content }
+      let(:expected_content) { Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file.id, use_valkyrie: false).original_file.content }
       it "downloads the file and deletes the link from the database" do
         expect(controller).to receive(:send_file_headers!).with(filename: 'world.png', disposition: 'attachment', type: 'image/png')
         get :download, params: { id: download_link_hash }

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -79,15 +79,7 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:translate_id_to_uri) }
   it { is_expected.to respond_to(:translate_uri_to_id) }
   it { is_expected.to respond_to(:upload_path) }
-  it { is_expected.to respond_to(:valkyrie_metadata_adapter) }
-  it { is_expected.to respond_to(:valkyrie_metadata_adapter=) }
-  it { is_expected.to respond_to(:valkyrie_storage_adapter) }
-  it { is_expected.to respond_to(:valkyrie_storage_adapter=) }
   it { is_expected.to respond_to(:whitelisted_ingest_dirs) }
   it { is_expected.to respond_to(:whitelisted_ingest_dirs=) }
   it { is_expected.to respond_to(:work_requires_files?) }
-
-  # Can be removed when Hyrax has support and established pattern for using non-Wings adapter
-  it { expect { subject.valkyrie_metadata_adapter = :bobross }.to raise_error(StandardError) }
-  it { expect { subject.valkyrie_metadata_adapter = :wings_adapter }.not_to raise_error(StandardError) }
 end


### PR DESCRIPTION
Introduces Hyrax accessors for configured Valkyrie adapters, persisters, and query services. Rather than use `Valkyrie.config` and longer method chains throughout the codebase, we can use these shorter abstractions.

At some point, we added hyrax configuration for valkyrie. This hasn't been used
by Wings developers for some time. At this point, the best thing seems to be to
simply remove it.

@samvera/hyrax-code-reviewers
