### PR TITLE
Temporary patch for Valkyrie#760

### DIFF
--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -38,6 +38,23 @@ module Hyrax
              :read_groups, :read_groups=,
              :read_users,  :read_users=, to: :permission_manager
 
+    def self.attributes(new_schema)
+      result = super
+
+      new_schema.each_key do |key|
+        key = key.to_s.chomp('?').to_sym
+        next if instance_methods.include?("#{key}=".to_sym)
+
+        class_eval(<<-RUBY)
+          def #{key}=(value)
+            set_value("#{key}".to_sym, value)
+          end
+        RUBY
+      end
+
+      result
+    end
+
     def permission_manager
       @permission_manager ||= Hyrax::PermissionManager.new(resource: self)
     end

--- a/spec/models/hyrax/schema_spec.rb
+++ b/spec/models/hyrax/schema_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::Schema do
 
   let(:resource_class) do
     module Hyrax::Test::Schema
-      class Resource < Valkyrie::Resource; end
+      class Resource < Hyrax::Resource; end
     end
 
     Hyrax::Test::Schema::Resource
@@ -23,6 +23,13 @@ RSpec.describe Hyrax::Schema do
 
     it 'raises for an missing schema' do
       expect { resource_class.include(Hyrax::Schema(:FAKE_SCHEMA)) } .to raise_error ArgumentError
+    end
+
+    it 'creates accessors for fields' do
+      expect { resource_class.include(Hyrax::Schema(:core_metadata)) }
+        .to change { resource_class.instance_methods }
+        .to include(:title=, :date_modified=, :date_uploaded=, :depositor=,
+                    :title, :date_modified, :date_uploaded, :depositor)
     end
   end
 


### PR DESCRIPTION
`Hyrax::Resource` wants to benefit from `.attributes(schema)` style schema
setting. Valkryie doesn't support this, due to a implementation limitation. This
patches in the fix until https://github.com/samvera/valkyrie/pull/761 is merged and released.

@samvera/hyrax-code-reviewers
