### PR TITLE
Write Metadata and ACL changes to valkyrie index with listeners

### DIFF
--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -95,6 +95,7 @@ module Hyrax
 
       change_set.sync
       persister.save(resource: change_set.resource)
+      Hyrax.publisher.publish('object.acl.updated', acl: self, result: :success)
       @change_set = nil
 
       true

--- a/app/services/hyrax/listeners/acl_index_listener.rb
+++ b/app/services/hyrax/listeners/acl_index_listener.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Reindexes resources when their ACLs are updated.
+    #
+    # Hyrax's `Ability` behavior depends on the index being up-to-date as
+    # concerns-their read/write users/groups, and visibility.
+    class AclIndexListener
+      ##
+      # Re-index the resource for the updated ACL.
+      #
+      # @param event [Dry::Event]
+      def on_object_acl_updated(event)
+        return unless event[:result] == :success # do nothing on failure
+        Hyrax.index_adapter.save(resource: event[:acl].resource)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/listeners/metadata_index_listener.rb
+++ b/app/services/hyrax/listeners/metadata_index_listener.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Reindexes resources when their metadata is updated.
+    #
+    # @note This listener makes no attempt to avoid reindexing when no metadata
+    #   has actually changed, or when real metadata changes won't impact the
+    #   indexed data. We trust that published metadata update events represent
+    #   actual changes to object metadata, and that the indexing adapter
+    #   optimizes reasonably for actual index document contents.
+    class MetadataIndexListener
+      ##
+      # Re-index the resource.
+      #
+      # @param event [Dry::Event]
+      def on_object_metadata_updated(event)
+        Hyrax.index_adapter.save(resource: event[:object])
+      end
+    end
+  end
+end

--- a/app/services/hyrax/solr_service.rb
+++ b/app/services/hyrax/solr_service.rb
@@ -116,9 +116,15 @@ module Hyrax
     private
 
       ##
-      # @api private
+      # @private
+      # Return the valkyrie solr index.
+      #
+      # Since this module depends closely on RSolr internals and makes use
+      # of `#connection`, it will always need to connect to a Solr index. Other
+      # valkyrie indexers used here would, at minimum, need to provide a
+      # functioning `rsolr` connection.
       def valkyrie_index
-        Hyrax.index_adapter
+        Valkyrie::IndexingAdapter.find(:solr_index)
       end
 
       ##

--- a/config/initializers/indexing_adapter_initializer.rb
+++ b/config/initializers/indexing_adapter_initializer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'valkyrie/indexing_adapter'
 require 'valkyrie/indexing/solr/indexing_adapter'
+require 'valkyrie/indexing/null_indexing_adapter'
 
 Rails.application.config.to_prepare do
   Valkyrie::IndexingAdapter.register(
@@ -8,5 +9,8 @@ Rails.application.config.to_prepare do
       resource_indexer: Hyrax::ValkyrieIndexer
     ),
     :solr_index
