### PR TITLE
Set depositor in `WorkCreate` transaction

### DIFF
--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -34,6 +34,7 @@ module Hyrax
       require 'hyrax/transactions/steps/set_default_admin_set'
       require 'hyrax/transactions/steps/set_modified_date'
       require 'hyrax/transactions/steps/set_uploaded_date_unless_present'
+      require 'hyrax/transactions/steps/set_user_as_depositor'
       require 'hyrax/transactions/steps/validate'
 
       extend Dry::Container::Mixin
@@ -67,6 +68,10 @@ module Hyrax
 
         ops.register 'set_uploaded_date_unless_present' do
           Steps::SetUploadedDateUnlessPresent.new
+        end
+
+        ops.register 'set_user_as_depositor' do
+          Steps::SetUserAsDepositor.new
         end
 
         ops.register 'validate' do

--- a/lib/hyrax/transactions/steps/set_user_as_depositor.rb
+++ b/lib/hyrax/transactions/steps/set_user_as_depositor.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Add a given `::User` as the `#depositor` via a ChangeSet.
+      #
+      # If no user is given, simply passes as a `Success`.
+      #
+      # @since 3.0.0
+      class SetUserAsDepositor
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Hyrax::ChangeSet] change_set
+        # @param [#user_key] user
+        #
+        # @return [Dry::Monads::Result]
+        def call(change_set, user: NullUser.new)
+          change_set.depositor = user.user_key if user.user_key
+
+          Success(change_set)
+        rescue NoMethodError => err
+          Failure([err.message, change_set])
+        end
+
+        ##
+        # @api private
+        class NullUser
+          ##
+          # @return [nil]
+          def user_key
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/work_create.rb
+++ b/lib/hyrax/transactions/work_create.rb
@@ -10,6 +10,7 @@ module Hyrax
     class WorkCreate < Transaction
       DEFAULT_STEPS = ['change_set.set_default_admin_set',
                        'change_set.ensure_admin_set',
+                       'change_set.set_user_as_depositor',
                        'change_set.add_to_collections',
                        'change_set.apply'].freeze
 

--- a/spec/hyrax/transactions/steps/set_user_as_depositor_spec.rb
+++ b/spec/hyrax/transactions/steps/set_user_as_depositor_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions/steps/set_user_as_depositor'
+
+RSpec.describe Hyrax::Transactions::Steps::SetUserAsDepositor do
+  subject(:step)   { described_class.new }
+  let(:change_set) { Hyrax::ChangeSet.for(resource) }
+  let(:resource)   { FactoryBot.build(:hyrax_work) }
+  let(:user)       { FactoryBot.create(:user) }
+
+  describe '#call' do
+    context 'with no user given' do
+      it 'is a success' do
+        expect(step.call(change_set)).to be_success
+      end
+
+      it 'does not alter the change_set' do
+        expect(step.call(change_set).value!).not_to be_changed
+      end
+
+      it 'does not override an existing depositor' do
+        change_set.depositor = 'user_1'
+
+        expect(step.call(change_set).value!)
+          .to have_attributes depositor: 'user_1'
+      end
+    end
+
+    context 'with a user' do
+      it 'changes the change_set' do
+        expect(step.call(change_set, user: user).value!).to be_changed
+      end
+
+      it 'overrides an existing depositor' do
+        change_set.depositor = 'user_1'
+
+        expect(step.call(change_set, user: user).value!)
+          .to have_attributes depositor: user.user_key
+      end
+    end
+
+    context 'when the change_set has no depositor' do
+      let(:resource) { FactoryBot.build(:hyrax_resource) }
+
+      it 'is a success with no user given' do
+        expect(step.call(change_set)).to be_success
+      end
+
+      it 'is a failure if a user is given' do
+        expect(step.call(change_set, user: user)).to be_failure
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/work_create_spec.rb
+++ b/spec/hyrax/transactions/work_create_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe Hyrax::Transactions::WorkCreate do
       end
     end
 
+    context 'when providing a depositor' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'sets the given user as the depositor' do
+        tx.with_step_args('change_set.set_user_as_depositor' => { user: user })
+
+        expect(tx.call(change_set).value!)
+          .to have_attributes depositor: user.user_key
+      end
+    end
+
     context 'when adding to collections' do
       let(:collections) do
         [FactoryBot.valkyrie_create(:hyrax_collection),


### PR DESCRIPTION
Use the new `Hyrax::Transactions::Transaction#with_step_args` interface to pass
a user to a step that sets the depositor via `ChangeSet`.

If no user is passed, this step is a no-op, and an automatic success. We trust
the `ChangeSet` to validate the presence of `depositor` if it is
required.

If a user is given, we set the `change_set.depositor` to the `::User#user_key`,
overriding any existing value.

@samvera/hyrax-code-reviewers
