### PR TITLE
Remove the no-op analytics flipper

### DIFF
--- a/app/controllers/hyrax/stats_controller.rb
+++ b/app/controllers/hyrax/stats_controller.rb
@@ -5,9 +5,6 @@ module Hyrax
 
     before_action :build_breadcrumbs, only: [:work, :file]
 
-    # TODO: New reporting features FlipFlop pattern:
-    # Flipflop.enabled?(:analytics_redesign)
-
     def work
       @stats = Hyrax::WorkUsage.new(params[:id])
     end

--- a/config/features.rb
+++ b/config/features.rb
@@ -31,10 +31,6 @@ Flipflop.configure do
           default: true,
           description: "Enable uploading batches of works"
 
-  feature :analytics_redesign,
-          default: false,
-          description: "Display new reporting features. *Very Experimental*"
-
   feature :hide_private_items,
           default: false,
           description: "Do not show the private items."


### PR DESCRIPTION
Since the analytics redesign has fizzled, and this flipper has no function,
let's remove it prior to 3.0.0.

Changes proposed in this pull request:
* Removes a "very experimental" flipper that has no functional impact.

@samvera/hyrax-code-reviewers
