### PR TITLE
Refactoring specs to ignore array order

### DIFF
--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -44,6 +44,14 @@ module Hyrax
       false
     end
 
+    # Return an array of global identifiers for collection types that do not allow multiple membership.
+    # @return [Array<String>] an array of Global Identifiers
+    # @see {#gid}
+    # @see Hyrax::MultipleMembershipChecker for usage
+    def self.gids_that_do_not_allow_multiple_membership
+      where(allow_multiple_membership: false).map(&:gid)
+    end
+
     # Find the collection type associated with the Global Identifier (gid)
     # @param [String] gid - Global Identifier for this collection_type (e.g. gid://internal/hyrax-collectiontype/3)
     # @return [Hyrax::CollectionType] an instance of Hyrax::CollectionType with id = the model_id portion of the gid (e.g. 3)

--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -34,7 +34,7 @@ module Hyrax
     # @return [nil, String] nil if no conflicts; an error message string if so
     def check(collection_ids:, include_current_members: false)
       # short-circuit if no single membership types have been created
-      return if single_membership_types.blank?
+      return if collection_type_gids_that_disallow_multiple_membership.blank?
       # short-circuit if no new single_membership_collections passed in
       new_single_membership_collections = single_membership_collections(collection_ids)
       return if new_single_membership_collections.blank?
@@ -52,11 +52,11 @@ module Hyrax
 
     def single_membership_collections(collection_ids)
       return [] if collection_ids.blank?
-      ::Collection.where(id: collection_ids, collection_type_gid_ssim: single_membership_types)
+      ::Collection.where(id: collection_ids, collection_type_gid_ssim: collection_type_gids_that_disallow_multiple_membership)
     end
 
-    def single_membership_types
-      Hyrax::CollectionType.where(allow_multiple_membership: false).map(&:gid)
+    def collection_type_gids_that_disallow_multiple_membership
+      Hyrax::CollectionType.gids_that_do_not_allow_multiple_membership
     end
 
     def build_error_message(problematic_collections)

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     end
   end
 
+  describe ".gids_that_do_not_allow_multiple_membership" do
+    let!(:type_allows_multiple_membership) { create(:collection_type, allow_multiple_membership: true) }
+    let!(:type_disallows_multiple_membership) { create(:collection_type, allow_multiple_membership: false) }
+
+    subject { described_class.gids_that_do_not_allow_multiple_membership }
+
+    it { is_expected.to match_array(type_disallows_multiple_membership.gid) }
+  end
+
   describe ".find_or_create_admin_set_type" do
     subject { described_class.find_or_create_admin_set_type }
 

--- a/spec/services/hyrax/multiple_membership_checker_spec.rb
+++ b/spec/services/hyrax/multiple_membership_checker_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
     let(:collection_ids) { ['foobar'] }
     let(:included) { false }
     let!(:collection_type) { create(:collection_type, title: 'Greedy', allow_multiple_membership: false) }
+    let(:collection_type_gids) { [collection_type] }
+    before do
+      allow(Hyrax::CollectionType).to receive(:gids_that_do_not_allow_multiple_membership).and_return(collection_type_gids)
+    end
 
     subject { checker.check(collection_ids: collection_ids, include_current_members: included) }
 
     context 'when there are no single-membership collection types' do
-      before do
-        allow(Hyrax::CollectionType).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: []).and_return([])
-      end
-
       it 'returns nil' do
-        expect(checker).to receive(:single_membership_types).and_return([])
+        expect(Hyrax::CollectionType).to receive(:gids_that_do_not_allow_multiple_membership).and_return([])
         expect(subject).to be nil
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
 
       it 'returns nil' do
         expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
-        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: [collection_type.gid]).once.and_return(collections)
+        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_type_gids).once.and_return(collections)
         expect(subject).to be nil
       end
     end
@@ -73,18 +73,18 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
       it 'returns an error' do
         expect(item).not_to receive(:member_of_collection_ids)
         expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
-        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: [collection_type.gid]).once.and_return(collections)
+        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_type_gids).once.and_return(collections)
         expect(subject).to eq 'Error: You have specified more than one of the same single-membership collection type (type: Greedy, collections: Foo and Bar)'
       end
 
       context 'with multiple single membership collection types' do
         let!(:collection_type_2) { create(:collection_type, title: 'Doc', allow_multiple_membership: false) }
-        let(:collection_types) { [collection_type.gid, collection_type_2.gid] }
+        let(:collection_type_gids) { [collection_type.gid, collection_type_2.gid] }
 
         it 'returns an error' do
           expect(item).not_to receive(:member_of_collection_ids)
           expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
