### PR TITLE
Fix for HYRAX-#3993

### DIFF
--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -25,7 +25,8 @@ module Hyrax
     # Updates a batch of embargos
     def update
       filter_docs_with_edit_access!
-      copy_visibility = params[:embargoes].values.map { |h| h[:copy_visibility] }
+      copy_visibility = []
+      copy_visibility = params[:embargoes].values.map { |h| h[:copy_visibility] } if params[:embargoes]
       af_objects = Hyrax.query_service.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
       af_objects.each do |curation_concern|
         Hyrax::Actors::EmbargoActor.new(curation_concern).destroy

--- a/spec/controllers/hyrax/embargoes_controller_spec.rb
+++ b/spec/controllers/hyrax/embargoes_controller_spec.rb
@@ -102,6 +102,18 @@ RSpec.describe Hyrax::EmbargoesController do
       context 'with an expired embargo' do
         let(:release_date) { Time.zone.today - 2 }
 
+        it 'deactivates embargo, do not update the file set visibility, and redirect' do
+          patch :update, params: { batch_document_ids: [a_work.id], embargoes: {} }
+          expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          expect(response).to redirect_to embargoes_path
+          expect(flash[:notice]).to be_present
+        end
+      end
+
+      context 'with an expired embargo' do
+        let(:release_date) { Time.zone.today - 2 }
+
         it 'deactivates embargo, update the visibility and redirect' do
           patch :update, params: { batch_document_ids: [a_work.id], embargoes: { '0' => { copy_visibility: a_work.id } } }
           expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC


### PR DESCRIPTION
In EmbargoesControllerBehavior#update allow the list of embargoes to be
empty so mapping to embargo ids for change visibility flag not fails
when embargoes param is undefined (that is, no change visibility
checkboxes are checked).

Expected behavior:
On the "Expired Active Embargoes" tab, select left hand column checkboxes for
at least one work, then click on "Deactivate Embargoes for Selected".
Do not click on "Change all files within..." checkboxes.

In order to test:
* Log in as Administrator
* Tasks > Manage Embargoes
* Click on "Expired Active Embargoes"
* (If this is empty, you will have to embargo at least one work with
  tomorrow's date and wait.)
* Select at least least one work in the left hand column by using its
  checkbox
* Do not select the "Change all files within..." checkboxes.
* Click on "Deactivate Embargoes for Selected"
* The work(s) should be unembargoed, and their child FileSets should still
  have their embargo visibility.

@samvera/hyrax-code-reviewers