### PR TITLE
simplify collection metadata rendering

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -1,9 +1,29 @@
 # frozen_string_literal: true
 module Hyrax
   module CollectionsHelper
+    ##
+    # @since 3.0.0
+    # @return [#to_s]
+    def collection_metadata_label(collection, field)
+      Hyrax::PresenterRenderer.new(collection, self).label(field)
+    end
+
+    ##
+    # @since 3.0.0
+    # @return [#to_s]
+    def collection_metadata_value(collection, field)
+      Hyrax::PresenterRenderer.new(collection, self).value(field)
+    end
+
+    ##
+    # @deprecated Use #collection_metadata_label and #collection_metadata_value instead.
+    #
     # @param presenter [Hyrax::CollectionPresenter]
     # @param terms [Array<Symbol>,:all] the list of terms to draw
     def present_terms(presenter, terms = :all, &block)
+      Deprecation.warn("the .present_terms is deprecated for removal in Hyrax 4.0.0; " \
+                       "use #collection_metadata_label/value instead")
+
       terms = presenter.terms if terms == :all
       Hyrax::PresenterRenderer.new(presenter, self).fields(terms, &block)
     end

--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
   module CollectionsHelper
-    # TODO: we could move this to CollectionPresenter if it had a view_context
     # @param presenter [Hyrax::CollectionPresenter]
     # @param terms [Array<Symbol>,:all] the list of terms to draw
     def present_terms(presenter, terms = :all, &block)

--- a/app/presenters/hyrax/presenter_renderer.rb
+++ b/app/presenters/hyrax/presenter_renderer.rb
@@ -8,6 +8,10 @@ module Hyrax
       @view_context = view_context
     end
 
+    ##
+    # Renders a collection field partial
+    #
+    # @return [ActiveSupport::SafeBuffer] an html safe string containing the value markup
     def value(field_name, locals = {})
       render_show_field_partial(field_name, locals)
     end
@@ -18,7 +22,10 @@ module Hyrax
         default: [:"defaults.#{field}", field.to_s.humanize]).presence
     end
 
+    ##
+    # @deprecated
     def fields(terms, &_block)
+      Deprecation.warn("Fields is deprecated for removal in Hyrax 4.0.0. use #value and #label directly instead.")
       @view_context.safe_join(terms.map { |term| yield self, term })
     end
 

--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -1,8 +1,8 @@
-<dl>
-  <% present_terms(@presenter, @presenter.terms_with_values) do |r, term| %>
-    <div>
-      <dt><%= r.label(term) %></dt>
-      <dd><%= r.value(term) %></dd>
+<dl class="hyc-collection-metadata">
+  <% @presenter.terms_with_values.each do |field_name| %>
+    <div id=<%= "hyc-collection-metadata-#{field_name}" %>>
+      <dt><%= collection_metadata_label(@presenter, field_name) %></dt>
+      <dd><%= collection_metadata_value(@presenter, field_name) %></dd>
     </div>
   <% end %>
 </dl>

--- a/app/views/hyrax/dashboard/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_descriptions.html.erb
@@ -1,7 +1,7 @@
 <h2 class="sr-only"><%= t('.descriptions') %></h2>
 <dl class="dl-horizontal metadata-collections">
-  <% present_terms(@presenter, @presenter.terms_with_values) do |r, term| %>
-      <dt><%= r.label(term) %></dt>
-      <dd><%= r.value(term) %></dd>
+  <% @presenter.terms_with_values.each do |field_name| %>
+    <dt><%= collection_metadata_label(@presenter, field_name) %></dt>
+    <dd><%= collection_metadata_value(@presenter, field_name) %></dd>
   <% end %>
 </dl>

--- a/spec/presenters/hyrax/presenter_renderer_spec.rb
+++ b/spec/presenters/hyrax/presenter_renderer_spec.rb
@@ -28,4 +28,10 @@ RSpec.describe Hyrax::PresenterRenderer, type: :view do
       it { is_expected.to eq 'Date uploaded' }
     end
   end
+
+  describe "#value" do
+    it 'provides an HTML safe string' do
+      expect(renderer.value(:date_created)).to be_html_safe
+    end
+  end
 end


### PR DESCRIPTION
Collection metadata had complex helper behavior that led to a cyclical
dependency between view code, helpers, and renderers. This rewrite simplifies
the direction of the dependency, removing an awkward `yield`.

Since these methods handle HTML safety of strings, simplicity is a major benefit
here; it's crucial to avoid confusing HTML saftey behavior.

@samvera/hyrax-code-reviewers
