### PR TITLE
Moved permission test to edit/delete button group

### DIFF
--- a/app/views/hyrax/admin/admin_sets/_show_actions.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_show_actions.html.erb
@@ -1,9 +1,10 @@
-    <% if can? :edit, presenter.solr_document %>
+
       <div class="panel-heading">
         <div class="row">
           <div class="col-sm-8">
             <h2 class="panel-title display-page"><%= presenter.to_s %></h2>
           </div>
+          <% if can? :edit, presenter.solr_document %>
           <div class="col-sm-4">
             <div class="pull-right">
               <%= link_to edit_admin_admin_set_path(presenter), class: 'btn btn-primary' do %>
@@ -22,6 +23,6 @@
               <% end %>
             </div>
           </div>
+          <% end %>
         </div>
       </div>
-    <% end %>

--- a/spec/views/hyrax/admin/admin_sets/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_show_actions.html.erb_spec.rb
@@ -64,5 +64,9 @@ RSpec.describe 'hyrax/admin/admin_sets/_show_actions.html.erb', type: :view do
       expect(rendered).not_to have_selector(:css, "a.btn-danger")
       expect(rendered).not_to have_selector(:css, "a.btn-primary")
     end
+
+    it "displays the admin_set title" do
+      expect(rendered).to have_selector(:css, "h2.panel-title")
+    end
   end
 end


### PR DESCRIPTION
Fixes #3273 

The title of an admin set is not shown to depositors, who does not have edit access. This is caused by a permissions check in the view, which contains both the title and the edit/delete button group. 

Changes proposed in this pull request:
* Move the permissions check only to contain the edit/delete button group not the admin set title

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Display an admin set as a manager, this shows both the title and edit/delete button group
* Display an admin set as a depositor, this shows only the title not the edit/delete button group

@samvera/hyrax-code-reviewers
