### PR TITLE
Create `FileSetDescription` to find characterization for FileSets

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -100,29 +100,28 @@ module Hyrax
         end
 
         def normalize_relation_for_active_fedora(relation)
-          return relation if relation.is_a? Symbol
           return relation.to_sym if relation.respond_to? :to_sym
 
-          # TODO: whereever these are set, they should use FileSet.*_use... making the casecmp unnecessary
-          return :original_file if relation.to_s.casecmp(Hyrax::FileMetadata::Use::ORIGINAL_FILE.to_s)
-          return :extracted_file if relation.to_s.casecmp(Hyrax::FileMetadata::Use::EXTRACTED_TEXT.to_s)
-          return :thumbnail_file if relation.to_s.casecmp(Hyrax::FileMetadata::Use::THUMBNAIL.to_s)
-          :original_file
+          case relation
+          when Hyrax::FileMetadata::Use::ORIGINAL_FILE
+            :original_file
+          when Hyrax::FileMetadata::Use::EXTRACTED_TEXT
+            :extracted_file
+          when Hyrax::FileMetadata::Use::THUMBNAIL
+            :thumbnail_file
+          else
+            :original_file
+          end
         end
 
+        ##
+        # @return [RDF::URI]
         def normalize_relation_for_valkyrie(relation)
-          # TODO: When this is fully switched to valkyrie, this should probably be removed and relation should always be passed
-          #       in as a valid URI already set to the file's use
-          case relation.to_s.to_sym
-          when :original_file
-            Hyrax::FileMetadata::Use::ORIGINAL_FILE
-          when :extracted_file
-            Hyrax::FileMetadata::Use::EXTRACTED_TEXT
-          when :thumbnail_file
-            Hyrax::FileMetadata::Use::THUMBNAIL
-          else
-            Hyrax::FileMetadata::Use::ORIGINAL_FILE
-          end
+          return relation if relation.is_a?(RDF::URI)
+
+          Hyrax::FileMetadata::Use.uri_for(use: relation.to_sym)
+        rescue ArgumentError
+          Hyrax::FileMetadata::Use::ORIGINAL_FILE
         end
     end
   end

--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -104,9 +104,9 @@ module Hyrax
           return relation.to_sym if relation.respond_to? :to_sym
 
           # TODO: whereever these are set, they should use FileSet.*_use... making the casecmp unnecessary
-          return :original_file if relation.to_s.casecmp(Hyrax::FileSet::ORIGINAL_FILE_USE.to_s)
-          return :extracted_file if relation.to_s.casecmp(Hyrax::FileSet::EXTRACTED_TEXT_USE.to_s)
-          return :thumbnail_file if relation.to_s.casecmp(Hyrax::FileSet::THUMBNAIL_USE.to_s)
+          return :original_file if relation.to_s.casecmp(Hyrax::FileMetadata::Use::ORIGINAL_FILE.to_s)
+          return :extracted_file if relation.to_s.casecmp(Hyrax::FileMetadata::Use::EXTRACTED_TEXT.to_s)
+          return :thumbnail_file if relation.to_s.casecmp(Hyrax::FileMetadata::Use::THUMBNAIL.to_s)
           :original_file
         end
 
@@ -115,13 +115,13 @@ module Hyrax
           #       in as a valid URI already set to the file's use
           case relation.to_s.to_sym
           when :original_file
-            Hyrax::FileSet::ORIGINAL_FILE_USE
+            Hyrax::FileMetadata::Use::ORIGINAL_FILE
           when :extracted_file
-            Hyrax::FileSet.EXTRACTED_TEXT_USE
+            Hyrax::FileMetadata::Use::EXTRACTED_TEXT
           when :thumbnail_file
-            Hyrax::FileSet::THUMBNAIL_USE
+            Hyrax::FileMetadata::Use::THUMBNAIL
           else
-            Hyrax::FileSet::ORIGINAL_FILE_USE
+            Hyrax::FileMetadata::Use::ORIGINAL_FILE
           end
         end
     end

--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -27,7 +27,7 @@ module Hyrax
       filter_docs_with_edit_access!
       copy_visibility = []
       copy_visibility = params[:embargoes].values.map { |h| h[:copy_visibility] } if params[:embargoes]
-      af_objects = Hyrax.query_service.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
+      af_objects = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
       af_objects.each do |curation_concern|
         Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
         # if the concern is a FileSet, set its visibility and visibility propagation

--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -26,7 +26,7 @@ module Hyrax
       filter_docs_with_edit_access!
       copy_visibility = []
       copy_visibility = params[:leases].values.map { |h| h[:copy_visibility] } if params[:leases]
-      af_objects = Hyrax.query_service.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
+      af_objects = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
       af_objects.each do |curation_concern|
         Hyrax::Actors::LeaseActor.new(curation_concern).destroy
         Hyrax::VisibilityPropagator.for(source: curation_concern).propagate if

--- a/app/jobs/concerns/hyrax/members_permission_job_behavior.rb
+++ b/app/jobs/concerns/hyrax/members_permission_job_behavior.rb
@@ -16,7 +16,7 @@ module Hyrax
         when ActiveFedora::Base
           ::FileSet.search_with_conditions(id: work.member_ids).map(&:id)
         when Valkyrie::Resource
-          Hyrax.query_service.custom_queries.find_child_fileset_ids(resource: work)
+          Hyrax.custom_queries.find_child_fileset_ids(resource: work)
         end
       end
 

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -55,7 +55,7 @@ module Hyrax
     #       add_member_objects using the member_of_collections relationship.  Deprecate?
     def add_members(new_member_ids)
       return if new_member_ids.blank?
