### PR TITLE
Deprecate feature to configure indexing for a property

### DIFF
--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -58,6 +58,7 @@
 module Wings; end
 
 require 'valkyrie'
+require 'wings/indexing_configuration'
 require 'wings/model_registry'
 require 'wings/model_transformer'
 require 'wings/orm_converter'

--- a/lib/wings/indexing_configuration.rb
+++ b/lib/wings/indexing_configuration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+ActiveFedora::Indexing::Map::IndexObject.class_eval do
+  # This is to deprecate the following index configuration style:
+  #   property :title, predicate: RDF::DC.title do |index|
+  #     index.as :discoverable, :stored_searchable
+  #   end
+  #
+  # in favor of:
+  #   class MyWork < ActiveFedora::Base
+  #     self.indexer = MyWorkIndexer
+  #   end
+  def as(*args)
+    Deprecation.warn(self, "Index configuration for a property are deprecated and support will be removed from Hyrax 4.0. Write indexers to handle each property explicitly instead.")
+
+    @term = args.last.is_a?(Hash) ? args.pop : {}
+    @behaviors = args
+  end
+end

--- a/spec/wings/indexing_configuration_spec.rb
+++ b/spec/wings/indexing_configuration_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'wings/indexing_configuration'
+
+RSpec.describe ActiveFedora::Indexing::Map::IndexObject do
+  describe '.as' do
+    let(:hash) { {} }
+    let(:args) { [:discoverable, :stored_searchable] }
+
+    subject { described_class.new hash }
+
+    it 'is deprecated' do
+      expect(Deprecation).to receive(:warn)
+      subject.as(*args)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3863

Deprecate feature with indexing configure style for a property defined in model.

@samvera/hyrax-code-reviewers
