### PR TITLE
Fix for HYRAX-#104

### DIFF
--- a/app/assets/stylesheets/hyrax/_file_sets.scss
+++ b/app/assets/stylesheets/hyrax/_file_sets.scss
@@ -48,3 +48,30 @@ table.files td.preview img {
 .edit_file_set_previous_version {
   margin-top: 3em;
 }
+
+input.versioning-files-input {
+  width: 250px;
+}
+
+div.versioning-files-input {
+  text-align: right;
+}
+
+div.versioning-files-row {
+  border-top: solid 1px #dddddd;
+  padding-top: 10px;
+}
+
+div.versioning-files-progress {
+  margin-top: -25px;
+}
+
+button.versioning-files-remove,
+button.versioning-files-remove:hover {
+  background-color: #ffffff;
+  border-color: #ffffff;
+  color: $brand-danger;
+  font-weight: normal;
+  text-decoration: underline;
+}
+

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -89,6 +89,9 @@ module Hyrax
           else
             update_metadata
           end
+        elsif params.key?(:files_files) # version file already uploaded with ref id in :files_files array
+          uploaded_files = Array(Hyrax::UploadedFile.find(params[:files_files]))
+          actor.update_content(uploaded_files.first)
         end
       end
 

--- a/app/views/hyrax/file_sets/_versioning.html.erb
+++ b/app/views/hyrax/file_sets/_versioning.html.erb
@@ -1,12 +1,51 @@
 <div id="versioning_display" class="tab-pane">
   <h2><%= t('.header') %></h2>
   <%= simple_form_for [main_app, curation_concern], html: { multipart: true, class: 'nav-safety' } do |f| %>
-    <%= hidden_field_tag('redirect_tab', 'versions') %>
-    <h3><%= t('.upload') %></h3>
-    <%= f.input :files, as: :multifile, wrapper: :vertical_file_input, required: true %>
-    <%= f.button :button, name: "update_versioning", id: "upload_submit", onclick: "confirmation_needed = false;", class: "btn btn-primary" do %>
-      <%= t('.upload') %>
-    <% end %>
+    <div id="fileuploadVersioning">
+      <!-- Redirect browsers with JavaScript disabled to the origin page -->
+      <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>"/></noscript>
+
+      <%= hidden_field_tag('redirect_tab', 'versions') %>
+
+      <!-- The table listing the files available for upload/download -->
+      <div class="row fileupload-buttonbar">
+
+        <h3><%= t('.upload') %></h3>
+
+        <div class="col-xs-4">
+          <input id="file_set_files" style="display:none;" type="file" name="files[]" single/>
+          <label for="file_set_files" class="btn btn-success fileinput-button"><%= t('.choose_file') %></label>
+        </div>
+
+        <div class="col-xs-8 fileupload-progress versioning-files-progress fade">
+          <!-- The global progress bar -->
+          <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+            <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+          </div>
+          <!-- The extended global progress state -->
+          <div class="progress-extended">&nbsp;</div>
+        </div> <!-- end col-xs-5 fileupload-progress fade -->
+      </div>
+
+      <div class="row versioning-files-list">
+        <div class="col-xs-12">
+          <div class="container">
+            <div role="presentation" class="table"><span class="files"></span></div>
+            <!-- The global file processing state -->
+            <span class="fileupload-process"></span>
+          </div> <!-- end container -->
+        </div> <!-- end row versioning-files-list -->
+      </div> <!-- end row versioning-files-list -->
+
+      <%= f.button :button,
+                   name: "update_versioning",
+                   id: "upload_submit",
+                   onclick: "confirmation_needed = false;",
+                   class: "btn btn-primary" do %>
+        <%= t('.upload') %>
+      <% end %>
+
+    </div> <!-- fileuploadVersioning -->
   <% end %>
 
   <%= form_for [main_app, curation_concern],
@@ -22,8 +61,15 @@
       </div>
     <% end %>
     <div id="save_version_note" class="alert hide"><%= t('.save_your_note') %></div>
-    <%= f.button :button, name: "revert_submit", id: "revert_submit", onclick: "confirmation_needed = false;", class: "btn btn-primary", type: 'submit' do %>
+    <%= f.button :button, name: "revert_submit",
+                 id: "revert_submit",
+                 onclick: "confirmation_needed = false;",
+                 class: "btn btn-primary",
+                 type: 'submit' do %>
       <%= t('.save') %>
     <% end %>
   <% end %>
+
+  <%= render 'hyrax/uploads/js_templates_versioning' %>
+
 </div> <!-- /row -->

--- a/app/views/hyrax/uploads/_js_templates_versioning.html.erb
+++ b/app/views/hyrax/uploads/_js_templates_versioning.html.erb
@@ -1,0 +1,172 @@
+<!-- The template to display files available for upload -->
+<% fade_class_if_not_test = Rails.env.test? ? '' : 'fade' %>
+<script id="versioning-template-upload" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+    <tr class="template-upload <%= fade_class_if_not_test %>">
+        <td>
+            <span class="preview"></span>
+        </td>
+        <td>
+            <p class="name">{%=file.name%}</p>
+            <strong class="error text-danger"></strong>
+        </td>
+        <td>
+            <p class="size">Processing...</p>
+            <div class="progress progress-striped active"
+                 role="progressbar"
+                 aria-valuemin="0"
+                 aria-valuemax="100"
+                 aria-valuenow="0">
+               <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+             </div>
+        </td>
+        <td class="text-right">
+            {% if (!i && !o.options.autoUpload) { %}
+                <button class="btn btn-primary start" disabled>
+                    <i class="glyphicon glyphicon-upload"></i>
+                    <span><%= t('.start') %></span>
+                </button>
+            {% } %}
+            {% if (!i) { %}
+                <button class="btn btn-sm btn-warning cancel">
+                    <i class="glyphicon glyphicon-ban-circle"></i>
+                    <span><%= t('helpers.action.cancel') %></span>
+                </button>
+            {% } %}
+        </td>
+    </tr>
+{% } %}
+</script>
+
+<!-- function used by the following template -->
+<script type="text/javascript">
+  function setAllResourceTypesVersioning(resourceTypeId) {
+    var firstResourceType = $("#resource_type_" + resourceTypeId.toString())[0];
+    var selected_options = [];
+    for (var i = 0; i < firstResourceType.length; i++) {
+      if (firstResourceType.options[i].selected) {
+        selected_options.push(firstResourceType.options[i].value);
+      }
+    }
+    $(".resource_type_dropdown").each(function(index, element) {
+      for(var i=0; i< this.length; i++) {
+        this.options[i].selected =
+            $.inArray(this.options[i].value, selected_options) > -1 ? true : false;
+      }
+    });
+  }
+</script>
+
+<!-- The template to display files available for download -->
+<script id="versioning-batch-template-download" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+    <tr class="template-download add-batch-work-file-wrapper <%= fade_class_if_not_test %>">
+        <td>
+          <div class="row padding-bottom">
+            <div class="col-sm-6 name">
+                <span>{%=file.name%}</span>
+                <input type="hidden" name="uploaded_files[]" value="{%=file.id%}">
+            </div>
+            <div class="col-sm-6">
+              {% if (file.error) { %}
+                  <div><span class="label label-danger">Error</span> {%=file.error%}</div>
+              {% } %}
+              <span class="size">{%=o.formatFileSize(file.size)%}</span>
+              <button class="btn btn-sm btn-danger delete pull-right"
+                      data-type="{%=file.deleteType%}"
+                      data-url="{%=file.deleteUrl%}"
+                      {% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
+                  <i class="glyphicon glyphicon-trash"></i>
+                  <span><%= t('helpers.action.delete') %></span>
+              </button>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-12 form-horizontal">
+              <div class="form-group">
+                <label for="title_{%=file.id%}" class="col-sm-5 control-label"><%= t('.display_label') %></label>
+                <div class="col-sm-7 padding-bottom">
+                  <input type="text" class="form-control" name="title[{%=file.id%}]" id="title_{%=file.id%}" value="{%=file.name%}">
+                </div>
+                <label for="resource_type_{%=file.id%}" class="col-sm-5 control-label">Resource Type</label>
+                <div class="col-sm-7 padding-bottom">
+                  <select class="form-control resource_type_dropdown"
+                          multiple="multiple"
+                          size="6"
+                          name="resource_type[{%=file.id%}][]"
+                           id="resource_type_{%=file.id%}"
+                           value="{%=file.name%}">
+                    <%= options_for_select(Hyrax::ResourceTypesService.select_options) %>
+                  </select>
+                  <button class="btn btn-default pull-right resource_type_button"
+                          onClick="setAllResourceTypesVersioning({%= file.id %}); return false;">
+                          <%= t('.set_all_to_this_resource_type') %>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+    </tr>
+{% } %}
+</script>
+
+<!-- Simpler display of files available for download. Originally from hyrax/base/_form_files -->
+<!-- TODO: further consolidate with template-download above -->
+<!-- The template to display the files once upload is complete -->
+<script id="versioning-template-download" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+        <span class="template-download fade">
+          <div id="files">
+            <div class="row versioning-files-row">
+              <div class="col-sm-3">
+                <span class="name">
+                  <span>{%=file.name%}</span>
+                  <input type="hidden" name="files_files[]" value="{%=file.id%}">
+                </span>
+                {% if (file.error) { %}
+                  <span><span class="label label-danger"><%= t('.error') %></span> {%=file.error%}</span>
+                {% } %}
+              </div>
+
+              <div class="col-sm-2">
+                <button class="btn btn-link remove versioning-files-remove"
+                        data-type="{%=file.deleteType%}"
+                        data-url="{%=file.deleteUrl%}"
+                        onclick=$("#files").remove(); {% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
+                  <span class="glyphicon glyphicon-remove"></span>
+                  <span class="controls-remove-text"><%= t('.remove') %></span>
+                  <span class="sr-only">
+                    <%= t('.previous') %>
+                    <span class="controls-field-name-text"><%= t('.remove_new_version') %></span>
+                  </span>
+                </button>
+              </div> <!-- end col-sm-2 -->
+            </div> <!-- row versioning-files-row -->
+          </div> <!-- end container files -->
+        </span>
+{% }  $("div#files").remove(); %}
+</script>
+
+<script>
+    $(function () {
+        // will run after DOM is loaded
+        $('#fileuploadVersioning').hyraxUploader({downloadTemplateId: 'versioning-template-download',
+            uploadTemplateId: 'versioning-template-upload',
+            // The regular expression for allowed file types, matches
+            // against either file type or file name:
+            //acceptFileTypes: /(\.|\/)(gif|jpe?g|png)$/i,
+            // The maximum allowed file size in bytes:
+            maxFileSize: <%= Hyrax.config.uploader[:maxFileSize] %>,
+            // The minimum allowed file size in bytes:
+            //minFileSize: undefined, // No minimal file size
+            // The limit of files to be uploaded:
+            //maxNumberOfFiles: 100,
+            messages: {
+                acceptFileTypes: '<%= t(".options.messages.accept_file_types") %>',
+                maxFileSize: '<%= t(".options.messages.max_file_size") %>',
+                maxNumberOfFiles: '<%= t(".options.messages.max_number_of_files") %>',
+                minFileSize: '<%= t(".options.messages.min_file_size") %>',
+            }});
+    });
+</script>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1105,8 +1105,13 @@ en:
         fixity_check: Fixity Check
         not_yet_characterized: Not Yet Characterized
       versioning:
