### PR TITLE
Extract characterization service to allow ActiveFedora and Valkyrie filesets

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,33 +1,10 @@
+# Characterizes the file at 'filepath' if available, otherwise, pulls a copy from the repository
+# and runs characterization on that file.
+
 class CharacterizeJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
-  # Characterizes the file at 'filepath' if available, otherwise, pulls a copy from the repository
-  # and runs characterization on that file.
-  # @param [FileSet] file_set
-  # @param [String] file_id identifier for a Hydra::PCDM::File
-  # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
-  def perform(file_set, file_id, filepath = nil)
-    raise "#{file_set.class.characterization_proxy} was not found for FileSet #{file_set.id}" unless file_set.characterization_proxy?
-    filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id) unless filepath && File.exist?(filepath)
-    characterize(file_set, file_id, filepath)
-    CreateDerivativesJob.perform_later(file_set, file_id, filepath)
+  def perform(work)
+    Hyrax::Characterizer.for(source: work).characterize
   end
-
-  private
-
-    def characterize(file_set, _file_id, filepath)
-      Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filepath)
-      Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
-      file_set.characterization_proxy.alpha_channels = channels(filepath) if file_set.image? && Hyrax.config.iiif_image_server?
-      file_set.characterization_proxy.save!
-      file_set.update_index
-    end
-
-    def channels(filepath)
-      ch = MiniMagick::Tool::Identify.new do |cmd|
-        cmd.format '%[channels]'
-        cmd << filepath
-      end
-      [ch]
-    end
 end

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,10 +1,9 @@
 # Characterizes the file at 'filepath' if available, otherwise, pulls a copy from the repository
 # and runs characterization on that file.
-
 class CharacterizeJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
-  def perform(work)
-    Hyrax::Characterizer.for(source: work).characterize
+  def perform(file_set)
+    Hyrax::Characterizer.for(source: file_set).characterize
   end
 end

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -7,6 +7,8 @@ module Hyrax
   # @see https://wiki.duraspace.org/display/samvera/Hydra%3A%3AWorks+Shared+Modeling
   class FileSet < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
+    include Hyrax::FileSet::Characterization
+    include Hydra::Works::MimeTypes
 
     attribute :file_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID) # id for FileMetadata resources
     attribute :original_file_id, Valkyrie::Types::ID # id for FileMetadata resource

--- a/app/services/hyrax/characterizer.rb
+++ b/app/services/hyrax/characterizer.rb
@@ -11,9 +11,8 @@ module Hyrax
       case source
       when Hyrax::FileSetBehavior # ActiveFedora
         FileSetCharacterizer.new(source: source)
-      when Hyrax::Resource # Valkyrie
-        byebug
-        ResourceVisibilityPropagator.new(source: source)
+      when Hyrax::FileSet # Valkyrie
+        FileSetCharacterizer.new(source: source)
       end
     end
   end

--- a/app/services/hyrax/characterizer.rb
+++ b/app/services/hyrax/characterizer.rb
@@ -12,7 +12,7 @@ module Hyrax
       when Hyrax::FileSetBehavior # ActiveFedora
         FileSetCharacterizer.new(source: source)
       when Hyrax::FileSet # Valkyrie
-        FileSetCharacterizer.new(source: source)
+        ResourceCharacterizer.new(source: source)
       end
     end
   end

--- a/app/services/hyrax/characterizer.rb
+++ b/app/services/hyrax/characterizer.rb
@@ -1,0 +1,20 @@
+module Hyrax
+  ##
+  # @abstract Propogates visibility from a provided object (e.g. a Work) to some
+  # group of its members (e.g. file_sets).
+  class Characterizer
+    ##
+    # @param source [#visibility] the object to propogate visibility from
+    #
+    # @return [#propogate]
+    def self.for(source:)
+      case source
+      when Hyrax::FileSetBehavior # ActiveFedora
+        FileSetCharacterizer.new(source: source)
+      when Hyrax::Resource # Valkyrie
+        byebug
+        ResourceVisibilityPropagator.new(source: source)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/characterizer.rb
+++ b/app/services/hyrax/characterizer.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 module Hyrax
   ##
