### PR TITLE
Use uploaded_file for new versions

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -85,11 +85,16 @@ module Hyrax
           actor.revert_content(params[:revision])
         elsif params.key?(:file_set)
           if params[:file_set].key?(:files)
-            actor.update_content(params[:file_set][:files].first)
+            actor.update_content(uploaded_file_from_path)
           else
             update_metadata
           end
         end
+      end
+
+      def uploaded_file_from_path
+        uploaded_file = CarrierWave::SanitizedFile.new(params[:file_set][:files].first)
+        Hyrax::UploadedFile.create(user_id: current_user.id, file: uploaded_file)
       end
 
       def after_update_response


### PR DESCRIPTION
This PR fixes an issue with file version where the jobs are being run on a different server to the web application - a common scenario in production.

New file versions are uploaded to the system temp (normally /tmp) and so cannot be found on the jobs server.

I have fixed this in the `FileSetsController` by creating a `Hyrax::UploadedFile` for the new version. This is in line with behaviour for uploading files during work create and update, and ensures that the file is written to the hyrax uploads directory, which will have been shared across servers.

@samvera/hyrax-code-reviewers
