### PR TITLE
Gh 4193 content event job

### DIFF
--- a/app/jobs/content_deposit_event_job.rb
+++ b/app/jobs/content_deposit_event_job.rb
@@ -1,6 +1,6 @@
 # Log a concern deposit to activity streams
 class ContentDepositEventJob < ContentEventJob
   def action
-    "User #{link_to_profile depositor} has deposited #{link_to repo_object.title.first, polymorphic_path(repo_object)}"
+    "User #{link_to_profile depositor} has deposited #{polymorphic_link_to(repo_object)}"
   end
 end

--- a/app/jobs/content_depositor_change_event_job.rb
+++ b/app/jobs/content_depositor_change_event_job.rb
@@ -2,9 +2,6 @@
 #
 # @attr [Boolean] reset (false) should the access controls be reset. This means revoking edit access from the depositor
 class ContentDepositorChangeEventJob < ContentEventJob
-  include Rails.application.routes.url_helpers
-  include ActionDispatch::Routing::PolymorphicRoutes
-
   attr_accessor :reset
 
   # @param [ActiveFedora::Base] work the work to be transfered
@@ -16,11 +13,7 @@ class ContentDepositorChangeEventJob < ContentEventJob
   end
 
   def action
-    "User #{link_to_profile work.proxy_depositor} has transferred #{link_to_work work.title.first} to user #{link_to_profile depositor}"
-  end
-
-  def link_to_work(text)
-    link_to text, polymorphic_path(work)
+    "User #{link_to_profile work.proxy_depositor} has transferred #{polymorphic_link_to work} to user #{link_to_profile depositor}"
   end
 
   # Log the event to the work's stream

--- a/app/jobs/content_event_job.rb
+++ b/app/jobs/content_event_job.rb
@@ -19,4 +19,11 @@ class ContentEventJob < EventJob
   def log_user_event(depositor)
     depositor.log_profile_event(event)
   end
+
+  def polymorphic_link_to(object, *args)
+    link_to(
+      object.title.first,
+      Rails.application.routes.url_helpers.polymorphic_path(object, *args)
+    )
+  end
 end

--- a/app/jobs/content_new_version_event_job.rb
+++ b/app/jobs/content_new_version_event_job.rb
@@ -1,6 +1,6 @@
 # Log new version of a file to activity streams
 class ContentNewVersionEventJob < ContentEventJob
   def action
-    @action ||= "User #{link_to_profile depositor} has added a new version of #{link_to repo_object.title.first, Rails.application.routes.url_helpers.hyrax_file_set_path(repo_object)}"
+    "User #{link_to_profile depositor} has added a new version of #{polymorphic_link_to(repo_object)}"
   end
 end

--- a/app/jobs/content_restored_version_event_job.rb
+++ b/app/jobs/content_restored_version_event_job.rb
@@ -8,6 +8,6 @@ class ContentRestoredVersionEventJob < ContentEventJob
   end
 
   def action
-    "User #{link_to_profile depositor} has restored a version '#{revision_id}' of #{link_to repo_object.title.first, Rails.application.routes.url_helpers.hyrax_file_set_path(repo_object)}"
+    "User #{link_to_profile depositor} has restored a version '#{revision_id}' of #{polymorphic_link_to(repo_object)}"
   end
 end

--- a/app/jobs/content_update_event_job.rb
+++ b/app/jobs/content_update_event_job.rb
@@ -1,6 +1,6 @@
 # Log content update to activity streams
 class ContentUpdateEventJob < ContentEventJob
   def action
-    "User #{link_to_profile depositor} has updated #{link_to repo_object.title.first, polymorphic_path(repo_object)}"
+    "User #{link_to_profile depositor} has updated #{polymorphic_link_to(repo_object)}"
   end
 end

--- a/app/jobs/file_set_attached_event_job.rb
+++ b/app/jobs/file_set_attached_event_job.rb
@@ -7,26 +7,10 @@ class FileSetAttachedEventJob < ContentEventJob
   end
 
   def action
-    "User #{link_to_profile depositor} has attached #{file_link} to #{work_link}"
+    "User #{link_to_profile depositor} has attached #{polymorphic_link_to(repo_object)} to #{polymorphic_link_to(curation_concern)}"
   end
 
   private
-
-    def file_link
-      link_to file_title, polymorphic_path(repo_object)
-    end
-
-    def work_link
-      link_to work_title, polymorphic_path(curation_concern)
-    end
-
-    def file_title
-      repo_object.title.first
-    end
-
-    def work_title
-      curation_concern.title.first
-    end
 
     def curation_concern
       repo_object.in_works.first

--- a/app/jobs/user_edit_profile_event_job.rb
+++ b/app/jobs/user_edit_profile_event_job.rb
@@ -2,7 +2,7 @@
 class UserEditProfileEventJob < EventJob
   def perform(editor)
     @editor = editor
-    super
+    super(editor)
   end
 
   def action


### PR DESCRIPTION
## Adding explicit parameter to `super` call

dcdb2d42caaa1210beafa87a3d3109eb51c7bb6e

Prior to this commit the perform method had an explicit call to super
with an implicit passing of parameters. This commit adds an explicit
passing of those parameters.

## Refactoring to unify a subsystem of Event behavior

a182c855f52fd4aa5de4ed2d2e9fd4c0173e63ca

Prior to this commit, the descendants of ContentEventJob each
approached writing their `action` string differently. With this
change, I've normalized that behavior. There is still work to be done
to get a handle on the whole event ecosystem.

Relates to: #4193