-  # @abstract Propogates visibility from a provided object (e.g. a Work) to some
-  # group of its members (e.g. file_sets).
+  # Determines which characterizer to run based on the file_set type
+  # allowing implementation of Valkyrie file_sets
   class Characterizer
     ##
-    # @param source [#visibility] the object to propogate visibility from
+    # @param source: the object to run a characterizer on
     #
-    # @return [#propogate]
+    # @return [#characterize]
     def self.for(source:)
       case source
       when Hyrax::FileSetBehavior # ActiveFedora

--- a/app/services/hyrax/file_set_characterizer.rb
+++ b/app/services/hyrax/file_set_characterizer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Propogates visibility from a given Work to its FileSets
+  class FileSetCharacterizer 
+    ##
+    # @!attribute [rw] source
+    #   @return [#visibility]
+    attr_accessor :source
+
+    ##
+    # @param source [#visibility] the object to propogate visibility from
+    def initialize(source:)
+      self.source = source
+    end
+
+    ##
+    # @return [void]
+    #
+    # @raise [RuntimeError] if visibility propogation fails
+    def characterize
+      Hydra::Works::CharacterizationService.run(source.characterization_proxy, filepath)
+      Rails.logger.debug "Ran characterization on #{source.characterization_proxy.id} (#{source.characterization_proxy.mime_type})"
+      source.characterization_proxy.alpha_channels = channels(filepath) if source.image? && Hyrax.config.iiif_image_server?
+      source.characterization_proxy.save!
+      source.update_index
+      source.parent&.in_collections&.each(&:update_index)
+      CreateDerivativesJob.perform_later(source, source.original_file.id, filepath)
+    end
+
+    private
+
+      def filepath
+        Hyrax::WorkingDirectory.find_or_retrieve(source.original_file.id, source.id)
+      end
+
+      def channels(path)
+        ch = MiniMagick::Tool::Identify.new do |cmd|
+          cmd.format '%[channels]'
+          cmd << path
+        end
+        [ch]
+      end
+  end
+end

--- a/app/services/hyrax/file_set_characterizer.rb
+++ b/app/services/hyrax/file_set_characterizer.rb
@@ -20,6 +20,7 @@ module Hyrax
     #
     # @raise [RuntimeError] if visibility propogation fails
     def characterize
+      byebug
       Hydra::Works::CharacterizationService.run(source.characterization_proxy, filepath)
       Rails.logger.debug "Ran characterization on #{source.characterization_proxy.id} (#{source.characterization_proxy.mime_type})"
       source.characterization_proxy.alpha_channels = channels(filepath) if source.image? && Hyrax.config.iiif_image_server?

--- a/app/services/hyrax/file_set_characterizer.rb
+++ b/app/services/hyrax/file_set_characterizer.rb
@@ -24,12 +24,16 @@ module Hyrax
       Rails.logger.debug "Ran characterization on #{characterization_proxy.id} (#{characterization_proxy.mime_type})"
       characterization_proxy.alpha_channels = channels(filepath) if source.image? && Hyrax.config.iiif_image_server?
       characterization_proxy.save!
-      source.update_index
-      source.parent&.in_collections&.each(&:update_index)
+      update_source
       CreateDerivativesJob.perform_later(source, source.original_file.id, filepath)
     end
 
     private
+
+      def update_source
+        source.update_index
+        source.parent&.in_collections&.each(&:update_index)
+      end
 
       def characterization_proxy
         raise "#{source.class.characterization_proxy} was not found for FileSet #{source.id}" unless source.characterization_proxy?

--- a/app/services/hyrax/resource_characterizer.rb
+++ b/app/services/hyrax/resource_characterizer.rb
@@ -2,37 +2,33 @@
 
 module Hyrax
   ##
