### PR TITLE
Removes configurability for resource indexer in solr indexing adapter

### DIFF
--- a/config/initializers/indexing_adapter_initializer.rb
+++ b/config/initializers/indexing_adapter_initializer.rb
@@ -5,9 +5,7 @@ require 'valkyrie/indexing/null_indexing_adapter'
 
 Rails.application.config.to_prepare do
   Valkyrie::IndexingAdapter.register(
-    Valkyrie::Indexing::Solr::IndexingAdapter.new(
-      resource_indexer: Hyrax::ValkyrieIndexer
-    ),
+    Valkyrie::Indexing::Solr::IndexingAdapter.new(),
     :solr_index
   )
   Valkyrie::IndexingAdapter.register(

--- a/config/initializers/indexing_adapter_initializer.rb
+++ b/config/initializers/indexing_adapter_initializer.rb
@@ -5,7 +5,7 @@ require 'valkyrie/indexing/null_indexing_adapter'
 
 Rails.application.config.to_prepare do
   Valkyrie::IndexingAdapter.register(
-    Valkyrie::Indexing::Solr::IndexingAdapter.new(),
+    Valkyrie::Indexing::Solr::IndexingAdapter.new,
     :solr_index
   )
   Valkyrie::IndexingAdapter.register(

--- a/lib/valkyrie/indexing/solr/indexing_adapter.rb
+++ b/lib/valkyrie/indexing/solr/indexing_adapter.rb
@@ -9,7 +9,7 @@ module Valkyrie
         ##
         # @!attribute [r] connection
         #   @return [RSolr::Client]
-        attr_reader :connection, :resource_indexer
+        attr_reader :connection
 
         ##
         # @param connection [RSolr::Client] The RSolr connection to index to.

--- a/lib/valkyrie/indexing/solr/indexing_adapter.rb
+++ b/lib/valkyrie/indexing/solr/indexing_adapter.rb
@@ -9,17 +9,13 @@ module Valkyrie
         ##
         # @!attribute [r] connection
         #   @return [RSolr::Client]
-        # @!attribute [r] resource_indexer
-        #   @return [Class]
         attr_reader :connection, :resource_indexer
 
         ##
         # @param connection [RSolr::Client] The RSolr connection to index to.
-        # @param resource_indexer [Class, #to_solr] An indexer which is able to
-        #   receive a `resource` argument and then has an instance method `#to_solr`
-        def initialize(connection: default_connection, resource_indexer: default_indexer)
+        def initialize(connection: default_connection)
           @connection = connection
-          @resource_indexer = resource_indexer
+          @resource_indexer = default_indexer
         end
 
         def save(resource:)

--- a/lib/valkyrie/indexing/solr/indexing_adapter.rb
+++ b/lib/valkyrie/indexing/solr/indexing_adapter.rb
@@ -48,7 +48,7 @@ module Valkyrie
           end
 
           def solr_document(resource)
-            resource_indexer.for(resource: resource).to_solr
+            @resource_indexer.for(resource: resource).to_solr
           end
 
           def add_documents(documents)

--- a/lib/valkyrie/indexing/solr/indexing_adapter.rb
+++ b/lib/valkyrie/indexing/solr/indexing_adapter.rb
@@ -15,7 +15,6 @@ module Valkyrie
         # @param connection [RSolr::Client] The RSolr connection to index to.
         def initialize(connection: default_connection)
           @connection = connection
-          @resource_indexer = default_indexer
         end
 
         def save(resource:)
@@ -48,7 +47,7 @@ module Valkyrie
           end
 
           def solr_document(resource)
-            @resource_indexer.for(resource: resource).to_solr
+            resource_indexer.for(resource: resource).to_solr
           end
 
           def add_documents(documents)
@@ -89,7 +88,7 @@ module Valkyrie
             RSolr.connect(url: connection_url)
           end
 
-          def default_indexer
+          def resource_indexer
             Hyrax::ValkyrieIndexer
           end
       end

--- a/lib/valkyrie/indexing/solr/indexing_adapter.rb
+++ b/lib/valkyrie/indexing/solr/indexing_adapter.rb
@@ -90,7 +90,7 @@ module Valkyrie
           end
 
           def default_indexer
-            Valkyrie::Persistence::Solr::MetadataAdapter::NullIndexer
+            Hyrax::ValkyrieIndexer
           end
       end
     end


### PR DESCRIPTION
Fixes #issuenumber ; refs #issuenumber

This PR pushes up some changes that had been discussed at Solar Vortex. There is not much of a reason to have a configurable indexer for the Indexing adapters. This is for the fact that indexing adapters will be the piece that is created and registered. So if someone wishes to use a new resource indexer in a specific adapter, they would either swap it or register a new indexer. 

There are no tests that tested the configurability of the adapter as it was a way to create an ambiguous enough interface for testing purposes. 

@samvera/hyrax-code-reviewers
