### PR TITLE
Index digest as a collection, instead of a single value

### DIFF
--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -21,7 +21,7 @@ module Hyrax
         solr_doc['mime_type_ssi']  = object.mime_type
         # Index the Fedora-generated SHA1 digest to create a linkage between
         # files on disk (in fcrepo.binary-store-path) and objects in the repository.
-        solr_doc['digest_ssim'] = digest_from_content
+        solr_doc['digest_ssim']             = [digest_from_content]
         solr_doc['page_count_tesim']        = object.page_count
         solr_doc['file_title_tesim']        = object.file_title
         solr_doc['duration_tesim']          = object.duration

--- a/spec/indexers/hyrax/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/file_set_indexer_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Hyrax::FileSetIndexer do
       expect(subject['all_text_timv']).to eq('abcxyz')
       expect(subject['height_is']).to eq 500
       expect(subject['width_is']).to eq 600
-      expect(subject['digest_ssim']).to eq 'urn:sha1:f794b23c0c6fe1083d0ca8b58261a078cd968967'
+      expect(subject['digest_ssim']).to contain_exactly 'urn:sha1:f794b23c0c6fe1083d0ca8b58261a078cd968967'
       expect(subject['visibility_ssi']).to eq 'restricted'
       expect(subject['page_count_tesim']).to eq ['1']
       expect(subject['file_title_tesim']).to eq ['title']


### PR DESCRIPTION
Fixes #1079.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Ensure a new file displays its checksum correctly:
  * Create a new work and attach a file.
  * Wait for the file to attach to the work.
  * Browse to the File's show view
  * Ensure `Original Checksum: 1ce7b58f2c49c409551b8f9c07e43e66 ` appears (the checksum will be different).


@samvera/hyrax-code-reviewers
