### PR TITLE
Remove code marked as removable on AF 12.0.0

### DIFF
--- a/app/models/concerns/hyrax/work_behavior.rb
+++ b/app/models/concerns/hyrax/work_behavior.rb
@@ -31,12 +31,6 @@ module Hyrax
       self.default_system_virus_scanner = Hyrax::VirusScanner
     end
 
-    # TODO: This can be removed when we upgrade to ActiveFedora 12.0
-    def etag
-      raise "Unable to produce an etag for a unsaved object" unless persisted?
-      ldp_source.head.etag
-    end
-
     module ClassMethods
       # This governs which partial to draw when you render this type of object
       def _to_partial_path #:nodoc:


### PR DESCRIPTION
We're on ActiveFedora 13. Drop this pre-12.0.0 patch.

@samvera/hyrax-code-reviewers
