### PR TITLE
[Backport] Allow for injection of new tabs on edit page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ _yardoc
 lib/bundler/man
 spec/reports
 /spec/examples.txt
+node_modules

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -12,6 +12,7 @@ module Hyrax
     include Hyrax::ChartsHelper
     include Hyrax::DashboardHelperBehavior
     include Hyrax::IiifHelper
+    include Hyrax::WorkFormHelper
 
     # Which translations are available for the user to select
     # @return [Hash<String,String>] locale abbreviations as keys and flags as values

--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Hyrax
+  module WorkFormHelper
+    def form_tabs_for(form:)
+      if form.instance_of? Hyrax::Forms::BatchUploadForm
+        %w[files metadata relationships]
+      else
+        %w[metadata files relationships]
+      end
+    end
+  end
+end

--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -19,7 +19,7 @@
       <p class="switch-upload-type">To create a separate work for each of the files, go to <%= link_to "Batch upload", hyrax.new_batch_upload_path %></p>
     <% end %>
   <% end %>
-  <%= render 'hyrax/base/guts4form', f: f %>
+  <%= render 'hyrax/base/guts4form', f: f, tabs: form_tabs_for(form: f.object) %>
 <% end %>
 
 <script type="text/javascript">

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -1,5 +1,11 @@
 <% # we will yield to content_for for each tab, e.g. :files_tab %>
-<% tabs ||= %w[metadata files relationships] # default tab order %>
+<%# Not passing tabs local param to this partial is deprecated and the tabs param will be required in Hyrax 3.0 %>
+<% unless defined?(tabs) %>
+  <% Deprecation.warn(self, "Passing the tabs local param to the _guts4form partial will be required in Hyrax 3.0.  " \
+                            "Consider removing overriding view partials and customizing the tab list " \
+                            "by overriding the new form_tabs_for(form:) helper.") %>
+  <% tabs = form_tabs_for(form: f.object) # default tab order %>
+<% end %>
 <div class="row">
   <div class="col-xs-12 col-sm-8">
     <div class="panel panel-default tabs" role="main">

--- a/app/views/hyrax/batch_uploads/_form.html.erb
+++ b/app/views/hyrax/batch_uploads/_form.html.erb
@@ -10,7 +10,7 @@
       <%= link_to t("hyrax.batch_uploads.files.button_label"), [main_app, :new, Hyrax.primary_work_type.model_name.singular_route_key] %>
     </p>
   <% end %>
-  <%= render 'hyrax/base/guts4form', f: f, tabs: %w[files metadata relationships] %>
+  <%= render 'hyrax/base/guts4form', f: f, tabs: form_tabs_for(form: f.object) %>
   <%= f.hidden_field :payload_concern, value: @form.payload_concern %>
 <% end %>
 

--- a/spec/helpers/hyrax/work_helper_spec.rb
+++ b/spec/helpers/hyrax/work_helper_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::WorkFormHelper do
+  describe 'form_tabs_for' do
+    context 'with a work form' do
+      let(:work) { stub_model(GenericWork, id: '456') }
+      let(:ability) { double }
+      let(:form) { Hyrax::GenericWorkForm.new(work, ability, controller) }
+
+      it 'returns a default tab list' do
+        expect(form_tabs_for(form: form)).to eq ["metadata", "files", "relationships"]
+      end
+    end
+
+    context 'with a batch upload form' do
+      let(:work) { stub_model(GenericWork, id: '456') }
+      let(:ability) { double }
+      let(:form) { Hyrax::Forms::BatchUploadForm.new(work, ability, controller) }
+
+      it 'returns an alternate tab ordering' do
+        expect(form_tabs_for(form: form)).to eq ["files", "metadata", "relationships"]
+      end
+    end
+  end
+end

--- a/spec/views/hyrax/base/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form.html.erb_spec.rb
@@ -77,4 +77,43 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
       expect(rendered).to have_content("visibility_error")
     end
   end
