### PR TITLE
Update database_migrator.rb

### DIFF
--- a/app/services/hyrax/database_migrator.rb
+++ b/app/services/hyrax/database_migrator.rb
@@ -1,3 +1,4 @@
+require 'rails/generators/actions'
 require 'rails/generators/active_record'
 
 module Hyrax


### PR DESCRIPTION
We're trying to run the hyrax install generator as part of a hyrax plugin (`hyrax-active_encode`) but running into an issue when it tries to install migrations leading to the error below: 
```
        rake  hyrax:install:migrations
rake aborted!
NameError: uninitialized constant Rails::Generators::Actions
/usr/local/bundle/gems/railties-5.1.7/lib/rails/generators/base.rb:17:in `<class:Base>'
/usr/local/bundle/gems/railties-5.1.7/lib/rails/generators/base.rb:15:in `<module:Generators>'
/usr/local/bundle/gems/railties-5.1.7/lib/rails/generators/base.rb:11:in `<module:Rails>'
/usr/local/bundle/gems/railties-5.1.7/lib/rails/generators/base.rb:10:in `<top (required)>'
/usr/local/bundle/gems/railties-5.1.7/lib/rails/generators/named_base.rb:2:in `<top (required)>'
/usr/local/bundle/gems/activerecord-5.1.7/lib/rails/generators/active_record.rb:1:in `<top (required)>'
/usr/local/bundle/gems/hyrax-2.5.1/app/services/hyrax/database_migrator.rb:1:in `<top (required)>'
/usr/local/bundle/gems/activesupport-5.1.7/lib/active_support/dependencies/interlock.rb:12:in `block in loading'
/usr/local/bundle/gems/activesupport-5.1.7/lib/active_support/concurrency/share_lock.rb:149:in `exclusive'
/usr/local/bundle/gems/activesupport-5.1.7/lib/active_support/dependencies/interlock.rb:11:in `loading'
/usr/local/bundle/gems/hyrax-2.5.1/lib/tasks/install.rake:5:in `block (3 levels) in <top (required)>'
/usr/local/bundle/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
Tasks: TOP => hyrax:install:migrations
(See full trace by running task with --trace)
```

We've worked around this by rerunning the migration installation: https://github.com/samvera-labs/hyrax-active_encode/blob/work_type/spec/test_app_templates/lib/generators/test_app_generator.rb#L14-L19

This PR should fix this issue so the migration installation works during the normal hyrax install generator.

@samvera/hyrax-code-reviewers
