### PR TITLE
Rename FileNode to FileMetadata

### DIFF
--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Hyrax
-  class FileNode < Valkyrie::Resource
+  class FileMetadata < Valkyrie::Resource
     attribute :file_identifiers, ::Valkyrie::Types::Set # id of the file stored by the storage adapter
     attribute :alternate_id, ::Valkyrie::Types::Set # id of the Hydra::PCDM::File which holds metadata and the file in ActiveFedora
     attribute :file_set_id, ::Valkyrie::Types::ID # id of parent file set resource

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -71,16 +71,16 @@ class JobIoWrapper < ApplicationRecord
     Hyrax::Actors::FileActor.new(file_set, relation.to_sym, user)
   end
 
-  # @return [Hyrax::FileNode, FalseClass] the created file node on success, false on failure
+  # @return [Hyrax::FileMetadata, FalseClass] the created file node on success, false on failure
   def ingest_file
     file_actor.ingest_file(self)
   end
 
-  def to_file_node
-    Hyrax::FileNode.new(label: original_name,
-                        original_filename: original_name,
-                        mime_type: mime_type,
-                        use: [Valkyrie::Vocab::PCDMUse.OriginalFile])
+  def to_file_metadata
+    Hyrax::FileMetadata.new(label: original_name,
+                            original_filename: original_name,
+                            mime_type: mime_type,
+                            use: [Valkyrie::Vocab::PCDMUse.OriginalFile])
   end
 
   # The magic that switches *once* between local filepath and CarrierWave file

--- a/app/services/hyrax/versioning_service.rb
+++ b/app/services/hyrax/versioning_service.rb
@@ -1,41 +1,41 @@
-require 'wings/services/file_node_builder'
+require 'wings/services/file_metadata_builder'
 
 module Hyrax
   class VersioningService
     class << self
       # Make a version and record the version committer
-      # @param [ActiveFedora::File | Hyrax::FileNode] content
+      # @param [ActiveFedora::File | Hyrax::FileMetadata] content
       # @param [User, String] user
       def create(content, user = nil)
-        use_valkyrie = content.is_a? Hyrax::FileNode
+        use_valkyrie = content.is_a? Hyrax::FileMetadata
         perform_create(content, user, use_valkyrie)
       end
 
-      # @param [ActiveFedora::File | Hyrax::FileNode] content
+      # @param [ActiveFedora::File | Hyrax::FileMetadata] content
       def latest_version_of(file)
         file.versions.last
       end
 
       # Record the version committer of the last version
-      # @param [ActiveFedora::File | Hyrax::FileNode] content
+      # @param [ActiveFedora::File | Hyrax::FileMetadata] content
       # @param [User, String] user_key
       def record_committer(content, user_key)
         user_key = user_key.user_key if user_key.respond_to?(:user_key)
         version = latest_version_of(content)
         return if version.nil?
-        version_id = content.is_a?(Hyrax::FileNode) ? version.id.to_s : version.uri
+        version_id = content.is_a?(Hyrax::FileMetadata) ? version.id.to_s : version.uri
         Hyrax::VersionCommitter.create(version_id: version_id, committer_login: user_key)
       end
 
       # TODO: WINGS - Copied from valkyrie6 branch.  Need to explore whether this is needed?
       # # @param [FileSet] file_set
-      # # @param [Hyrax::FileNode] content
+      # # @param [Hyrax::FileMetadata] content
       # # @param [String] revision_id
       # # @param [User, String] user
       # def restore_version(file_set, content, revision_id, user = nil)
       #   found_version = content.versions.find { |x| x.label == Array.wrap(revision_id) }
       #   return unless found_version
-      #   node = Wings::FileNodeBuilder.new(storage_adapter: nil, persister: indexing_adapter.persister).attach_file_node(node: found_version, file_set: file_set)
+      #   node = Wings::FileMetadataBuilder.new(storage_adapter: nil, persister: indexing_adapter.persister).attach_file_metadata(node: found_version, file_set: file_set)
       #   create(node, user)
       # end
 

--- a/lib/wings/services/file_metadata_builder.rb
+++ b/lib/wings/services/file_metadata_builder.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
-require 'wings/hydra/works/services/add_file_node_to_file_set'
+require 'wings/hydra/works/services/add_file_metadata_to_file_set'
 
