### PR TITLE
Use the `Hyrax::TimeService` for events

### DIFF
--- a/app/jobs/event_job.rb
+++ b/app/jobs/event_job.rb
@@ -25,8 +25,9 @@ class EventJob < Hyrax::ApplicationJob
   end
 
   # create an event with an action and a timestamp for the user
+  # Use Hyrax time service!
   def event
-    @event ||= Hyrax::Event.create(action, Time.current.to_i)
+    @event ||= Hyrax::Event.create_now(action)
   end
 
   # log the event to the users event stream

--- a/app/models/hyrax/event.rb
+++ b/app/models/hyrax/event.rb
@@ -1,12 +1,33 @@
 module Hyrax
   class Event
+    ##
     # Creates an event in Redis
+    #
+    # @note it's advisable to use Hyrax::TimeService for timestamps, or use the
+    #   `.create_now` method provided
+    #
+    # @example
+    #
+    # @param [String] action
+    # @param [Integer] timestamp
     def self.create(action, timestamp)
       store.create(action, timestamp)
     end
 
+    ##
+    # @return [#create]
     def self.store
       Hyrax::RedisEventStore
+    end
+
+    ##
+    # Creates an event in Redis with a timestamp generated now
+    #
+    # @param [String] action
+    #
+    # @return [Event]
+    def self.create_now(action)
+      create(action, Hyrax::TimeService.time_in_utc.to_i)
     end
   end
 end


### PR DESCRIPTION
`Hyrax::Event` usually wants to be created "now". For Hyrax, "now" generally
means `Hyrax::TimeService.time_in_utc`.

We switch to using this method, and add a utility method for this. The method is
convenient for users, and extracts behavior from `EventJob` where it's not as
visible to users who might be trying to understand how to use the Event.

@samvera/hyrax-code-reviewers
