### PR TITLE
Customize CI cache key for 2.x-stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ jobs:
       rails_version:
         type: string
         default: '5.2.2'
+      cache_version:
+        type: string
+        default: '1-2.x'
     executor:
       name: 'samvera/ruby'
       ruby_version: << parameters.ruby_version >>
@@ -37,6 +40,9 @@ jobs:
       ruby_version:
         type: string
         default: 2.5.5
+      cache_version:
+        type: string
+        default: '1-2.x'
     executor:
       name: 'samvera/ruby'
       ruby_version: << parameters.ruby_version >>
@@ -57,6 +63,9 @@ jobs:
       rails_version:
         type: string
         default: '5.2.2'
+      cache_version:
+        type: string
+        default: '1-2.x'
     executor:
       name: 'samvera/ruby'
       ruby_version: << parameters.ruby_version >>
@@ -69,10 +78,11 @@ jobs:
       - attach_workspace:
           at: ~/
       - samvera/engine_cart_generate:
-          cache_key: v1-internal-test-app-{{ checksum "hyrax.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/hyrax/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
+          cache_key: v<< parameters.cache_version >>--internal-test-app-{{ checksum "hyrax.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/hyrax/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
+          cache_version: << parameters.cache_version >>
           project: hyrax
       - persist_to_workspace:
           root: ~/
@@ -88,6 +98,9 @@ jobs:
       bundler_version:
         type: string
         default: 1.17.3
+      cache_version:
+        type: string
+        default: '1-2.x'
     executor:
       name: 'samvera/ruby_fcrepo_solr_redis'
       ruby_version: << parameters.ruby_version >>
@@ -104,6 +117,7 @@ jobs:
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
+          cache_version: << parameters.cache_version >>
           project: hyrax
       - samvera/parallel_rspec
 
@@ -114,13 +128,16 @@ workflows:
       - bundle:
           ruby_version: "2.5.5"
           rails_version: "5.1.7"
+          cache_version: "1-2.x"
       - lint:
           ruby_version: "2.5.5"
+          cache_version: "1-2.x"
           requires:
             - bundle
       - build:
           ruby_version: "2.5.5"
           rails_version: "5.1.7"
+          cache_version: "1-2.x"
           requires:
             - bundle
       - test:
@@ -132,6 +149,7 @@ workflows:
       - test:
           name: "ruby2-6-2"
           ruby_version: "2.6.2"
+          cache_version: "1-2.x"
           requires:
             - build
             - lint

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -113,4 +113,7 @@ SUMMARY
   # simple_form 3.5.1 broke hydra-editor for certain model types;
   #   see: https://github.com/plataformatec/simple_form/issues/1549
   spec.add_dependency 'simple_form', '~> 3.2', '<= 3.5.0'
+  # Pin sass-rails to 5.x because rails 5.x apps have this same dependency in their generated Gemfiles
+  # See https://github.com/samvera/hyrax/issues/3919
+  spec.add_dependency 'sass-rails',  '~> 5.0'
 end


### PR DESCRIPTION
Fix the CI build for 2.x by adding a stable branch name to the cache key.

This avoids drift in the Hyrax `master` cache breaking the maintenance branch.

@samvera/hyrax-code-reviewers
