### PR TITLE
Add a `hyrax:work_resource` generator for valkyrie native works

### DIFF
--- a/app/services/hyrax/form_factory.rb
+++ b/app/services/hyrax/form_factory.rb
@@ -5,7 +5,7 @@ module Hyrax
   # A factory class for Hyrax forms.
   #
   # @note We use a factory class (rather than a factory method like `.for`) to
-  #   provide compatibility with the legacy `Hyrax::WorkFormService`.y
+  #   provide compatibility with the legacy `Hyrax::WorkFormService`.
   #
   # @example
   #   factory = Hyrax::FormFactory.new

--- a/app/services/hyrax/form_factory.rb
+++ b/app/services/hyrax/form_factory.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # A factory class for Hyrax forms.
+  #
+  # @note We use a factory class (rather than a factory method like `.for`) to
+  #   provide compatibility with the legacy `Hyrax::WorkFormService`.y
+  #
+  # @example
+  #   factory = Hyrax::FormFactory.new
+  #
+  #   form_change_set = factory.build(work)
+  #
+  # @since 3.0.0
+  class FormFactory
+    ##
+    # @param model      [Object]
+    # @param ability    [Hyrax::Ability]
+    # @param controller [ApplicationController]
+    def build(model, _ability, _controller)
+      Hyrax::ChangeSet.for(model)
+    end
+  end
+end

--- a/app/services/hyrax/work_form_service.rb
+++ b/app/services/hyrax/work_form_service.rb
@@ -1,4 +1,6 @@
 module Hyrax
+  ##
+  # A factory that builds work forms based on the `#model_name` of the work.
   class WorkFormService
     def self.build(curation_concern, current_ability, *extra)
       form_class(curation_concern).new(curation_concern, current_ability, *extra)

--- a/lib/generators/hyrax/work_resource/USAGE
+++ b/lib/generators/hyrax/work_resource/USAGE
@@ -1,0 +1,12 @@
+Description:
+  This generator creates the necessary files for valkyrie-native work types.
+
+Example:
+  rails generate hyrax:work_resource Monograph
+
+  This will create:
+    app/models/monograph.rb
+    app/controllers/hyrax/monographs_controller.rb
+    app/views/monographs/_monograph.html.erb
+    spec/models/monograph_spec.rb
+    spec/views/monographs/_monograph.html.erb_spec.rb

--- a/lib/generators/hyrax/work_resource/templates/controller.rb.erb
+++ b/lib/generators/hyrax/work_resource/templates/controller.rb.erb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:work <%= class_name %>`
+module Hyrax
+  # Generated controller for <%= class_name %>
+  class <%= class_name.pluralize %>Controller < ApplicationController
+    # Adds Hyrax behaviors to the controller.
+    include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
+    self.curation_concern_type = ::<%= class_name %>
+
+    # Use the Wings search builder for Valkyrie models until legacy ActiveFedora
+    # indexing is turned off. See:
+    # https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#indexing
+    self.search_builder_class = Wings::WorkSearchBuilder(::<%= class_name %>)
+
+    # Use a Valkyrie aware form service to generate Valkyrie::ChangeSet style
+    # forms.
+    self.work_form_service = Hyrax::FormFactory.new
+  end
+end

--- a/lib/generators/hyrax/work_resource/templates/work.html.erb_spec.rb.erb
+++ b/lib/generators/hyrax/work_resource/templates/work.html.erb_spec.rb.erb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe '<%= plural_file_name %>/<%= file_name %>.html.erb', type: :view do
+
+end

--- a/lib/generators/hyrax/work_resource/templates/work.html.erb_spec.rb.erb
+++ b/lib/generators/hyrax/work_resource/templates/work.html.erb_spec.rb.erb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work <%= class_name %>`
 RSpec.describe '<%= plural_file_name %>/<%= file_name %>.html.erb', type: :view do
 
 end

--- a/lib/generators/hyrax/work_resource/templates/work.rb.erb
+++ b/lib/generators/hyrax/work_resource/templates/work.rb.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:work_resource <%= class_name %>`
+class <%= class_name %> < Hyrax::Work
+  include Hyrax::Schema(:basic_metadata)
+end

--- a/lib/generators/hyrax/work_resource/templates/work_spec.rb.erb
+++ b/lib/generators/hyrax/work_resource/templates/work_spec.rb.erb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:work <%= class_name %>`
+require 'rails_helper'
+require 'hyrax/specs/shared_specs/hydra_works'
+
+RSpec.describe <%= class_name %> do
+  subject(:work) { described_class.new }
+
+  it_behaves_like 'a Hyrax::Work'
+end

