### PR TITLE
Valkyrize attach file to work job.

### DIFF
--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -5,25 +5,73 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
   # @param [ActiveFedora::Base] work - the work object
   # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
   def perform(work, uploaded_files, **work_attributes)
-    validate_files!(uploaded_files)
-    depositor = proxy_or_depositor(work)
-    user = User.find_by_user_key(depositor)
-
-    work, work_permissions = create_permissions work, depositor
-    metadata = visibility_attributes(work_attributes)
-    uploaded_files.each do |uploaded_file|
-      next if uploaded_file.file_set_uri.present?
-
-      actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
-      uploaded_file.update(file_set_uri: actor.file_set.uri)
-      actor.file_set.permissions_attributes = work_permissions
-      actor.create_metadata(metadata)
-      actor.create_content(uploaded_file)
-      actor.attach_to_work(work)
+    case work
+    when ActiveFedora::Base
+      perform_af(work, uploaded_files, work_attributes)
+    when Valkyrie::Resource
+      perform_valkyrie(work, uploaded_files, work_attributes)
     end
   end
 
   private
+
+    def perform_af(work, uploaded_files, work_attributes)
+      validate_files!(uploaded_files)
+      depositor = proxy_or_depositor(work)
+      user = User.find_by_user_key(depositor)
+
+      work, work_permissions = create_permissions work, depositor
+      metadata = visibility_attributes(work_attributes)
+      uploaded_files.each do |uploaded_file|
+        next if uploaded_file.file_set_uri.present?
+
+        actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
+        uploaded_file.add_file_set!(actor.file_set)
+        actor.file_set.permissions_attributes = work_permissions
+        actor.create_metadata(metadata)
+        actor.create_content(uploaded_file)
+        actor.attach_to_work(work)
+      end
+    end
+
+    def perform_valkyrie(work, uploaded_files, work_attributes)
+      validate_files!(uploaded_files)
+      depositor = proxy_or_depositor(work)
+      user = User.find_by_user_key(depositor)
+      work_permissions = permissions_map(work.permission_manager.acl.permissions)
+      uploaded_files.each do |uploaded_file|
+        next if uploaded_file.file_set_uri.present?
+        attach_uploaded_file!(uploaded_file, user, work, work_permissions, work_attributes)
+      end
+    end
+
+    def attach_uploaded_file!(uploaded_file, user, work, work_permissions, work_attributes)
+      file_set = Hyrax.persister.save(resource: Hyrax::FileSet.new(user: user))
+      actor = Hyrax::Actors::FileSetActor.new(file_set, user)
+      uploaded_file.add_file_set!(actor.file_set)
+      file_acl = Hyrax::AccessControlList.new(resource: actor.file_set)
+      work_permissions.each { |perm| file_acl.grant(perm[:mode]).to(perm[:agent]).save }
+      file_acl.save
+      metadata = visibility_attributes(work_attributes)
+      actor.create_metadata(metadata)
+      actor.create_content(uploaded_file)
+      actor.attach_to_work(work)
+    end
+
+    # Return array of hashes representing permissions without their :access_to objects
+    # @param permissions [Permission]
+    # @return [Array<Hash>]
+    def permissions_map(permissions)
+      permissions.collect { |p| { agent: agent_object(p.agent), mode: p.mode } }
+    end
+
+    # Converts string representation of Permission.agent to either User or Hyrax::Group
+    # @param agent [String]
+    # @return [User] or [Hyrax::Group]
+    def agent_object(agent)
+      return Hyrax::Group.new(agent.sub(Hyrax::Group.name_prefix, '')) if agent.starts_with?(Hyrax::Group.name_prefix)
+      User.find_by_user_key(agent)
+    end
 
     def create_permissions(work, depositor)
       work.edit_users += [depositor]

--- a/app/models/hyrax/uploaded_file.rb
+++ b/app/models/hyrax/uploaded_file.rb
@@ -10,5 +10,15 @@ module Hyrax
              class_name: 'JobIoWrapper',
              dependent: :destroy
     belongs_to :user, class_name: '::User'
+
+    def add_file_set!(file_set)
+      uri = case file_set
+            when ActiveFedora::Base
+              file_set.uri
+            when Hyrax::Resource
+              file_set.id
+            end
+      update!(file_set_uri: uri)
+    end
   end
 end

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -3,77 +3,160 @@ RSpec.describe AttachFilesToWorkJob, perform_enqueued: [AttachFilesToWorkJob] do
   let(:file2) { File.open(fixture_path + '/image.jp2') }
   let(:uploaded_file1) { build(:uploaded_file, file: file1) }
   let(:uploaded_file2) { build(:uploaded_file, file: file2) }
