### PR TITLE
cast ResourceForm#member_ids and #member_of_collection_ids to Array

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -69,6 +69,8 @@ module Hyrax
 
       property :visibility # visibility has an accessor on the model
 
+      property :date_modified, readable: false
+      property :date_uploaded, readable: false
       property :agreement_accepted, virtual: true, default: false, prepopulator: ->(_opts) { self.agreement_accepted = !model.new_record }
 
       collection :permissions, virtual: true, default: [], form: Permission, prepopulator: ->(_opts) { self.permissions = Hyrax::AccessControl.for(resource: model).permissions }
@@ -84,8 +86,8 @@ module Hyrax
 
       # pcdm relationships
       property :admin_set_id
-      property :member_ids, default: []
-      property :member_of_collection_ids, default: []
+      property :member_ids, default: [], type: Valkyrie::Types::Array
+      property :member_of_collection_ids, default: [],  type: Valkyrie::Types::Array
 
       # provide a lock token for optimistic locking; we name this `version` for
       # backwards compatibility

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -87,7 +87,7 @@ module Hyrax
       # pcdm relationships
       property :admin_set_id
       property :member_ids, default: [], type: Valkyrie::Types::Array
-      property :member_of_collection_ids, default: [],  type: Valkyrie::Types::Array
+      property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 
       # provide a lock token for optimistic locking; we name this `version` for
       # backwards compatibility

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -116,6 +116,12 @@ RSpec.describe Hyrax::Forms::ResourceForm do
       expect(form.member_ids).to be_empty
     end
 
+    it 'casts to an array' do
+      expect { form.validate(member_ids: '123') }
+        .to change { form.member_ids }
+        .to contain_exactly('123')
+    end
+
     context 'when the object has members' do
       let(:work) { FactoryBot.build(:monograph, :with_member_works) }
 


### PR DESCRIPTION
add types for these two form fields, enabling coercion. this makes the form
better at handling user/browser input.

see: http://trailblazer.to/gems/reform/options.html#coercion

@samvera/hyrax-code-reviewers
