### PR TITLE
handle conversion of custom use types for files

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -103,10 +103,10 @@ module Hyrax
           return relation if relation.is_a? Symbol
           return relation.to_sym if relation.respond_to? :to_sym
 
-          # TODO: whereever these are set, they should use Valkyrie::Vocab::PCDMUse... making the casecmp unnecessary
-          return :original_file if relation.to_s.casecmp(Valkyrie::Vocab::PCDMUse.original_file.to_s)
-          return :extracted_file if relation.to_s.casecmp(Valkyrie::Vocab::PCDMUse.extracted_file.to_s)
-          return :thumbnail_file if relation.to_s.casecmp(Valkyrie::Vocab::PCDMUse.thumbnail_file.to_s)
+          # TODO: whereever these are set, they should use FileSet.*_use... making the casecmp unnecessary
+          return :original_file if relation.to_s.casecmp(Hyrax::FileSet.original_file_use.to_s)
+          return :extracted_file if relation.to_s.casecmp(Hyrax::FileSet.extracted_text_use.to_s)
+          return :thumbnail_file if relation.to_s.casecmp(Hyrax::FileSet.thumbnail_use.to_s)
           :original_file
         end
 
@@ -114,10 +114,10 @@ module Hyrax
           # TODO: When this is fully switched to valkyrie, this should probably be removed and relation should always be passed
           #       in as a valid URI already set to the file's use
           relation = relation.to_s.to_sym
-          return Valkyrie::Vocab::PCDMUse.original_file if relation == :original_file
-          return Valkyrie::Vocab::PCDMUse.extracted_file if relation == :extracted_file
-          return Valkyrie::Vocab::PCDMUse.thumbnail_file if relation == :thumbnail_file
-          Valkyrie::Vocab::PCDMUse.original_file
+          return Hyrax::FileSet.original_file_use if relation == :original_file
+          return FileSet.extracted_file_use if relation == :extracted_file
+          return FileSet.thumbnail_file_use if relation == :thumbnail_file
+          Hyrax::FileSet.original_file_use
         end
     end
   end

--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -113,11 +113,16 @@ module Hyrax
         def normalize_relation_for_valkyrie(relation)
           # TODO: When this is fully switched to valkyrie, this should probably be removed and relation should always be passed
           #       in as a valid URI already set to the file's use
-          relation = relation.to_s.to_sym
-          return Hyrax::FileSet::ORIGINAL_FILE_USE if relation == :original_file
-          return FileSet.extracted_file_use if relation == :extracted_file
-          return FileSet.thumbnail_file_use if relation == :thumbnail_file
-          Hyrax::FileSet::ORIGINAL_FILE_USE
+          case relation.to_s.to_sym
+          when :original_file
+            Hyrax::FileSet::ORIGINAL_FILE_USE
+          when :extracted_file
+            Hyrax::FileSet.EXTRACTED_TEXT_USE
+          when :thumbnail_file
+            Hyrax::FileSet::THUMBNAIL_USE
+          else
+            Hyrax::FileSet::ORIGINAL_FILE_USE
+          end
         end
     end
   end

--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -104,9 +104,9 @@ module Hyrax
           return relation.to_sym if relation.respond_to? :to_sym
 
           # TODO: whereever these are set, they should use FileSet.*_use... making the casecmp unnecessary
-          return :original_file if relation.to_s.casecmp(Hyrax::FileSet.original_file_use.to_s)
-          return :extracted_file if relation.to_s.casecmp(Hyrax::FileSet.extracted_text_use.to_s)
-          return :thumbnail_file if relation.to_s.casecmp(Hyrax::FileSet.thumbnail_use.to_s)
+          return :original_file if relation.to_s.casecmp(Hyrax::FileSet::ORIGINAL_FILE_USE.to_s)
+          return :extracted_file if relation.to_s.casecmp(Hyrax::FileSet::EXTRACTED_TEXT_USE.to_s)
+          return :thumbnail_file if relation.to_s.casecmp(Hyrax::FileSet::THUMBNAIL_USE.to_s)
           :original_file
         end
 
@@ -114,10 +114,10 @@ module Hyrax
           # TODO: When this is fully switched to valkyrie, this should probably be removed and relation should always be passed
           #       in as a valid URI already set to the file's use
           relation = relation.to_s.to_sym
-          return Hyrax::FileSet.original_file_use if relation == :original_file
+          return Hyrax::FileSet::ORIGINAL_FILE_USE if relation == :original_file
           return FileSet.extracted_file_use if relation == :extracted_file
           return FileSet.thumbnail_file_use if relation == :thumbnail_file
-          Hyrax::FileSet.original_file_use
+          Hyrax::FileSet::ORIGINAL_FILE_USE
         end
     end
   end

--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -77,7 +77,7 @@ module Hyrax
         def perform_ingest_file_through_valkyrie(io)
           # Skip versioning because versions will be minted by VersionCommitter as necessary during save_characterize_and_record_committer.
           unsaved_file_metadata = io.to_file_metadata
-          unsaved_file_metadata.use = relation
+          unsaved_file_metadata.type = [relation]
           begin
             saved_file_metadata = file_metadata_builder.create(io_wrapper: io, file_metadata: unsaved_file_metadata, file_set: file_set)
           rescue StandardError => e # Handle error persisting file metadata

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -76,19 +76,19 @@ module Hyrax
       new(label: file.original_filename,
           original_filename: file.original_filename,
           mime_type: file.content_type,
-          use: file.try(:use) || [::Valkyrie::Vocab::PCDMUse.OriginalFile])
+          use: file.try(:use) || [Hyrax::FileSet.original_file_use])
     end
 
     def original_file?
-      use.include?(::Valkyrie::Vocab::PCDMUse.OriginalFile)
+      use.include?(Hyrax::FileSet.original_file_use)
     end
 
     def thumbnail_file?
-      use.include?(::Valkyrie::Vocab::PCDMUse.ThumbnailImage)
+      use.include?(Hyrax::FileSet.thumbnail_use)
     end
 
     def extracted_file?
-      use.include?(::Valkyrie::Vocab::PCDMUse.ExtractedImage)
+      use.include?(Hyrax::FileSet.extracted_text_use)
     end
 
     def title

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -76,19 +76,19 @@ module Hyrax
       new(label: file.original_filename,
           original_filename: file.original_filename,
           mime_type: file.content_type,
-          type: file.try(:type) || [Hyrax::FileSet.original_file_use])
+          type: file.try(:type) || [Hyrax::FileSet::ORIGINAL_FILE_USE])
     end
 
     def original_file?
-      type.include?(Hyrax::FileSet.original_file_use)
+      type.include?(Hyrax::FileSet::ORIGINAL_FILE_USE)
     end
 
     def thumbnail_file?
-      type.include?(Hyrax::FileSet.thumbnail_use)
+      type.include?(Hyrax::FileSet::THUMBNAIL_USE)
     end
 
     def extracted_file?
-      type.include?(Hyrax::FileSet.extracted_text_use)
+      type.include?(Hyrax::FileSet::EXTRACTED_TEXT_USE)
     end
 
     def title

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -10,7 +10,7 @@ module Hyrax
     attribute :label, ::Valkyrie::Types::Set
     attribute :original_filename, ::Valkyrie::Types::Set
     attribute :mime_type, ::Valkyrie::Types::Set
-    attribute :use, ::Valkyrie::Types::Set # AF::File type
+    attribute :type, ::Valkyrie::Types::Set # AF::File type
     attribute :content, ::Valkyrie::Types::Set
 
     # attributes set by fits
@@ -76,19 +76,19 @@ module Hyrax
       new(label: file.original_filename,
           original_filename: file.original_filename,
           mime_type: file.content_type,
-          use: file.try(:use) || [Hyrax::FileSet.original_file_use])
+          type: file.try(:type) || [Hyrax::FileSet.original_file_use])
     end
 
     def original_file?
-      use.include?(Hyrax::FileSet.original_file_use)
+      type.include?(Hyrax::FileSet.original_file_use)
     end
 
     def thumbnail_file?
-      use.include?(Hyrax::FileSet.thumbnail_use)
+      type.include?(Hyrax::FileSet.thumbnail_use)
     end
 
     def extracted_file?
-      use.include?(Hyrax::FileSet.extracted_text_use)
+      type.include?(Hyrax::FileSet.extracted_text_use)
     end
 
     def title

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -29,7 +29,6 @@ module Hyrax
     # Gives file metadata for the file filling the http://pcdm.org/OriginalFile use
     # @return [FileMetadata] the FileMetadata resource of the original file
     def original_file
