### PR TITLE
Use a custom Indexer for AdminSets

### DIFF
--- a/app/indexers/hyrax/admin_set_indexer.rb
+++ b/app/indexers/hyrax/admin_set_indexer.rb
@@ -7,7 +7,12 @@ module Hyrax
     def generate_solr_document
       super.tap do |solr_doc|
         # Makes Admin Sets show under the "Admin Sets" tab
-        solr_doc['generic_type_sim'] = ['Admin Set']
+        solr_doc['generic_type_sim']  = ['Admin Set']
+        solr_doc['alt_title_tesim']   = object.alt_title
+        solr_doc['creator_ssim']      = object.creator
+        solr_doc['description_tesim'] = object.description
+        solr_doc['title_tesim']       = object.title
+        solr_doc['title_sim']         = object.title
       end
     end
   end

--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -28,21 +28,11 @@ class AdminSet < ActiveFedora::Base
   validates_with Hyrax::HasOneTitleValidator
   class_attribute :human_readable_short_description
   self.indexer = Hyrax::AdminSetIndexer
-  property :title, predicate: ::RDF::Vocab::DC.title do |index|
-    index.as :stored_searchable, :facetable
-  end
 
-  property :alt_title, predicate: ::RDF::Vocab::DC.alternative do |index|
-    index.as :stored_searchable
-  end
-
-  property :description, predicate: ::RDF::Vocab::DC.description do |index|
-    index.as :stored_searchable
-  end
-
-  property :creator, predicate: ::RDF::Vocab::DC11.creator do |index|
-    index.as :symbol
-  end
+  property :title,       predicate: ::RDF::Vocab::DC.title
+  property :alt_title,   predicate: ::RDF::Vocab::DC.alternative
+  property :description, predicate: ::RDF::Vocab::DC.description
+  property :creator,     predicate: ::RDF::Vocab::DC11.creator
   has_many :members,
            predicate:  Hyrax.config.admin_set_predicate,
            class_name: 'ActiveFedora::Base'

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -21,5 +21,11 @@ FactoryBot.define do
       # false, true, or Hash with keys for permission_template
       with_permission_template { false }
     end
+
+    factory :complete_admin_set do
+      alt_title   { ['alternate admin set title'] }
+      creator     { ['moomin', 'snufkin'] }
+      description { ['Before a revolution happens', 'it is perceived as impossible'] }
+    end
   end
 end

--- a/spec/indexers/hyrax/admin_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/admin_set_indexer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::AdminSetIndexer do
   describe 'alt_title' do
     it 'is stored searchable' do
       expect(indexer.generate_solr_document)
-        .to match a_hash_including('alt_title_sim' => admin_set.alt_title)
+        .to match a_hash_including('alt_title_tesim' => admin_set.alt_title)
     end
   end
 
@@ -30,7 +30,7 @@ RSpec.describe Hyrax::AdminSetIndexer do
   describe 'description' do
     it 'is stored searchable' do
       expect(indexer.generate_solr_document)
-        .to match a_hash_including('description_sim' => admin_set.description)
+        .to match a_hash_including('description_tesim' => admin_set.description)
     end
   end
 

--- a/spec/indexers/hyrax/admin_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/admin_set_indexer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Hyrax::AdminSetIndexer do
   let(:indexer) { described_class.new(admin_set) }
-  let(:admin_set) { build(:admin_set) }
+  let(:admin_set) { build(:complete_admin_set) }
   let(:doc) do
     {
       'generic_type_sim' => ['Admin Set']
@@ -10,6 +10,39 @@ RSpec.describe Hyrax::AdminSetIndexer do
   describe "#generate_solr_document" do
     it "has required fields" do
       expect(indexer.generate_solr_document).to match a_hash_including(doc)
+    end
+  end
+
+  describe 'alt_title' do
+    it 'is stored searchable' do
+      expect(indexer.generate_solr_document)
+        .to match a_hash_including('alt_title_sim' => admin_set.alt_title)
+    end
+  end
+
+  describe 'creator' do
+    it 'is indexed as a symbol' do
+      expect(indexer.generate_solr_document)
+        .to match a_hash_including('creator_ssim' => admin_set.creator)
+    end
+  end
+
+  describe 'description' do
+    it 'is stored searchable' do
+      expect(indexer.generate_solr_document)
+        .to match a_hash_including('description_sim' => admin_set.description)
+    end
+  end
+
+  describe 'title' do
+    it 'is stored searchable' do
+      expect(indexer.generate_solr_document)
+        .to match a_hash_including('title_tesim' => admin_set.title)
+    end
+
+    it 'is facetable' do
+      expect(indexer.generate_solr_document)
+        .to match a_hash_including('title_sim' => admin_set.title)
     end
   end
 end

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -60,14 +60,24 @@ RSpec.describe AdminSet, type: :model do
   describe "#to_solr" do
     let(:admin_set) do
       build(:admin_set, title: ['A good title'],
-                        creator: ['jcoyne@justincoyne.com'])
+                        creator: ['jcoyne@justincoyne.com'],
+                        alt_title: ['A bad title'],
+                        description: ['a description'])
     end
-    let(:solr_document) { admin_set.to_solr }
 
     it "has title and creator information" do
-      expect(solr_document).to include 'title_tesim' => ['A good title'],
-                                       'title_sim' => ['A good title'],
-                                       'creator_ssim' => ['jcoyne@justincoyne.com']
+      expect(admin_set.to_solr).to include 'title_tesim' => ['A good title'],
+                                           'title_sim' => ['A good title'],
+                                           'creator_ssim' => ['jcoyne@justincoyne.com']
+    end
+
+    it 'indexes all properties' do
+      keys = ["system_create_dtsi", "system_modified_dtsi", "has_model_ssim",
+              :id, "title_tesim", "title_sim", "alt_title_tesim", "description_tesim",
+              "creator_ssim", "thumbnail_path_ss", "generic_type_sim",
+              "human_readable_type_sim", "human_readable_type_tesim"]
+
+      expect(admin_set.to_solr.keys).to contain_exactly(*keys)
     end
   end
 


### PR DESCRIPTION
Avoid deprecated `index.as` syntax for `AdminSet` data.

Admin Sets should be able to index using the AdminSetIndexer, rather than the
old-style `index.as` syntax.

@samvera/hyrax-code-reviewers
