### PR TITLE
in expired embargoes tab have file checkboxes default to checked

### DIFF
--- a/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
+++ b/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
@@ -40,7 +40,7 @@
         <tr data-behavior="extra" data-id="<%= curation_concern.id %>" class="extra-embargo-info">
           <td></td>
           <td colspan=5>
-            <%= check_box_tag "embargoes[#{i}][copy_visibility]", curation_concern.id, false %>
+            <%= check_box_tag "embargoes[#{i}][copy_visibility]", curation_concern.id, true %>
             <%= t('.change_all', cc: curation_concern) %>
             <%= visibility_badge(curation_concern.visibility_after_embargo) %>?
           </td>


### PR DESCRIPTION
Fixes #4161

When admin goes to the Expired embargoes tab, have all the associated files to the works checkboxes checked by default.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a few works and put them in embargo.
* Since it could take some time for the embargo to expired, comment this line out so that they will show in the Expired Embargoes tab.  https://github.com/samvera/hyrax/blob/master/app/search_builders/hyrax/expired_embargo_search_builder.rb#L8
* Go to the Expired Embargoes tab and verify that all the files checkboxes are checked.

@samvera/hyrax-code-reviewers