--- a/lib/generators/hyrax/work_resource/work_resource_generator.rb
+++ b/lib/generators/hyrax/work_resource/work_resource_generator.rb
@@ -1,0 +1,58 @@
+require 'rails/generators'
+require 'rails/generators/model_helpers'
+
+class Hyrax::WorkResourceGenerator < Rails::Generators::NamedBase
+  # ActiveSupport can interpret models as plural which causes
+  # counter-intuitive route paths. Pull in ModelHelpers from
+  # Rails which warns users about pluralization when generating
+  # new models or scaffolds.
+  include Rails::Generators::ModelHelpers
+
+  source_root File.expand_path('../templates', __FILE__)
+
+  argument :attributes, type: :array, default: [], banner: 'field:type field:type'
+
+  def banner
+    if revoking?
+      say_status("info", "DESTROYING VALKYRIE WORK MODEL: #{class_name}", :blue)
+    else
+      say_status("info", "GENERATING VALKYRIE WORK MODEL: #{class_name}", :blue)
+    end
+  end
+
+  def create_controller
+    template('controller.rb.erb', File.join('app/controllers/hyrax', class_path, "#{plural_file_name}_controller.rb"))
+  end
+
+  def create_model
+    template('work.rb.erb', File.join('app/models/', class_path, "#{file_name}.rb"))
+  end
+
+  def create_model_spec
+    template('work_spec.rb.erb', File.join('spec/models/', class_path, "#{file_name}_spec.rb")) if
+      rspec_installed?
+  end
+
+  def create_views
+    create_file File.join('app/views/hyrax', class_path, "#{plural_file_name}/_#{file_name}.html.erb") do
+      "<%# This is a search result view %>\n" \
+      "<%= render 'catalog/document', document: #{file_name}, document_counter: #{file_name}_counter  %>\n"
+    end
+  end
+
+  def create_view_spec
+    return unless rspec_installed?
+    template('work.html.erb_spec.rb.erb',
+             File.join('spec/views/', class_path, "#{plural_file_name}/_#{file_name}.html.erb_spec.rb"))
+  end
+
+  private
+
+    def rspec_installed?
+      defined?(RSpec) && defined?(RSpec::Rails)
+    end
+
+    def revoking?
+      behavior == :revoke
+    end
+end

--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -55,7 +55,25 @@
 #
 # @see https://wiki.duraspace.org/display/samvera/Hyrax-Valkyrie+Development+Working+Group
 #      for further context regarding the approach
-module Wings; end
+module Wings
+  ##
+  # @api public
+  #
+  # Provides a search builder for new valkyrie types that are indexed as their
+  # corresponding legacy ActiveFedora classes.
+  #
+  # @example
+  #   builder = Wings::WorkSearchBuilder(Monograph)
+  def self.WorkSearchBuilder(work_type) # rubocop:disable Naming/MethodName
+    Class.new(Hyrax::WorkSearchBuilder) do
+      @@_legacy_type = Wings::ModelRegistry.lookup(work_type) # rubocop:disable Style/ClassVars
+
+      def work_types
+        [@@_legacy_type]
+      end
+    end
+  end
+end
 
 require 'valkyrie'
 require 'wings/model_registry'

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -5,6 +5,12 @@ Valkyrie::MetadataAdapter.register(
 )
 Valkyrie.config.metadata_adapter = :wings_adapter
 
