### PR TITLE
begin to generalize the FixityService API

### DIFF
--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -52,16 +52,7 @@ class FixityCheckJob < Hyrax::ApplicationJob
       error_msg = 'resource not found'
     end
 
-    log = ChecksumAuditLog.create_and_prune!(passed: fixity_ok, file_set_id: file_set_id, checked_uri: uri.to_s, file_id: file_id, expected_result: expected_result)
-    # Note that the after_fixity_check_failure will be called if the fixity check fail. This
-    # logging is for additional information related to the failure. Wondering if we should
-    # also include the error message?
-    logger.error "FIXITY CHECK FAILURE: Fixity failed for #{uri} #{error_msg}: #{log}" unless fixity_ok
-    log
-  end
-
-  def logger
-    Hyrax.logger
+    ChecksumAuditLog.create_and_prune!(passed: fixity_ok, file_set_id: file_set_id, checked_uri: uri.to_s, file_id: file_id, expected_result: expected_result)
   end
 
   ##

--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -25,7 +25,6 @@ class FixityCheckJob < Hyrax::ApplicationJob
   # @param file_set_id [FileSet] the id for FileSet parent object of URI being checked.
   # @param file_id [String] File#id, used for logging/reporting.
   def perform(uri, file_set_id:, file_id:)
-    uri = uri.to_s # sometimes we get an RDF::URI gah
     log = run_check(file_set_id, file_id, uri)
 
     if log.failed? && Hyrax.config.callback.set?(:after_fixity_check_failure)
@@ -50,7 +49,7 @@ class FixityCheckJob < Hyrax::ApplicationJob
       error_msg = 'resource not found'
     end
 
-    log = ChecksumAuditLog.create_and_prune!(passed: fixity_ok, file_set_id: file_set_id, checked_uri: uri, file_id: file_id, expected_result: expected_result)
+    log = ChecksumAuditLog.create_and_prune!(passed: fixity_ok, file_set_id: file_set_id, checked_uri: uri.to_s, file_id: file_id, expected_result: expected_result)
     # Note that the after_fixity_check_failure will be called if the fixity check fail. This
     # logging is for additional information related to the failure. Wondering if we should
     # also include the error message?

--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class FixityCheckJob < Hyrax::ApplicationJob
-  # A Job class that runs a fixity check (using ActiveFedora::FixityService,
+  # A Job class that runs a fixity check (using Hyrax.config.fixity_service)
   # which contacts fedora and requests a fixity check), and stores the results
   # in an ActiveRecord ChecksumAuditLog row. It also prunes old ChecksumAuditLog
   # rows after creating a new one, to keep old ones you don't care about from
@@ -41,7 +41,7 @@ class FixityCheckJob < Hyrax::ApplicationJob
   private
 
   def run_check(file_set_id, file_id, uri)
-    service = ActiveFedora::FixityService.new(uri)
+    service = fixity_service.new(uri)
     begin
       fixity_ok = service.check
       expected_result = service.expected_message_digest
@@ -60,5 +60,11 @@ class FixityCheckJob < Hyrax::ApplicationJob
 
   def logger
     Hyrax.logger
+  end
+
+  ##
+  # @return [Class]
+  def fixity_service
+    Hyrax.config.fixity_service
   end
 end

--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -45,7 +45,7 @@ class FixityCheckJob < Hyrax::ApplicationJob
     begin
       fixity_ok = service.check
       expected_result = service.expected_message_digest
-    rescue Ldp::NotFound
+    rescue Hyrax::Fixity::MissingContentError
       # Either the #check or #expected_message_digest could raise this exception
       error_msg = 'resource not found'
     end

--- a/app/services/hyrax/fixity/active_fedora_fixity_service.rb
+++ b/app/services/hyrax/fixity/active_fedora_fixity_service.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module Hyrax
+  module Fixity
+    ##
+    # Wraps `ActiveFedora::FixityService` to avoid leaking Fedora-specific errors.
+    #
+    # @see ActiveFedora::FixityService
+    class ActiveFedoraFixityService < ActiveFedora::FixityService
+      ##
+      # @raise MissingContentError
+      # @see ActiveFedora::FixityService#response
+      def response
+        super
+      rescue Ldp::NotFound
+        raise MissingContentError,
+              "Tried to check fixity of #{@target}, but it was not found."
+      end
+    end
+  end
+end

--- a/app/services/hyrax/fixity/missing_content_error.rb
+++ b/app/services/hyrax/fixity/missing_content_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Hyrax
+  module Fixity
+    ##
+    # @note this inherits `Ldp::NotFonud` for backwards compatibility.
+    #   This should be a `RuntimeError` or `ArgumentError` in Hyrax 4.0.
+    class MissingContentError < Ldp::NotFound; end
+  end
+end

--- a/app/services/hyrax/listeners/file_set_lifecycle_notification_listener.rb
+++ b/app/services/hyrax/listeners/file_set_lifecycle_notification_listener.rb
@@ -13,6 +13,8 @@ module Hyrax
       def on_file_set_audited(event)
         return unless event[:result] == :failure # do nothing on success
 
+        Hyrax.logger.error "FIXITY CHECK FAILURE: Fixity failed for #{event[:audit_log]}"
+
         Hyrax::FixityCheckFailureService
           .new(event[:file_set], checksum_audit_log: event[:audit_log])
           .call

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -30,10 +30,6 @@ Hyrax.config.callback.set(:after_destroy, warn: false) do |id, user|
   Hyrax.publisher.publish('object.deleted', id: id, user: user)
 end
 
-Hyrax.config.callback.set(:after_fixity_check_failure, warn: false) do |file_set, checksum_audit_log:|
-  Hyrax.publisher.publish('file.set.audited', file_set: file_set, audit_log: checksum_audit_log, result: :failure)
-end
-
 Hyrax.config.callback.set(:after_batch_create_success, warn: false) do |user|
   Hyrax.publisher.publish('batch.created', user: user, messages: [], result: :success)
 end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -101,6 +101,11 @@ module Hyrax
       @microdata_default_type ||= 'http://schema.org/CreativeWork'
     end
 
+    attr_writer :fixity_service
+    def fixity_service
+      @fixity_service ||= ActiveFedora::FixityService
+    end
+
     attr_writer :max_days_between_fixity_checks
     def max_days_between_fixity_checks
       @max_days_between_fixity_checks ||= 7

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -103,7 +103,7 @@ module Hyrax
 
     attr_writer :fixity_service
     def fixity_service
-      @fixity_service ||= ActiveFedora::FixityService
+      @fixity_service ||= Hyrax::Fixity::ActiveFedoraFixityService
     end
 
     attr_writer :max_days_between_fixity_checks


### PR DESCRIPTION
Hyrax needs to be clear about its own `FixityService` contract. To date, it has
only relied on the `ActiveFedora` service.

Immediately, this is a problem because other service implementations won't throw
the same LDP errors `ActiveFedora`. As a first step: abstract those errors away
for Hyrax users. Instead of catching `Ldp::NotFound` directly, use a
`Hyrax::Fixity::MissingContentError`. For now, the new error inherits the old to
prevent unexpected transition issues.

@samvera/hyrax-code-reviewers
