### PR TITLE
extend `MembershipHelper` and `ResourceForm` for `member_ids`

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -57,6 +57,7 @@ module Hyrax
 
       # pcdm relationships
       property :admin_set_id
+      property :member_ids, default: []
       property :member_of_collection_ids, default: []
 
       class << self

--- a/app/helpers/hyrax/membership_helper.rb
+++ b/app/helpers/hyrax/membership_helper.rb
@@ -25,5 +25,24 @@ module Hyrax
           path: url_for(collection) }
       end.to_json
     end
+
+    ##
+    # @param resource [#work_members_json]
+    #
+    # @return [String] JSON for `data-members`
+    #
+    # @see app/assets/javascripts/hyrax/relationships.js
+    def work_members_json(resource)
+      return resource.work_members_json if
+        resource.respond_to?(:work_members_json)
+
+      resource = resource.model if resource.respond_to?(:model)
+
+      Hyrax.custom_queries.find_child_works(resource: resource).map do |member|
+        { id: member.id.to_s,
+          label: member.title.first,
+          path: url_for(member) }
+      end.to_json
+    end
   end
 end

--- a/app/views/hyrax/base/_form_child_work_relationships.html.erb
+++ b/app/views/hyrax/base/_form_child_work_relationships.html.erb
@@ -9,7 +9,7 @@ HTML Properties:
   table:
     [data-behavior="child-relationships"] : allows the javascript to be initialized
     data-param-key : the parameter key value for this model type %>
-<div class="form-group" data-behavior="child-relationships" data-param-key="<%= f.object.model_name.param_key %>" data-members="<%= f.object.work_members_json %>">
+<div class="form-group" data-behavior="child-relationships" data-param-key="<%= f.object.model_name.param_key %>" data-members="<%= work_members_json(f.object) %>">
   <div class="form-inline">
       <%= f.label :find_child_work %>
       <%= f.input_field :find_child_work,

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -72,6 +72,12 @@ FactoryBot.define do
       end
     end
 
-    factory :monograph, class: 'Monograph'
+    factory :monograph, class: 'Monograph' do
+      trait :with_member_works do
+        transient do
+          members { [valkyrie_create(:monograph), valkyrie_create(:monograph)] }
+        end
+      end
+    end
   end
 end

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -111,6 +111,20 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
   end
 
+  describe '#member_ids' do
+    it 'for a new object has empty membership' do
+      expect(form.member_ids).to be_empty
+    end
+
+    context 'when the object has members' do
+      let(:work) { FactoryBot.build(:monograph, :with_member_works) }
+
+      it 'gives member work ids' do
+        expect(form.member_ids).to contain_exactly(*work.member_ids.map(&:id))
+      end
+    end
+  end
+
   describe '#model_class' do
     it 'is the class of the model' do
       expect(form.model_class).to eq work.class

--- a/spec/helpers/hyrax/membership_helper_spec.rb
+++ b/spec/helpers/hyrax/membership_helper_spec.rb
@@ -46,12 +46,73 @@ RSpec.describe Hyrax::MembershipHelper do
         end
       end
     end
+
     context 'with a WorkForm' do
       let(:resource) { double(Hyrax::Forms::WorkForm) }
 
       it 'calls the form json implementation and returns its result' do
         expect(resource).to receive(:member_of_collections_json).and_return(:FAKE_JSON)
         expect(helper.member_of_collections_json(resource)).to eq :FAKE_JSON
+      end
+    end
+  end
+
+  describe '.work_members_json' do
+    context 'with a ChangeSet form' do
+      let(:resource) { Hyrax::Forms::ResourceForm.for(work) }
+      let(:work) { build(:monograph) }
+
+      context 'when it has no members' do
+        it 'gives an empty JSON array' do
+          expect(helper.work_members_json(resource)).to eq [].to_json
+        end
+      end
+
+      context 'when it is a member of a collection' do
+        let(:work) { FactoryBot.valkyrie_create(:monograph, :with_member_works) }
+
+        it 'gives member work details' do
+          expect(JSON.parse(helper.work_members_json(resource)))
+            .to contain_exactly(include('id' => an_instance_of(String),
+                                        'label' => nil,
+                                        'path' => an_instance_of(String)),
+                                include('id' => an_instance_of(String),
+                                        'label' => nil,
+                                        'path' => an_instance_of(String)))
+        end
+      end
+    end
+
+    context 'with a Valkyrie work' do
+      let(:resource) { build(:monograph) }
+
+      context 'when it has no members' do
+        it 'gives an empty JSON array' do
+          expect(helper.work_members_json(resource)).to eq [].to_json
+        end
+      end
+
+      context 'when it has work members' do
+        let(:resource) { FactoryBot.valkyrie_create(:monograph, :with_member_works) }
+
+        it 'gives member work details' do
+          expect(JSON.parse(helper.work_members_json(resource)))
+            .to contain_exactly(include('id' => an_instance_of(String),
+                                        'label' => nil,
+                                        'path' => an_instance_of(String)),
+                                include('id' => an_instance_of(String),
+                                        'label' => nil,
+                                        'path' => an_instance_of(String)))
+        end
+      end
+    end
+
+    context 'with a WorkForm' do
+      let(:resource) { double(Hyrax::Forms::WorkForm) }
+
+      it 'calls the form json implementation and returns its result' do
+        expect(resource).to receive(:work_members_json).and_return(:FAKE_JSON)
+        expect(helper.work_members_json(resource)).to eq :FAKE_JSON
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -144,6 +144,7 @@ end
 query_registration_target =
   Valkyrie::MetadataAdapter.find(:test_adapter).query_service.custom_queries
 [Hyrax::CustomQueries::Navigators::CollectionMembers,
+ Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
  Hyrax::CustomQueries::FindAccessControl,
  Hyrax::CustomQueries::FindManyByAlternateIds,
  Hyrax::CustomQueries::FindFileMetadata,


### PR DESCRIPTION
add a `MembershipHelper#work_members_json` with support for legacy forms as well
as valkyrie resources. extend `ResourceForm` to add support for `member_ids`.

@samvera/hyrax-code-reviewers