+
+  describe "tabs" do
+    let(:work) { stub_model(GenericWork, id: '456') }
+
+    before do
+      allow(form).to receive(:select_files).and_return([])
+    end
+
+    context "wtth default tabs" do
+      it 'renders the expected tabs' do
+        render
+        expect(rendered).to have_link('Descriptions')
+        expect(rendered).to have_link('Files')
+        expect(rendered).to have_link('Relationships')
+        expect(rendered).to have_link('Sharing')
+      end
+    end
+
+    context 'with non-default tabs' do
+      let(:tab_order) { ['metadata', 'relationships', 'newtab'] }
+
+      before do
+        allow(view).to receive(:form_tabs_for).with(form: form).and_return(tab_order)
+        allow(view).to receive(:t).and_call_original
+        allow(view).to receive(:t).with('hyrax.works.form.tab.newtab').and_return('New Tab')
+        stub_template 'hyrax/base/_form_newtab.html.erb' => 'NewTab Content'
+      end
+
+      it 'renders the expected tabs' do
+        render
+        expect(rendered).to have_link('Descriptions')
+        expect(rendered).to have_link('Relationships')
+        expect(rendered).to have_link('New Tab')
+        expect(rendered).to have_link('Sharing')
+        expect(rendered).not_to have_link('Files')
+        expect(rendered).to match(/NewTab Content/)
+      end
+    end
+  end
 end

--- a/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe 'hyrax/batch_uploads/_form.html.erb', type: :view do
   let(:work) { GenericWork.new }
   let(:ability) { double('ability', current_user: user) }
+  let(:controller_class) { Hyrax::BatchUploadsController }
+  let(:options_presenter) { double(select_options: []) }
   let(:form) { Hyrax::Forms::BatchUploadForm.new(work, ability, controller) }
   let(:user) { stub_model(User) }
   let(:page) do
@@ -9,7 +11,13 @@ RSpec.describe 'hyrax/batch_uploads/_form.html.erb', type: :view do
   end
 
   before do
-    stub_template "hyrax/base/_guts4form.html.erb" => "Form guts"
+    # Tell rspec where to find form_* partials
+    view.lookup_context.prefixes << 'hyrax/base'
+    allow(controller).to receive(:current_user).and_return(stub_model(User))
+    allow(controller).to receive(:repository).and_return(controller_class.new.repository)
+    allow(controller).to receive(:blacklight_config).and_return(controller_class.new.blacklight_config)
+    # mock the admin set options presenter to avoid hitting Solr
+    allow(Hyrax::AdminSetOptionsPresenter).to receive(:new).and_return(options_presenter)
     assign(:form, form)
   end
 
@@ -20,5 +28,14 @@ RSpec.describe 'hyrax/batch_uploads/_form.html.erb', type: :view do
     # No title, because it's captured per file (e.g. Display label)
     expect(page).not_to have_selector("input#generic_work_title")
     expect(view.content_for(:files_tab)).to have_link("New Work", href: "/concern/generic_works/new")
+  end
+
+  describe 'tabs' do
+    it 'shows form tabs' do
+      expect(page).to have_link('Files')
+      expect(page).to have_link('Descriptions')
+      expect(page).to have_link('Relationships')
+      expect(page).to have_link('Sharing')
+    end
   end
 end


### PR DESCRIPTION
This commit adds a new code seam allowing for the modification of tab
ordering and the addition (or removal) of tabs on a form by form basis.
The default tab order is moved out of the guts4form view partial and
into a helper.

To modify the default list of tabs in an application override the `form_tabs_for` helper method and make sure it gets loaded
after Hyrax::HyraxHelperBehavoir (by default included in app/helpers/hyrax_helper.rb). For example:
```
module WorksHelper
  def form_tabs_for(form:)
    super + ["my_new_tab"]
  end
end
```

A deprecation warning was added for cases where the view calling
guts4form doesn't pass the tabs local param.

The share tab has not been included in the default tab order because it
wasn't in the view partial.  Future work is to simplify the guts4form
partial so share can be treated the same as the other tabs and included
in the default list.

Backport of #4440.

@samvera/hyrax-code-reviewers