-      members << Hyrax.query_service.custom_queries.find_many_by_alternate_ids(alternate_ids: new_member_ids, use_valkyrie: false)
+      members << Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: new_member_ids, use_valkyrie: false)
     end
 
     # Add member objects by adding this collection to the objects' member_of_collection association.

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -10,7 +10,7 @@ module Hyrax
     module Use
       ORIGINAL_FILE = ::Valkyrie::Vocab::PCDMUse.OriginalFile
       EXTRACTED_TEXT = ::Valkyrie::Vocab::PCDMUse.ExtractedText
-      THUMBNAIL = ::Valkyrie::Vocab::PCDMUse.Thumbnail
+      THUMBNAIL = ::Valkyrie::Vocab::PCDMUse.ThumbnailImage
 
       ##
       # @param use [Symbol]

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -21,7 +21,7 @@ module Hyrax
     attribute :label, ::Valkyrie::Types::Set
     attribute :original_filename, ::Valkyrie::Types::Set
     attribute :mime_type, ::Valkyrie::Types::String.default(GENERIC_MIME_TYPE)
-    attribute :type, ::Valkyrie::Types::Set # AF::File type
+    attribute :type, ::Valkyrie::Types::Set.default([Use::ORIGINAL_FILE])
     attribute :content, ::Valkyrie::Types::Set
 
     # attributes set by fits
@@ -86,8 +86,7 @@ module Hyrax
     def self.for(file:)
       new(label: file.original_filename,
           original_filename: file.original_filename,
-          mime_type: file.content_type,
-          type: file.try(:type) || [Use::ORIGINAL_FILE])
+          mime_type: file.content_type)
     end
 
     ##

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -4,6 +4,15 @@ module Hyrax
   class FileMetadata < Valkyrie::Resource
     GENERIC_MIME_TYPE = 'application/octet-stream'
 
+    ##
+    # Constants for PCDM Use URIs; use these constants in place of hard-coded
+    # URIs in the `::Valkyrie::Vocab::PCDMUse` vocabulary.
+    module Use
+      ORIGINAL_FILE = ::Valkyrie::Vocab::PCDMUse.OriginalFile
+      EXTRACTED_TEXT = ::Valkyrie::Vocab::PCDMUse.ExtractedText
+      THUMBNAIL = ::Valkyrie::Vocab::PCDMUse.Thumbnail
+    end
+
     attribute :file_identifiers, ::Valkyrie::Types::Set # id of the file stored by the storage adapter
     attribute :alternate_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID) # id of the Hydra::PCDM::File which holds metadata and the file in ActiveFedora
     attribute :file_set_id, ::Valkyrie::Types::ID # id of parent file set resource
@@ -78,7 +87,7 @@ module Hyrax
       new(label: file.original_filename,
           original_filename: file.original_filename,
           mime_type: file.content_type,
-          type: file.try(:type) || [Hyrax::FileSet::ORIGINAL_FILE_USE])
+          type: file.try(:type) || [Use::ORIGINAL_FILE])
     end
 
     ##
@@ -91,19 +100,19 @@ module Hyrax
     ##
     # @return [Boolean]
     def original_file?
-      type.include?(Hyrax::FileSet::ORIGINAL_FILE_USE)
+      type.include?(Use::ORIGINAL_FILE)
     end
 
     ##
     # @return [Boolean]
     def thumbnail_file?
-      type.include?(Hyrax::FileSet::THUMBNAIL_USE)
+      type.include?(Use::THUMBNAIL)
     end
 
     ##
     # @return [Boolean]
     def extracted_file?
-      type.include?(Hyrax::FileSet::EXTRACTED_TEXT_USE)
+      type.include?(Use::EXTRACTED_TEXT)
     end
 
     def title

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -11,6 +11,25 @@ module Hyrax
       ORIGINAL_FILE = ::Valkyrie::Vocab::PCDMUse.OriginalFile
       EXTRACTED_TEXT = ::Valkyrie::Vocab::PCDMUse.ExtractedText
       THUMBNAIL = ::Valkyrie::Vocab::PCDMUse.Thumbnail
+
+      ##
+      # @param use [Symbol]
+      #
+      # @return [RDF::URI]
+      # @raise [ArgumentError] if no use is known for the argument
+      def uri_for(use:)
+        case use
+        when :original_file
+          ORIGINAL_FILE
+        when :extracted_file
+          EXTRACTED_TEXT
+        when :thumbnail_file
+          THUMBNAIL
+        else
+          raise ArgumentError, "No PCDM use is recognized for #{use}"
+        end
+      end
+      module_function :uri_for
     end
 
     attribute :file_identifiers, ::Valkyrie::Types::Set # id of the file stored by the storage adapter
@@ -87,13 +106,6 @@ module Hyrax
       new(label: file.original_filename,
           original_filename: file.original_filename,
           mime_type: file.content_type)
-    end
-
-    ##
-    # @param [Symbol] use
-    # @return [Boolean]
-    def used_for?(use)
-      public_send("#{use}?")
     end
 
     ##

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -2,6 +2,8 @@
 
 module Hyrax
   class FileMetadata < Valkyrie::Resource
+    GENERIC_MIME_TYPE = 'application/octet-stream'
+
     attribute :file_identifiers, ::Valkyrie::Types::Set # id of the file stored by the storage adapter
     attribute :alternate_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID) # id of the Hydra::PCDM::File which holds metadata and the file in ActiveFedora
     attribute :file_set_id, ::Valkyrie::Types::ID # id of parent file set resource
@@ -9,7 +11,7 @@ module Hyrax
     # all remaining attributes are on AF::File metadata_node unless otherwise noted
     attribute :label, ::Valkyrie::Types::Set
     attribute :original_filename, ::Valkyrie::Types::Set
-    attribute :mime_type, ::Valkyrie::Types::Set
+    attribute :mime_type, ::Valkyrie::Types::String.default(GENERIC_MIME_TYPE)
     attribute :type, ::Valkyrie::Types::Set # AF::File type
     attribute :content, ::Valkyrie::Types::Set
 
@@ -79,14 +81,27 @@ module Hyrax
           type: file.try(:type) || [Hyrax::FileSet::ORIGINAL_FILE_USE])
     end
 
