### PR TITLE
in transfer page, correct labels.

### DIFF
--- a/app/views/hyrax/transfers/_received.html.erb
+++ b/app/views/hyrax/transfers/_received.html.erb
@@ -1,11 +1,11 @@
 <table class="table table-striped" id="incoming-transfers">
   <thead>
     <tr>
-      <th>t(".title")</th>
-      <th>t(".date")</th>
-      <th>t(".from")</th>
-      <th>t(".status")</th>
-      <th>t(".comments")</th>
+      <th><%= t(".title") %></th>
+      <th><%= t(".date") %></th>
+      <th><%= t(".from") %></th>
+      <th><%= t(".status") %></th>
+      <th><%= t(".comments") %></th>
     </tr>
   </thead>
   <tbody>
@@ -22,7 +22,7 @@
       <td>
         <% if req.pending? %>
             <div class="btn-group">
-              <button class="btn btn-sm btn-primary" href="#">t(".accept")</button>
+              <button class="btn btn-sm btn-primary" href="#"><%= t(".accept") %></button>
               <button class="btn btn-sm dropdown-toggle accept" data-toggle="dropdown" href="#"><span class="caret"></span></button>
               <ul class="dropdown-menu">
                 <li>

--- a/app/views/hyrax/transfers/_sent.html.erb
+++ b/app/views/hyrax/transfers/_sent.html.erb
@@ -1,11 +1,11 @@
 <table class="table table-striped" id="outgoing-transfers">
   <thead>
     <tr>
-      <th>t(".title")</th>
-      <th>t(".date")</th>
-      <th>t(".from")</th>
-      <th>t(".status")</th>
-      <th>t(".comments")</th>
+      <th><%= t(".title") %></th>
+      <th><%= t(".date") %></th>
+      <th><%= t(".from") %></th>
+      <th><%= t(".status") %></th>
+      <th><%= t(".comments") %></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
Fixes #3956 
The labels in the Transfer pages were not being displayed correctly.  

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Have two registered users ( user 1, and user 2) on the system, and one work created by user 1.
* Transfer ownership of the work by user 1, to user 2
* Go to the dashboard for user 1, and from 'Your activity', select Transfers
* Verify that the labels on the table are correct
* Go to the dashboard for user 2, and from 'Your activity' select Transfers
* Verify that the labels on the table are correct, and that the accept button label is correct too.

@samvera/hyrax-code-reviewers
