### PR TITLE
[wings] Round trip registered valkyrie native classes

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -65,11 +65,10 @@ module Wings
 
     def active_fedora_class
       klass = resource.internal_resource.constantize
+
       return klass if klass <= ActiveFedora::Base
-      return Hydra::AccessControl           if klass <= Hyrax::AccessControl
-      return Hydra::AccessControls::Embargo if klass <= Hyrax::Embargo
-      return Hydra::AccessControls::Lease   if klass <= Hyrax::Lease
-      DefaultWork
+
+      ModelRegistry.lookup(klass) || DefaultWork
     end
 
     ##

--- a/lib/wings/model_registry.rb
+++ b/lib/wings/model_registry.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Wings
+  ##
+  # This registry provides an off-ramp for legacy ActiveFedora models.
+  #
+  # New valkyrie models can be defined manually and registered as an analogue
+  # of an existing `ActiveFedora::Base` implementer. This allows Wings to cast
+  # the new model to the legacy model when saving, ensuring backwards compatible
+  # data on save.
+  #
+  # Several models from Hyrax components have default mappings provided by Wings.
+  #
+  # @example
+  #   Wings::ModelRegistry.register(NewValkyrieModel, OldActiveFedoraModel)
+  #
+  #   Wings::ModelRegistry.lookup(NewValkyrieModel) # => OldActiveFedoraModel
+  #   Wings::ModelRegistry.reverse_lookup(OldActiveFedoraModel) # => NewValkyrieModel
+  #
+  class ModelRegistry
+    include Singleton
+
+    def self.register(*args)
+      instance.register(*args)
+    end
+
+    def self.lookup(*args)
+      instance.lookup(*args)
+    end
+
+    def self.reverse_lookup(*args)
+      instance.reverse_lookup(*args)
+    end
+
+    def initialize
+      @map = {}
+    end
+
+    def register(valkyrie, active_fedora)
+      @map[valkyrie] = active_fedora
+    end
+
+    def lookup(valkyrie)
+      @map[valkyrie]
+    end
+
+    def reverse_lookup(active_fedora)
+      @map.rassoc(active_fedora)&.first
+    end
+  end
+end

--- a/lib/wings/orm_converter.rb
+++ b/lib/wings/orm_converter.rb
@@ -29,13 +29,7 @@ module Wings
     #
     # @return [Class]
     def self.base_for(klass:)
-      if klass == Hydra::AccessControls::Embargo
-        Hyrax::Embargo
-      elsif klass == Hydra::AccessControls::Lease
-        Hyrax::Lease
-      else
-        Hyrax::Resource
-      end
+      ModelRegistry.reverse_lookup(klass) || Hyrax::Resource
     end
 
     ##

--- a/spec/support/book_resource.rb
+++ b/spec/support/book_resource.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class BookResource < Hyrax::Resource
+  attribute :title,    Valkyrie::Types::String
+  attribute :author,   Valkyrie::Types::String
+  attribute :created,  Valkyrie::Types::Date
+  attribute :isbn,     Valkyrie::Types::String
+  attribute :pubisher, Valkyrie::Types::String
+end

--- a/spec/support/book_resource.rb
+++ b/spec/support/book_resource.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
+module Hyrax
+  module Test
+    class BookResource < Hyrax::Resource
+      attribute :author,   Valkyrie::Types::String
+      attribute :created,  Valkyrie::Types::Date
+      attribute :isbn,     Valkyrie::Types::String
+      attribute :pubisher, Valkyrie::Types::String
+      attribute :title,    Valkyrie::Types::String
+    end
 
