### PR TITLE
remove the indexer initializer generator

### DIFF
--- a/lib/generators/hyrax/config_generator.rb
+++ b/lib/generators/hyrax/config_generator.rb
@@ -46,10 +46,6 @@ class Hyrax::ConfigGenerator < Rails::Generators::Base
     copy_file 'config/initializers/hyrax.rb'
   end
 
-  def create_initializer_indexers_file
-    copy_file 'config/initializers/indexers.rb'
-  end
-
   # Add mini-magick configuration
   def minimagick_config
     copy_file 'config/initializers/mini_magick.rb'

--- a/lib/generators/hyrax/templates/config/initializers/indexers.rb
+++ b/lib/generators/hyrax/templates/config/initializers/indexers.rb
@@ -1,4 +1,0 @@
-Rails.application.config.to_prepare do
-  # Register Indexers
-  Hyrax::ValkyrieIndexer.register Hyrax::ValkyrieWorkIndexer, as_indexer_for: Hyrax::Work
-end

--- a/lib/generators/hyrax/work_resource/templates/indexer.rb.erb
+++ b/lib/generators/hyrax/work_resource/templates/indexer.rb.erb
@@ -3,7 +3,7 @@
 # Generated via
 #  `rails generate hyrax:work_resource <%= class_name %>`
 class <%= class_name %>Indexer < Hyrax::ValkyrieWorkIndexer
-  Hyrax::ValkyrieIndexer.register self, as_indexer_for: <%= class_name %>
+  include Hyrax::Indexer(:basic_metadata)
 
   # Uncomment this block if you want to add custom indexing behavior:
   #  def to_solr

--- a/lib/generators/hyrax/work_resource/work_resource_generator.rb
+++ b/lib/generators/hyrax/work_resource/work_resource_generator.rb
@@ -38,10 +38,12 @@ class Hyrax::WorkResourceGenerator < Rails::Generators::NamedBase
   end
 
   def register_indexer
-    config = 'config/initializers/indexers.rb'
-    register_line = "  Hyrax::ValkyrieIndexer.register #{class_name}Indexer, as_indexer_for: #{class_name}\n"
-    inject_into_file config, after: "# Register Indexers\n" do
-      return if File.read(config).include?(register_line)
+    config = 'config/initializers/hyrax.rb'
+    register_line = "Hyrax::ValkyrieIndexer.register #{class_name}Indexer, as_indexer_for: #{class_name}\n"
+
+    return if File.read(config).include?(register_line)
+
+    append_to_file config do
       register_line
     end
   end

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -16,6 +16,7 @@ require 'hydra/works'
 require 'hyrax/engine'
 require 'hyrax/version'
 require 'hyrax/inflections'
+require 'hyrax/name'
 require 'hyrax/valkyrie_can_can_adapter'
 require 'kaminari_route_prefix'
 


### PR DESCRIPTION
the code this generator injects isn't really necessary (if we want to register
this indexer for the generic `Hyrax::Work`, we can do it in Hyrax
directly). including it complicates the upgrade process for existing
apps. instead, while we need to manually register indexers for specific
works (maybe we can do this with configuration soon, instead?), inject them into
the hyrax initializer when the work generator runs.

additionally, generate basic metadata into the indexer.

@samvera/hyrax-code-reviewers
