### PR TITLE
use helpers to i18nize configured permission levels/options

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -12,6 +12,7 @@ module Hyrax
     include Hyrax::ChartsHelper
     include Hyrax::DashboardHelperBehavior
     include Hyrax::IiifHelper
+    include Hyrax::PermissionLevelsHelper
 
     # Which translations are available for the user to select
     # @return [Hash<String,String>] locale abbreviations as keys and flags as values

--- a/app/helpers/hyrax/permission_levels_helper.rb
+++ b/app/helpers/hyrax/permission_levels_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module PermissionLevelsHelper
+    ##
+    # @return [Hash<String, String>] a map from i18nized strings to permission
+    #   level keywords
+    def configured_permission_levels
+      Hyrax.config.permission_levels.values.each_with_object({}) do |level, hsh|
+        hsh[I18n.t("hyrax.permission_levels.#{level}")] = level
+      end
+    end
+
+    ##
+    # @return [Hash<String, String>] a map from i18nized strings to permission
+    #   level keywords
+    def configured_owner_permission_levels
+      Hyrax.config.owner_permission_levels.values.each_with_object({}) do |level, hsh|
+        hsh[I18n.t("hyrax.permission_levels.owner.#{level}")] = level
+      end
+    end
+
+    ##
+    # @return [Hash<String, String>] a map from i18nized strings to permission
+    #   level keywords
+    def configured_permission_options
+      Hyrax.config.permission_options.values.each_with_object({}) do |option, hsh|
+        hsh[I18n.t("hyrax.permission_levels.options.#{option}")] = option
+      end
+    end
+  end
+end

--- a/app/views/hyrax/base/_form_share.html.erb
+++ b/app/views/hyrax/base/_form_share.html.erb
@@ -24,7 +24,7 @@
       <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>
     <% end %>
     <label for="new_group_permission_skel" class="sr-only"><%= t(".access_type_to_grant") %></label>
-    <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
+    <%= select_tag 'new_group_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
 
     <button class="btn btn-default" id="add_new_group_skel">
       <span><%= t(".add_this_group_html") %></span>
@@ -41,7 +41,7 @@
     <label for="new_user_name_skel" class="sr-only"><%= t('.account_label_without_suffix', account_label: t('hyrax.account_label'), suffix: t('hyrax.directory.suffix')) %> </label>
     <%= text_field_tag 'new_user_name_skel', nil %>
     <label for="new_user_permission_skel" class="sr-only"><%= t('.access_type_to_grant') %></label>
-    <%= select_tag 'new_user_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
+    <%= select_tag 'new_user_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
     <button class="btn btn-default" id="add_new_user_skel">
       <span>Add<span class="sr-only"> this <%= t('hyrax.account_label') %></span></span>
     </button>
@@ -54,7 +54,7 @@
 <table class="table">
   <tr id="file_permissions">
     <td width="20%">
-      <%= Hyrax.config.owner_permission_levels.keys[0] %>
+      <%= configured_owner_permission_levels.keys.first %>
     </td>
     <td width="60%">
       <%= label_tag :owner_access, class: "control-label" do %>
@@ -67,7 +67,7 @@
     <% next if ['public', 'registered', depositor].include? permission_fields.object.agent_name.downcase %>
     <tr>
       <td>
-        <%= permission_fields.select :access, Hyrax.config.permission_levels, {}, class: 'form-control select_perm' %>
+        <%= permission_fields.select :access, configured_permission_levels, {}, class: 'form-control select_perm' %>
       </td>
       <td>
         <%= permission_fields.label :agent_name, class: "control-label" do %>

--- a/app/views/hyrax/file_sets/_permission_form.html.erb
+++ b/app/views/hyrax/file_sets/_permission_form.html.erb
@@ -34,7 +34,7 @@
     </div>
     <div class="col-sm-4">
       <label for="new_user_permission_skel" class="sr-only"><%= t('.new_user_permission_skel') %></label>
-      <%= select_tag 'new_user_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
+      <%= select_tag 'new_user_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
     </div>
     <div class="col-sm-3">
       <button class="btn btn-default" id="add_new_user_skel">
@@ -55,7 +55,7 @@
     </div>
     <div class="col-sm-4">
       <label for="new_group_permission_skel" class="sr-only"><%= t('.new_group_permission_skel') %></label>
