### PR TITLE
Removing spec as its a unique db-adapter query

### DIFF
--- a/spec/controllers/hyrax/users_controller_spec.rb
+++ b/spec/controllers/hyrax/users_controller_spec.rb
@@ -85,15 +85,6 @@ RSpec.describe Hyrax::UsersController, type: :controller do
         end
       end
 
-      it "uses the base query" do
-        u3 = create(:user)
-        allow(controller).to receive(:base_query).and_return(["email == \"#{u3.email}\""])
-        get :index
-        expect(assigns[:users]).to include(u3)
-        expect(assigns[:users]).not_to include(u1, u2)
-        u3.destroy
-      end
-
       it "uses the base query with hash as where clause" do
         u3 = create(:user)
         allow(controller).to receive(:base_query).and_return({ Hydra.config.user_key_field => u3.email })


### PR DESCRIPTION
Postgresql treats the following as though `"my@email.com"` is a column
name (`email == "my@email.com"`).

There exists a spec that tests the `base_query` using Hash
syntax (e.g. `{ email: "my@email.com"}`).  In using Hash syntax, we lean
on AREL translating that Hash into the adapter specific behavior.

@samvera/hyrax-code-reviewers
