### PR TITLE
[wings] Remove method missing

### DIFF
--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -132,24 +132,9 @@ module Wings
         in_collections(valkyrie: valkyrie).map(&:id)
       end
 
-      ##
-      # Any method not implemented is sent to the ActiveFedora version of the resource.
-      def method_missing(name, *args, &block)
-        # TODO: Remove the puts and this method when all methods are valkyrized
+      def original_file
         af_object = Wings::ActiveFedoraConverter.new(resource: self).convert
-        unless af_object.respond_to? name
-          Rails.logger.warn "#{af_object.class} does not respond to method #{name}"
-          super
-        end
-        Rails.logger.info "Calling through Method Missing with name: #{name}    args: #{args}   block_given? #{block_given?}"
-        args.delete_if { |arg| arg.is_a?(Hash) && arg.key?(:valkyrie) }
-        return af_object.send(name, args, block) if block_given?
-        return af_object.send(name, args) if args.present?
-        af_object.send(name)
-      end
-
-      def respond_to_missing?(_name, _include_private = false)
-        true
+        af_object.original_file
       end
 
       # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?

--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -137,6 +137,24 @@ module Wings
         af_object.original_file
       end
 
+      ##
+      # @return [Boolean] whether this instance is an audio.
+      def audio?
+        af_object = Wings::ActiveFedoraConverter.new(resource: self).convert
+        af_object.audio?
+      end
+
+      # TODO: This can be removed when we upgrade to ActiveFedora 12.0
+      # @return [String] the etag from the response headers
+      #
+      # @raise [RuntimeError] when the resource is new and has no etag
+      # @raise [Ldp::Gone]    when the resource is deleted
+      def etag
+        raise "Unable to produce an etag for a unsaved object" unless persisted?
+        af_object = Wings::ActiveFedoraConverter.new(resource: self).convert
+        af_object.ldp_source.head.etag
+      end
+
       # @param valkyrie [Boolean] Should the returned ids be for Valkyrie or AF objects?
       # @return [Enumerable<Hydra::Works::Work>] The works this work is contained in
       # @note This method avoids using the Hydra::Works version of parent_works because of Issue #361


### PR DESCRIPTION
There's no reason to pass through these methods, we'd prefer they fail. The
`original_file` case is used internally, but should also be removed.

@samvera/hyrax-code-reviewers
