### PR TITLE
Fixes HYRAX-#3775

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Hyrax
   class FileSetsController < ApplicationController
+    rescue_from WorkflowAuthorizationException, with: :render_unavailable
+
     include Blacklight::Base
     include Blacklight::AccessControls::Catalog
     include Hyrax::Breadcrumbs
@@ -42,6 +44,7 @@ module Hyrax
 
     # GET /concern/parent/:parent_id/file_sets/:id
     def show
+      workflow_check(parent_id: params[:parent_id])
       respond_to do |wants|
         wants.html { presenter }
         wants.json { presenter }
@@ -52,12 +55,15 @@ module Hyrax
     # DELETE /concern/file_sets/:id
     def destroy
       parent = curation_concern.parent
+      workflow_check(parent_id: parent.id)
       actor.destroy
       redirect_to [main_app, parent], notice: view_context.t('hyrax.file_sets.asset_deleted_flash.message')
     end
 
     # PATCH /concern/file_sets/:id
     def update
+      parent = curation_concern.parent
+      workflow_check(parent_id: parent.id)
       if attempt_update
         after_update_response
       else
@@ -146,9 +152,22 @@ module Hyrax
 
     def initialize_edit_form
       @parent = @file_set.in_objects.first
+      workflow_check(parent_id: @parent.id)
       original = @file_set.original_file
       @version_list = Hyrax::VersionListPresenter.new(original ? original.versions.all : [])
       @groups = current_user.groups
+    end
+
+    def workflow_check(parent_id: nil)
+      return if current_ability.can?(:edit, @solr_document)
+      if parent_id.nil?
+        curation_concern = ::FileSet.find(params[:id])
+        parent = curation_concern.parent
+        parent_id = parent.id
+      end
+      doc = ::SolrDocument.find(parent_id)
+      return if current_ability.can?(:edit, doc)
+      raise WorkflowAuthorizationException if doc.suppressed?
     end
 
     def actor
@@ -161,8 +180,10 @@ module Hyrax
 
     def presenter
       @presenter ||= begin
-        show_presenter.new(curation_concern_document, current_ability, request)
-      end
+                       presenter = show_presenter.new(curation_concern_document, current_ability, request)
+                       raise WorkflowAuthorizationException if presenter.parent.blank?
+                       presenter
+                     end
     end
 
     def curation_concern_document
@@ -199,6 +220,36 @@ module Hyrax
                  'dashboard'
                end
       File.join(theme, layout)
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def render_unavailable
+      message = I18n.t("hyrax.workflow.unauthorized_parent")
+      respond_to do |wants|
+        wants.html do
+          unavailable_presenter
+          flash[:notice] = message
+          render 'unavailable', status: :unauthorized
+        end
+        wants.json do
+          render plain: message, status: :unauthorized
+        end
+        additional_response_formats(wants)
+        wants.ttl do
+          render plain: message, status: :unauthorized
+        end
+        wants.jsonld do
+          render plain: message, status: :unauthorized
+        end
+        wants.nt do
+          render plain: message, status: :unauthorized
+        end
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def unavailable_presenter
+      @presenter ||= show_presenter.new(::SolrDocument.find(params[:id]), current_ability, request)
     end
   end
 end

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -159,28 +159,14 @@ module Hyrax
       @groups = current_user.groups
     end
 
-    # @see Hyrax::WorkShowPresenter#workflow_restriction?
-    # @see Hyrax::FileSetShowPresenter#workflow_restriction?
-    # @see #presenter
-    #
-    # Note, this method echoes the logic of the #workflow_restriction?
-    # in presenter classes.  My preference would be to rely on that
-    # method.  However, in specs the :parent parameter is of two
-    # different types:
-    #
-    # - Hyrax::WorkShowPresenter (for show actions)
-    # - GenericWork (for edit/delete/update actions)
-    #
-    # @todo How is this related to the presenter logic around building the presenter?
-    #
+    include WorkflowsHelper # Provides #workflow_restriction?, and yes I mean include not helper; helper exposes the module methods
     # @param parent [Hyrax::WorkShowPresenter, GenericWork, #suppressed?] an
     #        object on which we check if the current can take action.
     #
     # @return true if we did not encounter any workflow restrictions
     # @raise WorkflowAuthorizationException if we encountered some workflow_restriction
     def guard_for_workflow_restriction_on!(parent:)
-      return true if current_ability.can?(:edit, parent)
-      return true unless parent.suppressed?
+      return true unless workflow_restriction?(parent, ability: current_ability)
       raise WorkflowAuthorizationException
     end
 

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -18,6 +18,7 @@ module Hyrax
     include Hyrax::MembershipHelper
     include Hyrax::PermissionLevelsHelper
     include Hyrax::WorkFormHelper
+    include Hyrax::WorkflowsHelper
 
     # Which translations are available for the user to select
     # @return [Hash{String => String}] locale abbreviations as keys and flags as values

--- a/app/helpers/hyrax/workflows_helper.rb
+++ b/app/helpers/hyrax/workflows_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hyrax
   module WorkflowsHelper
     # Does a workflow restriction exist for the given :object and
@@ -23,9 +24,16 @@ module Hyrax
     # @note This is Jeremy, I encourage you to look at the views that
     #       call this method to understand the conceptual space this
     #       method covers.
-    def workflow_restriction?(object, with_ability: current_ability)
+    #
+    # @todo As I noodle on this, I'm fairly certain we should be
+    #       registering a CanCan ability check.  I believe in
+    #       promoting this to a helper method it will be easier to
+    #       incorporate this into an ability.
+    def workflow_restriction?(object, ability: current_ability)
       return object.workflow_restriction? if object.respond_to?(:workflow_restriction?)
-      return false
+      return false if ability.can?(:edit, object)
+      return object.suppressed? if object.respond_to?(:suppressed?)
+      false
     end
   end
 end

--- a/app/helpers/hyrax/workflows_helper.rb
+++ b/app/helpers/hyrax/workflows_helper.rb
@@ -29,6 +29,8 @@ module Hyrax
     #       registering a CanCan ability check.  I believe in
     #       promoting this to a helper method it will be easier to
     #       incorporate this into an ability.
+    #
+    # @see Hyrax::FileSetsController for non-view usage.
     def workflow_restriction?(object, ability: current_ability)
       return object.workflow_restriction? if object.respond_to?(:workflow_restriction?)
       return false if ability.can?(:edit, object)