-class BookResource < Hyrax::Resource
-  attribute :title,    Valkyrie::Types::String
-  attribute :author,   Valkyrie::Types::String
-  attribute :created,  Valkyrie::Types::Date
-  attribute :isbn,     Valkyrie::Types::String
-  attribute :pubisher, Valkyrie::Types::String
+    class Book < ActiveFedora::Base
+      property :author,    predicate: ::RDF::URI('http://example.com/ns/author')
+      property :created,   predicate: ::RDF::URI('http://example.com/ns/created')
+      property :isbn,      predicate: ::RDF::URI('http://example.com/ns/isbn')
+      property :publisher, predicate: ::RDF::URI('http://example.com/ns/publisher')
+      property :title,     predicate: ::RDF::URI("http://example.com/ns/title")
+    end
+  end
 end
+
+Wings::ModelRegistry.register(Hyrax::Test::BookResource, Hyrax::Test::Book)

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -22,11 +22,24 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
     end
 
     context 'when given a valkyrie native model' do
-      let(:resource) { BookResource.new }
+      let(:resource) { klass.new }
+
+      let(:klass) do
+        class ConverterDummyResource < Valkyrie::Resource; end
+        ConverterDummyResource
+      end
 
       it 'gives a default work' do
         expect(converter.convert)
           .to be_a Wings::ActiveFedoraConverter::DefaultWork
+      end
+
+      context 'and it is registered' do
+        let(:resource) { Hyrax::Test::BookResource.new }
+
+        it 'maps to the registered ActiveFedora class' do
+          expect(converter.convert).to be_a Hyrax::Test::Book
+        end
       end
     end
 

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       expect(converter.convert).to eq work
     end
 
+    context 'when given a valkyrie native model' do
+      let(:resource) { BookResource.new }
+
+      it 'gives a default work' do
+        expect(converter.convert)
+          .to be_a Wings::ActiveFedoraConverter::DefaultWork
+      end
+    end
+
     context 'with attributes' do
       let(:attributes) do
         FactoryBot.attributes_for(:generic_work)

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Wings::ModelTransformer, :clean_repo do
     let(:page2)       { page_class.new(id: 'pg2') }
 
     let(:book_class) do
-      Book = Class.new(ActiveFedora::Base) do
+      Monograph = Class.new(ActiveFedora::Base) do
         has_many :pages
         property :title, predicate: ::RDF::Vocab::DC.title
         property :contributor, predicate: ::RDF::Vocab::DC.contributor
@@ -273,7 +273,7 @@ RSpec.describe Wings::ModelTransformer, :clean_repo do
 
     after do
       Object.send(:remove_const, :Page)
-      Object.send(:remove_const, :Book)
+      Object.send(:remove_const, :Monograph)
     end
 
     let(:attributes) do

--- a/spec/wings/orm_converter_spec.rb
+++ b/spec/wings/orm_converter_spec.rb
@@ -24,5 +24,14 @@ RSpec.describe Wings::OrmConverter do
         expect { described_class.to_valkyrie_resource_class(klass: String) }.to raise_error
       end
     end
+
+    context 'when given a registered class' do
+      it 'returns a subclass of the corresponding native valkyrie resource' do
+        klass = Wings::ModelRegistry.lookup(Hyrax::Test::BookResource)
+
+        expect(described_class.to_valkyrie_resource_class(klass: klass).ancestors)
+          .to include Hyrax::Test::BookResource
+      end
+    end
   end
 end

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -6,22 +6,26 @@ require 'wings'
 RSpec.describe Wings::Valkyrie::Persister do
   context "When passing a Valkyrie::Resource converted from an ActiveFedora::Base" do
     before do
-      class Book < ActiveFedora::Base
-        include Hydra::AccessControls::Permissions
-        include Hyrax::CoreMetadata
-        include Hydra::WithDepositor
-        property :title, predicate: ::RDF::Vocab::DC.title, multiple: true
+      module Hyrax::Test
+        module Persister
+          class Book < ActiveFedora::Base
+            include Hydra::AccessControls::Permissions
+            include Hyrax::CoreMetadata
+            include Hydra::WithDepositor
+            property :title, predicate: ::RDF::Vocab::DC.title, multiple: true
+          end
+        end
       end
     end
 
     after do
