### PR TITLE
if admin, show all groups in sharing tab, ALSO removed html tags from page

### DIFF
--- a/app/views/hyrax/base/_form_share.html.erb
+++ b/app/views/hyrax/base/_form_share.html.erb
@@ -3,7 +3,7 @@
 
 <% depositor = f.object.depositor %>
 
-<div class="alert alert-info hidden" id="save_perm_note"><%= t('.permissions_save_note') %></div>
+<div class="alert alert-info hidden" id="save_perm_note"><%= raw t('.permissions_save_note') %></div>
 
 <div class="alert alert-warning hidden" role="alert" id="permissions_error">
   <span id="permissions_error_text"></span>
@@ -18,7 +18,11 @@
   </legend>
   <div class="col-sm-9 form-inline">
     <label for="new_group_name_skel" class="sr-only"><%= t(".group") %></label>
-    <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>
+    <% if current_ability.admin? %>
+      <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.group_service.map.keys), class: 'form-control' %>
+    <% else %>
+      <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>
+    <% end %>
     <label for="new_group_permission_skel" class="sr-only"><%= t(".access_type_to_grant") %></label>
     <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
 

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe 'Editing a work', type: :feature do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, groups: 'librarians') }
+  let(:user_admin) { create(:user, groups: 'admin') }
   let(:work) { build(:work, user: user, admin_set: another_admin_set) }
   let(:default_admin_set) do
     create(:admin_set, id: AdminSet::DEFAULT_ID,
@@ -56,6 +57,24 @@ RSpec.describe 'Editing a work', type: :feature do
       visit edit_hyrax_generic_work_path(work)
       click_link "Relationships" # switch tab
       expect(page).to have_select('generic_work_admin_set_id', selected: another_admin_set.title)
+    end
+
+    it 'selects group assigned to user' do
+      visit edit_hyrax_generic_work_path(work)
+      click_link "Sharing" # switch tab
+      expect(page).to have_selector('#new_group_name_skel', text: 'librarians')
+    end
+  end
+
+  context 'when logged in as admin' do
+    before do
+      sign_in user_admin
+    end
+
+    it 'selects group all available groups' do
+      visit edit_hyrax_generic_work_path(work)
+      click_link "Sharing" # switch tab
+      expect(page).to have_selector('#new_group_name_skel', text: 'archivist admin_policy_object_editor donor researcher patron')
     end
   end
 end


### PR DESCRIPTION
Fixes #3534
When creating or editing a work, and user goes to the sharing tab, if the user is an admin, a complete list of all the groups should be displayed in the group selection widget.  If the user is not an admin, then the list will only list all the groups for which the user is a member.

Also, the Sharing page had some html tags being displayed.  That was cleaned up.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a few groups in the role_map.yml file, some groups will have an admin user, and some will have other users.
* Login as an admin, and go edit a work.
* Verify that the groups listed in the group widget of the sharing tab is a complete list of all the groups.
* Login as a non admin, and go edit a work.
* Verify that the groups listed in the group widget of the sharing tab is just the groups for which this user is a member.
* Verify that the Sharing page does not display any html attributes as part of the text on the page.


@samvera/hyrax-code-reviewers
