### PR TITLE
Allow for injection of new sections in form progress panel

### DIFF
--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -1,12 +1,48 @@
 # frozen_string_literal: true
 module Hyrax
   module WorkFormHelper
+    ##
+    # This helper allows downstream applications and engines to add/remove/reorder the tabs to be
+    # rendered on the work form.
+    #
+    # @example with additional tabs
+    #  Override this helper and ensure that it loads after Hyrax's helpers.
+    #  module WorksHelper
+    #    def form_tabs_for(form:)
+    #      super + ["my_new_tab"]
+    #    end
+    #  end
+    #  Add the new section partial at app/views/hyrax/base/_form_my_new_tab.html.erb
+    #
+    # @todo The share tab isn't included because it wasn't in guts4form.  guts4form should be
+    #   cleaned up so share is treated the same as other tabs and can be included below.
+    # @param form [Hyrax::Forms::WorkForm, Hyrax::Forms::ResourceForm]
+    # @return [Array<String>] the list of names of tabs to be rendered in the form
     def form_tabs_for(form:)
       if form.instance_of? Hyrax::Forms::BatchUploadForm
         %w[files metadata relationships]
       else
         %w[metadata files relationships]
       end
+    end
+
+    ##
+    # This helper allows downstream applications and engines to add additional sections to be
+    # rendered after the visibility section in the Save Work panel on the work form.
+    #
+    # @example with additional sections
+    #  Override this helper and ensure that it loads after Hyrax's helpers.
+    #  module WorksHelper
+    #    def form_progress_sections_for(*)
+    #      super + ["my_new_section"]
+    #    end
+    #  end
+    #  Add the new section partial at app/views/hyrax/base/_form_progress_my_new_section.html.erb
+    #
+    # @param form [Hyrax::Forms::WorkForm, Hyrax::Forms::ResourceForm]
+    # @return [Array<String>] the list of names of sections to be rendered in the form_progress panel
+    def form_progress_sections_for(*)
+      []
     end
   end
 end

--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -26,6 +26,10 @@
           <%= f.input :on_behalf_of, label: t(".proxy_depositors"), collection: current_user.can_make_deposits_for, prompt: t(".yourself"), value_method: :user_key %>
         </div>
     <% end %>
+
+    <% form_progress_sections_for(form: f.object).each do |section| %>
+      <%= render "form_progress_#{section}", f: f %>
+    <% end %>
   </div>
   <div class="panel-footer text-center">
     <% if ::Flipflop.show_deposit_agreement? %>

--- a/spec/helpers/hyrax/work_form_helper_spec.rb
+++ b/spec/helpers/hyrax/work_form_helper_spec.rb
@@ -31,4 +31,35 @@ RSpec.describe Hyrax::WorkFormHelper do
       end
     end
   end
+
+  describe 'form_progress_sections_for' do
+    context 'with a change set style form' do
+      let(:work) { build(:hyrax_work) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+
+      it 'returns an empty list' do
+        expect(form_progress_sections_for(form: form)).to eq []
+      end
+    end
+
+    context 'with a legacy GenericWork form' do
+      let(:work) { stub_model(GenericWork, id: '456') }
+      let(:ability) { double }
+      let(:form) { Hyrax::GenericWorkForm.new(work, ability, controller) }
+
+      it 'returns an empty list' do
+        expect(form_progress_sections_for(form: form)).to eq []
+      end
+    end
+
+    context 'with a batch upload form' do
+      let(:work) { stub_model(GenericWork, id: '456') }
+      let(:ability) { double }
+      let(:form) { Hyrax::Forms::BatchUploadForm.new(work, ability, controller) }
+
+      it 'returns an empty list' do
+        expect(form_progress_sections_for(form: form)).to eq []
+      end
+    end
+  end
 end

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -129,4 +129,22 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
       expect(page).to have_selector("input#generic_work_version[value=\"123456\"]", visible: false)
     end
   end
+
+  context 'when additional sections are added' do
+    let(:work) { stub_model(GenericWork, id: '456', etag: '123456') }
+
+    before do
+      allow(work).to receive(:new_record?).and_return(false)
+      assign(:form, form)
+      allow(Hyrax.config).to receive(:active_deposit_agreement_acceptance)
+        .and_return(true)
+
+      allow(view).to receive(:form_progress_sections_for).with(form: form).and_return(['newsection'])
+      stub_template 'hyrax/base/_form_progress_newsection.html.erb' => '<div class="list-group-item">New Section</div>'
+    end
+
+    it 'renders the additional sections' do
+      expect(page).to have_text('New Section')
+    end
+  end
 end


### PR DESCRIPTION
This commit adds a new code seam allowing for adding new sections to the
form progress panel that renders on the right side of the work form.

To add a section in an application override the form_progress_sections_for helper method and make sure it gets loaded
after Hyrax::HyraxHelperBehavoir (by default included in app/helpers/hyrax_helper.rb). For example:

```
module WorksHelper
  def form_progress_sections_for(*)
    super + ["my_new_section"]
  end
end
```

Then add a new partial at `app/views/hyrax/base/_form_progress_my_new_section.html.erb`.

Also in this PR:
- work form helper spec file renamed to match the name of the module tested
- yard docs added for new helper methods with examples

@samvera/hyrax-code-reviewers
