### PR TITLE
Format informative errors for workflow schema validation

### DIFF
--- a/app/services/hyrax/workflow/workflow_importer.rb
+++ b/app/services/hyrax/workflow/workflow_importer.rb
@@ -165,14 +165,27 @@ module Hyrax
           # @param data [Hash]
           # @param schema [#call]
           #
-          # @return true if the data validates from the schema
-          # @raise Exceptions::InvalidSchemaError if the data does not validate against the schema
+          # @return [Boolean] true if the data validates from the schema
+          # @raise [RuntimeError] if the data does not validate against the schema
           def self.call(data:, schema:, logger:)
             result = schema.call(data)
             return true if result.success?
-            message = result.errors(full: true).inspect
+            message = format_message(result)
             logger.error(message)
             raise message
+          end
+
+          ##
+          # @param result [Dry::Validation::Result]
+          #
+          # @return [String]
+          def self.format_message(result)
+            messages = result.errors(full: true).map do |msg|
+              "Error on workflow entry #{msg.path}\n\t#{msg.text}\n\tGot: #{msg.input || '[no entry]'}"
+            end
+
+            messages << "Input was:\n\t#{result.to_h}"
+            messages.join("\n")
           end
         end
     end


### PR DESCRIPTION
This is a hack at formatting errors for workflow schema issues.

The new errors are formatted like:

```
Error on workflow entry [:workflows, 0, :label]
      label must be filled
      Got:
Error on workflow entry [:workflows, 0, :description]
      description must be filled
      Got:
Input was:
      {:workflows=>[{:name=>"ulra_submission", :label=>"", :description=>"",
      :actions=>[{:name=>"approve", :from_states=>[{:names=>["under_review"],
      :roles=>["ulra_reviewing"]}], :transition_to=>"reviewed"}]}]}
```

Fixes #267.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* In a test application, update a workflow schema configuration to an invalid format. Observe the new and improved error messages.

@samvera/hyrax-code-reviewers
