### PR TITLE
Custom dashboard sidebar partials rendered using sidebar_partials class attribute

### DIFF
--- a/app/controllers/hyrax/dashboard_controller.rb
+++ b/app/controllers/hyrax/dashboard_controller.rb
@@ -6,6 +6,12 @@ module Hyrax
     before_action :authenticate_user!
     before_action :build_breadcrumbs, only: [:show]
 
+    ##
+    # @!attribute [rw] sidebar_partials
+    #   @return [Hash]
+    #
+    # @example Add a custom partial to the tasks sidebar block
+    #   Hyrax::DashboardController.sidebar_partials[:tasks] << "hyrax/dashboard/sidebar/custom_task"
     class_attribute :sidebar_partials
     self.sidebar_partials = { activity: [], configuration: [], repository_content: [], tasks: [] }
 

--- a/app/controllers/hyrax/dashboard_controller.rb
+++ b/app/controllers/hyrax/dashboard_controller.rb
@@ -6,6 +6,9 @@ module Hyrax
     before_action :authenticate_user!
     before_action :build_breadcrumbs, only: [:show]
 
+    class_attribute :sidebar_partials
+    self.sidebar_partials = { activity: [], configuration: [], repository_content: [], tasks: [] }
+
     def show
       if can? :read, :admin_dashboard
         @presenter = Hyrax::Admin::DashboardPresenter.new

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -31,3 +31,7 @@
       <span class="fa fa-bar-chart" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.statistics') %></span>
     <% end %>
   <% end %>
+
+  <% Hyrax::DashboardController.sidebar_partials[:activity].each do |partial| %>
+    <%= render partial, menu: menu %>
+  <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -32,6 +32,4 @@
     <% end %>
   <% end %>
 
-  <% Hyrax::DashboardController.sidebar_partials[:activity].each do |partial| %>
-    <%= render partial, menu: menu %>
-  <% end %>
+  <%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :activity %>

--- a/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
@@ -35,7 +35,5 @@
       <% end %>
     <% end %>
 
-    <% Hyrax::DashboardController.sidebar_partials[:configuration].each do |partial| %>
-      <%= render partial, menu: menu %>
-    <% end %>
+    <%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :configuration %>
   <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
@@ -28,9 +28,14 @@
         <% end %>
       <% end %>
     </li>
+
     <% if can?(:manage, Sipity::WorkflowResponsibility) %>
       <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
         <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>
       <% end %>
-    <% end # end of configuration block %>
+    <% end %>
+
+    <% Hyrax::DashboardController.sidebar_partials[:configuration].each do |partial| %>
+      <%= render partial, menu: menu %>
+    <% end %>
   <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_menu_partials.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_menu_partials.html.erb
@@ -1,0 +1,3 @@
+<% Hyrax::DashboardController.sidebar_partials[section].each do |partial| %>
+  <%= render partial, menu: menu %>
+<% end %>

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -10,6 +10,4 @@
     <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
   <% end %>
 
-  <% Hyrax::DashboardController.sidebar_partials[:repository_content].each do |partial| %>
-    <%= render partial, menu: menu %>
-  <% end %>
+  <%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :repository_content %>

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -9,3 +9,7 @@
                     also_active_for: hyrax.dashboard_works_path) do %>
     <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
   <% end %>
+
+  <% Hyrax::DashboardController.sidebar_partials[:repository_content].each do |partial| %>
+    <%= render partial, menu: menu %>
+  <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -21,6 +21,4 @@
     <% end %>
   <% end %>
 
-  <% Hyrax::DashboardController.sidebar_partials[:tasks].each do |partial| %>
-    <%= render partial, menu: menu %>
-  <% end %>
+  <%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :tasks %>

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -20,3 +20,7 @@
       <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.leases.index.manage_leases') %></span>
     <% end %>
   <% end %>
+
+  <% Hyrax::DashboardController.sidebar_partials[:tasks].each do |partial| %>
+    <%= render partial, menu: menu %>
+  <% end %>

--- a/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
@@ -129,4 +129,43 @@ RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
 
     it { is_expected.not_to have_link t('hyrax.dashboard.manage_proxies') }
   end
+
+  context 'when sidebar partials are configured' do
+    around do |example|
+      original_partials = Hyrax::DashboardController.sidebar_partials.deep_dup
+      example.call
+      Hyrax::DashboardController.sidebar_partials = original_partials
+    end
+
+    # Show configuration menu
+    let(:manage_feature) { true }
+
+    it 'renders custom activity partials' do
+      stub_template "hyrax/dashboard/sidebar/_custom_activity.html.erb" => "Custom Activity Item"
+      Hyrax::DashboardController.sidebar_partials[:activity] << "hyrax/dashboard/sidebar/custom_activity"
+      render
+      expect(rendered).to have_content "Custom Activity Item"
+    end
+
+    it 'renders custom configuration partials' do
+      stub_template "hyrax/dashboard/sidebar/_custom_configuration.html.erb" => "Custom Configuration Item"
+      Hyrax::DashboardController.sidebar_partials[:configuration] << "hyrax/dashboard/sidebar/custom_configuration"
+      render
+      expect(rendered).to have_content "Custom Configuration Item"
+    end
+
+    it 'renders custom repository content partials' do
+      stub_template "hyrax/dashboard/sidebar/_custom_repository_content.html.erb" => "Custom Repository Content Item"
+      Hyrax::DashboardController.sidebar_partials[:repository_content] << "hyrax/dashboard/sidebar/custom_repository_content"
+      render
+      expect(rendered).to have_content "Custom Repository Content Item"
+    end
+
+    it 'renders custom tasks partials' do
+      stub_template "hyrax/dashboard/sidebar/_custom_task.html.erb" => "Custom Task Item"
+      Hyrax::DashboardController.sidebar_partials[:tasks] << "hyrax/dashboard/sidebar/custom_task"
+      render
+      expect(rendered).to have_content "Custom Task Item"
+    end
+  end
 end


### PR DESCRIPTION
We have at least two use cases of adding links into the dashboard sidebar.  This PR is an attempt to create a seam where these partials can be injected without having to override any partials.  Feedback is welcome especially if you know of a better pattern for this.

@samvera/hyrax-code-reviewers
