### PR TITLE
move #member_of_collections_json to a helper

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -57,6 +57,7 @@ module Hyrax
 
       # pcdm relationships
       property :admin_set_id
+      property :member_of_collection_ids, default: []
 
       class << self
         ##

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -12,6 +12,7 @@ module Hyrax
     include Hyrax::ChartsHelper
     include Hyrax::DashboardHelperBehavior
     include Hyrax::IiifHelper
+    include Hyrax::MembershipHelper
     include Hyrax::PermissionLevelsHelper
 
     # Which translations are available for the user to select

--- a/app/helpers/hyrax/membership_helper.rb
+++ b/app/helpers/hyrax/membership_helper.rb
@@ -7,12 +7,23 @@ module Hyrax
     #
     # @return [String] JSON for `data-members`
     #
-    # @todo implement for objects with only an ids field
+    # @todo optimize collection name lookup. the legacy `WorkForm`
+    #   implementation pulls all the collections already (though maybe with
+    #   instance-level caching?), but we should consider doing this more
+    #   efficiently.
     #
     # @see app/assets/javascripts/hyrax/relationships.js
     def member_of_collections_json(resource)
-      resource.try(:member_of_collections_json) ||
-        [].to_json
+      return resource.member_of_collections_json if
+        resource.respond_to?(:member_of_collections_json)
+
+      resource = resource.model if resource.respond_to?(:model)
+
+      Hyrax.custom_queries.find_collections_for(resource: resource).map do |collection|
+        { id: collection.id.to_s,
+          label: collection.title.first,
+          path: url_for(collection) }
+      end.to_json
     end
   end
 end

--- a/app/helpers/hyrax/membership_helper.rb
+++ b/app/helpers/hyrax/membership_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module MembershipHelper
+    ##
+    # @param resource [#member_of_collection_ids, #member_of_collections_json]
+    #
+    # @return [String] JSON for `data-members`
+    #
+    # @todo implement for objects with only an ids field
+    #
+    # @see app/assets/javascripts/hyrax/relationships.js
+    def member_of_collections_json(resource)
+      resource.try(:member_of_collections_json) ||
+        [].to_json
+    end
+  end
+end

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency 'hyrax/collection_name'
+
 module Hyrax
   ##
   # Valkyrie model for Collection domain objects in the Hydra Works model.
@@ -8,5 +10,13 @@ module Hyrax
 
     attribute :collection_type_gid, Valkyrie::Types::String
     attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)
+
+    ##
+    # @api private
+    #
+    # @return [Class] an ActiveModel::Name compatible class
+    def self._hyrax_default_name_class
+      Hyrax::CollectionName
+    end
   end
 end

--- a/app/services/hyrax/custom_queries/navigators/collection_members.rb
+++ b/app/services/hyrax/custom_queries/navigators/collection_members.rb
@@ -11,7 +11,7 @@ module Hyrax
         ##
         # @return [Array<Symbol>
         def self.queries
-          [:find_child_works, :find_child_work_ids]
+          [:find_collections_for, :find_members_of]
         end
         ##
         # @!attribute [r] query_service

--- a/app/views/hyrax/base/_form_member_of_collections.html.erb
+++ b/app/views/hyrax/base/_form_member_of_collections.html.erb
@@ -11,7 +11,7 @@ HTML Properties:
     data-param-key : the parameter key value for this model type %>
 <h2><%= t("hyrax.works.form.in_collections") %></h2>
 
-<div class="form-group" data-behavior="collection-relationships" data-param-key="<%= f.object.model_name.param_key %>" data-members="<%= f.object.member_of_collections_json %>">
+<div class="form-group" data-behavior="collection-relationships" data-param-key="<%= f.object.model_name.param_key %>" data-members="<%= member_of_collections_json(f.object) %>">
 
   <div class="form-inline">
       <%= f.label :member_of_collection_ids %>

--- a/lib/hyrax/collection_name.rb
+++ b/lib/hyrax/collection_name.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # A custom name for Valkyrie PcdmCollection objects. Route keys are mapped to `collection`
+  # not be the same as the model name.
+  class CollectionName < Name
+    def initialize(klass, namespace = nil, name = nil)
+      super
+
+      @route_key          = Collection.model_name.route_key
+      @singular_route_key = Collection.model_name.singular_route_key
+    end
+  end
+end

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -20,7 +20,8 @@ Valkyrie.config.storage_adapter = :active_fedora
 
 # TODO: Custom query registration is not Wings specific.  These custom_queries need to be registered for other adapters too.
 #       A refactor is needed to add the default implementations to hyrax.rb and only handle the wings specific overrides here.
