### PR TITLE
allow apps to forego a custom ModelActor

### DIFF
--- a/app/actors/hyrax/actors/model_actor.rb
+++ b/app/actors/hyrax/actors/model_actor.rb
@@ -30,6 +30,12 @@ module Hyrax
           actor_identifier = env.curation_concern.class
           klass = "Hyrax::Actors::#{actor_identifier}Actor".constantize
           klass.new(next_actor)
+        rescue NameError => error
+          Hyrax.logger.info 'No ModelActor provided for ' \
+                            "#{env.curation_concern.class}; falling back on " \
+                            "NullActor\n\t#{error}"
+
+          NullActor.new(next_actor)
         end
     end
   end

--- a/app/actors/hyrax/actors/null_actor.rb
+++ b/app/actors/hyrax/actors/null_actor.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Actors
+    ##
+    # @note this is effectively an alias for AbstractActor; it exists to
+    #   communicate to readers that this actor is intended to be a concrete,
+    #   do-nothing actor (and also in case `AbstractActor` ever becomes actually
+    #   abstract).
+    class NullActor < AbstractActor; end
+  end
+end

--- a/spec/actors/hyrax/actors/model_actor_spec.rb
+++ b/spec/actors/hyrax/actors/model_actor_spec.rb
@@ -20,5 +20,11 @@ RSpec.describe Hyrax::Actors::ModelActor do
     it "preserves the namespacing" do
       is_expected.to be_kind_of Hyrax::Actors::MusicalWork::CoverActor
     end
+
+    context 'when no actor exists for the work' do
+      let(:work) { Class.new(ActiveFedora::Base).new }
+
+      it { is_expected.to be_kind_of Hyrax::Actors::NullActor }
+    end
   end
 end

--- a/spec/actors/hyrax/actors/null_actor_spec.rb
+++ b/spec/actors/hyrax/actors/null_actor_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Actors::NullActor do
+  subject(:actor) { described_class.new(spy_actor) }
+
+  let(:attributes) { {} }
+  let(:work) { :FAKE_WORK }
+  let(:ability) { :FAKE_ABILITY }
+  let(:env) { Hyrax::Actors::Environment.new(work, ability, attributes) }
+  let(:spy_actor) { FakeActor.new(:TERMINATOR) }
+
+  describe '#create' do
+    it 'calls create on next actor' do
+      expect { actor.create(env) }
+        .to change { spy_actor.created }
+        .from be_falsey
+    end
+  end
+
+  describe '#update' do
+    it 'calls update on next actor' do
+      expect { actor.update(env) }
+        .to change { spy_actor.updated }
+        .from be_falsey
+    end
+  end
+
+  describe '#destroy' do
+    it 'calls destroy on next actor' do
+      expect { actor.destroy(env) }
+        .to change { spy_actor.destroyed }
+        .from be_falsey
+    end
+  end
+end


### PR DESCRIPTION
in the past we fail at runtime with NameError if an application fails to provide
a custom actor for its local models. this isn't particularly forgiving or
informative, and we probably don't want to require actors forever (see
the dry-monad transaction infrastructure). besides many applications don't
provide work-specific actor customizations, so requiring them to provide an
actor per-work might be silly.

instead we provide a new `NullActor`, which just does nothing and passes along
to the next actor. if a model actor is missing, log the miss and use `NullActor`
instead.

@samvera/hyrax-code-reviewers
