### PR TITLE
Deprecate `PowerConverter`

### DIFF
--- a/app/conversions/power_converters/polymorphic_type.rb
+++ b/app/conversions/power_converters/polymorphic_type.rb
@@ -1,4 +1,5 @@
 PowerConverter.define_conversion_for(:polymorphic_type) do |input|
+  Deprecation.warn('PowerConverter is deprecated. Use `.base_class` instead')
   if input.respond_to?(:base_class)
     input.base_class
   elsif input.is_a?(ActiveRecord::Base)

--- a/app/conversions/power_converters/sipity_action.rb
+++ b/app/conversions/power_converters/sipity_action.rb
@@ -1,4 +1,5 @@
 PowerConverter.define_conversion_for(:sipity_action) do |input, scope|
+  Deprecation.warn('PowerConverter is deprecated. Use `Sipity::WorkflowAction(input, workflow)` instead')
   workflow_id = PowerConverter.convert_to_sipity_workflow_id(scope)
   case input
   when Sipity::WorkflowAction

--- a/app/conversions/power_converters/sipity_action_name.rb
+++ b/app/conversions/power_converters/sipity_action_name.rb
@@ -1,4 +1,5 @@
 PowerConverter.define_conversion_for(:sipity_action_name) do |input|
+  Deprecation.warn('PowerConverter is deprecated. Use `Sipity::WorkflowAction.name_for(input)` instead')
   case input
   when String, Symbol
     input.to_s.sub(/[\?\!]\Z/, '')

--- a/app/conversions/power_converters/sipity_agent.rb
+++ b/app/conversions/power_converters/sipity_agent.rb
@@ -1,4 +1,6 @@
 PowerConverter.define_conversion_for(:sipity_agent) do |input|
+  Deprecation.warn('PowerConverter is deprecated. Use `Sipity::Agent(input)` instead')
+
   case input
   when Sipity::Agent
     input

--- a/app/conversions/power_converters/sipity_entity.rb
+++ b/app/conversions/power_converters/sipity_entity.rb
@@ -1,4 +1,5 @@
 PowerConverter.define_conversion_for(:sipity_entity) do |input|
+  Deprecation.warn('PowerConverter is deprecated. Use `Sipity::Entity(input)` instead')
   case input
   when URI::GID
     Sipity::Entity.find_by(proxy_for_global_id: input.to_s)

--- a/app/conversions/power_converters/sipity_role.rb
+++ b/app/conversions/power_converters/sipity_role.rb
@@ -1,4 +1,5 @@
 PowerConverter.define_conversion_for(:sipity_role) do |input|
+  Deprecation.warn('PowerConverter is deprecated. Use `Sipity::WorkflowAction.name_for(input)` instead')
   case input
   when Sipity::Role
     input

--- a/app/conversions/power_converters/sipity_workflow_state.rb
+++ b/app/conversions/power_converters/sipity_workflow_state.rb
@@ -1,6 +1,8 @@
 require 'power_converter'
 
 PowerConverter.define_conversion_for(:sipity_workflow_state) do |input, workflow|
+  Deprecation.warn('PowerConverter is deprecated. Use `Sipity::WorkflowState(input, workflow)` instead')
+
   case input
   when Sipity::WorkflowState
     input

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -149,7 +149,7 @@ module Hyrax
                     else
                       Hyrax::Group.new(grant[:agent_id])
                     end
-            PowerConverter.convert_to_sipity_agent(agent)
+            Sipity::Agent(agent)
           end
         end
 

--- a/app/forms/hyrax/forms/workflow_action_form.rb
+++ b/app/forms/hyrax/forms/workflow_action_form.rb
@@ -50,9 +50,15 @@ module Hyrax
 
       private
 
+        class << self
+          def workflow_action_for(name, scope:)
+            Sipity::WorkflowAction(name, scope) { nil }
+          end
+        end
+
         def convert_to_sipity_objects!
           @subject = WorkflowActionInfo.new(work, current_user)
-          @sipity_workflow_action = PowerConverter.convert_to_sipity_action(name, scope: subject.entity.workflow) { nil }
+          @sipity_workflow_action = self.class.workflow_action_for(name, scope: subject.entity.workflow)
         end
 
         attr_reader :subject, :sipity_workflow_action

--- a/app/indexers/hyrax/indexes_workflow.rb
+++ b/app/indexers/hyrax/indexes_workflow.rb
@@ -21,11 +21,11 @@ module Hyrax
     # Write the workflow roles and state so one can see where the document moves to next
     # @param [Hash] solr_document the solr document to add the field to
     def index_workflow_fields(solr_document)
