### PR TITLE
prefer pattern of setting use_valkyrie in the initializer

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -5,16 +5,16 @@ module Hyrax
     # Actions for a file identified by file_set and relation (maps to use predicate)
     # @note Spawns asynchronous jobs
     class FileActor
-      attr_reader :file_set, :relation, :user
+      attr_reader :file_set, :relation, :user, :use_valkyrie
 
       # @param [FileSet] file_set the parent FileSet
       # @param [Symbol, #to_sym] relation the type/use for the file
       # @param [User] user the user to record as the Agent acting upon the file
       def initialize(file_set, relation, user, use_valkyrie: false)
-        @file_set = file_set
-        @relation = normalize_relation(relation, use_valkyrie: use_valkyrie)
-        @user = user
         @use_valkyrie = use_valkyrie
+        @file_set = file_set
+        @relation = normalize_relation(relation)
+        @user = user
       end
 
       # Persists file as part of file_set and spawns async job to characterize and create derivatives.
@@ -24,7 +24,7 @@ module Hyrax
       # @see IngestJob
       # @todo create a job to monitor the temp directory (or in a multi-worker system, directories!) to prune old files that have made it into the repo
       def ingest_file(io)
-        perform_ingest_file(io, use_valkyrie: @use_valkyrie)
+        perform_ingest_file(io)
       end
 
       # Reverts file and spawns async job to characterize and create derivatives.
@@ -57,7 +57,7 @@ module Hyrax
         # @param [JobIoWrapper] io the file to save in the repository, with mime_type and original_name
         # @return [FileMetadata, FalseClass] the created file metadata on success, false on failure
         # @todo create a job to monitor the temp directory (or in a multi-worker system, directories!) to prune old files that have made it into the repo
-        def perform_ingest_file(io, use_valkyrie: false)
+        def perform_ingest_file(io)
           use_valkyrie ? perform_ingest_file_through_valkyrie(io) : perform_ingest_file_through_active_fedora(io)
         end
 
@@ -95,7 +95,7 @@ module Hyrax
                                          persister:       Hyrax.persister)
         end
 
-        def normalize_relation(relation, use_valkyrie: false)
+        def normalize_relation(relation)
           use_valkyrie ? normalize_relation_for_valkyrie(relation) : normalize_relation_for_active_fedora(relation)
         end
 

--- a/spec/services/hyrax/solr_service_spec.rb
+++ b/spec/services/hyrax/solr_service_spec.rb
@@ -22,12 +22,21 @@ RSpec.describe Hyrax::SolrService do
       expect(described_class.get('querytext', fq: ["id:\"1234\""])).to eq stub_result
     end
 
-    it "uses the valkyrie solr core" do
-      service = described_class.new
-      stub_result = double("Valkyrie Result")
-      expect(mock_conn).to receive(:get).with('select', params: { q: 'querytext' }).and_return(stub_result)
-      allow(service).to receive(:valkyrie_index).and_return(double("valkyrie_index", connection: mock_conn))
-      expect(service.get('querytext', use_valkyrie: true)).to eq stub_result
+    context "when use_valkyrie: true" do
+      before do
+        Hyrax.config.query_index_from_valkyrie = true
+      end
+      after do
+        Hyrax.config.query_index_from_valkyrie = false
+      end
+
+      it "uses valkyrie solr based on config query_index_from_valkyrie" do
+        service = described_class.new
+        stub_result = double("Valkyrie Result")
+        expect(mock_conn).to receive(:get).with('select', params: { q: 'querytext' }).and_return(stub_result)
+        allow(service).to receive(:valkyrie_index).and_return(double("valkyrie_index", connection: mock_conn))
+        expect(service.get('querytext')).to eq stub_result
+      end
     end
   end
 
@@ -46,12 +55,21 @@ RSpec.describe Hyrax::SolrService do
       expect(described_class.post('querytext', fq: ["id:\"1234\""])).to eq stub_result
     end
 
