### PR TITLE
Fix latest recommended Rails 5.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Hyrax requires Rails 5. We recommend the latest Rails 5.1 release.
 
 ```
 # If you don't already have Rails at your disposal...
-gem install rails -v 5.1.6
+gem install rails -v 5.1.7
 ```
 
 ### JavaScript runtime


### PR DESCRIPTION
We recommend Rails 5.1.7 in the `rails new` call below, but give the wrong
version here. This bumps the version for a clearer install process.

@samvera/hyrax-code-reviewers
