### PR TITLE
Don't short-circut actor Environment when interpreting visibility

### DIFF
--- a/app/actors/hyrax/actors/create_with_files_ordered_members_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_ordered_members_actor.rb
@@ -35,9 +35,9 @@ module Hyrax
     # Creates a work and attaches files to the work
     class CreateWithFilesOrderedMembersActor < CreateWithFilesActor
       # @return [TrueClass]
-      def attach_files(files, env)
+      def attach_files(files, curation_concern, attributes)
         return true if files.blank?
-        AttachFilesToWorkWithOrderedMembersJob.perform_later(env.curation_concern, files, env.attributes.to_h.symbolize_keys)
+        AttachFilesToWorkWithOrderedMembersJob.perform_later(curation_concern, files, attributes.to_h.symbolize_keys)
         true
       end
     end

--- a/app/actors/hyrax/actors/environment.rb
+++ b/app/actors/hyrax/actors/environment.rb
@@ -10,8 +10,14 @@ module Hyrax
         @attributes = attributes.to_h.with_indifferent_access
       end
 
-      attr_reader   :current_ability, :attributes
-      attr_accessor :curation_concern
+      ##
+      # @!attribute [rw] attributes
+      #   @return [Hash]
+      # @!attribute [rw] curation_concern
+      #   @return [Object]
+      # @!attribute [rw] current_ability
+      #   @return [Hyrax::Ability]
+      attr_accessor :attributes, :curation_concern, :current_ability
 
       # @return [User] the user from the current_ability
       def user

--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -72,20 +72,18 @@ module Hyrax
       # @return [Boolean] true if create was successful
       def create(env)
         intention = Intention.new(env.attributes)
-        attributes = intention.sanitize_params
-        new_env = Environment.new(env.curation_concern, env.current_ability, attributes)
-        validate(env, intention, attributes) && apply_visibility(new_env, intention) &&
-          next_actor.create(new_env)
+        env.attributes = intention.sanitize_params
+        validate(env, intention, env.attributes) && apply_visibility(env, intention) &&
+          next_actor.create(env)
       end
 
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if update was successful
       def update(env)
         intention = Intention.new(env.attributes)
-        attributes = intention.sanitize_params
-        new_env = Environment.new(env.curation_concern, env.current_ability, attributes)
-        validate(env, intention, attributes) && apply_visibility(new_env, intention) &&
-          next_actor.update(new_env)
+        env.attributes = intention.sanitize_params
+        validate(env, intention, env.attributes) && apply_visibility(env, intention) &&
+          next_actor.update(env)
       end
 
       private


### PR DESCRIPTION
`InterpretVisibilityActor` previously short-circuited `env` by initializing a completely new copy for use further down the stack. Changes to the environment after that point would fail to have any impact further up the stack, where actors are already using the older `env`.

The original reason the `InterpretVisibilityActor` did this was to alter the attributes in batch; i.e. this was a work around for `#attributes=`. We add support for that method, then we can use it instead.

The `CreateFilesActor`, by contrast, was counting on those attributes not to change. Since any actor further down the stack may change them, it's better to cache them immediately.

@samvera/hyrax-code-reviewers
