### PR TITLE
Configure Redis with ENV variables if present

### DIFF
--- a/lib/generators/hyrax/templates/config/redis.yml
+++ b/lib/generators/hyrax/templates/config/redis.yml
@@ -1,9 +1,9 @@
 development:
-  host: localhost
-  port: 6379
+  host: <%= ENV.fetch('REDIS_HOST', 'localhost') %>
+  port: <%= ENV.fetch('REDIS_PORT', 6379) %>
 test:
-  host: localhost
-  port: 6379
+  host: <%= ENV.fetch('REDIS_HOST', 'localhost') %>
+  port: <%= ENV.fetch('REDIS_PORT', 6379) %>
 production:
-  host: localhost
-  port: 6379
+  host: <%= ENV.fetch('REDIS_HOST') %>
+  port: <%= ENV.fetch('REDIS_PORT', 6379) %>


### PR DESCRIPTION
adds the `REDIS_HOST` and `REDIS_PORT` ENV variables to allow applications to
configure in keeping with 12-factor. defaults are provided for dev and test
environments, while production fails eagerly if configuration is missing.

this will only affect new applications, since this configuration is generated
into the application when hyrax is installed.

@samvera/hyrax-code-reviewers
