### PR TITLE
Use Clamby gem for ClamAV integration

### DIFF
--- a/app/models/hyrax/virus_scanner.rb
+++ b/app/models/hyrax/virus_scanner.rb
@@ -1,10 +1,9 @@
-# The default virus scanner Hyrax::Works, ported from hydra_works.
-# If ClamAV is present, it will be used to check for the presence of a virus. If ClamAV is not
-# installed or otherwise not available to your application, Hyrax::Works does no virus checking
+# If Clamby is present, it will be used to check for the presence of a virus. If Clamby is not
+# installed or otherwise not available to your application, Hyrax does no virus checking
 # add assumes files have no viruses.
 #
 # To use a virus checker other than ClamAV:
-#   class MyScanner < Hyrax::Works::VirusScanner
+#   class MyScanner < Hyrax::VirusScanner
 #     def infected?
 #       my_result = Scanner.check_for_viruses(file)
 #       [return true or false]
@@ -30,18 +29,36 @@ module Hyrax
     # Override this method to use your own virus checking software
     # @return [Boolean]
     def infected?
-      defined?(Clamby) ? clam_av_scanner : null_scanner
+      if defined?(Clamby)
+        clamby_scanner
+      elsif defined?(ClamAV)
+        clam_av_scanner
+      else
+        null_scanner
+      end
     end
 
+    ##
+    # @deprecated ClamAV is replaced by Clamby
     def clam_av_scanner
-      scan_result = Clamby.virus?(file)
-      return false if scan_result == false
+      scan_result = ClamAV.instance.method(:scanfile).call(file)
+      return false if scan_result.zero?
       warning "A virus was found in #{file}: #{scan_result}"
       true
     end
 
-    # Always return zero if there's nothing available to check for viruses. This means that
+    ##
+    # @return [Boolean]
+    def clamby_scanner
+      scan_result = Clamby.virus?(file)
+      warning("A virus was found in #{file}") if scan_result
+      scan_result
+    end
+
+    # Always return false if there's nothing available to check for viruses. This means that
     # we assume all files have no viruses because we can't conclusively say if they have or not.
+    ##
+    # @return [Boolean]
     def null_scanner
       warning "Unable to check #{file} for viruses because no virus scanner is defined"
       false

--- a/app/models/hyrax/virus_scanner.rb
+++ b/app/models/hyrax/virus_scanner.rb
@@ -30,12 +30,12 @@ module Hyrax
     # Override this method to use your own virus checking software
     # @return [Boolean]
     def infected?
-      defined?(ClamAV) ? clam_av_scanner : null_scanner
+      defined?(Clamby) ? clam_av_scanner : null_scanner
     end
 
     def clam_av_scanner
-      scan_result = ClamAV.instance.method(:scanfile).call(file)
-      return false if scan_result.zero?
+      scan_result = Clamby.virus?(file)
+      return false if scan_result == false
       warning "A virus was found in #{file}: #{scan_result}"
       true
     end

--- a/app/models/hyrax/virus_scanner.rb
+++ b/app/models/hyrax/virus_scanner.rb
@@ -41,6 +41,9 @@ module Hyrax
     ##
     # @deprecated ClamAV is replaced by Clamby
     def clam_av_scanner
+      Deprecation.warn(self, "The ClamAV has been replaced by Clamby " \
+                             "as the supported virus scanner for Hyrax. " \
+                             "ClamAV support will be removed in Hyrax 4.0.0.")
       scan_result = ClamAV.instance.method(:scanfile).call(file)
       return false if scan_result.zero?
       warning "A virus was found in #{file}: #{scan_result}"

--- a/lib/generators/hyrax/templates/config/clamav.rb
+++ b/lib/generators/hyrax/templates/config/clamav.rb
@@ -1,1 +1,1 @@
-ClamAV.instance.loaddb if defined? ClamAV
+# ClamAV.instance.loaddb if defined? ClamAV

