### PR TITLE
Removing spec files from gem distribution…

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -16,7 +16,7 @@ SUMMARY
 
   spec.homepage      = "http://github.com/samvera/hyrax"
 
-  spec.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
+  spec.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR).select { |f| File.dirname(f) !~ %r{\A"?spec\/?} }
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.name          = "hyrax"
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This time for real.

With SHA 42bf8a1c41c52ceaa9811f60ae94411fce57c785 I removed the
test_files from gem distrubtion. However, the files would have
continued to be distributed. I discovered this when I went to try to
release Hyrax 2.7.0, and got the same error.

I wrote the Regular Expression to skip the spec directory. This leaves
me a bit non-plussed, as its more invasive and seems to break more of
the practices.

To test if this would work, I made the change and then ran:

```console
$ gem build hyrax.gemspec
```

That command built the gem file for distribution, and worked. My plan
is to push up a second commit to compare and contrast. I'm not happy
with what is needed, as the previous commit felt appropriate and this
feels more invasive. Perhaps I'm overly concerned and this is the best
means forward, especially considering our discussion.

This builds on PR #4239

@samvera/hyrax-code-reviewers
