### PR TITLE
Backporting fix of logic around deleting nested membership

### DIFF
--- a/app/actors/hyrax/actors/attach_members_actor.rb
+++ b/app/actors/hyrax/actors/attach_members_actor.rb
@@ -30,11 +30,11 @@ module Hyrax
           # checking for existing works to avoid rewriting/loading works that are
           # already attached
           existing_works = env.curation_concern.member_ids
-          little_boolean = ActiveModel::Type::Boolean.new
+          boolean_type_caster = ActiveModel::Type::Boolean.new
 
           attributes_collection.each do |attributes|
             next if attributes['id'].blank?
-            if little_boolean.cast(attributes['_destroy'])
+            if boolean_type_caster.cast(attributes['_destroy'])
               # Likely someone in the UI sought to add the collection, then
               # changed their mind and checked the "delete" checkbox and posted
               # their update.

--- a/app/actors/hyrax/actors/attach_members_actor.rb
+++ b/app/actors/hyrax/actors/attach_members_actor.rb
@@ -30,10 +30,16 @@ module Hyrax
           # checking for existing works to avoid rewriting/loading works that are
           # already attached
           existing_works = env.curation_concern.member_ids
+          little_boolean = ActiveModel::Type::Boolean.new
+
           attributes_collection.each do |attributes|
             next if attributes['id'].blank?
-            if existing_works.include?(attributes['id'])
-              remove(env.curation_concern, attributes['id']) if has_destroy_flag?(attributes)
+            if little_boolean.cast(attributes['_destroy'])
+              # Likely someone in the UI sought to add the collection, then
+              # changed their mind and checked the "delete" checkbox and posted
+              # their update.
+              next unless existing_works.include?(attributes['id'])
+              remove(env.curation_concern, attributes['id'])
             else
               add(env, attributes['id'])
             end

--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -46,10 +46,10 @@ module Hyrax
           attributes_collection = attributes_collection.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes }
           # checking for existing works to avoid rewriting/loading works that are already attached
           existing_collections = env.curation_concern.member_of_collection_ids
-          little_boolean = ActiveModel::Type::Boolean.new
+          boolean_type_caster = ActiveModel::Type::Boolean.new
           attributes_collection.each do |attributes|
             next if attributes['id'].blank?
-            if little_boolean.cast(attributes['_destroy'])
+            if boolean_type_caster.cast(attributes['_destroy'])
               # Likely someone in the UI sought to add the collection, then
               # changed their mind and checked the "delete" checkbox and posted
               # their update.

--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -46,10 +46,15 @@ module Hyrax
           attributes_collection = attributes_collection.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes }
           # checking for existing works to avoid rewriting/loading works that are already attached
           existing_collections = env.curation_concern.member_of_collection_ids
+          little_boolean = ActiveModel::Type::Boolean.new
           attributes_collection.each do |attributes|
             next if attributes['id'].blank?
-            if existing_collections.include?(attributes['id'])
-              remove(env.curation_concern, attributes['id']) if has_destroy_flag?(attributes)
+            if little_boolean.cast(attributes['_destroy'])
+              # Likely someone in the UI sought to add the collection, then
+              # changed their mind and checked the "delete" checkbox and posted
+              # their update.
+              next unless existing_collections.include?(attributes['id'])
+              remove(env.curation_concern, attributes['id'])
             else
               add(env, attributes['id'])
             end
@@ -114,13 +119,6 @@ module Hyrax
           collection = Collection.find(id)
           curation_concern.member_of_collections.delete(collection)
         end
-
-        # Determines if a hash contains a truthy _destroy key.
-        # rubocop:disable Naming/PredicateName
-        def has_destroy_flag?(hash)
-          ActiveFedora::Type::Boolean.new.cast(hash['_destroy'])
-        end
-        # rubocop:enable Naming/PredicateName
 
         # Extact a singleton collection id from the collection attributes and save it in env.  Later in the actor stack,
         # in apply_permission_template_actor.rb, `env.attributes[:collection_id]` will be used to apply the


### PR DESCRIPTION
## Backporting fix of logic around deleting nested membership

6f28a2fba144e2a8b426a585896575cbfc7c3f50

> When removing a collection after adding it to a work,
> CollectionsMembershipActor still adds the collection even though the
> _destroy flag is set to true.
>
> This is happening in both new/update works, in version 2.4.1, 2.7.0,
> and most likely 3.x.
>
> Steps to reproduce the past behavior
>
> 1.    Edit an existing work
> 2.    Add a collection to the work
> 3.    Remove the collection (before saving)
> 4.    Save the work

Based on this report, someone via the UI goes to a work, then chooses
to add a collection to the work. They then change their mind and mark
"delete" for that collection, then go to save. Prior to the logic that
is put in place, this would add the collection to the work.

The fix now prioritizes checking did someone say delete? If so, go
down that logic path else go down the add logic path.

Closes #4193

## Expanding backport of logic around deleting nested membership

21be50b9bf989c78d9b18a366c1dcf0effdbf5c8

In looking at a backport for #4193, I found similar logic in the
Hyrax::Actors::AttachMembersActor. I believe this is something that is
likely possible in the UI for work members.

Related to #4193 and #4278

## Renaming variable attach_members_actor

da7e8927ce58aec9cd1454162ead58f7b2a602cb

Renaming `little_boolean` to `boolean_type_caster`. As the originator
of the `little_boolean` variable name, I was aiming for playful. Yet
the name was a bit opaque. I believe the spirit of playfulness and
improved clarity of variable name shines through in
`boolean_type_caster`.

## Renaming variable for collections_membership_actor

10c0b738a3ee9b5271ae2b99fba37cb39a324d7b

Renaming `little_boolean` to `boolean_type_caster`. As the originator
of the `little_boolean` variable name, I was aiming for playful. Yet
the name was a bit opaque. I believe the spirit of playfulness and
improved clarity of variable name shines through in
`boolean_type_caster`.

Why did I not squash this into the previous commit ("Renaming variable
for attach_members_actor")? Because I am intending to cherry-pick one
of the commits to apply to master. The other commit, is not a problem
in master because that file has been refactored.
