### PR TITLE
[wings] Use the model's id minting logic in the transformer

### DIFF
--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -121,10 +121,13 @@ RSpec.describe Wings::ModelTransformer do
       let(:minted_id) { 'bobross' }
 
       before do
+        Hyrax.config.enable_noids = true
         allow_any_instance_of(::Noid::Rails.config.minter_class)
           .to receive(:mint)
           .and_return(minted_id)
       end
+
+      after { Hyrax.config.enable_noids = false }
 
       it { expect(factory.build).to have_a_valkyrie_alternate_id_of minted_id }
     end


### PR DESCRIPTION
The ActiveFedora model provides an `#assign_id` method, which can be used
directly instead of reaching into the id minter for assigning ids. This
reinstates compatibility between wings and models that are using Hyrax's
prescribed interfaces for minting identifiers.

By default, this only mints ids when the noid minter is enabled.

@samvera/hyrax-code-reviewers
