### PR TITLE
remove raw html from batch edit pages.

### DIFF
--- a/app/views/hyrax/base/_form_permission.html.erb
+++ b/app/views/hyrax/base/_form_permission.html.erb
@@ -6,7 +6,7 @@
 <% else %>
   <fieldset class="set-access-controls">
     <legend>
-      <%= t('.visibility') %>
+      <%= raw(t('.visibility')) %>
     </legend>
 
     <div class="form-group">

--- a/app/views/hyrax/base/_form_share.html.erb
+++ b/app/views/hyrax/base/_form_share.html.erb
@@ -23,7 +23,7 @@
     <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
 
     <button class="btn btn-default" id="add_new_group_skel">
-      <span><%= t(".add_this_group") %></span>
+      <span><%= raw(t(".add_this_group")) %></span>
     </button>
     <br /><span id="directory_group_result"></span>
   </div>
@@ -54,7 +54,7 @@
     </td>
     <td width="60%">
       <%= label_tag :owner_access, class: "control-label" do %>
-        t('.depositor') (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
+        <%= t('.depositor') %>(<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
       <% end %>
     </td>
   </tr>

--- a/app/views/hyrax/batch_edits/edit.html.erb
+++ b/app/views/hyrax/batch_edits/edit.html.erb
@@ -1,4 +1,4 @@
-<h2 class="non lower"><%= t('.batch_edit_descriptions') %></h2>
+<h2 class="non lower"><%= raw(t('.batch_edit_descriptions')) %></h2>
 
 <div class="scrollx scrolly fileHeight"> <!-- original values -->
   <h3> <b><%= t('.apply_changes_to', x_number_of: @form.names.size ) %></b></h3>


### PR DESCRIPTION
Fixes #3959 
The UI text was displaying HTML code in headings on the Batch Edit Descriptions page and in the Permissions tab. This PR corrects this.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Login
* Click on Works
* Select two or more works form the table
* Click on Edit Selected
* Look at the page heading.  It should not contain any raw html
* Click on the Permissions tab.  It should not contain any raw html
* Look at the Visibility heading. It should not contain any raw html
* Look at the Sharing heading.  It should not contain any raw html
* From sharing heading, select a group and user to share.
* Look at the updated display showing the group and user selected.  It should not contain any raw html. 

@samvera/hyrax-code-reviewers
