### PR TITLE
Removing Capybara Maleficent

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -84,7 +84,6 @@ SUMMARY
   spec.add_dependency 'valkyrie', '>= 2.1.1', "< 3.0"
 
   spec.add_development_dependency "capybara", '~> 3.29'
-  spec.add_development_dependency 'capybara-maleficent', '~> 0.3.0'
   spec.add_development_dependency 'chromedriver-helper', '~> 2.1'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
   spec.add_development_dependency 'engine_cart', '~> 2.2'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,19 +38,6 @@ require 'equivalent-xml'
 require 'equivalent-xml/rspec_matchers'
 require 'database_cleaner'
 
-unless ENV['SKIP_MALEFICENT']
-  # See https://github.com/jeremyf/capybara-maleficent
-  # Wrap Capybara matchers with sleep intervals to reduce fragility of specs.
-  require 'capybara/maleficent/spindle'
-
-  Capybara::Maleficent.configure do |c|
-    # Quieting down maleficent's logging
-    logger = Logger.new(STDOUT)
-    logger.level = Logger::INFO
-    c.logger = logger
-  end
-end
-
 # rubocop:disable Lint/Void
 # ensure Hyrax::Schema gets loaded is resolvable for `support/` models
 Hyrax::Schema


### PR DESCRIPTION
Jeremy here, I introduced Maleficent at Notre Dame as we observed odd
behavior in an older version of Capybara.  I know for certain that
Maleficent is not keeping up with Capybara releases.

At the time of its creation, there were assertions that Capybara was
waiting for DOM resolution.  However, in our observations this was not
always true.

However, this is a place where we could very easily be experiencing
increased fragility (and a slow down in specs).

I'd like to see if things work without this past hack.

NOTE: Today, I have been walking back gems from recently released
versions.  It's slow going, and my observation is that the feature specs
are the fragile ones.  The inner workings of Capybara may have changed
and thus either: 1) removing the need of Maleficent or 2) breaking
Maleficent.  So let's remove Maleficent and see how things fare.

Fixes #issuenumber ; refs #issuenumber

Present tense short summary (50 characters or less)

More detailed description, if necessary. Try to be as descriptive as you can: even if you think that the PR content is obvious, it may not be obvious to others. Include tracebacks if helpful, and be sure to call out any bits of the PR that may be work-in-progress.

Description can have multiple paragraphs and you can use code examples inside:

``` ruby
class PostsController
  def index
    respond_with Post.limit(10)
  end
end
```

Changes proposed in this pull request:
*
*
*

Guidance for testing, such as acceptance criteria or new user interface behaviors:
*
*
*

@samvera/hyrax-code-reviewers
