### PR TITLE
Use a Hyrax configuration option to set the system virus scanner

### DIFF
--- a/app/models/hyrax/virus_scanner.rb
+++ b/app/models/hyrax/virus_scanner.rb
@@ -3,7 +3,7 @@
 # installed or otherwise not available to your application, Hyrax::Works does no virus checking
 # add assumes files have no viruses.
 #
-# To use a virus checker other than ClamAV:
+# @example to use a virus checker other than Hyrax::VirusScanner:
 #   class MyScanner < Hyrax::Works::VirusScanner
 #     def infected?
 #       my_result = Scanner.check_for_viruses(file)
@@ -11,8 +11,8 @@
 #     end
 #   end
 #
-# Then set Hyrax::Works to use your scanner either in a config file or initializer:
-#   Hyrax::Works.default_system_virus_scanner = MyScanner
+#   # Then set Hyrax::Works to use your scanner either in a config file or initializer:
+#   Hyrax.config.virus_scanner = MyScanner
 module Hyrax
   class VirusScanner
     attr_reader :file

--- a/app/services/hyrax/virus_checker_service.rb
+++ b/app/services/hyrax/virus_checker_service.rb
@@ -11,7 +11,7 @@ module Hyrax
       new(original_file).file_has_virus?
     end
 
-    def initialize(original_file, system_virus_scanner = Hyrax.primary_work_type.default_system_virus_scanner)
+    def initialize(original_file, system_virus_scanner = Hyrax.config.virus_scanner)
       self.original_file = original_file
       self.system_virus_scanner = system_virus_scanner
     end

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -276,6 +276,10 @@ Hyrax.config do |config|
   # mount point.
   #
   # config.whitelisted_ingest_dirs = []
+
+  ##
+  # Set the system-wide virus scanner
+  config.virus_scanner = Hyrax::VirusScanner
 end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -183,6 +183,18 @@ module Hyrax
       @bagit_dir ||= "tmp/descriptions"
     end
 
+    # @!attribute [w] virus_scanner
+    #   @return [Hyrax::VirusScanner] the default system virus scanner
+    attr_writer :virus_scanner
+    def virus_scanner
+      @virus_scanner ||=
+        if Hyrax.primary_work_type.respond_to?(:default_system_virus_scanner)
+          Hyrax.primary_work_type.default_system_virus_scanner
+        else
+          Hyrax::VirusScanner
+        end
+    end
+
     # @!attribute [w] whitelisted_ingest_dirs
     #   List of directories which can be used for local file system ingestion.
     attr_writer :whitelisted_ingest_dirs


### PR DESCRIPTION
Previously, we used `Hyrax.primary_work_type` to set the system wide virus
scanner. There appears to be  no reason for this to be configurable on a
per-work basis; we always use the "primary work type" (i.e. whichever one
happens to be first in the registered work types list!) to choose the virus
scanner.

Using a system-wide configuration is much more clear. The default for this
configuration is to fall back on the `primary_work_type`'s configured scanner.

@samvera/hyrax-code-reviewers
