### PR TITLE
Isolate select AF::Base calls

### DIFF
--- a/app/actors/hyrax/actors/apply_order_actor.rb
+++ b/app/actors/hyrax/actors/apply_order_actor.rb
@@ -52,7 +52,7 @@ module Hyrax
               proxy.prev.next = curation_concern.ordered_member_proxies.last.next
               break
             end
-            proxy.proxy_for = ActiveFedora::Base.id_to_uri(new_order[index])
+            proxy.proxy_for = Hyrax::Base.id_to_uri(new_order[index])
             proxy.target = nil
           end
           curation_concern.list_source.order_will_change!

--- a/app/models/hyrax/base.rb
+++ b/app/models/hyrax/base.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Isolate calls to ActiveFedora::Base
+  class Base
+    def self.uncached(&block)
+      ActiveFedora::Base.uncached(&block)
+    end
+
+    def self.uri_to_id(uri)
+      ActiveFedora::Base.uri_to_id(uri)
+    end
+
+    def self.id_to_uri(id)
+      ActiveFedora::Base.id_to_uri(id)
+    end
+  end
+end

--- a/app/services/hyrax/adapters/nesting_index_adapter.rb
+++ b/app/services/hyrax/adapters/nesting_index_adapter.rb
@@ -21,7 +21,7 @@ module Hyrax
       def self.find_preservation_parent_ids_for(id:)
         # Not everything is guaranteed to have library_collection_ids
         # If it doesn't have it, what do we do?
-        fedora_object = ActiveFedora::Base.uncached do
+        fedora_object = Hyrax::Base.uncached do
           fedora_object = ActiveFedora::Base.find(id)
         end
 
@@ -47,7 +47,7 @@ module Hyrax
       # rubocop:disable Lint/UnusedMethodArgument
       def self.each_perservation_document_id_and_parent_ids(&block)
         ActiveFedora::Base.descendant_uris(ActiveFedora.fedora.base_uri, exclude_uri: true).each do |uri|
-          id = ActiveFedora::Base.uri_to_id(uri)
+          id = Hyrax::Base.uri_to_id(uri)
           object = ActiveFedora::Base.find(id)
           parent_ids = object.try(:member_of_collection_ids) || []
 
@@ -70,7 +70,7 @@ module Hyrax
       # @param nesting_document [Samvera::NestingIndexer::Documents::IndexDocument]
       # @return Hash - the attributes written to the indexing layer
       def self.write_nesting_document_to_index_layer(nesting_document:)
-        solr_doc = ActiveFedora::Base.uncached do
+        solr_doc = Hyrax::Base.uncached do
           ActiveFedora::Base.find(nesting_document.id).to_solr # What is the current state of the solr document
         end
 

--- a/app/services/hyrax/graph_exporter.rb
+++ b/app/services/hyrax/graph_exporter.rb
@@ -36,7 +36,7 @@ module Hyrax
       # This method is called once for each statement in the graph.
       def replacer
         lambda do |resource_id, graph|
-          url = ActiveFedora::Base.id_to_uri(resource_id)
+          url = Hyrax::Base.id_to_uri(resource_id)
           klass = graph.query([:s, ActiveFedora::RDF::Fcrepo::Model.hasModel, :o]).first.object.to_s.constantize
 
           # if the subject URL matches

--- a/app/services/hyrax/list_source_exporter.rb
+++ b/app/services/hyrax/list_source_exporter.rb
@@ -31,7 +31,7 @@ module Hyrax
       # This method is called once for each statement in the graph.
       def replacer
         lambda do |resource_id, _graph|
-          parent_id = ActiveFedora::Base.uri_to_id(parent_url)
+          parent_id = Hyrax::Base.uri_to_id(parent_url)
           return parent_url + resource_id.sub(parent_id, '') if resource_id.start_with?(parent_id)
           Rails.application.routes.url_helpers.solr_document_url(resource_id, host: hostname)
         end

--- a/app/services/hyrax/persist_directly_contained_output_file_service.rb
+++ b/app/services/hyrax/persist_directly_contained_output_file_service.rb
@@ -24,7 +24,7 @@ module Hyrax
     def self.retrieve_file_set(directives)
       uri = URI(directives.fetch(:url))
       raise ArgumentError, "#{uri} is not an http(s) uri" unless uri.is_a?(URI::HTTP)
