### PR TITLE
Implement a Valkyrie-native `Hyrax::Work` model 

### DIFF
--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -55,6 +55,36 @@ module Hyrax
       result
     end
 
+    ##
+    # @return [Boolean]
+    def collection?
+      false
+    end
+
+    ##
+    # @return [Boolean]
+    def file?
+      false
+    end
+
+    ##
+    # @return [Boolean]
+    def file_set?
+      false
+    end
+
+    ##
+    # @return [Boolean]
+    def pcdm_object?
+      false
+    end
+
+    ##
+    # @return [Boolean]
+    def work?
+      false
+    end
+
     def permission_manager
       @permission_manager ||= Hyrax::PermissionManager.new(resource: self)
     end

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Valkyrie model for `Work` domain objects in the Hydra Works model.
+  #
+  # @see https://wiki.duraspace.org/display/samvera/Hydra%3A%3AWorks+Shared+Modeling
+  class Work < Hyrax::Resource
+    include Hyrax::Schema(:core_metadata)
+  end
+end

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -8,6 +8,8 @@ module Hyrax
   class Work < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
 
+    attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)
+
     ##
     # @return [Boolean] true
     def pcdm_object?

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -7,5 +7,17 @@ module Hyrax
   # @see https://wiki.duraspace.org/display/samvera/Hydra%3A%3AWorks+Shared+Modeling
   class Work < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
+
+    ##
+    # @return [Boolean] true
+    def pcdm_object?
+      true
+    end
+
+    ##
+    # @return [Boolean] true
+    def work?
+      true
+    end
   end
 end

--- a/lib/hyrax/specs/shared_specs.rb
+++ b/lib/hyrax/specs/shared_specs.rb
@@ -1,2 +1,4 @@
 require 'hyrax/specs/shared_specs/derivative_service'
+require 'hyrax/specs/shared_specs/metadata'
+require 'hyrax/specs/shared_specs/hydra_works'
 require 'hyrax/specs/shared_specs/workflow_method'

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -18,9 +18,21 @@ RSpec.shared_examples 'a Hyrax::Resource' do
         .to contain_exactly id
     end
   end
+
+  it { is_expected.to respond_to :collection? }
+  it { is_expected.to respond_to :file? }
+  it { is_expected.to respond_to :file_set? }
+  it { is_expected.to respond_to :pcdm_object? }
+  it { is_expected.to respond_to :work? }
 end
 
 RSpec.shared_examples 'a Hyrax::Work' do
   it_behaves_like 'a Hyrax::Resource'
   it_behaves_like 'a model with core metadata'
+
+  it { is_expected.not_to be_collection }
+  it { is_expected.not_to be_file }
+  it { is_expected.not_to be_file_set }
+  it { is_expected.to be_pcdm_object }
+  it { is_expected.to be_work }
 end

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -3,7 +3,7 @@ require 'hyrax/specs/shared_specs/metadata'
 
 RSpec.shared_examples 'a Hyrax::Resource' do
   subject(:resource) { described_class.new }
-  let(:adapter)      { Valkyrie::Persistence::Memory::MetadataAdapter.new }
+  let(:adapter)      { Valkyrie::MetadataAdapter.find(:test_adapter) }
 
   it_behaves_like 'a Valkyrie::Resource' do
     let(:resource_klass) { described_class }
@@ -27,6 +27,11 @@ RSpec.shared_examples 'a Hyrax::Resource' do
 end
 
 RSpec.shared_examples 'a Hyrax::Work' do
+  subject(:work)      { described_class.new }
+  let(:adapter)       { Valkyrie::MetadataAdapter.find(:test_adapter) }
+  let(:persister)     { adapter.persister }
+  let(:query_service) { adapter.query_service }
+
   it_behaves_like 'a Hyrax::Resource'
   it_behaves_like 'a model with core metadata'
 
@@ -35,4 +40,39 @@ RSpec.shared_examples 'a Hyrax::Work' do
   it { is_expected.not_to be_file_set }
   it { is_expected.to be_pcdm_object }
   it { is_expected.to be_work }
+
+  describe 'members' do
+    it 'has empty member_ids by default' do
+      expect(work.member_ids).to be_empty
+    end
+
+    it 'has empty members by default' do
+      expect(query_service.find_members(resource: work)).to be_empty
+    end
+
+    context 'with members' do
+      let(:other_works) do
+        [described_class.new, described_class.new, described_class.new]
+          .map! { |w| persister.save(resource: w) }
+      end
+
+      let(:member_ids) { other_works.map(&:id) }
+
+      before { work.member_ids = member_ids }
+
+      it 'has member_ids' do
+        expect(work.member_ids).to eq member_ids
+      end
+
+      it 'can query members' do
+        expect(query_service.find_members(resource: work)).to eq other_works
+      end
+
+      it 'can have the same member multiple times' do
+        expect { work.member_ids << member_ids.first }
+          .to change { query_service.find_members(resource: work) }
+          .to eq(other_works + [other_works.first])
+      end
+    end
+  end
 end

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -1,0 +1,26 @@
+require 'valkyrie/specs/shared_specs'
+require 'hyrax/specs/shared_specs/metadata'
+
+RSpec.shared_examples 'a Hyrax::Resource' do
+  subject(:resource) { described_class.new }
+  let(:adapter)      { Valkyrie::Persistence::Memory::MetadataAdapter.new }
+
+  it_behaves_like 'a Valkyrie::Resource' do
+    let(:resource_klass) { described_class }
+  end
+
+  describe '#alternate_ids' do
+    let(:id) { Valkyrie::ID.new('fake_identifier') }
+
+    it 'has an attribute for alternate ids' do
+      expect { resource.alternate_ids = id }
+        .to change { resource.alternate_ids }
+        .to contain_exactly id
+    end
+  end
+end
+
+RSpec.shared_examples 'a Hyrax::Work' do
+  it_behaves_like 'a Hyrax::Resource'
+  it_behaves_like 'a model with core metadata'
+end

