### PR TITLE
Fix for HYRAX-#4002

### DIFF
--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -24,7 +24,8 @@ module Hyrax
 
     def update
       filter_docs_with_edit_access!
-      copy_visibility = params[:leases].values.map { |h| h[:copy_visibility] }
+      copy_visibility = []
+      copy_visibility = params[:leases].values.map { |h| h[:copy_visibility] } if params[:leases]
       af_objects = Hyrax.query_service.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
       af_objects.each do |curation_concern|
         Hyrax::Actors::LeaseActor.new(curation_concern).destroy

--- a/spec/controllers/hyrax/leases_controller_spec.rb
+++ b/spec/controllers/hyrax/leases_controller_spec.rb
@@ -105,6 +105,17 @@ RSpec.describe Hyrax::LeasesController do
       context 'with an expired lease' do
         let(:expiration_date) { Time.zone.today - 2 }
 
+        it 'deactivates lease, do not update the visibility, and redirect' do
+          patch :update, params: { batch_document_ids: [a_work.id], leases: {} }
+          expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          expect(response).to redirect_to leases_path
+        end
+      end
+
+      context 'with an expired lease' do
+        let(:expiration_date) { Time.zone.today - 2 }
+
         it 'deactivates lease, update the visibility and redirect' do
           patch :update, params: { batch_document_ids: [a_work.id], leases: { '0' => { copy_visibility: a_work.id } } }
           expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED


### PR DESCRIPTION
In LeasesControllerBehavior#update allow the list of leases to be
empty so mapping to lease ids for change visibility flag does not fail
when leases param is undefined (that is, no change visibility
checkboxes were checked).

Expected behavior:
On the "Expired Active Leases" tab, select left hand column checkboxes for
at least one work, then click on "Deactivate Leases for Selected".
Do not click on "Change all files within..." checkboxes.

In order to test:
* Log in as Administrator
* Tasks > Manage Leases
* Click on "Expired Active Leases"
* (If this is empty, you will have to lease at least one work with
  tomorrow's date and wait.)
* Select at least one work in the left hand column by using its
  checkbox
* Do not select the "Change all files within..." checkboxes.
* Click on "Deactivate Leases for Selected"
* The work(s) should be un-leased, and their child FileSets should still
  have their lease visibility.

@samvera/hyrax-code-reviewers
