### PR TITLE
Cleaning up Rubocop exclusions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,10 +32,6 @@ Metrics/BlockLength:
     - 'lib/tasks/*.rake'
     - 'spec/**/*.rb'
 
-# Naming/FileName: # https://github.com/bbatsov/rubocop/issues/2973
-#   Exclude:
-#     - 'Gemfile'
-
 Style/AsciiComments:
   Enabled: false
 
@@ -58,10 +54,6 @@ Style/MethodMissing:
   Exclude:
     - 'app/models/concerns/hyrax/file_set/characterization.rb'
 
-Style/NumericPredicate:
-  Exclude:
-    - 'app/controllers/hyrax/file_sets_controller.rb'
-
 Style/SymbolArray:
   Enabled: false
 
@@ -70,10 +62,6 @@ Style/ClassAndModuleChildren:
 
 Style/SingleLineBlockParams:
   Enabled: false
-
-Style/ZeroLengthPredicate:
-  Exclude:
-    - 'app/controllers/hyrax/file_sets_controller.rb'
 
 Rails/ApplicationJob:
   Enabled: false


### PR DESCRIPTION
One is a commented out exclusion; that can go away.

For NumericPredicate and ZeroLengthPredicate cops, the excluded file is
no longer in violation. As such, I'm removing the exclusion.

@samvera/hyrax-code-reviewers
