### PR TITLE
Make permission level configuration defaults use I18n locale.

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1283,6 +1283,15 @@ en:
         terms_page: Terms of Use
       updated: Pages updated.
     passive_consent_to_agreement: By saving this work I agree to the
+    permission_levels:
+      edit: "Edit access"
+      read: "View/Download"
+      owner:
+        edit: "Edit access"
+      options:
+        edit: "Edit"
+        none: "Choose Access"
+        read: "View/Download"
     search:
       button:
         html: <span class="glyphicon glyphicon-search" aria-hidden="true"></span> Go

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -488,20 +488,20 @@ module Hyrax
 
     attr_writer :permission_levels
     def permission_levels
-      @permission_levels ||= { "View/Download" => "read",
-                               "Edit access" => "edit" }
+      @permission_levels ||= { I18n.t('hyrax.permission_levels.read') => "read",
+                               I18n.t('hyrax.permission_levels.edit') => "edit" }
     end
 
     attr_writer :owner_permission_levels
     def owner_permission_levels
-      @owner_permission_levels ||= { "Edit access" => "edit" }
+      @owner_permission_levels ||= { I18n.t('hyrax.permission_levels.owner.edit') => "edit" }
     end
 
     attr_writer :permission_options
     def permission_options
-      @permission_options ||= { "Choose Access" => "none",
-                                "View/Download" => "read",
-                                "Edit" => "edit" }
+      @permission_options ||= { I18n.t('hyrax.permission_levels.options.none') => "none",
+                                I18n.t('hyrax.permission_levels.options.read') => "read",
+                                I18n.t('hyrax.permission_levels.options.edit') => "edit" }
     end
 
     attr_writer :publisher


### PR DESCRIPTION
Any overrides of these defaults in initializers would remove the ability to support multiple languages as pointed out by @j-dornbusch in #4285.  Thus I'm not exactly sure of the value of these configuration methods if the values have been put in the locale, but I left them as-is to be backwards compatible.

Fixes #4285

@samvera/hyrax-code-reviewers