-      Hyrax.query_service.custom_queries.find_file_metadata_by(id: original_file_id)
       Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.original_file_use)
     end
 
@@ -37,7 +36,6 @@ module Hyrax
     # Gives file metadata for the file filling the http://pcdm.org/ExtractedText use
     # @return [FileMetadata] the FileMetadata resource of the extracted text
     def extracted_text
-      # Hyrax.query_service.custom_queries.find_file_metadata_by(id: extracted_text_id)
       Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.extracted_text_use)
     end
 
@@ -45,7 +43,6 @@ module Hyrax
     # Gives file metadata for the file filling the http://pcdm.org/Thumbnail use
     # @return [FileMetadata] the FileMetadata resource of the thumbnail
     def thumbnail
-      # Hyrax.query_service.custom_queries.find_file_metadata_by(id: thumbnail_id)
       Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.thumbnail_use)
     end
 

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -8,6 +8,10 @@ module Hyrax
   class FileSet < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
 
+    ORIGINAL_FILE_USE = ::Valkyrie::Vocab::PCDMUse.OriginalFile
+    EXTRACTED_TEXT_USE = ::Valkyrie::Vocab::PCDMUse.ExtractedText
+    THUMBNAIL_USE = ::Valkyrie::Vocab::PCDMUse.Thumbnail
+
     attribute :file_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID) # id for FileMetadata resources
     attribute :original_file_id, Valkyrie::Types::ID # id for FileMetadata resource
     attribute :thumbnail_id, Valkyrie::Types::ID # id for FileMetadata resource
@@ -29,21 +33,21 @@ module Hyrax
     # Gives file metadata for the file filling the http://pcdm.org/OriginalFile use
     # @return [FileMetadata] the FileMetadata resource of the original file
     def original_file
-      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.original_file_use).first
+      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet::ORIGINAL_FILE_USE).first
     end
 
     ##
     # Gives file metadata for the file filling the http://pcdm.org/ExtractedText use
     # @return [FileMetadata] the FileMetadata resource of the extracted text
     def extracted_text
-      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.extracted_text_use).first
+      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet::EXTRACTED_TEXT_USE).first
     end
 
     ##
     # Gives file metadata for the file filling the http://pcdm.org/Thumbnail use
     # @return [FileMetadata] the FileMetadata resource of the thumbnail
     def thumbnail
-      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.thumbnail_use).first
+      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet::THUMBNAIL_USE).first
     end
 
     ##
@@ -54,24 +58,6 @@ module Hyrax
     #   filter_files_by_type(::RDF::URI("http://pcdm.org/ExtractedText"))
     def filter_files_by_type(uri)
       Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: uri)
-    end
-
-    ##
-    # @return [RDF::URI] RDF Type for original file use
-    def self.original_file_use
-      ::Valkyrie::Vocab::PCDMUse.OriginalFile
-    end
-
-    ##
-    # @return [RDF::URI] RDF Type for extracted text use
-    def self.extracted_text_use
-      ::Valkyrie::Vocab::PCDMUse.ExtractedText
-    end
-
-    ##
-    # @return [RDF::URI] RDF Type for thumbnail use
-    def self.thumbnail_use
-      ::Valkyrie::Vocab::PCDMUse.Thumbnail
     end
   end
 end

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -33,21 +33,21 @@ module Hyrax
     # Gives file metadata for the file filling the http://pcdm.org/OriginalFile use
     # @return [FileMetadata] the FileMetadata resource of the original file
     def original_file
-      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet::ORIGINAL_FILE_USE).first
+      filter_files_by_type(Hyrax::FileSet::ORIGINAL_FILE_USE).first
     end
 
     ##
     # Gives file metadata for the file filling the http://pcdm.org/ExtractedText use
     # @return [FileMetadata] the FileMetadata resource of the extracted text
     def extracted_text
-      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet::EXTRACTED_TEXT_USE).first
+      filter_files_by_type(Hyrax::FileSet::EXTRACTED_TEXT_USE).first
     end
 
     ##
     # Gives file metadata for the file filling the http://pcdm.org/Thumbnail use
     # @return [FileMetadata] the FileMetadata resource of the thumbnail
     def thumbnail
-      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet::THUMBNAIL_USE).first
+      filter_files_by_type(Hyrax::FileSet::THUMBNAIL_USE).first
     end
 
     ##

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -25,16 +25,56 @@ module Hyrax
       true
     end
 
+    ##
+    # Gives file metadata for the file filling the http://pcdm.org/OriginalFile use
+    # @return [FileMetadata] the FileMetadata resource of the original file
     def original_file
       Hyrax.query_service.custom_queries.find_file_metadata_by(id: original_file_id)
+      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.original_file_use)
     end
 
+    ##
+    # Gives file metadata for the file filling the http://pcdm.org/ExtractedText use
+    # @return [FileMetadata] the FileMetadata resource of the extracted text
     def extracted_text
-      Hyrax.query_service.custom_queries.find_file_metadata_by(id: extracted_text_id)
+      # Hyrax.query_service.custom_queries.find_file_metadata_by(id: extracted_text_id)
+      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.extracted_text_use)
     end
 
+    ##
+    # Gives file metadata for the file filling the http://pcdm.org/Thumbnail use
+    # @return [FileMetadata] the FileMetadata resource of the thumbnail
     def thumbnail
-      Hyrax.query_service.custom_queries.find_file_metadata_by(id: thumbnail_id)
+      # Hyrax.query_service.custom_queries.find_file_metadata_by(id: thumbnail_id)
+      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.thumbnail_use)
+    end
+
+    ##
+    # Gives file metadata for files that have the requested RDF Type for use
+    # @param [RDF::URI] uri for the desired Type
+    # @return [Enumerable<FileMetadata>] the FileMetadata resources
+    # @example
+    #   filter_files_by_type(::RDF::URI("http://pcdm.org/ExtractedText"))
+    def filter_files_by_type(uri)
+      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: uri)
+    end
+
+    ##
+    # @return [RDF::URI] RDF Type for original file use
+    def self.original_file_use
+      ::Valkyrie::Vocab::PCDMUse.OriginalFile
+    end
+
+    ##
+    # @return [RDF::URI] RDF Type for extracted text use
+    def self.extracted_text_use
+      ::Valkyrie::Vocab::PCDMUse.ExtractedText
+    end
+
+    ##
+    # @return [RDF::URI] RDF Type for thumbnail use
+    def self.thumbnail_use
+      ::Valkyrie::Vocab::PCDMUse.Thumbnail
     end
   end
 end

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -29,21 +29,21 @@ module Hyrax
     # Gives file metadata for the file filling the http://pcdm.org/OriginalFile use
     # @return [FileMetadata] the FileMetadata resource of the original file
     def original_file
-      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.original_file_use)
+      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.original_file_use).first
     end
 
     ##
     # Gives file metadata for the file filling the http://pcdm.org/ExtractedText use
     # @return [FileMetadata] the FileMetadata resource of the extracted text
     def extracted_text
-      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.extracted_text_use)
+      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.extracted_text_use).first
     end
 
     ##
     # Gives file metadata for the file filling the http://pcdm.org/Thumbnail use
     # @return [FileMetadata] the FileMetadata resource of the thumbnail
     def thumbnail
-      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.thumbnail_use)
+      Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: self, use: Hyrax::FileSet.thumbnail_use).first
     end
 
     ##

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -24,5 +24,17 @@ module Hyrax
     def file_set?
       true
     end
+
+    def original_file
+      Hyrax.query_service.custom_queries.find_file_metadata_by(id: original_file_id)
+    end
+
+    def extracted_text
+      Hyrax.query_service.custom_queries.find_file_metadata_by(id: extracted_text_id)
+    end
+
+    def thumbnail
+      Hyrax.query_service.custom_queries.find_file_metadata_by(id: thumbnail_id)
+    end
   end
 end

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -80,7 +80,7 @@ class JobIoWrapper < ApplicationRecord
     Hyrax::FileMetadata.new(label: original_name,
                             original_filename: original_name,
                             mime_type: mime_type,
-                            use: [Valkyrie::Vocab::PCDMUse.OriginalFile])
+                            use: [Hyrax::FileSet.original_file_use])
   end
 
   # The magic that switches *once* between local filepath and CarrierWave file

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -80,7 +80,7 @@ class JobIoWrapper < ApplicationRecord
     Hyrax::FileMetadata.new(label: original_name,
                             original_filename: original_name,
                             mime_type: mime_type,
-                            use: [Hyrax::FileSet.original_file_use])
+                            use: [Hyrax::FileSet::ORIGINAL_FILE_USE])
   end
 
   # The magic that switches *once* between local filepath and CarrierWave file

