### PR TITLE
Add a Valkyrie-based Admin Set model (`AdministrativeSet`)

### DIFF
--- a/app/models/hyrax/administrative_set.rb
+++ b/app/models/hyrax/administrative_set.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Valkyrie model for Admin Set domain objects.
+  class AdministrativeSet < Hyrax::Resource
+    attribute :alt_title,   Valkyrie::Types::Set.of(Valkyrie::Types::String)
+    attribute :creator,     Valkyrie::Types::Set.of(Valkyrie::Types::String)
+    attribute :description, Valkyrie::Types::Set.of(Valkyrie::Types::String)
+    attribute :title,       Valkyrie::Types::Set.of(Valkyrie::Types::String)
+  end
+end

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -8,7 +8,8 @@ module Hyrax
   class Work < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
 
-    attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)
+    attribute :admin_set_id, Valkyrie::Types::ID
+    attribute :member_ids,   Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)
 
     ##
     # @return [Boolean] true

--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -100,11 +100,12 @@ custom_queries.each do |query_handler|
   Valkyrie.config.metadata_adapter.query_service.custom_queries.register_query_handler(query_handler)
 end
 
-Wings::ModelRegistry.register(Hyrax::AccessControl,  Hydra::AccessControl)
-Wings::ModelRegistry.register(Hyrax::PcdmCollection, '::Collection')
-Wings::ModelRegistry.register(Hyrax::FileSet,        'FileSet')
-Wings::ModelRegistry.register(Hyrax::Embargo,        Hydra::AccessControls::Embargo)
-Wings::ModelRegistry.register(Hyrax::Lease,          Hydra::AccessControls::Lease)
+Wings::ModelRegistry.register(Hyrax::AccessControl,     Hydra::AccessControl)
+Wings::ModelRegistry.register(Hyrax::AdministrativeSet, AdminSet)
+Wings::ModelRegistry.register(Hyrax::PcdmCollection,    ::Collection)
+Wings::ModelRegistry.register(Hyrax::FileSet,           FileSet)
+Wings::ModelRegistry.register(Hyrax::Embargo,           Hydra::AccessControls::Embargo)
+Wings::ModelRegistry.register(Hyrax::Lease,             Hydra::AccessControls::Lease)
 
 Hydra::AccessControl.send(:define_method, :valkyrie_resource) do
   attrs = attributes.symbolize_keys

--- a/spec/factories/administrative_sets.rb
+++ b/spec/factories/administrative_sets.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :hyrax_admin_set, class: 'Hyrax::AdministrativeSet' do
+    title { ['My Admin Set'] }
+  end
+end

--- a/spec/models/hyrax/administrative_set_spec.rb
+++ b/spec/models/hyrax/administrative_set_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'hyrax/specs/shared_specs/hydra_works'
+
+RSpec.describe Hyrax::AdministrativeSet do
+  it_behaves_like 'a Hyrax::AdministrativeSet'
+end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       end
     end
 
+    context 'when given a valkyrie Admin Set' do
+      let(:resource) { FactoryBot.valkyrie_create(:hyrax_admin_set) }
+
+      it 'gives an AdminSet' do
+        expect(converter.convert).to be_a AdminSet
+      end
+    end
+
     context 'when given a valkyrie Work' do
       let(:resource) { FactoryBot.valkyrie_create(:hyrax_work) }
 
@@ -62,6 +70,17 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
           expect(converter.convert.members)
             .to contain_exactly(an_instance_of(Hyrax::Test::SimpleWorkLegacy),
                                 an_instance_of(Hyrax::Test::SimpleWorkLegacy))
+        end
+      end
+
+      context 'as Admin Set member' do
+        let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+
+        before { resource.admin_set_id = admin_set_id }
+
+        it 'is a member of the admin set' do
+          expect(converter.convert.admin_set)
+            .to eq AdminSet.find(AdminSet::DEFAULT_ID)
         end
       end
     end


### PR DESCRIPTION
Implement a basic Valkryie Admin Set model. Add support for admin sets to
Valkyrie native Work models.

We played with the idea of making `AdministrativeSet` a subclass of
`PcdmCollection` but the assumption of ordered membership in collection is
problematic, here. We don't want order in Admin Sets, and the AF models won't
support it.

@samvera/hyrax-code-reviewers
