### PR TITLE
Replace custom Hyrax callbacks with `dry-events`

### DIFF
--- a/app/services/hyrax/listeners/batch_event_listener.rb
+++ b/app/services/hyrax/listeners/batch_event_listener.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Listens for events related to batch activity
+    class BatchEventListener
+      ##
+      # @param event [Dry::Event]
+      def on_batch_created(event)
+        case event[:result]
+        when :success
+          Hyrax::BatchCreateSuccessService
+            .new(event[:user])
+            .call
+        when :failure
+          Hyrax::BatchCreateFailureService
+            .new(event[:user], event[:messages])
+            .call
+        end
+      end
+    end
+  end
+end

--- a/app/services/hyrax/listeners/batch_notification_listener.rb
+++ b/app/services/hyrax/listeners/batch_notification_listener.rb
@@ -3,9 +3,11 @@
 module Hyrax
   module Listeners
     ##
-    # Listens for events related to batch activity
-    class BatchEventListener
+    # Listens for events related to batch activity and creates notifications
+    class BatchNotificationListener
       ##
+      # Notify requesting users of batch success/failure
+      #
       # @param event [Dry::Event]
       def on_batch_created(event)
         case event[:result]

--- a/app/services/hyrax/listeners/file_set_lifecycle_listener.rb
+++ b/app/services/hyrax/listeners/file_set_lifecycle_listener.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Listens for events related to Hydra Works FileSets
+    class FileSetLifecycleListener
+      ##
+      # @param event [Dry::Event]
+      def on_file_set_attached(event)
+        FileSetAttachedEventJob.perform_later(event[:file_set], event[:user])
+      end
+
+      ##
+      # @param event [Dry::Event]
+      def on_file_set_audited(event)
+        return unless event[:result] == :failure # do nothing on success
+
+        Hyrax::FixityCheckFailureService
+          .new(event[:file_set], checksum_audit_log: event[:audit_log])
+          .call
+      end
+
+      ##
+      # @param event [Dry::Event]
+      def on_file_set_url_imported(event)
+        Hyrax::ImportUrlFailureService.new(event[:file_set], event[:user]).call if
+          event[:result] == :failure
+      end
+
+      ##
+      # @param event [Dry::Event]
+      def on_file_set_restored(event)
+        ContentRestoredVersionEventJob
+          .perform_later(event[:file_set], event[:user], event[:revision])
+      end
+    end
+  end
+end

--- a/app/services/hyrax/listeners/file_set_lifecycle_listener.rb
+++ b/app/services/hyrax/listeners/file_set_lifecycle_listener.rb
@@ -13,23 +13,6 @@ module Hyrax
 
       ##
       # @param event [Dry::Event]
-      def on_file_set_audited(event)
-        return unless event[:result] == :failure # do nothing on success
-
-        Hyrax::FixityCheckFailureService
-          .new(event[:file_set], checksum_audit_log: event[:audit_log])
-          .call
-      end
-
-      ##
-      # @param event [Dry::Event]
-      def on_file_set_url_imported(event)
-        Hyrax::ImportUrlFailureService.new(event[:file_set], event[:user]).call if
-          event[:result] == :failure
-      end
-
-      ##
-      # @param event [Dry::Event]
       def on_file_set_restored(event)
         ContentRestoredVersionEventJob
           .perform_later(event[:file_set], event[:user], event[:revision])

--- a/app/services/hyrax/listeners/object_lifecycle_listener.rb
+++ b/app/services/hyrax/listeners/object_lifecycle_listener.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Listens for events related to the PCDM Object lifecycles.
+    class ObjectLifecycleListener
+      ##
+      # @param event [Dry::Event]
+      def on_object_deleted(event)
+        ContentDeleteEventJob.perform_later(event[:id], event[:user])
+      end
+
+      ##
+      # @param event [Dry::Event]
+      def on_object_deposited(event)
+        ContentDepositEventJob.perform_later(event[:object], event[:user])
+      end
+
+      ##
+      # @param event [Dry::Event]
+      def on_object_metadata_updated(event)
+        ContentUpdateEventJob.perform_later(event[:object], event[:user])
+      end
+    end
+  end
+end