-      Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: ActiveFedora::Base.uri_to_id(uri.to_s), use_valkyrie: false)
+      Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: Hyrax::Base.uri_to_id(uri.to_s), use_valkyrie: false)
     end
     private_class_method :retrieve_file_set
 

--- a/app/services/hyrax/versioning_service.rb
+++ b/app/services/hyrax/versioning_service.rb
@@ -20,7 +20,7 @@ module Hyrax
       def versioned_file_id(file)
         versions = file.versions.all
         if versions.present?
-          ActiveFedora::File.uri_to_id versions.last.uri
+          Hyrax::Base.uri_to_id(versions.last.uri)
         else
           file.id
         end

--- a/lib/generators/hyrax/templates/config/initializers/riiif.rb
+++ b/lib/generators/hyrax/templates/config/initializers/riiif.rb
@@ -13,7 +13,7 @@ Riiif::Image.info_service = lambda do |id, _file|
 end
 
 Riiif::Image.file_resolver.id_to_uri = lambda do |id|
-  ActiveFedora::Base.id_to_uri(CGI.unescape(id)).tap do |url|
+  Hyrax::Base.id_to_uri(CGI.unescape(id)).tap do |url|
     Rails.logger.info "Riiif resolved #{id} to #{url}"
   end
 end

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -125,7 +125,7 @@ module Wings
         raise ArgumentError, "Provide resource or id" unless resource || id
         id ||= resource.alternate_ids.first
         raise ArgumentError, "Resource has no id; is it persisted?" unless id
-        uri = ActiveFedora::Base.id_to_uri(id.to_s)
+        uri = Hyrax::Base.id_to_uri(id.to_s)
         ActiveFedora::Base.where("+(#{property}_ssim: \"#{uri}\" OR #{property}_ssim: \"#{id}\")").map do |obj|
           resource_factory.to_resource(object: obj)
         end
@@ -160,7 +160,7 @@ module Wings
         end
 
         def find_id_for(reference)
-          return ::ActiveFedora::Base.uri_to_id(reference.id) if reference.class == ActiveTriples::Resource
+          return ::Hyrax::Base.uri_to_id(reference.id) if reference.class == ActiveTriples::Resource
           return reference if reference.class == String
           # not a supported type
           ''

--- a/spec/models/hyrax/base_spec.rb
+++ b/spec/models/hyrax/base_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Base do
+  describe '.uncached' do
+    let(:block) { proc { puts 'I do nothing' } }
+
+    it 'calls ActiveFedora::Base.uncached' do
+      allow(ActiveFedora::Base).to receive(:uncached)
+      described_class.uncached(&block)
+      expect(ActiveFedora::Base).to have_received(:uncached) do |&passed_block|
+        expect(passed_block).to eq(block)
+      end
+    end
+  end
+
+  describe '.id_to_uri' do
+    let(:id) { 'abc123' }
+
+    it 'calls ActiveFedora::Base.id_to_uri' do
+      allow(ActiveFedora::Base).to receive(:id_to_uri)
+      described_class.id_to_uri(id)
+      expect(ActiveFedora::Base).to have_received(:id_to_uri).with(id).once
+    end
+  end
+
+  describe '.uri_to_id' do
+    let(:uri) { 'https://foo.bar/abc123' }
+
+    it 'calls ActiveFedora::Base.uri_to_id' do
+      allow(ActiveFedora::Base).to receive(:uri_to_id)
+      described_class.uri_to_id(uri)
+      expect(ActiveFedora::Base).to have_received(:uri_to_id).with(uri).once
+    end
+  end
+end

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe Hyrax::FileSetPresenter do
     let(:solr_document) { SolrDocument.new(file_set.to_solr) }
     let(:request) { double(base_url: 'http://test.host') }
     let(:presenter) { described_class.new(solr_document, ability, request) }
-    let(:id) { ActiveFedora::File.uri_to_id(file_set.original_file.versions.last.uri) }
+    let(:id) { Hyrax::Base.uri_to_id(file_set.original_file.versions.last.uri) }
     let(:read_permission) { true }
 
     before do


### PR DESCRIPTION
Connects to #3821
Connects to #3824

This branch handles the "first pass" suggestion in two issues (#3821 and #3824), isolating certain `ActiveFedora::Base` class method calls within a new wrapper class (`Hyrax::Base`). Those calls are `.id_to_uri`, `.uri_to_id`, and `.uncached`. This provides a single location in the codebase where these calls might be refactored, replaced, or removed in the "second pass" work.

@samvera/hyrax-code-reviewers
