### PR TITLE
Remove unneeded TODO in `child_works_navigator`

### DIFF
--- a/app/services/hyrax/custom_queries/navigators/child_filesets_navigator.rb
+++ b/app/services/hyrax/custom_queries/navigators/child_filesets_navigator.rb
@@ -17,8 +17,6 @@ module Hyrax
         # Find child filesets of a given resource, and map to Valkyrie Resources
         # @param [Valkyrie::Resource]
         # @return [Array<Valkyrie::Resource>]
-        # TODO: By storing all children in a single relationship, it requires that the full resource be constructed for all children
-        #       and then selecting only the children of a particular type to return.
         def find_child_filesets(resource:)
           query_service.find_members(resource: resource).select(&:file_set?)
         end
@@ -26,10 +24,6 @@ module Hyrax
         # Find the ids of child filesets of a given resource, and map to Valkyrie Resources
         # @param [Valkyrie::Resource]
         # @return [Array<Valkyrie::ID>]
-        # TODO: By storing all children in a single relationship, it requires that the full resource be constructed for all children
-        #       and then selecting only the children of a particular type.  If we stored works in a works relationship and filesets
-        #       in a filesets relationship, then a request for IDs would return all ids from the relationship and not instantiate
-        #       any resources.
         def find_child_fileset_ids(resource:)
           find_child_filesets(resource: resource).map(&:id)
         end

--- a/app/services/hyrax/custom_queries/navigators/child_works_navigator.rb
+++ b/app/services/hyrax/custom_queries/navigators/child_works_navigator.rb
@@ -14,22 +14,20 @@ module Hyrax
           @query_service = query_service
         end
 
+        ##
         # Find child works of a given resource, and map to Valkyrie Resources
+        #
         # @param [Valkyrie::Resource]
         # @return [Array<Valkyrie::Resource>]
-        # TODO: By storing all children in a single relationship, it requires that the full resource be constructed for all children
-        #       and then selecting only the children of a particular type to return.
         def find_child_works(resource:)
           query_service.find_members(resource: resource).select(&:work?)
         end
 
+        ##
         # Find the ids of child works of a given resource, and map to Valkyrie Resources
+        #
         # @param [Valkyrie::Resource]
         # @return [Array<Valkyrie::ID>]
-        # TODO: By storing all children in a single relationship, it requires that the full resource be constructed for all children
-        #       and then selecting only the children of a particular type.  If we stored works in a works relationship and filesets
-        #       in a filesets relationship, then a request for IDs would return all ids from the relationship and not instantiate
-        #       any resources.
         def find_child_work_ids(resource:)
           find_child_works(resource: resource).map(&:id)
         end


### PR DESCRIPTION
While it's true that these query implementations aren't optimized, these TODO
items imply that we plan to remedy that by changing the data model. There aren't
any plans to do that, and it's much more likely that we'd optimize these queries
by providing adapter-specific implementations that can filter by type.

@samvera/hyrax-code-reviewers