-  let(:generic_work) { create(:public_generic_work) }
   let(:user) { create(:user) }
+  let(:user2) { create(:user, email: 'userz@bbb.ddd') }
 
-  shared_examples 'a file attacher', perform_enqueued: [AttachFilesToWorkJob, IngestJob] do
-    it 'attaches files, copies visibility and permissions and updates the uploaded files' do
-      expect(CharacterizeJob).to receive(:perform_later).twice
-      described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
-      generic_work.reload
-      expect(generic_work.file_sets.count).to eq 2
-      expect(generic_work.file_sets.map(&:visibility)).to all(eq 'open')
-      expect(uploaded_file1.reload.file_set_uri).not_to be_nil
-      expect(ImportUrlJob).not_to have_been_enqueued
-    end
-  end
+  context "when use_valkyrie is false" do
+    let(:generic_work) { create(:public_generic_work) }
 
-  context "with uploaded files on the filesystem" do
-    before do
-      generic_work.permissions.build(name: 'userz@bbb.ddd', type: 'person', access: 'edit')
-      generic_work.save
+    shared_examples 'a file attacher', perform_enqueued: [AttachFilesToWorkJob, IngestJob] do
+      it 'attaches files, copies visibility and permissions and updates the uploaded files' do
+        expect(CharacterizeJob).to receive(:perform_later).twice
+        described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
+        generic_work.reload
+        expect(generic_work.file_sets.count).to eq 2
+        expect(generic_work.file_sets.map(&:visibility)).to all(eq 'open')
+        expect(uploaded_file1.reload.file_set_uri).not_to be_nil
+        expect(ImportUrlJob).not_to have_been_enqueued
+      end
     end
-    it_behaves_like 'a file attacher' do
-      it 'records the depositor(s) in edit_users' do
-        expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor, 'userz@bbb.ddd']))
+
+    context "with uploaded files on the filesystem" do
+      before do
+        generic_work.permissions.build(name: 'userz@bbb.ddd', type: 'person', access: 'edit')
+        generic_work.save
+      end
+      it_behaves_like 'a file attacher' do
+        it 'records the depositor(s) in edit_users' do
+          expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor, 'userz@bbb.ddd']))
+        end
+
+        describe 'with existing files' do
+          let(:file_set)       { create(:file_set) }
+          let(:uploaded_file1) { build(:uploaded_file, file: file1, file_set_uri: 'http://example.com/file_set') }
+
+          it 'skips files that already have a FileSet' do
+            expect { described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2]) }
+              .to change { generic_work.file_sets.count }.to eq 1
+          end
+        end
+      end
+    end
+
+    context "with uploaded files at remote URLs" do
+      let(:url1) { 'https://example.com/my/img.png' }
+      let(:url2) { URI('https://example.com/other/img.png') }
+      let(:fog_file1) { double(CarrierWave::Storage::Abstract, url: url1) }
+      let(:fog_file2) { double(CarrierWave::Storage::Abstract, url: url2) }
+
+      before do
+        allow(uploaded_file1.file).to receive(:file).and_return(fog_file1)
+        allow(uploaded_file2.file).to receive(:file).and_return(fog_file2)
       end
 
-      describe 'with existing files' do
-        let(:file_set)       { create(:file_set) }
-        let(:uploaded_file1) { build(:uploaded_file, file: file1, file_set_uri: 'http://example.com/file_set') }
+      it_behaves_like 'a file attacher'
+    end
 
-        it 'skips files that already have a FileSet' do
-          expect { described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2]) }
-            .to change { generic_work.file_sets.count }.to eq 1
+    context "deposited on behalf of another user" do
+      before do
+        generic_work.on_behalf_of = user.user_key
+        generic_work.save
+      end
+      it_behaves_like 'a file attacher' do
+        it 'records the depositor(s) in edit_users' do
+          expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([user.user_key]))
+        end
+      end
+    end
+
+    context "deposited as 'Yourself' selected in on behalf of list" do
+      before do
+        generic_work.on_behalf_of = ''
+        generic_work.save
+      end
+      it_behaves_like 'a file attacher' do
+        it 'records the depositor(s) in edit_users' do
+          expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor]))
         end
       end
     end
   end
 
