### PR TITLE
[wings] Use Valkyrie for `DepositedNotification`

### DIFF
--- a/app/services/hyrax/workflow/deposited_notification.rb
+++ b/app/services/hyrax/workflow/deposited_notification.rb
@@ -13,7 +13,7 @@ module Hyrax
         end
 
         def users_to_notify
-          user_key = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: work_id, use_valkyrie: false).depositor
+          user_key = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: work_id).depositor
           super << ::User.find_by(email: user_key)
         end
     end


### PR DESCRIPTION
Uses Valkyrie to determine the depostior `user_key` for `DepositedNotification`.

This is a straight `Wings` refactor.

@samvera/hyrax-code-reviewers