+        choose_file: Choose New Version File
         current: Current Version
         header: Versions
+        previous: Previous
+        remove: Remove
+        remove_current_files: Remove Current Files
+        remove_new_version: Remove New Version File
         restore: Restore Previous Version
         restore_from: Restore From
         save: Save Revision
@@ -1422,6 +1427,20 @@ en:
         remove: Remove
         remove_new_banner: Remove New Banner
         remove_new_logo: Remove New Logo
+      js_templates_versioning:
+        display_label: Display label
+        error: Error
+        previous: previous
+        remove: Remove
+        remove_new_version: Remove New Version File
+        set_all_to_this_resource_type: Set all to this Resource Type
+        start: Start
+        options:
+          messages:
+            accept_file_types:   File type not allowed
+            max_file_size:       File is too large
+            max_number_of_files: Maximum number of files exceeded
+            min_file_size:       File is too small
     user_profile:
       orcid:
         alt: ORCID icon

--- a/spec/views/hyrax/file_sets/_versioning.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_versioning.html.erb_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe 'hyrax/file_sets/_versioning.html.erb', type: :view do
 
   context "without additional users" do
     it "draws the new version form without error" do
-      expect(rendered).to have_css("input[name='file_set[files][]']")
+      expect(rendered).to have_content t("hyrax.file_sets.versioning.choose_file")
+      expect(rendered).to have_content t("hyrax.uploads.js_templates_versioning.options.messages.max_file_size")
+      expect(rendered).to have_content "maxFileSize: #{Hyrax.config.uploader[:maxFileSize]}"
     end
   end
 end


### PR DESCRIPTION
Align uploading of new versions with uploading of files

* Changed version upload to use jquery fileupload.
* Enforced max file size
* Added internationalization for messages

Expected behavior:

Select a file to be the new version. Selected file will upload.
File will be saved as new version and be properly ingested.
If the file is too large, it will not be uploaded and a message
in the current language will be displayed telling the user
that the file is too large.

In order to test:

Happy path:
* Go to the users dashboard.
* Select a work with a file set.
* Edit a file set.
* Go to versions tab.
* Upload a new file.
* Save the new version.

File too large:
* As above, but select a file that is larger than 500 MB.
* Message should display that the file is too large.
* When the interationalization files have been updated
* Change the language
* Repeat the above and file is too large message should be
  in the new language

Additionally:
* A file upload can be canceled (if it is slow enough)
* An uploaded file should be able to be deleted
* A second (or third, etc) file should be able to be uploaded
  and replace the prior new version

@samvera/hyrax-code-reviewers