-# TODO: The file_node resource and the file_node_builder should be in Hyrax as they will be needed for non-wings valkyrie implementations too.
+# TODO: The file_metadata resource and the file_metadata_builder should be in Hyrax as they will be needed for non-wings valkyrie implementations too.
 
 module Wings
-  # Stores a file and an associated Hyrax::FileNode
-  class FileNodeBuilder
+  # Stores a file and an associated Hyrax::FileMetadata
+  class FileMetadataBuilder
     include Hyrax::Noid
 
     attr_reader :storage_adapter, :persister
@@ -15,9 +15,9 @@ module Wings
     end
 
     # @param io_wrapper [JobIOWrapper] with details about the uploaded file
-    # @param node [Hyrax::FileNode] the metadata to represent the file
+    # @param node [Hyrax::FileMetadata] the metadata to represent the file
     # @param file_set [Valkyrie::Resouce, Hydra::Works::FileSet] the associated FileSet # TODO: WINGS - Remove Hydra::Works::FileSet as a potential type when valkyrization is complete.
-    # @return [Hyrax::FileNode] the persisted metadata node that represents the file
+    # @return [Hyrax::FileMetadata] the persisted metadata node that represents the file
     def create(io_wrapper:, node:, file_set:)
       io_wrapper = build_file(io_wrapper, node.use)
       file_set.save unless file_set.persisted?
@@ -29,17 +29,17 @@ module Wings
                                            resource: node,
                                            resource_uri_transformer: Hyrax.config.resource_id_to_uri_transformer)
       node.file_identifiers = [stored_file.id]
-      attach_file_node(node: node, file_set: file_set)
+      attach_file_metadata(node: node, file_set: file_set)
     end
 
-    # @param node [Hyrax::FileNode] the metadata to represent the file
+    # @param node [Hyrax::FileMetadata] the metadata to represent the file
     # @param file_set [Valkyrie::Resouce, Hydra::Works::FileSet] the associated FileSet # TODO: WINGS - Remove Hydra::Works::FileSet as a potential type when valkyrization is complete.
-    # @return [Hyrax::FileNode] the persisted metadata node that represents the file
-    def attach_file_node(node:, file_set:)
-      file_set.is_a?(::Valkyrie::Resource) ? attach_file_node_to_valkyrie_file_set(node, file_set) : node
+    # @return [Hyrax::FileMetadata] the persisted metadata node that represents the file
+    def attach_file_metadata(node:, file_set:)
+      file_set.is_a?(::Valkyrie::Resource) ? attach_file_metadata_to_valkyrie_file_set(node, file_set) : node
     end
 
-    def attach_file_node_to_valkyrie_file_set(node, file_set)
+    def attach_file_metadata_to_valkyrie_file_set(node, file_set)
       # This is for storage adapters other than wings.  The wings storage adapter already attached the file to the file_set.
       # This process is a no-op for wings.  # TODO: WINGS - May need to verify this is a no-op for wings once file_set is passed in as a resource.
       # TODO: WINGS - Need to test this against other adapters once they are available for use.

--- a/lib/wings/valkyrie/persister.rb
+++ b/lib/wings/valkyrie/persister.rb
@@ -16,7 +16,7 @@ module Wings
       # @param [Valkyrie::Resource] resource
       # @return [Valkyrie::Resource] the persisted/updated resource
       def save(resource:)
-        return save_file(file_node: resource) if resource.is_a? Hyrax::FileNode
+        return save_file(file_metadata: resource) if resource.is_a? Hyrax::FileMetadata
         af_object = resource_factory.from_resource(resource: resource)
         af_object.save!
         resource_factory.to_resource(object: af_object)
@@ -24,13 +24,13 @@ module Wings
         raise FailedSaveError.new(err.message, obj: af_object)
       end
 
-      def save_file(file_node:)
+      def save_file(file_metadata:)
         # This is a no-op when the file is being created or updated through the FileActor.
         # There may be other scenarios where something needs to happen here.
 
         # TODO: SKIP for now, but potentially need to...
         #   find existing af File
-        #   convert file_node resource into af File metadata
+        #   convert file_metadata resource into af File metadata
         #   save af File
       end
 

--- a/lib/wings/valkyrie/storage/active_fedora.rb
+++ b/lib/wings/valkyrie/storage/active_fedora.rb
@@ -1,4 +1,4 @@
-require 'wings/hydra/works/services/add_file_node_to_file_set'
+require 'wings/hydra/works/services/add_file_metadata_to_file_set'
 
 # frozen_string_literal: true
 module Wings::Storage
