### PR TITLE
pin reform to v2.2.x and under

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -72,6 +72,7 @@ SUMMARY
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
   spec.add_dependency 'redis-namespace', '~> 1.5'
   spec.add_dependency 'redlock', '>= 0.1.2'
+  spec.add_dependency 'reform', '< 2.3'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'samvera-nesting_indexer', '~> 2.0'
   spec.add_dependency 'select2-rails', '~> 3.5'


### PR DESCRIPTION
the Reform v2.3.1 release broke `reform-rails` and
`valkyrie`. https://github.com/trailblazer/reform/issues/508

the plan on the `trailblazer` side appears to be to roll forward by releasing a
new, compatible version of `reform-rails`. to fix the build in the meanwhile,
pin `reform` to a working release.

if `reform-rails` is released from a current release candidate, that should also
patch this issue; see https://github.com/samvera/hyrax/pull/4332. assuming that
happens before Hyrax 3.0.0, we can bump both the `reform` and `reform-rails`
depend on the latest versions directly.

@samvera/hyrax-code-reviewers
