### PR TITLE
Removing Rails 6.0 deprecation warning

### DIFF
--- a/app/services/hyrax/workflow/permission_query.rb
+++ b/app/services/hyrax/workflow/permission_query.rb
@@ -52,7 +52,7 @@ module Hyrax
           workflow_actions_scope.arel_table[:id].in(
             workflow_state_actions_scope.arel_table.project(
               workflow_state_actions_scope.arel_table[:workflow_action_id]
-            ).where(workflow_state_actions_scope.constraints.reduce)
+            ).where(workflow_state_actions_scope.arel.constraints.reduce)
           )
         )
       end
@@ -428,7 +428,7 @@ module Hyrax
       # @return [ActiveRecord::Relation<Sipity::WorkflowAction>]
       def scope_workflow_actions_available_for_current_state(entity:)
         workflow_actions_for_current_state = scope_workflow_actions_for_current_state(entity: entity)
-        Sipity::WorkflowAction.where(workflow_actions_for_current_state.constraints.reduce)
+        Sipity::WorkflowAction.where(workflow_actions_for_current_state.arel.constraints.reduce)
       end
     end
   end


### PR DESCRIPTION
Prior to this change, specs reported the following warning:

```console
DEPRECATION WARNING: Delegating constraints to arel is deprecated and
will be removed in Rails 6.0.
```

I removed the deprecation warnings with this change (e.g. adding an
explicit call to #arel).

@samvera/hyrax-code-reviewers
