### PR TITLE
expand the `EmbargoManager` interface to handle releasing embargos

### DIFF
--- a/app/services/hyrax/embargo_manager.rb
+++ b/app/services/hyrax/embargo_manager.rb
@@ -5,7 +5,24 @@ module Hyrax
   # Provides utilities for managing the lifecycle of an `Hyrax::Embargo` on a
   # `Hyrax::Resource`.
   #
-  # This can do things like
+  # The embargo terminology used here is as follows:
+  #
+  #    - "Release Date" is the day an embargo is scheduled to be released.
+  #    - "Under Embargo" means the embargo is "active"; i.e. that its release
+  #       date is today or later.
+  #    - "Applied" means the embargo's pre-release visibility has been set on
+  #      the resource.
+  #    - "Released" means the embargo's post-release visibility has been set on
+  #      the resource.
+  #    - "Enforced" means the object's visibility matches the pre-release
+  #      visibility of the embargo; i.e. the embargo has been applied,
+  #      but not released.
+  #
+  # Note that an resource may be `#under_embargo?` even if the embargo is not
+  # be `#enforced?` (in this case, the application should seek to apply the
+  # embargo, e.g. via a scheduled job). Additionally, an embargo may be
+  # `#enforced?` after its release date (in this case, the application should
+  # seek to release the embargo).
   #
   # @example check whether a resource is under an active embargo
   #   manager = EmbargoManager.new(resource: my_resource)
@@ -21,8 +38,41 @@ module Hyrax
   #
   #   manager = EmbargoManager.new(resource: resource)
   #
-  #   manager.apply
+  #   manager.apply!
+  #   manager.enforced? => true
   #   resource.visibility # => 'restricted'
+  #
+  # @example releasing an embargo
+  #   embargo = Hyrax::Embargo.new(visibility_during_embargo: 'restricted',
+  #                                visibility_after_embargo:  'open',
+  #                                embargo_release_date:      Time.zone.today + 1000)
+  #
+  # @example releasing an embargo
+  #   embargo = Hyrax::Embargo.new(visibility_during_embargo: 'restricted',
+  #                                visibility_after_embargo:  'open',
+  #                                embargo_release_date:      Time.zone.today + 1)
+  #
+  #   resource = Hyrax::Resource.new(embargo: embargo)
+  #   manager  = EmbargoManager.new(resource: resource)
+  #
+  #   manager.under_embargo? => true
+  #   manager.enforced? => false
+  #
+  #   manager.apply!
+  #
+  #   resource.visibility # => 'restricted'
+  #   manager.enforced? => true
+  #
+  #   manager.release! # => NotReleasableError
+  #
+  #   # <spongebob narrator>ONE DAY LATER</spongebob narrator>
+  #   manager.under_embargo? => false
+  #   manager.enforced? => true
+  #
+  #   manager.release!
+  #
+  #   resource.visibility # => 'open'
+  #   manager.enforced? => false
   #
   class EmbargoManager
     ##
@@ -48,9 +98,24 @@ module Hyrax
           .apply
       end
 
+      def apply_embargo_for!(resource:, query_service: Hyrax.query_service)
+        new(resource: resource, query_service: query_service)
+          .apply!
+      end
+
       def embargo_for(resource:, query_service: Hyrax.query_service)
         new(resource: resource, query_service: query_service)
           .embargo
+      end
+
+      def release_embargo_for(resource:, query_service: Hyrax.query_service)
+        new(resource: resource, query_service: query_service)
+          .release
+      end
+
+      def release_embargo_for!(resource:, query_service: Hyrax.query_service)
+        new(resource: resource, query_service: query_service)
+          .release!
       end
     end
 
@@ -68,6 +133,8 @@ module Hyrax
     end
 
     ##
+    # Sets the visibility of the resource to the embargo's visibility condition
+    #
     # @return [Boolean]
     def apply
       return false unless under_embargo?
@@ -76,16 +143,53 @@ module Hyrax
     end
 
     ##
