### PR TITLE
Return empty string if APAFormatter authors_list is empty

### DIFF
--- a/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
@@ -30,6 +30,7 @@ module Hyrax
         public
 
         def format_authors(authors_list = [])
+          return '' if authors_list.blank?
           authors_list = Array.wrap(authors_list).collect { |name| abbreviate_name(surname_first(name)).strip }
           text = ''
           text << authors_list.first if authors_list.first

--- a/spec/helpers/hyrax/citations_behaviors/formatters/apa_formatter_spec.rb
+++ b/spec/helpers/hyrax/citations_behaviors/formatters/apa_formatter_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Hyrax::CitationsBehaviors::Formatters::ApaFormatter do
+  subject(:formatter) { described_class.new(:no_context) }
+
+  let(:presenter) { Hyrax::WorkShowPresenter.new(SolrDocument.new(work.to_solr), :no_ability) }
+  let(:work)      { build(:generic_work, title: ['Title'], creator: []) }
+
+  it 'formats citations without creators' do
+    expect(formatter.format(presenter)).to eq("<i class=\"citation-title\">Title.</i> ")
+  end
+end


### PR DESCRIPTION
The citations link will throw an error if no authors are present. The error is in the APAFormatter where there is an assumption that there will be at least one author. The ChicagoFormatter already handles this by returning an empty string for an empty authors_list. This PR applies the same change to the APAFormatter.

In a Hyrax application where creator is required, this will never happen. But if a Hyrax application is customised to remove creator from the required files, this error could then arise.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Remove creator from required fields
* Add work without a creator
* The citations render

@samvera/hyrax-code-reviewers
