### PR TITLE
Require browse everything 0.16.0+

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -37,7 +37,7 @@ SUMMARY
   spec.add_dependency 'blacklight', '~> 6.14'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
-  spec.add_dependency 'browse-everything', '< 2.0'
+  spec.add_dependency 'browse-everything', '>= 0.16'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'dry-equalizer', '~> 0.2'


### PR DESCRIPTION
This aligns with what got committed into the 2.x branch
Without this circleci is failing because it is still using a cached BE 0.15.1 leading to failing tests: 
```
undefined method `can_retrieve?' for BrowseEverything::Retriever:Class
```
which is currently blocking https://github.com/samvera/hyrax/pull/3878

@samvera/hyrax-code-reviewers