--- a/app/helpers/hyrax/workflows_helper.rb
+++ b/app/helpers/hyrax/workflows_helper.rb
@@ -32,6 +32,7 @@ module Hyrax
     #
     # @see Hyrax::FileSetsController for non-view usage.
     def workflow_restriction?(object, ability: current_ability)
+      return false if object.nil? # Yup, we may get nil, and there's no restriction on nil
       return object.workflow_restriction? if object.respond_to?(:workflow_restriction?)
       return false if ability.can?(:edit, object)
       return object.suppressed? if object.respond_to?(:suppressed?)

--- a/app/helpers/hyrax/workflows_helper.rb
+++ b/app/helpers/hyrax/workflows_helper.rb
@@ -1,0 +1,31 @@
+module Hyrax
+  module WorkflowsHelper
+    # Does a workflow restriction exist for the given :object and
+    # given :ability?
+    #
+    # @note If the object responds to a :workflow_restriction?, we'll
+    #       use that answer.
+    #
+    # This method doesn't answer what kind of restriction is in place
+    # (that requires a far more nuanced permissioning system than
+    # Hyrax presently has).  Instead, it answers is there one in
+    # place.  From that answer, you may opt out of rendering a region
+    # on a view (e.g. don't show links to the edit page).
+    #
+    # @param object [Object]
+    # @param ability [Ability]
+    #
+    # @return [false] when there are no applicable workflow restrictions
+    #
+    # @return [true] when there is an applicable workflow restriction,
+    #         and you likely want to not render something.
+    #
+    # @note This is Jeremy, I encourage you to look at the views that
+    #       call this method to understand the conceptual space this
+    #       method covers.
+    def workflow_restriction?(object, with_ability: current_ability)
+      return object.workflow_restriction? if object.respond_to?(:workflow_restriction?)
+      return false
+    end
+  end
+end

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -94,11 +94,8 @@ module Hyrax
     end
 
     def user_can_perform_any_action?
+      Deprecation.warn("We're removing Hyrax::FileSetPresenter.user_can_perform_any_action? in Hyrax 4.0.0; Instead use can? in view contexts.")
       current_ability.can?(:edit, id) || current_ability.can?(:destroy, id) || current_ability.can?(:download, id)
-    end
-
-    def workflow_restriction?
-      parent_presenter.try(:workflow_restriction?)
     end
 
     private

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -50,6 +50,11 @@ module Hyrax
       @workflow ||= WorkflowPresenter.new(solr_document, current_ability)
     end
 
+    def workflow_restriction?
+      return false if current_ability.can?(:edit, @solr_document)
+      @solr_document.suppressed? # && current_ability.can?(:read, @solr_document)
+    end
+
     def inspect_work
       @inspect_workflow ||= InspectWorkPresenter.new(solr_document, current_ability)
     end

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -37,7 +37,7 @@ module Hyrax
     end
 
     # CurationConcern methods
-    delegate :stringify_keys, :human_readable_type, :collection?, :to_s,
+    delegate :stringify_keys, :human_readable_type, :collection?, :to_s, :suppressed?,
              to: :solr_document
 
     # Metadata Methods
@@ -50,6 +50,7 @@ module Hyrax
       @workflow ||= WorkflowPresenter.new(solr_document, current_ability)
     end
 
+    # @see Hyrax::FileSetsController#guard_for_workflow_restriction_on!
     def workflow_restriction?
       return false if current_ability.can?(:edit, @solr_document)
       @solr_document.suppressed? # && current_ability.can?(:read, @solr_document)

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -50,12 +50,6 @@ module Hyrax
       @workflow ||= WorkflowPresenter.new(solr_document, current_ability)
     end
 
-    # @see Hyrax::FileSetsController#guard_for_workflow_restriction_on!
-    def workflow_restriction?
-      return false if current_ability.can?(:edit, @solr_document)
-      @solr_document.suppressed? # && current_ability.can?(:read, @solr_document)
-    end
-
     def inspect_work
       @inspect_workflow ||= InspectWorkPresenter.new(solr_document, current_ability)
     end

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,19 +1,21 @@
 <div class="row show-actions button-row-top-two-column">
   <div class="col-sm-6">
-    <% if presenter.show_deposit_for?(collections: @user_collections) %>
-      <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
-      <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
-                    class: 'btn btn-default submits-batches submits-batches-add',
-                    data: { toggle: "modal", target: "#collection-list-container" } %>
-    <% end %>
-    <% if presenter.work_featurable? %>
-      <%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
-          data: { behavior: 'feature' },
-          class: presenter.display_feature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
+    <% if !@presenter.try(:workflow_restriction?) %>
+      <% if presenter.show_deposit_for?(collections: @user_collections) %>
+        <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+        <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+                      class: 'btn btn-default submits-batches submits-batches-add',
+                      data: { toggle: "modal", target: "#collection-list-container" } %>
+      <% end %>
+      <% if presenter.work_featurable? %>
+        <%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
+            data: { behavior: 'feature' },
+            class: presenter.display_feature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
 
-      <%= link_to t('.unfeature'), hyrax.featured_work_path(presenter, format: :json),
-          data: { behavior: 'unfeature' },
-          class: presenter.display_unfeature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
+        <%= link_to t('.unfeature'), hyrax.featured_work_path(presenter, format: :json),
+            data: { behavior: 'unfeature' },
+            class: presenter.display_unfeature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
+      <% end %>
     <% end %>
     <% if Hyrax.config.analytics? %>
       <% # turbolinks needs to be turned off or the page will use the cache and the %>
@@ -23,7 +25,7 @@
   </div>
 
   <div class="col-sm-6 text-right">
-    <% if presenter.editor? %>
+    <% if presenter.editor? && !@presenter.try(:workflow_restriction?) %>
       <%= link_to t('.edit'), edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
       <% if presenter.member_presenters.size > 1 %>
           <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,6 +1,6 @@
 <div class="row show-actions button-row-top-two-column">
   <div class="col-sm-6">
-    <% if !@presenter.try(:workflow_restriction?) %>
+    <% if !presenter.try(:workflow_restriction?) %>
       <% if presenter.show_deposit_for?(collections: @user_collections) %>
         <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
         <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
@@ -25,7 +25,7 @@
   </div>
 
   <div class="col-sm-6 text-right">
-    <% if presenter.editor? && !@presenter.try(:workflow_restriction?) %>
+    <% if presenter.editor? && !presenter.try(:workflow_restriction?) %>
       <%= link_to t('.edit'), edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
       <% if presenter.member_presenters.size > 1 %>
           <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,6 +1,6 @@
 <div class="row show-actions button-row-top-two-column">
   <div class="col-sm-6">
