### PR TITLE
fix match_valkyrie_ids_with_af_ids

### DIFF
--- a/app/services/hyrax/file_set_csv_service.rb
+++ b/app/services/hyrax/file_set_csv_service.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 module Hyrax
   #
   # Generates CSV from a FileSet

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -237,7 +237,14 @@ module Wings
           read_users: pcdm_object.try(:read_users),
           edit_groups: pcdm_object.try(:edit_groups),
           edit_users: pcdm_object.try(:edit_users),
-          member_ids: pcdm_object.try(:ordered_member_ids) } # We want members in order, so extract from ordered_members.
+          member_ids: member_ids }
+      end
+
+      # Prefer ordered members, but if ordered members don't exist, use non-ordered members.
+      def member_ids
+        ordered_member_ids = pcdm_object.try(:ordered_member_ids)
+        return ordered_member_ids if ordered_member_ids.present?
+        pcdm_object.try(:member_ids)
       end
 
       def append_embargo(attrs)

--- a/spec/matcher_tests/match_valkyrie_ids_with_af_ids_spec.rb
+++ b/spec/matcher_tests/match_valkyrie_ids_with_af_ids_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe RSpec::Matchers::BuiltIn::MatchValkyrieIdsWithActiveFedoraIds do
+  context 'when valkyrie ids and active fedora ids match' do
+    let(:valkyrie_ids) { [Valkyrie::ID.new('id1'), Valkyrie::ID.new('id2')] }
+    let(:af_ids) { ['id1', 'id2'] }
+
+    it 'returns true' do
+      expect(valkyrie_ids).to match_valkyrie_ids_with_active_fedora_ids(af_ids)
+    end
+  end
+
+  context 'when valkyrie ids exist and active fedora id array is empty' do
+    let(:valkyrie_ids) { [Valkyrie::ID.new('id1'), Valkyrie::ID.new('id2')] }
+    let(:af_ids) { [] }
+
+    it 'returns false' do
+      expect(valkyrie_ids).not_to match_valkyrie_ids_with_active_fedora_ids(af_ids)
+    end
+  end
+
+  context 'when valkyrie id array is empty and active fedora ids exist' do
+    let(:valkyrie_ids) { [] }
+    let(:af_ids) { ['id1', 'id2'] }
+
+    it 'returns false' do
+      expect(valkyrie_ids).not_to match_valkyrie_ids_with_active_fedora_ids(af_ids)
+    end
+  end
+
+  context 'when valkyrie ids and active fedora ids DO NOT match' do
+    let(:valkyrie_ids) { [Valkyrie::ID.new('id1'), Valkyrie::ID.new('id2')] }
+    let(:af_ids) { ['id1', 'id3'] }
+
+    it 'returns false' do
+      expect(valkyrie_ids).not_to match_valkyrie_ids_with_active_fedora_ids(af_ids)
+    end
+  end
+end

--- a/spec/matcher_tests/match_valkyrie_ids_with_af_ids_spec.rb
+++ b/spec/matcher_tests/match_valkyrie_ids_with_af_ids_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-RSpec.describe RSpec::Matchers::BuiltIn::MatchValkyrieIdsWithActiveFedoraIds do
+RSpec.describe Hyrax::Matchers::MatchValkyrieIdsWithActiveFedoraIds do
   context 'when valkyrie ids and active fedora ids match' do
     let(:valkyrie_ids) { [Valkyrie::ID.new('id1'), Valkyrie::ID.new('id2')] }
     let(:af_ids) { ['id1', 'id2'] }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -146,6 +146,7 @@ RSpec.configure do |config|
   config.include Shoulda::Matchers::ActiveRecord, type: :model
   config.include Shoulda::Matchers::ActiveModel, type: :form
   config.include Shoulda::Callback::Matchers::ActiveModel
