### PR TITLE
Add original_file.id to FileSetIndexer

### DIFF
--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -27,6 +27,7 @@ module Hyrax
         solr_doc['duration_tesim']          = object.duration
         solr_doc['sample_rate_tesim']       = object.sample_rate
         solr_doc['original_checksum_tesim'] = object.original_checksum
+        solr_doc['original_file_id_ssi']    = original_file_id
       end
     end
 
@@ -35,6 +36,11 @@ module Hyrax
       def digest_from_content
         return unless object.original_file
         object.original_file.digest.first.to_s
+      end
+
+      def original_file_id
+        return unless object.original_file
+        object.original_file.id
       end
 
       def file_format

--- a/spec/indexers/hyrax/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/file_set_indexer_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe Hyrax::FileSetIndexer do
       expect(subject['file_title_tesim']).to eq ['title']
       expect(subject['duration_tesim']).to eq ['0:1']
       expect(subject['sample_rate_tesim']).to eq ['sample rate']
+      expect(subject['original_file_id_ssi']).to eq file_set.original_file.id
     end
   end
 


### PR DESCRIPTION
Connected to samvera/hyrax#3860

This modifies the `FileSetIndexer` so that
the `original_file.id` of the `FileSet` is
indexed in solr as an indexed single value
string.

This will allow for accessing the property
without using the `FileSet` object directly.

@samvera/hyrax-code-reviewers
