### PR TITLE
Backport: slight optimization to IIIF Manifest generation

### DIFF
--- a/app/controllers/concerns/hyrax/local_file_downloads_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/local_file_downloads_controller_behavior.rb
@@ -29,6 +29,7 @@ module Hyrax
       end
 
       def send_local_file_contents
+        return unless stale?(last_modified: local_file_last_modified, template: false)
         self.status = 200
         prepare_local_file_headers
         # For derivatives stored on the local file system
@@ -65,7 +66,7 @@ module Hyrax
         response.headers['Content-Type'] = local_file_mime_type
         response.headers['Content-Length'] ||= local_file_size.to_s
         # Prevent Rack::ETag from calculating a digest over body
-        response.headers['Last-Modified'] = local_file_last_modified.utc.strftime("%a, %d %b %Y %T GMT")
+        response.headers['Last-Modified'] ||= local_file_last_modified.httpdate
         self.content_type = local_file_mime_type
       end
 

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -27,7 +27,7 @@ module Hyrax
         solr_doc['duration_tesim']          = object.duration
         solr_doc['sample_rate_tesim']       = object.sample_rate
         solr_doc['original_checksum_tesim'] = object.original_checksum
-        solr_doc['alpha_channels_ssi']      = object.alpha_channels
+        solr_doc['alpha_channels_ssi']      = object.try(:alpha_channels)
         solr_doc['original_file_id_ssi']    = original_file_id
       end
     end

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -27,11 +27,22 @@ module Hyrax
         solr_doc['duration_tesim']          = object.duration
         solr_doc['sample_rate_tesim']       = object.sample_rate
         solr_doc['original_checksum_tesim'] = object.original_checksum
+        solr_doc['alpha_channels_ssi']      = object.alpha_channels
+        solr_doc['current_file_version_ssi'] = latest_version_id
         solr_doc['original_file_id_ssi']    = original_file_id
       end
     end
 
     private
+
+      def latest_version_id
+        return unless object.original_file.present?
+        if object.original_file.versions.present?
+          ActiveFedora::File.uri_to_id(object.current_content_version_uri)
+        else
+          ActiveFedora::File.uri_to_id(object.original_file.uri)
+        end
+      end
 
       def digest_from_content
         return unless object.original_file

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -28,21 +28,11 @@ module Hyrax
         solr_doc['sample_rate_tesim']       = object.sample_rate
         solr_doc['original_checksum_tesim'] = object.original_checksum
         solr_doc['alpha_channels_ssi']      = object.alpha_channels
-        solr_doc['current_file_version_ssi'] = latest_version_id
         solr_doc['original_file_id_ssi']    = original_file_id
       end
     end
 
     private
-
-      def latest_version_id
-        return unless object.original_file.present?
-        if object.original_file.versions.present?
-          ActiveFedora::File.uri_to_id(object.current_content_version_uri)
-        else
-          ActiveFedora::File.uri_to_id(object.original_file.uri)
-        end
-      end
 
       def digest_from_content
         return unless object.original_file
@@ -51,7 +41,11 @@ module Hyrax
 
       def original_file_id
         return unless object.original_file
-        object.original_file.id
+        if object.original_file.versions.present?
+          ActiveFedora::File.uri_to_id(object.current_content_version_uri)
+        else
+          object.original_file.id
+        end
       end
 
       def file_format

--- a/app/models/concerns/hyrax/solr_document/characterization.rb
+++ b/app/models/concerns/hyrax/solr_document/characterization.rb
@@ -99,7 +99,11 @@ module Hyrax
       end
 
       def original_checksum
-        self[Solrizer.solr_name("original_checksum")]
+        self["original_checksum_tesim"]
+      end
+
+      def alpha_channels
+        self["alpha_channels_ssi"]
       end
     end
   end

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -79,6 +79,7 @@ module Hyrax
         attribute :label, Solr::String, "label_tesim"
         attribute :file_format, Solr::String, "file_format_tesim"
         attribute :suppressed?, Solr::String, "suppressed_bsi"
