### PR TITLE
Remove collection size feature

### DIFF
--- a/app/indexers/hyrax/collection_indexer.rb
+++ b/app/indexers/hyrax/collection_indexer.rb
@@ -12,8 +12,6 @@ module Hyrax
       super.tap do |solr_doc|
         # Makes Collections show under the "Collections" tab
         solr_doc['generic_type_sim'] = ["Collection"]
-        # Index the size of the collection in bytes
-        solr_doc['bytes_lts'] = object.bytes
         solr_doc['visibility_ssi'] = object.visibility
 
         object.in_collections.each do |col|

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -21,7 +21,6 @@ class CharacterizeJob < Hyrax::ApplicationJob
       file_set.characterization_proxy.alpha_channels = channels(filepath) if file_set.image? && Hyrax.config.iiif_image_server?
       file_set.characterization_proxy.save!
       file_set.update_index
-      file_set.parent&.in_collections&.each(&:update_index)
     end
 
     def channels(filepath)

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -111,6 +111,17 @@ module Hyrax
       end
     end
 
+    # @deprecated to be removed in 4.0.0; this feature was replaced with a
+    #   hard-coded null implementation
+    # @return [Fixnum] 0
+    def bytes
+      Deprecation.warn('#bytes has been deprecated for removal in Hyrax 4.0.0; ' \
+                       'The implementation of the indexed Collection size ' \
+                       'feature is extremely inefficient, so it has been removed. ' \
+                       'This method now returns a hard-coded `0` for compatibility.')
+      0
+    end
+
     # @api public
     # Retrieve the permission template for this collection.
     # @return [Hyrax::PermissionTemplate]

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -41,7 +41,7 @@ module Hyrax
     # Terms is the list of fields displayed by
     # app/views/collections/_show_descriptions.html.erb
     def self.terms