--- a/app/services/hyrax/custom_queries/find_file_metadata.rb
+++ b/app/services/hyrax/custom_queries/find_file_metadata.rb
@@ -61,7 +61,7 @@ module Hyrax
       #   Hyrax.query_service.find_file_metadata_by_use(use: ::RDF::URI("http://pcdm.org/ExtractedText"))
       def find_many_file_metadata_by_use(resource:, use:)
         results = find_many_file_metadata_by_ids(ids: resource.file_ids)
-        results.select { |fm| fm.use.include?(use) }
+        results.select { |fm| fm.type.include?(use) }
       end
     end
   end

--- a/app/services/hyrax/custom_queries/find_file_metadata.rb
+++ b/app/services/hyrax/custom_queries/find_file_metadata.rb
@@ -53,6 +53,16 @@ module Hyrax
         results = query_service.find_many_by_ids(ids: ids)
         results.select { |resource| resource.is_a? Hyrax::FileMetadata }
       end
+
+      # Find file metadata for files within a resource that have the requested use.
+      # @param use [RDF::URI] uri for the desired use Type
+      # @return [Array<Hyrax::FileMetadata] or empty array if there are no files with the requested use
+      # @example
+      #   Hyrax.query_service.find_file_metadata_by_use(use: ::RDF::URI("http://pcdm.org/ExtractedText"))
+      def find_many_file_metadata_by_use(resource:, use:)
+        results = find_many_file_metadata_by_ids(ids: resource.file_ids)
+        results.select { |fm| fm.use.include?(use) }
+      end
     end
   end
 end

--- a/app/services/hyrax/custom_queries/navigators/find_files.rb
+++ b/app/services/hyrax/custom_queries/navigators/find_files.rb
@@ -5,7 +5,7 @@ module Hyrax
         # @example
         #   Hyrax.query_service.custom_queries.find_files(file_set: file_set_resource)
         #   Hyrax.query_service.custom_queries.find_original_file(file_set: file_set_resource)
-        #   Hyrax.query_service.custom_queries.find_extracted_text_file(file_set: file_set_resource)
+        #   Hyrax.query_service.custom_queries.find_extracted_text(file_set: file_set_resource)
         #   Hyrax.query_service.custom_queries.find_thumbnail(file_set: file_set_resource)
 
         def self.queries

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -120,21 +120,20 @@ module Wings
       def convert_members(af_object)
         return unless resource.respond_to?(:member_ids) && resource.member_ids
         # TODO: It would be better to find a way to add the members without resuming all the member AF objects
-        af_object.ordered_members = resource.member_ids.each_with_object([]) { |valkyrie_id, arr| arr << ActiveFedora::Base.find(valkyrie_id.id) }
+        af_object.ordered_members = resource.member_ids.map { |valkyrie_id| ActiveFedora::Base.find(valkyrie_id.id) }
       end
 
       def convert_member_of_collections(af_object)
         return unless resource.respond_to?(:member_of_collection_ids) && resource.member_of_collection_ids
         # TODO: It would be better to find a way to set the parent collections without resuming all the collection AF objects
-        af_object.member_of_collections = resource.member_of_collection_ids.each_with_object([]) { |valkyrie_id, arr| arr << ActiveFedora::Base.find(valkyrie_id.id) }
+        af_object.member_of_collections = resource.member_of_collection_ids.map { |valkyrie_id| ActiveFedora::Base.find(valkyrie_id.id) }
       end
 
       def convert_files(af_object)
         return unless resource.respond_to? :file_ids
-        af_object.files = resource.file_ids.each_with_object([]) do |fid, arr|
+        af_object.files = resource.file_ids.map do |fid|
           pcdm_file = Hydra::PCDM::File.new(fid.id)
           assign_association_target(af_object, pcdm_file)
-          arr << pcdm_file
         end
       end
 
@@ -146,6 +145,8 @@ module Wings
           af_object.association(:extracted_text).target = pcdm_file
         when ->(types) { types.include?(RDF::URI.new('http://pcdm.org/use#Thumbnail')) }
           af_object.association(:thumbnail).target = pcdm_file
+        else
+          pcdm_file
         end
       end
 

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -120,34 +120,33 @@ module Wings
       def convert_members(af_object)
         return unless resource.respond_to?(:member_ids) && resource.member_ids
         # TODO: It would be better to find a way to add the members without resuming all the member AF objects
-        ordered_members = []
-        resource.member_ids.each do |valkyrie_id|
-          ordered_members << ActiveFedora::Base.find(valkyrie_id.id)
-        end
-        af_object.ordered_members = ordered_members
+        af_object.ordered_members = resource.member_ids.each_with_object([]) { |valkyrie_id, arr| arr << ActiveFedora::Base.find(valkyrie_id.id) }
       end
 
       def convert_member_of_collections(af_object)
         return unless resource.respond_to?(:member_of_collection_ids) && resource.member_of_collection_ids
         # TODO: It would be better to find a way to set the parent collections without resuming all the collection AF objects
-        member_of_collections = []
-        resource.member_of_collection_ids.each do |valkyrie_id|
-          member_of_collections << ActiveFedora::Base.find(valkyrie_id.id)
-        end
-        af_object.member_of_collections = member_of_collections
+        af_object.member_of_collections = resource.member_of_collection_ids.each_with_object([]) { |valkyrie_id, arr| arr << ActiveFedora::Base.find(valkyrie_id.id) }
       end
 
       def convert_files(af_object)
         return unless resource.respond_to? :file_ids
-        files = []
-        resource.file_ids.each do |fid|
+        af_object.files = resource.file_ids.each_with_object([]) do |fid, arr|
           pcdm_file = Hydra::PCDM::File.new(fid.id)
-          af_object.association(:original_file).target = pcdm_file if pcdm_file.metadata_node.type.include? RDF::URI.new('http://pcdm.org/use#OriginalFile')
-          af_object.association(:extracted_text).target = pcdm_file if pcdm_file.metadata_node.type.include? RDF::URI.new('http://pcdm.org/use#ExtractedText')
-          af_object.association(:thumbnail).target = pcdm_file if pcdm_file.metadata_node.type.include? RDF::URI.new('http://pcdm.org/use#Thumbnail')
-          files << pcdm_file
+          assign_association_target(af_object, pcdm_file)
+          arr << pcdm_file
         end
-        af_object.files = files
+      end
+
+      def assign_association_target(af_object, pcdm_file)
+        case pcdm_file.metadata_node.type
+        when ->(types) { types.include?(RDF::URI.new('http://pcdm.org/use#OriginalFile')) }
+          af_object.association(:original_file).target = pcdm_file
+        when ->(types) { types.include?(RDF::URI.new('http://pcdm.org/use#ExtractedText')) }
+          af_object.association(:extracted_text).target = pcdm_file
+        when ->(types) { types.include?(RDF::URI.new('http://pcdm.org/use#Thumbnail')) }
+          af_object.association(:thumbnail).target = pcdm_file
+        end
       end
 
       # Normalizes the attributes parsed from the resource
@@ -155,16 +154,13 @@ module Wings
       #   ActiveFedora::Base Class)
       # @return [Hash]
       def normal_attributes
-        normalized = {}
-        attributes.each_pair do |attr, value|
+        attributes.each_with_object({}) do |(attr, value), hash|
           property = active_fedora_class.properties[attr.to_s]
-          # This handles some cases where the attributes do not directly map to an
-          #   RDF property value
-          normalized[attr] = value
+          # This handles some cases where the attributes do not directly map to an RDF property value
+          hash[attr] = value
           next if property.nil?
-          normalized[attr] = Array.wrap(value) if property.multiple?
+          hash[attr] = Array.wrap(value) if property.multiple?
         end
-        normalized
       end
 
       def apply_depositor_to(af_object)

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -138,12 +138,13 @@ module Wings
       end
 
       def convert_files(af_object)
