### PR TITLE
Implement Resource state in a model agnostic way

### DIFF
--- a/app/models/concerns/hyrax/suppressible.rb
+++ b/app/models/concerns/hyrax/suppressible.rb
@@ -14,9 +14,7 @@ module Hyrax
     #
     # Override this method if you have some criteria by which records should not display in the search results.
     def suppressed?
-      return false if state.nil?
-
-      state == Vocab::FedoraResourceStatus.inactive
+      Hyrax::ResourceStatus.new(resource: self).inactive?
     end
 
     ##

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -10,6 +10,7 @@ module Hyrax
 
     attribute :admin_set_id, Valkyrie::Types::ID
     attribute :member_ids,   Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)
+    attribute :state,        Valkyrie::Types::URI.default(Hyrax::ResourceStatus::ACTIVE)
 
     ##
     # @return [Boolean] true

--- a/app/services/hyrax/resource_status.rb
+++ b/app/services/hyrax/resource_status.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Implements the Fedora objState ontology against the given resource.
+  #
+  # Use the provided constants as values for `#status` to set state. The
+  # boolean methods provide easy checking of state.
+  #
+  # We assume that no-state, means none of the three object statuses are
+  # satisfied. Errors are raised if the `#state` attribute isn't defined.
+  #
+  # @see http://fedora.info/definitions/1/0/access/ObjState
+  #
+  # @example
+  #   status = ResourceStatus.new(resource: my_resource)
+  #   status.inactive? # => false
+  #
+  #   my_resource.state = ResourceStatus::INACTIVE
+  #   status = ResourceStatus.new(resource: my_resource)
+  #   status.inactive? # => true
+  #
+  class ResourceStatus
+    ACTIVE   = Vocab::FedoraResourceStatus.active.freeze
+    DELETED  = Vocab::FedoraResourceStatus.deleted.freeze
+    INACTIVE = Vocab::FedoraResourceStatus.inactive.freeze
+
+    ##
+    # @!attribute [rw] resource
+    #   @return [#state]
+    attr_accessor :resource
+
+    ##
+    # @param [#state] resource
+    def initialize(resource:)
+      self.resource = resource
+    end
+
+    ##
+    # @return [Boolean]
+    # @raise [NoMethodError] if the resource doesn't have a state attribute
+    def active?
+      resource.state == ACTIVE
+    end
+
+    ##
+    # @return [Boolean]
+    # @raise [NoMethodError] if the resource doesn't have a state attribute
+    def deleted?
+      resource.state == DELETED
+    end
+
+    ##
+    # @return [Boolean]
+    # @raise [NoMethodError] if the resource doesn't have a state attribute
+    def inactive?
+      resource.state == INACTIVE
+    end
+  end
+end

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -154,6 +154,16 @@ RSpec.shared_examples 'a Hyrax::Work' do
       end
     end
   end
+
+  describe '#state' do
+    it 'accepts URIS' do
+      uri = RDF::URI('http://example.com/ns/moomin_state')
+
+      expect { work.state = uri}
+        .to change { work.state }
+        .to uri
+    end
+  end
 end
 
 RSpec.shared_examples 'a Hyrax::FileSet' do

--- a/spec/models/hyrax/work_spec.rb
+++ b/spec/models/hyrax/work_spec.rb
@@ -13,4 +13,10 @@ RSpec.describe Hyrax::Work do
       expect(work.human_readable_type).to eq 'Work'
     end
   end
+
+  describe '#state' do
+    it 'is active by default' do
+      expect(work.state).to eq Hyrax::ResourceStatus::ACTIVE
+    end
+  end
 end

