### PR TITLE
use :alternative_title instead of :alt_title

### DIFF
--- a/app/forms/hyrax/forms/admin_set_form.rb
+++ b/app/forms/hyrax/forms/admin_set_form.rb
@@ -9,9 +9,9 @@ module Hyrax
         return super if key == :thumbnail_id
         if key == :title
           @attributes["title"].each do |value|
-            @attributes["alt_title"] << value
+            @attributes["alternative_title"] << value
           end
-          @attributes["alt_title"].delete(@attributes["alt_title"].sort.first) unless @attributes["alt_title"].empty?
+          @attributes["alternative_title"].delete(@attributes["alternative_title"].sort.first) unless @attributes["alternative_title"].empty?
           return @attributes["title"].sort.first unless @attributes["title"].empty?
           return ""
         end

--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -7,7 +7,8 @@ module Hyrax
       # Used by the search builder
       attr_reader :scope
 
-      delegate :id, :depositor, :permissions, :human_readable_type, :member_ids, :nestable?, :alt_title, to: :model
+      delegate :id, :depositor, :permissions, :human_readable_type, :member_ids, :nestable?,
+               :alternative_title, to: :model
 
       class_attribute :membership_service_class
 
@@ -20,7 +21,7 @@ module Hyrax
 
       delegate :blacklight_config, to: Hyrax::CollectionsController
 
