### PR TITLE
Replace calls to `solr_name`

### DIFF
--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -44,6 +44,6 @@ class Hyrax::HomepageController < ApplicationController
     end
 
     def sort_field
-      "#{Hyrax.config.index_field_mapper.solr_name('date_uploaded', :stored_sortable, type: :date)} desc"
+      "date_uploaded_dtsi desc"
     end
 end

--- a/app/controllers/hyrax/my/works_controller.rb
+++ b/app/controllers/hyrax/my/works_controller.rb
@@ -4,8 +4,8 @@ module Hyrax
       # Define collection specific filter facets.
       def self.configure_facets
         configure_blacklight do |config|
-          config.add_facet_field solr_name("admin_set", :facetable), limit: 5
-          config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5
+          config.add_facet_field "admin_set_sim", limit: 5
+          config.add_facet_field "member_of_collections_ssim", limit: 5
         end
       end
       configure_facets

--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -9,11 +9,11 @@ module Hyrax
       blacklight_config.facet_fields = {}
       configure_blacklight do |config|
         # TODO: add a visibility facet (requires visibility to be indexed)
-        config.add_facet_field solr_name('visibility', :stored_sortable),
+        config.add_facet_field "visibility_ssi",
                                helper_method: :visibility_badge,
                                limit: 5, label: I18n.t('hyrax.dashboard.my.heading.visibility')
         config.add_facet_field IndexesWorkflow.suppressed_field, helper_method: :suppressed_to_status
-        config.add_facet_field solr_name("resource_type", :facetable), limit: 5
+        config.add_facet_field "resource_type_sim", limit: 5
       end
     end
 

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -89,7 +89,7 @@ module Hyrax
     # @return [ActiveSupport::SafeBuffer] the html_safe link
     def link_to_facet_list(values, solr_field, empty_message = "No value entered", separator = ", ")
       return empty_message if values.blank?
-      facet_field = Hyrax.config.index_field_mapper.solr_name(solr_field, :facetable)
+      facet_field = solr_field.to_s + "_sim"
       safe_join(values.map { |item| link_to_facet(item, facet_field) }, separator)
     end
 
@@ -261,7 +261,7 @@ module Hyrax
     def collection_title_by_id(id)
       solr_docs = controller.repository.find(id).docs
       return nil if solr_docs.empty?
-      solr_field = solr_docs.first[Hyrax.config.index_field_mapper.solr_name("title", :stored_searchable)]
+      solr_field = solr_docs.first["title_tesim"]
       return nil if solr_field.nil?
       solr_field.first
     end
@@ -307,8 +307,7 @@ module Hyrax
       def search_state_with_facets(params, facet = {})
         state = Blacklight::SearchState.new(params, CatalogController.blacklight_config)
         return state.params if facet.none?
-        state.add_facet_params(Hyrax.config.index_field_mapper.solr_name(facet.keys.first, :facetable),
-                               facet.values.first)
+        state.add_facet_params(facet.keys.first.to_s + "_sim", facet.values.first)
       end
 
       def institution

--- a/app/indexers/hyrax/indexes_workflow.rb
+++ b/app/indexers/hyrax/indexes_workflow.rb
@@ -1,9 +1,7 @@
 module Hyrax
   module IndexesWorkflow
-    STORED_BOOL = ActiveFedora::Indexing::Descriptor.new(:boolean, :stored, :indexed)
-
     mattr_accessor :suppressed_field, instance_writer: false do
-      Hyrax.config.index_field_mapper.solr_name('suppressed', STORED_BOOL)
+      "suppressed_bsi"
     end
 
     # Adds thumbnail indexing to the solr document
@@ -31,11 +29,11 @@ module Hyrax
     end
 
     def workflow_state_name_field
-      @workflow_state_name_field ||= Hyrax.config.index_field_mapper.solr_name('workflow_state_name', :symbol)
+      "workflow_state_name_ssim"
     end
 
     def workflow_role_field
-      @workflow_role_field ||= Hyrax.config.index_field_mapper.solr_name('actionable_workflow_roles', :symbol)
+      "actionable_workflow_roles_ssim"
     end
 
     def workflow_roles(entity)

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -106,7 +106,7 @@ module Hyrax
       end
 
       def collection_type_gid_document_field_name
-        Hyrax.config.index_field_mapper.solr_name('collection_type_gid', *index_collection_type_gid_as)
+        "collection_type_gid_ssim"
       end
     end
 
@@ -181,12 +181,12 @@ module Hyrax
       # Field name to look up when locating the size of each file in Solr.
       # Override for your own installation if using something different
       def file_size_field
-        Hyrax.config.index_field_mapper.solr_name(:file_size, Hyrax::FileSetIndexer::STORED_LONG)
+        "file_size_lts"
       end
 
       # Solr field name works use to index member ids
       def member_ids_field
-        Hyrax.config.index_field_mapper.solr_name('member_ids', :symbol)
+        "member_ids_ssim"
       end
 
       def destroy_permission_template

--- a/app/models/concerns/hyrax/file_set/querying.rb
+++ b/app/models/concerns/hyrax/file_set/querying.rb
@@ -5,7 +5,7 @@ module Hyrax
 
       module ClassMethods
         def where_digest_is(digest_string)
-          where Hyrax.config.index_field_mapper.solr_name('digest', :symbol) => urnify(digest_string)
+          where "digest_ssim" => urnify(digest_string)
         end
 
         def urnify(digest_string)

