### PR TITLE
Attempting to squash a flappy test

### DIFF
--- a/lib/wings/orm_converter.rb
+++ b/lib/wings/orm_converter.rb
@@ -33,7 +33,7 @@ module Wings
     end
 
     ##
-    # @param klass [String] an `ActiveFedora` model
+    # @param klass [Class] an `ActiveFedora` model class
     #
     # @return [Class] a dyamically generated `Valkyrie::Resource` subclass
     #   mirroring the provided `ActiveFedora` model

--- a/spec/wings/orm_converter_spec.rb
+++ b/spec/wings/orm_converter_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Wings::OrmConverter do
 
     context 'when given a non-ActiveFedora class' do
       it 'raises an exception' do
-        expect { described_class.to_valkyrie_resource_class(klass: String) }.to raise_error
+        expect { described_class.to_valkyrie_resource_class(klass: String) }.to raise_error(NoMethodError)
       end
     end
 

--- a/spec/wings/services/custom_queries/find_many_by_alternate_ids_spec.rb
+++ b/spec/wings/services/custom_queries/find_many_by_alternate_ids_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe Wings::CustomQueries::FindManyByAlternateIds do
     context 'when list includes an invalid id' do
       let(:id_list) { [work1.id, work2.id, '1212121212'] }
 
-      it 'returns error' do
-        expect { subject } .to raise_error
+      it 'raises an exception' do
+        expect { subject } .to raise_error(NameError)
       end
     end
   end


### PR DESCRIPTION
## Fixing spec that intermittently fails

accad29808b702ed8f16fa6476d6f303f97abb79

Alas, the hardest of PRs to review, as its addressing an occassional
but regular failure. However, bear with me.

The error occurred in this [CircleCI Build][1], which had a spec error
as follows.

```log
1) Hyrax::Actors::FileSetActor when use_valkyrie is false \
       #create_content when from_url is true calls ingest_file and \
       kicks off jobs
     Failure/Error: expect(VisibilityCopyJob).to have_been_enqueued

       expected to enqueue exactly 1 jobs, but enqueued 7
```

This lead me to believe that the queues were not being properly cleared
out (or even if that is expected behavior). However, as we are relying
on the Rspec matcher `have_been_enqueued`, there may be something
related to the ActiveJob queue.

Based on the phrase of the failure (e.g. "exactly") and the
[code for building][2] that phrase in `have_been_enqueued`, we have
been relying on the previous code state to clear the queues only after
a `:perform_enqueued` example was run.

This meant that we had a queue that was filling up with more and more
of the same type of jobs, and thus the implicit "exactly" match of
`have_been_enqueued` raised the error.

To replicate the fix, you will need to checkout SHA da3b4632b45a8bf22100f691612d299a0ac79448
of the codebase. You will then need to run the specs using the seed
2186 (e.g. with all services running, use `rspec --seed 2186`).

I believe there is an implicit assumption that we had a cleared out
queue after each run. This change ensures that prior to each run, we
clear the queue.

[1]:https://circleci.com/gh/samvera/hyrax/17187#tests/containers/5
[2]:https://github.com/rspec/rspec-rails/blob/v3.9.0/lib/rspec/rails/matchers/active_job.rb#L86

## Addressing spec warnings concerning `raise_error`

82be9beff3709e1268656f64ec784b711fa07f22

This also involved tidying up the documentation to reflect the expected
parameter type.

@samvera/hyrax-code-reviewers
