### PR TITLE
[WIP] allow characterize_job to receive valkyrie resource

### DIFF
--- a/app/helpers/valkyrie_transition_helper.rb
+++ b/app/helpers/valkyrie_transition_helper.rb
@@ -1,0 +1,87 @@
+class ValkyrieTransitionHelper
+  class << self
+    # Save an object
+    # @param object [ActiveFedora::Base | Valkyrie::Resource] the object to be saved
+    # @return [ActiveFedora::Base | Valkyrie::Resource | FalseClass] the saved object or false if save fails
+    # @raise [ArgumentError]
+    def save(object:)
+      raise ArgumentError, "Object argument must be a Valkyrie::Resource or an ActiveFedora object" unless valkyrie_object?(object) || active_fedora_object?(object)
+      return object.save if active_fedora_object?(object)
+      save_resource(resource: object)
+    end
+
+    # Save a resource
+    # @param resource [Valkyrie::Resource] the resource to be saved
+    # @return [Valkyrie::Resource | FalseClass] the saved resource or false if save fails
+    # @raise [ArgumentError]
+    def save_resource(resource:)
+      raise ArgumentError, "Resource argument must be a Valkyrie::Resource" unless valkyrie_object? resource
+      Hyrax.persister.save(resource: resource)
+    rescue Wings::Valkyrie::Persister::FailedSaveError
+      false
+    end
+
+    # Reload an object
+    # @param object [ActiveFedora::Base | Valkyrie::Resource] the object to be reloaded
+    # @return [ActiveFedora::Base | Valkyrie::Resource | FalseClass] the reloaded object
+    # @raise [Hyrax::ObjectNotFoundError, ArgumentError]
+    def reload(object:)
+      raise ArgumentError, "Object argument must be a Valkyrie::Resource or an ActiveFedora object" unless valkyrie_object?(object) || active_fedora_object?(object)
+      return object.reload if active_fedora_object?(object)
+      reload_resource(resource: object)
+    end
+
+    # Reload a resource
+    # @param resource [Valkyrie::Resource] the resource to be reloaded
+    # @return [Valkyrie::Resource | FalseClass] the reloaded resource
+    # @raise [Hyrax::ObjectNotFoundError, ArgumentError]
+    def reload_resource(resource:)
+      raise ArgumentError, "Resource argument must be a Valkyrie::Resource" unless valkyrie_object? resource
+      raise ArgumentError, "Resource argument must have an id assigned" unless resource.id
+      Hyrax.query_service.find_by(id: resource.id)
+    end
+
+    # Determine if valkyrie processing should be used either because it was specifically requested (i.e. use_valkyrie == true)
+    # or because at least one the objects is a valkyrie object.
+    # @param use_valkyrie [Boolean] true if valkyrie processing was specifically requested.
+    # @param objects [Array<ActiveFedora::Base, Valkyrie::Resource>] the set of objects to check; if any are valkyrie resources, then true is returned
+    # @return [Boolean] true if valkyrie was requested or any of the objects is a valkyrie object
+    def force_use_valkyrie(use_valkyrie: false, objects: [])
+      use_valkyrie || (objects.any? { |o| valkyrie_object?(o) })
+    end
+
+    # Convert the objects to Valkyrie resources, if needed.
+    # @param object [ActiveFedora::Base, Valkyrie::Resource] the object to convert to valkyrie if it isn't already
+    # @return [Valkyrie::Resource]
+    # @raise [ArgumentError]
+    def to_resource(object)
+      raise ArgumentError, "Object argument must be a Valkyrie::Resource or an ActiveFedora object" unless valkyrie_object?(object) || active_fedora_object?(object)
+      return object if valkyrie_object?(object)
+      object.valkyrie_resource
+    end
+
+    # Convert the objects to Active Fedora objects, if needed.
+    # @param object [ActiveFedora::Base, Valkyrie::Resource] the object to convert to active fedora if it isn't already
+    # @return [ActiveFedora::Base]
+    # @raise [ArgumentError]
+    def to_active_fedora(object)
+      raise ArgumentError, "Object argument must be a Valkyrie::Resource or an ActiveFedora object" unless valkyrie_object?(object) || active_fedora_object?(object)
+      return object if active_fedora_object?(object)
+      Wings::ActiveFedoraConverter.new(resource: object).convert
+    end
+
+    # determine if the object is a valkyrie resource
+    # @param object [ActiveFedora::Base | Valkyrie::Resource] the object being checked
+    # @return true if it is a Valkyrie::Resource
+    def valkyrie_object?(object)
+      object.is_a? Valkyrie::Resource
+    end
+
+    # determine if the object is an ActiveFedora object
+    # @param object [ActiveFedora::Base | Valkyrie::Resource] the object being checked
+    # @return true if it is a ActiveFedora::Base
+    def active_fedora_object?(object)
+      object.is_a? ActiveFedora::Base
+    end
+  end
+end

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -3,10 +3,14 @@ class CharacterizeJob < Hyrax::ApplicationJob
 
   # Characterizes the file at 'filepath' if available, otherwise, pulls a copy from the repository
   # and runs characterization on that file.
