### PR TITLE
Restoring a check for permissions on JSON document

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -68,6 +68,7 @@ module Hyrax
 
     # Finds a solr document matching the id and sets @presenter
     # @raise CanCan::AccessDenied if the document is not found or the user doesn't have access to it.
+    # rubocop:disable Metrics/AbcSize
     def show
       @user_collections = user_collections
 
@@ -76,6 +77,7 @@ module Hyrax
         wants.json do
           # load @curation_concern manually because it's skipped for html
           @curation_concern = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id])
+          curation_concern # This is here for authorization checks (we could add authorize! but let's use the same method for CanCanCan)
           render :show, status: :ok
         end
         additional_response_formats(wants)
@@ -84,6 +86,7 @@ module Hyrax
         wants.nt { render body: presenter.export_as_nt, mime_type: Mime[:nt] }
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def edit
       build_form


### PR DESCRIPTION
I'm not certain why this started appearing now, but it has.  The problem
is seen in builds of @f90d703dcd8c65fa0e0d0be0e0fa65b378c76cc8.  When
you run specs against that SHA, we get the following errors:

```shell
rspec ./spec/controllers/hyrax/generic_works_controller_json_spec.rb:24
rspec ./spec/controllers/hyrax/generic_works_controller_json_spec.rb:32
````

The following commit (@696dee503e987ebed726b6e76e6925425f8c892f) removed
the call for `curation_conern`; This left the JSON requests
unauthorized.

Devise did release a new gem on 2020-06-10, so it could be related to
that.

@samvera/hyrax-code-reviewers
