### PR TITLE
Make Add files and Add folder buttons to work with tab key navigation

### DIFF
--- a/app/assets/stylesheets/fileupload/jquery.fileupload-ui.scss
+++ b/app/assets/stylesheets/fileupload/jquery.fileupload-ui.scss
@@ -17,23 +17,9 @@
 
 .fileinput-button {
   float: left;
-  margin-right: .50em;
+  margin-right: 0.5em;
   overflow: hidden;
   position: relative;
-
-  input {
-    border-width: 0 0 100px 200px;
-    border: solid transparent;
-    cursor: pointer;
-    direction: ltr;
-    filter: alpha(opacity = 0);
-    margin: 0;
-    opacity: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    -moz-transform: translate(-300px, 0) scale(4);
-  }
 }
 
 // Global progress bar

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -12,18 +12,20 @@
         <div class="fileupload-buttonbar">
           <div class="row">
             <div class="col-xs-12">
-                <!-- The fileinput-button span is used to style the file input field as button -->
-                <span id="addfiles" class="btn btn-success fileinput-button">
+                <div class="fileinput-button" id="add-files">
+                  <input id="addfiles" type="file" style="display:none;"  name="files[]" multiple />
+                  <button type="button" class="btn btn-success" onclick="document.getElementById('addfiles').click();">
                     <span class="glyphicon glyphicon-plus"></span>
                     <span><%=  t(".add_files") %></span>
-                    <input type="file" name="files[]" multiple />
-                </span>
-                <!-- The fileinput-button span is used to style the file input field as button -->
-                <span id="addfolder" class="btn btn-success fileinput-button">
+                  </button>
+                </div>
+                <div class="fileinput-button">
+                  <input id="addfolder" type="file" style="display:none;"  name="files[]" multiple directory webkitdirectory />
+                  <button type="button" class="btn btn-success" onclick="document.getElementById('addfolder').click();">
                     <span class="glyphicon glyphicon-plus"></span>
                     <span><%=  t(".add_folder") %></span>
-                    <input type="file" name="files[]" multiple directory webkitdirectory />
-                </span>
+                  </button>
+                </div>
                 <% if Hyrax.config.browse_everything? %>
                   <%= button_tag(type: 'button', class: 'btn btn-success', id: "browse-btn",
                     'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
     it "allows on-behalf-of batch deposit", :js do
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
-      within('span#addfiles') do
+      within('div#add-files') do
         # two arbitrary files that aren't actually related, but should be
         # small enough to require minimal processessing.
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/small_file.txt", visible: false)

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
       expect(page).to have_content "Add folder"
-      within('span#addfiles') do
+      within('div#add-files') do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
@@ -70,7 +70,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
     it "allows on-behalf-of deposit" do
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
-      within('span#addfiles') do
+      within('div#add-files') do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
@@ -122,7 +122,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
 
     it 'updates the required file check status' do
       click_link "Files" # switch to the Files tab
-      within('span#addfiles') do
+      within('div#add-files') do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
       end
       expect(page).to have_css('ul li#required-files.complete', text: 'Add files')

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -669,13 +669,14 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         # add required file
         click_link "Files" # switch tab
-        within('span#addfiles') do
+        within('div#add-files') do
           attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         end
         # set required metadata
         click_link "Descriptions" # switch tab
         fill_in('Title', with: 'New Work for Collection')
         fill_in('Creator', with: 'Doe, Jane')
+
         select('In Copyright', from: 'Rights statement')
         # check required acceptance
         check('agreement')


### PR DESCRIPTION
Fixes #3451

This PR allows access `Add Files...` and `Add Folder...` buttons using Tab key in the keyboard within the `Files` tab when a user is creating a new work.
The previous implementation of `span` along with `input` HTML elements to add files/folder acted as 2 different elements in the tab order in the page. Therefore it did not show hover selections when using keyboard navigation.

Changes proposed in this pull request:
* Using `button` elements instead of `span` to open file dialog

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Add new work
* Go to `Files` tab in the window
* Use `Tab` to focus on `Add Files...` and `Add Folder...` buttons
* Press `Enter` to open the file dialog

@samvera/hyrax-code-reviewers
