### PR TITLE
Further tidying of rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,10 +121,6 @@ RSpec/DescribeClass:
 RSpec/MessageSpies:
   Enabled: false
 
-RSpec/InstanceVariable:
-  Exclude:
-    - 'spec/services/hyrax/derivative_service_spec.rb'
-
 RSpec/ExpectActual:
   Enabled: false
 

--- a/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
@@ -41,7 +41,7 @@ module Hyrax
               text << ", " << author
             end
           end
-          text << "." unless text =~ /\.$/
+          text << "." unless text.end_with?(".")
           text
         end
 

--- a/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
@@ -35,7 +35,7 @@ module Hyrax
           text << " et al." if authors_list.length > 7
           # if for some reason the first author ended with a comma
           text.gsub!(',,', ',')
-          text << "." unless text =~ /\.$/
+          text << "." unless text.end_with?(".")
           whitewash(text)
         end
         # rubocop:enable Metrics/MethodLength
@@ -45,7 +45,7 @@ module Hyrax
         def format_title(title_info)
           return "" if title_info.blank?
           title_text = chicago_citation_title(title_info)
-          title_text << '.' unless title_text =~ /\.$/
+          title_text << '.' unless title_text.end_with?(".")
           title_text = whitewash(title_text)
           " <i class=\"citation-title\">#{title_text}</i>"
         end

--- a/app/helpers/hyrax/citations_behaviors/formatters/mla_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/mla_formatter.rb
@@ -27,7 +27,7 @@ module Hyrax
           authors_list = Array.wrap(authors_list)
           text = concatenate_authors_from(authors_list)
           if text.present?
-            text << "." unless text =~ /\.$/
+            text << "." unless text.end_with?(".")
             text << " "
           end
           text

--- a/app/helpers/hyrax/citations_behaviors/name_behavior.rb
+++ b/app/helpers/hyrax/citations_behaviors/name_behavior.rb
@@ -15,7 +15,7 @@ module Hyrax
 
       def given_name_first(name)
         name = clean_end_punctuation(name)
-        return name unless name =~ /,/
+        return name unless name.include?(',')
         temp_name = name.split(/,\s*/)
         temp_name.last + " " + temp_name.first
       end

--- a/lib/generators/hyrax/work/work_generator.rb
+++ b/lib/generators/hyrax/work/work_generator.rb
@@ -59,7 +59,7 @@ class Hyrax::WorkGenerator < Rails::Generators::NamedBase
     lastmatch = nil
     in_root do
       File.open(config).each_line do |line|
-        lastmatch = line if line =~ /config.register_curation_concern :(?!#{file_name})/
+        lastmatch = line if line.match?(/config.register_curation_concern :(?!#{file_name})/)
       end
       content = "  # Injected via `rails g hyrax:work #{class_name}`\n" \
                 "  config.register_curation_concern #{registration_path_symbol}\n"

--- a/spec/services/hyrax/derivative_service_spec.rb
+++ b/spec/services/hyrax/derivative_service_spec.rb
@@ -6,11 +6,10 @@ RSpec.describe Hyrax::DerivativeService do
   subject { described_class.new(file_set) }
 
   it_behaves_like "a Hyrax::DerivativeService"
-  before do
-    @cached_services = described_class.services
-  end
-  after do
-    described_class.services = @cached_services
+  around do |example|
+    cached_services = described_class.services
+    example.run
+    described_class.services = cached_services
   end
 
   describe ".services=" do


### PR DESCRIPTION
## Replacing spec instance variable with `around`

cb30826baecab1a7a65c28acca774b87c5351e8b

This commit appeases by Rubocop's dislike of RSpec instance variables
and tidies up the spec to use `around` instead of inter-dependent
`before` and `after` specs.

## Replacing regular expression with string comparison

9ce198c2dbdbab1f4d33a4b48bfdbe755058fbbe

Based on benchmarking, string comparison is faster than regular
express. I also believe that `end_with?(".")` reads better than
mentally parsing a regular expression; It is certainly more "new
developer" friendly.

Here is the benchmark that I ran locally to test performance:

```ruby
require 'benchmark'
n = 30_000_000
Benchmark.bm do |x|
  x.report { n.times { ".".end_with?(".") } }
  x.report { n.times { "." =~ /\.$/ } }
end

```

And here are the results:

```log
    user     system      total        real
4.108148   0.021553   4.129701 (  4.194707)
7.508562   0.018433   7.526995 (  7.585707)
```

And as a bonus, when attempting to bump Rubocop's `TargetRubyVersion`
from `2.3` to `2.4`, the one violation was that we were using `=~`.
Rubocop recommended that we switch to `match?` for regular
expressions.

## Replacing regular expression with string comparison

571d3d6245cc224433044fef8c83cd3ff57e80c3

Based on benchmarking, string comparison is faster than regular
express. I also believe that `include?(",")` reads better than
mentally parsing a regular expression; It is certainly more "new
developer" friendly.

Here is the benchmark that I ran locally to test performance:

```ruby
require 'benchmark'
n = 30_000_000
Benchmark.bm do |x|
  x.report { n.times { ",".include?(",") } }
  x.report { n.times { "," =~ /,/ } }
end
```

And here is the result:

```log
    user     system      total        real
4.250284   0.011629   4.261913 (  4.277509)
7.416814   0.021451   7.438265 (  7.467298)
```

And as a bonus, when attempting to bump Rubocop's `TargetRubyVersion`
from `2.3` to `2.4`, the one violation was that we were using `=~`.
Rubocop recommended that we switch to `match?` for regular
expressions (instead of `=~`).

And as an additional bonus, we were already using `include?(',')`
throughout the changed file. So this commit aligns the implementation
details of each of those points in the code.

## Favoring `match?` over `=~`

12bec9beb3ca43c48a59e45c989e7fe914ad4f09

Later versions of Rubocop, namely `TargetRubyVersion: 2.4` begin
flagging `=~` as something to replace. I suspect the warning is related
to `=~` pushing matching capture (e.g. the portion between `(` and `)`)
into the `$1` (and $2 if there are 2 captures). The `$1` and so on are
not thread safe.

As a matter of practice, it makes sense to move away from `=~` and into
the prefered `match?` method usage.