--- a/spec/services/hyrax/resource_status_spec.rb
+++ b/spec/services/hyrax/resource_status_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::ResourceStatus do
+  subject(:status) { described_class.new(resource: resource) }
+  let(:resource)   { fake_with_status.new }
+
+  let(:fake_with_status) do
+    Class.new do
+      attr_reader :state
+
+      def initialize(state = nil)
+        @state = state
+      end
+    end
+  end
+
+  describe '#active?' do
+    it { is_expected.not_to be_active }
+
+    context 'when active' do
+      let(:resource) { fake_with_status.new(Hyrax::ResourceStatus::ACTIVE) }
+
+      it { is_expected.to be_active }
+    end
+
+    context 'when deleted' do
+      let(:resource) { fake_with_status.new(Hyrax::ResourceStatus::DELETED) }
+
+      it { is_expected.not_to be_active }
+    end
+
+    context 'when inactive' do
+      let(:resource) { fake_with_status.new(Hyrax::ResourceStatus::INACTIVE) }
+
+      it { is_expected.not_to be_active }
+    end
+
+    context 'with a resource with no state' do
+      let(:resource) { Valkyrie::Resource.new }
+
+      it 'raises NoMethodError' do
+        expect { status.active? }.to raise_error NoMethodError
+      end
+    end
+  end
+
+  describe '#deleted?' do
+    it { is_expected.not_to be_deleted }
+
+    context 'when active' do
+      let(:resource) { fake_with_status.new(Hyrax::ResourceStatus::ACTIVE) }
+
+      it { is_expected.not_to be_deleted }
+    end
+
+    context 'when deleted' do
+      let(:resource) { fake_with_status.new(Hyrax::ResourceStatus::DELETED) }
+
+      it { is_expected.to be_deleted }
+    end
+
+    context 'when inactive' do
+      let(:resource) { fake_with_status.new(Hyrax::ResourceStatus::INACTIVE) }
+
+      it { is_expected.not_to be_deleted }
+    end
+
+    context 'with a resource with no state' do
+      let(:resource) { Valkyrie::Resource.new }
+
+      it 'raises NoMethodError' do
+        expect { status.deleted? }.to raise_error NoMethodError
+      end
+    end
+  end
+
+  describe '#inactive?' do
+    it { is_expected.not_to be_inactive }
+
+    context 'when active' do
+      let(:resource) { fake_with_status.new(Hyrax::ResourceStatus::ACTIVE) }
+
+      it { is_expected.not_to be_inactive }
+    end
+
+    context 'when deleted' do
+      let(:resource) { fake_with_status.new(Hyrax::ResourceStatus::DELETED) }
+
+      it { is_expected.not_to be_inactive }
+    end
+
+    context 'when inactive' do
+      let(:resource) { fake_with_status.new(Hyrax::ResourceStatus::INACTIVE) }
+
+      it { is_expected.to be_inactive }
+    end
+
+    context 'with a resource with no state' do
+      let(:resource) { Valkyrie::Resource.new }
+
+      it 'raises NoMethodError' do
+        expect { status.inactive? }.to raise_error NoMethodError
+      end
+    end
+  end
+end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -21,6 +21,22 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       expect(converter.convert).to eq work
     end
 
+    context 'fedora objState' do
+      let(:resource) { build(:hyrax_work) }
+
+      it 'is active by default' do
+        expect(converter.convert)
+          .to have_attributes state: Hyrax::ResourceStatus::ACTIVE
+      end
+
+      it 'converts non-active states' do
+        resource.state = Hyrax::ResourceStatus::INACTIVE
+
+        expect(converter.convert)
+          .to have_attributes state: Hyrax::ResourceStatus::INACTIVE
+      end
+    end
+
     context 'when given a valkyrie native model' do
       let(:resource) { klass.new }
 


### PR DESCRIPTION
Extract resource state/status to `Hyrax::ResourceStatus`. This service is
agnostic to Valkyrie/ActiveFedora models, but respects Fedora "resource status"
URIs. https://fedora.info/definitions/1/0/access/2016/06/02/ObjState

Additionally, add a `#state` attribute to `Hyrax::Work`. This readds an
attribute previously handled by `Hyrax::WorkBehavior`.

Though Hyrax only uses/respects Fedora's "inactive" status, the utility we
provide supports three statuses from the Fedora Resource Status vocabulary:
active, inactive, and deleted.

Changes proposed in this pull request:
* Refactors `Suppressible` to rely on a more complete implementation of the Fedora `objState` ontology.
* The new implementation supports ActiveFedora and Valkyrie models interchangeably.

@samvera/hyrax-code-reviewers
