### PR TITLE
circle ci: protect expensive builds with `lint`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,37 +125,50 @@ workflows:
       - bundle:
           ruby_version: "2.5.8"
           rails_version: "5.2.4.3"
+      - lint:
+          ruby_version: "2.5.8"
+          requires:
+            - bundle
       - build:
           ruby_version: "2.5.8"
           rails_version: "5.2.4.3"
           requires:
             - bundle
+            - lint
       - test:
           name: "ruby2-5-8"
           ruby_version: "2.5.8"
           requires:
             - build
+            - lint
   ruby2-6-6:
     jobs:
       - bundle:
           ruby_version: "2.6.6"
           rails_version: "5.2.4.3"
+      - lint:
+          ruby_version: "2.6.6"
+          requires:
+            - bundle
       - build:
           ruby_version: "2.6.6"
           rails_version: "5.2.4.3"
           requires:
             - bundle
+            - lint
       - test:
           name: "ruby2-6-6"
           ruby_version: "2.6.6"
           requires:
             - build
+            - lint
       - test:
           name: "ruby2-6-6-valkyrie"
           ruby_version: "2.6.6"
           hyrax_valkyrie: "true"
           requires:
             - build
+            - lint
   ruby2-7-1:
     jobs:
       - bundle:
@@ -172,6 +185,7 @@ workflows:
           bundler_version: "2.1.4"
           requires:
             - bundle
+            - lint
       - test:
           name: "ruby2-7-1"
           ruby_version: "2.7.1"


### PR DESCRIPTION
avoid computationally expensive builds by running lint for all workflows first.

there might be a more elegant DAG-oriented solution, where we have one lint
process instead of splitting it across the workflows, but i think this will
improve the situation overall.

@samvera/hyrax-code-reviewers
