### PR TITLE
Convert file ids in resource fileset to pcdm files in AF fileset

### DIFF
--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -328,6 +328,26 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
           expect(converter.convert.ordered_member_ids).to eq [work2.id, work3.id]
         end
       end
+
+      context 'for files' do
+        let(:pcdm_object) { fileset1 }
+
+        let(:fileset1) { create(:file_set) }
+        let(:file_id) { fileset1.original_file.id }
+
+        before do
+          binary = StringIO.new("hey")
+          Hydra::Works::AddFileToFileSet.call(fileset1, binary, :original_file)
+          expect(fileset1.original_file).not_to be_nil
+          expect(resource.original_file_ids.first.to_s).to eq file_id
+        end
+
+        it 'has same original_file id as valkyrie resource' do
+          converted_file_set = converter.convert
+          expect(converted_file_set.original_file).not_to be_nil
+          expect(converted_file_set.original_file.id).to eq file_id
+        end
+      end
     end
   end
 end

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -91,7 +91,6 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
     let(:versioning) { true }
     subject { described_class.call(file_set: file_set, file: pdf_file, type: original_file_use, versioning: versioning) }
     it 'updates the file and creates a version' do
-      pending 'Valkyrization of versioning for files'
       expect(subject.original_file.versions.all.count).to eq(1)
       expect(subject.original_file.content).to start_with('%PDF-1.3')
     end
@@ -116,7 +115,6 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
     end
     subject { described_class.call(file_set: file_set, file: text_file, type: original_file_use, versioning: versioning) }
     it 'skips creating versions' do
-      pending 'Valkyrization of versioning for files'
       expect(subject.original_file.versions.all.count).to eq(0)
       expect(subject.original_file.content).to eq("some updated content\n")
     end


### PR DESCRIPTION
### Description

Add `convert_files` to the process that converts a resource to af object

Related to Issue #4060 Wings: Round trip conversion of files does not maintain file relationships

### Description of Issue with this PR

When round tripping from AF to Valk to AF, the existing file is assigned a new ID while being set on the FileSet

### Behaviors 

The described behaviors assume the same starting `fileset1` object created in Issue #3406 

```
fileset1.class # FileSet
fileset1.id #  abc12345
fileset1.original_file.id # ab/c1/23/45/abc12345/files/xyz67890
```

`rt_fileset` is the round trip fileset from the conversion from `fileset1` to a valkyrie `resource` and back to an ActiveFedora based fileset.

#### Expected behavior

```
rt_fileset.class # FileSet
rt_fileset.id # abc12345
rt_fileset.original_file # <Hydra::PCDM::file uri="http://127.0.0.1:8986/rest/test/ab/c1/23/45/abc12345/files/xyz67890">
rt_fileset.filter_files_by_type(RDF::URI.new('http://pcdm.org/use#OriginalFile')) # [<Hydra::PCDM::File uri="http://127.0.0.1:8986/rest/test/ab/c1/23/45/abc12345/files/xyz67890">]
rt_fileset.original_file.id # "ab/c1/23/45/abc12345/files/xyz67890"
rt_fileset.original_file.uri # "http://127.0.0.1:8986/rest/test/ab/c1/23/45/abc12345/files/xyz67890"
rt_fileset.files # [#<Hydra::PCDM::File uri="http://127.0.0.1:8986/rest/test/ab/c1/23/45/abc12345/files/xyz67890" >]
rt_fileset.original_file.id == fileset1.original_file.id # true
```

#### Actual behavior using this PR's `ActiveFedoraConverter #convert_file` method

```
rt_fileset.class # FileSet
rt_fileset.id # abc12345
rt_fileset.original_file # <Hydra::PCDM::file uri="http://127.0.0.1:8986/rest/test/ab/c1/23/45/abc12345/files/DIFFERENT_ID">
rt_fileset.filter_files_by_type(RDF::URI.new('http://pcdm.org/use#OriginalFile')) # [<Hydra::PCDM::file uri="http://127.0.0.1:8986/rest/test/ab/c1/23/45/abc12345/files/DIFFERENT_ID">]
rt_fileset.original_file.id # "ab/c1/23/45/abc12345/files/DIFFERENT_ID"
rt_fileset.original_file.uri # "http://127.0.0.1:8986/rest/test/ab/c1/23/45/abc12345/files/DIFFERENT_ID"
rt_fileset.files # [<Hydra::PCDM::file uri="http://127.0.0.1:8986/rest/test/ab/c1/23/45/abc12345/files/DIFFERENT_ID">]
rt_fileset.original_file.id == fileset1.original_file.id # false
```

NOTE: The original_file's ID and URI show the file in the same fileset, but it has a different unique identifier extension for the file.

### To Reproduce

```
fileset1 = FileSet.new
binary = StringIO.new("hey")
Hydra::Works::AddFileToFileSet.call(fileset1, binary, :original_file)
resource = fileset1.valkyrie_resource
rt_fileset = ActiveFedoraConverter.new(resource: resource).convert
```

### Trace of significant method calls causing the IDs to be different

In Wings::ActiveFedoraConverter #convert_files call #convert_file with line...
```
      af_object[relation] = pcdm_file
```
calls ActiverFedora::Attributes #[]= with line...
```
      assoc.replace(value)
```
calls ActiveFedora::Associations::DirectlyContainsOneAssociation #replace with line...
```
      add_to_container(record)
```
calls ActiveFedora::Associations::DirectlyContainsOneAssociation #add_to_container with line...
```
      container_association.send(:initialize_attributes, record)
```
calls ActiveFedora::Associations::DirectlyContainsAssociation #initialize_attributes with line...
```
      record.uri = ActiveFedora::Base.id_to_uri(container.mint_id)
```
which mints the new id for the existing PCDM File
