### PR TITLE
Stop triggering autocomplete for non-auto complete fields. Support data attribute based autocomplete types.

### DIFF
--- a/app/assets/javascripts/hyrax/autocomplete.es6
+++ b/app/assets/javascripts/hyrax/autocomplete.es6
@@ -10,6 +10,34 @@ export default class Autocomplete {
    * @param {string} url - The url for the autocompete search endpoint
    */
   setup (element, fieldName, url) {
+    if(element.data('autocomplete-type') && element.data('autocomplete-type').length > 0) {
+      this.byDataAttribute(element, url)
+    } else {
+      this.byFieldName(element, fieldName, url)
+    }
+  }
+
+  byDataAttribute(element, url) {
+    let type = element.data('autocomplete-type')
+    let exlude = element.data('exclude-work')
+    if(type === 'resource' && exclude.length > 0) {
+      new Resource(
+        element,
+        url,
+        { excluding: exclude }
+      )
+    } else if(type === 'resource' ) {
+      new Resource(
+        element,
+        url)
+    } else if(type === 'linked') {
+      new LinkedData(element, url)
+    } else {
+      new Default(element, url)
+    }
+  }
+
+  byFieldName(element, fieldName, url) {
     switch (fieldName) {
       case 'work':
         new Resource(
@@ -30,4 +58,5 @@ export default class Autocomplete {
         break
     }
   }
+
 }

--- a/app/assets/javascripts/hyrax/editor.es6
+++ b/app/assets/javascripts/hyrax/editor.es6
@@ -53,17 +53,16 @@ export default class {
       $('[data-autocomplete]').each((function() {
         var elem = $(this)
         autocomplete.setup(elem, elem.data('autocomplete'), elem.data('autocompleteUrl'))
+        elem.parents('.multi_value.form-group').manage_fields({
+          add: function(e, element) {
+            var elem = $(element)
+            // Don't mark an added element as readonly even if previous element was
+            // Enable before initializing, as otherwise LinkedData fields remain disabled
+            elem.attr('readonly', false)
+            autocomplete.setup(elem, elem.data('autocomplete'), elem.data('autocompleteUrl'))
+          }
+        })
       }))
-
-      $('.multi_value.form-group').manage_fields({
-        add: function(e, element) {
-          var elem = $(element)
-          // Don't mark an added element as readonly even if previous element was
-          // Enable before initializing, as otherwise LinkedData fields remain disabled
-          elem.attr('readonly', false)
-          autocomplete.setup(elem, elem.data('autocomplete'), elem.data('autocompleteUrl'))
-        }
-      })
   }
 
   // initialize any controlled vocabulary widgets


### PR DESCRIPTION
Moves to a new autocomplete type choosing system that uses data[autocomplete-type] to declaritively select
the type instead of just keying of certain field names. Does not remove the existing functionality, but is
a baby step toward depricating it.

Fixes #3510 ; refs #99 (maybe?)

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* There are no specs around the autocomplete js as is, so none were modified or edited
* Only real way to test the autocomplete getting called all the time is with a JS breakpoint or debugger statement. 
    Here's a video that shows it happening on Hyku running on vanilla Hyrax 2.5.1 https://share.getcloudapp.com/d5uWdzZj (sorry about the fan noise my mac is prepping for launch)
* Adding a new field and making it linked data can be done by adding a helper like so to the `app/views/records/edit_fields/_language.html.erb` file for example

```
<%= f.input key,
      as: :multi_value,
      input_html: {
        class: 'form-control',
        data: {
          'autocomplete-type' => 'linked',
          'autocomplete-url' => "/authorities/search/local/languages",
          'autocomplete' => key
        }
      },
 required: f.object.required?(key) %>
```

@samvera/hyrax-code-reviewers
