### PR TITLE
Fix for HYRAX-#3385

### DIFF
--- a/app/controllers/concerns/hyrax/breadcrumbs.rb
+++ b/app/controllers/concerns/hyrax/breadcrumbs.rb
@@ -4,12 +4,18 @@ module Hyrax
     extend ActiveSupport::Concern
 
     def build_breadcrumbs
-      if request.referer
-        trail_from_referer
-      else
-        default_trail
-        add_breadcrumb_for_controller if user_signed_in?
-        add_breadcrumb_for_action
+      return if build_breadcrumbs_skip
+      trail_from_referer
+    end
+
+    def build_breadcrumbs_skip
+      return true if request.referer.blank?
+      referer_path = URI(request.referer).path
+      begin
+        Rails.application.routes.recognize_path(referer_path)
+        false
+      rescue ActionController::RoutingError
+        true
       end
     end
 

--- a/app/controllers/concerns/hyrax/breadcrumbs_for_works.rb
+++ b/app/controllers/concerns/hyrax/breadcrumbs_for_works.rb
@@ -17,6 +17,7 @@ module Hyrax
 
     def build_breadcrumbs
       return super if action_name == 'show'
+      return if build_breadcrumbs_skip
       # These breadcrumbs are for the edit/create actions
       add_breadcrumb t(:'hyrax.controls.home'), root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -77,7 +77,8 @@ module Hyrax
         wants.json do
           # load @curation_concern manually because it's skipped for html
           @curation_concern = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id])
-          curation_concern # This is here for authorization checks (we could add authorize! but let's use the same method for CanCanCan)
+          authorize!(:show, @curation_concern)
+          # curation_concern # This is here for authorization checks (we could add authorize! but let's use the same method for CanCanCan)
           render :show, status: :ok
         end
         additional_response_formats(wants)

--- a/spec/controllers/hyrax/batch_edits_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_edits_controller_spec.rb
@@ -18,9 +18,10 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
       expect(controller).to receive(:can?).with(:edit, one.id).and_return(true)
       expect(controller).to receive(:can?).with(:edit, two.id).and_return(true)
       expect(controller).to receive(:can?).with(:edit, three.id).and_return(false)
+      request.env['HTTP_REFERER'] = Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en')
     end
 
-    it "is successful" do
+    it "is successful and sets breadcrumbs" do
       expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
       expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
       expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
@@ -67,7 +68,7 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
       expect(controller).to receive(:can?).with(:edit, three.id).and_return(false)
     end
 
-    it "is successful" do
+    it "is successful and does not set breadcrumbs" do
       put :update, params: { update_type: "delete_all" }
       expect(response).to redirect_to(dashboard_path(locale: 'en'))
       expect { GenericWork.find(one.id) }.to raise_error(Ldp::Gone)

--- a/spec/controllers/hyrax/citations_controller_spec.rb
+++ b/spec/controllers/hyrax/citations_controller_spec.rb
@@ -4,16 +4,47 @@ RSpec.describe Hyrax::CitationsController do
     let(:user) { create(:user) }
     let(:work) { create(:work, user: user) }
 
-    context "with an authenticated_user" do
+    context "with an authenticated_user and sets breadcrumbs" do
       before do
         sign_in user
-        request.env['HTTP_REFERER'] = 'http://test.host/foo'
+        request.env['HTTP_REFERER'] = Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en')
         create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
       end
 
       it "is successful" do
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        get :work, params: { id: work }
+        expect(response).to be_successful
+        expect(response).to render_template('layouts/hyrax/1_column')
+        expect(assigns(:presenter)).to be_kind_of Hyrax::WorkShowPresenter
+      end
+    end
+
+    context "with an authenticated_user from without referer" do
+      before do
+        sign_in user
+        create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+      end
+
+      it "is successful and does not set breadcrumbs" do
+        expect(controller).not_to receive(:add_breadcrumb)
+        get :work, params: { id: work }
+        expect(response).to be_successful
+        expect(response).to render_template('layouts/hyrax/1_column')
+        expect(assigns(:presenter)).to be_kind_of Hyrax::WorkShowPresenter
+      end
+    end
+
+    context "with an authenticated_user from an external referer" do
+      before do
+        sign_in user
+        request.env['HTTP_REFERER'] = 'http://test.host/foo'
+        create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+      end
+
+      it "is successful and does not set breadcrumbs" do
+        expect(controller).not_to receive(:add_breadcrumb)
         get :work, params: { id: work }
         expect(response).to be_successful
         expect(response).to render_template('layouts/hyrax/1_column')
