### PR TITLE
broken logo image should not display broken link icon

### DIFF
--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -20,10 +20,10 @@
             <% @presenter.logo_record.each_with_index  do |lr, i| %>
 
                 <% if lr[:linkurl].blank? %>
-                    <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
+                    <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" onerror="this.style.display='none'"/>
                 <% else %>
                     <a href="<%= lr[:linkurl] %>">
-                      <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
+                      <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" onerror="this.style.display='none'"/>
                     </a>
                 <% end %>
 


### PR DESCRIPTION
Fixes #3999

When there is a broken logo image icon, the icon should not be displayed on any browser.  Before this change it was displayed in Safari.


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a collection and give it a banner and logo image.
* Go to the Collection landing page for the just created collection on Safari and Chrome.
* Verify that the banner and logo look correct.
* Now, go to the location on the server where the logo image lives.  This would be a location like this: .internal_test_app/public/branding/[work_id]/logo/[image_file]
* Delete the logo image file.  This will simulate a broken image on the browser.
* Go to the landing page for the Collection on Safari and Chrome and verify that there is no icon display for the logo.

@samvera/hyrax-code-reviewers