+if ENV['RAILS_ENV'] == 'test'
+  Valkyrie::MetadataAdapter.register(
+    Valkyrie::Persistence::Memory::MetadataAdapter.new, :test_adapter
+  )
+end
+
 Valkyrie::StorageAdapter.register(
   Wings::Storage::ActiveFedora
     .new(connection: Ldp::Client.new(ActiveFedora.fedora.host), base_path: ActiveFedora.fedora.base_path),

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     include Hyrax::WorksControllerBehavior
 
     self.curation_concern_type = Hyrax::Test::SimpleWork
-    self.search_builder_class  = Hyrax::Test::SimpleWorkSearchBuilder
+    self.search_builder_class  = Wings::WorkSearchBuilder(Hyrax::Test::SimpleWork)
     self.work_form_service     = Hyrax::FormFactory.new
   end
 

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
     self.curation_concern_type = Hyrax::Test::SimpleWork
     self.search_builder_class  = Hyrax::Test::SimpleWorkSearchBuilder
+    self.work_form_service     = Hyrax::FormFactory.new
   end
 
   shared_context 'with a logged in user' do
@@ -75,7 +76,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
       expect(response).to redirect_to paths.new_user_session_path(locale: :en)
     end
 
-    xcontext 'with a logged in user' do
+    context 'with a logged in user' do
       include_context 'with a logged in user'
 
       it 'is successful' do
@@ -84,10 +85,16 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         expect(response).to be_successful
       end
 
-      it 'renders a form' do
+      it 'assigns a change_set as the form' do
         get :new
 
-        expect(assigns[:form]).to be_kind_of Hyrax::WorkForm
+        expect(assigns[:form]).to be_a Valkyrie::ChangeSet
+      end
+
+      it 'renders form' do
+        get :new
+
+        expect(controller).to render_template('hyrax/base/new')
       end
     end
   end

--- a/spec/services/hyrax/form_factory_spec.rb
+++ b/spec/services/hyrax/form_factory_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::FormFactory do
+  subject(:factory) { described_class.new }
+  let(:model)       { FactoryBot.build(:hyrax_work) }
+
+  describe '.build' do
+    let(:ability)    { :FAKE_ABILITY }
+    let(:controller) { :FAKE_CONTROLLER }
+
+    it 'returns a change set' do
+      expect(factory.build(model, ability, controller)).to be_a Hyrax::ChangeSet
+    end
+  end
+end

--- a/spec/services/hyrax/work_form_service_spec.rb
+++ b/spec/services/hyrax/work_form_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::WorkFormService do
+  subject(:form_service) { described_class }
+  let(:work)             { GenericWork.new }
+
+  describe '.form_class' do
+    it 'returns a form class by constant name convention' do
+      expect(form_service.form_class(work)).to eq Hyrax::GenericWorkForm
+    end
+
+    context 'with a missing form class' do
+      let(:work) { Hyrax::Test::SimpleWorkLegacy.new }
+
+      it 'raises a NameError' do
+        expect { form_service.form_class(work) }.to raise_error NameError
+      end
+    end
+  end
+
+  describe '.build' do
+    let(:ability)    { :FAKE_ABILITY }
+    let(:controller) { :FAKE_CONTROLLER }
+
+    it 'returns an instance of the form class' do
+      expect(form_service.build(work, ability, controller))
+        .to be_a Hyrax::GenericWorkForm
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -143,10 +143,6 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-Valkyrie::MetadataAdapter.register(
-  Valkyrie::Persistence::Memory::MetadataAdapter.new, :test_adapter
-)
-
 query_registration_target =
   Valkyrie::MetadataAdapter.find(:test_adapter).query_service.custom_queries
 [Hyrax::CustomQueries::FindAccessControl,

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -13,6 +13,10 @@ class TestAppGenerator < Rails::Generators::Base
     generate "browse_everything:install --skip-assets"
   end
 
+  def create_work
+    generate 'hyrax:work_resource Monograph'
+  end
+
   def create_generic_work
     generate 'hyrax:work GenericWork'
   end


### PR DESCRIPTION
The new generator creates a valkyrie-driven `Hyrax::Work` subclass, with a
controller and a spec file. The specs include the Hyrax shared examples (and the
valkyrie shared examples) by default.

Since a custom search builder is needed to ensure Valkyrie works can be found by
their legacy `ActiveFedora` model names, we include a class builder for that,
and register the custom class with the generated `Controller`. This can be
removed when Wings is deleted; applications that are ready to move to
valkyrie-only index behavior will need to drop this search builder in favor of
one that uses the valkyrie index at a later date.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* in a new hyrax app (built from this branch) do: `rails g hyrax:work_resource Monograph`; when it's done, run the new spec

@samvera/hyrax-code-reviewers
