### PR TITLE
Remove call to dead ActiveFedora code

### DIFF
--- a/app/search_builders/hyrax/filter_by_type.rb
+++ b/app/search_builders/hyrax/filter_by_type.rb
@@ -29,8 +29,7 @@ module Hyrax
       end
 
       def models_to_solr_clause
-        # to_class_uri is deprecated in AF 11
-        [ActiveFedora::Base.respond_to?(:to_rdf_representation) ? models.map(&:to_rdf_representation) : models.map(&:to_class_uri)].join(',')
+        models.map(&:to_rdf_representation).join(',')
       end
 
       def generic_type_field


### PR DESCRIPTION
This conditional was needed to support ActiveFedora 11. We have since dropped
support, so the check is no longer needed.

@samvera/hyrax-code-reviewers
