### PR TITLE
Support `i18n` for Valkyrie `#human_readable_type`

### DIFF
--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -56,6 +56,12 @@ module Hyrax
     end
 
     ##
+    # @return [String] a human readable name for the model
+    def self.human_readable_type
+      I18n.translate("hyrax.models.#{model_name.i18n_key}", default: model_name.human)
+    end
+
+    ##
     # @return [Boolean]
     def collection?
       false

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1200,6 +1200,10 @@ en:
         single: has been saved.
         subject: Batch upload complete
         title: Files uploaded successfully
+    models:
+      hyrax/file_set: File Set
+      hyrax/pcdm_collection: Collection
+      hyrax/work: Work
     my:
       count:
         collections:

--- a/spec/models/hyrax/file_set_spec.rb
+++ b/spec/models/hyrax/file_set_spec.rb
@@ -4,5 +4,13 @@ require 'spec_helper'
 require 'hyrax/specs/shared_specs/hydra_works'
 
 RSpec.describe Hyrax::FileSet do
+  subject(:file_set) { described_class.new }
+
   it_behaves_like 'a Hyrax::FileSet'
+
+  describe '#human_readable_type' do
+    it 'has a human readable type' do
+      expect(file_set.human_readable_type).to eq 'File Set'
+    end
+  end
 end

--- a/spec/models/hyrax/pcdm_collection_spec.rb
+++ b/spec/models/hyrax/pcdm_collection_spec.rb
@@ -4,5 +4,13 @@ require 'spec_helper'
 require 'hyrax/specs/shared_specs/hydra_works'
 
 RSpec.describe Hyrax::PcdmCollection do
+  subject(:collection) { described_class.new }
+
   it_behaves_like 'a Hyrax::PcdmCollection'
+
+  describe '#human_readable_type' do
+    it 'has a human readable type' do
+      expect(collection.human_readable_type).to eq 'Collection'
+    end
+  end
 end

--- a/spec/models/hyrax/work_spec.rb
+++ b/spec/models/hyrax/work_spec.rb
@@ -4,5 +4,13 @@ require 'spec_helper'
 require 'hyrax/specs/shared_specs/hydra_works'
 
 RSpec.describe Hyrax::Work do
+  subject(:work) { described_class.new }
+
   it_behaves_like 'a Hyrax::Work'
+
+  describe '#human_readable_type' do
+    it 'has a human readable type' do
+      expect(work.human_readable_type).to eq 'Work'
+    end
+  end
 end


### PR DESCRIPTION
Use `i18n` keys for `Hyrax::Resource#human_readable_type` if available. Fall
back on `ActiveModel::Name#human` if keys are missing.


@samvera/hyrax-code-reviewers