+  config.include Hyrax::Matchers
   config.full_backtrace = true if ci_build?
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/matchers/match_valkyrie_ids_with_af_ids.rb
+++ b/spec/support/matchers/match_valkyrie_ids_with_af_ids.rb
@@ -1,5 +1,19 @@
-RSpec::Matchers.define :match_valkyrie_ids_with_active_fedora_ids do |_active_fedora_ids|
-  match do |valkyrie_ids|
-    contain_exactly(valkyrie_ids.map(&:id))
+module RSpec
+  module Matchers
+    module BuiltIn
+      class MatchValkyrieIdsWithActiveFedoraIds < RSpec::Matchers::BuiltIn::ContainExactly
+        def match_when_sorted?
+          values_match?(safe_sort(expected), safe_sort(actual.map(&:id)))
+        end
+      end
+    end
+  end
+end
+
+module RSpec
+  module Matchers
+    def match_valkyrie_ids_with_active_fedora_ids(items)
+      BuiltIn::MatchValkyrieIdsWithActiveFedoraIds.new(items)
+    end
   end
 end

--- a/spec/support/matchers/match_valkyrie_ids_with_af_ids.rb
+++ b/spec/support/matchers/match_valkyrie_ids_with_af_ids.rb
@@ -1,19 +1,11 @@
-module RSpec
-  module Matchers
-    module BuiltIn
-      class MatchValkyrieIdsWithActiveFedoraIds < RSpec::Matchers::BuiltIn::ContainExactly
-        def match_when_sorted?
-          values_match?(safe_sort(expected), safe_sort(actual.map(&:id)))
-        end
-      end
+module Hyrax::Matchers
+  class MatchValkyrieIdsWithActiveFedoraIds < RSpec::Matchers::BuiltIn::ContainExactly
+    def match_when_sorted?
+      values_match?(safe_sort(expected), safe_sort(actual.map(&:id)))
     end
   end
-end
 
-module RSpec
-  module Matchers
-    def match_valkyrie_ids_with_active_fedora_ids(items)
-      BuiltIn::MatchValkyrieIdsWithActiveFedoraIds.new(items)
-    end
+  def match_valkyrie_ids_with_active_fedora_ids(expected_fedora_ids)
+    MatchValkyrieIdsWithActiveFedoraIds.new(expected_fedora_ids)
   end
 end

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -274,4 +274,37 @@ RSpec.describe Wings::ModelTransformer do
       end
     end
   end
+
+  context 'with members' do
+    let(:pcdm_object) { parent_work }
+    let(:parent_work) { FactoryBot.create(:work, id: 'pw', title: ['Parent Work']) }
+    let(:child_work1) { FactoryBot.create(:work, id: 'cw1', title: ['Child Work 1']) }
+    let(:child_work2) { FactoryBot.create(:work, id: 'cw2', title: ['Child Work 2']) }
+
+    context 'and members are ordered' do
+      before do
+        parent_work.ordered_members << child_work1
+        parent_work.ordered_members << child_work2
+      end
+
+      describe '#build' do
+        it 'sets member_ids to the ids of the ordered members' do
+          expect(subject.build.member_ids).to match_valkyrie_ids_with_active_fedora_ids(['cw1', 'cw2'])
+        end
+      end
+    end
+
+    context 'and members are unordered' do
+      before do
+        parent_work.members << child_work1
+        parent_work.members << child_work2
+      end
+
+      describe '#build' do
+        it 'sets member_ids to the ids of the unordered members' do
+          expect(subject.build.member_ids).to match_valkyrie_ids_with_active_fedora_ids(['cw1', 'cw2'])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes several bugs...

* matcher checking valkyrie ids against active fedora ids passes when it shouldn't
* when using members instead of ordered members, model transformer fails to copy member ids to valkyrie resource
* csv constant not found

#### matcher
This matcher was incorrectly returning true in certain circumstances.  It now extends contain_exactly builtin matcher and overrides the match method to map the valkyrie ids there instead.

Tests were added to confirm the matcher is operating as expected.

#### members
Fixing the matcher revealed that the tests for `navigators/child_works_navigator_spec.rb` were not correctly finding work members.  This was happening because the model transformer discards member ids in preference for ordered member ids.  But if members were not added as ordered, then ordered_member_ids returns an empty array.  The second commit adds code to try and get ordered members first, but if none are found, it tries to get the unordered member ids.

Test was added to confirm that members are added regardless of whether they are ordered or unordered.

#### csv
This code hasn't been touched in 2 years, so I'm not sure why this suddenly doesn't work, but it was failing locally and on CCI.  The fix was simply to add `require 'csv'` in the test.