### PR TITLE
Rename `Hyrax.collection.browse_view` to `edit_view` & update value

### DIFF
--- a/app/controllers/concerns/hyrax/breadcrumbs_for_collections.rb
+++ b/app/controllers/concerns/hyrax/breadcrumbs_for_collections.rb
@@ -14,7 +14,7 @@ module Hyrax
     def add_breadcrumb_for_action
       case action_name
       when 'edit'.freeze
-        add_breadcrumb I18n.t("hyrax.collection.browse_view"), collection_path(params["id"]), mark_active_action
+        add_breadcrumb I18n.t("hyrax.collection.edit_view"), collection_path(params["id"]), mark_active_action
       when 'show'.freeze
         add_breadcrumb presenter.to_s, polymorphic_path(presenter), mark_active_action
       end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -596,6 +596,7 @@ en:
         no_visible_works: The collection is either empty or does not contain items to which you have access.
       edit:
         manage_items: Manage Items in this Collection
+      edit_view: Edit View
       form:
         additional_fields: Additional fields
         description: Descriptions

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.browse_view"), collection_path(collection.id, locale: 'en'), "aria-current" => "page")
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.edit_view"), collection_path(collection.id, locale: 'en'), "aria-current" => "page")
         get :edit, params: { id: collection }
         expect(response).to be_successful
       end
@@ -506,7 +506,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.browse_view"), collection_path(collection.id, locale: 'en'), "aria-current" => "page")
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.edit_view"), collection_path(collection.id, locale: 'en'), "aria-current" => "page")
         get :edit, params: { id: collection }
         expect(response).to be_successful
       end


### PR DESCRIPTION
This view is more properly called the 'Edit View' and that should be reflected
in the breadcrumbs. The i18n key was previously also `browse_view` and changing
it to `edit_view` helps ensure translations get updated.

Fixes #2164.

Changes proposed in this pull request:
* Change the `i18n` key for the collection edit view to `edit_view`
* Update text to match.
*

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to a collection edit page; observe breadcrumb name "Edit View"

@samvera/hyrax-code-reviewers