--- a/lib/hyrax/specs/shared_specs/metadata.rb
+++ b/lib/hyrax/specs/shared_specs/metadata.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a model with core metadata' do
+  subject(:resource) { described_class.new }
+  let(:date)         { Time.zone.today }
+
+  it 'has a date_modified' do
+    expect { resource.date_modified = date }
+      .to change { resource.date_modified }
+      .to eq date
+  end
+
+  it 'has a date_uploaded' do
+    expect { resource.date_uploaded = date }
+      .to change { resource.date_uploaded }
+      .to eq date
+  end
+
+  it 'has a depositor' do
+    expect { resource.depositor = 'userid' }
+      .to change { resource.depositor }
+      .to eq 'userid'
+  end
+
+  it 'has a title' do
+    expect { resource.title = ['title'] }
+      .to change { resource.title }
+      .to contain_exactly('title')
+  end
+end

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     end
 
     transient do
+      members            { nil }
       visibility_setting { nil }
     end
 
@@ -22,6 +23,8 @@ FactoryBot.define do
           .new(resource: work)
           .assign_access_for(visibility: evaluator.visibility_setting)
       end
+
+      work.member_ids = evaluator.members.map(&:id) if evaluator.members
     end
 
     after(:create) do |work, evaluator|
@@ -35,6 +38,12 @@ FactoryBot.define do
     trait :public do
       transient do
         visibility_setting { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+      end
+    end
+
+    trait :with_member_works do
+      transient do
+        members { [valkyrie_create(:hyrax_work), valkyrie_create(:hyrax_work)] }
       end
     end
   end

--- a/spec/models/hyrax/resource_spec.rb
+++ b/spec/models/hyrax/resource_spec.rb
@@ -1,24 +1,13 @@
 # frozen_string_literal: true
 
+require 'hyrax/specs/shared_specs/hydra_works'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Hyrax::Resource do
   subject(:resource) { described_class.new }
   let(:adapter)      { Valkyrie::Persistence::Memory::MetadataAdapter.new }
 
-  it_behaves_like 'a Valkyrie::Resource' do
-    let(:resource_klass) { described_class }
-  end
-
-  describe '#alternate_ids' do
-    let(:id) { Valkyrie::ID.new('fake_identifier') }
-
-    it 'has an attribute for alternate ids' do
-      expect { resource.alternate_ids = id }
-        .to change { resource.alternate_ids }
-        .to contain_exactly id
-    end
-  end
+  it_behaves_like 'a Hyrax::Resource'
 
   describe '#embargo' do
     subject(:resource) { described_class.new(embargo: embargo) }

--- a/spec/models/hyrax/work_spec.rb
+++ b/spec/models/hyrax/work_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'hyrax/specs/shared_specs/hydra_works'
+
+RSpec.describe Hyrax::Work do
+  it_behaves_like 'a Hyrax::Work'
+end

--- a/spec/models/hyrax/work_spec.rb
+++ b/spec/models/hyrax/work_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
 require 'hyrax/specs/shared_specs/hydra_works'
 
 RSpec.describe Hyrax::Work do

--- a/spec/support/simple_work.rb
+++ b/spec/support/simple_work.rb
@@ -10,11 +10,7 @@ module Hyrax
     #
     # @example creating with FactoryBot
     #   work = FactoryBot.valkyrie_create(:hyrax_work, :public, title: ['Comet in Moominland'])
-    class SimpleWork < Hyrax::Resource
-      # use the *private* initalizer here to ensure the module gets loaded
-      # use `include Hyrax::Schema(:core_metadata)
-      include Hyrax::Schema(:core_metadata)
-    end
+    class SimpleWork < Hyrax::Work; end
 
     class SimpleWorkLegacy < ActiveFedora::Base
       include WorkBehavior

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -43,6 +43,29 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       end
     end
 
+    context 'when given a valkyrie Work' do
+      let(:resource) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+      it 'gives a work' do
+        expect(converter.convert).to be_work
+      end
+
+      context 'with members' do
+        let(:resource)   { FactoryBot.valkyrie_create(:hyrax_work, :with_member_works) }
+        let(:member_ids) { resource.member_ids.map(&:id) }
+
+        it 'saves members' do
+          expect(converter.convert).to have_attributes(member_ids: member_ids)
+        end
+
+        it 'can access member models from converted object' do
+          expect(converter.convert.members)
+            .to contain_exactly(an_instance_of(Hyrax::Test::SimpleWorkLegacy),
+                                an_instance_of(Hyrax::Test::SimpleWorkLegacy))
+        end
+      end
+    end
+
     context 'with attributes' do
       let(:attributes) do
         FactoryBot.attributes_for(:generic_work)


### PR DESCRIPTION
Adds a top-level PCDM/Hydra Works model for `Work` in native Valkyrie. Shared examples for Hydra Works-level domain objects are added. Likewise for the `:core_metadata` schema. Membership for works is supported, and `Wings` support for membership is tested.

Hydra Works type inspectors (`#work?`, `#collection`, etc...) are added at the `Hyrax::Resource` level.

Changes proposed in this pull request:
* Adds valkyrie native models and support code, not yet used in production code.

@samvera/hyrax-code-reviewers
