### PR TITLE
[wings] Reinstate quoting of `::Collection` and `FileSet`

### DIFF
--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -102,8 +102,8 @@ end
 
 Wings::ModelRegistry.register(Hyrax::AccessControl,     Hydra::AccessControl)
 Wings::ModelRegistry.register(Hyrax::AdministrativeSet, AdminSet)
-Wings::ModelRegistry.register(Hyrax::PcdmCollection,    ::Collection)
-Wings::ModelRegistry.register(Hyrax::FileSet,           FileSet)
+Wings::ModelRegistry.register(Hyrax::PcdmCollection,    '::Collection')
+Wings::ModelRegistry.register(Hyrax::FileSet,           'FileSet')
 Wings::ModelRegistry.register(Hyrax::Embargo,           Hydra::AccessControls::Embargo)
 Wings::ModelRegistry.register(Hyrax::Lease,             Hydra::AccessControls::Lease)
 


### PR DESCRIPTION
These were initially quoted to fix naming issues in 1a795752. Later #4094, which
predated that change, was merged and reverted the quoting. This has left the
build in a broken state WRT engine cart builds and `rails new`.

@samvera/hyrax-code-reviewers
