### PR TITLE
Start to generalize Work Controllers for Valkyrie

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -231,5 +231,19 @@ module Hyrax
                .where('sipity_workflow_roles.role_id' => approving_role.id).any?
         end
       end
+
+      ##
+      # @api private
+      #
+      # Overwrite extract subjects to map permissions
+      #
+      # @note this shims in support for using existing abilities when passing
+      #   Valkyrie::Resources. We'll need to support valkyrie resources natively
+      #   as well.
+      def extract_subjects(subject)
+        subject = subject.alternate_ids&.first&.id if subject.is_a?(Hyrax::Resource)
+
+        super
+      end
   end
 end

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -16,6 +16,7 @@ require 'hydra/works'
 require 'hyrax/engine'
 require 'hyrax/version'
 require 'hyrax/inflections'
+require 'hyrax/valkyrie_can_can_adapter'
 require 'kaminari_route_prefix'
 
 module Hyrax

--- a/lib/hyrax/valkyrie_can_can_adapter.rb
+++ b/lib/hyrax/valkyrie_can_can_adapter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # A `CanCan::ModelAdapter` for valkyrie resources
+  class ValkyrieCanCanAdapter < CanCan::ModelAdapters::AbstractAdapter
+    ##
+    # @param [Class] member_class
+    def self.for_class?(member_class)
+      member_class == Hyrax::Resource ||
+        member_class < Hyrax::Resource
+    end
+
+    ##
+    # @param [Class] model_class
+    # @param [String] id
+    #
+    # @return [Hyrax::Resource]
+    #
+    # @raise Hyrax::ObjectNotFoundError
+    def self.find(_model_class, id)
+      Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: id)
+    end
+  end
+end

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::WorksControllerBehavior, type: :controller do
+  let(:paths) { Rails.application.routes.url_helpers }
+
+  controller(ApplicationController) do
+    include Hyrax::WorksControllerBehavior
+
+    self.curation_concern_type = Hyrax::Test::BookResource
+  end
+
+  shared_context 'with a logged in user' do
+    let(:user) { create(:user) }
+
+    before { sign_in user }
+  end
+
+  describe '#edit' do
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :public, alternate_ids: [id]) }
+    let(:id)   { '123' }
+
+    before { Hyrax.persister.save(resource: work) }
+
+    it 'gives a 404 for a missing object' do
+      expect { get :edit, params: { id: 'missing_id' } }
+        .to raise_error Hyrax::ObjectNotFoundError
+    end
+
+    it 'redirects to new user login' do
+      get :edit, params: { id: id }
+
+      expect(response).to redirect_to paths.new_user_session_path(locale: :en)
+    end
+
+    context 'with a logged in user' do
+      include_context 'with a logged in user'
+
+      it 'gives unauthorized' do
+        get :edit, params: { id: id }
+
+        expect(response.status).to eq 401
+      end
+    end
+  end
+end

--- a/spec/hyrax/valkyrie_can_can_adapter_spec.rb
+++ b/spec/hyrax/valkyrie_can_can_adapter_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::ValkyrieCanCanAdapter do
+  describe '.find' do
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+    it 'raises an ObjectNotFoundError' do
+      expect { described_class.find(work.class, 'MISSING_ID') }
+        .to raise_error Hyrax::ObjectNotFoundError
+    end
+
+    it 'finds a work' do
+      expect(described_class.find(work.class, work.id).id)
+        .to eq work.id
+    end
+  end
+
+  describe '.for_class' do
+    let(:subclass) { Class.new(Hyrax::Resource) }
+
+    it 'is true for Hyrax::Resource' do
+      expect(described_class.for_class?(Hyrax::Resource)).to eq true
+    end
+
+    it 'is true for Hyrax::Resource subclass' do
+      expect(described_class.for_class?(subclass)).to eq true
+    end
+  end
+end


### PR DESCRIPTION
Working under the hypothesis that `WorkControllerBehavior` can reasonably
support Valkyrie native Works as well as ActiveFedora ones, begin to test
behavior for Valkyrie works in `works_controller_behavior_spec.rb`.

In the past, we've tested controller behavior using generated work
controllers (`GenericWorkController`) in the test application. Locating the
tests for this sharable module in a file named for a specific implementation
makes it hard to find, and encourages sloppy testing. So we are shifting away
from this approach, and instead bootstrapping a controller and routes directly
for use in testing---if we need additional controllers to test other code paths,
they should be easy to add following this pattern.

A `ValkyrieCanCanAdapter` is added to resolve Resource objects from
ids. Inheriting `CanCan::ModelAdapters::AbstractAdapter` automatically registers
this adapter for use based on `.for_class?`.

A simple version of `Hyrax::Ability` support is added via a specialized
`#extract_subjects` case: whenever the `subject` is a `Hyrax::Resource`, cast it
to an ID and check permissions based on this. This will often (always? )involve
querying permissions from Solr within `Ability`, but should work for most
ability checks. As usage in Controllers grows, we'll need to support Valkyrie
native ability checking.

Changes proposed in this pull request:
* Expand Valkyrie support into `WorkControllerBehavior` and `Ability`, in a very preliminary way.
* No functional changes.


@samvera/hyrax-code-reviewers
