### PR TITLE
Removing an out of date comment

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -79,7 +79,6 @@ SUMMARY
   spec.add_dependency 'tinymce-rails', '~> 4.1'
   spec.add_dependency 'valkyrie', '~> 2.0', '>= 2.0.2'
 
-  # temporary pin to 2.17 due to failures caused in 2.18.0
   spec.add_development_dependency "capybara", '~> 3.29'
   spec.add_development_dependency 'capybara-maleficent', '~> 0.3.0'
   spec.add_development_dependency 'chromedriver-helper', '~> 2.1'


### PR DESCRIPTION
In reviewing the Gemspec, I noticed a comment that did not match the
underlying reality.