### PR TITLE
support `#find_child_work` in the new `ResourceForm`

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -60,6 +60,10 @@ module Hyrax
       property :member_ids, default: []
       property :member_of_collection_ids, default: []
 
+      # backs the child work search element;
+      # @todo: look for a way for the view template not to depend on this
+      property :find_child_work, default: nil, virtual: true
+
       class << self
         ##
         # @api public

--- a/spec/views/hyrax/base/_form_child_work_relationships.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_child_work_relationships.html.erb_spec.rb
@@ -1,13 +1,6 @@
 RSpec.describe "hyrax/base/_form_child_work_relationships.html.erb", type: :view do
-  let(:work) do
-    stub_model(GenericWork, id: '456', title: ["MyWork"])
-  end
-
-  let(:ability) { double }
-
-  let(:form) do
-    Hyrax::GenericWorkForm.new(work, ability, controller)
-  end
+  let(:work) { valkyrie_create(:monograph, :with_member_works) }
+  let(:form) { Hyrax::Forms::ResourceForm.for(work) }
 
   let(:f) do
     view.simple_form_for(form, url: '/update') do |work_form|
@@ -16,9 +9,6 @@ RSpec.describe "hyrax/base/_form_child_work_relationships.html.erb", type: :view
   end
 
   before do
-    # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
-    allow(work).to receive(:new_record?).and_return(false)
-
     allow(view).to receive(:params).and_return(id: work.id)
     allow(view).to receive(:curation_concern).and_return(work)
     allow(view).to receive(:f).and_return(f)


### PR DESCRIPTION
wire up a view partial test to check this behavior on the new form, then add
support for it.

i'm uncertain whether this should really be necessary, but it seems best to
support the current views as a starting place, and maybe tweak things from there.

@samvera/hyrax-code-reviewers
