### PR TITLE
wings: support optimistic locking for Valkyrie resources

### DIFF
--- a/lib/wings/converter_value_mapper.rb
+++ b/lib/wings/converter_value_mapper.rb
@@ -13,7 +13,8 @@ module Wings
     ConverterValueMapper.register(self)
 
     ATTRIBUTES = [:internal_resource, :access_to, :new_record, :id,
-                  :alternate_ids, :created_at, :updated_at].freeze
+                  :alternate_ids, :created_at, :updated_at,
+                  :optimistic_lock_token].freeze
 
     def self.handles?(value)
       ATTRIBUTES.include?(value.first)

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe Wings::Valkyrie::Persister do
 
     context "optimistic locking" do
       before do
-        class MyLockingResource < Valkyrie::Resource
+        class MyLockingResource < Hyrax::Resource
           enable_optimistic_locking
           attribute :title
         end
@@ -376,15 +376,17 @@ RSpec.describe Wings::Valkyrie::Persister do
 
       describe "#save" do
         context "when creating a resource" do
-          xit "returns the value of the system-generated optimistic locking attribute on the resource" do
+          it "returns the value of the system-generated optimistic locking attribute on the resource" do
             resource = MyLockingResource.new(title: ["My Locked Resource"])
             saved_resource = persister.save(resource: resource)
-            expect(saved_resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK]).not_to be_empty
+
+            expect(saved_resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK])
+              .to include(an_instance_of(Valkyrie::Persistence::OptimisticLockToken))
           end
         end
 
         context "when updating a resource with a correct lock token" do
-          xit "successfully saves the resource and returns the updated value of the optimistic locking attribute" do
+          it "successfully saves the resource and returns the updated value of the optimistic locking attribute" do
             resource = MyLockingResource.new(title: ["My Locked Resource"])
             initial_resource = persister.save(resource: resource)
             updated_resource = persister.save(resource: initial_resource)
@@ -394,18 +396,18 @@ RSpec.describe Wings::Valkyrie::Persister do
         end
 
         context "when updating a resource with an incorrect lock token" do
-          xit "raises a Valkyrie::Persistence::StaleObjectError" do
+          it "raises a Valkyrie::Persistence::StaleObjectError" do
             resource = MyLockingResource.new(title: ["My Locked Resource"])
             resource = persister.save(resource: resource)
             # update the resource in the datastore to make its token stale
             persister.save(resource: resource)
 
-            expect { persister.save(resource: resource) }.to raise_error(Valkyrie::Persistence::StaleObjectError, "The object #{resource.id} has been updated by another process.")
+            expect { persister.save(resource: resource) }.to raise_error(Valkyrie::Persistence::StaleObjectError, /#{resource.id}/)
           end
         end
 
         context "when lock token is nil" do
-          xit "successfully saves the resource and returns the updated value of the optimistic locking attribute" do
+          it "successfully saves the resource and returns the updated value of the optimistic locking attribute" do
             resource = MyLockingResource.new(title: ["My Locked Resource"])
             initial_resource = persister.save(resource: resource)
             initial_token = initial_resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK].first
@@ -418,7 +420,7 @@ RSpec.describe Wings::Valkyrie::Persister do
         end
 
         context "when there is a token, but it's for a different adapter (migration use case)" do
-          xit "successfully saves the resource and returns a token for the adapter that was saved to" do
+          it "successfully saves the resource and returns a token for the adapter that was saved to" do
             resource = MyLockingResource.new(title: ["My Locked Resource"])
             initial_resource = persister.save(resource: resource)
             new_token = Valkyrie::Persistence::OptimisticLockToken.new(
@@ -436,7 +438,7 @@ RSpec.describe Wings::Valkyrie::Persister do
 
       describe "#save_all" do
         context "when creating multiple resources" do
-          xit "returns an array of resources with their system-generated optimistic locking attributes" do
+          it "returns an array of resources with their system-generated optimistic locking attributes" do
             resource1 = MyLockingResource.new(title: ["My Locked Resource 1"])
             resource2 = MyLockingResource.new(title: ["My Locked Resource 2"])
             resource3 = MyLockingResource.new(title: ["My Locked Resource 3"])
@@ -448,7 +450,7 @@ RSpec.describe Wings::Valkyrie::Persister do
         end
 
         context "when updating multiple resources that all have a correct lock token" do
-          xit "saves the resources and returns them with updated values of the optimistic locking attribute" do
+          it "saves the resources and returns them with updated values of the optimistic locking attribute" do
             resource1 = MyLockingResource.new(title: ["My Locked Resource 1"])
             resource2 = MyLockingResource.new(title: ["My Locked Resource 2"])
             resource3 = MyLockingResource.new(title: ["My Locked Resource 3"])
@@ -465,7 +467,7 @@ RSpec.describe Wings::Valkyrie::Persister do
         end
 
         context "when one of the resources has an incorrect lock token" do
-          xit "raises a Valkyrie::Persistence::StaleObjectError" do
+          it "raises a Valkyrie::Persistence::StaleObjectError" do
             resource1 = MyLockingResource.new(title: ["My Locked Resource 1"])
             resource2 = MyLockingResource.new(title: ["My Locked Resource 2"])
             resource3 = MyLockingResource.new(title: ["My Locked Resource 3"])
@@ -474,7 +476,7 @@ RSpec.describe Wings::Valkyrie::Persister do
             persister.save(resource: resource2)
 
             expect { persister.save_all(resources: [resource1, resource2, resource3]) }
-              .to raise_error(Valkyrie::Persistence::StaleObjectError, "One or more resources have been updated by another process.")
+              .to raise_error(Valkyrie::Persistence::StaleObjectError)
           end
         end
       end


### PR DESCRIPTION
adds an optimistic locking implementation to `Wings` using Fedora's
`Last-Modified` property and etags.

the existing optimistic locking in the Actor stack counts on etags, so including
them in the lock tokens has immediate value. we'll need a strategy for removing
them later.

for now, this is a fairly naive implementation for early consideration.

@samvera/hyrax-code-reviewers
