### PR TITLE
links from Profile page show users collections and works

### DIFF
--- a/app/views/hyrax/users/_vitals.html.erb
+++ b/app/views/hyrax/users/_vitals.html.erb
@@ -4,12 +4,12 @@
 
 <div class="list-group-item">
   <span class="badge"><%= number_of_collections(user) %></span>
-  <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.collections"), generic_type: "Collection") %>
+  <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.collections"), {generic_type: "Collection", depositor: user.to_s}) %>
 </div>
 
 <div class="list-group-item">
   <span class="badge"><%= number_of_works(user) %></span>
-  <span class="glyphicon glyphicon-upload" aria-hidden="true"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.works"), generic_type: "Work") %>
+  <span class="glyphicon glyphicon-upload" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.works"), {generic_type: "Work", depositor: user.to_s}) %>
 
   <ul class="views-downloads-dashboard list-unstyled">
       <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>

--- a/lib/generators/hyrax/templates/catalog_controller.rb
+++ b/lib/generators/hyrax/templates/catalog_controller.rb
@@ -46,9 +46,10 @@ class CatalogController < ApplicationController
     config.add_facet_field "file_format_sim", limit: 5
     config.add_facet_field "member_of_collection_ids_ssim", limit: 5, label: 'Collections', helper_method: :collection_title_by_id
 
-    # The generic_type isn't displayed on the facet list
-    # It's used to give a label to the filter that comes from the user profile
+    # The generic_type and depositor are not displayed on the facet list
+    # They are used to give a label to the filters that comes from the user profile
     config.add_facet_field "generic_type_sim", if: false
+    config.add_facet_field "depositor_ssim", label: "Depositor", if: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request


### PR DESCRIPTION
This is a resubmission with some changes/improvements for the stale and closed PR:
https://github.com/samvera/hyrax/pull/4024

Fixes #3478

With this change, if a user goes to the Profile page from the dashboard, and then tries to see a listing of works and collections created by the user, the listing should be presented.

The code originally used the params search_field and a value for q to search for the depositor. For example, search_field=depositor&q=user@abc.com and then it appended a facet to indicate if looking for a work or a collection. I could not get this to work. The search_field with q value did not really seem to do anything. So...I tried using facets for depositor value, and this seems to work just fine. 

Guidance for testing, such as acceptance criteria or new user interface behaviors:

Since there is a change to the catalog controller generator, you will need to `bundle exec rake engine_cart:generate`, if you do not do this, it will still work, but the label for Depositor will not be right. 
The user should have a few works and collections.
Go to the dashboard and select Profile from Your activity dropdown.
Click on Works created and then Collections created and make sure that the lists are accurate in both cases.

@samvera/hyrax-code-reviewers
