### PR TITLE
Remove deprecated `human_readable_type` setter

### DIFF
--- a/app/models/concerns/hyrax/human_readable_type.rb
+++ b/app/models/concerns/hyrax/human_readable_type.rb
@@ -4,16 +4,8 @@ module Hyrax
 
     module ClassMethods
       def human_readable_type
-        default = @_human_readable_type || name.demodulize.titleize
-        I18n.translate("activefedora.models.#{model_name.i18n_key}", default: default)
+        I18n.translate("activefedora.models.#{model_name.i18n_key}", default: name.demodulize.titleize)
       end
-
-      def human_readable_type=(val)
-        @_human_readable_type = val
-      end
-      deprecation_deprecate :human_readable_type= => 'human_readable_type is deprecated. ' \
-        'Set the i18n key for activefedora.models.#{model_name.i18n_key} instead. ' \
-        'This will be removed in Hyrax 3'
     end
 
     def human_readable_type

--- a/spec/models/hyrax/work_behavior_spec.rb
+++ b/spec/models/hyrax/work_behavior_spec.rb
@@ -33,11 +33,6 @@ RSpec.describe Hyrax::WorkBehavior do
     it 'has a default' do
       expect(subject.human_readable_type).to eq 'Essential Work'
     end
-    it 'is settable (deprecated)' do
-      allow(Deprecation).to receive(:warn)
-      EssentialWork.human_readable_type = 'Custom Type'
-      expect(subject.human_readable_type).to eq 'Custom Type'
-    end
   end
 
   it 'inherits (and extends) to_solr behaviors from superclass' do


### PR DESCRIPTION
This setter was deprecated for removal in 3.0.0, so we can yank it now and stop
supporting its use.

@samvera/hyrax-code-reviewers
