### PR TITLE
Fix to improve accessibility in home page

### DIFF
--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,6 +1,6 @@
 <header>
   <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation" aria-label="masthead">
-    <h1 class="sr-only"><%=  application_name %></h1>
+    <h1 class="sr-only"><%= application_name %></h1>
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->
       <div class="navbar-header">

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,5 +1,6 @@
 <header>
-  <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation">
+  <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation" aria-label="masthead">
+    <h1 class="sr-only"><%=  application_name %></h1>
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->
       <div class="navbar-header">

--- a/app/views/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/hyrax/homepage/_explore_collections.html.erb
@@ -7,7 +7,7 @@
             <div class="media-body">
               <div class="media-heading">
                 <%= link_to [hyrax, collection] do %>
-                  <%= render_thumbnail_tag(collection, { class: 'hidden-xs file_listing_thumbnail', alt: collection.title_or_label + t('hyrax.homepage.admin_sets.thumbnail') },
+                  <%= render_thumbnail_tag(collection, { class: 'hidden-xs file_listing_thumbnail', alt: "#{collection.title_or_label} #{ t('hyrax.homepage.admin_sets.thumbnail')}" },
                                            { suppress_link: true }) + collection.title_or_label %>
                 <% end %>
               </div>

--- a/app/views/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/hyrax/homepage/_explore_collections.html.erb
@@ -7,7 +7,7 @@
             <div class="media-body">
               <div class="media-heading">
                 <%= link_to [hyrax, collection] do %>
-                  <%= render_thumbnail_tag(collection, { class: 'hidden-xs file_listing_thumbnail' },
+                  <%= render_thumbnail_tag(collection, { class: 'hidden-xs file_listing_thumbnail', alt: collection.title_or_label + t('hyrax.homepage.admin_sets.thumbnail') },
                                            { suppress_link: true }) + collection.title_or_label %>
                 <% end %>
               </div>

--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -3,7 +3,7 @@
     <span class="sr-only"><%= t('hyrax.homepage.featured_works.document.title_label') %></span>
     <h3>
       <%= link_to [main_app, featured] do %>
-        <%= render_thumbnail_tag(featured, {width: 90}, {suppress_link: true}) + featured.title.first %>
+        <%= render_thumbnail_tag(featured, {width: 90, alt: "#{featured.title.first.to_s} #{ t('hyrax.homepage.admin_sets.thumbnail')}" }, {suppress_link: true}) + featured.title.first %>
       <% end %>
     </h3>
   </div>

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -1,7 +1,7 @@
 <div class="col-sm-6">
-  <ul id="homeTabs" class="nav nav-tabs">
-    <li class="active"><a href="#featured_container" data-toggle="tab" role="tab" id="featureTab"><%= t('hyrax.homepage.featured_works.tab_label') %></a></li>
-    <li><a href="#recently_uploaded" data-toggle="tab" role="tab" id="recentTab"><%= t('hyrax.homepage.recently_uploaded.tab_label') %></a></li>
+  <ul id="homeTabs" class="nav nav-tabs" role="list">
+    <li class="active"><a href="#featured_container" data-toggle="tab" id="featureTab"><%= t('hyrax.homepage.featured_works.tab_label') %></a></li>
+    <li><a href="#recently_uploaded" data-toggle="tab" id="recentTab"><%= t('hyrax.homepage.recently_uploaded.tab_label') %></a></li>
   </ul>
   <div class="tab-content">
     <div class="tab-pane fade in active" id="featured_container" role="tabpanel" aria-labelledby="featureTab">
@@ -15,9 +15,9 @@
 
 <div class="col-sm-6">
 
-  <ul class="nav nav-tabs" role="tablist">
-    <li class="active"><a aria-expanded="true" href="#tab-col2-first" role="tab" data-toggle="tab"><%= t('hyrax.homepage.admin_sets.title') %></a></li>
-    <li class=""><a aria-expanded="false" href="#tab-col2-second" role="tab" data-toggle="tab"><%= t('hyrax.homepage.featured_researcher.tab_label') %></a></li>
+  <ul class="nav nav-tabs" role="list">
+    <li class="active"><a aria-expanded="true" href="#tab-col2-first" data-toggle="tab"><%= t('hyrax.homepage.admin_sets.title') %></a></li>
+    <li class=""><a aria-expanded="false" href="#tab-col2-second" data-toggle="tab"><%= t('hyrax.homepage.featured_researcher.tab_label') %></a></li>
   </ul>
 
   <div class="tab-content">

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -4,7 +4,7 @@
         <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
         <h3>
           <%= link_to [main_app, recent_document] do %>
-            <%= render_thumbnail_tag(recent_document, {width: 90}, {suppress_link: true}) + recent_document.to_s %>
+            <%= render_thumbnail_tag(recent_document, {width: 90, alt: recent_document.to_s + t('hyrax.homepage.admin_sets.thumbnail') }, {suppress_link: true}) + recent_document.to_s %>
           <% end %>
         </h3>
         <p class="recent-field">

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -4,7 +4,7 @@
         <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
         <h3>
           <%= link_to [main_app, recent_document] do %>
-            <%= render_thumbnail_tag(recent_document, {width: 90, alt: "#{recent_document.to_s} #{ t('hyrax.homepage.admin_sets.thumbnail'}" }, {suppress_link: true}) + recent_document.to_s %>
+            <%= render_thumbnail_tag(recent_document, {width: 90, alt: "#{recent_document.to_s} #{ t('hyrax.homepage.admin_sets.thumbnail')}" }, {suppress_link: true}) + recent_document.to_s %>
           <% end %>
         </h3>
         <p class="recent-field">

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -4,7 +4,7 @@
         <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
         <h3>
           <%= link_to [main_app, recent_document] do %>
-            <%= render_thumbnail_tag(recent_document, {width: 90, alt: recent_document.to_s + t('hyrax.homepage.admin_sets.thumbnail') }, {suppress_link: true}) + recent_document.to_s %>
+            <%= render_thumbnail_tag(recent_document, {width: 90, alt: "#{recent_document.to_s} #{ t('hyrax.homepage.admin_sets.thumbnail'}" }, {suppress_link: true}) + recent_document.to_s %>
           <% end %>
         </h3>
         <p class="recent-field">

--- a/app/views/hyrax/homepage/_sortable_featured.html.erb
+++ b/app/views/hyrax/homepage/_sortable_featured.html.erb
@@ -13,6 +13,7 @@
               data: {behavior: 'unfeature'} do %>
               <i class='glyphicon glyphicon-remove'></i>
             <% end %>
+            <p class="sr-only"><%= t 'helpers.action.remove' %></p>
           </h3>
         <% end %>
         <%= render 'hyrax/homepage/featured_fields', featured: presenter %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1115,6 +1115,7 @@ en:
         link: View all collections
         tab_label: Explore Collections
         title: Explore Collections
+        thumbnail: " thumbnail"
       featured_researcher:
         missing: No researchers have been featured.
         tab_label: Featured Researcher

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1115,7 +1115,7 @@ en:
         link: View all collections
         tab_label: Explore Collections
         title: Explore Collections
-        thumbnail: " thumbnail"
+        thumbnail: thumbnail
       featured_researcher:
         missing: No researchers have been featured.
         tab_label: Featured Researcher


### PR DESCRIPTION
Fixes #3961 

Improve accessibility of the homepage, using `axe` to assess the accessibility of the elements in the page. 
**Tab test:** Safari and Fireforx in MacOS skips buttons, check-boxes, and links in tab rotation by default.
It is an advanced feature to include these into the tab order, which can be enabled in Accessibility in Advanced preferences in Safari.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Install the Axe plugin or addon from Deque (https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/ is the firefox version).
* Go to the homepage
* Open dev tools and go to `axe` tab
* Click 'Analyze'

@samvera/hyrax-code-reviewers
