### PR TITLE
Refactoring for hopefully making 4195 easier

### DIFF
--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -8,7 +8,7 @@ require 'browse_everything/retriever'
 # and CreateWithRemoteFilesActor when files are located in some other service.
 class ImportUrlJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
-  attr_reader :file_set, :operation, :headers
+  attr_reader :file_set, :operation, :headers, :user, :uri
 
   before_enqueue do |job|
     operation = job.arguments[1]
@@ -18,10 +18,19 @@ class ImportUrlJob < Hyrax::ApplicationJob
   # @param [FileSet] file_set
   # @param [Hyrax::BatchCreateOperation] operation
   # @param [Hash] headers - header data to use in interaction with remote url
-  def perform(file_set, operation, headers = {}, use_valkyrie: Hyrax.config.use_valkyrie?)
+  # @param [Boolean] use_valkyrie - a switch on whether or not to use Valkyrie processing
+  #
+  # @todo At present, this job works for ActiveFedora objects. The use_valkyrie is not complete.
+  def perform(file_set, operation, headers = {}, use_valkyrie: false)
     @file_set = file_set
     @operation = operation
     @headers = headers
+    operation.performing!
+    @user = User.find_by_user_key(file_set.depositor)
+    @uri = URI(file_set.import_url)
+
+    return false unless can_retrieve_remote?
+
     if use_valkyrie
       # TODO
     else
@@ -31,27 +40,25 @@ class ImportUrlJob < Hyrax::ApplicationJob
 
   private
 
-    def perform_af
-      operation.performing!
-      user = User.find_by_user_key(file_set.depositor)
-      uri = URI(file_set.import_url)
-      name = file_set.label
+    def can_retrieve_remote?
+      return true if BrowseEverything::Retriever.can_retrieve?(uri, headers)
+      send_error('Expired URL')
+      false
+    end
 
-      unless BrowseEverything::Retriever.can_retrieve?(uri, headers)
-        send_error('Expired URL')
-        return false
-      end
+    def perform_af
+      name = file_set.label
 
       # @todo Use Hydra::Works::AddExternalFileToFileSet instead of manually
       #       copying the file here. This will be gnarly.
-      copy_remote_file(uri, name, headers) do |f|
+      copy_remote_file(name) do |f|
         # reload the FileSet once the data is copied since this is a long running task
         file_set.reload
 
         # FileSetActor operates synchronously so that this tempfile is available.
         # If asynchronous, the job might be invoked on a machine that did not have this temp file on its file system!
         # NOTE: The return status may be successful even if the content never attaches.
-        log_import_status(uri, f, user)
+        log_import_status(f)
       end
     end
 
@@ -59,18 +66,16 @@ class ImportUrlJob < Hyrax::ApplicationJob
     # It is important that the file on disk has the same file name as the URL,
     # because when the file in added into Fedora the file name will get persisted in the
     # metadata.
-    # @param uri [URI] the uri of the file to download
     # @param name [String] the human-readable name of the file
-    # @param headers [Hash] the HTTP headers for the GET request (these may contain an authentication token)
     # @yield [IO] the stream to write to
-    def copy_remote_file(uri, name, headers = {})
+    def copy_remote_file(name)
       filename = File.basename(name)
       dir = Dir.mktmpdir
       Rails.logger.debug("ImportUrlJob: Copying <#{uri}> to #{dir}")
 
       File.open(File.join(dir, filename), 'wb') do |f|
         begin
-          write_file(uri, f, headers)
+          write_file(f)
           yield f
         rescue StandardError => e
           send_error(e.message)
@@ -83,16 +88,14 @@ class ImportUrlJob < Hyrax::ApplicationJob
     # @param filename [String] the filename of the file to download
     # @param error_message [String] the download error message
     def send_error(error_message)
-      user = User.find_by_user_key(file_set.depositor)
       file_set.errors.add('Error:', error_message)
       Hyrax.config.callback.run(:after_import_url_failure, file_set, user, warn: false)
       operation.fail!(file_set.errors.full_messages.join(' '))
     end
 
     # Write file to the stream
-    # @param uri [URI] the uri of the file to download
     # @param f [IO] the stream to write to
-    def write_file(uri, f, headers)
+    def write_file(f)
       retriever = BrowseEverything::Retriever.new
       uri_spec = ActiveSupport::HashWithIndifferentAccess.new(url: uri, headers: headers)
       retriever.retrieve(uri_spec) do |chunk|
@@ -102,14 +105,12 @@ class ImportUrlJob < Hyrax::ApplicationJob
     end
 
     # Set the import operation status
-    # @param uri [URI] the uri of the file to download
     # @param f [IO] the stream to write to
-    # @param user [User]
-    def log_import_status(uri, f, user)
+    def log_import_status(f)
       if Hyrax::Actors::FileSetActor.new(file_set, user).create_content(f, from_url: true)
         operation.success!
       else
-        send_error(uri.path, nil)
+        send_error(uri.path)
       end
     end
 end


### PR DESCRIPTION
This morning, I thought I'd tackle one of the jobs. However, it is not immediately obvious how I should proceed (my Hyrax w/ Valkyrie skills are academic at best). These commits reflect a bit of work to get things into a state that I _could_ make it easier to incorporate Valkyrie.

What would be helpful is to see what the next work should be. I attempted to follow #4213, but did not find that helpful in the limited time that I had to look into the problem. My hope is that this is a "leaves the code-base a little better than before I touched it" set of commits.

I'm very curious what the next steps are regarding Valkyrizing this particular job. I feel once I see a pattern, I may be able to crank out a few more.

Below are the two commits and their messages.

## Refactoring ImportUrlJob to ease Valkyrization

369f318b98dc4081e1d94db72172e35cbbfe31bd

The code changes reflect a simple re-structuring that will make future
work easier:

1) Extract method from perform into context specific private method
2) Extract additional attr_reader to allow for common means of using
   instance variables

Refactoring related to #4195

## Refactoring object to leverage instance vars

bfd316e23b5bfbf8d811e8a8dd582c1a2529887b

Prior to this commit, there were parameters passed that could be
instead assigned at the beginning of the `#perform` method. In doing,
we have less chatter on the method calls.

This also involved extract additional instance variables that were
commonly used throughout.

Refactoring related to #4195

@samvera/hyrax-code-reviewers