-    <% if !presenter.try(:workflow_restriction?) %>
+    <% if !workflow_restriction?(presenter) %>
       <% if presenter.show_deposit_for?(collections: @user_collections) %>
         <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
         <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
@@ -25,7 +25,7 @@
   </div>
 
   <div class="col-sm-6 text-right">
-    <% if presenter.editor? && !presenter.try(:workflow_restriction?) %>
+    <% if presenter.editor? && !workflow_restriction?(presenter) %>
       <%= link_to t('.edit'), edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
       <% if presenter.member_presenters.size > 1 %>
           <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>

--- a/app/views/hyrax/base/unavailable.html.erb
+++ b/app/views/hyrax/base/unavailable.html.erb
@@ -1,5 +1,5 @@
 <h1>
-    <%= @presenter %> <%= @presenter.workflow.badge %>
+    <%= @presenter %> <%= @presenter.try(:workflow).try(:badge) %>
 </h1>
 <% if @parent_presenter %>
     <ul class="breadcrumb">

--- a/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
@@ -2,7 +2,7 @@
   <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown"><%= t('.select') %> <span class="caret"></span>
   </button>
   <ul class="dropdown-menu dropdown-menu-right">
-    <% if can?( :edit, document ) && !@presenter.try(:workflow_restriction?) %>
+    <% if can?( :edit, document ) && !workflow_restriction?(@presenter) %>
       <li>
         <%= link_to [main_app, :edit, document],
                     class: "itemicon itemedit",

--- a/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
@@ -2,7 +2,7 @@
   <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown"><%= t('.select') %> <span class="caret"></span>
   </button>
   <ul class="dropdown-menu dropdown-menu-right">
-    <% if can? :edit, document %>
+    <% if can?( :edit, document ) && !@presenter.try(:workflow_restriction?) %>
       <li>
         <%= link_to [main_app, :edit, document],
                     class: "itemicon itemedit",

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,6 +1,5 @@
-<% if file_set.user_can_perform_any_action? %>
+<% if file_set.user_can_perform_any_action? && !@presenter.try(:workflow_restriction?) %>
   <div class="btn-group">
-
     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
       <span class="sr-only"><%= t('.press_to') %> </span>
       <%= t('.header') %>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,4 +1,4 @@
-<% if file_set.user_can_perform_any_action? && !@presenter.try(:workflow_restriction?) %>
+<% if file_set.user_can_perform_any_action? && !workflow_restriction?(@presenter) %>
   <div class="btn-group">
     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
       <span class="sr-only"><%= t('.press_to') %> </span>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,4 +1,4 @@
-<% if file_set.user_can_perform_any_action? && !workflow_restriction?(@presenter) %>
+<% if (can?(:download, file_set.id) || can?(:destroy, file_set.id) || can?(:edit, file_set.id)) && !workflow_restriction?(file_set.parent) %>
   <div class="btn-group">
     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
       <span class="sr-only"><%= t('.press_to') %> </span>

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -5,7 +5,7 @@
     <%= link_to t('.analytics'), @presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
   <% end %>
 
-  <% if @presenter.editor? && !workflow_restriction?(@presenter.parent) %>
+  <% if @presenter.editor? && !workflow_restriction?(@presenter) %>
       <%= link_to t(".edit_this", type: @presenter.human_readable_type), edit_polymorphic_path([main_app, @presenter]),
                   class: 'btn btn-default' %>
       <%= link_to t(".delete_this", type: @presenter.human_readable_type), [main_app, @presenter],

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -5,7 +5,7 @@
     <%= link_to t('.analytics'), @presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
   <% end %>
 
-  <% if @presenter.editor? && !@presenter.try(:workflow_restriction?) %>
+  <% if @presenter.editor? && !workflow_restriction?(@presenter) %>
       <%= link_to t(".edit_this", type: @presenter.human_readable_type), edit_polymorphic_path([main_app, @presenter]),
                   class: 'btn btn-default' %>
       <%= link_to t(".delete_this", type: @presenter.human_readable_type), [main_app, @presenter],

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -5,7 +5,7 @@
     <%= link_to t('.analytics'), @presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
   <% end %>
 
-  <% if @presenter.editor? && !workflow_restriction?(@presenter) %>
+  <% if @presenter.editor? && !workflow_restriction?(@presenter.parent) %>
       <%= link_to t(".edit_this", type: @presenter.human_readable_type), edit_polymorphic_path([main_app, @presenter]),
                   class: 'btn btn-default' %>
       <%= link_to t(".delete_this", type: @presenter.human_readable_type), [main_app, @presenter],

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -5,7 +5,7 @@
     <%= link_to t('.analytics'), @presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
   <% end %>
 
-  <% if @presenter.editor? %>
+  <% if @presenter.editor? && !@presenter.try(:workflow_restriction?) %>
       <%= link_to t(".edit_this", type: @presenter.human_readable_type), edit_polymorphic_path([main_app, @presenter]),
                   class: 'btn btn-default' %>
       <%= link_to t(".delete_this", type: @presenter.human_readable_type), [main_app, @presenter],

--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(@presenter) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.parent) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">

--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !@presenter.try(:workflow_restriction?) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(@presenter) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">

--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.parent) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.try(:parent)) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">

--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -1,5 +1,5 @@
-<% if Hyrax.config.display_media_download_link? %>
-    <div>
+<% if Hyrax.config.display_media_download_link? && !@presenter.try(:workflow_restriction?) %>
+  <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">
         <source src="<%= hyrax.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,6 +1,6 @@
 <div class="no-preview">
   <%= t('hyrax.works.show.no_preview') %>
-  <% if Hyrax.config.display_media_download_link? && !@presenter.try(:workflow_restriction?) %>
+  <% if Hyrax.config.display_media_download_link? && !workflow_restriction?(@presenter) %>
     <p /><%= link_to t('hyrax.file_set.show.download'),
       hyrax.download_path(file_set),
       id: "file_download",

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,6 +1,6 @@
 <div class="no-preview">
   <%= t('hyrax.works.show.no_preview') %>
-  <% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.parent) %>
+  <% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.try(:parent)) %>
     <p /><%= link_to t('hyrax.file_set.show.download'),
       hyrax.download_path(file_set),
       id: "file_download",

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,6 +1,6 @@
 <div class="no-preview">
   <%= t('hyrax.works.show.no_preview') %>
