### PR TITLE
Refactor `AttachMembersActor` for Valkyrie membership adding

### DIFF
--- a/app/actors/hyrax/actors/attach_members_actor.rb
+++ b/app/actors/hyrax/actors/attach_members_actor.rb
@@ -11,6 +11,9 @@ module Hyrax
     # The goal of this actor is to mutate the ordered_members with as few writes
     # as possible, because changing ordered_members is slow. This class only
     # writes changes, not the full ordered list.
+    #
+    # The `env` for this actor may contain a `Valkyrie::Resource` or an
+    # `ActiveFedora::Base` model, as required by the
     class AttachMembersActor < Hyrax::Actors::AbstractActor
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if update was successful
@@ -24,39 +27,61 @@ module Hyrax
 
         # Attaches any unattached members.  Deletes those that are marked _delete
         # @param [Hash<Hash>] a collection of members
+        #
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # Complexity in this method is incleased by dual AF/Valkyrie support
+        # when removing AF, we should be able to reduce it substantially.
         def assign_nested_attributes_for_collection(env, attributes_collection)
           return true unless attributes_collection
 
-          attributes_collection = attributes_collection
-                                  .sort_by { |i, _| i.to_i }
-                                  .map { |_, attributes| attributes }
+          attributes         = extract_attributes(attributes_collection)
+          cast_concern       = !env.curation_concern.is_a?(Valkyrie::Resource)
+          resource           = cast_concern ? env.curation_concern.valkyrie_resource : env.curation_concern
+          inserts, destroys  = split_inserts_and_destroys(attributes, resource)
 
-          resource           = env.curation_concern.valkyrie_resource
-          current_member_ids = resource.member_ids.map(&:id)
-          inserts, destroys  = split_inserts_and_destroys(attributes_collection, current_member_ids)
-
+          # short circuit to avoid casting unnecessarily
           return true if destroys.empty? && inserts.empty?
           # we fail silently if we can't insert the object; this is for legacy
           # compatibility
-          return true unless inserts.all? { |id| env.current_ability.can?(:edit, id) }
+          return true unless check_permissions(ability: env.current_ability,
+                                               inserts: inserts,
+                                               destroys: destroys)
 
-          resource.member_ids += inserts.map  { |id| Valkyrie::ID.new(id) }
-          resource.member_ids -= destroys.map { |id| Valkyrie::ID.new(id) }
+          update_members(resource: resource, inserts: inserts, destroys: destroys)
 
+          return true unless cast_concern
           env.curation_concern = Hyrax.metadata_adapter
                                       .resource_factory
                                       .from_resource(resource: resource)
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
-        def split_inserts_and_destroys(attributes_collection, current_member_ids)
-          destroys = attributes_collection.select do |col_hash|
+        def extract_attributes(collection)
+          collection
+            .sort_by { |i, _| i.to_i }
+            .map { |_, attributes| attributes }
+        end
+
+        def split_inserts_and_destroys(attributes, resource)
+          current_member_ids = resource.member_ids.map(&:id)
+
+          destroys = attributes.select do |col_hash|
             ActiveModel::Type::Boolean.new.cast(col_hash['_destroy'])
           end
 
-          inserts  = (attributes_collection - destroys).map { |h| h['id'] }.compact - current_member_ids
+          inserts  = (attributes - destroys).map { |h| h['id'] }.compact - current_member_ids
           destroys = destroys.map { |h| h['id'] }.compact & current_member_ids
 
           [inserts, destroys]
+        end
+
+        def update_members(resource:, inserts: [], destroys: [])
+          resource.member_ids += inserts.map  { |id| Valkyrie::ID.new(id) }
+          resource.member_ids -= destroys.map { |id| Valkyrie::ID.new(id) }
+        end
+
+        def check_permissions(ability:, inserts: [], **_opts)
+          inserts.all? { |id| ability.can?(:edit, id) }
         end
     end
   end

--- a/app/actors/hyrax/actors/attach_members_actor.rb
+++ b/app/actors/hyrax/actors/attach_members_actor.rb
@@ -33,7 +33,8 @@ module Hyrax
           attributes_collection.each do |attributes|
             next if attributes['id'].blank?
             if existing_works.include?(attributes['id'])
-              remove(env.curation_concern, attributes['id']) if has_destroy_flag?(attributes)
+              remove(env.curation_concern, attributes['id']) if
+                ActiveModel::Type::Boolean.new.cast(attributes['_destroy'])
             else
               add(env, attributes['id'])
             end
@@ -59,13 +60,6 @@ module Hyrax
           curation_concern.ordered_members.delete(member)
           curation_concern.members.delete(member)
         end
-
-        # Determines if a hash contains a truthy _destroy key.
-        # rubocop:disable Naming/PredicateName
-        def has_destroy_flag?(hash)
-          ActiveFedora::Type::Boolean.new.cast(hash['_destroy'])
-        end
-      # rubocop:enable Naming/PredicateName
     end
   end
 end

