### PR TITLE
wings: round trip Valkyrie-native models, even when unregistered

### DIFF
--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -76,6 +76,7 @@ module Wings
 end
 
 require 'valkyrie'
+require 'wings/active_fedora_classifier'
 require 'wings/model_registry'
 require 'wings/model_transformer'
 require 'wings/orm_converter'

--- a/lib/wings/active_fedora_classifier.rb
+++ b/lib/wings/active_fedora_classifier.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Wings
+  class ActiveFedoraClassifier < ActiveFedora::ModelClassifier
+    private
+
+      def classify(model_value)
+        if (match = model_value.match(/Wings\((.*)\)/))
+          valkyrie_class = match[1].constantize
+          Wings::ActiveFedoraConverter::DefaultWork(valkyrie_class)
+        else
+          super
+        end
+      end
+  end
+end

--- a/lib/wings/orm_converter.rb
+++ b/lib/wings/orm_converter.rb
@@ -29,7 +29,9 @@ module Wings
     #
     # @return [Class]
     def self.base_for(klass:)
-      ModelRegistry.reverse_lookup(klass) || Hyrax::Resource
+      klass.try(:valkyrie_class) ||
+        ModelRegistry.reverse_lookup(klass) ||
+        Hyrax::Resource
     end
 
     ##
@@ -39,6 +41,7 @@ module Wings
     #   mirroring the provided `ActiveFedora` model
     #
     # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/MethodLength because metaprogramming a class
     #   results in long methods
     def self.to_valkyrie_resource_class(klass:)
@@ -52,8 +55,8 @@ module Wings
         include Wings::Works::WorkValkyrieBehavior if klass.included_modules.include?(Hyrax::WorkBehavior)
         include Wings::Works::FileSetValkyrieBehavior if klass.included_modules.include?(Hyrax::FileSetBehavior)
 
-        # Based on Valkyrie implementation, we call Class.to_s to define the internal resource.
-        @internal_resource = klass.to_s
+        # store a string we can resolve to the internal resource
+        @internal_resource = klass.try(:to_rdf_representation) || klass.name
 
         class << self
           attr_reader :internal_resource
@@ -88,3 +91,5 @@ module Wings
 end
 # rubocop:enable Metrics/AbcSize
 # rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/PerceivedComplexity

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -1,4 +1,12 @@
+# frozen_string_literal: true
+
 ActiveFedora::Base.include Wings::Valkyrizable
+
+module ActiveFedora
+  def self.model_mapper
+    ActiveFedora::DefaultModelMapper.new(classifier_class: Wings::ActiveFedoraClassifier)
+  end
+end
 
 Valkyrie::MetadataAdapter.register(
   Wings::Valkyrie::MetadataAdapter.new, :wings_adapter

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
           .to be_a Wings::ActiveFedoraConverter::DefaultWork
       end
 
+      it 'round trips as the existing class' do
+        expect(converter.convert.valkyrie_resource).to be_a klass
+      end
+
       context 'and it is registered' do
         let(:resource) { build(:hyrax_work) }
 

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -107,10 +107,10 @@ RSpec.describe Wings::Valkyrie::Persister do
     let(:adapter) { Wings::Valkyrie::MetadataAdapter.new }
     let(:query_service) { adapter.query_service }
     before do
-      class CustomResource < Valkyrie::Resource
+      class CustomResource < Hyrax::Resource
         attribute :title
         attribute :author
-        attribute :member_ids
+        attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID)
         attribute :nested_resource
         attribute :depositor, Valkyrie::Types::String.optional
         attribute :ordered_authors, Valkyrie::Types::Array.of(Valkyrie::Types::Anything).meta(ordered: true)
@@ -126,6 +126,7 @@ RSpec.describe Wings::Valkyrie::Persister do
         property :ordered_authors, predicate: ::RDF::Vocab::DC.creator
         property :ordered_nested, predicate: ::RDF::URI("http://example.com/ordered_nested")
         accepts_nested_attributes_for :nested_resource
+        include Hydra::Works::WorkBehavior
       end
     end
     after do


### PR DESCRIPTION
this is the beginning of an effort to better generalize model conversion
handling in `Wings` to handle native models without an explicit,
application-side `ActiveFedora` equivalent.

the bar we're seeking to clear here is: get a resource/work class generated with
the Hyrax valkyrie generator to round trip in Wings without any specialized
AF-related handling. this doesn't yet try to assess the quality of metadata
round tripping, but that work should follow.

@samvera/hyrax-code-reviewers