-  context "with uploaded files at remote URLs" do
-    let(:url1) { 'https://example.com/my/img.png' }
-    let(:url2) { URI('https://example.com/other/img.png') }
-    let(:fog_file1) { double(CarrierWave::Storage::Abstract, url: url1) }
-    let(:fog_file2) { double(CarrierWave::Storage::Abstract, url: url2) }
+  context "when use_valkyrie is true" do
+    let(:generic_work) { valkyrie_create(:hyrax_work, :public, title: ['BethsMac'], depositor: user.user_key) }
 
-    before do
-      allow(uploaded_file1.file).to receive(:file).and_return(fog_file1)
-      allow(uploaded_file2.file).to receive(:file).and_return(fog_file2)
-    end
-
-    it_behaves_like 'a file attacher'
-  end
-
-  context "deposited on behalf of another user" do
-    before do
-      generic_work.on_behalf_of = user.user_key
-      generic_work.save
-    end
-    it_behaves_like 'a file attacher' do
-      it 'records the depositor(s) in edit_users' do
-        expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([user.user_key]))
+    shared_examples 'a file attacher', perform_enqueued: [AttachFilesToWorkJob, IngestJob] do
+      it 'attaches files, copies visibility and permissions and updates the uploaded files' do
+        id = generic_work.id
+        expect(CharacterizeJob).to receive(:perform_later).twice
+        described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
+        generic_work = Hyrax.query_service.find_by(id: id)
+        expect(generic_work.file_sets.count).to eq 2
+        expect(generic_work.file_sets.map(&:visibility)).to all(eq 'open')
+        expect(uploaded_file1.reload.file_set_uri).not_to be_nil
+        expect(ImportUrlJob).not_to have_been_enqueued
       end
     end
-  end
 
-  context "deposited as 'Yourself' selected in on behalf of list" do
-    before do
-      generic_work.on_behalf_of = ''
-      generic_work.save
+    context "with uploaded files on the filesystem" do
+      before do
+        Hyrax::AccessControlList.new(resource: generic_work).grant(:edit).to(user2).save
+      end
+      it_behaves_like 'a file attacher' do
+        it 'records the depositor(s) in edit_users' do
+          expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor, 'userz@bbb.ddd']))
+        end
+
+        describe 'with existing files' do
+          let(:file_set)       { create(:file_set) }
+          let(:uploaded_file1) { build(:uploaded_file, file: file1, file_set_uri: 'http://example.com/file_set') }
+
+          it 'skips files that already have a FileSet' do
+            id = generic_work.id
+            expect(generic_work.file_sets.count).to eq 0
+            described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
+            generic_work = Hyrax.query_service.find_by(id: id)
+            expect(generic_work.file_sets.count).to eq 1
+          end
+        end
+      end
     end
-    it_behaves_like 'a file attacher' do
-      it 'records the depositor(s) in edit_users' do
-        expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor]))
+
+    context "with uploaded files at remote URLs" do
+      let(:url1) { 'https://example.com/my/img.png' }
+      let(:url2) { URI('https://example.com/other/img.png') }
+      let(:fog_file1) { double(CarrierWave::Storage::Abstract, url: url1) }
+      let(:fog_file2) { double(CarrierWave::Storage::Abstract, url: url2) }
+
+      before do
+        allow(uploaded_file1.file).to receive(:file).and_return(fog_file1)
+        allow(uploaded_file2.file).to receive(:file).and_return(fog_file2)
+      end
+
+      it_behaves_like 'a file attacher'
+    end
+
+    context "deposited on behalf of another user" do
+      before do
+        generic_work.on_behalf_of = user.user_key
+        generic_work.permission_manager.acl.save
+      end
+      it_behaves_like 'a file attacher' do
+        it 'records the depositor(s) in edit_users' do
+          expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([user.user_key]))
+        end
+      end
+    end
+
+    context "deposited as 'Yourself' selected in on behalf of list" do
+      before do
+        generic_work.on_behalf_of = ''
+        generic_work.permission_manager.acl.save
+      end
+      it_behaves_like 'a file attacher' do
+        it 'records the depositor(s) in edit_users' do
+          expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor]))
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #4197 

Allows AttachFilesToWorkJob to receive either an ActiveFedora object or a Valkyrie resource

TODO: For ActiveFedora, uploaded file are associated to their corresponding FileSet using the FileSet's uri. Do the same for those based on Valkyrie Resources. 

@samvera/hyrax-code-reviewers
