### PR TITLE
Adding Sipity docs and heeding deprecation warning

### DIFF
--- a/app/models/concerns/hyrax/suppressible.rb
+++ b/app/models/concerns/hyrax/suppressible.rb
@@ -22,7 +22,7 @@ module Hyrax
     def to_sipity_entity
       Deprecation.warn "Use `Sipity::Entity(entity)` instead."
       raise "Can't create an entity until the model has been persisted" unless persisted?
-      @sipity_entity ||= Sipity::Entity.find_by(proxy_for_global_id: to_global_id.to_s)
+      @sipity_entity ||= Sipity::Entity(to_global_id)
     end
   end
 end

--- a/app/models/sipity/entity.rb
+++ b/app/models/sipity/entity.rb
@@ -1,7 +1,8 @@
 module Sipity
-  # A proxy for the entity that is being processed.
+  # A proxy for the entity that is being processed via workflows.
+  #
   # By using a proxy, we need not worry about polluting the proxy's concerns
-  # with things related to processing.
+  # with things related to workflow processing.
   #
   # The goal is to keep this behavior separate, so that we can possibly
   # extract the information.

--- a/app/services/hyrax/workflow/workflow_factory.rb
+++ b/app/services/hyrax/workflow/workflow_factory.rb
@@ -2,10 +2,11 @@ module Hyrax
   module Workflow
     # Responsible for:
     #
-    # * Creating a workflow entity
-    # * Assigning specific roles to the entity (but not the workflow)
+    # * Creating a Sipity::Entity (aka a database proxy for the given work)
+    # * Assigning specific roles to the Sipity::Entity (but not the workflow)
     # * Running the deposit_action
     #
+    # @see Sipity:Entity
     # @see Hyrax::Workflow::WorkflowActionService
     # @see Hyrax::Workflow::PermissionGenerator
     # @see Hyrax::RoleRegistry


### PR DESCRIPTION
I had an action item from of the [Samvera Tech call for 2020-05-27][1]
to review the Sipity workflow.

@no-reply  raised their hesitation about adding global_ids to
Valkyrie. In the construction of [Sipity][2], I chose to implement the
concept of the Sipity::Entity. The Sipity::Entity is persisted in the
same database as the Sipity workflow configurations. The Sipity::Entity
is a proxy for the conceptual thing that will go through a workflow.

Key to this proxy concept is that the Sipity::Entity need not be
persisted in the same storage system as the object which it proxies.

This brought about the idea of the PowerConverter and now the
[Sipity::Entity function][3]. It is envisioned that all transformations
from an object with a workflow would use the `Sipity::Entity` function.

The original conversion functions had the following logical structure:

```gherkin
Given a conversion function (e.g., convert input to Sipity::Entity
  object)
Given an input object
When the input object responds to `to_sipity_entity`
Then send `to_sipity_entity` to the input object
```

```gherkin
Given a conversion function (e.g., convert input to Sipity::Entity
  object)
Given an input object
When the input object does not respond `to_sipity_entity`
Then, using a case statement, attempt to coerce the object
```

The above behavior is the Work to Proxy path. In Hyrax, we rely on a
simple strategy to go from Proxy to Work (e.g. `Sipity::Entity#proxy_for`).

The `#proxy_for` method reifies the string value stored in the
Sipity::Entity's database record. That string encodes the behavior for
looking up both class and id.

In the Notre Dame implementation, I did not use a global_id, instead
relying on the Single Table Inheritance pattern that I had long
used. This separated the class_name and id into two fields (e.g., type
and id respectively). I could then use `class_name.classify.find(id)`,
relying on the presumptive method contract.

I believe a path forward would be to create a method
"to_sipity_entity_id". This could be an alias of the current
to_global_id, but would narrow the scope and meaning.

Then update Sipity::Entity to not use the word "global" instead favor a
context specific field name (e.g. this_sipity_entity_is_proxy_of_this_object).
Then the Sipity::Entity.proxy_for could apply the strategy for mapping
that field value to the corresponding object.

Alternatively, we can add a global_id concept to the Valkyrie resource. :)

My notes on the request are as follows:

> Working through works controller behavior, running tests on everything
> with native valkyrie works. The edit forms mostly work. The show
> behavior mostly works. It's basically done.
>
> You can hit the save button and it works.
>
> The first problem encountered is the workflow initializer, which calls
> workflow factory. For this to work, we need a global ID for a Valkyrie work.
>
> Workflow factory, port this to Valkyrie.

[1]:https://wiki.lyrasis.org/display/samvera/Samvera+Tech+Call+2020-05-27
[2]:https://github.com/ndlib/sipity
[3]:https://github.com/samvera/hyrax/blob/8f2924bf04aad670576d92b5c3690a3fe4fd1f55/app/models/sipity.rb

@samvera/hyrax-code-reviewers
