### PR TITLE
WIP: ensure iiif manifest order backport to 2.x

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter.rb
@@ -85,9 +85,14 @@ module Hyrax
     end
 
     ##
+    # @todo the hard coded dependency on `MemberPresenterFactory` is
+    #   undesirable and very weird. it's the only thing talking to the index
+    #   layer that knows about order, so here we are; extract ordered member
+    #   queries to someplace more reusable.
+    #
     # @return [Array<#to_s>]
     def member_ids
-      Array(model.try(:member_ids))
+      Hyrax::MemberPresenterFactory.new(model, ability, :FAKE_REQUEST).ordered_ids
     end
 
     ##


### PR DESCRIPTION
still thinking about how to do a robust test for this, but this ought to reinstate careful ordering for IIIF manifests.

backports #4447 

@samvera/hyrax-code-reviewers