@@ -12,15 +12,15 @@ module Wings::Storage
     # @param extra_arguments [Hash] additional arguments which may be passed to other adapters
     # @return [Valkyrie::StorageAdapter::StreamFile]
     def upload(file:, original_filename:, resource:, resource_uri_transformer: default_resource_uri_transformer, **_extra_arguments) # rubocop:disable Lint/UnusedMethodArgument
-      Wings::Works::AddFileNodeToFileSet.call(file_set: file_set(resource), file_node: resource, file: file)
+      Wings::Works::AddFileMetadataToFileSet.call(file_set: file_set(resource), file_metadata: resource, file: file)
       identifier = resource_uri_transformer.call(resource, base_url)
       find_by(id: Valkyrie::ID.new(identifier.to_s.sub(/^.+\/\//, PROTOCOL)))
     end
 
     private
 
-      def file_set(file_node)
-        file_set_id = file_node.file_set_id
+      def file_set(file_metadata)
+        file_set_id = file_metadata.file_set_id
         Hyrax.query_service.find_by(id: file_set_id)
       end
   end

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -1,4 +1,4 @@
-require 'wings/services/file_node_builder'
+require 'wings/services/file_metadata_builder'
 require 'wings/valkyrie/query_service'
 
 RSpec.describe Hyrax::Actors::FileActor do
@@ -140,45 +140,45 @@ RSpec.describe Hyrax::Actors::FileActor do
     let(:metadata_adapter) { Hyrax.metadata_adapter }
     let(:persister) { metadata_adapter.persister }
     let(:query_service) { Wings::Valkyrie::QueryService.new(adapter: metadata_adapter) }
-    let(:file_node) do
-      node_builder = Wings::FileNodeBuilder.new(storage_adapter: storage_adapter, persister: persister)
-      node = Hyrax::FileNode.for(file: fixture)
-      node_builder.create(file: fixture, node: node, file_set: file_set)
+    let(:file_metadata) do
+      metadata_builder = Wings::FileMetadataBuilder.new(storage_adapter: storage_adapter, persister: persister)
+      file_metadata = Hyrax::FileMetadata.for(file: fixture)
+      metadata_builder.create(file: fixture, node: file_metadata, file_set: file_set)
     end
 
     context 'relation' do
       let(:relation) { RDF::URI.new("http://pcdm.org/use#remastered") }
 
       it 'uses the relation from the actor' do
-        pending 'implementation of Wings::Valkyrie::Persister #save_file_node'
-        expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileNode, user)
+        pending 'implementation of Wings::Valkyrie::Persister #save_file_metadata'
+        expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileMetadata, user)
         expect(CharacterizeJob).to receive(:perform_later)
-        saved_node = actor.ingest_file(io)
+        saved_metadata = actor.ingest_file(io)
         reloaded = query_service.find_by(id: file_set.id)
-        expect(reloaded.member_by(use: relation).id).to eq saved_node.id
+        expect(reloaded.member_by(use: relation).id).to eq saved_metadata.id
       end
 
       context 'when relation is a string' do
         let(:relation) { 'thumbnail_file' }
 
         it 'converts relation to URI before using the relation from the actor' do
-          pending 'implementation of Wings::Valkyrie::Persister #save_file_node'
-          expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileNode, user)
+          pending 'implementation of Wings::Valkyrie::Persister #save_file_metadata'
+          expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileMetadata, user)
           expect(CharacterizeJob).to receive(:perform_later)
-          saved_node = actor.ingest_file(io)
+          saved_metadata = actor.ingest_file(io)
           reloaded = query_service.find_by(id: file_set.id)
-          expect(reloaded.member_by(use: relation).id).to eq saved_node.id
+          expect(reloaded.member_by(use: relation).id).to eq saved_metadata.id
         end
       end
     end
 
     xit 'uses the provided mime_type' do
-      pending 'implementation of Wings::Valkyrie::Persister #save_file_node'
+      pending 'implementation of Wings::Valkyrie::Persister #save_file_metadata'
       allow(fixture).to receive(:content_type).and_return('image/gif')