-    # @return [Valkyrie::Resource]
+    # @return [void]
+    # @raise [NotEnforcableError] when trying to apply an embargo that isn't active
+    def apply!
+      apply || raise(NotEnforcableError)
+    end
+
+    ##
+    # @return [Boolean]
+    def enforced?
+      embargo.visibility_during_embargo.to_s == resource.visibility
+    end
+
+    ##
+    # @return [Hyrax::Embargo]
     def embargo
       resource.embargo || Embargo.new
     end
 
     ##
-    # @return [Boolean]
+    # Sets the visibility of the resource to the embargo's visibility condition.
+    # no-op if the embargo period is current.
+    #
+    # @return [Boolean] truthy if the embargo has been applied
+    def release
+      return false if under_embargo?
+      return true if embargo.visibility_after_embargo.nil?
+
+      resource.visibility = embargo.visibility_after_embargo
+    end
+
+    ##
+    # @return [void]
+    # @raise [NotEnforcableError] when trying to release an embargo that
+    #   is currently active
+    def release!
+      release || raise(NotReleasableError)
+    end
+
+    ##
+    # @return [Boolean] indicates whether the date range for the embargo's
+    #   applicability includes the present date.
     def under_embargo?
       embargo.active?
     end
+
+    class NotEnforcableError < RuntimeError; end
+    class NotReleasableError < RuntimeError; end
 
     private
 

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module Hyrax
+  ##
+  # Provides utilities for managing the lifecycle of an `Hyrax::Lease` on a
+  # `Hyrax::Resource`.
   class LeaseManager
     ##
     # @!attribute [rw] resource
@@ -31,6 +34,12 @@ module Hyrax
       end
     end
 
+    ##
+    # Copies and applies the lease to a new (target) resource.
+    #
+    # @param target [Hyrax::Resource]
+    #
+    # @return [Boolean]
     def copy_lease_to(target:)
       return false unless under_lease?
 
@@ -47,7 +56,14 @@ module Hyrax
     end
 
     ##
-    # @return [Valkyrie::Resource]
+    # @return [void]
+    # @raise [NotEnforcableError] when trying to apply an lease that isn't active
+    def apply!
+      apply || raise(NotEnforcableError)
+    end
+
+    ##
+    # @return [Hyrax::Lease]
     def lease
       resource.lease || Lease.new
     end
@@ -57,6 +73,9 @@ module Hyrax
     def under_lease?
       lease.active?
     end
+
+    class NotEnforcableError < RuntimeError; end
+    class NotReleasableError < RuntimeError; end
 
     private
 

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -63,9 +63,30 @@ module Hyrax
     end
 
     ##
+    # @return [Boolean]
+    def enforced?
+      lease.visibility_during_lease.to_s == resource.visibility
+    end
+
+    ##
     # @return [Hyrax::Lease]
     def lease
       resource.lease || Lease.new
+    end
+
+    ##
+    # @return [Boolean]
+    def release
+      return false if under_lease?
+      return true if lease.visibility_after_lease.nil?
+
+      resource.visibility = lease.visibility_after_lease
+    end
+
+    ##
+    # @return [void]
+    def release!
+      release || raise(NotReleasableError)
     end
 
     ##

--- a/spec/services/hyrax/lease_manager_spec.rb
+++ b/spec/services/hyrax/lease_manager_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::LeaseManager do
 
   shared_context 'with expired lease' do
     let(:resource) { FactoryBot.build(:hyrax_resource, lease: lease) }
-    let(:lease)  { FactoryBot.build(:hyrax_lease, :expired) }
+    let(:lease)    { FactoryBot.build(:hyrax_lease, :expired) }
   end
 
   describe '#apply' do
@@ -44,6 +44,36 @@ RSpec.describe Hyrax::LeaseManager do
     end
   end
 
+  describe '#enforced' do
+    it { is_expected.not_to be_enforced }
+
+    context 'when under lease' do
+      include_context 'when under lease'
+
+      it { is_expected.not_to be_enforced }
+
+      context 'and it is applied' do
+        before { manager.apply! }
+
+        it { is_expected.to be_enforced }
+      end
+    end
+
+    context 'with expired lease' do
+      include_context 'with expired lease'
+
+      it { is_expected.not_to be_enforced }
+    end
+
+    context 'with an lease that is in force, but expired' do
+      include_context 'with expired lease'
+
+      before { resource.visibility = lease.visibility_during_lease }
+
+      it { is_expected.to be_enforced }
+    end
+  end
+
   describe '#lease' do
     it 'gives an inactive lease' do
       expect(manager.lease).not_to be_active
