### PR TITLE
do not disrupt item list when changing to masonry view

### DIFF
--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -661,7 +661,7 @@ button.branding-banner-remove:hover {
 
 .hyc-bl-results {
 
-  margin: 0 0 2em;
+  margin: 5em 0 2em;
 
   .alert {
     margin: 0;


### PR DESCRIPTION
Fixes #3626

Prior to this change, if a collection  contained some works and you were looking at the list of works on the collection home page, and switched to the masonry view, the sort button would be obscured, and the other view buttons would no longer work.  Lowering the top margin a bit, corrects these problems.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a user collection or use an existing one.
* Add a few works to the collection.
* Go to the collection home page and make sure you are able to sort and change view configurations.  Here is an image of what you are looking for in the collection home page.

<img width="1379" alt="Screen Shot 2019-08-15 at 2 06 31 PM" src="https://user-images.githubusercontent.com/11095558/63115809-0bf9cb00-bf66-11e9-85d7-ff25b570add6.png">


@samvera/hyrax-code-reviewers
