### PR TITLE
Qualify references to the application's `Collection` class

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -59,7 +59,7 @@ module Hyrax
         # Adds the item to the ordered members so that it displays in the items
         # along side the FileSets on the show page
         def add(env, id)
-          collection = Collection.find(id)
+          collection = ::Collection.find(id)
           collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
 
           return unless env.current_ability.can?(:deposit, collection)
@@ -68,7 +68,7 @@ module Hyrax
 
         # Remove the object from the members set and the ordered members list
         def remove(curation_concern, id)
-          collection = Collection.find(id)
+          collection = ::Collection.find(id)
           curation_concern.member_of_collections.delete(collection)
         end
 

--- a/app/controllers/hyrax/dashboard/collection_members_controller.rb
+++ b/app/controllers/hyrax/dashboard/collection_members_controller.rb
@@ -59,7 +59,7 @@ module Hyrax
         end
 
         def collection
-          @collection ||= Collection.find(collection_id)
+          @collection ||= ::Collection.find(collection_id)
         end
 
         def batch_ids

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -448,7 +448,7 @@ module Hyrax
         end
 
         def collection_object
-          action_name == 'show' ? Collection.find(collection.id) : collection
+          action_name == 'show' ? ::Collection.find(collection.id) : collection
         end
 
         # You can override this method if you need to provide additional

--- a/app/controllers/hyrax/dashboard/nest_collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/nest_collections_controller.rb
@@ -63,28 +63,28 @@ module Hyrax
       private
 
         def build_within_form
-          child = Collection.find(params.fetch(:child_id))
+          child = ::Collection.find(params.fetch(:child_id))
           authorize! :read, child
-          parent = params.key?(:parent_id) ? Collection.find(params[:parent_id]) : nil
+          parent = params.key?(:parent_id) ? ::Collection.find(params[:parent_id]) : nil
           form_class.new(child: child, parent: parent, context: self)
         end
 
         def build_under_form
-          parent = Collection.find(params.fetch(:parent_id))
+          parent = ::Collection.find(params.fetch(:parent_id))
           authorize! :deposit, parent
-          child = params.key?(:child_id) ? Collection.find(params[:child_id]) : nil
+          child = params.key?(:child_id) ? ::Collection.find(params[:child_id]) : nil
           form_class.new(child: child, parent: parent, context: self)
         end
 
         def build_create_collection_form
-          parent = Collection.find(params.fetch(:parent_id))
+          parent = ::Collection.find(params.fetch(:parent_id))
           authorize! :deposit, parent
           form_class.new(child: nil, parent: parent, context: self)
         end
 
         def build_remove_form
-          child = Collection.find(params.fetch(:child_id))
-          parent = Collection.find(params.fetch(:parent_id))
+          child = ::Collection.find(params.fetch(:child_id))
+          parent = ::Collection.find(params.fetch(:parent_id))
           authorize! :edit, parent
           form_class.new(child: child, parent: parent, context: self)
         end

--- a/app/controllers/hyrax/my/collections_controller.rb
+++ b/app/controllers/hyrax/my/collections_controller.rb
@@ -5,9 +5,9 @@ module Hyrax
       def self.configure_facets
         configure_blacklight do |config|
           # Name of pivot facet must match field name that uses helper_method
-          config.add_facet_field Collection.collection_type_gid_document_field_name,
+          config.add_facet_field ::Collection.collection_type_gid_document_field_name,
                                  helper_method: :collection_type_label, limit: 5,
-                                 pivot: ['has_model_ssim', Collection.collection_type_gid_document_field_name],
+                                 pivot: ['has_model_ssim', ::Collection.collection_type_gid_document_field_name],
                                  label: I18n.t('hyrax.dashboard.my.heading.collection_type')
           # This causes AdminSets to also be shown with the Collection Type label
           config.add_facet_field 'has_model_ssim',

--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -33,7 +33,7 @@ module Hyrax
         end
       end
 
-      # @param model [Collection] the collection model that backs this form
+      # @param model [::Collection] the collection model that backs this form
       # @param current_ability [Ability] the capabilities of the current user
       # @param repository [Blacklight::Solr::Repository] the solr repository
       def initialize(model, current_ability, repository)