-  <% if Hyrax.config.display_media_download_link? && !workflow_restriction?(@presenter) %>
+  <% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.parent) %>
     <p /><%= link_to t('hyrax.file_set.show.download'),
       hyrax.download_path(file_set),
       id: "file_download",

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,6 +1,6 @@
 <div class="no-preview">
   <%= t('hyrax.works.show.no_preview') %>
-  <% if Hyrax.config.display_media_download_link? %>
+  <% if Hyrax.config.display_media_download_link? && !@presenter.try(:workflow_restriction?) %>
     <p /><%= link_to t('hyrax.file_set.show.download'),
       hyrax.download_path(file_set),
       id: "file_download",

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) && !@presenter.try(:workflow_restriction?) %>
+<% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) && !workflow_restriction?(@presenter) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) && !workflow_restriction?(@presenter) %>
+<% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) && !workflow_restriction?(file_set.parent) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) %>
+<% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) && !@presenter.try(:workflow_restriction?) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) && !workflow_restriction?(file_set.parent) %>
+<% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) && !workflow_restriction?(file_set.try(:parent)) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !@presenter.try(:workflow_restriction?) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(@presenter) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(@presenter) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.parent) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? %>
+<% if Hyrax.config.display_media_download_link? && !@presenter.try(:workflow_restriction?) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.parent) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.try(:parent)) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(@presenter) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.parent) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,5 +1,5 @@
-<% if Hyrax.config.display_media_download_link? %>
-    <div>
+<% if Hyrax.config.display_media_download_link? && !@presenter.try(:workflow_restriction?) %>
+  <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),
                     class: "representative-media",

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !@presenter.try(:workflow_restriction?) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(@presenter) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.parent) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.try(:parent)) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,5 +1,5 @@
-<% if Hyrax.config.display_media_download_link? %>
-    <div>
+<% if Hyrax.config.display_media_download_link? && !@presenter.try(:workflow_restriction?) %>
+  <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
         <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(@presenter) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.parent) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !@presenter.try(:workflow_restriction?) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(@presenter) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.parent) %>
+<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.try(:parent)) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1510,6 +1510,7 @@ en:
       load:
         state_error: 'The workflow: %{workflow_name} has not been updated.  You are removing a state: %{state_name} with %{entity_count} entity/ies.  A state may not be removed while it has active entities!'
       unauthorized: The work is not currently available because it has not yet completed the approval process
+      unauthorized_parent: The file is not currently available because its parent work has not yet completed the approval process
     works:
       missing_title: 'No Title'
       create:

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -70,8 +70,14 @@ RSpec.describe Hyrax::FileSetsController do
     end
 
     describe "#update" do
+      let(:parent) do
+        create(:work, :public, user: user)
+      end
       let(:file_set) do
-        create(:file_set, user: user, title: ['test title'])
+        create(:file_set, user: user, title: ['test title']).tap do |file_set|
+          parent.ordered_members << file_set
+          parent.save!
+        end
       end
 
       context "when updating metadata" do
@@ -206,8 +212,14 @@ RSpec.describe Hyrax::FileSetsController do
       end
 
       context "when there's an error saving" do
+        let(:parent) do
+          create(:work, :public, user: user)
+        end
         let(:file_set) do
-          create(:file_set, user: user)
+          create(:file_set, user: user).tap do |file_set|
+            parent.ordered_members << file_set
+            parent.save!
+          end
         end
 
         before do
@@ -249,8 +261,22 @@ RSpec.describe Hyrax::FileSetsController do
     end
 
     describe "#show" do
+      let(:work) do
+        create(:generic_work, :public,
+               title: ['test title'],
+               user: user)
+      end
+
       let(:file_set) do
-        create(:file_set, title: ['test file'], user: user)
+        create(:file_set, title: ['test file'], user: user).tap do |file_set|
+          work.ordered_members << file_set
+          work.save!
+        end
+      end
+
+      before do
+        work.ordered_members << file_set
+        work.save!
       end
 
       context "without a referer" do
@@ -283,12 +309,6 @@ RSpec.describe Hyrax::FileSetsController do
       end
 
       context "with a referer" do
-        let(:work) do
-          create(:generic_work, :public,
-                 title: ['test title'],
-                 user: user)
-        end
-
         before do
           request.env['HTTP_REFERER'] = 'http://test.host/foo'
           work.ordered_members << file_set
@@ -310,7 +330,15 @@ RSpec.describe Hyrax::FileSetsController do
 
     context 'someone elses (public) files' do
       let(:creator) { create(:user, email: 'archivist1@example.com') }
