### PR TITLE
Ensuring clean repo on feature specs

### DIFF
--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -2,15 +2,9 @@
 
 RSpec.describe 'Batch creation of works', type: :feature do
   let(:user) { create(:user) }
-  let!(:default_admin_set) do
-    build(:admin_set,
-          id: AdminSet::DEFAULT_ID,
-          title: ["Default Admin Set"],
-          description: ["A description"],
-          with_permission_template: { deposit_groups: [::Ability.registered_group_name] })
-  end
 
   before do
+    AdminSet.find_or_create_default_admin_set_id
     sign_in user
     allow(Flipflop).to receive(:batch_upload?).and_return true
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -176,7 +176,7 @@ RSpec.configure do |config|
     # using :workflow is preferable to :clean_repo, use the former if possible
     # It's important that this comes after DatabaseCleaner.start
     ensure_deposit_available_for(user) if example.metadata[:workflow]
-    if example.metadata[:clean_repo]
+    if example.metadata[:clean_repo] || example.metadata[:type] == :feature
       ActiveFedora::Cleaner.clean!
       # The JS is executed in a different thread, so that other thread
       # may think the root path has already been created:


### PR DESCRIPTION
## Ensuring clean repo on feature specs

365a4aab3fd24b9c54987e99e80fd423c4dbf883

I've spent a several hours debugging, and I believe a root cause of some
erratic spec failures are the result of non-clean repositories.

First, I've noticed that our consistently failing specs are most often
feature specs.

Second, I was able to reproduce an error in isolation, so I kept running
th specs.  The spec in question
`./spec/features/create_child_work_spec.rb:24` started raising a new
error:

```console
ActiveRecord::RecordNotFound:
Couldn't find Hyrax::PermissionTemplate
  ./app/actors/hyrax/actors/interpret_visibility_actor.rb:98:in `validate'
  ./app/actors/hyrax/actors/interpret_visibility_actor.rb:77:in `create'
  ./app/actors/hyrax/actors/default_admin_set_actor.rb:15:in `create'
  ./app/actors/hyrax/actors/abstract_actor.rb:92:in `create'
  ./app/actors/hyrax/actors/abstract_actor.rb:92:in `create'
  ./app/actors/hyrax/actors/add_to_work_actor.rb:11:in `create'
  ./app/actors/hyrax/actors/collections_membership_actor.rb:18:in `create'
  ./app/actors/hyrax/actors/create_with_files_actor.rb:15:in `create'
  ./app/actors/hyrax/actors/create_with_remote_files_actor.rb:17:in `create'
  ./app/actors/hyrax/actors/abstract_actor.rb:92:in `create'
  ./app/controllers/concerns/hyrax/works_controller_behavior.rb:184:in `create_work'
  ./app/controllers/concerns/hyrax/works_controller_behavior.rb:59:in `create'
  ./.internal_test_app/app/middleware/disable_animations_in_test_environment.rb:9:in `call'
  ./spec/features/create_child_work_spec.rb:29:in `block (3 levels) in <top (required)>'
  ./spec/features/create_child_work_spec.rb:27:in `block (2 levels) in <top (required)>'
```

I went looking in
`/app/actors/hyrax/actors/default_admin_set_actor.rb` (as this made sure
we had a default admin set).

The following logic got to the `else` case:

```ruby
def ensure_admin_set_attribute!(env)
  if env.attributes[:admin_set_id].present?
    ensure_permission_template!(admin_set_id: env.attributes[:admin_set_id])
  elsif env.curation_concern.admin_set_id.present?
    env.attributes[:admin_set_id] = env.curation_concern.admin_set_id
    ensure_permission_template!(admin_set_id: env.attributes[:admin_set_id])
  else
    env.attributes[:admin_set_id] = default_admin_set_id
  end
end
```

Digging further:

```ruby
class AdminSet
  def self.find_or_create_default_admin_set_id
    Hyrax::AdminSetCreateService.create_default_admin_set(admin_set_id: DEFAULT_ID, title: DEFAULT_TITLE) unless exists?(DEFAULT_ID)
    DEFAULT_ID
  end
end
```

I checked, and the `DEFAULT_ID` existed in Fedora.  However, there was
no associated PermissionTemplate for the DEFAULT_ID.  Which makes sense,
the repository wasn't clean YET the database was cleaned as part of each
spec (via `DatabaseCleaner.clean` in ./spec/spec_helper.rb:220).

Am I comfortable with this solution?  Somewhat.  However, there's a lot
of inter-play around the presumptive state of an application and
permissions.  Frankly, I would assume before every feature spec, we'd
want a clean repository.

_Note: This change does increase the spec time. Locally when I run a
feature speak I see about a 30s load time, and about a 5.5s run time for
the above spec.  With the change, the load time remains 30s and the spec
run time inches up to 6.25s or so._

_With the improvements we've made in parallelization in CircleCI, I
believe this slow-down is acceptable as it will likely reduce the number
of erratically failing specs._

## Ensuring that we have a default admin set

d8aa5f98c9a44cf1d093ff15f59f3ab26ab45f09

In introducing clean_repo logic to all feature tests, this feature spec
started regularly failing.  In the past, it would fail somewhat
arbitrarily.

With this change, we're ensuring that we have a default admin set before
running the spec.  Prior to the change, we were instatiating the default
admin set but not persisting it.  This leads me to believe that the spec
succeeded when a prior run spec would persist and admin set AND no
clean_repo calls were made between that prior spec and this spec.

As writing, just building the admin_set does not make it available to
feature tests (as the feature will be querying for persisted objects).
