### PR TITLE
Fix spurious test failure in template-generated create_worktype_spec files

### DIFF
--- a/lib/generators/hyrax/work/templates/feature_spec.rb.erb
+++ b/lib/generators/hyrax/work/templates/feature_spec.rb.erb
@@ -43,7 +43,7 @@ RSpec.feature 'Create a <%= class_name %>', js: false do
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
       expect(page).to have_content "Add folder"
-      within('span#addfiles') do
+      within('div#add-files') do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end


### PR DESCRIPTION
Template-generated feature specs were looking for an old version of the "Add Files" button.  