+    ##
+    # @param [Symbol] use
+    # @return [Boolean]
+    def used_for?(use)
+      public_send("#{use}?")
+    end
+
+    ##
+    # @return [Boolean]
     def original_file?
       type.include?(Hyrax::FileSet::ORIGINAL_FILE_USE)
     end
 
+    ##
+    # @return [Boolean]
     def thumbnail_file?
       type.include?(Hyrax::FileSet::THUMBNAIL_USE)
     end
 
+    ##
+    # @return [Boolean]
     def extracted_file?
       type.include?(Hyrax::FileSet::EXTRACTED_TEXT_USE)
     end

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -24,41 +24,5 @@ module Hyrax
     def file_set?
       true
     end
-
-    ##
-    # Gives file metadata for the file filling the http://pcdm.org/OriginalFile use
-    # @return [FileMetadata] the FileMetadata resource of the original file
-    def original_file
-      filter_files_by_type(Hyrax::FileMetadata::Use::ORIGINAL_FILE).first
-    end
-
-    ##
-    # Gives file metadata for the file filling the http://pcdm.org/ExtractedText use
-    # @return [FileMetadata] the FileMetadata resource of the extracted text
-    def extracted_text
-      filter_files_by_type(Hyrax::FileMetadata::Use::EXTRACTED_TEXT).first
-    end
-
-    ##
-    # Gives file metadata for the file filling the http://pcdm.org/Thumbnail use
-    # @return [FileMetadata] the FileMetadata resource of the thumbnail
-    def thumbnail
-      filter_files_by_type(Hyrax::FileMetadata::Use::THUMBNAIL).first
-    end
-
-    private
-
-      ##
-      # @api private
-      #
-      # Gives file metadata for files that have the requested RDF Type for use
-      # @param [RDF::URI] uri for the desired Type
-      # @return [Enumerable<FileMetadata>] the FileMetadata resources
-      #
-      # @example
-      #   filter_files_by_type(::RDF::URI("http://pcdm.org/ExtractedText"))
-      def filter_files_by_type(uri)
-        Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: uri)
-      end
   end
 end

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -8,10 +8,6 @@ module Hyrax
   class FileSet < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
 
-    ORIGINAL_FILE_USE = ::Valkyrie::Vocab::PCDMUse.OriginalFile
-    EXTRACTED_TEXT_USE = ::Valkyrie::Vocab::PCDMUse.ExtractedText
-    THUMBNAIL_USE = ::Valkyrie::Vocab::PCDMUse.Thumbnail
-
     attribute :file_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID) # id for FileMetadata resources
     attribute :original_file_id, Valkyrie::Types::ID # id for FileMetadata resource
     attribute :thumbnail_id, Valkyrie::Types::ID # id for FileMetadata resource
@@ -33,31 +29,36 @@ module Hyrax
     # Gives file metadata for the file filling the http://pcdm.org/OriginalFile use
     # @return [FileMetadata] the FileMetadata resource of the original file
     def original_file
-      filter_files_by_type(Hyrax::FileSet::ORIGINAL_FILE_USE).first
+      filter_files_by_type(Hyrax::FileMetadata::Use::ORIGINAL_FILE).first
     end
 
     ##
     # Gives file metadata for the file filling the http://pcdm.org/ExtractedText use
     # @return [FileMetadata] the FileMetadata resource of the extracted text
     def extracted_text
-      filter_files_by_type(Hyrax::FileSet::EXTRACTED_TEXT_USE).first
+      filter_files_by_type(Hyrax::FileMetadata::Use::EXTRACTED_TEXT).first
     end
 
     ##
     # Gives file metadata for the file filling the http://pcdm.org/Thumbnail use
     # @return [FileMetadata] the FileMetadata resource of the thumbnail
     def thumbnail
-      filter_files_by_type(Hyrax::FileSet::THUMBNAIL_USE).first
+      filter_files_by_type(Hyrax::FileMetadata::Use::THUMBNAIL).first
     end
 
-    ##
-    # Gives file metadata for files that have the requested RDF Type for use
-    # @param [RDF::URI] uri for the desired Type
-    # @return [Enumerable<FileMetadata>] the FileMetadata resources
-    # @example
-    #   filter_files_by_type(::RDF::URI("http://pcdm.org/ExtractedText"))
-    def filter_files_by_type(uri)
-      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: uri)
-    end
+    private
+
+      ##
+      # @api private
+      #
+      # Gives file metadata for files that have the requested RDF Type for use
+      # @param [RDF::URI] uri for the desired Type
+      # @return [Enumerable<FileMetadata>] the FileMetadata resources
+      #
+      # @example
+      #   filter_files_by_type(::RDF::URI("http://pcdm.org/ExtractedText"))
+      def filter_files_by_type(uri)
+        Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: uri)
+      end
   end
 end

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -80,7 +80,7 @@ class JobIoWrapper < ApplicationRecord
     Hyrax::FileMetadata.new(label: original_name,
                             original_filename: original_name,
                             mime_type: mime_type,
-                            use: [Hyrax::FileSet::ORIGINAL_FILE_USE])
+                            use: [Hyrax::FileMetadata::Use::ORIGINAL_FILE])
   end
 
   # The magic that switches *once* between local filepath and CarrierWave file

--- a/app/services/hyrax/characterization/file_set_description.rb
+++ b/app/services/hyrax/characterization/file_set_description.rb
@@ -38,7 +38,7 @@ module Hyrax
         ##
         # @api private
         def queries
-          Hyrax.query_service.custom_queries
+          Hyrax.custom_queries
         end
     end
   end

