### PR TITLE
Begin to rework Hyrax's `Dry::Transactions` work to use Do notation

### DIFF
--- a/app/models/hyrax/change_set.rb
+++ b/app/models/hyrax/change_set.rb
@@ -11,7 +11,9 @@ module Hyrax
   #   Hyrax::ChangeSet(Monograph)
   def self.ChangeSet(resource_class)
     Class.new(Hyrax::ChangeSet) do
-      self.fields = resource_class.fields - resource_class.reserved_attributes
+      (resource_class.fields - resource_class.reserved_attributes).each do |field|
+        property field, default: nil
+      end
     end
   end
 

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -42,7 +42,7 @@ module Hyrax
     attribute :label, ::Valkyrie::Types::Set
     attribute :original_filename, ::Valkyrie::Types::Set
     attribute :mime_type, ::Valkyrie::Types::String.default(GENERIC_MIME_TYPE)
-    attribute :type, ::Valkyrie::Types::Set.default([Use::ORIGINAL_FILE])
+    attribute :type, ::Valkyrie::Types::Set.default([Use::ORIGINAL_FILE].freeze)
     attribute :content, ::Valkyrie::Types::Set
 
     # attributes set by fits

--- a/lib/hyrax/transactions/apply_change_set.rb
+++ b/lib/hyrax/transactions/apply_change_set.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/transaction'
+
+module Hyrax
+  module Transactions
+    ##
+    # Applies and saves a ChangeSet.
+    #
+    # @since 3.0.0
+    #
+    # @example Applying a ChangeSet to a Work
+    #   work = Hyrax::Work.new
+    #   change_set = Hyrax::ChangeSet.for(work)
+    #   change_set.title = ['Comet in Moominland']
+    #
+    #   transaction = Hyrax::Transactions::ApplyChangeSet.new
+    #   result = transaction.call(change_set)
+    #
+    #   result.bind(&:persisted?) => true
+    #
+    #   persisted = result.value_or { raise 'oh no!' } # safe unwrap
+    #   persisted.title      # => ['Comet in Moominland']
+    #
+    class ApplyChangeSet < Transaction
+      DEFAULT_STEPS = ['change_set.set_modified_date',
+                       'change_set.set_uploaded_date',
+                       'change_set.validate',
+                       'change_set.save'].freeze
+
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/apply_change_set.rb
+++ b/lib/hyrax/transactions/apply_change_set.rb
@@ -33,7 +33,7 @@ module Hyrax
     #
     class ApplyChangeSet < Transaction
       DEFAULT_STEPS = ['change_set.set_modified_date',
-                       'change_set.set_uploaded_date',
+                       'change_set.set_uploaded_date_unless_present',
                        'change_set.validate',
                        'change_set.save'].freeze
 

--- a/lib/hyrax/transactions/apply_change_set.rb
+++ b/lib/hyrax/transactions/apply_change_set.rb
@@ -4,7 +4,17 @@ require 'hyrax/transactions/transaction'
 module Hyrax
   module Transactions
     ##
-    # Applies and saves a ChangeSet.
+    # Applies and saves a `ChangeSet`.
+    #
+    # This transaction is intended to ensure appropriate results for a Hyrax
+    # model when saving changes from a `ChangeSet`. For example: it will set the
+    # system-managed metadata like modified date.
+    #
+    # If your application has custom system managed metadata, this is an
+    # appropriate place to inject that behavior.
+    #
+    # This will also validate the `ChangeSet`. Which validations to use is
+    # delegated on the `ChangeSet` itself.
     #
     # @since 3.0.0
     #

--- a/lib/hyrax/transactions/apply_change_set.rb
+++ b/lib/hyrax/transactions/apply_change_set.rb
@@ -27,7 +27,6 @@ module Hyrax
                        'change_set.validate',
                        'change_set.save'].freeze
 
-
       ##
       # @see Hyrax::Transactions::Transaction
       def initialize(container: Container, steps: DEFAULT_STEPS)

--- a/lib/hyrax/transactions/apply_change_set.rb
+++ b/lib/hyrax/transactions/apply_change_set.rb
@@ -24,7 +24,7 @@ module Hyrax
     #   change_set.title = ['Comet in Moominland']
     #
     #   transaction = Hyrax::Transactions::ApplyChangeSet.new
-    #   result = transaction.call(change_set)
+    #   result = transaction.call(change_set) # => Success(#<Hyrax::Work ...>)
     #
     #   result.bind(&:persisted?) => true
     #

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -26,15 +26,35 @@ module Hyrax
       require 'hyrax/transactions/steps/destroy_work'
       require 'hyrax/transactions/steps/ensure_admin_set'
       require 'hyrax/transactions/steps/ensure_permission_template'
+      require 'hyrax/transactions/steps/save'
       require 'hyrax/transactions/steps/save_work'
       require 'hyrax/transactions/steps/set_default_admin_set'
       require 'hyrax/transactions/steps/set_modified_date'
       require 'hyrax/transactions/steps/set_uploaded_date'
+      require 'hyrax/transactions/steps/validate'
 
       extend Dry::Container::Mixin
 
       # Disable BlockLength rule for DSL code
       # rubocop:disable Metrics/BlockLength
+      namespace 'change_set' do |ops|
+        ops.register 'save' do
+          Steps::Save.new
+        end
+
+        ops.register 'set_modified_date' do
+          Steps::SetModifiedDate.new
+        end
+
+        ops.register 'set_uploaded_date' do
+          Steps::SetUploadedDate.new
+        end
+
+        ops.register 'validate' do
+          Steps::Validate.new
+        end
+      end
+
       namespace 'work' do |ops|
         ops.register 'apply_collection_permission_template' do
           Steps::ApplyCollectionPermissionTemplate.new

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -32,7 +32,7 @@ module Hyrax
       require 'hyrax/transactions/steps/save_work'
       require 'hyrax/transactions/steps/set_default_admin_set'
       require 'hyrax/transactions/steps/set_modified_date'
