### PR TITLE
Put an upper limit on `browse_everything` support

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -37,7 +37,7 @@ SUMMARY
   spec.add_dependency 'blacklight', '~> 6.14'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
-  spec.add_dependency 'browse-everything', '>= 0.16'
+  spec.add_dependency 'browse-everything', '>= 0.16', '< 2.0'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'dry-equalizer', '~> 0.2'


### PR DESCRIPTION
We support BrowseEverything 0.16+ and 1.x; but can't support 2.x yet (it doesn't
exist and will likely have extensive breaking changes).

@samvera/hyrax-code-reviewers
