### PR TITLE
Ensuring CSV usage has same namespace consideration

### DIFF
--- a/spec/services/hyrax/file_set_csv_service_spec.rb
+++ b/spec/services/hyrax/file_set_csv_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hyrax::FileSetCSVService do
 
       it { is_expected.to eq "123abc,My Title,jilluser@example.com,\"Von, Creator\",restricted,Book|Other,Mine,pdf\n" }
       it "parses as valid csv" do
-        expect(CSV.parse(subject)).to eq([["123abc", "My Title", "jilluser@example.com", "Von, Creator", "restricted", "Book|Other", "Mine", "pdf"]])
+        expect(::CSV.parse(subject)).to eq([["123abc", "My Title", "jilluser@example.com", "Von, Creator", "restricted", "Book|Other", "Mine", "pdf"]])
       end
     end
 


### PR DESCRIPTION
This is a bit of a stab in the dark. However, we had a failed Ruby
build with the following message:

```console
1) Hyrax::FileSetCSVService when specifying terms and separator csv
     Failure/Error:
       ::CSV.generate do |csv|
         csv << terms.map do |term|
           values = file_set.send(term)
           values = values.respond_to?(:to_a) ? values.to_a : [values] # make sure we have an array
           values.join(multi_value_separator)
         end
       end

     NameError:
       uninitialized constant CSV
```

What I suspect to be in play is that the corresponding spec does not
similarly namespace the `CSV` constant. The production ruby file uses
`::CSV` whereas the spec ruby file uses `CSV`. This commit seeks to use
the same namespacing, hopefully reducing an intermittent error.

See the following  CircleCI build for the failures:

-  https://circleci.com/gh/samvera/hyrax/17063#tests/containers/3

@samvera/hyrax-code-reviewers
