### PR TITLE
Upgrade Valkyrie to 2.0

### DIFF
--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -6,9 +6,9 @@ module Hyrax
   class Resource < Valkyrie::Resource
     include Valkyrie::Resource::AccessControls
 
-    attribute :alternate_ids, ::Valkyrie::Types::Array
-    attribute :embargo,       Hyrax::Embargo
-    attribute :lease,         Hyrax::Lease
+    attribute :alternate_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID)
+    attribute :embargo,       Hyrax::Embargo.optional
+    attribute :lease,         Hyrax::Lease.optional
 
     def visibility=(value)
       visibility_writer.assign_access_for(visibility: value)

--- a/app/services/hyrax/workflow/workflow_importer.rb
+++ b/app/services/hyrax/workflow/workflow_importer.rb
@@ -113,7 +113,7 @@ module Hyrax
         end
 
         def default_schema
-          Hyrax::Workflow::WorkflowSchema
+          Hyrax::Workflow::WorkflowSchema.new
         end
 
         def validate!
@@ -170,7 +170,7 @@ module Hyrax
           def self.call(data:, schema:, logger:)
             result = schema.call(data)
             return true if result.success?
-            message = result.messages(full: true).inspect
+            message = result.errors(full: true).inspect
             logger.error(message)
             raise message
           end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -41,9 +41,9 @@ SUMMARY
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'dry-equalizer', '~> 0.2'
-  spec.add_dependency 'dry-struct', '~> 0.4'
+  spec.add_dependency 'dry-struct', '~> 1.0'
   spec.add_dependency 'dry-transaction', '~> 0.11'
-  spec.add_dependency 'dry-validation', '~> 0.9'
+  spec.add_dependency 'dry-validation', '~> 1.3'
   spec.add_dependency 'flipflop', '~> 2.3'
   # Pin more tightly because 0.x gems are potentially unstable
   spec.add_dependency 'flot-rails', '~> 0.0.6'
@@ -77,7 +77,7 @@ SUMMARY
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
-  spec.add_dependency 'valkyrie', '~> 1.6'
+  spec.add_dependency 'valkyrie', '~> 2.0'
 
   # temporary pin to 2.17 due to failures caused in 2.18.0
   spec.add_development_dependency "capybara", '~> 2.4', '< 2.18.0'

--- a/spec/services/hyrax/workflow/workflow_schema_spec.rb
+++ b/spec/services/hyrax/workflow/workflow_schema_spec.rb
@@ -1,6 +1,8 @@
 module Hyrax
   module Workflow
-    RSpec.describe 'WorkflowSchema' do
+    RSpec.describe WorkflowSchema do
+      subject(:schema) { described_class.new }
+
       let(:valid_data) do
         {
           workflows: [
@@ -51,12 +53,12 @@ module Hyrax
         Object.send(:remove_const, :DoTheThing)
       end
 
-      it 'validates valid data by returning an empty message' do
-        expect(WorkflowSchema.call(valid_data).messages).to be_empty
+      it 'validates valid data by returning an empty error set' do
+        expect(schema.call(valid_data).errors).to be_empty
       end
 
       it 'reports invalid data via the returned messages' do
-        expect(WorkflowSchema.call(invalid_data).messages).not_to be_empty
+        expect(schema.call(invalid_data).errors).not_to be_empty
       end
 
       describe 'notification names' do
@@ -64,7 +66,7 @@ module Hyrax
           let(:notification_name) { 'FooBar' }
 
           it 'is invalid' do
-            expect(WorkflowSchema.call(valid_data).messages).not_to be_empty
+            expect(schema.call(valid_data).errors).not_to be_empty
           end
         end
 
@@ -76,8 +78,8 @@ module Hyrax
           after { Hyrax::Workflow.send(:remove_const, :DoTheThing) }
           let(:notification_name) { 'Hyrax::Workflow::DoTheThing' }
 
-          it 'returns an empty message because valid' do
-            expect(WorkflowSchema.call(valid_data).messages).to be_empty
+          it 'returns an empty error set because valid' do
+            expect(schema.call(valid_data).errors).to be_empty
           end
         end
       end


### PR DESCRIPTION
The main impact of this is that `Dry::Validations` and `Dry::Struct` are
updated. Neither is backward compatible.

The `WorkflowSchema` is rewritten using the new syntax, and it is now slightly
more strict. It expects `notifications:` to have names that can be constantized
to a `Class`, not just to any registered constant.

`Wings::ConverterValueMapper` has to handle ids and nested structs/`Valkyrie::Resources`
slightly more aggressively, since types are more aggressively coerced, and aren't
squashed into hashes when nested in a parent's `#attributes`.

@samvera/hyrax-code-reviewers
