### PR TITLE
Rewrite Arel.sql calls to other arel methods

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -73,7 +73,9 @@ module Hyrax
         ids = PermissionTemplateAccess.for_user(ability: self,
                                                 access: ['deposit', 'manage'])
                                       .joins(:permission_template)
-                                      .pluck(Arel.sql('DISTINCT source_id'))
+                                      .select(:source_id)
+                                      .distinct
+                                      .pluck(:source_id)
         query = "_query_:\"{!raw f=has_model_ssim}AdminSet\" AND {!terms f=id}#{ids.join(',')}"
         Hyrax::SolrService.count(query).positive?
       end

--- a/app/services/hyrax/collection_types/permissions_service.rb
+++ b/app/services/hyrax/collection_types/permissions_service.rb
@@ -13,7 +13,7 @@ module Hyrax
       #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
       def self.collection_type_ids_for_user(roles:, user: nil, ability: nil)
         return false unless user.present? || ability.present?
-        return Hyrax::CollectionType.all.pluck(Arel.sql('DISTINCT id')) if user_admin?(user, ability)
+        return Hyrax::CollectionType.all.select(:id).distinct.pluck(:id) if user_admin?(user, ability)
         Hyrax::CollectionTypeParticipant.where(agent_type: Hyrax::CollectionTypeParticipant::USER_TYPE,
                                                agent_id: user_id(user, ability),
                                                access: roles)
@@ -21,7 +21,10 @@ module Hyrax
                                           Hyrax::CollectionTypeParticipant.where(agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE,
                                                                                  agent_id: user_groups(user, ability),
                                                                                  access: roles)
-                                        ).pluck(Arel.sql('DISTINCT hyrax_collection_type_id'))
+                                        )
+                                        .select(:hyrax_collection_type_id)
+                                        .distinct
+                                        .pluck(:hyrax_collection_type_id)
       end
 
       # @api public

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -13,7 +13,7 @@ module Hyrax
       def self.source_ids_for_user(access:, ability:, source_type: nil, exclude_groups: [])
         scope = PermissionTemplateAccess.for_user(ability: ability, access: access, exclude_groups: exclude_groups)
                                         .joins(:permission_template)
-        ids = scope.pluck(Arel.sql('DISTINCT source_id'))
+        ids = scope.select(:source_id).distinct.pluck(:source_id)
         return ids unless source_type
         filter_source(source_type: source_type, ids: ids)
       end


### PR DESCRIPTION
It looks like cases of

.pluck(Arel.sql('DISTINCT field_name'))
can be equivalently rewritten as

.select(:field_name).distinct.pluck(:field_name)
to avoid the raw SQL.


Replaces #4110 as it was based on a fork that only had a CircleCI concurrency limit of 4

@geekscruff @cjcolvar @no-reply