### PR TITLE
Fixing parameter order for `have_content`

### DIFF
--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -370,7 +370,8 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
         find(:xpath, "//tr[td[contains(.,'#{not_empty_collection_type.title}')]]/td/button", text: 'Delete').click
 
         within('div#deleteDenyModal') do
-          expect(page).to have_content(deny_delete_modal_text, :all)
+          # Check both hidden and visible HTML attributes
+          expect(page).to have_content(:all, deny_delete_modal_text)
           click_link('View collections of this type')
         end
         sleep 3


### PR DESCRIPTION
The following are [specs copied from Capybara 3.33.0][1]

```ruby
it 'can check for all text' do
  expect(session).to have_text(:all, 'Some of this text is hidden!')
end

it 'can check for visible text' do
  expect(session).to have_text(:visible, 'Some of this text is')
  expect(session).not_to have_text(:visible, 'Some of this text is hidden!')
end
```

This change complies with the parameter order identified in Capybara.
Note "have_content" is an alias for "have_text" ([see code][2])

Background:

I noticed that there was an [odd error in our CircleCI build][3]; This
was both unchanged and not something we specifically looked at.  Based
on cursory exploration, this appears to have been the method format
since at least 2.3.0.  Why it's failing now?  No clue.  But hopefully
this fixes that particular failure.

[1]:https://github.com/teamcapybara/capybara/blob/3.33.0/spec/rspec/shared_spec_matchers.rb#L459-L466
[2]:https://github.com/teamcapybara/capybara/blob/3.33.0/lib/capybara/rspec/matchers.rb#L127-L133
[3]:https://app.circleci.com/pipelines/github/samvera/hyrax/3692/workflows/2998f493-989c-45d0-806a-5d397c624140/jobs/24460/steps

Related to #4397 

@samvera/hyrax-code-reviewers
