### PR TITLE
rescue correct error in WorkflowRolePresenter

### DIFF
--- a/app/presenters/hyrax/admin/workflow_role_presenter.rb
+++ b/app/presenters/hyrax/admin/workflow_role_presenter.rb
@@ -23,7 +23,7 @@ module Hyrax
       def admin_set_label(id)
         result = Hyrax::SolrService.search_by_id(id, fl: 'title_tesim')
         result['title_tesim'].first
-      rescue ActiveFedora::ObjectNotFoundError
+      rescue Hyrax::ObjectNotFoundError
         "[AdminSet ID=#{id}]"
       end
     end


### PR DESCRIPTION
Hyrax::SolrService raises `Hyrax::ObjectNotFound`, not `ActiveFedora::ObjectNotFound`.

@samvera/hyrax-code-reviewers
