### PR TITLE
Index Visibility when using the valkyrie indexer

### DIFF
--- a/app/indexers/hyrax/permission_indexer.rb
+++ b/app/indexers/hyrax/permission_indexer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Indexes `*_groups`/`*_users` style permissions. We depend on these
+  # permissions being up-to-date in the index to support `Hyrax::Ability`.
+  #
+  # @example
+  #   class MyIndexer < Hyrax::ValkyrieIndexer
+  #     include Hyrax::PermissionIndexer
+  #   end
+  module PermissionIndexer
+    def to_solr
+      super.tap do |index_document|
+        config      = Hydra.config.permissions
+        permissions = Hyrax::PermissionManager.new(resource: resource)
+
+        index_document[config.edit.group] = permissions.edit_groups.to_a
+        index_document[config.edit.individual] = permissions.edit_users.to_a
+        index_document[config.read.group] = permissions.read_groups.to_a
+        index_document[config.read.individual] = permissions.read_users.to_a
+      end
+    end
+  end
+end

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -7,6 +7,7 @@ module Hyrax
     Hyrax::ValkyrieIndexer.register self, as_indexer_for: Hyrax::Work
 
     include Hyrax::ResourceIndexer
+    include Hyrax::VisibilityIndexer
     include Hyrax::Indexer(:core_metadata)
   end
 end

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -7,6 +7,7 @@ module Hyrax
     Hyrax::ValkyrieIndexer.register self, as_indexer_for: Hyrax::Work
 
     include Hyrax::ResourceIndexer
+    include Hyrax::PermissionIndexer
     include Hyrax::VisibilityIndexer
     include Hyrax::Indexer(:core_metadata)
   end

--- a/app/indexers/hyrax/visibility_indexer.rb
+++ b/app/indexers/hyrax/visibility_indexer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Indexes visibility of the resource; Blacklight depends on visibility being
+  # present in the index to determine visibility of results and object show
+  # views.
+  #
+  # @example
+  #   class MyIndexer < Hyrax::ValkyrieIndexer
+  #     include Hyrax::VisibilityIndexer
+  #   end
+  module VisibilityIndexer
+    def to_solr
+      super.tap do |index_document|
+        index_document[:visibility_ssi] = visibility_reader.read
+      end
+    end
+
+    private
+
+      def visibility_reader
+        Hyrax::VisibilityReader.new(resource: resource)
+      end
+  end
+end

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -13,6 +13,35 @@ RSpec.shared_examples 'a Hyrax::Resource indexer' do
   end
 end
 
+RSpec.shared_examples 'a permission indexer' do
+  subject(:indexer) { indexer_class.new(resource: resource) }
+  let(:edit_groups) { [:managers] }
+  let(:edit_users)  { [FactoryBot.create(:user)] }
+  let(:read_users)  { [FactoryBot.create(:user)] }
+
+  let(:resource) do
+    FactoryBot.valkyrie_create(:hyrax_work, :public,
+                               read_users: read_users,
+                               edit_groups: edit_groups,
+                               edit_users: edit_users)
+  end
+
+
+  describe '#to_solr' do
+    it 'indexes read permissions' do
+      expect(indexer.to_solr)
+        .to include(Hydra.config.permissions.read.group => ['public'],
+                    Hydra.config.permissions.read.individual => read_users.map(&:user_key))
+    end
+
+    it 'indexes edit permissions' do
+      expect(indexer.to_solr)
+        .to include(Hydra.config.permissions.edit.group => edit_groups.map(&:to_s),
+                    Hydra.config.permissions.edit.individual => edit_users.map(&:user_key))
+    end
+  end
+end
+
 RSpec.shared_examples 'a visibility indexer' do
   subject(:indexer) { indexer_class.new(resource: resource) }
   let(:resource)    { FactoryBot.build(:hyrax_work) }

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -13,6 +13,25 @@ RSpec.shared_examples 'a Hyrax::Resource indexer' do
   end
 end
 
