### PR TITLE
force upgrade of `reform` and `reform-rails`

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -72,7 +72,8 @@ SUMMARY
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
   spec.add_dependency 'redis-namespace', '~> 1.5'
   spec.add_dependency 'redlock', '>= 0.1.2'
-  spec.add_dependency 'reform', '< 2.3'
+  spec.add_dependency 'reform', '~> 2.3'
+  spec.add_dependency 'reform-rails', '~> 0.2.0'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'samvera-nesting_indexer', '~> 2.0'
   spec.add_dependency 'select2-rails', '~> 3.5'


### PR DESCRIPTION
this is a proposed fix for failing builds caused by
https://github.com/trailblazer/reform/issues/508
and release of `reform` v2.3.1.

@samvera/hyrax-code-reviewers
