### PR TITLE
Add resource to collection with create Transaction

### DIFF
--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -22,6 +22,7 @@ module Hyrax
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/destroy_work'
       require 'hyrax/transactions/work_create'
+      require 'hyrax/transactions/steps/add_to_collections'
       require 'hyrax/transactions/steps/apply_collection_permission_template'
       require 'hyrax/transactions/steps/apply_permission_template'
       require 'hyrax/transactions/steps/apply_visibility'
@@ -40,6 +41,10 @@ module Hyrax
       # Disable BlockLength rule for DSL code
       # rubocop:disable Metrics/BlockLength
       namespace 'change_set' do |ops|
+        ops.register 'add_to_collections' do
+          Steps::AddToCollections.new
+        end
+
         ops.register 'apply' do
           ApplyChangeSet.new
         end

--- a/lib/hyrax/transactions/steps/add_to_collections.rb
+++ b/lib/hyrax/transactions/steps/add_to_collections.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Add a resource to collections via `ChangeSet`.
+      #
+      # Accepts `:collection_ids` and never retrieves the actual collections
+      # from the persisted data. We trust that the identifiers passed refer to
+      # actual, extant collections, and that the permissions to add to
+      # collection membership have been established, or else that they'll be
+      # validated prior to save.
+      #
+      # @since 3.0.0
+      class AddToCollections
+        include Dry::Monads[:result]
+
+        ##
+        # Add to collections by inserting collections to
+        # `ChangeSet#member_of_collection_ids`.
+        #
+        # @param [Hyrax::ChangeSet] change_set
+        # @param [Array<#to_s>] collection_ids
+        #
+        # @return [Dry::Monads::Result]
+        def call(change_set, collection_ids: [])
+          change_set.member_of_collection_ids += collection_ids
+
+          Success(change_set)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/work_create.rb
+++ b/lib/hyrax/transactions/work_create.rb
@@ -10,6 +10,7 @@ module Hyrax
     class WorkCreate < Transaction
       DEFAULT_STEPS = ['change_set.set_default_admin_set',
                        'change_set.ensure_admin_set',
+                       'change_set.add_to_collections',
                        'change_set.apply'].freeze
 
       ##

--- a/spec/hyrax/transactions/steps/add_to_collections_spec.rb
+++ b/spec/hyrax/transactions/steps/add_to_collections_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions/steps/add_to_collections'
+require 'hyrax/specs/spy_listener'
+
+RSpec.describe Hyrax::Transactions::Steps::AddToCollections do
+  subject(:step)   { described_class.new }
+  let(:change_set) { Hyrax::ChangeSet.for(resource) }
+  let(:resource)   { FactoryBot.build(:hyrax_work) }
+
+  describe '#call' do
+    let(:collections) do
+      [FactoryBot.valkyrie_create(:hyrax_collection),
+       FactoryBot.valkyrie_create(:hyrax_collection)]
+    end
+
+    let(:collection_ids) { collections.map(&:id) }
+
+    it 'is a success' do
+      expect(step.call(change_set)).to be_success
+    end
+
+    it 'adds given collections' do
+      expect(step.call(change_set, collection_ids: collection_ids).value!)
+        .to have_attributes member_of_collection_ids: contain_exactly(*collection_ids)
+    end
+
+    context 'when resource already has collections' do
+      let(:resource) { build(:hyrax_work, :as_member_of_multiple_collections) }
+
+      it 'does not override collection membership' do
+        expect(step.call(change_set).value!)
+          .to have_attributes(
+            member_of_collection_ids: contain_exactly(*resource.member_of_collection_ids)
+          )
+      end
+
+      it 'adds new collections to existing ones' do
+        expected = resource.member_of_collection_ids + collection_ids
+
+        expect(step.call(change_set, collection_ids: collection_ids).value!)
+          .to have_attributes(member_of_collection_ids: contain_exactly(*expected))
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/work_create_spec.rb
+++ b/spec/hyrax/transactions/work_create_spec.rb
@@ -31,5 +31,21 @@ RSpec.describe Hyrax::Transactions::WorkCreate do
           .to have_attributes admin_set_id: admin_set.id
       end
     end
+
+    context 'when adding to collections' do
+      let(:collections) do
+        [FactoryBot.valkyrie_create(:hyrax_collection),
+         FactoryBot.valkyrie_create(:hyrax_collection)]
+      end
+
+      let(:collection_ids) { collections.map(&:id) }
+
+      it 'adds to the collections' do
+        tx.with_step_args('change_set.add_to_collections' => { collection_ids: collection_ids })
+
+        expect(tx.call(change_set).value!)
+          .to have_attributes member_of_collection_ids: contain_exactly(*collection_ids)
+      end
+    end
   end
 end


### PR DESCRIPTION
Introduces a new transaction step to add an object to collections. This
step only uses `:collection_ids`, never actually requiring the collection to be
retrieved.

Issues around validity of a change that adds a work to a collection that doesn't
exist and about user permissions/abilities are dealt with in the corresponding
actor. We deliberately avoid them here since they seem best situated in
different parts of the codebase.

E.g. maybe the validation step should handle both of these concerns?

@samvera/hyrax-code-reviewers