-custom_queries = [Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator,
+custom_queries = [Hyrax::CustomQueries::Navigators::CollectionMembers,
+                  Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator,
                   Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator,
                   Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
                   Hyrax::CustomQueries::Navigators::FindFiles,

--- a/spec/helpers/hyrax/membership_helper_spec.rb
+++ b/spec/helpers/hyrax/membership_helper_spec.rb
@@ -1,7 +1,51 @@
 # frozen_string_literal: true
 
 RSpec.describe Hyrax::MembershipHelper do
+  before { helper.class.include Hyrax::Engine.routes.url_helpers }
+
   describe '.member_of_collections_json' do
+    context 'with a ChangeSet form' do
+      let(:resource) { Hyrax::Forms::ResourceForm.for(work) }
+      let(:work) { build(:monograph) }
+
+      context 'when it has no collections' do
+        it 'gives an empty JSON array' do
+          expect(helper.member_of_collections_json(resource)).to eq [].to_json
+        end
+      end
+
+      context 'when it is a member of a collection' do
+        let(:work) { build(:monograph, :as_collection_member) }
+
+        it 'gives collection details' do
+          expect(JSON.parse(helper.member_of_collections_json(resource)))
+            .to contain_exactly(include('id' => an_instance_of(String),
+                                        'label' => 'The Tove Jansson Collection',
+                                        'path' => an_instance_of(String)))
+        end
+      end
+    end
+
+    context 'with a Valkyrie work' do
+      let(:resource) { build(:hyrax_work) }
+
+      context 'when it has no collections' do
+        it 'gives an empty JSON array' do
+          expect(helper.member_of_collections_json(resource)).to eq [].to_json
+        end
+      end
+
+      context 'when it is a member of a collection' do
+        let(:resource) { build(:hyrax_work, :as_collection_member) }
+
+        it 'gives collection details' do
+          expect(JSON.parse(helper.member_of_collections_json(resource)))
+            .to contain_exactly(include('id' => an_instance_of(String),
+                                        'label' => 'The Tove Jansson Collection',
+                                        'path' => an_instance_of(String)))
+        end
+      end
+    end
     context 'with a WorkForm' do
       let(:resource) { double(Hyrax::Forms::WorkForm) }
 

--- a/spec/helpers/hyrax/membership_helper_spec.rb
+++ b/spec/helpers/hyrax/membership_helper_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::MembershipHelper do
+  describe '.member_of_collections_json' do
+    context 'with a WorkForm' do
+      let(:resource) { double(Hyrax::Forms::WorkForm) }
+
+      it 'calls the form json implementation and returns its result' do
+        expect(resource).to receive(:member_of_collections_json).and_return(:FAKE_JSON)
+        expect(helper.member_of_collections_json(resource)).to eq :FAKE_JSON
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -143,7 +143,8 @@ end
 
 query_registration_target =
   Valkyrie::MetadataAdapter.find(:test_adapter).query_service.custom_queries
-[Hyrax::CustomQueries::FindAccessControl,
+[Hyrax::CustomQueries::Navigators::CollectionMembers,
+ Hyrax::CustomQueries::FindAccessControl,
  Hyrax::CustomQueries::FindManyByAlternateIds,
  Hyrax::CustomQueries::FindFileMetadata,
  Hyrax::CustomQueries::Navigators::FindFiles].each do |handler|

--- a/spec/views/hyrax/base/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form.html.erb_spec.rb
@@ -17,11 +17,6 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
     let(:form) { Hyrax::Forms::ResourceForm.for(work) }
     let(:work) { build(:monograph, title: 'comet in moominland') }
 
-    before do
-      # TODO: unstub these when they are supported by the form
-      stub_template('hyrax/base/_form_member_of_collections.html.erb' => 'collection membership')
-    end
-
     context 'for a new object' do
       it 'renders a form' do
         render


### PR DESCRIPTION
this behavior is *very inefficiently* implemented in WorkForm. as a first step
to supporting this for ChangeSet-style forms, extract the behavior to a helper.

then, add a valkyrie implementation using ` Hyrax.custom_queries.find_collections_for`. we keep the calls to the object's implementation, if present. otherwise, we use the (still inefficient) loop and query approach.

@samvera/hyrax-code-reviewers
