### PR TITLE
Remove call to deprecated PowerConverter

### DIFF
--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -163,7 +163,8 @@ module Hyrax
                 Hyrax::Group.new(access.agent_id)
               end
             end
-            authorized_agents.map { |agent| PowerConverter.convert_to_sipity_agent(agent) }
+
+            authorized_agents.map { |agent| Sipity::Agent(agent) }
           end
         end
 


### PR DESCRIPTION
This converter was deprecated. Transition this call to the new thing.

@samvera/hyrax-code-reviewers