-      let(:public_file_set) { create(:file_set, user: creator, read_groups: ['public']) }
+      let(:parent) do
+        create(:work, :public, user: creator, read_groups: ['public'])
+      end
+      let(:public_file_set) do
+        create(:file_set, user: creator, read_groups: ['public']).tap do |file_set|
+          parent.ordered_members << file_set
+          parent.save!
+        end
+      end
 
       let(:work) do
         create(:generic_work, :public,
@@ -344,6 +372,7 @@ RSpec.describe Hyrax::FileSetsController do
   end
 
   context 'when not signed in' do
+    let(:work) { create(:work, :public, user: user) }
     let(:private_file_set) { create(:file_set) }
     let(:public_file_set) { create(:file_set, read_groups: ['public']) }
 
@@ -354,6 +383,7 @@ RSpec.describe Hyrax::FileSetsController do
     end
 
     before do
+      work.ordered_members << private_file_set
       work.ordered_members << public_file_set
       work.save!
       public_file_set.save!
@@ -377,6 +407,66 @@ RSpec.describe Hyrax::FileSetsController do
         get :show, params: { id: public_file_set }
         expect(response).to be_successful
       end
+    end
+
+    describe '#show' do
+      let(:parent_work_active) do
+        create(:work, :public, state: ::RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#active'))
+      end
+      let(:file_set_active) do
+        create(:file_set, read_groups: ['public']).tap do |file_set|
+          parent_work_active.ordered_members << file_set
+          parent_work_active.save!
+        end
+      end
+      let(:parent_work_inactive) do
+        create(:work, :public, state: ::RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#inactive'))
+      end
+      let(:file_set_inactive) do
+        create(:file_set, read_groups: ['public']).tap do |file_set|
+          parent_work_inactive.ordered_members << file_set
+          parent_work_inactive.save!
+        end
+      end
+
+      it "shows active parent" do
+        expect(controller).to receive(:additional_response_formats).with(ActionController::MimeResponds::Collector)
+        get :show, params: { id: file_set_active }
+        expect(response).to be_success
+      end
+
+      it "shows not currently available for inactive parent" do
+        get :show, params: { id: file_set_inactive }
+        expect(response).to render_template 'unavailable'
+        expect(flash[:notice]).to eq 'The file is not currently available because its parent work has not yet completed the approval process'
+        expect(response.status).to eq 401
+      end
+    end
+  end
+
+  describe 'integration test for suppressed documents' do
+    let(:work) do
+      create(:work, :public, state: Vocab::FedoraResourceStatus.inactive)
+    end
+    let(:file_set) do
+      create(:file_set, read_groups: ['public']).tap do |file_set|
+        work.ordered_members << file_set
+        work.save!
+      end
+    end
+
+    before do
+      work.ordered_members << file_set
+      work.save!
+      create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+    end
+
+    it 'renders the unavailable message because it is in workflow' do
+      get :show, params: { id: file_set }
+      expect(response.code).to eq '401'
+      expect(response).to render_template(:unavailable)
+      expect(assigns[:presenter]).to be_instance_of Hyrax::FileSetPresenter
+      expect(flash[:notice]).to eq 'The file is not currently available because its parent work has not yet completed the approval process'
     end
   end
 end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -432,7 +432,7 @@ RSpec.describe Hyrax::FileSetsController do
       it "shows active parent" do
         expect(controller).to receive(:additional_response_formats).with(ActionController::MimeResponds::Collector)
         get :show, params: { id: file_set_active }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it "shows not currently available for inactive parent" do

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "work show view" do
              ordered_members: [file_set],
              representative_id: file_set.id)
     end
+
     let(:user) { FactoryBot.create(:user) }
     let(:file_set) { FactoryBot.create(:file_set, user: user, title: ['A Contained FileSet'], content: file) }
     let(:file) { File.open(fixture_path + '/world.png') }
@@ -26,6 +27,8 @@ RSpec.describe "work show view" do
     let!(:collection) { FactoryBot.create(:collection_lw, user: user, collection_type: multi_membership_type_1) }
 
     before do
+      work.ordered_members << file_set
+      work.save!
       sign_in user
       visit work_path
     end

--- a/spec/helpers/hyrax/workflows_helper_spec.rb
+++ b/spec/helpers/hyrax/workflows_helper_spec.rb
@@ -15,5 +15,29 @@ RSpec.describe Hyrax::WorkflowsHelper do
         it { is_expected.to be_falsey }
       end
     end
+
+    describe "when given object does not respond to #workflow_restriction?" do
+      let(:object) { double }
+      describe "when given ability can edit the given object" do
+        before { expect(ability).to receive(:can?).with(:edit, object).and_return(true) }
+        it { is_expected.to be_falsey }
+      end
+      describe "when given ability cannot edit the given object" do
+        before { expect(ability).to receive(:can?).with(:edit, object).and_return(false) }
+        context "and the object is suppressed" do
+          let(:object) { double(suppressed?: true) }
+          it { is_expected.to be_truthy }
+        end
+        context "and the object is NOT suppressed" do
+          let(:object) { double(suppressed?: false) }
+          it { is_expected.to be_falsey }
+        end
+
+        context "and the object does not respond to #suppressed?" do
+          let(:object) { double }
+          it { is_expected.to be_falsey }
+        end
+      end
+    end
   end
 end

--- a/spec/helpers/hyrax/workflows_helper_spec.rb
+++ b/spec/helpers/hyrax/workflows_helper_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe Hyrax::WorkflowsHelper do
     let(:ability) { double }
     before { allow(controller).to receive(:current_ability).and_return(ability) }
     subject { helper.workflow_restriction?(object) }
+
+    describe "when given nil" do
+      let(:object) { nil }
+      it { is_expected.to be_falsey }
+    end
     describe "when given object responds to #workflow_restriction?" do
       let(:object) { double(workflow_restriction?: returning_value) }
       context "with true" do

--- a/spec/helpers/hyrax/workflows_helper_spec.rb
+++ b/spec/helpers/hyrax/workflows_helper_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::WorkflowsHelper do
+  describe "#workflow_restriction?" do
+    let(:ability) { double }
+    before { allow(controller).to receive(:current_ability).and_return(ability) }
+    subject { helper.workflow_restriction?(object) }
+    describe "when given object responds to #workflow_restriction?" do
+      let(:object) { double(workflow_restriction?: returning_value) }
+      context "with true" do
+        let(:returning_value) { true }
+        it { is_expected.to be_truthy }
+      end
+      context "with false" do
+        let(:returning_value) { false }
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
+end

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -60,6 +60,11 @@ RSpec.describe Hyrax::FileSetPresenter do
     subject { presenter.user_can_perform_any_action? }
     let(:current_ability) { ability }
 
+    it 'is deprecated' do
+      expect(Deprecation).to receive(:warn)
+      subject
+    end
+
     context 'when user can perform at least 1 action' do
       before do
         expect(current_ability).to receive(:can?).with(:edit, presenter.id).and_return false

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
   end
 
   it { is_expected.to delegate_method(:to_s).to(:solr_document) }
+  it { is_expected.to delegate_method(:suppressed?).to(:solr_document) }
   it { is_expected.to delegate_method(:human_readable_type).to(:solr_document) }
   it { is_expected.to delegate_method(:date_created).to(:solr_document) }
   it { is_expected.to delegate_method(:date_modified).to(:solr_document) }

--- a/spec/views/hyrax/base/_member.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_member.html.erb_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/base/_member.html.erb' do
+  let(:work_solr_document) do
+    SolrDocument.new(id: '900', title_tesim: ['My Title'])
+  end
   let(:solr_document) do
     SolrDocument.new(id: '999',
                      has_model_ssim: ['FileSet'],
@@ -12,9 +15,12 @@ RSpec.describe 'hyrax/base/_member.html.erb' do
   # Ability is checked in FileSetPresenter#link_name
   let(:ability) { double(can?: true) }
   let(:presenter) { Hyrax::FileSetPresenter.new(solr_document, ability) }
+  let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
 
   before do
     assign(:presenter, presenter)
+    assign(:parent_presenter, parent_presenter)
+    allow(presenter).to receive(:parent_presenter).and_return parent_presenter
     allow(view).to receive(:current_search_session).and_return nil
     allow(view).to receive(:search_session).and_return({})
     # abilities called in _actions.html.erb

--- a/spec/views/hyrax/base/_member.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_member.html.erb_spec.rb
@@ -18,9 +18,11 @@ RSpec.describe 'hyrax/base/_member.html.erb' do
   let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
 
   before do
+    allow(controller).to receive(:current_ability).and_return(ability)
     assign(:presenter, presenter)
     assign(:parent_presenter, parent_presenter)
     allow(presenter).to receive(:parent_presenter).and_return parent_presenter
+    allow(presenter).to receive(:parent).and_return parent_presenter
     allow(view).to receive(:current_search_session).and_return nil
     allow(view).to receive(:search_session).and_return({})
     # abilities called in _actions.html.erb
@@ -34,7 +36,7 @@ RSpec.describe 'hyrax/base/_member.html.erb' do
   end
 
   it 'checks the :download ability' do
-    expect(view).to have_received(:can?).with(:download, kind_of(String)).once
+    expect(view).to have_received(:can?).with(:download, kind_of(String)).at_least(1).times
   end
 
   it 'renders the view' do

--- a/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'hyrax/base/_show_actions.html.erb', type: :view do
 
   before do
     allow(ability).to receive(:can?).with(:create, FeaturedWork).and_return(false)
+    allow(presenter).to receive(:workflow_restriction?).and_return(false)
   end
 
   context "as an unregistered user" do

--- a/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'hyrax/base/_show_actions.html.erb', type: :view do
 
   before do
     allow(ability).to receive(:can?).with(:create, FeaturedWork).and_return(false)
-    allow(presenter).to receive(:workflow_restriction?).and_return(false)
+    allow(view).to receive(:workflow_restriction?).and_return(false)
   end
 
   context "as an unregistered user" do

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
   end
 
   before do
+    allow(ability).to receive(:can?).with(:edit, work_solr_document).and_return(false)
     allow(presenter).to receive(:workflow).and_return(workflow_presenter)
     allow(presenter).to receive(:representative_presenter).and_return(representative_presenter)
     allow(presenter).to receive(:representative_id).and_return(representative_presenter&.id)

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
                      publisher_tesim: ['French Press'])
   end
 
+  let(:decorated_work_solr_document) { Hyrax::SolrDocument::OrderedMembers.decorate(work_solr_document) }
+
   let(:file_set_solr_document) do
     SolrDocument.new(id: '123',
                      title_tesim: ['My FileSet'],
@@ -46,7 +48,7 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
   end
 
   before do
-    allow(ability).to receive(:can?).with(:edit, work_solr_document).and_return(false)
+    allow(ability).to receive(:can?).with(:edit, decorated_work_solr_document).and_return(false)
     allow(presenter).to receive(:workflow).and_return(workflow_presenter)
     allow(presenter).to receive(:representative_presenter).and_return(representative_presenter)
     allow(presenter).to receive(:representative_id).and_return(representative_presenter&.id)

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
     allow(presenter).to receive(:representative_id).and_return(representative_presenter&.id)
     allow(presenter).to receive(:tweeter).and_return("@#{depositor.twitter_handle}")
     allow(presenter).to receive(:human_readable_type).and_return("Work")
+    allow(representative_presenter).to receive(:parent).and_return(presenter)
     allow(controller).to receive(:current_user).and_return(depositor)
     allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
     allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)

--- a/spec/views/hyrax/base/unavailable.html.erb_spec.rb
+++ b/spec/views/hyrax/base/unavailable.html.erb_spec.rb
@@ -1,37 +1,71 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/base/unavailable.html.erb', type: :view do
-  let(:model) do
-    double('model',
-           persisted?: true,
-           to_param: '123',
-           model_name: GenericWork.model_name)
-  end
-  let(:workflow_presenter) do
-    double('workflow_presenter',
-           badge: '<span class="label label-primary state state-deposited">really deposited</span>')
-  end
-  let(:presenter) do
-    double('presenter',
-           to_s: 'super cool',
-           workflow: workflow_presenter,
-           human_readable_type: 'Generic Work')
-  end
-  let(:parent_presenter) do
-    double('parent_presenter',
-           to_s: 'parental remark',
-           to_model: model,
-           human_readable_type: 'Foo Bar')
+  context "for works" do
+    let(:model) do
+      double('model',
+             persisted?: true,
+             to_param: '123',
+             model_name: GenericWork.model_name)
+    end
+    let(:workflow_presenter) do
+      double('workflow_presenter',
+             badge: '<span class="label label-primary state state-deposited">really deposited</span>')
+    end
+    let(:presenter) do
+      double('presenter',
+             to_s: 'super cool',
+             workflow: workflow_presenter,
+             human_readable_type: 'Generic Work')
+    end
+    let(:parent_presenter) do
+      double('parent_presenter',
+             to_s: 'parental remark',
+             to_model: model,
+             human_readable_type: 'Foo Bar')
+    end
+
+    before do
+      assign(:presenter, presenter)
+      assign(:parent_presenter, parent_presenter)
+      render
+    end
+    it "renders with page" do
+      expect(rendered).to have_content 'super cool'
+      expect(rendered).to have_content 'really deposited'
+      expect(rendered).to have_content 'parental remark'
+      expect(rendered).to have_content 'Generic Work'
+    end
   end
 
-  before do
-    assign(:presenter, presenter)
-    assign(:parent_presenter, parent_presenter)
-    render
-  end
-  it "renders with page" do
-    expect(rendered).to have_content 'super cool'
-    expect(rendered).to have_content 'really deposited'
-    expect(rendered).to have_content 'parental remark'
-    expect(rendered).to have_content 'Generic Work'
+  context "for file sets" do
+    let(:model) do
+      double('model',
+             persisted?: true,
+             to_param: '123',
+             model_name: FileSet.model_name)
+    end
+    let(:presenter) do
+      double('presenter',
+             to_s: 'super cool',
+             workflow: nil, # File sets don't have workflow
+             human_readable_type: "File Set")
+    end
+    let(:parent_presenter) do
+      double('parent_presenter',
+             to_s: 'parental remark',
+             to_model: model,
+             human_readable_type: 'Foo Bar')
+    end
+
+    before do
+      assign(:presenter, presenter)
+      assign(:parent_presenter, parent_presenter)
+      render
+    end
+    it "renders with page" do
+      expect(rendered).to have_content 'super cool'
+      expect(rendered).to have_content 'parental remark'
+      expect(rendered).to have_content 'File Set'
+    end
   end
 end

--- a/spec/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'hyrax/dashboard/collections/_show_document_list_menu.html.erb', 
     end
 
     it "displays the action list in a drop down for an individual work the user can edit" do
-      allow(ability).to receive(:can?).with(:edit, document).and_return(true)
+      allow(ability).to receive(:can?).with(:edit, anything).and_return(true)
       render('show_document_list_menu', document: document, current_user: user)
       expect(rendered).to have_content 'Select'
       expect(rendered).to have_content 'Edit'
@@ -21,7 +21,7 @@ RSpec.describe 'hyrax/dashboard/collections/_show_document_list_menu.html.erb', 
     end
 
     it "displays the action list in a drop down for an individual work the user cannot edit" do
-      allow(ability).to receive(:can?).with(:edit, document).and_return(false)
+      allow(ability).to receive(:can?).with(:edit, anything).and_return(false)
       render('show_document_list_menu', document: document, current_user: user)
       expect(rendered).to have_content 'Select'
       expect(rendered).not_to have_content 'Edit'

--- a/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
@@ -4,10 +4,14 @@ RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
   let(:user) { build(:user) }
   let(:ability) { Ability.new(user) }
   let(:file_set) { Hyrax::FileSetPresenter.new(solr_document, ability) }
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(file_set).to receive(:parent).and_return(:parent)
+  end
 
   context 'with download permission' do
     before do
-      allow(file_set).to receive(:user_can_perform_any_action?).and_return(true)
+      allow(view).to receive(:workflow_restriction?).and_return(false)
       allow(view).to receive(:can?).with(:edit, file_set.id).and_return(false)
       allow(view).to receive(:can?).with(:destroy, file_set.id).and_return(false)
       allow(view).to receive(:can?).with(:download, file_set.id).and_return(true)
@@ -21,12 +25,10 @@ RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
   end
 
   context 'with no permission' do
-    let(:current_ability) { ability }
-
     before do
-      allow(current_ability).to receive(:can?).with(:edit, file_set.id).and_return(false)
-      allow(current_ability).to receive(:can?).with(:destroy, file_set.id).and_return(false)
-      allow(current_ability).to receive(:can?).with(:download, file_set.id).and_return(false)
+      allow(view).to receive(:can?).with(:edit, file_set.id).and_return(false)
+      allow(view).to receive(:can?).with(:destroy, file_set.id).and_return(false)
+      allow(view).to receive(:can?).with(:download, file_set.id).and_return(false)
       render 'hyrax/file_sets/actions', file_set: file_set
     end
 

--- a/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'hyrax/file_sets/_show_actions.html.erb', type: :view do
       rights_tesim: ['http://creativecommons.org/licenses/by/3.0/us/']
     )
   end
+  let(:decorated_solr_document) { Hyrax::SolrDocument::OrderedMembers.decorate(solr_document) }
   let(:ability) { Ability.new(user) }
   let(:presenter) do
     Hyrax::WorkShowPresenter.new(solr_document, ability)
@@ -49,7 +50,7 @@ RSpec.describe 'hyrax/file_sets/_show_actions.html.erb', type: :view do
 
   describe 'editor' do
     before do
-      allow(ability).to receive(:can?).with(:edit, solr_document).and_return(true)
+      allow(ability).to receive(:can?).with(:edit, decorated_solr_document).and_return(true)
       allow(presenter).to receive(:editor?).and_return(true)
       assign(:presenter, presenter)
       view.lookup_context.view_paths.push 'app/views/hyrax/base'

--- a/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe 'hyrax/file_sets/_show_actions.html.erb', type: :view do
 
   describe 'editor' do
     before do
+      allow(ability).to receive(:can?).with(:edit, solr_document).and_return(true)
       allow(presenter).to receive(:editor?).and_return(true)
       assign(:presenter, presenter)
       view.lookup_context.view_paths.push 'app/views/hyrax/base'

--- a/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'hyrax/file_sets/_show_actions.html.erb', type: :view do
     Hyrax::WorkShowPresenter.new(solr_document, ability)
   end
   let(:page) { Capybara::Node::Simple.new(rendered) }
+  before { allow(controller).to receive(:current_ability).and_return(ability) }
 
   describe 'citations' do
     before do
@@ -50,7 +51,7 @@ RSpec.describe 'hyrax/file_sets/_show_actions.html.erb', type: :view do
 
   describe 'editor' do
     before do
-      allow(ability).to receive(:can?).with(:edit, decorated_solr_document).and_return(true)
+      allow(ability).to receive(:can?).with(:edit, anything).and_return(true)
       allow(presenter).to receive(:editor?).and_return(true)
       assign(:presenter, presenter)
       view.lookup_context.view_paths.push 'app/views/hyrax/base'

--- a/spec/views/hyrax/file_sets/media_display/_audio.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_audio.html.erb_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/file_sets/media_display/_audio.html.erb', type: :view do
-  let(:file_set) { stub_model(FileSet) }
+  let(:file_set) { stub_model(FileSet, parent: parent) }
   let(:config) { double }
+  let(:parent) { double }
   let(:link) { true }
 
   before do
+    allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
     render 'hyrax/file_sets/media_display/audio', file_set: file_set
   end

--- a/spec/views/hyrax/file_sets/media_display/_default.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_default.html.erb_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/file_sets/media_display/_default.html.erb', type: :view do
-  let(:file_set) { stub_model(FileSet) }
+  let(:file_set) { stub_model(FileSet, parent: parent) }
+  let(:parent) { double }
   let(:config) { double }
   let(:link) { true }
 
   before do
+    allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
     render 'hyrax/file_sets/media_display/default', file_set: file_set
   end

--- a/spec/views/hyrax/file_sets/media_display/_video.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_video.html.erb_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/file_sets/media_display/_video.html.erb', type: :view do
-  let(:file_set) { stub_model(FileSet) }
+  let(:file_set) { stub_model(FileSet, parent: parent) }
+  let(:parent) { double }
   let(:config) { double }
   let(:link) { true }
 
   before do
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
+    allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
     render 'hyrax/file_sets/media_display/video', file_set: file_set
   end
 

--- a/spec/views/hyrax/file_sets/show.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/show.html.erb_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe 'hyrax/file_sets/show.html.erb', type: :view do
 
   before do
     view.lookup_context.prefixes.push 'hyrax/base'
+    allow(view).to receive(:can?).with(:edit, Hyrax::SolrDocument::OrderedMembers).and_return(false)
+    allow(ability).to receive(:can?).with(:edit, Hyrax::SolrDocument::OrderedMembers).and_return(false)
     allow(view).to receive(:can?).with(:edit, SolrDocument).and_return(false)
     allow(ability).to receive(:can?).with(:edit, SolrDocument).and_return(false)
     allow(presenter).to receive(:fixity_status).and_return(mock_metadata)

--- a/spec/views/hyrax/file_sets/show.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/show.html.erb_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe 'hyrax/file_sets/show.html.erb', type: :view do
       logged_fixity_status: "Fixity checks have not yet been run on this file"
     }
   end
