### PR TITLE
Adds Valkyrie native permissions and ACL handling

### DIFF
--- a/app/models/hyrax/permission.rb
+++ b/app/models/hyrax/permission.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Valkyrie native permissions (access policies) for Hyrax
+  #
+  # Permissions are persisted independently from `Hyrax::Resource`s (works,
+  # collections, file sets, etc...) since their scope is different. Access policies
+  # may be application-specific and tend to update more frequently than resource
+  # metadata. This approach also allows policies to be persisted using a
+  # different database or adapter than is used for curatorial objects.
+  class Permission < Valkyrie::Resource
+    attribute :access_to, Valkyrie::Types::ID
+    attribute :agent,     Valkyrie::Types::String
+    attribute :mode,      Valkyrie::Types::String
+  end
+end

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -3,6 +3,9 @@
 module Hyrax
   ##
   # ACLs for `Hyrax::Resource` models
+  #
+  # Allows managing `Hyrax::Permission` entries referring to a specific
+  # `Hyrax::Resource` using a simple add/delete model.
   class AccessControlList
     ##
     # @!attribute [rw] resource
@@ -16,6 +19,8 @@ module Hyrax
 
     ##
     # @param resource [Valkyrie::Resource]
+    # @param persister [#save]
+    # @param query_service [#find_inverse_references_by]
     def initialize(resource:, persister: Hyrax.persister, query_service: Hyrax.query_service)
       self.resource  = resource
       @persister     = persister
@@ -47,6 +52,15 @@ module Hyrax
     end
 
     ##
+    # @example
+    #    user = User.find('user_id')
+    #
+    #    acl.grant(:read).to(user)
+    def grant(mode)
+      ModeGrant.new(self, mode)
+    end
+
+    ##
     # @return [Boolean]
     def pending_changes?
       additions.any? || deletions.any?
@@ -58,6 +72,15 @@ module Hyrax
       Set.new(query_service.find_inverse_references_by(resource: resource, property: :access_to)) -
         deletions |
         additions
+    end
+
+    ##
+    # @example
+    #    user = User.find('user_id')
+    #
+    #    acl.revoke(:read).from(user)
+    def revoke(mode)
+      ModeRevoke.new(self, mode)
     end
 
     ##
@@ -77,6 +100,44 @@ module Hyrax
     end
 
     private
+
+      ##
+      # @abstract
+      class ModeEditor
+        def initialize(acl, mode)
+          @acl  = acl
+          @mode = mode.to_sym
+        end
+
+        private
+
+          def id_for(agent: user_or_group)
+            agent.id
+          end
+      end
+
+      class ModeGrant < ModeEditor
+        ##
+        # @return [Hyrax::AccessControlList]
+        def to(user_or_group)
+          agent_id = id_for(agent: user_or_group)
+
+          @acl << Hyrax::Permission.new(access_to: @acl.resource.id, agent: agent_id, mode: @mode)
+          @acl
+        end
+      end
+
+      class ModeRevoke < ModeEditor
+        def from(user_or_group)
+          permission_for_deletion = @acl.permissions.find do |p|
+            p.mode == @mode &&
+              p.agent == id_for(agent: user_or_group)
+          end
+
+          @acl.delete(permission_for_deletion) if permission_for_deletion
+          @acl
+        end
+      end
 
       def additions
         @additions ||= Set.new

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # ACLs for `Hyrax::Resource` models
+  class AccessControlList
+    ##
+    # @!attribute [rw] resource
+    #   @return [Valkyrie::Resource]
+    # @!attribute [r] persister
+    #   @return [#save]
+    # @!attribute [r] query_service
+    #   @return [#find_inverse_references_by]
+    attr_reader :persister, :query_service
+    attr_accessor :resource
+
+    ##
+    # @param resource [Valkyrie::Resource]
+    def initialize(resource:, persister: Hyrax.persister, query_service: Hyrax.query_service)
+      self.resource  = resource
+      @persister     = persister
+      @query_service = query_service
+    end
+
+    ##
+    # @param permission [Hyrax::Permission]
+    #
+    # @return [Boolean]
+    def <<(permission)
+      permission.access_to = resource.id
+
+      additions << permission
+
+      true
+    end
+    alias add <<
+
+    ##
+    # @param permission [Hyrax::Permission]
+    #
+    # @return [Boolean]
+    def delete(permission)
+      additions.delete(permission)
+      deletions << permission
+
+      true
+    end
+
+    ##
+    # @return [Boolean]
+    def pending_changes?
+      additions.any? || deletions.any?
+    end
+
+    ##
+    # @return [Enumerable<Hyrax::Permission>]
+    def permissions
+      Set.new(query_service.find_inverse_references_by(resource: resource, property: :access_to)) -
+        deletions |
+        additions
+    end
+
+    ##
+    # Saves the ACL for the resource, by saving each permission policy
+    #
+    # @return [Boolean]
+    def save
+      return true unless pending_changes?
+
+      deletions.each { |p| persister.delete(resource: p) }
+      deletions.clear
+
+      additions.each { |p| persister.save(resource: p) }
+      additions.clear
+
+      true
+    end
+
+    private
+
+      def additions
+        @additions ||= Set.new
+      end
+
+      def deletions
+        @deletions ||= Set.new
+      end
+  end
+end

