### PR TITLE
Reworking OrcidValidator

### DIFF
--- a/app/models/concerns/hyrax/user.rb
+++ b/app/models/concerns/hyrax/user.rb
@@ -106,7 +106,7 @@ module Hyrax::User
     #   2. the orcid field is blank
     #   3. the orcid is already in its normalized form
     return if errors[:orcid].first.present? || orcid.blank? || orcid.starts_with?('https://orcid.org/')
-    bare_orcid = Hyrax::OrcidValidator.match(orcid)
+    bare_orcid = Hyrax::OrcidValidator.extract_bare_orcid(from: orcid)
     self.orcid = "https://orcid.org/#{bare_orcid}"
   end
 

--- a/app/models/hyrax/orcid_validator.rb
+++ b/app/models/hyrax/orcid_validator.rb
@@ -1,17 +1,24 @@
 module Hyrax
   class OrcidValidator < ActiveModel::Validator
+    ORCID_REGEXP = %r{^(?<prefix>https?://orcid.org/)?(?<orcid>\d{4}-\d{4}-\d{4}-\d{3}[\dX])/?$}
     def validate(record)
       return if record.orcid.blank?
-      record.errors.add(:orcid, 'must be a string of 19 characters, e.g., "0000-0000-0000-0000"') unless self.class.match(record.orcid)
+      record.errors.add(:orcid, 'must be a string of 19 characters, e.g., "0000-0000-0000-0000"') unless ORCID_REGEXP.match?(record.orcid)
     end
 
+    # @deprecated
     def self.match(string)
-      Regexp.new(orcid_regex).match(string) { |m| m[:orcid] }
+      Deprecation.warn "Use 'Hyrax::OrcidValidator.extract_bare_orcid(from:)'"
+      extract_bare_orcid_from(from: string)
     end
 
-    def self.orcid_regex
-      '^(?<prefix>https?://orcid.org/)?(?<orcid>\d{4}-\d{4}-\d{4}-\d{3}[\dX])/?$'
+    # @api public
+    # @param [String] from
+    # @return nil if the given string is not in the Orcid form
+    # @return string of the form "0000-0000-0000-0000" if the given string conforms to Orcid's format
+    # @see ORCID_REGEXP
+    def self.extract_bare_orcid(from:)
+      ORCID_REGEXP.match(from) { |m| m[:orcid] }
     end
-    private_class_method :orcid_regex
   end
 end


### PR DESCRIPTION
Earlier today, I was looking at Rubocop and doing some chores (see pull
request #4250) to see if I could remove some exclusions and even update
elements of Rubocop.

I tried bumping `.rubocop.yml`'s `TargetRubyVersion` from `2.3` to
`2.4`. I got a `Performance/RegexpMatch` violation, encouraging me to
use `match?` instead of `match` and/or `=~`. I spent some time shifting
from Regular Expressions to string matches (see PR #4250).

That left one violation; The one that is fixed in this pull request.

In addition to reworking to use `match?`, I reworked to be more
explicit about what the original `match` method was intended for;
Namely extracting an orcid from the given string.

@samvera/hyrax-code-reviewers
