### PR TITLE
Make `Hyrax::FileSet` a class

### DIFF
--- a/app/models/concerns/hyrax/file_set/belongs_to_works.rb
+++ b/app/models/concerns/hyrax/file_set/belongs_to_works.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  module FileSet
+  class FileSet
     module BelongsToWorks
       extend ActiveSupport::Concern
 

--- a/app/models/concerns/hyrax/file_set/characterization.rb
+++ b/app/models/concerns/hyrax/file_set/characterization.rb
@@ -11,7 +11,7 @@
 # MyFileSet.characterization_proxy = :master_file
 # MyFileSet.characterization_terms = [:term1, :term2, :term3]
 module Hyrax
-  module FileSet
+  class FileSet
     module Characterization
       extend ActiveSupport::Concern
 

--- a/app/models/concerns/hyrax/file_set/derivatives.rb
+++ b/app/models/concerns/hyrax/file_set/derivatives.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  module FileSet
+  class FileSet
     module Derivatives
       extend ActiveSupport::Concern
 

--- a/app/models/concerns/hyrax/file_set/indexing.rb
+++ b/app/models/concerns/hyrax/file_set/indexing.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  module FileSet
+  class FileSet
     module Indexing
       extend ActiveSupport::Concern
 

--- a/app/models/concerns/hyrax/file_set/querying.rb
+++ b/app/models/concerns/hyrax/file_set/querying.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  module FileSet
+  class FileSet
     module Querying
       extend ActiveSupport::Concern
 

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Hyrax
+  class FileSet < Hyrax::Resource
+  end
+end


### PR DESCRIPTION
`Hyrax::FileSet` will be the name of a `Valkyrie::Resource` model. This begins
that transition by moving it from a module to a class inheriting `Resource`.

@samvera/hyrax-code-reviewers
