### PR TITLE
start to bridge the gap between HydraEditor forms and ChangeSets

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Forms
+    ##
+    # @api public
+    #
+    # @example defining a form class using HydraEditor-like configuration
+    #   class MonographForm < Hyrax::Forms::ResourceForm(Monograph)
+    #     self.required_fields = [:title, :creator, :rights_statement]
+    #     # other WorkForm-like configuration here
+    #   end
+    #
+    def self.ResourceForm(work_class)
+      Class.new(Hyrax::Forms::ResourceForm) do
+        (work_class.fields - work_class.reserved_attributes).each do |field|
+          property field, default: nil
+        end
+      end
+    end
+
+    ##
+    # @api public
+    #
+    # This form wraps `Hyrax::ChangeSet` in the `HydraEditor::Form` interface.
+    class ResourceForm < Hyrax::ChangeSet
+      class << self
+        ##
+        # @api public
+        #
+        # Factory for generic, per-work froms
+        #
+        # @example
+        #   monograph  = Monograph.new
+        #   change_set = Hyrax::Forms::ResourceForm.for(monograph)
+        def for(work)
+          Hyrax::Forms::ResourceForm(work.class).new(work)
+        end
+
+        ##
+        # @return [Array<Symbol>] list of required field names as symbols
+        def required_fields
+          definitions
+            .select { |_, definition| definition[:required] }
+            .keys.map(&:to_sym)
+        end
+
+        ##
+        # @param [Enumerable<#to_s>] fields
+        #
+        # @return [Array<Symbol>] list of required field names as symbols
+        def required_fields=(fields)
+          fields = fields.map(&:to_s)
+          raise(KeyError) unless fields.all? { |f| definitions.key?(f) }
+
+          fields.each { |field| definitions[field].merge!(required: true) }
+
+          required_fields
+        end
+      end
+
+      ##
+      # @param [#to_s] attr
+      # @param [Object] value
+      #
+      # @return [Object] the set value
+      def []=(attr, value)
+        public_send("#{attr}=".to_sym, value)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/form_factory.rb
+++ b/app/services/hyrax/form_factory.rb
@@ -19,7 +19,7 @@ module Hyrax
     # @param ability    [Hyrax::Ability]
     # @param controller [ApplicationController]
     def build(model, _ability, _controller)
-      Hyrax::ChangeSet.for(model)
+      Hyrax::Forms::ResourceForm.for(model)
     end
   end
 end

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Forms::ResourceForm do
+  subject(:form)   { described_class.for(work) }
+  let(:work)       { Hyrax::Work.new }
+
+  describe '.required_fields=' do
+    subject(:form) { form_class.new(work) }
+
+    let(:form_class) do
+      Class.new(Hyrax::Forms::ResourceForm(work.class)) do
+        self.required_fields = [:title]
+      end
+    end
+
+    it 'lists required fields' do
+      expect(form_class.required_fields).to contain_exactly :title
+    end
+
+    it 'can add required fields' do
+      expect { form_class.required_fields += [:depositor] }
+        .to change { form.required?(:depositor) && form.required?(:title) }
+        .to true
+    end
+  end
+
+  describe '#[]' do
+    it 'supports access to work attributes' do
+      expect(form[:title]).to eq work.title
+    end
+
+    it 'gives nil for unsupported attributes' do
+      expect(form[:not_a_real_attribute]).to be_nil
+    end
+  end
+
+  describe '#[]=' do
+    it 'supports setting work attributes' do
+      new_title = 'comet in moominland'
+
+      expect { form[:title] = new_title }
+        .to change { form[:title] }
+        .to new_title
+    end
+  end
+
+  describe '#required?' do
+    it 'is false for non-required fields' do
+      expect(form.required?(:title)).to eq false
+    end
+
+    context 'when some fields are required' do
+      subject(:form) { form_class.new(work) }
+
+      let(:form_class) do
+        Class.new(Hyrax::Forms::ResourceForm(work.class)) do
+          self.required_fields = [:title]
+        end
+      end
+
+      it 'is true for required fields' do
+        expect(form.required?(:title)).to eq true
+      end
+
+      it 'is false for non-required fields' do
+        expect(form.required?(:depositor)).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
for Valkyrie models, we'd like to use Reform-based `ChangeSet` instances as the
basis for forms. this is a lot simpler for "dirty tracking" than the large-scale
delegation approach used by HydraEditor. it's also more powerful, allowing these
form objects to be used to construct forms and manage attribute processing. this
latter responsibility is currently a bit scattered between controllers, service
classes, and the actor stack. there's reason to believe this shift will help us
clean that up.

however, we *also* want to avoid major controller/view side changes, so we want
these forms to support `HydraEditor::Form`-like interfaces, as well as the
specific behavior existing `Hyrax::Forms` classes.

this starts to extend the `Valkyrie::ChangeSet`/`Hyrax::ChangeSet` behavior to
support expected behavior of `HydraEditor::Form`. the expectation is that
application-side forms for valkyrie models will be defined like:

    class MonographForm < Hyrax::Forms::ResourceForm(Monograph)
      self.required_fields = [:title, :creator, :rights_statement]

      # other WorkForm-like configuration here
    end

this won't necessarily result in an attempt to *completely* reproduce the
WorkForm interface; rather, the goal is to narrow the scope of application-side
porting work required to shift to the above. especially, we want external
behavior to be as close as possible.

@samvera/hyrax-code-reviewers