+RSpec.shared_examples 'a visibility indexer' do
+  subject(:indexer) { indexer_class.new(resource: resource) }
+  let(:resource)    { FactoryBot.build(:hyrax_work) }
+
+  describe '#to_solr' do
+    it 'indexes visibility' do
+      expect(indexer.to_solr).to include(visibility_ssi: 'restricted')
+    end
+
+    context 'when resource is public' do
+      let(:resource) { FactoryBot.valkyrie_create(:hyrax_work, :public) }
+
+      it 'indexes as open' do
+        expect(indexer.to_solr).to include(visibility_ssi: 'open')
+      end
+    end
+  end
+end
+
 RSpec.shared_examples 'a Basic metadata indexer' do
   subject(:indexer) { indexer_class.new(resource: resource) }
   let(:resource)    { resource_class.new(**attributes) }

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -13,6 +13,9 @@ FactoryBot.define do
     end
 
     transient do
+      edit_users         { [] }
+      edit_groups        { [] }
+      read_users         { [] }
       members            { nil }
       visibility_setting { nil }
     end
@@ -24,15 +27,25 @@ FactoryBot.define do
           .assign_access_for(visibility: evaluator.visibility_setting)
       end
 
+      work.permission_manager.edit_groups = evaluator.edit_groups
+      work.permission_manager.edit_users  = evaluator.edit_users
+      work.permission_manager.read_users  = evaluator.read_users
+
       work.member_ids = evaluator.members.map(&:id) if evaluator.members
     end
 
     after(:create) do |work, evaluator|
       if evaluator.visibility_setting
-        writer = Hyrax::VisibilityWriter.new(resource: work)
-        writer.assign_access_for(visibility: evaluator.visibility_setting)
-        writer.permission_manager.acl.save
+        Hyrax::VisibilityWriter
+          .new(resource: work)
+          .assign_access_for(visibility: evaluator.visibility_setting)
       end
+
+      work.permission_manager.edit_groups = evaluator.edit_groups
+      work.permission_manager.edit_users  = evaluator.edit_users
+      work.permission_manager.read_users  = evaluator.read_users
+
+      work.permission_manager.acl.save
     end
 
     trait :public do

--- a/spec/indexers/hyrax/permission_indexer_spec.rb
+++ b/spec/indexers/hyrax/permission_indexer_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'hyrax/specs/shared_specs'
+
+RSpec.describe Hyrax::PermissionIndexer do
+  let(:indexer_class) do
+    Class.new(Hyrax::ValkyrieIndexer) do
+      include Hyrax::PermissionIndexer
+    end
+  end
+
+  it_behaves_like 'a permission indexer'
+end

--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
 
   it_behaves_like 'a Hyrax::Resource indexer'
   it_behaves_like 'a Core metadata indexer'
+  it_behaves_like 'a permission indexer'
   it_behaves_like 'a visibility indexer'
 
   context 'when extending with basic metadata' do

--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
 
   it_behaves_like 'a Hyrax::Resource indexer'
   it_behaves_like 'a Core metadata indexer'
+  it_behaves_like 'a visibility indexer'
 
   context 'when extending with basic metadata' do
     let(:indexer_class) do

--- a/spec/indexers/hyrax/visibility_indexer_spec.rb
+++ b/spec/indexers/hyrax/visibility_indexer_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'hyrax/specs/shared_specs'
+
+RSpec.describe Hyrax::VisibilityIndexer do
+  let(:indexer_class) do
+    Class.new(Hyrax::ValkyrieIndexer) do
+      include Hyrax::VisibilityIndexer
+    end
+  end
+
+  it_behaves_like 'a visibility indexer'
+end


### PR DESCRIPTION
Adds `Hyrax::VisibilityIndexer` and `Hyrax::PermissionIndexer`. We need to index visibility and permissions  in real-time in order to support `Blacklight::AccessControls` and `Hydra::AccessControls`.

@samvera/hyrax-code-reviewers
