### PR TITLE
Move SolrService deprecation target to 4.0

### DIFF
--- a/app/services/hyrax/solr_service.rb
+++ b/app/services/hyrax/solr_service.rb
@@ -110,7 +110,7 @@ module Hyrax
       end
 
       def rsolr_call_warning
-        "Calling Hyrax::SolrService.instance are deprecated and support will be removed from Hyrax 3.0. Use methods in Hyrax::SolrService instead."
+        "Calls to Hyrax::SolrService.instance are deprecated and support will be removed from Hyrax 4.0. Use methods in Hyrax::SolrService instead."
       end
   end
 end

--- a/app/services/hyrax/solr_service.rb
+++ b/app/services/hyrax/solr_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hyrax
   ##
   # Supports a range of basic Solr interactions.


### PR DESCRIPTION
The new interfaces will first be released in 3.0.0, so we can't remove the old
ones until 4.0.

@samvera/hyrax-code-reviewers
