### PR TITLE
Adjusting specs to be less brittle

### DIFF
--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -259,8 +259,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       it "has properly formed collection type buttons" do
-        expect(page).not_to have_selector("input[data-path$='collections/new&collection_type_id=1']")
-        expect(page).to have_selector("input[data-path$='collections/new?locale=en&collection_type_id=1']")
+        expect(page).not_to have_selector("input[data-path$='collections/new&collection_type_id=#{collection_type.id}']")
+        expect(page).to have_selector("input[data-path$='collections/new?locale=en&collection_type_id=#{collection_type.id}']")
       end
     end
 

--- a/spec/services/hyrax/workflow/permission_query_spec.rb
+++ b/spec/services/hyrax/workflow/permission_query_spec.rb
@@ -33,7 +33,7 @@ module Hyrax
 
       def expect_agents_for(agents:, entity:, role:)
         agents = Array.wrap(agents).map { |agent| Sipity::Agent(agent) }
-        expect(described_class.scope_agents_associated_with_entity_and_role(role: role, entity: entity)).to eq(agents)
+        expect(described_class.scope_agents_associated_with_entity_and_role(role: role, entity: entity)).to contain_exactly(*agents)
       end
 
       def expect_roles_for(entity:, roles:)


### PR DESCRIPTION
Prior to this commit, there is an assumption that the database
auto-incrementer was always reset to 1 between tests.  This is true with
Sqlite, but not true with other databases.  So, instead of using a magic
number, I'm opting to use the ID of the object that was created for the
spec.

In the case of `eq(agents)` and `contain_exactly(*agents)`, this is a
similar-ish concern.  When using `eq` the order of elements matter.  And
the order of those elements can vary from DB adapter.  Instead, rely on
the more flexibily `contain_exactly`.

@samvera/hyrax-code-reviewers