--- a/spec/factories/permission.rb
+++ b/spec/factories/permission.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :permission, class: "Hyrax::Permission" do
+    agent { create(:user).id }
+    mode  { :read }
+  end
+end

--- a/spec/features/actor_stack_spec.rb
+++ b/spec/features/actor_stack_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe Hyrax::DefaultMiddlewareStack, :clean_repo do
       end
     end
 
+    context 'when adding permissions' do
+      before do
+        work.permissions.build(name: 'discover_user', type: 'person', access: 'discover')
+      end
+
+      it 'persists arbitrary ACL permissions' do
+        expect { actor.create(env) }
+          .to change { env.curation_concern.permissions }
+          .to include(grant_permission(:discover).to_user('discover_user'))
+      end
+    end
+
     context 'when noids are disabled' do
       let(:uuid_regex) { /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ }
 

--- a/spec/models/hyrax/permission_spec.rb
+++ b/spec/models/hyrax/permission_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Hyrax::Permission do
+  subject(:permission) { described_class.new }
+  let(:resource_id)    { Valkyrie::ID.new('fake_resource_id') }
+  let(:user_id)        { 'fake_user_id' }
+
+  it_behaves_like 'a Valkyrie::Resource' do
+    let(:resource_klass) { described_class }
+  end
+
+  describe '#access_to' do
+    it 'sets the resource for the policy' do
+      expect { permission.access_to = resource_id }
+        .to change { permission.access_to }
+        .to resource_id
+    end
+  end
+
+  describe '#agent' do
+    it 'sets the agent for the policy' do
+      expect { permission.agent = user_id }
+        .to change { permission.agent }
+        .to user_id
+    end
+  end
+
+  describe '#mode' do
+    it 'sets the mode for the policy' do
+      expect { permission.mode = :read }
+        .to change { permission.mode }
+        .to :read
+    end
+  end
+end

