### PR TITLE
Fix bug in date validation in admin_set form

### DIFF
--- a/app/assets/javascripts/hyrax/admin/admin_set/visibility.es6
+++ b/app/assets/javascripts/hyrax/admin/admin_set/visibility.es6
@@ -168,12 +168,12 @@ export default class {
       // Detect mm/dd/yyyy format
       const regex = /^\d{2}[./-]\d{2}[./-]\d{4}$/;
 
-      let $form = $('form');
+      let $form = this.element.find('form');
       $form.on('submit', function() {
         let data = $(this).serializeArray();
         let releaseDate = data.find(item => item.name === 'permission_template[release_date]');
 
-        if(releaseDate.value.match(regex)) {
+        if(releaseDate && releaseDate.value.match(regex)) {
           const [mm, dd, yyyy] = releaseDate.value.split('/');
           releaseDate.value = yyyy + '-' + mm + '-' + dd;
         }


### PR DESCRIPTION
Fixes #4144 

When creating a new work, the work form fails to load because a date validation check in admin_set edit forms introduced in #4067 leaked into the work form. This produces a JavaScript error causing failure in loading the work form.

Changes proposed in this pull request:
* Change the jQuery form selection to pick only the relevant form to perform the date validation 

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Sign in as a user in Safari
* Go to `Works` page in `Dashboard`
* Click on `Add new work`
* Select a work type and click `Create work` in the modal
* Work form loads

@samvera/hyrax-code-reviewers
