### PR TITLE
Removing expensive CircleCI steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,12 +114,6 @@ jobs:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
           project: hyrax
-      - run:
-          command: |
-            cd .internal_test_app
-            bundle install
-            bundle exec rake hyrax:install:migrations
-            bundle exec rake db:migrate
       - samvera/parallel_rspec
 
 workflows:

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -143,4 +143,10 @@ class TestAppGenerator < Rails::Generators::Base
   def create_sample_metadata_configuration
     copy_file 'sample_metadata.yaml', 'config/metadata/sample_metadata.yaml'
   end
+
+  def run_finishing_migrations
+    # Because other upstream methods may have installed migrations, we
+    # should catch them here.
+    rake "db:migrate"
+  end
 end


### PR DESCRIPTION
In working to get Hyrax building on CircleCI with Postgresql, I added
the step to CirclCI's build.  I'd prefer that this not exist, as it adds
5 minutes to the build process.

I believe that in adding `run_finishing_migrations` to the test app
generator, I should get what I'm after.

Here's hoping!

How to test and verify? At present, you can look at a [CircleCI job][https://app.circleci.com/pipelines/github/samvera/hyrax/3835/workflows/497885bd-6d5a-420c-bd05-ecbd263a7dd0/jobs/25977] and see a step labeled "`cd .internal_test_app bundle install…`". It appears just before `run rspec in parallel`.

If this change works, you won't see that step AND the specs will pass.

@samvera/hyrax-code-reviewers
