### PR TITLE
Fixing the issue in #show when remove use_valkyrie: false.

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -25,7 +25,8 @@ module Hyrax
     end
 
     def show
-      @curation_concern ||= Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id], use_valkyrie: false)
+      valkyrie_obj = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id])
+      @curation_concern ||= Wings::ActiveFedoraConverter.new(resource: valkyrie_obj).convert
       presenter
       query_collection_members
     end

--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -25,8 +25,7 @@ module Hyrax
     end
 
     def show
-      valkyrie_obj = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id])
-      @curation_concern ||= Wings::ActiveFedoraConverter.new(resource: valkyrie_obj).convert
+      @curation_concern ||= Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id])
       presenter
       query_collection_members
     end

--- a/app/views/hyrax/base/show.json.jbuilder
+++ b/app/views/hyrax/base/show.json.jbuilder
@@ -1,2 +1,17 @@
 json.extract! @curation_concern, *[:id] + @curation_concern.class.fields.reject { |f| [:has_model].include? f }
 json.version @curation_concern.etag
+
+if @curation_concern.is_a? Valkyrie::Resource
+  json.id @curation_concern.id.id
+  json.access_control_id @curation_concern.access_control_id.id
+  json.representative_id @curation_concern.representative_id.id
+  json.thumbnail_id @curation_concern.thumbnail_id.id
+  json.alternate_ids @curation_concern.alternate_ids.map(&:id)
+  json.member_of_collection_ids @curation_concern.member_of_collection_ids.map(&:id)
+  json.member_ids @curation_concern.member_ids.map(&:id)
+  json.access_control_ids @curation_concern.access_control_ids.map(&:id)
+  json.list_source_ids @curation_concern.list_source_ids.map(&:id)
+  json.related_object_ids @curation_concern.related_object_ids.map(&:id)
+  json.representative_ids @curation_concern.representative_ids.map(&:id)
+  json.thumbnail_ids @curation_concern.thumbnail_ids.map(&:id)
+end

--- a/app/views/hyrax/base/show.json.jbuilder
+++ b/app/views/hyrax/base/show.json.jbuilder
@@ -1,17 +1,12 @@
-json.extract! @curation_concern, *[:id] + @curation_concern.class.fields.reject { |f| [:has_model].include? f }
+j = json.extract! @curation_concern, *[:id] + @curation_concern.class.fields.reject { |f| [:has_model].include? f }
 json.version @curation_concern.etag
 
 if @curation_concern.is_a? Valkyrie::Resource
-  json.id @curation_concern.id.id
-  json.access_control_id @curation_concern.access_control_id.id
-  json.representative_id @curation_concern.representative_id.id
-  json.thumbnail_id @curation_concern.thumbnail_id.id
-  json.alternate_ids @curation_concern.alternate_ids.map(&:id)
-  json.member_of_collection_ids @curation_concern.member_of_collection_ids.map(&:id)
-  json.member_ids @curation_concern.member_ids.map(&:id)
-  json.access_control_ids @curation_concern.access_control_ids.map(&:id)
-  json.list_source_ids @curation_concern.list_source_ids.map(&:id)
-  json.related_object_ids @curation_concern.related_object_ids.map(&:id)
-  json.representative_ids @curation_concern.representative_ids.map(&:id)
-  json.thumbnail_ids @curation_concern.thumbnail_ids.map(&:id)
+  j.each do |ele|
+    if ele.to_s.include?('_ids')
+      json.set! ele, @curation_concern[ele].map(&:id)
+    elsif ele.to_s.include?('_id') || ele.to_s == 'id'
+      json.set! ele, @curation_concern[ele].id
+    end
+  end
 end

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -54,12 +54,13 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       expect(page).not_to have_content(work2.title.first)
     end
 
-    it "returns json results" do
+    it "returns json results with correct id and ids" do
       visit "/collections/#{collection.id}.json"
       expect(page).to have_http_status(:success)
       json = JSON.parse(page.body)
       expect(json['id']).to eq collection.id
       expect(json['title']).to match_array collection.title
+      expect(json['member_of_collection_ids']).to match_array collection.member_of_collection_ids
     end
 
     context "with a non-nestable collection type" do


### PR DESCRIPTION
Fixes #3865 ; refs #3865

- Removed `use_valkyrie: false` from `uery_service.find_by_alternate_identifier` method call. 
- Added customized code to parse out ids for json output for collections page so that fix the failed test that caused by `Valkyrie::ID` object when remove `use_valkyrie: false`.

@samvera/hyrax-code-reviewers
