### PR TITLE
display thumbnail in public collection page.  Fixes issue #3358

### DIFF
--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -69,6 +69,7 @@
 
     </div>
     <div class="col-md-4 hyc-metadata">
+      <%= render 'hyrax/collections/media_display', presenter: @presenter %>
       <% unless collection_search_parameters? %>
           <h2><%= t('hyrax.dashboard.collections.show.metadata_header') %></h2>
           <%= render 'show_descriptions' %>


### PR DESCRIPTION
Fixes #3358

If an image has been selected to serve as the thumbnail for a collection, then the thumbnail should be visible in the descriptive metadata area of the public show page for the collection.  Before this PR, the representative image was not showing up.  I have placed the image right above the "Collection Details".  It seemed to me that if the collection had a banner and a long title this is where it would look the best.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a public collection
* Create a public work that includes an image file
* Put the work in the collection
* Edit the collection and select the work's image as the thumbnail for the collection
* Navigate to the collection's public show page.  Notice that the representative thumbnail is right above the Collection Details.

You can experiment by adding a banner to the collection and title and see how it looks.  Attached is an image of how it rendered for me:
<img width="1560" alt="Screen Shot 2020-06-09 at 11 21 29 AM" src="https://user-images.githubusercontent.com/11095558/84170994-47f7a280-aa48-11ea-8611-10538a0161ba.png">


@samvera/hyrax-code-reviewers
