### PR TITLE
Make the valkyrie index adapter configurable

### DIFF
--- a/app/services/hyrax/solr_service.rb
+++ b/app/services/hyrax/solr_service.rb
@@ -142,7 +142,7 @@ module Hyrax
     private
 
       def valkyrie_index
-        Valkyrie::IndexingAdapter.find(:solr_index)
+        Hyrax.index_adapter
       end
 
       def rows_warning

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -57,6 +57,12 @@ module Hyrax
   end
 
   ##
+  # @return [Valkyrie::IndexingAdapter]
+  def self.index_adapter
+    config.index_adapter
+  end
+
+  ##
   # The Valkyrie persister used for PCDM models throughout Hyrax
   #
   # @note always use this method to retrieve the persister when data

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -440,6 +440,18 @@ module Hyrax
     end
     attr_writer :iiif_metadata_fields
 
+    ##
+    # @return [#save, #save_all, #delete, #wipe] an indexing adapter
+    def index_adapter
+      @index_adapter ||= Valkyrie::IndexingAdapter.find(:solr_index)
+    end
+
+    ##
+    # @param [#to_sym] adapter
+    def index_adapter=(adapter)
+      @index_adapter ||= Valkyrie::IndexingAdapter.find(adapter.to_sym)
+    end
+
     attr_writer :index_field_mapper
     def index_field_mapper
       @index_field_mapper ||= ActiveFedora.index_field_mapper

--- a/spec/support/clean_solr.rb
+++ b/spec/support/clean_solr.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.configure do |config|
   config.before(:each, clean_index: true) do
-    client = Valkyrie::IndexingAdapter.find(:solr_index).connection
+    client = Hyrax.index_adapter.connection
     client.delete_by_query("*:*", params: { softCommit: true })
   end
 end


### PR DESCRIPTION
Add configuration for the indexing adapter to make access consistent with other
valkyrie adapters. The one-true-way to access the indexing adapter is now
`Hyrax.indexing_adapter`.

We'll likely only really support the Solr indexing adapter (or things that very
closely conform to its behavior) for the forseeable future.

@samvera/hyrax-code-reviewers
