### PR TITLE
Make `Skip to content` link focus on main content

### DIFF
--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -25,7 +25,6 @@
 
       <a name="skip-to-content" id="skip-to-content"></a>
       <%= content_for?(:content) ? yield(:content) : yield %>
-  
     </div><!-- /#content-wrapper -->
     <%= render 'shared/footer' %>
     <%= render 'shared/ajax_modal' %>

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -23,11 +23,26 @@
         </div>
       <% end %>
 
-        <a name="skip-to-content" id="skip-to-content"></a>
-        <%= content_for?(:content) ? yield(:content) : yield %>
-
+      <a name="skip-to-content" id="skip-to-content"></a>
+      <%= content_for?(:content) ? yield(:content) : yield %>
+  
     </div><!-- /#content-wrapper -->
     <%= render 'shared/footer' %>
     <%= render 'shared/ajax_modal' %>
   </body>
+  <script type="text/javascript">
+    $( document ).ready(function() {
+      $(".skip-to-content").click(function(event) {
+        event.preventDefault();
+        // element to focus on
+        let skipTo = '#' + $(this)[0].firstElementChild.hash.split('#')[1];
+
+        // Setting 'tabindex' to -1 takes an element out of normal 
+        // tab flow but allows it to be focused via javascript
+        $(skipTo).attr('tabindex', -1).on('blur focusout', function () {
+          $(this).removeAttr('tabindex');
+        }).focus();
+      });
+    });
+  </script>
 </html>


### PR DESCRIPTION
Fixes #3774 

When a user use tab key on `Skip to content` link in Firefox, it does not shift the keyboard to focus to main content, even though the view is focused. The user has to go through all the navigation links to reach the main content.

Changes proposed in this pull request:
* Use JavaScript on the `click` event of `Skip to content` link to change keyboard focus to the main content

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Open Hyrax in Firefox
* Press `Tab` key and then `Enter`
* Press `Tab` again to see the focus is skipped to main content

@samvera/hyrax-code-reviewers
