### PR TITLE
[wings] Implement visibility mapping for Valkyrie resources

### DIFF
--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -7,7 +7,24 @@ module Hyrax
     include Valkyrie::Resource::AccessControls
 
     attribute :alternate_ids, ::Valkyrie::Types::Array
-    attribute :visibility,    ::Valkyrie::Types::String
     attribute :embargo_id,    Valkyrie::Types::ID
+
+    def visibility=(value)
+      visibility_writer.assign_access_for(visibility: value)
+    end
+
+    def visibility
+      visibility_reader.read
+    end
+
+    protected
+
+      def visibility_writer
+        Hyrax::VisibilityWriter.new(resource: self)
+      end
+
+      def visibility_reader
+        Hyrax::VisibilityReader.new(resource: self)
+      end
   end
 end

--- a/app/services/hyrax/resource_visibility_propagator.rb
+++ b/app/services/hyrax/resource_visibility_propagator.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Propagates visibility from a valkyrie Work to its FileSets
+  class ResourceVisibilityPropagator
+    ##
+    # @!attribute [rw] source
+    #   @return [#visibility]
+    attr_accessor :source
+
+    ##
+    # @!attribute [r] persister
+    #   @return [#save]
+    # @!attribute [r] queries
+    #   @return [Valkyrie::Persistence::CustomQueryContainer]
+    attr_reader :persister, :queries
+
+    ##
+    # @param source [#visibility] the object to propogate visibility from
+    def initialize(source:,
+                   persister: Hyrax.persister,
+                   queries:   Hyrax.query_service.custom_queries)
+      @persister  = persister
+      @queries    = queries
+      self.source = source
+    end
+
+    ##
+    # @return [void]
+    #
+    # @raise [RuntimeError] if visibility propogation fails
+    def propagate
+      queries.find_child_filesets(resource: source).each do |file_set|
+        file_set.visibility = source.visibility
+
+        persister.save(resource: file_set)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/visibility_map.rb
+++ b/app/services/hyrax/visibility_map.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Defines a map from a visibility string value to appropriate permissions
+  # representing that visibility.
+  #
+  # @see Hyrax::VisibilityReader
+  # @see Hyrax::VisibilityWriter
+  # @see Hyrax::Resource#visibility
+  class VisibilityMap
+    DEFAULT_MAP = {
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC => {
+        permission: Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC,
+        additions: [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC].freeze,
+        deletions: [].freeze
+      }.freeze,
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED => {
+        permission: Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED,
+        additions: [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED].freeze,
+        deletions: [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC].freeze
+      }.freeze,
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE => {
+        permission: :PRIVATE,
+        additions: [].freeze,
+        deletions: [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC,
+                    Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED].freeze
+      }.freeze
+    }.freeze
+
+    extend Forwardable
+    include Singleton
+
+    def_delegators :@map, :[]
+
+    ##
+    # @!attribute [r] map
+    #   @return [Hash<String, Hash>]
+    attr_reader :map
+
+    ##
+    # @param map [Hash<String, String>]
+    def initialize(map: DEFAULT_MAP)
+      @map = map
+    end
+
+    ##
+    # Reverse lookup a visibility stirng from the permission group value
+    def visibility_for(group:)
+      @map.find { |_, v| v[:permission] == group }&.first
+    end
+
+    def additions_for(visibility:)
+      self[visibility][:additions]
+    end
+
+    def deletions_for(visibility:)
+      self[visibility][:deletions]
+    end
+
+    def visibilities
+      @map.keys
+    end
+  end
+end

--- a/app/services/hyrax/visibility_propagator.rb
+++ b/app/services/hyrax/visibility_propagator.rb
@@ -8,7 +8,12 @@ module Hyrax
     #
     # @return [#propogate]
     def self.for(source:)
