### PR TITLE
Renaming variable for collections_membership_actor

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -42,10 +42,10 @@ module Hyrax
           attributes_collection = attributes_collection.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes }
           # checking for existing works to avoid rewriting/loading works that are already attached
           existing_collections = env.curation_concern.member_of_collection_ids
-          little_boolean = ActiveModel::Type::Boolean.new
+          boolean_type_caster = ActiveModel::Type::Boolean.new
           attributes_collection.each do |attributes|
             next if attributes['id'].blank?
-            if little_boolean.cast(attributes['_destroy'])
+            if boolean_type_caster.cast(attributes['_destroy'])
               # Likely someone in the UI sought to add the collection, then
               # changed their mind and checked the "delete" checkbox and posted
               # their update.


### PR DESCRIPTION
Renaming `little_boolean` to `boolean_type_caster`. As the originator
of the `little_boolean` variable name, I was aiming for playful. Yet
the name was a bit opaque. I believe the spirit of playfulness and
improved clarity of variable name shines through in
`boolean_type_caster`.

@samvera/hyrax-code-reviewers
