### PR TITLE
Implement member->collection directional Collection membership

### DIFF
--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -8,9 +8,10 @@ module Hyrax
   class Work < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
 
-    attribute :admin_set_id, Valkyrie::Types::ID
-    attribute :member_ids,   Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)
-    attribute :state,        Valkyrie::Types::URI.default(Hyrax::ResourceStatus::ACTIVE)
+    attribute :admin_set_id,             Valkyrie::Types::ID
+    attribute :member_ids,               Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)
+    attribute :member_of_collection_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
+    attribute :state,                    Valkyrie::Types::URI.default(Hyrax::ResourceStatus::ACTIVE)
 
     ##
     # @return [Boolean] true

--- a/app/services/hyrax/custom_queries/find_access_control.rb
+++ b/app/services/hyrax/custom_queries/find_access_control.rb
@@ -19,6 +19,8 @@ module Hyrax
           .find_inverse_references_by(resource: resource, property: :access_to)
           .find { |r| r.is_a?(Hyrax::AccessControl) } ||
           raise(Valkyrie::Persistence::ObjectNotFoundError)
+      rescue ArgumentError # some adapters raise ArgumentError for missing resources
+        raise(Valkyrie::Persistence::ObjectNotFoundError)
       end
     end
   end

--- a/app/services/hyrax/custom_queries/navigators/collection_members.rb
+++ b/app/services/hyrax/custom_queries/navigators/collection_members.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module CustomQueries
+    module Navigators
+      ##
+      # Find members of collections and collections for members
+      #
+      # @since 3.0.0
+      class CollectionMembers
+        ##
+        # @return [Array<Symbol>
+        def self.queries
+          [:find_child_works, :find_child_work_ids]
+        end
+        ##
+        # @!attribute [r] query_service
+        #   @return [#custom_queries]
+        attr_reader :query_service
+
+        def initialize(query_service:)
+          @query_service = query_service
+        end
+
+        ##
+        # Find child works of a given resource, and map to Valkyrie Resources
+        #
+        # @param [Valkyrie::Resource] resource
+        # @return [Array<Valkyrie::Resource>]
+        def find_collections_for(resource:)
+          query_service
+            .find_references_by(resource: resource, property: :member_of_collection_ids)
+        end
+
+        ##
+        # Find members for the given collection
+        #
+        # @param [Valkyrie::Resource] collection
+        # @return [Array<Valkyrie::Resource>]
+        def find_members_of(collection:)
+          query_service
+            .find_inverse_references_by(resource: collection, property: :member_of_collection_ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -34,7 +34,7 @@ RSpec.shared_examples 'belongs to collections' do
   let(:collection_class) { Hyrax::PcdmCollection }
 
   describe 'collection membership' do
-    it 'is in no collections default' do
+    it 'is in no collections by default' do
       expect(model.member_of_collection_ids).to be_empty
     end
 

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -60,6 +60,18 @@ FactoryBot.define do
       end
     end
 
+    trait :as_collection_member do
+      member_of_collection_ids { [valkyrie_create(:hyrax_collection).id] }
+    end
+
+    trait :as_member_of_multiple_collections do
+      member_of_collection_ids do
+        [valkyrie_create(:hyrax_collection).id,
+         valkyrie_create(:hyrax_collection).id,
+         valkyrie_create(:hyrax_collection).id]
+      end
+    end
+
     factory :monograph, class: 'Monograph'
   end
 end

--- a/spec/services/hyrax/custom_queries/navigators/collection_members_spec.rb
+++ b/spec/services/hyrax/custom_queries/navigators/collection_members_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::CustomQueries::Navigators::CollectionMembers, valkyrie_adapter: :test_adapter do
+  subject(:query_handler) { described_class.new(query_service: query_service) }
+  let(:adapter)           { Hyrax.metadata_adapter }
+  let(:persister)         { adapter.persister }
+  let(:query_service)     { adapter.query_service }
+
+  describe '#find_collections_for' do
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+    it 'is empty with no collections' do
+      expect(query_handler.find_collections_for(resource: work))
+        .to be_empty
+    end
+
+    context 'when it is a member of collections' do
+      let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :as_member_of_multiple_collections) }
+
+      it 'finds collections' do
+        expect(query_handler.find_collections_for(resource: work).map(&:id))
+          .to contain_exactly(*work.member_of_collection_ids)
+      end
+    end
+  end
+
+  describe '#find_members_of' do
+    let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection) }
+
+    it 'is empty with no member' do
+      expect(query_handler.find_members_of(collection: collection))
+        .to be_empty
+    end
+
+    context 'when collections has inverse work members' do
+      let(:work) do
+        FactoryBot.valkyrie_create(:hyrax_work, member_of_collection_ids: collection.id)
+      end
+
+      before { work } # save work with collection membership
+
+      it 'finds collections' do
+        expect(query_handler.find_members_of(collection: collection))
+          .to contain_exactly(work)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Works should be able to track their collection membership directly, without
writing to the collection to determine membership.

There are a few things to note here:

  - This tracks closely with the `Hydra::PCDM` implementation, which has
    advantages in the short term.
  - It may be possible to simply implement membership as parent->child with
    `#member_ids` across the board, and handle the inversion for `ActiveFedora`
    in `Wings`. Currently thinking this isn't a fruitful exercise though...
  - We already support `member_ids` in Collections; maybe we should drop this?
    It's in `Hydra::PCDM`, too.

@samvera/hyrax-code-reviewers