-      return unless object.persisted?
-      entity = PowerConverter.convert_to_sipity_entity(object)
-      return if entity.nil?
+      entity = Sipity::Entity(object)
       solr_document[workflow_role_field] = workflow_roles(entity).map { |role| "#{entity.workflow.permission_template.source_id}-#{entity.workflow.name}-#{role}" }
       solr_document[workflow_state_name_field] = entity.workflow_state.name if entity.workflow_state
+    rescue Sipity::ConversionError
+      nil
     end
 
     def workflow_state_name_field

--- a/app/models/concerns/hyrax/suppressible.rb
+++ b/app/models/concerns/hyrax/suppressible.rb
@@ -22,7 +22,7 @@ module Hyrax
     ##
     # @deprecated Use `PowerConverter.convert_to_sipity_entity(obj)` instead.
     def to_sipity_entity
-      Deprecation.warn "Use `PowerConverter.convert_to_sipity_entity(obj)` instead."
+      Deprecation.warn "Use `Sipity::Entity(entity)` instead."
       raise "Can't create an entity until the model has been persisted" unless persisted?
       @sipity_entity ||= Sipity::Entity.find_by(proxy_for_global_id: to_global_id.to_s)
     end

--- a/app/models/hyrax/workflow_action_info.rb
+++ b/app/models/hyrax/workflow_action_info.rb
@@ -5,7 +5,7 @@ module Hyrax
       @work = work
       @user = user
       @entity = Sipity::Entity(work)
-      @agent = PowerConverter.convert(user, to: :sipity_agent)
+      @agent = Sipity::Agent(user)
     end
 
     attr_reader :entity, :agent, :user, :work

--- a/app/models/hyrax/workflow_action_info.rb
+++ b/app/models/hyrax/workflow_action_info.rb
@@ -4,7 +4,7 @@ module Hyrax
     def initialize(work, user)
       @work = work
       @user = user
-      @entity = PowerConverter.convert(work, to: :sipity_entity)
+      @entity = Sipity::Entity(work)
       @agent = PowerConverter.convert(user, to: :sipity_agent)
     end
 

--- a/app/models/sipity.rb
+++ b/app/models/sipity.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 module Sipity
+  def Agent(input, &block) # rubocop:disable Naming/MethodName
+    result = case input
+             when Sipity::Agent
+               input
+             end
+
+    handle_conversion(input, result, :to_sipity_agent, &block)
+  end
+  module_function :Agent
+
   ##
   # Cast an object to an Entity
   # rubocop:disable Naming/MethodName, Metrics/CyclomaticComplexity, Metrics/MethodLength

--- a/app/models/sipity.rb
+++ b/app/models/sipity.rb
@@ -55,6 +55,20 @@ module Sipity
   end
   module_function :WorkflowAction
 
+  ##
+  # Cast an object to a WorkflowState in a given workflow
+  def WorkflowState(input, workflow, &block) # rubocop:disable Naming/MethodName
+    result = case input
+             when Sipity::WorkflowState
+               input
+             when Symbol, String
+               WorkflowState.find_by(workflow_id: workflow.id, name: input)
+             end
+
+    handle_conversion(input, result, :to_sipity_workflow_state, &block)
+  end
+  module_function :WorkflowState
+
   class ConversionError < PowerConverter::ConversionError
     def initialize(value, **options)
       options[:scope] ||= nil

--- a/app/models/sipity.rb
+++ b/app/models/sipity.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/RaiseArgs
+module Sipity
+  ##
+  # Cast an object to a WorkflowAction in a given workflow
+  def WorkflowAction(input, workflow) # rubocop:disable Naming/MethodName
+    workflow_id = PowerConverter.convert_to_sipity_workflow_id(workflow)
+
+    result = case input
+             when WorkflowAction
+               input if input.workflow_id == workflow_id
+             when String, Symbol
+               WorkflowAction.find_by(workflow_id: workflow_id, name: input.to_s)
+             end
+
+    result ||= input.try(:to_sipity_action)
+    return result unless result.nil?
+    return yield if block_given?
+
+    raise ConversionError.new(input)
+  end
+  module_function :WorkflowAction
+
+  # rubocop:enable Style/RaiseArgs
+  class ConversionError < PowerConverter::ConversionError
+    def initialize(value, **options)
+      options[:scope] ||= nil
+      options[:to]    ||= nil
+      super(value, options)
+    end
+  end
+end

--- a/app/models/sipity.rb
+++ b/app/models/sipity.rb
@@ -1,10 +1,33 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/RaiseArgs
 module Sipity
   ##
