### PR TITLE
Deprecate `Hyrax::WithFileSets` in favor of `VisibilityPropagator`

### DIFF
--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -28,7 +28,8 @@ module Hyrax
       af_objects = Hyrax.query_service.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
       af_objects.each do |curation_concern|
         Hyrax::Actors::LeaseActor.new(curation_concern).destroy
-        curation_concern.copy_visibility_to_files if copy_visibility.include?(curation_concern.id)
+        Hyrax::VisibilityPropagator.for(source: curation_concern).propagate if
+          copy_visibility.include?(curation_concern.id)
       end
       redirect_to leases_path
     end

--- a/app/models/concerns/hyrax/with_file_sets.rb
+++ b/app/models/concerns/hyrax/with_file_sets.rb
@@ -1,7 +1,12 @@
 module Hyrax
   module WithFileSets
     extend ActiveSupport::Concern
+
+    ##
+    # @deprecated Use 'Hyrax::VisibilityPropagator' instead.
     def copy_visibility_to_files
+      Deprecation.warn "Use 'Hyrax::VisibilityPropagator' instead."
+
       file_sets.each do |fs|
         fs.visibility = visibility
         fs.save!


### PR DESCRIPTION
`WithFileSets` partially implemented visibility copy behavior used elsewhere in
the application. Instead of duplicating the partial behavior, use the better
maintained version relied on by the Actor stack.

This deprecates both the method, and the module for which the method is the only
content.

@samvera/hyrax-code-reviewers 