### PR TITLE
Split out functionality behind ModelTransformer

### DIFF
--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -21,6 +21,8 @@ module Wings; end
 
 require 'valkyrie'
 require 'wings/model_transformer'
+require 'wings/orm_converter'
+require 'wings/attribute_transformer'
 require 'wings/valkyrizable'
 require 'wings/valkyrie/metadata_adapter'
 require 'wings/valkyrie/resource_factory'

--- a/lib/wings/attribute_transformer.rb
+++ b/lib/wings/attribute_transformer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'wings/transformer_value_mapper'
+
+module Wings
+  ##
+  # Transform AF attributes to Valkyrie::Resource attributes representation.
+  #
+  class AttributeTransformer
+    def self.run(obj, keys)
+      # TODO: There is an open question about whether we want to treat all these relationships the same.  See Issue #3904.
+      attrs = keys.select { |k| k.to_s.end_with? '_ids' }.each_with_object({}) do |attr_name, mem|
+        mem[attr_name.to_sym] =
+          TransformerValueMapper.for(obj.try(attr_name)).result ||
+          TransformerValueMapper.for(attribute_ids_for(name: attr_name.chomp('_ids'), obj: obj)).result ||
+          TransformerValueMapper.for(attribute_ids_for(name: attr_name.chomp('_ids').pluralize, obj: obj)).result || []
+      end
+      keys.each_with_object(attrs) do |attr_name, mem|
+        next unless obj.respond_to?(attr_name) && !mem.key?(attr_name.to_sym)
+        mem[attr_name.to_sym] = TransformerValueMapper.for(obj.public_send(attr_name)).result
+      end
+    end
+
+    def self.attribute_ids_for(name:, obj:)
+      attribute_value = obj.try(name)
+      return if attribute_value.nil?
+      Array(attribute_value).map(&:id)
+    end
+  end
+end

--- a/lib/wings/orm_converter.rb
+++ b/lib/wings/orm_converter.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'wings/transformer_value_mapper'
+require 'wings/models/concerns/collection_behavior'
+require 'wings/hydra/works/models/concerns/work_valkyrie_behavior'
+require 'wings/hydra/works/models/concerns/file_set_valkyrie_behavior'
+
+module Wings
+  ##
+  # Transform AF object class to Valkyrie::Resource class representation.
+  #
+  class OrmConverter
+    ##
+    # @param reflections [Hash<Symbol, Object>]
+    #
+    # @return [Array<Symbol>]
+    def self.relationship_keys_for(reflections:)
+      relationships = reflections
+                      .keys
+                      .reject { |k| k.to_s.include?('id') }
+                      .map { |k| k.to_s.singularize + '_ids' }
+      relationships.delete('member_ids') # Remove here.  Members will be extracted as ordered_members in attributes method.
+      relationships.delete('ordered_member_proxy_ids') # This does not have a Valkyrie equivalent.
+      relationships
+    end
+
+    ##
+    # Selects an existing base class for the generated valkyrie class
+    #
+    # @return [Class]
+    def self.base_for(klass:)
+      if klass == Hydra::AccessControls::Embargo
+        Hyrax::Embargo
+      elsif klass == Hydra::AccessControls::Lease
+        Hyrax::Lease
+      else
+        Hyrax::Resource
+      end
+    end
+
+    ##
+    # @param klass [String] an `ActiveFedora` model
+    #
+    # @return [Class] a dyamically generated `Valkyrie::Resource` subclass
+    #   mirroring the provided `ActiveFedora` model
+    #
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength because metaprogramming a class
+    #   results in long methods
+    def self.to_valkyrie_resource_class(klass:)
+      relationship_keys = klass.respond_to?(:reflections) ? relationship_keys_for(reflections: klass.reflections) : []
+      relationship_keys.delete('member_ids')
+      relationship_keys.delete('member_of_collection_ids')
+      reflection_id_keys = klass.respond_to?(:reflections) ? klass.reflections.keys.select { |k| k.to_s.end_with? '_id' } : []
+
+      Class.new(base_for(klass: klass)) do
+        include Wings::CollectionBehavior if klass.included_modules.include?(Hyrax::CollectionBehavior)
+        include Wings::Works::WorkValkyrieBehavior if klass.included_modules.include?(Hyrax::WorkBehavior)
+        include Wings::Works::FileSetValkyrieBehavior if klass.included_modules.include?(Hyrax::FileSetBehavior)
+
+        # Based on Valkyrie implementation, we call Class.to_s to define
+        # the internal resource.
+        @internal_resource = klass.to_s
+
+        class << self
+          attr_reader :internal_resource
+        end
+
+        def self.to_s
+          internal_resource
+        end
+
+        klass.properties.each_key do |property_name|
+          attribute property_name.to_sym, ::Valkyrie::Types::String
+        end
+
+        relationship_keys.each do |linked_property_name|
+          attribute linked_property_name.to_sym, ::Valkyrie::Types::Set.of(::Valkyrie::Types::ID)
+        end
+
+        reflection_id_keys.each do |property_name|
+          attribute property_name, ::Valkyrie::Types::ID
+        end
+
+        # Defined after properties in case we have an `internal_resource` property.
+        # This may not be ideal, but based on my understanding of the `internal_resource`
+        # usage in Valkyrie, I'd rather keep synchronized the instance_method and class_method value for
+        # `internal_resource`
+        def internal_resource
+          self.class.internal_resource
+        end
+      end
+    end
+  end
+end

