### PR TITLE
Test Wings version of `find_access_control_for` query

### DIFF
--- a/spec/wings/services/custom_queries/find_access_control_spec.rb
+++ b/spec/wings/services/custom_queries/find_access_control_spec.rb
@@ -2,14 +2,29 @@
 require 'wings_helper'
 require 'wings/services/custom_queries/find_access_control'
 
-# rubocop:disable RSpec/EmptyExampleGroup
 RSpec.describe Wings::CustomQueries::FindAccessControl do
-  let(:query_service) { Hyrax.query_service }
-  let(:resource) { double } # TODO: Stubbed waiting for tests
-  let(:subject) { query_service.custom_queries.find_access_control(for: resource) }
+  subject(:query_handler) { described_class.new(query_service: query_service) }
+  let(:adapter)           { Valkyrie::MetadataAdapter.find(:wings_adapter) }
+  let(:persister)         { adapter.persister }
+  let(:query_service)     { adapter.query_service }
 
-  describe '.find_access_control' do
-    # TODO: Need tests for this custom query
+  describe '#find_access_control' do
+    context 'for missing object' do
+      let(:resource) { Valkyrie::Resource.new }
+
+      it 'raises ObjectNotFoundError' do
+        expect { query_handler.find_access_control_for(resource: resource) }
+          .to raise_error { Valkyrie::Persistence::ObjectNotFoundError }
+      end
+    end
+
+    context 'when the resource has been created via Wings' do
+      let(:resource) { persister.save(resource: Hyrax::Resource.new) }
+
+      it 'finds an empty acl' do
+        expect(query_handler.find_access_control_for(resource: resource))
+          .to have_attributes(permissions: be_empty)
+      end
+    end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup


### PR DESCRIPTION
Some initial tests for this custom query; the Wings version of this went
untested initiially. I wrote these (uncomprehensive) tests while debugging an
issue that turned out to be unrelated; so here they are.

@samvera/hyrax-code-reviewers
