### PR TITLE
ensure iiif manifest order

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter.rb
@@ -87,7 +87,12 @@ module Hyrax
     ##
     # @return [Array<#to_s>]
     def member_ids
-      Array(model.try(:member_ids))
+      case model
+      when Valkyrie::Resource
+        Array(model.try(:member_ids))
+      else
+        Hyrax::SolrDocument::OrderedMembers.decorate(model).ordered_member_ids
+      end
     end
 
     ##

--- a/spec/features/iiif_manifest_spec.rb
+++ b/spec/features/iiif_manifest_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'building a IIIF Manifest' do
 
   before do
     work.ordered_members += file_sets
-    work.members += member_works
+    work.ordered_members += member_works
     work.save
 
     sign_in user

--- a/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::IiifManifestPresenter do
 
         it 'includes items with read permissions' do
           readable = FactoryBot.create(:file_set, :image, user: user)
-          work.members << readable
+          work.ordered_members << readable
           work.save
 
           expect(builder_service.manifest_for(presenter: presenter)['sequences'].first['canvases'].count)
@@ -126,7 +126,7 @@ RSpec.describe Hyrax::IiifManifestPresenter do
 
           it 'has file sets the user can read' do
             readable = FactoryBot.create(:file_set, :image, user: user)
-            work.members << readable
+            work.ordered_members << readable
             work.save
 
             expect(presenter.file_set_presenters)


### PR DESCRIPTION
still thinking about how to do a robust test for this, but this ought to
reinstate careful ordering for IIIF manifests.

@samvera/hyrax-code-reviewers
