### PR TITLE
Show confirmation when there are unsaved changes in the form

### DIFF
--- a/app/assets/javascripts/hyrax/admin/collection_type/settings.es6
+++ b/app/assets/javascripts/hyrax/admin/collection_type/settings.es6
@@ -1,42 +1,76 @@
 // Enable/disable sharing APPLIES_TO_NEW_WORKS checkbox based on the state of checkbox SHARABLE
 export default class {
   constructor(element) {
-    this.element = element
+    this.element = element;
   }
 
   setup() {
-    this.sharable_checkbox = $("#collection_type_sharable")
-    this.applies_to_new_works = $("#collection_type_share_applies_to_new_works")
-    this.container = $("#sharable-applies-to-new-works-setting-checkbox-container")
-    this.label = $("#sharable-applies-to-new-works-setting-label")
+    this.sharable_checkbox = $('#collection_type_sharable');
+    this.applies_to_new_works = $(
+      '#collection_type_share_applies_to_new_works'
+    );
+    this.container = $(
+      '#sharable-applies-to-new-works-setting-checkbox-container'
+    );
+    this.label = $('#sharable-applies-to-new-works-setting-label');
 
     // Watch for changes to "sharable" checkbox
-    $("#collection_type_sharable").on('change', () => { this.sharableChanged() })
-    this.sharableChanged()
+    $('#collection_type_sharable').on('change', () => {
+      this.sharableChanged();
+    });
+    this.sharableChanged();
+
+    // Watch for unsaved changes in the form
+    var formChanged = false,
+      $form = $('#collections-editor'),
+      origForm = $form.serialize();
+
+    $('form :input').on('change input', function() {
+      if ($form.serialize() !== origForm) {
+        formChanged = true;
+      }
+    });
+
+    // Watch for changes to the tab, and alert user that changes need to be saved.
+    $('.panel-default li.coll-panel').on('click', function(evt) {
+      var activeTabLink = $('ul.nav-tabs li.active a').attr('href');
+
+      if (formChanged) {
+        $('#collection-edit-switch-tabs-modal').modal('show');
+        $('#modal-cancel-btn').click(function() {
+          window.location = activeTabLink;
+        });
+        $('#modal-okay-btn').on('click', function() {
+          // Reset the form
+          $form.get(0).reset();
+          // Remove unsaved branding files if exists
+          $('span.files').empty();
+          formChanged = false;
+        });
+      }
+    });
   }
 
   // Based on the "sharable" checked/unchecked, enable/disable adjust share_applies_to_new_works checkbox
   sharableChanged() {
-    let selected = this.sharable_checkbox.is(':checked')
-    let disabled = this.sharable_checkbox.is(':disabled')
+    let selected = this.sharable_checkbox.is(':checked');
+    let disabled = this.sharable_checkbox.is(':disabled');
 
-    if(selected) {
-        // if sharable is selected, then base disabled on whether or not sharable is disabled.  It will be disabled when a
-        // collection of this type exists.  In that case, share_applies_to_new_works is readonly, that is, it has the value
-        // from the database and is disabled
-        this.applies_to_new_works.prop("disabled", disabled)
-        if(disabled) {
-            this.addDisabledClasses()
-        }
-        else {
-            this.removeDisabledClasses()
-        }
-    }
-    else {
-        // if sharable is not selected, then share_applies_to_new_works must be unchecked and disabled so it cannot be changed
-        this.applies_to_new_works.prop("checked", false)
-        this.applies_to_new_works.prop("disabled", true)
-        this.addDisabledClasses()
+    if (selected) {
+      // if sharable is selected, then base disabled on whether or not sharable is disabled.  It will be disabled when a
+      // collection of this type exists.  In that case, share_applies_to_new_works is readonly, that is, it has the value
+      // from the database and is disabled
+      this.applies_to_new_works.prop('disabled', disabled);
+      if (disabled) {
+        this.addDisabledClasses();
+      } else {
+        this.removeDisabledClasses();
+      }
+    } else {
+      // if sharable is not selected, then share_applies_to_new_works must be unchecked and disabled so it cannot be changed
+      this.applies_to_new_works.prop('checked', false);
+      this.applies_to_new_works.prop('disabled', true);
+      this.addDisabledClasses();
     }
   }
 
@@ -44,17 +78,17 @@ export default class {
    * Add disabled class to elements surrounding the APPLIES TO NEW WORKS checkbox when it is disabled
    */
   addDisabledClasses() {
-      this.container.addClass("disabled")
-      this.label.addClass("disabled")
-      this.applies_to_new_works.addClass("disabled")
+    this.container.addClass('disabled');
+    this.label.addClass('disabled');
+    this.applies_to_new_works.addClass('disabled');
   }
 
-    /**
-     * Remove disabled class from elements surrounding the APPLIES TO NEW WORKS checkbox when it is not disabled
-     */
+  /**
+   * Remove disabled class from elements surrounding the APPLIES TO NEW WORKS checkbox when it is not disabled
+   */
   removeDisabledClasses() {
-      this.container.removeClass("disabled")
-      this.label.removeClass("disabled")
-      this.applies_to_new_works.removeClass("disabled")
+    this.container.removeClass('disabled');
+    this.label.removeClass('disabled');
+    this.applies_to_new_works.removeClass('disabled');
   }
 }

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -1,28 +1,28 @@
 <div class="panel panel-default tabs" id="collection-edit-controls">
   <ul class="nav nav-tabs" role="tablist">
-    <li class="active">
+    <li class="coll-panel active">
       <a href="#description" role="tab" data-toggle="tab"><%= t('.tabs.description') %></a>
     </li>
     <% if @form.persisted? %>
       <% if @collection.brandable? %>
-      <li>
+      <li class="coll-panel">
         <a href="#branding" role="tab" data-toggle="tab"><%= t('.tabs.branding') %></a>
       </li>
       <% end %>
       <% if @collection.discoverable? %>
-      <li>
+      <li class="coll-panel">
         <a href="#discovery" role="tab" data-toggle="tab"><%= t('.tabs.discovery') %></a>
       </li>
       <% end %>
       <% if @collection.sharable? %>
-      <li>
+      <li class="coll-panel">
         <a href="#sharing" role="tab" data-toggle="tab"><%= t('.tabs.sharing') %></a>
       </li>
       <% end %>
     <% end %>
   </ul>
 
-  <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor' } do |f| %>
+  <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor', id: 'collections-editor' } do |f| %>
     <div class="tab-content">
       <div id="description" class="tab-pane active">
         <div class="panel panel-default labels">
@@ -108,3 +108,5 @@
   <% end # simple_form_for %>
 
 </div> <!-- end collection-controls -->
+
+<%= render 'modal_collection_tabs' %>

--- a/app/views/hyrax/dashboard/collections/_modal_collection_tabs.html.erb
+++ b/app/views/hyrax/dashboard/collections/_modal_collection_tabs.html.erb
@@ -1,0 +1,18 @@
+<div class="modal fade" id="collection-edit-switch-tabs-modal" tabindex="-1" role="dialog" data-backdrop="static">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="delete-collection-form">
+        <div class="modal-body">
+          <!-- Any alert messaging mounts to this element -->
+          <div class="modal-ajax-alert"></div>
+
+          <p><%= t('hyrax.dashboard.collections.form_relationships.modals.switch_tabs_confirmation') %></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" id="modal-cancel-btn" data-dismiss="modal"><%= t('helpers.action.cancel') %></button>
+          <button type="button" class="btn btn-default" id="modal-okay-btn" data-dismiss="modal"><%= t('helpers.action.okay') %></button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -47,6 +47,7 @@ en:
       batch:
         new: Create batch of works
       cancel: Cancel
+      okay: OK
       close: Close
       collection:
         new: New Collection
@@ -237,19 +238,19 @@ en:
           description: Collection types enable you to define settings that govern collections that serve different purposes in your repository.  You can define as many collection types as you need.
           header: Collection Types
           modal:
-            can_delete_body_html: "<p>Deleting this collection type will permanently remove the type and its settings from the repository.  Are you sure you want to delete this collection type?</p>"
-            cannot_delete_body_html: "<p>You cannot delete this collection type because one or more collections of this type have already been created.</p> <p>To delete this collection type, first ensure that all collections of this type have been deleted.</p>"
+            can_delete_body_html: '<p>Deleting this collection type will permanently remove the type and its settings from the repository.  Are you sure you want to delete this collection type?</p>'
+            cannot_delete_body_html: '<p>You cannot delete this collection type because one or more collections of this type have already been created.</p> <p>To delete this collection type, first ensure that all collections of this type have been deleted.</p>'
             header_can_delete: Delete Collection Type?
             header_cannot_delete: Cannot Delete Collection Type
             view_collections: View collections of this type
-          more_toggle_content_html: "<p>Typical scenarios for collection types include:</p> <ul> <li><strong>User Collections</strong> that any registered user can create to organize items they deposit.</li> <li><strong>Exhibits</strong> that staff create and curate for public display, where items can be included in any number of exhibits.</li> <li><strong>Controlled Collections</strong> created and managed by staff and not intended for public display, such as collections associated with organizational units or departments.</li> <li><strong>Community Collections</strong> that are intended for public display, similar to how DSpace communities and collections are sometimes used.</li> </ul>"
-          more_toggle_header_html: "<span>More</span> about collection types"
+          more_toggle_content_html: '<p>Typical scenarios for collection types include:</p> <ul> <li><strong>User Collections</strong> that any registered user can create to organize items they deposit.</li> <li><strong>Exhibits</strong> that staff create and curate for public display, where items can be included in any number of exhibits.</li> <li><strong>Controlled Collections</strong> created and managed by staff and not intended for public display, such as collections associated with organizational units or departments.</li> <li><strong>Community Collections</strong> that are intended for public display, similar to how DSpace communities and collections are sometimes used.</li> </ul>'
+          more_toggle_header_html: '<span>More</span> about collection types'
           table:
             actions: Actions
             name: Name
         multiple_membership_checker:
           error_preamble: 'Error: You have specified more than one of the same single-membership collection type '
-          error_type_and_collections: "(type: %{type}, collections: %{collections})"
+          error_type_and_collections: '(type: %{type}, collections: %{collections})'
         new:
           header: Create New Collection Type
           submit: Save
@@ -399,7 +400,7 @@ en:
           files within a short period of time, the provider may not be able to
           accommodate your request. If you experience errors uploading from the
           cloud, let us know via the %{contact_href}.</p>
-        local_upload_html: "<p>You can add one or more files to associate with this work.</p>"
+        local_upload_html: '<p>You can add one or more files to associate with this work.</p>'
       form_member_of_collections:
         actions:
           remove: Remove from collection
@@ -415,11 +416,11 @@ en:
       form_permission:
         visibility: Visibility <small>Who should be able to view or download this content?</small>
       form_permission_under_embargo:
-        help_html: "<strong>This work is under embargo.</strong> You can change the settings of the embargo here, or you can visit the %{edit_link} to deactivate it."
+        help_html: '<strong>This work is under embargo.</strong> You can change the settings of the embargo here, or you can visit the %{edit_link} to deactivate it.'
         legend_html: Visibility <small>Who should be able to view or download this content?</small>
         management_page: Embargo Management Page
       form_permission_under_lease:
-        help_html: "<strong>This work is under lease.</strong> You can change the settings of the lease here, or you can visit the %{edit_link} to deactivate it."
+        help_html: '<strong>This work is under lease.</strong> You can change the settings of the lease here, or you can visit the %{edit_link} to deactivate it.'
         legend_html: Visibility <small>Who should be able to view or download this content?</small>
         management_page: Lease Management Page
       form_progress:
@@ -482,7 +483,7 @@ en:
         label: 'In %{type}:'
       share_with:
         definition_heading: Permission Definitions
-        definitions_html: "<strong>View/Download:</strong> this file (both contents and metadata) is accessible from within %{application_name}.<br /> <strong>Edit:</strong> this file (both contents and metadata) can be edited. You may only grant this permission to %{institution_name} users and/or groups."
+        definitions_html: '<strong>View/Download:</strong> this file (both contents and metadata) is accessible from within %{application_name}.<br /> <strong>Edit:</strong> this file (both contents and metadata) can be edited. You may only grant this permission to %{institution_name} users and/or groups.'
         share_with_html: You may grant &quot;View/Download&quot; or &quot;Edit&quot; access for specific users and/or groups to files. Enter a valid %{account_name}, one at a time, select the access level for that user, and click +Add.
       show:
         items: Items
@@ -627,14 +628,14 @@ en:
         no_visible_parent_collections: There are no visible parent collections.
         no_visible_subcollections: There are no visible subcollections.
         parent_collection_header: Parent Collections
-        show_less_parent_collections: "...show less"
+        show_less_parent_collections: '...show less'
         show_more_parent_collections: show more...
         subcollection_count: Subcollections
         works_in_collection: Works
       sort_and_per_page:
         number_of_results_to_display_per_page: Number of results to display per page
         results_per_page: 'Results per page:'
-        sort_by_html: "<span>Sort by:</span>"
+        sort_by_html: '<span>Sort by:</span>'
     contact_form:
       button_label: Send
       email_label: Your Email
@@ -729,6 +730,7 @@ en:
             remove_from_collection_description: Removing this collection will not remove it from the repository, only as a parent of this collection.  Are you sure you want to remove this collection?
             remove_parent_collection_deny: You do not have sufficient privileges for the parent collection to be able to remove it.
             remove_this_sub_collection_description: Removing this sub-collection will not remove it from the repository, only from this parent collection.  Are you sure you want to remove this sub-collection?
+            switch_tabs_confirmation: It is best to "Save changes" before moving to another tab, or your changes may be lost. Do you want to change tab?
           sub_collections_of_collection_description: These collections are currently sub-collections of this collection
           table:
             action: Action
@@ -783,7 +785,7 @@ en:
           parent_collection_header: Parent Collections
           public_view_label: Public view of Collection
           search_results: Search Results within this Collection
-          show_less_parent_collections: "...show less"
+          show_less_parent_collections: '...show less'
           show_more_parent_collections: show more...
           subcollection_count: Subcollections
         show_descriptions:
@@ -971,9 +973,9 @@ en:
         embargo_apply: Apply Embargo
         embargo_cancel: Cancel and manage all embargoes
         embargo_deactivate: Deactivate Embargo
-        embargo_false_html: "<strong>This %{cc} is not currently under embargo.</strong> If you would like to apply an embargo, provide the information here."
+        embargo_false_html: '<strong>This %{cc} is not currently under embargo.</strong> If you would like to apply an embargo, provide the information here.'
         embargo_return: Return to editing this %{cc}
-        embargo_true_html: "<strong>This %{cc} is under embargo.</strong>"
+        embargo_true_html: '<strong>This %{cc} is under embargo.</strong>'
         embargo_update: Update Embargo
         header:
           current: Current Embargo
@@ -1058,6 +1060,7 @@ en:
       permission:
         save: Save
       permission_form:
+<<<<<<< HEAD
         add_new_group_skel: Add this group
         add_new_user_skel: Add this %{account_label}
         applied_to: "(applied to all files just uploaded)"
@@ -1072,6 +1075,13 @@ en:
         new_user_name_skel: "%{account_label} (without the %{suffix} part)"
         new_user_permission_skel: Access type to grant
         optional: "(optional)"
+=======
+        applied_to: '(applied to all files just uploaded)'
+        depositor: Depositor
+        enter: Enter %{account_label} (one at a time)
+        header: Permissions
+        optional: '(optional)'
+>>>>>>> Show confirmation when there are unsaved changes in the form
         save_note_html: Permissions are <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.
         select_group: Select a group
         share_with: Share With
@@ -1148,9 +1158,9 @@ en:
         lease_apply: Apply Lease
         lease_cancel: Cancel and manage all leases
         lease_deactivate: Deactivate Lease
-        lease_false_html: "<strong>This %{cc} is not currently under lease.</strong> If you would like to apply a lease, provide the information here."
+        lease_false_html: '<strong>This %{cc} is not currently under lease.</strong> If you would like to apply a lease, provide the information here.'
         lease_return: Return to editing this %{cc}
-        lease_true_html: "<strong>This %{cc} is under lease.</strong>"
+        lease_true_html: '<strong>This %{cc} is under lease.</strong>'
         lease_update: Update Lease
         manage_leases_html: Manage Leases for %{cc} <span class='human_readable_type'>(%{cc_type})</span>
       index:
@@ -1197,6 +1207,7 @@ en:
     my:
       count:
         collections:
+<<<<<<< HEAD
           collections_listing: Collections listing
           in_repo: "<strong>%{total_count} collections</strong> in the repository"
           you_manage: "<strong>%{total_count} collections</strong> you can manage in the repository"
@@ -1208,6 +1219,15 @@ en:
           you_own: "<strong>%{total_count} works</strong> you own in the repository"
       sort_and_per_page:
         number_of_results_to_display_per_page: Number of results to display per page
+=======
+          in_repo: '<strong>%{total_count} collections</strong> in the repository'
+          you_manage: '<strong>%{total_count} collections</strong> you can manage in the repository'
+          you_own: '<strong>%{total_count} collections</strong> you own in the repository'
+        works:
+          in_repo: '<strong>%{total_count} works</strong> in the repository'
+          you_manage: '<strong>%{total_count} works</strong> you can manage in the repository'
+          you_own: '<strong>%{total_count} works</strong> you own in the repository'
+>>>>>>> Show confirmation when there are unsaved changes in the form
     nav_safety:
       change_tab_message: Are you sure you want to leave this tab?  Any unsaved data will be lost.
     notifications:
@@ -1224,7 +1244,7 @@ en:
         subject: File Import Error
       proxy_deposit_request:
         transfer_on_create:
-          message: "%{user_link} wants to transfer a work to you. Review all %{transfer_link}"
+          message: '%{user_link} wants to transfer a work to you. Review all %{transfer_link}'
           subject: Ownership Change Request
           transfer_link_label: transfer requests
         transfer_on_update:
@@ -1232,7 +1252,7 @@ en:
           message: Your transfer request was %{status}.
           subject: Ownership Change %{status}
       proxy_depositor_added:
-        grantee_message: "%{grantor} has assigned you as a proxy depositor"
+        grantee_message: '%{grantor} has assigned you as a proxy depositor'
         grantor_message: You have assigned %{grantee} as a proxy depositor
         subject: Proxy Depositor Added
       workflow:
@@ -1242,10 +1262,10 @@ en:
              '%{comment}'
           subject: Your deposit requires changes
         deposited:
-          message: "%{title} (%{link}) was approved by %{user}. %{comment}"
+          message: '%{title} (%{link}) was approved by %{user}. %{comment}'
           subject: Deposit has been approved
         pending_review:
-          message: "%{title} (%{link}) was deposited by %{user} and is awaiting approval %{comment}"
+          message: '%{title} (%{link}) was deposited by %{user} and is awaiting approval %{comment}'
           subject: Deposit needs review
     operations:
       index:
@@ -1379,11 +1399,11 @@ en:
         sr_tab_label: Access Files from
         tab_label: Cloud Providers
       change_access_flash_message: Updating file access levels. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file access levels.
-      change_access_message_html: "<p>You have changed the access level on work <i>%{curation_concern}</i>, making it accessible to other users or groups to view or edit.</p><p>Would you like change all of the files within the work to have the same access users, groups and visibility as well?</p>"
+      change_access_message_html: '<p>You have changed the access level on work <i>%{curation_concern}</i>, making it accessible to other users or groups to view or edit.</p><p>Would you like change all of the files within the work to have the same access users, groups and visibility as well?</p>'
       change_access_no_message: No. I'll update it manually.
       change_access_title_html: Apply changes to contents?
       change_access_yes_message: Yes please.
-      change_permissions_message_html: "<p>You have changed the permissions on this %{curation_concern_human_readable_type}, <i>%{curation_concern}</i>, making it visible to <b>%{visibility_badge}</b>.</p><p>Would you like change all of the files within the %{curation_concern_human_readable_type} to <b>%{visibility_badge}</b> as well?</p>"
+      change_permissions_message_html: '<p>You have changed the permissions on this %{curation_concern_human_readable_type}, <i>%{curation_concern}</i>, making it visible to <b>%{visibility_badge}</b>.</p><p>Would you like change all of the files within the %{curation_concern_human_readable_type} to <b>%{visibility_badge}</b> as well?</p>'
       local_ingest:
         tab_label: Network/Server Location
       my_computer:
@@ -1439,7 +1459,7 @@ en:
     visibility:
       authenticated:
         note_html: Restrict access to %{institution}.
-        text: "%{institution}"
+        text: '%{institution}'
       embargo:
         note_html: Set date for future release.
         text: Embargo


### PR DESCRIPTION
Fixes #3454 

Present a confirmation only when there are unsaved changes in the active tab when editing a collection. This is a continuation of work from the PR [#3543](https://github.com/samvera/hyrax/pull/3543)

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Edit a collection from collections list
* Change description of the collection in the `Description` tab of the edit form
![new desc](https://user-images.githubusercontent.com/1331659/62877898-05651c80-bcf6-11e9-9a11-6421afbdce39.png)

* Click on `Branding` tab/any other tab without saving the changes
* A confirmation message appears
![prompt](https://user-images.githubusercontent.com/1331659/62877929-144bcf00-bcf6-11e9-9641-baf3b56514af.png)

* If `OK` is clicked -> goes to `Branding` tab/the clicked tab and changes made in the previous tab are discarded
* If `Cancel` is clicked -> stays on the same tab

@samvera/hyrax-code-reviewers