+        attribute :original_file_id, Solr::String, "original_file_id_ssi"
         attribute :date_modified, Solr::Date, "date_modified_dtsi"
         attribute :date_uploaded, Solr::Date, "date_uploaded_dtsi"
         attribute :create_date, Solr::Date, "system_create_dtsi"

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -75,14 +75,14 @@ module Hyrax
         attribute :rendering_ids, Solr::Array, solr_name(Hyrax.config.rendering_predicate.value.split(/#|\/|,/).last, :symbol)
         attribute :thumbnail_id, Solr::String, solr_name('hasRelatedImage', :symbol)
         attribute :thumbnail_path, Solr::String, CatalogController.blacklight_config.index.thumbnail_field
-        attribute :label, Solr::String, solr_name('label')
-        attribute :file_format, Solr::String, solr_name('file_format')
-        attribute :suppressed?, Solr::String, solr_name('suppressed', Solrizer::Descriptor.new(:boolean, :stored, :indexed))
 
-        attribute :date_modified, Solr::Date, solr_name('date_modified', :stored_sortable, type: :date)
-        attribute :date_uploaded, Solr::Date, solr_name('date_uploaded', :stored_sortable, type: :date)
-        attribute :create_date, Solr::Date, solr_name('system_create', :stored_sortable, type: :date)
-        attribute :modified_date, Solr::Date, solr_name('system_modified', :stored_sortable, type: :date)
+        attribute :label, Solr::String, "label_tesim"
+        attribute :file_format, Solr::String, "file_format_tesim"
+        attribute :suppressed?, Solr::String, "suppressed_bsi"
+        attribute :date_modified, Solr::Date, "date_modified_dtsi"
+        attribute :date_uploaded, Solr::Date, "date_uploaded_dtsi"
+        attribute :create_date, Solr::Date, "system_create_dtsi"
+        attribute :modified_date, Solr::Date, "system_modified_dtsi"
         attribute :embargo_release_date, Solr::Date, Hydra.config.permissions.embargo.release_date
         attribute :lease_expiration_date, Solr::Date, Hydra.config.permissions.lease.expiration_date
       end

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -10,9 +10,11 @@ module Hyrax
     #
     # @return [IIIFManifest::DisplayImage] the display image required by the manifest builder.
     def display_image
-      return nil unless ::FileSet.exists?(id) && solr_document.image? && current_ability.can?(:read, id)
-      # @todo this is slow, find a better way (perhaps index iiif url):
-      original_file = ::FileSet.find(id).original_file
+      return nil unless solr_document.image? && current_ability.can?(:read, solr_document)
+
+      latest_file_id = lookup_original_file_id
+
+      return nil unless latest_file_id
 
       url = Hyrax.config.iiif_image_url_builder.call(
         original_file.id,

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -22,9 +22,6 @@ module Hyrax
         Hyrax.config.iiif_image_size_default
       )
 
-      # @todo this is slow, find a better way (perhaps index iiif url):
-      original_file = ::FileSet.find(id).original_file
-
       # @see https://github.com/samvera-labs/iiif_manifest
       IIIFManifest::DisplayImage.new(url,
                                      width: solr_document[:width_is],

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -19,14 +19,16 @@ module Hyrax
       url = Hyrax.config.iiif_image_url_builder.call(
         latest_file_id,
         request.base_url,
-        Hyrax.config.iiif_image_size_default
+        Hyrax.config.iiif_image_size_default,
+        format: image_format(alpha_channels)
       )
 
       # @see https://github.com/samvera-labs/iiif_manifest
       IIIFManifest::DisplayImage.new(url,
-                                     width: solr_document[:width_is],
-                                     height: solr_document[:height_is],
-                                     iiif_endpoint: iiif_endpoint(original_file.id))
+                                     format: image_format(alpha_channels),
+                                     width: width,
+                                     height: height,
+                                     iiif_endpoint: iiif_endpoint(latest_file_id))
     end
 
     private

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -17,10 +17,14 @@ module Hyrax
       return nil unless latest_file_id
 
       url = Hyrax.config.iiif_image_url_builder.call(
-        original_file.id,
+        latest_file_id,
         request.base_url,
         Hyrax.config.iiif_image_size_default
       )
+
+      # @todo this is slow, find a better way (perhaps index iiif url):
+      original_file = ::FileSet.find(id).original_file
+
       # @see https://github.com/samvera-labs/iiif_manifest
       IIIFManifest::DisplayImage.new(url,
                                      width: solr_document[:width_is],

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -19,13 +19,12 @@ module Hyrax
       url = Hyrax.config.iiif_image_url_builder.call(
         latest_file_id,
         request.base_url,
-        Hyrax.config.iiif_image_size_default,
-        format: image_format(alpha_channels)
+        Hyrax.config.iiif_image_size_default
       )
 
       # @see https://github.com/samvera-labs/iiif_manifest
       IIIFManifest::DisplayImage.new(url,
-                                     format: image_format(alpha_channels),
+                                     format: image_format([]),
                                      width: width,
                                      height: height,
                                      iiif_endpoint: iiif_endpoint(latest_file_id))

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -30,6 +30,7 @@ module Hyrax
              :embargo_release_date, :lease_expiration_date,
              :depositor, :keyword, :title_or_label, :keyword,
              :date_created, :date_modified, :itemtype,
+             :current_file_version,
              to: :solr_document
 
     def single_use_links

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -33,6 +33,10 @@ module Hyrax
              :original_file_id,
              to: :solr_document
 
+    def alpha_channels
+      []
+    end
+
     def single_use_links
       @single_use_links ||= SingleUseLink.where(itemId: id).map { |link| link_presenter_class.new(link) }
     end

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -30,7 +30,7 @@ module Hyrax
              :embargo_release_date, :lease_expiration_date,
              :depositor, :keyword, :title_or_label, :keyword,
              :date_created, :date_modified, :itemtype,
-             :current_file_version,
+             :original_file_id,
              to: :solr_document
 
     def single_use_links

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -1,10 +1,11 @@
 require 'iiif_manifest'
 
 RSpec.describe Hyrax::FileSetPresenter do
+  subject(:presenter) { described_class.new(solr_document, ability) }
   let(:solr_document) { SolrDocument.new(attributes) }
-  let(:ability) { double "Ability" }
-  let(:presenter) { described_class.new(solr_document, ability) }
+  let(:ability) { Ability.new(user) }
   let(:attributes) { file.to_solr }
+
   let(:file) do
     build(:file_set,
           id: '123abc',
@@ -13,7 +14,7 @@ RSpec.describe Hyrax::FileSetPresenter do
           depositor: user.user_key,
           label: "filename.tif")
   end
-  let(:user) { double(user_key: 'sarah') }
+  let(:user) { create(:admin) }
 
   describe 'stats_path' do
     before do
@@ -22,8 +23,6 @@ RSpec.describe Hyrax::FileSetPresenter do
     end
     it { expect(presenter.stats_path).to eq Hyrax::Engine.routes.url_helpers.stats_file_path(id: file, locale: 'en') }
   end
-
-  subject { presenter }
 
   describe "#to_s" do
     subject { presenter.to_s }
@@ -144,8 +143,8 @@ RSpec.describe Hyrax::FileSetPresenter do
   describe '#events' do
     subject(:events) { presenter.events }
 
-    let(:event_stream) { double }
-    let(:response) { double }
+    let(:event_stream) { double('event stream') }
+    let(:response) { double('response') }
 
     before do
       allow(presenter).to receive(:event_stream).and_return(event_stream)
@@ -158,7 +157,7 @@ RSpec.describe Hyrax::FileSetPresenter do
   end
 
   describe '#event_stream' do
-    let(:object_stream) { double }
+    let(:object_stream) { double('object_stream') }
 
     it 'returns a Nest stream' do
       expect(Hyrax::RedisEventStore).to receive(:for).with(Nest).and_return(object_stream)
@@ -167,8 +166,6 @@ RSpec.describe Hyrax::FileSetPresenter do
   end
 
   describe "characterization" do
-    let(:user) { double(user_key: 'user') }
-
     describe "#characterization_metadata" do
       subject { presenter.characterization_metadata }
 
@@ -307,14 +304,9 @@ RSpec.describe Hyrax::FileSetPresenter do
   describe 'IIIF integration' do
     let(:file_set) { create(:file_set) }
     let(:solr_document) { SolrDocument.new(file_set.to_solr) }
-    let(:request) { double(base_url: 'http://test.host') }
+    let(:request) { double('request', base_url: 'http://test.host') }
     let(:presenter) { described_class.new(solr_document, ability, request) }
     let(:id) { CGI.escape(file_set.original_file.id) }
-    let(:read_permission) { true }
-
-    before do
-      allow(ability).to receive(:can?).with(:read, solr_document.id).and_return(read_permission)
-    end
 
     describe "#display_image" do
       subject { presenter.display_image }
@@ -379,7 +371,7 @@ RSpec.describe Hyrax::FileSetPresenter do
           end
 
           context "when the user doesn't have permission to view the image" do
-            let(:read_permission) { false }
+            let(:user) { create(:user) }
 
             it { is_expected.to be_nil }
           end

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Hyrax::FileSetPresenter do
        "subject", "language", "license", "format_label", "file_size",
        "height", "width", "filename", "well_formed", "page_count",
        "file_title", "last_modified", "original_checksum", "mime_type",
-       "duration", "sample_rate"]
+       "duration", "sample_rate", "current_file_version", "alpha_channels"]
     end
 
     it "delegates to the solr_document" do
@@ -302,11 +302,15 @@ RSpec.describe Hyrax::FileSetPresenter do
   end
 
   describe 'IIIF integration' do
+    def uri_segment_escape(uri)
+      ActionDispatch::Journey::Router::Utils.escape_segment(uri)
+    end
+
     let(:file_set) { create(:file_set) }
     let(:solr_document) { SolrDocument.new(file_set.to_solr) }
     let(:request) { double('request', base_url: 'http://test.host') }
     let(:presenter) { described_class.new(solr_document, ability, request) }
-    let(:id) { CGI.escape(file_set.original_file.id) }
+    let(:id) { ActiveFedora::File.uri_to_id(file_set.original_file.versions.last.uri) }
 
     describe "#display_image" do
       subject { presenter.display_image }
@@ -337,7 +341,7 @@ RSpec.describe Hyrax::FileSetPresenter do
           end
 
           it { is_expected.to be_instance_of IIIFManifest::DisplayImage }
-          its(:url) { is_expected.to eq "http://test.host/images/#{id}/full/600,/0/default.jpg" }
+          its(:url) { is_expected.to eq "http://test.host/images/#{uri_segment_escape(id)}/full/600,/0/default.jpg" }
 
           context 'with custom image size default' do
             let(:custom_image_size) { '666,' }
@@ -350,7 +354,7 @@ RSpec.describe Hyrax::FileSetPresenter do
             end
 
             it { is_expected.to be_instance_of IIIFManifest::DisplayImage }
-            its(:url) { is_expected.to eq "http://test.host/images/#{id}/full/#{custom_image_size}/0/default.jpg" }
+            its(:url) { is_expected.to eq "http://test.host/images/#{uri_segment_escape(id)}/full/#{custom_image_size}/0/default.jpg" }
           end
 
           context 'with custom image url builder' do
@@ -380,7 +384,7 @@ RSpec.describe Hyrax::FileSetPresenter do
     end
 
     describe "#iiif_endpoint" do
-      subject { presenter.send(:iiif_endpoint, file_set.original_file.id) }
+      subject { presenter.send(:iiif_endpoint, id) }
 
       before do
         allow(Hyrax.config).to receive(:iiif_image_server?).and_return(riiif_enabled)
@@ -391,7 +395,7 @@ RSpec.describe Hyrax::FileSetPresenter do
       context 'with iiif_image_server enabled' do
         let(:riiif_enabled) { true }
 
-        its(:url) { is_expected.to eq "http://test.host/images/#{id}" }
+        its(:url) { is_expected.to eq "http://test.host/images/#{uri_segment_escape(id)}" }
         its(:profile) { is_expected.to eq 'http://iiif.io/api/image/2/level2.json' }
 
         context 'with a custom iiif image profile' do

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Hyrax::FileSetPresenter do
        "subject", "language", "license", "format_label", "file_size",
        "height", "width", "filename", "well_formed", "page_count",
        "file_title", "last_modified", "original_checksum", "mime_type",
-       "duration", "sample_rate", "current_file_version", "alpha_channels"]
+       "duration", "sample_rate", "alpha_channels", "original_file_id"]
     end
 
     it "delegates to the solr_document" do

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Hyrax::FileSetPresenter do
        "subject", "language", "license", "format_label", "file_size",
        "height", "width", "filename", "well_formed", "page_count",
        "file_title", "last_modified", "original_checksum", "mime_type",
-       "duration", "sample_rate", "alpha_channels", "original_file_id"]
+       "duration", "sample_rate", "original_file_id"]
     end
 
     it "delegates to the solr_document" do

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -18,7 +18,9 @@ module Hyrax
                  original_checksum: opts.fetch(:original_checksum, []),
                  digest:            opts.fetch(:digest, []),
                  duration:          opts.fetch(:duration, []),
-                 sample_rate:       opts.fetch(:sample_rate, []))
+                 sample_rate:       opts.fetch(:sample_rate, []),
+                 versions:          opts.fetch(:versions, []),
+                 uri:               opts.fetch(:versions, []))
     end
   end
 end


### PR DESCRIPTION
avoid some Fedora and solr calls when generating IIIF manifests. these presenter
checks call Fedora multiple times (`#exists?` and `can?(:read, id)` each make
separate round trips), per image.

instead, assume any resource we `#can?(:read)` exists, and use the solr document
to check (Blacklight-style) permissions.

Backports #4344 for Hyrax 2.x

@samvera/hyrax-code-reviewers