-      <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
+      <%= select_tag 'new_group_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
     </div>
     <div class="col-sm-3">
       <span class="sr-only"><%= t('.add_new_group_skel') %></span>
@@ -77,7 +77,7 @@
       <% end %>
     </td>
     <td>
-      <%= Hyrax.config.owner_permission_levels.keys[0] %>
+      <%= configured_owner_permission_levels.keys.first %>
     </td>
   </tr>
   <%= f.fields_for :permissions do |permission_fields| %>

--- a/spec/helpers/hyrax/permission_levels_helper_spec.rb
+++ b/spec/helpers/hyrax/permission_levels_helper_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::PermissionLevelsHelper do
+  before { @old_locale = I18n.locale }
+  after { I18n.locale = @old_locale } # rubocop:disable RSpec/InstanceVariable
+
+  describe '#configured_permission_levels' do
+    it 'gives a hash with default values' do
+      expect(configured_permission_levels)
+        .to eq('Edit access' => 'edit', 'View/Download' => 'read')
+    end
+
+    context 'overridden as empty' do
+      before do
+        allow(Hyrax.config).to receive(:permission_levels).and_return({})
+      end
+
+      it 'gives an empty hash' do
+        expect(configured_permission_levels).to eq({})
+      end
+    end
+
+    context 'overridden with values' do
+      let(:values) do
+        { 'View/Download' => 'read', 'moomin' => 'edit' }
+      end
+
+      before do
+        allow(Hyrax.config).to receive(:permission_levels).and_return(values)
+      end
+
+      it 'gives i18nized hash' do
+        expect { I18n.locale = :de }
+          .to change { configured_permission_levels }
+          .from('Edit access' => 'edit', 'View/Download' => 'read')
+      end
+    end
+  end
+
+  describe '#configured_owner_permission_levels' do
+    it 'gives a hash with default values' do
+      expect(configured_owner_permission_levels)
+        .to eq('Edit access' => 'edit')
+    end
+
+    context 'overridden as empty' do
+      before do
+        allow(Hyrax.config).to receive(:owner_permission_levels).and_return({})
+      end
+
+      it 'gives an empty hash' do
+        expect(configured_owner_permission_levels).to eq({})
+      end
+    end
+
+    context 'overridden with values' do
+      let(:values) do
+        { 'moomin' => 'edit' }
+      end
+
+      before do
+        allow(Hyrax.config).to receive(:owner_permission_levels).and_return(values)
+      end
+
+      it 'gives i18nized hash' do
+        expect { I18n.locale = :de }
+          .to change { configured_owner_permission_levels }
+          .from('Edit access' => 'edit')
+      end
+    end
+  end
+
+  describe '#configured_permission_options' do
+    it 'gives a hash with default values' do
+      expect(configured_permission_options)
+        .to eq('Choose Access' => 'none',
+               'Edit' => 'edit',
+               'View/Download' => 'read')
+    end
+
+    context 'overridden as empty' do
+      before do
+        allow(Hyrax.config).to receive(:permission_options).and_return({})
+      end
+
+      it 'gives an empty hash' do
+        expect(configured_permission_options).to eq({})
+      end
+    end
+
+    context 'overridden with values' do
+      let(:values) do
+        { 'View/Download' => 'read', 'moomin' => 'edit' }
+      end
+
+      before do
+        allow(Hyrax.config).to receive(:permission_options).and_return(values)
+      end
+
+      it 'gives i18nized hash' do
+        expect { I18n.locale = :de }
+          .to change { configured_permission_options }
+          .from('Edit' => 'edit', 'View/Download' => 'read')
+      end
+    end
+  end
+end


### PR DESCRIPTION
these configured options (why do they need to be configurable? how would one
configure them successfully?) need to be i18nized, but the current fix only
caches the i18n strings at app startup (or maybe when the configurations are
first hit?).

to translate on-the-fly we need to hit the i18n key while the user is in the
desired locale.

this is a stop-gap fix. probably we want to make the configuration options just
straight arrays, or remove them completely. discussion on longer term approachs
is scheduled in https://wiki.lyrasis.org/display/samvera/Samvera+Tech+Call+2020-06-05.

related to #4297.

@samvera/hyrax-code-reviewers
