### PR TITLE
backport: VersioningService.versioned_file_id

### DIFF
--- a/app/services/hyrax/versioning_service.rb
+++ b/app/services/hyrax/versioning_service.rb
@@ -22,5 +22,14 @@ module Hyrax
       return if version.nil?
       VersionCommitter.create(version_id: version.uri, committer_login: user_key)
     end
+
+    # @param [ActiveFedora::File | Hyrax::FileMetadata] content
+    def self.versioned_file_id(file)
+      versions = file.versions.all
+
+      return ActiveFedora::Base.uri_to_id(versions.last.uri) if versions.present?
+
+      file.id
+    end
   end
 end

--- a/spec/services/hyrax/versioning_service_spec.rb
+++ b/spec/services/hyrax/versioning_service_spec.rb
@@ -1,4 +1,30 @@
 RSpec.describe Hyrax::VersioningService do
+  describe '#versioned_file_id' do
+    subject { described_class.versioned_file_id file.original_file }
+    let(:file) { create(:file_set) }
+
+    before do
+      # Add the original_file (this service  creates a version after saving when you call it with versioning: true)
+      Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :original_file, versioning: true)
+    end
+
+    context 'without version data' do
+      before { allow(file.original_file).to receive(:has_versions?).and_return(false) }
+
+      it { is_expected.to eq file.original_file.id }
+    end
+
+    context 'with one version' do
+      it { is_expected.to eq "#{file.original_file.id}/fcr:versions/version1" }
+    end
+
+    context 'with two versions' do
+      before { file.original_file.create_version }
+
+      it { is_expected.to eq "#{file.original_file.id}/fcr:versions/version2" }
+    end
+  end
+
   describe '#latest_version_of' do
     let(:user) { build(:user) }
     let(:file) { create(:file_set) }


### PR DESCRIPTION
`Hyrax::DisplaysImage` relies on this `.versioned_file_id` method, but it was
missed in previous backports.

@samvera/hyrax-code-reviewers
