### PR TITLE
Removing reference to Valkyrie on 2.x branch

### DIFF
--- a/spec/services/hyrax/file_set_csv_service_spec.rb
+++ b/spec/services/hyrax/file_set_csv_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hyrax::FileSetCSVService do
 
       it { is_expected.to eq "123abc,My Title,jilluser@example.com,\"Von, Creator\",restricted,Book|Other,Mine,pdf\n" }
       it "parses as valid csv" do
-        expect(CSV.parse(subject)).to eq([["123abc", "My Title", "jilluser@example.com", "Von, Creator", "restricted", "Book|Other", "Mine", "pdf"]])
+        expect(::CSV.parse(subject)).to eq([["123abc", "My Title", "jilluser@example.com", "Von, Creator", "restricted", "Book|Other", "Mine", "pdf"]])
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -142,15 +142,6 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-query_registration_target =
-  Valkyrie::MetadataAdapter.find(:test_adapter).query_service.custom_queries
-[Hyrax::CustomQueries::FindAccessControl,
- Hyrax::CustomQueries::FindManyByAlternateIds,
- Hyrax::CustomQueries::FindFileMetadata,
- Hyrax::CustomQueries::Navigators::FindFiles].each do |handler|
-  query_registration_target.register_query_handler(handler)
-end
-
 ActiveJob::Base.queue_adapter = :test
 
 require 'active_fedora/cleaner'
@@ -309,13 +300,5 @@ RSpec.configure do |config|
   config.after do
     ActiveJob::Base.queue_adapter.enqueued_jobs  = []
     ActiveJob::Base.queue_adapter.performed_jobs = []
-  end
-
-  config.before(:example, :valkyrie_adapter) do |example|
-    adapter_name = example.metadata[:valkyrie_adapter]
-
-    allow(Hyrax)
-      .to receive(:metadata_adapter)
-      .and_return(Valkyrie::MetadataAdapter.find(adapter_name))
   end
 end


### PR DESCRIPTION
* Ensuring CSV usage has same namespace consideration
* Removing reference to Valkyrie on `2.x-stable` branch

These two commits, which don't effect the production version of Hyrax, do impact the test suite for Hyrax development on the `2.x-stable` branch.

@samvera/hyrax-code-reviewers
