### PR TITLE
Refactor `PermissionTemplate#source_model`; deprecate unused methods

### DIFF
--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -32,15 +32,17 @@ module Hyrax
     # @return [AdminSet, ::Collection]
     # @raise [Hyrax::ObjectNotFoundError] when neither an AdminSet or Collection is found
     def source_model
-      admin_set
-    rescue Hyrax::ObjectNotFoundError
-      collection
+      ActiveFedora::Base.find(source_id)
+    rescue ActiveFedora::ObjectNotFoundError
+      raise Hyrax::ObjectNotFoundError
     end
 
     # A bit of an analogue for a `belongs_to :admin_set` as it crosses from Fedora to the DB
+    # @deprecated Use #source_model instead
     # @return [AdminSet]
     # @raise [Hyrax::ObjectNotFoundError] when the we cannot find the AdminSet
     def admin_set
+      Deprecation.warn('Use #source_model instead')
       return AdminSet.find(source_id) if AdminSet.exists?(source_id)
       raise Hyrax::ObjectNotFoundError
     rescue ActiveFedora::ActiveFedoraError # TODO: remove the rescue when active_fedora issue #1276 is fixed
@@ -48,9 +50,11 @@ module Hyrax
     end
 
     # A bit of an analogue for a `belongs_to :collection` as it crosses from Fedora to the DB
+    # @deprecated Use #source_model instead
     # @return [Collection]
     # @raise [Hyrax::ObjectNotFoundError] when the we cannot find the Collection
     def collection
+      Deprecation.warn('Use #source_model instead')
       return ::Collection.find(source_id) if ::Collection.exists?(source_id)
       raise Hyrax::ObjectNotFoundError
     rescue ActiveFedora::ActiveFedoraError # TODO: remove the rescue when active_fedora issue #1276 is fixed

--- a/spec/models/hyrax/permission_template_spec.rb
+++ b/spec/models/hyrax/permission_template_spec.rb
@@ -14,22 +14,22 @@ RSpec.describe Hyrax::PermissionTemplate, :clean_repo do
     context 'with_admin_set parameter' do
       it 'will create an AdminSet when true' do
         permission_template = create(:permission_template, with_admin_set: true)
-        expect(permission_template.admin_set).to be_persisted
+        expect(permission_template.source_model).to be_persisted
       end
       it 'will not persist an AdminSet when false (or not given)' do
         permission_template = create(:permission_template, with_admin_set: false)
-        expect { permission_template.admin_set }.to raise_error(Hyrax::ObjectNotFoundError)
+        expect { permission_template.source_model }.to raise_error(Hyrax::ObjectNotFoundError)
       end
     end
 
     context 'with_collection parameter' do
       it 'will create an Collection when true' do
         permission_template = create(:permission_template, with_collection: true)
-        expect(permission_template.collection).to be_persisted
+        expect(permission_template.source_model).to be_persisted
       end
       it 'will not persist an Collection when false (or not given)' do
         permission_template = create(:permission_template, with_collection: false)
-        expect { permission_template.collection }.to raise_error(Hyrax::ObjectNotFoundError)
+        expect { permission_template.source_model }.to raise_error(Hyrax::ObjectNotFoundError)
       end
     end
 
@@ -90,27 +90,6 @@ RSpec.describe Hyrax::PermissionTemplate, :clean_repo do
         expect(col_permission_template.source_model).to be_kind_of(Collection)
         expect(col_permission_template.source_model).to eq(collection)
       end
-    end
-  end
-
-  describe "#admin_set" do
-    it 'leverages AdminSet.find for the given permission_template' do
-      expect(AdminSet).to receive(:find).with(permission_template.source_id).and_return(admin_set)
-      expect(permission_template.admin_set).to eq(admin_set)
-    end
-  end
-
-  describe "#collection" do
-    let(:col_permission_template) { described_class.new(col_attributes) }
-    let(:col_attributes) { { source_id: collection.id } }
-
-    before do
-      allow(Collection).to receive(:find).with(col_permission_template.source_id).and_return(collection)
-    end
-
-    it 'leverages Collection.find for the given permission_template' do
-      expect(col_permission_template.collection).to be_kind_of(Collection)
-      expect(col_permission_template.collection).to eq(collection)
     end
   end
 


### PR DESCRIPTION
`PermissionTemplate` had a complex ActiveFedora-based
`.exists?`/`.find`/`rescue` logic that wasn't needed. Just doing `.find` on
`ActiveFedora::Base` works just as well and saves a significant number of
LDP calls.

The methods that serviced the old logic were public, so they are deprecated.

@samvera/hyrax-code-reviewers