@@ -152,7 +152,7 @@ module Hyrax
       def available_parent_collections(scope:)
         return @available_parents if @available_parents.present?
 
-        collection = Collection.find(id)
+        collection = ::Collection.find(id)
         colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: scope, limit_to_id: nil)
         @available_parents = colls.map do |col|
           { "id" => col.id, "title_first" => col.title.first }

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -9,8 +9,8 @@ module Hyrax
         self.default_query_service = Hyrax::Collections::NestedCollectionQueryService
         self.default_persistence_service = Hyrax::Collections::NestedCollectionPersistenceService
 
-        # @param parent [Collection, NilClass]
-        # @param child [Collection, NilClass]
+        # @param parent [::Collection, NilClass]
+        # @param child [::Collection, NilClass]
         # @param context [#can?,#repository,#blacklight_config]
         # @param query_service [Hyrax::Collections::NestedCollectionQueryService]
         # @param persistence_service [Hyrax::Collections::NestedCollectionPersistenceService] responsible for persisting the parent/child relationship

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -66,7 +66,7 @@ module Hyrax
       def member_of_collections
         base = model.member_of_collections
         return base unless @controller.params[:add_works_to_collection]
-        base + [Collection.find(@controller.params[:add_works_to_collection])]
+        base + [::Collection.find(@controller.params[:add_works_to_collection])]
       end
 
       # @return [String] an etag representing the current version of this form

--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -1,6 +1,6 @@
 module Hyrax::FileSetHelper
   def parent_path(parent)
-    if parent.is_a?(Collection)
+    if parent.is_a?(::Collection)
       main_app.collection_path(parent)
     else
       polymorphic_path([main_app, parent])

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -255,7 +255,7 @@ module Hyrax
 
     # Used by the gallery view
     def collection_thumbnail(_document, _image_options = {}, _url_options = {})
-      content_tag(:span, "", class: [Hyrax::ModelIcon.css_class_for(Collection), "collection-icon-search"])
+      content_tag(:span, "", class: [Hyrax::ModelIcon.css_class_for(::Collection), "collection-icon-search"])
     end
 
     def collection_title_by_id(id)

--- a/app/models/concerns/hyrax/ability/collection_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_ability.rb
@@ -3,34 +3,34 @@ module Hyrax
     module CollectionAbility
       def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         if admin?
-          can :manage, Collection
-          can :manage_any, Collection
-          can :create_any, Collection
-          can :view_admin_show_any, Collection
+          can :manage, ::Collection
+          can :manage_any, ::Collection
+          can :create_any, ::Collection
+          can :view_admin_show_any, ::Collection
         else
-          can :manage_any, Collection if Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
-          can :create_any, Collection if Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
-          can :view_admin_show_any, Collection if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_collection?(ability: self)
+          can :manage_any, ::Collection if Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
+          can :create_any, ::Collection if Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
+          can :view_admin_show_any, ::Collection if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_collection?(ability: self)
 
-          can [:edit, :update, :destroy], Collection do |collection| # for test by solr_doc, see solr_document_ability.rb
+          can [:edit, :update, :destroy], ::Collection do |collection| # for test by solr_doc, see solr_document_ability.rb
             test_edit(collection.id)
           end
 
-          can :deposit, Collection do |collection|
+          can :deposit, ::Collection do |collection|
             Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: collection.id)
           end
           can :deposit, ::SolrDocument do |solr_doc|
             Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
           end
 
-          can :view_admin_show, Collection do |collection| # admin show page
+          can :view_admin_show, ::Collection do |collection| # admin show page
             Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: collection.id)
           end
           can :view_admin_show, ::SolrDocument do |solr_doc| # admin show page
             Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
           end
 
-          can :read, Collection do |collection| # public show page  # for test by solr_doc, see solr_document_ability.rb
+          can :read, ::Collection do |collection| # public show page  # for test by solr_doc, see solr_document_ability.rb
             test_read(collection.id)
           end
         end

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -71,7 +71,7 @@ module Hyrax
 
     # Method to return the ActiveFedora model
     def hydra_model
