### PR TITLE
support Valkyrie query for `CollectionType#collections` 

### DIFF
--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -163,7 +163,7 @@ module Hyrax
     end
 
     def exists_for_machine_id?(machine_id)
-      Hyrax::CollectionType.exists?(machine_id: machine_id)
+      self.class.exists?(machine_id: machine_id)
     end
   end
 end


### PR DESCRIPTION
continue to use ActiveFedora by default for now. this will be a cheap changeover
when wings is deprecated.

@samvera/hyrax-code-reviewers
