### PR TITLE
Try to get a grip on the interfaces for `Hyrax::Event` 

### DIFF
--- a/app/models/concerns/hyrax/with_events.rb
+++ b/app/models/concerns/hyrax/with_events.rb
@@ -13,6 +13,10 @@ module Hyrax
       model_name.name
     end
 
+    ##
+    # @param [Integer] size  the maximum number of events to fetch from the log.
+    #   Offset by 1; to get one event, use `0`, for two, use `1`, etc...
+    #   `-1` gives all events.
     def events(size = -1)
       event_stream.fetch(size)
     end

--- a/app/models/concerns/hyrax/with_events.rb
+++ b/app/models/concerns/hyrax/with_events.rb
@@ -10,7 +10,7 @@ module Hyrax
 
     # @return [String]
     def event_class
-      self.class.name
+      model_name.name
     end
 
     def events(size = -1)

--- a/app/models/concerns/hyrax/with_events.rb
+++ b/app/models/concerns/hyrax/with_events.rb
@@ -1,9 +1,14 @@
 module Hyrax
+  # A mixin module intended to provide an interface into creating the paper trail
+  # of activity on the target model of the mixin.
+  #
+  # @see Hyrax::Event
   module WithEvents
     def stream
       Nest.new(event_class)[to_param]
     end
 
+    # @return [String]
     def event_class
       self.class.name
     end

--- a/app/models/hyrax/event.rb
+++ b/app/models/hyrax/event.rb
@@ -1,4 +1,12 @@
 module Hyrax
+  ##
+  # Events are timestamped, named actions that provide a streamed 'paper trail'
+  # of certain repository activities.
+  #
+  # Not to be confused with the `Dry::Events`-based pub/sub interface at
+  # `Hyrax::Publisher`.
+  #
+  # @see `Hyrax::RedisEventStore`
   class Event
     ##
     # Creates an event in Redis

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -27,6 +27,7 @@ module Hyrax
     autoload :Collections
     autoload :Configuration
     autoload :ControlledVocabularies
+    autoload :EventStore
     autoload :RedisEventStore
     autoload :ResourceSync
     autoload :Zotero

--- a/lib/hyrax/event_store.rb
+++ b/lib/hyrax/event_store.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # @abstract
+  # The event store provides an interface to log numbered events into a storage
+  # system, e.g. a key-value store.
+  #
+  # At the class level, we provide a `.create` method for logging event data
+  # with incrementing ids. Events have an "action" (a string description of the
+  # event), and a (numeric) timestamp. Clients *SHOULD* provide a timestamp that
+  # represnts the current application time (i.e. via `Hyrax::TimeService`); see
+  # `Hyrax::Event.create_now`.
+  #
+  # At the instance level, events can be pushed by id onto a list of events for
+  # a given topic key, and fetched by the same topic. Initialize an instance
+  # with `.for('topic_key')` and use `#push(event_id)` to associate events with
+  # the topic.
+  #
+  # @see Hyrax::RedisEventStore for the default implementation
+  # @see Hyrax::Event
+  class EventStore
+    class << self
+      delegate :logger, to: Hyrax
+
+      ##
+      # @abstract
+      # @api public
+      #
+      # @note clients should consider using `Hyrax::Event` to manage events instead
+      #   of directly interfacing with this method.
+      #
+      # @param [String] action
+      # @param [Integer] timestamp  the time to log the event. usually now.
+      #
+      # @return [Integer] the id of the event
+      def create(_action, _timestamp)
+        raise NotImplementedError, 'EventStore.create should be provided by ' \
+                                   'a concrete implementation'
+      end
+
+      ##
+      # @api public
+      #
+      # @todo this is really just an initializer; deprecate in favor of `.new`?
+      #
+      # @param [String] key
+      def for(key)
+        new(key)
+      end
+    end
+
+    ##
+    # @api private
+    #
+    # @param [String] key
+    def initialize(key)
+      @key = key
+    end
+
+    ##
+    # @param [Integer] size
+    #
+    # @return [Enumerable<Hash<Symbol, String>>]
+    def fetch(_size)
+      raise NotImplementedError, 'EventStore#fetch should be provided by ' \
+                                 'a concrete implementation'
+    end
+
+    #
+    # Adds a value to the end of a list identified by key
+    #
+    # @param [Integer] value
+    #
+    # @return [void]
+    def push(_value)
+      raise NotImplementedError, 'EventStore#push should be provided by ' \
+                                 'a concrete implementation'
+    end
+  end
+end

--- a/spec/models/concerns/hyrax/with_events_spec.rb
+++ b/spec/models/concerns/hyrax/with_events_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::WithEvents do
+  subject(:eventable) { model_with_events.new }
+  let(:action) { 'FAKE EVENT ACTION' }
+  let(:event) { Hyrax::Event.create_now(action) }
+
+  let(:model_with_events) do
+    module Hyrax
+      module Test
+        module WithEvents
+          class Model
+            extend ActiveModel::Naming
+            include Hyrax::WithEvents
+          end
+        end
+      end
+    end
+  end
+
+  after { Hyrax::Test.send(:remove_const, :WithEvents) }
+
+  describe '#events' do
+    context 'when there are no events' do
+      it 'is empty' do
+        expect(eventable.events).to be_empty
+      end
+    end
+
+    context 'with many events' do
+      before do
+        12.times { eventable.log_event(event) }
+      end
+
+      it 'lists all events' do
+        expect(eventable.events.count).to eq 12
+      end
+
+      it 'accepts an argument to list most recent events' do
+        eventable.log_event(Hyrax::Event.create_now('NEW ACTION'))
+        expect(eventable.events(0))
+          .to contain_exactly(action: 'NEW ACTION', timestamp: an_instance_of(String))
+      end
+    end
+  end
+
+  describe '#log_event' do
+    it 'appends the event to the log' do
+      expect { eventable.log_event(event) }
+        .to change { eventable.events }
+        .to contain_exactly(action: action, timestamp: an_instance_of(String))
+    end
+  end
+end


### PR DESCRIPTION
It's important that we grapple with how these events are used. A simple starting
point is to try to document it. Maybe some tests next.

Also:

Pin the namespacing for events to the model name, not the Ruby class name. In
most cases (excepting adopters who have specificially overridden ActiveModel
naming behavior) this should have no impact, but loosens the dependency on
specific Ruby class names.

@samvera/hyrax-code-reviewers