-      Object.send(:remove_const, :Book)
+      Hyrax::Test.send(:remove_const, :Persister)
     end
 
     subject(:persister) { described_class.new(adapter: adapter) }
     let(:adapter) { Wings::Valkyrie::MetadataAdapter.new }
     let(:query_service) { adapter.query_service }
-    let(:af_resource_class) { Book }
+    let(:af_resource_class) { Hyrax::Test::Persister::Book }
     let(:resource_class) { Wings::OrmConverter.to_valkyrie_resource_class(klass: af_resource_class) }
     let(:resource) { resource_class.new(title: ['Foo']) }
 

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -5,31 +5,35 @@ require 'wings'
 
 RSpec.describe Wings::Valkyrie::QueryService do
   before do
-    class Book < ActiveFedora::Base
-      include Hyrax::WorkBehavior
-      include Hydra::AccessControls::Permissions
-      property :title, predicate: ::RDF::Vocab::DC.title, multiple: true
-      property :a_member_of, predicate: ::RDF::URI.new('http://www.example.com/a_member_of'), multiple: true do |index|
-        index.as :symbol
+    module Hyrax::Test
+      module QueryService
+        class Book < ActiveFedora::Base
+          include Hyrax::WorkBehavior
+          include Hydra::AccessControls::Permissions
+          property :title, predicate: ::RDF::Vocab::DC.title, multiple: true
+          property :a_member_of, predicate: ::RDF::URI.new('http://www.example.com/a_member_of'), multiple: true do |index|
+            index.as :symbol
+          end
+          property :an_ordered_member_of, predicate: ::RDF::URI.new('http://www.example.com/an_ordered_member_of'), multiple: true
+        end
+
+        class Image < ActiveFedora::Base
+          include Hydra::AccessControls::Permissions
+          property :title, predicate: ::RDF::Vocab::DC.title, multiple: true
+        end
       end
-      property :an_ordered_member_of, predicate: ::RDF::URI.new('http://www.example.com/an_ordered_member_of'), multiple: true
-    end
-    class Image < ActiveFedora::Base
-      include Hydra::AccessControls::Permissions
-      property :title, predicate: ::RDF::Vocab::DC.title, multiple: true
     end
   end
 
   after do
-    Object.send(:remove_const, :Book)
-    Object.send(:remove_const, :Image)
+    Hyrax::Test.send(:remove_const, :QueryService)
   end
 
   subject(:query_service) { described_class.new(adapter: adapter) }
   let(:adapter) { Wings::Valkyrie::MetadataAdapter.new }
   let(:persister) { Wings::Valkyrie::Persister.new(adapter: adapter) }
-  let(:af_resource_class) { Book }
-  let(:af_image_resource_class) { Image }
+  let(:af_resource_class) { Hyrax::Test::QueryService::Book }
+  let(:af_image_resource_class) { Hyrax::Test::QueryService::Image }
   let(:resource_class) { Wings::OrmConverter.to_valkyrie_resource_class(klass: af_resource_class) }
   let(:image_resource_class) { Wings::OrmConverter.to_valkyrie_resource_class(klass: af_image_resource_class) }
   let(:resource) { resource_class.new(title: ['Foo']) }


### PR DESCRIPTION
Fixes #3671; supersedes #3937 

Users will want to define their models with native Valkyrie. This supports a transition by allowing them to define Valkyrie analogues for their existing ActiveFedora models.

New Valkyrie models need to be registered with `Wings` to cast to the correct ActiveFedora models within Wings. Wings continues to return meta-programmed model objects, but these now subclass the user's native Valkyrie models.

Changes proposed in this pull request:
* Add a registry for Wings models
* support and test round-tripping of native Valkyrie models in Wings

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Documentation should be added to https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide
* This has no end-user facing changes.

@samvera/hyrax-code-reviewers