-      FileSetVisibilityPropagator.new(source: source)
+      case source
+      when Hyrax::WorkBehavior # ActiveFedora
+        FileSetVisibilityPropagator.new(source: source)
+      when Hyrax::Resource # Valkyrie
+        ResourceVisibilityPropagator.new(source: source)
+      end
     end
   end
 end

--- a/app/services/hyrax/visibility_reader.rb
+++ b/app/services/hyrax/visibility_reader.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Translates a set of ACLs into a visibility string.
+  #
+  # @example
+  #   resource = Hyrax::Resource.new
+  #   reader   = Hyrax::VisibilityReader.new(resource: resource)
+  #   reader.read # => "restricted"
+  #
+  #   resource.read_groups = ["public"]
+  #   reader.read # => "open"
+  #
+  class VisibilityReader
+    ##
+    # @!attribute [rw] resource
+    #   @return [Valkyrie::Resource::AccessControls]
+    attr_accessor :resource
+
+    ##
+    # @param resource [Valkyrie::Resource::AccessControls]
+    def initialize(resource:)
+      self.resource = resource
+    end
+
+    ##
+    # @return [String]
+    def read
+      if resource.read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
+        visibility_map.visibility_for(group: Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
+      elsif resource.read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
+        visibility_map.visibility_for(group: Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED)
+      else
+        visibility_map.visibility_for(group: :PRIVATE)
+      end
+    end
+
+    def visibility_map
+      Hyrax::VisibilityMap.instance
+    end
+  end
+end

--- a/app/services/hyrax/visibility_writer.rb
+++ b/app/services/hyrax/visibility_writer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Sets ACLs from a visibility string
+  #
+  # @example
+  #   resource = Hyrax::Resource.new
+  #   writer   = Hyrax::VisibilityWriter.new(resource: resource)
+  #   resource.read_groups # => []
+  #
+  #   writer.assign_access_for(visibility: 'open')
+  #   resource.read_groups # => ["public"]
+  #
+  #   writer.assign_access_for(visibility: 'authenticated')
+  #   resource.read_groups # => ["registered"]
+  #
+  class VisibilityWriter
+    ##
+    # @!attribute [rw] resource
+    #   @return [Valkyrie::Resource::AccessControls]
+    attr_accessor :resource
+
+    ##
+    # @param resource [Valkyrie::Resource::AccessControls]
+    def initialize(resource:)
+      self.resource = resource
+    end
+
+    ##
+    # @param visibility [String]
+    #
+    # @return [void]
+    def assign_access_for(visibility:)
+      resource.read_groups -= visibility_map.deletions_for(visibility: visibility)
+      resource.read_groups += visibility_map.additions_for(visibility: visibility)
+    end
+
+    def visibility_map
+      Hyrax::VisibilityMap.instance
+    end
+  end
+end

--- a/spec/models/hyrax/resource_spec.rb
+++ b/spec/models/hyrax/resource_spec.rb
@@ -3,7 +3,8 @@
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Hyrax::Resource do
-  subject(:object) { described_class.new }
+  subject(:resource) { described_class.new }
+  let(:adapter)      { Valkyrie::Persistence::Memory::MetadataAdapter.new }
 
   it_behaves_like 'a Valkyrie::Resource' do
     let(:resource_klass) { described_class }
@@ -11,10 +12,29 @@ RSpec.describe Hyrax::Resource do
 
   describe '#alternate_ids' do
     let(:id) { Valkyrie::ID.new('fake_identifier') }
+
     it 'has an attribute for alternate ids' do
-      expect { object.alternate_ids = id }
-        .to change { object.alternate_ids }
+      expect { resource.alternate_ids = id }
+        .to change { resource.alternate_ids }
         .to contain_exactly id
+    end
+  end
+
+  describe '#visibility' do
+    let(:open) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+
+    it 'round trips' do
+      expect { resource.visibility = open }
+        .to change { resource.visibility }
+        .to open
+    end
+
+    context 'when setting to public' do
+      it 'adds public read group' do
+        expect { resource.visibility = open }
+          .to change { resource.read_groups }
+          .to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
+      end
     end
   end
 end

--- a/spec/services/hyrax/resource_visibility_propagator_spec.rb
+++ b/spec/services/hyrax/resource_visibility_propagator_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::ResourceVisibilityPropagator do
+  subject(:propagator) { described_class.new(source: work) }
+  let(:queries)        { Hyrax.query_service.custom_queries }
+  let(:work)           { FactoryBot.create(:work_with_files).valkyrie_resource }
+  let(:file_sets)      { queries.find_child_filesets(resource: work) }
+
+  context 'a public work' do
+    before { work.visibility = 'open' }
+
+    it 'updates the file_set permissions' do
+      # files are private at the outset
+      expect(file_sets.first.visibility).to eq 'restricted'
+
+      expect { propagator.propagate }
+        .to change { queries.find_child_filesets(resource: work).map(&:visibility) }
+        .to contain_exactly(work.visibility, work.visibility)
+    end
+  end
+end

--- a/spec/services/hyrax/visibility_reader_spec.rb
+++ b/spec/services/hyrax/visibility_reader_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::VisibilityReader do
+  subject(:reader) { described_class.new(resource: resource) }
+  let(:resource)   { Hyrax::Resource.new }
+
+  let(:open) { Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC }
+  let(:auth) { Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED }
+
+  describe '#read' do
+    context 'when public group can read' do
+      before { resource.read_groups = [open] }
+
+      it 'is open' do
+        expect(reader.read).to eq 'open'
+      end
+    end
+
+    context 'when authenticated group can read' do
+      before { resource.read_groups = [auth] }
+
+      it 'is authenticated' do
+        expect(reader.read).to eq 'authenticated'
+      end
+
+      it 'and public can also read is open' do
+        resource.read_groups += [open]
+        expect(reader.read).to eq 'open'
+      end
+    end
+
+    context 'when neither group can read' do
+      it 'is restricted' do
+        expect(reader.read).to eq 'restricted'
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/visibility_writer_spec.rb
+++ b/spec/services/hyrax/visibility_writer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::VisibilityWriter do
+  subject(:writer) { described_class.new(resource: resource) }
+  let(:resource)   { Hyrax::Resource.new }
+  let(:open)       { writer.visibility_map.visibilities.first }
+  let(:auth)       { writer.visibility_map.visibilities[1] }
+  let(:restricted) { writer.visibility_map.visibilities[2] }
+
+  describe '#assign_access_for' do
+    context 'when setting to public' do
+      it 'adds public read group' do
+        expect { writer.assign_access_for(visibility: open) }
+          .to change { resource.read_groups }
+          .to contain_exactly(writer.visibility_map[open][:permission])
+      end
+    end
+
+    context 'when setting to authenticated' do
+      it 'adds authenticated read group and removes public' do
+        writer.assign_access_for(visibility: open)
+
+        expect { writer.assign_access_for(visibility: auth) }
+          .to change { resource.read_groups }
+          .to contain_exactly(writer.visibility_map[auth][:permission])
+      end
+    end
+
+    context 'when setting to private' do
+      it 'removes public' do
+        writer.assign_access_for(visibility: open)
+
+        expect { writer.assign_access_for(visibility: restricted) }
+          .to change { resource.read_groups }
+          .to be_empty
+      end
+
+      it 'removes authenticated' do
+        writer.assign_access_for(visibility: auth)
+
+        expect { writer.assign_access_for(visibility: restricted) }
+          .to change { resource.read_groups }
+          .to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Valkyrie resources should be able to set and retrieve visibility, based on
access controls. This introduces a *very* pared down version of the visibility
and ACL setters in `Hydra::AccessControls`, without the dependency on
`ActiveFedora`.

Connected to #3862.

@samvera/hyrax-code-reviewers