### PR TITLE
use :access_rights instead of :access_right

### DIFF
--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -20,9 +20,9 @@ module Hyrax
                :member_ids, :alternative_title, to: :model
 
       self.terms = [:title, :alternative_title, :creator, :contributor, :description, :abstract,
-                    :keyword, :license, :rights_statement, :access_right, :rights_notes, :publisher, :date_created,
-                    :subject, :language, :identifier, :based_near, :related_url,
-                    :representative_id, :thumbnail_id, :rendering_ids, :files,
+                    :keyword, :license, :rights_statement, :access_rights, :rights_notes,
+                    :publisher, :date_created, :subject, :language, :identifier, :based_near,
+                    :related_url, :representative_id, :thumbnail_id, :rendering_ids, :files,
                     :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
                     :visibility_during_lease, :lease_expiration_date, :visibility_after_lease,
                     :visibility, :ordered_member_ids, :source, :in_works_ids,

--- a/app/indexers/hyrax/basic_metadata_indexer.rb
+++ b/app/indexers/hyrax/basic_metadata_indexer.rb
@@ -3,7 +3,7 @@ module Hyrax
   class BasicMetadataIndexer < ActiveFedora::RDF::IndexingService
     class_attribute :stored_and_facetable_fields, :stored_fields, :symbol_fields
     self.stored_and_facetable_fields = %i[resource_type creator contributor keyword publisher subject language based_near]
-    self.stored_fields = %i[alternative_title description abstract license rights_statement rights_notes access_right date_created identifier related_url bibliographic_citation source]
+    self.stored_fields = %i[alternative_title description abstract license rights_statement rights_notes access_rights date_created identifier related_url bibliographic_citation source]
     self.symbol_fields = %i[import_url]
 
     private

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -26,7 +26,7 @@ module Hyrax
 
       # This is for the rights statement
       property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
-      property :access_right, predicate: ::RDF::Vocab::DC.accessRights
+      property :access_rights, predicate: ::RDF::Vocab::DC.accessRights
       property :publisher, predicate: ::RDF::Vocab::DC11.publisher
       property :date_created, predicate: ::RDF::Vocab::DC.created
       property :subject, predicate: ::RDF::Vocab::DC11.subject

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -65,7 +65,7 @@ module Hyrax
         attribute :date_created, Solr::Array, "date_created_tesim"
         attribute :rights_statement, Solr::Array, "rights_statement_tesim"
         attribute :rights_notes, Solr::Array, "rights_notes_tesim"
-        attribute :access_right, Solr::Array, "access_right_tesim"
+        attribute :access_rights, Solr::Array, "access_rights_tesim"
         attribute :mime_type, Solr::String, "mime_type_ssi"
         attribute :workflow_state, Solr::String, "workflow_state_name_ssim"
         attribute :human_readable_type, Solr::String, "human_readable_type_tesim"

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -15,7 +15,7 @@ module Hyrax
 
     # delegate fields from Hyrax::Works::Metadata to solr_document
     delegate :based_near_label, :related_url, :depositor, :identifier, :resource_type,
-             :keyword, :itemtype, :admin_set, :rights_notes, :access_right, :abstract, to: :solr_document
+             :keyword, :itemtype, :admin_set, :rights_notes, :access_rights, :abstract, to: :solr_document
 
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -14,5 +14,5 @@
 <%= presenter.attribute_to_html(:source, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_notes, html_dl: true) %>
-<%= presenter.attribute_to_html(:access_right, html_dl: true) %>
+<%= presenter.attribute_to_html(:access_rights, html_dl: true) %>
 <%= presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>

--- a/app/views/records/edit_fields/_access_right.html.erb
+++ b/app/views/records/edit_fields/_access_right.html.erb
@@ -1,5 +1,0 @@
-<% if f.object.multiple? key %>
-  <%= f.input :access_right, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
-<% else %>
-  <%= f.input :access_right, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
-<% end %>

--- a/app/views/records/edit_fields/_access_rights.html.erb
+++ b/app/views/records/edit_fields/_access_rights.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.multiple? key %>
+  <%= f.input :access_rights, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input :access_rights, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
+<% end %>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -1516,7 +1516,7 @@ de:
         title: ''
       defaults:
         abstract: Eine kurze Zusammenfassung eines Forschungsartikels, einer Abschlussarbeit, eines Reviews, eines Konferenzverfahrens oder einer eingehenden Analyse eines bestimmten Themas.
-        access_right: Enthält Informationen darüber, wer auf die Ressource zugreifen kann, oder einen Hinweis auf den Sicherheitsstatus.
+        access_rights: Enthält Informationen darüber, wer auf die Ressource zugreifen kann, oder einen Hinweis auf den Sicherheitsstatus.
         based_near: Ein Ortsname in Bezug auf die Arbeit, wie ihre Website der Veröffentlichung, oder die Stadt, Staat oder Land die Inhalt der Arbeit sind. Ruft die Seite <a href='http://www.geonames.org'> GeoNames Web Service </a> auf.
         contributor: Eine Person oder Gruppe, die Sie für eine Rolle bei der Schaffung der Arbeit kenntlich machen wollen, aber nicht die primäre Rolle besitzen.
         creator: Die Person oder Gruppe, welche verantwortlich für die Arbeit ist. In der Regel ist dies der Autor des Inhalts. Persönliche Namen sollten zuerst mit dem Nachnamen eingegeben werden, z.B. „Smith, John“.
@@ -1551,7 +1551,7 @@ de:
         title: Typname
       defaults:
         abstract: Zusammenfassung
-        access_right: Zugangsrechte
+        access_rights: Zugangsrechte
         admin_set_id: Admin-Set
         based_near: Ort
         creator: Schöpfer

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1532,7 +1532,7 @@ en:
         title: ''
       defaults:
         abstract: A brief summary of a research article, thesis, review, conference proceeding, or any in-depth analysis of a particular subject.
-        access_right: Contains information about who can access the resource or an indication of its security status.
+        access_rights: Contains information about who can access the resource or an indication of its security status.
         based_near: A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>.
         contributor: A person or group you want to recognize for playing a role in the creation of the work, but not the primary role.
         creator: The person or group responsible for the work. Usually this is the author of the content. Personal names should be entered with the last name first, e.g. &quot;Smith, John.&quot;.
@@ -1567,7 +1567,7 @@ en:
         title: Type name
       defaults:
         abstract: Abstract
-        access_right: Access Rights
+        access_rights: Access Rights
         admin_set_id: Administrative Set
         based_near: Location
         creator: Creator

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1523,7 +1523,7 @@ es:
         title: ''
       defaults:
         abstract: Un breve resumen de un artículo de investigación, tesis, revisión, conferencia o cualquier análisis en profundidad de un tema en particular.
-        access_right: Contiene información sobre quién puede acceder al recurso o una indicación de su estado de seguridad.
+        access_rights: Contiene información sobre quién puede acceder al recurso o una indicación de su estado de seguridad.
         based_near: Nombre de un lugar relacionado con el trabajo, tal como el sitio de publicación, ciudad, estado, o país, que esté relacionado con los contenidos de el trabajo. Obtenidos a través del servicio de <a href='http://www.geonames.org'>GeoNames</a>.
         contributor: Una persona o grupo que se quiera reconocer por tener un rol en la creación del trabajo, pero no el rol principal.
         creator: La persona o grupo responsable del trabajo. Generalmente es el autor del contenido. Los nombres personales deben llevar los apellidos al principio, ej. &quot;Smith, John&quot;.
@@ -1558,7 +1558,7 @@ es:
         title: Escribe un nombre
       defaults:
         abstract: Resumen
-        access_right: Derechos de acceso
+        access_rights: Derechos de acceso
         admin_set_id: Conjunto Administrativo
         based_near: Ubicación
         creator: Creador

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -1522,7 +1522,7 @@ fr:
         title: ''
       defaults:
         abstract: Un bref résumé d'un article de recherche, d'une thèse, d'un compte rendu, d'une procédure de conférence ou de toute analyse approfondie d'un sujet particulier.
-        access_right: Contient des informations sur les personnes pouvant accéder à la ressource ou une indication de son statut de sécurité.
+        access_rights: Contient des informations sur les personnes pouvant accéder à la ressource ou une indication de son statut de sécurité.
         based_near: Un nom de lieu lié au travail, tel que son site de publication, ou la ville, l'état ou le pays sur lequel se trouvent les contenus du travail. Appelle le <a href='http://www.geonames.org'> service web GeoNames </a>.
         contributor: Une personne ou un groupe que vous souhaitez reconnaître pour avoir joué un rôle dans la création du travail, mais pas le rôle principal.
         creator: La personne ou le groupe responsable du travail. Habituellement, c'est l'auteur du contenu. Les noms personnels doivent être saisis d'abord avec le nom de famille, par ex. "Smith, John".
@@ -1557,7 +1557,7 @@ fr:
         title: Nom du type
       defaults:
         abstract: Abstrait
-        access_right: Des droits d'accès
+        access_rights: Des droits d'accès
         admin_set_id: L'ensemble Administratif
         based_near: Emplacement
         creator: Créateur

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -1521,7 +1521,7 @@ it:
         title: ''
       defaults:
         abstract: Un breve riassunto di un articolo di ricerca, tesi, revisione, atti del convegno o qualsiasi analisi approfondita di un particolare argomento.
-        access_right: Contiene informazioni su chi può accedere alla risorsa o un'indicazione del suo stato di sicurezza.
+        access_rights: Contiene informazioni su chi può accedere alla risorsa o un'indicazione del suo stato di sicurezza.
         based_near: Un nome di posto relativo al lavoro, come il suo sito di pubblicazione, o la città, lo stato o il paese sono i contenuti del lavoro. Chiama il <a href='http://www.geonames.org'> servizio Web di GeoNames </a>.
         contributor: Una persona o un gruppo che si desidera riconoscere per svolgere un ruolo nella creazione del lavoro, ma non il ruolo primario.
         creator: La persona o il gruppo responsabile del lavoro. Di solito questo è l'autore del contenuto. Devono essere inseriti i nomi personali con l'ultimo nome, ad esempio & Quot; Smith, John. & Quot ;.
@@ -1556,7 +1556,7 @@ it:
         title: Digita il nome
       defaults:
         abstract: Astratto
-        access_right: Diritti di accesso
+        access_rights: Diritti di accesso
         admin_set_id: Set Amministrativo
         based_near: luogo
         creator: Creatore

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -1516,7 +1516,7 @@ pt-BR:
         title: ''
       defaults:
         abstract: Um breve resumo de um artigo de pesquisa, tese, revisão, processo de conferência ou qualquer análise aprofundada de um determinado assunto.
-        access_right: Contém informações sobre quem pode acessar o recurso ou uma indicação de seu status de segurança.
+        access_rights: Contém informações sobre quem pode acessar o recurso ou uma indicação de seu status de segurança.
         based_near: Um nome de local relacionado à obra, como seu local de publicação, ou a cidade, estado ou país a que se refere o conteúdo da obra. Solicita o <a href='http://www.geonames.org'> serviço de Web GeoNames </a>.
         contributor: Uma pessoa ou grupo que você deseja reconhecer por desempenhar um papel na criação da obra, mas não o papel principal.
         creator: A pessoa ou grupo responsável pelo obra. Normalmente é o autor do conteúdo. Os nomes pessoais devem ser entrados com o sobrenome primeiro, p.ex. "Smith, John.".
@@ -1551,7 +1551,7 @@ pt-BR:
         title: Digite o nome
       defaults:
         abstract: Resumo
-        access_right: Direitos de acesso
+        access_rights: Direitos de acesso
         admin_set_id: Conjunto Administrativo
         based_near: Localização
         creator: Criador

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -1519,7 +1519,7 @@ zh:
         title: ''
       defaults:
         abstract: 研究文章，论文，评论，会议程序或对特定主题的任何深入分析的简要概述。
-        access_right: 包含有关谁可以访问资源或其安全状态指示的信息。
+        access_rights: 包含有关谁可以访问资源或其安全状态指示的信息。
         based_near: 与作品相关的地名，例如出版品的地点，或者是作品中涉及的城市，州、或国家。 参见<a href='http://www.geonames.org'>GeoNames web service</a>。
         contributor: 个人与团体，虽未担任主要职责，却对作品创建做出贡献。
         creator: 对作品负责的个人与团体。通常指作品内容的作者。 个人姓名应该先输入姓氏，例如 &quot;Smith, John.&quot;。
@@ -1554,7 +1554,7 @@ zh:
         title: 类型名称
       defaults:
         abstract: 抽象
-        access_right: 访问权限
+        access_rights: 访问权限
         admin_set_id: 在行政
         based_near: 地点
         creator: 创建者

--- a/lib/hyrax/metadata/basic.rb
+++ b/lib/hyrax/metadata/basic.rb
@@ -7,7 +7,7 @@ module Hyrax
     class Basic
       ATTRIBUTES = {
         abstract:               Valkyrie::Types::Array.of(Valkyrie::Types::String),
-        access_right:           Valkyrie::Types::Array.of(Valkyrie::Types::String),
+        access_rights:           Valkyrie::Types::Array.of(Valkyrie::Types::String),
         alternative_title:      Valkyrie::Types::Array.of(Valkyrie::Types::String),
         based_near:             Valkyrie::Types::Array.of(Valkyrie::Types::String),
         contributor:            Valkyrie::Types::Array.of(Valkyrie::Types::String),

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Hyrax::Forms::BatchUploadForm do
                          :keyword,
                          :license,
                          :rights_statement,
-                         :access_right,
+                         :access_rights,
                          :rights_notes,
                          :publisher,
                          :date_created,

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
         rights_statement: 'http://rightsstatements.org/vocab/InC-EDU/1.0/',
         rights_notes: ['Notes on the rights'],
         license: ['http://creativecommons.org/licenses/by/3.0/us/'],
-        access_right: ['Only accessible via login.']
+        access_rights: ['Only accessible via login.']
       }
     end
 
@@ -131,7 +131,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
       expect(subject['license']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
       expect(subject['rights_statement']).to eq 'http://rightsstatements.org/vocab/InC-EDU/1.0/'
       expect(subject['rights_notes']).to eq ['Notes on the rights']
-      expect(subject['access_right']).to eq ['Only accessible via login.']
+      expect(subject['access_rights']).to eq ['Only accessible via login.']
     end
 
     it 'excludes non-permitted params' do

--- a/spec/hyrax/schema_spec.rb
+++ b/spec/hyrax/schema_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Hyrax::Schema do
 
     let(:attributes) do
       { abstract:               ['lorem ipsum', 'sit dolor'],
-        access_right:           ['lorem ipsum', 'sit dolor'],
+        access_rights:           ['lorem ipsum', 'sit dolor'],
         alternative_title:      [RDF::Literal('Finn Family Moomintroll', language: :en)],
         based_near:             ['lorem ipsum', 'sit dolor'],
         contributor:            ['moominpapa', 'moominmama'],


### PR DESCRIPTION
Changes `:access_right` property to `:access_rights` so property name more closely matches predicate and semantics.

Changes proposed in this pull request:
* change `:access_right` metadata property to `:access_rights`

@samvera/hyrax-code-reviewers