--- a/lib/wings/transformer_value_mapper.rb
+++ b/lib/wings/transformer_value_mapper.rb
@@ -22,7 +22,7 @@ module Wings
       attributes = value.attributes.symbolize_keys
       nested_object = Wings::ActiveFedoraConverter::NestedResource.new(attributes)
       klass = Wings::ModelTransformer::ResourceClassCache.instance.fetch(Wings::ActiveFedoraConverter::NestedResource) do
-        ModelTransformer.to_valkyrie_resource_class(klass: nested_object.class)
+        OrmConverter.to_valkyrie_resource_class(klass: nested_object.class)
       end
       klass.new(attributes)
     end

--- a/spec/wings/attribute_transformer_spec.rb
+++ b/spec/wings/attribute_transformer_spec.rb
@@ -1,0 +1,29 @@
+require 'wings/attribute_transformer'
+
+RSpec.describe Wings::AttributeTransformer do
+  let(:pcdm_object) { work }
+  let(:id)          { 'moomin123' }
+  let(:work)        { GenericWork.new(id: id, **attributes) }
+  let(:keys)        { attributes.keys }
+
+  let(:attributes) do
+    {
+      title: ['fake title', 'fake title 2'],
+      contributor: ['user1'],
+      description: ['a description']
+    }
+  end
+
+  let(:uris) do
+    [RDF::URI('http://example.com/fake1'),
+     RDF::URI('http://example.com/fake2')]
+  end
+
+  subject { described_class.run(pcdm_object, keys) }
+
+  it "transform the attributes" do
+    expect(subject).to include title: work.title,
+                               contributor: work.contributor,
+                               description: work.description
+  end
+end

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -47,28 +47,6 @@ RSpec.describe Wings::ModelTransformer, :clean_repo do
     end
   end
 
-  describe '.to_valkyrie_resource_class' do
-    context 'when given a ActiveFedora class (eg. a constant that responds to #properties)' do
-      context 'for the returned object (e.g. a class)' do
-        subject { described_class.to_valkyrie_resource_class(klass: GenericWork) }
-        it 'will be Valkyrie::Resource build' do
-          expect(subject.new).to be_a Valkyrie::Resource
-        end
-        it 'has a to_s instance that delegates to the given klass' do
-          expect(subject.to_s).to eq(GenericWork.to_s)
-        end
-        it 'has a internal_resource instance that is the given klass' do
-          expect(subject.internal_resource).to eq(GenericWork.to_s)
-        end
-      end
-    end
-    context 'when given a non-ActiveFedora class' do
-      it 'raises an exception' do
-        expect { described_class.to_valkyrie_resource_class(klass: String) }.to raise_error
-      end
-    end
-  end
-
   describe '.for' do
     it 'returns a Valkyrie::Resource' do
       expect(described_class.for(work)).to be_a Valkyrie::Resource

