### PR TITLE
Refactoring module to reduce redundant calls

### DIFF
--- a/app/search_builders/hyrax/filter_suppressed_with_roles.rb
+++ b/app/search_builders/hyrax/filter_suppressed_with_roles.rb
@@ -10,28 +10,34 @@ module Hyrax
     extend ActiveSupport::Concern
     include FilterSuppressed
 
-    # Skip the filter if the current user is permitted to take
-    # workflow actions on the work corresponding to the SolrDocument
-    # with id = `blacklight_params[:id]`
+    # Skip the filter if the current user is:
+    #
+    # *  permitted to take workflow actions on the work
+    # *  the depositor
+    #
+    # corresponding to the SolrDocument with id = `blacklight_params[:id]`
+    #
+    # @note This is another case in which the Sipity workflows and the
+    #       SOLR permissions are not adequately synchronized.  Sipity COULD
+    #       be used to include that information, however that is not
+    #       presently scoped work.
     def only_active_works(solr_parameters)
-      return if user_has_active_workflow_role? || depositor?
+      current_work = ::SolrDocument.find(blacklight_params[:id])
+      return if user_has_active_workflow_role?(current_work: current_work)
+      return if depositor?(current_work: current_work)
       super
     end
 
     private
 
-    def current_work
-      ::SolrDocument.find(blacklight_params[:id])
-    end
-
-    def user_has_active_workflow_role?
+    def user_has_active_workflow_role?(current_work:)
       Hyrax::Workflow::PermissionQuery.scope_permitted_workflow_actions_available_for_current_state(user: current_ability.current_user, entity: current_work).any?
     rescue PowerConverter::ConversionError
       # The current_work doesn't have a sipity workflow entity
       false
     end
 
-    def depositor?
+    def depositor?(current_work:)
       depositors = current_work[DepositSearchBuilder.depositor_field]
 
       return false if depositors.nil?


### PR DESCRIPTION
Because we were not memoizing the `current_work` method call, we could
be issuing two SOLR queries that are identical.  This small refactor now
moves the `::SolrDocument.find` call to a local variable which we pass
to the two methods.

I've also opted to break the guard clauses into separate steps.  I
believe this reads more clearly.

And I updated the documentation and added some points about Sipity and
SOLR integration.

@samvera/hyrax-code-reviewers