-      first("has_model_ssim").constantize
+      "::#{first('has_model_ssim')}".constantize
     end
 
     def depositor(default = '')

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -10,10 +10,10 @@ module Hyrax
     has_many :collection_type_participants, class_name: 'Hyrax::CollectionTypeParticipant', foreign_key: 'hyrax_collection_type_id', dependent: :destroy
 
     USER_COLLECTION_MACHINE_ID    = 'user_collection'.freeze
-    USER_COLLECTION_DEFAULT_TITLE = I18n.t('hyrax.collection_type.default_title').freeze
+    USER_COLLECTION_DEFAULT_TITLE = I18n.t('hyrax.collection_type.default_title', default: 'User Collection').freeze
 
     ADMIN_SET_MACHINE_ID = 'admin_set'.freeze
-    ADMIN_SET_DEFAULT_TITLE = I18n.t('hyrax.collection_type.admin_set_title').freeze
+    ADMIN_SET_DEFAULT_TITLE = I18n.t('hyrax.collection_type.admin_set_title', default: 'Admin Set').freeze
 
     def title=(value)
       super

--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -29,7 +29,7 @@ module Hyrax
     has_one :active_workflow, -> { where(active: true) }, class_name: 'Sipity::Workflow', foreign_key: :permission_template_id
 
     # A bit of an analogue for a `belongs_to :source_model` as it crosses from Fedora to the DB
-    # @return [AdminSet | Collection]
+    # @return [AdminSet, ::Collection]
     # @raise [Hyrax::ObjectNotFoundError] when neither an AdminSet or Collection is found
     def source_model
       admin_set
@@ -51,7 +51,7 @@ module Hyrax
     # @return [Collection]
     # @raise [Hyrax::ObjectNotFoundError] when the we cannot find the Collection
     def collection
-      return Collection.find(source_id) if Collection.exists?(source_id)
+      return ::Collection.find(source_id) if ::Collection.exists?(source_id)
       raise Hyrax::ObjectNotFoundError
     rescue ActiveFedora::ActiveFedoraError # TODO: remove the rescue when active_fedora issue #1276 is fixed
       raise Hyrax::ObjectNotFoundError

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -148,7 +148,7 @@ module Hyrax
 
     def available_parent_collections(scope:)
       return @available_parents if @available_parents.present?
-      collection = Collection.find(id)
+      collection = ::Collection.find(id)
       colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: scope, limit_to_id: nil)
       @available_parents = colls.map do |col|
         { "id" => col.id, "title_first" => col.title.first }

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -225,10 +225,10 @@ module Hyrax
     end
 
     # determine if the user can add this work to a collection
-    # @param collections <Collections> list of collections to which this user can deposit
+    # @param collections [Array<::Collection>] list of collections to which this user can deposit
     # @return true if the user can deposit to at least one collection OR if the user can create a collection; otherwise, false
     def show_deposit_for?(collections:)
-      collections.present? || current_ability.can?(:create_any, Collection)
+      collections.present? || current_ability.can?(:create_any, ::Collection)
     end
 
     private

--- a/app/search_builders/hyrax/admin_admin_set_member_search_builder.rb
+++ b/app/search_builders/hyrax/admin_admin_set_member_search_builder.rb
@@ -8,7 +8,7 @@ module Hyrax
     attr_reader :collection
 
     # @param [scope] Typically the controller object
-    # @param [Collection]
+    # @param [::Collection]
     def initialize(scope:, collection:)
       @collection = collection
       super(scope)

--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -3,7 +3,7 @@ module Hyrax
     # Responsible for searching for collections of the same type that are not the given collection
     class NestedCollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
       # @param access [Symbol] :edit, :read, :discover - With the given :access what all can
-      # @param collection [Collection]
+      # @param collection [::Collection]
       # @param scope [Object] Typically a controller that responds to #current_ability, #blackligh_config
       # @param nesting_attributes [NestingAttributes] an object encapsulating nesting attributes of the collection
       # @param nest_direction [Symbol] (:as_parent or :as_child) the direction we are adding nesting to this collection
