### PR TITLE
adds support for ActiveModel-safe decoration

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -232,5 +232,14 @@ module Hyrax
              .where('sipity_workflow_roles.role_id' => approving_role.id).any?
       end
     end
+
+    def extract_subjects(subject)
+      case subject
+      when Draper::Decorator
+        super(subject.model)
+      else
+        super
+      end
+    end
   end
 end

--- a/app/models/concerns/hyrax/solr_document/ordered_members.rb
+++ b/app/models/concerns/hyrax/solr_document/ordered_members.rb
@@ -16,9 +16,7 @@ module Hyrax
     #
     #   solr_document.ordered_member_ids # => ['abc', '123']
     #
-    class OrderedMembers < Draper::Decorator
-      delegate_all
-
+    class OrderedMembers < Hyrax::ModelDecorator
       ##
       # @note the purpose of this method is to provide fast access to member
       #   order. currently this is achieved by accessing indexed list proxies

--- a/app/models/sipity.rb
+++ b/app/models/sipity.rb
@@ -22,6 +22,8 @@ module Sipity
                Entity.find_by(proxy_for_global_id: input.to_s)
              when SolrDocument
                Entity(input.to_model)
+             when Draper::Decorator
+               Entity(input.model)
              when Sipity::Comment
                Entity(input.entity)
              else

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -27,7 +27,7 @@ module Hyrax
     # @param [ActionDispatch::Request] request the http request context. Used so
     #                                  the GraphExporter knows what URLs to draw.
     def initialize(solr_document, current_ability, request = nil)
-      @solr_document = solr_document
+      @solr_document = Hyrax::SolrDocument::OrderedMembers.decorate(solr_document)
       @current_ability = current_ability
       @request = request
     end

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -24,6 +24,7 @@ module Hyrax
     require 'hyrax/controller_resource'
     require 'hyrax/form_fields'
     require 'hyrax/indexer'
+    require 'hyrax/model_decorator'
     require 'hyrax/publisher'
     require 'hyrax/schema'
     require 'hyrax/search_state'

--- a/lib/hyrax/model_decorator.rb
+++ b/lib/hyrax/model_decorator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # Provides ActiveModel-safe decoration via `Draper`.
+  #
+  # This is needed to preserve Presenter, View, and URL
+  # helper behavior for decorated models.
+  #
+  # @example
+  #   class TitleDecorator < Hyrax::ModelDecorator
+  #     ##
+  #     # @return [String]
+  #     def title
+  #       Array(object.title).first.capitalize
+  #     end
+  #   end
+  #
+  #   my_model.title # => ['moomin']
+  #   decorated = TitleDecorator.decorate(my_model)
+  #
+  #   decorated.title # => 'Moomin'
+  #   url_helpers.download_url(decorated) == url_helpers.download_url(my_model) # => true
+  #
+  class ModelDecorator < Draper::Decorator
+    delegate_all
+
+    def to_model(*args)
+      object.to_model(*args)
+    end
+  end
+end

--- a/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_show_actions.html.erb_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'hyrax/file_sets/_show_actions.html.erb', type: :view do
   describe 'citations' do
     before do
       Hyrax.config.citations = citations
-      allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
+      allow(ability).to receive(:can?).with(:edit, anything).and_return(false)
       assign(:presenter, presenter)
       view.lookup_context.view_paths.push 'app/views/hyrax/base'
       render


### PR DESCRIPTION
we have a few `Draper::Decorators`, which we use to good effect. most recently,
we've introduced a Decorator for `SolrDocument` which layers on support for
querying order. when we decorate `SolrDocument` in this way in a presenter,
however, it breaks `Ability#can?`, url helpers, and more. the reasons for this
are rooted in `#to_model` and `#model_name` both of which we handle specially
within Hyrax. `Draper` tries to address this issue in various ways, but isn't
terribly clear about its own design goals on this front; see, e.g.
 https://github.com/drapergem/draper/pull/357

this is a bit of an inflection point. i'm half tempted to turn around completely
on using `Draper` (though Valkyrie users seem happy enough?). i'm another
fraction tempted to just only use decorators in very narrow, internal
circumstances, never exposing them to presenters or views as a strict rule.

this PR represents the alternative: commit to supporting absolutely transparent
model decoration in a way that works for `Hyrax::Naming`,
`SimpleForm`/`Hydra::Editor`, `SolrDocument`, and `Hyrax::Ability`/
`Hydra::AccessControls`.

probably if we go down this route this class will grow, and we'll have taken on
its maintenance in the bargain. so what do we think?

@samvera/hyrax-code-reviewers
