### PR TITLE
Test custom query `FindManyByAlternateIds`

### DIFF
--- a/app/services/hyrax/custom_queries/find_many_by_alternate_ids.rb
+++ b/app/services/hyrax/custom_queries/find_many_by_alternate_ids.rb
@@ -16,11 +16,15 @@ module Hyrax
 
       # implements a combination of two Valkyrie queries:
       # => find_many_by_ids & find_by_alternate_identifier
+      #
       # @param alternate_ids [Enumerator<#to_s>] list of ids
-      # @return [Array<Valkyrie::Resource>, Array<ActiveFedora::Base>]
+      # @return [Enumerable<Valkyrie::Resource>, Enumerable<ActiveFedora::Base>]
       def find_many_by_alternate_ids(alternate_ids:)
-        alternate_ids.uniq.map(&:to_s).each_with_object([]) do |id, resources|
-          resources << query_service.find_by_alternate_identifier(alternate_identifier: id)
+        return enum_for(:find_many_by_alternate_ids, alternate_ids: alternate_ids) unless
+          block_given?
+
+        alternate_ids.uniq do |id|
+          yield query_service.find_by_alternate_identifier(alternate_identifier: id.to_s)
         end
       end
     end

--- a/spec/services/hyrax/custom_queries/find_many_by_alternate_ids_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_many_by_alternate_ids_spec.rb
@@ -1,17 +1,41 @@
-# rubocop:disable RSpec/EmptyExampleGroup
-RSpec.describe Wings::CustomQueries::FindManyByAlternateIds do
-  let(:query_service) { Hyrax.query_service }
-  let(:id_list) { double } # TODO: Stubbed waiting for tests
-  subject { query_service.custom_queries.find_many_by_alternate_ids(alternate_ids: id_list) }
+# frozen_string_literal: true
 
-  describe '.find_many_by_alternate_ids' do
+RSpec.describe Hyrax::CustomQueries::FindManyByAlternateIds do
+  subject(:query_handler) { described_class.new(query_service: query_service) }
+  let(:adapter)           { Valkyrie::MetadataAdapter.find(:test_adapter) }
+  let(:persister)         { adapter.persister }
+  let(:query_service)     { adapter.query_service }
+
+  let(:ids) { resources.map { |r| r.alternate_ids.first } }
+
+  let(:resources) do
+    [persister.save(resource: Hyrax::Resource.new(alternate_ids: ['1'])),
+     persister.save(resource: Hyrax::Resource.new(alternate_ids: ['2'])),
+     persister.save(resource: Hyrax::Resource.new(alternate_ids: ['3']))]
+  end
+
+  before { persister.wipe! }
+
+  describe '#find_many_by_alternate_ids' do
+    it 'returns empty with no ids' do
+      expect(query_handler.find_many_by_alternate_ids(alternate_ids: []).count)
+        .to eq 0
+    end
+
     context 'with Valkyrie::ID input' do
-      # TODO: Need tests for this custom query once inMemory adapter is supported
+      it 'returns matching resources' do
+        expect(query_handler.find_many_by_alternate_ids(alternate_ids: ids))
+          .to contain_exactly(*resources)
+      end
     end
 
     context 'when list includes an invalid id' do
-      # TODO: Need tests for this custom query once inMemory adapter is supported
+      let(:ids) { resources.map { |r| r.alternate_ids.first } + ['fake_id'] }
+
+      it 'raises ObjectNotFoundError' do
+        expect { query_handler.find_many_by_alternate_ids(alternate_ids: ids).to_a }
+          .to raise_error Valkyrie::Persistence::ObjectNotFoundError
+      end
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup


### PR DESCRIPTION
Add tests for the `find_many_by_alternate_ids(alternate_ids:)` query.

Additionally, refactor the query implementation to use an enumerator based
implementation. This avoids querying individually for unused items.

Changes proposed in this pull request:
* Adds missing tests for a Valkyrie custom query

@samvera/hyrax-code-reviewers
