### PR TITLE
Allow iiif_manifest 1.x

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -52,7 +52,7 @@ SUMMARY
   spec.add_dependency 'hydra-editor', '~> 5.0'
   spec.add_dependency 'hydra-head', '~> 11.0'
   spec.add_dependency 'hydra-works', '>= 0.16', '< 2.0'
-  spec.add_dependency 'iiif_manifest', '>= 0.3', '< 0.7'
+  spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4'
   spec.add_dependency 'jquery-ui-rails', '~> 6.0'
   spec.add_dependency 'json-schema' # for Arkivo


### PR DESCRIPTION
IIIF Manifest 1.0 was released the middle of last year and I don't believe it has any significant differences from 0.6 other than bumping to 1.0.

@samvera/hyrax-code-reviewers
