### PR TITLE
Deprecate `Hyrax.config.callback`

### DIFF
--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -46,7 +46,7 @@ module Hyrax
       private
 
         def run_callbacks(hook, env)
-          Hyrax.config.callback.run(hook, env.curation_concern, env.user)
+          Hyrax.config.callback.run(hook, env.curation_concern, env.user, warn: false)
           true
         end
 

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -81,7 +81,7 @@ module Hyrax
           # Save the work so the association between the work and the file_set is persisted (head_id)
           # NOTE: the work may not be valid, in which case this save doesn't do anything.
           work.save
-          Hyrax.config.callback.run(:after_create_fileset, file_set, user)
+          Hyrax.config.callback.run(:after_create_fileset, file_set, user, warn: false)
         end
       end
       alias attach_file_to_work attach_to_work
@@ -92,7 +92,7 @@ module Hyrax
       # @return [Boolean] true on success, false otherwise
       def revert_content(revision_id, relation = :original_file)
         return false unless build_file_actor(relation).revert_to(revision_id)
-        Hyrax.config.callback.run(:after_revert_content, file_set, user, revision_id)
+        Hyrax.config.callback.run(:after_revert_content, file_set, user, revision_id, warn: false)
         true
       end
 
@@ -104,7 +104,7 @@ module Hyrax
       def destroy
         unlink_from_work
         file_set.destroy
-        Hyrax.config.callback.run(:after_destroy, file_set.id, user)
+        Hyrax.config.callback.run(:after_destroy, file_set.id, user, warn: false)
       end
 
       class_attribute :file_actor_class

--- a/app/actors/hyrax/actors/ordered_members_actor.rb
+++ b/app/actors/hyrax/actors/ordered_members_actor.rb
@@ -19,7 +19,7 @@ module Hyrax
           work.ordered_members = ordered_members
           work.save
           ordered_members.each do |file_set|
-            Hyrax.config.callback.run(:after_create_fileset, file_set, user)
+            Hyrax.config.callback.run(:after_create_fileset, file_set, user, warn: false)
           end
         end
       end

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -112,7 +112,7 @@ module Hyrax
       title = curation_concern.to_s
       env = Actors::Environment.new(curation_concern, current_ability, {})
       return unless actor.destroy(env)
-      Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user)
+      Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user, warn: false)
       after_destroy_response(title)
     end
 

--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -31,7 +31,7 @@ class FixityCheckJob < Hyrax::ApplicationJob
       file_set = ::FileSet.find(file_set_id)
       Hyrax.config.callback.run(:after_fixity_check_failure,
                                 file_set,
-                                checksum_audit_log: log)
+                                checksum_audit_log: log, warn: false)
     end
 
     log

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -76,7 +76,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
     def send_error(error_message)
       user = User.find_by_user_key(file_set.depositor)
       @file_set.errors.add('Error:', error_message)
-      Hyrax.config.callback.run(:after_import_url_failure, @file_set, user)
+      Hyrax.config.callback.run(:after_import_url_failure, @file_set, user, warn: false)
       @operation.fail!(@file_set.errors.full_messages.join(' '))
     end
 

--- a/app/jobs/ingest_local_file_job.rb
+++ b/app/jobs/ingest_local_file_job.rb
@@ -10,13 +10,13 @@ class IngestLocalFileJob < Hyrax::ApplicationJob
     actor = Hyrax::Actors::FileSetActor.new(file_set, user)
 
     if actor.create_content(File.open(path))
-      Hyrax.config.callback.run(:after_import_local_file_success, file_set, user, path)
+      Hyrax.config.callback.run(:after_import_local_file_success, file_set, user, path, warn: false)
     else
-      Hyrax.config.callback.run(:after_import_local_file_failure, file_set, user, path)
+      Hyrax.config.callback.run(:after_import_local_file_failure, file_set, user, path, warn: false)
     end
   rescue SystemCallError
     # This is generic in order to handle Errno constants raised when accessing files
     # @see https://ruby-doc.org/core-2.5.3/Errno.html
-    Hyrax.config.callback.run(:after_import_local_file_failure, file_set, user, path)
+    Hyrax.config.callback.run(:after_import_local_file_failure, file_set, user, path, warn: false)
   end
 end

--- a/app/models/hyrax/batch_create_operation.rb
+++ b/app/models/hyrax/batch_create_operation.rb
@@ -5,12 +5,12 @@ module Hyrax
 
     def batch_success_message
       return unless Hyrax.config.callback.set?(:after_batch_create_success)