-      require 'hyrax/transactions/steps/set_uploaded_date'
+      require 'hyrax/transactions/steps/set_uploaded_date_unless_present'
       require 'hyrax/transactions/steps/validate'
 
       extend Dry::Container::Mixin
@@ -60,8 +60,8 @@ module Hyrax
           Steps::SetModifiedDate.new
         end
 
-        ops.register 'set_uploaded_date' do
-          Steps::SetUploadedDate.new
+        ops.register 'set_uploaded_date_unless_present' do
+          Steps::SetUploadedDateUnlessPresent.new
         end
 
         ops.register 'validate' do
@@ -106,8 +106,8 @@ module Hyrax
           Steps::SetModifiedDate.new
         end
 
-        ops.register 'set_uploaded_date' do
-          Steps::SetUploadedDate.new
+        ops.register 'set_uploaded_date_unless_present' do
+          Steps::SetUploadedDateUnlessPresent.new
         end
       end
       # rubocop:enable Metrics/BlockLength

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -18,8 +18,10 @@ module Hyrax
     #
     # @see https://dry-rb.org/gems/dry-container/
     class Container
+      require 'hyrax/transactions/apply_change_set'
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/destroy_work'
+      require 'hyrax/transactions/work_create'
       require 'hyrax/transactions/steps/apply_collection_permission_template'
       require 'hyrax/transactions/steps/apply_permission_template'
       require 'hyrax/transactions/steps/apply_visibility'
@@ -38,6 +40,10 @@ module Hyrax
       # Disable BlockLength rule for DSL code
       # rubocop:disable Metrics/BlockLength
       namespace 'change_set' do |ops|
+        ops.register 'apply' do
+          ApplyChangeSet.new
+        end
+
         ops.register 'save' do
           Steps::Save.new
         end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -44,8 +44,16 @@ module Hyrax
           ApplyChangeSet.new
         end
 
+        ops.register 'ensure_admin_set' do
+          Steps::EnsureAdminSet.new
+        end
+
         ops.register 'save' do
           Steps::Save.new
+        end
+
+        ops.register 'set_default_admin_set' do
+          Steps::SetDefaultAdminSet.new
         end
 
         ops.register 'set_modified_date' do

--- a/lib/hyrax/transactions/create_work.rb
+++ b/lib/hyrax/transactions/create_work.rb
@@ -42,6 +42,10 @@ module Hyrax
     # @todo validate PermissionTemplate against visibility, lease, and embargo (see: `InterpretVisibilityActor`)
     # @todo add locking/transactionality. Just do better than the Actor Stack
     # @todo add support for proxy deposit (see: TransferRequestActor)
+    #
+    # @deprecated Development on Dry::Transaction has been discontinued, we're
+    #   removing existing transactions and replacing them with Dry::Monad-based
+    #   valkyrie versions.
     class CreateWork
       include Dry::Transaction(container: Hyrax::Transactions::Container)
 

--- a/lib/hyrax/transactions/create_work.rb
+++ b/lib/hyrax/transactions/create_work.rb
@@ -55,7 +55,7 @@ module Hyrax
       step :apply_collection_template, with: 'work.apply_collection_permission_template'
       step :apply_visibility,          with: 'work.apply_visibility'
       step :set_modified_date,         with: 'work.set_modified_date'
-      step :set_uploaded_date,         with: 'work.set_uploaded_date'
+      step :set_uploaded_date,         with: 'work.set_uploaded_date_unless_present'
       step :save_work,                 with: 'work.save_work'
     end
   end

--- a/lib/hyrax/transactions/destroy_work.rb
+++ b/lib/hyrax/transactions/destroy_work.rb
@@ -12,6 +12,10 @@ module Hyrax
     # @since 3.0.0
     #
     # @see https://dry-rb.org/gems/dry-transaction/
+    #
+    # @deprecated Development on Dry::Transaction has been discontinued, we're
+    #   removing existing transactions and replacing them with Dry::Monad-based
+    #   valkyrie versions.
     class DestroyWork
       include Dry::Transaction(container: Hyrax::Transactions::Container)
 

--- a/lib/hyrax/transactions/steps/ensure_admin_set.rb
+++ b/lib/hyrax/transactions/steps/ensure_admin_set.rb
@@ -3,19 +3,19 @@ module Hyrax
   module Transactions
     module Steps
       ##
-      # A `dry-transaction` step that ensures the input `work` has an AdminSet.
+      # A step that ensures the input object has an `#admin_set_id`.
       #
       # @since 2.4.0
       class EnsureAdminSet
-        include Dry::Transaction::Operation
+        include Dry::Monads[:result]
 
         ##
-        # @param [Hyrax::WorkBehavior] work
+        # @param [#admin_set_id] obj
         #
         # @return [Dry::Monads::Result] `Failure` if there is no `AdminSet` for
         #   the input; `Success(input)`, otherwise.
-        def call(work)
-          work.admin_set_id ? Success(work) : Failure(:no_admin_set_id)
+        def call(obj)
+          obj.admin_set_id ? Success(obj) : Failure(:no_admin_set_id)
         end
       end
     end

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Saves a given work, returning a Result (Success|Failure)
+      class Save
+        include Dry::Monads[:result]
+
+        ##
+        # @params [#save] persister
+        def initialize(persister: Hyrax.persister)
+          @persister = persister
+        end
+
+        ##
+        # @param [Hyrax::ChangeSet] change_set
+        #
+        # @return [Dry::Monads::Result] `Success(work)` if the change_set is
+        #   applied and the resource is saved;
+        #   `Failure([#to_s, change_set.resource])`, otherwise.
+        def call(change_set)
+          change_set.sync
+
+          Success(@persister.save(resource: change_set.resource))
+        rescue StandardError => err
+          Failure([err.message, change_set.resource])
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -23,17 +23,17 @@ module Hyrax
 
         ##
         # @param [Hyrax::ChangeSet] change_set
