### PR TITLE
Update DC Terms License predicate URI

### DIFF
--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -20,7 +20,7 @@ module Hyrax
       property :abstract, predicate: ::RDF::Vocab::DC.abstract
       property :keyword, predicate: ::RDF::Vocab::SCHEMA.keywords
       # Used for a license
-      property :license, predicate: ::RDF::URI.new('http://dublincore.org/documents/dcmi-terms/#terms-license'), multiple: true
+      property :license, predicate: ::RDF::Vocab::DC.license, multiple: true
 
       property :rights_notes, predicate: ::RDF::URI.new('http://purl.org/dc/elements/1.1/rights'), multiple: true
 

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -38,7 +38,7 @@ namespace :hyrax do
     # Migrate any orphan fedora data from the first to the second predicate
     task migrate_keyword_predicate: :environment do
       Hyrax::Works::MigrationService.migrate_predicate(::RDF::Vocab::DC11.relation, ::RDF::Vocab::SCHEMA.keywords)
-      Hyrax::Works::MigrationService.migrate_predicate(::RDF::Vocab::DC.rights, ::RDF::URI.new('http://dublincore.org/documents/dcmi-terms/#terms-license'))
+      Hyrax::Works::MigrationService.migrate_predicate(::RDF::Vocab::DC.rights, ::RDF::Vocab::DC.license)
     end
   end
 end

--- a/spec/services/hyrax/works/migration_service_spec.rb
+++ b/spec/services/hyrax/works/migration_service_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe Hyrax::Works::MigrationService, clean_repo: true do
   let(:predicate_from) { ::RDF::Vocab::DC11.description }
   let(:predicate_to) { ::RDF::Vocab::SCHEMA.description }
   let(:predicate_from2) { ::RDF::Vocab::DC.rights }
-  let(:predicate_to2) { ::RDF::URI.new('http://dublincore.org/documents/dcmi-terms/#terms-license') }
+  let(:predicate_to2) { ::RDF::Vocab::DC.license }
 
   describe "#migrate_predicate" do
-    it "uses DC description and terms-license license by default" do
+    it "uses DC description and DC license by default" do
       @work = GenericWork.create(title: ["War and Peace"], description: ["war", "peace"],
                                  license: ["the_license_string"])
       expect(@work.ldp_source.content).to include("http://purl.org/dc/elements/1.1/description")


### PR DESCRIPTION
Fixes #4064 

Update DC Terms License predicate URI

Change basic_metadata, migration service and spec to use the correct DC Terms License predicate URI. This ensures valid predicates saved in the metadata.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Works are saved with correct DC Terms License predicate URI, can check JSON or other console metadata dumps.
* No user interface changes.

@samvera/hyrax-code-reviewers