### PR TITLE
add a `#find_collections_by_type` query

### DIFF
--- a/app/services/hyrax/custom_queries/find_collections_by_type.rb
+++ b/app/services/hyrax/custom_queries/find_collections_by_type.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module Hyrax
+  module CustomQueries
+    # @example
+    #   collection_type = Hyrax::CollectionType.find(1)
+    #
+    #   Hyrax.custom_queries.find_collections_by_type(global_id: collection_type.to_global_id)
+    #
+    # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
+    class FindCollectionsByType
+      def self.queries
+        [:find_collections_by_type]
+      end
+
+      def initialize(query_service:)
+        @query_service = query_service
+      end
+
+      attr_reader :query_service
+      delegate :resource_factory, to: :query_service
+
+      ##
+      # @note this is an unoptimized default implementation of this custom
+      #   query. it's Hyrax's policy to provide such implementations of custom
+      #   queries in use for cross-compatibility of Valkyrie query services.
+      #   it's advisable to provide an optimized query for the specific adapter.
+      #
+      # @param global_id [GlobalID] global id for a Hyrax::CollectionType
+      #
+      # @return [Enumerable<PcdmCollection>]
+      def find_collections_by_type(global_id:)
+        query_service
+          .find_all_of_model(model: PcdmCollection)
+          .select { |collection| collection.collection_type_gid == global_id }
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/custom_queries/find_collections_by_type_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_collections_by_type_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::CustomQueries::FindCollectionsByType, valkyrie_adapter: :test_adapter do
+  subject(:query_handler) { described_class.new(query_service: query_service) }
+  let(:adapter)           { Valkyrie::MetadataAdapter.find(:test_adapter) }
+  let(:collection_type)   { FactoryBot.create(:collection_type) }
+  let(:persister)         { adapter.persister }
+  let(:type_gid)          { collection_type.to_global_id }
+  let(:query_service)     { adapter.query_service }
+
+  describe '#find_collections_by_type' do
+    before { persister.wipe! }
+
+    context 'when there are no collections' do
+      it 'is empty' do
+        expect(query_handler.find_collections_by_type(global_id: type_gid))
+          .to be_empty
+      end
+    end
+
+    describe 'when there are collections with the type' do
+      let(:collection_with_default_type) { FactoryBot.valkyrie_create(:hyrax_collection) }
+      let(:non_collection_model)         { FactoryBot.valkyrie_create(:hyrax_work) }
+
+      let(:collections_with_target_type) do
+        [FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: type_gid),
+         FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: type_gid)]
+      end
+
+      before do # force create all the models
+        non_collection_model
+        collection_with_default_type
+        collections_with_target_type
+      end
+
+      it 'returns exactly the collections of the type' do
+        expect(query_handler.find_collections_by_type(global_id: type_gid))
+          .to contain_exactly(*collections_with_target_type)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -134,6 +134,7 @@ query_registration_target =
 [Hyrax::CustomQueries::Navigators::CollectionMembers,
  Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
  Hyrax::CustomQueries::FindAccessControl,
+ Hyrax::CustomQueries::FindCollectionsByType,
  Hyrax::CustomQueries::FindManyByAlternateIds,
  Hyrax::CustomQueries::FindFileMetadata,
  Hyrax::CustomQueries::Navigators::FindFiles].each do |handler|


### PR DESCRIPTION
support query of collections by type. as noted, this is a default query
implementation without adapter optimization. we'll want to provide a better
version of this for Wings; and later, probably one for postgres.

@samvera/hyrax-code-reviewers
