### PR TITLE
use a helper for lease/embargo expiration

### DIFF
--- a/app/helpers/hyrax/embargo_helper.rb
+++ b/app/helpers/hyrax/embargo_helper.rb
@@ -11,5 +11,16 @@ module Hyrax
     def assets_with_deactivated_embargoes
       @assets_with_deactivated_embargoes ||= EmbargoService.assets_with_deactivated_embargoes
     end
+
+    ##
+    # @since 3.0.0
+    #
+    # @param [Valkyrie::Resource, ActiveFedora::Base] resource
+    #
+    # @return [Boolean] whether the resource has an embargo that is currently
+    #   enforced (regardless of whether it has expired)
+    def embargo_enforced?(resource)
+      !resource.embargo_release_date.nil?
+    end
   end
 end

--- a/app/helpers/hyrax/lease_helper.rb
+++ b/app/helpers/hyrax/lease_helper.rb
@@ -11,5 +11,16 @@ module Hyrax
     def assets_with_deactivated_leases
       @assets_with_deactivated_leases ||= LeaseService.assets_with_deactivated_leases
     end
+
+    ##
+    # @since 3.0.0
+    #
+    # @param [Valkyrie::Resource, ActiveFedora::Base] resource
+    #
+    # @return [Boolean] whether the resource has an lease that is currently
+    #   enforced (regardless of whether it has expired)
+    def lease_enforced?(resource)
+      !resource.lease_expiration_date.nil?
+    end
   end
 end

--- a/app/views/hyrax/base/_form_permission.html.erb
+++ b/app/views/hyrax/base/_form_permission.html.erb
@@ -1,7 +1,7 @@
 <% # This is used by works and by FileSet and the layout (col-6 vs col-12) is different for both %>
-<% if f.object.embargo_release_date %>
+<% if embargo_enforced?(f.object) %>
   <%= render 'form_permission_under_embargo', f: f %>
-<% elsif f.object.lease_expiration_date %>
+<% elsif lease_enforced?(f.object) %>
   <%= render 'form_permission_under_lease', f: f %>
 <% else %>
   <fieldset class="set-access-controls">

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -1,6 +1,6 @@
-<% if f.object.embargo_release_date %>
+<% if embargo_enforced?(f.object) %>
   <%= render 'form_permission_under_embargo', f: f %>
-<% elsif f.object.lease_expiration_date %>
+<% elsif lease_enforced?(f.object) %>
   <%= render 'form_permission_under_lease', f: f %>
 <% else %>
     <fieldset>

--- a/spec/helpers/hyrax/embargo_helper_spec.rb
+++ b/spec/helpers/hyrax/embargo_helper_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::EmbargoHelper do
+  let(:resource) { build(:monograph) }
+
+  describe 'embargo_enforced?' do
+    context 'with an ActiveFedora resource' do
+      let(:resource) { build(:work) }
+
+      it 'returns false' do
+        expect(embargo_enforced?(resource)).to be false
+      end
+
+      context 'when the resource is under embargo' do
+        let(:resource) { build(:embargoed_work) }
+
+        it 'returns true' do
+          expect(embargo_enforced?(resource)).to be true
+        end
+
+        it 'and the embargo is expired returns true' do
+          resource.embargo.embargo_release_date = Time.zone.today - 1
+
+          expect(embargo_enforced?(resource)).to be true
+        end
+
+        it 'and the embargo is deactivated returns false' do
+          resource.embargo.embargo_release_date = Time.zone.today - 1
+          resource.embargo.deactivate!
+
+          expect(embargo_enforced?(resource)).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/hyrax/lease_helper_spec.rb
+++ b/spec/helpers/hyrax/lease_helper_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::LeaseHelper do
+  let(:resource) { build(:monograph) }
+
+  describe 'lease_enforced?' do
+    context 'with an ActiveFedora resource' do
+      let(:resource) { build(:work) }
+
+      it 'returns false' do
+        expect(lease_enforced?(resource)).to be false
+      end
+
+      context 'when the resource is under lease' do
+        let(:resource) { build(:leased_work) }
+
+        it 'returns true' do
+          expect(lease_enforced?(resource)).to be true
+        end
+
+        it 'and the lease is expired returns true' do
+          resource.lease.lease_expiration_date = Time.zone.today - 1
+
+          expect(lease_enforced?(resource)).to be true
+        end
+
+        it 'and the lease is deactivated returns false' do
+          resource.lease.lease_expiration_date = Time.zone.today - 1
+          resource.lease.deactivate!
+
+          expect(lease_enforced?(resource)).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
these views relied on internal knowledge about Embargo and Lease implementations
that likely won't hold under Valkyrie models. extracting this knowledge into a
helper method is a first step toward making it implementation agnostic.

this is connected to https://github.com/samvera/hydra-head/issues/511.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* find an object that has an expired embargo but which has not been deactivated: https://nurax-dev.curationexperts.com/embargoes
* browse to that object's edit page
* check that the embargo deactivate button is still in the permissions sidebar.

@samvera/hyrax-code-reviewers