-      self.terms = [:alt_title, :resource_type, :title, :creator, :contributor, :description,
+      self.terms = [:alternative_title, :resource_type, :title, :creator, :contributor, :description,
                     :keyword, :license, :publisher, :date_created, :subject, :language,
                     :representative_id, :thumbnail_id, :identifier, :based_near,
                     :related_url, :visibility, :collection_type_gid]
@@ -48,8 +49,8 @@ module Hyrax
         return attrs unless attributes[:title]
 
         attrs[:title] = Array(attributes[:title])
-        return attrs if attributes[:alt_title].nil?
-        Array(attributes[:alt_title]).each do |value|
+        return attrs if attributes[:alternative_title].nil?
+        Array(attributes[:alternative_title]).each do |value|
           attrs["title"] << value if value != ""
         end
         attrs
@@ -62,9 +63,9 @@ module Hyrax
         return model.member_of_collection_ids if key == :member_of_collection_ids
         if key == :title
           @attributes["title"].each do |value|
-            @attributes["alt_title"] << value
+            @attributes["alternative_title"] << value
           end
-          @attributes["alt_title"].delete(@attributes["alt_title"].sort.first) unless @attributes["alt_title"].empty?
+          @attributes["alternative_title"].delete(@attributes["alternative_title"].sort.first) unless @attributes["alternative_title"].empty?
           return @attributes["title"].sort.first unless @attributes["title"].empty?
           return ""
         end
@@ -90,7 +91,7 @@ module Hyrax
 
       # Terms that appear within the accordion
       def secondary_terms
-        [:alt_title,
+        [:alternative_title,
          :creator,
          :contributor,
          :keyword,

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -17,9 +17,9 @@ module Hyrax
                :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
                :visibility_during_lease, :lease_expiration_date, :visibility_after_lease,
                :visibility, :in_works_ids, :depositor, :on_behalf_of, :permissions,
-               :member_ids, :alt_title, to: :model
+               :member_ids, :alternative_title, to: :model
 
-      self.terms = [:title, :alt_title, :creator, :contributor, :description, :abstract,
+      self.terms = [:title, :alternative_title, :creator, :contributor, :description, :abstract,
                     :keyword, :license, :rights_statement, :access_right, :rights_notes, :publisher, :date_created,
                     :subject, :language, :identifier, :based_near, :related_url,
                     :representative_id, :thumbnail_id, :rendering_ids, :files,
@@ -46,8 +46,8 @@ module Hyrax
         return attrs unless attributes[:title]
 
         attrs[:title] = Array(attributes[:title])
-        return attrs if attributes[:alt_title].nil?
-        Array(attributes[:alt_title]).each do |value|
+        return attrs if attributes[:alternative_title].nil?
+        Array(attributes[:alternative_title]).each do |value|
           attrs["title"] << value if value != ""
         end
         attrs
@@ -119,9 +119,9 @@ module Hyrax
         return model.member_of_collection_ids if key == :member_of_collection_ids
         if key == :title
           @attributes["title"].each do |value|
-            @attributes["alt_title"] << value
+            @attributes["alternative_title"] << value
           end
-          @attributes["alt_title"].delete(@attributes["alt_title"].sort.first) unless @attributes["alt_title"].empty?
+          @attributes["alternative_title"].delete(@attributes["alternative_title"].sort.first) unless @attributes["alternative_title"].empty?
           return @attributes[key.to_s].sort.first
         end
         super

--- a/app/indexers/hyrax/admin_set_indexer.rb
+++ b/app/indexers/hyrax/admin_set_indexer.rb
@@ -7,12 +7,12 @@ module Hyrax
     def generate_solr_document
       super.tap do |solr_doc|
         # Makes Admin Sets show under the "Admin Sets" tab
-        solr_doc['generic_type_sim']  = ['Admin Set']
-        solr_doc['alt_title_tesim']   = object.alt_title
-        solr_doc['creator_ssim']      = object.creator
-        solr_doc['description_tesim'] = object.description
-        solr_doc['title_tesim']       = object.title
-        solr_doc['title_sim']         = object.title
+        solr_doc['generic_type_sim']        = ['Admin Set']
+        solr_doc['alternative_title_tesim'] = object.alternative_title
+        solr_doc['creator_ssim']            = object.creator
+        solr_doc['description_tesim']       = object.description
+        solr_doc['title_tesim']             = object.title
+        solr_doc['title_sim']               = object.title
       end
     end
   end

--- a/app/indexers/hyrax/basic_metadata_indexer.rb
+++ b/app/indexers/hyrax/basic_metadata_indexer.rb
@@ -3,7 +3,7 @@ module Hyrax
   class BasicMetadataIndexer < ActiveFedora::RDF::IndexingService
     class_attribute :stored_and_facetable_fields, :stored_fields, :symbol_fields
     self.stored_and_facetable_fields = %i[resource_type creator contributor keyword publisher subject language based_near]
-    self.stored_fields = %i[alt_title description abstract license rights_statement rights_notes access_right date_created identifier related_url bibliographic_citation source]
+    self.stored_fields = %i[alternative_title description abstract license rights_statement rights_notes access_right date_created identifier related_url bibliographic_citation source]
     self.symbol_fields = %i[import_url]
 
     private

--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -29,10 +29,10 @@ class AdminSet < ActiveFedora::Base
   class_attribute :human_readable_short_description
   self.indexer = Hyrax::AdminSetIndexer
 
-  property :title,       predicate: ::RDF::Vocab::DC.title
-  property :alt_title,   predicate: ::RDF::Vocab::DC.alternative
-  property :description, predicate: ::RDF::Vocab::DC.description
-  property :creator,     predicate: ::RDF::Vocab::DC11.creator
+  property :title,             predicate: ::RDF::Vocab::DC.title
+  property :alternative_title, predicate: ::RDF::Vocab::DC.alternative
+  property :description,       predicate: ::RDF::Vocab::DC.description
+  property :creator,           predicate: ::RDF::Vocab::DC11.creator
   has_many :members,
            predicate:  Hyrax.config.admin_set_predicate,
            class_name: 'ActiveFedora::Base'

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -6,7 +6,7 @@ module Hyrax
     extend ActiveSupport::Concern
 
     included do
-      property :alt_title, predicate: ::RDF::Vocab::DC.alternative
+      property :alternative_title, predicate: ::RDF::Vocab::DC.alternative
 
       property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false
 

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -40,7 +40,7 @@ module Hyrax
       end
 
       included do
-        attribute :alt_title, Solr::Array, "alt_title_tesim"
+        attribute :alternative_title, Solr::Array, "alternative_title_tesim"
         attribute :identifier, Solr::Array, "identifier_tesim"
         attribute :based_near, Solr::Array, "based_near_tesim"
         attribute :based_near_label, Solr::Array, "based_near_label_tesim"

--- a/app/models/hyrax/administrative_set.rb
+++ b/app/models/hyrax/administrative_set.rb
@@ -4,9 +4,9 @@ module Hyrax
   ##
   # Valkyrie model for Admin Set domain objects.
   class AdministrativeSet < Hyrax::Resource
-    attribute :alt_title,   Valkyrie::Types::Set.of(Valkyrie::Types::String)
-    attribute :creator,     Valkyrie::Types::Set.of(Valkyrie::Types::String)
-    attribute :description, Valkyrie::Types::Set.of(Valkyrie::Types::String)
-    attribute :title,       Valkyrie::Types::Set.of(Valkyrie::Types::String)
+    attribute :alternative_title, Valkyrie::Types::Set.of(Valkyrie::Types::String)
+    attribute :creator,           Valkyrie::Types::Set.of(Valkyrie::Types::String)
+    attribute :description,       Valkyrie::Types::Set.of(Valkyrie::Types::String)
+    attribute :title,             Valkyrie::Types::Set.of(Valkyrie::Types::String)
   end
 end

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -39,7 +39,7 @@ module Hyrax
     delegate :title, :date_created, :description,
              :creator, :contributor, :subject, :publisher, :language, :embargo_release_date,
              :lease_expiration_date, :license, :source, :rights_statement, :thumbnail_id, :representative_id,
-             :rendering_ids, :member_of_collection_ids, :alt_title, to: :solr_document
+             :rendering_ids, :member_of_collection_ids, :alternative_title, to: :solr_document
 
     def workflow
       @workflow ||= WorkflowPresenter.new(solr_document, current_ability)

--- a/app/views/records/edit_fields/_alt_title.html.erb
+++ b/app/views/records/edit_fields/_alt_title.html.erb
@@ -1,3 +1,0 @@
-<% f.object.alt_title.each do |value| %>
-  <%= f.hidden_field :alt_title, multiple: true, value: value.to_s  %>
-<% end %>

--- a/app/views/records/edit_fields/_alternative_title.html.erb
+++ b/app/views/records/edit_fields/_alternative_title.html.erb
@@ -1,0 +1,3 @@
+<% f.object.alternative_title.each do |value| %>
+  <%= f.hidden_field :alternative_title, multiple: true, value: value.to_s  %>
+<% end %>

--- a/lib/hyrax/metadata/basic.rb
+++ b/lib/hyrax/metadata/basic.rb
@@ -8,7 +8,7 @@ module Hyrax
       ATTRIBUTES = {
         abstract:               Valkyrie::Types::Array.of(Valkyrie::Types::String),
         access_right:           Valkyrie::Types::Array.of(Valkyrie::Types::String),
-        alt_title:              Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        alternative_title:      Valkyrie::Types::Array.of(Valkyrie::Types::String),
         based_near:             Valkyrie::Types::Array.of(Valkyrie::Types::String),
         contributor:            Valkyrie::Types::Array.of(Valkyrie::Types::String),
         creator:                Valkyrie::Types::Array.of(Valkyrie::Types::String),

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -89,9 +89,9 @@ end
 RSpec.shared_examples 'a Hyrax::AdministrativeSet' do
   subject(:admin_set) { described_class.new }
 
-  it 'has an #alt_title' do
-    expect { admin_set.alt_title = ['Moomin'] }
-      .to change { admin_set.alt_title }
+  it 'has an #alternative_title' do
+    expect { admin_set.alternative_title = ['Moomin'] }
+      .to change { admin_set.alternative_title }
       .to contain_exactly('Moomin')
   end
 

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -23,9 +23,9 @@ FactoryBot.define do
     end
 
     factory :complete_admin_set do
-      alt_title   { ['alternate admin set title'] }
-      creator     { ['moomin', 'snufkin'] }
-      description { ['Before a revolution happens', 'it is perceived as impossible'] }
+      alternative_title { ['alternative admin set title'] }
+      creator           { ['moomin', 'snufkin'] }
+      description       { ['Before a revolution happens', 'it is perceived as impossible'] }
     end
   end
 end

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Hyrax::Forms::BatchUploadForm do
     subject { form.terms }
 
     it do
-      is_expected.to eq [:alt_title,
+      is_expected.to eq [:alternative_title,
                          :creator,
                          :contributor,
                          :description,

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
     subject { described_class.terms }
 
     it do
-      is_expected.to eq [:alt_title,
+      is_expected.to eq [:alternative_title,
                          :resource_type,
                          :title,
                          :creator,
@@ -41,7 +41,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
 
     it do
       is_expected.to eq [
-        :alt_title,
+        :alternative_title,
         :creator,
         :contributor,
         :keyword,
@@ -129,7 +129,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
     subject { described_class.build_permitted_params }
 
     it do
-      is_expected.to eq [{ alt_title: [] },
+      is_expected.to eq [{ alternative_title: [] },
                          { resource_type: [] },
                          { title: [] },
                          { creator: [] },

--- a/spec/hyrax/schema_spec.rb
+++ b/spec/hyrax/schema_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Hyrax::Schema do
     let(:attributes) do
       { abstract:               ['lorem ipsum', 'sit dolor'],
         access_right:           ['lorem ipsum', 'sit dolor'],
-        alt_title:              [RDF::Literal('Finn Family Moomintroll', language: :en)],
+        alternative_title:      [RDF::Literal('Finn Family Moomintroll', language: :en)],
         based_near:             ['lorem ipsum', 'sit dolor'],
         contributor:            ['moominpapa', 'moominmama'],
         creator:                ['moomin'],

--- a/spec/indexers/hyrax/admin_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/admin_set_indexer_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe Hyrax::AdminSetIndexer do
     end
   end
 
-  describe 'alt_title' do
+  describe 'alternative_title' do
     it 'is stored searchable' do
       expect(indexer.generate_solr_document)
-        .to match a_hash_including('alt_title_tesim' => admin_set.alt_title)
+        .to match a_hash_including('alternative_title_tesim' => admin_set.alternative_title)
     end
   end
 

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe AdminSet, type: :model do
     let(:admin_set) do
       build(:admin_set, title: ['A good title'],
                         creator: ['jcoyne@justincoyne.com'],
-                        alt_title: ['A bad title'],
+                        alternative_title: ['A bad title'],
                         description: ['a description'])
     end
 
@@ -73,7 +73,7 @@ RSpec.describe AdminSet, type: :model do
 
     it 'indexes all properties' do
       keys = ["system_create_dtsi", "system_modified_dtsi", "has_model_ssim",
-              :id, "title_tesim", "title_sim", "alt_title_tesim", "description_tesim",
+              :id, "title_tesim", "title_sim", "alternative_title_tesim", "description_tesim",
               "creator_ssim", "thumbnail_path_ss", "generic_type_sim",
               "human_readable_type_sim", "human_readable_type_tesim"]
 

--- a/spec/views/records/edit_fields/_alternative_title.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_alternative_title.html.erb_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe 'records/edit_fields/_title.html.erb', type: :view do
   let(:form_template) do
     %(
       <%= simple_form_for [main_app, @form] do |f| %>
-        <%= render "records/edit_fields/alt_title", f: f, key: 'description' %>
+        <%= render "records/edit_fields/alternative_title", f: f, key: 'description' %>
       <% end %>
     )
   end
 
   before do
     work.title = ["bbb", "aaa", "ccc"]
-    work.alt_title = []
+    work.alternative_title = []
     assign(:form, form)
   end
 


### PR DESCRIPTION
Changes `:alt_title` property to `:alternative_title` so property name more closely matches predicate, avoids arbitrary truncation, can be more easily parsed for display, etc.

Also plays nicer with existing projects such as [NewspaperWorks](https://github.com/samvera-labs/newspaper_works/blob/master/app/models/concerns/newspaper_works/newspaper_core_metadata.rb#L12-L18) and [Bulkrax](https://github.com/samvera-labs/bulkrax/blob/master/lib/bulkrax.rb#L53)

Changes proposed in this pull request:
* change `:alt_title` property to `:alternative_title`


@samvera/hyrax-code-reviewers
