### PR TITLE
add an explicit `draper` dependency

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -40,6 +40,7 @@ SUMMARY
   spec.add_dependency 'browse-everything', '>= 0.16', '< 2.0'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
+  spec.add_dependency 'draper', '~> 4.0'
   spec.add_dependency 'dry-events', '~> 0.2.0'
   spec.add_dependency 'dry-equalizer', '~> 0.2'
   spec.add_dependency 'dry-struct', '~> 1.0'

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -5,6 +5,7 @@ module Hyrax
 
     require 'awesome_nested_set'
     require 'breadcrumbs_on_rails'
+    require 'draper'
     require 'dry/struct'
     require 'dry/equalizer'
     require 'dry/events'


### PR DESCRIPTION
`draper` has been required by `valkyrie` for a while, but is now  explicitly
required for the `IiifManifestPresenter` so we need to have it in the
dependencies to protect against changes upstream.

@samvera/hyrax-code-reviewers
