### PR TITLE
add optimized `#fid_collections_by_type` query for Wings

### DIFF
--- a/lib/wings/services/custom_queries/find_collections_by_type.rb
+++ b/lib/wings/services/custom_queries/find_collections_by_type.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+module Wings
+  module CustomQueries
+    ##
+    # @see Hyrax::CustomQueries::FindCollectionsByType
+    class FindCollectionsByType
+      def self.queries
+        [:find_collections_by_type]
+      end
+
+      def initialize(query_service:)
+        @query_service = query_service
+      end
+
+      attr_reader :query_service
+      delegate :resource_factory, to: :query_service
+
+      ##
+      # @param global_id [GlobalID] global id for a Hyrax::CollectionType
+      #
+      # @return [Enumerable<PcdmCollection>]
+      def find_collections_by_type(global_id:)
+        ::Collection.where(collection_type_gid_ssim: global_id.to_s)
+      end
+    end
+  end
+end

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -34,6 +34,7 @@ custom_queries = [Hyrax::CustomQueries::Navigators::CollectionMembers,
                   Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
                   Hyrax::CustomQueries::Navigators::FindFiles,
                   Wings::CustomQueries::FindAccessControl, # override Hyrax::CustomQueries::FindAccessControl
+                  Wings::CustomQueries::FindCollectionsByType,
                   Wings::CustomQueries::FindFileMetadata, # override Hyrax::CustomQueries::FindFileMetadata
                   Wings::CustomQueries::FindManyByAlternateIds] # override Hyrax::CustomQueries::FindManyByAlternateIds
 custom_queries.each do |query_handler|

--- a/spec/wings/services/custom_queries/find_collections_by_type_spec.rb
+++ b/spec/wings/services/custom_queries/find_collections_by_type_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'wings_helper'
+require 'wings/services/custom_queries/find_collections_by_type'
+
+RSpec.describe Wings::CustomQueries::FindCollectionsByType, :clean_repo do
+  subject(:query_handler) { described_class.new(query_service: query_service) }
+  let(:collection_type)   { FactoryBot.create(:collection_type) }
+  let(:type_gid)          { collection_type.to_global_id }
+  let(:query_service)     { Hyrax.query_service }
+
+  describe '#find_collections_by_type' do
+    context 'when there are no collections' do
+      it 'is empty' do
+        expect(query_handler.find_collections_by_type(global_id: type_gid))
+          .to be_empty
+      end
+    end
+
+    context 'when collections exist' do
+      let(:collection_with_default_type) { FactoryBot.create(:collection) }
+      let(:non_collection_model)         { FactoryBot.create(:work) }
+
+      let(:collections_with_target_type) do
+        FactoryBot.create_list(:collection_lw, 3, collection_type_gid: type_gid)
+      end
+
+      before do # force create all the models
+        non_collection_model
+        collection_with_default_type
+        collections_with_target_type
+      end
+
+      it 'returns only the collections of requested type' do
+        expect(query_handler.find_collections_by_type(global_id: type_gid))
+          .to contain_exactly(*collections_with_target_typev)
+      end
+    end
+  end
+end


### PR DESCRIPTION
this is follow-up to #4430, adding an optimized query to Wings. this should be
vastly faster than the default query for the Wings adapter.

@samvera/hyrax-code-reviewers
