### PR TITLE
move ordered member id querying to a decorator for SolrDocument

### DIFF
--- a/app/models/concerns/hyrax/solr_document/ordered_members.rb
+++ b/app/models/concerns/hyrax/solr_document/ordered_members.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+module Hyrax
+  module SolrDocument
+    ##
+    # Decorates an object responding to `#id` with an `#ordered_member_ids` method.
+    #
+    # @note this decorator is intended for use with data representations other
+    #   than the core model objects, as an alternative to a direct query of the
+    #   canonical database. for example, it can be used with `SolrDocument` to
+    #   quickly retrieve member order in a way that is compatible with the
+    #   fast access required in Blacklight's search contexts.
+    #
+    # @example
+    #   base_document = SolrDocument.new(my_work.to_solr)
+    #   solr_document = Hyrax::SolrDocument::OrderedMembers.decorate(base_document)
+    #
+    #   solr_document.ordered_member_ids # => ['abc', '123']
+    #
+    class OrderedMembers < Draper::Decorator
+      delegate_all
+
+      ##
+      # @note the purpose of this method is to provide fast access to member
+      #   order. currently this is achieved by accessing indexed list proxies
+      #   from Solr. however, this strategy may change in the future.
+      #
+      # @return [Enumerable<String>] ids in the order of their membership,
+      #   only includes ids of ordered members.
+      def ordered_member_ids
+        return [] if id.blank?
+        @ordered_member_ids ||= query_for_ordered_ids
+      end
+
+      private
+
+      def query_for_ordered_ids(limit: 10_000,
+                                proxy_field: 'proxy_in_ssi',
+                                target_field: 'ordered_targets_ssim')
+        Hyrax::SolrService
+          .query("#{proxy_field}:#{id}", rows: limit, fl: target_field)
+          .flat_map { |x| x.fetch(target_field, nil) }
+          .compact
+      end
+    end
+  end
+end

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -10,7 +10,7 @@ module Hyrax
     self.work_presenter_class = WorkShowPresenter
 
     def initialize(work, ability, request = nil)
-      @work = work
+      @work = Hyrax::SolrDocument::OrderedMembers.decorate(work)
       @current_ability = ability
       @request = request
     end
@@ -38,12 +38,7 @@ module Hyrax
     end
 
     def ordered_ids
-      @ordered_ids ||= begin
-                         Hyrax::SolrService.query("proxy_in_ssi:#{id}",
-                                                  rows: 10_000,
-                                                  fl: "ordered_targets_ssim")
-                                           .flat_map { |x| x.fetch("ordered_targets_ssim", []) }
-                       end
+      @work.ordered_member_ids
     end
 
     private

--- a/spec/models/concerns/hyrax/solr_document/ordered_members_spec.rb
+++ b/spec/models/concerns/hyrax/solr_document/ordered_members_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::SolrDocument::OrderedMembers do
+  subject(:decorated) { described_class.decorate(document) }
+  let(:data) { { id: parent_id } }
+  let(:document) { SolrDocument.new(data) }
+  let(:parent_id) { '1' }
+
+  describe '#ordered_member_ids' do
+    context 'with no id' do
+      let(:data) { {} }
+
+      it 'is empty' do
+        expect(decorated.ordered_member_ids).to be_empty
+      end
+    end
+
+    context 'with no members' do
+      it 'is empty' do
+        expect(decorated.ordered_member_ids).to be_empty
+      end
+    end
+
+    context 'with ordered members' do
+      let(:parent) { create(:work_with_ordered_files) }
+      let(:parent_id) { parent.id.to_s }
+
+      it 'has the file ids in exact order' do
+        expect(decorated.ordered_member_ids).to eq parent.ordered_member_ids
+      end
+    end
+  end
+end


### PR DESCRIPTION
instead of isolating this logic `MemberPresenterFactory`, where i need an
Ability and a request context in order to run the query, extract for use with
`SolrDocument`.

since this isn't behavior for accessing `SolrDocument` data, per se, we can
avoid clutter and accidental querying by putting it in a decorator. to use, you
need to explictly `.decorate` the `SolrDocument` instance.

this will actually work for anything that's indexed with an `#id` and that has
`ActiveFedora`-style list proxy indexes. that means it *won't* work for
`Valkyrie` resources, at least as currently setup. maybe we don't need it for
them? work still to do on order there.

@samvera/hyrax-code-reviewers
