### PR TITLE
Provide a Valkyrie changeset factory 

### DIFF
--- a/app/models/hyrax/change_set.rb
+++ b/app/models/hyrax/change_set.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # @api private
+  #
+  # Build a changeset class for the given resource class. The ChangeSet will
+  # have fields to match the resource class given.
+  #
+  # @example
+  #   Hyrax::ChangeSet(Monograph)
+  def self.ChangeSet(resource_class)
+    Class.new(Hyrax::ChangeSet) do
+      self.fields = resource_class.fields - resource_class.reserved_attributes
+    end
+  end
+
+  class ChangeSet < Valkyrie::ChangeSet
+    ##
+    # @api public
+    #
+    # Factory for resource ChangeSets
+    #
+    # @example
+    #   monograph  = Monograph.new
+    #   change_set = Hyrax::ChangeSet.for(monograph)
+    #
+    #   change_set.title = 'comet in moominland'
+    #   change_set.sync
+    #   monograph.title # => 'comet in moominland'
+    #
+    def self.for(resource)
+      Hyrax::ChangeSet(resource.class).new(resource)
+    end
+  end
+end

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -150,11 +150,7 @@ module Hyrax
       end
 
       def change_set
-        @change_set ||= ChangeSet.new(access_control_model)
-      end
-
-      class ChangeSet < Valkyrie::ChangeSet
-        self.fields = [:permissions]
+        @change_set ||= Hyrax::ChangeSet.for(access_control_model)
       end
   end
 end

--- a/spec/models/hyrax/change_set_spec.rb
+++ b/spec/models/hyrax/change_set_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::ChangeSet do
+  subject(:change_set) { described_class.for(resource) }
+  let(:resource)       { resource_class.new }
+  let(:resource_class) { Hyrax::Test::BookResource }
+  let(:titles)         { ['comet in moominland', 'finn family moomintroll'] }
+
+  it 'changes when changed' do
+    expect { change_set.title = titles }
+      .to change { change_set.changed? }
+      .from(false)
+      .to(true)
+  end
+
+  it 'sets changeset attributes' do
+    expect { change_set.title = titles }
+      .to change { change_set.title }
+      .to contain_exactly(*titles)
+  end
+
+  it 'applies changeset attributes' do
+    change_set.title = titles
+
+    expect { change_set.sync }
+      .to change { resource.title }
+      .to contain_exactly(*titles)
+  end
+
+  it 'does not expose reserved attributes' do
+    expect { change_set.id = 'fake id' }.to raise_error NoMethodError
+  end
+
+  it 'does not list attributes' do
+    expect(change_set.class.fields)
+      .not_to include(*resource_class.reserved_attributes)
+  end
+end


### PR DESCRIPTION
For any given Valkyrie model, we want a factory for an appropriate `ChangeSet`,
with attribute accessors and a `#sync` method.

We provide this with a `Hyrax::ChangeSet.for(my_resource)` factory. This builds
the changeset class on the fly, applying the fields from the resource
schema. Then a new instance of the class is initialized to handle the `ChangeSet`
for the specific object.

As future work, we could consider caching the changeset classes. For now, it
seems best to watch and wait--avoiding premature optimization.

Changes proposed in this pull request:
* Extends the valkyrie interfaces by adding a ChangeSet factory

@samvera/hyrax-code-reviewers
