### PR TITLE
Warn user with pop-up modal of unsaved changes

### DIFF
--- a/app/assets/javascripts/hyrax/nav_safety.js
+++ b/app/assets/javascripts/hyrax/nav_safety.js
@@ -4,7 +4,9 @@
 // - Add the nav-safety class to the form element.
 
 Blacklight.onLoad(function() {
+  var clickedTab;
   $('.nav-safety-confirm').on('click', function(evt) {
+    clickedTab = $(this).attr('href');
     var dirtyData = $('#nav-safety-modal[dirtyData=true]');
     if (dirtyData.length > 0) {
       evt.preventDefault();
@@ -14,9 +16,9 @@ Blacklight.onLoad(function() {
   });
   
   $('#nav-safety-dismiss').on('click', function(evt) {
-    // evt.preventDefault();
     nav_safety_off();
-    // $('#nav-safety-change-tab').modal('hide');
+    // Navigate away from active tab to clicked tab
+    window.location = clickedTab;
   });
   
   $('form.nav-safety').on('change', function(evt) {

--- a/app/views/hyrax/admin/admin_sets/_form.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form.html.erb
@@ -1,24 +1,25 @@
+    <%= render 'shared/nav_safety_modal' %>
     <div class="panel panel-default tabs" id="admin-set-controls">
       <ul class="nav nav-tabs" role="tablist">
         <li class="active">
-          <a href="#description" role="tab" data-toggle="tab"><%= t('.tabs.description') %></a>
+          <a href="#description" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.description') %></a>
         </li>
         <% if @form.persisted? %>
           <li>
-            <a href="#participants" role="tab" data-toggle="tab"><%= t('.tabs.participants') %></a>
+            <a href="#participants" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.participants') %></a>
           </li>
           <li>
-            <a href="#visibility" role="tab" data-toggle="tab"><%= t('.tabs.visibility') %></a>
+            <a href="#visibility" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.visibility') %></a>
           </li>
           <li>
-            <a href="#workflow" role="tab" data-toggle="tab"><%= t('.tabs.workflow') %></a>
+            <a href="#workflow" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.workflow') %></a>
           </li>
         <% end %>
       </ul>
       <div class="tab-content">
         <div id="description" class="tab-pane active">
           <div class="panel panel-default labels">
-            <%= simple_form_for @form, url: [hyrax, :admin, @form] do |f| %>
+            <%= simple_form_for @form, url: [hyrax, :admin, @form], html: { class: 'nav-safety' } do |f| %>
               <div class="panel-body">
                 <%= render 'form_metadata', f: f %>
 

--- a/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
@@ -1,7 +1,8 @@
           <div id="visibility" class="tab-pane">
             <div class="panel panel-default labels">
               <%= simple_form_for @form.permission_template,
-                                  url: [hyrax, :admin, @form, :permission_template] do |f| %>
+                                  url: [hyrax, :admin, @form, :permission_template],
+                                  html: { class: 'nav-safety' } do |f| %>
                 <div class="panel-body">
                   <p><%= t('.page_description') %></p>
                   <h3><%= t('.release.title') %></h3>

--- a/app/views/hyrax/admin/admin_sets/_form_workflow.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_workflow.erb
@@ -2,7 +2,7 @@
                   <div class="panel panel-default labels">
                     <%= simple_form_for @form.permission_template,
                       url: [hyrax, :admin, @form, :permission_template],
-                      html: { id: 'form_workflows' } do |f| %>
+                      html: { id: 'form_workflows', class: 'nav-safety' } do |f| %>
                       <% if f.object.available_workflows.any? %>
                         <div class="panel-body">
                           <p><%= t('.page_description') %></p>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -1,28 +1,29 @@
+<%= render "shared/nav_safety_modal" %>
 <div class="panel panel-default tabs" id="collection-edit-controls">
   <ul class="nav nav-tabs" role="tablist">
     <li class="active">
-      <a href="#description" role="tab" data-toggle="tab"><%= t('.tabs.description') %></a>
+      <a href="#description" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.description') %></a>
     </li>
     <% if @form.persisted? %>
       <% if @collection.brandable? %>
       <li>
-        <a href="#branding" role="tab" data-toggle="tab"><%= t('.tabs.branding') %></a>
+        <a href="#branding" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.branding') %></a>
       </li>
       <% end %>
       <% if @collection.discoverable? %>
       <li>
-        <a href="#discovery" role="tab" data-toggle="tab"><%= t('.tabs.discovery') %></a>
+        <a href="#discovery" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.discovery') %></a>
       </li>
       <% end %>
       <% if @collection.sharable? %>
       <li>
-        <a href="#sharing" role="tab" data-toggle="tab"><%= t('.tabs.sharing') %></a>
+        <a href="#sharing" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.sharing') %></a>
       </li>
       <% end %>
     <% end %>
   </ul>
 
-  <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor' } do |f| %>
+  <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor nav-safety' } do |f| %>
     <div class="tab-content">
       <div id="description" class="tab-pane active">
         <div class="panel panel-default labels">

--- a/app/views/hyrax/file_sets/_form.html.erb
+++ b/app/views/hyrax/file_sets/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [main_app, curation_concern], html: { multipart: true } do |f| %>
+<%= simple_form_for [main_app, curation_concern], html: { multipart: true, class: 'nav-safety' } do |f| %>
   <fieldset class="required">
     <span class="control-label">
       <%= label_tag 'file_set[title][]', t('.title'),  class: "string optional" %>

--- a/app/views/hyrax/file_sets/_permission.html.erb
+++ b/app/views/hyrax/file_sets/_permission.html.erb
@@ -2,7 +2,8 @@
     <%= simple_form_for [main_app, file_set],
                         html: { multipart: true,
                                 id: 'permission',
-                                data: { param_key: file_set.model_name.param_key }
+                                data: { param_key: file_set.model_name.param_key },
+                                class: 'nav-safety'
                               } do |f| %>
       <%= hidden_field_tag('redirect_tab', 'permissions') %>
       <%= render "permission_form", f: f %>

--- a/app/views/hyrax/file_sets/_versioning.html.erb
+++ b/app/views/hyrax/file_sets/_versioning.html.erb
@@ -1,6 +1,6 @@
 <div id="versioning_display" class="tab-pane">
   <h2><%= t('.header') %></h2>
-  <%= simple_form_for [main_app, curation_concern], html: { multipart: true } do |f| %>
+  <%= simple_form_for [main_app, curation_concern], html: { multipart: true, class: 'nav-safety' } do |f| %>
     <%= hidden_field_tag('redirect_tab', 'versions') %>
     <h3><%= t('.upload') %></h3>
     <%= f.input :files, as: :multifile, wrapper: :vertical_file_input, required: true %>
@@ -10,7 +10,7 @@
   <% end %>
 
   <%= form_for [main_app, curation_concern],
-               html: { class: 'edit_file_set_previous_version' } do |f| %>
+               html: { class: 'edit_file_set_previous_version nav-safety' } do |f| %>
     <h3><%= t('.restore') %></h3>
     <% @version_list.each do |version| %>
       <div class="radio">

--- a/app/views/hyrax/file_sets/edit.html.erb
+++ b/app/views/hyrax/file_sets/edit.html.erb
@@ -1,3 +1,4 @@
+<%= render "shared/nav_safety_modal" %>
 <% provide :page_title, curation_concern_page_title(curation_concern) %>
 <% provide :page_header do %>
   <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t('.header', file_set: curation_concern) %></h1>
@@ -11,13 +12,13 @@
     <div class="panel panel-default tabs">
       <ul class="nav nav-tabs" role="tablist">
         <li id="edit_descriptions_link" class="active">
-          <a href="#descriptions_display" data-toggle="tab"><i class="fa fa-tags" aria-hidden="true"></i></span> <%= t('.descriptions') %></a>
+          <a href="#descriptions_display" data-toggle="tab" class="nav-safety-confirm"><i class="fa fa-tags" aria-hidden="true"></i></span> <%= t('.descriptions') %></a>
         </li>
         <li id="edit_versioning_link">
-          <a href="#versioning_display" data-toggle="tab"><i class="fa fa-sitemap" aria-hidden="true"></i> <%= t('.versions') %></a>
+          <a href="#versioning_display" data-toggle="tab" class="nav-safety-confirm"><i class="fa fa-sitemap" aria-hidden="true"></i> <%= t('.versions') %></a>
         </li>
         <li id="edit_permissions_link">
-          <a href="#permissions_display" data-toggle="tab"><i class="fa fa-key" aria-hidden="true"></i> <%= t('.permissions') %></a>
+          <a href="#permissions_display" data-toggle="tab" class="nav-safety-confirm"><i class="fa fa-key" aria-hidden="true"></i> <%= t('.permissions') %></a>
         </li>
       </ul>
       <div class="panel-body">

--- a/app/views/hyrax/pages/_form.html.erb
+++ b/app/views/hyrax/pages/_form.html.erb
@@ -1,82 +1,83 @@
+<%= render "shared/nav_safety_modal" %>
 <div class="panel panel-default tabs">
   <ul class="nav nav-tabs" role="tablist">
     <li class="active">
-      <a href="#about" role="tab" data-toggle="tab"><%= t(:'hyrax.pages.tabs.about_page') %></a>
+      <a href="#about" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.pages.tabs.about_page') %></a>
     </li>
     <li>
-      <a href="#help" role="tab" data-toggle="tab"><%= t(:'hyrax.pages.tabs.help_page') %></a>
+      <a href="#help" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.pages.tabs.help_page') %></a>
     </li>
     <li>
-      <a href="#agreement" role="tab" data-toggle="tab"><%= t(:'hyrax.pages.tabs.agreement_page') %></a>
+      <a href="#agreement" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.pages.tabs.agreement_page') %></a>
     </li>
     <li>
-      <a href="#terms" role="tab" data-toggle="tab"><%= t(:'hyrax.pages.tabs.terms_page') %></a>
+      <a href="#terms" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.pages.tabs.terms_page') %></a>
     </li>
   </ul>
   <div class="tab-content">
-    <div id="about" class="tab-pane active">
-      <div class="panel panel-default labels">
-        <%= simple_form_for ContentBlock.for(:about), url: hyrax.page_path(ContentBlock.for(:about)) do |f| %>
-          <div class="panel-body">
-            <div class="field form-group">
-                <%= f.label :about %><br />
-                <%= f.text_area :about, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
-            </div>
+  <div id="about" class="tab-pane active">
+    <div class="panel panel-default labels">
+      <%= simple_form_for ContentBlock.for(:about), url: hyrax.page_path(ContentBlock.for(:about)), html: { class: 'nav-safety' } do |f| %>
+        <div class="panel-body">
+          <div class="field form-group">
+              <%= f.label :about %><br />
+              <%= f.text_area :about, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
           </div>
-          <div class="panel-footer">
-            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
-            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
-          </div>
-        <% end %>
-      </div>
+        </div>
+        <div class="panel-footer">
+          <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
+          <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+        </div>
+      <% end %>
     </div>
-    <div id="help" class="tab-pane">
-      <div class="panel panel-default labels">
-        <%= simple_form_for ContentBlock.for(:help), url: hyrax.page_path(ContentBlock.for(:help)) do |f| %>
-          <div class="panel-body">
-            <div class="field form-group">
-                <%= f.label :help %><br />
-                <%= f.text_area :help, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
-            </div>
+  </div>
+  <div id="help" class="tab-pane">
+    <div class="panel panel-default labels">
+      <%= simple_form_for ContentBlock.for(:help), url: hyrax.page_path(ContentBlock.for(:help)), html: { class: 'nav-safety' } do |f| %>
+        <div class="panel-body">
+          <div class="field form-group">
+              <%= f.label :help %><br />
+              <%= f.text_area :help, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
           </div>
-          <div class="panel-footer">
-            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
-            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
-          </div>
-        <% end %>
-      </div>
+        </div>
+        <div class="panel-footer">
+          <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
+          <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+        </div>
+      <% end %>
     </div>
-    <div id="agreement" class="tab-pane">
-      <div class="panel panel-default labels">
-        <%= simple_form_for ContentBlock.for(:agreement), url: hyrax.page_path(ContentBlock.for(:agreement)) do |f| %>
-          <div class="panel-body">
-            <div class="field form-group">
-                <%= f.label :agreement %><br />
-                <%= f.text_area :agreement, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
-            </div>
+  </div>
+  <div id="agreement" class="tab-pane">
+    <div class="panel panel-default labels">
+      <%= simple_form_for ContentBlock.for(:agreement), url: hyrax.page_path(ContentBlock.for(:agreement)), html: { class: 'nav-safety' } do |f| %>
+        <div class="panel-body">
+          <div class="field form-group">
+              <%= f.label :agreement %><br />
+              <%= f.text_area :agreement, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
           </div>
-          <div class="panel-footer">
-            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
-            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
-          </div>
-        <% end %>
-      </div>
+        </div>
+        <div class="panel-footer">
+          <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
+          <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+        </div>
+      <% end %>
     </div>
-    <div id="terms" class="tab-pane">
-      <div class="panel panel-default labels">
-        <%= simple_form_for ContentBlock.for(:terms), url: hyrax.page_path(ContentBlock.for(:terms)) do |f| %>
-          <div class="panel-body">
-            <div class="field form-group">
-                <%= f.label :terms %><br />
-                <%= f.text_area :terms, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
-            </div>
+  </div>
+  <div id="terms" class="tab-pane">
+    <div class="panel panel-default labels">
+      <%= simple_form_for ContentBlock.for(:terms), url: hyrax.page_path(ContentBlock.for(:terms)), html: { class: 'nav-safety' } do |f| %>
+        <div class="panel-body">
+          <div class="field form-group">
+              <%= f.label :terms %><br />
+              <%= f.text_area :terms, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
           </div>
-          <div class="panel-footer">
-            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
-            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
-          </div>
-        <% end %>
-      </div>
+        </div>
+        <div class="panel-footer">
+          <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
+          <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>
+<%= tinymce :content_block %>

--- a/spec/features/edit_pages_admin.spec.rb
+++ b/spec/features/edit_pages_admin.spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Editing content blocks as admin', :js do
+RSpec.describe 'Editing pages as admin', :js do
   let(:user) { create(:admin) }
 
   context 'when user wants to change tabs' do
@@ -8,54 +8,54 @@ RSpec.describe 'Editing content blocks as admin', :js do
       sign_in user
       visit '/dashboard'
       click_link 'Settings'
-      click_link 'Content Blocks'
+      click_link 'Pages'
     end
 
     it "does not display a confirmation message when form data has not changed" do
       expect(page).to have_content('Content Blocks')
-      expect(page).to have_content('Announcement')
-      click_link 'Marketing Text'
+      expect(page).to have_content('About')
+      click_link 'Help Page'
       expect(page).not_to have_content(confirm_modal_text)
     end
 
     it "displays a confirmation message when form data has changed" do
       expect(page).to have_content('Content Blocks')
-      expect(page).to have_content('Announcement')
-      expect(page).to have_selector('#content_block_announcement_ifr')
-      within_frame('content_block_announcement_ifr') do
+      expect(page).to have_content('About')
+      expect(page).to have_selector('#content_block_about_ifr')
+      within_frame('content_block_about_ifr') do
         find('body').set('Updated text.')
       end
-      click_link 'Marketing Text'
+      click_link 'Help Page'
       within('#nav-safety-modal') do
         expect(page).to have_content(confirm_modal_text)
       end
     end
 
-    it "change tab when user dismisses the confirmation" do
-      expect(page).to have_selector('#announcement_text', class: 'active')
-      expect(page).not_to have_selector('#marketing', class: 'active')
-      within_frame('content_block_announcement_ifr') do
+    it "changes tab when user dismisses the confirmation by clicking OK" do
+      expect(page).to have_selector('#about', class: 'active')
+      expect(page).not_to have_selector('#help', class: 'active')
+      within_frame('content_block_about_ifr') do
         find('body').set('Updated text.')
       end
-      click_link 'Marketing Text'
+      click_link 'Help Page'
       within('#nav-safety-modal') do
         click_button('OK')
       end
-      expect(page).to have_selector('#marketing', class: 'active')
-      expect(page).not_to have_selector('#announcement_text', class: 'active')
+      expect(page).to have_selector('#help', class: 'active')
+      expect(page).not_to have_selector('#about', class: 'active')
     end
 
     it "does not redisplay the confirmation unless form data is changed" do
-      expect(page).to have_selector('#announcement_text', class: 'active')
-      expect(page).not_to have_selector('#marketing', class: 'active')
-      within_frame('content_block_announcement_ifr') do
+      expect(page).to have_selector('#about', class: 'active')
+      expect(page).not_to have_selector('#help', class: 'active')
+      within_frame('content_block_about_ifr') do
         find('body').set('Updated text.')
       end
-      click_link 'Marketing Text'
+      click_link 'Help Page'
       within('#nav-safety-modal') do
         click_button('OK')
       end
-      click_link 'Marketing Text'
+      click_link 'Deposit Agreement'
       expect(page).not_to have_content(confirm_modal_text)
     end
   end


### PR DESCRIPTION
Fixes #3911  ; refs #3454 

This uses the modal implementation in [#2977](https://github.com/samvera/hyrax/pull/2799), across the following scenarios.

Changes proposed in this pull request:
* Use confirmation when editing tabbed forms in Admin Pages, Collection edit, and File-set edit

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Dashboard -> Collections
* Choose 'Edit collection' from the drop-down for one collection in the list 
* Change a field in the `Description` tab
* Go to `Discovery` tab without saving the changes
* A modal pops up as follows;
![modal-confirm](https://user-images.githubusercontent.com/1331659/64258229-e15fba00-cef4-11e9-9fb6-795947b19962.png)
* Click `OK` to go to the `Discovery` tab OR click on modal backdrop/hit `ESC` button on keyboard to close the modal

@samvera/hyrax-code-reviewers