@@ -27,7 +27,7 @@ module Hyrax
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += [
           "-" + Hyrax::SolrQueryBuilderService.construct_query_for_ids([limit_ids]),
-          Hyrax::SolrQueryBuilderService.construct_query(Collection.collection_type_gid_document_field_name => @collection.collection_type_gid)
+          Hyrax::SolrQueryBuilderService.construct_query(::Collection.collection_type_gid_document_field_name => @collection.collection_type_gid)
         ]
         solr_parameters[:fq] += limit_clause if limit_clause # add limits to prevent illegal nesting arrangements
       end

--- a/app/search_builders/hyrax/exposed_models_relation.rb
+++ b/app/search_builders/hyrax/exposed_models_relation.rb
@@ -2,7 +2,7 @@ module Hyrax
   # A relation that scopes to all user visible models (e.g. works + collections + file sets)
   class ExposedModelsRelation < AbstractTypeRelation
     def allowable_types
-      Hyrax.config.curation_concerns + [Collection, ::FileSet]
+      Hyrax.config.curation_concerns + [::Collection, ::FileSet]
     end
   end
 end

--- a/app/services/hyrax/admin_set_member_service.rb
+++ b/app/services/hyrax/admin_set_member_service.rb
@@ -5,7 +5,7 @@ module Hyrax
     delegate :repository, to: :scope
 
     # @param scope [#repository] Typically acontroller object which responds to :repository
-    # @param [Collection] an collection of type admin set
+    # @param [::Collection] an collection of type admin set
     # @param [ActionController::Parameters] query params
     def initialize(scope:, collection:, params:)
       @scope = scope

--- a/app/services/hyrax/collections/collection_member_service.rb
+++ b/app/services/hyrax/collections/collection_member_service.rb
@@ -6,7 +6,7 @@ module Hyrax
       delegate :repository, to: :scope
 
       # @param scope [#repository] Typically a controller object which responds to :repository
-      # @param [Collection]
+      # @param [::Collection]
       # @param [ActionController::Parameters] query params
       def initialize(scope:, collection:, params:)
         @scope = scope

--- a/app/services/hyrax/collections/migration_service.rb
+++ b/app/services/hyrax/collections/migration_service.rb
@@ -8,8 +8,8 @@ module Hyrax
       # Migrate all legacy collections to extended collections with collection type assigned.  Legacy collections are those
       # created before Hyrax 2.1.0 and are identified by the lack of the collection having a collection type gid.
       def self.migrate_all_collections
-        Rails.logger.info "*** Migrating #{Collection.count} collections"
-        Collection.all.each do |col|
+        Rails.logger.info "*** Migrating #{::Collection.count} collections"
+        ::Collection.all.each do |col|
           migrate_collection(col)
           Rails.logger.info "  migrating collection - id: #{col.id}, title: #{col.title}"
         end
@@ -26,7 +26,7 @@ module Hyrax
       # Migrate a single legacy collection to extended collections with collection type assigned.  Legacy collections are those
       # created before Hyrax 2.1.0 and are identified by the lack of the collection having a collection type gid.
       #
-      # @param collection [Collection] collection object to be migrated
+      # @param collection [::Collection] collection object to be migrated
       def self.migrate_collection(collection)
         return if collection.collection_type_gid.present? # already migrated
         collection.collection_type_gid = Hyrax::CollectionType.find_or_create_default_collection_type.gid
@@ -56,7 +56,7 @@ module Hyrax
       # the default collection type are ignored.
       def self.repair_migrated_collections
         Rails.logger.info "*** Repairing migrated collections"
-        Collection.all.each do |col|
+        ::Collection.all.each do |col|
           repair_migrated_collection(col)
           Rails.logger.info "  repairing collection - id: #{col.id}, title: #{col.title}"
         end
@@ -71,7 +71,7 @@ module Hyrax
       #
       # Validate and repair a migrated collection if needed.
       #
-      # @param collection [Collection] collection object to be migrated/repaired
+      # @param collection [::Collection] collection object to be migrated/repaired
       def self.repair_migrated_collection(collection)
         return if collection.collection_type_gid.present? && collection.collection_type_gid != Hyrax::CollectionType.find_or_create_default_collection_type.gid
         collection.collection_type_gid = Hyrax::CollectionType.find_or_create_default_collection_type.gid

