### PR TITLE
Ensure view tests always use the :test_adapter

### DIFF
--- a/app/forms/hyrax/forms/batch_edit_form.rb
+++ b/app/forms/hyrax/forms/batch_edit_form.rb
@@ -64,7 +64,7 @@ module Hyrax
         def initialize_combined_fields
           # For each of the files in the batch, set the attributes to be the concatenation of all the attributes
           batch_document_ids.each_with_object({}) do |doc_id, combined_attributes|
-            work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false)
+            work = ActiveFedora::Base.find(doc_id)
             terms.each do |field|
               combined_attributes[field] ||= []
               combined_attributes[field] = (combined_attributes[field] + work[field].to_a).uniq

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -206,6 +206,10 @@ RSpec.configure do |config|
   config.before(:each, type: :view) do
     initialize_controller_helpers(view)
     WebMock.disable_net_connect!(allow_localhost: false, allow: 'chromedriver.storage.googleapis.com')
+
+    allow(Hyrax)
+      .to receive(:metadata_adapter)
+      .and_return(Valkyrie::MetadataAdapter.find(:test_adapter))
   end
 
   config.after(:each, type: :view) do


### PR DESCRIPTION
We don't want to hit the official backend from view tests. The easiest way to
avoid this is to always use the test adapter (which is the Valkyrie in-memory
adapter, by default).

@samvera/hyrax-code-reviewers
