### PR TITLE
Improve accessibility on collection show page

### DIFF
--- a/app/builders/hyrax/bootstrap_breadcrumbs_builder.rb
+++ b/app/builders/hyrax/bootstrap_breadcrumbs_builder.rb
@@ -27,6 +27,6 @@ class Hyrax::BootstrapBreadcrumbsBuilder < BreadcrumbsOnRails::Breadcrumbs::Buil
   end
 
   def breadcrumbs_options
-    { class: 'breadcrumb', role: "region", "aria-label" => "Breadcrumb" }
+    { class: 'breadcrumb', role: "navigation", "aria-label" => "Breadcrumb" }
   end
 end

--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -1,5 +1,5 @@
   <%= form_for presenter, url: url, method: :get, class: "well form-search" do |f| %>
-      <label class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
+      <label for="collection_search" class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
       <div class="input-group">
         <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('hyrax.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
         <div class="input-group-btn">

--- a/app/views/hyrax/dashboard/collections/_collection_title.html.erb
+++ b/app/views/hyrax/dashboard/collections/_collection_title.html.erb
@@ -8,12 +8,12 @@
   data-post-delete-url="<%= hyrax.dashboard_collection_path(id) %>">
 
     <div class="collection-title-row-content">
-      <h3 class="collection-title">
+      <h2 class="collection-title">
         <% # List multiple titles %>
         <% presenter.title.each_with_index do |title, index| %>
           <span><%= title %></span>
         <% end %>
-      </h3>
+      </h2>
       <%= presenter.permission_badge %>
       <%= presenter.collection_type_badge %>
     </div>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -8,7 +8,7 @@
   <td>
     <div class="media">
       <%= link_to [main_app, document], class: "media-left" do %>
-        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
+        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail", alt: document.title_or_label }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">
         <p class="media-heading">

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -46,6 +46,7 @@
               <% if has_collection_search_parameters? %>
                   <%= t('hyrax.dashboard.collections.show.search_results') %>
               <% end %>
+              <p class="sr-only"><%= t('hyrax.dashboard.collections.show.search_results') %></p>
             </h2>
           </div>
       <% end %>
@@ -63,7 +64,7 @@
       <!-- Subcollections -->
       <% if @presenter.collection_type_is_nestable? %>
         <section id="sub-collections-wrapper" class="sub-collections-wrapper">
-          <h4><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h4>
+          <h3><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h3>
           <div class="row">
             <div class="col-md-7">
               <%= render 'subcollection_list', id: @presenter.id, collection: @subcollection_docs %>
@@ -79,7 +80,7 @@
 
       <!-- Works -->
       <section class="works-wrapper">
-        <h4><%= t('.item_count') %> (<%= @members_count %>)</h4>
+        <h3><%= t('.item_count') %> (<%= @members_count %>)</h3>
         <% unless has_collection_search_parameters? %>
           <%= render 'show_add_items_actions', presenter: @presenter %>
         <% end %>


### PR DESCRIPTION
Fixes #3962 

Improve accessibility of the collection view page, using `axe` to assess the accessibility of the elements in the page. 

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Install the Axe plugin or addon from Deque (https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/ is the firefox version).
* Go to the dashboard, and click on 'Collections'
* Click on one of the collections in the list to view it
* Open dev tools and go to `axe` tab
* Click 'Analyze'

@samvera/hyrax-code-reviewers
