### PR TITLE
Use valkyrie for `BaseActor#create`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,9 @@ jobs:
       bundler_version:
         type: string
         default: 1.17.3
+      hyrax_valkyrie:
+        type: string
+        default: "false"
     executor:
       name: 'samvera/ruby_fcrepo_solr_redis'
       ruby_version: << parameters.ruby_version >>
@@ -95,6 +98,7 @@ jobs:
     parallelism: 10
     environment:
       COVERALLS_PARALLEL: true
+      HYRAX_VALKYRIE: << parameters.hyrax_valkyrie >>
       VALKYRIE_SOLR_PORT: 8985
     steps:
       - attach_workspace:
@@ -161,5 +165,11 @@ workflows:
       - test:
           name: "ruby2-6-2"
           ruby_version: "2.6.2"
+          requires:
+            - build
+      - test:
+          name: "ruby2-6-2-valkyrie"
+          ruby_version: "2.6.2"
+          hyrax_valkyrie: "true"
           requires:
             - build

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -315,6 +315,10 @@ module Hyrax
     end
     # rubocop:enable Metrics/LineLength
 
+    def use_valkyrie?
+      ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYRAX_VALKYRIE', false))
+    end
+
     def geonames_username=(username)
       Qa::Authorities::Geonames.username = username
     end


### PR DESCRIPTION
At the base level of the actor stack, use valkyrie for `#create`. This is a
simple flag swich; all the blockers to this swap have been cleared in prior
work.

The use of valkyrie for sensitive operations is moved behind an environment
variable HYRAX_VALKYRIE. This should help low-risk production environments avoid
its use, but make testing easy for users.

The new permission models in Valkyrie expect a manual save. Since we don't fully
round-trip them, we need to ensure we set them with the proper #access_to id and
request a save for the AccessControl object. Unnecessary manual saves of Embargo
and Lease are removed, and a refactor to drop valkyrie save behavior into its
own method is included.

Fixes #3941 

@samvera/hyrax-code-reviewers
