### PR TITLE
correct accessibility audit from embargo page.  Fixes issue #4003

### DIFF
--- a/app/views/hyrax/dashboard/_sidebar.html.erb
+++ b/app/views/hyrax/dashboard/_sidebar.html.erb
@@ -1,6 +1,6 @@
 <% menu = Hyrax::MenuPresenter.new(self) %>
 <div class="sidebar-toggle"><span class="fa fa-chevron-circle-right"></span></div>
-<nav>
+<nav aria-label="sidebar-nav">
   <ul class="nav nav-pills nav-stacked">
     <li>
       <div class="profile">


### PR DESCRIPTION
Fixes #4003 Fixes #3990

This pull request is to address the accessibility errors reported when on the Manage Embargo Page and Transfer Page.  When I ran axe on this page I only found one of the two errors reported by Axe.  I am assuming that since the time this issue was written till now the other issue was resolved.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Make sure you have a work in the system that is under embargo.
* Install the Axe plugin or addon from Deque (https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/ is the firefox version).
* Open manage embargo page for a work with an embargo. Need to be in edit mode.
* You then need to run Axe.
* In Chrome, you open the Developer Tools and find the Axe function, then run Analyze. You should see no problems detected. 
* If you have Safari. Open the inspector (right-click, and select "Inspect element").  Click 'Axe' tab, and click 'Analyze'.  You should see no problems detected.

To test the issue mentioned in issue #3390
* Open manage Transfer of Ownership page. 
* You then need to run Axe.
* You should see no errors reported.

@samvera/hyrax-code-reviewers
