### PR TITLE
document and refactor QuickClassificationQuery

### DIFF
--- a/app/presenters/hyrax/select_type_list_presenter.rb
+++ b/app/presenters/hyrax/select_type_list_presenter.rb
@@ -23,8 +23,9 @@ module Hyrax
 
     # Return or yield the first model in the list. This is used when the list
     # only has a single element.
-    # @yieldparam [Class] model a class that decends from ActiveFedora::Base
-    # @return [Class] a class that decends from ActiveFedora::Base
+    #
+    # @yieldparam [Class] model a model class
+    # @return [Class] a model class
     def first_model
       yield(authorized_models.first) if block_given?
       authorized_models.first

--- a/app/services/hyrax/quick_classification_query.rb
+++ b/app/services/hyrax/quick_classification_query.rb
@@ -1,16 +1,26 @@
 # frozen_string_literal: true
 module Hyrax
+  ##
+  # Provides an enumerator of the Work classes the user is authorized to create.
+  #
+  # @example
+  #   QuickClassificationQuery.new(user: current_user).to_a
   class QuickClassificationQuery
+    ##
+    # @!attribute [r] user
+    #   @return [::User]
     attr_reader :user
 
-    # @param [User] user the current user
+    # @param [::User] user the current user
     # @param [Hash] options
     # @option options [#call] :concern_name_normalizer (String#constantize) a proc that translates names to classes
     # @option options [Array<String>] :models the options to display, defaults to everything.
-    def initialize(user, options = {})
+    def initialize(user,
+                   models: Hyrax.config.registered_curation_concern_types,
+                   concern_name_normalizer: ->(str) { str.constantize })
       @user = user
-      @concern_name_normalizer = options.fetch(:concern_name_normalizer, ->(str) { str.constantize })
-      @models = options.fetch(:models, Hyrax.config.registered_curation_concern_types)
+      @concern_name_normalizer = concern_name_normalizer
+      @models = models
     end
 
     def each(&block)
@@ -26,6 +36,7 @@ module Hyrax
     def authorized_models
       normalized_model_names.select { |klass| user.can?(:create, klass) }
     end
+    alias to_a authorized_models
 
     private
 

--- a/spec/services/hyrax/quick_classification_query_spec.rb
+++ b/spec/services/hyrax/quick_classification_query_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe Hyrax::QuickClassificationQuery do
         # Ensure that no other test has altered the configuration:
         allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return(['GenericWork'])
       end
+
       it "calls the block once for every model" do
         expect(thing).to receive(:test).with(GenericWork)
-        query.each do |f|
-          thing.test(f)
-        end
+
+        query.each { |f| thing.test(f) }
       end
     end
   end


### PR DESCRIPTION
this is only called from one place, but documenting it and removing some of the
complexity seemed better than deprecating.

@samvera/hyrax-code-reviewers
