### PR TITLE
WIP [wings] Use valkyrie resources for BatchEditForm

### DIFF
--- a/app/forms/hyrax/forms/batch_edit_form.rb
+++ b/app/forms/hyrax/forms/batch_edit_form.rb
@@ -9,7 +9,9 @@ module Hyrax
       self.required_fields = []
       self.model_class = Hyrax.primary_work_type
 
-      # Contains a list of titles of all the works in the batch
+      ##
+      # @!attribute [rw] names
+      #   @return [Array<String>] a list of titles of all the works in the batch
       attr_accessor :names
 
       # @param [ActiveFedora::Base] model the model backing the form
@@ -64,12 +66,14 @@ module Hyrax
         def initialize_combined_fields
           # For each of the files in the batch, set the attributes to be the concatenation of all the attributes
           batch_document_ids.each_with_object({}) do |doc_id, combined_attributes|
-            work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false)
+            work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: doc_id)
+
             terms.each do |field|
               combined_attributes[field] ||= []
               combined_attributes[field] = (combined_attributes[field] + work[field].to_a).uniq
             end
-            names << work.to_s
+
+            names << work.first_title
           end
         end
 


### PR DESCRIPTION
Removes the implicit direct `ActiveFedora` dependency from `BatchEditForm`. This
class now uses Valkyrie objects, except where behavior is inherited from
`Hyrax::Forms::WorkForm`.

@samvera/hyrax-code-reviewers
