### PR TITLE
Fix landmark issue in Homepage

### DIFF
--- a/app/assets/stylesheets/hyrax/_home-page.scss
+++ b/app/assets/stylesheets/hyrax/_home-page.scss
@@ -125,7 +125,7 @@ div#announcement {
   text-align: center;
   color: white;
   font-size: 1.5em;
-  background-color: $vermilion;
+  background-color: $rufous;
   border: 10px solid white;
   padding-top: 10px;
   border-radius: 15px;

--- a/app/assets/stylesheets/hyrax/_settings.scss
+++ b/app/assets/stylesheets/hyrax/_settings.scss
@@ -4,7 +4,7 @@
 // Some are unique or override other variables from Bootstrap.
 
 $classic-white: #FFF !default;
-$vermilion: #F30 !default;
+$rufous: #a81c07 !default;
 
 // Nav and Search Bar
 $search-bar-margin-top: 0.50em;
@@ -12,7 +12,7 @@ $search-bar-margin-top: 0.50em;
 // Dashboard
 $dashboard-border-color: $gray-lighter !default;
 
-$icon-background-color: $vermilion !default;
+$icon-background-color: $rufous !default;
 $icon-border-color: $classic-white !default;
 $icon-font-color: $classic-white !default;
 $icon-link-color: $gray-light !default;

--- a/app/views/hyrax/homepage/_announcement.html.erb
+++ b/app/views/hyrax/homepage/_announcement.html.erb
@@ -1,5 +1,5 @@
 <% if display_content_block? @announcement_text %>
-  <div id="announcement" class="row">
-    <%= displayable_content_block @announcement_text, class: 'row', id: 'announcement' %>
+  <div id="announcement_text" class="row">
+    <%= displayable_content_block @announcement_text, class: 'row', id: 'announcement', role: 'complementary', 'aria-label': 'announcement-text' %>
   </div>
 <% end %>

--- a/app/views/hyrax/homepage/_marketing.html.erb
+++ b/app/views/hyrax/homepage/_marketing.html.erb
@@ -1,5 +1,5 @@
 <% if display_content_block? @marketing_text %>
   <div class="home_marketing_text">
-    <%= displayable_content_block @marketing_text, class: 'col-sm-offset-2 col-sm-9 col-md-offset-1 home_marketing_text' %>
+    <%= displayable_content_block @marketing_text, class: 'col-sm-offset-2 col-sm-9 col-md-offset-1 home_marketing_text', role: 'complementary' %>
   </div>
 <% end %>


### PR DESCRIPTION
Fixes #3961

For the content introduced by the content blocks into the Homepage are at a similar level as the main content in the DOM hierarchy. Therefore these elements are not contained within the landmark in the page. These elements can be identified as complementary landmarks in the page.

Changes proposed in this pull request:
* Add `complementary` role to the content injected into the home page by the content blocks

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Install the Axe plugin or addon from Deque (https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/ is the firefox version).
* Go to the homepage
* Open dev tools and go to `axe` tab
* Click 'Analyze'

Related work: #4139 

@samvera/hyrax-code-reviewers
