### PR TITLE
wings: refactor model lookup behavior for better fallback

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -70,7 +70,7 @@ module Wings
 
       return klass if klass <= ActiveFedora::Base
 
-      ModelRegistry.lookup(klass) || self.class.DefaultWork(klass)
+      ModelRegistry.lookup(klass)
     end
 
     ##

--- a/lib/wings/model_registry.rb
+++ b/lib/wings/model_registry.rb
@@ -41,7 +41,7 @@ module Wings
     end
 
     def lookup(valkyrie)
-      @map[valkyrie]
+      @map.fetch(valkyrie) { ActiveFedoraConverter::DefaultWork(valkyrie) }
     end
 
     def reverse_lookup(active_fedora)


### PR DESCRIPTION
since we introduced proper handling for valkyrie models without AF equivalents,
we've been casting Valkyrie models to `DefaultWork` directly in the
`ActiveFedoraConverter`. this is a bit fragile, since anything that looks them
up (like the `Wings::WorkSearchBuilder`), is going to miss in the registry,
leaking `nil` about where folks might see it! instead, let the registry handle
resolution to the appropriate class even in case of misses.

this points to a further refactor, extracting (and probably renaming)
`DefaultWork` from `Wings::ActiveFedoraConverter`, since it's no longer (and
never really was) neatly encapsulated there.

this fixes an intermittent failure in the test suite.

@samvera/hyrax-code-reviewers
