### PR TITLE
prepopulate forms before rendering

### DIFF
--- a/app/services/hyrax/form_factory.rb
+++ b/app/services/hyrax/form_factory.rb
@@ -15,11 +15,15 @@ module Hyrax
   # @since 3.0.0
   class FormFactory
     ##
+    # Builds and prepopulates a form for the given model.
+    #
     # @param model      [Object]
     # @param ability    [Hyrax::Ability]
     # @param controller [ApplicationController]
+    #
+    # @see https://trailblazer.to/2.0/gems/reform/prepopulator.html
     def build(model, _ability, _controller)
-      Hyrax::Forms::ResourceForm.for(model)
+      Hyrax::Forms::ResourceForm.for(model).prepopulate!
     end
   end
 end

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -124,6 +124,13 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
         expect(controller).to render_template('hyrax/base/edit')
       end
+
+      it 'prepopulates the form' do
+        get :edit, params: { id: work.id }
+
+        expect(assigns[:form])
+          .to have_attributes(title: work.title.first, version: an_instance_of(String))
+      end
     end
   end
 

--- a/spec/services/hyrax/form_factory_spec.rb
+++ b/spec/services/hyrax/form_factory_spec.rb
@@ -11,5 +11,14 @@ RSpec.describe Hyrax::FormFactory do
     it 'returns a change set' do
       expect(factory.build(model, ability, controller)).to be_a Hyrax::ChangeSet
     end
+
+    context 'when the work is persisted' do
+      let(:model) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+      it 'prepopulates the changeset with a lock token' do
+        expect(factory.build(model, ability, controller))
+          .to have_attributes(version: an_instance_of(String))
+      end
+    end
   end
 end


### PR DESCRIPTION
reform supports a `#prepopulate!` method for configurable defaults within the
form object. our base form objects use this to provide a `#version` (optimistic
lock) token, as well as permissions and embargo/lease data (which don't travel
with the object). ensuring we call it before displaying the form ensures these
fields are populated as expected. it also makes it possible for adopters to
extend with their own preopulator logic, supporting a wide range of
default-value behavior for forms.

@samvera/hyrax-code-reviewers
