### PR TITLE
use a `collection_member_sort_fields` helper to manage sort options

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -8,6 +8,14 @@ module Hyrax
       Hyrax::PresenterRenderer.new(presenter, self).fields(terms, &block)
     end
 
+    ##
+    # @since 3.0.0
+    #
+    # @see Blacklight::ConfigurationHelperBehavior#active_sort_fields
+    def collection_member_sort_fields
+      active_sort_fields
+    end
+
     def render_collection_links(solr_doc)
       collection_list = Hyrax::CollectionMemberService.run(solr_doc, controller.current_ability)
       return if collection_list.empty?

--- a/app/views/hyrax/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/collections/_sort_and_per_page.html.erb
@@ -1,10 +1,10 @@
-<% if show_sort_and_per_page? && active_sort_fields.many? %>
+<% if show_sort_and_per_page? && collection_member_sort_fields.many? %>
   <%= form_tag collection_path(collection), method: :get, class: 'per_page form-horizontal' do %>
     <%= render 'view_type_group' %>
     <fieldset class="pull-left">
       <legend class="sr-only"><%= t('hyrax.sort_label') %></legend>
       <%= label_tag(:sort, t('.sort_by_html')) %>
-      <%= select_tag(:sort, options_from_collection_for_select(active_sort_fields, 'first', lambda {|field| field.last.label}, h(params[:sort]))) %>
+      <%= select_tag(:sort, options_from_collection_for_select(collection_member_sort_fields, 'first', lambda {|field| field.last.label}, h(params[:sort]))) %>
       <%= label_tag(:per_page) do %>
         <span class="tiny-nudge"><%= t('.results_per_page') %></span>
         <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: t('.number_of_results_to_display_per_page')) %>

--- a/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
@@ -8,14 +8,14 @@
     </div>
   <% end %>
 
-  <% if show_sort_and_per_page? && active_sort_fields.many? %>
+  <% if show_sort_and_per_page? && collection_member_sort_fields.many? %>
     <div class="sort-toggle">
       <%= form_tag dashboard_collection_path(collection), method: :get, class: 'per_page form-horizontal' do %>
          <div class="form-group form-group-lg">
            <fieldset class="col-sm-9">
              <legend class="sr-only"><%= t('hyrax.sort_label') %></legend>
              <%= label_tag(:sort, t(".sort_by")) %>
-             <%= select_tag(:sort, options_from_collection_for_select(active_sort_fields, 'first', lambda {|field| field.last.label}, h(params[:sort]))) %>
+             <%= select_tag(:sort, options_from_collection_for_select(collection_member_sort_fields, 'first', lambda {|field| field.last.label}, h(params[:sort]))) %>
              <%= label_tag(:per_page) do %>
                <%= t(".show_par_page_html", select: select_tag(:per_page, options_for_select(['10', '20', '50', '100'], params[:per_page]), title: t('hyrax.dashboard.my.sr.results_per_page'))) %>
              <% end %>

--- a/spec/views/hyrax/collections/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_sort_and_per_page.html.erb_spec.rb
@@ -17,19 +17,19 @@ RSpec.describe 'hyrax/collections/_sort_and_per_page.html.erb', type: :view do
     end
 
     it "renders the sort options without any selected when no sort param given" do
-      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      render(subject, collection: collection, collection_member_sort_fields: active_sort_fields)
       expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: [])
     end
 
     it "renders the sort options with the correct option selected when a valid sort param given" do
       allow(view).to receive(:params).and_return(sort: "sort field value 1")
-      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      render(subject, collection: collection, collection_member_sort_fields: active_sort_fields)
       expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: ["sort field label 1"])
     end
 
     it "renders the sort options without any selected when an invalid sort param given" do
       allow(view).to receive(:params).and_return(sort: "sort field value DNE")
-      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      render(subject, collection: collection, collection_member_sort_fields: active_sort_fields)
       expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: [])
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe 'hyrax/collections/_sort_and_per_page.html.erb', type: :view do
     end
 
     it "does not render sort options" do
-      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      render(subject, collection: collection, collection_member_sort_fields: active_sort_fields)
       expect(rendered).not_to have_select('sort')
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe 'hyrax/collections/_sort_and_per_page.html.erb', type: :view do
     end
 
     it "does not render sort options" do
-      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      render(subject, collection: collection, collection_member_sort_fields: active_sort_fields)
       expect(rendered).not_to have_select('sort')
     end
   end

--- a/spec/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb_spec.rb
@@ -17,19 +17,19 @@ RSpec.describe 'hyrax/dashboard/collections/_sort_and_per_page.html.erb', type: 
     end
 
     it "renders the sort options without any selected when no sort param given" do
-      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      render(subject, collection: collection, collection_member_sort_fields: active_sort_fields)
       expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: [])
     end
 
     it "renders the sort options with the correct option selected when a valid sort param given" do
       allow(view).to receive(:params).and_return(sort: "sort field value 1")
-      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      render(subject, collection: collection, collection_member_sort_fields: active_sort_fields)
       expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: ["sort field label 1"])
     end
 
     it "renders the sort options without any selected when an invalid sort param given" do
       allow(view).to receive(:params).and_return(sort: "sort field value DNE")
-      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      render(subject, collection: collection, collection_member_sort_fields: active_sort_fields)
       expect(rendered).to have_select('sort', options: ["sort field label 1", "sort field label 2"], with_selected: [])
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe 'hyrax/dashboard/collections/_sort_and_per_page.html.erb', type: 
     end
 
     it "does not render sort options" do
-      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      render(subject, collection: collection, collection_member_sort_fields: active_sort_fields)
       expect(rendered).not_to have_select('sort')
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe 'hyrax/dashboard/collections/_sort_and_per_page.html.erb', type: 
     end
 
     it "does not render sort options" do
-      render(subject, collection: collection, active_sort_fields: active_sort_fields)
+      render(subject, collection: collection, collection_member_sort_fields: active_sort_fields)
       expect(rendered).not_to have_select('sort')
     end
   end


### PR DESCRIPTION
collection show views were using the default blacklight config for
`active_sort_fields`. there's not much point in sorting by relevance, and other
changes to how these sort options present may be desirable on a per-application
basis.

to make it easy to make this kind of change, add a
`collection_member_sort_fields` helper. for now, its implementation is just a
call to the existing helper, so actual behavior is fixed for this commit.

connected to #4308.

@samvera/hyrax-code-reviewers
