### PR TITLE
[wings] Use valkyrie for the thumbnail path

### DIFF
--- a/app/services/hyrax/derivative_path.rb
+++ b/app/services/hyrax/derivative_path.rb
@@ -20,7 +20,7 @@ module Hyrax
     # @param [ActiveFedora::Base, String] object either the AF object or its id
     # @param [String] destination_name
     def initialize(object, destination_name = nil)
-      @id = object.is_a?(String) ? object : object.id
+      @id = object.is_a?(String) ? object : object.id.to_s
       @destination_name = destination_name.gsub(/^original_file_/, '') if destination_name
     end
 

--- a/app/services/hyrax/thumbnail_path_service.rb
+++ b/app/services/hyrax/thumbnail_path_service.rb
@@ -7,8 +7,9 @@ module Hyrax
         return default_image unless object.thumbnail_id
 
         thumb = fetch_thumbnail(object)
+
         return unless thumb
-        return call(thumb) unless thumb.is_a?(::FileSet)
+        return call(thumb) unless thumb.file_set?
         if thumb.audio?
           audio_image
         elsif thumbnail?(thumb)
@@ -22,8 +23,9 @@ module Hyrax
 
         def fetch_thumbnail(object)
           return object if object.thumbnail_id == object.id
-          Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: object.thumbnail_id, use_valkyrie: false)
-        rescue ActiveFedora::ObjectNotFoundError
+          service = Valkyrie.config.metadata_adapter.query_service
+          service.find_by_alternate_identifier(alternate_identifier: object.thumbnail_id)
+        rescue Valkyrie::Persistence::ObjectNotFoundError
           Rails.logger.error("Couldn't find thumbnail #{object.thumbnail_id} for #{object.id}")
           nil
         end

--- a/spec/services/hyrax/thumbnail_path_service_spec.rb
+++ b/spec/services/hyrax/thumbnail_path_service_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe Hyrax::ThumbnailPathService do
       it { is_expected.to eq '/downloads/999?file=thumbnail' }
     end
 
+    context 'when it has a missing thumbnail' do
+      let(:object) { GenericWork.new(thumbnail_id: 'very_fake') }
+
+      it { is_expected.to be_nil }
+    end
+
     context "that doesn't have a representative" do
       let(:object) { FileSet.new }
 


### PR DESCRIPTION
Remove the direct dependency on `ActiveFedora` from the thumbnail path service.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Check thumbnails for non-audio content.

@samvera/hyrax-code-reviewers
