### PR TITLE
Refining behavior of UsersController#base_query

### DIFF
--- a/spec/controllers/hyrax/users_controller_spec.rb
+++ b/spec/controllers/hyrax/users_controller_spec.rb
@@ -93,6 +93,15 @@ RSpec.describe Hyrax::UsersController, type: :controller do
         expect(assigns[:users]).not_to include(u1, u2)
         u3.destroy
       end
+
+      it "uses the base query with hash as where clause" do
+        u3 = create(:user)
+        allow(controller).to receive(:base_query).and_return({ Hydra.config.user_key_field => u3.email })
+        get :index
+        expect(assigns[:users]).to include(u3)
+        expect(assigns[:users]).not_to include(u1, u2)
+        u3.destroy
+      end
     end
   end
 


### PR DESCRIPTION
This commit clarifies the behavior, the public @api nature of the
method, and adds another test case around hash based parameters.

As I was exploring Postgresql, I believe the `[nil]` as a query
parameter may have caused an issue.

This change should preserve the previous "public" implementation.

@samvera/hyrax-code-reviewers
