### PR TITLE
add some inspect methods for generated classes and modules

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -16,6 +16,13 @@ module Hyrax
         self.model_class = work_class
 
         include Hyrax::FormFields(:core_metadata)
+
+        ##
+        # @return [String]
+        def self.inspect
+          return "Hyrax::Forms::ResourceForm(#{model_class})" unless name.present?
+          super
+        end
       end
     end
 

--- a/app/models/hyrax/change_set.rb
+++ b/app/models/hyrax/change_set.rb
@@ -14,6 +14,13 @@ module Hyrax
       (resource_class.fields - resource_class.reserved_attributes).each do |field|
         property field, default: nil
       end
+
+      ##
+      # @return [String]
+      def self.inspect
+        return "Hyrax::ChangeSet(#{model_class})" unless name.present?
+        super
+      end
     end
   end
 

--- a/lib/hyrax/form_fields.rb
+++ b/lib/hyrax/form_fields.rb
@@ -36,6 +36,12 @@ module Hyrax
       @definition_loader.form_definitions_for(schema: name)
     end
 
+    ##
+    # @return [String]
+    def inspect
+      "#{self.class}(#{@name})"
+    end
+
     private
 
       def included(descendant)

--- a/lib/hyrax/schema.rb
+++ b/lib/hyrax/schema.rb
@@ -72,6 +72,12 @@ module Hyrax
       @schema_loader.attributes_for(schema: name)
     end
 
+    ##
+    # @return [String]
+    def inspect
+      "#{self.class}(#{@name})"
+    end
+
     private
 
       ##


### PR DESCRIPTION
follow up for #4340;

classes and modules generated using the Class/Module builder pattern will
regularly look like `#<Class:0x00005579fb5a39b0>:0x00005579fb5a3a00>` or  `
`#<Module:0x0000561be6a7f618>`. adding an `#inspect` makes them easier to
understand at-a-glance.

https://dejimata.com/2017/5/20/the-ruby-module-builder-pattern#note-8

@samvera/hyrax-code-reviewers