+  # Cast an object to an Entity
+  # rubocop:disable Naming/MethodName, Metrics/CyclomaticComplexity, Metrics/MethodLength
+  def Entity(input, &block)
+    result = case input
+             when Sipity::Entity
+               input
+             when URI::GID, GlobalID
+               Entity.find_by(proxy_for_global_id: input.to_s)
+             when SolrDocument
+               Entity(input.to_model)
+             when Sipity::Comment
+               Entity(input.entity)
+             else
+               Entity(input.to_global_id) if input.respond_to?(:to_global_id)
+             end
+
+    handle_conversion(input, result, :to_sipity_entity, &block)
+  rescue URI::GID::MissingModelIdError
+    Entity(nil)
+  end
+  module_function :Entity
+  # rubocop:enable Naming/MethodName, Metrics/CyclomaticComplexity, Metrics/MethodLength
+
+  ##
   # Cast an object to a WorkflowAction in a given workflow
-  def WorkflowAction(input, workflow) # rubocop:disable Naming/MethodName
+  def WorkflowAction(input, workflow, &block) # rubocop:disable Naming/MethodName
     workflow_id = PowerConverter.convert_to_sipity_workflow_id(workflow)
 
     result = case input
@@ -14,15 +37,10 @@ module Sipity
                WorkflowAction.find_by(workflow_id: workflow_id, name: input.to_s)
              end
 
-    result ||= input.try(:to_sipity_action)
-    return result unless result.nil?
-    return yield if block_given?
-
-    raise ConversionError.new(input)
+    handle_conversion(input, result, :to_sipity_action, &block)
   end
   module_function :WorkflowAction
 
-  # rubocop:enable Style/RaiseArgs
   class ConversionError < PowerConverter::ConversionError
     def initialize(value, **options)
       options[:scope] ||= nil
@@ -30,4 +48,15 @@ module Sipity
       super(value, options)
     end
   end
+
+  ##
+  # Provides compatibility with the old `PowerConverter` conventions
+  def handle_conversion(input, result, method_name)
+    result ||= input.try(method_name)
+    return result unless result.nil?
+    return yield if block_given?
+
+    raise ConversionError.new(input) # rubocop:disable Style/RaiseArgs
+  end
+  module_function :handle_conversion
 end

--- a/app/models/sipity.rb
+++ b/app/models/sipity.rb
@@ -26,6 +26,20 @@ module Sipity
   # rubocop:enable Naming/MethodName, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
   ##
+  # Cast an object to an Role
+  def Role(input, &block) # rubocop:disable Naming/MethodName
+    result = case input
+             when Sipity::Role
+               input
+             when String, Symbol
+               Sipity::Role.find_or_create_by(name: input)
+             end
+
+    handle_conversion(input, result, :to_sipity_role, &block)
+  end
+  module_function :Role
+
+  ##
   # Cast an object to a WorkflowAction in a given workflow
   def WorkflowAction(input, workflow, &block) # rubocop:disable Naming/MethodName
     workflow_id = PowerConverter.convert_to_sipity_workflow_id(workflow)

--- a/app/models/sipity/workflow_action.rb
+++ b/app/models/sipity/workflow_action.rb
@@ -27,18 +27,14 @@ module Sipity
     ##
     # @param [Object] input
     # @return [String]
-    def self.name_for(input)
+    def self.name_for(input, &block)
       result = case input
                when String, Symbol
                  input.to_s.sub(/[\?\!]\Z/, '')
                when Sipity::WorkflowAction
                  input.name
                end
-      result ||= input.try(:to_sipity_action_name)
-      return result unless result.nil?
-      return yield if block_given?
-
-      raise ConversionError.new(input) # rubocop:disable Style/RaiseArgs
+      Sipity.handle_conversion(result, &block)
     end
   end
 end

--- a/app/models/sipity/workflow_action.rb
+++ b/app/models/sipity/workflow_action.rb
@@ -34,7 +34,7 @@ module Sipity
                when Sipity::WorkflowAction
                  input.name
                end
-      Sipity.handle_conversion(result, &block)
+      Sipity.handle_conversion(input, result, :to_sipity_action_name, &block)
     end
   end
 end

--- a/app/models/sipity/workflow_action.rb
+++ b/app/models/sipity/workflow_action.rb
@@ -23,5 +23,22 @@ module Sipity
              dependent: :destroy,
              as: :scope_for_notification,
              class_name: 'Sipity::NotifiableContext'
+
+    ##
+    # @param [Object] input
+    # @return [String]
+    def self.name_for(input)
+      result = case input
+               when String, Symbol
+                 input.to_s.sub(/[\?\!]\Z/, '')
+               when Sipity::WorkflowAction
+                 input.name
+               end
+      result ||= input.try(:to_sipity_action_name)
+      return result unless result.nil?
+      return yield if block_given?
+
+      raise ConversionError.new(input) # rubocop:disable Style/RaiseArgs
+    end
   end
 end

--- a/app/presenters/hyrax/inspect_work_presenter.rb
+++ b/app/presenters/hyrax/inspect_work_presenter.rb
@@ -27,7 +27,7 @@ module Hyrax
     private
 
       def sipity_entity