+        # @param [::User, nil] user
         #
         # @return [Dry::Monads::Result] `Success(work)` if the change_set is
         #   applied and the resource is saved;
         #   `Failure([#to_s, change_set.resource])`, otherwise.
-        def call(change_set)
+        def call(change_set, user: nil)
           saved = @persister.save(resource: change_set.sync)
 
-          depositor = ::User.find_by_user_key(saved.try(:depositor))
           Hyrax.publisher.publish('object.metadata.updated',
                                   object: saved,
-                                  user: depositor)
+                                  user: user)
 
           Success(saved)
         rescue StandardError => err

--- a/lib/hyrax/transactions/steps/set_default_admin_set.rb
+++ b/lib/hyrax/transactions/steps/set_default_admin_set.rb
@@ -3,21 +3,22 @@ module Hyrax
   module Transactions
     module Steps
       ##
-      # A `dry-transaction` step that sets the `AdminSet` for an input work to
-      # the default admin set, if none is already set. Creates the default
-      # admin set if it doesn't already exist.
+      # A step that sets the `AdminSet` for an input work to the default admin
+      # set if none is already set. Creates the default admin set if it doesn't
+      # already exist.
+      #
+      # @since 2.4.0
       class SetDefaultAdminSet
-        include Dry::Transaction::Operation
+        include Dry::Monads[:result]
 
         ##
-        # @param [Hyrax::WorkBehavior] work
+        # @param [#admin_set_id=] obj
         #
         # @return [Dry::Monads::Result]
-        def call(work)
-          work.admin_set ||=
-            AdminSet.find(AdminSet.find_or_create_default_admin_set_id)
+        def call(obj)
+          obj.admin_set_id ||= AdminSet.find_or_create_default_admin_set_id
 
-          Success(work)
+          Success(obj)
         end
       end
     end

--- a/lib/hyrax/transactions/steps/set_modified_date.rb
+++ b/lib/hyrax/transactions/steps/set_modified_date.rb
@@ -3,21 +3,30 @@ module Hyrax
   module Transactions
     module Steps
       ##
-      # A `dry-transaction` step that sets the modified date to now for an
-      # input work.
+      # A step that sets the modified date to now for an input resource or
+      # change_set
       #
       # @since 2.4.0
       class SetModifiedDate
-        include Dry::Transaction::Operation
+        include Dry::Monads[:result]
 
         ##
-        # @param [Hyrax::WorkBehavior] work
+        # @param [#time_in_utc] time_service
+        def initialize(time_service: Hyrax::TimeService)
+          @time_service = time_service
+        end
+
+        ##
+        # @param [#date_modified=] obj
         #
         # @return [Dry::Monads::Result]
-        def call(work)
-          work.date_modified = Hyrax::TimeService.time_in_utc
+        def call(obj)
+          return Failure[:no_date_modified_attribute, obj] unless
+            obj.respond_to?(:date_modified=)
 
-          Success(work)
+          obj.date_modified = @time_service.time_in_utc
+
+          Success(obj)
         end
       end
     end

--- a/lib/hyrax/transactions/steps/set_uploaded_date_unless_present.rb
+++ b/lib/hyrax/transactions/steps/set_uploaded_date_unless_present.rb
@@ -3,11 +3,26 @@ module Hyrax
   module Transactions
     module Steps
       ##
-      # A step that sets the uploaded date to now for an input resource or
-      # change_set
+      # A step that sets the uploaded date for an input `Valkyrie::Resource` or
+      # `ValkyrieChangeSet`.
       #
-      # @since 2.4.0
-      class SetUploadedDate
+      # The uploaded date is derived in the following way:
+      #
+      #   - if a `date_uploaded` is already present, keep it;
+      #   - if there is no current `date_uploaded` but `date_modified` is
+      #     present, use the value of `date_modified`.
+      #   - if neither `date_uploaded` nor `date_modified` is present, set the
+      #     time to now using the given `time_service`. `Hyrax::TimeService`
+      #     is used by default.
+      #
+      # A useful pattern is to run this step immediately following one to set
+      # the `date_modified` to now, and just before validation and save. This
+      # pattern ensures the times for a newly created object have the same
+      # value as close to the actual save time as practicable, and avoids
+      # overwriting `date_uploaded` for existing objects.
+      #
+      # @since 3.0.0
+      class SetUploadedDateUnlessPresent
         include Dry::Monads[:result]
 
         ##

--- a/lib/hyrax/transactions/steps/validate.rb
+++ b/lib/hyrax/transactions/steps/validate.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Validates a ChangeSet, returning `Success(change_set)` if valid, and
+      # a `Failure` including the errors otherwise.
+      #
+      # Callers provide the particular `ChangeSet` to validate, and its validity
+      # status is delegated by its own configuration/implementation.
+      #
+      # It is good practice to run this validation as a precursor to any step
+      # that will sync a ChangeSet or save its resource. A `Failure` return
+      # value in the context of a transaction will prevent the sync/save step
+      # from running.
+      #
+      # @since 3.0.0
+      class Validate
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Hyrax::ChangeSet] change_set
+        #
+        # @return [Dry::Monads::Result] `Success(input)` if the change_set is valid;
+        #   `Failure`, otherwise.
+        def call(change_set)
+          return Success(change_set) if change_set.valid?
+
+          Failure([:failed_validation, change_set.errors])
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/transaction.rb
+++ b/lib/hyrax/transactions/transaction.rb
@@ -44,7 +44,7 @@ module Hyrax
     #
     # @example a pattern for subclassing to create new transactions
     #   class CustomTransaction < Transaction
-    #     DEFAULT_STEPS ['step.1', 'step.2', 'step.3']
+    #     DEFAULT_STEPS = ['step.1', 'step.2', 'step.3'].freeze
     #
     #     def initialize(container: Container, steps: DEFAULT_STEPS)
     #       super

--- a/lib/hyrax/transactions/transaction.rb
+++ b/lib/hyrax/transactions/transaction.rb
@@ -100,10 +100,10 @@ module Hyrax
       ##
       # Sets arguments to pass to a given step in the transaction.
       #
