### PR TITLE
[wings] move base Hyrax `Valkyrie::Resource` model to `PcdmObject`

### DIFF
--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # The base Valkyrie model for Hyrax.
+  class Resource < Valkyrie::Resource
+    include Valkyrie::Resource::AccessControls
+
+    attribute :alternate_ids, ::Valkyrie::Types::Array
+  end
+end

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -134,11 +134,10 @@ module Wings
       relationship_keys.delete('member_of_collection_ids')
       reflection_id_keys = klass.respond_to?(:reflections) ? klass.reflections.keys.select { |k| k.to_s.end_with? '_id' } : []
 
-      Class.new(ActiveFedoraResource) do
+      Class.new(Hyrax::Resource) do
         include Wings::CollectionBehavior if klass.included_modules.include?(Hyrax::CollectionBehavior)
         include Wings::Works::WorkValkyrieBehavior if klass.included_modules.include?(Hyrax::WorkBehavior)
         include Wings::Works::FileSetValkyrieBehavior if klass.included_modules.include?(Hyrax::FileSetBehavior)
-        include ::Valkyrie::Resource::AccessControls
 
         # Based on Valkyrie implementation, we call Class.to_s to define
         # the internal resource.
@@ -175,10 +174,6 @@ module Wings
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
-
-    class ActiveFedoraResource < ::Valkyrie::Resource
-      attribute :alternate_ids, ::Valkyrie::Types::Array
-    end
 
     class AttributeTransformer
       def self.run(obj, keys)

--- a/spec/models/hyrax/resource_spec.rb
+++ b/spec/models/hyrax/resource_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Hyrax::Resource do
+  subject(:object) { described_class.new }
+
+  it_behaves_like 'a Valkyrie::Resource' do
+    let(:resource_klass) { described_class }
+  end
+
+  describe '#alternate_ids' do
+    let(:id) { Valkyrie::ID.new('fake_identifier') }
+    it 'has an attribute for alternate ids' do
+      expect { object.alternate_ids = id }
+        .to change { object.alternate_ids }
+        .to contain_exactly id
+    end
+  end
+end


### PR DESCRIPTION
We want the base `Valkyrie::Resource` to be available application-wide, so client
code can use it de define native `valkyrie` models in the future. To this end,
we move it to `app/models` as `Hyrax::Resource`.

Unit tests are added for conformance to basic `valkyrie` behavior.
This is a straight refactor.

@samvera/hyrax-code-reviewers
