### PR TITLE
Add find_related custom queries

### DIFF
--- a/app/services/hyrax/custom_queries/find_related.rb
+++ b/app/services/hyrax/custom_queries/find_related.rb
@@ -1,0 +1,31 @@
+# Navigate from a resource to the child works in the resource.
+module Hyrax
+  module CustomQueries
+    class FindRelated
+      # Define the queries that can be fulfilled by this custom query.
+      def self.queries
+        [:find_related_for, :find_related_ids_for]
+      end
+
+      attr_reader :query_service
+
+      def initialize(query_service:)
+        @query_service = query_service
+      end
+
+      # Find related resources, and map to Valkyrie Resources
+      # @param [Valkyrie::Resource]
+      # @return [Array<Valkyrie::Resource>]
+      def find_related_for(resource:, relationship:)
+        find_related_ids_for(resource: resource, relationship: relationship).map { |id| query_service.find_by(id: id) }
+      end
+
+      # Find ids for related resource
+      # @param [Valkyrie::Resource]
+      # @return [Array<Valkyrie::ID>]
+      def find_related_ids_for(resource:, relationship:)
+        (resource[relationship] || []).select { |x| x.is_a?(Valkyrie::ID) }
+      end
+    end
+  end
+end

--- a/app/services/hyrax/custom_queries/find_related.rb
+++ b/app/services/hyrax/custom_queries/find_related.rb
@@ -4,7 +4,10 @@ module Hyrax
     class FindRelated
       # Define the queries that can be fulfilled by this custom query.
       def self.queries
-        [:find_related_for, :find_related_ids_for]
+        [:find_related_for,
+         :find_related_ids_for,
+         :find_inverse_related_for,
+         :find_inverse_related_ids_for]
       end
 
       attr_reader :query_service
@@ -25,6 +28,22 @@ module Hyrax
       # @return [Array<Valkyrie::ID>]
       def find_related_ids_for(resource:, relationship:)
         (resource[relationship] || []).select { |x| x.is_a?(Valkyrie::ID) }
+      end
+
+      # Find the inverse related resources, and map to Valkyrie Resources.  These are other resources that have the
+      # relationship attribute in their model that include this resource's id.
+      # @param [Valkyrie::Resource]
+      # @return [Array<Valkyrie::Resource>]
+      def find_inverse_related_for(resource:, relationship:)
+        query_service.find_inverse_references_by(resource: resource, property: relationship) || []
+      end
+
+      # Find ids for inverse related resource.  These are other resources that have the relationship attribute in their
+      # model that include this resource's id.
+      # @param [Valkyrie::Resource]
+      # @return [Array<Valkyrie::ID>]
+      def find_inverse_related_ids_for(resource:, relationship:)
+        find_inverse_related_for(resource: resource, relationship: relationship).map(&:id)
       end
     end
   end