-  # @param [FileSet] file_set
+  # @param [FileSet, Valkyrie::Resource] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
   def perform(file_set, file_id, filepath = nil)
+    # STATUS: Valkyrie Transistion - currently converts a Valkyrie::Resource to a FileSet as it enters this method.
+    # TODO: Valkyrie Transistion - Next step is to make the characterization process operate on a Valkyrie::Resource.
+    file_set = ValkyrieTransitionHelper.to_active_fedora(file_set)
+
     raise "#{file_set.class.characterization_proxy} was not found for FileSet #{file_set.id}" unless file_set.characterization_proxy?
     filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id) unless filepath && File.exist?(filepath)
     characterize(file_set, file_id, filepath)

--- a/spec/helpers/valkyrie_transition_helper_spec.rb
+++ b/spec/helpers/valkyrie_transition_helper_spec.rb
@@ -1,0 +1,204 @@
+require 'spec_helper'
+require 'wings'
+
+RSpec.describe ValkyrieTransitionHelper do
+  # before do
+  #   Valkyrie::MetadataAdapter.register(
+  #       Valkyrie::Persistence::Memory::MetadataAdapter.new, :memory_adapter
+  #   )
+  #   Valkyrie.config.metadata_adapter = :memory_adapter
+  # end
+
+  let(:af_object) { FileSet.new }
+  let(:resource) { af_object.valkyrie_resource }
+
+  describe ".save" do
+    context 'when given an active fedora object' do
+      it 'saves the active fedora object using active fedora' do
+        expect(af_object).to receive(:save)
+        described_class.save(object: af_object)
+      end
+    end
+
+    context 'when given a valkyrie resource' do
+      it 'saves the resource using .save_resource' do
+        expect(described_class).to receive(:save_resource).with(resource: resource)
+        described_class.save(object: resource)
+      end
+    end
+
+    context 'when object is neither an active fedora object or a valkyrie resource' do
+      it 'raises ArgumentError' do
+        expect { described_class.save(object: 'invalid_object') }.to raise_error(ArgumentError, "Object argument must be a Valkyrie::Resource or an ActiveFedora object")
+      end
+    end
+  end
+
+  describe ".save_resource" do
+    context 'when passed a resource' do
+      context 'and saves without errors' do
+        it 'saves the resource' do
+          expect(described_class.save_resource(resource: resource)).to be_a Valkyrie::Resource
+        end
+      end
+
+      context 'and fails to save' do
+        before do
+          allow_any_instance_of(Wings::Valkyrie::Persister) # rubocop:disable RSpec/AnyInstance
+            .to receive(:save)
+            .with(resource: resource)
+            .and_raise(Wings::Valkyrie::Persister::FailedSaveError, obj: af_object) # TODO: Should not rescue a wings specific exception in Hyrax code
+        end
+
+        it 'returns false' do
+          expect(described_class.save_resource(resource: resource)).to eq false
+        end
+      end
+    end
+
+    context 'when resource is not a valkyrie resource' do
+      it 'raises ArgumentError' do
+        expect { described_class.save_resource(resource: af_object) }.to raise_error(ArgumentError, "Resource argument must be a Valkyrie::Resource")
+      end
+    end
+  end
+
+  describe ".reload" do
+    context 'when given an active fedora object' do
+      it 'reloads the active fedora object using active fedora' do
+        expect(af_object).to receive(:reload)
+        described_class.reload(object: af_object)
+      end
+    end
+
+    context 'when given a valkyrie resource' do
+      it 'reloads the resource using .reload_resource' do
+        expect(described_class).to receive(:reload_resource).with(resource: resource)
+        described_class.reload(object: resource)
+      end
+    end
+
+    context 'when object is neither an active fedora object or a valkyrie resource' do
+      it 'raises ArgumentError' do
+        expect { described_class.reload(object: 'invalid_object') }.to raise_error(ArgumentError, "Object argument must be a Valkyrie::Resource or an ActiveFedora object")
+      end
+    end
+  end
+
+  describe ".reload_resource" do
+    context 'when passed a resource with an id' do
+      it 'reloads the resource' do
+        expect(described_class.reload_resource(resource: Hyrax.persister.save(resource: resource))).to be_a Valkyrie::Resource
+      end
+    end
+
+    context 'when resource does not have an id assigned' do
+      before { allow(resource).to receive(:id).and_return(nil) }
+      it 'raises ArgumentError' do
+        expect { described_class.reload_resource(resource: resource) }.to raise_error(ArgumentError, "Resource argument must have an id assigned")
+      end
+    end
+
+    context 'when resource is not a valkyrie resource' do
+      it 'raises ArgumentError' do
+        expect { described_class.reload_resource(resource: af_object) }.to raise_error(ArgumentError, "Resource argument must be a Valkyrie::Resource")
+      end
+    end
+  end
+
+  describe ".force_use_valkyrie" do
+    context 'when use_valkyrie is true' do
+      it 'returns true' do
+        expect(described_class.force_use_valkyrie(use_valkyrie: true)).to eq true
+      end
+    end
+
+    context 'when use_valkyrie is false' do
+      context 'and at least one object is a valkyrie object' do
+        it 'returns true' do
+          expect(described_class.force_use_valkyrie(use_valkyrie: false, objects: [resource])).to eq true
+        end
+      end
+
+      context 'and none of the objects is a valkyrie object' do
+        it 'returns false' do
+          expect(described_class.force_use_valkyrie(use_valkyrie: false, objects: [af_object])).to eq false
+        end
+      end
+
+      context 'and there are no objects' do
+        it 'returns false' do
+          expect(described_class.force_use_valkyrie(use_valkyrie: false, objects: [])).to eq false
+        end
+      end
+    end
+  end
+
+  describe ".to_resource" do
+    context 'when object is a valkyrie resource' do
+      it 'returns the passed in valkyrie resource' do
+        expect(described_class.to_resource(resource)).to eq resource
+      end
+    end
+
+    context 'when object is an active fedora object' do
+      it 'returns a valkyrie resource' do
+        expect(described_class.to_resource(af_object)).to be_a Valkyrie::Resource
+      end
+    end
+
+    context 'when object is neither an active fedora object or a valkyrie resource' do
+      it 'raises ArgumentError' do
+        expect { described_class.to_resource('invalid_object') }.to raise_error(ArgumentError, "Object argument must be a Valkyrie::Resource or an ActiveFedora object")
+      end
+    end
+  end
+
+  describe ".to_active_fedora" do
+    context 'when object is a valkyrie resource' do
+      it 'returns a active fedora object' do
+        expect(described_class.to_active_fedora(resource)).to be_a ActiveFedora::Base
+      end
+    end
+
+    context 'when object is an active fedora object' do
+      it 'returns the passed in active fedora object' do
+        expect(described_class.to_active_fedora(af_object)).to eq af_object
+      end
+    end
+
+    context 'when object is neither an active fedora object or a valkyrie resource' do
+      it 'raises ArgumentError' do
+        expect { described_class.to_active_fedora('invalid_object') }.to raise_error(ArgumentError, "Object argument must be a Valkyrie::Resource or an ActiveFedora object")
+      end
+    end
+  end
+
+  describe ".valkyrie_object?" do
+    context 'when object is a valkyrie resource' do
+      it 'returns true' do
+        expect(described_class.valkyrie_object?(resource)).to eq true
+      end
+    end
+
+    context 'when object is an active fedora object' do
+      it 'returns false' do
+        expect(described_class.valkyrie_object?(af_object)).to eq false
+      end
+    end
+  end
+
+  describe ".active_fedora_object?" do
+    context 'when object is a valkyrie resource' do
+      it 'returns false' do
+        expect(described_class.active_fedora_object?(resource)).to eq false
+      end
+    end
+
+    context 'when object is an active fedora object' do
+      it 'returns true' do
+        expect(described_class.active_fedora_object?(af_object)).to eq true
+      end
+    end
+  end
+end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -1,80 +1,70 @@
 RSpec.describe CharacterizeJob do
   [true, false].each do |test_valkyrie|
     context "when test_valkyrie is #{test_valkyrie}" do
