### PR TITLE
support Valkyrie work creation with Hyrax transactions

### DIFF
--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
+
+##
+# A mixin for Hyrax support methods. This is meant to be included in
+# `ApplicationController`.
+#
+# @note private methods within this module are normally still "public API",
+#   since they are meant to be called by inheriting controllers.
 module Hyrax::Controller
   extend ActiveSupport::Concern
 
@@ -22,6 +29,21 @@ module Hyrax::Controller
   end
 
   private
+
+  ##
+  # @api public
+  #
+  # @return [#[]] a resolver for Hyrax's Transactions; this *should* be a
+  #   thread-safe Dry::Container, but callers to this method should strictly
+  #   use #[] for access
+  #
+  # @example
+  #   transactions['change_set.create_work'].call(my_form)
+  #
+  # @see https://dry-rb.org/gems/dry-container
+  def transactions
+    Hyrax::Transactions::Container
+  end
 
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -53,7 +53,7 @@ module Hyrax
     end
 
     def create
-      if actor.create(actor_environment)
+      if create_work
         after_create_response
       else
         respond_to do |wants|
@@ -168,6 +168,20 @@ module Hyrax
 
     def actor
       @actor ||= Hyrax::CurationConcern.actor
+    end
+
+    ##
+    # @return [#errors]
+    def create_work
+      case curation_concern
+      when ActiveFedora::Base
+        actor.create(actor_environment)
+      else
+        form = build_form
+
+        @curation_concern = form.validate(params[hash_key_for_curation_concern]) &&
+                            transactions['change_set.create_work'].call(form).value!
+      end
     end
 
     def presenter

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -333,6 +333,7 @@ module Hyrax
         wants.html do
           # Calling `#t` in a controller context does not mark _html keys as html_safe
           flash[:notice] = view_context.t('hyrax.works.create.after_create_html', application_name: view_context.application_name)
+
           redirect_to [main_app, curation_concern]
         end
         wants.json { render :show, status: :created, location: polymorphic_path([main_app, curation_concern]) }

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -26,6 +26,7 @@ module Hyrax
     require 'hyrax/publisher'
     require 'hyrax/schema'
     require 'hyrax/search_state'
+    require 'hyrax/transactions'
     require 'hyrax/errors'
 
     # Force these models to be added to Legato's registry in development mode

--- a/lib/hyrax/transactions.rb
+++ b/lib/hyrax/transactions.rb
@@ -5,17 +5,12 @@ module Hyrax
   ##
   # This is a parent module for DRY Transaction classes handling Hyrax
   # processes. Especially: transactions and steps for creating, updating, and
-  # destroying PCDM Objects are located here. Loading this module provides an
-  # easy way to load the full suite of transactions included for these purposes.
-  #
-  # @note These uses of `dry-transaction` are currently experimental
-  #   replacements for actor stack behavior. They are not loaded during normal
-  #   execution in a stock Hyrax application.
+  # destroying PCDM Objects are located here.
   #
   # @since 2.4.0
   #
   # @example
-  #   require 'hyrax/transactions'
+  #   Hyrax::Transaction::Container['transaction_name'].call(:input)
   #
   # @see https://dry-rb.org/gems/dry-transaction/
   module Transactions

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -50,6 +50,10 @@ module Hyrax
           ApplyChangeSet.new
         end
 
+        ops.register 'create_work' do
+          WorkCreate.new
+        end
+
         ops.register 'ensure_admin_set' do
           Steps::EnsureAdminSet.new
         end

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -9,23 +9,16 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
   routes { Rails.application.routes.dup }
 
   before do
+    allow(Hyrax.config)
+      .to receive(:registered_curation_concern_types)
+      .and_return([work.model_name.name])
+
     routes.draw do # draw minimal routes for this controller mixin
       mount Hyrax::Engine, at: '/'
       namespaced_resources 'hyrax/test/simple_work_legacies', except: [:index]
       devise_for :users
       resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog'
     end
-  end
-
-  before(:context) do
-    Hyrax.config.register_curation_concern(Hyrax::Test::SimpleWork)
-  end
-
-  after(:context) do
-    config = Hyrax.config
-    types  = config.registered_curation_concern_types - ["Hyrax::Test::SimpleWork"]
-
-    Hyrax.config.instance_variable_set(:@registered_concerns, types)
   end
 
   controller(ApplicationController) do

--- a/spec/support/form_with_validations.rb
+++ b/spec/support/form_with_validations.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Hyrax
+  module Test
+    class FormWithValidations < Hyrax::Forms::ResourceForm
+      property :title
+
+      validates :title, presence: true
+    end
+  end
+end


### PR DESCRIPTION
add Valkyrie work creation handling for `WorksControllerBehavior`. this uses `Hyrax::Transactions` to process the work.

to accomplish this, we first bump `Hyrax::Transactions` into the engine for use with Valkyrie resources.

@samvera/hyrax-code-reviewers
