### PR TITLE
Improve accessibility on Contact page

### DIFF
--- a/app/assets/stylesheets/hyrax/_home-page.scss
+++ b/app/assets/stylesheets/hyrax/_home-page.scss
@@ -54,6 +54,9 @@
           color: $navbar-transparent-link-hover-color;
         }
       }
+      li {
+        background-color: #286090;
+      }
     }
 
     @media only screen and (max-width: 767px) {


### PR DESCRIPTION
Fixes #3963 

Improve accessibility on `Contact` page. This PR improves the contrast ratio between the nav-bar links in the home page which applies to entire home page, not only the contact page. 

Changes proposed in this pull request:
* Improve contrast ratio of nav-bar links on home page

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Install the Axe plugin or addon from Deque (https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/ is the firefox version).
* Open `Contact` page
* Open `Dev tools` in the browser and go to `axe` tab
* Click Analyze

@samvera/hyrax-code-reviewers
