### PR TITLE
Support proxy deposit for Valkryie Work models

### DIFF
--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -11,6 +11,8 @@ module Hyrax
     attribute :admin_set_id,             Valkyrie::Types::ID
     attribute :member_ids,               Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)
     attribute :member_of_collection_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
+    attribute :on_behalf_of,             Valkyrie::Types::String
+    attribute :proxy_depositor,          Valkyrie::Types::String
     attribute :state,                    Valkyrie::Types::URI.default(Hyrax::ResourceStatus::ACTIVE)
 
     ##

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -213,6 +213,22 @@ RSpec.shared_examples 'a Hyrax::Work' do
     end
   end
 
+  describe '#on_behalf_of' do
+    it 'can set a proxy deposit target' do
+      expect { work.on_behalf_of = 'moomin@example.com' }
+        .to change { work.on_behalf_of }
+        .to eq 'moomin@example.com'
+    end
+  end
+
+  describe '#proxy_depositor' do
+    it 'can set a proxy deposit source' do
+      expect { work.proxy_depositor = 'snufkin@example.com' }
+        .to change { work.proxy_depositor }
+        .to eq 'snufkin@example.com'
+    end
+  end
+
   describe '#state' do
     it 'accepts URIS' do
       uri = RDF::URI('http://example.com/ns/moomin_state')


### PR DESCRIPTION
Our proxy deposit implementation requires metadata for `proxy_depositor` and
`on_behalf_of`.

There's some question about the need to store this data on the curation
metadata, but our existing metadata holds it, so it's important to keep it here
for now.

@samvera/hyrax-code-reviewers
