### PR TITLE
Bump valkyrie requirement to 2.1

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -78,7 +78,7 @@ SUMMARY
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
-  spec.add_dependency 'valkyrie', '~> 2.0', '>= 2.0.2'
+  spec.add_dependency 'valkyrie', '~> 2.1'
 
   spec.add_development_dependency "capybara", '~> 3.29'
   spec.add_development_dependency 'capybara-maleficent', '~> 0.3.0'


### PR DESCRIPTION
Valkyrie 2.1 is released, and fixes issues with `JSON::LD` references that
constitute a Hyrax bug (see: samvera/valkyrie#810). Bumping to 2.1.0 fixes this
issue.

@samvera/hyrax-code-reviewers
