### PR TITLE
[wings] Implement `#name` for classes generated by `OrmConverter`

### DIFF
--- a/lib/wings/orm_converter.rb
+++ b/lib/wings/orm_converter.rb
@@ -52,12 +52,15 @@ module Wings
         include Wings::Works::WorkValkyrieBehavior if klass.included_modules.include?(Hyrax::WorkBehavior)
         include Wings::Works::FileSetValkyrieBehavior if klass.included_modules.include?(Hyrax::FileSetBehavior)
 
-        # Based on Valkyrie implementation, we call Class.to_s to define
-        # the internal resource.
+        # Based on Valkyrie implementation, we call Class.to_s to define the internal resource.
         @internal_resource = klass.to_s
 
         class << self
           attr_reader :internal_resource
+
+          def name
+            ancestors[1..-1].find { |parent| parent < ::Valkyrie::Resource }&.name
+          end
         end
 
         def self.to_s
@@ -76,10 +79,6 @@ module Wings
           attribute property_name, ::Valkyrie::Types::ID
         end
 
-        # Defined after properties in case we have an `internal_resource` property.
-        # This may not be ideal, but based on my understanding of the `internal_resource`
-        # usage in Valkyrie, I'd rather keep synchronized the instance_method and class_method value for
-        # `internal_resource`
         def internal_resource
           self.class.internal_resource
         end
@@ -87,3 +86,5 @@ module Wings
     end
   end
 end
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/MethodLength

--- a/spec/wings/orm_converter_spec.rb
+++ b/spec/wings/orm_converter_spec.rb
@@ -6,15 +6,42 @@ RSpec.describe Wings::OrmConverter do
   describe '.to_valkyrie_resource_class' do
     context 'when given a ActiveFedora class (eg. a constant that responds to #properties)' do
       context 'for the returned object (e.g. a class)' do
-        subject { described_class.to_valkyrie_resource_class(klass: GenericWork) }
-        it 'will be Valkyrie::Resource build' do
-          expect(subject.new).to be_a Valkyrie::Resource
+        subject(:klass) { described_class.to_valkyrie_resource_class(klass: GenericWork) }
+
+        it 'will be Hyrax::Resource build' do
+          expect(subject.new).to be_a Hyrax::Resource
         end
+
         it 'has a to_s instance that delegates to the given klass' do
           expect(subject.to_s).to eq(GenericWork.to_s)
         end
+
         it 'has a internal_resource instance that is the given klass' do
           expect(subject.internal_resource).to eq(GenericWork.to_s)
+        end
+
+        it 'has a name' do
+          expect(klass.name).to eq 'Hyrax::Resource'
+        end
+
+        it 'includes name in instance inspect' do
+          expect(klass.new.inspect).to start_with '#<Hyrax::Resource'
+        end
+      end
+
+      context 'for a custom class' do
+        subject(:klass) { described_class.to_valkyrie_resource_class(klass: Hyrax::Test::Book) }
+
+        it 'will be the registered resource class' do
+          expect(subject.new).to be_a Hyrax::Test::BookResource
+        end
+
+        it 'has a name' do
+          expect(klass.name).to eq 'Hyrax::Test::BookResource'
+        end
+
+        it 'includes name in instance inspect' do
+          expect(klass.new.inspect).to start_with '#<Hyrax::Test::BookResource'
         end
       end
     end


### PR DESCRIPTION
Allows `Wings` generated classes to have a `.name` for `#inspect` and error reporting cases.

@samvera/hyrax-code-reviewers
