### PR TITLE
set checkbox for file within file.

### DIFF
--- a/app/assets/javascripts/hyrax/batch_select_all.js
+++ b/app/assets/javascripts/hyrax/batch_select_all.js
@@ -81,6 +81,11 @@ Blacklight.onLoad(function() {
     $("input:checkbox").prop('checked', $(this).prop("checked"));
   });
 
+  // Check files within
+  $('[checks="active"]').on('click', function(evt) {
+     $("[value=" + this.value + "]").prop('checked', $(this).prop("checked"));
+  });
+
   // toggle button on or off based on boxes being clicked
   $(".batch_document_selector").bind('click', function(e) {
      toggleButtons();

--- a/app/views/hyrax/batch_select/_add_button.html.erb
+++ b/app/views/hyrax/batch_select/_add_button.html.erb
@@ -1,3 +1,3 @@
 <div data-behavior="batch-add-button">
-  <%= check_box_tag "batch_document_#{document.id}", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}" %>
+  <%= check_box_tag "batch_document_#{document.id}", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}", checks: "active" %>
 </div>


### PR DESCRIPTION
@no-reply,  this PR contains the corrections you asked for in the stale and closed PR:  https://github.com/samvera/hyrax/pull/4169

Fixes #4161

When admin goes to the Expired embargoes tab, have all the associated files to the works checkboxes checked by default.

Guidance for testing, such as acceptance criteria or new user interface behaviors:

Create a few works and put them in embargo.
Since it could take some time for the embargo to expired, comment this line out so that they will show in the Expired Embargoes tab. https://github.com/samvera/hyrax/blob/master/app/search_builders/hyrax/expired_embargo_search_builder.rb#L8
Go to the Expired Embargoes tab and when you click on the File or Generic Work checkbox, the corresponding "file within this file" checkbox is checked.

@samvera/hyrax-code-reviewers
