### PR TITLE
add tests for My Collections tabs; remove incorrect sr-only data

### DIFF
--- a/app/views/hyrax/my/collections/_tabs.html.erb
+++ b/app/views/hyrax/my/collections/_tabs.html.erb
@@ -1,8 +1,7 @@
 <ul class="nav nav-tabs" id="my_nav" role="navigation">
-  <span class="sr-only">You are currently listing your collections.  You have <%= @response.docs.count %> <%= 'collection'.pluralize(@response.docs.count) %> </span>
-    <li<%= ' class="active"'.html_safe if current_page?(hyrax.dashboard_collections_path(locale: nil)) %>>
-      <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.collections"), hyrax.dashboard_collections_path %>
-    </li>
+  <li<%= ' class="active"'.html_safe if current_page?(hyrax.dashboard_collections_path(locale: nil)) %>>
+    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.collections"), hyrax.dashboard_collections_path %>
+  </li>
   <li<%= ' class="active"'.html_safe if current_page?(hyrax.my_collections_path(locale: nil)) %>>
     <%= link_to t('hyrax.dashboard.my.your_collections'), hyrax.my_collections_path %>
   </li>

--- a/spec/views/hyrax/my/collections/index.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/index.html.erb_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "hyrax/my/collections/index.html.erb", type: :view do
     allow(view).to receive(:can?).with(any_args).and_return(false)
 
     stub_template "hyrax/my/collections/_scripts" => " "
-    stub_template "hyrax/my/collections/_tabs" => " "
     stub_template "hyrax/my/collections/_default_group" => " "
     stub_template "hyrax/my/collections/_search_header" => " "
     stub_template "hyrax/my/collections/_results_pagination" => " "
@@ -31,5 +30,30 @@ RSpec.describe "hyrax/my/collections/index.html.erb", type: :view do
   it 'indicate the number of collections to be 11' do
     render
     expect(rendered).to have_content("11 collections in the repository")
+  end
+
+  describe 'tabs' do
+    let(:ability) { instance_double(Ability, admin?: false) }
+
+    before do
+      assign(:managed_collection_count, 1)
+      allow(view).to receive(:current_ability).and_return(ability)
+    end
+
+    it 'shows managed and my collections' do
+      render
+      expect(rendered).to have_link('Managed Collections')
+      expect(rendered).to have_link('Your Collections')
+    end
+
+    context 'as admin' do
+      let(:ability) { instance_double(Ability, admin?: true) }
+
+      it 'shows all and my collections' do
+        render
+        expect(rendered).to have_link('All Collections')
+        expect(rendered).to have_link('Your Collections')
+      end
+    end
   end
 end


### PR DESCRIPTION
test My Collections tabs.

this partial had an un-i18nized `sr-only` span that included incorrect data: it
would displays "You are currently listing your collections.  you have 10
collections" anytime the user/repository has more than 10
collections. additionally the count, but not the text, was sensitive to tab
selection.

in any case, the correct information is displayed and i18nized
on-screen. deleting the span seems like a good call.

@samvera/hyrax-code-reviewers
