### PR TITLE
Make 'Add files...' and 'Add folder...' buttons to work with tab key navigation

### DIFF
--- a/app/assets/stylesheets/fileupload/jquery.fileupload-ui.scss
+++ b/app/assets/stylesheets/fileupload/jquery.fileupload-ui.scss
@@ -15,25 +15,11 @@
   padding: 1.5em 0;
 }
 
-.fileinput-button {
+.upload-button {
   float: left;
-  margin-right: .50em;
+  margin-right: 0.5em;
   overflow: hidden;
   position: relative;
-
-  input {
-    border-width: 0 0 100px 200px;
-    border: solid transparent;
-    cursor: pointer;
-    direction: ltr;
-    filter: alpha(opacity = 0);
-    margin: 0;
-    opacity: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    -moz-transform: translate(-300px, 0) scale(4);
-  }
 }
 
 // Global progress bar

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -12,18 +12,20 @@
         <div class="fileupload-buttonbar">
           <div class="row">
             <div class="col-xs-12">
-                <!-- The fileinput-button span is used to style the file input field as button -->
-                <span id="addfiles" class="btn btn-success fileinput-button">
+                <div class="upload-button">
+                  <input id="addfiles" type="file" style="display:none;"  name="files[]" multiple />
+                  <button type="button" class="btn btn-success" onclick="document.getElementById('addfiles').click();">
                     <span class="glyphicon glyphicon-plus"></span>
                     <span><%=  t(".add_files") %></span>
-                    <input type="file" name="files[]" multiple />
-                </span>
-                <!-- The fileinput-button span is used to style the file input field as button -->
-                <span id="addfolder" class="btn btn-success fileinput-button">
+                  </button>
+                </div>
+                <div class="upload-button">
+                  <input id="addfolder" type="file" style="display:none;"  name="files[]" multiple directory webkitdirectory />
+                  <button type="button" class="btn btn-success" onclick="document.getElementById('addfolder').click();">
                     <span class="glyphicon glyphicon-plus"></span>
                     <span><%=  t(".add_folder") %></span>
-                    <input type="file" name="files[]" multiple directory webkitdirectory />
-                </span>
+                  </button>
+                </div>
                 <% if Hyrax.config.browse_everything? %>
                   <%= button_tag(type: 'button', class: 'btn btn-success', id: "browse-btn",
                     'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,


### PR DESCRIPTION
Fixes #3451

This PR allows access `Add Files...` and `Add Folder...` buttons using Tab key in the keyboard within the `Files` tab when a user is creating a new work.

Changes proposed in this pull request:
* Using `button` elements instead of `span` to open file dialog

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Add new work
* Go to `Files` tab in the window
* Use `Tab` to focus on `Add Files...` and `Add Folder...` buttons
* Press `Enter` to open the file dialog

@samvera/hyrax-code-reviewers