-  # Propogates visibility from a given Work to its FileSets
+  # Characterizes a Valkyrie based FileSet
   class ResourceCharacterizer
     ##
     # @!attribute [rw] source
-    #   @return [#visibility]
+    #   @return [#characterize]
     attr_accessor :source
 
     ##
-    # @param source [#visibility] the object to propogate visibility from
+    # @param source the object to characterize
     def initialize(source:)
-      self.source = source
+      @source = source
     end
 
     ##
     # @return [void]
     #
-    # @raise [RuntimeError] if visibility propogation fails
+    # @raise [RuntimeError] if FileSet is missing the characterization_proxy
     def characterize
       Hydra::Works::CharacterizationService.run(characterization_proxy, filepath)
       Rails.logger.debug "Ran characterization on #{characterization_proxy.id} (#{characterization_proxy.mime_type})"
       characterization_proxy.alpha_channels = channels(filepath) if source.image? && Hyrax.config.iiif_image_server?
-      persist
+      Hyrax.persister.save(resource: characterization_proxy)
+      Hyrax.persister.save(resource: source)
       CreateDerivativesJob.perform_later(source, source.original_file.id, filepath)
     end
 
     private
-
-      def persist
-        Hyrax.persister.save(resource: characterization_proxy)
-        Hyrax.persister.save(resource: source)
-      end
 
       def characterization_proxy
         raise "#{source.class.characterization_proxy} was not found for FileSet #{source.id}" unless source.characterization_proxy?
@@ -40,6 +36,8 @@ module Hyrax
       end
 
       def filepath
+        # The current version of Valkyrie id returns a Valkyrie::ID and requires a .id to actually retrieve the id.
+        # This should be updated to source.id after a Valkyrie update
         Hyrax::WorkingDirectory.find_or_retrieve(source.original_file.id, source.id.id)
       end
 

--- a/app/services/hyrax/resource_characterizer.rb
+++ b/app/services/hyrax/resource_characterizer.rb
@@ -20,15 +20,24 @@ module Hyrax
     #
     # @raise [RuntimeError] if visibility propogation fails
     def characterize
-      Hydra::Works::CharacterizationService.run(source.characterization_proxy, filepath)
-      Rails.logger.debug "Ran characterization on #{source.characterization_proxy.id} (#{source.characterization_proxy.mime_type})"
-      source.characterization_proxy.alpha_channels = channels(filepath) if source.image? && Hyrax.config.iiif_image_server?
-      Hyrax.persister.save(resource: source.characterization_proxy)
-      Hyrax.persister.save(resource: source)
+      Hydra::Works::CharacterizationService.run(characterization_proxy, filepath)
+      Rails.logger.debug "Ran characterization on #{characterization_proxy.id} (#{characterization_proxy.mime_type})"
+      characterization_proxy.alpha_channels = channels(filepath) if source.image? && Hyrax.config.iiif_image_server?
+      persist
       CreateDerivativesJob.perform_later(source, source.original_file.id, filepath)
     end
 
     private
+
+      def persist
+        Hyrax.persister.save(resource: characterization_proxy)
+        Hyrax.persister.save(resource: source)
+      end
+
+      def characterization_proxy
+        raise "#{source.class.characterization_proxy} was not found for FileSet #{source.id}" unless source.characterization_proxy?
+        source.characterization_proxy
+      end
 
       def filepath
         Hyrax::WorkingDirectory.find_or_retrieve(source.original_file.id, source.id.id)

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe CharacterizeJob do
       allow(f).to receive(:save!)
     end
   end
+  let(:resource) { FactoryBot.create(:work_with_files).valkyrie_resource }
 
   before do
     allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
@@ -34,12 +35,15 @@ RSpec.describe CharacterizeJob do
   end
 
   context 'when the characterization proxy content is present' do
-    it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
-      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-      expect(file).to receive(:save!)
-      expect(file_set).to receive(:update_index)
-      expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
-      described_class.perform_now(file_set)
+    context 'when the work is an ActiveFedora FileSet' do
+      it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
+        byebug
+        expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+        expect(file).to receive(:save!)
+        expect(file_set).to receive(:update_index)
+        expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+        described_class.perform_now(file_set)
+      end
     end
   end
 

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CharacterizeJob do
       allow(f).to receive(:save!)
     end
   end
