### PR TITLE
Document and normalize `Hyrax` valkyrie adapter references

### DIFF
--- a/app/actors/hyrax/actors/add_to_work_actor.rb
+++ b/app/actors/hyrax/actors/add_to_work_actor.rb
@@ -62,10 +62,8 @@ module Hyrax
         end
 
         def new_works_for(env, new_work_ids)
-          query_service = Valkyrie.config.metadata_adapter.query_service
-
           (new_work_ids - env.curation_concern.in_works_ids).map do |work_id|
-            query_service.find_by_alternate_identifier(alternate_identifier: work_id, use_valkyrie: false)
+            Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: work_id, use_valkyrie: false)
           end
         end
 

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -56,18 +56,38 @@ module Hyrax
     config.curation_concerns.first
   end
 
+  ##
+  # The Valkyrie persister used for PCDM models throughout Hyrax
+  #
+  # @note always use this method to retrieve the persister when data
+  #   interoperability with Hyrax is required
   def self.persister
     metadata_adapter.persister
   end
 
+  ##
+  # The Valkyrie metadata adapter used for PCDM models throughout Hyrax
+  #
+  # @note always use this method to retrieve the metadata adapter when data
+  #   interoperability with Hyrax is required
   def self.metadata_adapter
     Valkyrie.config.metadata_adapter
   end
 
+  ##
+  # The Valkyrie storage_adapter used for PCDM files throughout Hyrax
+  #
+  # @note always use this method to retrieve the storage adapter when handling
+  #   files that will be used by Hyrax
   def self.storage_adapter
     Valkyrie.config.storage_adapter
   end
 
+  ##
+  # The Valkyrie query service used for PCDM files throughout Hyrax
+  #
+  # @note always use this method to retrieve the query service when data
+  #   interoperability with Hyrax is required
   def self.query_service
     metadata_adapter.query_service
   end


### PR DESCRIPTION
Always use the Hyrax configuration for retrieving valkyrie components that will handle Hyrax/PCDM data.

@samvera/hyrax-code-reviewers
