### PR TITLE
Improving HTML rendering error tolerance

### DIFF
--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -4,7 +4,7 @@
         <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
         <h3>
           <%= link_to [main_app, recent_document] do %>
-            <%= render_thumbnail_tag(recent_document, {width: 90, alt: "#{recent_document.to_s} #{ t('hyrax.homepage.admin_sets.thumbnail')}" }, {suppress_link: true}) + recent_document.to_s %>
+            <%= render_thumbnail_tag(recent_document, {width: 90, alt: "#{recent_document} #{ t('hyrax.homepage.admin_sets.thumbnail')}" }, {suppress_link: true}) %><%= recent_document %>
           <% end %>
         </h3>
         <p class="recent-field">


### PR DESCRIPTION
From [CircleCI build 17168][1] for [PR #4326][2], we encountered an
error in which we attempted to `+` together `nil` and a String object.
This commit will prevent an application exception when we encounter that
behavior. Below is log entry regarding the error.

```log
ActionView::Template::Error:
       undefined method `+' for nil:NilClass
     # ./app/views/hyrax/homepage/_recent_document.html.erb:7
```

**Is this appropriate?**

I don't know. It looks as though we might want to treat this as in
error. But, given some of the challenges we've had with our feature
specs, I think I'd prefer that this erratic error not break the build.

(Note: When this build broke, Ruby 2.4.7 and 2.6.2 builds of the same
code worked)

[1]:https://circleci.com/gh/samvera/hyrax/17168#tests/containers/5
[2]:https://github.com/samvera/hyrax/pull/4236/

@samvera/hyrax-code-reviewers

Created in response to #4236 failed CI