### PR TITLE
mark test as pending

### DIFF
--- a/spec/wings/models/file_node_spec.rb
+++ b/spec/wings/models/file_node_spec.rb
@@ -137,7 +137,10 @@ RSpec.describe Wings::FileNode do
       end
     end
     context 'when versions saved' do
-      it 'returns a set of file_nodes for previous versions'
+      it 'returns a set of file_nodes for previous versions' do
+        pending 'TODO: write test when Wings file versioning is implemented'
+        expect(false).to be true
+      end
     end
   end
 end


### PR DESCRIPTION
It is better to have a test emit a pending statement than to quietly not run and possibly get lost.

Related to Issue #3813, #3800 

The pending test is for versioning of files which is dependent on completion of the rework of the indexing process (#3800).