### PR TITLE
Use `Arel.sql` to wrap a known safe SQL string in PermissionsService

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -73,7 +73,7 @@ module Hyrax
         ids = PermissionTemplateAccess.for_user(ability: self,
                                                 access: ['deposit', 'manage'])
                                       .joins(:permission_template)
-                                      .pluck('DISTINCT source_id')
+                                      .pluck(Arel.sql('DISTINCT source_id'))
         query = "_query_:\"{!raw f=has_model_ssim}AdminSet\" AND {!terms f=id}#{ids.join(',')}"
         Hyrax::SolrService.count(query).positive?
       end

--- a/app/services/hyrax/collection_types/permissions_service.rb
+++ b/app/services/hyrax/collection_types/permissions_service.rb
@@ -13,7 +13,7 @@ module Hyrax
       #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
       def self.collection_type_ids_for_user(roles:, user: nil, ability: nil)
         return false unless user.present? || ability.present?
-        return Hyrax::CollectionType.all.pluck('DISTINCT id') if user_admin?(user, ability)
+        return Hyrax::CollectionType.all.pluck(Arel.sql('DISTINCT id')) if user_admin?(user, ability)
         Hyrax::CollectionTypeParticipant.where(agent_type: Hyrax::CollectionTypeParticipant::USER_TYPE,
                                                agent_id: user_id(user, ability),
                                                access: roles)
@@ -21,7 +21,7 @@ module Hyrax
                                           Hyrax::CollectionTypeParticipant.where(agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE,
                                                                                  agent_id: user_groups(user, ability),
                                                                                  access: roles)
-                                        ).pluck('DISTINCT hyrax_collection_type_id')
+                                        ).pluck(Arel.sql('DISTINCT hyrax_collection_type_id'))
       end
 
       # @api public
@@ -174,7 +174,7 @@ module Hyrax
       def self.agent_ids_for(collection_type:, agent_type:, access:)
         Hyrax::CollectionTypeParticipant.where(hyrax_collection_type_id: collection_type.id,
                                                agent_type: agent_type,
-                                               access: access).pluck('DISTINCT agent_id')
+                                               access: access).pluck(Arel.sql('DISTINCT agent_id'))
       end
       private_class_method :agent_ids_for
 
@@ -190,7 +190,7 @@ module Hyrax
         return [] unless collection_type
         Hyrax::CollectionTypeParticipant.joins(:hyrax_collection_type).where(hyrax_collection_type_id: collection_type.id,
                                                                              agent_type: Hyrax::CollectionTypeParticipant::USER_TYPE,
-                                                                             access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS).pluck('DISTINCT agent_id')
+                                                                             access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS).pluck(Arel.sql('DISTINCT agent_id'))
       end
 
       # @api public
@@ -205,7 +205,7 @@ module Hyrax
         return [] unless collection_type
         groups = Hyrax::CollectionTypeParticipant.joins(:hyrax_collection_type).where(hyrax_collection_type_id: collection_type.id,
                                                                                       agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE,
-                                                                                      access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS).pluck('DISTINCT agent_id')
+                                                                                      access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS).pluck(Arel.sql('DISTINCT agent_id'))
         groups | ['admin']
       end
 

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -13,7 +13,7 @@ module Hyrax
       def self.source_ids_for_user(access:, ability:, source_type: nil, exclude_groups: [])
         scope = PermissionTemplateAccess.for_user(ability: ability, access: access, exclude_groups: exclude_groups)
                                         .joins(:permission_template)
-        ids = scope.pluck('DISTINCT source_id')
+        ids = scope.pluck(Arel.sql('DISTINCT source_id'))
         return ids unless source_type
         filter_source(source_type: source_type, ids: ids)
       end


### PR DESCRIPTION
To protect against injection attacks, `#pluck` has deprecated raw SQL strings in
Rails 5.2.

We could use `pluck(:source_id).uniq` here. This would be less efficient in
some cases. I didn't have the time to look into whether those cases are likely
to arise, so we simply mark the SQL string as safe by wrapping it with
`Arel.sql()`.

Connected to #3030 

@samvera/hyrax-code-reviewers
