### PR TITLE
Adding .inspect to anonymous WorkSearchBuilder

### DIFF
--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -66,15 +66,15 @@ module Wings
   #   builder = Wings::WorkSearchBuilder(Monograph)
   def self.WorkSearchBuilder(work_type) # rubocop:disable Naming/MethodName
     Class.new(Hyrax::WorkSearchBuilder) do
-      @@_given_work_type = work_type # rubocop:disable Style/ClassVars
-      @@_legacy_type = Wings::ModelRegistry.lookup(work_type) # rubocop:disable Style/ClassVars
+      class_attribute :legacy_work_type, instance_writer: false
+      self.legacy_work_type = Wings::ModelRegistry.lookup(work_type)
 
       def work_types
-        [@@_legacy_type]
+        [legacy_work_type]
       end
 
       def self.inspect
-        "Wings::WorkSearchBuilder(#{@@_given_work_type} -> #{@@_legacy_type})"
+        "Wings::WorkSearchBuilder(#{legacy_work_type})"
       end
     end
   end

--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -66,10 +66,15 @@ module Wings
   #   builder = Wings::WorkSearchBuilder(Monograph)
   def self.WorkSearchBuilder(work_type) # rubocop:disable Naming/MethodName
     Class.new(Hyrax::WorkSearchBuilder) do
+      @@_given_work_type = work_type # rubocop:disable Style/ClassVars
       @@_legacy_type = Wings::ModelRegistry.lookup(work_type) # rubocop:disable Style/ClassVars
 
       def work_types
         [@@_legacy_type]
+      end
+
+      def self.inspect
+        "Wings::WorkSearchBuilder(#{@@_given_work_type} -> #{@@_legacy_type})"
       end
     end
   end

--- a/spec/wings_spec.rb
+++ b/spec/wings_spec.rb
@@ -3,6 +3,15 @@ require 'spec_helper'
 require 'wings'
 
 RSpec.describe Wings do
+  describe 'WorkSearchBuilder' do
+    it "does not pollute the class variables after separate calls" do
+      generic_work_search_builder = described_class::WorkSearchBuilder(Hyrax::Test::SimpleWork)
+      monograph_search_builder = described_class::WorkSearchBuilder(Monograph)
+      expect(monograph_search_builder).not_to eq(generic_work_search_builder)
+      expect(monograph_search_builder.legacy_work_type).not_to eq(generic_work_search_builder.legacy_work_type)
+    end
+  end
+
   it 'adds mixin to AF::Base' do
     expect(GenericWork.new).to respond_to :valkyrie_resource
   end


### PR DESCRIPTION
## Adding .inspect to anonymous WorkSearchBuilder

7ae3bf0c675150bab3da206acf0d9b62fe90ac5c

Prior to this commit, when working with the anonymous search builder, it
was difficult to see exactly how the search builder ended up configured.

This change now provides insight both to the original work type and the
legacy work type.  This should help in debugging.

In particular, I've found it useful in debugging the mixin module:
`app/controllers/concerns/hyrax/works_controller_behavior.rb`

Tested-by: Jeremy Friesen <jeremy.n.friesen@gmail.com>

## Isolating variables for WorkSearchBuilder

3575b267572a2ef80ae5ffce1c1e5bd5b73d65e4

Prior to this commit, the module variables set in the anonymous class
were shared across classes built via `Wings.WorkSearchBuilder`.

I believe this may be a key contributor to erratic spec failure.

I observed this when I was running specs and saw that the resulting
search builder would query for work_types of "Wings(Monograph)" but the
indexed object had a model of "Hyrax::Test::SimpleWorkLegacy".  The
"Wings(Monograph)" and "Hyrax::Test::SimpleWorkLegacy" are not expected
to map to each other in the `Wings::ModelRegistry.lookup`.

If I ran the specs in isolation, they would always pass.  However, if I
ran the suite, I would often see failures for the specs that passed in
isolation.

`rspec
./spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb`

By switching to [.class_attribute][1], the variables are inheritable and
changes in subclasses don't impact changes upstream.

[1]:https://api.rubyonrails.org/classes/Class.html#method-i-class_attribute

Here's hoping!
