### PR TITLE
Add find_file_metadata custom queries

### DIFF
--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -3,7 +3,7 @@
 module Hyrax
   class FileMetadata < Valkyrie::Resource
     attribute :file_identifiers, ::Valkyrie::Types::Set # id of the file stored by the storage adapter
-    attribute :alternate_id, ::Valkyrie::Types::Set # id of the Hydra::PCDM::File which holds metadata and the file in ActiveFedora
+    attribute :alternate_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID) # id of the Hydra::PCDM::File which holds metadata and the file in ActiveFedora
     attribute :file_set_id, ::Valkyrie::Types::ID # id of parent file set resource
 
     # all remaining attributes are on AF::File metadata_node unless otherwise noted

--- a/app/services/hyrax/custom_queries/find_file_metadata.rb
+++ b/app/services/hyrax/custom_queries/find_file_metadata.rb
@@ -1,0 +1,29 @@
+module Hyrax
+  module CustomQueries
+    class FindFileMetadata
+      # Use:
+      #   Hyrax.query_service.custom_queries.find_file_metadata_by(id: valkyrie_id)
+      #   Hyrax.query_service.custom_queries.find_file_metadata_by_alternate_identifier(alternate_identifier: alt_id)
+
+      def self.queries
+        [:find_file_metadata_by,
+         :find_file_metadata_by_alternate_identifier]
+      end
+
+      def initialize(query_service:)
+        @query_service = query_service
+      end
+
+      attr_reader :query_service
+      delegate :resource_factory, to: :query_service
+
+      def find_file_metadata_by(id:)
+        query_service.find_by(id: id)
+      end
+
+      def find_file_metadata_by_alternate_identifier(alternate_id:)
+        query_service.find_by_alternate_identifier(alternate_id: alternate_id)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/custom_queries/find_file_metadata.rb
+++ b/app/services/hyrax/custom_queries/find_file_metadata.rb
@@ -21,8 +21,8 @@ module Hyrax
         query_service.find_by(id: id)
       end
 
-      def find_file_metadata_by_alternate_identifier(alternate_id:)
-        query_service.find_by_alternate_identifier(alternate_id: alternate_id)
+      def find_file_metadata_by_alternate_identifier(alternate_identifier:)
+        query_service.find_by_alternate_identifier(alternate_identifier: alternate_identifier)
       end
     end
   end

--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -64,6 +64,7 @@ require 'wings/model_transformer'
 require 'wings/orm_converter'
 require 'wings/attribute_transformer'
 require 'wings/services/custom_queries/find_access_control'
+require 'wings/services/custom_queries/find_file_metadata'
 require 'wings/services/custom_queries/find_many_by_alternate_ids'
 require 'wings/valkyrizable'
 require 'wings/valkyrie/metadata_adapter'
@@ -92,6 +93,7 @@ custom_queries = [Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator,
                   Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator,
                   Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
                   Wings::CustomQueries::FindAccessControl, # override Hyrax::CustomQueries::FindAccessControl
+                  Wings::CustomQueries::FindFileMetadata, # override Hyrax::CustomQueries::FindFileMetadata
                   Wings::CustomQueries::FindManyByAlternateIds] # override Hyrax::CustomQueries::FindManyByAlternateIds
 custom_queries.each do |query_handler|
   Valkyrie.config.metadata_adapter.query_service.custom_queries.register_query_handler(query_handler)

