### PR TITLE
increase limit for google analytics stats downloads

### DIFF
--- a/app/models/file_download_stat.rb
+++ b/app/models/file_download_stat.rb
@@ -13,7 +13,8 @@ class FileDownloadStat < Hyrax::Statistic
       end
       profile.hyrax__download(sort: 'date',
                               start_date: start_date,
-                              end_date: Date.yesterday)
+                              end_date: Date.yesterday,
+                              limit: 10_000)
              .for_file(file.id)
     end
 

--- a/app/models/hyrax/statistic.rb
+++ b/app/models/hyrax/statistic.rb
@@ -33,7 +33,11 @@ module Hyrax
           Rails.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
           return []
         end
-        profile.hyrax__pageview(sort: 'date', start_date: start_date).for_path(path)
+        profile.hyrax__pageview(sort: 'date',
+                                start_date: start_date,
+                                end_date: Date.yesterday,
+                                limit: 10_000)
+               .for_path(path)
       end
 
       private


### PR DESCRIPTION
Fixes #3925

Increases GA download limit to the maximum of 10,000 per page.  This does not implement paging of results.

Changes proposed in this pull request:
* increase GA download limits for works and files to 10,000
* add end date to work stats downloads

@samvera/hyrax-code-reviewers
