### PR TITLE
fix comments to be more accurate; fix test for child_collections_navigator_ids

### DIFF
--- a/app/services/hyrax/custom_queries/navigators/child_collections_navigator.rb
+++ b/app/services/hyrax/custom_queries/navigators/child_collections_navigator.rb
@@ -23,7 +23,7 @@ module Hyrax
             .find_inverse_references_by(resource: resource, property: :member_of_collection_ids)
         end
 
-        # Find the ids of child collections of a given resource, and map to Valkyrie Resources
+        # Find the ids of child collections of a given resource, and map to Valkyrie Resources IDs
         # @param [Valkyrie::Resource]
         # @return [Array<Valkyrie::ID>]
         def find_child_collection_ids(resource:)

--- a/app/services/hyrax/custom_queries/navigators/child_filesets_navigator.rb
+++ b/app/services/hyrax/custom_queries/navigators/child_filesets_navigator.rb
@@ -22,7 +22,7 @@ module Hyrax
           query_service.find_members(resource: resource).select(&:file_set?)
         end
 
-        # Find the ids of child filesets of a given resource, and map to Valkyrie Resources
+        # Find the ids of child filesets of a given resource, and map to Valkyrie Resources IDs
         # @param [Valkyrie::Resource]
         # @return [Array<Valkyrie::ID>]
         def find_child_fileset_ids(resource:)

--- a/app/services/hyrax/custom_queries/navigators/child_works_navigator.rb
+++ b/app/services/hyrax/custom_queries/navigators/child_works_navigator.rb
@@ -25,7 +25,7 @@ module Hyrax
         end
 
         ##
-        # Find the ids of child works of a given resource, and map to Valkyrie Resources
+        # Find the ids of child works of a given resource, and map to Valkyrie Resources IDs
         #
         # @param [Valkyrie::Resource]
         # @return [Array<Valkyrie::ID>]

--- a/spec/services/hyrax/custom_queries/navigators/child_collections_navigator_spec.rb
+++ b/spec/services/hyrax/custom_queries/navigators/child_collections_navigator_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator, :cle
     end
 
     it 'returns Valkyrie ids for child collections only' do
-      child_collections = custom_query_service.find_child_collections(resource: collection1_resource)
-      expect(child_collections.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([collection2.id, collection3.id])
+      child_collection_ids = custom_query_service.find_child_collection_ids(resource: collection1_resource)
+      expect(child_collection_ids).to match_valkyrie_ids_with_active_fedora_ids([collection2.id, collection3.id])
     end
   end
 end


### PR DESCRIPTION
Several comments for *_ids tests for navigator custom queries did not include IDs in the comment.  This was added for greater clarity.

Also, child_collections_navigator_ids test was calling child_collections_navigator.  This is fixed.

@samvera/hyrax-code-reviewers