+        return unless resource.respond_to? :file_ids
         files = []
         resource.file_ids.each do |fid|
           pcdm_file = Hydra::PCDM::File.new(fid.id)
           af_object.association(:original_file).target = pcdm_file if pcdm_file.metadata_node.type.include? RDF::URI.new('http://pcdm.org/use#OriginalFile')
-          af_object.association(:extracted_text_file).target = pcdm_file if pcdm_file.metadata_node.type.include? RDF::URI.new('http://pcdm.org/use#ExtractedText')
-          af_object.association(:thumbnail_file).target = pcdm_file if pcdm_file.metadata_node.type.include? RDF::URI.new('http://pcdm.org/use#Thumbnail')
+          af_object.association(:extracted_text).target = pcdm_file if pcdm_file.metadata_node.type.include? RDF::URI.new('http://pcdm.org/use#ExtractedText')
+          af_object.association(:thumbnail).target = pcdm_file if pcdm_file.metadata_node.type.include? RDF::URI.new('http://pcdm.org/use#Thumbnail')
           files << pcdm_file
         end
         af_object.files = files

--- a/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
+++ b/lib/wings/hydra/pcdm/models/concerns/pcdm_valkyrie_behavior.rb
@@ -132,11 +132,6 @@ module Wings
         in_collections(valkyrie: valkyrie).map(&:id)
       end
 
-      def original_file
-        af_object = Wings::ActiveFedoraConverter.new(resource: self).convert
-        af_object.original_file
-      end
-
       ##
       # @return [Boolean] whether this instance is an audio.
       def audio?

--- a/lib/wings/hydra/works/services/add_file_to_file_set.rb
+++ b/lib/wings/hydra/works/services/add_file_to_file_set.rb
@@ -37,9 +37,9 @@ module Wings::Works
         end
 
         def type_to_association_type(type)
-          return :original_file if type.to_s.casecmp?(Valkyrie::Vocab::PCDMUse.original_file.to_s)
-          return :extracted_text if type.to_s.casecmp?(Valkyrie::Vocab::PCDMUse.extracted_text.to_s)
-          return :thumbnail if type.to_s.casecmp?(Valkyrie::Vocab::PCDMUse.thumbnail.to_s)
+          return :original_file if type.to_s.casecmp?(Hyrax::FileSet.original_file_use.to_s)
+          return :extracted_text if type.to_s.casecmp?(Hyrax::FileSet.extracted_text_use.to_s)
+          return :thumbnail if type.to_s.casecmp?(Hyrax::FileSet.thumbnail_use.to_s)
         end
 
         def type_to_rdf_uri(type)

--- a/lib/wings/hydra/works/services/add_file_to_file_set.rb
+++ b/lib/wings/hydra/works/services/add_file_to_file_set.rb
@@ -37,9 +37,9 @@ module Wings::Works
         end
 
         def type_to_association_type(type)
-          return :original_file if type.to_s.casecmp?(Hyrax::FileSet.original_file_use.to_s)
-          return :extracted_text if type.to_s.casecmp?(Hyrax::FileSet.extracted_text_use.to_s)
-          return :thumbnail if type.to_s.casecmp?(Hyrax::FileSet.thumbnail_use.to_s)
+          return :original_file if type.to_s.casecmp?(Hyrax::FileSet::ORIGINAL_FILE_USE.to_s)
+          return :extracted_text if type.to_s.casecmp?(Hyrax::FileSet::EXTRACTED_TEXT_USE.to_s)
+          return :thumbnail if type.to_s.casecmp?(Hyrax::FileSet::THUMBNAIL_USE.to_s)
         end
 
         def type_to_rdf_uri(type)

--- a/lib/wings/services/custom_queries/find_file_metadata.rb
+++ b/lib/wings/services/custom_queries/find_file_metadata.rb
@@ -80,10 +80,7 @@ module Wings
       #   Hyrax.query_service.find_file_metadata_by_use(use: ::RDF::URI("http://pcdm.org/ExtractedText"))
       def find_many_file_metadata_by_use(resource:, use:, use_valkyrie: true)
         pcdm_files = find_many_file_metadata_by_ids(ids: resource.file_ids, use_valkyrie: false)
-        pcdm_files.select! do |pcdm_file|
-          pcdm_file.metadata_node.type.include?(use)
-        end
-        # pcdm_files.select { |pcdm_file| pcdm_file.metadata_node.type.include?(use) }
+        pcdm_files.select! { |pcdm_file| pcdm_file.metadata_node.type.include?(use) }
         return pcdm_files if use_valkyrie == false
         pcdm_files.collect { |pcdm_file| Wings::FileConverterService.af_file_to_resource(af_file: pcdm_file) }
       end

--- a/lib/wings/services/custom_queries/find_file_metadata.rb
+++ b/lib/wings/services/custom_queries/find_file_metadata.rb
@@ -10,7 +10,7 @@ module Wings
         [:find_file_metadata_by,
          :find_file_metadata_by_alternate_identifier,
          :find_many_file_metadata_by_ids,
-         :find_file_metadata_by_use]
+         :find_many_file_metadata_by_use]
       end
 
       def initialize(query_service:)
@@ -54,7 +54,8 @@ module Wings
 
       # Find an array of file metadata using Valkyrie IDs, and map them to Hyrax::FileMetadata maintaining order based on given ids
       # @param ids [Array<Valkyrie::ID, String>]
-      # @return [Array<Hyrax::FileMetadata>] or empty array if there are no ids or none of the ids map to Hyrax::FileMetadata
+      # @param use_valkyrie [boolean] defaults to true; optionally return ActiveFedora::File objects if false
+      # @return [Array<Hyrax::FileMetadata, Hydra::PCDM::File>] or empty array if there are no ids or none of the ids map to Hyrax::FileMetadata
       # NOTE: Ignores non-existent ids and ids for non-file metadata resources.
       def find_many_file_metadata_by_ids(ids:, use_valkyrie: true)
         results = []
@@ -71,18 +72,20 @@ module Wings
       end
 
       ##
-      # Find files within a rource that have the requested use.
-      #
-      # @param use [RDF::URI] uri for the desired Type
-      # @return [Enumerable<Valkyrie::Resource>]
-      #
+      # Find file metadata for files within a resource that have the requested use.
+      # @param use [RDF::URI] uri for the desired use Type
+      # @param use_valkyrie [boolean] defaults to true; optionally return ActiveFedora::File objects if false
+      # @return [Array<Hyrax::FileMetadata, Hydra::PCDM::File>] or empty array if there are no files with the requested use
       # @example
       #   Hyrax.query_service.find_file_metadata_by_use(use: ::RDF::URI("http://pcdm.org/ExtractedText"))
-      def find_file_metadata_by_use(resource:, use:)
-        resource.file_ids.collect do |file_id|
-          pcdm_file = Hydra::PCDM::File.find(file_id.id)
-          Wings::FileConverterService.af_file_to_resource(af_file: pcdm_file) if pcdm_file.metadata_node.type.include?(use)
-        end.compact
+      def find_many_file_metadata_by_use(resource:, use:, use_valkyrie: true)
+        pcdm_files = find_many_file_metadata_by_ids(ids: resource.file_ids, use_valkyrie: false)
+        pcdm_files.select! do |pcdm_file|
+          pcdm_file.metadata_node.type.include?(use)
+        end
+        # pcdm_files.select { |pcdm_file| pcdm_file.metadata_node.type.include?(use) }
+        return pcdm_files if use_valkyrie == false
+        pcdm_files.collect { |pcdm_file| Wings::FileConverterService.af_file_to_resource(af_file: pcdm_file) }
       end
     end
   end

--- a/lib/wings/services/custom_queries/find_file_metadata.rb
+++ b/lib/wings/services/custom_queries/find_file_metadata.rb
@@ -9,7 +9,8 @@ module Wings
       def self.queries
         [:find_file_metadata_by,
          :find_file_metadata_by_alternate_identifier,
-         :find_many_file_metadata_by_ids]
+         :find_many_file_metadata_by_ids,
+         :find_file_metadata_by_use]
       end
 
       def initialize(query_service:)
@@ -67,6 +68,21 @@ module Wings
           end
         end
         results
+      end
+
+      ##
+      # Find files within a rource that have the requested use.
+      #
+      # @param use [RDF::URI] uri for the desired Type
+      # @return [Enumerable<Valkyrie::Resource>]
+      #
+      # @example
+      #   Hyrax.query_service.find_file_metadata_by_use(use: ::RDF::URI("http://pcdm.org/ExtractedText"))
+      def find_file_metadata_by_use(resource:, use:)
+        resource.file_ids.collect do |file_id|
+          pcdm_file = Hydra::PCDM::File.find(file_id.id)
+          Wings::FileConverterService.af_file_to_resource(af_file: pcdm_file) if pcdm_file.metadata_node.type.include?(use)
+        end.compact
       end
     end
   end

