### PR TITLE
allow language switching in FileManager. Fixes issue #4171

### DIFF
--- a/app/assets/javascripts/hyrax/file_manager/save_manager.es6
+++ b/app/assets/javascripts/hyrax/file_manager/save_manager.es6
@@ -24,7 +24,7 @@ export default class SaveManager {
   }
 
   check_button() {
-    if(this.is_changed && this.save_button.text() == "Save") {
+    if(this.is_changed && this.save_button.selector.valueOf("data-action") === "*[data-action='save-actions']") {
       this.save_button.removeClass("disabled")
     } else {
       this.save_button.addClass("disabled")
@@ -41,13 +41,14 @@ export default class SaveManager {
         .fail((element) => { this.push_changed(element) })
       )
     })
-    this.save_button.text("Saving...")
+    var label = this.save_button.text()
+    this.save_button.text(label + " ...")
     this.save_button.addClass("disabled")
-    $.when.apply($, promises).always(() => { this.reset_save_button() })
+    $.when.apply($, promises).always(() => { this.reset_save_button(label) })
   }
   
-  reset_save_button() {
-    this.save_button.text("Save")
+  reset_save_button(label) {
+    this.save_button.text(label)
     this.check_button()
   }
 

--- a/spec/javascripts/save_manager_spec.coffee
+++ b/spec/javascripts/save_manager_spec.coffee
@@ -56,7 +56,7 @@ describe "FileManager Save Button", ->
       save_manager.persist()
 
       expect($("button").hasClass("disabled")).toEqual(true)
-      expect($("button").text()).toEqual("Saving...")
+      expect($("button").text()).toEqual("Save ...")
     it "calls persist on each registered handler", ->
       spyOn(handler, "persist").and.callThrough()
       save_manager.push_changed(handler)


### PR DESCRIPTION
Fixes #4171

When in the in the FileManager page, if user changes language from English to something else the Save button stops working.  In fixing this issue, I also noticed that while the changes are being saved, the es6 script wrote "Saving...".  In order to make this work with all languages, I changed the code so that it will use the label of the button to inform the user that the work is being saved.  So in English, it would be "Save ...", for example.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a work with multiple files.
* Navigate to the file manager page
* Notice that if you change the thumbnail or representative media the Save button is enabled.
* Set the thumbnail or representative media selection to how you found them when you first got to this page.  Notice that the Save button is disabled.
* Change the language selection. Notice Save is now in the new language.
* Change the thumbnail r representation media selection, notice that the "Save" button is enabled.
* Save  your changes.  Notice that the "Save" button will say "Save ..." in the new language and once the save completes the Save button will be disabled and it will read "Save" in whatever language you are working with.

@samvera/hyrax-code-reviewers