-    it "uses the valkyrie solr core" do
-      service = described_class.new
-      stub_result = double("Valkyrie Result")
-      expect(mock_conn).to receive(:post).with('select', data: { q: 'querytext' }).and_return(stub_result)
-      allow(service).to receive(:valkyrie_index).and_return(double("valkyrie_index", connection: mock_conn))
-      expect(service.post('querytext', use_valkyrie: true)).to eq stub_result
+    context "when use_valkyrie: true" do
+      before do
+        Hyrax.config.query_index_from_valkyrie = true
+      end
+      after do
+        Hyrax.config.query_index_from_valkyrie = false
+      end
+
+      it "uses valkyrie solr based on config query_index_from_valkyrie" do
+        service = described_class.new
+        stub_result = double("Valkyrie Result")
+        expect(mock_conn).to receive(:post).with('select', data: { q: 'querytext' }).and_return(stub_result)
+        allow(service).to receive(:valkyrie_index).and_return(double("valkyrie_index", connection: mock_conn))
+        expect(service.post('querytext')).to eq stub_result
+      end
     end
   end
 
@@ -97,11 +115,18 @@ RSpec.describe Hyrax::SolrService do
     context "when use_valkyrie: true" do
       let(:doc) { { 'id' => 'valkyrie-x' } }
 
-      it "accepts and passes through use_valkyrie:true" do
+      before do
+        Hyrax.config.query_index_from_valkyrie = true
+      end
+      after do
+        Hyrax.config.query_index_from_valkyrie = false
+      end
+
+      it "uses valkyrie solr based on config query_index_from_valkyrie" do
         service = described_class.new
         expect(mock_conn).to receive(:get).with('select', params: { q: 'querytext' }).and_return(stub_result)
         allow(service).to receive(:valkyrie_index).and_return(double("valkyrie_index", connection: mock_conn))
-        result = service.query('querytext', use_valkyrie: true)
+        result = service.query('querytext')
         expect(result.first.id).to eq 'valkyrie-x'
       end
     end
@@ -117,10 +142,17 @@ RSpec.describe Hyrax::SolrService do
     context "when use_valkyrie: true" do
       let(:service) { described_class.new }
 
-      it "accepts and passes through use_valkyrie:true" do
+      before do
+        Hyrax.config.query_index_from_valkyrie = true
+      end
+      after do
+        Hyrax.config.query_index_from_valkyrie = false
+      end
+
+      it "uses valkyrie solr based on config query_index_from_valkyrie" do
         expect(mock_conn).to receive(:commit)
         allow(service).to receive(:valkyrie_index).and_return(double("valkyrie_index", connection: mock_conn))
-        service.commit use_valkyrie: true
+        service.commit
       end
     end
   end
@@ -135,10 +167,17 @@ RSpec.describe Hyrax::SolrService do
     context "when use_valkyrie: true" do
       let(:service) { described_class.new }
 
-      it "accepts and passes through use_valkyrie:true" do
+      before do
+        Hyrax.config.query_index_from_valkyrie = true
+      end
+      after do
+        Hyrax.config.query_index_from_valkyrie = false
+      end
+
+      it "uses valkyrie solr based on config query_index_from_valkyrie" do
         expect(mock_conn).to receive(:delete_by_query).with("*:*", params: {})
         allow(service).to receive(:valkyrie_index).and_return(double("valkyrie_index", connection: mock_conn))
-        service.delete_by_query("*:*", use_valkyrie: true)
+        service.delete_by_query("*:*")
       end
     end
   end
@@ -158,9 +197,16 @@ RSpec.describe Hyrax::SolrService do
     context "when use_valkyrie: true" do
       let(:service) { described_class.new }
 
-      it "accepts and passes through use_valkyrie:true" do
+      before do
+        Hyrax.config.query_index_from_valkyrie = true
+      end
+      after do
+        Hyrax.config.query_index_from_valkyrie = false
+      end
+
+      it "uses valkyrie solr based on config query_index_from_valkyrie" do
         allow(service).to receive(:valkyrie_index).and_return(double("valkyrie_index", connection: mock_conn))
-        service.delete("fade_solr_id#01", use_valkyrie: true)
+        service.delete("fade_solr_id#01")
       end
     end
   end
@@ -190,10 +236,19 @@ RSpec.describe Hyrax::SolrService do
       expect(described_class.add(mock_doc)).to eq true
     end
 
-    it "uses the valkyrie solr core" do
-      service = described_class.new
-      allow(service).to receive(:valkyrie_index).and_return(double("valkyrie_index", connection: mock_conn))
-      expect(service.add(mock_doc, use_valkyrie: true)).to eq true
+    context "when use_valkyrie: true" do
+      before do
+        Hyrax.config.query_index_from_valkyrie = true
+      end
+      after do
+        Hyrax.config.query_index_from_valkyrie = false
+      end
+
+      it "uses valkyrie solr based on config query_index_from_valkyrie" do
+        service = described_class.new
+        allow(service).to receive(:valkyrie_index).and_return(double("valkyrie_index", connection: mock_conn))
+        expect(service.add(mock_doc)).to eq true
+      end
     end
   end
 
