### PR TITLE
Fixing logic around deleting nested membership

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -42,11 +42,15 @@ module Hyrax
           attributes_collection = attributes_collection.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes }
           # checking for existing works to avoid rewriting/loading works that are already attached
           existing_collections = env.curation_concern.member_of_collection_ids
+          little_boolean = ActiveModel::Type::Boolean.new
           attributes_collection.each do |attributes|
             next if attributes['id'].blank?
-            if existing_collections.include?(attributes['id'])
-              remove(env.curation_concern, attributes['id']) if
-                ActiveModel::Type::Boolean.new.cast(attributes['_destroy'])
+            if little_boolean.cast(attributes['_destroy'])
+              # Likely someone in the UI sought to add the collection, then
+              # changed their mind and checked the "delete" checkbox and posted
+              # their update.
+              next unless existing_collections.include?(attributes['id'])
+              remove(env.curation_concern, attributes['id'])
             else
               add(env, attributes['id'])
             end


### PR DESCRIPTION
> When removing a collection after adding it to a work,
> CollectionsMembershipActor still adds the collection even though the
> _destroy flag is set to true.
>
> This is happening in both new/update works, in version 2.4.1, 2.7.0,
> and most likely 3.x.
>
> Steps to reproduce the past behavior
>
> 1.    Edit an existing work
> 2.    Add a collection to the work
> 3.    Remove the collection (before saving)
> 4.    Save the work

Based on this report, someone via the UI goes to a work, then chooses
to add a collection to the work. They then change their mind and mark
"delete" for that collection, then go to save. Prior to the logic that
is put in place, this would add the collection to the work.

The fix now prioritizes checking did someone say delete? If so, go
down that logic path else go dwn the add logic path.

Fixes #4193

@samvera/hyrax-code-reviewers