--- a/lib/wings/services/file_converter_service.rb
+++ b/lib/wings/services/file_converter_service.rb
@@ -34,7 +34,8 @@ module Wings
             content: af_file.content,
             size: af_file.size,
             original_filename: [af_file.original_name],
-            mime_type: [af_file.mime_type] }
+            mime_type: [af_file.mime_type],
+            type: af_file.metadata_node.type.to_a }
         end
 
         # extracts attributes that come from the metadata_node
@@ -47,7 +48,7 @@ module Wings
 
         def valkyrie_attributes_to_af_file(attributes:, af_file:)
           attributes.each do |k, v|
-            next if [:id, :content].include? k
+            next if [:id, :content, :type].include? k
             mname = (k.to_s + '=').to_sym
             if af_file.respond_to? mname
               af_file.send(mname, v)

--- a/lib/wings/services/file_metadata_builder.rb
+++ b/lib/wings/services/file_metadata_builder.rb
@@ -17,7 +17,7 @@ module Wings
     # @param file_set [Valkyrie::Resouce, Hydra::Works::FileSet] the associated FileSet # TODO: WINGS - Remove Hydra::Works::FileSet as a potential type when valkyrization is complete.
     # @return [Hyrax::FileMetadata] the persisted metadata file_metadata that represents the file
     def create(io_wrapper:, file_metadata:, file_set:)
-      io_wrapper = build_file(io_wrapper, file_metadata.use)
+      io_wrapper = build_file(io_wrapper, file_metadata.type)
       file_set.save unless file_set.persisted?
       file_metadata.id = ::Valkyrie::ID.new(assign_id)
       file_metadata.file_set_id = file_set.id

--- a/lib/wings/valkyrie/storage/active_fedora.rb
+++ b/lib/wings/valkyrie/storage/active_fedora.rb
@@ -4,15 +4,14 @@ require 'wings/hydra/works/services/add_file_to_file_set'
 module Wings::Storage
   # Implements the DataMapper Pattern to store binary data in fedora following the ActiveFedora structures
   class ActiveFedora < Valkyrie::Storage::Fedora
-    # @param file [IO]
+    # @param file [Wings::FileMetadataBuilder::IoDecorator]
     # @param original_filename [String]
-    # @param resource [Valkyrie::Resource] FileMetadata resource
-    # @param content_type [String] content type of file (e.g. 'image/tiff') (default='application/octet-stream')
-    # @param resource_uri_transformer [Lambda] transforms the resource's id (e.g. 'DDS78RK') into a uri (optional)
+    # @param resource [Hyrax::FileMetadata] FileMetadata resource
+    # @param resource_uri_transformer [Proc] transforms the resource's id (e.g. 'DDS78RK') into a uri (optional)
     # @param extra_arguments [Hash] additional arguments which may be passed to other adapters
     # @return [Valkyrie::StorageAdapter::StreamFile]
     def upload(file:, original_filename:, resource:, resource_uri_transformer: default_resource_uri_transformer, **_extra_arguments) # rubocop:disable Lint/UnusedMethodArgument
