### PR TITLE
allow transfer of ownership of works even when proxy is disabled.

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -113,7 +113,7 @@ module Hyrax
           end
         end
 
-        can :create, ProxyDepositRequest if Flipflop.proxy_deposit? && registered_user?
+        can :create, ProxyDepositRequest if (Flipflop.proxy_deposit? || Flipflop.transfer_works?) && registered_user?
 
         can :accept, ProxyDepositRequest, receiving_user_id: current_user.id, status: 'pending'
         can :reject, ProxyDepositRequest, receiving_user_id: current_user.id, status: 'pending'


### PR DESCRIPTION
Fixes #3836 

Present tense short summary (50 characters or less)

If a user disables the proxy feature, and then from the dashboard tries to transfer ownership of one of his/her works, prior to this change, he/she would receive an unauthorized message and not be allowed to transfer ownership of the work.  This PR allows transfer of work to be done even if proxy is disabled.


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Disable proxy and enable transfer from the features setting page.
* Go to the works/my page and transfer ownership of one of your works.  This should now work.

@samvera/hyrax-code-reviewers