--- a/app/models/concerns/hyrax/human_readable_type.rb
+++ b/app/models/concerns/hyrax/human_readable_type.rb
@@ -22,8 +22,8 @@ module Hyrax
 
     def to_solr(solr_doc = {})
       super(solr_doc).tap do |doc|
-        doc[Hyrax.config.index_field_mapper.solr_name('human_readable_type', :facetable)] = human_readable_type
-        doc[Hyrax.config.index_field_mapper.solr_name('human_readable_type', :stored_searchable)] = human_readable_type
+        doc["human_readable_type_sim"] = human_readable_type
+        doc["human_readable_type_tesim"] = human_readable_type
       end
     end
   end

--- a/app/models/concerns/hyrax/solr_document/characterization.rb
+++ b/app/models/concerns/hyrax/solr_document/characterization.rb
@@ -3,27 +3,27 @@ module Hyrax
     # TODO: aside from height and width, I don't think any of these other terms are indexed by default. - Justin 3/2016
     module Characterization
       def byte_order
-        self[Hyrax.config.index_field_mapper.solr_name("byte_order")]
+        self["byte_order_tesim"]
       end
 
       def capture_device
-        self[Hyrax.config.index_field_mapper.solr_name("capture_device")]
+        self["capture_device_tesim"]
       end
 
       def color_map
-        self[Hyrax.config.index_field_mapper.solr_name("color_map")]
+        self["color_map_tesim"]
       end
 
       def color_space
-        self[Hyrax.config.index_field_mapper.solr_name("color_space")]
+        self["color_space_tesim"]
       end
 
       def compression
-        self[Hyrax.config.index_field_mapper.solr_name("compression")]
+        self["compression_tesim"]
       end
 
       def gps_timestamp
-        self[Hyrax.config.index_field_mapper.solr_name("gps_timestamp")]
+        self["gps_timestamp_tesim"]
       end
 
       def height
@@ -31,31 +31,31 @@ module Hyrax
       end
 
       def image_producer
-        self[Hyrax.config.index_field_mapper.solr_name("image_producer")]
+        self["image_producer_tesim"]
       end
 
       def latitude
-        self[Hyrax.config.index_field_mapper.solr_name("latitude")]
+        self["latitude_tesim"]
       end
 
       def longitude
-        self[Hyrax.config.index_field_mapper.solr_name("longitude")]
+        self["longitude_tesim"]
       end
 
       def orientation
-        self[Hyrax.config.index_field_mapper.solr_name("orientation")]
+        self["orientation_tesim"]
       end
 
       def profile_name
-        self[Hyrax.config.index_field_mapper.solr_name("profile_name")]
+        self["profile_name_tesim"]
       end
 
       def profile_version
-        self[Hyrax.config.index_field_mapper.solr_name("profile_version")]
+        self["profile_version_tesim"]
       end
 
       def scanning_software
-        self[Hyrax.config.index_field_mapper.solr_name("scanning_software")]
+        self["scanning_software_tesim"]
       end
 
       def width
@@ -63,43 +63,43 @@ module Hyrax
       end
 
       def format_label
-        self[Hyrax.config.index_field_mapper.solr_name("format_label")]
+        self["format_label_tesim"]
       end
 
       def file_size
-        self[Hyrax.config.index_field_mapper.solr_name("file_size")]
+        self["file_size_tesim"]
       end
 
       def filename
-        self[Hyrax.config.index_field_mapper.solr_name("filename")]
+        self["filename_tesim"]
       end
 
       def well_formed
-        self[Hyrax.config.index_field_mapper.solr_name("well_formed")]
+        self["well_formed_tesim"]
       end
 
       def page_count
-        self[Hyrax.config.index_field_mapper.solr_name("page_count")]
+        self["page_count_tesim"]
       end
 
       def file_title
-        self[Hyrax.config.index_field_mapper.solr_name("file_title")]
+        self["file_title_tesim"]
       end
 
       def duration
-        self[Hyrax.config.index_field_mapper.solr_name("duration")]
+        self["duration_tesim"]
       end
 
       def sample_rate
-        self[Hyrax.config.index_field_mapper.solr_name("sample_rate")]
+        self["sample_rate_tesim"]
       end
 
       def last_modified
-        self[Hyrax.config.index_field_mapper.solr_name("last_modified")]
+        self["last_modified_tesim"]
       end
 
       def original_checksum
-        self[Hyrax.config.index_field_mapper.solr_name("original_checksum")]
+        self["original_checksum_tesim"]
       end
     end
   end

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -8,10 +8,6 @@ module Hyrax
             type.coerce(self[field])
           end
         end
-
-        def solr_name(*args)
-          Hyrax.config.index_field_mapper.solr_name(*args)
-        end
       end
 
       module Solr
@@ -44,49 +40,47 @@ module Hyrax
       end
 
       included do
