### PR TITLE
allow embago and leased works to be updated

### DIFF
--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -203,12 +203,20 @@ module Hyrax
         def apply_lease(env, intention)
           return true unless intention.wants_lease?
           env.curation_concern.apply_lease(*intention.lease_params)
+          # apply_lease returns true if there has been a change in the lease period,
+          # otherwise it returns nil.  Since we want to continue processing, even when the date
+          # does not change, we return true from this method.
+          true
         end
 
         # If they want an embargo, we can assume it's valid
         def apply_embargo(env, intention)
           return true unless intention.wants_embargo?
           env.curation_concern.apply_embargo(*intention.embargo_params)
+          # apply_embargo returns true if there has been a change in the embargo period,
+          # otherwise it returns nil.  Since we want to continue processing, even when the date
+          # does not change, we return true from this method.
+          true
         end
     end
   end

--- a/spec/features/embargo_spec.rb
+++ b/spec/features/embargo_spec.rb
@@ -30,6 +30,23 @@ RSpec.describe 'embargo' do
 
       click_button 'Update Embargo'
       expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard))
+
+      click_link 'Edit'
+      fill_in 'Title', with: 'Embargo test CHANGED'
+      click_button 'Save'
+
+      expect(page).to have_content('CHANGED')
+
+      click_link 'Edit'
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+      within('div#add-files') do
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
+      end
+
+      click_button 'Save' # Save the work
+      expect(page).to have_content('CHANGED')
     end
   end
 

--- a/spec/features/lease_spec.rb
+++ b/spec/features/lease_spec.rb
@@ -30,6 +30,23 @@ RSpec.describe 'leases' do
 
       click_button 'Update Lease'
       expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard)) # new lease date is displayed in message
+
+      click_link 'Edit'
+      fill_in 'Title', with: 'Lease test CHANGED'
+      click_button 'Save'
+
+      expect(page).to have_content('CHANGED')
+
+      click_link 'Edit'
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+      within('div#add-files') do
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
+      end
+
+      click_button 'Save' # Save the work
+      expect(page).to have_content('CHANGED')
     end
   end
 end


### PR DESCRIPTION
Fixes #3958 
Allows embargoed and leased works to be updated.  Before this change, the only way an embargoed or leased work could be updated was if the date range were changed.  I have placed an explanatory comment on how to get around this in the code.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create an embargo work.
* Edit the title of the work and save it.
* Verify the title was changed.
* Edit the work again, and this time add a file to the work and save it.
* Verify that the new file was uploaded.
AND
* Create a leased work.
* Edit the title of the work and save it.
* Verify the title was changed.
* Edit the work again, and this time add a file to the work and save it.
* Verify that the new file was uploaded.

@samvera/hyrax-code-reviewers
