### PR TITLE
Use valkyrie for BaseActor#create when ENV['HYRAX_VALKYRIE'] is true

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
     resource_class: medium+
     environment:
       RAILS_VERSION: << parameters.rails_version >>
+      HYRAX_VALKYRIE: true
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
     steps:
       - samvera/cached_checkout

--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -19,7 +19,7 @@ module Hyrax
         apply_creation_data_to_curation_concern(env)
         apply_save_data_to_curation_concern(env)
 
-        save(env, use_valkyrie: true) &&
+        save(env, use_valkyrie: Hyrax.config.use_valkyrie?) &&
           next_actor.create(env) &&
           run_callbacks(:after_create_concern, env)
       end

--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -19,7 +19,7 @@ module Hyrax
         apply_creation_data_to_curation_concern(env)
         apply_save_data_to_curation_concern(env)
 
-        save(env, use_valkyrie: false) &&
+        save(env, use_valkyrie: true) &&
           next_actor.create(env) &&
           run_callbacks(:after_create_concern, env)
       end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -315,6 +315,10 @@ module Hyrax
     end
     # rubocop:enable Metrics/LineLength
 
+    def use_valkyrie?
+      ENV.fetch('HYRAX_VALKYRIE', false)
+    end
+
     def geonames_username=(username)
       Qa::Authorities::Geonames.username = username
     end


### PR DESCRIPTION
Fixes #3572

Changes to support saving permissions in the valkyrie branch of BaseActor#save are included. The new permission models in Valkyrie expect a manual save. Since we don't fully round-trip them, we need to ensure we set them with the proper #access_to id and request a save for the AccessControl object.

Now unnecessary manual saves of Embargo and Lease are removed, and a refactor to drop valkyrie save behavior into its own method is included.

The use of valkyrie for sensitive operations is moved behind an environment variable HYRAX_VALKYRIE. This should help low-risk production environments avoid its use, but make testing easy for users.

@samvera/hyrax-code-reviewers

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* This is a non-functional change.

@samvera/hyrax-code-reviewers