-      # This makes it easy for individual steps to require peices of information
+      # This makes it easy for individual steps to require pieces of information
       # without other steps having to handle them. This is desirable since it
       # avoids passing mutable values between steps, which commonly results in
-      # tight intedependence and less flexible composibility between steps.
+      # tight interdependence and less flexible composibility between steps.
       #
       # Instead we expect the caller to provide the correct data to each step
       # when the transaction starts.

--- a/lib/hyrax/transactions/transaction.rb
+++ b/lib/hyrax/transactions/transaction.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'dry/monads/do'
+
+module Hyrax
+  module Transactions
+    ##
+    # @since 3.0.0
+    class Transaction
+      include Dry::Monads[:result]
+      include Dry::Monads::Do.for(:call)
+
+      ##
+      # @!attribute [rw] container
+      #   @return [Container]
+      # @!attribute [rw] steps
+      #   @return [Array<String>]
+      attr_accessor :container, :steps
+
+      ##
+      # @param [Container] container
+      # @param [Array<String>] steps
+      def initialize(container: Container, steps:)
+        self.container = container
+        self.steps     = steps
+      end
+
+      ##
+      # @param [Valkyrie::ChangeSet] change_set
+      #
+      # @return [Dry::Monads::Result]
+      def call(change_set)
+        Success(
+          steps.inject(change_set) do |w, s|
+            yield container[s].call(w)
+          end
+        )
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/transaction.rb
+++ b/lib/hyrax/transactions/transaction.rb
@@ -6,7 +6,54 @@ require 'dry/monads/do'
 module Hyrax
   module Transactions
     ##
+    # Queues up a set of `#steps` to run over a value via `#call`. Steps are
+    # given by name, and resolved at runtime via `container`, which defaults to
+    # `Hyrax::Transactions::Container`. This allows injection of specific
+    # handling for named steps at any time.
+    #
+    # `#call` will **ALWAYS** return a `Result` (`Success`|`Failure`) and it's
+    # recommended for users to handle the output in a way that directly
+    # addresses the `Failure` case. The simplest way to do this is to use
+    # `#value_or`: `tx.call(my_value).value_or { |failure| handle_failure(f) }`.
+    #
     # @since 3.0.0
+    #
+    # @example running a transaction for a set of steps
+    #   steps = ['change_set.validate', 'change_set.save']
+    #   tx    = Hyrax::Transactions::Transaction.new(steps: steps)
+    #
+    #   change_set = Hyrax::ChangeSet.for(Hyrax::Work.new)
+    #   change_set.title = ['comet in moominland']
+    #
+    #   tx.call(change_set) # => Success(#<Hyrax::Work ...>)
+    #
+    # @example with a failure
+    #   class ChangeSetWithTitleValidation < Hyrax::ChangeSet
+    #     self.fields = [:title]
+    #     validates :title, presence: true
+    #   end
+    #
+    #   change_set = ChangeSetWithTitleValidation.new(Hyrax::Work.new)
+    #   change_set.title = []
+    #
+    #   tx.call(change_set)
+    #   # => Failure([:failed_validation, #<Reform::Form::ActiveModel::Errors ...>]
+    #
+    # @example unwapping values safely with handling for failures
+    #   tx.call(change_set).value_or { |failure| "uh oh: #{failure} }
+    #
+    # @example a pattern for subclassing to create new transactions
+    #   class CustomTransaction < Transaction
+    #     DEFAULT_STEPS ['step.1', 'step.2', 'step.3']
+    #
+    #     def initialize(container: Container, steps: DEFAULT_STEPS)
+    #       super
+    #     end
+    #   end
+    #
+    #   tx = CustomTransaction.new
+    #   tx.call(:some_value)
+    #
     class Transaction
       include Dry::Monads[:result]
       include Dry::Monads::Do.for(:call)
@@ -27,13 +74,21 @@ module Hyrax
       end
 
       ##
-      # @param [Valkyrie::ChangeSet] change_set
+      # Run each step name in `#steps` by resolving the name in the given
+      # `container` and passing a value to call. Each step must return a
+      # `Result`. In the event of a `Success`, the wrapped value is passed
+      # through to the next step; for `Failure` the whole chain is short-
+      # circuited and the failure result is given.
       #
-      # @return [Dry::Monads::Result]
-      def call(change_set)
+      # @param [Object] value
+      #
+      # @return [Dry::Monads::Result] either the `Success` result of the entire
+      #   `#steps` chain over `value`, or a `Failure` from the failed step.
+      # @see Dry::Monads::Do
+      def call(value)
         Success(
-          steps.inject(change_set) do |w, s|
-            yield container[s].call(w)
+          steps.inject(value) do |val, step_name|
+            yield container[step_name].call(val)
           end
         )
       end

--- a/lib/hyrax/transactions/work_create.rb
+++ b/lib/hyrax/transactions/work_create.rb
@@ -8,7 +8,9 @@ module Hyrax
     #
     # @since 3.0.0
     class WorkCreate < Transaction
