### PR TITLE
Valkyrizes job that revokes :edit permissions

### DIFF
--- a/app/jobs/hyrax/revoke_edit_from_members_job.rb
+++ b/app/jobs/hyrax/revoke_edit_from_members_job.rb
@@ -1,14 +1,15 @@
 module Hyrax
   # Revokes edit access for the supplied user for the members attached to a work
-  class RevokeEditFromMembersJob < ApplicationJob
+  class RevokeEditFromMembersJob < Hyrax::ApplicationJob
     queue_as Hyrax.config.ingest_queue_name
 
     # @param [ActiveFedora::Base] work - the work object
     # @param [String] user_key - the user to remove
-    def perform(work, user_key)
+    # @param [Boolean] use_valkyrie - use valkyrie objects for this operation?
+    def perform(work, user_key, use_valkyrie: Hyrax.config.use_valkyrie?)
       # Iterate over ids because reifying objects is slow.
       file_set_ids(work).each do |file_set_id|
-        RevokeEditJob.perform_now(file_set_id, user_key)
+        RevokeEditJob.perform_now(file_set_id, user_key, use_valkyrie: use_valkyrie)
       end
     end
 
@@ -17,7 +18,12 @@ module Hyrax
       # Filter the member ids and return only the FileSet ids (filter out child works)
       # @return [Array<String>] the file set ids
       def file_set_ids(work)
-        ::FileSet.search_with_conditions(id: work.member_ids).map(&:id)
+        case work
+        when ActiveFedora::Base
+          ::FileSet.search_with_conditions(id: work.member_ids).map(&:id)
+        when Valkyrie::Resource
+          Hyrax.query_service.custom_queries.find_child_fileset_ids(resource: work)
+        end
       end
   end
 end

--- a/app/jobs/hyrax/revoke_edit_job.rb
+++ b/app/jobs/hyrax/revoke_edit_job.rb
@@ -1,14 +1,21 @@
 module Hyrax
   # Revokes the user's edit access on the provided FileSet
-  class RevokeEditJob < ApplicationJob
+  class RevokeEditJob < Hyrax::ApplicationJob
     queue_as Hyrax.config.ingest_queue_name
 
     # @param [String] file_set_id - the identifier of the object to revoke access from
     # @param [String] user_key - the user to remove
-    def perform(file_set_id, user_key)
-      file_set = ::FileSet.find(file_set_id)
-      file_set.edit_users -= [user_key]
-      file_set.save!
+    def perform(file_set_id, user_key, use_valkyrie: Hyrax.config.use_valkyrie?)
+      if use_valkyrie
+        file_set_resource = Hyrax.query_service.find_by(id: file_set_id)
+        acl = Hyrax::AccessControlList.new(resource: file_set_resource)
+        acl.revoke(:edit).from(::User.find_by_user_key(user_key))
+        acl.save
+      else
+        file_set = ::FileSet.find(file_set_id)
+        file_set.edit_users -= [user_key]
+        file_set.save!
+      end
     end
   end
 end

--- a/spec/jobs/hyrax/revoke_edit_from_members_job_spec.rb
+++ b/spec/jobs/hyrax/revoke_edit_from_members_job_spec.rb
@@ -1,16 +1,33 @@
 RSpec.describe Hyrax::RevokeEditFromMembersJob do
   let(:depositor) { create(:user) }
-  let(:work) { build(:work) }
-  let(:file_set_ids) { ['xyz123abc', 'abc789zyx'] }
 
-  before do
-    allow_any_instance_of(described_class).to receive(:file_set_ids).with(work).and_return(file_set_ids)
+
+  context "when use_valkyrie is false" do
+    let(:work) { build(:work) }
+    let(:file_set_ids) { ['xyz123abc', 'abc789zyx'] }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:file_set_ids).with(work).and_return(file_set_ids)
+    end
+
+    it 'loops over FileSet IDs, spawning a job for each' do
+      file_set_ids.each do |file_set_id|
+        expect(Hyrax::GrantReadJob).to receive(:perform_now).with(file_set_id, depositor.user_key, use_valkyre: false).once
+      end
+      described_class.perform_now(work, depositor.user_key, use_valkyrie: false)
+    end
   end
 
-  it 'loops over FileSet IDs, spawning a job for each' do
-    file_set_ids.each do |file_set_id|
-      expect(Hyrax::RevokeEditJob).to receive(:perform_now).with(file_set_id, depositor.user_key).once
+  context "when use_valkyrie is true" do
+    let(:file_set1) { valkyrie_create(:hyrax_file_set) }
+    let(:file_set2) { valkyrie_create(:hyrax_file_set) }
+    let(:work) { valkyrie_create(:hyrax_work, member_ids: [file_set1.id, file_set2.id]) }
+
+    it 'loops over FileSet IDs, spawning a job for each' do
+      work.member_ids.each do |file_set_id|
+        expect(Hyrax::RevokeEditJob).to receive(:perform_now).with(file_set_id, depositor.user_key, use_valkyre: true).once
+      end
+      described_class.perform_now(work, depositor.user_key, use_valkyrie: true)
     end
-    described_class.perform_now(work, depositor.user_key)
   end
 end


### PR DESCRIPTION
Fixes #4102 

Modifies the job for revoking edit permissions for a given user on a given resource to be compatible when using Valkyrie resources.