### PR TITLE
wings: generate metadata dynamically for fallback AF classes

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -55,7 +55,6 @@ module Wings
       active_fedora_class.new(normal_attributes).tap do |af_object|
         af_object.id = id unless id.empty?
         add_access_control_attributes(af_object)
-        apply_depositor_to(af_object)
         convert_members(af_object)
         convert_member_of_collections(af_object)
         convert_files(af_object)
@@ -194,10 +193,6 @@ module Wings
           property = active_fedora_class.properties[attr.to_s]
           hash[attr] = property&.multiple? ? Array.wrap(value) : value
         end
-      end
-
-      def apply_depositor_to(af_object)
-        af_object.apply_depositor_metadata(attributes[:depositor]) unless attributes[:depositor].blank?
       end
 
       # Add attributes from resource which aren't AF properties into af_object

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -43,12 +43,10 @@ module Wings
 
     ##
     # Accesses and parses the attributes from the resource through ConverterValueMapper
-    # @return [Hash]
+    #
+    # @return [Hash] attributes with values mapped for building an ActiveFedora model
     def attributes
-      @attribs ||= begin
-        wrapper = self.class.attributes_class.new(resource.attributes)
-        wrapper.result
-      end
+      @attributes ||= self.class.attributes_class.mapped_attributes(attributes: resource.attributes)
     end
 
     ##
@@ -82,9 +80,9 @@ module Wings
     # then the id hasn't been minted and shouldn't yet be set.
     # @return [String]
     def id
-      id_attr = resource[:id]
-      return id_attr.to_s if id_attr.present? && id_attr.is_a?(::Valkyrie::ID) && !id_attr.blank?
+      return resource[:id].to_s if resource[:id]&.is_a?(::Valkyrie::ID) && !resource[:id].blank?
       return "" unless resource.respond_to?(:alternate_ids)
+
       resource.alternate_ids.first.to_s
     end
 
@@ -102,8 +100,7 @@ module Wings
           property schema_key.name, predicate: RDF::URI("http://hyrax.samvera.org/ns/wings##{schema_key.name}")
         end
 
-        # nested attributes in AF don't inherit! this needs to be here until
-        # we can drop it completely.
+        # nested attributes in AF don't inherit! this needs to be here until we can drop it completely.
         accepts_nested_attributes_for :nested_resource
       end
     end
@@ -139,6 +136,7 @@ module Wings
       property :title, predicate: ::RDF::Vocab::DC.title
       property :ordered_authors, predicate: ::RDF::Vocab::DC.creator
       property :ordered_nested, predicate: ::RDF::URI("http://example.com/ordered_nested")
+
       def initialize(uri = RDF::Node.new, _parent = ActiveTriples::Resource.new)
         uri = if uri.try(:node?)
                 RDF::URI("#nested_resource_#{uri.to_s.gsub('_:', '')}")
@@ -147,6 +145,7 @@ module Wings
               end
         super
       end
+
       include ::Hyrax::BasicMetadata
     end
 
@@ -166,6 +165,7 @@ module Wings
 
       def convert_files(af_object)
         return unless resource.respond_to? :file_ids
+
         af_object.files = resource.file_ids.map do |fid|
           pcdm_file = Hydra::PCDM::File.new(fid.id)
           assign_association_target(af_object, pcdm_file)
@@ -192,10 +192,7 @@ module Wings
       def normal_attributes
         attributes.each_with_object({}) do |(attr, value), hash|
           property = active_fedora_class.properties[attr.to_s]
-          # This handles some cases where the attributes do not directly map to an RDF property value
-          hash[attr] = value
-          next if property.nil?
-          hash[attr] = Array.wrap(value) if property.multiple?
+          hash[attr] = property&.multiple? ? Array.wrap(value) : value
         end
       end
 

--- a/lib/wings/converter_value_mapper.rb
+++ b/lib/wings/converter_value_mapper.rb
@@ -177,8 +177,13 @@ module Wings
 
   class ActiveFedoraAttributes
     attr_reader :attributes
+
     def initialize(attributes)
       @attributes = attributes.compact
+    end
+
+    def self.mapped_attributes(attributes:)
+      new(attributes).result
     end
 
     def result

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -38,12 +38,21 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
     end
 
     context 'when given a valkyrie native model' do
-      let(:resource) { klass.new }
+      let(:resource) { klass.new(title: ['comet in moominland'], distant_relation: ['Snufkin']) }
+      let(:klass) { Hyrax::Test::Converter::Resource }
 
-      let(:klass) do
-        class ConverterDummyResource < Valkyrie::Resource; end
-        ConverterDummyResource
+      before do
+        module Hyrax::Test
+          module Converter
+            class Resource < Valkyrie::Resource
+              attribute :title, Valkyrie::Types::Array.of(Valkyrie::Types::String)
+              attribute :distant_relation, Valkyrie::Types::String
+            end
+          end
+        end
       end
+
+      after { Hyrax::Test.send(:remove_const, :Converter) }
 
       it 'gives a default work' do
         expect(converter.convert)
@@ -53,6 +62,15 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       it 'round trips as the existing class' do
         expect(converter.convert.valkyrie_resource).to be_a klass
       end
+
+      it 'converts arbitrary metadata' do
+        expect(converter.convert)
+          .to have_attributes(title: ['comet in moominland'], distant_relation: ['Snufkin'])
+      end
+
+      it 'does not add superflous metadata'
+      it 'converts single-valued fields'
+      it 'supports nested resources'
 
       context 'and it is registered' do
         let(:resource) { build(:hyrax_work) }

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -84,6 +84,26 @@ RSpec.describe Wings::ModelTransformer, :clean_repo do
                             source: work.source
     end
 
+    context 'when handling an auto-generated object' do
+      let(:pcdm_object) { Wings::ActiveFedoraConverter.convert(resource: resource) }
+      let(:resource) { Hyrax::Test::Transformer::Book.new }
+
+      before do
+        module Hyrax::Test
+          module Transformer
+            class Book < Valkyrie::Resource
+            end
+          end
+        end
+      end
+
+      after { Hyrax::Test.send(:remove_const, :Transformer) }
+
+      it 'reconstitutes as the correct class' do
+        expect(factory.build).to be_a Hyrax::Test::Transformer::Book
+      end
+    end
+
     # rubocop:disable RSpec/AnyInstance
     context 'without an existing id' do
       let(:id)        { nil }


### PR DESCRIPTION
simplify `ActiveFedoraConverter` behavior by stripping out hard coded metadata and Hyrax-specific behaviors in favor of dynamically generated metadata.

there's still a bit more work to do here, to add robust support for Valkyrie-native nested models.

a small stylistic refactor is undertaken in dfdb7c6, because looking at the file was offending my sensibilities.
