### PR TITLE
add `DefaultWork.inspect` method for console output on models

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -114,16 +114,18 @@ module Wings
       class_attribute :valkyrie_class
       self.valkyrie_class = Hyrax::Resource
 
-      def self.model_name(*)
-        _hyrax_default_name_class.new(valkyrie_class)
-      end
+      class << self
+        delegate :human_readable_type, to: :valkyrie_class
 
-      def self.human_readable_type
-        valkyrie_class.human_readable_type
-      end
+        def model_name(*)
+          _hyrax_default_name_class.new(valkyrie_class)
+        end
 
-      def self.to_rdf_representation
-        "Wings(#{valkyrie_class})"
+        def to_rdf_representation
+          "Wings(#{valkyrie_class})"
+        end
+        alias inspect to_rdf_representation
+        alias to_s inspect
       end
 
       def to_global_id


### PR DESCRIPTION
Wings models generated AF models used to show output like
 `#<Class:0x00005579fb5a39b0>:0x00005579fb5a3a00>` when printed to the
 console. By adding a class-level `.inspect` and `.to_s` method, we can have
 nicer console output, both for the instances themselves and when outputting an
 ancestor chain. This should make debugging a bit nicer.

looking at doing this with some other classes and modules constructed with the
Class/Module Builder pattern, as
well. cf. https://dejimata.com/2017/5/20/the-ruby-module-builder-pattern#note-8
@samvera/hyrax-code-reviewers