-        @sipity_entity ||= PowerConverter.convert(solr_document, to: :sipity_entity)
+        @sipity_entity ||= Sipity::Entity(solr_document)
       end
 
       def sipity_entity_roles

--- a/app/presenters/hyrax/workflow_presenter.rb
+++ b/app/presenters/hyrax/workflow_presenter.rb
@@ -42,7 +42,7 @@ module Hyrax
       end
 
       def sipity_entity
-        PowerConverter.convert(solr_document, to: :sipity_entity)
+        Sipity::Entity(solr_document)
       rescue PowerConverter::ConversionError
         nil
       end

--- a/app/services/hyrax/workflow/notification_generator.rb
+++ b/app/services/hyrax/workflow/notification_generator.rb
@@ -39,7 +39,7 @@ module Hyrax
           notification_configuration.recipients.slice(:to, :cc, :bcc).each do |(recipient_strategy, recipient_roles)|
             Array.wrap(recipient_roles).each do |role|
               notification.recipients.find_or_create_by!(
-                role: PowerConverter.convert_to_sipity_role(role), recipient_strategy: recipient_strategy.to_s
+                role: Sipity::Role(role), recipient_strategy: recipient_strategy.to_s
               )
             end
           end

--- a/app/services/hyrax/workflow/notification_generator.rb
+++ b/app/services/hyrax/workflow/notification_generator.rb
@@ -57,7 +57,7 @@ module Hyrax
         attr_reader :scope
 
         def assign_scope!
-          @scope = PowerConverter.convert_to_sipity_action(notification_configuration.scope, scope: workflow)
+          @scope = Sipity::WorkflowAction(notification_configuration.scope, workflow)
         end
     end
   end

--- a/app/services/hyrax/workflow/permission_generator.rb
+++ b/app/services/hyrax/workflow/permission_generator.rb
@@ -63,7 +63,7 @@ module Hyrax
         end
 
         def roles=(input)
-          @roles = Array.wrap(input).map { |role| PowerConverter.convert_to_sipity_role(role) }
+          @roles = Array.wrap(input).map { |role| Sipity::Role(role) }
         end
 
         def entity=(entity)

--- a/app/services/hyrax/workflow/permission_generator.rb
+++ b/app/services/hyrax/workflow/permission_generator.rb
@@ -55,7 +55,7 @@ module Hyrax
         attr_reader :entity, :agents, :action_names, :roles
 
         def agents=(input)
-          @agents = Array.wrap(input).map { |agent| PowerConverter.convert_to_sipity_agent(agent) }
+          @agents = Array.wrap(input).map { |agent| Sipity::Agent(agent) }
         end
 
         def action_names=(input)

--- a/app/services/hyrax/workflow/permission_generator.rb
+++ b/app/services/hyrax/workflow/permission_generator.rb
@@ -67,7 +67,7 @@ module Hyrax
         end
 
         def entity=(entity)
-          @entity = PowerConverter.convert_to_sipity_entity(entity)
+          @entity = Sipity::Entity(entity)
         end
 
       public

--- a/app/services/hyrax/workflow/permission_query.rb
+++ b/app/services/hyrax/workflow/permission_query.rb
@@ -67,7 +67,7 @@ module Hyrax
       # @return [ActiveRecord::Relation<Sipity::Agent>] augmented with
       def scope_agents_associated_with_entity_and_role(entity:, role:)
         entity = Sipity::Entity(entity)
-        role = PowerConverter.convert_to_sipity_role(role)
+        role = Sipity::Role(role)
 
         agents = Sipity::Agent.arel_table
 
@@ -241,7 +241,7 @@ module Hyrax
       # @return [ActiveRecord::Relation<User>]
       def scope_users_for_entity_and_roles(entity:, roles:)
         entity = Sipity::Entity(entity)
-        role_ids = Array.wrap(roles).map { |role| PowerConverter.convert_to_sipity_role(role).id }
+        role_ids = Array.wrap(roles).map { |role| Sipity::Role(role).id }
         user_polymorphic_type = PowerConverter.convert_to_polymorphic_type(::User)
 
         user_table = ::User.arel_table

--- a/app/services/hyrax/workflow/permission_query.rb
+++ b/app/services/hyrax/workflow/permission_query.rb
@@ -43,7 +43,7 @@ module Hyrax
       # * Actions to which the user Only actions permitted to the user
       #
       # @param user [User]
-      # @param entity [#to_sipity_entity] an object that can be converted into a Sipity::Entity
+      # @param entity [Object] an object that can be converted into a Sipity::Entity
       # @return [ActiveRecord::Relation<Sipity::WorkflowAction>]
       def scope_permitted_workflow_actions_available_for_current_state(user:, entity:)
         workflow_actions_scope = scope_workflow_actions_available_for_current_state(entity: entity)