-        attribute :alt_title, Solr::Array, solr_name('alt_title')
-        attribute :identifier, Solr::Array, solr_name('identifier')
-        attribute :based_near, Solr::Array, solr_name('based_near')
-        attribute :based_near_label, Solr::Array, solr_name('based_near_label')
-        attribute :related_url, Solr::Array, solr_name('related_url')
-        attribute :resource_type, Solr::Array, solr_name('resource_type')
+        attribute :alt_title, Solr::Array, "alt_title_tesim"
+        attribute :identifier, Solr::Array, "identifier_tesim"
+        attribute :based_near, Solr::Array, "based_near_tesim"
+        attribute :based_near_label, Solr::Array, "based_near_label_tesim"
+        attribute :related_url, Solr::Array, "related_url_tesim"
+        attribute :resource_type, Solr::Array, "resource_type_tesim"
         attribute :edit_groups, Solr::Array, ::Ability.edit_group_field
         attribute :edit_people, Solr::Array, ::Ability.edit_user_field
         attribute :read_groups, Solr::Array, ::Ability.read_group_field
         attribute :collection_ids, Solr::Array, 'collection_ids_tesim'
-        attribute :admin_set, Solr::Array, solr_name('admin_set')
-        attribute :member_of_collection_ids, Solr::Array, solr_name('member_of_collection_ids', :symbol)
-        attribute :description, Solr::Array, solr_name('description')
-        attribute :abstract, Solr::Array, solr_name('abstract')
-        attribute :title, Solr::Array, solr_name('title')
-        attribute :contributor, Solr::Array, solr_name('contributor')
-        attribute :subject, Solr::Array, solr_name('subject')
-        attribute :publisher, Solr::Array, solr_name('publisher')
-        attribute :language, Solr::Array, solr_name('language')
-        attribute :keyword, Solr::Array, solr_name('keyword')
-        attribute :license, Solr::Array, solr_name('license')
-        attribute :source, Solr::Array, solr_name('source')
-        attribute :date_created, Solr::Array, solr_name('date_created')
-        attribute :rights_statement, Solr::Array, solr_name('rights_statement')
-        attribute :rights_notes, Solr::Array, solr_name('rights_notes')
-        attribute :access_right, Solr::Array, solr_name('access_right')
-
-        attribute :mime_type, Solr::String, solr_name('mime_type', :stored_sortable)
-        attribute :workflow_state, Solr::String, solr_name('workflow_state_name', :symbol)
-        attribute :human_readable_type, Solr::String, solr_name('human_readable_type', :stored_searchable)
-        attribute :representative_id, Solr::String, solr_name('hasRelatedMediaFragment', :symbol)
+        attribute :admin_set, Solr::Array, "admin_set_tesim"
+        attribute :member_of_collection_ids, Solr::Array, "member_of_collection_ids_ssim"
+        attribute :description, Solr::Array, "description_tesim"
+        attribute :abstract, Solr::Array, "abstract_tesim"
+        attribute :title, Solr::Array, "title_tesim"
+        attribute :contributor, Solr::Array, "contributor_tesim"
+        attribute :subject, Solr::Array, "subject_tesim"
+        attribute :publisher, Solr::Array, "publisher_tesim"
+        attribute :language, Solr::Array, "language_tesim"
+        attribute :keyword, Solr::Array, "keyword_tesim"
+        attribute :license, Solr::Array, "license_tesim"
+        attribute :source, Solr::Array, "source_tesim"
+        attribute :date_created, Solr::Array, "date_created_tesim"
+        attribute :rights_statement, Solr::Array, "rights_statement_tesim"
+        attribute :rights_notes, Solr::Array, "rights_notes_tesim"
+        attribute :access_right, Solr::Array, "access_right_tesim"
+        attribute :mime_type, Solr::String, "mime_type_ssi"
+        attribute :workflow_state, Solr::String, "workflow_state_name_ssim"
+        attribute :human_readable_type, Solr::String, "human_readable_type_tesim"
+        attribute :representative_id, Solr::String, "hasRelatedMediaFragment_ssim"
         # extract the term name from the rendering_predicate (it might be after the final / or #)
