### PR TITLE
Define a schema sharing pattern for Hyrax/Valkyrie

### DIFF
--- a/app/models/hyrax/metadata/basic.rb
+++ b/app/models/hyrax/metadata/basic.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Metadata
+    ##
+    # @api private
+    class Basic
+      ATTRIBUTES = {
+        abstract:               Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        access_right:           Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        alt_title:              Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        based_near:             Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        contributor:            Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        creator:                Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        date_created:           Valkyrie::Types::Array.of(Valkyrie::Types::DateTime),
+        description:            Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        bibliographic_citation: Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        identifier:             Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        import_url:             Valkyrie::Types::String,
+        keyword:                Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        publisher:              Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        label:                  Valkyrie::Types::String,
+        language:               Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        license:                Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        relative_path:          Valkyrie::Types::String,
+        related_url:            Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        resource_type:          Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        rights_notes:           Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        rights_statement:       Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        source:                 Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        subject:                Valkyrie::Types::Array.of(Valkyrie::Types::String)
+      }.freeze
+
+      def attributes
+        ATTRIBUTES
+      end
+    end
+  end
+end

--- a/app/models/hyrax/metadata/core.rb
+++ b/app/models/hyrax/metadata/core.rb
@@ -2,6 +2,8 @@
 
 module Hyrax
   module Metadata
+    ##
+    # @api private
     class Core
       ATTRIBUTES = {
         title:         Valkyrie::Types::Array.of(Valkyrie::Types::String),

--- a/app/models/hyrax/metadata/core.rb
+++ b/app/models/hyrax/metadata/core.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Metadata
+    class Core
+      ATTRIBUTES = {
+        title:         Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        date_modified: Valkyrie::Types::DateTime,
+        date_uploaded: Valkyrie::Types::DateTime,
+        depositor:     Valkyrie::Types::String
+      }.freeze
+
+      def attributes
+        ATTRIBUTES
+      end
+    end
+  end
+end

--- a/app/models/hyrax/schema.rb
+++ b/app/models/hyrax/schema.rb
@@ -50,7 +50,8 @@ module Hyrax
     # @see https://github.com/samvera-labs/houndstooth
     class SimpleSchemaLoader
       SCHEMAS = {
-        core_metadata: Hyrax::Metadata::Core.new
+        core_metadata: Hyrax::Metadata::Core.new,
+        basic_metadata: Hyrax::Metadata::Basic.new
       }.freeze
 
       ##

--- a/app/models/hyrax/schema.rb
+++ b/app/models/hyrax/schema.rb
@@ -50,18 +50,13 @@ module Hyrax
     # @see https://github.com/samvera-labs/houndstooth
     class SimpleSchemaLoader
       SCHEMAS = {
-        core_metadata: {
-          title:         Valkyrie::Types::Array.of(Valkyrie::Types::String),
-          date_modified: Valkyrie::Types::DateTime,
-          date_uploaded: Valkyrie::Types::DateTime,
-          depositor:     Valkyrie::Types::String
-        }.freeze
+        core_metadata: Hyrax::Metadata::Core.new
       }.freeze
 
       ##
       # @param [Symbol] schema
       def attributes_for(schema:)
-        SCHEMAS[schema] || raise(ArgumentError, "No schema defined: #{schema}")
+        SCHEMAS[schema]&.attributes || raise(ArgumentError, "No schema defined: #{schema}")
       end
     end
 

--- a/app/models/hyrax/schema.rb
+++ b/app/models/hyrax/schema.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # @param [Symbol] schema_name
+  #
+  # @return [Module]
+  #
+  # @example
+  #   class Monograph < Valkyrie::Resource
+  #     include Hyrax::Schema(:book)
+  #   end
+  #
+  # @since 3.0.0
+  def self.Schema(schema_name, **options)
+    Hyrax::Schema.new(schema_name, **options)
+  end
+
+  ##
+  # Specify a schema
+  class Schema < Module
+    ##
+    # @!attribute [r] name
+    #   @return [Symbol]
+    attr_reader :name
+
+    ##
+    # @param [Symbol] schema_name
+    #
+    # @note use Hyrax::Schema(:my_schema) instead
+    #
+    # @api private
+    def initialize(schema_name, schema_loader: SimpleSchemaLoader.new)
+      @name = schema_name
+      @schema_loader = schema_loader
+    end
+
+    ##
+    # @return [Hash{Symbol => Dry::Types::Type}]
+    def attributes
+      @schema_loader.attributes_for(schema: name)
+    end
+
+    ##
+    # @api private
+    #
+    # This is a placeholder schema loader. it's here to help us define the API
+    # for loading user defined schemas.
+    #
+    # @see https://github.com/samvera-labs/houndstooth
+    class SimpleSchemaLoader
+      SCHEMAS = {
+        core_metadata: {
+          title:         Valkyrie::Types::Array.of(Valkyrie::Types::String),
+          date_modified: Valkyrie::Types::DateTime,
+          date_uploaded: Valkyrie::Types::DateTime,
+          depositor:     Valkyrie::Types::String
+        }.freeze
+      }.freeze
+
+      ##
+      # @param [Symbol] schema
+      def attributes_for(schema:)
+        SCHEMAS[schema] || raise(ArgumentError, "No schema defined: #{schema}")
+      end
+    end
+
+    private
+
+      ##
+      # @param [Module] descendant
+      #
+      # @api private
+      def included(descendant)
+        super
+        descendant.attributes(attributes)
+      end
+  end
+end

--- a/spec/models/hyrax/schema_spec.rb
+++ b/spec/models/hyrax/schema_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Schema do
+  let(:resource_class) do
+    Class.new(Valkyrie::Resource)
+  end
+
+  describe 'including' do
+    it 'applies the specified schema' do
+      expect { resource_class.include(Hyrax::Schema(:core_metadata)) }
+        .to change { resource_class.attribute_names }
+        .to include(:title, :date_uploaded, :date_modified, :depositor)
+    end
+
+    it 'raises for an missing schema' do
+      expect { resource_class.include(Hyrax::Schema(:FAKE_SCHEMA)) } .to raise_error ArgumentError
+    end
+  end
+end


### PR DESCRIPTION
Allow schema reuse for Valkyrie resources with `include
Hyrax::Schema(:schema_name)`.

Resolution of schema names is hidden behind an abstraction, with the idea that
we can support schema loaders for
[Houndstooth](https://github.com/samvera-labs/houndstooth), but also support
simple schema definitions. For now, the schemas are hard-coded and only specify
attribute-type pairs.

@samvera/hyrax-code-reviewers
