### PR TITLE
better tests and documentation for `Hyrax::SimpleSchemaLoader`

### DIFF
--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -10,12 +10,19 @@ module Hyrax
   class SimpleSchemaLoader
     ##
     # @param [Symbol] schema
+    #
+    # @return [Hash<Symbol, Dry::Types::Type>] a map from attribute names to
+    #   types
     def attributes_for(schema:)
       definitions(schema).each_with_object({}) do |definition, hash|
         hash[definition.name] = definition.type
       end
     end
 
+    ##
+    # @param [Symbol] schema
+    #
+    # @return [Hash<Symbol, Symbol>] a map from index keys to attribute names
     def index_rules_for(schema:)
       definitions(schema).each_with_object({}) do |definition, hash|
         definition.index_keys.each do |key|
@@ -45,7 +52,7 @@ module Hyrax
       ##
       # @return [Enumerable<Symbol>]
       def index_keys
-        config['index_keys']&.map(&:to_sym) || []
+        config.fetch('index_keys', []).map(&:to_sym)
       end
 
       ##

--- a/spec/services/hyrax/simple_schema_loader_spec.rb
+++ b/spec/services/hyrax/simple_schema_loader_spec.rb
@@ -17,4 +17,10 @@ RSpec.describe Hyrax::SimpleSchemaLoader do
         .to raise_error described_class::UndefinedSchemaError
     end
   end
+
+  describe '#index_rules_for' do
+    it 'provides index configuration' do
+      expect(schema_loader.index_rules_for(schema: :core_metadata)).to include(title_sim: :title, title_tesim: :title)
+    end
+  end
 end


### PR DESCRIPTION
this private class is heavily used by the lightweight schema definitions for
core and basic metadata. a bit more testing and documentation seemed called for
as i was looking at this, so i put it together.

i also refactored an internal method to maybe be a bit more clear, and avoid an
`&.` operator.

@samvera/hyrax-code-reviewers
