### PR TITLE
From profile page be able to link to "Works created" page and see accurate counts

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -305,9 +305,15 @@ module Hyrax
       # @param [Hash] facet
       # @note Ignores all but the first facet.  Probably a bug.
       def search_state_with_facets(params, facet = {})
-        state = Blacklight::SearchState.new(params, CatalogController.blacklight_config)
+        state = Blacklight::SearchState.new([], CatalogController.blacklight_config)
         return state.params if facet.none?
-        state.add_facet_params(facet.keys.first.to_s + "_sim", facet.values.first)
+
+        facet_type = state.add_facet_params(facet.keys.first.to_s + "_sim", facet.values.first)
+        facet_search = state.add_facet_params(params[:search_field] + "_ssim", params[:q].delete('"'))
+
+        query = Hash.new {}
+        query["f"] = facet_type["f"].merge(facet_search["f"])
+        query
       end
 
       def institution


### PR DESCRIPTION
Fixes #3478 

With this change, if a user goes to the Profile page from the dashboard, and then tries to see a listing of works and collections created by the user,  the listing should be presented.

The code originally used the params `search_field` and a value for `q` to search for the depositor.  For example, `search_field=depositor&q=user@abc.com` and then it appended a facet to indicate if looking for a work or a collection.  I could not get this to work.  The `search_field with q value` did not really seem to do anything.  So...I tried using facets for depositor value, and this seems to work just fine.  What to you think?

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* The user should have a few works and collections.
* Go to the dashboard and select Profile from Your activity dropdown.
* Click on `Works created` and then `Collections created` and make sure that the lists are accurate in both cases.

@samvera/hyrax-code-reviewers
