### PR TITLE
allow ValkyrieIndexer resolution by naming convention

### DIFF
--- a/spec/indexers/hyrax/valkyrie_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_indexer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Hyrax::ValkyrieIndexer do
       end
     end
 
-    context 'with registered Monograph indexer' do
+    context 'with a matching indexer by naming convention' do
       let(:resource) { build(:monograph) }
       let(:indexer_class) { MonographIndexer }
 


### PR DESCRIPTION
this is proposed replacement for the registry pattern. if this makes it in, we
can remove registration from the generators and deprecate/remove the registry in
a follow-up.

@samvera/hyrax-code-reviewers