--- a/lib/wings/services/custom_queries/find_file_metadata.rb
+++ b/lib/wings/services/custom_queries/find_file_metadata.rb
@@ -1,0 +1,55 @@
+require 'wings/services/file_converter_service'
+module Wings
+  module CustomQueries
+    class FindFileMetadata
+      # Custom query override specific to Wings
+      # Use:
+      #   Hyrax.query_service.custom_queries.find_file_metadata_by(id: valkyrie_id, use_valkyrie: true)
+      #   Hyrax.query_service.custom_queries.find_file_metadata_by_alternate_identifier(alternate_identifier: id, use_valkyrie: true)
+
+      def self.queries
+        [:find_file_metadata_by,
+         :find_file_metadata_by_alternate_identifier]
+      end
+
+      def initialize(query_service:)
+        @query_service = query_service
+      end
+
+      attr_reader :query_service
+      delegate :resource_factory, to: :query_service
+
+      # WARNING: In general, prefer find_by_alternate_identifier over this
+      # method.
+      #
+      # Hyrax uses a shortened noid in place of an id, and this is what is
+      # stored in ActiveFedora, which is still the storage backend for Hyrax.
+      #
+      # If you do not heed this warning, then switch to Valyrie's Postgres
+      # MetadataAdapter, but continue passing noids to find_by, you will
+      # start getting ObjectNotFoundErrors instead of the objects you wanted
+      #
+      # Find a file metadata record using a Valkyrie ID, and map it to a FileMetadata Resource
+      # @param id [Valkyrie::ID, String]
+      # @param use_valkyrie [boolean] defaults to true; optionally return ActiveFedora::File objects if false
+      # @return [FileMetadata]
+      # @raise [Hyrax::ObjectNotFoundError]
+      def find_file_metadata_by(id:, use_valkyrie: true)
+        find_file_metadata_by_alternate_identifier(alternate_identifier: id, use_valkyrie: use_valkyrie)
+      end
+
+      # Find a file record using an alternate ID, and map it to a Valkyrie FileMetadata Resource
+      # @param alternate_identifier [Valkyrie::ID, String]
+      # @param use_valkyrie [boolean] defaults to true; optionally return ActiveFedora::File objects if false
+      # @return [Valkyrie::Resource]
+      # @raise [Hyrax::ObjectNotFoundError]
+      def find_file_metadata_by_alternate_identifier(alternate_identifier:, use_valkyrie: true)
+        alternate_identifier = ::Valkyrie::ID.new(alternate_identifier.to_s) if alternate_identifier.is_a?(String)
+        raise Hyrax::ObjectNotFoundError unless Hydra::PCDM::File.exists?(alternate_identifier.to_s)
+        object = Hydra::PCDM::File.find(alternate_identifier.to_s)
+        return object if use_valkyrie == false
+        Wings::FileConverterService.af_file_to_resource(af_file: object)
+      end
+    end
+  end
+end

--- a/lib/wings/services/file_converter_service.rb
+++ b/lib/wings/services/file_converter_service.rb
@@ -11,8 +11,8 @@ module Wings
       end
 
       def resource_to_af_file(metadata_resource:)
-        return unless metadata_resource&.alternate_id.present?
-        af_file = Hydra::PCDM::File.new(id: metadata_resource.alternate_id.first.to_s)
+        return unless metadata_resource&.alternate_ids.present?
+        af_file = Hydra::PCDM::File.new(id: metadata_resource.alternate_ids.first.to_s)
         af_file.content = content(metadata_resource)
         af_file.original_name = metadata_resource.original_filename.first
         af_file.mime_type = metadata_resource.mime_type.first
