### PR TITLE
[wings] Use attributes to build embargo/lease in `ModelTransformer`

### DIFF
--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -241,15 +241,21 @@ module Wings
       end
 
       def append_embargo(attrs)
-        embargo_id      = pcdm_object.try(:embargo_id) || pcdm_object.try(:embargo)&.id
-        attrs[:embargo] = Hyrax.query_service.find_by(id: ::Valkyrie::ID.new(embargo_id)) if
-          embargo_id
+        return unless pcdm_object.try(:embargo)
+        embargo_attrs = pcdm_object.embargo.attributes.symbolize_keys
+        embargo_attrs[:embargo_history] = embargo_attrs[:embargo_history].to_a
+        embargo_attrs[:id] = ::Valkyrie::ID.new(embargo_attrs[:id]) if embargo_attrs[:id]
+
+        attrs[:embargo] = Hyrax::Embargo.new(**embargo_attrs)
       end
 
       def append_lease(attrs)
-        lease_id      = pcdm_object.try(:lease_id) || pcdm_object.try(:lease)&.id
-        attrs[:lease] = Hyrax.query_service.find_by(id: ::Valkyrie::ID.new(lease_id)) if
-          lease_id
+        return unless pcdm_object.try(:lease)
+        lease_attrs = pcdm_object.lease.attributes.symbolize_keys
+        lease_attrs[:lease_history] = lease_attrs[:embargo_history].to_a
+        lease_attrs[:id] = ::Valkyrie::ID.new(lease_attrs[:id]) if lease_attrs[:id]
+
+        attrs[:lease] = Hyrax::Lease.new(**lease_attrs)
       end
   end
   # rubocop:enable Style/ClassVars Metrics/ClassLength

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -149,6 +149,14 @@ RSpec.describe Wings::ModelTransformer do
       end
     end
 
+    context 'with an unsaved embargo' do
+      let(:work) { FactoryBot.build(:embargoed_work) }
+
+      it 'has the correct embargo details' do
+        expect(factory.build.embargo).to have_attributes work.embargo.attributes.symbolize_keys
+      end
+    end
+
     context 'with newly saved embargo' do
       let(:work) { FactoryBot.build(:embargoed_work) }
 
@@ -156,6 +164,14 @@ RSpec.describe Wings::ModelTransformer do
         work.embargo.save
 
         expect(subject.build.embargo.id.id).to eq work.embargo.id
+      end
+    end
+
+    context 'with an unsaved lease' do
+      let(:work) { FactoryBot.build(:leased_work) }
+
+      it 'has the correct lease details' do
+        expect(factory.build.lease).to have_attributes work.lease.attributes.symbolize_keys
       end
     end
 


### PR DESCRIPTION
The embargo and lease casting in `ModelTransformer` previously involved fetching
embargoes and leases from the persistence layer. Since we already have the
necessary data in hand when casting, we can simply construct new instances from
the data.

This has the added benefit of adding support for saving new embargoes after
casting from `ActiveFedora`.

@samvera/hyrax-code-reviewers
