### PR TITLE
Remove unauthorized.png from generator

### DIFF
--- a/lib/generators/hyrax/assets_generator.rb
+++ b/lib/generators/hyrax/assets_generator.rb
@@ -25,10 +25,6 @@ class Hyrax::AssetsGenerator < Rails::Generators::Base
     end
   end
 
-  def copy_image_file
-    copy_file 'app/assets/images/unauthorized.png'
-  end
-
   private
 
     def hyrax_javascript_installed?


### PR DESCRIPTION
We now provide a default `unauthorized.png` in the engine. Generating one into
the application isn't needed. This is a follow-up to #4033.

Connected to #3885

Changes proposed in this pull request:
* Rely on the engine's `unauthorized.png` instead of a generated one in the application.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Generate a new application (or delete the local `unauthorized.png` from an existing one.
* Deposit a work with a private file
* Log out
* Request the thumbnail for the file and ensure the file in `unauthorized.png` is retrieved.

@samvera/hyrax-code-reviewers