@@ -207,11 +262,18 @@ RSpec.describe Hyrax::SolrService do
     end
 
     context "when use_valkyrie: true" do
-      it "uses the valkyrie solr core" do
+      before do
+        Hyrax.config.query_index_from_valkyrie = true
+      end
+      after do
+        Hyrax.config.query_index_from_valkyrie = false
+      end
+
+      it "uses valkyrie solr based on config query_index_from_valkyrie" do
         service = described_class.new
         expect(mock_conn).to receive(:get).with('select', params: { rows: 0, q: 'querytext' }).and_return(stub_result)
         allow(service).to receive(:valkyrie_index).and_return(double("valkyrie_index", connection: mock_conn))
-        expect(service.count('querytext', use_valkyrie: true)).to eq 2
+        expect(service.count('querytext')).to eq 2
       end
     end
   end

--- a/spec/valkyrie/indexing/solr/indexing_adapter_spec.rb
+++ b/spec/valkyrie/indexing/solr/indexing_adapter_spec.rb
@@ -15,27 +15,34 @@ RSpec.describe Valkyrie::Indexing::Solr::IndexingAdapter, :clean_index do
     end
   end
 
+  before do
+    Hyrax.config.query_index_from_valkyrie = true
+  end
+  after do
+    Hyrax.config.query_index_from_valkyrie = false
+  end
+
   it "can save a resource" do
     adapter.save(resource: resource)
-    expect(Hyrax::SolrService.query("*:*", use_valkyrie: true).map(&:id)).to eq [resource.id.to_s]
+    expect(Hyrax::SolrService.query("*:*").map(&:id)).to eq [resource.id.to_s]
   end
 
   it "can save multiple resources at once" do
     adapter.save_all(resources: [resource, resource2])
-    expect(Hyrax::SolrService.query("*:*", use_valkyrie: true).map(&:id)).to contain_exactly resource.id.to_s, resource2.id.to_s
+    expect(Hyrax::SolrService.query("*:*").map(&:id)).to contain_exactly resource.id.to_s, resource2.id.to_s
   end
 
   it "can delete an object" do
     adapter.save(resource: resource)
-    expect(Hyrax::SolrService.query("*:*", use_valkyrie: true).count).to eq 1
+    expect(Hyrax::SolrService.query("*:*").count).to eq 1
     adapter.delete(resource: resource)
-    expect(Hyrax::SolrService.query("*:*", use_valkyrie: true).count).to eq 0
+    expect(Hyrax::SolrService.query("*:*").count).to eq 0
   end
 
   it "can delete all objects" do
     adapter.save_all(resources: [resource, resource2])
-    expect(Hyrax::SolrService.query("*:*", use_valkyrie: true).count).to eq 2
+    expect(Hyrax::SolrService.query("*:*").count).to eq 2
     adapter.wipe!
-    expect(Hyrax::SolrService.query("*:*", use_valkyrie: true).count).to eq 0
+    expect(Hyrax::SolrService.query("*:*").count).to eq 0
   end
 end


### PR DESCRIPTION
This was identified while exploring FileSetActor use of `use_valkyrie`.  FileSetActor actor is not in this PR because it is under development, but the pattern can be clearly seen in FileActor.

To use the pattern...

```
attr_reader :use_valkyrie
def initializer( _existing_args_, use_valkyrie: false)
  @use_valkyrie = use_valkyrie
  # rest is the same as it was before applying the pattern
end

# no other method receives the use_valkyrie parameter, but instead calls the use_valkyrie attr_reader method to get the value
```

This pattern cannot generally be used for class methods.  For example, the query service has several class methods that accept `use_valkyrie:` as a parameter to determine if the result should return a valkyrie resource or an AF object.  The preferred value is on a case by case usage of the caller.

The exception to the class methods pattern is solr_service where class methods are delegated to instance methods.  Whether or not to use_valkyrie is determined by `Hyrax.config.query_index_from_valkyrie` and is set as the default on the initializer instead of defaulting to false.