--- a/spec/services/hyrax/custom_queries/find_related_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_related_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::CustomQueries::FindRelated do
+  let(:metadata_adapter) { Valkyrie::Persistence::Memory::MetadataAdapter.new }
+  let(:query_service) { metadata_adapter.query_service }
+  let(:persister) { metadata_adapter.persister }
+
+  before do
+    query_service.custom_queries.register_query_handler(described_class)
+    module Hyrax::Test::FindRelated
+      class Work < Valkyrie::Resource
+        attribute :child_work_ids, Valkyrie::Types::Set
+        attribute :child_file_set_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
+      end
+      class FileSet < Valkyrie::Resource; end
+    end
+    # Hyrax::Test::FindRelated::Work
+    # Hyrax::Test::FindRelated::FileSet
+  end
+
+  after { Hyrax::Test.send(:remove_const, :FindRelated) }
+
+  let(:fileset_id1) { Valkyrie::ID.new'fs1' }
+  let(:fileset_id2) { Valkyrie::ID.new'fs2' }
+  let(:fileset1) { persister.save(resource: Hyrax::Test::FindRelated::FileSet.new(id: fileset_id1)) }
+  let(:fileset2) { persister.save(resource: Hyrax::Test::FindRelated::FileSet.new(id: fileset_id2)) }
+
+  let(:work_id1) { Valkyrie::ID.new'wk1' }
+  let(:work_id2) { Valkyrie::ID.new'wk2' }
+  let(:work1) do
+    persister.save(resource:
+      Hyrax::Test::FindRelated::Work.new.tap do |w|
+        w.id = work_id1
+        w.child_work_ids = [work_id2, 'NOT_AN_ID']
+        w.child_file_set_ids = [fileset_id1, fileset_id2]
+      end)
+  end
+  let(:work2) { persister.save(resource: Hyrax::Test::FindRelated::Work.new(id: work_id2)) }
+
+  describe '.find_related_ids_for' do
+    context 'when all values for the relationship are ids' do
+      subject { query_service.custom_queries.find_related_ids_for(resource: work1, relationship: :child_file_set_ids) }
+      before do
+        fileset1
+        fileset2
+      end
+      it 'returns all related' do
+        expect(subject).to contain_exactly(fileset_id1, fileset_id2)
+      end
+    end
+
+    context 'when mix of ids and other types for the relationship' do
+      subject { query_service.custom_queries.find_related_ids_for(resource: work1, relationship: :child_work_ids) }
+      before { work2 }
+      it 'returns only related values that are ids' do
+        expect(subject).to contain_exactly(work_id2)
+      end
+    end
+  end
+
+  describe '.find_related_for' do
+    context 'when all values for the relationship are ids' do
+      subject { query_service.custom_queries.find_related_for(resource: work1, relationship: :child_file_set_ids) }
+      before do
+        fileset1
+        fileset2
+      end
+      it 'returns all related' do
+        expect(subject.map(&:class).first).to eq(Hyrax::Test::FindRelated::FileSet)
+        expect(subject.map(&:id)).to contain_exactly(fileset_id1, fileset_id2)
+      end
+    end
+
+    context 'when mix of ids and other types for the relationship' do
+      subject { query_service.custom_queries.find_related_for(resource: work1, relationship: :child_work_ids) }
+      before { work2 }
+      it 'returns only related values that are ids' do
+        expect(subject.map(&:class).first).to eq(Hyrax::Test::FindRelated::Work)
+        expect(subject.map(&:id)).to contain_exactly(work_id2)
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/custom_queries/find_related_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_related_spec.rb
@@ -7,63 +7,98 @@ RSpec.describe Hyrax::CustomQueries::FindRelated do
   before do
     query_service.custom_queries.register_query_handler(described_class)
     module Hyrax::Test::FindRelated
+      class Collection < Valkyrie::Resource
+        attribute :collection_has_child_collection_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
+        attribute :collection_has_child_work_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
+      end
       class Work < Valkyrie::Resource
-        attribute :child_work_ids, Valkyrie::Types::Set
-        attribute :child_file_set_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
+        attribute :work_has_child_work_ids, Valkyrie::Types::Set
+        attribute :work_has_child_file_set_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
       end
       class FileSet < Valkyrie::Resource; end
     end
-    # Hyrax::Test::FindRelated::Work
-    # Hyrax::Test::FindRelated::FileSet
   end
 
   after { Hyrax::Test.send(:remove_const, :FindRelated) }
 
