### PR TITLE
use a decorator for page titles

### DIFF
--- a/app/helpers/hyrax/title_helper.rb
+++ b/app/helpers/hyrax/title_helper.rb
@@ -9,13 +9,21 @@ module Hyrax::TitleHelper
     (elements.flatten.compact + [application_name]).join(' // ')
   end
 
+  ##
+  # @deprecated
   def curation_concern_page_title(curation_concern)
-    Hyrax::PageTitleDecorator.new(curation_concern).page_title
+    Deprecation.warn 'The curation_concern_page_title helper will be removed in Hyrax 4.0.' \
+                     "\n\tUse title_presenter(curation_concern).page_title instead."
+    title_presenter(curation_concern).page_title
   end
 
   def default_page_title
     text = controller_name.singularize.titleize
     text = "#{action_name.titleize} " + text if action_name
     construct_page_title(text)
+  end
+
+  def title_presenter(resource)
+    Hyrax::PageTitleDecorator.new(resource)
   end
 end

--- a/app/helpers/hyrax/title_helper.rb
+++ b/app/helpers/hyrax/title_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hyrax::TitleHelper
   def application_name
     t('hyrax.product_name', default: super)
@@ -8,11 +10,7 @@ module Hyrax::TitleHelper
   end
 
   def curation_concern_page_title(curation_concern)
-    if curation_concern.persisted?
-      construct_page_title(curation_concern.to_s, "#{curation_concern.human_readable_type} [#{curation_concern.to_param}]")
-    else
-      construct_page_title("New #{curation_concern.human_readable_type}")
-    end
+    Hyrax::PageTitleDecorator.new(curation_concern).page_title
   end
 
   def default_page_title

--- a/app/models/concerns/hyrax/serializers.rb
+++ b/app/models/concerns/hyrax/serializers.rb
@@ -6,7 +6,7 @@ module Hyrax
       elsif label.present?
         label
       else
-        'No Title'
+        I18n.t('hyrax.works.missing_title')
       end
     end
   end

--- a/app/presenters/hyrax/page_title_decorator.rb
+++ b/app/presenters/hyrax/page_title_decorator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Decorates Work-like objects with a `#title` and `#page_title` for display.
+  class PageTitleDecorator < Draper::Decorator
+    ##
+    # overlays the `#title` of the object, making an effort to guarantee
+    # a reasonable title is found. if one isn't found, it uses an i18n
+    # key to produce a generic 'No Title' string.
+    #
+    # @return [String] a displayable title for this object
+    def title
+      title = Array(object.try(:title)).join(' | ')
+      return title if title.present?
+      label = Array(object.try(:label)).join(' | ')
+      return label if label.present?
+
+      h.t('hyrax.works.missing_title')
+    end
+
+    ##
+    # @return [String] a title for pages about this object
+    def page_title
+      result = "#{object.human_readable_type} [#{object.to_param}] // #{h.application_name}"
+      result = title + ' // ' + result if object.persisted?
+      result
+    end
+  end
+end

--- a/app/views/hyrax/base/edit.html.erb
+++ b/app/views/hyrax/base/edit.html.erb
@@ -1,4 +1,4 @@
-<% provide :page_title, curation_concern_page_title(curation_concern) %>
+<% provide :page_title, title_presenter(curation_concern).page_title %>
 <% provide :page_header do %>
   <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t("hyrax.works.update.header") %></h1>
 <% end %>

--- a/app/views/hyrax/base/new.html.erb
+++ b/app/views/hyrax/base/new.html.erb
@@ -1,4 +1,4 @@
-<% provide :page_title, curation_concern_page_title(curation_concern) %>
+<% provide :page_title, title_presenter(curation_concern).page_title %>
 <% provide :page_header do %>
   <h1><%= t("hyrax.works.create.header", type: curation_concern.human_readable_type) %></h1>
 <% end %>

