### PR TITLE
Adjusting UsersController#search for agnosticism

### DIFF
--- a/app/controllers/hyrax/users_controller.rb
+++ b/app/controllers/hyrax/users_controller.rb
@@ -21,13 +21,20 @@ module Hyrax
     private
 
     # TODO: this should move to a service.
+    #
+    # @todo Given that this method sends its methods to ::User, I
+    # believe it could be extracted to User; I don't think the
+    # base_query can be as it may require controller level context
+    #
     # Returns a list of users excluding the system users and guest_users
     # @param query [String] the query string
     def search(query)
-      clause = query.blank? ? nil : "%" + query.downcase + "%"
       base = ::User
+      clause = query.blank? ? nil : "%#{base.sanitize_sql_like(query.downcase)}%"
       base = base.where(*Array.wrap(base_query))
-      base = base.where("#{Hydra.config.user_key_field} like lower(?) OR display_name like lower(?)", clause, clause) if clause.present?
+      # This may have some DB adapter specific behavior, which is
+      # definitely logic I'd like to keep out of a controller.
+      base = base.where("LOWER(#{base.user_key_field}) LIKE :clause OR LOWER(display_name) LIKE :clause", clause: clause) if clause.present?
       base.registered
           .without_system_accounts
           .references(:trophies)


### PR DESCRIPTION
Prior to this commit, I believe the syntax was less generalize.  In
particular, the "field like lower(value)" was suspect. Namely, we were
already downcasing the query, but we weren't telling the field to be
treated as lower case.

I believe in SQLite and Mysql, LIKE clauses are already assumed to be
case agnostic.  That is, I think, not the case in Postgresql.  In other
words, Postgresql needs to be told whether or not to treat the field as
lower (or upper) case.

With this change, I'm also introducing sanitization of possible "like"
characters as part of the query.

And, I also note that this method has feature envy; That is to say the
method sends lots of messages to `::User`, strongly implying that this
method belongs in `::User`

@samvera/hyrax-code-reviewers