@@ -27,7 +27,7 @@ module Wings
         def base_af_file_attributes(af_file:)
           id = ::Valkyrie::ID.new(af_file.id)
           { id: id,
-            alternate_id: [id],
+            alternate_ids: [id],
             file_identifiers: [id],
             created_at: af_file.create_date,
             updated_at: af_file.modified_date,

--- a/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
@@ -1,11 +1,104 @@
-# rubocop:disable RSpec/EmptyExampleGroup
 RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
-  let(:query_service) { Hyrax.query_service }
-  let(:valk_id) { double } # TODO: Stubbed waiting for tests
-  subject { query_service.custom_queries.find_file_metadata_by(id: valk_id) }
+  before do
+    query_service.custom_queries.register_query_handler(described_class)
+  end
+  let(:metadata_adapter) { Valkyrie::Persistence::Memory::MetadataAdapter.new }
+  let(:query_service) { metadata_adapter.query_service }
+  let(:persister) { metadata_adapter.persister }
+
+  let(:id1) { 'file1' }
+  let(:alt_id1) { 'file1_alt' }
+  let(:valk_id1) { ::Valkyrie::ID.new(id1) }
+  let(:valk_alt_id1) { ::Valkyrie::ID.new(alt_id1) }
+  let(:content1) { 'some text for content' }
+  let(:original_filename1) { 'some_text.txt' }
+  let(:mimetype1) { 'text/plain' }
+  let(:file_metadata) do
+    Hyrax::FileMetadata.new.tap do |fm|
+      fm.id = valk_id1
+      fm.alternate_ids = valk_alt_id1
+      fm.content = content1
+      fm.original_filename = original_filename1
+      fm.mime_type = mimetype1
+      persister.save(resource: fm)
+    end
+  end
+
+  let(:id2) { 'file2' }
+  let(:alt_id2) { 'file2_alt' }
+  let(:valk_id2) { ::Valkyrie::ID.new(id2) }
+  let(:valk_alt_id2) { ::Valkyrie::ID.new(alt_id2) }
+  let(:content2) { '<h3>other context we should not find</h3>' }
+  let(:original_filename2) { 'other_text.html' }
+  let(:mimetype2) { 'text/html' }
+  let(:file_metadata2) do
+    Hyrax::FileMetadata.new.tap do |fm|
+      fm.id = valk_id2
+      fm.alternate_ids = valk_alt_id2
+      fm.content = content2
+      fm.original_filename = original_filename2
+      fm.mime_type = mimetype2
+      persister.save(resource: fm)
+    end
+  end
 
   describe '.find_file_metadata_by' do
-    # TODO: Need tests for this custom query once inMemory adapter is supported
+    subject { query_service.custom_queries.find_file_metadata_by(id: valk_id) }
+    context 'when file exists' do
+      before do
+        file_metadata
+        file_metadata2
+      end
+      let(:valk_id) { valk_id1 }
+      it 'returns file metadata resource' do
+        expect(subject.is_a?(Hyrax::FileMetadata)).to be true
+        expect(subject.id.to_s).to eq id1
+        expect(subject.alternate_ids.first.to_s).to eq alt_id1
+        expect(subject.content.first).to eq content1
+        expect(subject.original_filename.first).to eq original_filename1
+        expect(subject.mime_type.first).to eq mimetype1
+      end
+    end
+
+    context 'when file does not exist' do
+      before do
+        file_metadata
+        file_metadata2
+      end
+      let(:valk_id) { ::Valkyrie::ID.new('BOGUS') }
+      it 'raises not found error' do
+        expect { subject }.to raise_error Valkyrie::Persistence::ObjectNotFoundError
+      end
+    end
+  end
+
+  describe '.find_file_metadata_by_alternate_identifier' do
+    subject { query_service.custom_queries.find_file_metadata_by_alternate_identifier(alternate_identifier: valk_alt_id) }
+    context 'when file exists' do
+      before do
+        file_metadata
+        file_metadata2
+      end
+      let(:valk_alt_id) { valk_alt_id2 }
+      it 'returns file metadata resource' do
+        expect(subject.is_a?(Hyrax::FileMetadata)).to be true
+        expect(subject.id.to_s).to eq id2
+        expect(subject.alternate_ids.first.to_s).to eq alt_id2
+        expect(subject.content.first).to eq content2
+        expect(subject.original_filename.first).to eq original_filename2
+        expect(subject.mime_type.first).to eq mimetype2
+      end
+    end
+
+    context 'when file does not exist' do
+      before do
+        file_metadata
+        file_metadata2
+      end
+      let(:valk_alt_id) { ::Valkyrie::ID.new('BOGUS') }
+      it 'raises not found error' do
+        expect { subject }.to raise_error Valkyrie::Persistence::ObjectNotFoundError
+      end
+    end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
@@ -1,0 +1,11 @@
+# rubocop:disable RSpec/EmptyExampleGroup
+RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
+  let(:query_service) { Hyrax.query_service }
+  let(:valk_id) { double } # TODO: Stubbed waiting for tests
+  subject { query_service.custom_queries.find_file_metadata_by(id: valk_id) }
+
+  describe '.find_file_metadata_by' do
+    # TODO: Need tests for this custom query once inMemory adapter is supported
+  end
+end
+# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -33,11 +33,9 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
         expect(ids.first).to be_a Valkyrie::ID
         expect(ids.first.to_s).to start_with "#{file_set.id}/files/"
 
-        # file_metadata = Hyrax::query_service.find_by(id: ids.first) # TODO: Can't do this b/c Wings tries to get an ActiveFedora::Base object instead of FileMetadata Resource
-        # expect(file_metadata.content).to start_with('%PDF-1.3')
-        af_file_set = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set.id, use_valkyrie: false)
-        expect(af_file_set.original_file.content).to start_with('%PDF-1.3')
-        expect(af_file_set.original_file.mime_type).to eq(pdf_mimetype)
+        file_metadata = Hyrax.query_service.custom_queries.find_file_metadata_by(id: ids.first)
+        expect(file_metadata.content.first).to start_with('%PDF-1.3')
+        expect(file_metadata.mime_type.first).to eq pdf_mimetype
       end
     end
 
@@ -52,11 +50,9 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
         expect(ids.first).to be_a Valkyrie::ID
         expect(ids.first.to_s).to start_with "#{file_set.id}/files/"
 
-        # file_metadata = Hyrax::query_service.find_by(id: ids.first) # TODO: Can't do this b/c Wings tries to get an ActiveFedora::Base object instead of FileMetadata Resource
-        # expect(file_metadata.content).to start_with('some updated content')
-        af_file_set = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set.id, use_valkyrie: false)
-        expect(af_file_set.extracted_text.content).to start_with('some updated content')
-        expect(af_file_set.extracted_text.mime_type).to eq(text_mimetype)
+        file_metadata = Hyrax.query_service.custom_queries.find_file_metadata_by(id: ids.first)
+        expect(file_metadata.content.first).to start_with('some updated content')
+        expect(file_metadata.mime_type.first).to eq text_mimetype
       end
     end
 