+  let(:work_solr_document) do
+    SolrDocument.new(id: '900', title_tesim: ['My Title'])
+  end
+  let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
 
   before do
     view.lookup_context.prefixes.push 'hyrax/base'
@@ -27,6 +31,8 @@ RSpec.describe 'hyrax/file_sets/show.html.erb', type: :view do
     allow(ability).to receive(:can?).with(:edit, SolrDocument).and_return(false)
     allow(presenter).to receive(:fixity_status).and_return(mock_metadata)
     assign(:presenter, presenter)
+    assign(:parent_presenter, parent_presenter)
+    allow(presenter).to receive(:parent_presenter).and_return parent_presenter
     assign(:document, solr_doc)
     assign(:fixity_status, "none")
   end

--- a/spec/views/hyrax/file_sets/show.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/show.html.erb_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'hyrax/file_sets/show.html.erb', type: :view do
   let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
 
   before do
+    allow(view).to receive(:workflow_restriction?).and_return(false)
     view.lookup_context.prefixes.push 'hyrax/base'
     allow(view).to receive(:can?).with(:edit, Hyrax::SolrDocument::OrderedMembers).and_return(false)
     allow(ability).to receive(:can?).with(:edit, Hyrax::SolrDocument::OrderedMembers).and_return(false)
@@ -34,6 +35,7 @@ RSpec.describe 'hyrax/file_sets/show.html.erb', type: :view do
     allow(presenter).to receive(:fixity_status).and_return(mock_metadata)
     assign(:presenter, presenter)
     assign(:parent_presenter, parent_presenter)