--- a/app/services/hyrax/collections/nested_collection_persistence_service.rb
+++ b/app/services/hyrax/collections/nested_collection_persistence_service.rb
@@ -6,8 +6,8 @@ module Hyrax
       # Responsible for persisting the relationship between the parent and the child.
       # @see Hyrax::Collections::NestedCollectionQueryService
       #
-      # @param parent [Collection]
-      # @param child [Collection]
+      # @param parent [::Collection]
+      # @param child [::Collection]
       # @note There is odd permission arrangement based on the NestedCollectionQueryService:
       #       You can nest the child within a parent if you can edit the parent and read the child.
       #       See https://wiki.duraspace.org/display/samvera/Samvera+Tech+Call+2017-08-23 for tech discussion.

--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -28,7 +28,7 @@ module Hyrax
       #
       # What possible collections can be nested within the given parent collection?
       #
-      # @param parent [Collection]
+      # @param parent [::Collection]
       # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
       # @param limit_to_id [nil, String] Limit the query to just check if the given id is in the response. Useful for validation.
       # @return [Array<SolrDocument>]
@@ -42,7 +42,7 @@ module Hyrax
       #
       # What possible collections can the given child be nested within?
       #
-      # @param child [Collection]
+      # @param child [::Collection]
       # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
       # @param limit_to_id [nil, String] Limit the query to just check if the given id is in the response. Useful for validation.
       # @return [Array<SolrDocument>]
@@ -56,7 +56,7 @@ module Hyrax
       #
       # What collections is the given child nested within?
       #
-      # @param child [Collection]
+      # @param child [::Collection]
       # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
       # @param page [Integer] Starting page for pagination
       # @param limit [Integer] Limit to number of collections for pagination
@@ -110,8 +110,8 @@ module Hyrax
       #
       # Is it valid to nest the given child within the given parent?
       #
-      # @param parent [Collection]
-      # @param child [Collection]
+      # @param parent [::Collection]
+      # @param child [::Collection]
       # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
       # @return [Boolean] true if the parent can nest the child; false otherwise
       # @todo Consider expanding from same collection type to a lookup table that says "This collection type can have within it, these collection types"
@@ -127,8 +127,8 @@ module Hyrax
       #
       # Does the nesting depth fall within defined limit?
       #
-      # @param parent [Collection]
-      # @param child [nil, Collection] will be nil if we are nesting a new collection under the parent
+      # @param parent [::Collection]
+      # @param child [nil, ::Collection] will be nil if we are nesting a new collection under the parent
       # @param scope [Object] Typically a controller object that responds to `repository`, `can?`, `blacklight_config`, `current_ability`
       # @return [Boolean] true if the parent can nest the child; false otherwise
       def self.valid_combined_nesting_depth?(parent:, child: nil, scope:)
@@ -143,7 +143,7 @@ module Hyrax
       #
       # Get the child collection's nesting depth
       #
-      # @param child [Collection]
+      # @param child [::Collection]
       # @return [Fixnum] the largest number of collections in a path nested under this collection (including this collection)
       def self.child_nesting_depth(child:, scope:)
         return 1 if child.nil?
@@ -175,7 +175,7 @@ module Hyrax
       #
       # Get the parent collection's nesting depth
       #
-      # @param parent [Collection]
+      # @param parent [::Collection]
       # @return [Fixnum] the largest number of collections above this collection (includes this collection)
       def self.parent_nesting_depth(parent:, scope:)
         return 1 if parent.nil?

--- a/app/services/hyrax/collections/permissions_create_service.rb
+++ b/app/services/hyrax/collections/permissions_create_service.rb
@@ -5,7 +5,7 @@ module Hyrax
       #
       # Set the default permissions for a (newly created) collection
       #
-      # @param collection [Collection] the collection the new permissions will act on
+      # @param collection [::Collection] the collection the new permissions will act on
       # @param creating_user [User] the user that created the collection
       # @param grants [Array<Hash>] additional grants to apply to the new collection
       # @return [Hyrax::PermissionTemplate]