-  let(:fileset_id1) { Valkyrie::ID.new'fs1' }
-  let(:fileset_id2) { Valkyrie::ID.new'fs2' }
-  let(:fileset1) { persister.save(resource: Hyrax::Test::FindRelated::FileSet.new(id: fileset_id1)) }
-  let(:fileset2) { persister.save(resource: Hyrax::Test::FindRelated::FileSet.new(id: fileset_id2)) }
+  let(:collection_id1) { Valkyrie::ID.new'col1' }
+  let(:collection_id2) { Valkyrie::ID.new'col2' }
+  let(:collection_id3) { Valkyrie::ID.new'col3' }
+  let!(:collection1) do
+    persister.save(resource:
+      Hyrax::Test::FindRelated::Collection.new.tap do |c|
+        c.id = collection_id1
+        c.collection_has_child_collection_ids = [collection_id2, collection_id3]
+        c.collection_has_child_work_ids = [work_id1]
+      end)
+  end
+  let!(:collection2) do
+    persister.save(resource:
+      Hyrax::Test::FindRelated::Collection.new.tap do |c|
+        c.id = collection_id2
+        c.collection_has_child_work_ids = [work_id1, work_id2]
+      end)
+  end
+  let!(:collection3) { persister.save(resource: Hyrax::Test::FindRelated::Collection.new(id: collection_id3)) }
 
   let(:work_id1) { Valkyrie::ID.new'wk1' }
   let(:work_id2) { Valkyrie::ID.new'wk2' }
-  let(:work1) do
+  let(:work_id3) { Valkyrie::ID.new'wk3' }
+  let!(:work1) do
     persister.save(resource:
       Hyrax::Test::FindRelated::Work.new.tap do |w|
         w.id = work_id1
-        w.child_work_ids = [work_id2, 'NOT_AN_ID']
-        w.child_file_set_ids = [fileset_id1, fileset_id2]
+        w.work_has_child_work_ids = [work_id3, 'NOT_AN_ID']
+        w.work_has_child_file_set_ids = [fileset_id1, fileset_id2]
       end)
   end
-  let(:work2) { persister.save(resource: Hyrax::Test::FindRelated::Work.new(id: work_id2)) }
+  let!(:work2) do
+    persister.save(resource:
+      Hyrax::Test::FindRelated::Work.new.tap do |w|
+        w.id = work_id2
+        w.work_has_child_work_ids = [work_id3]
+      end)
+  end
+  let!(:work3) { persister.save(resource: Hyrax::Test::FindRelated::Work.new(id: work_id3)) }
+
+  let(:fileset_id1) { Valkyrie::ID.new'fs1' }
+  let(:fileset_id2) { Valkyrie::ID.new'fs2' }
+  let!(:fileset1) { persister.save(resource: Hyrax::Test::FindRelated::FileSet.new(id: fileset_id1)) }
+  let!(:fileset2) { persister.save(resource: Hyrax::Test::FindRelated::FileSet.new(id: fileset_id2)) }
 
   describe '.find_related_ids_for' do
     context 'when all values for the relationship are ids' do
-      subject { query_service.custom_queries.find_related_ids_for(resource: work1, relationship: :child_file_set_ids) }
-      before do
-        fileset1
-        fileset2
-      end
+      subject { query_service.custom_queries.find_related_ids_for(resource: work1, relationship: :work_has_child_file_set_ids) }
       it 'returns all related' do
         expect(subject).to contain_exactly(fileset_id1, fileset_id2)
       end
     end
 
     context 'when mix of ids and other types for the relationship' do
-      subject { query_service.custom_queries.find_related_ids_for(resource: work1, relationship: :child_work_ids) }
-      before { work2 }
+      subject { query_service.custom_queries.find_related_ids_for(resource: work1, relationship: :work_has_child_work_ids) }
       it 'returns only related values that are ids' do
-        expect(subject).to contain_exactly(work_id2)
+        expect(subject).to contain_exactly(work_id3)
+      end
+    end
+
+    context 'when there are no resources with the relationship' do
+      subject { query_service.custom_queries.find_related_ids_for(resource: collection2, relationship: :collection_has_child_collection_ids) }
+      it 'returns an empty array' do
+        expect(subject).to eq []
+      end
+    end
+
+    context "when the relationship isn't defined on the resource" do
+      subject { query_service.custom_queries.find_related_ids_for(resource: collection1, relationship: :work_has_child_file_set_ids) }
+      it 'returns an empty array' do
+        expect(subject).to eq []
       end
     end
   end
 
   describe '.find_related_for' do
     context 'when all values for the relationship are ids' do
