### PR TITLE
change labels on dashboard for visibility to indicate work or collection

### DIFF
--- a/app/views/hyrax/dashboard/collections/_default_group.html.erb
+++ b/app/views/hyrax/dashboard/collections/_default_group.html.erb
@@ -16,7 +16,7 @@
       <th><%= t("hyrax.dashboard.my.heading.access") %></th>
     <% end %>
     <th><%= t("hyrax.dashboard.my.heading.type") %></th>
-    <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.collection.visibility") %></th>
     <th><%= t("hyrax.dashboard.my.heading.items") %></th>
     <th><%= t("hyrax.dashboard.my.heading.last_modified") %></th>
     <th><%= t("hyrax.dashboard.my.heading.action") %></th>

--- a/app/views/hyrax/dashboard/works/_default_group.html.erb
+++ b/app/views/hyrax/dashboard/works/_default_group.html.erb
@@ -6,7 +6,7 @@
       <th><%= t("hyrax.dashboard.my.heading.title") %></th>
       <th class="date text-center"><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
       <th class="text-center"><%= t("blacklight.search.fields.facet.suppressed_bsi") %></th>
-      <th class="text-center"><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+      <th class="text-center"><%= t("hyrax.dashboard.my.heading.work.visibility") %></th>
       <th class="text-center"><%= t("hyrax.dashboard.my.heading.action") %></th>
     </tr>
   </thead>

--- a/app/views/hyrax/my/collections/_default_group.html.erb
+++ b/app/views/hyrax/my/collections/_default_group.html.erb
@@ -5,7 +5,7 @@
     <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>
     <th><%= t("hyrax.dashboard.my.heading.type") %></th>
-    <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.collection.visibility") %></th>
     <th><%= t("hyrax.dashboard.my.heading.items") %></th>
     <th><%= t("hyrax.dashboard.my.heading.last_modified") %></th>
     <th><%= t("hyrax.dashboard.my.heading.action") %></th>

--- a/app/views/hyrax/my/works/_default_group.html.erb
+++ b/app/views/hyrax/my/works/_default_group.html.erb
@@ -6,7 +6,7 @@
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>
     <th class='text-center'><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
     <th class='text-center'><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
-    <th class='text-center'><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+    <th class='text-center'><%= t("hyrax.dashboard.my.heading.work.visibility") %></th>
     <th class='text-center'><%= t("hyrax.dashboard.my.heading.action") %></th>
   </tr>
   </thead>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -889,6 +889,10 @@ en:
           title: Title
           type: Type
           visibility: Visibility
+          collection:
+            visibility: Visibility of Collection
+          work:
+            visibility: Visibility of Work
         highlighted: My Highlights
         shared: Works Shared with Me
         sr:


### PR DESCRIPTION
Fixes #i3459
On the dashboard the table labels for visibility should indicate whether dealing with a Work or a Collection.  

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* If you don't have works and collections create at least one of each.
* Go to the the work dashboard and verify that in both tabs ( all/my ) the visibility column header is "Visibility of Work".
* Go to the the collection dashboard and verify that in both tabs ( all/my ) the visibility column header is "Visibility of Collection".

@samvera/hyrax-code-reviewers
