### PR TITLE
Only override logger for VirusScanner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 # Please see hyrax.gemspec for dependency information.
 gemspec
 
+gem 'hydra-works', github: 'samvera/hydra-works'
+
 group :development, :test do
   gem 'coveralls', require: false
   gem 'easy_translate'

--- a/app/models/hyrax/virus_scanner.rb
+++ b/app/models/hyrax/virus_scanner.rb
@@ -14,39 +14,7 @@
 # Then set Hyrax::Works to use your scanner either in a config file or initializer:
 #   Hyrax::Works.default_system_virus_scanner = MyScanner
 module Hyrax
-  class VirusScanner
-    attr_reader :file
-
-    # @api public
-    # @param file [String]
-    def self.infected?(file)
-      new(file).infected?
-    end
-
-    def initialize(file)
-      @file = file
-    end
-
-    # Override this method to use your own virus checking software
-    # @return [Boolean]
-    def infected?
-      defined?(ClamAV) ? clam_av_scanner : null_scanner
-    end
-
-    def clam_av_scanner
-      scan_result = ClamAV.instance.method(:scanfile).call(file)
-      return false if scan_result.zero?
-      warning "A virus was found in #{file}: #{scan_result}"
-      true
-    end
-
-    # Always return zero if there's nothing available to check for viruses. This means that
-    # we assume all files have no viruses because we can't conclusively say if they have or not.
-    def null_scanner
-      warning "Unable to check #{file} for viruses because no virus scanner is defined"
-      false
-    end
-
+  class VirusScanner < Hydra::Works::VirusScanner
     private
 
       def warning(msg)

--- a/lib/generators/hyrax/templates/config/clamav.rb
+++ b/lib/generators/hyrax/templates/config/clamav.rb
@@ -1,1 +1,10 @@
-ClamAV.instance.loaddb if defined? ClamAV
+if defined?(Clamby)
+  Clamby.configure(
+    check: false,
+    # daemonize: true,
+    output_level: 'medium',
+    fdpass: true
+  )
+elsif defined?(ClamAV)
+  ClamAV.instance.loaddb if defined? ClamAV
+end


### PR DESCRIPTION
This PR pulls in hydra-works master to include https://github.com/samvera/hydra-works/pull/372 in order to allow upgrading to `clamby` for ClamAV integration.  It then subclasses `Hydra::Works::VirusScanner` and removes overrides except for the logging since the rest is supplied in super.  The change to the generator is a guess at a default Clamby configuration based upon a suggestion in slack.

@samvera/hyrax-code-reviewers