@@ -66,7 +66,7 @@ module Hyrax
       # @param role [Object] that can be converted into a Sipity::Role
       # @return [ActiveRecord::Relation<Sipity::Agent>] augmented with
       def scope_agents_associated_with_entity_and_role(entity:, role:)
-        entity = PowerConverter.convert_to_sipity_entity(entity)
+        entity = Sipity::Entity(entity)
         role = PowerConverter.convert_to_sipity_role(role)
 
         agents = Sipity::Agent.arel_table
@@ -126,7 +126,7 @@ module Hyrax
       # @param entity [Object] that can be converted into a Sipity::Entity
       # @return [ActiveRecord::Relation<Sipity::Role>]
       def scope_roles_associated_with_the_given_entity(entity:)
-        entity = PowerConverter.convert_to_sipity_entity(entity)
+        entity = Sipity::Entity(entity)
         return Sipity::Role.none unless entity
         Sipity::Role.where(
           Sipity::Role.arel_table[:id].in(
@@ -240,7 +240,7 @@ module Hyrax
       # @param entity an object that can be converted into a Sipity::Entity
       # @return [ActiveRecord::Relation<User>]
       def scope_users_for_entity_and_roles(entity:, roles:)
-        entity = PowerConverter.convert_to_sipity_entity(entity)
+        entity = Sipity::Entity(entity)
         role_ids = Array.wrap(roles).map { |role| PowerConverter.convert_to_sipity_role(role).id }
         user_polymorphic_type = PowerConverter.convert_to_polymorphic_type(::User)
 
@@ -290,7 +290,7 @@ module Hyrax
       # @param entity an object that can be converted into a Sipity::Entity
       # @return [ActiveRecord::Relation<Sipity::WorkflowRole>]
       def scope_processing_workflow_roles_for_user_and_entity(user:, entity:)
-        entity = PowerConverter.convert_to_sipity_entity(entity)
+        entity = Sipity::Entity(entity)
         workflow_scope = scope_processing_workflow_roles_for_user_and_workflow(user: user, workflow: entity.workflow)
 
         entity_specific_scope = scope_processing_workflow_roles_for_user_and_entity_specific(user: user, entity: entity)
@@ -335,7 +335,7 @@ module Hyrax
       # @param entity an object that can be converted into a Sipity::Entity
       # @return [ActiveRecord::Relation<Sipity::WorkflowRole>]
       def scope_processing_workflow_roles_for_user_and_entity_specific(user:, entity:)
-        entity = PowerConverter.convert_to_sipity_entity(entity)
+        entity = Sipity::Entity(entity)
         agent_scope = scope_processing_agents_for(user: user)
 
         Sipity::WorkflowRole.where(
@@ -373,7 +373,7 @@ module Hyrax
       # @param entity an object that can be converted into a Sipity::Entity
       # @return [ActiveRecord::Relation<Sipity::WorkflowStateAction>]
       def scope_permitted_entity_workflow_state_actions(user:, entity:)
-        entity = PowerConverter.convert_to_sipity_entity(entity)
+        entity = Sipity::Entity(entity)
         workflow_state_actions = Sipity::WorkflowStateAction
         permissions = Sipity::WorkflowStateActionPermission
         role_scope = scope_processing_workflow_roles_for_user_and_entity(user: user, entity: entity)
@@ -405,7 +405,7 @@ module Hyrax
       # @param entity an object that can be converted into a Sipity::Entity
       # @return [ActiveRecord::Relation<Sipity::WorkflowAction>]
       def scope_workflow_actions_for_current_state(entity:)
-        entity = PowerConverter.convert_to_sipity_entity(entity)
+        entity = Sipity::Entity(entity)
         state_actions_table = Sipity::WorkflowStateAction.arel_table
         Sipity::WorkflowAction.where(
           Sipity::WorkflowAction.arel_table[:id].in(

--- a/app/services/hyrax/workflow/permission_query.rb
+++ b/app/services/hyrax/workflow/permission_query.rb
@@ -242,7 +242,7 @@ module Hyrax
       def scope_users_for_entity_and_roles(entity:, roles:)
         entity = Sipity::Entity(entity)
         role_ids = Array.wrap(roles).map { |role| Sipity::Role(role).id }
-        user_polymorphic_type = PowerConverter.convert_to_polymorphic_type(::User)
+        user_polymorphic_type = ::User.base_class
 
         user_table = ::User.arel_table
         agent_table = Sipity::Agent.arel_table

--- a/app/services/hyrax/workflow/permission_query.rb
+++ b/app/services/hyrax/workflow/permission_query.rb
@@ -163,9 +163,9 @@ module Hyrax
       def scope_processing_agents_for(user:)
         return Sipity::Agent.none if user.blank?
         return Sipity::Agent.none unless user.persisted?
-        user_agent = PowerConverter.convert_to_sipity_agent(user)
+        user_agent = Sipity::Agent(user)
         group_agents = user.groups.map do |g|
-          PowerConverter.convert_to_sipity_agent(Hyrax::Group.new(g))
+          Sipity::Agent(Hyrax::Group.new(g))
         end
         Sipity::Agent.where(id: group_agents + [user_agent])
       end

--- a/app/services/hyrax/workflow/permission_query.rb
+++ b/app/services/hyrax/workflow/permission_query.rb
@@ -147,7 +147,7 @@ module Hyrax
       # @param action an object that can be converted into a Sipity::WorkflowAction#name
       # @return [Boolean]
       def authorized_for_processing?(user:, entity:, action:)
-        action_name = PowerConverter.convert_to_sipity_action_name(action)
+        action_name = Sipity::WorkflowAction.name_for(action)
         scope_permitted_workflow_actions_available_for_current_state(user: user, entity: entity)
           .find_by(Sipity::WorkflowAction.arel_table[:name].eq(action_name)).present?
       end

--- a/spec/forms/hyrax/forms/workflow_action_form_spec.rb
+++ b/spec/forms/hyrax/forms/workflow_action_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Hyrax::Forms::WorkflowActionForm do
 
   context 'if the given user cannot perform the given action' do
     before do
-      allow(PowerConverter).to receive(:convert_to_sipity_action).with('an_action', scope: sipity_entity.workflow).and_return(an_action)
+      allow(described_class).to receive(:workflow_action_for).with('an_action', scope: sipity_entity.workflow).and_return(an_action)
       expect(Hyrax::Workflow::PermissionQuery).to receive(:authorized_for_processing?).and_return(false)
     end
 
@@ -53,7 +53,7 @@ RSpec.describe Hyrax::Forms::WorkflowActionForm do
 
   context 'if the given user can perform the given action' do
     before do
-      allow(PowerConverter).to receive(:convert_to_sipity_action).with('an_action', scope: sipity_entity.workflow).and_return(an_action)
+      allow(described_class).to receive(:workflow_action_for).with('an_action', scope: sipity_entity.workflow).and_return(an_action)
       expect(Hyrax::Workflow::PermissionQuery).to receive(:authorized_for_processing?)
         .and_return(true)
     end

--- a/spec/models/sipity/workflow_action_spec.rb
+++ b/spec/models/sipity/workflow_action_spec.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
 module Sipity
   RSpec.describe WorkflowAction, type: :model do
     context 'database configuration' do
@@ -6,6 +10,35 @@ module Sipity
       its(:column_names) { is_expected.to include('workflow_id') }
       its(:column_names) { is_expected.to include('resulting_workflow_state_id') }
       its(:column_names) { is_expected.to include('name') }
+    end
+
+    describe '.name' do
+      [
+        [:show, 'show'],
+        [:show?, 'show'],
+        [:new?, 'new'],
+        [:new, 'new'],
+        [:edit?, 'edit'],
+        [:edit, 'edit'],
+        [:submit, 'submit'],
+        [:submit?, 'submit'],
+        [:attach, 'attach'],
+        [Sipity::WorkflowAction.new(name: 'hello'), 'hello']
+      ].each_with_index do |(original, expected), index|
+        it "will convert #{original.inspect} to #{expected.inspect} (scenario ##{index})" do
+          expect(described_class.name_for(original)).to eq(expected)
+        end
+      end
+    end
+
+    it 'will raise an exception if it is not processible' do
+      object = double('Bad Wolf')
+      expect { described_class.name_for(object) }.to raise_error(Sipity::ConversionError)
+    end
+
+    it 'will leverage a short-circuit #to_processing_action_name' do
+      object = double(to_sipity_action_name: 'bob')
+      expect(described_class.name_for(object)).to eq('bob')
     end
   end
 end

--- a/spec/models/sipity_spec.rb
+++ b/spec/models/sipity_spec.rb
@@ -1,4 +1,69 @@
 RSpec.describe Sipity do
+  describe '.Entity' do
+    context "with a Sipity::Entity" do
+      let(:object) { Sipity::Entity.new }
+
+      it { expect(described_class.Entity(object)).to eq object }
+    end
+
+    context "with a Sipity::Comment" do
+      let(:object) { Sipity::Comment.new(entity: entity) }
+      let(:entity) { Sipity::Entity.new }
+
+      it { expect(described_class.Entity(object)).to eq entity }
+    end
+
+    context "with a SolrDocument" do
+      let(:object) { SolrDocument.new(id: '9999', has_model_ssim: ["GenericWork"]) }
+      let(:workflow_state) { create(:workflow_state) }
+      let!(:entity) do
+        Sipity::Entity.create(proxy_for_global_id: 'gid://internal/GenericWork/9999',
+                              workflow_state: workflow_state,
+                              workflow: workflow_state.workflow)
+      end
+
+      it { expect(described_class.Entity(object)).to eq entity }
+    end
+
+    context 'a Work' do
+      let(:workflow_state) { create(:workflow_state) }
+
+      it 'will raise an conversion error if an id has not been assigned' do
+        object = build(:generic_work)
+
+        expect { described_class.Entity(object) }
+          .to raise_error Sipity::ConversionError
+      end
+
+      it 'raises a conversion error when there is no matching entity' do
+        object = create(:generic_work)
+
+        expect { described_class.Entity(object) }
+          .to raise_error Sipity::ConversionError
+      end
+
+      it 'gives a matching entity' do
+        object = create(:generic_work)
+
+        entity = Sipity::Entity.create(proxy_for_global_id: object.to_global_id,
+                                       workflow_state: workflow_state,
+                                       workflow: workflow_state.workflow)
+
+        expect(described_class.Entity(object)).to eq entity
+      end
+    end
+
+    it 'will return the to_processing_entity if the object responds to the processing entity' do
+      object = double(to_sipity_entity: :processing_entity)
+      expect(described_class.Entity(object)).to eq(:processing_entity)
+    end
+
+    it 'will raise an error if it cannot convert' do
+      expect { described_class.Entity(nil) }
+        .to raise_error PowerConverter::ConversionError
+    end
+  end
+
   describe '.WorkflowAction' do
     let(:workflow_id) { 1 }
     let(:action) { Sipity::WorkflowAction.new(id: 4, name: 'show', workflow_id: workflow_id) }

--- a/spec/models/sipity_spec.rb
+++ b/spec/models/sipity_spec.rb
@@ -135,4 +135,26 @@ RSpec.describe Sipity do
       end
     end
   end
+
+  describe '.WorkflowState' do
+    let(:workflow_state) { Sipity::WorkflowState.new(id: 1, name: 'hello') }
+    let(:workflow) { create(:workflow) }
+
+    it 'will convert a Sipity::WorkflowState' do
+      expect(described_class.WorkflowState(workflow_state, workflow))
+        .to eq workflow_state
+    end
+
+    it 'will convert a string based on scope' do
+      state = create(:workflow_state, workflow_id: workflow.id, name: 'hello')
+
+      expect(described_class.WorkflowState('hello', workflow))
+        .to eq state
+    end
+
+    it 'will attempt convert a string based on scope' do
+      expect { described_class.WorkflowState('missing', workflow) }
+        .to raise_error(PowerConverter::ConversionError)
+    end
+  end
 end

--- a/spec/models/sipity_spec.rb
+++ b/spec/models/sipity_spec.rb
@@ -1,4 +1,21 @@
 RSpec.describe Sipity do
+  describe '.Agent' do
+    it 'will convert a Sipity::Agent' do
+      object = Sipity::Agent.new
+      expect(described_class.Agent(object)).to eq(object)
+    end
+
+    it 'will convert an object that responds to #to_sipity_agent' do
+      object = double(to_sipity_agent: :a_sipity_agent)
+      expect(described_class.Agent(object)).to eq(:a_sipity_agent)
+    end
+
+    it 'will raise an exception if it cannot convert the given object' do
+      expect { described_class.Agent(double) }
+        .to raise_error(PowerConverter::ConversionError)
+    end
+  end
+
   describe '.Entity' do
     context "with a Sipity::Entity" do
       let(:object) { Sipity::Entity.new }

--- a/spec/models/sipity_spec.rb
+++ b/spec/models/sipity_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe Sipity do
+  describe '.WorkflowAction' do
+    let(:workflow_id) { 1 }
+    let(:action) { Sipity::WorkflowAction.new(id: 4, name: 'show', workflow_id: workflow_id) }
+
+    context "with workflow_id and action's workflow_id matching" do
+      it 'will return the object if it is a Sipity::WorkflowAction' do
+        expect(described_class.WorkflowAction(action, workflow_id)).to eq(action)
+      end
+
+      it 'will return the object if it responds to #to_sipity_action' do
+        object = double(to_sipity_action: action)
+        expect(described_class.WorkflowAction(object, workflow_id)).to eq(action)
+      end
+
+      it 'will raise an error if it cannot convert the object' do
+        object = double
+        expect { described_class.WorkflowAction(object, workflow_id) }
+          .to raise_error(Sipity::ConversionError)
+      end
+
+      it 'will use a found action based on the given string and workflow_id' do
+        expect(Sipity::WorkflowAction).to receive(:find_by).and_return(action)
+        expect(described_class.WorkflowAction(action.name, workflow_id)).to eq(action)
+      end
+
+      context "when the WorkflowAction can not be found" do
+        it 'will raise an error' do
+          expect(Sipity::WorkflowAction).to receive(:find_by).and_return(nil)
+          expect { described_class.WorkflowAction(action.name, workflow_id) }
+            .to raise_error(Sipity::ConversionError)
+        end
+      end
+    end
+
+    context "with mismatching workflow_id and action's workflow_id" do
+      it "will fail an error if the scope's workflow_id is different than the actions" do
+        expect { described_class.WorkflowAction(action, workflow_id + 1) }
+          .to raise_error(Sipity::ConversionError)
+      end
+    end
+  end
+end

--- a/spec/models/sipity_spec.rb
+++ b/spec/models/sipity_spec.rb
@@ -64,6 +64,36 @@ RSpec.describe Sipity do
     end
   end
 
+  describe '.Role' do
+    it "converts Sipity::Role" do
+      object = Sipity::Role.new
+      expect(described_class.Role(object)).to eq object
+    end
+
+    it "converts a #to_sipity_role object" do
+      object = double(to_sipity_role: Sipity::Role.new)
+      expect(described_class.Role(object)).to eq object.to_sipity_role
+    end
+
+    it "converts a string to a Sipity::Role if there exists a Sipity::Role with a name equal to the string" do
+      Sipity::Role.create!(name: 'hello')
+      expect(described_class.Role('hello')).to be_a(Sipity::Role)
+    end
+
+    it "creates a new role if given a string and no Sipity::Role exists with that name" do
+      expect { described_class.Role('new_role_name') }.to change { Sipity::Role.count }.by(1)
+    end
+
+    it "converts a base object with composed attributes delegator" do
+      base_object = Sipity::Role.new
+      expect(described_class.Role(base_object)).to eq(base_object)
+    end
+
+    it 'does not convert an arbitrary object' do
+      expect { described_class.Role(double) }.to raise_error(PowerConverter::ConversionError)
+    end
+  end
+
   describe '.WorkflowAction' do
     let(:workflow_id) { 1 }
     let(:action) { Sipity::WorkflowAction.new(id: 4, name: 'show', workflow_id: workflow_id) }

--- a/spec/services/hyrax/workflow/permission_query_spec.rb
+++ b/spec/services/hyrax/workflow/permission_query_spec.rb
@@ -26,7 +26,7 @@ module Hyrax
       before { Hyrax::Workflow::WorkflowImporter.generate_from_hash(data: workflow_config, permission_template: sipity_workflow.permission_template) }
 
       def expect_actions_for(user:, entity:, actions:)
-        actions = Array.wrap(actions).map { |action| PowerConverter.convert_to_sipity_action(action, scope: entity.workflow) }
+        actions = Array.wrap(actions).map { |action| Sipity::WorkflowAction(action, entity.workflow) }
         expect(described_class.scope_permitted_workflow_actions_available_for_current_state(user: user, entity: entity)).to eq(actions)
       end
 

--- a/spec/services/hyrax/workflow/permission_query_spec.rb
+++ b/spec/services/hyrax/workflow/permission_query_spec.rb
@@ -19,7 +19,7 @@ module Hyrax
       let(:sipity_entity) do
         Sipity::Entity.create!(proxy_for_global_id: 'gid://internal/Mock/1',
                                workflow: sipity_workflow,
-                               workflow_state: PowerConverter.convert_to_sipity_workflow_state('initial', scope: sipity_workflow))
+                               workflow_state: Sipity::WorkflowState('initial', sipity_workflow))
       end
       let(:sipity_workflow) { create(:workflow, name: 'testing') }
 
@@ -110,7 +110,7 @@ module Hyrax
 
           # Then transition to Sipity::Entity
           sipity_entity.update!(
-            workflow_state: PowerConverter.convert_to_sipity_workflow_state('forwarded', scope: sipity_workflow)
+            workflow_state: Sipity::WorkflowState('forwarded', sipity_workflow)
           )
 
           # Now permissions have changed
@@ -156,7 +156,7 @@ module Hyrax
 
           # Then transition to Sipity::Entity
           sipity_entity.update!(
-            workflow_state: PowerConverter.convert_to_sipity_workflow_state('forwarded', scope: sipity_workflow)
+            workflow_state: Sipity::WorkflowState('forwarded', sipity_workflow)
           )
 
           # Now permissions have changed


### PR DESCRIPTION
`PowerConverter` is a community-maintained gem, but is not in the Samvera
namespace. Depending on it under these circumstances is not in keeping with our
policy.

Rather than simply inline the `PowerConverter` class, this proposes pushing in
the direction a more generic ruby pattern that inspired
it. http://devblog.avdi.org/2012/05/07/a-ruby-conversion-idiom/

  - When casting to a specific class, use `MyClass(thing_to_cast_from)`, as is done in Ruby core.
  - When the conversion is polymorphic, use a `.*_for` method as a factory

Refs #4096 

@samvera/hyrax-code-reviewers
