### PR TITLE
add a 'object.failed_deposit' event

### DIFF
--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -56,6 +56,7 @@ module Hyrax
     register_event('file.set.url.imported')
     register_event('file.set.restored')
     register_event('object.deleted')
+    register_event('object.failed_deposit')
     register_event('object.deposited')
     register_event('object.acl.updated')
     register_event('object.metadata.updated')

--- a/lib/hyrax/specs/spy_listener.rb
+++ b/lib/hyrax/specs/spy_listener.rb
@@ -4,7 +4,7 @@ module Hyrax
   module Specs
     class SpyListener
       attr_reader :file_set_attached, :file_set_url_imported, :object_deleted,
-                  :object_deposited, :object_acl_updated,
+                  :object_deposited, :object_failed_deposit, :object_acl_updated,
                   :object_metadata_updated
 
       def on_object_deleted(event)
@@ -13,6 +13,10 @@ module Hyrax
 
       def on_object_deposited(event)
         @object_deposited = event
+      end
+
+      def on_object_failed_deposit(event)
+        @object_failed_deposit = event
       end
 
       def on_object_acl_updated(event)


### PR DESCRIPTION
when a deposit fails, we can publish an event; this gets that in place, in
anticipation of publishing them from the `WorksControllerBehavior`, and possibly
other places (batch)?

this is extracted from some exploratory work on using our transactions interface
for Valkyrie work deposit.

some consideration about how to document Hyrax's pub/sub contracts is still
owed.

@samvera/hyrax-code-reviewers
