### PR TITLE
Change the way collection edit thumbnail url is calculated.

### DIFF
--- a/app/assets/javascripts/hyrax/collections/editor.es6
+++ b/app/assets/javascripts/hyrax/collections/editor.es6
@@ -6,12 +6,17 @@ import tabifyForm from 'hyrax/tabbed_form'
 // Add search for thumbnail to the edit descriptions
 export default class {
   constructor(elem) {
-    let url =  window.location.pathname.replace('edit', 'files')
     let field = elem.find('#collection_thumbnail_id')
-    this.thumbnailSelect = new ThumbnailSelect(url, field)
+    this.thumbnailSelect = new ThumbnailSelect(this.url(), field)
     tabifyForm(elem.find('form.editor'))
 
     let participants = new Participants(elem.find('#participants'))
     participants.setup()
+  }
+
+  url() {
+    let urlParts = window.location.pathname.split("/")
+    urlParts[urlParts.length - 1] = "files"
+    return urlParts.join("/") 
   }
 }

--- a/spec/javascripts/collections_editor_spec.js
+++ b/spec/javascripts/collections_editor_spec.js
@@ -1,0 +1,29 @@
+describe('thumbnail select', () => {
+  var CollectionEditor = require('hyrax/collections/editor')
+  var localContext = {
+    "window":{
+      location:{
+        href: "http://example.com/dashboard/collections/edith-stein-collection/edit?_=1566882335253"
+      }
+    }
+  }
+
+  var editor;
+  beforeEach(() =>  {
+    setFixtures(`
+        <form class='editor'>
+        <input type="text" id="collection_thumbnail_id autocomplete="off">
+        <input type="text" id="participants">
+        </form>
+        `)
+    editor = new CollectionEditor($('form'))
+  })
+
+
+
+  it('should change the thumbnail select url for auto complete', () => {
+    with(localContext){
+	    expect(editor.url()).toEqual('/dashboard/collections/edith-stein-collection/files?_=1566882335253')
+    }
+  })
+})


### PR DESCRIPTION
Fixes #3930

This is the 2.x version. I'm not sure if we're still patching there with rc1 out, but I'll need this branch anyway, so I figured I'd toss it up. 

Changes the way we split the path for the collection thumbnails URL to defend against the letters 'edit' appearing anywhere else in the URL.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
- The key to causing this issue it to have a collection with 'edit' somewhere in the url. In Nurax this would have to be in the identifier.

@samvera/hyrax-code-reviewers