### PR TITLE
Removing magic numbers

### DIFF
--- a/spec/controllers/hyrax/content_blocks_controller_spec.rb
+++ b/spec/controllers/hyrax/content_blocks_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::ContentBlocksController, type: :controller do
 
     describe "PATCH #update" do
       it "denies the request" do
-        patch :update, params: { id: 1 }
+        patch :update, params: { id: ContentBlock.first.to_param }
         expect(response).to have_http_status(401)
       end
     end

--- a/spec/controllers/hyrax/pages_controller_spec.rb
+++ b/spec/controllers/hyrax/pages_controller_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe Hyrax::PagesController, type: :controller do
     context 'with an unprivileged user' do
       describe "GET #edit" do
         it "denies the request" do
-          get :edit
+          get :edit, params: { id: ContentBlock.first.id }
           expect(response).to have_http_status(401)
         end
       end
 
       describe "PATCH #update" do
         it "denies the request" do
-          patch :update, params: { id: 1 }
+          patch :update, params: { id: ContentBlock.first.id }
           expect(response).to have_http_status(401)
         end
       end

--- a/spec/jobs/batch_create_job_spec.rb
+++ b/spec/jobs/batch_create_job_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe BatchCreateJob do
                                                               keyword: [],
                                                               title: ['File One'],
                                                               resource_type: ["Article"],
-                                                              uploaded_files: ['1']
+                                                              uploaded_files: [upload1.id.to_s]
                                                             },
                                                             child_operation).and_return(true)
       expect(CreateWorkJob).to receive(:perform_later).with(user,
@@ -44,7 +44,7 @@ RSpec.describe BatchCreateJob do
                                                               keyword: [],
                                                               title: ['File Two'],
                                                               resource_type: ["Image"],
-                                                              uploaded_files: ['2']
+                                                              uploaded_files: [upload2.id.to_s]
                                                             },
                                                             child_operation).and_return(true)
       subject
@@ -60,7 +60,7 @@ RSpec.describe BatchCreateJob do
                                                                 keyword: [],
                                                                 title: ['File One'],
                                                                 resource_type: ["Article", 'Text'],
-                                                                uploaded_files: ['1']
+                                                                uploaded_files: [upload1.id.to_s]
                                                               },
                                                               child_operation).and_return(true)
         expect(CreateWorkJob).to receive(:perform_later).with(user,
@@ -69,7 +69,7 @@ RSpec.describe BatchCreateJob do
                                                                 keyword: [],
                                                                 title: ['File Two'],
                                                                 resource_type: ["Image", 'Text'],
-                                                                uploaded_files: ['2']
+                                                                uploaded_files: [upload2.id.to_s]
                                                               },
                                                               child_operation).and_return(true)
         subject


### PR DESCRIPTION
Prior to this commit, there was a presumption about the order in which
things ran AND the state of the auto-incrementer for the database.

This works, however, when you move to a different
database (e.g. Postgresql), this behavior won't work (unless you do some
really expensive work between each test).

Instead of relying on magic numbers, provide the number based on the
object.

@samvera/hyrax-code-reviewers