@@ -34,15 +65,44 @@ RSpec.describe Hyrax::CitationsController do
     let(:user) { create(:user) }
     let(:file_set) { create(:file_set, user: user) }
 
-    context "with an authenticated_user" do
+    context "with an authenticated_user and sets breadcrumbs" do
+      before do
+        sign_in user
+        request.env['HTTP_REFERER'] = Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en')
+      end
+
+      it "is successful and sets breadcrumbs" do
+        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        get :file, params: { id: file_set }
+        expect(response).to be_successful
+        expect(response).to render_template('layouts/hyrax/1_column')
+        expect(assigns(:presenter)).to be_kind_of Hyrax::FileSetPresenter
+      end
+    end
+
+    context "with an authenticated_user without referer" do
+      before do
+        sign_in user
+      end
+
+      it "is successful and does not set breadcrumbs" do
+        expect(controller).not_to receive(:add_breadcrumb)
+        get :file, params: { id: file_set }
+        expect(response).to be_successful
+        expect(response).to render_template('layouts/hyrax/1_column')
+        expect(assigns(:presenter)).to be_kind_of Hyrax::FileSetPresenter
+      end
+    end
+
+    context "with an authenticated_user from an external referer" do
       before do
         sign_in user
         request.env['HTTP_REFERER'] = 'http://test.host/foo'
       end
 
-      it "is successful" do
-        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+      it "is successful and does not set breadcrumbs" do
+        expect(controller).not_to receive(:add_breadcrumb)
         get :file, params: { id: file_set }
         expect(response).to be_successful
         expect(response).to render_template('layouts/hyrax/1_column')

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -31,11 +31,8 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
         end
       end
 
-      it "returns the collection and its members" do # rubocop:disable RSpec/ExampleLength
-        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
+      it "returns the collection and its members without breadcrumbs" do # rubocop:disable RSpec/ExampleLength
+        expect(controller).not_to receive(:add_breadcrumb)
         get :show, params: { id: collection }
         expect(response).to be_successful
         expect(response).to render_template("layouts/hyrax/1_column")
@@ -49,6 +46,7 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
 
       context "and searching" do
         it "returns some works and subcollections" do
+          expect(controller).not_to receive(:add_breadcrumb)
           # "/collections/4m90dv529?utf8=%E2%9C%93&cq=King+Louie&sort="
           get :show, params: { id: collection, cq: "Second" }
           expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
@@ -61,6 +59,7 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
 
       context 'when the page parameter is passed' do
         it 'loads the collection (paying no attention to the page param)' do
+          expect(controller).not_to receive(:add_breadcrumb)
           get :show, params: { id: collection, page: '2' }
           expect(response).to be_successful
           expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
@@ -68,20 +67,29 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
         end
       end
 
-      context "without a referer" do
-        it "sets breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
+      context "with an empty referer" do
+        it "does not set breadcrumbs" do
+          expect(controller).not_to receive(:add_breadcrumb)
           get :show, params: { id: collection }
           expect(response).to be_successful
         end
       end
 
-      context "with a referer" do
+      context "with an external referer" do
         before do
           request.env['HTTP_REFERER'] = 'http://test.host/foo'
+        end
+
+        it "does not set breadcrumbs" do
+          expect(controller).not_to receive(:add_breadcrumb)
+          get :show, params: { id: collection }
+          expect(response).to be_successful
+        end
+      end
+
+      context "with a collection referer" do
+        before do
+          request.env['HTTP_REFERER'] = collection_path(collection.id, locale: 'en')
         end
 
         it "sets breadcrumbs" do
