### PR TITLE
test & document DisplaysImage fallback behavior

### DIFF
--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -45,6 +45,24 @@ module Hyrax
       channels&.include?('rgba') ? 'png' : 'jpg'
     end
 
+    ##
+    # @api private
+    #
+    # Get the id for the latest version of original file. If
+    # `#originial_file_id` is available on the object, simply use that value.
+    # Otherwise, retrieve the original file directly from the datastore and
+    # resolve the current version using `VersioningService`.
+    #
+    # The fallback lookup normally happens when a File Set was indexed prior
+    # to the introduction of `#original_file_id` to the index document,
+    # but is useful as a generalized failsafe to ensure we have done our best
+    # to resolve the content.
+    #
+    # @note this method caches agressively. it's here to support IIIF
+    #   manifest generation and we expect this object to exist only for
+    #   the generation of a single manifest document. this insulates callers
+    #   from the complex lookup behavior and protects against expensive and
+    #   unnecessary database lookups.
     def latest_file_id
       @latest_file_id ||=
         begin

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -25,6 +25,13 @@ FactoryBot.define do
       content { File.open(Hyrax::Engine.root + 'spec/fixtures/world.png') }
     end
 
+    trait :with_original_file do
+      after(:create) do |file_set, _evaluator|
+        Hydra::Works::AddFileToFileSet
+          .call(file_set, File.open(Hyrax::Engine.root + 'spec/fixtures/world.png'), :original_file)
+      end
+    end
+
     factory :file_with_work do
       after(:build) do |file, _evaluator|
         file.title = ['testfile']

--- a/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
@@ -62,6 +62,20 @@ RSpec.describe Hyrax::IiifManifestPresenter do
           expect(presenter.display_image).to be_nil
         end
       end
+
+      context 'when no original file is indexed' do
+        let(:solr_doc) do
+          index_hash = file_set.to_solr
+          index_hash.delete('original_file_id_ssi')
+
+          SolrDocument.new(index_hash)
+        end
+
+        it 'can still resolve the image' do
+          expect(presenter.display_image.to_json)
+            .to include 'fcr:versions%2Fversion1/full'
+        end
+      end
     end
   end
 


### PR DESCRIPTION
when no `original_file_id` is available on an indexed file_set, we have a
fallback approach, retrieving the data from datastore (via ActiveFedora for
now) and resolving it via `VersioningService`.

@samvera/hyrax-code-reviewers