--- a/app/views/hyrax/file_sets/edit.html.erb
+++ b/app/views/hyrax/file_sets/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/nav_safety_modal" %>
-<% provide :page_title, curation_concern_page_title(curation_concern) %>
+<% provide :page_title, title_presenter(curation_concern).page_title %>
 <% provide :page_header do %>
   <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t('.header', file_set: curation_concern) %></h1>
 <% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1508,6 +1508,7 @@ en:
         state_error: 'The workflow: %{workflow_name} has not been updated.  You are removing a state: %{state_name} with %{entity_count} entity/ies.  A state may not be removed while it has active entities!'
       unauthorized: The work is not currently available because it has not yet completed the approval process
     works:
+      missing_title: 'No Title'
       create:
         after_create_html: Your files are being processed by %{application_name} in the background. The metadata and access controls you specified are being applied. You may need to refresh this page to see these updates.
         breadcrumb: Add New Work

--- a/spec/presenters/hyrax/page_title_decorator_spec.rb
+++ b/spec/presenters/hyrax/page_title_decorator_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::PageTitleDecorator do
+  subject(:decorated) { described_class.new(work) }
+  let(:work) { build(:hyrax_work) }
+
+  describe '#title' do
+    it 'returns "No Title"' do
+      expect(decorated.title).to eq 'No Title'
+    end
+
+    context 'with a title' do
+      let(:work) { build(:hyrax_work, title: 'comet in moominland') }
+
+      it 'returns the title' do
+        expect(decorated.title).to eq 'comet in moominland'
+      end
+    end
+
+    context 'with multiple titles' do
+      let(:work) do
+        build(:hyrax_work, title: ['first title', 'second title'])
+      end
+
+      it 'returns a string with both titles' do
+        expect(decorated.title).to eq 'first title | second title'
+      end
+    end
+  end
+
+  describe '#page_title' do
+    it 'gives a string' do
+      expect(decorated.page_title).to be_a String
+    end
+  end
+end

--- a/spec/views/hyrax/base/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/base/edit.html.erb_spec.rb
@@ -1,18 +1,19 @@
+# frozen_string_literal: true
+
 RSpec.describe 'hyrax/base/edit.html.erb', type: :view do
   let(:work) { stub_model(GenericWork, id: '456', title: ["A nice work"]) }
   let(:ability) { double }
+  let(:controller_class) { Hyrax::GenericWorksController }
 
   let(:form) do
     Hyrax::GenericWorkForm.new(work, ability, controller)
   end
 
   before do
-    # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
-    allow(work).to receive(:new_record?).and_return(false)
     allow(view).to receive(:curation_concern).and_return(work)
     allow(controller).to receive(:current_user).and_return(stub_model(User))
     assign(:form, form)
-    view.controller = Hyrax::GenericWorksController.new
+    view.controller = controller_class.new
     view.controller.action_name = 'edit'
     stub_template "hyrax/base/_form.html.erb" => 'a form'
   end
@@ -22,5 +23,18 @@ RSpec.describe 'hyrax/base/edit.html.erb', type: :view do
     expect(view).to receive(:provide).with(:page_header).and_yield
     render
     expect(rendered).to eq "  <h1><span class=\"fa fa-edit\" aria-hidden=\"true\"></span>Edit Work</h1>\n\na form\n"
+  end
+
+  context 'with a change_set style form' do
+    let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+    let(:work) { valkyrie_create(:hyrax_work, title: 'comet in moominland') }
+    let(:controller_class) { Hyrax::MonographsController }
+
+    it "sets a header and draws the form" do
+      expect(view).to receive(:provide).with(:page_title, "comet in moominland // Simple work [#{work.id}] // Hyrax")
+      expect(view).to receive(:provide).with(:page_header).and_yield
+      render
+      expect(rendered).to eq "  <h1><span class=\"fa fa-edit\" aria-hidden=\"true\"></span>Edit Work</h1>\n\na form\n"
+    end
   end
 end


### PR DESCRIPTION
provides a more flexible implementation of the page title helper, that can be
adapted to different kinds of models. the decorator included here is usable for
both Valkyrie and ActiveFedora models.

an i18n key is added for the previosly hard-coded `"No Title"` string.

#### Guidance for testing
  1. make a work with no title
  1. ensure the page titles still contain "No Title"

@samvera/hyrax-code-reviewers
