### PR TITLE
link missing payload_concern param

### DIFF
--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -16,7 +16,7 @@
   <% end %>
   <% if Flipflop.batch_upload? && f.object.new_record? %>
     <% provide :metadata_tab do %>
-      <p class="switch-upload-type"><%= t('.batch_upload_hint') %> <%= link_to t('.batch_link'), hyrax.new_batch_upload_path %></p>
+      <p class="switch-upload-type"><%= t('.batch_upload_hint') %> <%= link_to t('.batch_link'), hyrax.new_batch_upload_path(payload_concern: @form.model.class) %></p>
     <% end %>
   <% end %>
   <%= render 'hyrax/base/guts4form', f: f %>

--- a/spec/views/hyrax/base/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form.html.erb_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
         render
       end
       it 'shows batch uploads' do
-        expect(rendered).to have_link('Batch upload')
+        expect(rendered).to have_link('Batch upload', href: hyrax.new_batch_upload_path(payload_concern: 'GenericWork'))
         expect(rendered).to have_selector("form[action='/concern/generic_works'][data-param-key='generic_work']")
         # Draws the "Share" tab, with data for the javascript.
         expect(rendered).to have_selector('#share[data-param-key="generic_work"]')
@@ -50,7 +50,7 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
         render
       end
       it 'hides batch uploads' do
-        expect(rendered).not_to have_link('Batch upload')
+        expect(rendered).not_to have_link('Batch upload', href: hyrax.new_batch_upload_path(payload_concern: 'GenericWork'))
       end
     end
   end


### PR DESCRIPTION
Fixes #3195

Adds missing `payload_concern` parameter to currently-broken link from the single Work creation form to the batch Work creation form. This enables the batch create form and controller to know what the model/class of the Work being batch created is.

@samvera/hyrax-code-reviewers
