### PR TITLE
Use `Hyrax::Serializers` in `AdminSet`

### DIFF
--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -20,6 +20,7 @@ class AdminSet < ActiveFedora::Base
   include Hyrax::Noid
   include Hyrax::HumanReadableType
   include Hyrax::HasRepresentative
+  include Hyrax::Serializers
 
   DEFAULT_ID = 'admin_set/default'.freeze
   DEFAULT_TITLE = ['Default Admin Set'].freeze
@@ -63,10 +64,6 @@ class AdminSet < ActiveFedora::Base
   def self.find_or_create_default_admin_set_id
     Hyrax::AdminSetCreateService.create_default_admin_set(admin_set_id: DEFAULT_ID, title: DEFAULT_TITLE) unless exists?(DEFAULT_ID)
     DEFAULT_ID
-  end
-
-  def to_s
-    title.present? ? title : 'No Title'
   end
 
   # @api public


### PR DESCRIPTION
`AdminSet` has a custom `#to_s` implementation, but it is a subset of the
behavior in `#to_s` via `Hyrax::Serializers`. Deduplicate by using the behavior
in the module and deleting the local version.

@samvera/hyrax-code-reviewers