--- a/app/services/hyrax/characterization/file_set_description.rb
+++ b/app/services/hyrax/characterization/file_set_description.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Characterization
+    ##
+    # @api public
+    class FileSetDescription
+      include Hydra::Works::MimeTypes
+
+      ##
+      # @!attribute [rw] file_set
+      #   @return [Hyrax::FileSet]
+      attr_accessor :file_set
+
+      delegate :mime_type, to: :primary_file
+
+      ##
+      # @param [Hyrax::FileSet] file_set
+      # @param [Symbol] primary_file  a symbol mapping to the file_set member
+      #   used for characterization
+      def initialize(file_set:, primary_file: :original_file)
+        self.file_set = file_set
+        @primary_file = primary_file
+      end
+
+      ##
+      # @api public
+      # @return [Hyrax::FileMetadata] the member file to use for characterization
+      def primary_file
+        files.find { |f| f.used_for?(@primary_file) } || Hyrax::FileMetadata.new
+      end
+
+      private
+
+        ##
+        # @api private
+        def files
+          @__files__ ||= Hyrax.query_service.custom_queries.find_files(file_set: file_set)
+        end
+    end
+  end
+end

--- a/app/services/hyrax/characterization/file_set_description.rb
+++ b/app/services/hyrax/characterization/file_set_description.rb
@@ -20,22 +20,25 @@ module Hyrax
       #   used for characterization
       def initialize(file_set:, primary_file: :original_file)
         self.file_set = file_set
-        @primary_file = primary_file
+
+        @primary_file_type_uri =
+          Hyrax::FileMetadata::Use.uri_for(use: primary_file)
       end
 
       ##
       # @api public
       # @return [Hyrax::FileMetadata] the member file to use for characterization
       def primary_file
-        files.find { |f| f.used_for?(@primary_file) } || Hyrax::FileMetadata.new
+        queries.find_many_file_metadata_by_use(resource: file_set, use: @primary_file_type_uri).first ||
+          Hyrax::FileMetadata.new
       end
 
       private
 
         ##
         # @api private
-        def files
-          @__files__ ||= Hyrax.query_service.custom_queries.find_files(file_set: file_set)
+        def queries
+          Hyrax.query_service.custom_queries
         end
     end
   end

--- a/app/services/hyrax/custom_queries/find_access_control.rb
+++ b/app/services/hyrax/custom_queries/find_access_control.rb
@@ -1,7 +1,7 @@
 module Hyrax
   module CustomQueries
     # @example
-    #   Hyrax.query_service.custom_queries.find_access_control_for(resource: resource)
+    #   Hyrax.custom_queries.find_access_control_for(resource: resource)
     class FindAccessControl
       def self.queries
         [:find_access_control_for]

--- a/app/services/hyrax/custom_queries/find_file_metadata.rb
+++ b/app/services/hyrax/custom_queries/find_file_metadata.rb
@@ -9,7 +9,8 @@ module Hyrax
       def self.queries
         [:find_file_metadata_by,
          :find_file_metadata_by_alternate_identifier,
-         :find_many_file_metadata_by_ids]
+         :find_many_file_metadata_by_ids,
+         :find_many_file_metadata_by_use]
       end
 
       def initialize(query_service:)

--- a/app/services/hyrax/custom_queries/find_file_metadata.rb
+++ b/app/services/hyrax/custom_queries/find_file_metadata.rb
@@ -1,8 +1,8 @@
 # Provide custom queries for finding Hyrax::FileMetadata
 # @example
-#   Hyrax.query_service.custom_queries.find_file_metadata_by(id: valkyrie_id)
-#   Hyrax.query_service.custom_queries.find_file_metadata_by_alternate_identifier(alternate_identifier: alt_id)
-#   Hyrax.query_service.custom_queries.find_many_file_metadata_by_ids(ids: [valkyrie_id, valkyrie_id])
+#   Hyrax.custom_queries.find_file_metadata_by(id: valkyrie_id)
+#   Hyrax.custom_queries.find_file_metadata_by_alternate_identifier(alternate_identifier: alt_id)
+#   Hyrax.custom_queries.find_many_file_metadata_by_ids(ids: [valkyrie_id, valkyrie_id])
 module Hyrax
   module CustomQueries
     class FindFileMetadata

--- a/app/services/hyrax/custom_queries/find_many_by_alternate_ids.rb
+++ b/app/services/hyrax/custom_queries/find_many_by_alternate_ids.rb
@@ -2,7 +2,7 @@ module Hyrax
   module CustomQueries
     class FindManyByAlternateIds
       # Use:
-      #   Hyrax.query_service.custom_queries.find_many_by_alternate_ids(alternate_ids: ids)
+      #   Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: ids)
 
       def self.queries
         [:find_many_by_alternate_ids]

--- a/app/services/hyrax/custom_queries/navigators/find_files.rb
+++ b/app/services/hyrax/custom_queries/navigators/find_files.rb
@@ -3,10 +3,10 @@ module Hyrax
     module Navigators
       class FindFiles
         # @example
-        #   Hyrax.query_service.custom_queries.find_files(file_set: file_set_resource)
-        #   Hyrax.query_service.custom_queries.find_original_file(file_set: file_set_resource)
-        #   Hyrax.query_service.custom_queries.find_extracted_text(file_set: file_set_resource)
-        #   Hyrax.query_service.custom_queries.find_thumbnail(file_set: file_set_resource)
+        #   Hyrax.custom_queries.find_files(file_set: file_set_resource)
+        #   Hyrax.custom_queries.find_original_file(file_set: file_set_resource)
+        #   Hyrax.custom_queries.find_extracted_text(file_set: file_set_resource)
+        #   Hyrax.custom_queries.find_thumbnail(file_set: file_set_resource)
 
         def self.queries
           [:find_files,

--- a/app/services/hyrax/resource_visibility_propagator.rb
+++ b/app/services/hyrax/resource_visibility_propagator.rb
@@ -26,7 +26,7 @@ module Hyrax
                    embargo_manager: Hyrax::EmbargoManager,
                    lease_manager:   Hyrax::LeaseManager,
                    persister:       Hyrax.persister,
-                   queries:         Hyrax.query_service.custom_queries)
+                   queries:         Hyrax.custom_queries)
       @persister       = persister
       @queries         = queries
       self.source      = source

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -104,4 +104,10 @@ module Hyrax
   def self.query_service
     metadata_adapter.query_service
   end
