### PR TITLE
deleted proxy is deleted even if page is refreshed.  Fixes issue #3542.

### DIFF
--- a/app/controllers/hyrax/depositors_controller.rb
+++ b/app/controllers/hyrax/depositors_controller.rb
@@ -25,7 +25,7 @@ module Hyrax
       else
         grantor.can_receive_deposits_from << grantee
         send_proxy_depositor_added_messages(grantor, grantee)
-        render json: { name: grantee.name, delete_path: hyrax.user_depositor_path(grantor.user_key, grantee.user_key) }
+        render json: { name: grantee.name, delete_path: sanitize_route_string(hyrax.user_depositor_path(grantor.user_key, grantee.user_key)) }
       end
     end
 
@@ -36,6 +36,13 @@ module Hyrax
     end
 
     private
+
+    # The reason the period has to be converted to -dot- is because in the destroy method
+    # ::User.from_url_component is called, and from_url_componet expects -dot- in place of
+    # a period.  I believe this is done because Rails does not like periods in urls.
+    def sanitize_route_string(route)
+      route.gsub("\.", "-dot-")
+    end
 
     def authorize_and_return_grantor
       grantor = ::User.from_url_component(params[:user_id])

--- a/spec/features/proxy_spec.rb
+++ b/spec/features/proxy_spec.rb
@@ -23,6 +23,36 @@ RSpec.describe 'proxy', type: :feature do
       expect(page).to have_link('Delete Proxy')
     end
 
+    it "delete a proxy, and verify it was deleted" do
+      sign_in user
+      click_link "Your activity"
+      within 'div#proxy_management' do
+        click_link "Manage Proxies"
+      end
+      expect(page).not_to have_css("td.depositor-name")
+
+      # BEGIN create_proxy_using_partial
+      find('a.select2-choice').click
+      find(".select2-input").set(second_user.user_key)
+      expect(page).to have_css("div.select2-result-label")
+      find("div.select2-result-label").click
+      # END create_proxy_using_partial
+
+      expect(page).to have_css('td.depositor-name', text: second_user.user_key)
+      expect(page).to have_link('Delete Proxy')
+
+      click_link('Delete Proxy')
+
+      # Go back to page and verify second_user is not a proxy.
+      sign_in user
+      click_link "Your activity"
+      within 'div#proxy_management' do
+        click_link "Manage Proxies"
+      end
+      expect(page).not_to have_css('td.depositor-name', text: second_user.user_key)
+      expect(page).not_to have_link('Delete Proxy')
+    end
+
     it "try to make yourself a proxy" do
       sign_in user
       click_link "Your activity"


### PR DESCRIPTION
Fixes #3542

On the Manage Proxies page, after adding a proxy the user pops up under "Current Proxies" list with a delete button next to it. If you click on the "Delete Proxy" button the proxy will be removed from the Current Proxies list. But before this change, if you refreshed the page, the proxy was still being shown with the Delete button next to it.  This PR ensures that the proxy is actually deleted even after refreshing the page.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Visit the Manage Proxies page.
* Authorize a user as a proxy
* Delete the user you have just made a proxy using the Delete button next to it
* Refresh the manage proxies page
* Verify the user is not shown under the  Current Proxies list

@samvera/hyrax-code-reviewers
