### PR TITLE
Ensuring a clean Redis state for each spec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -166,6 +166,12 @@ RSpec.configure do |config|
   end
 
   config.before do |example|
+    # Many of the specs push data into Redis. This ensures that we
+    # have a clean slate when processing.  It is possible that we
+    # could narrow the call for this method to be done for clean_repo
+    # or feature specs.
+    Hyrax::RedisEventStore.instance.redis.flushdb
+
     if example.metadata[:type] == :feature && Capybara.current_driver != :rack_test
       DatabaseCleaner.strategy = :truncation
     else


### PR DESCRIPTION
I've been noticing the following errors:

```console
1) Creating a new Work when the user is a proxy allows on-behalf-of deposit
     Failure/Error: click_link "My Test Work"

     Capybara::Ambiguous:
       Ambiguous match, found 2 elements matching visible link "My Test Work for on-behalf"
     ./spec/features/create_work_spec.rb:117:in `block (3 levels) in <top (required)>'
     ./spec/spec_helper.rb:294:in `block (2 levels) in
     <top (required)>'
```

At first, I thought this was related to duplicate entries in Fedora.
However, we've since adjusted feature specs to always have a clean
Fedora (see @d68f0f775f7f4bca65c58335a1baed7e6eb9f66b).  Then I started
wondering if we had concurrency issues.

I decided to start debugging.

I saw the following entries in the rendered page that was failing:

```
User user1@example.com has transferred My Test Work to user user2@example.com just now
User user1@example.com has transferred My Test Work to user user2@example.com a minute ago
```

This section was the activity log, which is pushed into Redis. With some
further digging, I checked `Redis.current.keys` and found hundreds of
keys.  And since these keys are based on user ids (e.g., 1) when I would
call the above spec (`rspec ./spec/features/create_work_spec.rb:117`)
multiple times, I'd get the same user key.

So, prior to this commit, I could load a clean Hyrax test suite, call
`rspec ./spec/features/create_work_spec.rb:117` and it would pass.  I
could then immediately call the same `rspec
./spec/features/create_work_spec.rb:117` and it would fail.

After this commit, I can keep calling the same rspec and all things
pass.

@samvera/hyrax-code-reviewers
