### PR TITLE
Deprecate unused `#to_sipity_entity`

### DIFF
--- a/app/models/concerns/hyrax/suppressible.rb
+++ b/app/models/concerns/hyrax/suppressible.rb
@@ -19,7 +19,10 @@ module Hyrax
       state == Vocab::FedoraResourceStatus.inactive
     end
 
+    ##
+    # @deprecated Use `PowerConverter.convert_to_sipity_entity(obj)` instead.
     def to_sipity_entity
+      Deprecation.warn "Use `PowerConverter.convert_to_sipity_entity(obj)` instead."
       raise "Can't create an entity until the model has been persisted" unless persisted?
       @sipity_entity ||= Sipity::Entity.find_by(proxy_for_global_id: to_global_id.to_s)
     end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -23,20 +23,6 @@ RSpec.describe GenericWork do
     it { is_expected.to include("has_model", "create_date", "modified_date") }
   end
 
-  describe "to_sipity_entity" do
-    let(:state) { create(:workflow_state) }
-    let(:work) { create(:work) }
-
-    before do
-      Sipity::Entity.create!(proxy_for_global_id: work.to_global_id.to_s,
-                             workflow_state: state,
-                             workflow: state.workflow)
-    end
-    subject { work.to_sipity_entity }
-
-    it { is_expected.to be_kind_of Sipity::Entity }
-  end
-
   describe '#state' do
     let(:work) { described_class.new(state: inactive) }
     let(:inactive) { ::RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#inactive') }


### PR DESCRIPTION
This method avoids the more robust `PowerConverter` approach, which is actually used throughout Hyrax. Encourage applications to use that instead.

@samvera/hyrax-code-reviewers
