### PR TITLE
deprecate `CollectionType#collections?`

### DIFF
--- a/app/forms/hyrax/forms/admin/collection_type_form.rb
+++ b/app/forms/hyrax/forms/admin/collection_type_form.rb
@@ -12,10 +12,14 @@ module Hyrax
                  :assigns_visibility, :id, :collection_type_participants, :persisted?,
                  :admin_set?, :user_collection?, :badge_color, to: :collection_type
 
+        ##
+        # @return [Boolean]
         def all_settings_disabled?
           collections? || admin_set? || user_collection?
         end
 
+        ##
+        # @return [Boolean]
         def share_options_disabled?
           all_settings_disabled? || !sharable
         end

--- a/app/forms/hyrax/forms/admin/collection_type_form.rb
+++ b/app/forms/hyrax/forms/admin/collection_type_form.rb
@@ -10,7 +10,7 @@ module Hyrax
         delegate :title, :description, :brandable, :discoverable, :nestable, :sharable, :share_applies_to_new_works,
                  :require_membership, :allow_multiple_membership, :assigns_workflow,
                  :assigns_visibility, :id, :collection_type_participants, :persisted?,
-                 :collections?, :admin_set?, :user_collection?, :badge_color, to: :collection_type
+                 :admin_set?, :user_collection?, :badge_color, to: :collection_type
 
         def all_settings_disabled?
           collections? || admin_set? || user_collection?
@@ -18,6 +18,12 @@ module Hyrax
 
         def share_options_disabled?
           all_settings_disabled? || !sharable
+        end
+
+        ##
+        # @return [Boolean]
+        def collections?
+          collection_type.collections.any?
         end
       end
     end

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -73,9 +73,13 @@ module Hyrax
       ActiveFedora::Base.where(collection_type_gid_ssim: gid.to_s)
     end
 
+    ##
+    # @deprecated Use #collections.any? instead
+    #
     # @return [Boolean] True if there is at least one collection of this type
     def collections?
-      collections.count.positive?
+      Deprecation.warn('Use #collections.any? instead.')
+      collections.any?
     end
 
     # @return [Boolean] True if this is the Admin Set type
@@ -127,7 +131,7 @@ module Hyrax
     end
 
     def ensure_no_collections
-      return true unless collections?
+      return true unless collections.any?
       errors[:base] << I18n.t('hyrax.admin.collection_types.errors.not_empty')
       throw :abort
     end
@@ -147,7 +151,7 @@ module Hyrax
     end
 
     def ensure_no_settings_changes_if_collections_exist
-      return true unless collections?
+      return true unless collections.any?
       return true unless collection_type_settings_changed?
       errors[:base] << I18n.t('hyrax.admin.collection_types.errors.no_settings_change_if_not_empty')
       throw :abort

--- a/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
+++ b/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
-  subject(:form) { described_class.new }
+RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm, :clean_repo do
+  subject(:form) { described_class.new(collection_type: collection_type) }
   let(:collection_type) { FactoryBot.build(:collection_type) }
 
   shared_context 'with a collection' do
@@ -28,13 +28,9 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
   it { is_expected.to delegate_method(:badge_color).to(:collection_type) }
 
   describe '#all_settings_disabled?' do
-    before do
-      allow(form).to receive(:collection_type).and_return(collection_type)
-    end
-
     context 'when editing admin set collection type' do
       before do
-        allow(form).to receive(:admin_set?).and_return(true)
+        allow(collection_type).to receive(:admin_set?).and_return(true)
       end
 
       it 'returns true' do
@@ -44,7 +40,7 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
 
     context 'when editing user collection type' do
       before do
-        allow(form).to receive(:user_collection?).and_return(true)
+        allow(collection_type).to receive(:user_collection?).and_return(true)
       end
 
       it 'returns true' do
@@ -62,8 +58,8 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
 
     context 'when not admin set collection type AND not user collection type AND there are no collections of this collection type' do
       before do
-        allow(form).to receive(:admin_set?).and_return(false)
-        allow(form).to receive(:user_collection?).and_return(false)
+        allow(collection_type).to receive(:admin_set?).and_return(false)
+        allow(collection_type).to receive(:user_collection?).and_return(false)
       end
 
       it 'returns false' do
@@ -72,14 +68,10 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
     end
   end
 
-  describe 'share_options_disabled?' do
-    before do
-      allow(form).to receive(:collection_type).and_return(collection_type)
-    end
-
+  describe '#share_options_disabled?' do
     context 'when all settings are disabled' do
       before do
-        allow(form).to receive(:all_settings_disabled?).and_return(true)
+        allow(collection_type).to receive(:user_collection?).and_return(true)
       end
 
       it 'returns true' do
@@ -89,22 +81,22 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
 
     context 'when collection type sharable setting is off' do
       before do
-        allow(form).to receive(:sharable).and_return(false)
+        allow(collection_type).to receive(:sharable).and_return(false)
       end
 
       it 'returns true' do
-        expect(subject.share_options_disabled?).to be true
+        expect(form.share_options_disabled?).to be true
       end
     end
 
     context 'when all options are not disabled and the collection type sharable setting is on' do
       before do