--- a/config/initializers/hyrax_callbacks.rb
+++ b/config/initializers/hyrax_callbacks.rb
@@ -1,43 +1,42 @@
+# frozen_string_literal: true
+
+Hyrax.publisher.subscribe(Hyrax::Listeners::BatchEventListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
+
 # These events are triggered by actions within Hyrax Actors
 Hyrax.config.callback.set(:after_create_concern) do |curation_concern, user|
-  ContentDepositEventJob.perform_later(curation_concern, user)
+  Hyrax.publisher.publish('object.deposited', object: curation_concern, user: user)
 end
 
 Hyrax.config.callback.set(:after_create_fileset) do |file_set, user|
-  FileSetAttachedEventJob.perform_later(file_set, user)
+  Hyrax.publisher.publish('file.set.attached', file_set: file_set, user: user)
 end
 
 Hyrax.config.callback.set(:after_revert_content) do |file_set, user, revision|
-  ContentRestoredVersionEventJob.perform_later(file_set, user, revision)
+  Hyrax.publisher.publish('file.set.restored', file_set: file_set, user: user, revision: revision)
 end
 
-# :after_update_content callback replaced by after_perform block in IngestJob
-
 Hyrax.config.callback.set(:after_update_metadata) do |curation_concern, user|
-  ContentUpdateEventJob.perform_later(curation_concern, user)
+  Hyrax.publisher.publish('object.metadata.updated', object: curation_concern, user: user)
 end
 
 Hyrax.config.callback.set(:after_destroy) do |id, user|
-  ContentDeleteEventJob.perform_later(id, user)
+  Hyrax.publisher.publish('object.deleted', id: id, user: user)
 end
 
 Hyrax.config.callback.set(:after_fixity_check_failure) do |file_set, checksum_audit_log:|
-  Hyrax::FixityCheckFailureService.new(file_set, checksum_audit_log: checksum_audit_log).call
+  Hyrax.publisher.publish('file.set.audited', file_set: file_set, audit_log: checksum_audit_log, result: :failure)
 end
 
 Hyrax.config.callback.set(:after_batch_create_success) do |user|
-  Hyrax::BatchCreateSuccessService.new(user).call
+  Hyrax.publisher.publish('batch.created', user: user, messages: [], result: :success)
 end
 
 Hyrax.config.callback.set(:after_batch_create_failure) do |user, messages|
-  Hyrax::BatchCreateFailureService.new(user, messages).call
-end
-
-Hyrax.config.callback.set(:after_import_url_success) do |file_set, user|
-  # ImportUrlSuccessService was removed here since it's duplicative of
-  # the :after_create_fileset notification
+  Hyrax.publisher.publish('batch.created', user: user, messages: messages, result: :failure)
 end
 
 Hyrax.config.callback.set(:after_import_url_failure) do |file_set, user|
-  Hyrax::ImportUrlFailureService.new(file_set, user).call
+  Hyrax.publisher.publish('file.set.url.imported', file_set: file_set, user: user, result: :failure)
 end

--- a/config/initializers/hyrax_callbacks.rb
+++ b/config/initializers/hyrax_callbacks.rb
@@ -3,6 +3,7 @@
 Hyrax.publisher.subscribe(Hyrax::Listeners::BatchNotificationListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleNotificationListener.new)
 
 # These events are triggered by actions within Hyrax Actors
 Hyrax.config.callback.set(:after_create_concern) do |curation_concern, user|

--- a/config/initializers/hyrax_callbacks.rb
+++ b/config/initializers/hyrax_callbacks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Hyrax.publisher.subscribe(Hyrax::Listeners::BatchEventListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::BatchNotificationListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
 

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -40,6 +40,7 @@ SUMMARY
   spec.add_dependency 'browse-everything', '>= 0.16'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
+  spec.add_dependency 'dry-events', '~> 0.2.0'
   spec.add_dependency 'dry-equalizer', '~> 0.2'
   spec.add_dependency 'dry-struct', '~> 1.0'
   spec.add_dependency 'dry-transaction', '~> 0.11'

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -55,13 +55,13 @@ module Hyrax
   def self.primary_work_type
     config.curation_concerns.first
   end
-   
+
   ##
   # @return [Valkyrie::IndexingAdapter]
   def self.index_adapter
     config.index_adapter
   end
-  
+
   ##
   # @return [Dry::Events::Publisher]
   def self.publisher

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -57,6 +57,12 @@ module Hyrax
   end
 
   ##
+  # @return [Dry::Events::Publisher]
+  def self.publisher
+    config.publisher
+  end
+
+  ##
   # The Valkyrie persister used for PCDM models throughout Hyrax
   #
   # @note always use this method to retrieve the persister when data

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -480,6 +480,11 @@ module Hyrax
                                 "Edit" => "edit" }
     end
 
+    attr_writer :publisher
+    def publisher
+      @publisher ||= Hyrax::Publisher.instance
+    end
+
     attr_writer :translate_uri_to_id
 
     def translate_uri_to_id

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -6,6 +6,7 @@ module Hyrax
     require 'breadcrumbs_on_rails'
     require 'dry/struct'
     require 'dry/equalizer'
+    require 'dry/events'
     require 'dry/validation'
     require 'jquery-ui-rails'
     require 'flot-rails'
@@ -19,6 +20,7 @@ module Hyrax
 
     require 'hydra/derivatives'
     require 'hyrax/controller_resource'
+    require 'hyrax/publisher'
     require 'hyrax/schema'
     require 'hyrax/search_state'
     require 'hyrax/errors'

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # This is an application-wide publisher for Hyrax's Pub/Sub interface.
+  #
+  # Hyrax publishes events on a variety of streams. The streams are namespaced
+  # using `dry-rb`'s dot notation idiom to help with organization. Namespaces
+  # reflect the kinds of resources the event applied to.
+  #
+  #   - `batch`: events related to the performance of `BatchCreateJob`
+  #   - `file_set`: events related to the lifecycle of Hydra Works FileSets
+  #   - `object`: events related to the lifecycle of all PCDM Objects
+  #
+  # Applications *SHOULD* publish events whenever the relevant actions are
+  # performed. While Hyrax provides certain out-of-the-box listeners to power
+  # (e.g.) notifications, event streams are useful for much more: implementing
+  # local logging or instrumentation, adding application-specific callback-like
+  # handlers, etc... Ensuring events are consistently published is key to their
+  # usefulness.
+  #
+  # @note this API replaces an older `Hyrax::Callbacks` interface, with added
+  #   thread safety and capacity for many listeners on a single publication
+  #   stream.
+  #
+  # @note we call this "Publisher" to differentiate from the `Hyrax::Event`
+  #   model. This class is a `Dry::Events` publisher.
+  #
+  # @todo audit Hyrax code (and dependencies!) for places where events should be
+  #   published, but are not.
+  #
+  # @example publishing an event
+  #   publisher = Hyrax::Publisher.instance
+  #
+  #   publisher.publish('object.deposited', object: deposited_object, user: depositing_user)
+  #
+  # @example use Hyrax.publisher
+  #   Hyrax.publisher.publish('object.deposited', object: deposited_object, user: depositing_user)
+  #
+  # @example subscribing to an event type/stream with a block handler
+  #   publisher = Hyrax::Publisher.instance
+  #
+  #   publisher.subscribe('object.deposited') do |event |
+  #     do_something(event[:object])
+  #   end
+  #
+  # @see https://dry-rb.org/gems/dry-events/0.2/
+  # @see Dry::Events::Publisher
+  class Publisher
+    include Singleton
+    include Dry::Events::Publisher[:hyrax]
+
+    register_event('batch.created')
+    register_event('file.set.audited')
+    register_event('file.set.attached')
+    register_event('file.set.url.imported')
+    register_event('file.set.restored')
+    register_event('object.deleted')
+    register_event('object.deposited')
+    register_event('object.metadata.updated')
+  end
+end

--- a/spec/services/hyrax/listeners/batch_notification_listener_spec.rb
+++ b/spec/services/hyrax/listeners/batch_notification_listener_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Listeners::BatchNotificationListener do
+  subject(:listener) { described_class.new }
+
+  describe '#on_batch_created' do
+    let(:user)  { create(:user) }
+    let(:data)  { { result: :success, user: user, messages: [] } }
+    let(:event) { Dry::Events::Event.new(:on_batch_created, data) }
+    let(:inbox) { user.mailbox.inbox }
+
+    it 'creates a success message for the user' do
+      expect { listener.on_batch_created(event) }
+        .to change { inbox.last }
+        .to have_attributes subject: 'Passing batch create'
+    end
+
+    context 'on failure' do
+      let(:data) { { result: :failure, user: user, messages: [] } }
+
+      it 'creates a failure message for the user' do
+        expect { listener.on_batch_created(event) }
+          .to change { inbox.last }
+          .to have_attributes subject: 'Failing batch create'
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/listeners/file_set_lifecycle_notification_listener_spec.rb
+++ b/spec/services/hyrax/listeners/file_set_lifecycle_notification_listener_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Listeners::FileSetLifecycleNotificationListener do
+  subject(:listener) { described_class.new }
+  let(:data)         { { result: :success } }
+  let(:event)        { Dry::Events::Event.new(event_type, data) }
+  let(:file_set)     { create(:file_set, user: user) }
+  let(:inbox)        { user.mailbox.inbox }
+  let(:user)         { create(:user) }
+
+  describe '#on_file_set_audited' do
+    let(:event_type) { :on_file_set_audited }
+
+    it 'does not raise an error; is resilient to missing event payload data' do
+      expect { listener.on_file_set_audited(event) }.not_to raise_error
+    end
+
+    context 'on failure' do
+      let(:data)    { { result: :failure, file_set: file_set, audit_log: log } }
+      let(:file)    { Hydra::PCDM::File.new }
+      let(:version) { "#{file.uri}/fcr:versions/version1" }
+
+      let(:log) do
+        ChecksumAuditLog.new(file_set_id: file_set.id,
+                             file_id: file_set.original_file.id,
+                             checked_uri: version,
+                             created_at: '2019-11-04 03:06:59',
+                             updated_at: '2019-11-04 03:06:59',
+                             passed: false)
+      end
+
+      let(:file_set) do
+        create(:file_set, user: user, title: ['Bad Checksum']).tap { |fs| fs.original_file = file }
+      end
+
+      it 'creates a failure message for the user' do
+        expect { listener.on_file_set_audited(event) }
+          .to change { inbox.last }
+          .to have_attributes subject: 'Failing Fixity Check'
+      end
+    end
+  end
+
+  describe '#on_file_set_url_imported' do
+    let(:event_type) { :on_file_set_url_imported }
+
+    it 'does not raise an error; is resilient to missing event payload data' do
+      expect { listener.on_file_set_url_imported(event) }.not_to raise_error
+    end
+
+    context 'on failure' do
+      let(:data) { { result: :failure, user: user, file_set: file_set } }
+
+      before do
+        allow(file_set.errors).to receive(:full_messages).and_return(['huge mistake'])
+      end
+
+      it 'creates a failure message for the user' do
+        expect { listener.on_file_set_url_imported(event) }
+          .to change { inbox.last }
+          .to have_attributes subject: 'File Import Error'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hyrax has had its own internal events API since Hyrax late 2015. The approach
taken has a few drawbacks:

  - only one subscriber (as a block) to each event;
  - the subscriber registry, though mutable, isn't threadsafe.

We'll want to change the individual subscribers as we move toward Valkyrie. We
may also want to add new event types. Before continuing to develop against this
internal API, we should replace it with the externally maintained and more
robust `Dry::Events` tooling.

Since the existing callbacks make use of dependency inversion (i.e. adopters may
have custom listeners/callbacks defined) we can't stop calling their hooks. As a
first step, we implement the `Dry::Events` replacement and call them from the
callbacks.

We name the application events publisher `Hyrax::Publisher` to avoid confusion
with `Hyrax::Event`. Possibly more naming consideration is called for here.

An explicit dependency is added for `dry-events`, since this is the first time
we depend on it directly.

@samvera/hyrax-code-reviewers
