### PR TITLE
grab config file from proper directory.

### DIFF
--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -117,7 +117,7 @@ module Hyrax
       end
 
       def config_path(schema_name)
-        "config/metadata/#{schema_name}.yaml"
+        Hyrax::Engine.root.to_s + "/config/metadata/#{schema_name}.yaml"
       end
   end
 end


### PR DESCRIPTION
Fixes #4166 
When bringing up hyrax the browser throughs a `core_metadata` error.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Bring up hyrax and confirm no error takes place.

@samvera/hyrax-code-reviewers
