### PR TITLE
create methods for attaching file_set to work using valkyrie and using active fedora

### DIFF
--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -68,7 +68,7 @@ module Hyrax
           ::FileSet.new(import_url: import_url, label: file_name) do |fs|
             actor = Hyrax::Actors::FileSetActor.new(fs, env.user)
             actor.create_metadata(visibility: env.curation_concern.visibility)
-            actor.attach_to_work(env.curation_concern)
+            env.curation_concern = actor.attach_to_work(env.curation_concern)
             fs.save!
             if uri.scheme == 'file'
               # Turn any %20 into spaces.

--- a/app/actors/hyrax/actors/create_with_remote_files_ordered_members_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_ordered_members_actor.rb
@@ -70,7 +70,7 @@ module Hyrax
         ::FileSet.new(import_url: uri.to_s, label: file_name) do |fs|
           actor = file_set_actor_class.new(fs, env.user)
           actor.create_metadata(visibility: env.curation_concern.visibility)
-          actor.attach_to_work(env.curation_concern)
+          env.curation_concern = actor.attach_to_work(env.curation_concern)
           fs.save!
           ordered_members << fs
           if uri.scheme == 'file'

--- a/app/actors/hyrax/actors/file_set_ordered_members_actor.rb
+++ b/app/actors/hyrax/actors/file_set_ordered_members_actor.rb
@@ -10,6 +10,7 @@ module Hyrax
         file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
         work.representative = file_set if work.representative_id.blank?
         work.thumbnail = file_set if work.thumbnail_id.blank?
+        work
       end
     end
   end

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -273,15 +273,30 @@ RSpec.describe Hyrax::Actors::FileSetActor do
         end
 
         context 'without representative and thumbnail' do
-          it 'assigns them (with persistence)' do
-            actor.attach_to_work(work)
-            expect(work.representative).to eq(file_set)
-            expect(work.thumbnail).to eq(file_set)
-            expect { work.reload }.not_to change { [work.representative.id, work.thumbnail.id] }
+          context 'when work is new' do
+            it 'assigns them (with persistence)' do
+              expect(work.new_record?).to eq true
+              ret_work = actor.attach_to_work(work)
+              expect(ret_work.representative).to eq(file_set)
+              expect(ret_work.thumbnail).to eq(file_set)
+            end
+          end
+
+          context 'when work exists' do
+            it 'assigns them (with persistence)' do
+              work.save!
+              ret_work = actor.attach_to_work(work)
+              expect(ret_work.representative).to eq(file_set)
+              expect(ret_work.thumbnail).to eq(file_set)
+            end
           end
         end
 
         context 'with representative and thumbnail' do
+          before do
+            create(:file_set, id: 'ab123c78h')
+            create(:file_set, id: 'zz365c78h')
+          end
           it 'does not (re)assign them' do
             allow(work).to receive(:thumbnail_id).and_return('ab123c78h')
             allow(work).to receive(:representative_id).and_return('zz365c78h')
@@ -301,6 +316,7 @@ RSpec.describe Hyrax::Actors::FileSetActor do
           end
 
           it "writes to the most up to date version" do
+            pending 'implementation of valkyrized versioning' if use_valkyrie
             actor.attach_to_work(work_v1)
             expect(work_v1.members.size).to eq 2
           end


### PR DESCRIPTION
### Support for valkyrie

There are multiple steps in the attach_to_work method that must change to work with valkyrie.  If each step is separated into its own method, the conversion between active fedora and valkyrie would have to happen multiple times.  So to valkyrize attach_to_work, the entire method is written once for active fedora and again for valkyrie.  A switching method, ‘perform_attach_to_work’ is used to determine which to call.

### Modified behavior

For new works to be able to complete the attach_to_work process when using Valkyrie, the updated work needs to be returned to the caller.  This is because the passed in work does not have an id and the resource save process returns a new instance of the work with the id.  The original work object has no way to reload the values saved by the valkyrie persister.

### Delayed work

Marked pending the test for versions as the valkyrie resource is not maintaining the versions.  This work will be addressed separately.
