### PR TITLE
Force linkeddata 3.x for compatibility with rdf 3.x

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -58,7 +58,7 @@ SUMMARY
   # Pin more tightly because 0.x gems are potentially unstable
   spec.add_dependency 'kaminari_route_prefix', '~> 0.1.1'
   spec.add_dependency 'legato', '~> 0.3'
-  spec.add_dependency 'linkeddata' # Required for getting values from geonames
+  spec.add_dependency 'linkeddata', '~> 3.1' # Required for getting values from geonames
   spec.add_dependency 'mailboxer', '~> 0.12'
   spec.add_dependency 'nest', '~> 3.1'
   spec.add_dependency 'noid-rails', '~> 3.0.0'


### PR DESCRIPTION
I ran into this issue when testing for #4379.  ebnf 2.0 was released on Friday and was getting pulled in and the only version of linkeddata which resolves then is 1.1.1 which has compatibility issues with rdf 3.x.  If ebnf is backed down to 1.x then I believe the correct version of linkeddata will be used but I think specifying the version of linkeddata better describes the true dependency requirement.

@samvera/hyrax-code-reviewers