--- a/spec/wings/orm_converter_spec.rb
+++ b/spec/wings/orm_converter_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/orm_converter'
+
+RSpec.describe Wings::OrmConverter do
+  describe '.to_valkyrie_resource_class' do
+    context 'when given a ActiveFedora class (eg. a constant that responds to #properties)' do
+      context 'for the returned object (e.g. a class)' do
+        subject { described_class.to_valkyrie_resource_class(klass: GenericWork) }
+        it 'will be Valkyrie::Resource build' do
+          expect(subject.new).to be_a Valkyrie::Resource
+        end
+        it 'has a to_s instance that delegates to the given klass' do
+          expect(subject.to_s).to eq(GenericWork.to_s)
+        end
+        it 'has a internal_resource instance that is the given klass' do
+          expect(subject.internal_resource).to eq(GenericWork.to_s)
+        end
+      end
+    end
+
+    context 'when given a non-ActiveFedora class' do
+      it 'raises an exception' do
+        expect { described_class.to_valkyrie_resource_class(klass: String) }.to raise_error
+      end
+    end
+  end
+end

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Wings::Valkyrie::Persister do
     let(:adapter) { Wings::Valkyrie::MetadataAdapter.new }
     let(:query_service) { adapter.query_service }
     let(:af_resource_class) { Book }
-    let(:resource_class) { Wings::ModelTransformer.to_valkyrie_resource_class(klass: af_resource_class) }
+    let(:resource_class) { Wings::OrmConverter.to_valkyrie_resource_class(klass: af_resource_class) }
     let(:resource) { resource_class.new(title: ['Foo']) }
 
     # it_behaves_like "a Valkyrie::Persister", :no_deep_nesting, :no_mixed_nesting

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Wings::Valkyrie::QueryService do
   let(:persister) { Wings::Valkyrie::Persister.new(adapter: adapter) }
   let(:af_resource_class) { Book }
   let(:af_image_resource_class) { Image }
-  let(:resource_class) { Wings::ModelTransformer.to_valkyrie_resource_class(klass: af_resource_class) }
-  let(:image_resource_class) { Wings::ModelTransformer.to_valkyrie_resource_class(klass: af_image_resource_class) }
+  let(:resource_class) { Wings::OrmConverter.to_valkyrie_resource_class(klass: af_resource_class) }
+  let(:image_resource_class) { Wings::OrmConverter.to_valkyrie_resource_class(klass: af_image_resource_class) }
   let(:resource) { resource_class.new(title: ['Foo']) }
 
   # it_behaves_like "a Valkyrie query provider"
@@ -256,7 +256,7 @@ RSpec.describe Wings::Valkyrie::QueryService do
     context "filtering by model" do
       subject { query_service.find_members(resource: parent, model: resource_class) }
       let(:gw_resource_class) { GenericWork }
-      let(:parent_resource_class) { Wings::ModelTransformer.to_valkyrie_resource_class(klass: gw_resource_class) }
+      let(:parent_resource_class) { Wings::OrmConverter.to_valkyrie_resource_class(klass: gw_resource_class) }
 
       context "when the object has members" do
         let(:child1) { persister.save(resource: resource_class.new(title: ['Child 1'])) }


### PR DESCRIPTION
Fixes #3639

Split out functionality behind ModelTransformer into its own Wings::ORMConverter class.

Changes proposed in this pull request:
* Break out the parts that handle the actual conversion details to OrmConverter class
* Separate AttributeTransformer to its own class file.
* Add test for AttributeTransformer.

@samvera/hyrax-code-reviewers

