### PR TITLE
[WIP] move alternative title to core metadata to avoid nil error

### DIFF
--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -6,8 +6,6 @@ module Hyrax
     extend ActiveSupport::Concern
 
     included do
-      property :alternative_title, predicate: ::RDF::Vocab::DC.alternative
-
       property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false
 
       property :relative_path, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#relativePath'), multiple: false

--- a/app/models/concerns/hyrax/core_metadata.rb
+++ b/app/models/concerns/hyrax/core_metadata.rb
@@ -13,6 +13,8 @@ module Hyrax
         index.as :stored_searchable, :facetable
       end
 
+      property :alternative_title, predicate: ::RDF::Vocab::DC.alternative
+
       def first_title
         title.first
       end

--- a/config/metadata/basic_metadata.yaml
+++ b/config/metadata/basic_metadata.yaml
@@ -9,11 +9,6 @@ attributes:
     multiple: true
     form:
       primary: false
-  alternative_title:
-    type: string
-    multiple: true
-    form:
-      primary: false
   based_near:
     type: string
     multiple: true

--- a/config/metadata/core_metadata.yaml
+++ b/config/metadata/core_metadata.yaml
@@ -9,6 +9,11 @@ attributes:
       required: true
       primary: true
       multiple: false
+  alternative_title:
+    type: string
+    multiple: true
+    form:
+      primary: false
   date_modified:
     type: date_time
   date_uploaded:


### PR DESCRIPTION
### Description

Fix bug where `@attributes["alternative_title"] << value` throws an exception because `@attributes["alternative_title"]` is nil.  This happens when a model does not include basic metadata causing alternative_title to not be defined.

### Related work:

* Issue #4318 - reconsidering impact of PR #3554
* PR #3554 - separates multiple titles into title and alternative titles


@samvera/hyrax-code-reviewers
