### PR TITLE
Stop triggering autocomplete for non-auto complete fields. Support da…

### DIFF
--- a/app/assets/javascripts/hyrax/autocomplete.es6
+++ b/app/assets/javascripts/hyrax/autocomplete.es6
@@ -10,6 +10,34 @@ export default class Autocomplete {
    * @param {string} url - The url for the autocompete search endpoint
    */
   setup (element, fieldName, url) {
+    if(element.data('autocomplete-type') && element.data('autocomplete-type').length > 0) {
+      this.byDataAttribute(element, url)
+    } else {
+      this.byFieldName(element, fieldName, url)
+    }
+  }
+
+  byDataAttribute(element, url) {
+    let type = element.data('autocomplete-type')
+    let exlude = element.data('exclude-work')
+    if(type === 'resource' && exclude.length > 0) {
+      new Resource(
+        element,
+        url,
+        { excluding: exclude }
+      )
+    } else if(type === 'resource' ) {
+      new Resource(
+        element,
+        url)
+    } else if(type === 'linked') {
+      new LinkedData(element, url)
+    } else {
+      new Default(element, url)
+    }
+  }
+
+  byFieldName(element, fieldName, url) {
     switch (fieldName) {
       case 'work':
         new Resource(
@@ -30,4 +58,5 @@ export default class Autocomplete {
         break
     }
   }
+
 }

--- a/app/assets/javascripts/hyrax/editor.es6
+++ b/app/assets/javascripts/hyrax/editor.es6
@@ -53,17 +53,16 @@ export default class {
       $('[data-autocomplete]').each((function() {
         var elem = $(this)
         autocomplete.setup(elem, elem.data('autocomplete'), elem.data('autocompleteUrl'))
+        elem.parents('.multi_value.form-group').manage_fields({
+          add: function(e, element) {
+            var elem = $(element)
+            // Don't mark an added element as readonly even if previous element was
+            // Enable before initializing, as otherwise LinkedData fields remain disabled
+            elem.attr('readonly', false)
+            autocomplete.setup(elem, elem.data('autocomplete'), elem.data('autocompleteUrl'))
+          }
+        })
       }))
-
-      $('.multi_value.form-group').manage_fields({
-        add: function(e, element) {
-          var elem = $(element)
-          // Don't mark an added element as readonly even if previous element was
-          // Enable before initializing, as otherwise LinkedData fields remain disabled
-          elem.attr('readonly', false)
-          autocomplete.setup(elem, elem.data('autocomplete'), elem.data('autocompleteUrl'))
-        }
-      })
   }
 
   // initialize any controlled vocabulary widgets


### PR DESCRIPTION
…ta attribute based autocomplete types.

Moves to a new autocomplete type choosing system that uses data[autocomplete-type] to declaritively select
the type instead of just keying of certain field names. Does not remove the existing functionality, but is
a baby step toward depricating it.

@samvera/hyrax-code-reviewers
