### PR TITLE
support optimistic locking for `ResourceForm`

### DIFF
--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -242,6 +242,43 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
   end
 
+  describe '#version' do
+    context 'when using wings', valkyrie_adapter: :wings_adapter do
+      it 'prepopulates as empty before save' do
+        form.prepopulate!
+        expect(form.version).to eq ''
+      end
+
+      context 'with a saved work' do
+        let(:work) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+        it 'prepopulates with the etag' do
+          af_object = Wings::ActiveFedoraConverter.convert(resource: work)
+
+          form.prepopulate!
+          expect(form.version).to eq af_object.etag
+        end
+      end
+    end
+
+    context 'when using a generic valkyrie adapter', valkyrie_adapter: :test_adapter do
+      it 'prepopulates as empty before save' do
+        form.prepopulate!
+        expect(form.version).to eq ''
+      end
+
+      context 'with a saved work' do
+        let(:work) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+        it 'prepopulates empty' do
+          form.prepopulate!
+
+          expect(form.version).to eq ''
+        end
+      end
+    end
+  end
+
   describe '#visibility' do
     it 'can set visibility' do
       form.visibility = 'open'

--- a/spec/views/hyrax/base/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
     # mock the admin set options presenter to avoid hitting Solr
     allow(Hyrax::AdminSetOptionsPresenter).to receive(:new).and_return(options_presenter)
     allow(controller).to receive(:current_user).and_return(stub_model(User))
+    allow(view).to receive(:curation_concern).and_return(work)
     assign(:form, form)
     allow(controller).to receive(:action_name).and_return(controller_action)
     allow(controller).to receive(:repository).and_return(controller_class.new.repository)
@@ -39,12 +40,8 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
     context 'with an existing object' do
       let(:work) { FactoryBot.valkyrie_create(:monograph) }
 
-      xit 'renders a form' do
-        # pending handling for #version/optimistic locking, and maybe other
-        # issues. a good way to make progress on ChangeSet forms is to enable
-        # this test, analyze the stacktrace, and try to patch.
+      it 'renders a form' do
         render
-
         expect(rendered).to have_selector("form[action='/concern/monographs/#{work.id}']")
       end
     end
@@ -65,7 +62,6 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
       # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
       allow(work).to receive(:new_record?).and_return(true)
       allow(work).to receive(:member_ids).and_return([1, 2])
-      allow(view).to receive(:curation_concern).and_return(work)
       allow(controller).to receive(:controller_name).and_return('batch_uploads')
       allow(form).to receive(:permissions).and_return([])
       allow(form).to receive(:visibility).and_return('public')


### PR DESCRIPTION
introduces a field and prepopulator for the (maybe confusingly named?) `version`
virtual attribute. `Hyrax::WorkForm` implements this by calling `model.etag`,
but we don't have that luxury here (since non-fedora backed valkyrie may not
have an etag at all). the logic added here is specific Wings adapter, pulling
out the etag for compatibility.

it's probably okay to keep this wings-specific indefinitely. other adapters
should support optimistic locking internally (indeed, so does Wings) so we can
phase out application-layer lock validation in favor of leaning on
Valkyrie/backend datastore features.

@samvera/hyrax-code-reviewers
