### PR TITLE
Better model resolution for wings

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -70,7 +70,7 @@ module Wings
 
       return klass if klass <= ActiveFedora::Base
 
-      ModelRegistry.lookup(klass) || self.class.DefaultWork(klass)
+      ModelRegistry.lookup(klass)
     end
 
     ##

--- a/lib/wings/model_registry.rb
+++ b/lib/wings/model_registry.rb
@@ -41,7 +41,10 @@ module Wings
     end
 
     def lookup(valkyrie)
-      @map[valkyrie]
+      valkyrie = valkyrie._canonical_valkyrie_model if
+        valkyrie.respond_to?(:_canonical_valkyrie_model)
+
+      @map.fetch(valkyrie) { ActiveFedoraConverter::DefaultWork(valkyrie) }
     end
 
     def reverse_lookup(active_fedora)

--- a/lib/wings/orm_converter.rb
+++ b/lib/wings/orm_converter.rb
@@ -41,6 +41,7 @@ module Wings
     #   mirroring the provided `ActiveFedora` model
     #
     # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/BlockLength
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/MethodLength because metaprogramming a class
     #   results in long methods
@@ -62,7 +63,13 @@ module Wings
           attr_reader :internal_resource
 
           def name
-            ancestors[1..-1].find { |parent| parent < ::Valkyrie::Resource }&.name
+            _canonical_valkyrie_model&.name
+          end
+
+          ##
+          # @api private
+          def _canonical_valkyrie_model
+            ancestors[1..-1].find { |parent| parent < ::Valkyrie::Resource }
           end
         end
 
@@ -90,6 +97,6 @@ module Wings
   end
 end
 # rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/BlockLength
 # rubocop:enable Metrics/MethodLength
 # rubocop:enable Metrics/CyclomaticComplexity
-# rubocop:enable Metrics/PerceivedComplexity

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -92,7 +92,7 @@ module Wings
         all_members = find_many_by_ids(ids: resource.member_ids)
         return all_members unless model
         find_model = model_class_for(model)
-        all_members.select { |member_resource| model_class_for(member_resource) == find_model }
+        all_members.select { |member_resource| model_class_for(member_resource.class) == find_model }
       end
 
       # Find the Valkyrie Resources referenced by another Valkyrie Resource
@@ -167,7 +167,9 @@ module Wings
       end
 
       def model_class_for(model)
-        ModelRegistry.lookup(model) || model.internal_resource.constantize
+        internal_resource = model.respond_to?(:internal_resource) ? model.internal_resource : nil
+
+        internal_resource&.safe_constantize || ModelRegistry.lookup(model)
       end
     end
   end

--- a/spec/jobs/content_depositor_change_event_job_spec.rb
+++ b/spec/jobs/content_depositor_change_event_job_spec.rb
@@ -32,21 +32,26 @@ RSpec.describe ContentDepositorChangeEventJob do
   end
 
   context "when use_valkyrie is true" do
-    let(:generic_work) { valkyrie_create(:hyrax_work, title: ['BethsMac'], depositor: user.user_key) }
+    let(:monograph) { valkyrie_create(:monograph, title: ['BethsMac'], depositor: user.user_key) }
+
+    let(:event) do
+      { action: "User <a href=\"/users/#{user.to_param}\">#{user.user_key}</a> " \
+                "has transferred <a href=\"/concern/monographs/#{monograph.id}\">BethsMac</a> " \
+                "to user <a href=\"/users/#{another_user.to_param}\">#{another_user.user_key}</a>",
+        timestamp: '1' }
+    end
 
     it "logs the event to the proxy depositor's profile, the depositor's dashboard, and the FileSet" do
-      allow(subject).to receive(:hyrax_test_simple_work_path).and_return("/concern/generic_works/#{generic_work.id}")
-
-      expect { subject.perform(generic_work, another_user) }
+      expect { subject.perform(monograph, another_user) }
         .to change { user.profile_events.length }
         .by(1)
         .and change { another_user.events.length }
         .by(1)
-        .and change { generic_work.events.length }
+        .and change { monograph.events.length }
         .by(1)
       expect(user.profile_events.first).to eq(event)
       expect(another_user.events.first).to eq(event)
-      expect(generic_work.events.first).to eq(event)
+      expect(monograph.events.first).to eq(event)
     end
   end
 end

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'iiif_manifest'
 
+# rubocop:disable RSpec/SubjectStub
 RSpec.describe Hyrax::FileSetPresenter do
   subject(:presenter) { described_class.new(solr_document, ability) }
   let(:solr_document) { SolrDocument.new(attributes) }
@@ -421,3 +422,4 @@ RSpec.describe Hyrax::FileSetPresenter do
     end
   end
 end
+# rubocop:enable RSpec/SubjectStub

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -115,7 +115,8 @@ RSpec.describe Wings::Valkyrie::QueryService do
       persister.save(resource: resource_class.new)
       resource2 = persister.save(resource: image_resource_class.new)
 
-      expect(query_service.find_all_of_model(model: image_resource_class).map(&:id)).to contain_exactly resource2.id
+      expect(query_service.find_all_of_model(model: image_resource_class))
+        .to contain_exactly(have_attributes(id: resource2.id))
     end
 
     it "returns an empty array if there are none" do


### PR DESCRIPTION
since we introduced proper handling for valkyrie models without AF equivalents,
we've been casting Valkyrie models to `DefaultWork` directly in the
`ActiveFedoraConverter`. this is a bit fragile, since anything that looks them
up (like the `Wings::WorkSearchBuilder`), is going to miss in the registry,
leaking `nil` about where folks might see it! instead, let the registry handle
resolution to the appropriate class even in case of misses.

this points to a further refactor, extracting (and probably renaming)
`DefaultWork` from `Wings::ActiveFedoraConverter`, since it's no longer (and
never really was) neatly encapsulated there.

this fixes an intermittent failure in the test suite.

@samvera/hyrax-code-reviewers
