### PR TITLE
add a default health check endpoint at `/healthz`

### DIFF
--- a/lib/generators/hyrax/health_check_generator.rb
+++ b/lib/generators/hyrax/health_check_generator.rb
@@ -1,0 +1,13 @@
+require 'rails/generators'
+
+class Hyrax::HealthCheckGenerator < Rails::Generators::Base
+  desc """
+    Installs Hyrax's default health check endpoints at `/healthz`.
+  """
+
+  source_root File.expand_path('../templates', __FILE__)
+
+  def add_to_gemfile
+    gem 'okcomputer', '~> 1.18'
+  end
+end

--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -6,6 +6,8 @@ module Hyrax
 
     class_option :'skip-riiif', type: :boolean, default: false, desc: "Skip generating RIIIF image service."
 
+    class_option :'skip-health-check', type: :boolean, default: true, desc: "Generate the default health check endpoints."
+
     desc """
   This generator makes the following changes to your application:
   1. Runs installers for blacklight & hydra-head (which also install & configure devise)
@@ -168,6 +170,10 @@ module Hyrax
 
     def noid_rails_database_minter_initialize
       generate 'noid:rails:install'
+    end
+
+    def health_check
+      generate 'hyrax:health_check' unless options[:'skip-health-check']
     end
 
     def riiif_image_server


### PR DESCRIPTION
creates a health check endpoint at `/healthz` if the application has
the `okcomputer` gem installed. this gets us:

    - an application liveness check at `/healthz`
    - a relatively robust readiness check at `/healthz/all`

we choose `OkComputer` for the framework for this endpoint due to the ease of
extension, and due to an existing install base in parts of the community. we
should be able to source a reasonable set of default health checks from existing
code with relatively minor effort.

we'll want to extend this to check Fedora and Solr connections, and maybe
certain `valkyrie` features. for now, we just check the `ActiveRecord` DB and
the configured rails cache. if `MEMCACHED_HOST` is set, we check that; otherwise
we just use the `OkComputer` default cache check. some applications may need to
do special configuration to make sure the cache check is functioning properly.

introducing this now as an incomplete service, and with an extra step required
to turn on will give us a chance to iron out details and avoid stepping on the
toes of any applications with their own `healthz` endpoints.

the check can be installed during app generation by passing `false` to the
`skip-health-check` option.

@samvera/hyrax-code-reviewers
