### PR TITLE
Test indexing basic metadata for Hyrax

### DIFF
--- a/config/metadata/basic_metadata.yaml
+++ b/config/metadata/basic_metadata.yaml
@@ -34,6 +34,8 @@ attributes:
   keyword:
     type: string
     multiple: true
+    index_keys:
+      - "keyword_sim"
   publisher:
     type: string
     multiple: true
@@ -65,3 +67,6 @@ attributes:
   subject:
     type: string
     multiple: true
+    index_keys:
+      - "subject_sim"
+      - "subject_tesim"

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -13,6 +13,33 @@ RSpec.shared_examples 'a Hyrax::Resource indexer' do
   end
 end
 
+RSpec.shared_examples 'a Basic metadata indexer' do
+  subject(:indexer) { indexer_class.new(resource: resource) }
+  let(:resource)    { resource_class.new(**attributes) }
+
+  let(:attributes) do
+    {
+      keyword: ['comic strip'],
+      subject: ['moomins', 'snorks']
+    }
+  end
+
+  let(:resource_class) do
+    Class.new(Hyrax::Work) do
+      include Hyrax::Schema(:basic_metadata)
+    end
+  end
+
+  describe '#to_solr' do
+    it 'indexes basic metadata' do
+      expect(indexer.to_solr)
+        .to include(keyword_sim: a_collection_containing_exactly(*attributes[:keyword]),
+                    subject_tesim: a_collection_containing_exactly(*attributes[:subject]),
+                    subject_sim:   a_collection_containing_exactly(*attributes[:subject]))
+    end
+  end
+end
+
 RSpec.shared_examples 'a Core metadata indexer' do
   subject(:indexer) { indexer_class.new(resource: resource) }
   let(:titles)      { ['Comet in Moominland', 'Finn Family Moomintroll'] }

--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -9,4 +9,14 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
 
   it_behaves_like 'a Hyrax::Resource indexer'
   it_behaves_like 'a Core metadata indexer'
+
+  context 'when extending with basic metadata' do
+    let(:indexer_class) do
+      Class.new(described_class) do
+        include Hyrax::Indexer(:basic_metadata)
+      end
+    end
+
+    it_behaves_like 'a Basic metadata indexer'
+  end
 end


### PR DESCRIPTION
Add a shared spec for indexing basic metadata using the new
`Hyrax::Indexer`. Since none of the hyrax core models include basic metadata by
default (yet?), the tests are run as an extension on `ValkyrieWorkIndexer`. This
feels natural/appropriate, since it guarantees that the extension for tha class
works as expected.

@samvera/hyrax-code-reviewers
