### PR TITLE
Bumping Ruby versions in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.5.5
+        default: 2.5.8
       bundler_version:
         type: string
         default: 1.17.3
@@ -36,7 +36,7 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.5.5
+        default: 2.5.8
     executor:
       name: 'samvera/ruby'
       ruby_version: << parameters.ruby_version >>
@@ -50,7 +50,7 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.5.5
+        default: 2.5.8
       bundler_version:
         type: string
         default: 1.17.3
@@ -84,7 +84,7 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.5.5
+        default: 2.5.8
       bundler_version:
         type: string
         default: 1.17.3
@@ -116,59 +116,59 @@ jobs:
 
 workflows:
   version: 2
-  ruby2-4-7:
+  ruby2-4-10:
     jobs:
       - bundle:
-          ruby_version: "2.4.7"
+          ruby_version: "2.4.10"
           rails_version: "5.2.3"
       - lint:
-          ruby_version: "2.4.7"
+          ruby_version: "2.4.10"
           requires:
             - bundle
       - build:
-          ruby_version: "2.4.7"
+          ruby_version: "2.4.10"
           rails_version: "5.2.3"
           requires:
             - bundle
       - test:
-          name: "ruby2-4-7"
-          ruby_version: "2.4.7"
+          name: "ruby2-4-10"
+          ruby_version: "2.4.10"
           requires:
             - build
             - lint
-  ruby2-5-5:
+  ruby2-5-8:
     jobs:
       - bundle:
-          ruby_version: "2.5.5"
+          ruby_version: "2.5.8"
           rails_version: "5.2.3"
       - build:
-          ruby_version: "2.5.5"
+          ruby_version: "2.5.8"
           rails_version: "5.2.3"
           requires:
             - bundle
       - test:
-          name: "ruby2-5-5"
-          ruby_version: "2.5.5"
+          name: "ruby2-5-8"
+          ruby_version: "2.5.8"
           requires:
             - build
-  ruby2-6-2:
+  ruby2-6-6:
     jobs:
       - bundle:
-          ruby_version: "2.6.2"
+          ruby_version: "2.6.6"
           rails_version: "5.2.3"
       - build:
-          ruby_version: "2.6.2"
+          ruby_version: "2.6.6"
           rails_version: "5.2.3"
           requires:
             - bundle
       - test:
-          name: "ruby2-6-2"
-          ruby_version: "2.6.2"
+          name: "ruby2-6-6"
+          ruby_version: "2.6.6"
           requires:
             - build
       - test:
-          name: "ruby2-6-2-valkyrie"
-          ruby_version: "2.6.2"
+          name: "ruby2-6-6-valkyrie"
+          ruby_version: "2.6.6"
           hyrax_valkyrie: "true"
           requires:
             - build


### PR DESCRIPTION
The Ruby maintainers released several minor versions upgrades to
address security vulnerabilities. These changes bump the versions to
those latest versions (and in all cases bump them more than 0.0.1)

_Note this is a minimal effort stab in the dark at CircleCI ruby
version hygiene._

@samvera/hyrax-code-reviewers