-  let(:resource) { FactoryBot.create(:work_with_files).valkyrie_resource }
+  let(:resource) { FactoryBot.create(:file_set, content: File.open(fixture_path + '/world.png')).valkyrie_resource }
 
   before do
     allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
@@ -37,12 +37,21 @@ RSpec.describe CharacterizeJob do
   context 'when the characterization proxy content is present' do
     context 'when the work is an ActiveFedora FileSet' do
       it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
-        byebug
         expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
         expect(file).to receive(:save!)
         expect(file_set).to receive(:update_index)
         expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
         described_class.perform_now(file_set)
+      end
+    end
+
+    context 'when the work is a Valkyrie FileSet' do
+      it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
+        expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+        expect(file).to receive(:save!)
+        expect(file_set).to receive(:update_index)
+        expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+        described_class.perform_now(resource)
       end
     end
   end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CharacterizeJob do
       expect(file).to receive(:save!)
       expect(file_set).to receive(:update_index)
       expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
-      described_class.perform_now(file_set, file.id)
+      described_class.perform_now(file_set)
     end
   end
 

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -1,41 +1,40 @@
 RSpec.describe CharacterizeJob do
-  let(:file_set_id) { 'abc12345' }
-  let(:filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
-  let(:file_set) do
-    FileSet.new(id: file_set_id).tap do |fs|
-      allow(fs).to receive(:original_file).and_return(file)
-      allow(fs).to receive(:update_index)
+  context 'when the work is an ActiveFedora FileSet' do
+    let(:file_set_id) { 'abc12345' }
+    let(:filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
+    let(:file_set) do
+      FileSet.new(id: file_set_id).tap do |fs|
+        allow(fs).to receive(:original_file).and_return(file)
+        allow(fs).to receive(:update_index)
+      end
     end
-  end
-  # let(:io)          { JobIoWrapper.new(file_set_id: file_set.id, user: create(:user), path: filename) }
-  let(:file) do
-    Hydra::PCDM::File.new.tap do |f|
-      f.content = 'foo'
-      f.original_name = 'picture.png'
-      f.save!
-      allow(f).to receive(:save!)
+    # let(:io)          { JobIoWrapper.new(file_set_id: file_set.id, user: create(:user), path: filename) }
+    let(:file) do
+      Hydra::PCDM::File.new.tap do |f|
+        f.content = 'foo'
+        f.original_name = 'picture.png'
+        f.save!
+        allow(f).to receive(:save!)
+      end
     end
-  end
-  let(:resource) { FactoryBot.create(:file_set, content: File.open(fixture_path + '/world.png')).valkyrie_resource }
 
-  before do
-    allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
-    allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-    allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
-  end
-
-  context 'with valid filepath param' do
-    let(:filename) { File.join(fixture_path, 'world.png') }
-
-    it 'skips Hyrax::WorkingDirectory' do
-      expect(Hyrax::WorkingDirectory).not_to receive(:find_or_retrieve)
-      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-      described_class.perform_now(file_set, file.id, filename)
+    before do
+      allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
+      allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
     end
-  end
 
-  context 'when the characterization proxy content is present' do
-    context 'when the work is an ActiveFedora FileSet' do
+    context 'with valid filepath param' do
+      let(:filename) { File.join(fixture_path, 'world.png') }
+
+      it 'skips Hyrax::WorkingDirectory' do
+        expect(Hyrax::WorkingDirectory).not_to receive(:find_or_retrieve)
+        expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+        described_class.perform_now(file_set, file.id, filename)
+      end
+    end
+
+    context 'when the characterization proxy content is present' do
       it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
         expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
         expect(file).to receive(:save!)
@@ -45,21 +44,45 @@ RSpec.describe CharacterizeJob do
       end
     end
 
-    context 'when the work is a Valkyrie FileSet' do
-      it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
-        expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-        expect(file).to receive(:save!)
-        expect(file_set).to receive(:update_index)
-        expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
-        described_class.perform_now(resource)
+    context 'when the characterization proxy content is absent' do
+      before { allow(file_set).to receive(:characterization_proxy?).and_return(false) }
+      it 'raises an error' do
+        expect { described_class.perform_now(file_set, file.id) }.to raise_error(StandardError, /original_file was not found/)
+      end
+    end
+
+    context "when the file set's work is in a collection" do
+      let(:work)       { build(:generic_work) }
+      let(:collection) { build(:collection_lw) }
+
+      before do
+        allow(file_set).to receive(:parent).and_return(work)
+        allow(work).to receive(:in_collections).and_return([collection])
+      end
+      it "reindexes the collection" do
+        expect(collection).to receive(:update_index)
+        described_class.perform_now(file_set, file.id)
       end
     end
   end
 
-  context 'when the characterization proxy content is absent' do
-    before { allow(file_set).to receive(:characterization_proxy?).and_return(false) }
-    it 'raises an error' do
-      expect { described_class.perform_now(file_set, file.id) }.to raise_error(StandardError, /original_file was not found/)
+  context 'when the work is a Valkyrie FileSet' do
+    let(:resource) { FactoryBot.create(:file_set, content: File.open(fixture_path + '/world.png')).valkyrie_resource }
+
+    before do
+      allow(Hydra::Works::CharacterizationService).to receive(:run) # .with(resource.characterization_proxy, resource.original_file.file_name)
+      allow(Hyrax.persister).to receive(:save) # .with(resource.characterization_proxy, resource.original_file.file_name)
+      # allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+    end
+
+    it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
+      # expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      # expect(file).to receive(:save!)
+      # expect(file_set).to receive(:update_index)
+      # byebug
+      expect(CreateDerivativesJob).to receive(:perform_later).with(resource, resource.original_file.id, anything)
+      expect(Hyrax.persister).to receive(:save).twice
+      described_class.perform_now(resource)
     end
   end
 end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -1,34 +1,32 @@
 RSpec.describe CharacterizeJob do
-  context 'when the work is an ActiveFedora FileSet' do
-    let(:file_set_id) { 'abc12345' }
-    let(:filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
-    let(:file_set) do
-      FileSet.new(id: file_set_id).tap do |fs|
-        allow(fs).to receive(:original_file).and_return(file)
-        allow(fs).to receive(:update_index)
-      end
+  let(:file_set_id) { 'abc12345' }
+  let(:filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
+  let(:file_set) do
+    FileSet.new(id: file_set_id).tap do |fs|
+      allow(fs).to receive(:original_file).and_return(file)
+      allow(fs).to receive(:update_index)
     end
-    let(:file) do
-      Hydra::PCDM::File.new.tap do |f|
-        f.content = 'foo'
-        f.original_name = 'picture.png'
-        f.save!
-        allow(f).to receive(:save!)
-      end
+  end
+  let(:file) do
+    Hydra::PCDM::File.new.tap do |f|
+      f.content = 'foo'
+      f.original_name = 'picture.png'
+      f.save!
+      allow(f).to receive(:save!)
     end
+  end
 
-    context "when the file set's work is in a collection" do
-      let(:work)       { build(:generic_work) }
-      let(:collection) { build(:collection_lw) }
+  context "when the file set's work is in a collection" do
+    let(:work)       { build(:generic_work) }
+    let(:collection) { build(:collection_lw) }
 
-      before do
-        allow(file_set).to receive(:parent).and_return(work)
-        allow(work).to receive(:in_collections).and_return([collection])
-      end
-      it "reindexes the collection" do
-        expect(collection).to receive(:update_index)
-        described_class.perform_now(file_set)
-      end
+    before do
+      allow(file_set).to receive(:parent).and_return(work)
+      allow(work).to receive(:in_collections).and_return([collection])
+    end
+    it "reindexes the collection" do
+      expect(collection).to receive(:update_index)
+      described_class.perform_now(file_set)
     end
   end
 end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -24,16 +24,6 @@ RSpec.describe CharacterizeJob do
       allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
     end
 
-    context 'with valid filepath param' do
-      let(:filename) { File.join(fixture_path, 'world.png') }
-
-      it 'skips Hyrax::WorkingDirectory' do
-        expect(Hyrax::WorkingDirectory).not_to receive(:find_or_retrieve)
-        expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-        described_class.perform_now(file_set, file.id, filename)
-      end
-    end
-
     context 'when the characterization proxy content is present' do
       it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
         expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
@@ -47,7 +37,7 @@ RSpec.describe CharacterizeJob do
     context 'when the characterization proxy content is absent' do
       before { allow(file_set).to receive(:characterization_proxy?).and_return(false) }
       it 'raises an error' do
-        expect { described_class.perform_now(file_set, file.id) }.to raise_error(StandardError, /original_file was not found/)
+        expect { described_class.perform_now(file_set) }.to raise_error(StandardError, /original_file was not found/)
       end
     end
 
@@ -61,7 +51,7 @@ RSpec.describe CharacterizeJob do
       end
       it "reindexes the collection" do
         expect(collection).to receive(:update_index)
-        described_class.perform_now(file_set, file.id)
+        described_class.perform_now(file_set)
       end
     end
   end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -55,24 +55,4 @@ RSpec.describe CharacterizeJob do
       end
     end
   end
-
-  context 'when the work is a Valkyrie FileSet' do
-    let(:resource) { FactoryBot.create(:file_set, content: File.open(fixture_path + '/world.png')).valkyrie_resource }
-
-    before do
-      allow(Hydra::Works::CharacterizationService).to receive(:run) # .with(resource.characterization_proxy, resource.original_file.file_name)
-      allow(Hyrax.persister).to receive(:save) # .with(resource.characterization_proxy, resource.original_file.file_name)
-      # allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
-    end
-
-    it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
-      # expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-      # expect(file).to receive(:save!)
-      # expect(file_set).to receive(:update_index)
-      # byebug
-      expect(CreateDerivativesJob).to receive(:perform_later).with(resource, resource.original_file.id, anything)
-      expect(Hyrax.persister).to receive(:save).twice
-      described_class.perform_now(resource)
-    end
-  end
 end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -8,36 +8,12 @@ RSpec.describe CharacterizeJob do
         allow(fs).to receive(:update_index)
       end
     end
-    # let(:io)          { JobIoWrapper.new(file_set_id: file_set.id, user: create(:user), path: filename) }
     let(:file) do
       Hydra::PCDM::File.new.tap do |f|
         f.content = 'foo'
         f.original_name = 'picture.png'
         f.save!
         allow(f).to receive(:save!)
-      end
-    end
-
-    before do
-      allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
-      allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-      allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
-    end
-
-    context 'when the characterization proxy content is present' do
-      it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
-        expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-        expect(file).to receive(:save!)
-        expect(file_set).to receive(:update_index)
-        expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
-        described_class.perform_now(file_set)
-      end
-    end
-
-    context 'when the characterization proxy content is absent' do
-      before { allow(file_set).to receive(:characterization_proxy?).and_return(false) }
-      it 'raises an error' do
-        expect { described_class.perform_now(file_set) }.to raise_error(StandardError, /original_file was not found/)
       end
     end
 

--- a/spec/services/hyrax/file_set_characterizer_spec.rb
+++ b/spec/services/hyrax/file_set_characterizer_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Hyrax::FileSetCharacterizer do
+  subject(:characterizer) { described_class.new(source: file_set) }
+  let(:file_set_id) { 'abc12345' }
+  let(:filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
+  let(:file_set) do
+    FileSet.new(id: file_set_id).tap do |fs|
+      allow(fs).to receive(:original_file).and_return(file)
+      allow(fs).to receive(:update_index)
+    end
+  end
+  let(:file) do
+    Hydra::PCDM::File.new.tap do |f|
+      f.content = 'foo'
+      f.original_name = 'picture.png'
+      f.save!
+      allow(f).to receive(:save!)
+    end
+  end
+
+  before do
+    allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
+    allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+    allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+  end
+
+  context 'when the characterization proxy content is present' do
+    it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
+      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      expect(file).to receive(:save!)
+      expect(file_set).to receive(:update_index)
+      expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+      characterizer.characterize
+    end
+  end
+
+  context 'when the characterization proxy content is absent' do
+    before { allow(file_set).to receive(:characterization_proxy?).and_return(false) }
+    it 'raises an error' do
+      expect { characterizer.characterize }.to raise_error(StandardError, /original_file was not found/)
+    end
+  end
+end

--- a/spec/services/hyrax/file_set_characterizer_spec.rb
+++ b/spec/services/hyrax/file_set_characterizer_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Hyrax::FileSetCharacterizer do
   subject(:characterizer) { described_class.new(source: file_set) }
+
   let(:file_set_id) { 'abc12345' }
   let(:filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
   let(:file_set) do

--- a/spec/services/hyrax/resource_characterizer_spec.rb
+++ b/spec/services/hyrax/resource_characterizer_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Hyrax::ResourceCharacterizer do
   let(:resource) { FactoryBot.create(:file_set).valkyrie_resource }
 
   before do
+    allow(Hyrax::FileSet).to receive(:find).with(resource.id).and_return(resource)
     allow(Hydra::Works::CharacterizationService).to receive(:run)
     allow(Hyrax.persister).to receive(:save)
     allow(CreateDerivativesJob).to receive(:perform_later)

--- a/spec/services/hyrax/resource_characterizer_spec.rb
+++ b/spec/services/hyrax/resource_characterizer_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Hyrax::ResourceCharacterizer do
+  subject(:characterizer) { described_class.new(source: resource) }
+  let(:resource) { FactoryBot.create(:file_set).valkyrie_resource }
+
+  before do
+    allow(Hydra::Works::CharacterizationService).to receive(:run)
+    allow(Hyrax.persister).to receive(:save)
+    allow(CreateDerivativesJob).to receive(:perform_later)
+  end
+
+  context 'with a complete Valkyrie FileSet' do
+    let(:resource) { FactoryBot.create(:file_set, content: File.open(fixture_path + '/world.png')).valkyrie_resource }
+
+    it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
+      expect(Hydra::Works::CharacterizationService).to receive(:run).with(resource.original_file, anything)
+      expect(CreateDerivativesJob).to receive(:perform_later).with(resource, resource.original_file.id, anything)
+      expect(Hyrax.persister).to receive(:save).twice
+      characterizer.characterize
+    end
+  end
+
+  context 'without a complete Valkyrie FileSet' do
+    let(:resource) { FactoryBot.create(:file_set).valkyrie_resource }
+
+    before { allow(resource).to receive(:characterization_proxy?).and_return(false) }
+
+    it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
+      expect { characterizer.characterize }.to raise_error(StandardError, /original_file was not found/)
+    end
+  end
+end

--- a/spec/services/hyrax/resource_characterizer_spec.rb
+++ b/spec/services/hyrax/resource_characterizer_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe Hyrax::ResourceCharacterizer do
   subject(:characterizer) { described_class.new(source: resource) }
-  let(:resource) { FactoryBot.create(:file_set).valkyrie_resource }
 
   before do
     allow(Hyrax::FileSet).to receive(:find).with(resource.id).and_return(resource)


### PR DESCRIPTION
Fixes #4100  

This extracts the majority of the current CharacterizerJob into a Characterizer that implements individual characterize methods per FileSet type.

The pattern followed here was based on suggestion by @no-reply 

Note: the remainder of characterizer_job_spec can likely be removed after #4207

@samvera/hyrax-code-reviewers
