### PR TITLE
Fix dashboard accessibility issues

### DIFF
--- a/app/views/hyrax/dashboard/_index_partials/_transfers.html.erb
+++ b/app/views/hyrax/dashboard/_index_partials/_transfers.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-xs-12 col-sm-9">
-    <h4><%= t("hyrax.dashboard.transfers_sent") %></h4>
+    <h3><%= t("hyrax.dashboard.transfers_sent") %></h3>
   </div>
   <div class="col-xs-12 col-sm-3 transfer_link">
     <%= link_to hyrax.my_works_path do %>
@@ -10,5 +10,5 @@
 </div>
 <%= presenter.render_sent_transfers %>
 
-<h4><%= t("hyrax.dashboard.transfers_received") %></h4>
+<h3><%= t("hyrax.dashboard.transfers_received") %></h3>
 <%= presenter.render_received_transfers %>

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -7,6 +7,7 @@
   data-post-delete-url="<%= is_admin_set ? hyrax.admin_admin_set_path(id) : hyrax.dashboard_collection_path(id) %>">
 
   <td>
+    <label class="sr-only" for="batch_document_<%= id %>"><%= t('hyrax.dashboard.my.sr.batch_checkbox') %></label>
     <% if collection_presenter.allow_batch? %>
     <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
       data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>" />
@@ -20,7 +21,7 @@
         <% if (collection_presenter.thumbnail_path == nil) %>
           <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small"></span>
         <% else %>
-          <%= image_tag(collection_presenter.thumbnail_path) %>
+          <%= image_tag(collection_presenter.thumbnail_path, alt: "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
         <% end %>
       </div>
       <%= link_to collection_presenter.show_path do %>

--- a/app/views/hyrax/dashboard/show_admin.html.erb
+++ b/app/views/hyrax/dashboard/show_admin.html.erb
@@ -6,7 +6,7 @@
   <div class="col-md-3">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title text-center"><%= t('.registered_users') %></h3>
+        <h2 class="panel-title text-center"><%= t('.registered_users') %></h2>
       </div>
       <div class="panel-body text-center">
         <%= t('.current_registered_users') %>
@@ -18,7 +18,7 @@
   <div class="col-md-3">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title text-center"><%= t('.total_visitors') %></h3>
+        <h2 class="panel-title text-center"><%= t('.total_visitors') %></h2>
       </div>
       <div class="panel-body text-center"><%= t('.past_30_days') %>
         <div class="h3">n/a</div>
@@ -29,7 +29,7 @@
     <div class="col-md-3">
       <div class="panel panel-default">
         <div class="panel-heading">
-          <h3 class="panel-title text-center"><%= t('.returning_visitors') %></h3>
+          <h2 class="panel-title text-center"><%= t('.returning_visitors') %></h2>
         </div>
         <div class="panel-body text-center"><%= t('.past_30_days') %>
           <div class="h3">n/a</div>
@@ -40,7 +40,7 @@
     <div class="col-md-3">
       <div class="panel panel-default">
         <div class="panel-heading">
-          <h3 class="panel-title text-center"><%= t('.new_visitors') %></h3>
+          <h2 class="panel-title text-center"><%= t('.new_visitors') %></h2>
         </div>
         <div class="panel-body text-center"><%= t('.past_30_days') %>
           <div class="h3">n/a</div>

--- a/app/views/hyrax/dashboard/show_user.html.erb
+++ b/app/views/hyrax/dashboard/show_user.html.erb
@@ -4,7 +4,7 @@
 
 <div class="panel panel-default user-activity">
   <div class="panel-heading">
-    <h3 class="panel-title "><%= t("hyrax.dashboard.user_activity.title") %></h3>
+    <h2 class="panel-title "><%= t("hyrax.dashboard.user_activity.title") %></h2>
   </div>
   <div class="panel-body">
     <%= @presenter.render_recent_activity %>
@@ -13,7 +13,7 @@
 
 <div class="panel panel-default" id="notifications">
   <div class="panel-heading">
-    <h3 class="panel-title "><%= t("hyrax.dashboard.user_notifications") %></h3>
+    <h2 class="panel-title "><%= t("hyrax.dashboard.user_notifications") %></h2>
   </div>
   <div class="panel-body">
     <%= @presenter.render_recent_notifications %>
@@ -24,7 +24,7 @@
 <% if Flipflop.proxy_deposit? %>
   <div class="panel panel-default" id="proxy_management">
     <div class="panel-heading">
-      <h3 class="panel-title "><%= t("hyrax.dashboard.current_proxies") %></h3>
+      <h2 class="panel-title "><%= t("hyrax.dashboard.current_proxies") %></h2>
     </div>
     <div class="panel-body">
       <%= render 'hyrax/dashboard/_index_partials/current_proxy_rights', user: current_user %>
@@ -35,7 +35,7 @@
 
 <div class="panel panel-default transfers">
   <div class="panel-heading">
-    <h3 class="panel-title "><%= t("hyrax.dashboard.transfer_of_ownership") %></h3>
+    <h2 class="panel-title "><%= t("hyrax.dashboard.transfer_of_ownership") %></h2>
   </div>
   <div class="panel-body">
     <%= render 'hyrax/dashboard/_index_partials/transfers', presenter: @presenter.transfers %>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -9,6 +9,7 @@
   data-post-delete-url="<%= is_admin_set ? hyrax.admin_admin_set_path(id) : hyrax.dashboard_collection_path(id) %>">
 
   <td>
+    <label class="sr-only" for="batch_document_<%= id %>"><%= t('hyrax.dashboard.my.sr.batch_checkbox') %></label>
     <% if collection_presenter.allow_batch? %>
         <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
                data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>" />
@@ -22,7 +23,7 @@
         <% if (collection_presenter.thumbnail_path == nil) %>
           <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small"></span>
         <% else %>
-          <%= image_tag(collection_presenter.thumbnail_path) %>
+          <%= image_tag(collection_presenter.thumbnail_path, alt: "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
         <% end %>
       </div>
       <%= link_to collection_presenter.show_path, id: "src_copy_link#{id}" do %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -905,6 +905,7 @@ en:
           press_to: Press to
           results_per_page: Number of results to display per page
           show_label: Display all details of
+          thumbnail: thumbnail
         works: Works
         your_collections: Your Collections
         your_works: Your Works


### PR DESCRIPTION
Fixes #3964 

Improve accessibility of the dashboard, using `axe` to assess the accessibility of the elements in the page. 

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Install the Axe plugin or addon from Deque (https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/ is the firefox version).
* Login as an admin user
* Go to the dashboard
* Open dev tools and go to `axe` tab
* Click 'Analyze'
* Logout and login again as a normal user
* Open dev tools and go to `axe` tab
* Click 'Analyze'

@samvera/hyrax-code-reviewers