--- a/spec/models/hyrax/virus_scanner_spec.rb
+++ b/spec/models/hyrax/virus_scanner_spec.rb
@@ -10,28 +10,28 @@ RSpec.describe Hyrax::VirusScanner do
 
   context 'when ClamAV is defined' do
     before do
-      class ClamAV
+      class Clamby
         def self.instance
           @instance ||= new
         end
 
-        def scanfile(path)
+        def virus?(path)
           puts "scanfile: #{path}"
         end
       end
     end
     after do
-      Object.send(:remove_const, :ClamAV)
+      Object.send(:remove_const, :Clamby)
     end
     context 'with a clean file' do
-      before { allow(ClamAV.instance).to receive(:scanfile).with('/tmp/path').and_return(0) }
+      before { allow(Clamby.instance).to receive(:virus?).with('/tmp/path').and_return(0) }
       it 'returns false with no warning' do
         expect(Hyrax.logger).not_to receive(:warn)
         is_expected.not_to be_infected
       end
     end
     context 'with an infected file' do
-      before { allow(ClamAV.instance).to receive(:scanfile).with('/tmp/path').and_return(1) }
+      before { allow(Clamby.instance).to receive(:virus?).with('/tmp/path').and_return(1) }
       it 'returns true with a warning' do
         expect(Hyrax.logger).to receive(:warn).with(kind_of(String))
         is_expected.to be_infected
@@ -39,8 +39,8 @@ RSpec.describe Hyrax::VirusScanner do
     end
   end
 
-  context 'when ClamAV is not defined' do
-    before { Object.send(:remove_const, :ClamAV) if defined?(ClamAV) }
+  context 'when Clamby is not defined' do
+    before { Object.send(:remove_const, :Clamby) if defined?(Clamby) }
 
     it 'returns false with a warning' do
       expect(Hyrax.logger).to receive(:warn).with(kind_of(String))

--- a/spec/models/hyrax/virus_scanner_spec.rb
+++ b/spec/models/hyrax/virus_scanner_spec.rb
@@ -11,11 +11,7 @@ RSpec.describe Hyrax::VirusScanner do
   context 'when ClamAV is defined' do
     before do
       class Clamby
-        def self.instance
-          @instance ||= new
-        end
-
-        def virus?(path)
+        def self.virus?(path)
           puts "scanfile: #{path}"
         end
       end
@@ -24,14 +20,14 @@ RSpec.describe Hyrax::VirusScanner do
       Object.send(:remove_const, :Clamby)
     end
     context 'with a clean file' do
-      before { allow(Clamby.instance).to receive(:virus?).with('/tmp/path').and_return(0) }
+      before { allow(Clamby).to receive(:virus?).with('/tmp/path').and_return(false) }
       it 'returns false with no warning' do
         expect(Hyrax.logger).not_to receive(:warn)
         is_expected.not_to be_infected
       end
     end
     context 'with an infected file' do
-      before { allow(Clamby.instance).to receive(:virus?).with('/tmp/path').and_return(1) }
+      before { allow(Clamby).to receive(:virus?).with('/tmp/path').and_return(true) }
       it 'returns true with a warning' do
         expect(Hyrax.logger).to receive(:warn).with(kind_of(String))
         is_expected.to be_infected

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,17 +95,11 @@ ActiveJob::Base.queue_adapter = :test
 # HttpLogger.ignore = [/localhost:8983\/solr/]
 # HttpLogger.colorize = false
 
-if defined?(ClamAV)
-  ClamAV.instance.loaddb
-else
-  class ClamAV
+unless defined?(Clamby)
+  class Clamby
     include Singleton
-    def scanfile(_f)
-      0
-    end
-
-    def loaddb
-      nil
+    def virus?(_f)
+      false
     end
   end
 end


### PR DESCRIPTION
New versions of ClamAV appear to break the `clamav` gem.  This PR replaces `clamav` with `clamby` for integrating with ClamAV.