### PR TITLE
Drop support for Ruby 2.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Note here that the following commands assume you're setting up Hyrax in a develo
 
 First, you'll need a working Ruby installation. You can install this via your operating system's package manager -- you are likely to get farther with OSX, Linux, or UNIX than Windows but your mileage may vary -- but we recommend using a Ruby version manager such as [RVM](https://rvm.io/) or [rbenv](https://github.com/sstephenson/rbenv).
 
-Hyrax supports Ruby 2.4, 2.5, and 2.6. When starting a new project, we recommend using the latest Ruby 2.6 version.
+Hyrax supports Ruby 2.5, and 2.6. When starting a new project, we recommend using the latest Ruby 2.6 version.
 
 ## Redis
 

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -24,7 +24,7 @@ SUMMARY
   spec.version       = Hyrax::VERSION
   spec.license       = 'Apache-2.0'
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.5'
 
   # Note: rails does not follow sem-ver conventions, it's
   # minor version releases can include breaking changes; see


### PR DESCRIPTION
We run CI on Ruby 2.5 and 2.6, it seems reasonable to bump support to 2.5+ at
this point.

@samvera/hyrax-code-reviewers
