### PR TITLE
Wings/add extracted text

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -31,7 +31,7 @@ SUMMARY
   # http://guides.rubyonrails.org/maintenance_policy.html
   spec.add_dependency 'rails', '~> 5.0'
 
-  spec.add_dependency 'active-fedora', '~> 13.0'
+  spec.add_dependency 'active-fedora', '~> 13.1.2'
   spec.add_dependency 'almond-rails', '~> 0.1'
   spec.add_dependency 'awesome_nested_set', '~> 3.1'
   spec.add_dependency 'blacklight', '~> 6.14'

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -42,9 +42,6 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
     context 'and requesting extracted text' do
       subject { described_class.call(file_set: file_set, file: text_file, type: [extracted_text_use]) }
       it "builds and uses the association's target" do
-        pending 'fix failing spec'
-        # TODO: LDP fails to write the file to Fedora even though the LDP put request looks correct and
-        #       has the correct file with expected content as part of the put request.
         ids = subject.extracted_text_ids
         expect(ids.size).to eq 1
         expect(ids.first).to be_a Valkyrie::ID


### PR DESCRIPTION
Fixes #4018 

### Changes

* pin active-fedora to 13.1.2
* remove pending marker for add_file_to_file_set for extracted text

The release of active-fedora v13.1.2 includes a bug fix to always rewind context.  Before this release, files added with the extracted text association were getting consumed prior the ldp put call that added them to Fedora resulting in the content being empty.  Other file associations may have also been effected.

@samvera/hyrax-code-reviewers
