### PR TITLE
create a better label for proxy deposits.

### DIFF
--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -23,7 +23,7 @@
     </div>
     <% if Flipflop.proxy_deposit? && current_user.can_make_deposits_for.any? %>
         <div class="list-group-item">
-          <%= f.input :on_behalf_of, collection: current_user.can_make_deposits_for, prompt: t(".yourself"), value_method: :user_key %>
+          <%= f.input :on_behalf_of, label: t(".proxy_depositors"), collection: current_user.can_make_deposits_for, prompt: t(".yourself"), value_method: :user_key %>
         </div>
     <% end %>
   </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -423,6 +423,7 @@ en:
         legend_html: Visibility <small>Who should be able to view or download this content?</small>
         management_page: Lease Management Page
       form_progress:
+        proxy_depositors: Proxy Depositors - Select the user on whose behalf you are depositing
         required_agreement: Check deposit agreement
         required_descriptions: Describe your work
         required_files: Add files

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
 
       choose('batch_upload_item_visibility_open')
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
-      select(second_user.user_key, from: 'On behalf of')
+      select(second_user.user_key, from: 'Proxy Depositors - Select the user on whose behalf you are depositing')
       check('agreement')
       click_on('Save')
 

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
       find('body').click
       choose('generic_work_visibility_open')
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
-      select(second_user.user_key, from: 'On behalf of')
+      select(second_user.user_key, from: 'Proxy Depositors - Select the user on whose behalf you are depositing')
       check('agreement')
       # These lines are for debugging, should this test fail
       # puts "Required metadata: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').requiredFields.areComplete})}"

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
       end
 
       it "shows options for proxy" do
-        expect(page).to have_content 'On behalf of'
+        expect(page).to have_content 'Proxy Depositors - Select the user on whose behalf you are depositing'
         expect(page).to have_selector("select#generic_work_on_behalf_of option[value=\"\"]", text: 'Yourself')
         expect(page).to have_selector("select#generic_work_on_behalf_of option[value=\"bob@example.com\"]")
       end
@@ -43,7 +43,7 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
         end
 
         it "does not show options for proxy" do
-          expect(page).not_to have_content 'On behalf of'
+          expect(page).not_to have_content 'Proxy Depositors - Select the user on whose behalf you are depositing'
           expect(page).not_to have_selector("select#generic_work_on_behalf_of option[value=\"\"]", text: 'Yourself')
           expect(page).not_to have_selector("select#generic_work_on_behalf_of option[value=\"bob@example.com\"]")
         end
@@ -57,7 +57,7 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
         allow(user).to receive(:can_make_deposits_for).and_return(proxies)
       end
       it "doesn't show options for proxy" do
-        expect(page).not_to have_content 'On behalf of'
+        expect(page).not_to have_content 'Proxy Depositors - Select the user on whose behalf you are depositing'
         expect(page).not_to have_selector 'select#generic_work_on_behalf_of'
       end
     end


### PR DESCRIPTION
Fixes #1630

When depositing a work as a proxy depositor, the label presented to the user simply says "On behalf of".  This is not user friendly, so a better label was suggested in the issue.  With this PR, the label becomes "Proxy Depositors - Select the user on whose behalf you are depositing"

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a proxy depositor for yourself.
* Login as the proxy depositor.
* Go to create a new work.
* Verify that in the portion of the form where you indicate who you are depositing this work for, you see the label: "Proxy Depositors - Select the user on whose behalf you are depositing"

@samvera/hyrax-code-reviewers