+
+  ##
+  # The custom queries common to Hyrax
+  def self.custom_queries
+    query_service.custom_queries
+  end
 end

--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -44,7 +44,7 @@ module Wings
       # @return [Enumerable<ActiveFedora::Base> | Enumerable<Valkyrie::Resource>] an enumerable over the child collections
       # @todo There is no guarantee to collection ordering until Hyrax is fully valkyrie-native, see issue 3784
       def child_collections(valkyrie: false)
-        resources = Hyrax.query_service.custom_queries.find_child_collections(resource: self)
+        resources = Hyrax.custom_queries.find_child_collections(resource: self)
         return resources if valkyrie
         resources.map { |r| Wings::ActiveFedoraConverter.new(resource: r).convert }
       end

--- a/lib/wings/hydra/works/services/add_file_to_file_set.rb
+++ b/lib/wings/hydra/works/services/add_file_to_file_set.rb
@@ -37,9 +37,9 @@ module Wings::Works
         end
 
         def type_to_association_type(type)
-          return :original_file if type.to_s.casecmp?(Hyrax::FileSet::ORIGINAL_FILE_USE.to_s)
-          return :extracted_text if type.to_s.casecmp?(Hyrax::FileSet::EXTRACTED_TEXT_USE.to_s)
-          return :thumbnail if type.to_s.casecmp?(Hyrax::FileSet::THUMBNAIL_USE.to_s)
+          return :original_file if type.to_s.casecmp?(Hyrax::FileMetadata::Use::ORIGINAL_FILE.to_s)
+          return :extracted_text if type.to_s.casecmp?(Hyrax::FileMetadata::Use::EXTRACTED_TEXT.to_s)
+          return :thumbnail if type.to_s.casecmp?(Hyrax::FileMetadata::Use::THUMBNAIL.to_s)
         end
 
         def type_to_rdf_uri(type)

--- a/lib/wings/hydra/works/services/add_file_to_file_set.rb
+++ b/lib/wings/hydra/works/services/add_file_to_file_set.rb
@@ -37,9 +37,14 @@ module Wings::Works
         end
 
         def type_to_association_type(type)
-          return :original_file if type.to_s.casecmp?(Hyrax::FileMetadata::Use::ORIGINAL_FILE.to_s)
-          return :extracted_text if type.to_s.casecmp?(Hyrax::FileMetadata::Use::EXTRACTED_TEXT.to_s)
-          return :thumbnail if type.to_s.casecmp?(Hyrax::FileMetadata::Use::THUMBNAIL.to_s)
+          case type
+          when Hyrax::FileMetadata::Use::ORIGINAL_FILE
+            :original_file
+          when Hyrax::FileMetadata::Use::EXTRACTED_TEXT
+            :extracted_text
+          when Hyrax::FileMetadata::Use::THUMBNAIL
+            :thumbnail
+          end
         end
 
         def type_to_rdf_uri(type)

--- a/lib/wings/services/custom_queries/find_access_control.rb
+++ b/lib/wings/services/custom_queries/find_access_control.rb
@@ -3,7 +3,7 @@ module Wings
     class FindAccessControl
       # Custom query override specific to Wings
       # Use:
-      #   Hyrax.query_service.custom_queries.find_access_control_for(resource: resource)
+      #   Hyrax.custom_queries.find_access_control_for(resource: resource)
 
       def self.queries
         [:find_access_control_for]

--- a/lib/wings/services/custom_queries/find_file_metadata.rb
+++ b/lib/wings/services/custom_queries/find_file_metadata.rb
@@ -1,7 +1,7 @@
 # Custom query override specific to Wings for finding Hydra::PCDM::File and converting to Hyrax::FileMetadata.
 # @example
-#   Hyrax.query_service.custom_queries.find_file_metadata_by(id: valkyrie_id, use_valkyrie: true)
-#   Hyrax.query_service.custom_queries.find_file_metadata_by_alternate_identifier(alternate_identifier: id, use_valkyrie: true)
+#   Hyrax.custom_queries.find_file_metadata_by(id: valkyrie_id, use_valkyrie: true)
+#   Hyrax.custom_queries.find_file_metadata_by_alternate_identifier(alternate_identifier: id, use_valkyrie: true)
 require 'wings/services/file_converter_service'
 module Wings
   module CustomQueries

--- a/lib/wings/services/custom_queries/find_many_by_alternate_ids.rb
+++ b/lib/wings/services/custom_queries/find_many_by_alternate_ids.rb
@@ -3,7 +3,7 @@ module Wings
     class FindManyByAlternateIds
       # Custom query override specific to Wings
       # Use:
-      #   Hyrax.query_service.custom_queries.find_many_by_alternate_ids(alternate_ids: ids, use_valkyrie: true)
+      #   Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: ids, use_valkyrie: true)
 
       def self.queries
         [:find_many_by_alternate_ids]

--- a/lib/wings/services/file_metadata_builder.rb
+++ b/lib/wings/services/file_metadata_builder.rb
@@ -39,16 +39,28 @@ module Wings
 
     private
 
+      ##
+      # @api private
       def attach_file_metadata_to_valkyrie_file_set(file_metadata, file_set)
         # This is for storage adapters other than wings.  The wings storage adapter already attached the file to the file_set.
         # This process is a no-op for wings.  # TODO: WINGS - May need to verify this is a no-op for wings once file_set is passed in as a resource.
         # TODO: WINGS - Need to test this against other adapters once they are available for use.