-  let(:file_set_id) { 'abc12345' }
-  let(:filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
-  # let(:af_filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
-  # let(:valk_filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'files', 'picture.png').to_s }
-  # let(:filename) { test_valkyrie ? valk_filename : af_filename }
-  let(:af_file_set) do
-    FileSet.new(id: file_set_id).tap do |fs|
-      allow(fs).to receive(:original_file).and_return(file)
-      allow(fs).to receive(:update_index)
-    end
-  end
-  let(:valk_file_set) { af_file_set.valkyrie_resource }
-  let(:file_set) { test_valkyrie ? valk_file_set : af_file_set }
-  let(:file) do
-    # af_file_set.file_set.association(:original_file)
-    Hydra::PCDM::File.new.tap do |f|
-    # Hydra::PCDM::File.new(id: "ab/c1/23/45/abc12345/files/xyp98764").tap do |f|
-      f.content = 'foo'
-      f.original_name = 'picture.png'
-      f.save!
-      allow(f).to receive(:save!)
-    end
-  end
-  let(:valk_file_ids) { [Valkyrie::ID.new(file.id)] }
+      before do
+        Hydra::Works::AddFileToFileSet.call(af_file_set,
+                                            File.open(fixture_path + '/world.png'),
+                                            :original_file)
+        allow(ValkyrieTransitionHelper).to receive(:to_active_fedora).with(any_args).and_return(af_file_set)
+        allow(FileSet).to receive(:find).with(file_set_id).and_return(af_file_set)
+        allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+        allow(CreateDerivativesJob).to receive(:perform_later).with(af_file_set, file_id, filename)
+      end
 
-  before do
-    allow(FileSet).to receive(:find).with(file_set_id).and_return(af_file_set)
-    allow_any_instance_of(FileSet).to receive(:new_record?).and_return(false) if test_valkyrie # rubocop:disable RSpec/AnyInstance
-byebug
-    allow_any_instance_of(valk_file_set).to receive(:original_file_ids).and_return(valk_file_ids) if test_valkyrie # rubocop:disable RSpec/AnyInstance
-    allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-    allow(CreateDerivativesJob).to receive(:perform_later).with(af_file_set, file.id, filename)
-  end
+      let(:file_set_id) { af_file_set.id }
+      let(:af_file_set) { create(:file_set) }
+      let(:valk_file_set) { af_file_set.valkyrie_resource }
+      let(:file_set) { test_valkyrie ? valk_file_set : af_file_set }
 
-  context 'with valid filepath param' do
-    let(:filename) { File.join(fixture_path, 'world.png') }
+      let(:file_id) { file.id }
+      let(:file) { af_file_set.original_file }
+      let(:filename) do
+        Rails.root.join('tmp', 'uploads',
+                        file_set_id[0..1], file_set_id[2..3], file_set_id[4..5], file_set_id[6..7],
+                        file_set_id, 'world.png').to_s
+      end
+      let(:valk_file_ids) { [Valkyrie::ID.new(file_id)] }
 
-    it 'skips Hyrax::WorkingDirectory' do
-      expect(Hyrax::WorkingDirectory).not_to receive(:find_or_retrieve)
-      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-      described_class.perform_now(file_set, file.id, filename)
-    end
-  end
+      context 'with valid filepath param' do
+        let(:filename) { File.join(fixture_path, 'world.png') }
 
-  context 'when the characterization proxy content is present' do
-    it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
-      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-      expect(file).to receive(:save!)
-      expect(af_file_set).to receive(:update_index)
-      expect(CreateDerivativesJob).to receive(:perform_later).with(af_file_set, file.id, filename)
-      described_class.perform_now(file_set, file.id)
-    end
-  end
+        it 'skips Hyrax::WorkingDirectory' do
+          expect(Hyrax::WorkingDirectory).not_to receive(:find_or_retrieve)
+          expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+          described_class.perform_now(file_set, file_id, filename)
+        end
+      end
 
-  context 'when the characterization proxy content is absent' do
-    before { allow(af_file_set).to receive(:characterization_proxy?).and_return(false) }
-    it 'raises an error' do
-      expect { described_class.perform_now(file_set, file.id) }.to raise_error(StandardError, /original_file was not found/)
-    end
-  end
+      context 'when the characterization proxy content is present' do
+        it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
+          expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+          expect(file).to receive(:save!)
+          expect(af_file_set).to receive(:update_index)
+          expect(CreateDerivativesJob).to receive(:perform_later).with(af_file_set, file_id, filename)
+          described_class.perform_now(file_set, file_id)
+        end
+      end
 
-  context "when the file set's work is in a collection" do
-    let(:work)       { build(:generic_work) }
-    let(:collection) { build(:collection_lw) }
+      context 'when the characterization proxy content is absent' do
+        before { allow(af_file_set).to receive(:characterization_proxy?).and_return(false) }
+        it 'raises an error' do
+          expect { described_class.perform_now(file_set, file_id) }.to raise_error(StandardError, /original_file was not found/)
+        end
+      end
 
-    before do
-      allow(af_file_set).to receive(:parent).and_return(work)
-      allow(work).to receive(:in_collections).and_return([collection])
-    end
-    it "reindexes the collection" do
-      expect(collection).to receive(:update_index)
-      described_class.perform_now(file_set, file.id)
-    end
-  end
+      context "when the file set's work is in a collection" do
+        let(:work)       { build(:generic_work) }
+        let(:collection) { build(:collection_lw) }
+
+        before do
+          allow(af_file_set).to receive(:parent).and_return(work)
+          allow(work).to receive(:in_collections).and_return([collection])
+        end
+        it "reindexes the collection" do
+          expect(collection).to receive(:update_index)
+          described_class.perform_now(file_set, file_id)
+        end
+      end
     end
   end
 end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -1,26 +1,38 @@
 RSpec.describe CharacterizeJob do
+  [true, false].each do |test_valkyrie|
+    context "when test_valkyrie is #{test_valkyrie}" do
   let(:file_set_id) { 'abc12345' }
   let(:filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
-  let(:file_set) do
+  # let(:af_filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
+  # let(:valk_filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'files', 'picture.png').to_s }
+  # let(:filename) { test_valkyrie ? valk_filename : af_filename }
+  let(:af_file_set) do
     FileSet.new(id: file_set_id).tap do |fs|
       allow(fs).to receive(:original_file).and_return(file)
       allow(fs).to receive(:update_index)
     end
   end
-  # let(:io)          { JobIoWrapper.new(file_set_id: file_set.id, user: create(:user), path: filename) }
+  let(:valk_file_set) { af_file_set.valkyrie_resource }
+  let(:file_set) { test_valkyrie ? valk_file_set : af_file_set }
   let(:file) do
+    # af_file_set.file_set.association(:original_file)
     Hydra::PCDM::File.new.tap do |f|
+    # Hydra::PCDM::File.new(id: "ab/c1/23/45/abc12345/files/xyp98764").tap do |f|
       f.content = 'foo'
       f.original_name = 'picture.png'
       f.save!
       allow(f).to receive(:save!)
     end
   end
+  let(:valk_file_ids) { [Valkyrie::ID.new(file.id)] }
 
   before do
-    allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
+    allow(FileSet).to receive(:find).with(file_set_id).and_return(af_file_set)
+    allow_any_instance_of(FileSet).to receive(:new_record?).and_return(false) if test_valkyrie # rubocop:disable RSpec/AnyInstance
+byebug
+    allow_any_instance_of(valk_file_set).to receive(:original_file_ids).and_return(valk_file_ids) if test_valkyrie # rubocop:disable RSpec/AnyInstance
     allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-    allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+    allow(CreateDerivativesJob).to receive(:perform_later).with(af_file_set, file.id, filename)
   end
 
   context 'with valid filepath param' do
@@ -37,14 +49,14 @@ RSpec.describe CharacterizeJob do
     it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
       expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
       expect(file).to receive(:save!)
-      expect(file_set).to receive(:update_index)
-      expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+      expect(af_file_set).to receive(:update_index)
+      expect(CreateDerivativesJob).to receive(:perform_later).with(af_file_set, file.id, filename)
       described_class.perform_now(file_set, file.id)
     end
   end
 
   context 'when the characterization proxy content is absent' do
-    before { allow(file_set).to receive(:characterization_proxy?).and_return(false) }
+    before { allow(af_file_set).to receive(:characterization_proxy?).and_return(false) }
     it 'raises an error' do
       expect { described_class.perform_now(file_set, file.id) }.to raise_error(StandardError, /original_file was not found/)
     end
@@ -55,12 +67,14 @@ RSpec.describe CharacterizeJob do
     let(:collection) { build(:collection_lw) }
 
     before do
-      allow(file_set).to receive(:parent).and_return(work)
+      allow(af_file_set).to receive(:parent).and_return(work)
       allow(work).to receive(:in_collections).and_return([collection])
     end
     it "reindexes the collection" do
       expect(collection).to receive(:update_index)
       described_class.perform_now(file_set, file.id)
+    end
+  end
     end
   end
 end


### PR DESCRIPTION
**[WIP]**

**PR #4057 needs to be merged and this PR rebased before this one is merged.**

NOTE: Passing a valkyrie resource will not work until PR #4055 is fixed.  It is safe to merge this without this fix because the error is only seen when using valkyrie.  Normal functioning with an active fedora object works the same as before this PR.

----

If CharacterizeJob receives a Valkyrie::Resource immediately convert it to an AF object.  This allows callers of this job to be fully valkyrized.

### Prerequisite

* PR #4055 Convert file ids in resource fileset to pcdm files in AF fileset
* PR #4057 add valkyrie_transition_helper to help with the transition

### TODO for Valkyrie Transition

Make CharacterizeJob able to process a Valkyrie::Resource.

### Related Work

This supports full valkyrization of new service Hyrax::Files::IngestFileService (replacing FileActor #ingest_file method).
