### PR TITLE
update USAGE for hyrax:work_resource generator

### DIFF
--- a/lib/generators/hyrax/work_resource/USAGE
+++ b/lib/generators/hyrax/work_resource/USAGE
@@ -2,12 +2,15 @@ Description:
   This generator creates the necessary files for valkyrie-native work types.
 
 Example:
-  rails generate hyrax:work_resource Monograph
+  rails generate hyrax:work_resource Monograph field:type author:string created:date isbn:string publisher:string title:string
 
   This will create:
-    app/models/monograph.rb
     app/controllers/hyrax/monographs_controller.rb
-    app/indexer/monograph_indexer.rb
-    app/views/monographs/_monograph.html.erb
+    app/forms/monograph_form.rb
+    app/indexers/monograph_indexer.rb
+    app/models/monograph.rb
+    app/views/hyrax/monographs/_monograph.html.erb
+    config/initializers/hyrax.rb
+    config/metadata/monograph.yaml
     spec/models/monograph_spec.rb
     spec/views/monographs/_monograph.html.erb_spec.rb


### PR DESCRIPTION
This updates the USAGE doc for hyrax:work_resource generator to reflect recent changes.

Changes:
* add attributes to the example
* update files to the actual set of files that are generated

Question:
* The view is the only file put in the hyrax namespace. Is this done intentionally?  Or should it be changed outside the hyrax namespace.  Moving it outside would be more consistent with the naming followed for other files.

Recent changes to the generator to add attributes:
* PR #4347 
* PR #4348 


@samvera/hyrax-code-reviewers