-      [:total_items, :resource_type, :creator, :contributor, :keyword, :license, :publisher, :date_created, :subject,
+      [:total_items, :size, :resource_type, :creator, :contributor, :keyword, :license, :publisher, :date_created, :subject,
        :language, :identifier, :based_near, :related_url]
     end
 
@@ -49,13 +49,30 @@ module Hyrax
       self.class.terms.select { |t| self[t].present? }
     end
 
+    ##
+    # @param [Symbol] key
+    # @return [Object]
     def [](key)
       case key
+      when :size
+        size
       when :total_items
         total_items
       else
         solr_document.send key
       end
+    end
+
+    # @deprecated to be removed in 4.0.0; this feature was replaced with a
+    #   hard-coded null implementation
+    # @return [String] 'unknown'
+    def size
+      Deprecation.warn('#size has been deprecated for removal in Hyrax 4.0.0; ' \
+                       'The implementation of the indexed Collection size ' \
+                       'feature is extremely inefficient, so it has been removed. ' \
+                       'This method now returns a hard-coded `"unknown"` for ' \
+                       'compatibility.')
+      'unknown'
     end
 
     def total_items

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -41,7 +41,7 @@ module Hyrax
     # Terms is the list of fields displayed by
     # app/views/collections/_show_descriptions.html.erb
     def self.terms
-      [:total_items, :size, :resource_type, :creator, :contributor, :keyword, :license, :publisher, :date_created, :subject,
+      [:total_items, :resource_type, :creator, :contributor, :keyword, :license, :publisher, :date_created, :subject,
        :language, :identifier, :based_near, :related_url]
     end
 
@@ -51,17 +51,11 @@ module Hyrax
 
     def [](key)
       case key
-      when :size
-        size
       when :total_items
         total_items
       else
         solr_document.send key
       end
-    end
-
-    def size
-      number_to_human_size(@solr_document['bytes_lts'])
     end
 
     def total_items

--- a/spec/indexers/hyrax/collection_indexer_spec.rb
+++ b/spec/indexers/hyrax/collection_indexer_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Hyrax::CollectionIndexer do
   let(:doc) do
     {
       'generic_type_sim' => ['Collection'],
-      'bytes_lts' => 1000,
       'thumbnail_path_ss' => '/downloads/1234?file=thumbnail',
       'member_of_collection_ids_ssim' => [col1id, col2id],
       'member_of_collections_ssim' => [col1title, col2title],
@@ -20,7 +19,6 @@ RSpec.describe Hyrax::CollectionIndexer do
 
   describe "#generate_solr_document" do
     before do
-      allow(collection).to receive(:bytes).and_return(1000)
       allow(collection).to receive(:in_collections).and_return([col1, col2])
       allow(Hyrax::ThumbnailPathService).to receive(:call).and_return("/downloads/1234?file=thumbnail")
     end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -49,18 +49,4 @@ RSpec.describe CharacterizeJob do
       expect { described_class.perform_now(file_set, file.id) }.to raise_error(StandardError, /original_file was not found/)
     end
   end
-
-  context "when the file set's work is in a collection" do
-    let(:work)       { build(:generic_work) }
-    let(:collection) { build(:collection_lw) }
-
-    before do
-      allow(file_set).to receive(:parent).and_return(work)
-      allow(work).to receive(:in_collections).and_return([collection])
-    end
-    it "reindexes the collection" do
-      expect(collection).to receive(:update_index)
-      described_class.perform_now(file_set, file.id)
-    end
-  end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe ::Collection, type: :model do
     expect(collection.read_groups).to eq ['public']
   end
 
+  describe '#bytes' do
+    it 'returns a hard-coded integer and issues a deprecation warning' do
+      expect(Deprecation).to receive(:warn).once
+      expect(collection.bytes).to eq(0)
+    end
+  end
+
   describe "#validates_with" do
     before { collection.title = nil }
     it "ensures the collection has a title" do

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     subject { described_class.terms }
 
     it do
-      is_expected.to eq [:total_items, :resource_type, :creator,
+      is_expected.to eq [:total_items, :size, :resource_type, :creator,
                          :contributor, :keyword, :license, :publisher,
                          :date_created, :subject, :language, :identifier,
                          :based_near, :related_url]
@@ -78,6 +78,7 @@ RSpec.describe Hyrax::CollectionPresenter do
 
     it do
       is_expected.to eq [:total_items,
+                         :size,
                          :resource_type,
                          :keyword,
                          :date_created,
@@ -120,6 +121,13 @@ RSpec.describe Hyrax::CollectionPresenter do
     subject { presenter.to_key }
 
     it { is_expected.to eq ['adc12v'] }
+  end
+
+  describe '#size' do
+    it 'returns a hard-coded string and issues a deprecation warning' do
+      expect(Deprecation).to receive(:warn).once
+      expect(presenter.size).to eq('unknown')
+    end
   end
 
   describe "#total_items", :clean_repo do

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     subject { described_class.terms }
 
     it do
-      is_expected.to eq [:total_items, :size, :resource_type, :creator,
+      is_expected.to eq [:total_items, :resource_type, :creator,
                          :contributor, :keyword, :license, :publisher,
                          :date_created, :subject, :language, :identifier,
                          :based_near, :related_url]
@@ -24,9 +24,6 @@ RSpec.describe Hyrax::CollectionPresenter do
   let(:ability) { double }
   let(:presenter) { described_class.new(solr_doc, ability) }
   let(:solr_doc) { SolrDocument.new(collection.to_solr) }
-
-  # Mock bytes so collection does not have to be saved.
-  before { allow(collection).to receive(:bytes).and_return(0) }
 
   describe "collection type methods" do
     subject { presenter }
@@ -81,7 +78,6 @@ RSpec.describe Hyrax::CollectionPresenter do
 
     it do
       is_expected.to eq [:total_items,
-                         :size,
                          :resource_type,
                          :keyword,
                          :date_created,
@@ -124,12 +120,6 @@ RSpec.describe Hyrax::CollectionPresenter do
     subject { presenter.to_key }
 
     it { is_expected.to eq ['adc12v'] }
-  end
-
-  describe "#size", :clean_repo do
-    subject { presenter.size }
-
-    it { is_expected.to eq '0 Bytes' }
   end
 
   describe "#total_items", :clean_repo do
@@ -282,12 +272,6 @@ RSpec.describe Hyrax::CollectionPresenter do
 
       it { is_expected.to eq 0 }
     end
-  end
-
-  describe "#size", :clean_repo do
-    subject { presenter.size }
-
-    it { is_expected.to eq '0 Bytes' }
   end
 
   describe "#parent_collection_count" do

--- a/spec/views/hyrax/collections/_show_descriptions.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_descriptions.html.erb_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe 'hyrax/collections/_show_descriptions.html.erb', type: :view do
   context 'displaying a custom collection' do
-    let(:collection_size) { 123_456_678 }
     let(:collection) do
       {
         id: '999',
@@ -15,7 +14,6 @@ RSpec.describe 'hyrax/collections/_show_descriptions.html.erb', type: :view do
 
     before do
       allow(presenter).to receive(:total_items).and_return(2)
-      allow(presenter).to receive(:size).and_return("118 MB")
       assign(:presenter, presenter)
     end
 
@@ -25,8 +23,6 @@ RSpec.describe 'hyrax/collections/_show_descriptions.html.erb', type: :view do
       expect(rendered).to include('itemprop="dateCreated"')
       expect(rendered).to have_content 'Total items'
       expect(rendered).to have_content '2'
-      expect(rendered).to have_content 'Size'
-      expect(rendered).to have_content '118 MB'
     end
   end
 end

--- a/spec/views/hyrax/dashboard/collections/_show_descriptions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_descriptions.html.erb_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe 'hyrax/dashboard/collections/_show_descriptions.html.erb', type: :view do
   context 'displaying a custom collection' do
-    let(:collection_size) { 123_456_678 }
     let(:collection) do
       {
         id: '999',
@@ -15,7 +14,6 @@ RSpec.describe 'hyrax/dashboard/collections/_show_descriptions.html.erb', type: 
 
     before do
       allow(presenter).to receive(:total_items).and_return(2)
-      allow(presenter).to receive(:size).and_return("118 MB")
       assign(:presenter, presenter)
     end
 
@@ -25,8 +23,6 @@ RSpec.describe 'hyrax/dashboard/collections/_show_descriptions.html.erb', type: 
       expect(rendered).to include('itemprop="dateCreated"')
       expect(rendered).to have_content 'Total items'
       expect(rendered).to have_content '2'
-      expect(rendered).to have_content 'Size'
-      expect(rendered).to have_content '118 MB'
     end
   end
 end


### PR DESCRIPTION
While looking into #4100, we noticed that `CharacterizeJob` not only saves a file set's `original_file`, but also reindexes the file set, *and* reindexes every collection to which the file set's work belongs. It appears that this feature was added way back in the Sufia days in order to support the use case of displaying on the collection show page the total size of all files uploaded to a collection's works.

Why is this problematic?

At large scale, this means touching a potentially huge portion of the repository—iterating over all files in all works in a collection—in order to display an arguably useful string to a subset of repository users who care about such information. Doing this in `CharacterizeJob` introduces significant potential delay in the ingest pipeline, increasing how long it takes for a deposit to finish and render in the Hyrax UI (e.g., by delaying the creation of derivatives).

We propose removing this feature for now and encourage folks who need this feature to contribute it back with a better-performing, more streamlined design.