### PR TITLE
Refactor `VisibilityJob` to be single responsibility 

### DIFF
--- a/app/jobs/visibility_copy_job.rb
+++ b/app/jobs/visibility_copy_job.rb
@@ -7,21 +7,6 @@ class VisibilityCopyJob < Hyrax::ApplicationJob
   # @api public
   # @param [#file_sets, #visibility, #lease, #embargo] work - a Work model
   def perform(work)
-    work.file_sets.each do |file|
-      file.visibility = work.visibility # visibility must come first, because it can clear an embargo/lease
-      copy_visibility_modifier(work: work, file: file, modifier: :lease)
-      copy_visibility_modifier(work: work, file: file, modifier: :embargo)
-      file.save!
-    end
+    Hyrax::VisibilityPropagator.for(source: work).propagate
   end
-
-  private
-
-    def copy_visibility_modifier(work:, file:, modifier:)
-      work_modifier = work.public_send(modifier)
-      return unless work_modifier
-      file.public_send("build_#{modifier}") unless file.public_send(modifier)
-      file.public_send(modifier).attributes = work_modifier.attributes.except('id')
-      file.public_send(modifier).save
-    end
 end

--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -7,5 +7,6 @@ module Hyrax
     include Valkyrie::Resource::AccessControls
 
     attribute :alternate_ids, ::Valkyrie::Types::Array
+    attribute :visibility,    ::Valkyrie::Types::String
   end
 end

--- a/app/services/hyrax/file_set_visibility_propagator.rb
+++ b/app/services/hyrax/file_set_visibility_propagator.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Propogates visibility from a given Work to its FileSets
+  class FileSetVisibilityPropagator
+    ##
+    # @!attribute [rw] source
+    #   @return [#visibility]
+    attr_accessor :source
+
+    ##
+    # @param source [#visibility] the object to propogate visibility from
+    def initialize(source:)
+      self.source = source
+    end
+
+    ##
+    # @return [void]
+    #
+    # @raise [RuntimeError] if visibility propogation fails
+    def propagate
+      source.file_sets.each do |file|
+        file.visibility = source.visibility # visibility must come first, because it can clear an embargo/lease
+        copy_visibility_modifier(source: source, file: file, modifier: :lease)
+        copy_visibility_modifier(source: source, file: file, modifier: :embargo)
+        file.save!
+      end
+    end
+
+    private
+
+      def copy_visibility_modifier(source:, file:, modifier:)
+        source_modifier = source.public_send(modifier)
+        return unless source_modifier
+        file.public_send("build_#{modifier}") unless file.public_send(modifier)
+        file.public_send(modifier).attributes = source_modifier.attributes.except('id')
+        file.public_send(modifier).save
+      end
+  end
+end

--- a/app/services/hyrax/visibility_propagator.rb
+++ b/app/services/hyrax/visibility_propagator.rb
@@ -1,0 +1,14 @@
+module Hyrax
+  ##
+  # @abstract Propogates visibility from a provided object (e.g. a Work) to some
+  # group of its members (e.g. file_sets).
+  class VisibilityPropagator
+    ##
+    # @param source [#visibility] the object to propogate visibility from
+    #
+    # @return [#propogate]
+    def self.for(source:)
+      FileSetVisibilityPropagator.new(source: source)
+    end
+  end
+end

--- a/spec/services/hyrax/file_set_visibility_propagator_spec.rb
+++ b/spec/services/hyrax/file_set_visibility_propagator_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::FileSetVisibilityPropagator do
+  subject(:propagator) { described_class.new(source: work) }
+  let(:work)           { FactoryBot.create(:work_with_files) }
+
+  context 'a public work' do
+    before do
+      work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    it 'copies visibility to its contained files' do
+      # files are private at the outset
+      expect(work.file_sets.first.visibility)
+        .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+      propagator.propagate
+
+      work.reload.file_sets.each do |file|
+        expect(file.visibility)
+          .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      end
+    end
+  end
+
+  context 'when work is under embargo' do
+    let(:work) { create(:embargoed_work_with_files) }
+    let(:file) { work.file_sets.first }
+
+    it 'copies visibility to its contained files and apply a copy of the embargo to the files' do
+      expect(work.visibility)
+        .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      expect(work).to be_under_embargo
+      expect(work.file_sets.first).not_to be_under_embargo
+
+      propagator.propagate
+
+      expect(file).to be_under_embargo
+      expect(file.embargo.id).not_to eq work.embargo.id
+    end
+  end
+
+  context 'when work is under lease' do
+    let(:work) { create(:leased_work_with_files) }
+    let(:file) { work.file_sets.first }
+
+    it 'copies visibility to its contained files and apply a copy of the lease to the files' do
+      expect(work.visibility)
+        .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      expect(work).to be_active_lease
+      expect(work.file_sets.first).not_to be_active_lease
+
+      propagator.propagate
+
+      expect(file).to be_active_lease
+      expect(file.lease.id).not_to eq work.lease.id
+    end
+  end
+end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
 
       let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
 
-      before { work.visibility = visibility }
+      before { resource.visibility = visibility }
 
       it 'sets the visibility' do
         expect(converter.convert).to have_attributes(visibility: visibility)


### PR DESCRIPTION
Move the resposibility for actually changing visibility out of the Job, allowing
job code to focus on asynchronous processing. An abstract `VisibilityPropogator`
with a factory method (`for(source: my_work)`) is introduced, and the visibility
copy code is moved into a concrete implementation.

This prepares for the introduction of an additional `VisibilityPropogator` that
supports `Hyrax::Resource` objects.

This is progress toward managing visibility and ACLs directly in Valkyrie.

@samvera/hyrax-code-reviewers
