### PR TITLE
[WIP] failing test for reload new af object failure

### DIFF
--- a/spec/wings/valkyrie/resource_factory_spec.rb
+++ b/spec/wings/valkyrie/resource_factory_spec.rb
@@ -29,4 +29,12 @@ RSpec.describe Wings::Valkyrie::ResourceFactory do
       end
     end
   end
+
+  describe 'round trip starting from unsaved af object' do
+    let(:work) { build(:work) }
+    let(:resource) { factory.to_resource(object: work).save }
+    it 'allows af object to be reloaded' do
+      expect(work.reload.id).to eq resource.alternate_id.to_s
+    end
+  end
 end


### PR DESCRIPTION
### AF Testing Pattern in use in Hyrax:
* build an af_object and don’t save
* call a method that modifies the af_object and saves
* in test, reload af_object and test changes

### Challenge when using valkyrie

* build an af_object and don’t save
* call a method that converts af_object to a valkyrie resource, modifies the resource and saves, converts the resource back to an af_object (this has a different object_id from the one passed in)
* in test, reload original af_object passed to the method and test changes

FAILS because the original af_object does not have the same `object_id` as the af_object converted from the saved resource.  And because it wasn’t saved, it does not have the same `af_object.id` value.  The one in the test has `af_object.id=nil`.

So the question is how to address this as we continue converting code and tests to be valkyrized.

### Potential Options

OPTION 1:  Require save of af_object created in the test.  This may not always be an option since at times we may be intentionally testing the case where the starting object is new and unsaved.

OPTION 2:  Methods that change the passed in object (af_object or resource) should pass back the updated object which can then be tested for expected changes by comparing to the values in the original unsaved object.  This may require updates to code that is currently not expecting to receive the updated object and may be depending on the passed in object being updated.

OPTION 3: ???
