### PR TITLE
have sidebar menu behave consistently when switching options.  Fixes #1495

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -104,6 +104,7 @@
 //= require hyrax/tabbed_form
 //= require hyrax/turbolinks_events
 //= require hyrax/i18n_helper
+//= require hyrax/collapse
 
 // this needs to be after batch_select so that the form ids get setup correctly
 //= require hyrax/batch_edit

--- a/app/assets/javascripts/hyrax/collapse.js
+++ b/app/assets/javascripts/hyrax/collapse.js
@@ -1,0 +1,91 @@
+Blacklight.onLoad(function() {
+    const isCollapsed = getCollapsedActivity();
+    if(isCollapsed){
+        localStorage.setItem('collapsedActivity', 'collapsed');
+    }else{
+        localStorage.setItem('collapsedActivity', 'un-collapsed');
+    }
+    getStatusActivity();
+
+    const isCollapsedSettings = getCollapsedSettings();
+    if(isCollapsedSettings){
+        localStorage.setItem('collapsedSettings', 'collapsed');
+    }else{
+        localStorage.setItem('collapsedSettings', 'un-collapsed');
+    }
+    getStatusSettings();
+});
+
+function getCollapsedActivity() {
+    const state = localStorage.getItem('collapsedActivity');
+    if(state === 'un-collapsed'){
+        return false;
+    }
+    return true;
+}
+
+function getCollapsedSettings() {
+    const state = localStorage.getItem('collapsedSettings');
+    if(state === 'un-collapsed'){
+        return false;
+    }
+    return true;
+}
+
+function getStatusActivity(){
+    const resultDiv = document.getElementById('collapseUserActivity');
+    const isCollapsed = getCollapsedActivity();
+    if (resultDiv === null) {
+        return;
+    }
+    else if(isCollapsed){
+        resultDiv.classList.remove("in");
+        resultDiv.setAttribute("aria-expanded", "false");
+    }else{
+        resultDiv.classList.add("in");
+        resultDiv.setAttribute("aria-expanded", "true");
+    }
+}
+
+function getStatusSettings(){
+    const resultDiv = document.getElementById('collapseSettings');
+    const isCollapsed = getCollapsedSettings();
+    if (resultDiv === null) {
+        return;
+    }
+    else if(isCollapsed){
+        resultDiv.classList.remove("in");
+        resultDiv.setAttribute("aria-expanded", "false");
+    }else{
+        resultDiv.classList.add("in");
+        resultDiv.setAttribute("aria-expanded", "true");
+    }
+}
+
+function toggleCollapse(input){
+    var type = input.href;
+    var start = type.indexOf("#");
+    type = type.substring(start + 1);
+
+    if (type === "collapseUserActivity"){
+        const isCollapsedActivity = getCollapsedActivity();
+        if(isCollapsedActivity){
+            localStorage.setItem('collapsedActivity', 'un-collapsed');
+        }else{
+            localStorage.setItem('collapsedActivity', 'collapsed');
+        }
+    }
+
+    if (type === "collapseSettings"){
+        const isCollapsedSettings = getCollapsedSettings();
+        if(isCollapsedSettings){
+            localStorage.setItem('collapsedSettings', 'un-collapsed');
+        }else{
+            localStorage.setItem('collapsedSettings', 'collapsed');
+        }
+    }
+}
+
+function dontChangeAccordion(e) {
+    e.stopPropagation();
+}

--- a/app/presenters/hyrax/collapsable_section_presenter.rb
+++ b/app/presenters/hyrax/collapsable_section_presenter.rb
@@ -24,6 +24,7 @@ module Hyrax
             class: "#{button_class}collapse-toggle",
             data: { toggle: 'collapse' },
             href: "##{id}",
+            onclick: "toggleCollapse(this)",
             'aria-expanded' => open,
             'aria-controls' => id) do
         safe_join([tag.span('', class: icon_class, 'aria-hidden': true),

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -1,11 +1,13 @@
   <li class="h5"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
 
   <%= menu.nav_link(hyrax.my_collections_path,
+                    onclick: "dontChangeAccordion(event);",
                     also_active_for: hyrax.dashboard_collections_path) do %>
     <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
   <% end %>
 
   <%= menu.nav_link(hyrax.my_works_path,
+                    onclick: "dontChangeAccordion(event);",
                     also_active_for: hyrax.dashboard_works_path) do %>
     <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
   <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -1,22 +1,26 @@
   <% if can? :review, :submissions %>
     <li class="h5"><%= t('hyrax.admin.sidebar.tasks') %></li>
-    <%= menu.nav_link(hyrax.admin_workflows_path) do %>
+    <%= menu.nav_link(hyrax.admin_workflows_path,
+                      onclick: "dontChangeAccordion(event);") do %>
       <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_review') %></span>
     <% end %>
   <% end %>
 
   <% if can? :manage, User %>
-    <%= menu.nav_link(hyrax.admin_users_path) do %>
+    <%= menu.nav_link(hyrax.admin_users_path,
+                      onclick: "dontChangeAccordion(event);") do %>
       <span class="fa fa-user" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
     <% end %>
   <% end %>
 
   <% if can? :read, :admin_dashboard %>
-    <%= menu.nav_link(hyrax.embargoes_path) do %>
+    <%= menu.nav_link(hyrax.embargoes_path,
+                      onclick: "dontChangeAccordion(event);") do %>
       <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.embargoes.index.manage_embargoes') %></span>
     <% end %>
 
-    <%= menu.nav_link(hyrax.leases_path) do %>
+    <%= menu.nav_link(hyrax.leases_path,
+                      onclick: "dontChangeAccordion(event);") do %>
       <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.leases.index.manage_leases') %></span>
     <% end %>
   <% end %>

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -100,13 +100,18 @@ RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
       expect(page).to have_content "My Test Work"
 
       # check that user can get to the files
-      click_link "My Test Work"
+      within('.media-heading') do
+        click_link "My Test Work"
+      end
       click_link "image.jp2"
       expect(page).to have_content "image.jp2"
 
       visit '/dashboard'
       click_link 'Works'
-      click_link "My Test Work"
+
+      within('.media-heading') do
+        click_link "My Test Work"
+      end
       click_link "jp2_fits.xml"
       expect(page).to have_content "jp2_fits.xml"
     end


### PR DESCRIPTION
Fixes issue #1495

Presently when the user goes to the dashboard and opens up one or two of the accordion options ( User Activity, or Settings ), and then selects a link, like say Collections, the accordions close.  With this change the accordions stay in the position the user has them in as the user switches from one option to another.

I want to point out that in the code I added a javascript called `dontChangeAccordion` that gets called by the non accordion options.  This was needed because clicking on these non accordion options was causing the accordions to switch to the state in which they were in when the page was originally rendered before taking on the expected state.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to the dashboard
* Open  the UserActivity Accordion to open it.
* Clink on the Collections option.
* Note that the accordion remains open
* Close the UserActivity Accordion.
* Go to the Works option
* Notice that the accordion remains closed.
* Do the same thing with the Settings accordion
* There are lots of tests combinations to try out. The main thing is that the accordion(s) remain in the state they were in when the user switches options.


@samvera/hyrax-code-reviewers