-      Hyrax.config.callback.run(:after_batch_create_success, user)
+      Hyrax.config.callback.run(:after_batch_create_success, user, warn: false)
     end
 
     def batch_failure_message
       return unless Hyrax.config.callback.set?(:after_batch_create_failure)
-      Hyrax.config.callback.run(:after_batch_create_failure, user, rollup_messages)
+      Hyrax.config.callback.run(:after_batch_create_failure, user, rollup_messages, warn: false)
     end
   end
 end

--- a/config/initializers/hyrax_callbacks.rb
+++ b/config/initializers/hyrax_callbacks.rb
@@ -6,38 +6,38 @@ Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleNotificationListener.new)
 
 # These events are triggered by actions within Hyrax Actors
-Hyrax.config.callback.set(:after_create_concern) do |curation_concern, user|
+Hyrax.config.callback.set(:after_create_concern, warn: false) do |curation_concern, user|
   Hyrax.publisher.publish('object.deposited', object: curation_concern, user: user)
 end
 
-Hyrax.config.callback.set(:after_create_fileset) do |file_set, user|
+Hyrax.config.callback.set(:after_create_fileset, warn: false) do |file_set, user|
   Hyrax.publisher.publish('file.set.attached', file_set: file_set, user: user)
 end
 
-Hyrax.config.callback.set(:after_revert_content) do |file_set, user, revision|
+Hyrax.config.callback.set(:after_revert_content, warn: false) do |file_set, user, revision|
   Hyrax.publisher.publish('file.set.restored', file_set: file_set, user: user, revision: revision)
 end
 
-Hyrax.config.callback.set(:after_update_metadata) do |curation_concern, user|
+Hyrax.config.callback.set(:after_update_metadata, warn: false) do |curation_concern, user|
   Hyrax.publisher.publish('object.metadata.updated', object: curation_concern, user: user)
 end
 
-Hyrax.config.callback.set(:after_destroy) do |id, user|
+Hyrax.config.callback.set(:after_destroy, warn: false) do |id, user|
   Hyrax.publisher.publish('object.deleted', id: id, user: user)
 end
 
-Hyrax.config.callback.set(:after_fixity_check_failure) do |file_set, checksum_audit_log:|
+Hyrax.config.callback.set(:after_fixity_check_failure, warn: false) do |file_set, checksum_audit_log:|
   Hyrax.publisher.publish('file.set.audited', file_set: file_set, audit_log: checksum_audit_log, result: :failure)
 end
 
-Hyrax.config.callback.set(:after_batch_create_success) do |user|
+Hyrax.config.callback.set(:after_batch_create_success, warn: false) do |user|
   Hyrax.publisher.publish('batch.created', user: user, messages: [], result: :success)
 end
 
-Hyrax.config.callback.set(:after_batch_create_failure) do |user, messages|
+Hyrax.config.callback.set(:after_batch_create_failure, warn: false) do |user, messages|
   Hyrax.publisher.publish('batch.created', user: user, messages: messages, result: :failure)
 end
 
-Hyrax.config.callback.set(:after_import_url_failure) do |file_set, user|
+Hyrax.config.callback.set(:after_import_url_failure, warn: false) do |file_set, user|
   Hyrax.publisher.publish('file.set.url.imported', file_set: file_set, user: user, result: :failure)
 end

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -5,7 +5,8 @@ Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleNotificationListener.new)
 
-# These events are triggered by actions within Hyrax Actors
+# Publish events from old style Hyrax::Callbacks to trigger the listeners
+# When callbacks are removed and replaced with direct event publication, drop these blocks
 Hyrax.config.callback.set(:after_create_concern, warn: false) do |curation_concern, user|
   Hyrax.publisher.publish('object.deposited', object: curation_concern, user: user)
 end

--- a/lib/hyrax/callbacks/registry.rb
+++ b/lib/hyrax/callbacks/registry.rb
@@ -23,7 +23,8 @@ module Hyrax
       end
 
       # Defines a callback for a given hook.
-      def set(hook, &block)
+      def set(hook, warn: true, &block)
+        Deprecation.warn(self, warning_for_set) if warn
         raise NoBlockGiven, "a block is required when setting a callback" unless block_given?
         @callbacks[hook] = proc(&block)
       end
@@ -34,11 +35,26 @@ module Hyrax
       end
 
       # Runs the callback defined for a given hook, with the arguments provided
