### PR TITLE
Introduce a `SimpleWork` for testing, and a factory for it

### DIFF
--- a/spec/factories/hyrax_resource.rb
+++ b/spec/factories/hyrax_resource.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+##
+# Use for generic Resources, with Hyrax assumptions.
 FactoryBot.define do
   factory :hyrax_resource, class: "Hyrax::Resource" do
     trait :under_embargo do

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+##
+# Use this factory for generic Hyrax/HydraWorks Works in valkyrie.
 FactoryBot.define do
   factory :hyrax_work, class: 'Hyrax::Test::SimpleWork' do
     trait :under_embargo do

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :hyrax_work, class: 'Hyrax::Test::SimpleWork' do
+    trait :under_embargo do
+      association :embargo, factory: :hyrax_embargo
+    end
+
+    trait :under_lease do
+      association :lease, factory: :hyrax_lease
+    end
+
+    transient do
+      visibility_setting { nil }
+    end
+
+    after(:build) do |work, evaluator|
+      if evaluator.visibility_setting
+        Hyrax::VisibilityWriter
+          .new(resource: work)
+          .assign_access_for(visibility: evaluator.visibility_setting)
+      end
+    end
+
+    after(:create) do |work, evaluator|
+      if evaluator.visibility_setting
+        writer = Hyrax::VisibilityWriter.new(resource: work)
+        writer.assign_access_for(visibility: evaluator.visibility_setting)
+        writer.permission_manager.acl.save
+      end
+    end
+
+    trait :public do
+      transient do
+        visibility_setting { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,11 @@ unless ENV['SKIP_MALEFICENT']
   end
 end
 
+# rubocop:disable Lint/Void
+# ensure Hyrax::Schema gets loaded is resolvable for `support/` models
+Hyrax::Schema
+# rubocop:enable Lint/Void
+
 # Require supporting ruby files from spec/support/ and subdirectories.  Note: engine, not Rails.root context.
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 

--- a/spec/support/book_resource.rb
+++ b/spec/support/book_resource.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 module Hyrax
   module Test
+    ##
+    # A simple Hyrax::Resource with some metadata.
+    #
+    # Use this for testing valkyrie models generically, with Hyrax assumptions
+    # but no PCDM modelling behavior.
     class BookResource < Hyrax::Resource
       attribute :author,   Valkyrie::Types::String
       attribute :created,  Valkyrie::Types::Date

--- a/spec/support/simple_work.rb
+++ b/spec/support/simple_work.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Test
+    class SimpleWork < Hyrax::Resource
+      # use the *private* initalizer here to ensure the module gets loaded
+      # use `include Hyrax::Schema(:core_metadata)
+      include Hyrax::Schema(:core_metadata)
+    end
+
+    class SimpleWorkLegacy < ActiveFedora::Base
+      include WorkBehavior
+      include CoreMetadata
+    end
+  end
+end
+
+Wings::ModelRegistry.register(Hyrax::Test::SimpleWork, Hyrax::Test::SimpleWorkLegacy)

--- a/spec/support/simple_work.rb
+++ b/spec/support/simple_work.rb
@@ -2,6 +2,14 @@
 
 module Hyrax
   module Test
+    ##
+    # A generic PCDM Work, with only Hyrax "core" (required) metadata.
+    #
+    # @example building with FactoryBot
+    #   work = FactoryBot.build(:hyrax_work, :public, title: ['Comet in Moominland'])
+    #
+    # @example creating with FactoryBot
+    #   work = FactoryBot.valkyrie_create(:hyrax_work, :public, title: ['Comet in Moominland'])
     class SimpleWork < Hyrax::Resource
       # use the *private* initalizer here to ensure the module gets loaded
       # use `include Hyrax::Schema(:core_metadata)

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       end
 
       context 'and it is registered' do
-        let(:resource) { Hyrax::Test::BookResource.new }
+        let(:resource) { build(:hyrax_work) }
 
         it 'maps to the registered ActiveFedora class' do
-          expect(converter.convert).to be_a Hyrax::Test::Book
+          expect(converter.convert).to be_a Hyrax::Test::SimpleWorkLegacy
         end
       end
     end


### PR DESCRIPTION
This "Simple Work" is meant for testing native-Valkyrie works. It has only the
core Hyrax metadata for now, but should be extended with the minumum Work
model (members, etc...; i.e. it should inherit `Hyrax::Work` or something along
those lines).

A factory is added with some basic visibility traits.

For Wings support, `SimpleWorkLegacy`, a work with `CoreMetadata` and
`WorkBehavior` is provided.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* This is a test suite only PR

@samvera/hyrax-code-reviewers
