### PR TITLE
Adding .circleci/config.yml to circlci cache_key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - samvera/engine_cart_generate:
-          cache_key: v1-internal-test-app-{{ checksum "hyrax.gemspec" }}-{{ checksum ".regen" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
+          cache_key: v1-internal-test-app-{{ checksum "hyrax.gemspec" }}-{{ checksum ".regen" }}-{{ checksum ".circleci/config.yml" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>


### PR DESCRIPTION
As someone that has iterated on the CircleCI build in order to bring
Postgresql into the CircleCI test suite, I spent several times updating
the regen key.

By adding the checksum of .circleci/config.yml, whenever someone is
iterating on the configuration, CircleCI will naturally use a new cached instance.

@samvera/hyrax-code-reviewers