-      Wings::Works::AddFileToFileSet.call(file_set: file_set(resource), file: file, type: resource.use)
+      Wings::Works::AddFileToFileSet.call(file_set: file_set(resource), file: file, type: resource.type)
       identifier = resource_uri_transformer.call(resource, base_url)
       find_by(id: Valkyrie::ID.new(identifier.to_s.sub(/^.+\/\//, PROTOCOL)))
     end

--- a/lib/wings/valkyrie/storage/active_fedora.rb
+++ b/lib/wings/valkyrie/storage/active_fedora.rb
@@ -6,7 +6,7 @@ module Wings::Storage
   class ActiveFedora < Valkyrie::Storage::Fedora
     # @param file [IO]
     # @param original_filename [String]
-    # @param resource [Valkyrie::Resource]
+    # @param resource [Valkyrie::Resource] FileMetadata resource
     # @param content_type [String] content type of file (e.g. 'image/tiff') (default='application/octet-stream')
     # @param resource_uri_transformer [Lambda] transforms the resource's id (e.g. 'DDS78RK') into a uri (optional)
     # @param extra_arguments [Hash] additional arguments which may be passed to other adapters

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Hyrax::Actors::FileActor do
   context 'when using valkyrie' do
     let(:user)     { create(:user) }
     let(:file_set) { create(:file_set) }
-    let(:relation) { Hyrax::FileSet.original_file_use }
+    let(:relation) { Hyrax::FileSet::ORIGINAL_FILE_USE }
     let(:actor)    { described_class.new(file_set, relation, user, use_valkyrie: true) }
     let(:fixture)  { fixture_file_upload('/world.png', 'image/png') }
     let(:huf) { Hyrax::UploadedFile.new(user: user, file: fixture) }

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Hyrax::Actors::FileActor do
   context 'when using valkyrie' do
     let(:user)     { create(:user) }
     let(:file_set) { create(:file_set) }
-    let(:relation) { Valkyrie::Vocab::PCDMUse.OriginalFile }
+    let(:relation) { Hyrax::FileSet.original_file_use }
     let(:actor)    { described_class.new(file_set, relation, user, use_valkyrie: true) }
     let(:fixture)  { fixture_file_upload('/world.png', 'image/png') }
     let(:huf) { Hyrax::UploadedFile.new(user: user, file: fixture) }

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -19,18 +19,18 @@ RSpec.describe Hyrax::FileMetadata do
     expect(subject.original_filename).to contain_exactly('world.png')
     expect(subject.mime_type).to contain_exactly('image/png')
     expect(subject.format_label).to contain_exactly('test_format_label')
-    expect(subject.use).to contain_exactly(Hyrax::FileSet.original_file_use)
+    expect(subject.type).to contain_exactly(Hyrax::FileSet.original_file_use)
   end
 
   describe '#original_file?' do
     context 'when use says file is the original file' do
-      before { subject.use = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_original_file
       end
     end
     context 'when use does not say file is the original file' do
-      before { subject.use = [Hyrax::FileSet.thumbnail_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet.thumbnail_use, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_original_file
       end
@@ -39,13 +39,13 @@ RSpec.describe Hyrax::FileMetadata do
 
   describe '#thumbnail_file?' do
     context 'when use says file is the thumbnail file' do
-      before { subject.use = [Hyrax::FileSet.thumbnail_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet.thumbnail_use, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_thumbnail_file
       end
     end
     context 'when use does not say file is the thumbnail file' do
-      before { subject.use = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_thumbnail_file
       end
@@ -54,13 +54,13 @@ RSpec.describe Hyrax::FileMetadata do
 
   describe '#extracted_file?' do
     context 'when use says file is the extracted file' do
-      before { subject.use = [Hyrax::FileSet.extracted_text_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet.extracted_text_use, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_extracted_file
       end
     end
     context 'when use does not say file is the extracted file' do
-      before { subject.use = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_extracted_file
       end

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -19,18 +19,18 @@ RSpec.describe Hyrax::FileMetadata do
     expect(subject.original_filename).to contain_exactly('world.png')
     expect(subject.mime_type).to contain_exactly('image/png')
     expect(subject.format_label).to contain_exactly('test_format_label')
-    expect(subject.type).to contain_exactly(Hyrax::FileSet.original_file_use)
+    expect(subject.type).to contain_exactly(Hyrax::FileSet::ORIGINAL_FILE_USE)
   end
 
   describe '#original_file?' do
     context 'when use says file is the original file' do
-      before { subject.type = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet::ORIGINAL_FILE_USE, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_original_file
       end
     end
     context 'when use does not say file is the original file' do
-      before { subject.type = [Hyrax::FileSet.thumbnail_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet::THUMBNAIL_USE, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_original_file
       end
@@ -39,13 +39,13 @@ RSpec.describe Hyrax::FileMetadata do
 
   describe '#thumbnail_file?' do
     context 'when use says file is the thumbnail file' do
-      before { subject.type = [Hyrax::FileSet.thumbnail_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet::THUMBNAIL_USE, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_thumbnail_file
       end
     end
     context 'when use does not say file is the thumbnail file' do
-      before { subject.type = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet::ORIGINAL_FILE_USE, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_thumbnail_file
       end
@@ -54,13 +54,13 @@ RSpec.describe Hyrax::FileMetadata do
 
   describe '#extracted_file?' do
     context 'when use says file is the extracted file' do
-      before { subject.type = [Hyrax::FileSet.extracted_text_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet::EXTRACTED_TEXT_USE, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_extracted_file
       end
     end
     context 'when use does not say file is the extracted file' do
-      before { subject.type = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
+      before { subject.type = [Hyrax::FileSet::ORIGINAL_FILE_USE, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_extracted_file
       end

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -19,18 +19,18 @@ RSpec.describe Hyrax::FileMetadata do
     expect(subject.original_filename).to contain_exactly('world.png')
     expect(subject.mime_type).to contain_exactly('image/png')
     expect(subject.format_label).to contain_exactly('test_format_label')
-    expect(subject.use).to contain_exactly(Valkyrie::Vocab::PCDMUse.OriginalFile)
+    expect(subject.use).to contain_exactly(Hyrax::FileSet.original_file_use)
   end
 
   describe '#original_file?' do
     context 'when use says file is the original file' do
-      before { subject.use = [Valkyrie::Vocab::PCDMUse.OriginalFile, pcdm_file_uri] }
+      before { subject.use = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_original_file
       end
     end
     context 'when use does not say file is the original file' do
-      before { subject.use = [Valkyrie::Vocab::PCDMUse.ThumbnailImage, pcdm_file_uri] }
+      before { subject.use = [Hyrax::FileSet.thumbnail_use, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_original_file
       end
@@ -39,13 +39,13 @@ RSpec.describe Hyrax::FileMetadata do
 
   describe '#thumbnail_file?' do
     context 'when use says file is the thumbnail file' do
-      before { subject.use = [Valkyrie::Vocab::PCDMUse.ThumbnailImage, pcdm_file_uri] }
+      before { subject.use = [Hyrax::FileSet.thumbnail_use, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_thumbnail_file
       end
     end
     context 'when use does not say file is the thumbnail file' do
-      before { subject.use = [Valkyrie::Vocab::PCDMUse.OriginalFile, pcdm_file_uri] }
+      before { subject.use = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_thumbnail_file
       end
@@ -54,13 +54,13 @@ RSpec.describe Hyrax::FileMetadata do
 
   describe '#extracted_file?' do
     context 'when use says file is the extracted file' do
-      before { subject.use = [Valkyrie::Vocab::PCDMUse.ExtractedImage, pcdm_file_uri] }
+      before { subject.use = [Hyrax::FileSet.extracted_text_use, pcdm_file_uri] }
       it 'returns true' do
         expect(subject).to be_extracted_file
       end
     end
     context 'when use does not say file is the extracted file' do
-      before { subject.use = [Valkyrie::Vocab::PCDMUse.OriginalFile, pcdm_file_uri] }
+      before { subject.use = [Hyrax::FileSet.original_file_use, pcdm_file_uri] }
       it 'returns false' do
         expect(subject).not_to be_extracted_file
       end

--- a/spec/models/hyrax/file_set_spec.rb
+++ b/spec/models/hyrax/file_set_spec.rb
@@ -13,22 +13,4 @@ RSpec.describe Hyrax::FileSet do
       expect(file_set.human_readable_type).to eq 'File Set'
     end
   end
-
-  describe '.original_file_use' do
-    it 'returns URI for original file use' do
-      expect(described_class.original_file_use).to eq ::Valkyrie::Vocab::PCDMUse.OriginalFile
-    end
-  end
-
-  describe '.extracted_text_use' do
-    it 'returns URI for extracted text use' do
-      expect(described_class.extracted_text_use).to eq ::Valkyrie::Vocab::PCDMUse.ExtractedText
-    end
-  end
-
-  describe '.thumbnail_use' do
-    it 'returns URI for thumbnail use' do
-      expect(described_class.thumbnail_use).to eq ::Valkyrie::Vocab::PCDMUse.Thumbnail
-    end
-  end
 end

--- a/spec/models/hyrax/file_set_spec.rb
+++ b/spec/models/hyrax/file_set_spec.rb
@@ -13,4 +13,22 @@ RSpec.describe Hyrax::FileSet do
       expect(file_set.human_readable_type).to eq 'File Set'
     end
   end
+
+  describe '.original_file_use' do
+    it 'returns URI for original file use' do
+      expect(described_class.original_file_use).to eq ::Valkyrie::Vocab::PCDMUse.OriginalFile
+    end
+  end
+
+  describe '.extracted_text_use' do
+    it 'returns URI for extracted text use' do
+      expect(described_class.extracted_text_use).to eq ::Valkyrie::Vocab::PCDMUse.ExtractedText
+    end
+  end
+
+  describe '.thumbnail_use' do
+    it 'returns URI for thumbnail use' do
+      expect(described_class.thumbnail_use).to eq ::Valkyrie::Vocab::PCDMUse.Thumbnail
+    end
+  end
 end

--- a/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
@@ -103,9 +103,9 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
     let!(:et_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, type: extracted_text_use) }
     let!(:th_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, type: thumbnail_use) }
 
-    let(:original_file_use)  { Hyrax::FileSet.original_file_use }
-    let(:extracted_text_use) { Hyrax::FileSet.extracted_text_use }
-    let(:thumbnail_use)      { Hyrax::FileSet.thumbnail_use }
+    let(:original_file_use)  { Hyrax::FileSet::ORIGINAL_FILE_USE }
+    let(:extracted_text_use) { Hyrax::FileSet::EXTRACTED_TEXT_USE }
+    let(:thumbnail_use)      { Hyrax::FileSet::THUMBNAIL_USE }
 
     context 'when file set has files of the requested use' do
       let!(:file_set) { FactoryBot.create_using_test_adapter(:hyrax_file_set, files: [of_file_metadata, et_file_metadata, th_file_metadata]) }

--- a/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
@@ -99,9 +99,9 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
   end
 
   describe '.find_file_metadata_by_use' do
-    let!(:of_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, use: original_file_use) }
-    let!(:et_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, use: extracted_text_use) }
-    let!(:th_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, use: thumbnail_use) }
+    let!(:of_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, type: original_file_use) }
+    let!(:et_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, type: extracted_text_use) }
+    let!(:th_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, type: thumbnail_use) }
 
     let(:original_file_use)  { Hyrax::FileSet.original_file_use }
     let(:extracted_text_use) { Hyrax::FileSet.extracted_text_use }
@@ -114,7 +114,7 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
         result = query_handler.find_many_file_metadata_by_use(resource: file_set, use: extracted_text_use)
         expect(result.size).to eq 1
         expect(result.first).to be_a Hyrax::FileMetadata
-        expect(result.first.use.first).to eq extracted_text_use
+        expect(result.first.type.first).to eq extracted_text_use
       end
     end
 

--- a/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
@@ -97,4 +97,42 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
       end
     end
   end
+
+  describe '.find_file_metadata_by_use' do
+    let!(:of_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, use: original_file_use) }
+    let!(:et_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, use: extracted_text_use) }
+    let!(:th_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, use: thumbnail_use) }
+
+    let(:original_file_use)  { Hyrax::FileSet.original_file_use }
+    let(:extracted_text_use) { Hyrax::FileSet.extracted_text_use }
+    let(:thumbnail_use)      { Hyrax::FileSet.thumbnail_use }
+
+    context 'when file set has files of the requested use' do
+      let!(:file_set) { FactoryBot.create_using_test_adapter(:hyrax_file_set, files: [of_file_metadata, et_file_metadata, th_file_metadata]) }
+
+      it 'returns Hyrax::FileMetadata resources matching use' do
+        result = query_handler.find_many_file_metadata_by_use(resource: file_set, use: extracted_text_use)
+        expect(result.size).to eq 1
+        expect(result.first).to be_a Hyrax::FileMetadata
+        expect(result.first.use.first).to eq extracted_text_use
+      end
+    end
+
+    context 'when file set has no files of the requested use' do
+      let!(:file_set) { FactoryBot.create_using_test_adapter(:hyrax_file_set, files: [of_file_metadata, th_file_metadata]) }
+
+      it 'result is empty' do
+        result = query_handler.find_many_file_metadata_by_use(resource: file_set, use: extracted_text_use)
+        expect(result).to be_empty
+      end
+    end
+
+    context 'when file set has no files' do
+      let!(:file_set) { FactoryBot.create_using_test_adapter(:hyrax_file_set) }
+      it 'result is empty' do
+        result = query_handler.find_many_file_metadata_by_use(resource: file_set, use: original_file_use)
+        expect(result).to be_empty
+      end
+    end
+  end
 end

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
   let(:af_file_set)             { create(:file_set, id: 'fileset_id') }
   let!(:file_set)               { af_file_set.valkyrie_resource }
 
-  let(:original_file_use)  { Valkyrie::Vocab::PCDMUse.OriginalFile }
-  let(:extracted_text_use) { Valkyrie::Vocab::PCDMUse.ExtractedText }
-  let(:thumbnail_use)      { Valkyrie::Vocab::PCDMUse.Thumbnail }
+  let(:original_file_use)  { Hyrax::FileSet.original_file_use }
+  let(:extracted_text_use) { Hyrax::FileSet.extracted_text_use }
+  let(:thumbnail_use)      { Hyrax::FileSet.thumbnail_use }
 
   let(:pdf_filename)  { 'sample-file.pdf' }
   let(:pdf_mimetype)  { 'application/pdf' }
@@ -72,18 +72,18 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
     let(:transcript_use)   { Valkyrie::Vocab::PCDMUse.Transcript }
     let(:service_file_use) { Valkyrie::Vocab::PCDMUse.ServiceFile }
 
-    subject do 
+    subject do
       updated_file_set = described_class.call(file_set: file_set, file: pdf_file, type: service_file_use)
       described_class.call(file_set: updated_file_set, file: text_file, type: transcript_use)
     end
     it 'adds the given file and applies the specified RDF::URI use to it' do
-      ids = subject.file_ids      
+      ids = subject.file_ids
       expect(ids.size).to eq 2
       expect(ids.first).to be_a Valkyrie::ID
       expect(ids.first.to_s).to start_with "#{file_set.id}/files/"
 
-      expect(Hyrax.query_service.custom_queries.find_file_metadata_by_use(resource: subject, use: transcript_use).first.content.first).to start_with('some updated content')
-      expect(Hyrax.query_service.custom_queries.find_file_metadata_by_use(resource: subject, use: service_file_use).first.content.first).to start_with('%PDF-1.3')
+      expect(Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: subject, use: transcript_use).first.content.first).to start_with('some updated content')
+      expect(Hyrax.query_service.custom_queries.find_many_file_metadata_by_use(resource: subject, use: service_file_use).first.content.first).to start_with('%PDF-1.3')
     end
   end
 

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
     let(:versioning) { true }
     subject { described_class.call(file_set: file_set, file: pdf_file, type: original_file_use, versioning: versioning) }
     it 'updates the file and creates a version' do
+      pending 'Valkyrization of versioning in Hyrax::FileMetadata'
       expect(subject.original_file.versions.all.count).to eq(1)
       expect(subject.original_file.content).to start_with('%PDF-1.3')
     end
@@ -101,6 +102,7 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
         described_class.call(file_set: updated_file_set, file: text_file, type: original_file_use, versioning: versioning)
       end
       it 'adds to the version history' do
+        pending 'Valkyrization of versioning in Hyrax::FileMetadata'
         expect(subject.original_file.versions.all.count).to eq(2)
         expect(subject.original_file.content).to eq("some updated content\n")
       end
@@ -114,6 +116,7 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
       described_class.call(file_set: updated_file_set, file: text_file, type: original_file_use, versioning: versioning)
     end
     it 'skips creating versions' do
+      pending 'Valkyrization of versioning in Hyrax::FileMetadata'
       expect(subject.original_file.versions.all.count).to eq(0)
       expect(subject.original_file.content).to eq("some updated content\n")
     end

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
   let(:af_file_set)             { create(:file_set, id: 'fileset_id') }
   let!(:file_set)               { af_file_set.valkyrie_resource }
 
-  let(:original_file_use)  { Hyrax::FileSet.original_file_use }
-  let(:extracted_text_use) { Hyrax::FileSet.extracted_text_use }
-  let(:thumbnail_use)      { Hyrax::FileSet.thumbnail_use }
+  let(:original_file_use)  { Hyrax::FileSet::ORIGINAL_FILE_USE }
+  let(:extracted_text_use) { Hyrax::FileSet::EXTRACTED_TEXT_USE }
+  let(:thumbnail_use)      { Hyrax::FileSet::THUMBNAIL_USE }
 
   let(:pdf_filename)  { 'sample-file.pdf' }
   let(:pdf_mimetype)  { 'application/pdf' }

--- a/spec/wings/services/custom_queries/find_file_metadata_spec.rb
+++ b/spec/wings/services/custom_queries/find_file_metadata_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Wings::CustomQueries::FindFileMetadata, :clean_repo do
     it 'lists queries' do
       expect(described_class.queries).to eq [:find_file_metadata_by,
                                              :find_file_metadata_by_alternate_identifier,
-                                             :find_many_file_metadata_by_ids]
+                                             :find_many_file_metadata_by_ids,
+                                             :find_many_file_metadata_by_use]
     end
   end
 
@@ -110,6 +111,75 @@ RSpec.describe Wings::CustomQueries::FindFileMetadata, :clean_repo do
       let(:ids) { [] }
       it 'result is empty' do
         expect(query_handler.find_many_file_metadata_by_ids(ids: ids)).to be_empty
+      end
+    end
+  end
+
+  describe '.find_file_metadata_by_use' do
+    let(:af_file_set)             { create(:file_set, id: 'fileset_id') }
+    let!(:file_set)               { af_file_set.valkyrie_resource }
+
+    let(:original_file_use)  { Hyrax::FileSet.original_file_use }
+    let(:extracted_text_use) { Hyrax::FileSet.extracted_text_use }
+    let(:thumbnail_use)      { Hyrax::FileSet.thumbnail_use }
+
+    let(:pdf_filename)  { 'sample-file.pdf' }
+    let(:pdf_mimetype)  { 'application/pdf' }
+    let(:pdf_file)      { File.open(File.join(fixture_path, pdf_filename)) }
+
+    let(:text_filename) { 'updated-file.txt' }
+    let(:text_mimetype) { 'text/plain' }
+    let(:text_file)     { File.open(File.join(fixture_path, text_filename)) }
+
+    let(:image_filename) { 'world.png' }
+    let(:image_mimetype) { 'image/png' }
+    let(:image_file)     { File.open(File.join(fixture_path, image_filename)) }
+
+    context 'when file set has files of the requested use' do
+      let!(:file_set) do
+        file_set = af_file_set.valkyrie_resource
+        file_set = Wings::Works::AddFileToFileSet.call(file_set: file_set, file: pdf_file, type: original_file_use)
+        file_set = Wings::Works::AddFileToFileSet.call(file_set: file_set, file: text_file, type: extracted_text_use)
+        Wings::Works::AddFileToFileSet.call(file_set: file_set, file: image_file, type: thumbnail_use)
+      end
+
+      context 'and use_valkyrie is false' do
+        it 'returns AF Files matching use' do
+          result = query_handler.find_many_file_metadata_by_use(resource: file_set, use: original_file_use, use_valkyrie: false)
+          expect(result.size).to eq 1
+          expect(result.first).to be_a Hydra::PCDM::File
+          expect(result.first.content).to start_with('%PDF-1.3')
+        end
+      end
+
+      context 'and use_valkyrie is true' do
+        it 'returns Hyrax::FileMetadata resources matching use' do
+          result = query_handler.find_many_file_metadata_by_use(resource: file_set, use: extracted_text_use, use_valkyrie: true)
+          expect(result.size).to eq 1
+          expect(result.first).to be_a Hyrax::FileMetadata
+          expect(result.first.content.first).to start_with('some updated content')
+          expect(result.first.use.first).to eq extracted_text_use
+        end
+      end
+    end
+
+    context 'when file set has no files of the requested use' do
+      let!(:file_set) do
+        file_set = af_file_set.valkyrie_resource
+        file_set = Wings::Works::AddFileToFileSet.call(file_set: file_set, file: pdf_file, type: original_file_use)
+        Wings::Works::AddFileToFileSet.call(file_set: file_set, file: image_file, type: thumbnail_use)
+      end
+
+      it 'result is empty' do
+        result = query_handler.find_many_file_metadata_by_use(resource: file_set, use: extracted_text_use)
+        expect(result).to be_empty
+      end
+    end
+
+    context 'when file set has no files' do
+      it 'result is empty' do
+        result = query_handler.find_many_file_metadata_by_use(resource: file_set, use: original_file_use)
+        expect(result).to be_empty
       end
     end
   end

--- a/spec/wings/services/custom_queries/find_file_metadata_spec.rb
+++ b/spec/wings/services/custom_queries/find_file_metadata_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Wings::CustomQueries::FindFileMetadata, :clean_repo do
           expect(result.size).to eq 1
           expect(result.first).to be_a Hyrax::FileMetadata
           expect(result.first.content.first).to start_with('some updated content')
-          expect(result.first.use.first).to eq extracted_text_use
+          expect(result.first.type).to include extracted_text_use
         end
       end
     end

--- a/spec/wings/services/custom_queries/find_file_metadata_spec.rb
+++ b/spec/wings/services/custom_queries/find_file_metadata_spec.rb
@@ -119,9 +119,9 @@ RSpec.describe Wings::CustomQueries::FindFileMetadata, :clean_repo do
     let(:af_file_set)             { create(:file_set, id: 'fileset_id') }
     let!(:file_set)               { af_file_set.valkyrie_resource }
 
-    let(:original_file_use)  { Hyrax::FileSet.original_file_use }
-    let(:extracted_text_use) { Hyrax::FileSet.extracted_text_use }
-    let(:thumbnail_use)      { Hyrax::FileSet.thumbnail_use }
+    let(:original_file_use)  { Hyrax::FileSet::ORIGINAL_FILE_USE }
+    let(:extracted_text_use) { Hyrax::FileSet::EXTRACTED_TEXT_USE }
+    let(:thumbnail_use)      { Hyrax::FileSet::THUMBNAIL_USE }
 
     let(:pdf_filename)  { 'sample-file.pdf' }
     let(:pdf_mimetype)  { 'application/pdf' }

--- a/spec/wings/services/file_converter_service_spec.rb
+++ b/spec/wings/services/file_converter_service_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Wings::FileConverterService do
       expect(subject.file_identifiers).to match_valkyrie_ids_with_active_fedora_ids [af_file_id]
       expect(subject.created_at).to eq af_file.create_date
       expect(subject.updated_at).to eq af_file.modified_date
+      expect(subject.type).to match_array af_file.metadata_node.type
       expect(subject.original_filename).to eq Array(plain_text_af_attrs[:original_name])
       expect(subject.mime_type).to eq Array(plain_text_af_attrs[:mime_type])
       expect(subject.content).to eq Array(plain_text_af_attrs[:content])
@@ -72,6 +73,7 @@ RSpec.describe Wings::FileConverterService do
   private
 
     def validate_af_file_metadata(expected_attrs) # rubocop:disable Metrics/AbcSize
+      expect(subject.metadata_node.type).to match_array expected_attrs[:type]
       expect(subject.mime_type).to eq expected_attrs[:mime_type]
       expect(subject.content).to eq expected_attrs[:content]
       expect(subject.format_label).to eq Array(expected_attrs[:format_label])
@@ -86,7 +88,11 @@ RSpec.describe Wings::FileConverterService do
         mime_type: 'text/plain',
         content: 'some text content for af_file_to_resource test',
         format_label: 'Plain Text',
-        language: 'en' }
+        language: 'en',
+        type: [RDF::URI.new('http://pcdm.org/models#File'),
+               RDF::URI.new('http://fedora.info/definitions/v4/repository#Binary'),
+               RDF::URI.new('http://fedora.info/definitions/v4/repository#Resource'),
+               RDF::URI.new('http://www.w3.org/ns/ldp#NonRDFSource')] }
     end
 
     def plain_text_valkyrie_attrs
@@ -95,6 +101,7 @@ RSpec.describe Wings::FileConverterService do
         content: '<h3>different text content for valkyrie_to_af_file test</h3>',
         format_label: 'HTML Text',
         language: 'en',
+        type: [RDF::URI.new('http://pcdm.org/models#File')],
         created_at: Time.now.getlocal - 5.days,
         updated_at: Time.now.getlocal }
     end

--- a/spec/wings/services/file_metadata_builder_spec.rb
+++ b/spec/wings/services/file_metadata_builder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Wings::FileMetadataBuilder do
   let(:file)          { File.open(File.join(fixture_path, original_name)) }
   let(:original_name) { 'sample-file.pdf' }
   let(:mime_type)     { 'application/pdf' }
-  let(:use)           { Hyrax::FileSet.original_file_use }
+  let(:use)           { Hyrax::FileSet::ORIGINAL_FILE_USE }
 
   let(:original_file_metadata) do
     Hyrax::FileMetadata.new(label: original_name,

--- a/spec/wings/services/file_metadata_builder_spec.rb
+++ b/spec/wings/services/file_metadata_builder_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Wings::FileMetadataBuilder do
     Hyrax::FileMetadata.new(label: original_name,
                             original_filename: original_name,
                             mime_type: mime_type,
-                            use: [use])
+                            type: [use])
   end
 
   describe '#create(io_wrapper:, file_metadata:, file_set:)' do
@@ -33,7 +33,7 @@ RSpec.describe Wings::FileMetadataBuilder do
       expect(built_file_metadata.label).to contain_exactly(original_name)
       expect(built_file_metadata.original_filename).to contain_exactly(original_name)
       expect(built_file_metadata.mime_type).to contain_exactly(mime_type)
-      expect(built_file_metadata.use).to contain_exactly(use)
+      expect(built_file_metadata.type).to contain_exactly(use)
     end
   end
 end

--- a/spec/wings/services/file_metadata_builder_spec.rb
+++ b/spec/wings/services/file_metadata_builder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Wings::FileMetadataBuilder do
   let(:file)          { File.open(File.join(fixture_path, original_name)) }
   let(:original_name) { 'sample-file.pdf' }
   let(:mime_type)     { 'application/pdf' }
-  let(:use)           { Valkyrie::Vocab::PCDMUse.OriginalFile }
+  let(:use)           { Hyrax::FileSet.original_file_use }
 
   let(:original_file_metadata) do
     Hyrax::FileMetadata.new(label: original_name,


### PR DESCRIPTION
NOTE: PR #4215 is working toward similar issues around use types.  Both approaches need to be reviewed for compatibility.

----

Fixes #4203

Co-authored-by: cjcolvar <cjcolvard@indiana.edu>

### Conversion of files with custom use type

Conversion of the 3 primary use types were handled in PR #4055. That made use of the AF association target.   That does not work for custom file.  This PR includes a generalized approach that works for all relationships.


### Refactor:  type instead of use

There is no conversion path from `pcdm_file.metadata_node.type` as used in AF to `fiile_metadata.use`  in FileMetadata.  

metadata_node.type is an ActiveTriples::Relation that includes all RDF types for the file, not just the use type.  For example...

```
 [#<RDF::URI:0x3fc9c096fe3c URI:http://fedora.info/definitions/v4/repository#Binary>,
  #<RDF::URI:0x3fc9c096f938 URI:http://fedora.info/definitions/v4/repository#Resource>, 
  #<RDF::URI:0x3fc9c096f234 URI:http://pcdm.org/models#File>, 
  #<RDF::URI:0x3fc9c096fa04 URI:http://www.w3.org/ns/ldp#NonRDFSource>,
  #<RDF::URI:0x3fc9c096fb83 URI:http://pcdm.org/use#OriginalFile>]
```

The only part of this that is the use is the last one ending in `#OriginalFile`.  We could have search the types for one beginning with `http://pcdm.org/use`, but there is not a guarantee that a site wouldn't have custom uses defined that do not begin with this.

For backward compatibility, we decided to remove the `use` attribute from FileMetadata and replace it with `type`.

To support functionality like #original_file, we added a custom query `find_many_file_metadata_by_use(resource:, use:)` to FindFileMetadata.  Then we defined methods #original_file, #extracted_text, and #thumbnail in Hyrax::FileSet using the new custom query to locate the file with the corresponding use.

### Refactor: Centralize definition of 3 primary file use types

In making changes to for this PR, we noticed that there were differing URIs used for the 3 primary file use types  (i.e., original_file, extracted_text, and thumbnail).  To address this, we centralized the definition of the primary uses in Hyrax::FileSet.  All references to the associated use URIs were updated to use Hyrax::FileSet.original_file_use, Hyrax::FileSet.extracted_text_use, and Hyrax::FileSet.thumbnail.

