### PR TITLE
Allow for injection of new tabs on edit page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ _yardoc
 lib/bundler/man
 spec/reports
 /spec/examples.txt
+node_modules

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -16,6 +16,7 @@ module Hyrax
     include Hyrax::IiifHelper
     include Hyrax::MembershipHelper
     include Hyrax::PermissionLevelsHelper
+    include Hyrax::WorkFormHelper
 
     # Which translations are available for the user to select
     # @return [Hash<String,String>] locale abbreviations as keys and flags as values

--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Hyrax
+  module WorkFormHelper
+    def form_tabs_for(form:)
+      if form.instance_of? Hyrax::Forms::BatchUploadForm
+        %w[files metadata relationships]
+      else
+        %w[metadata files relationships]
+      end
+    end
+  end
+end

--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -19,7 +19,7 @@
       <p class="switch-upload-type"><%= t('.batch_upload_hint') %> <%= link_to t('.batch_link'), hyrax.new_batch_upload_path(payload_concern: @form.model.class) %></p>
     <% end %>
   <% end %>
-  <%= render 'hyrax/base/guts4form', f: f %>
+  <%= render 'hyrax/base/guts4form', f: f, tabs: form_tabs_for(form: f.object) %>
 <% end %>
 
 <script type="text/javascript">

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -1,5 +1,4 @@
 <% # we will yield to content_for for each tab, e.g. :files_tab %>
-<% tabs ||= %w[metadata files relationships] # default tab order %>
 <div class="row">
   <div class="col-xs-12 col-sm-8">
     <div class="panel panel-default tabs" role="main">

--- a/app/views/hyrax/batch_uploads/_form.html.erb
+++ b/app/views/hyrax/batch_uploads/_form.html.erb
@@ -10,7 +10,7 @@
       <%= link_to t("hyrax.batch_uploads.files.button_label"), [main_app, :new, Hyrax.primary_work_type.model_name.singular_route_key] %>
     </p>
   <% end %>
-  <%= render 'hyrax/base/guts4form', f: f, tabs: %w[files metadata relationships] %>
+  <%= render 'hyrax/base/guts4form', f: f, tabs: form_tabs_for(form: f.object) %>
   <%= f.hidden_field :payload_concern, value: @form.payload_concern %>
 <% end %>
 

--- a/spec/helpers/hyrax/work_helper_spec.rb
+++ b/spec/helpers/hyrax/work_helper_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::WorkFormHelper do
+  describe 'form_tabs_for' do
+    context 'with a change set style form' do
+      let(:work) { build(:hyrax_work) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+
+      it 'returns a default tab list' do
+        expect(form_tabs_for(form: form)).to eq ["metadata", "files", "relationships"]
+      end
+    end
+
+    context 'with a legacy GenericWork form' do
+      let(:work) { stub_model(GenericWork, id: '456') }
+      let(:ability) { double }
+      let(:form) { Hyrax::GenericWorkForm.new(work, ability, controller) }
+
+      it 'returns a default tab list' do
+        expect(form_tabs_for(form: form)).to eq ["metadata", "files", "relationships"]
+      end
+    end
+
+    context 'with a batch upload form' do
+      let(:work) { stub_model(GenericWork, id: '456') }
+      let(:ability) { double }
+      let(:form) { Hyrax::Forms::BatchUploadForm.new(work, ability, controller) }
+
+      it 'returns an alternate tab ordering' do
+        expect(form_tabs_for(form: form)).to eq ["files", "metadata", "relationships"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a new code seam allowing for the modification of tab
ordering and the addition (or removal) of tabs on a form by form basis.
The default tab order is moved out of the guts4form view partial and
into a helper.

To modify the default list of tabs in an application override the `form_tabs_for` helper method and make sure it gets loaded
after Hyrax::HyraxHelperBehavoir (by default included in app/helpers/hyrax_helper.rb). For example:
```
module WorksHelper
  def form_tabs_for(form:)
    super + ["my_new_tab"]
  end
end
```

The share tab has not been included in the default tab order because it
wasn't in the view partial.  Future work is to simplify the guts4form
partial so share can be treated the same as the other tabs and included
in the default list.

@samvera/hyrax-code-reviewers