+    allow(presenter).to receive(:parent).and_return(parent_presenter)
     allow(presenter).to receive(:parent_presenter).and_return parent_presenter
     assign(:document, solr_doc)
     assign(:fixity_status, "none")


### PR DESCRIPTION
## Recommended updates.

1efe93929285985751cc270675c243f628cf31ca

The above title is from the original commit.  What follows is the
description put in the PR message:

Add parent_presenter to file_set_presenter and use it to enforce access
restrictions from workflow mediated review. If public view not available
generate an unavailable page similar to a work's unavailable page.

Fixes #3775 ; refs #3881

Update to prevent direct navigation to file sets under works that are
public but restricted by workflow. When a user navigates to public file
sets in a workflow without and that user does not have edit privileges,
an unavailable screen is displayed.  From a work in the workflow that is
pending review, the file sets will not be
editable/deletable/downloadable.  Direct navigation to a file set for
users without edit privileges will result in an unavailable screen.

Guidance for testing, such as acceptance criteria or new user interface
behaviors:

* As a non-admin user, create a work with an attached file and place it
  in a mediate workflow (such as one step mediated workflow)
* From the work, you should not be able to edit/delete/download the file
* Navigate to the file set, it will show an unavailable file set
* Copy the url of file set
* Log out
* Directly navigate to the file set url, it will show unavailable