-        attribute :rendering_ids, Solr::Array, solr_name(Hyrax.config.rendering_predicate.value.split(/#|\/|,/).last, :symbol)
-        attribute :thumbnail_id, Solr::String, solr_name('hasRelatedImage', :symbol)
+        attribute :rendering_ids, Solr::Array, Hyrax.config.rendering_predicate.value.split(/#|\/|,/).last + "_ssim"
+        attribute :thumbnail_id, Solr::String, "hasRelatedImage_ssim"
         attribute :thumbnail_path, Solr::String, CatalogController.blacklight_config.index.thumbnail_field
-        attribute :label, Solr::String, solr_name('label')
-        attribute :file_format, Solr::String, solr_name('file_format')
-        attribute :suppressed?, Solr::String, solr_name('suppressed', ActiveFedora::Indexing::Descriptor.new(:boolean, :stored, :indexed))
-
-        attribute :date_modified, Solr::Date, solr_name('date_modified', :stored_sortable, type: :date)
-        attribute :date_uploaded, Solr::Date, solr_name('date_uploaded', :stored_sortable, type: :date)
-        attribute :create_date, Solr::Date, solr_name('system_create', :stored_sortable, type: :date)
-        attribute :modified_date, Solr::Date, solr_name('system_modified', :stored_sortable, type: :date)
+        attribute :label, Solr::String, "label_tesim"
+        attribute :file_format, Solr::String, "file_format_tesim"
+        attribute :suppressed?, Solr::String, "suppressed_bsi"
+        attribute :date_modified, Solr::Date, "date_modified_dtsi"
+        attribute :date_uploaded, Solr::Date, "date_uploaded_dtsi"
+        attribute :create_date, Solr::Date, "system_create_dtsi"
+        attribute :modified_date, Solr::Date, "system_modified_dtsi"
         attribute :embargo_release_date, Solr::Date, Hydra.config.permissions.embargo.release_date
         attribute :lease_expiration_date, Solr::Date, Hydra.config.permissions.lease.expiration_date
       end

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -71,21 +71,17 @@ module Hyrax
 
     # Method to return the ActiveFedora model
     def hydra_model
-      first(Hyrax.config.index_field_mapper.solr_name('has_model', :symbol)).constantize
+      first("has_model_ssim").constantize
     end
 
     def depositor(default = '')
-      val = first(Hyrax.config.index_field_mapper.solr_name('depositor'))
+      val = first("depositor_tesim")
       val.present? ? val : default
     end
 
     def creator
-      descriptor = if hydra_model == AdminSet
-                     hydra_model.index_config[:creator].behaviors.first
-                   else
-                     :stored_searchable
-                   end
-      fetch(Hyrax.config.index_field_mapper.solr_name('creator', descriptor), [])
+      solr_term = hydra_model == AdminSet ? "creator_ssim" : "creator_tesim"
+      fetch(solr_term, [])
     end
 
     def visibility

--- a/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
@@ -12,7 +12,7 @@ module Hyrax
         end
 
         def search_field
-          ERB::Util.h(Hyrax.config.index_field_mapper.solr_name(options.fetch(:search_field, field), :facetable, type: :string))
+          ERB::Util.h(options.fetch(:search_field, field).to_s + "_sim")
         end
     end
   end

--- a/app/search_builders/hyrax/collection_search_builder.rb
+++ b/app/search_builders/hyrax/collection_search_builder.rb
@@ -19,7 +19,7 @@ module Hyrax
 
     # @return [String] Solr field name indicating default sort order
     def sort_field
-      Hyrax.config.index_field_mapper.solr_name('title', :sortable)
+      "title_si"
     end
 
     # This overrides the models in FilterByType

--- a/app/search_builders/hyrax/deposit_search_builder.rb
+++ b/app/search_builders/hyrax/deposit_search_builder.rb
@@ -17,7 +17,7 @@ module Hyrax
     end
 
     def self.depositor_field
-      @depositor_field ||= Hyrax.config.index_field_mapper.solr_name('depositor', :symbol).freeze
+      "depositor_ssim"
     end
 
     private

--- a/app/services/hyrax/statistics/file_sets/by_format.rb
+++ b/app/services/hyrax/statistics/file_sets/by_format.rb
@@ -6,7 +6,7 @@ module Hyrax
 
           # Returns 'file_format_sim'
           def index_key
-            Hyrax.config.index_field_mapper.solr_name('file_format', :facetable)
+            "file_format_sim"
           end
       end
     end

--- a/app/services/hyrax/statistics/works/by_resource_type.rb
+++ b/app/services/hyrax/statistics/works/by_resource_type.rb
@@ -5,7 +5,7 @@ module Hyrax
         private
 
           def index_key
-            Hyrax.config.index_field_mapper.solr_name("resource_type", :facetable)
+            "resource_type_sim"
           end
       end
     end

--- a/app/views/records/show_fields/_based_near.html.erb
+++ b/app/views/records/show_fields/_based_near.html.erb
@@ -1,6 +1,6 @@
 <% record.based_near.each do |bn| %>
   <span itemprop="contentLocation" itemscope itemtype="http://schema.org/Place">
-    <span itemprop="name"><%= link_to_facet(bn, Hyrax.config.index_field_mapper.solr_name("based_near", :facetable)) %></span>
+    <span itemprop="name"><%= link_to_facet(bn, "based_near_sim") %></span>
   </span>
   <br />
 <% end %>

--- a/app/views/records/show_fields/_creator.html.erb
+++ b/app/views/records/show_fields/_creator.html.erb
@@ -1,6 +1,6 @@
 <% record.creator.each do |creator| %>
 <span itemprop="creator" itemscope itemtype="http://schema.org/Person">
-  <span itemprop="name"><%= link_to_facet(creator, Hyrax.config.index_field_mapper.solr_name("creator", :facetable)) %></span>
+  <span itemprop="name"><%= link_to_facet(creator, "creator_sim") %></span>
 </span>
 <br />
 <% end %>

--- a/app/views/records/show_fields/_keyword.html.erb
+++ b/app/views/records/show_fields/_keyword.html.erb
@@ -1,3 +1,3 @@
 <% record.keyword.each do |t| %>
-  <span itemprop="keywords"><%= link_to_facet(t, Hyrax.config.index_field_mapper.solr_name("keyword", :facetable)) %></span><br />
+  <span itemprop="keywords"><%= link_to_facet(t, "keyword_sim") %></span><br />
 <% end %>

--- a/app/views/records/show_fields/_language.html.erb
+++ b/app/views/records/show_fields/_language.html.erb
@@ -1,3 +1,3 @@
 <% record.language.each do |lang| %>
-  <span itemprop="inLanguage"><%= link_to_facet(lang, Hyrax.config.index_field_mapper.solr_name("language", :facetable)) %></span><br />
+  <span itemprop="inLanguage"><%= link_to_facet(lang, "language_sim") %></span><br />
 <% end %>

--- a/app/views/records/show_fields/_publisher.html.erb
+++ b/app/views/records/show_fields/_publisher.html.erb
@@ -1,6 +1,6 @@
 <% record.publisher.each do |pub| %>
   <span itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
-    <span itemprop="name"><%= link_to_facet(pub, Hyrax.config.index_field_mapper.solr_name("publisher", :facetable)) %></span>
+    <span itemprop="name"><%= link_to_facet(pub, "publisher_sim") %></span>
         </span>
   <br />
 <% end %>

--- a/app/views/records/show_fields/_resource_type.html.erb
+++ b/app/views/records/show_fields/_resource_type.html.erb
@@ -1,3 +1,3 @@
 <% record.resource_type.each do |rtype| %>
-  <%= link_to_facet(rtype, Hyrax.config.index_field_mapper.solr_name("resource_type", :facetable)) %><br />
+  <%= link_to_facet(rtype, "resource_type_sim") %><br />
 <% end %>

--- a/app/views/records/show_fields/_subject.html.erb
+++ b/app/views/records/show_fields/_subject.html.erb
@@ -1,6 +1,6 @@
 <% record.subject.each do |sub| %>
   <span itemprop="about" itemscope itemtype="http://schema.org/Thing">
-    <span itemprop="name"><%= link_to_facet(sub, Hyrax.config.index_field_mapper.solr_name("subject", :facetable)) %></span>
+    <span itemprop="name"><%= link_to_facet(sub, "subject_sim") %></span>
   </span>
   <br />
 <% end %>

--- a/config/initializers/samvera-nesting_indexer_initializer.rb
+++ b/config/initializers/samvera-nesting_indexer_initializer.rb
@@ -9,8 +9,8 @@ Samvera::NestingIndexer.configure do |config|
   # C1 <- C2 <- C3 <- W1
   config.maximum_nesting_depth = 5
   config.adapter = Hyrax::Adapters::NestingIndexAdapter
-  config.solr_field_name_for_storing_parent_ids = Hyrax.config.index_field_mapper.solr_name('nesting_collection__parent_ids', :symbol)
-  config.solr_field_name_for_storing_ancestors =  Hyrax.config.index_field_mapper.solr_name('nesting_collection__ancestors', :symbol)
-  config.solr_field_name_for_storing_pathnames =  Hyrax.config.index_field_mapper.solr_name('nesting_collection__pathnames', :symbol)
+  config.solr_field_name_for_storing_parent_ids = "nesting_collection__parent_ids_ssim"
+  config.solr_field_name_for_storing_ancestors =  "nesting_collection__ancestors_ssim"
+  config.solr_field_name_for_storing_pathnames =  "nesting_collection__pathnames_ssim"
   config.solr_field_name_for_deepest_nested_depth = 'nesting_collection__deepest_nested_depth_isi'
 end

--- a/lib/generators/hyrax/templates/catalog_controller.rb
+++ b/lib/generators/hyrax/templates/catalog_controller.rb
@@ -6,11 +6,11 @@ class CatalogController < ApplicationController
   before_action :enforce_show_permissions, only: :show
 
   def self.uploaded_field
-    solr_name('system_create', :stored_sortable, type: :date)
+    "system_create_dtsi"
   end
 
   def self.modified_field
-    solr_name('system_modified', :stored_sortable, type: :date)
+    "system_modified_dtsi"
   end
 
   configure_blacklight do |config|
@@ -28,27 +28,27 @@ class CatalogController < ApplicationController
     }
 
     # solr field configuration for document/show views
-    config.index.title_field = solr_name("title", :stored_searchable)
-    config.index.display_type_field = solr_name("has_model", :symbol)
+    config.index.title_field = "title_tesim"
+    config.index.display_type_field = "has_model_ssim"
     config.index.thumbnail_field = 'thumbnail_path_ss'
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type", limit: 5
-    config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5
-    config.add_facet_field solr_name("creator", :facetable), limit: 5
-    config.add_facet_field solr_name("contributor", :facetable), label: "Contributor", limit: 5
-    config.add_facet_field solr_name("keyword", :facetable), limit: 5
-    config.add_facet_field solr_name("subject", :facetable), limit: 5
-    config.add_facet_field solr_name("language", :facetable), limit: 5
-    config.add_facet_field solr_name("based_near_label", :facetable), limit: 5
-    config.add_facet_field solr_name("publisher", :facetable), limit: 5
-    config.add_facet_field solr_name("file_format", :facetable), limit: 5
-    config.add_facet_field solr_name('member_of_collection_ids', :symbol), limit: 5, label: 'Collections', helper_method: :collection_title_by_id
+    config.add_facet_field "human_readable_type_sim", label: "Type", limit: 5
+    config.add_facet_field "resource_type_sim", label: "Resource Type", limit: 5
+    config.add_facet_field "creator_sim", limit: 5
+    config.add_facet_field "contributor_sim", label: "Contributor", limit: 5
+    config.add_facet_field "keyword_sim", limit: 5
+    config.add_facet_field "subject_sim", limit: 5
+    config.add_facet_field "language_sim", limit: 5
+    config.add_facet_field "based_near_label_sim", limit: 5
+    config.add_facet_field "publisher_sim", limit: 5
+    config.add_facet_field "file_format_sim", limit: 5
+    config.add_facet_field "member_of_collection_ids_ssim", limit: 5, label: 'Collections', helper_method: :collection_title_by_id
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile
-    config.add_facet_field solr_name("generic_type", :facetable), if: false
+    config.add_facet_field "generic_type_sim", if: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -57,47 +57,47 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field solr_name("title", :stored_searchable), label: "Title", itemprop: 'name', if: false
-    config.add_index_field solr_name("description", :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link
-    config.add_index_field solr_name("keyword", :stored_searchable), itemprop: 'keywords', link_to_search: solr_name("keyword", :facetable)
-    config.add_index_field solr_name("subject", :stored_searchable), itemprop: 'about', link_to_search: solr_name("subject", :facetable)
-    config.add_index_field solr_name("creator", :stored_searchable), itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
-    config.add_index_field solr_name("contributor", :stored_searchable), itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
-    config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
-    config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile
-    config.add_index_field solr_name("publisher", :stored_searchable), itemprop: 'publisher', link_to_search: solr_name("publisher", :facetable)
-    config.add_index_field solr_name("based_near_label", :stored_searchable), itemprop: 'contentLocation', link_to_search: solr_name("based_near_label", :facetable)
-    config.add_index_field solr_name("language", :stored_searchable), itemprop: 'inLanguage', link_to_search: solr_name("language", :facetable)
-    config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
-    config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
-    config.add_index_field solr_name("date_created", :stored_searchable), itemprop: 'dateCreated'
-    config.add_index_field solr_name("rights_statement", :stored_searchable), helper_method: :rights_statement_links
-    config.add_index_field solr_name("license", :stored_searchable), helper_method: :license_links
-    config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type", link_to_search: solr_name("resource_type", :facetable)
-    config.add_index_field solr_name("file_format", :stored_searchable), link_to_search: solr_name("file_format", :facetable)
-    config.add_index_field solr_name("identifier", :stored_searchable), helper_method: :index_field_link, field_name: 'identifier'
-    config.add_index_field solr_name("embargo_release_date", :stored_sortable, type: :date), label: "Embargo release date", helper_method: :human_readable_date
-    config.add_index_field solr_name("lease_expiration_date", :stored_sortable, type: :date), label: "Lease expiration date", helper_method: :human_readable_date
+    config.add_index_field "title_tesim", label: "Title", itemprop: 'name', if: false
+    config.add_index_field "description_tesim", itemprop: 'description', helper_method: :iconify_auto_link
+    config.add_index_field "keyword_tesim", itemprop: 'keywords', link_to_search: "keyword_sim"
+    config.add_index_field "subject_tesim", itemprop: 'about', link_to_search: "subject_sim"
+    config.add_index_field "creator_tesim", itemprop: 'creator', link_to_search: "creator_sim"
+    config.add_index_field "contributor_tesim", itemprop: 'contributor', link_to_search: "contributor_sim"
+    config.add_index_field "proxy_depositor_ssim", label: "Depositor", helper_method: :link_to_profile
+    config.add_index_field "depositor_tesim", label: "Owner", helper_method: :link_to_profile
+    config.add_index_field "publisher_tesim", itemprop: 'publisher', link_to_search: "publisher_sim"
+    config.add_index_field "based_near_label_tesim", itemprop: 'contentLocation', link_to_search: "based_near_label_sim"
+    config.add_index_field "language_tesim", itemprop: 'inLanguage', link_to_search: "language_sim"
+    config.add_index_field "date_uploaded_dtsi", itemprop: 'datePublished', helper_method: :human_readable_date
+    config.add_index_field "date_modified_dtsi", itemprop: 'dateModified', helper_method: :human_readable_date
+    config.add_index_field "date_created_tesim", itemprop: 'dateCreated'
+    config.add_index_field "rights_statement_tesim", helper_method: :rights_statement_links
+    config.add_index_field "license_tesim", helper_method: :license_links
+    config.add_index_field "resource_type_tesim", label: "Resource Type", link_to_search: "resource_type_sim"
+    config.add_index_field "file_format_tesim", link_to_search: "file_format_sim"
+    config.add_index_field "identifier_tesim", helper_method: :index_field_link, field_name: 'identifier'
+    config.add_index_field Hydra.config.permissions.embargo.release_date, label: "Embargo release date", helper_method: :human_readable_date
+    config.add_index_field Hydra.config.permissions.lease.expiration_date, label: "Lease expiration date", helper_method: :human_readable_date
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    config.add_show_field solr_name("title", :stored_searchable)
-    config.add_show_field solr_name("description", :stored_searchable)
-    config.add_show_field solr_name("keyword", :stored_searchable)
-    config.add_show_field solr_name("subject", :stored_searchable)
-    config.add_show_field solr_name("creator", :stored_searchable)
-    config.add_show_field solr_name("contributor", :stored_searchable)
-    config.add_show_field solr_name("publisher", :stored_searchable)
-    config.add_show_field solr_name("based_near_label", :stored_searchable)
-    config.add_show_field solr_name("language", :stored_searchable)
-    config.add_show_field solr_name("date_uploaded", :stored_searchable)
-    config.add_show_field solr_name("date_modified", :stored_searchable)
-    config.add_show_field solr_name("date_created", :stored_searchable)
-    config.add_show_field solr_name("rights_statement", :stored_searchable)
-    config.add_show_field solr_name("license", :stored_searchable)
-    config.add_show_field solr_name("resource_type", :stored_searchable), label: "Resource Type"
-    config.add_show_field solr_name("format", :stored_searchable)
-    config.add_show_field solr_name("identifier", :stored_searchable)
+    config.add_show_field "title_tesim"
+    config.add_show_field "description_tesim"
+    config.add_show_field "keyword_tesim"
+    config.add_show_field "subject_tesim"
+    config.add_show_field "creator_tesim"
+    config.add_show_field "contributor_tesim"
+    config.add_show_field "publisher_tesim"
+    config.add_show_field "based_near_label_tesim"
+    config.add_show_field "language_tesim"
+    config.add_show_field "date_uploaded_tesim"
+    config.add_show_field "date_modified_tesim"
+    config.add_show_field "date_created_tesim"
+    config.add_show_field "rights_statement_tesim"
+    config.add_show_field "license_tesim"
+    config.add_show_field "resource_type_tesim", label: "Resource Type"
+    config.add_show_field "format_tesim"
+    config.add_show_field "identifier_tesim"
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
@@ -118,7 +118,7 @@ class CatalogController < ApplicationController
     # since we aren't specifying it otherwise.
     config.add_search_field('all_fields', label: 'All Fields') do |field|
       all_names = config.show_fields.values.map(&:field).join(" ")
-      title_name = solr_name("title", :stored_searchable)
+      title_name = "title_tesim"
       field.solr_parameters = {
         qf: "#{all_names} file_format_tesim all_text_timv",
         pf: title_name.to_s
@@ -137,7 +137,7 @@ class CatalogController < ApplicationController
       # syntax, as eg {! qf=$title_qf }. This is neccesary to use
       # Solr parameter de-referencing like $title_qf.
       # See: http://wiki.apache.org/solr/LocalParams
-      solr_name = solr_name("contributor", :stored_searchable)
+      solr_name = "contributor_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -145,7 +145,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('creator') do |field|
-      solr_name = solr_name("creator", :stored_searchable)
+      solr_name = "creator_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -153,7 +153,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('title') do |field|
-      solr_name = solr_name("title", :stored_searchable)
+      solr_name = "title_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -162,7 +162,7 @@ class CatalogController < ApplicationController
 
     config.add_search_field('description') do |field|
       field.label = "Description"
-      solr_name = solr_name("description", :stored_searchable)
+      solr_name = "description_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -170,7 +170,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('publisher') do |field|
-      solr_name = solr_name("publisher", :stored_searchable)
+      solr_name = "publisher_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -178,7 +178,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('date_created') do |field|
-      solr_name = solr_name("created", :stored_searchable)
+      solr_name = "created_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -186,7 +186,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('subject') do |field|
-      solr_name = solr_name("subject", :stored_searchable)
+      solr_name = "subject_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -194,7 +194,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('language') do |field|
-      solr_name = solr_name("language", :stored_searchable)
+      solr_name = "language_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -202,7 +202,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('resource_type') do |field|
-      solr_name = solr_name("resource_type", :stored_searchable)
+      solr_name = "resource_type_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -210,7 +210,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('format') do |field|
-      solr_name = solr_name("format", :stored_searchable)
+      solr_name = "format_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -218,7 +218,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('identifier') do |field|
-      solr_name = solr_name("id", :stored_searchable)
+      solr_name = "id_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -227,7 +227,7 @@ class CatalogController < ApplicationController
 
     config.add_search_field('based_near') do |field|
       field.label = "Location"
-      solr_name = solr_name("based_near_label", :stored_searchable)
+      solr_name = "based_near_label_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -235,7 +235,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('keyword') do |field|
-      solr_name = solr_name("keyword", :stored_searchable)
+      solr_name = "keyword_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -243,7 +243,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('depositor') do |field|
-      solr_name = solr_name("depositor", :symbol)
+      solr_name = "depositor_ssim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -251,7 +251,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('rights_statement') do |field|
-      solr_name = solr_name("rights_statement", :stored_searchable)
+      solr_name = "rights_statement_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -259,7 +259,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('license') do |field|
-      solr_name = solr_name("license", :stored_searchable)
+      solr_name = "license_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         }
 
         expect(assigns[:collection].member_objects).to eq [asset1]
-        asset_results = Hyrax::SolrService.instance.conn.get "select", params: { fq: ["id:\"#{asset1.id}\""], fl: ['id', Hyrax.config.index_field_mapper.solr_name(:collection)] }
+        asset_results = Hyrax::SolrService.instance.conn.get "select", params: { fq: ["id:\"#{asset1.id}\""], fl: ['id', "collection_tesim"] }
         expect(asset_results["response"]["numFound"]).to eq 1
         doc = asset_results["response"]["docs"].first
         expect(doc["id"]).to eq asset1.id

--- a/spec/controllers/hyrax/homepage_controller_spec.rb
+++ b/spec/controllers/hyrax/homepage_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Hyrax::HomepageController, type: :controller do
     it "includes only GenericWork objects in recent documents" do
       get :index
       assigns(:recent_documents).each do |doc|
-        expect(doc[Hyrax.config.index_field_mapper.solr_name("has_model", :symbol)]).to eql ["GenericWork"]
+        expect(doc["has_model_ssim"]).to eql ["GenericWork"]
       end
     end
 
@@ -60,8 +60,8 @@ RSpec.describe Hyrax::HomepageController, type: :controller do
         old_to_solr = gw3.method(:to_solr)
         allow(gw3).to receive(:to_solr) do
           old_to_solr.call.merge(
-            Hyrax.config.index_field_mapper.solr_name('system_create', :stored_sortable, type: :date) => 1.day.ago.iso8601,
-            Hyrax.config.index_field_mapper.solr_name('date_uploaded', :stored_sortable, type: :date) => 1.day.ago.iso8601
+            "system_create_dtsi" => 1.day.ago.iso8601,
+            "date_uploaded_dtsi" => 1.day.ago.iso8601
           )
         end
         gw3.save

--- a/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
+++ b/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
@@ -62,13 +62,13 @@ RSpec.describe Hyrax::DashboardHelperBehavior, type: :helper do
   def create_models(model, user1, user2)
     # deposited by the first user
     3.times do |t|
-      conn.add id: "199#{t}", Hyrax.config.index_field_mapper.solr_name('depositor', :stored_searchable) => user1.user_key, "has_model_ssim" => [model],
-               Hyrax.config.index_field_mapper.solr_name('depositor', :symbol) => user1.user_key
+      conn.add id: "199#{t}", "depositor_tesim" => user1.user_key, "has_model_ssim" => [model],
+               "depositor_ssim" => user1.user_key
     end
 
     # deposited by the second user, but editable by the first
-    conn.add id: "1994", Hyrax.config.index_field_mapper.solr_name('depositor', :stored_searchable) => user2.user_key, "has_model_ssim" => [model],
-             Hyrax.config.index_field_mapper.solr_name('depositor', :symbol) => user2.user_key, "edit_access_person_ssim" => user1.user_key
+    conn.add id: "1994", "depositor_tesim" => user2.user_key, "has_model_ssim" => [model],
+             "depositor_ssim" => user2.user_key, "edit_access_person_ssim" => user1.user_key
     conn.commit
   end
 end

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe HyraxHelper, type: :helper do
     subject { helper.link_to_each_facet_field(options) }
 
     context "with helper_facet and default separator" do
-      let(:options) { { config: { helper_facet: Hyrax.config.index_field_mapper.solr_name("document_types", :facetable).to_sym }, value: ["Imaging > Object Photography"] } }
+      let(:options) { { config: { helper_facet: "document_types_sim".to_sym }, value: ["Imaging > Object Photography"] } }
 
       it do
         is_expected.to eq("<a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Imaging\">" \
@@ -127,7 +127,7 @@ RSpec.describe HyraxHelper, type: :helper do
     end
 
     context "with helper_facet and optional separator" do
-      let(:options) { { config: { helper_facet: Hyrax.config.index_field_mapper.solr_name("document_types", :facetable).to_sym, separator: " : " }, value: ["Imaging : Object Photography"] } }
+      let(:options) { { config: { helper_facet: "document_types_sim".to_sym, separator: " : " }, value: ["Imaging : Object Photography"] } }
 
       it do
         is_expected.to eq("<a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Imaging\">" \
@@ -138,7 +138,7 @@ RSpec.describe HyraxHelper, type: :helper do
 
     context "with :output_separator" do
       let(:options) do
-        { config: { helper_facet: Hyrax.config.index_field_mapper.solr_name("document_types", :facetable).to_sym, output_separator: ' ~ ', separator: ":" }, value: ["Imaging : Object Photography"] }
+        { config: { helper_facet: "document_types_sim".to_sym, output_separator: ' ~ ', separator: ":" }, value: ["Imaging : Object Photography"] }
       end
 
       it do
@@ -150,7 +150,7 @@ RSpec.describe HyraxHelper, type: :helper do
 
     context "with :no_spaces_around_separator" do
       let(:options) do
-        { config: { helper_facet: Hyrax.config.index_field_mapper.solr_name("document_types", :facetable).to_sym, output_separator: '~', separator: ":" }, value: ["Imaging : Object Photography"] }
+        { config: { helper_facet: "document_types_sim".to_sym, output_separator: '~', separator: ":" }, value: ["Imaging : Object Photography"] }
       end
 
       it do

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -487,8 +487,8 @@ RSpec.describe FileSet do
     end
 
     let(:depositor) { 'jcoyne' }
-    let(:depositor_key) { Hyrax.config.index_field_mapper.solr_name('depositor') }
-    let(:title_key) { Hyrax.config.index_field_mapper.solr_name('title', :stored_searchable, type: :string) }
+    let(:depositor_key) { "depositor_tesim" }
+    let(:title_key) { "title_tesim" }
     let(:title) { ['abc123'] }
     let(:no_terms) { described_class.find(subject.id).to_solr }
     let(:terms) do

--- a/spec/views/hyrax/base/_attributes.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attributes.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'hyrax/base/_attributes.html.erb' do
   let(:solr_document) { SolrDocument.new(attributes) }
   let(:attributes) do
     {
-      Hyrax.config.index_field_mapper.solr_name('has_model', :symbol) => ["GenericWork"],
+      has_model_ssim: ["GenericWork"],
       subject_tesim: subject,
       contributor_tesim: contributor,
       creator_tesim: creator,


### PR DESCRIPTION
Replaces calls to `solr_name` method with actual solr field names.

Completes https://github.com/samvera/hyrax/issues/3794

@samvera/hyrax-code-reviewers
