### PR TITLE
count collection items with the SolrService directly

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -76,7 +76,7 @@ module Hyrax
     end
 
     def total_items
-      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}").count
+      Hyrax::SolrService.new.count("member_of_collection_ids_ssim:#{id}")
     end
 
     def total_viewable_items


### PR DESCRIPTION
remove a hard dependency on ActiveFedora by querying solr directly instead of
using the `Relation#count` interface.

there are other methods here using similar queries, but working out the
relationship with `Blacklight::AccessControls::Enforcement` is going to take
some more work. for one thing, we have local `Enforcement` additions that are
being bypassed (inappropriately?) by the existing queries.

@samvera/hyrax-code-reviewers