-      expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileNode, user)
+      expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileMetadata, user)
       expect(CharacterizeJob).to receive(:perform_later)
-      saved_node = actor.ingest_file(io)
-      expect(saved_node.mime_type).to eq ['image/gif']
+      saved_metadata = actor.ingest_file(io)
+      expect(saved_metadata.mime_type).to eq ['image/gif']
     end
 
     context 'with two existing versions from different users' do
@@ -196,8 +196,8 @@ RSpec.describe Hyrax::Actors::FileActor do
 
       before do
         # TODO: WINGS - When #ingest_file works, these should be uncommented.
-        # expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileNode, user)
-        # expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileNode, user2)
+        # expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileMetadata, user)
+        # expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileMetadata, user2)
         # expect(CharacterizeJob).to receive(:perform_later)
         allow(CharacterizeJob).to receive(:perform_later)
         actor.ingest_file(io)
@@ -205,7 +205,7 @@ RSpec.describe Hyrax::Actors::FileActor do
       end
 
       it 'has two versions' do
-        pending 'implementation of Wings::Valkyrie::Persister #save_file_node'
+        pending 'implementation of Wings::Valkyrie::Persister #save_file_metadata'
         expect(versions.count).to eq 2
         # the current version
         reloaded = query_service.find_by(id: file_set.id)
@@ -221,8 +221,8 @@ RSpec.describe Hyrax::Actors::FileActor do
 
     describe '#ingest_file' do
       it 'when the file is available' do
-        pending 'implementation of Wings::Valkyrie::Persister #save_file_node'
-        expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileNode, user)
+        pending 'implementation of Wings::Valkyrie::Persister #save_file_metadata'
+        expect(Hyrax::VersioningService).to receive(:create).with(Hyrax::FileMetadata, user)
         expect(CharacterizeJob).to receive(:perform_later)
         actor.ingest_file(io)
         reloaded = query_service.find_by(id: file_set.id)
@@ -230,9 +230,9 @@ RSpec.describe Hyrax::Actors::FileActor do
       end
       # rubocop:disable RSpec/AnyInstance
       it 'returns false when save fails' do
-        expect(Hyrax::VersioningService).not_to receive(:create).with(Hyrax::FileNode, user)
+        expect(Hyrax::VersioningService).not_to receive(:create).with(Hyrax::FileMetadata, user)
         expect(CharacterizeJob).not_to receive(:perform_later)
-        allow_any_instance_of(Wings::FileNodeBuilder).to receive(:create).and_raise(StandardError)
+        allow_any_instance_of(Wings::FileMetadataBuilder).to receive(:create).and_raise(StandardError)
         expect(actor.ingest_file(io)).to be_falsey
       end
       # rubocop:enable RSpec/AnyInstance

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -2,7 +2,7 @@
 
 require 'valkyrie/specs/shared_specs'
 
-RSpec.describe Hyrax::FileNode do
+RSpec.describe Hyrax::FileMetadata do
   it_behaves_like 'a Valkyrie::Resource' do
     let(:resource_klass) { described_class }
   end
@@ -101,7 +101,7 @@ RSpec.describe Hyrax::FileNode do
       end
     end
     context 'when versions saved' do
-      it 'returns a set of file_nodes for previous versions' do
+      it 'returns a set of file_metadatas for previous versions' do
         pending 'TODO: write test when Wings file versioning is implemented (Issue #3923)'
         expect(false).to be true
       end

--- a/spec/models/job_io_wrapper_spec.rb
+++ b/spec/models/job_io_wrapper_spec.rb
@@ -223,9 +223,9 @@ RSpec.describe JobIoWrapper, type: :model do
     end
   end
 
-  describe '#to_file_node' do
-    it 'creates and returns file_node' do
-      expect(subject.to_file_node).to be_a_kind_of(Hyrax::FileNode)
+  describe '#to_file_metadata' do
+    it 'creates and returns file_metadata' do
+      expect(subject.to_file_metadata).to be_a_kind_of(Hyrax::FileMetadata)
     end
   end
 


### PR DESCRIPTION
This also impacts related classes…
* FileNodeBuilder becomes FileMetadataBuilder
* AddFileNodeToFileSet becomes AddFileMetadataToFileSet

### MERGING NOTE 

If PR #3918 (Add FileNodeBuilder test) gets merges first, then this PR will need to be rebased before merging.