### PR TITLE
Allow iiif_manifest 0.6

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -52,7 +52,7 @@ SUMMARY
   spec.add_dependency 'hydra-editor', '>= 3.3', '< 5.0'
   spec.add_dependency 'hydra-head', '>= 10.6.1'
   spec.add_dependency 'hydra-works', '>= 0.16', '< 2.0'
-  spec.add_dependency 'iiif_manifest', '>= 0.3', '< 0.6'
+  spec.add_dependency 'iiif_manifest', '>= 0.3', '< 0.7'
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4'
   spec.add_dependency 'jquery-ui-rails', '~> 6.0'
   spec.add_dependency 'json-schema' # for Arkivo


### PR DESCRIPTION
`iiif_manifest` 0.6 was released in May and shouldn't break anything as it includes new optional features and bugfixes only in the presentation V3 code.