### PR TITLE
Test the custom `find_access_control_for(resource:)` valkyrie query

### DIFF
--- a/app/services/hyrax/custom_queries/find_access_control.rb
+++ b/app/services/hyrax/custom_queries/find_access_control.rb
@@ -1,9 +1,8 @@
 module Hyrax
   module CustomQueries
+    # @example
+    #   Hyrax.query_service.custom_queries.find_access_control_for(resource: resource)
     class FindAccessControl
-      # Use:
-      #   Hyrax.query_service.custom_queries.find_access_control_for(resource: resource)
-
       def self.queries
         [:find_access_control_for]
       end

--- a/spec/services/hyrax/custom_queries/find_access_control_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_access_control_spec.rb
@@ -1,11 +1,45 @@
-# rubocop:disable RSpec/EmptyExampleGroup
 RSpec.describe Hyrax::CustomQueries::FindAccessControl do
-  let(:query_service) { Hyrax.query_service }
-  let(:resource) { double } # TODO: Stubbed waiting for tests
-  subject { query_service.custom_queries.find_access_control(for: resource) }
+  subject(:query_handler) { described_class.new(query_service: query_service) }
+  let(:adapter)           { Valkyrie::MetadataAdapter.find(:test_adapter) }
+  let(:persister)         { adapter.persister }
+  let(:query_service)     { adapter.query_service }
 
-  describe '.find_access_control' do
-    # TODO: Need tests for this custom query once inMemory adapter is supported
+  describe '#find_access_control' do
+    context 'for missing object' do
+      let(:resource) { Valkyrie::Resource.new }
+
+      it 'raises ObjectNotFoundError' do
+        expect { query_handler.find_access_control_for(resource: resource) }
+          .to raise_error { Valkyrie::Persistence::ObjectNotFoundError }
+      end
+    end
+
+    context 'when an acl exists' do
+      let(:acl)      { persister.save(resource: Hyrax::AccessControl.new(access_to: resource.id)) }
+      let(:resource) { persister.save(resource: Hyrax::Resource.new) }
+
+      before { acl } # ensure the acl gets saved
+
+      it 'returns the acl' do
+        expect(query_handler.find_access_control_for(resource: resource))
+          .to eq acl
+      end
+    end
+
+    context 'for another class purporting to provide access_to' do
+      let(:malicious_acl) { malicious_acl_class }
+      let(:resource)      { adapter.persister.save(resource: Hyrax::Resource.new) }
+
+      let(:malicious_acl_class) do
+        Class.new(Valkyrie::Resource) do
+          attribute :access_to, Valkyrie::Types::ID
+        end
+      end
+
+      it 'raises ObjectNotFoundError' do
+        expect { query_handler.find_access_control_for(resource: resource) }
+          .to raise_error { Valkyrie::Persistence::ObjectNotFoundError }
+      end
+    end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup


### PR DESCRIPTION
Test this custom query against the test metadata adapter.

Changes proposed in this pull request:
* Adds tests for an existing valkyrie custom query.

@samvera/hyrax-code-reviewers