-      def run(hook, *args)
+      def run(hook, *args, warn: true, **opts)
+        Deprecation.warn(self, warning_for_run) if warn
         raise NotEnabled unless enabled?(hook)
         return nil unless set?(hook)
-        @callbacks[hook].call(*args)
+        @callbacks[hook].call(*args, **opts)
       end
+
+      private
+
+        def warning_for_set
+          "Hyrax.config.callback is deprecated; register your callback handler " \
+            "as a listener on Hyrax.publisher instead. See Hyrax::Publisher " \
+            "and Dry::Events"
+        end
+
+        def warning_for_run
+          "Hyrax.config.callback is deprecated; to trigger handlers publish " \
+            "events to Hyrax.publisher instead of running callbacks. See " \
+            "Hyrax::Publisher and Dry::Events"
+        end
     end
 
     # Custom exceptions

--- a/lib/hyrax/specs/spy_listener.rb
+++ b/lib/hyrax/specs/spy_listener.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Specs
+    class SpyListener
+      attr_reader :file_set_attached, :file_set_url_imported, :object_deleted,
+                  :object_deposited, :object_metadata_updated
+
+      def on_object_deleted(event)
+        @object_deleted = event
+      end
+
+      def on_object_deposited(event)
+        @object_deposited = event
+      end
+
+      def on_object_metadata_updated(event)
+        @object_metadata_updated = event
+      end
+
+      def on_file_set_attached(event)
+        @file_set_attached = event
+      end
+
+      def on_file_set_url_imported(event)
+        @file_set_url_imported = event
+      end
+    end
+  end
+end

--- a/spec/config/hyrax_events_spec.rb
+++ b/spec/config/hyrax_events_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe "hyrax_events using Hyrax callbacks" do
   describe "after_create_concern" do
     it "queues a ContentDepositEventJob" do
       expect(ContentDepositEventJob).to receive(:perform_later).with(curation_concern, user)
-      Hyrax.config.callback.run(:after_create_concern, curation_concern, user)
+      Hyrax.config.callback.run(:after_create_concern, curation_concern, user, warn: false)
     end
   end
 
   describe "after_create_fileset" do
     it "queues a FileSetAttachedEventJob" do
       expect(FileSetAttachedEventJob).to receive(:perform_later).with(file_set, user)
-      Hyrax.config.callback.run(:after_create_fileset, file_set, user)
+      Hyrax.config.callback.run(:after_create_fileset, file_set, user, warn: false)
     end
   end
 
@@ -22,14 +22,14 @@ RSpec.describe "hyrax_events using Hyrax callbacks" do
 
     it "queues a ContentRestoredVersionEventJob" do
       expect(ContentRestoredVersionEventJob).to receive(:perform_later).with(file_set, user, revision)
-      Hyrax.config.callback.run(:after_revert_content, file_set, user, revision)
+      Hyrax.config.callback.run(:after_revert_content, file_set, user, revision, warn: false)
     end
   end
 
   describe "after_update_metadata" do
     it "queues a ContentUpdateEventJob" do
       expect(ContentUpdateEventJob).to receive(:perform_later).with(curation_concern, user)
-      Hyrax.config.callback.run(:after_update_metadata, curation_concern, user)
+      Hyrax.config.callback.run(:after_update_metadata, curation_concern, user, warn: false)
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe "hyrax_events using Hyrax callbacks" do
 
     it "queues a ContentDeleteEventJob" do
       expect(ContentDeleteEventJob).to receive(:perform_later).with(id, user)
-      Hyrax.config.callback.run(:after_destroy, id, user)
+      Hyrax.config.callback.run(:after_destroy, id, user, warn: false)
     end
   end
 end

--- a/spec/jobs/ingest_local_file_job_spec.rb
+++ b/spec/jobs/ingest_local_file_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe IngestLocalFileJob do
   let(:user) { create(:user) }
 
@@ -34,7 +36,7 @@ RSpec.describe IngestLocalFileJob do
     end
 
     it "invokes the file failure callback" do
-      expect(callback).to have_received(:run).with(:after_import_local_file_failure, file_set, user, path)
+      expect(callback).to have_received(:run).with(:after_import_local_file_failure, file_set, user, path, warn: false)
     end
   end
 end


### PR DESCRIPTION
Emit deprecation warnings on `#set` and `#run`.

A `warn:` flag is added, defaulting to true. Internal Hyrax callers pass it
`false` to avoid emitting warnings. These callers will still need to register
and invoke callbacks until downstream applications are using `Hyrax.publisher`.

Closes #4154 

@samvera/hyrax-code-reviewers
