### PR TITLE
Route Valkyrie models registered with Wings to legacy models

### DIFF
--- a/app/models/concerns/hyrax/naming.rb
+++ b/app/models/concerns/hyrax/naming.rb
@@ -1,18 +1,27 @@
+# frozen_string_literal: true
+
 require_dependency 'hyrax/name'
+
 module Hyrax
   module Naming
     extend ActiveSupport::Concern
 
     module ClassMethods
       # Override of ActiveModel::Model name that allows us to use our custom name class
-      def model_name
+      def model_name(name_class: _hyrax_default_name_class)
         @_model_name ||= begin
           namespace = parents.detect do |n|
             n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
           end
-          Hyrax::Name.new(self, namespace)
+          name_class.new(self, namespace)
         end
       end
+
+      private
+
+        def _hyrax_default_name_class
+          Hyrax::Name
+        end
     end
   end
 end

--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency 'hyrax/resource_name'
+
 module Hyrax
   ##
   # The base Valkyrie model for Hyrax.
@@ -29,6 +31,8 @@ module Hyrax
   #   implementations).
   #
   class Resource < Valkyrie::Resource
+    include Hyrax::Naming
+
     attribute :alternate_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID)
     attribute :embargo,       Hyrax::Embargo.optional
     attribute :lease,         Hyrax::Lease.optional
@@ -38,10 +42,22 @@ module Hyrax
              :read_groups, :read_groups=,
              :read_users,  :read_users=, to: :permission_manager
 
-    ##
-    # @return [String] a human readable name for the model
-    def self.human_readable_type
-      I18n.translate("hyrax.models.#{model_name.i18n_key}", default: model_name.human)
+    class << self
+      ##
+      # @return [String] a human readable name for the model
+      def human_readable_type
+        I18n.translate("hyrax.models.#{model_name.i18n_key}", default: model_name.human)
+      end
+
+      private
+
+        ##
+        # @api private
+        #
+        # @return [Class] an ActiveModel::Name compatible class
+        def _hyrax_default_name_class
+          Hyrax::ResourceName
+        end
     end
 
     ##

--- a/lib/hyrax/resource_name.rb
+++ b/lib/hyrax/resource_name.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # A custom name for Valkyrie Resource objects. Route keys for resources may
+  # not be the same as the model name.
+  class ResourceName < Name
+    def initialize(klass, namespace = nil, name = nil)
+      super
+
+      legacy_model = Wings::ModelRegistry.lookup(klass)
+      return unless legacy_model
+
+      @route_key          = legacy_model.model_name.route_key
+      @singular_route_key = legacy_model.model_name.singular_route_key
+    end
+  end
+end

--- a/spec/hyrax/resource_name_spec.rb
+++ b/spec/hyrax/resource_name_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::ResourceName do
+  subject(:name) { described_class.new(work_class) }
+  let(:work_class) { Monograph }
+
+  it 'has a namespaced route key' do
+    expect(name.route_key).to start_with 'hyrax_'
+  end
+
+  it 'has a namespaced singular route key' do
+    expect(name.singular_route_key).to start_with 'hyrax_'
+  end
+
+  context 'when a legacy resource is registered with Wings' do
+    let(:work_class) { Hyrax::Test::BookResource }
+
+    it 'uses the legacy route key' do
+      expect(name.route_key).to eq 'test_books'
+    end
+
+    it 'uses the legacy singular route key' do
+      expect(name.singular_route_key).to eq 'test_book'
+    end
+  end
+end

--- a/spec/models/concerns/hyrax/naming_spec.rb
+++ b/spec/models/concerns/hyrax/naming_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Naming do
+  subject(:class_with_naming) do
+    Hyrax::Test::Naming::TestClass
+  end
+
+  before do
+    module Hyrax::Test::Naming
+      class TestClass
+        include ActiveModel::Model
+        include Hyrax::Naming
+      end
+    end
+  end
+
+  after { Hyrax::Test.send(:remove_const, :Naming) }
+
+  describe '.model_name' do
+    it 'is a Hyrax::Name' do
+      expect(class_with_naming.model_name).to be_a Hyrax::Name
+    end
+
+    it 'accepts a name_class' do
+      expect(class_with_naming.model_name(name_class: ActiveModel::Name))
+        .to be_a ActiveModel::Name
+    end
+  end
+end


### PR DESCRIPTION
When a Valkyrie model exists and replaces an equivalent `ActiveFedora` model,
use the `ActiveModel::Name` API to route to the legacy model.

This allows existing apps to avoid changing their routes when introducing and
using Valkyrie models.

@samvera/hyrax-code-reviewers