--- a/app/actors/hyrax/actors/attach_members_actor.rb
+++ b/app/actors/hyrax/actors/attach_members_actor.rb
@@ -43,9 +43,14 @@ module Hyrax
         # Adds the item to the ordered members so that it displays in the items
         # along side the FileSets on the show page
         def add(env, id)
-          member = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false)
-          return unless env.current_ability.can?(:edit, member)
-          env.curation_concern.ordered_members << member
+          return unless env.current_ability.can?(:edit, id)
+
+          resource = env.curation_concern.valkyrie_resource
+          resource.member_ids << Valkyrie::ID.new(id)
+
+          env.curation_concern = Hyrax.metadata_adapter
+                                      .resource_factory
+                                      .from_resource(resource: resource)
         end
 
         # Remove the object from the members set and the ordered members list

--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -45,7 +45,8 @@ module Hyrax
           attributes_collection.each do |attributes|
             next if attributes['id'].blank?
             if existing_collections.include?(attributes['id'])
-              remove(env.curation_concern, attributes['id']) if has_destroy_flag?(attributes)
+              remove(env.curation_concern, attributes['id']) if
+                ActiveModel::Type::Boolean.new.cast(attributes['_destroy'])
             else
               add(env, attributes['id'])
             end
@@ -70,13 +71,6 @@ module Hyrax
           collection = Collection.find(id)
           curation_concern.member_of_collections.delete(collection)
         end
-
-        # Determines if a hash contains a truthy _destroy key.
-        # rubocop:disable Naming/PredicateName
-        def has_destroy_flag?(hash)
-          ActiveFedora::Type::Boolean.new.cast(hash['_destroy'])
-        end
-        # rubocop:enable Naming/PredicateName
 
         # Extact a singleton collection id from the collection attributes and save it in env.  Later in the actor stack,
         # in apply_permission_template_actor.rb, `env.attributes[:collection_id]` will be used to apply the

--- a/spec/actors/hyrax/actors/attach_members_actor_spec.rb
+++ b/spec/actors/hyrax/actors/attach_members_actor_spec.rb
@@ -30,16 +30,16 @@ RSpec.describe Hyrax::Actors::AttachMembersActor do
 
     context "when the id already exists in the members" do
       it "does nothing" do
-        expect { subject }.not_to change { work.ordered_members.to_a }
+        expect { subject }.not_to change { env.curation_concern.ordered_members.to_a }
       end
 
       context "and the _destroy flag is set" do
         let(:attributes) { HashWithIndifferentAccess.new(work_members_attributes: { '0' => { id: id, _destroy: 'true' } }) }
 
         it "removes from the member and the ordered members" do
-          expect { subject }.to change { work.ordered_members.to_a }
-          expect(work.ordered_member_ids).not_to include(existing_child_work.id)
-          expect(work.member_ids).not_to include(existing_child_work.id)
+          expect { subject }.to change { env.curation_concern.ordered_members.to_a }
+          expect(env.curation_concern.ordered_member_ids).not_to include(existing_child_work.id)
+          expect(env.curation_concern.member_ids).not_to include(existing_child_work.id)
         end
       end
     end
@@ -49,18 +49,17 @@ RSpec.describe Hyrax::Actors::AttachMembersActor do
       let(:id) { another_work.id }
 
       context "and I can edit that object" do
-        before do
-          allow(ability).to receive(:can?).with(:edit, GenericWork).and_return(true)
-        end
+        let(:another_work) { create(:work, user: depositor) }
+
         it "is added to the ordered members" do
-          expect { subject }.to change { work.ordered_members.to_a }
-          expect(work.ordered_member_ids).to include(existing_child_work.id, another_work.id)
+          expect { subject }.to change { env.curation_concern.ordered_members.to_a }
+          expect(env.curation_concern.ordered_member_ids).to include(existing_child_work.id, another_work.id)
         end
       end
 
       context "and I can not edit that object" do
         it "does nothing" do
-          expect { subject }.not_to change { work.ordered_members.to_a }
+          expect { subject }.not_to change { env.curation_concern.ordered_members.to_a }
         end
       end
     end


### PR DESCRIPTION
Add members using Valkyrie.

First, we check the the Ability's permissions against the passed in `id` instead
of a specific object. Then we grab the `Valkyrie::Resource` for the env`s
`#curation_concern`, add the new member, and convert back to `ActiveFedora` to
reset the `#curation_concern`.

This removes the need for an explict `#find` in the private `#add` method, but
this find is, in fact, retained in the `Wings::ActiveFedora::Converter`. Further
refactors may be possible to do this addition directly

All the changes here are isolated to a private method, so the Valkyrie resources
won't leak into public behavior.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Check Work and Collection membership behavior through the UI.
* Try adding large numbers of works to other works, with an eye toward identifying major performance degradation.

@samvera/hyrax-code-reviewers
