### PR TITLE
Support `#find_all_by_model` query in Wings

### DIFF
--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -39,7 +39,7 @@ module Wings
       end
 
       # Find all work/collection records of a given model, and map to Valkyrie Resources
-      # @param [Valkyrie::ResourceClass]
+      # @param model [Class]
       # @return [Array<Valkyrie::Resource>]
       def find_all_of_model(model:)
         model_class_for(model).all.map do |obj|
@@ -84,8 +84,8 @@ module Wings
       end
 
       # Find all members of a given resource, and map to Valkyrie Resources
-      # @param [Valkyrie::Resource]
-      # @param [Valkyrie::ResourceClass]
+      # @param resource [Valkyrie::Resource]
+      # @param model [Class]
       # @return [Array<Valkyrie::Resource>]
       def find_members(resource:, model: nil)
         return [] unless resource.respond_to?(:member_ids) && resource.member_ids.present?
@@ -96,8 +96,8 @@ module Wings
       end
 
       # Find the Valkyrie Resources referenced by another Valkyrie Resource
-      # @param [<Valkyrie::Resource>]
-      # @param [Symbol] the property holding the references to another resource
+      # @param resource [<Valkyrie::Resource>]
+      # @param property [Symbol] the property holding the references to another resource
       # @return [Array<Valkyrie::Resource>]
       def find_references_by(resource:, property:)
         object = resource_factory.from_resource(resource: resource)
@@ -167,7 +167,7 @@ module Wings
         end
 
         def model_class_for(model)
-          model.internal_resource.constantize
+          ModelRegistry.lookup(model) || model.internal_resource.constantize
         end
     end
   end

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -124,6 +124,16 @@ RSpec.describe Wings::Valkyrie::QueryService do
 
       expect(query_service.find_all_of_model(model: image_resource_class).to_a).to eq []
     end
+
+    context 'with a native resource class' do
+      it 'returns all of the model' do
+        persister.save(resource: resource_class.new)
+        saved = persister.save(resource: Hyrax::Test::SimpleWork.new)
+
+        expect(query_service.find_all_of_model(model: Hyrax::Test::SimpleWork).map(&:id))
+          .to contain_exactly saved.id
+      end
+    end
   end
 
   describe ".find_by_alternate_identifier" do


### PR DESCRIPTION
This query used to only support specialized Wings generated models, not native
models. This fixes it to support native Valkyrie models when registered.

@samvera/hyrax-code-reviewers
