### PR TITLE
allow approvers to approve private works. Fixes issue #4411

### DIFF
--- a/app/search_builders/hyrax/search_filters.rb
+++ b/app/search_builders/hyrax/search_filters.rb
@@ -13,9 +13,22 @@ module Hyrax
       self
     end
 
+    # This method will return true if the user has an appoval role, and false otherwise.
+    # This is used to for approvers to gain access to a private work.  If this check were not done, the approver
+    # would not be able to access private works.
+    def user_approver?
+      approving_role = Sipity::Role.find_by(name: Hyrax::RoleRegistry::APPROVING)
+      return false unless approving_role
+      Hyrax::Workflow::PermissionQuery.scope_processing_agents_for(user: current_ability.current_user).any? do |agent|
+        agent.workflow_responsibilities.joins(:workflow_role)
+             .where('sipity_workflow_roles.role_id' => approving_role.id).any?
+      end
+    end
+
     # Override Hydra::AccessControlsEnforcement (or Hydra::PolicyAwareAccessControlsEnforcement)
     # Allows admin users to see everything (don't apply any gated_discovery_filters for those users)
     def gated_discovery_filters(permission_types = discovery_permissions, ability = current_ability)
+      return [] if user_approver?
       return [] if ability.admin?
       super
     end


### PR DESCRIPTION
Fixes #4411
Before this fix, if a user deposited a `private` work  using mediated deposit, and there were other users assigned the approver role, it was impossible for the users  with the approver role to actually approve the work.  When visiting the work page, they would get an Unauthorized warning.  It was working fine if the work being deposited was `public`, but not with `private` works.  With this change, approvers can approve both `public` and `private` works under mediated deposit.


Guidance for testing, such as acceptance criteria or new user interface behaviors:
*  Assign a user ( user1 ) an approver role.
*  Set the Admin set to use one step mediated deposit. 
*  Have an admin or a depositor deposit a work, and make the work private.
* Logout and login as user1
* Go to the dashboard and from the sidebar go to "Review Submissions"
* The private work just deposited should be listed there, click on it.
* Approve the work.

Repeat these steps with a public work.  

@samvera/hyrax-code-reviewers
