### PR TITLE
Addressing case where children are added again

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -32,6 +32,8 @@ module Hyrax
         # @return [Boolean]
         #
         # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/CyclomaticComplexity
         def assign_nested_attributes_for_collection(env)
           attributes_collection = env.attributes.delete(:member_of_collections_attributes)
           return true unless attributes_collection
@@ -52,13 +54,16 @@ module Hyrax
               next unless existing_collections.include?(attributes['id'])
               remove(env.curation_concern, attributes['id'])
             else
+              # Let's not try to add an item already
+              next if existing_collections.include?(attributes['id'])
               add(env, attributes['id'])
             end
           end
-
           true
         end
         # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         # Adds the item to the ordered members so that it displays in the items
         # along side the FileSets on the show page


### PR DESCRIPTION
Prior to this commit, there was no guard in place to prevent adding
children again.

The logic would check "is something marked for delete" if not, then
add it. That needed to change, because when a user would submit a
form changing keywords, then we would re-add all of the already added
members.

Related to #4301 

@samvera/hyrax-code-reviewers