--- a/spec/services/hyrax/access_control_list_spec.rb
+++ b/spec/services/hyrax/access_control_list_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::AccessControlList do
+  subject(:acl) do
+    described_class.new(resource:      resource,
+                        persister:     persister,
+                        query_service: query_service)
+  end
+
+  let(:permission)    { build(:permission) }
+  let(:adapter)       { Valkyrie::MetadataAdapter.find(:test_adapter) }
+  let(:persister)     { adapter.persister }
+  let(:query_service) { adapter.query_service }
+
+  let(:resource) do
+    r = build(:hyrax_resource)
+    Hyrax.persister.save(resource: r)
+  end
+
+  describe '#permissions' do
+    it 'is empty by default' do
+      expect(acl.permissions).to be_empty
+    end
+  end
+
+  describe '#<<' do
+    it 'adds the new permission with access_to' do
+      expect { acl << permission }
+        .to change { acl.permissions }
+        .to contain_exactly(have_attributes(mode:      permission.mode,
+                                            agent:     permission.agent,
+                                            access_to: resource.id))
+    end
+  end
+
+  describe '#delete' do
+    it 'does nothing when the permission is not in the set' do
+      expect { acl.delete(permission) }
+        .not_to change { acl.permissions }
+        .from be_empty
+    end
+
+    context 'when the permission exists' do
+      before { acl << permission }
+
+      it 'removes the permission' do
+        expect { acl.delete(permission) }
+          .to change { acl.permissions }
+          .from(contain_exactly(have_attributes(mode:      permission.mode,
+                                                agent:     permission.agent,
+                                                access_to: resource.id)))
+          .to be_empty
+      end
+    end
+  end
+
+  describe '#save' do
+    it 'leaves permissions unchanged by default' do
+      expect { acl.save }
+        .not_to change { acl.permissions }
+        .from be_empty
+    end
+
+    context 'with additions' do
+      let(:permissions)      { [permission, other_permission] }
+      let(:other_permission) { build(:permission, mode: 'edit') }
+
+      before { permissions.each { |p| acl << p } }
+
+      it 'saves the permission policies' do
+        expect { acl.save }
+          .to change { acl.permissions }
+          .to contain_exactly(be_persisted, be_persisted)
+      end
+    end
+
+    context 'with deletions' do
+      let(:permissions)      { [permission, other_permission] }
+      let(:other_permission) { build(:permission, mode: 'edit') }
+
+      before do
+        permissions.each { |p| acl << p }
+        acl.save
+      end
+
+      it 'deletes the permission policy' do
+        delete_me = acl.permissions.first
+        acl.delete(delete_me)
+
+        acl.save
+
+        expect { query_service.find_by(id: delete_me.id) }
+          .to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/access_control_list_spec.rb
+++ b/spec/services/hyrax/access_control_list_spec.rb
@@ -17,6 +17,34 @@ RSpec.describe Hyrax::AccessControlList do
     Hyrax.persister.save(resource: r)
   end
 
+  describe 'grant DSL' do
+    let(:mode) { :read }
+    let(:user) { ::User.find(permission.agent) }
+
+    describe '#grant' do
+      it 'grants a permission' do
+        expect { acl.grant(mode).to(user) }
+          .to change { acl.permissions }
+          .to contain_exactly(have_attributes(mode:      mode,
+                                              agent:     user.id,
+                                              access_to: resource.id))
+      end
+    end
+
+    describe '#revoke' do
+      before do
+        acl << permission
+        acl.save
+      end
+
+      it 'revokes a permission' do
+        expect { acl.revoke(mode).from(user) }
+          .to change { acl.permissions }
+          .to be_empty
+      end
+    end
+  end
+
   describe '#permissions' do
     it 'is empty by default' do
       expect(acl.permissions).to be_empty

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -140,6 +140,10 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
+Valkyrie::MetadataAdapter.register(
+  Valkyrie::Persistence::Memory::MetadataAdapter.new, :test_adapter
+)
+
 require 'active_fedora/cleaner'
 RSpec.configure do |config|
   config.disable_monkey_patching!

--- a/spec/support/matchers/permission.rb
+++ b/spec/support/matchers/permission.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :grant_permission do |acl_type|
+  match do |permission|
+    access_match = permission.access == acl_type.to_s
+    agent_match =
+      if user_id
+        permission.type == 'person' &&
+          permission.agent.first.id.include?(user_id)
+      elsif group_id
+        permission.type == 'group' &&
+          permission.agent.first.id.include?(group_id)
+      else
+        true
+      end
+
+    return access_match && agent_match
+  end
+
+  chain :to_user,  :user_id
+  chain :to_group, :group_id
+end


### PR DESCRIPTION
Adds `Hyrax::Permission` and `Hyrax::AccessControlList` as an initial implementation of ACLs and read/edit/discover grants for objects in Valkyrie.

A simple grant/revoke DSL is added to encapsulate the most common practice of granting or revoking a particular access mode for a given user or group.

For now, this is only working against the abstract Valkyrie interface; further work is needed to allow the Wings adapter to translate the Valkyrie native approach to `ActiveFedora`-compatible data/operations.

This moves work forward toward #3584.

Changes proposed in this pull request:
* Build out low-level infrastructure for Valkyrie handling of permissions

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* none; impact of this work is limited to internals.

@samvera/hyrax-code-reviewers