@@ -29,7 +29,7 @@ module Hyrax
       #       access: Hyrax::PermissionTemplateAccess::DEPOSIT } ]
       # @see Hyrax::PermissionTemplateAccess for valid values for agent_type and access
       def self.add_access(collection_id:, grants:)
-        collection = Collection.find(collection_id)
+        collection = ::Collection.find(collection_id)
         template = Hyrax::PermissionTemplate.find_by!(source_id: collection_id)
         grants.each do |grant|
           Hyrax::PermissionTemplateAccess.find_or_create_by(permission_template_id: template.id,

--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -51,7 +51,7 @@ module Hyrax
 
       def single_membership_collections(collection_ids)
         return [] if collection_ids.blank?
-        Collection.where(id: collection_ids, collection_type_gid_ssim: single_membership_types)
+        ::Collection.where(id: collection_ids, collection_type_gid_ssim: single_membership_types)
       end
 
       def single_membership_types

--- a/app/services/hyrax/statistics/collections/over_time.rb
+++ b/app/services/hyrax/statistics/collections/over_time.rb
@@ -5,7 +5,7 @@ module Hyrax
         private
 
           def relation
-            Collection
+            ::Collection
           end
       end
     end

--- a/app/views/hyrax/collections/_list_collections.html.erb
+++ b/app/views/hyrax/collections/_list_collections.html.erb
@@ -3,7 +3,7 @@
   <td></td>
   <td>
     <div class="media">
-      <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-small pull-left"></span>
+      <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small pull-left"></span>
       <div class="media-body">
         <div class="media-heading">
           <%= link_to collection_presenter.show_path do %>

--- a/app/views/hyrax/collections/_media_display.html.erb
+++ b/app/views/hyrax/collections/_media_display.html.erb
@@ -4,5 +4,5 @@
                 alt: "",
                 role: "presentation" %>
 <% else %>
-  <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-search" aria-hidden="true"></span>
+  <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-search" aria-hidden="true"></span>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -18,7 +18,7 @@
     <div class="thumbnail-title-wrapper">
       <div class="thumbnail-wrapper">
         <% if (collection_presenter.thumbnail_path == nil) %>
-          <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-small"></span>
+          <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small"></span>
         <% else %>
           <%= image_tag(collection_presenter.thumbnail_path) %>
         <% end %>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -20,7 +20,7 @@
     <div class="thumbnail-title-wrapper">
       <div class="thumbnail-wrapper">
         <% if (collection_presenter.thumbnail_path == nil) %>
-          <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-small"></span>
+          <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small"></span>
         <% else %>
           <%= image_tag(collection_presenter.thumbnail_path) %>
         <% end %>

--- a/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
@@ -1,5 +1,5 @@
 <div class="modal fade disable-unless-selected" id="add-subcollection-modal-<%= id %>" tabindex="-1" role="dialog" aria-labelledby="add-subcollection-label">
-<% collection = Collection.find id %>
+<% collection = ::Collection.find id %>
   <div class="modal-dialog" role="document">
     <div class="modal-content">
 

--- a/lib/hyrax/resource_sync/change_list_writer.rb
+++ b/lib/hyrax/resource_sync/change_list_writer.rb
@@ -62,7 +62,7 @@ module Hyrax
         def build_resources(xml, doc_set)
           doc_set.each do |doc|
             model = doc.fetch('has_model_ssim', []).first.constantize
-            if model == Collection
+            if model == ::Collection
               build_resource(xml, doc, model, hyrax_routes)
             else
               build_resource(xml, doc, model, main_app_routes)

--- a/lib/hyrax/resource_sync/resource_list_writer.rb
+++ b/lib/hyrax/resource_sync/resource_list_writer.rb
@@ -32,7 +32,7 @@ module Hyrax
         end
 
         def build_collections(xml)
-          Collection.search_in_batches(public_access) do |doc_set|
+          ::Collection.search_in_batches(public_access) do |doc_set|
             build_resources(xml, doc_set, hyrax_routes)
           end
         end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Collection, type: :model do
+RSpec.describe ::Collection, type: :model do
   let(:collection) { build(:public_collection_lw) }
 
   it "has open visibility" do

--- a/spec/services/hyrax/collections/migration_service_spec.rb
+++ b/spec/services/hyrax/collections/migration_service_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       let!(:col_mg) { build(:typeless_collection, user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
 
       it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
-        Collection.all.each do |col|
+        ::Collection.all.each do |col|
           expect(col.collection_type_gid).to be_nil
           expect { Hyrax::PermissionTemplate.find_by!(source_id: col.id) }.to raise_error ActiveRecord::RecordNotFound
         end
 
         Hyrax::Collections::MigrationService.migrate_all_collections
 
-        Collection.all.each do |col|
+        ::Collection.all.each do |col|
           expect(col.collection_type_gid).to eq default_gid
           pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
           expect(pt_id).not_to be_nil
@@ -54,7 +54,7 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
       let!(:edit_users) { collection.edit_users }
 
       before do
-        allow(Collection).to receive(:all).and_return([collection])
+        allow(::Collection).to receive(:all).and_return([collection])
       end
 
       it "doesn't change the collection" do
@@ -165,14 +165,14 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
         let!(:col_mg) { build(:typeless_collection_lw, user: user, edit_users: [user.user_key], edit_groups: ['edit_group_1', 'edit_group_2'], do_save: true) }
 
         it 'sets gid and adds permissions' do # rubocop:disable RSpec/ExampleLength
-          Collection.all.each do |col|
+          ::Collection.all.each do |col|
             expect(col.collection_type_gid).to be_nil
             expect { Hyrax::PermissionTemplate.find_by!(source_id: col.id) }.to raise_error ActiveRecord::RecordNotFound
           end
 
           Hyrax::Collections::MigrationService.repair_migrated_collections
 
-          Collection.all.each do |col|
+          ::Collection.all.each do |col|
             expect(col.collection_type_gid).to eq default_gid
             pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
             expect(pt_id).not_to be_nil
@@ -251,7 +251,7 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
         end
 
         it 'sets gid' do # rubocop:disable RSpec/ExampleLength
-          Collection.all.each do |col|
+          ::Collection.all.each do |col|
             expect(col.collection_type_gid).to be_nil
             pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
             expect(pt_id).not_to be_nil
@@ -263,7 +263,7 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
 
           Hyrax::Collections::MigrationService.repair_migrated_collections
 
-          Collection.all.each do |col|
+          ::Collection.all.each do |col|
             expect(col.collection_type_gid).to eq default_gid
             pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
             expect(pt_id).not_to be_nil
@@ -295,7 +295,7 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
         end
 
         it 'sets gid and adds access permissions' do # rubocop:disable RSpec/ExampleLength
-          Collection.all.each do |col|
+          ::Collection.all.each do |col|
             expect(col.collection_type_gid).to be_nil
             pt_id = Hyrax::PermissionTemplate.find_by!(source_id: col.id)
             expect(pt_id).not_to be_nil

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
                      'rights_tesim' => ["http://creativecommons.org/licenses/by-sa/3.0/us/"])
   end
   let(:ability) { double }
-  let(:collection) { mock_model(Collection) }
+  let(:collection) { mock_model(::Collection) }
   let(:presenter) { Hyrax::CollectionPresenter.new(document, ability) }
   let(:collection_type) { double }
 


### PR DESCRIPTION
Use `::Collection` when we mean to refer to the application-layer `Collection`
class. This ensures correct reference even if a class named `Collection` is
defined in another namespace.

We already provide this kind of disambiguation for `FileSet`. In general, we
should use `::`-prefixed names for all application-level names we want to
reference from the engine (inverted dependencies on the application). Failing to
do this means any new name defined in an in-scope namespace will resolve
preferentially, over the desired application class/module. If we intend to refer
to an application constant, we should do so with care.

For now, this will keep us from defining `Hyrax::Collection`, since the fallout
for adopters is a bit unpredictable. Still, it's good to clean up after our
mess, here.

@samvera/hyrax-code-reviewers
