### PR TITLE
Improve accessibility of collections public view

### DIFF
--- a/app/assets/stylesheets/hyrax/_styles.scss
+++ b/app/assets/stylesheets/hyrax/_styles.scss
@@ -62,3 +62,13 @@ label.disabled {
   align-items: center;
   display: flex;
 }
+
+.navbar-default {
+  .navbar-nav {
+    li {
+      a {
+        color: #666;
+      }
+    }
+  }
+}

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,4 +1,4 @@
-<header>
+<header aria-label="header">
   <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation" aria-label="masthead">
     <h1 class="sr-only"><%= application_name %></h1>
     <div class="container-fluid">

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -8,7 +8,7 @@
   <td>
     <div class="media">
       <%= link_to [main_app, document], class: "media-left" do %>
-        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
+        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail", alt: "#{document.title_or_label} #{t('hyrax.homepage.admin_sets.thumbnail')}" }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">
         <p class="media-heading">

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -4,9 +4,9 @@
     <div class="col-md-12">
 
       <% unless @presenter.banner_file.blank? %>
-          <header class="hyc-banner" style="background-image:url(<%= @presenter.banner_file %>)">
+          <div class="hyc-banner" style="background-image:url(<%= @presenter.banner_file %>)">
       <% else %>
-          <header class="hyc-generic">
+          <div class="hyc-generic">
       <% end %>
 
       <div class="hyc-title">
@@ -79,11 +79,11 @@
   <!-- Search results label -->
   <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
     <div class="hyc-blacklight hyc-bl-title">
+    <% if has_collection_search_parameters? %>
       <h2>
-        <% if has_collection_search_parameters? %>
-            <%= t('hyrax.dashboard.collections.show.search_results') %>
-        <% end %>
+        <%= t('hyrax.dashboard.collections.show.search_results') %>
       </h2>
+    <% end %>
     </div>
   <% end %>
 
@@ -97,7 +97,7 @@
   <!-- Subcollections -->
   <% if @presenter.collection_type_is_nestable? && @subcollection_count > 0 %>
       <div class="hyc-blacklight hyc-bl-title">
-        <h4><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h4>
+        <h2><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h2>
       </div>
       <div class="hyc-blacklight hyc-bl-results">
         <%= render 'subcollection_list', collection: @subcollection_docs %>
@@ -107,7 +107,7 @@
   <!-- Works -->
   <% if @members_count > 0 %>
       <div class="hyc-blacklight hyc-bl-title">
-        <h4><%= t('.works_in_collection') %> (<%= @members_count %>)</h4>
+        <h2><%= t('.works_in_collection') %> (<%= @members_count %>)</h2>
       </div>
 
       <div class="hyc-blacklight hyc-bl-sort">

--- a/spec/views/hyrax/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/show.html.erb_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'hyrax/collections/show.html.erb', type: :view do
   it 'draws the page' do
     expect(rendered).to have_content('Make Collections Great Again')
     expect(rendered).to have_content('Collection Details')
-    expect(rendered).to have_css('header.hyc-banner')
+    expect(rendered).to have_css('div.hyc-banner')
     expect(rendered).to have_css('div.hyc-description')
     expect(rendered).to have_css('div.hyc-metadata')
     expect(rendered).to have_css('div.hyc-logos')


### PR DESCRIPTION
Fixes #3962 

Improve accessibility of the collection's public view page, using `axe` to assess the accessibility of the elements in the page. 

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Install the Axe plugin or addon from Deque (https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/ is the firefox version).
* Go to the dashboard, and click on 'Collections'
* Click on one of the collections in the list to view it
* Open dev tools and go to `axe` tab
* Click 'Analyze'
* From the view page click on `Public view of Collection` link
* Open dev tools and go to `axe` tab
* Click 'Analyze'

@samvera/hyrax-code-reviewers