-        existing_file_metadata = file_set.original_file || file_metadata
+        existing_file_metadata = current_original_file(file_set) || file_metadata
         file_metadata = existing_file_metadata.new(file_metadata.to_h.except(:id))
         saved_file_metadata = persister.save(resource: file_metadata)
         file_set.file_ids = [saved_file_metadata.id]
         persister.save(resource: file_set)
         saved_file_metadata
+      end
+
+      ##
+      # @api private
+      # @return [Hyrax::FileMetadata, nil]
+      def current_original_file(file_set)
+        Hyrax.query_service
+             .custom_queries
+             .find_many_file_metadata_by_use(resource: file_set, use: Hyrax::FileMetadata::Use::ORIGINAL_FILE)
+             .first
       end
 
       # Class for wrapping the file being ingested

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Hyrax::Actors::FileActor do
   context 'when using valkyrie' do
     let(:user)     { create(:user) }
     let(:file_set) { create(:file_set) }
-    let(:relation) { Hyrax::FileSet::ORIGINAL_FILE_USE }
+    let(:relation) { Hyrax::FileMetadata::Use::ORIGINAL_FILE }
     let(:actor)    { described_class.new(file_set, relation, user, use_valkyrie: true) }
     let(:fixture)  { fixture_file_upload('/world.png', 'image/png') }
     let(:huf) { Hyrax::UploadedFile.new(user: user, file: fixture) }

--- a/spec/jobs/visibility_copy_job_spec.rb
+++ b/spec/jobs/visibility_copy_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe VisibilityCopyJob do
   context 'context with a valkyrie resource' do
     let(:proxy)    { Hyrax::ActiveJobProxy.new(resource: resource) }
     let(:resource) { FactoryBot.create(:work_with_files).valkyrie_resource }
-    let(:queries)  { Hyrax.query_service.custom_queries }
+    let(:queries)  { Hyrax.custom_queries }
 
     it 'converts resource to proxy when enqueuing' do
       expect { described_class.perform_later(resource) }

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -23,15 +23,6 @@ RSpec.describe Hyrax::FileMetadata do
     expect(subject.type).to contain_exactly(described_class::Use::ORIGINAL_FILE)
   end
 
-  describe '#used_for?' do
-    it 'is true when type matches' do
-      expect { file_metadata.type = [Valkyrie::Vocab::PCDMUse.ThumbnailImage] }
-        .to change { file_metadata.used_for?(:original_file) }
-        .from(true)
-        .to false
-    end
-  end
-
   describe '#original_file?' do
     context 'when use says file is the original file' do
       before { subject.type = [described_class::Use::ORIGINAL_FILE, pcdm_file_uri] }

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -7,19 +7,29 @@ RSpec.describe Hyrax::FileMetadata do
     let(:resource_klass) { described_class }
   end
 
-  let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/world.png', 'image/png') }
-  let(:subject) do
+  subject(:file_metadata) do
     described_class.for(file: file).new(id: 'test_id', format_label: 'test_format_label')
   end
+
+  let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/world.png', 'image/png') }
   let(:pcdm_file_uri) { RDF::URI('http://pcdm.org/models#File') }
 
   it 'sets the proper attributes' do
     expect(subject.id.to_s).to eq 'test_id'
     expect(subject.label).to contain_exactly('world.png')
     expect(subject.original_filename).to contain_exactly('world.png')
-    expect(subject.mime_type).to contain_exactly('image/png')
+    expect(subject.mime_type).to eq('image/png')
     expect(subject.format_label).to contain_exactly('test_format_label')
     expect(subject.type).to contain_exactly(Hyrax::FileSet::ORIGINAL_FILE_USE)
+  end
+
+  describe '#used_for?' do
+    it 'is true when use matches' do
+      expect { file_metadata.use = [Valkyrie::Vocab::PCDMUse.ThumbnailImage] }
+        .to change { file_metadata.used_for?(:original_file) }
+        .from(true)
+        .to false
+    end
   end
 
   describe '#original_file?' do

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe Hyrax::FileMetadata do
     expect(subject.original_filename).to contain_exactly('world.png')
     expect(subject.mime_type).to eq('image/png')
     expect(subject.format_label).to contain_exactly('test_format_label')
-    expect(subject.type).to contain_exactly(Hyrax::FileSet::ORIGINAL_FILE_USE)
+    expect(subject.type).to contain_exactly(described_class::Use::ORIGINAL_FILE)
   end
 
   describe '#used_for?' do
-    it 'is true when use matches' do
-      expect { file_metadata.use = [Valkyrie::Vocab::PCDMUse.ThumbnailImage] }
+    it 'is true when type matches' do
+      expect { file_metadata.type = [Valkyrie::Vocab::PCDMUse.ThumbnailImage] }
         .to change { file_metadata.used_for?(:original_file) }
         .from(true)
         .to false
@@ -34,13 +34,13 @@ RSpec.describe Hyrax::FileMetadata do
 
   describe '#original_file?' do
     context 'when use says file is the original file' do
