### PR TITLE
pin EBUCore to avoid changed predicates used by Hyrax

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -70,6 +70,7 @@ SUMMARY
   spec.add_dependency 'qa', '>= 2', '< 4' # questioning_authority
   spec.add_dependency 'rails_autolink', '~> 1.1'
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
+  spec.add_dependency 'rdf-vocab', '< 3.1.5'
   spec.add_dependency 'redis-namespace', '~> 1.5'
   spec.add_dependency 'redlock', '>= 0.1.2'
   spec.add_dependency 'reform', '~> 2.3'


### PR DESCRIPTION
Pin to a version of the vocabulary gem that supports the old EBUCore. A data
migration will be required for any prospective update involving ActiveFedora.

@samvera/hyrax-code-reviewers
