### PR TITLE
provide default `REDIS_HOST` in production

### DIFF
--- a/lib/generators/hyrax/templates/config/redis.yml
+++ b/lib/generators/hyrax/templates/config/redis.yml
@@ -5,5 +5,5 @@ test:
   host: <%= ENV.fetch('REDIS_HOST', 'localhost') %>
   port: <%= ENV.fetch('REDIS_PORT', 6379) %>
 production:
-  host: <%= ENV.fetch('REDIS_HOST') %>
+  host: <%= ENV.fetch('REDIS_HOST', 'localhost') %>
   port: <%= ENV.fetch('REDIS_PORT', 6379) %>


### PR DESCRIPTION
leaving this variable to fail eagerly breaks engine cart installation at various
stages (some of which fail silently!). it seems like Rails can't handle the
environment specific failure in this yaml. providing a default everywhere should
be fine.

@samvera/hyrax-code-reviewers
