### PR TITLE
reload valkyrie resource after running after_create

### DIFF
--- a/lib/hyrax/specs/shared_specs/factories/strategies/valkyrie_resource.rb
+++ b/lib/hyrax/specs/shared_specs/factories/strategies/valkyrie_resource.rb
@@ -10,13 +10,17 @@ class ValkyrieCreateStrategy
     result = persister.save(resource: evaluation.object)
 
     evaluation.notify(:after_create, result)
-    result
+    query_service.find_by(id: result.id)
   end
 
   private
 
   def persister
     Hyrax.persister
+  end
+
+  def query_service
+    Hyrax.query_service
   end
 end
 
@@ -28,5 +32,9 @@ class ValkyrieTestAdapterCreateStrategy < ValkyrieCreateStrategy
 
   def persister
     Valkyrie::MetadataAdapter.find(:test_adapter).persister
+  end
+
+  def query_service
+    Valkyrie::MetadataAdapter.find(:test_adapter).query_service
   end
 end


### PR DESCRIPTION
## Description of Change

If a resource created using ValkyrieCreateStrategy is changed in the after_create, those changes are lost unless `result` is reloaded with those changes.  This PR uses the query_service to find and reload the resource.

## Example of where this is required

If a work is added to a collection in after_create, it changes the work resource.  If the work is not reloaded using `query_service #find_by(id:)`, the relationship is lost.  The updated work resource needs to be returned by the ValkyrieCreateStrategy; otherwise, the test using the factory created resource will not pick up the changes to the resource.

@samvera/hyrax-code-reviewers