@@ -62,6 +92,44 @@ RSpec.describe Hyrax::LeaseManager do
                               visibility_during_lease: 'open',
                               lease_expiration_date: an_instance_of(Date),
                               lease_history: be_empty
+      end
+    end
+  end
+
+  describe '#release' do
+    context 'with no lease' do
+      it 'is a no-op' do
+        expect { manager.release }
+          .not_to change { resource.visibility }
+      end
+    end
+
+    context 'with expired lease' do
+      include_context 'with expired lease'
+
+      it 'ensures the post-lease visibility is set' do
+        manager.release
+        expect(resource.visibility).to eq lease.visibility_after_lease
+      end
+
+      context 'and lease was applied' do
+        before { resource.visibility = lease.visibility_during_lease }
+
+        it 'ensures the post-lease visibility is set' do
+          expect { manager.release }
+            .to change { resource.visibility }
+            .from(lease.visibility_during_lease)
+            .to lease.visibility_after_lease
+        end
+      end
+    end
+
+    context 'when under lease' do
+      include_context 'when under lease'
+
+      it 'is a no-op' do
+        expect { manager.release }
+          .not_to change { resource.visibility }
       end
     end
   end

--- a/spec/services/hyrax/lease_manager_spec.rb
+++ b/spec/services/hyrax/lease_manager_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::LeaseManager do
+  subject(:manager) { described_class.new(resource: resource) }
+  let(:resource)    { Hyrax::Resource.new }
+
+  shared_context 'when under lease' do
+    let(:resource) { FactoryBot.build(:hyrax_resource, :under_lease) }
+  end
+
+  shared_context 'with expired lease' do
+    let(:resource) { FactoryBot.build(:hyrax_resource, lease: lease) }
+    let(:lease)  { FactoryBot.build(:hyrax_lease, :expired) }
+  end
+
+  describe '#apply' do
+    context 'with no lease' do
+      it 'is a no-op' do
+        expect { manager.apply }
+          .not_to change { resource.visibility }
+      end
+    end
+
+    context 'with expired lease' do
+      include_context 'with expired lease'
+
+      it 'is a no-op' do
+        expect { manager.apply }
+          .not_to change { resource.visibility }
+      end
+    end
+
+    context 'when under lease' do
+      include_context 'when under lease'
+
+      before { resource.visibility = 'restricted' }
+
+      it 'applies the active lease visibility' do
+        expect { manager.apply }
+          .to change { resource.visibility }
+          .from('restricted')
+          .to 'open'
+      end
+    end
+  end
+
+  describe '#lease' do
+    it 'gives an inactive lease' do
+      expect(manager.lease).not_to be_active
+    end
+
+    context 'when under lease' do
+      include_context 'when under lease'
+
+      it 'gives an active lease' do
+        expect(manager.lease).to be_active
+      end
+
+      it 'has lease attributes' do
+        expect(manager.lease)
+          .to have_attributes visibility_after_lease: 'authenticated',
+                              visibility_during_lease: 'open',
+                              lease_expiration_date: an_instance_of(Date),
+                              lease_history: be_empty
+      end
+    end
+  end
+
+  describe '#under_lease?' do
+    it { is_expected.not_to be_under_lease }
+
+    context 'when under lease' do
+      include_context 'when under lease'
+
+      it { is_expected.to be_under_lease }
+    end
+
+    context 'with expired lease' do
+      include_context 'with expired lease'
+
+      it { is_expected.not_to be_under_lease }
+    end
+  end
+end


### PR DESCRIPTION
for Valkyrie models, we provide `Hyrax::EmbargoManager` to make the embargo
lifecycle easy to work with. to date, this has only supported applying
embargoes. this adds the ability to release an embargo after its period has expired.

a concept of 'enforcement' is added, represented by `#enforced?`. this addresses
the issue of embargoes which are not current (their period is past) but have not
yet been released.

the terminology used by the `EmbargoManager` is documented.

see also: https://github.com/samvera/hydra-head/issues/511.

@samvera/hyrax-code-reviewers