-        allow(form).to receive(:all_settings_disabled?).and_return(false)
-        allow(form).to receive(:sharable).and_return(true)
+        allow(collection_type).to receive(:all_settings_disabled?).and_return(false)
+        allow(collection_type).to receive(:sharable).and_return(true)
       end
 
       it 'returns false' do
-        expect(subject.share_options_disabled?).to be false
+        expect(form.share_options_disabled?).to be false
       end
     end
   end

--- a/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
+++ b/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
-  let(:collection_type) { build(:collection_type) }
-  let(:form) { described_class.new }
+  subject(:form) { described_class.new }
+  let(:collection_type) { FactoryBot.build(:collection_type) }
 
-  subject { form }
+  shared_context 'with a collection' do
+    let(:collection_type) { FactoryBot.create(:collection_type) }
+
+    before do
+      FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.gid)
+    end
+  end
 
   it { is_expected.to delegate_method(:title).to(:collection_type) }
   it { is_expected.to delegate_method(:description).to(:collection_type) }
@@ -17,7 +23,6 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
   it { is_expected.to delegate_method(:assigns_visibility).to(:collection_type) }
   it { is_expected.to delegate_method(:id).to(:collection_type) }
   it { is_expected.to delegate_method(:persisted?).to(:collection_type) }
-  it { is_expected.to delegate_method(:collections?).to(:collection_type) }
   it { is_expected.to delegate_method(:admin_set?).to(:collection_type) }
   it { is_expected.to delegate_method(:user_collection?).to(:collection_type) }
   it { is_expected.to delegate_method(:badge_color).to(:collection_type) }
@@ -48,9 +53,7 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
     end
 
     context 'when there are collections of this collection type' do
-      before do
-        allow(form).to receive(:collections?).and_return(true)
-      end
+      include_context 'with a collection'
 
       it 'returns true' do
         expect(subject.all_settings_disabled?).to be true
@@ -61,7 +64,6 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm do
       before do
         allow(form).to receive(:admin_set?).and_return(false)
         allow(form).to receive(:user_collection?).and_return(false)
-        allow(form).to receive(:collections?).and_return(false)
       end
 
       it 'returns false' do

--- a/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/_form_settings.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
     collection_type_allow_multiple_membership
   ].freeze
 
-  let(:collection_type_form) { Hyrax::Forms::Admin::CollectionTypeForm.new }
+  let(:collection_type_form) { Hyrax::Forms::Admin::CollectionTypeForm.new(collection_type: collection_type) }
   let(:collection_type) { stub_model(Hyrax::CollectionType) }
 
   let(:form) do
@@ -24,7 +24,6 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
   end
 
   before do
-    collection_type_form.collection_type = collection_type
     allow(view).to receive(:f).and_return(form)
     allow(form).to receive(:object).and_return(collection_type_form)
   end
@@ -32,7 +31,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
   context 'for non-special collection types' do
     context "when collection_type.collections? is false" do
       before do
-        allow(collection_type).to receive(:collections?).and_return(false)
+        allow(collection_type_form).to receive(:collections?).and_return(false)
         render
       end
 
@@ -52,8 +51,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
 
     context "when collection_type.collections? is true" do
       before do
-        collection_type_form.collection_type = collection_type
-        allow(collection_type).to receive(:collections?).and_return(true)
+        allow(collection_type_form).to receive(:collections?).and_return(true)
         assign(:form, collection_type_form)
         allow(view).to receive(:f).and_return(form)
         render
@@ -72,7 +70,7 @@ RSpec.describe 'hyrax/admin/collection_types/_form_settings.html.erb', type: :vi
   context 'when all_settings_disabled? is true (admin_set or user collection type)' do
     before do
       allow(collection_type_form).to receive(:all_settings_disabled?).and_return(true)
-      allow(collection_type).to receive(:collections?).and_return(false)
+      allow(collection_type_form).to receive(:collections?).and_return(false)
       render
     end
 

--- a/spec/views/hyrax/admin/collection_types/index.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/collection_types/index.html.erb_spec.rb
@@ -4,22 +4,22 @@ require 'spec_helper'
 RSpec.describe 'hyrax/admin/collection_types/index.html.erb', type: :view do
   let(:user_collection_type) do
     stub_model(Hyrax::CollectionType,
-               collections?: false,
+               collections: [],
                title: 'User Collection')
   end
   let(:admin_set_collection_type) do
     stub_model(Hyrax::CollectionType,
-               collections?: false,
+               collections: [],
                title: 'Admin Set')
   end
   let(:custom1) do
     stub_model(Hyrax::CollectionType,
-               collections?: false,
+               collections: [],
                title: 'Test Title 1')
   end
   let(:custom2) do
     stub_model(Hyrax::CollectionType,
-               collections?: false,
+               collections: [],
                title: 'Test Title 2')
   end
 


### PR DESCRIPTION
adjust semantics of collection checking from `#count.positive?` to `#any?`. for
most enumerables, `#count.positive?` will involve touching all the objects in the
enumerator. instead, use `#any?` which lets the enumerator optimize checking for
presence.

while we're at it, deprecate the entire method and advise users to use `#any?`
instead.

@samvera/hyrax-code-reviewers