-          expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_types).once.and_return(collections)
+          expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_type_gids).once.and_return(collections)
           expect(subject).to eq 'Error: You have specified more than one of the same single-membership collection type (type: Greedy, collections: Foo and Bar)'
         end
       end
@@ -103,19 +103,19 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
 
       it 'returns an error' do
         expect(item).to receive(:member_of_collection_ids)
-        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: [collection_type.gid]).once.and_return(collections)
-        expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: [collection_type.gid]).once.and_return([collection2])
+        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_type_gids).once.and_return(collections)
+        expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: collection_type_gids).once.and_return([collection2])
         expect(subject).to eq 'Error: You have specified more than one of the same single-membership collection type (type: Greedy, collections: Foo and Bar)'
       end
 
       context 'with multiple single membership collection types' do
         let!(:collection_type_2) { create(:collection_type, title: 'Doc', allow_multiple_membership: false) }
-        let(:collection_types) { [collection_type.gid, collection_type_2.gid] }
+        let(:collection_type_gids) { [collection_type.gid, collection_type_2.gid] }
 
         it 'returns an error' do
           expect(item).to receive(:member_of_collection_ids)
-          expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_types).once.and_return(collections)
-          expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: collection_types).once.and_return([collection2])
+          expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_type_gids).once.and_return(collections)
+          expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: collection_type_gids).once.and_return([collection2])
           expect(subject).to eq 'Error: You have specified more than one of the same single-membership collection type (type: Greedy, collections: Foo and Bar)'
         end
       end
@@ -127,12 +127,12 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
       let(:collections) { [collection1, collection2] }
       let(:collection_ids) { collections.map(&:id) }
       let(:collection_type_2) { create(:collection_type, title: 'Doc', allow_multiple_membership: false) }
-      let(:collection_types) { [collection_type.gid, collection_type_2.gid] }
+      let(:collection_type_gids) { [collection_type.gid, collection_type_2.gid] }
 
       it 'returns nil' do
         expect(item).not_to receive(:member_of_collection_ids)
         expect(checker).to receive(:single_membership_collections).with(collection_ids).once.and_call_original
-        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_types).once.and_return(collections)
+        expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_type_gids).once.and_return(collections)
         expect(subject).to be nil
       end
 
@@ -146,8 +146,8 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
 
         it 'returns nil' do
           expect(item).to receive(:member_of_collection_ids)
-          expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_types).once.and_return(collections)
-          expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: collection_types).once.and_return([collection2])
+          expect(Collection).to receive(:where).with(id: collection_ids, collection_type_gid_ssim: collection_type_gids).once.and_return(collections)
+          expect(Collection).to receive(:where).with(id: [collection2.id], collection_type_gid_ssim: collection_type_gids).once.and_return([collection2])
           expect(subject).to be nil
         end
       end


### PR DESCRIPTION
Prior to this commit, it was possible that the Rspec `.with` stubs would
receive collection type gids in an order different from what was
expected.  I believe this is a Postgresql only issue, as I have memories
that Postgresql does not apply an auto-sort by ID.  That may be a faulty
memory, however, the result is a fragile spec in which we have an
explicit order in the `.with` but a stochastic order in the actual array
that is built from a production code query.

In addition, I have take the opportunity to rename the variables and
methods to be more descriptive and precise.  I would expect variables
and method names that say "single_membership_types" to be a model (e.g.,
`Hyrax::CollectionType`) but they were instead an array of GIDs.

This change also draws the code closer to dependency injection, in that
we remove a chained call in favor of a method call.

Below is the failure that [I observed in CircleCI][1]:

```console
Failure/Error: ::Collection.where(id: collection_ids,
collection_type_gid_ssim: single_membership_types)
  <Collection (class)> received :where with unexpected arguments
  expected: ({:collection_type_gid_ssim=>["gid://internal/hyrax-collectiontype/52", "gid://internal/hyrax-collectiontype/53"], :id=>["object_id_8", "object_id_9"]})
  got: ({:collection_type_gid_ssim=>["gid://internal/hyrax-collectiontype/53", "gid://internal/hyrax-collectiontype/52"], :id=>["object_id_8", "object_id_9"]})
  Diff:
  @@ -1,5 +1,5 @@
  [{:collection_type_gid_ssim=>
  -   ["gid://internal/hyrax-collectiontype/52",
  -    "gid://internal/hyrax-collectiontype/53"],
  +   ["gid://internal/hyrax-collectiontype/53",
  +    "gid://internal/hyrax-collectiontype/52"],
     :id=>["object_id_8", "object_id_9"]}]
```

[1]:https://app.circleci.com/pipelines/github/samvera/hyrax/3714/workflows/e08b0c17-eb26-4e10-99ff-c02ea7ca6f78/jobs/24737/steps

@samvera/hyrax-code-reviewers