@@ -103,20 +111,29 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
       end
     end
 
-    context "without a referer" do
-      it "sets breadcrumbs" do
-        expect(controller).not_to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).not_to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(controller).not_to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'))
-
+    context "without an empty referer" do
+      it "does not set breadcrumbs" do
+        expect(controller).not_to receive(:add_breadcrumb)
         get :show, params: { id: collection }
         expect(response).to be_successful
       end
     end
 
-    context "with a referer" do
+    context "with an external referer" do
       before do
         request.env['HTTP_REFERER'] = 'http://test.host/foo'
+      end
+
+      it "does not set breadcrumbs" do
+        expect(controller).not_to receive(:add_breadcrumb)
+        get :show, params: { id: collection }
+        expect(response).to be_successful
+      end
+    end
+
+    context "with a collections referer" do
+      before do
+        request.env['HTTP_REFERER'] = collection_path(collection.id, locale: 'en')
       end
 
       it "sets breadcrumbs" do

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -351,11 +351,8 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         end
       end
 
-      it "returns the collection and its members" do
-        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
+      it "returns the collection and its members and does not set breadcrumbs" do
+        expect(controller).not_to receive(:add_breadcrumb)
         get :show, params: { id: collection }
         expect(response).to be_successful
         expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
@@ -368,6 +365,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
 
       context "and searching" do
         it "returns some works and collections" do
+          expect(controller).not_to receive(:add_breadcrumb)
           # "/dashboard/collections/4m90dv529?utf8=%E2%9C%93&cq=King+Louie&sort="
           get :show, params: { id: collection, cq: "Second" }
           expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
@@ -380,6 +378,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
 
       context 'when the page parameter is passed' do
         it 'loads the collection (paying no attention to the page param)' do
+          expect(controller).not_to receive(:add_breadcrumb)
           get :show, params: { id: collection, page: '2' }
           expect(response).to be_successful
           expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
@@ -388,19 +387,28 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       end
 
       context "without a referer" do
-        it "sets breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
+        it "does not set breadcrumbs" do
+          expect(controller).not_to receive(:add_breadcrumb)
           get :show, params: { id: collection }
           expect(response).to be_successful
         end
       end
 
-      context "with a referer" do
+      context "with an external referer" do
         before do
           request.env['HTTP_REFERER'] = 'http://test.host/foo'
+        end
+
+        it "does not set breadcrumbs" do
+          expect(controller).not_to receive(:add_breadcrumb)
+          get :show, params: { id: collection }
+          expect(response).to be_successful
+        end
+      end
+
+      context "with a collection referer" do
+        before do
+          request.env['HTTP_REFERER'] = collection_path(collection.id, locale: 'en')
         end
 
         it "sets breadcrumbs" do
@@ -488,19 +496,28 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
     end
 
     context "without a referer" do
-      it "sets breadcrumbs" do
-        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.edit_view"), collection_path(collection.id, locale: 'en'), "aria-current" => "page")
+      it "does not set breadcrumbs" do
+        expect(controller).not_to receive(:add_breadcrumb)
         get :edit, params: { id: collection }
         expect(response).to be_successful
       end
     end
 
-    context "with a referer" do
+    context "with an external referer" do
       before do
         request.env['HTTP_REFERER'] = 'http://test.host/foo'
+      end
+
+      it "does not set breadcrumbs" do
+        expect(controller).not_to receive(:add_breadcrumb)
+        get :edit, params: { id: collection }
+        expect(response).to be_successful
+      end
+    end
+
+    context "with a collection referer" do
+      before do
+        request.env['HTTP_REFERER'] = collection_path(collection.id, locale: 'en')
       end
 
       it "sets breadcrumbs" do

--- a/spec/controllers/hyrax/generic_works_controller_json_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_json_spec.rb
@@ -62,7 +62,10 @@ RSpec.describe Hyrax::GenericWorksController do
     end
 
     describe 'found' do
