### PR TITLE
[wings] Persist ACLs when they are changed in a Valkyrie::Resource

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -56,8 +56,8 @@ module Wings
     def convert
       active_fedora_class.new(normal_attributes).tap do |af_object|
         af_object.id = id unless id.empty?
-        apply_depositor_to(af_object)
         add_access_control_attributes(af_object)
+        apply_depositor_to(af_object)
         convert_members(af_object)
         convert_member_of_collections(af_object)
       end
@@ -157,10 +157,12 @@ module Wings
 
       # Add attributes from resource which aren't AF properties into af_object
       def add_access_control_attributes(af_object)
-        af_object.read_users = attributes[:read_users] unless attributes[:read_users].blank?
-        af_object.edit_users = attributes[:edit_users] unless attributes[:edit_users].blank?
-        af_object.read_groups = attributes[:read_groups] unless attributes[:read_groups].blank?
-        af_object.edit_groups = attributes[:edit_groups] unless attributes[:edit_groups].blank?
+        return unless af_object.is_a? Hydra::AccessControls::Permissions
+
+        af_object.read_users = attributes[:read_users]
+        af_object.edit_users = attributes[:edit_users]
+        af_object.read_groups = attributes[:read_groups]
+        af_object.edit_groups = attributes[:edit_groups]
       end
   end
 end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -96,6 +96,25 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       end
     end
 
+    context 'when setting ACLs' do
+      it 'converts ACLs' do
+        expect { resource.read_users = ['moomin'] }
+          .to change { described_class.new(resource: resource).convert }
+          .to have_attributes(read_users: contain_exactly('moomin'))
+      end
+
+      context 'when ACLs exist' do
+        let(:work) { FactoryBot.create(:public_work) }
+
+        it 'can delete ACLs' do
+          expect { resource.read_groups = [] }
+            .to change { described_class.new(resource: resource).convert }
+            .from(have_attributes(read_groups: contain_exactly('public')))
+            .to have_attributes(read_groups: be_empty)
+        end
+      end
+    end
+
     context 'with relationships' do
       subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 


### PR DESCRIPTION
When a native `Valkyrie::Resource` changes, ACLs, we need to persist them.

Previously, the converter would retain existing ACLs when the
`Valkyrie::Resource` had tried to delete them.

To make this work correctly, we had to move depositor application to *after* the
ACLs are converted. We should consider moving depositor logic out of the
converter altogether, and instead support it from `Hyrax::Resource` or a
subclass.


@samvera/hyrax-code-reviewers
