### PR TITLE
Support custom URI use/type in `FileSetDescription`

### DIFF
--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -13,12 +13,14 @@ module Hyrax
       THUMBNAIL = ::Valkyrie::Vocab::PCDMUse.ThumbnailImage
 
       ##
-      # @param use [Symbol]
+      # @param use [RDF::URI, Symbol]
       #
       # @return [RDF::URI]
       # @raise [ArgumentError] if no use is known for the argument
       def uri_for(use:)
         case use
+        when RDF::URI
+          use
         when :original_file
           ORIGINAL_FILE
         when :extracted_file

--- a/app/services/hyrax/characterization/file_set_description.rb
+++ b/app/services/hyrax/characterization/file_set_description.rb
@@ -16,9 +16,9 @@ module Hyrax
 
       ##
       # @param [Hyrax::FileSet] file_set
-      # @param [Symbol] primary_file  a symbol mapping to the file_set member
-      #   used for characterization
-      def initialize(file_set:, primary_file: :original_file)
+      # @param [RDF::URI, Symbol] primary_file  the type of file_set member to
+      #   use for characterization
+      def initialize(file_set:, primary_file: Hyrax::FileMetadata::Use::ORIGINAL_FILE)
         self.file_set = file_set
 
         @primary_file_type_uri =


### PR DESCRIPTION
When constructing a description of a Valkyrie description, prefer to use URIs.

@samvera/hyrax-code-reviewers
