### PR TITLE
backport: delegate IIIF Manifest cache key version to presenter

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter.rb
@@ -134,6 +134,16 @@ module Hyrax
     end
 
     ##
+    # @note ideally, this value will be cheap to retrieve, and will reliably
+    #   change any time the manifest JSON will change. the current implementation
+    #   is more blunt than this, changing only when the work itself changes.
+    #
+    # @return [String] a string tag suitable for cache keys for this manifiest
+    def version
+      object.try(:modified_date)&.to_s || ''
+    end
+
+    ##
     # An Ability-like object that gives `true` for all `can?` requests
     class NullAbility
       ##

--- a/app/services/hyrax/caching_iiif_manifest_builder.rb
+++ b/app/services/hyrax/caching_iiif_manifest_builder.rb
@@ -45,13 +45,9 @@ module Hyrax
       end
 
       ##
-      # @note `etag` is a better option than the solr document `_version_`; the
-      #   latter isn't always available, depending on how the presenter was
-      #   built!
-      #
       # @return [String]
       def version_for(presenter)
-        presenter.etag
+        presenter.version
       end
   end
 end

--- a/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
@@ -170,5 +170,21 @@ RSpec.describe Hyrax::IiifManifestPresenter do
       end
     end
   end
+
+  describe '#version' do
+    let(:work) { create(:work) }
+
+    it 'returns a string' do
+      expect(presenter.version).to be_a String
+    end
+
+    context 'when the work is unsaved' do
+      let(:work) { build(:work) }
+
+      it 'is still a string' do
+        expect(presenter.version).to be_a String
+      end
+    end
+  end
 end
 # rubocop:enable BracesAroundHashParameters

--- a/spec/services/hyrax/caching_iiif_manifest_builder_spec.rb
+++ b/spec/services/hyrax/caching_iiif_manifest_builder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::CachingIiifManifestBuilder, :clean_repo do
     double(
       'Presenter',
       id: id,
-      etag: etag,
+      version: etag,
       work_presenters: [work_presenter],
       manifest_url: manifest_url,
       description: ["A Treatise on Coding in Samvera"],


### PR DESCRIPTION
it turns out `etag` isn't a very good cache key because the default
`SolrDocument` doesn't contain this data. using the system/Fedora
`#modified_date` is equivalent (has the same weaknesses) but is available on
both an actual work instance, and on its index proxy.

since this is changing (and should likely change again!), delegate it to the
presenter so there's a clear source going forward.

backports #4418 

@samvera/hyrax-code-reviewers
