### PR TITLE
Backporting accessibility features to 2.x

### DIFF
--- a/app/views/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/hyrax/homepage/_explore_collections.html.erb
@@ -7,7 +7,7 @@
             <div class="media-body">
               <div class="media-heading">
                 <%= link_to [hyrax, collection] do %>
-                  <%= render_thumbnail_tag(collection, { class: 'hidden-xs file_listing_thumbnail' },
+                  <%= render_thumbnail_tag(collection, { class: 'hidden-xs file_listing_thumbnail', alt: "#{collection.title_or_label} #{ t('hyrax.homepage.admin_sets.thumbnail')}" },
                                            { suppress_link: true }) + collection.title_or_label %>
                 <% end %>
               </div>

--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -3,7 +3,7 @@
     <span class="sr-only"><%= t('hyrax.homepage.featured_works.document.title_label') %></span>
     <h3>
       <%= link_to [main_app, featured] do %>
-        <%= render_thumbnail_tag(featured, {width: 90}, {suppress_link: true}) + featured.title.first %>
+        <%= render_thumbnail_tag(featured, {width: 90, alt: "#{featured.title.first.to_s} #{ t('hyrax.homepage.admin_sets.thumbnail')}" }, {suppress_link: true}) + featured.title.first %>
       <% end %>
     </h3>
   </div>

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -4,7 +4,7 @@
         <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
         <h3>
           <%= link_to [main_app, recent_document] do %>
-            <%= render_thumbnail_tag(recent_document, {width: 90, alt: "#{recent_document.to_s} #{ t('hyrax.homepage.admin_sets.thumbnail')}" }, {suppress_link: true}) + recent_document.to_s %>
+            <%= render_thumbnail_tag(recent_document, {width: 90, alt: "#{recent_document} #{ t('hyrax.homepage.admin_sets.thumbnail')}" }, {suppress_link: true}) %><%= recent_document %>
           <% end %>
         </h3>
         <p class="recent-field">

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -4,7 +4,7 @@
         <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
         <h3>
           <%= link_to [main_app, recent_document] do %>
-            <%= render_thumbnail_tag(recent_document, {width: 90}, {suppress_link: true}) + recent_document.to_s %>
+            <%= render_thumbnail_tag(recent_document, {width: 90, alt: "#{recent_document.to_s} #{ t('hyrax.homepage.admin_sets.thumbnail')}" }, {suppress_link: true}) + recent_document.to_s %>
           <% end %>
         </h3>
         <p class="recent-field">

--- a/app/views/hyrax/homepage/_sortable_featured.html.erb
+++ b/app/views/hyrax/homepage/_sortable_featured.html.erb
@@ -13,6 +13,7 @@
               data: {behavior: 'unfeature'} do %>
               <i class='glyphicon glyphicon-remove'></i>
             <% end %>
+            <p class="sr-only"><%= t 'helpers.action.remove' %></p>
           </h3>
         <% end %>
         <%= render 'hyrax/homepage/featured_fields', featured: presenter %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -142,15 +142,6 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-query_registration_target =
-  Valkyrie::MetadataAdapter.find(:test_adapter).query_service.custom_queries
-[Hyrax::CustomQueries::FindAccessControl,
- Hyrax::CustomQueries::FindManyByAlternateIds,
- Hyrax::CustomQueries::FindFileMetadata,
- Hyrax::CustomQueries::Navigators::FindFiles].each do |handler|
-  query_registration_target.register_query_handler(handler)
-end
-
 ActiveJob::Base.queue_adapter = :test
 
 require 'active_fedora/cleaner'
@@ -309,13 +300,5 @@ RSpec.configure do |config|
   config.after do
     ActiveJob::Base.queue_adapter.enqueued_jobs  = []
     ActiveJob::Base.queue_adapter.performed_jobs = []
-  end
-
-  config.before(:example, :valkyrie_adapter) do |example|
-    adapter_name = example.metadata[:valkyrie_adapter]
-
-    allow(Hyrax)
-      .to receive(:metadata_adapter)
-      .and_return(Valkyrie::MetadataAdapter.find(adapter_name))
   end
 end


### PR DESCRIPTION
This is a bit of a speculative PR. I have been backport-ing commits AND working on stabilizing the intermittent spec failures. These two commits are part of both improving accessibility AND improving spec stability.

I don't know if these are something to merge, as I'll need someone far more aware of the UI considerations. However, it is work that helps ensure we can continue to more effectively back port code (as specs are less likely to have false failures).

@samvera/hyrax-code-reviewers
