### PR TITLE
Fixes #3911 Changed tab confirmation

### DIFF
--- a/app/assets/javascripts/hyrax/nav_safety.js
+++ b/app/assets/javascripts/hyrax/nav_safety.js
@@ -4,23 +4,35 @@
 // - Add the nav-safety class to the form element.
 
 Blacklight.onLoad(function() {
-  var clickedTab;
-  $('.nav-safety-confirm').on('click', function(evt) {
-    clickedTab = $(this).attr('href');
+  $('.nav-safety-confirm').on('show.bs.tab', function(evt) {
+    clickedTab = $(evt.target).attr('href');
+    var previousTab = $(evt.relatedTarget).attr('href')
+    var formId = $(previousTab).find('form').attr('id');
     var dirtyData = $('#nav-safety-modal[dirtyData=true]');
     if (dirtyData.length > 0) {
       evt.preventDefault();
       evt.stopPropagation();
+      $('#nav-safety-dismiss').data('form_id',formId);
+      $('#nav-safety-dismiss').data('new_tab',$(evt.target).attr('href'));
       $('#nav-safety-modal').modal('show');
     }
   });
-  
+
   $('#nav-safety-dismiss').on('click', function(evt) {
     nav_safety_off();
+    // Reset form content before navigating away
+    formId = '#'+$(this).data('form_id');
+    $(formId)[0].reset();
     // Navigate away from active tab to clicked tab
-    window.location = clickedTab;
+    window.location = $(this).data('new_tab');
   });
-  
+
+  $('#nav-safety-acknowledge').on('click', function(evt) {
+    // Stay on current tab to allow save
+    $('#nav-safety-modal').modal('hide');
+  });
+
+
   $('form.nav-safety').on('change', function(evt) {
     nav_safety_on();
   });

--- a/app/assets/javascripts/hyrax/nav_safety.js
+++ b/app/assets/javascripts/hyrax/nav_safety.js
@@ -5,7 +5,6 @@
 
 Blacklight.onLoad(function() {
   $('.nav-safety-confirm').on('show.bs.tab', function(evt) {
-    clickedTab = $(evt.target).attr('href');
     var previousTab = $(evt.relatedTarget).attr('href')
     var formId = $(previousTab).find('form').attr('id');
     if (typeof(formId)==="undefined") {

--- a/app/assets/javascripts/hyrax/nav_safety.js
+++ b/app/assets/javascripts/hyrax/nav_safety.js
@@ -8,6 +8,9 @@ Blacklight.onLoad(function() {
     clickedTab = $(evt.target).attr('href');
     var previousTab = $(evt.relatedTarget).attr('href')
     var formId = $(previousTab).find('form').attr('id');
+    if (typeof(formId)==="undefined") {
+      formId = $(previousTab).closest('form').attr('id');
+    }
     var dirtyData = $('#nav-safety-modal[dirtyData=true]');
     if (dirtyData.length > 0) {
       evt.preventDefault();
@@ -21,8 +24,10 @@ Blacklight.onLoad(function() {
   $('#nav-safety-dismiss').on('click', function(evt) {
     nav_safety_off();
     // Reset form content before navigating away
-    formId = '#'+$(this).data('form_id');
-    $(formId)[0].reset();
+    if ($(this).data('form_id')) {
+      formId = '#'+$(this).data('form_id');
+      $(formId)[0].reset();
+    }
     // Navigate away from active tab to clicked tab
     window.location = $(this).data('new_tab');
   });

--- a/app/views/shared/_nav_safety_modal.html.erb
+++ b/app/views/shared/_nav_safety_modal.html.erb
@@ -5,6 +5,7 @@
         <%= t(:'hyrax.nav_safety.change_tab_message') %>
       </div>
       <div class="modal-footer">
+        <button type="button" class="btn btn-default" id="nav-safety-acknowledge" data-dismiss="modal">Cancel</button>
         <button type="button" class="btn btn-default" id="nav-safety-dismiss" data-dismiss="modal">OK</button>
       </div>
     </div>


### PR DESCRIPTION
Fixes #3911 

For tabbed forms, adds ability to cancel navigation away from changed and unsaved tab. 
Resets unsaved form if navigation away is accepted.

Uses Bootstrap Tab's show.bs.tab event because it contains references to both the currently active tab and the clicked one.

@samvera/hyrax-code-reviewers
