### PR TITLE
Use Valkyrie::ID<=>String equality

### DIFF
--- a/config/initializers/valkyrie_id_equality.rb
+++ b/config/initializers/valkyrie_id_equality.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Valkyrie.config.id_string_equality = true

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -77,7 +77,7 @@ SUMMARY
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
-  spec.add_dependency 'valkyrie', '~> 2.1'
+  spec.add_dependency 'valkyrie', '>= 2.1.1', "< 3.0"
 
   spec.add_development_dependency "capybara", '~> 3.29'
   spec.add_development_dependency 'capybara-maleficent', '~> 0.3.0'


### PR DESCRIPTION
Valkyrie 2.1.0 overhauled ID equality as a feature-flag change, with the new
behavior to become default in 3.0.0. Turning it on preemptively for Hyrax will
save us and adopters a lot of trouble going forward.

@samvera/hyrax-code-reviewers
