### PR TITLE
Deprecate `Work#active_workflow`

### DIFF
--- a/app/models/concerns/hyrax/in_admin_set.rb
+++ b/app/models/concerns/hyrax/in_admin_set.rb
@@ -6,7 +6,10 @@ module Hyrax
       belongs_to :admin_set, predicate: Hyrax.config.admin_set_predicate
     end
 
+    ##
+    # @deprecated Use `Sipity::Workflow.find_active_workflow_for` instead.
     def active_workflow
+      Deprecation.warn 'Use `Sipity::Workflow.find_active_workflow_for` instead.'
       Sipity::Workflow.find_active_workflow_for(admin_set_id: admin_set_id)
     end
   end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -4,13 +4,6 @@ RSpec.describe GenericWork do
     expect(subject.title).to eq ['foo']
   end
 
-  describe '#active_workflow' do
-    it 'leverages "Sipity::Workflow.find_active_workflow_for"' do
-      expect(Sipity::Workflow).to receive(:find_active_workflow_for)
-      subject.active_workflow
-    end
-  end
-
   describe '.model_name' do
     subject { described_class.model_name.singular_route_key }
 


### PR DESCRIPTION
This method was explicitly required to use a specific external service. To decouple behavior, just use that service instead.

@samvera/hyrax-code-reviewers
