### PR TITLE
[wings] Introduce valkyrie-native Embargos

### DIFF
--- a/app/models/hyrax/embargo.rb
+++ b/app/models/hyrax/embargo.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # The Valkyrie model for embargos.
+  class Embargo < Valkyrie::Resource
+    attribute :visibility_after_embargo,  Valkyrie::Types::String
+    attribute :visibility_during_embargo, Valkyrie::Types::String
+    attribute :embargo_release_date,      Valkyrie::Types::DateTime
+    attribute :embargo_history,           Valkyrie::Types::Array
+
+    def active?
+      (embargo_release_date.present? && Time.zone.today < embargo_release_date)
+    end
+
+    class NullEmbargo
+      def id
+        nil
+      end
+
+      def visibility_after_embargo
+        nil
+      end
+
+      def visibility_during_embargo
+        nil
+      end
+
+      def embargo_release_date
+        nil
+      end
+
+      def embargo_history
+        []
+      end
+
+      def active?
+        false
+      end
+    end
+  end
+end

--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -8,5 +8,6 @@ module Hyrax
 
     attribute :alternate_ids, ::Valkyrie::Types::Array
     attribute :visibility,    ::Valkyrie::Types::String
+    attribute :embargo_id,    Valkyrie::Types::ID
   end
 end

--- a/app/services/hyrax/embargo_manager.rb
+++ b/app/services/hyrax/embargo_manager.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Manages an embargo for a `Hyrax::Resource`
+  class EmbargoManager
+    ##
+    # @!attribute [rw] resource
+    #   @return [Hyrax::Resource]
+    attr_accessor :resource
+
+    ##
+    # @!attribute [r] query_service
+    #   @return [#find_by]
+    attr_reader :query_service
+
+    ##
+    # @param resource [Hyrax::Resource]
+    def initialize(resource:, query_service: Hyrax.query_service)
+      @query_service = query_service
+      self.resource  = resource
+    end
+
+    ##
+    # @return [Valkyrie::Resource]
+    def embargo
+      return Embargo::NullEmbargo.new unless resource.embargo_id.present?
+
+      query_service.find_by(id: resource.embargo_id)
+    end
+
+    ##
+    # @return [Boolean]
+    def under_embargo?
+      embargo.active?
+    end
+  end
+end

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -105,6 +105,18 @@ module Wings
     end
 
     ##
+    # Selects an existing base class for the generated valkyrie class
+    #
+    # @return [Class]
+    def self.base_for(klass:)
+      if klass == Hydra::AccessControls::Embargo
+        Hyrax::Embargo
+      else
+        Hyrax::Resource
+      end
+    end
+
+    ##
     # @note The method signature is to conform to Valkyrie's method signature
     #   for ::Valkyrie.config.resource_class_resolver
     #
@@ -134,7 +146,7 @@ module Wings
       relationship_keys.delete('member_of_collection_ids')
       reflection_id_keys = klass.respond_to?(:reflections) ? klass.reflections.keys.select { |k| k.to_s.end_with? '_id' } : []
 
-      Class.new(Hyrax::Resource) do
+      Class.new(base_for(klass: klass)) do
         include Wings::CollectionBehavior if klass.included_modules.include?(Hyrax::CollectionBehavior)
         include Wings::Works::WorkValkyrieBehavior if klass.included_modules.include?(Hyrax::WorkBehavior)
         include Wings::Works::FileSetValkyrieBehavior if klass.included_modules.include?(Hyrax::FileSetBehavior)

--- a/spec/models/hyrax/embargo_spec.rb
+++ b/spec/models/hyrax/embargo_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Hyrax::Embargo do
+  subject(:embargo) { described_class.new }
+
+  it_behaves_like 'a Valkyrie::Resource' do
+    let(:resource_klass) { described_class }
+  end
+
+  describe '#active' do
+    subject(:embargo) { described_class.new(embargo_release_date: release) }
+
+    context 'when the embargo date is current' do
+      let(:release) { Time.zone.today + 3 }
+
+      it { is_expected.to be_active }
+    end
+
+    context 'when the embargo date is past' do
+      let(:release) { Time.zone.today - 3 }
+
+      it { is_expected.not_to be_active }
+    end
+  end
+end

--- a/spec/services/hyrax/embargo_manager_spec.rb
+++ b/spec/services/hyrax/embargo_manager_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::EmbargoManager do
+  subject(:manager) { described_class.new(resource: resource) }
+  let(:resource)    { Hyrax::Resource.new }
+
+  shared_context 'when under embargo' do
+    let(:resource) { FactoryBot.create(:embargoed_work).valkyrie_resource }
+  end
+
+  describe '#embargo' do
+    it 'gives an inactive embargo' do
+      expect(manager.embargo).not_to be_active
+    end
+
+    context 'when under embargo' do
+      include_context 'when under embargo'
+
+      it 'gives an active embargo' do
+        expect(manager.embargo).to be_active
+      end
+
+      it 'has embargo attributes' do
+        expect(manager.embargo)
+          .to have_attributes visibility_after_embargo: 'open',
+                              visibility_during_embargo: 'restricted',
+                              embargo_release_date: an_instance_of(DateTime),
+                              embargo_history: be_empty
+      end
+    end
+  end
+
+  describe '#under_embargo?' do
+    it { is_expected.not_to be_under_embargo }
+
+    context 'when under embargo' do
+      include_context 'when under embargo'
+
+      it { is_expected.to be_under_embargo }
+    end
+  end
+end

--- a/spec/support/clean_solr.rb
+++ b/spec/support/clean_solr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 RSpec.configure do |config|
-  config.before do
+  config.before(:each, clean_index: true) do
     client = Valkyrie::IndexingAdapter.find(:solr_index).connection
     client.delete_by_query("*:*", params: { softCommit: true })
   end

--- a/spec/valkyrie/indexing/solr/indexing_adapter_spec.rb
+++ b/spec/valkyrie/indexing/solr/indexing_adapter_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'valkyrie/indexing/solr/indexing_adapter'
 
-RSpec.describe Valkyrie::Indexing::Solr::IndexingAdapter do
+RSpec.describe Valkyrie::Indexing::Solr::IndexingAdapter, :clean_index do
   subject(:adapter) { described_class.new }
   let(:persister) { Wings::Valkyrie::Persister.new(adapter: metadata_adapter) }
   let(:metadata_adapter) { Wings::Valkyrie::MetadataAdapter.new }


### PR DESCRIPTION
Adds a `Hyrax::Embargo` as the valkyrie base class for embargos. The existing
Wings embargo handling is updated to use this base class.

A `NullEmbargo` is introduced as a static empty/inactive embargo. Whenever an
embargo is absent in Valkyrie driven code, we should use this `NullEmbargo`
class to represent a non-existent embargo on the object.

Additionally, an `EmbargoManager` is added to handle operations on the Embargo
as it relates to a given `Hyrax::Resource`.

Connected to #3869.

@samvera/hyrax-code-reviewers
