### PR TITLE
Add a `ChildTypes` to manage selection display during work attachment

### DIFF
--- a/app/presenters/hyrax/model_proxy.rb
+++ b/app/presenters/hyrax/model_proxy.rb
@@ -18,7 +18,11 @@ module Hyrax
       self
     end
 
+    ##
+    # @deprecated this isn't related to the ModelProxy issue, and has been moved
+    #   to `WorkShowPresenter`.
     def valid_child_concerns
+      Deprecation.warn "#{self.class}#valid_child_concerns will be removed in Hyrax 4.0."
       Hyrax::ChildTypes.for(parent: solr_document.hydra_model)
     end
 

--- a/app/presenters/hyrax/model_proxy.rb
+++ b/app/presenters/hyrax/model_proxy.rb
@@ -3,12 +3,7 @@ module Hyrax
   # object represented by the solr document.
   module ModelProxy
     delegate :to_param, :to_key, :id, to: :solr_document
-
-    delegate :model_name, to: :_delegated_to
-
-    def to_partial_path
-      _delegated_to._to_partial_path
-    end
+    delegate :model_name, :to_partial_path, to: :_delegated_to
 
     def persisted?
       true
@@ -29,7 +24,7 @@ module Hyrax
     private
 
       def _delegated_to
-        @_delegated_to ||= solr_document.hydra_model
+        solr_document.to_model
       end
   end
 end

--- a/app/presenters/hyrax/model_proxy.rb
+++ b/app/presenters/hyrax/model_proxy.rb
@@ -4,7 +4,7 @@ module Hyrax
   module ModelProxy
     delegate :to_param, :to_key, :id, to: :solr_document
 
-    delegate :model_name, :valid_child_concerns, to: :_delegated_to
+    delegate :model_name, to: :_delegated_to
 
     def to_partial_path
       _delegated_to._to_partial_path
@@ -16,6 +16,10 @@ module Hyrax
 
     def to_model
       self
+    end
+
+    def valid_child_concerns
+      Hyrax::ChildTypes.for(parent: solr_document.hydra_model)
     end
 
     private

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -231,6 +231,12 @@ module Hyrax
       collections.present? || current_ability.can?(:create_any, ::Collection)
     end
 
+    ##
+    # @return [Array<Class>]
+    def valid_child_concerns
+      Hyrax::ChildTypes.for(parent: solr_document.hydra_model).to_a
+    end
+
     private
 
       # list of item ids to display is based on ordered_ids

--- a/app/services/hyrax/child_types.rb
+++ b/app/services/hyrax/child_types.rb
@@ -23,6 +23,7 @@ module Hyrax
 
     ##
     # @params [Class] parent
+    # @return [Enumerable<Class>] a list of classes that are valid as child types for `parent`
     def self.for(parent:)
       return new(parent.valid_child_concerns) if
         parent.respond_to?(:valid_child_concerns)

--- a/app/services/hyrax/child_types.rb
+++ b/app/services/hyrax/child_types.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # A list of child work types a user may choose to attach for a given work type
+  #
+  # These lists are used when users select among work types to attach to an
+  # existing work, e.g. from Actions available on the show view.
+  #
+  # @example
+  #   child_types = Hyrax::ChildTypes.for(parent: MyWorkType)
+  #
+  class ChildTypes
+    include Enumerable
+    extend Forwardable
+
+    def_delegators :@types, :each
+
+    ##
+    # @!attribute [r] types
+    #   @return [Array<Class>]
+    attr_reader :types
+
+    ##
+    # @params [Class] parent
+    def self.for(parent:)
+      return new(parent.valid_child_concerns) if
+        parent.respond_to?(:valid_child_concerns)
+
+      new([parent])
+    end
+
+    ##
+    # @param [Array<Class>] types
+    def initialize(types)
+      @types = types.to_a
+    end
+  end
+end

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -240,11 +240,8 @@ RSpec.describe Hyrax::GenericWorksController do
       end
 
       context 'with a user granted workflow permission' do
-        before do
-          allow(document).to receive(:hydra_model).and_return(GenericWork)
-        end
+        let(:document) { SolrDocument.new(id: work.id, has_model_ssim: ["GenericWork"]) }
         let(:document_list) { [document] }
-        let(:document) { instance_double(SolrDocument) }
 
         it 'renders without the unauthorized message' do
           get :show, params: { id: work.id }

--- a/spec/presenters/hyrax/model_proxy_spec.rb
+++ b/spec/presenters/hyrax/model_proxy_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::ModelProxy do
+  subject(:proxy)     { proxy_class.new(solr_document) }
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:model)         { GenericWork }
+
+  let(:attributes) do
+    { "id" => '888888',
+      "has_model_ssim" => [model.to_s] }
+  end
+
+  let(:proxy_class) do
+    Class.new do
+      include Hyrax::ModelProxy
+
+      attr_accessor :solr_document
+
+      def initialize(solr_document)
+        self.solr_document = solr_document
+      end
+    end
+  end
+
+  it { is_expected.to be_persisted }
+
+  describe '#id' do
+    it 'delegates to the solr document' do
+      expect(proxy.id).to eq '888888'
+    end
+  end
+
+  describe '#model_name' do
+    it 'delegates to the has_model_ssim model' do
+      expect(proxy.model_name).to eq model.model_name
+    end
+  end
+
+  describe '#to_key' do
+    it 'delegates to the solr document' do
+      expect(proxy.to_key).to contain_exactly '888888'
+    end
+  end
+
+  describe '#to_model' do
+    it 'gives self' do
+      expect(proxy.to_model).to eql proxy
+    end
+  end
+
+  describe '#to_param' do
+    it 'delegates to the solr document' do
+      expect(proxy.to_param).to eq '888888'
+    end
+  end
+
+  describe '#valid_child_concerns' do
+    it 'delegates to the has_model_ssim model' do
+      expect(proxy.valid_child_concerns)
+        .to contain_exactly(*model.valid_child_concerns)
+    end
+  end
+end

--- a/spec/services/hyrax/child_types_spec.rb
+++ b/spec/services/hyrax/child_types_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::ChildTypes do
+  subject(:child_types) { described_class.new(types) }
+  let(:types)           { [GenericWork] }
+
+  describe '.for' do
+    let(:parent) { Hyrax::Test::SimpleWork }
+
+    it 'can have itself as a child by default' do
+      expect(described_class.for(parent: parent)).to contain_exactly(parent)
+    end
+
+    context 'with an ActiveFedora work' do
+      let(:parent) { GenericWork }
+
+      it 'gives the configured valid_child_concerns' do
+        expect(described_class.for(parent: parent)).to contain_exactly(*parent.valid_child_concerns)
+      end
+    end
+  end
+
+  describe '#types' do
+    it 'returns the initialized types' do
+      expect(child_types.types).to contain_exactly(*types)
+    end
+  end
+
+  describe '#to_a' do
+    it 'returns the initialized types' do
+      expect(child_types.to_a).to contain_exactly(*types)
+    end
+  end
+end


### PR DESCRIPTION
With `ActiveFedora` models, we use `MyWork.valid_child_concerns` to determine
which types the user can select to attach to an existing work.

Since this is a display-only issue, we break this out into a new service. For
legacy models, we delegate the configuration back to the model, avoiding any
need for configuration changes.

For Valkyrie models, we provide a default config (a work can nest works of its
own type), but punt on configuration issues. There are other configuration
matters to discuss.

@samvera/hyrax-code-reviewers
