### PR TITLE
Remove deprecated `WorkForm#collections_for_select`

### DIFF
--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -174,13 +174,6 @@ module Hyrax
         model.works
       end
 
-      # Get a list of collection id/title pairs for the select form
-      def collections_for_select
-        service = Hyrax::CollectionsService.new(@controller)
-        CollectionOptionsPresenter.new(service).select_options(:edit)
-      end
-      deprecation_deprecate collections_for_select: "will be removed in Hyrax 3"
-
       # Sanitize the parameters coming from the form. This ensures that the client
       # doesn't send us any more parameters than we expect.
       # In particular we are discarding any access grant parameters for works that


### PR DESCRIPTION
This is no longer used and has been deprecated for removal in 3.0.0. This
completes that removal process.

@samvera/hyrax-code-reviewers
