### PR TITLE
Index listener

### DIFF
--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Hyrax.publisher.subscribe(Hyrax::Listeners::AclIndexListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::MetadataIndexListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::BatchNotificationListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
@@ -10,6 +11,7 @@ Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleNotificationListener
 # When callbacks are removed and replaced with direct event publication, drop these blocks
 Hyrax.config.callback.set(:after_create_concern, warn: false) do |curation_concern, user|
   Hyrax.publisher.publish('object.deposited', object: curation_concern, user: user)
+  Hyrax.publisher.publish('object.metadata.updated', object: curation_concern, user: user)
 end
 
 Hyrax.config.callback.set(:after_create_fileset, warn: false) do |file_set, user|

--- a/spec/actors/hyrax/actors/generic_work_actor_spec.rb
+++ b/spec/actors/hyrax/actors/generic_work_actor_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe Hyrax::Actors::GenericWorkActor do
           .to change { listener.object_deposited&.payload }
           .to eq object: curation_concern, user: user
       end
+
+      it 'publishes an object.metadata.updated event' do
+        expect { middleware.create(env) }
+          .to change { listener.object_metadata_updated&.payload }
+          .to eq object: curation_concern, user: user
+      end
     end
 
     context 'valid attributes', perform_enqueued: [AttachFilesToWorkJob, IngestJob] do


### PR DESCRIPTION
Adds `Hyrax.publisher.subscribe(Hyrax::Listeners::MetadataIndexListener.new)` to `config/initializers/listeners.rb`

Adds publishing an `object.metadata.updated` event to the `after_create_concern` callback.