### PR TITLE
Updating TargetRubyVersion to 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_gem:
 inherit_from: .rubocop_fixme.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
   Exclude:
     - 'db/**/*'


### PR DESCRIPTION
Given that Ruby 2.3 is past EOL, and 2.4 is approaching EOL, I'm bumping
the targeted version to olded non-EOL ruby version. Note, Hyrax's
gemspec already states that you must use Ruby 2.4 or greater.

This should be a non-breaking change as the following PRs addressed the
Rubocop violations:

* https://github.com/samvera/hyrax/pull/4250 (and associated SHAs)
  * 12bec9beb3ca43c48a59e45c989e7fe914ad4f09
  * 571d3d6245cc224433044fef8c83cd3ff57e80c3
  * 9ce198c2dbdbab1f4d33a4b48bfdbe755058fbbe
* https://github.com/samvera/hyrax/pull/4251 (and associated SHA)
  * 988a8e3142e4f6472157dd24870fdfd2047843e2

@samvera/hyrax-code-reviewers