## Updating spec to use decorator

4fccf2b57ea282e4da0a57a77c7cecaae1675e09

This commit builds on the rebased commit of
e9697e4641ac50068fbda72e0bed94fc8adbdba4

The rebased commit was from an aging PR (#3881) that addressed #3775.
In the time between the submission of the original PR and the
revisitation, we updated some underlying aspects of Hyrax.

This is a quick fix to get a build working.  I'll rely on reviewers to
determine if its appropriate.

A question remains, should our `Hyrax::SolrDocument::OrderedMembers`
"be_a" SolrDocument?

## Favoring method usage instead of instance_variable

d6b83ad87b83514583aa2ff5536bc8061e09ddcf

It's odd to have both a method and a like named instance variable.  This
tidies that up.

## Addressing deprecation warning for success?

5a011e0a616d69a34570f113cf5cd8201d3b13ec

```
DEPRECATION WARNING: The success? predicate is deprecated and will
be removed in Rails 6.0. Please use successful? as provided by
Rack::Response::Helpers. (called from block (4 levels) in
<top (required)> at
./spec/controllers/hyrax/file_sets_controller_spec.rb:435)
```

## Compressing logic around workflow restriction

5463ea0aef511e3988783bf73cc754bfcb790c91

This commit attempts to normalize and consolidate the underlying logic
introduced in the Hyrax::FileSetsController.

As commented, there are application states in which we call the
guard_for_workflow_restriction_on! method:

- show action: when we start from a `presenter`
- edit/update/delete: when we start from a `curation_concern`

Both of those objects have a `parent` object but of different types.
The guard_for_workflow_restrion_on! now handles both of those parent
object types.

In doing so, the method begins to look like another method introduced in
a presenter (as noted).

To ensure that this works in the controller, I added the `#suppressed?`
method to the WorkShowPresenter.  Perhaps an oversight in delegation.

## Favoring helper method over presenter method

35f7d6f090e10256031dccdf00e888abd331e200

In discussions with @no_reply, I'm looking to trim the size of
presenters.  As envisioned, presenters should be more about gathering up
data to present.  Helpers shine when used for conditional rendering.

Since we don't ask presenters to "render themself" this inflection makes
sense; Let the helpers decide render logic.

This is an interstitial commit.  It preserves the backwards behavior.

## Fleshing out logic of workflow_restriction? helper

1a2e0ba05ce3df0e5fb06f6b7a87ecab35a99d41

As I noodle on this, I'm fairly certain we should be registering a
CanCan ability check.  I believe in promoting this to a helper method it
will be easier to incorporate this into an ability.

However, that is presently outside the scope of what I consider
necessary.

## Swiching Hyrax::FileSetsController to use helper

cb21570fadcea0b8d1dfd0b7cffecf5135c1ea76

The echoed the logic of `Hyrax::Workflows#workflow_restriction?`, this
change leverages that single source of logic for evaluation.

## Refactoring view logic to use helper method

cbdf4f6eabba0f131d4983075e11f8b629788f22

This also involves introducing a deprecation on a single use method.

## Fixing broken specs based on prior refactors

5d19677e8d668270ef82d3a10c1e559001120ad6


## Echoing past logic around `@presenter.try(:parent)`

38b3640a0467f818ab48cec03f646531e8213bb4

The `./spec/features/batch_edit_spec.rb` failed as the SolrDocuments did
not have a parent concept.

I'm uncertain what to do about this, but am offering it up for consideration.