-      before { resource_request }
+      before do
+        allow(controller).to receive(:authorize!).and_return(true)
+        resource_request
+      end
       it "returns json of the work" do
         # Ensure that @curation_concern is set for jbuilder template to use
         expect(controller).to render_template('hyrax/base/show')

--- a/spec/controllers/hyrax/stats_controller_spec.rb
+++ b/spec/controllers/hyrax/stats_controller_spec.rb
@@ -10,13 +10,28 @@ RSpec.describe Hyrax::StatsController do
   describe '#file' do
     let(:file_set) { create(:file_set, user: user) }
 
-    context 'when user has access to file' do
+    context 'when user has access to file and an external referer' do
       before do
         sign_in user
         request.env['HTTP_REFERER'] = 'http://test.host/foo'
       end
 
-      it 'renders the stats view' do
+      it 'renders the stats view without breadcrumbs' do
+        expect(Hyrax::FileUsage).to receive(:new).with(file_set.id).and_return(usage)
+        expect(controller).not_to receive(:add_breadcrumb)
+        get :file, params: { id: file_set }
+        expect(response).to be_success
+        expect(response).to render_template('stats/file')
+      end
+    end
+
+    context 'when user has access to file and comes from file set browse view' do
+      before do
+        sign_in user
+        request.env['HTTP_REFERER'] = Rails.application.routes.url_helpers.hyrax_file_set_path(file_set, locale: 'en')
+      end
+
+      it 'renders the stats view with breadcrumbs' do
         expect(Hyrax::FileUsage).to receive(:new).with(file_set.id).and_return(usage)
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
@@ -55,20 +70,37 @@ RSpec.describe Hyrax::StatsController do
   describe 'work' do
     let(:work) { create(:generic_work, user: user) }
 
-    before do
-      sign_in user
-      request.env['HTTP_REFERER'] = 'http://test.host/foo'
+    context 'when user has access and comes from external referer' do
+      before do
+        sign_in user
+        request.env['HTTP_REFERER'] = 'http://test.host/foo'
+      end
+
+      it 'renders the stats view without breadcrumbs' do
+        expect(Hyrax::WorkUsage).to receive(:new).with(work.id).and_return(usage)
+        expect(controller).not_to receive(:add_breadcrumb)
+        get :work, params: { id: work }
+        expect(response).to be_success
+        expect(response).to render_template('stats/work')
+      end
     end
 
-    it 'renders the stats view' do
-      expect(Hyrax::WorkUsage).to receive(:new).with(work.id).and_return(usage)
-      expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
-      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-      expect(controller).to receive(:add_breadcrumb).with('Test title', main_app.hyrax_generic_work_path(work, locale: 'en'))
-      get :work, params: { id: work }
-      expect(response).to be_successful
-      expect(response).to render_template('stats/work')
+    context 'when user has access and comes from generic work' do
+      before do
+        sign_in user
+        request.env['HTTP_REFERER'] = main_app.hyrax_generic_work_path(work, locale: 'en')
+      end
+
+      it 'renders the stats view with breadcrumbs' do
+        expect(Hyrax::WorkUsage).to receive(:new).with(work.id).and_return(usage)
+        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Test title', main_app.hyrax_generic_work_path(work, locale: 'en'))
+        get :work, params: { id: work }
+        expect(response).to be_successful
+        expect(response).to render_template('stats/work')
+      end
     end
   end
 end


### PR DESCRIPTION
Modified breadcrumbs to check referer and skip unless it is this website

Expected behavior:

For works, file sets, and collections: when navigating from within the website,
display breadcrumbs. When the referer is blank or some other website, then
don't display breadcrumbs.

In order to test:

* Go to the main page.
* Browse to a work or collection.
* Breadcrumbs should be displayed.
* Browse to a file set from a work or to a work from a collection.
* Breadcrumbs should be displayed.
* Copy the url.
* Open a new browser tab.
* Paste the url into the browser tab.
* No breadcrumbs should be displayed.
* Repeat for work, collection, file set, etc.
* Repeat for dashboard.

@samvera/hyrax-code-reviewers