@@ -68,11 +64,9 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
         expect(ids.first).to be_a Valkyrie::ID
         expect(ids.first.to_s).to start_with "#{file_set.id}/files/"
 
-        # file_metadata = Hyrax::query_service.find_by(id: ids.first) # TODO: Can't do this b/c Wings tries to get an ActiveFedora::Base object instead of FileMetadata Resource
-        # expect(file_metadata.content).to start_with('some updated content')
-        af_file_set = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set.id, use_valkyrie: false)
-        expect(af_file_set.thumbnail).to have_content
-        expect(af_file_set.thumbnail.mime_type).to eq(image_mimetype)
+        file_metadata = Hyrax.query_service.custom_queries.find_file_metadata_by(id: ids.first)
+        expect(file_metadata.content.first.present?).to eq true
+        expect(file_metadata.mime_type.first).to eq image_mimetype
       end
     end
   end

--- a/spec/wings/services/custom_queries/find_file_metadata_spec.rb
+++ b/spec/wings/services/custom_queries/find_file_metadata_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/services/custom_queries/find_file_metadata'
+
+RSpec.describe Wings::CustomQueries::FindFileMetadata, :clean_repo do
+  let(:query_service) { Hyrax.query_service }
+
+  let(:pcdmfile) do
+    Hydra::PCDM::File.new.tap do |f|
+      f.id = af_file_id
+      f.content = 'some text for content'
+      f.original_name = 'some_text.txt'
+      f.mime_type = 'text/plain'
+      f.save!
+    end
+  end
+  let(:af_file_id) { 'file1' }
+  let(:valk_id) { ::Valkyrie::ID.new(af_file_id) }
+
+  let(:subject) { query_service.custom_queries.find_file_metadata_by(id: valk_id, use_valkyrie: use_valkyrie_value) }
+
+  describe '.find_file_metadata_by' do
+    context 'when use_valkyrie: false' do
+      before { pcdmfile }
+      let(:use_valkyrie_value) { false }
+      it 'returns AF File' do
+        expect(subject.is_a?(ActiveFedora::File)).to be true
+        expect(subject.id).to eq af_file_id
+      end
+    end
+
+    context 'when use_valkyrie: true' do
+      before { pcdmfile }
+      let(:use_valkyrie_value) { true }
+      it 'returns ActiveFedora objects' do
+        expect(subject.is_a?(Hyrax::FileMetadata)).to be true
+        expect(subject.id).to eq valk_id
+      end
+    end
+
+    context 'when invalid id' do
+      let(:use_valkyrie_value) { true }
+      let(:valk_id) { ::Valkyrie::ID.new('1212121212') }
+      it 'returns error' do
+        expect { subject } .to raise_error
+      end
+    end
+  end
+end

--- a/spec/wings/services/file_converter_service_spec.rb
+++ b/spec/wings/services/file_converter_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Wings::FileConverterService do
     subject { described_class.af_file_to_resource(af_file: af_file) }
     it 'copies attributes to resource' do # rubocop:disable RSpec/ExampleLength
       expect(subject.id.to_s).to eq af_file_id
-      expect(subject.alternate_id).to match_valkyrie_ids_with_active_fedora_ids [af_file_id]
+      expect(subject.alternate_ids).to match_valkyrie_ids_with_active_fedora_ids [af_file_id]
       expect(subject.file_identifiers).to match_valkyrie_ids_with_active_fedora_ids [af_file_id]
       expect(subject.created_at).to eq af_file.create_date
       expect(subject.updated_at).to eq af_file.modified_date
@@ -42,7 +42,7 @@ RSpec.describe Wings::FileConverterService do
     let(:valkyrie_id) { ::Valkyrie::ID.new(id) }
     let(:valkyrie_attrs) { plain_text_valkyrie_attrs }
     let(:file_metadata) do
-      valkyrie_attrs[:alternate_id] = valkyrie_id
+      valkyrie_attrs[:alternate_ids] = valkyrie_id
       valkyrie_attrs[:file_identifiers] = valkyrie_id
       valkyrie_attrs[:word_count] = plain_text_valkyrie_attrs[:content].split(' ').count
       valkyrie_attrs[:size] = plain_text_valkyrie_attrs[:content].size


### PR DESCRIPTION
Adds custom queries...
* find_file_metadata_by
* find_file_metadata_by_alternate_id

Update add_file_to_file_set tests to use find_file_metadata_by custom query.

This includes a change to FileMetadata attribute alternate_id changed to alternate_ids.  This is a standard Valkyrie field and needs to use the Valkyrie attribute name to work with Valkyrie query services for all adapters.