### PR TITLE
extract hard view dependency on `Hyrax::ContactForm` to a helper

### DIFF
--- a/app/helpers/hyrax/contact_form_helper.rb
+++ b/app/helpers/hyrax/contact_form_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Helpers for displaying Hyrax's default contact form.
+  module ContactFormHelper
+    ##
+    # @api public
+    #
+    # Provides the "issue type" options for the contact form dropdown. The
+    # response should be compatible with ActionView's `options_for_select`
+    # helper.
+    #
+    # @note this helper should always provide i18nized values.
+    #
+    # @return [Array<String>]
+    #
+    # @see https://apidock.com/rails/ActionView/Helpers/FormOptionsHelper/options_for_select
+    def contact_form_issue_type_options
+      types = Hyrax::ContactForm.issue_types_for_locale.dup
+      types.unshift([t('hyrax.contact_form.select_type'), nil])
+    end
+  end
+end

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -3,6 +3,7 @@ module Hyrax
   module HyraxHelperBehavior
     include Hyrax::CitationsBehavior
     include ERB::Util # provides html_escape
+    include Hyrax::ContactFormHelper
     include Hyrax::TitleHelper
     include Hyrax::FileSetHelper
     include Hyrax::AbilityHelper

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -19,10 +19,8 @@
   <%= f.text_field :contact_method, class: 'hide' %>
   <div class="form-group">
     <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
-    <% issue_types = Hyrax::ContactForm.issue_types_for_locale.dup %>
-    <% issue_types.unshift([t('hyrax.contact_form.select_type'), nil]) %>
     <div class="col-sm-10">
-      <%= f.select 'category', options_for_select(issue_types), {}, {class: 'form-control', required: true } %>
+      <%= f.select 'category', options_for_select(contact_form_issue_type_options), {}, {class: 'form-control', required: true } %>
     </div>
   </div>
 

--- a/spec/helpers/hyrax/contact_form_helper_spec.rb
+++ b/spec/helpers/hyrax/contact_form_helper_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::ContactFormHelper, type: :helper do
+  describe '#contact_form_issue_type_options' do
+    it 'has a nil (label) option first' do
+      expect(helper.contact_form_issue_type_options.first).to match([an_instance_of(String), nil])
+    end
+
+    it 'has string options' do
+      expect(helper.contact_form_issue_type_options[1..-1]).to all(be_an_instance_of(String))
+    end
+  end
+end


### PR DESCRIPTION
this insulates the view contact form view from the model, with the idea of
deprecating `ContactForm`'s class method entirely, in favor of some
configuration elsewhere.

@samvera/hyrax-code-reviewers
