### PR TITLE
display full breadcrumb even when accessing the work/file/stat directly.

### DIFF
--- a/app/controllers/concerns/hyrax/breadcrumbs.rb
+++ b/app/controllers/concerns/hyrax/breadcrumbs.rb
@@ -7,6 +7,8 @@ module Hyrax
         trail_from_referer
       else
         default_trail
+        add_breadcrumb_for_controller if user_signed_in?
+        add_breadcrumb_for_action
       end
     end
 

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe Hyrax::CollectionsController do
 
       it "returns the collection and its members" do # rubocop:disable RSpec/ExampleLength
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
         get :show, params: { id: collection }
         expect(response).to be_successful
         expect(response).to render_template("layouts/hyrax/1_column")
@@ -68,7 +70,9 @@ RSpec.describe Hyrax::CollectionsController do
       context "without a referer" do
         it "sets breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
           get :show, params: { id: collection }
           expect(response).to be_successful
         end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -352,7 +352,9 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
 
       it "returns the collection and its members" do
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
         get :show, params: { id: collection }
         expect(response).to be_successful
         expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
@@ -387,7 +389,9 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       context "without a referer" do
         it "sets breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
           get :show, params: { id: collection }
           expect(response).to be_successful
         end
@@ -485,7 +489,9 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
     context "without a referer" do
       it "sets breadcrumbs" do
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.browse_view"), collection_path(collection.id, locale: 'en'), "aria-current" => "page")
         get :edit, params: { id: collection }
         expect(response).to be_successful
       end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -232,9 +232,24 @@ RSpec.describe Hyrax::FileSetsController do
       end
 
       context "without a referer" do
+        let(:work) do
+          create(:generic_work, :public,
+                 title: ['test title'],
+                 user: user)
+        end
+
+        before do
+          work.ordered_members << file_set
+          work.save!
+          file_set.save!
+        end
+
         it "shows me the file and set breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set, locale: 'en'))
           get :show, params: { id: file_set }
           expect(response).to be_successful
           expect(flash).to be_empty
@@ -275,7 +290,18 @@ RSpec.describe Hyrax::FileSetsController do
       let(:creator) { create(:user, email: 'archivist1@example.com') }
       let(:public_file_set) { create(:file_set, user: creator, read_groups: ['public']) }
 
-      before { sign_in user }
+      let(:work) do
+        create(:generic_work, :public,
+               title: ['test title'],
+               user: user)
+      end
+
+      before do
+        sign_in user
+        work.ordered_members << public_file_set
+        work.save!
+        public_file_set.save!
+      end
 
       describe '#edit' do
         it 'gives me the unauthorized page' do
@@ -298,6 +324,18 @@ RSpec.describe Hyrax::FileSetsController do
   context 'when not signed in' do
     let(:private_file_set) { create(:file_set) }
     let(:public_file_set) { create(:file_set, read_groups: ['public']) }
+
+    let(:work) do
+      create(:generic_work, :public,
+             title: ['test title'],
+             user: user)
+    end
+
+    before do
+      work.ordered_members << public_file_set
+      work.save!
+      public_file_set.save!
+    end
 
     describe '#edit' do
       it 'requires login' do

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -55,10 +55,14 @@ RSpec.describe Hyrax::GenericWorksController do
       before { sign_out user }
 
       context "without a referer" do
-        it "sets the default breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+        it "sets breadcrumbs with complete path" do
+          expect(controller).to receive(:add_breadcrumb).with('Home', main_app.root_path(locale: 'en'))
+          expect(controller).not_to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path(locale: 'en'))
+          expect(controller).not_to receive(:add_breadcrumb).with('Your Works', hyrax.my_works_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('public thing', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
           get :show, params: { id: work }
           expect(response).to be_successful
+          expect(response).to render_template("layouts/hyrax/1_column")
         end
       end
 
@@ -91,7 +95,9 @@ RSpec.describe Hyrax::GenericWorksController do
       context "without a referer" do
         it "sets breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with("Dashboard", hyrax.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Works', hyrax.my_works_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
           get :show, params: { id: work }
           expect(response).to be_successful
         end
@@ -171,6 +177,7 @@ RSpec.describe Hyrax::GenericWorksController do
           allow(controller).to receive(:presenter).and_return(presenter)
           allow(presenter).to receive(:export_as_ttl).and_return("ttl graph")
           allow(presenter).to receive(:editor?).and_return(true)
+          allow(presenter).to receive(:to_model).and_return(stub_model(GenericWork))
         end
 
         it 'renders a turtle file' do
@@ -231,6 +238,9 @@ RSpec.describe Hyrax::GenericWorksController do
       end
 
       context 'with a user granted workflow permission' do
+        before do
+          allow(document).to receive(:hydra_model).and_return(GenericWork)
+        end
         let(:document_list) { [document] }
         let(:document) { instance_double(SolrDocument) }
 


### PR DESCRIPTION
Fixes #3385 

When going to a work, fileset or analytics page directly using the url, the full breadcrumb should display.  Presently, the breadcrumb only displays when user arrives at these pages within the application.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to a work page, cp/pt the url onto a different tab on your browser. Confirm that the breadcrumb is complete in both browser tabs.
* Do the same thing for the file_set page
* Do the same thing for the analytics page.

@samvera/hyrax-code-reviewers