-      subject { query_service.custom_queries.find_related_for(resource: work1, relationship: :child_file_set_ids) }
-      before do
-        fileset1
-        fileset2
-      end
+      subject { query_service.custom_queries.find_related_for(resource: work1, relationship: :work_has_child_file_set_ids) }
       it 'returns all related' do
         expect(subject.map(&:class).first).to eq(Hyrax::Test::FindRelated::FileSet)
         expect(subject.map(&:id)).to contain_exactly(fileset_id1, fileset_id2)
@@ -71,11 +106,57 @@ RSpec.describe Hyrax::CustomQueries::FindRelated do
     end
 
     context 'when mix of ids and other types for the relationship' do
-      subject { query_service.custom_queries.find_related_for(resource: work1, relationship: :child_work_ids) }
-      before { work2 }
+      subject { query_service.custom_queries.find_related_for(resource: work1, relationship: :work_has_child_work_ids) }
       it 'returns only related values that are ids' do
         expect(subject.map(&:class).first).to eq(Hyrax::Test::FindRelated::Work)
-        expect(subject.map(&:id)).to contain_exactly(work_id2)
+        expect(subject.map(&:id)).to contain_exactly(work_id3)
+      end
+    end
+
+    context 'when there are no resources with the relationship' do
+      subject { query_service.custom_queries.find_related_ids_for(resource: collection2, relationship: :collection_has_child_collection_ids) }
+      it 'returns an empty array' do
+        expect(subject).to eq []
+      end
+    end
+
+    context "when the relationship isn't defined on the resource" do
+      subject { query_service.custom_queries.find_related_ids_for(resource: collection1, relationship: :work_has_child_file_set_ids) }
+      it 'returns an empty array' do
+        expect(subject).to eq []
+      end
+    end
+  end
+
+  describe '.find_inverse_related_ids_for' do
+    context 'when there are inverse related resources' do
+      subject { query_service.custom_queries.find_inverse_related_ids_for(resource: fileset1, relationship: :work_has_child_file_set_ids) }
+      it 'returns all inverse related' do
+        expect(subject).to contain_exactly(work_id1)
+      end
+    end
+
+    context "when there aren't any inverse related resources" do
+      subject { query_service.custom_queries.find_inverse_related_ids_for(resource: collection1, relationship: :collection_has_child_collection_ids) }
+      it 'returns an empty array' do
+        expect(subject).to eq []
+      end
+    end
+  end
+
+  describe '.find_inverse_related_for' do
+    context 'when there are inverse related resources' do
+      subject { query_service.custom_queries.find_inverse_related_for(resource: work3, relationship: :work_has_child_work_ids) }
+      it 'returns all related' do
+        expect(subject.map(&:class).first).to eq(Hyrax::Test::FindRelated::Work)
+        expect(subject.map(&:id)).to contain_exactly(work_id1, work_id2)
+      end
+    end
+
+    context "when there aren't any inverse related resources" do
+      subject { query_service.custom_queries.find_inverse_related_for(resource: collection1, relationship: :collection_has_child_collection_ids) }
+      it 'returns an empty array' do
+        expect(subject).to eq []
       end
     end
   end


### PR DESCRIPTION
Add a custom queries to find related ids and related resources for another resource given an attribute that holds ids to the other related resources.

* find_related_ids_for(resource:, relationship:) - returns ids for the identified relationship
* find_related_for(resource:, relationship:) - returns resources for the identified relationship

This can be used to define relationships in separate attributes instead of putting them all in the members relationship.  This allows for efficient retrieval of ids for a single relationship without having to bring the entire related objects into memory.

The spec shows defining a work with a works relationship (for child works) and file_sets relationship (for child file sets).