### PR TITLE
enlarge area where collection title is displayed on modal.

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
@@ -14,7 +14,7 @@
                 <legend><%= t("hyrax.collection.select_form.select_heading") %></legend>
               <ul>
                 <% if @add_works_to_collection.present? %>
-                  <%= text_field_tag 'member_of_collection_label', @add_works_to_collection_label, disabled: true %>
+                  <%= text_field_tag 'member_of_collection_label', @add_works_to_collection_label, size: '90', disabled: true %>
                   <%= hidden_field_tag 'member_of_collection_ids', @add_works_to_collection %>
                 <% else %>
                   <%= text_field_tag 'member_of_collection_ids', nil,


### PR DESCRIPTION
Fixes #3954 
When adding works from a preselected collection, the modal should display a good chunk of the collection name.  Before this change, the display was too brief.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Log in as a user who has the ability to deposit works to a collection, and make sure they have at least one work (or create a user/collection/work)
* Go to the Dashboard->collections-> click on the title of the collection
* Make sure the collection name is fairly long.
* Click on "Add existing works to this collection"
* Click on the checkbox to select at least one work
* Click on the "Add to Collection" button
* The modal that pops up should display a good chunk of the collection name if not all of it depending on how long the collection name is.

@samvera/hyrax-code-reviewers
