### PR TITLE
[wings] Remove `convert_class_name_to_valkyrie_resource_class`

### DIFF
--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -30,10 +30,6 @@ require 'wings/valkyrie/storage/active_fedora'
 
 ActiveFedora::Base.include Wings::Valkyrizable
 
-Valkyrie.config.resource_class_resolver = lambda do |_klass_name|
-  Wings::ModelTransformer.convert_class_name_to_valkyrie_resource_class(internal_resource)
-end
-
 Valkyrie::MetadataAdapter.register(
   Wings::Valkyrie::MetadataAdapter.new, :wings_adapter
 )

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -125,21 +125,6 @@ module Wings
     end
 
     ##
-    # @note The method signature is to conform to Valkyrie's method signature
-    #   for ::Valkyrie.config.resource_class_resolver
-    #
-    # @param class_name [String] a string representation of an `ActiveFedora`
-    #   model
-    #
-    # @return [Class] a dynamically generated `Valkyrie::Resource` subclass
-    #   mirroring the provided class name
-    #
-    def self.convert_class_name_to_valkyrie_resource_class(class_name)
-      klass = class_name.constantize
-      to_valkyrie_resource_class(klass: klass)
-    end
-
-    ##
     # @param klass [String] an `ActiveFedora` model
     #
     # @return [Class] a dyamically generated `Valkyrie::Resource` subclass

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -47,15 +47,6 @@ RSpec.describe Wings::ModelTransformer do
     end
   end
 
-  describe '.convert_class_name_to_valkyrie_resource_class' do
-    context 'when given a ActiveFedora class name (eg. a constant that responds to #properties)' do
-      it 'creates a Valkyrie::Resource class' do
-        subject = described_class.convert_class_name_to_valkyrie_resource_class('GenericWork')
-        expect(subject.new).to be_a Valkyrie::Resource
-      end
-    end
-  end
-
   describe '.to_valkyrie_resource_class' do
     context 'when given a ActiveFedora class (eg. a constant that responds to #properties)' do
       context 'for the returned object (e.g. a class)' do


### PR DESCRIPTION
This was an early addition to Wings, and predates much of the query work. at
this point, objects round trip just fine without the special class casting
handling. For certain adapters (e.g. the memory adapter) the call to
`internal_resource` results in a `NoMethodError` on `Object`, so this seems like
a good time to remove the superfluous code.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* This is a refactor/removal of dead code. No specific testing is required.

@samvera/hyrax-code-reviewers
