### PR TITLE
Fix release date issue in Safari

### DIFF
--- a/app/assets/javascripts/hyrax/admin/admin_set/visibility.es6
+++ b/app/assets/javascripts/hyrax/admin/admin_set/visibility.es6
@@ -4,6 +4,7 @@ export default class {
   }
 
   setup() {
+    this.formatDateOnLoad();
     // Watch for changes to "release_period" radio inputs
     let releasePeriodInput = this.element.find("input[type='radio'][name$='[release_period]']")
     $(releasePeriodInput).on('change', () => { this.releasePeriodSelected() })
@@ -13,6 +14,7 @@ export default class {
     let releaseVariesInput = this.element.find("input[type='radio'][name$='[release_varies]']")
     $(releaseVariesInput).on('change', () => { this.releaseVariesSelected() })
     this.releaseVariesSelected()
+    this.validateEmbargoDate();
   }
 
   // Based on the "release_period" radio selected, enable/disable other options
@@ -130,5 +132,60 @@ export default class {
   // Enable visibility "Restricted" option
   enableVisibilityRestricted() {
     this.element.find("input[type='radio'][name$='[visibility]'][value='restricted']").prop("disabled", false)
+  }
+
+  // Check whether the browser supports input[type="date"]
+  isDateSupported() {
+    let input = document.createElement('input');
+    input.setAttribute('type', 'date');
+    return (input.type === 'date');
+  }
+
+  // Change date form on from yyyy-mm-dd to mm/dd/yyyy on display
+  formatDateOnLoad() {
+    if(!this.isDateSupported()) {
+      // Detect yyyy-mm-dd format
+      const regex = /^\d{4}[./-]\d{2}[./-]\d{2}$/;
+
+      // Get all the input fields
+      let $inputs = this.element.find(':input');
+
+      $inputs.each(function() {
+        if($(this).attr('type') === 'date') {
+          let value = $(this).val();
+          if(value.match(regex)) {
+            const [yyyy, mm, dd] = value.split('-');
+            $(this).val(mm + '/' + dd + '/' + yyyy);
+          }
+        }
+      });
+    }
+  }
+
+  // Change date format from mm/dd/yyyy to yyyy-mm-dd on form submit
+  validateEmbargoDate() {
+    if(!this.isDateSupported()) {
+      // Detect mm/dd/yyyy format
+      const regex = /^\d{2}[./-]\d{2}[./-]\d{4}$/;
+
+      let $form = $('form');
+      $form.on('submit', function() {
+        let data = $(this).serializeArray();
+        let releaseDate = data.find(item => item.name === 'permission_template[release_date]');
+
+        if(releaseDate.value.match(regex)) {
+          const [mm, dd, yyyy] = releaseDate.value.split('/');
+          releaseDate.value = yyyy + '-' + mm + '-' + dd;
+        }
+
+        // Request with modified data
+        $.ajax({
+            type: "POST",
+            url: $(this).attr('action'),
+            data: data
+        });
+        return false; // prevents normal behaviour
+      });
+    }
   }
 }

--- a/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
@@ -30,7 +30,7 @@
                           <%= f.radio_button :release_varies, Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE %>
                           <%= t('.release.varies.between') %>
                         </label>
-                        <%= f.date_field :release_date, wrapper: :inline, class: 'datepicker form-control' %>
+                        <%= f.date_field :release_date, wrapper: :inline, class: 'datepicker form-control', placeholder: 'mm/dd/yyyy' %>
                       </li>
                       <li class="radio form-inline">
                         <label>
@@ -46,7 +46,7 @@
                       <%= f.radio_button :release_period, Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED %>
                       <%= t('.release.fixed') %>
                     </label>
-                    <%= f.date_field :release_date, wrapper: :inline, class: 'datepicker form-control' %>
+                    <%= f.date_field :release_date, wrapper: :inline, class: 'datepicker form-control', placeholder: 'mm/dd/yyyy' %>
                   </div>
                   <h3><%= t('.visibility.title') %></h3>
                   <p><%= t('.visibility.description') %></p>


### PR DESCRIPTION
Fixes #4005 

When editing admin sets in Safari, the embargo release date format shows up as yyyy-mm-dd and is not able to save dates in the format mm/dd/yyyy (expected format) sometimes.

Changes proposed in this pull request:
* Format date values on page load and on submit into desired date format.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Login as an admin user in Safari
* Create an admin set collection and save
* Select the `Release and Visibility` tab
* **See the placeholder text for the release dates fields**
* Select "Depositor must choose embargo"
* Enter date as `10/23/2025` and save
* **See the date appears in the same format as it was entered**

![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/1331659/66681130-0a841080-ec40-11e9-8f46-133fc319afaa.gif)


@samvera/hyrax-code-reviewers
