### PR TITLE
Add documentation for `Result#or` to transaction

### DIFF
--- a/lib/hyrax/transactions/transaction.rb
+++ b/lib/hyrax/transactions/transaction.rb
@@ -42,6 +42,9 @@ module Hyrax
     # @example unwapping values safely with handling for failures
     #   tx.call(change_set).value_or { |failure| "uh oh: #{failure} }
     #
+    # @example when there is no need to unwrap the value, handle errors with `#or`
+    #   tx.call(change_set).or { |failure| "uh oh: #{failure} }
+    #
     # @example a pattern for subclassing to create new transactions
     #   class CustomTransaction < Transaction
     #     DEFAULT_STEPS = ['step.1', 'step.2', 'step.3'].freeze


### PR DESCRIPTION
This use of `#or` is likely to be a common pattern in controllers, where we
often won't care to unwrap a newly saved value (instead redirecting to an
index-driven page), but want to handle errors carefully.

@samvera/hyrax-code-reviewers
