### PR TITLE
allow most recent version of file to be downloaded.

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -92,6 +92,7 @@ module Hyrax
         elsif params.key?(:files_files) # version file already uploaded with ref id in :files_files array
           uploaded_files = Array(Hyrax::UploadedFile.find(params[:files_files]))
           actor.update_content(uploaded_files.first)
+          update_metadata
         end
       end
 

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Hyrax::FileSetsController do
   routes { Rails.application.routes }
   let(:user) { create(:user) }
@@ -69,7 +71,7 @@ RSpec.describe Hyrax::FileSetsController do
 
     describe "#update" do
       let(:file_set) do
-        create(:file_set, user: user)
+        create(:file_set, user: user, title: ['test title'])
       end
 
       context "when updating metadata" do
@@ -86,6 +88,7 @@ RSpec.describe Hyrax::FileSetsController do
             }
           }
           expect(response).to redirect_to main_app.hyrax_file_set_path(file_set, locale: 'en')
+          expect(assigns[:file_set].modified_date).not_to be file_set.modified_date
         end
       end
 
@@ -117,7 +120,10 @@ RSpec.describe Hyrax::FileSetsController do
           expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
           file = fixture_file_upload('/world.png', 'image/png')
           allow(Hyrax::UploadedFile).to receive(:find).with(["1"]).and_return([file])
+
           post :update, params: { id: file_set, files_files: ["1"] }
+          expect(assigns[:file_set].modified_date).not_to be file_set.modified_date
+          expect(assigns[:file_set].title).to eq file_set.title
         end
       end
 


### PR DESCRIPTION
Fixes #4274

When a depositor or an admin wants to add a new version of a file, they download the file, edit it and upload it back as a new version. After uploading the new version, they download it to check it.  Before this change, hyrax downloaded the old version. After this PR, it downloads the most recent change.

The reason this was happening was because date_modified was not being updated when a new version was being uploaded.  The call to `update_metadata` ensures that the modified_date is updated.  This date is used to build the header when downloading, specifically the `Last-Modified` portion of the header.  The browser then knows that when this date has changed, it does not use the cache.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Download a txt file attached to a work
* Edit it
* Go to the Version option for the files, upload the new version
* Check the new version is uploaded in the version history
* Click on Download this file button, and it should download the most recent version of the file and not previous uploaded version.


@samvera/hyrax-code-reviewers
