### PR TITLE
Fix depositor summary page flicker when switching tabs

### DIFF
--- a/app/assets/stylesheets/hyrax/_users.scss
+++ b/app/assets/stylesheets/hyrax/_users.scss
@@ -16,11 +16,16 @@
 
 .activity-display {
   max-height: 100%;
-  overflow: scroll;
-  padding-bottom: 300px;
+  overflow-y: auto;
+  padding-bottom: 0;
   position: relative;
 
   .activity-date {
     padding-right: 130px;
   }
+}
+
+.tab-content .activity-display {
+  max-height: 30em;
+  position: absolute;
 }

--- a/app/views/hyrax/users/_profile_tabs.html.erb
+++ b/app/views/hyrax/users/_profile_tabs.html.erb
@@ -3,7 +3,7 @@
         <li><a href="#activity_log"><i class="glyphicon glyphicon-calendar"></i> <%= I18n.t('hyrax.user_profile.tab_activity') %></a></li>
       </ul>
 
-      <div class="tab-content">
+      <div class="tab-content panel-body">
         <%= render 'contributions', presenter: presenter %>
         <%= render 'activity', presenter: presenter %>
       </div> <!-- /tab-content -->


### PR DESCRIPTION
Fixes #3402 

Changes proposed in this pull request:
Styling changes to the html element showing the depositor summary

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to Home page
* Click on `Recently Uploaded` tab
* Click on depositor's name
* Switch between two tabs `Highlighted` and `Activity`

After the fix:
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/1331659/65915428-72fe0280-e3a1-11e9-95be-2c834131b4a3.gif)


@samvera/hyrax-code-reviewers
