### PR TITLE
Refactoring proxy feature spec

### DIFF
--- a/spec/features/proxy_spec.rb
+++ b/spec/features/proxy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'proxy', type: :feature do
   let(:second_user) { create(:user) }
 
   describe 'add proxy in profile', :js do
-    it "create a proxy, then deletes a proxy, and verifies deletion" do
+    it "creates a proxy, then deletes a proxy, and verifies deletion" do
       sign_in user
       # Prior to capturing the after sign in path, this code was later
       # re-signing to get to this captured path.

--- a/spec/features/proxy_spec.rb
+++ b/spec/features/proxy_spec.rb
@@ -4,27 +4,11 @@ RSpec.describe 'proxy', type: :feature do
   let(:second_user) { create(:user) }
 
   describe 'add proxy in profile', :js do
-    it "creates a proxy" do
+    it "create a proxy, then deletes a proxy, and verifies deletion" do
       sign_in user
-      click_link "Your activity"
-      within 'div#proxy_management' do
-        click_link "Manage Proxies"
-      end
-      expect(page).not_to have_css("td.depositor-name")
-
-      # BEGIN create_proxy_using_partial
-      find('a.select2-choice').click
-      find(".select2-input").set(second_user.user_key)
-      expect(page).to have_css("div.select2-result-label")
-      find("div.select2-result-label").click
-      # END create_proxy_using_partial
-
-      expect(page).to have_css('td.depositor-name', text: second_user.user_key)
-      expect(page).to have_link('Delete Proxy')
-    end
-
-    it "delete a proxy, and verify it was deleted" do
-      sign_in user
+      # Prior to capturing the after sign in path, this code was later
+      # re-signing to get to this captured path.
+      after_signin_path = page.current_path
       click_link "Your activity"
       within 'div#proxy_management' do
         click_link "Manage Proxies"
@@ -44,7 +28,7 @@ RSpec.describe 'proxy', type: :feature do
       click_link('Delete Proxy')
 
       # Go back to page and verify second_user is not a proxy.
-      sign_in user
+      visit(after_signin_path)
       click_link "Your activity"
       within 'div#proxy_management' do
         click_link "Manage Proxies"
@@ -53,7 +37,7 @@ RSpec.describe 'proxy', type: :feature do
       expect(page).not_to have_link('Delete Proxy')
     end
 
-    it "try to make yourself a proxy" do
+    it "does not allow you making yourself a proxy" do
       sign_in user
       click_link "Your activity"
       within 'div#proxy_management' do


### PR DESCRIPTION
Prior to this commit, there were two expensive feature specs.  The first
spec (e.g. "creates a proxy") is entirely a subset of a second feature
spec that created a proxy, deleted the proxy, and verified the deletion.

In addition, the second feature spec signed the same user in twice.  I
believe the reason being that we wanted to ensure that we were at the
same URL for the second set of tests.

I have added a temporary variable to capture that URL and avoid calling
a second time the computationally expensive sign-out/sign-in helper.

My hope is that this will address the following [CircleCI error][1]:

```console
1) proxy add proxy in profile delete a proxy, and verify it was deleted
   Failure/Error: fill_in 'Email', with: user.email

Capybara::ElementNotFound:
   Unable to find field "Email" that is not disabled

   ./vendor/bundle/gems/capybara-3.33.0/lib/capybara/node/finders.rb:302:in `block in synced_resolve'
   ./vendor/bundle/gems/capybara-3.33.0/lib/capybara/node/base.rb:83:in `synchronize'
   ./vendor/bundle/gems/capybara-3.33.0/lib/capybara/node/finders.rb:291:in `synced_resolve'
   ./vendor/bundle/gems/capybara-3.33.0/lib/capybara/node/finders.rb:52:in `find'
   ./vendor/bundle/gems/capybara-3.33.0/lib/capybara/node/actions.rb:91:in `fill_in'
   ./vendor/bundle/gems/capybara-3.33.0/lib/capybara/session.rb:759:in `block (2 levels) in <class:Session>'
   ./vendor/bundle/gems/capybara-3.33.0/lib/capybara/dsl.rb:58:in `block (2 levels) in <module:DSL>'
   ./spec/support/features/session_helpers.rb:9:in `sign_in'
   ./spec/features/proxy_spec.rb:47:in `block (3 levels) in <top (required)>'
 ```

[1]:https://app.circleci.com/pipelines/github/samvera/hyrax/3714/workflows/3ad37bcd-e08b-47d8-b6b8-0982ef89c591/jobs/24731/steps

@samvera/hyrax-code-reviewers
