### PR TITLE
Removing gemspec's test_files

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -18,7 +18,6 @@ SUMMARY
 
   spec.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.name          = "hyrax"
   spec.require_paths = ["lib"]
   spec.version       = Hyrax::VERSION


### PR DESCRIPTION
**Why you may ask?**

When attempting to release a new version of Hyrax, I encountered a
problem building the gem (via `rake release`). The exception thrown was:

```console
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    [""spec/fixtures/\344\270\226\347\225\214.png""] are not files
```

Since the last commit, we added the file `spec/fixtures/世界.png`
via commit @35d52b4642b0aafd1104e495dafb52eba03da4ee (e.g. "Support
non-ascii characters in filenames").

It appears that the Rubygems release process does not support non-ascii
characters in the gemspec. The line that raises the exception can be
seen [here][1].

There is discussion about the purpose of `test_files` in the Gemspec,
at least as it relates to `gem install.`

> I see that gemspec has test_files and many gemfiles include tests. I
> believe it is artifact from gem test times. I think tests in gemfiles
> are OK (e.g. in case if you decide to reintroduce gem test back #730).
> But gem install should not install these files, gem tests are useless
> for users (unless I missed something). -- [discussion on Rubygems][2]

By including the `test_files` as part of the Gemspec, every install of
Hyrax includes those `test_files` on the installed file system. In
development, I have on occassion found it helpful to be able to see
the specs (and thus expected and tested behavior) of the gems AS they
are installed on my system. However, I do not believe these are
necessary as part of other installations (production).

In removing the `test_files` we would now be saying that Hyrax as a Gem
does not ship with the automated specs that inform how we expect things
to work. From an ideological standpoint, that might be an issue.
However, access to the source code and specs continues to be available
via DVCS (eg. Git) means. Thus a developer can clone the repository at
the deployed state and see the expected specs (assuming tags are
annotated, which is another question/concern, but for another time).

**Other options?**

*   Write specific code to omit the fixture file that blocks releasing
    versions of Hyrax
*   Dive deeper into why its failing; a preliminary investation shows
    that its from `git ls-files` and not the Rubygems, Rake, Ruby
    ecosystem (as `File.file?("spec/fixtures/世界.png")` works but when
    I run `git ls-files` I get `"spec/fixtures/\344\270\226\347\225\214.png"`
    as one of the outputs. Interestingly when I run `git ls-files -z` I
    see "spec/fixtures/世界.png" but its nul)
*   Convert the existing fixture into something that we generate during
    the spec

[1]:https://github.com/rubygems/rubygems/blob/8669a644ec61cfee62d37d851ec24e83dc8802fa/lib/rubygems/specification_policy.rb#L259
[2]:https://github.com/rubygems/rubygems/issues/735

@samvera/hyrax-code-reviewers
