### PR TITLE
Upgrade Valkyrie to 2.0.2

### DIFF
--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -38,23 +38,6 @@ module Hyrax
              :read_groups, :read_groups=,
              :read_users,  :read_users=, to: :permission_manager
 
-    def self.attributes(new_schema)
-      result = super
-
-      new_schema.each_key do |key|
-        key = key.to_s.chomp('?').to_sym
-        next if instance_methods.include?("#{key}=".to_sym)
-
-        class_eval(<<-RUBY)
-          def #{key}=(value)
-            set_value("#{key}".to_sym, value)
-          end
-        RUBY
-      end
-
-      result
-    end
-
     ##
     # @return [Boolean]
     def collection?

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -77,7 +77,7 @@ SUMMARY
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
-  spec.add_dependency 'valkyrie', '~> 2.0'
+  spec.add_dependency 'valkyrie', '~> 2.0', '>= 2.0.2'
 
   # temporary pin to 2.17 due to failures caused in 2.18.0
   spec.add_development_dependency "capybara", '~> 3.29'


### PR DESCRIPTION
Valkyrie 2.0.2 fixes support for schema-style attribute setting, which Hyrax
relies on. Forcing the upgrade allows us to remove local code adding support.

@samvera/hyrax-code-reviewers