+  )
+  Valkyrie::IndexingAdapter.register(
+    Valkyrie::Indexing::NullIndexingAdapter.new, :null_index
   )
 end

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+Hyrax.publisher.subscribe(Hyrax::Listeners::AclIndexListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::BatchNotificationListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -441,9 +441,9 @@ module Hyrax
     attr_writer :iiif_metadata_fields
 
     ##
-    # @return [#save, #save_all, #delete, #wipe] an indexing adapter
+    # @return [#save, #save_all, #delete, #wipe!] an indexing adapter
     def index_adapter
-      @index_adapter ||= Valkyrie::IndexingAdapter.find(:solr_index)
+      @index_adapter ||= Valkyrie::IndexingAdapter.find(:null_index)
     end
 
     ##

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -57,6 +57,7 @@ module Hyrax
     register_event('file.set.restored')
     register_event('object.deleted')
     register_event('object.deposited')
+    register_event('object.acl.updated')
     register_event('object.metadata.updated')
   end
 end

--- a/lib/hyrax/specs/spy_listener.rb
+++ b/lib/hyrax/specs/spy_listener.rb
@@ -4,7 +4,8 @@ module Hyrax
   module Specs
     class SpyListener
       attr_reader :file_set_attached, :file_set_url_imported, :object_deleted,
-                  :object_deposited, :object_metadata_updated
+                  :object_deposited, :object_acl_updated,
+                  :object_metadata_updated
 
       def on_object_deleted(event)
         @object_deleted = event
@@ -12,6 +13,10 @@ module Hyrax
 
       def on_object_deposited(event)
         @object_deposited = event
+      end
+
+      def on_object_acl_updated(event)
+        @object_acl_updated = event
       end
 
       def on_object_metadata_updated(event)

--- a/lib/valkyrie/indexing/null_indexing_adapter.rb
+++ b/lib/valkyrie/indexing/null_indexing_adapter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+module Valkyrie
+  module Indexing
+    # A Valkyrie indexer that does nothing for all index requests. This is
+    # useful for applications using alternate/legacy (e.g. ActiveFedora)
+    # indexing strategies that don't want the overhead of running separate
+    # index requests.
+    #
+    # rubocop:disable Lint/UnusedMethodArgument RuboCop wants us to accept all
+    #   arguments, but we actually want to raise ArgumentError when the caller
+    #   isn't using the correct signature.
+    class NullIndexingAdapter
+      def save(resource:)
+        :noop
+      end
+
+      def save_all(resources:)
+        :noop
+      end
+
+      def delete(resource:)
+        :noop
+      end
+
+      def wipe!
+        :noop
+      end
+    end
+    # rubocop:enable Lint/UnusedMethodArgument
+  end
+end

--- a/lib/valkyrie/indexing_adapter.rb
+++ b/lib/valkyrie/indexing_adapter.rb
@@ -22,7 +22,7 @@ module Valkyrie
       def find(short_name)
         symbolized_key = short_name.to_sym
         return adapters[symbolized_key] if adapters.key?(symbolized_key)
-        raise "Unable to find unregistered adapter `#{short_name}'"
+        raise KeyError, "Unable to find unregistered adapter `#{short_name}'"
       end
     end
   end

--- a/spec/services/hyrax/listeners/acl_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/acl_index_listener_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Listeners::AclIndexListener do
+  subject(:listener) { described_class.new }
+  let(:acl)          { Hyrax::AccessControlList.new(resource: resource) }
+  let(:data)         { { result: result, resource: resource, acl: acl } }
+  let(:event)        { Dry::Events::Event.new(event_type, data) }
+  let(:result)       { :success }
+  let(:resource)     { FactoryBot.valkyrie_create(:hyrax_resource) }
+
+  let(:fake_adapter) do
+    Class.new do
+      attr_reader :saved_resources
+
+      def initialize
+        @saved_resources = []
+      end
+
+      def save(resource:)
+        @saved_resources << resource
+      end
+    end.new
+  end
+
+  # the listener always uses the currently configured Hyrax Index Adapter
+  before do
+    allow(Hyrax).to receive(:index_adapter).and_return(fake_adapter)
+  end
+
+  describe '#on_object_acl_updated' do
+    let(:event_type) { :on_object_acl_updated }
+
+    it 'reindexes the object on the configured adapter' do
+      expect { listener.on_object_acl_updated(event) }
+        .to change { fake_adapter.saved_resources }
+        .to contain_exactly(resource)
+    end
+
+    context 'on failure' do
+      let(:result) { :failure }
+
+      it 'does not reindex the object' do
+        expect { listener.on_object_acl_updated(event) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/listeners/acl_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/acl_index_listener_spec.rb
@@ -5,22 +5,9 @@ RSpec.describe Hyrax::Listeners::AclIndexListener do
   let(:acl)          { Hyrax::AccessControlList.new(resource: resource) }
   let(:data)         { { result: result, resource: resource, acl: acl } }
   let(:event)        { Dry::Events::Event.new(event_type, data) }
+  let(:fake_adapter) { FakeIndexingAdapter.new }
   let(:result)       { :success }
   let(:resource)     { FactoryBot.valkyrie_create(:hyrax_resource) }
-
-  let(:fake_adapter) do
-    Class.new do
-      attr_reader :saved_resources
-
-      def initialize
-        @saved_resources = []
-      end
-
-      def save(resource:)
-        @saved_resources << resource
-      end
-    end.new
-  end
 
   # the listener always uses the currently configured Hyrax Index Adapter
   before do

--- a/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Listeners::MetadataIndexListener do
+  subject(:listener) { described_class.new }
+  let(:data)         { { object: resource } }
+  let(:event)        { Dry::Events::Event.new(event_type, data) }
+  let(:fake_adapter) { FakeIndexingAdapter.new }
+  let(:resource)     { FactoryBot.valkyrie_create(:hyrax_resource) }
+
+  # the listener should always use the currently configured Hyrax Index Adapter
+  before do
+    allow(Hyrax).to receive(:index_adapter).and_return(fake_adapter)
+  end
+
+  describe '#on_object_metadata_updated' do
+    let(:event_type) { :on_object_metadata_updated }
+
+    it 'reindexes the object on the configured adapter' do
+      expect { listener.on_object_metadata_updated(event) }
+        .to change { fake_adapter.saved_resources }
+        .to contain_exactly(resource)
+    end
+  end
+end

--- a/spec/support/clean_solr.rb
+++ b/spec/support/clean_solr.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.configure do |config|
   config.before(:each, clean_index: true) do
-    client = Hyrax.index_adapter.connection
+    client = Valkyrie::IndexingAdapter.find(:solr_index).connection
     client.delete_by_query("*:*", params: { softCommit: true })
   end
 end

--- a/spec/support/fakes/indexing_adapter.rb
+++ b/spec/support/fakes/indexing_adapter.rb
@@ -1,0 +1,11 @@
+class FakeIndexingAdapter
+  attr_reader :saved_resources
+
+  def initialize
+    @saved_resources = []
+  end
+
+  def save(resource:)
+    @saved_resources << resource
+  end
+end


### PR DESCRIPTION
when an object's metadata is updated, update the Valkyrie-driven index via the
configured indexing adapter.

Also: When an ACL change event is published, write to the currently configured
Hyarx (valkyrie) indexing adapter. This ensures that when ACLs are changed
independently of the object, the permissions cached in Solr will stay up to
date.

Hyrax relies on permissions to be cached correctly in the index for various
`Ability` behaviors. This is perhaps not ideal for a long-term valkyrie future;
`ActiveFedora` basically requires this of us, though, unless we're willing to
take the performance hit of looking up the ACLs from Fedora per-request.

Note that both of these are presently no-op by default, since we use a null indexing
adapter. Changes to setup this behavior are included in earlier commits.

@samvera/hyrax-code-reviewers
