### PR TITLE
automatically convert valkyrie resource to ActiveJobProxy when enqueuing

### DIFF
--- a/app/jobs/hyrax/application_job.rb
+++ b/app/jobs/hyrax/application_job.rb
@@ -3,5 +3,10 @@ module Hyrax
   # This allows downstream applications to manipulate all the hyrax jobs by
   # including modules on this class.
   class ApplicationJob < ::ApplicationJob
+    before_enqueue do |job|
+      job.arguments.map! do |arg|
+        arg.is_a?(Valkyrie::Resource) ? Hyrax::ActiveJobProxy.new(resource: arg) : arg
+      end
+    end
   end
 end

--- a/spec/jobs/visibility_copy_job_spec.rb
+++ b/spec/jobs/visibility_copy_job_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe VisibilityCopyJob do
     let(:resource) { FactoryBot.create(:work_with_files).valkyrie_resource }
     let(:queries)  { Hyrax.query_service.custom_queries }
 
-    it 'serializes proxies' do
-      expect { described_class.perform_later(proxy) }.not_to raise_error
+    it 'converts resource to proxy when enqueuing' do
+      expect { described_class.perform_later(resource) }
+        .to have_enqueued_job.with("_aj_globalid" => proxy.to_global_id.to_s)
     end
 
     it 'copies visibility to file sets' do


### PR DESCRIPTION
refs Issue #4099

This eliminates the need to wrap a resource with a proxy everywhere a job is created.  The wrapping of the resource in a proxy happens automatically in `before_enqueue` callback.

@samvera/hyrax-code-reviewers