-      before { subject.type = [Hyrax::FileSet::ORIGINAL_FILE_USE, pcdm_file_uri] }
+      before { subject.type = [described_class::Use::ORIGINAL_FILE, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_original_file
       end
     end
     context 'when use does not say file is the original file' do
-      before { subject.type = [Hyrax::FileSet::THUMBNAIL_USE, pcdm_file_uri] }
+      before { subject.type = [described_class::Use::THUMBNAIL, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_original_file
       end
@@ -49,13 +49,13 @@ RSpec.describe Hyrax::FileMetadata do
 
   describe '#thumbnail_file?' do
     context 'when use says file is the thumbnail file' do
-      before { subject.type = [Hyrax::FileSet::THUMBNAIL_USE, pcdm_file_uri] }
+      before { subject.type = [described_class::Use::THUMBNAIL, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_thumbnail_file
       end
     end
     context 'when use does not say file is the thumbnail file' do
-      before { subject.type = [Hyrax::FileSet::ORIGINAL_FILE_USE, pcdm_file_uri] }
+      before { subject.type = [described_class::Use::ORIGINAL_FILE, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_thumbnail_file
       end
@@ -64,13 +64,13 @@ RSpec.describe Hyrax::FileMetadata do
 
   describe '#extracted_file?' do
     context 'when use says file is the extracted file' do
-      before { subject.type = [Hyrax::FileSet::EXTRACTED_TEXT_USE, pcdm_file_uri] }
+      before { subject.type = [described_class::Use::EXTRACTED_TEXT, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_extracted_file
       end
     end
     context 'when use does not say file is the extracted file' do
-      before { subject.type = [Hyrax::FileSet::ORIGINAL_FILE_USE, pcdm_file_uri] }
+      before { subject.type = [described_class::Use::ORIGINAL_FILE, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_extracted_file
       end

--- a/spec/services/hyrax/characterization/file_set_description_spec.rb
+++ b/spec/services/hyrax/characterization/file_set_description_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Characterization::FileSetDescription, valkyrie_adapter: :test_adapter do
+  subject(:description) { described_class.new(file_set: file_set) }
+
+  let(:ctype) { 'image/png' }
+  let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/world.png', ctype) }
+  let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set, file_ids: file_ids) }
+  let(:file_ids) { [] }
+
+  describe '#mime_type' do
+    context 'before the file set is saved' do
+      let(:file_set) { FactoryBot.build(:hyrax_file_set) }
+
+      it 'has a generic MIME type' do
+        expect(description.mime_type).to eq 'application/octet-stream'
+      end
+    end
+
+    context 'when it has no files' do
+      it 'has a generic MIME type' do
+        expect(description.mime_type).to eq 'application/octet-stream'
+      end
+    end
+
+    context 'when it has an original file' do
+      let(:file_ids) { [original_file.id] }
+      let(:original_file) { Hyrax.persister.save(resource: Hyrax::FileMetadata.for(file: file)) }
+
+      it { is_expected.to be_image }
+
+      it 'has a mime type from a file' do
+        expect(description.mime_type).to eq ctype
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
     it 'lists queries' do
       expect(described_class.queries).to eq [:find_file_metadata_by,
                                              :find_file_metadata_by_alternate_identifier,
-                                             :find_many_file_metadata_by_ids]
+                                             :find_many_file_metadata_by_ids,
+                                             :find_many_file_metadata_by_use]
     end
   end
 

--- a/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
@@ -103,9 +103,9 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
     let!(:et_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, type: extracted_text_use) }
     let!(:th_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, type: thumbnail_use) }
 
-    let(:original_file_use)  { Hyrax::FileSet::ORIGINAL_FILE_USE }
-    let(:extracted_text_use) { Hyrax::FileSet::EXTRACTED_TEXT_USE }
-    let(:thumbnail_use)      { Hyrax::FileSet::THUMBNAIL_USE }
+    let(:original_file_use)  { Hyrax::FileMetadata::Use::ORIGINAL_FILE }
+    let(:extracted_text_use) { Hyrax::FileMetadata::Use::EXTRACTED_TEXT }
+    let(:thumbnail_use)      { Hyrax::FileMetadata::Use::THUMBNAIL }
 
     context 'when file set has files of the requested use' do
       let!(:file_set) { FactoryBot.create_using_test_adapter(:hyrax_file_set, files: [of_file_metadata, et_file_metadata, th_file_metadata]) }

--- a/spec/services/hyrax/custom_queries/navigators/child_collections_navigator_spec.rb
+++ b/spec/services/hyrax/custom_queries/navigators/child_collections_navigator_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator, :clean_repo do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
   let(:resource) { subject.build }
-  let(:custom_query_service) { Hyrax.query_service.custom_queries }
+  let(:custom_query_service) { Hyrax.custom_queries }
 
   let(:collection1)    { build(:collection, id: 'col1', title: ['Collection 1']) }
   let(:collection2)    { build(:collection, id: 'col2', title: ['Child Collection 1']) }

--- a/spec/services/hyrax/custom_queries/navigators/child_filesets_navigator_spec.rb
+++ b/spec/services/hyrax/custom_queries/navigators/child_filesets_navigator_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator, :clean_repo do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
   let(:resource) { subject.build }
-  let(:custom_query_service) { Hyrax.query_service.custom_queries }
+  let(:custom_query_service) { Hyrax.custom_queries }
 
   let(:work1)    { build(:work, id: 'wk1', title: ['Work 1']) }
   let(:work2)    { build(:work, id: 'wk2', title: ['Child Work 1']) }

--- a/spec/services/hyrax/custom_queries/navigators/child_works_navigator_spec.rb
+++ b/spec/services/hyrax/custom_queries/navigators/child_works_navigator_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Hyrax::CustomQueries::Navigators::ChildWorksNavigator, :clean_rep
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
 
   let(:resource) { subject.build }
-  let(:custom_query_service) { Hyrax.query_service.custom_queries }
+  let(:custom_query_service) { Hyrax.custom_queries }
 
   let(:collection1)    { build(:collection, id: 'col1', title: ['Collection 1']) }
   let(:collection2)    { build(:collection, id: 'col2', title: ['Child Collection 1']) }

--- a/spec/services/hyrax/resource_visibility_propagator_spec.rb
+++ b/spec/services/hyrax/resource_visibility_propagator_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Hyrax::ResourceVisibilityPropagator do
   subject(:propagator) { described_class.new(source: work) }
-  let(:queries)        { Hyrax.query_service.custom_queries }
+  let(:queries)        { Hyrax.custom_queries }
   let(:work)           { FactoryBot.create(:work_with_files).valkyrie_resource }
   let(:file_sets)      { queries.find_child_filesets(resource: work) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -310,4 +310,12 @@ RSpec.configure do |config|
     ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = false
     ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
   end
+
+  config.before(:example, :valkyrie_adapter) do |example|
+    adapter_name = example.metadata[:valkyrie_adapter]
+
+    allow(Hyrax)
+      .to receive(:metadata_adapter)
+      .and_return(Valkyrie::MetadataAdapter.find(adapter_name))
+  end
 end

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
         expect(ids.first).to be_a Valkyrie::ID
         expect(ids.first.to_s).to start_with "#{file_set.id}/files/"
 
-        file_metadata = Hyrax.query_service.custom_queries.find_file_metadata_by(id: ids.first)
+        file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: ids.first)
         expect(file_metadata.content.first).to start_with('%PDF-1.3')
         expect(file_metadata.mime_type.first).to eq pdf_mimetype
       end
@@ -47,7 +47,7 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
         expect(ids.first).to be_a Valkyrie::ID
         expect(ids.first.to_s).to start_with "#{file_set.id}/files/"
 
-        file_metadata = Hyrax.query_service.custom_queries.find_file_metadata_by(id: ids.first)
+        file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: ids.first)
         expect(file_metadata.content.first).to start_with('some updated content')
         expect(file_metadata.mime_type.first).to eq text_mimetype
       end
@@ -61,7 +61,7 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
         expect(ids.first).to be_a Valkyrie::ID
         expect(ids.first.to_s).to start_with "#{file_set.id}/files/"
 
-        file_metadata = Hyrax.query_service.custom_queries.find_file_metadata_by(id: ids.first)
+        file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: ids.first)
         expect(file_metadata.content.first.present?).to eq true
         expect(file_metadata.mime_type.first).to eq image_mimetype
       end
@@ -82,8 +82,8 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
       expect(ids.first).to be_a Valkyrie::ID
       expect(ids.first.to_s).to start_with "#{file_set.id}/files/"
 
-      expect(Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: subject, use: transcript_use).first.content.first).to start_with('some updated content')
-      expect(Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: subject, use: service_file_use).first.content.first).to start_with('%PDF-1.3')
+      expect(Hyrax.custom_queries.find_many_file_metadata_by_use(resource: subject, use: transcript_use).first.content.first).to start_with('some updated content')
+      expect(Hyrax.custom_queries.find_many_file_metadata_by_use(resource: subject, use: service_file_use).first.content.first).to start_with('%PDF-1.3')
     end
   end
 

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
   let(:af_file_set)             { create(:file_set, id: 'fileset_id') }
   let!(:file_set)               { af_file_set.valkyrie_resource }
 
-  let(:original_file_use)  { Hyrax::FileSet::ORIGINAL_FILE_USE }
-  let(:extracted_text_use) { Hyrax::FileSet::EXTRACTED_TEXT_USE }
-  let(:thumbnail_use)      { Hyrax::FileSet::THUMBNAIL_USE }
+  let(:original_file_use)  { Hyrax::FileMetadata::Use::ORIGINAL_FILE }
+  let(:extracted_text_use) { Hyrax::FileMetadata::Use::EXTRACTED_TEXT }
+  let(:thumbnail_use)      { Hyrax::FileMetadata::Use::THUMBNAIL }
 
   let(:pdf_filename)  { 'sample-file.pdf' }
   let(:pdf_mimetype)  { 'application/pdf' }

--- a/spec/wings/services/custom_queries/find_file_metadata_spec.rb
+++ b/spec/wings/services/custom_queries/find_file_metadata_spec.rb
@@ -119,9 +119,9 @@ RSpec.describe Wings::CustomQueries::FindFileMetadata, :clean_repo do
     let(:af_file_set)             { create(:file_set, id: 'fileset_id') }
     let!(:file_set)               { af_file_set.valkyrie_resource }
 
-    let(:original_file_use)  { Hyrax::FileSet::ORIGINAL_FILE_USE }
-    let(:extracted_text_use) { Hyrax::FileSet::EXTRACTED_TEXT_USE }
-    let(:thumbnail_use)      { Hyrax::FileSet::THUMBNAIL_USE }
+    let(:original_file_use)  { Hyrax::FileMetadata::Use::ORIGINAL_FILE }
+    let(:extracted_text_use) { Hyrax::FileMetadata::Use::EXTRACTED_TEXT }
+    let(:thumbnail_use)      { Hyrax::FileMetadata::Use::THUMBNAIL }
 
     let(:pdf_filename)  { 'sample-file.pdf' }
     let(:pdf_mimetype)  { 'application/pdf' }

--- a/spec/wings/services/file_metadata_builder_spec.rb
+++ b/spec/wings/services/file_metadata_builder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Wings::FileMetadataBuilder do
   let(:file)          { File.open(File.join(fixture_path, original_name)) }
   let(:original_name) { 'sample-file.pdf' }
   let(:mime_type)     { 'application/pdf' }
-  let(:use)           { Hyrax::FileSet::ORIGINAL_FILE_USE }
+  let(:use)           { Hyrax::FileMetadata::Use::ORIGINAL_FILE }
 
   let(:original_file_metadata) do
     Hyrax::FileMetadata.new(label: original_name,

--- a/spec/wings/services/file_metadata_builder_spec.rb
+++ b/spec/wings/services/file_metadata_builder_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Wings::FileMetadataBuilder do
       expect(built_file_metadata.file_set_id.id).to eq file_set.id.id
       expect(built_file_metadata.label).to contain_exactly(original_name)
       expect(built_file_metadata.original_filename).to contain_exactly(original_name)
-      expect(built_file_metadata.mime_type).to contain_exactly(mime_type)
+      expect(built_file_metadata.mime_type).to eq mime_type
       expect(built_file_metadata.type).to contain_exactly(use)
     end
   end


### PR DESCRIPTION
**For discussion as possible input for #4213** 

Valkyrie-based FileSet objects don't have direct access to characterization
information. In ActiveFedora, we used a `#characterization_proxy` to provide
that information. Here, we provide a small service that can find the "primary"
file (`FileMetadata`) for a given FileSet, and ask it about its description.

Closes #4226

@samvera/hyrax-code-reviewers
