### PR TITLE
Add an actor stack spec for persisting permissions

### DIFF
--- a/spec/features/actor_stack_spec.rb
+++ b/spec/features/actor_stack_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe Hyrax::DefaultMiddlewareStack, :clean_repo do
       end
     end
 
+    context 'when adding permissions' do
+      before do
+        work.permissions.build(name: 'discover_user', type: 'person', access: 'discover')
+      end
+
+      it 'persists arbitrary ACL permissions' do
+        expect { actor.create(env) }
+          .to change { env.curation_concern.permissions }
+          .to include(grant_permission(:discover).to_user('discover_user'))
+      end
+    end
+
     context 'when noids are disabled' do
       let(:uuid_regex) { /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ }
 

--- a/spec/support/matchers/permission.rb
+++ b/spec/support/matchers/permission.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :grant_permission do |acl_type|
+  match do |permission|
+    access_match = permission.access == acl_type.to_s
+    agent_match =
+      if user_id
+        permission.type == 'person' &&
+          permission.agent.first.id.include?(user_id)
+      elsif group_id
+        permission.type == 'group' &&
+          permission.agent.first.id.include?(group_id)
+      else
+        true
+      end
+
+    return access_match && agent_match
+  end
+
+  chain :to_user,  :user_id
+  chain :to_group, :group_id
+end


### PR DESCRIPTION
The actor stack should persist arbitrary permissions. This behavior is untested
elsewhere, and may be at risk during the transition to Wings.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* No testing needed; this simply adds an integration test.

@samvera/hyrax-code-reviewers