-      DEFAULT_STEPS = ['change_set.apply'].freeze
+      DEFAULT_STEPS = ['change_set.set_default_admin_set',
+                       'change_set.ensure_admin_set',
+                       'change_set.apply'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/work_create.rb
+++ b/lib/hyrax/transactions/work_create.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/transaction'
+
+module Hyrax
+  module Transactions
+    ##
+    # Creates a Work from a ChangeSet
+    #
+    # @since 3.0.0
+    class WorkCreate < Transaction
+      DEFAULT_STEPS = ['change_set.apply'].freeze
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/apply_change_set_spec.rb
+++ b/spec/hyrax/transactions/apply_change_set_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+require 'dry/container/stub'
+
+RSpec.describe Hyrax::Transactions::ApplyChangeSet do
+  subject(:tx)     { described_class.new }
+  let(:change_set) { Hyrax::ChangeSet.for(resource) }
+  let(:resource)   { build(:hyrax_work) }
+  let(:xmas)       { DateTime.parse('2018-12-25 11:30').iso8601 }
+
+  before { allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(xmas) }
+
+  describe '#call' do
+    it 'is a success' do
+      expect(tx.call(change_set)).to be_success
+    end
+
+    it 'wraps a saved work' do
+      result = tx.call(change_set)
+
+      expect(result.value!).to be_persisted
+    end
+
+    it 'sets modified and uploaded date' do
+      expect(tx.call(change_set).value!)
+        .to have_attributes(date_modified: xmas,
+                            date_uploaded: xmas)
+    end
+
+    context 'with an invalid change_set' do
+      let(:change_set) { change_set_class.new(resource) }
+
+      let(:change_set_class) do
+        Class.new(Hyrax::ChangeSet) do
+          self.fields = [:title]
+
+          validates :title, presence: true
+        end
+      end
+
+      it 'is a failure' do
+        expect(tx.call(change_set)).to be_failure
+      end
+    end
+
+    context 'when save step fails' do
+      before do
+        tx.container.enable_stubs!
+        tx.container.stub('change_set.save', failure_step)
+      end
+
+      after { tx.container.unstub('change_set.save') }
+
+      let(:failure_step) do
+        Class.new do
+          include Dry::Monads[:result]
+
+          def call(*args)
+            Failure([:always_fails, *args])
+          end
+        end.new
+      end
+
+      it 'is a failure' do
+        expect(tx.call(change_set)).to be_failure
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/apply_change_set_spec.rb
+++ b/spec/hyrax/transactions/apply_change_set_spec.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 require 'spec_helper'
 require 'hyrax/transactions'
+require 'hyrax/specs/spy_listener'
 require 'dry/container/stub'
 
 RSpec.describe Hyrax::Transactions::ApplyChangeSet do
   subject(:tx)     { described_class.new }
   let(:change_set) { Hyrax::ChangeSet.for(resource) }
   let(:resource)   { build(:hyrax_work) }
+  let(:user)       { create(:user) }
   let(:xmas)       { DateTime.parse('2018-12-25 11:30').iso8601 }
 
   before { allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(xmas) }
@@ -26,6 +28,28 @@ RSpec.describe Hyrax::Transactions::ApplyChangeSet do
       expect(tx.call(change_set).value!)
         .to have_attributes(date_modified: xmas,
                             date_uploaded: xmas)
+    end
+
+    describe 'events' do
+      let(:listener) { Hyrax::Specs::SpyListener.new }
+
+      before { Hyrax.publisher.subscribe(listener) }
+      after  { Hyrax.publisher.unsubscribe(listener) }
+
+      it 'publishes a metadata updated event for the resource' do
+        created = tx.call(change_set).value!
+
+        expect(listener.object_metadata_updated&.payload)
+          .to eq object: created, user: nil
+      end
+
+      it 'includes a given user in the event payload' do
+        tx.with_step_args('change_set.save' => { user: user })
+
+        expect { tx.call(change_set) }
+          .to change { listener.object_metadata_updated&.payload }
+          .to include user: user
+      end
     end
 
     context 'with an invalid change_set' do

--- a/spec/hyrax/transactions/steps/ensure_admin_set_spec.rb
+++ b/spec/hyrax/transactions/steps/ensure_admin_set_spec.rb
@@ -4,7 +4,7 @@ require 'hyrax/transactions'
 
 RSpec.describe Hyrax::Transactions::Steps::EnsureAdminSet do
   subject(:step) { described_class.new }
-  let(:work)     { build(:generic_work) }
+  let(:work)     { build(:hyrax_work) }
 
   describe '#call' do
     context 'without an admin set' do

--- a/spec/hyrax/transactions/steps/save_spec.rb
+++ b/spec/hyrax/transactions/steps/save_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions/steps/save'
+
+RSpec.describe Hyrax::Transactions::Steps::Save do
+  subject(:step)      { described_class.new(persister: persister) }
+  let(:adapter)       { Valkyrie::MetadataAdapter.find(:test_adapter) }
+  let(:change_set)    { change_set_class.new(resource) }
+  let(:persister)     { adapter.persister }
+  let(:resource)      { build(:hyrax_work) }
+  let(:query_service) { adapter.query_service }
+
+  let(:change_set_class) do
+    Class.new(Hyrax::ChangeSet) { self.fields = [:title] }
+  end
+
+  describe '#call' do
+    it 'is a success' do
+      expect(step.call(change_set)).to be_success
+    end
+
+    it 'saves the resource' do
+      expect(step.call(change_set).value!).to be_persisted
+    end
+
+    context 'when the save fails' do
+      before do
+        allow(persister)
+          .to receive(:save)
+          .with(resource: resource)
+          .and_raise Valkyrie::Persistence::StaleObjectError
+      end
+
+      it 'is a failure' do
+        expect(step.call(change_set)).to be_failure
+      end
+
+      it 'gives the error message and resource' do
+        expect(step.call(change_set).failure.last).to eq resource
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/save_spec.rb
+++ b/spec/hyrax/transactions/steps/save_spec.rb
@@ -35,15 +35,14 @@ RSpec.describe Hyrax::Transactions::Steps::Save do
         .to eq object: created, user: nil
     end
 
-    context 'when the object has a depositor' do
-      let(:resource) { build(:hyrax_work, depositor: user.user_key) }
+    context 'when the caller passes a user' do
+      let(:resource) { build(:hyrax_work) }
       let(:user)     { create(:user) }
 
-      it 'publishes an event with the depositor' do
-        created = step.call(change_set).value!
-
-        expect(listener.object_metadata_updated&.payload)
-          .to eq object: created, user: user
+      it 'publishes an event with a user' do
+        expect { step.call(change_set, user: user) }
+          .to change { listener.object_metadata_updated&.payload }
+          .to match object: an_instance_of(resource.class), user: user
       end
     end
 

--- a/spec/hyrax/transactions/steps/set_default_admin_set_spec.rb
+++ b/spec/hyrax/transactions/steps/set_default_admin_set_spec.rb
@@ -3,35 +3,66 @@ require 'spec_helper'
 require 'hyrax/transactions'
 
 RSpec.describe Hyrax::Transactions::Steps::SetDefaultAdminSet do
-  subject(:step) { described_class.new }
-  let(:work)     { build(:generic_work) }
+  subject(:step)   { described_class.new }
+  let(:work)       { build(:hyrax_work) }
+  let(:change_set) { Hyrax::ChangeSet.for(work) }
 
   describe '#call' do
     let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
 
     it 'is success' do
-      expect(step.call(work)).to be_success
+      expect(step.call(change_set)).to be_success
     end
 
     it 'sets the default admin_set' do
-      expect { step.call(work) }
-        .to change { work.admin_set&.id }
+      expect { step.call(change_set) }
+        .to change { change_set.admin_set_id }
         .from(nil)
         .to(admin_set_id)
     end
 
     context 'when the work has an admin_set' do
-      let(:admin_set) { create(:admin_set) }
-      let(:work)      { build(:generic_work, admin_set: admin_set) }
+      let(:admin_set) { valkyrie_create(:hyrax_admin_set) }
+      let(:work)      { build(:hyrax_work, admin_set_id: admin_set.id) }
+
+      it 'is success' do
+        expect(step.call(change_set)).to be_success
+      end
+
+      it 'does not change the admin_set' do
+        expect { step.call(change_set) }
+          .not_to change { change_set.admin_set_id }
+          .from(admin_set.id)
+      end
+    end
+
+    context 'with an active fedora object' do
+      let(:work) { build(:generic_work) }
 
       it 'is success' do
         expect(step.call(work)).to be_success
       end
 
-      it 'does not change the admin_set' do
+      it 'sets the default admin_set' do
         expect { step.call(work) }
-          .not_to change { work.admin_set&.id }
-          .from(admin_set.id)
+          .to change { work.admin_set&.id }
+          .from(nil)
+          .to(admin_set_id)
+      end
+
+      context 'when the work has an admin_set' do
+        let(:admin_set) { create(:admin_set) }
+        let(:work)      { build(:generic_work, admin_set: admin_set) }
+
+        it 'is success' do
+          expect(step.call(work)).to be_success
+        end
+
+        it 'does not change the admin_set' do
+          expect { step.call(work) }
+            .not_to change { work.admin_set&.id }
+            .from(admin_set.id)
+        end
       end
     end
   end

--- a/spec/hyrax/transactions/steps/set_modified_date_spec.rb
+++ b/spec/hyrax/transactions/steps/set_modified_date_spec.rb
@@ -4,19 +4,50 @@ require 'hyrax/transactions'
 
 RSpec.describe Hyrax::Transactions::Steps::SetModifiedDate do
   subject(:step) { described_class.new }
-  let(:work)     { build(:generic_work) }
-
+  let(:work)     { build(:hyrax_work) }
   let(:xmas)     { DateTime.parse('2018-12-25 11:30').iso8601 }
 
   before { allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(xmas) }
 
   describe '#call' do
-    it 'is success' do
-      expect(step.call(work)).to be_success
+    context 'with a work' do
+      it 'is success' do
+        expect(step.call(work)).to be_success
+      end
+
+      it 'sets the modified date' do
+        expect { step.call(work) }.to change { work.date_modified }.to xmas
+      end
+    end
+  end
+
+  context 'with a change_set' do
+    let(:change_set) { change_set_class.new(work) }
+
+    let(:change_set_class) do
+      Class.new(Hyrax::ChangeSet) { self.fields = [:date_modified] }
     end
 
-    it 'sets the modified date' do
-      expect { step.call(work) }.to change { work.date_modified }.to xmas
+    it 'is a success' do
+      expect(step.call(change_set)).to be_success
+    end
+
+    it 'sets the uploaded date' do
+      expect { step.call(change_set) }
+        .to change { change_set.date_modified }
+        .to xmas
+    end
+  end
+
+  context 'with a change_set without date_modified' do
+    let(:change_set) { change_set_class.new(work) }
+
+    let(:change_set_class) do
+      Class.new(Hyrax::ChangeSet) { self.fields = [] }
+    end
+
+    it 'is a failure' do
+      expect(step.call(change_set)).to be_failure
     end
   end
 end

--- a/spec/hyrax/transactions/steps/set_uploaded_date_spec.rb
+++ b/spec/hyrax/transactions/steps/set_uploaded_date_spec.rb
@@ -4,28 +4,92 @@ require 'hyrax/transactions'
 
 RSpec.describe Hyrax::Transactions::Steps::SetUploadedDate do
   subject(:step) { described_class.new }
-  let(:work)     { build(:generic_work) }
+  let(:work)     { build(:hyrax_work) }
   let(:xmas)     { DateTime.parse('2018-12-25 11:30').iso8601 }
 
   before { allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(xmas) }
 
   describe '#call' do
-    it 'is success' do
-      expect(step.call(work)).to be_success
+    context 'with a work' do
+      it 'is success' do
+        expect(step.call(work)).to be_success
+      end
+
+      it 'sets the uploaded date' do
+        expect { step.call(work) }.to change { work.date_uploaded }.to xmas
+      end
+
+      context 'when a modified date exists' do
+        let(:work)      { build(:hyrax_work, date_modified: xmas_past) }
+        let(:xmas_past) { DateTime.parse('2009-12-25 11:30').iso8601 }
+
+        it 'sets the uploaded date to the modified date' do
+          expect { step.call(work) }
+            .to change { work.date_uploaded }
+            .to work.date_modified
+        end
+      end
     end
 
-    it 'sets the uploaded date' do
-      expect { step.call(work) }.to change { work.date_uploaded }.to xmas
+    context 'with a change_set' do
+      let(:change_set) { change_set_class.new(work) }
+
+      let(:change_set_class) do
+        Class.new(Hyrax::ChangeSet) do
+          self.fields = [:date_modified, :date_uploaded]
+        end
+      end
+
+      it 'is a success' do
+        expect(step.call(change_set)).to be_success
+      end
+
+      it 'sets the uploaded date' do
+        expect { step.call(change_set) }
+          .to change { change_set.date_uploaded }
+          .to xmas
+      end
+
+      context 'when a modified date exists' do
+        let(:xmas_past) { DateTime.parse('2009-12-25 11:30').iso8601 }
+
+        before { change_set.date_modified = xmas_past }
+
+        it 'sets the uploaded date to the modified date' do
+          expect { step.call(change_set) }
+            .to change { change_set.date_uploaded }
+            .to change_set.date_modified
+        end
+      end
     end
 
-    context 'when a modified date exists' do
-      let(:work)      { build(:generic_work, date_modified: xmas_past) }
-      let(:xmas_past) { DateTime.parse('2009-12-25 11:30').iso8601 }
+    context 'with a change_set without date_uploaded' do
+      let(:change_set) { change_set_class.new(work) }
 
-      it 'sets the uploaded date to the modified date' do
-        expect { step.call(work) }
-          .to change { work.date_uploaded }
-          .to work.date_modified
+      let(:change_set_class) do
+        Class.new(Hyrax::ChangeSet) { self.fields = [:date_modified] }
+      end
+
+      it 'is a failure' do
+        expect(step.call(change_set)).to be_failure
+      end
+    end
+
+    context 'with a change_set without date_modified' do
+      let(:change_set) { change_set_class.new(work) }
+
+      let(:change_set_class) do
+        Class.new(Hyrax::ChangeSet) { self.fields = [:date_uploaded] }
+      end
+
+      it 'is a success' do
+        expect(step.call(change_set)).to be_success
+      end
+
+      it 'sets the uploaded date' do
+        expect { step.call(change_set) }
+          .to change { change_set.date_uploaded }
+          .to xmas
       end
     end
   end

--- a/spec/hyrax/transactions/steps/set_uploaded_date_unless_present_spec.rb
+++ b/spec/hyrax/transactions/steps/set_uploaded_date_unless_present_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'hyrax/transactions'
 
-RSpec.describe Hyrax::Transactions::Steps::SetUploadedDate do
+RSpec.describe Hyrax::Transactions::Steps::SetUploadedDateUnlessPresent do
   subject(:step) { described_class.new }
   let(:work)     { build(:hyrax_work) }
   let(:xmas)     { DateTime.parse('2018-12-25 11:30').iso8601 }

--- a/spec/hyrax/transactions/steps/validate_spec.rb
+++ b/spec/hyrax/transactions/steps/validate_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions/steps/validate'
+
+RSpec.describe Hyrax::Transactions::Steps::Validate do
+  subject(:step)   { described_class.new }
+  let(:change_set) { Hyrax::ChangeSet.for(resource) }
+  let(:resource)   { build(:hyrax_work) }
+
+  describe '#call' do
+    it 'is a success' do
+      expect(step.call(change_set)).to be_success
+    end
+
+    it 'wraps the change_set' do
+      result = step.call(change_set)
+
+      expect(result.value!).to eql change_set
+    end
+
+    context 'when given an invalid change_set' do
+      let(:change_set) { change_set_class.new(resource) }
+
+      let(:change_set_class) do
+        Class.new(Hyrax::ChangeSet) do
+          self.fields = [:title]
+
+          validates :title, presence: true
+        end
+      end
+
+      it 'is a failure' do
+        expect(step.call(change_set)).to be_failure
+      end
+
+      it 'gives the change_set errors' do
+        expect(step.call(change_set).failure.last).to respond_to(:messages)
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/transaction_spec.rb
+++ b/spec/hyrax/transactions/transaction_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+require 'dry/container/stub'
+
+RSpec.describe Hyrax::Transactions::Transaction do
+  subject(:tx) { described_class.new(steps: step_names) }
+  let(:step_names) { ['change_set.validate', 'change_set.apply'] }
+  let(:value) { :moomin }
+
+  let(:failure_step) do
+    Class.new do # always fails
+      include Dry::Monads[:result]
+
+      def call(*args)
+        Failure([:always_fails, *args])
+      end
+    end.new
+  end
+
+  let(:success_step) do
+    Class.new do # always succeeds
+      include Dry::Monads[:result]
+
+      def call(arg)
+        Success(arg)
+      end
+    end.new
+  end
+
+  let(:step_with_arguments) do
+    Class.new do # always succeeds
+      include Dry::Monads[:result]
+
+      def call(arg, user: nil) # rubocop:disable Lint/UnusedMethodArgument
+        Success(arg)
+      end
+    end.new
+  end
+
+  before do
+    tx.container.enable_stubs!
+    tx.container.stub('change_set.validate', step_with_arguments)
+    tx.container.stub('change_set.apply', success_step)
+  end
+
+  after do
+    tx.container.unstub('change_set.validate')
+    tx.container.unstub('change_set.apply')
+  end
+
+  describe '#call' do
+    it 'runs the steps' do
+      expect(tx.call(value).value!).to eq value
+    end
+  end
+
+  describe '#with_step_args' do
+    let(:user) { :FAKE_USER }
+
+    it 'passes step options' do
+      expect(tx.container['change_set.validate'])
+        .to receive(:call)
+        .with(value, user: user)
+        .and_call_original
+
+      tx.with_step_args('change_set.validate' => [{ user: user }]).call(value)
+    end
+
+    it 'rejects options for mismatched steps' do
+      expect { tx.with_step_args('fake.step' => [:arg]) }
+        .to raise_error ArgumentError
+    end
+  end
+end

--- a/spec/hyrax/transactions/work_create_spec.rb
+++ b/spec/hyrax/transactions/work_create_spec.rb
@@ -16,5 +16,20 @@ RSpec.describe Hyrax::Transactions::WorkCreate do
     it 'wraps a saved work' do
       expect(tx.call(change_set).value!).to be_persisted
     end
+
+    it 'sets the default admin set' do
+      expect(tx.call(change_set).value!)
+        .to have_attributes admin_set_id: Valkyrie::ID.new('admin_set/default')
+    end
+
+    context 'when an admin set is already assigned to the work' do
+      let(:admin_set) { valkyrie_create(:hyrax_admin_set) }
+      let(:resource) { build(:hyrax_work, admin_set_id: admin_set.id) }
+
+      it 'keeps the existing admin set' do
+        expect(tx.call(change_set).value!)
+          .to have_attributes admin_set_id: admin_set.id
+      end
+    end
   end
 end

--- a/spec/hyrax/transactions/work_create_spec.rb
+++ b/spec/hyrax/transactions/work_create_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+require 'dry/container/stub'
+
+RSpec.describe Hyrax::Transactions::WorkCreate do
+  subject(:tx)     { described_class.new }
+  let(:change_set) { Hyrax::ChangeSet.for(resource) }
+  let(:resource)   { build(:hyrax_work) }
+
+  describe '#call' do
+    it 'is a success' do
+      expect(tx.call(change_set)).to be_success
+    end
+
+    it 'wraps a saved work' do
+      expect(tx.call(change_set).value!).to be_persisted
+    end
+  end
+end

--- a/spec/models/hyrax/change_set_spec.rb
+++ b/spec/models/hyrax/change_set_spec.rb
@@ -2,37 +2,50 @@
 
 RSpec.describe Hyrax::ChangeSet do
   subject(:change_set) { described_class.for(resource) }
-  let(:resource)       { resource_class.new }
-  let(:resource_class) { Hyrax::Test::BookResource }
+  let(:resource)       { build(:hyrax_work) }
   let(:titles)         { ['comet in moominland', 'finn family moomintroll'] }
 
-  it 'changes when changed' do
-    expect { change_set.title = titles }
-      .to change { change_set.changed? }
-      .from(false)
-      .to(true)
+  describe 'properties' do
+    it 'changes when changed' do
+      expect { change_set.title = titles }
+        .to change { change_set.changed? }
+        .from(false)
+        .to(true)
+    end
+
+    it 'sets changeset attributes' do
+      expect { change_set.title = titles }
+        .to change { change_set.title }
+        .to contain_exactly(*titles)
+    end
+
+    it 'does not expose reserved attributes' do
+      expect { change_set.id = 'fake id' }.to raise_error NoMethodError
+    end
+
+    it 'does not list reserved attributes as fields' do
+      expect(change_set.class.fields)
+        .not_to include(*resource.class.reserved_attributes)
+    end
   end
 
-  it 'sets changeset attributes' do
-    expect { change_set.title = titles }
-      .to change { change_set.title }
-      .to contain_exactly(*titles)
-  end
+  describe '#sync' do
+    it 'applies changeset attributes' do
+      change_set.title = titles
 
-  it 'applies changeset attributes' do
-    change_set.title = titles
+      expect { change_set.sync }
+        .to change { resource.title }
+        .to contain_exactly(*titles)
+    end
 
-    expect { change_set.sync }
-      .to change { resource.title }
-      .to contain_exactly(*titles)
-  end
+    it 'can save resources after sync' do
+      change_set.title = titles
+      change_set.sync
 
-  it 'does not expose reserved attributes' do
-    expect { change_set.id = 'fake id' }.to raise_error NoMethodError
-  end
+      id = Hyrax.persister.save(resource: resource).id
 
-  it 'does not list attributes' do
-    expect(change_set.class.fields)
-      .not_to include(*resource_class.reserved_attributes)
+      expect(Hyrax.query_service.find_by(id: id))
+        .to have_attributes(title: contain_exactly(*titles))
+    end
   end
 end


### PR DESCRIPTION
`Dry::Transaction` development has been sunsetted, replaced by a new "Do notation" syntax in `Dry::Monad`. `Do` is more flexible than the older `Transaction` interfaces, but is missing some of the `Dry` ecosystem features like `Dry::Container` driven step resolution.

Our goal in transitioning this nascent feature set to Do notation is to replace the parts of this that have direct value for Hyrax.

To this end, some base behavior on top of Do is added to `Hyrax::Transactions::Transaction`. This base class can either be used directly by passing a list of steps in on init, or subclassed to provide ready-to-use function-specific transactions.

A few of these are provided:
  - `ApplyChangeSet` is intended for general use when applying a `Valkyrie::ChangeSet`, ensuring appropriate results wrt Hyrax's system-managed metadata.
  - `WorkCreate` is an early-stage replacement for the Actor Stack's `#create` stack. There is much work left to do here.

In general, the plan is for Transactions to provide composable, customizable behavior sets for accomplishing sequential tasks, with a clear interface for error handling (`Dry::Monads::Result`). This is meant to show that working and begin to move us away from the false-start `Dry::Transaction` approach.

---
Adds a `Dry::Transaction`-like step argument setup via
`with_step_arguments`. When no arguments are passed for a given step, we pass
only the value wrapped by the previous step. But when step arguments are given,
we pass them into the specified step as supplemental data.

This makes it easy for individual steps to require pieces of information without
other steps having to handle them. In the actor stack, we struggled with
environment parameters mutating throughout the stack, causing brittle order and
behavior dependencies throughout the stack. Step arguments should avoid this
pitfall by ensuring callers pass step-specific data only to the step that
requires them.

To aid debugging and prevent running misconfigured transactions, we fail eagerly
when arguments are passed for steps that don't exist in the transaction.

---

~~One missing feature from `Dry::Transaction` is "step arguments". For example, one could do:~~

```ruby
transaction.with_step_args(step_name: [:additional, :arguments]).call(value)
```

~~This was handy for injecting step-specific arguments without needing to pass them through the other steps, risking mutation and a resulting strong inter-dependency between steps. e.g. `tx.with_step_args(save: {user: current_user})` would save some of the awkwardness about `depositor` in the current implementation.~~

~~What do folks think about reimplementing this in our local `Transaction` base?~~
@samvera/hyrax-code-reviewers
