### PR TITLE
display analytics without having to refresh browser.

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -16,7 +16,9 @@
           class: presenter.display_unfeature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
     <% end %>
     <% if Hyrax.config.analytics? %>
-      <%= link_to t('.analytics'), presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
+      <% # turbolinks needs to be turned off or the page will use the cache and the %>
+      <% # analytics graph will not show unless the page is refreshed. %>
+      <%= link_to t('.analytics'), presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
     <% end %>
   </div>
 

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -1,6 +1,8 @@
 <div class="form-actions">
   <% if Hyrax.config.analytics? %>
-    <%= link_to t('.analytics'), @presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
+    <% # turbolinks needs to be turned off or the page will use the cache and the %>
+    <% # analytics graph will not show unless the page is refreshed. %>
+    <%= link_to t('.analytics'), @presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
   <% end %>
 
   <% if @presenter.editor? %>


### PR DESCRIPTION
Fixes #3970 

When viewing a work's analytics or a file's analytics prior to this change, you would have to refresh the browser page to get the graphs to show.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to a work's show page and select the Analytics button.
* Verify you see the graph with some details, not just completely empty.
* Go to a work's file detail page and select Analytics button.
* Verify you see the graph with some details, not just completely empty.

@samvera/hyrax-code-reviewers
