### PR TITLE
allow for extensions of valkyrie indexer's to_solr that depends on resource custom metadata

### DIFF
--- a/app/indexers/hyrax/valkyrie_collection_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_collection_indexer.rb
@@ -7,6 +7,7 @@ module Hyrax
     include Hyrax::ResourceIndexer
     include Hyrax::PermissionIndexer
     include Hyrax::VisibilityIndexer
+    include Hyrax::Indexer(:core_metadata)
 
     def to_solr
       super.tap do |index_document|

--- a/app/services/hyrax/thumbnail_path_service.rb
+++ b/app/services/hyrax/thumbnail_path_service.rb
@@ -5,7 +5,7 @@ module Hyrax
       # @param [#id] object - to get the thumbnail for
       # @return [String] a path to the thumbnail
       def call(object)
-        return default_image unless object.try(:thumbnail_id)&.to_s&.present?
+        return default_image if object.try(:thumbnail_id).blank?
 
         thumb = fetch_thumbnail(object)
 

--- a/app/services/hyrax/thumbnail_path_service.rb
+++ b/app/services/hyrax/thumbnail_path_service.rb
@@ -5,7 +5,7 @@ module Hyrax
       # @param [#id] object - to get the thumbnail for
       # @return [String] a path to the thumbnail
       def call(object)
-        return default_image unless object.try(:thumbnail_id)
+        return default_image unless object.try(:thumbnail_id)&.to_s&.present?
 
         thumb = fetch_thumbnail(object)
 

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -1,12 +1,21 @@
 # frozen_string_literal: true
 
+# These shared specs test various aspects of valkyrie based indexers by calling the #to_solr method.
+# All tests require two variables to be set in the caller using let statements:
+#   * indexer_class - class of the indexer being tested
+#   * resource - a Hyrax::Resource that defines attributes and values consistent with the indexer
+#
+# NOTE: It is important that the resource has required values that the indexer #to_solr customizations expects to be available.
 RSpec.shared_examples 'a Hyrax::Resource indexer' do
-  subject(:indexer)  { indexer_class.new(resource: the_resource) }
-  let(:the_resource) { defined?(resource) ? resource : Hyrax::Resource.new }
+  before do
+    raise 'indexer_class must be set with `let(:indexer_class)`' unless defined? indexer_class
+    raise 'resource must be set with `let(:resource)` and is expected to be a kind of Hyrax::Resource' unless defined?(resource) && resource.kind_of?(Hyrax::Resource)
+    resource.alternate_ids = ids
+  end
+  subject(:indexer)  { indexer_class.new(resource: resource) }
   let(:ids)          { ['id1', 'id2'] }
 
   describe '#to_solr' do
-    before { the_resource.alternate_ids = ids }
     it 'indexes alternate_ids' do
       expect(indexer.to_solr)
         .to include(alternate_ids_sm: a_collection_containing_exactly(*ids))
@@ -15,23 +24,18 @@ RSpec.shared_examples 'a Hyrax::Resource indexer' do
 end
 
 RSpec.shared_examples 'a permission indexer' do
-  subject(:indexer) { indexer_class.new(resource: the_resource) }
-  let(:the_resource) do
-    if defined?(resource)
-      Hyrax::VisibilityWriter.new(resource: resource)
-          .assign_access_for(visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
-      resource.permission_manager.edit_groups = edit_groups
-      resource.permission_manager.edit_users  = edit_users
-      resource.permission_manager.read_users  = read_users
-      resource.permission_manager.acl.save
-      resource
-    else
-      FactoryBot.valkyrie_create(:hyrax_work, :public,
-                                 read_users: read_users,
-                                 edit_groups: edit_groups,
-                                 edit_users: edit_users)
-    end
+  before do
+    raise 'indexer_class must be set with `let(:indexer_class)`' unless defined? indexer_class
+    # NOTE: resource must be persisted for these tests to pass
+    raise 'resource must be set with `let(:resource)` and is expected to be a kind of Hyrax::Resource' unless defined?(resource) && resource.kind_of?(Hyrax::Resource)
+    Hyrax::VisibilityWriter.new(resource: resource)
+        .assign_access_for(visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+    resource.permission_manager.edit_groups = edit_groups
+    resource.permission_manager.edit_users  = edit_users
+    resource.permission_manager.read_users  = read_users
+    resource.permission_manager.acl.save
   end
+  subject(:indexer) { indexer_class.new(resource: resource) }
   let(:edit_groups) { [:managers] }
   let(:edit_users)  { [FactoryBot.create(:user)] }
   let(:read_users)  { [FactoryBot.create(:user)] }
@@ -52,17 +56,23 @@ RSpec.shared_examples 'a permission indexer' do
 end
 
 RSpec.shared_examples 'a visibility indexer' do
-  subject(:indexer)  { indexer_class.new(resource: the_resource) }
-  let(:the_resource) { defined?(resource) ? resource : FactoryBot.build(:hyrax_work) }
+  before do
+    raise 'indexer_class must be set with `let(:indexer_class)`' unless defined? indexer_class
+    raise 'resource must be set with `let(:resource)` and is expected to be a kind of Hyrax::Resource' unless defined?(resource) && resource.kind_of?(Hyrax::Resource)
+    # optionally can pass in default_visibility by setting it with a let statement if your application changes the default; Hyrax defines this as 'restricted'
+    # See samvera/hyrda-head hydra-access-controls/app/models/concerns/hydra/access_controls/access_rights.rb for possible VISIBILITY_TEXT_VALUE_...'
+  end
+  subject(:indexer)  { indexer_class.new(resource: resource) }
 
   describe '#to_solr' do
-    it 'indexes visibility' do
-      expect(indexer.to_solr).to include(visibility_ssi: 'restricted')
+    it 'indexes default visibility as restricted or passed in default' do
+      expected_value = defined?(default_visibility) ? default_visibility : 'restricted'
+      expect(indexer.to_solr).to include(visibility_ssi: expected_value)
     end
 
     context 'when resource is public' do
       before do
-        Hyrax::VisibilityWriter.new(resource: the_resource)
+        Hyrax::VisibilityWriter.new(resource: resource)
           .assign_access_for(visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
       end
 
@@ -73,9 +83,37 @@ RSpec.shared_examples 'a visibility indexer' do
   end
 end
 
+RSpec.shared_examples 'a Core metadata indexer' do
+  before do
+    raise 'indexer_class must be set with `let(:indexer_class)`' unless defined? indexer_class
+    # NOTE: The resource's class is expected to have or inherit `include Hyrax::Schema(:core_metadata)`
+    raise 'resource must be set with `let(:resource)` and is expected to be a kind of Hyrax::Resource' unless defined?(resource) && resource.kind_of?(Hyrax::Resource)
+    resource.title = titles
+  end
+  subject(:indexer) { indexer_class.new(resource: resource) }
+  let(:titles)      { ['Comet in Moominland', 'Finn Family Moomintroll'] }
+
+  describe '#to_solr' do
+    it 'indexes title as text' do
+      expect(indexer.to_solr)
+        .to include(title_tesim: a_collection_containing_exactly(*titles))
+    end
+
+    it 'indexes title as string' do
+      expect(indexer.to_solr)
+        .to include(title_sim: a_collection_containing_exactly(*titles))
+    end
+  end
+end
+
 RSpec.shared_examples 'a Basic metadata indexer' do
-  subject(:indexer) { indexer_class.new(resource: the_resource) }
-  let(:the_resource) { defined?(resource) ? resource : resource_class.new }
+  before do
+    raise 'indexer_class must be set with `let(:indexer_class)`' unless defined? indexer_class
+    # NOTE: The resource's class is expected to to have or inherit `include Hyrax::Schema(:basic_metadata)`
+    raise 'resource must be set with `let(:resource)` and is expected to be a kind of Hyrax::Resource' unless defined?(resource) && resource.kind_of?(Hyrax::Resource)
+    attributes.each { |k, v| resource.set_value(k, v) }
+  end
+  subject(:indexer) { indexer_class.new(resource: resource) }
 
   let(:attributes) do
     {
@@ -84,14 +122,7 @@ RSpec.shared_examples 'a Basic metadata indexer' do
     }
   end
 
-  let(:resource_class) do
-    Class.new(Hyrax::Work) do
-      include Hyrax::Schema(:basic_metadata)
-    end
-  end
-
   describe '#to_solr' do
-    before { attributes.each { |k, v| the_resource.set_value(k, v) } }
     it 'indexes basic metadata' do
       expect(indexer.to_solr)
         .to include(keyword_sim:   a_collection_containing_exactly(*attributes[:keyword]),
@@ -101,10 +132,32 @@ RSpec.shared_examples 'a Basic metadata indexer' do
   end
 end
 
-RSpec.shared_examples 'a Collection indexer' do
-  subject(:indexer) { indexer_class.new(resource: the_resource) }
-  let(:the_resource) { defined?(resource) ? resource : FactoryBot.valkyrie_create(:hyrax_collection) }
+RSpec.shared_examples 'a Work indexer' do
+  before do
+    raise 'indexer_class must be set with `let(:indexer_class)`' unless defined? indexer_class
+    # NOTE: resource must be persisted for permission tests to pass
+    raise 'resource must be set with `let(:resource)` and is expected to be a kind of Hyrax::Work' unless defined?(resource) && resource.kind_of?(Hyrax::Work)
+    # optionally can pass in default_visibility by setting it with a let statement if your application changes the default; Hyrax defines this as 'restricted'
+    # See samvera/hyrda-head hydra-access-controls/app/models/concerns/hydra/access_controls/access_rights.rb for possible VISIBILITY_TEXT_VALUE_...'
+  end
+  subject(:indexer) { indexer_class.new(resource: resource) }
 
+  it_behaves_like 'a Hyrax::Resource indexer'
+  it_behaves_like 'a Core metadata indexer'
+  it_behaves_like 'a permission indexer'
+  it_behaves_like 'a visibility indexer'
+end
+
+RSpec.shared_examples 'a Collection indexer' do
+  before do
+    raise 'indexer_class must be set with `let(:indexer_class)`' unless defined? indexer_class
+    # NOTE: resource must be persisted for permission tests to pass
+    raise 'resource must be set with `let(:resource)` and is expected to be a kind of Hyrax::PcdmCollection' unless defined?(resource) && resource.kind_of?(Hyrax::PcdmCollection)
+  end
+  subject(:indexer) { indexer_class.new(resource: resource) }
+
+  it_behaves_like 'a Hyrax::Resource indexer'
+  it_behaves_like 'a Core metadata indexer'
   it_behaves_like 'a permission indexer'
   it_behaves_like 'a visibility indexer'
 
@@ -117,25 +170,6 @@ RSpec.shared_examples 'a Collection indexer' do
     it 'indexes thumbnail' do
       expect(indexer.to_solr)
         .to include(thumbnail_path_ss: include('assets/collection', '.png'))
-    end
-  end
-end
-
-RSpec.shared_examples 'a Core metadata indexer' do
-  subject(:indexer) { indexer_class.new(resource: the_resource) }
-  let(:titles)      { ['Comet in Moominland', 'Finn Family Moomintroll'] }
-  let(:the_resource) { defined?(resource) ? resource : Hyrax::Work.new }
-
-  describe '#to_solr' do
-    before { the_resource.title = titles }
-    it 'indexes title as text' do
-      expect(indexer.to_solr)
-        .to include(title_tesim: a_collection_containing_exactly(*titles))
-    end
-
-    it 'indexes title as string' do
-      expect(indexer.to_solr)
-        .to include(title_sim: a_collection_containing_exactly(*titles))
     end
   end
 end

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'a Hyrax::Resource indexer' do
-  subject(:indexer) { indexer_class.new(resource: resource) }
-  let(:ids)         { ['id1', 'id2'] }
-  let(:resource)    { Hyrax::Resource.new(alternate_ids: ids) }
+  subject(:indexer)  { indexer_class.new(resource: the_resource) }
+  let(:the_resource) { defined?(resource) ? resource : Hyrax::Resource.new }
+  let(:ids)          { ['id1', 'id2'] }
 
   describe '#to_solr' do
+    before { the_resource.alternate_ids = ids }
     it 'indexes alternate_ids' do
       expect(indexer.to_solr)
         .to include(alternate_ids_sm: a_collection_containing_exactly(*ids))
@@ -14,18 +15,26 @@ RSpec.shared_examples 'a Hyrax::Resource indexer' do
 end
 
 RSpec.shared_examples 'a permission indexer' do
-  subject(:indexer) { indexer_class.new(resource: resource) }
+  subject(:indexer) { indexer_class.new(resource: the_resource) }
+  let(:the_resource) do
+    if defined?(resource)
+      Hyrax::VisibilityWriter.new(resource: resource)
+          .assign_access_for(visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+      resource.permission_manager.edit_groups = edit_groups
+      resource.permission_manager.edit_users  = edit_users
+      resource.permission_manager.read_users  = read_users
+      resource.permission_manager.acl.save
+      resource
+    else
+      FactoryBot.valkyrie_create(:hyrax_work, :public,
+                                 read_users: read_users,
+                                 edit_groups: edit_groups,
+                                 edit_users: edit_users)
+    end
+  end
   let(:edit_groups) { [:managers] }
   let(:edit_users)  { [FactoryBot.create(:user)] }
   let(:read_users)  { [FactoryBot.create(:user)] }
-
-  let(:resource) do
-    FactoryBot.valkyrie_create(:hyrax_work, :public,
-                               read_users: read_users,
-                               edit_groups: edit_groups,
-                               edit_users: edit_users)
-  end
-
 
   describe '#to_solr' do
     it 'indexes read permissions' do
@@ -43,8 +52,8 @@ RSpec.shared_examples 'a permission indexer' do
 end
 
 RSpec.shared_examples 'a visibility indexer' do
-  subject(:indexer) { indexer_class.new(resource: resource) }
-  let(:resource)    { FactoryBot.build(:hyrax_work) }
+  subject(:indexer)  { indexer_class.new(resource: the_resource) }
+  let(:the_resource) { defined?(resource) ? resource : FactoryBot.build(:hyrax_work) }
 
   describe '#to_solr' do
     it 'indexes visibility' do
@@ -52,7 +61,10 @@ RSpec.shared_examples 'a visibility indexer' do
     end
 
     context 'when resource is public' do
-      let(:resource) { FactoryBot.valkyrie_create(:hyrax_work, :public) }
+      before do
+        Hyrax::VisibilityWriter.new(resource: the_resource)
+          .assign_access_for(visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+      end
 
       it 'indexes as open' do
         expect(indexer.to_solr).to include(visibility_ssi: 'open')
@@ -62,8 +74,8 @@ RSpec.shared_examples 'a visibility indexer' do
 end
 
 RSpec.shared_examples 'a Basic metadata indexer' do
-  subject(:indexer) { indexer_class.new(resource: resource) }
-  let(:resource)    { resource_class.new(**attributes) }
+  subject(:indexer) { indexer_class.new(resource: the_resource) }
+  let(:the_resource) { defined?(resource) ? resource : resource_class.new }
 
   let(:attributes) do
     {
@@ -79,9 +91,10 @@ RSpec.shared_examples 'a Basic metadata indexer' do
   end
 
   describe '#to_solr' do
+    before { attributes.each { |k, v| the_resource.set_value(k, v) } }
     it 'indexes basic metadata' do
       expect(indexer.to_solr)
-        .to include(keyword_sim: a_collection_containing_exactly(*attributes[:keyword]),
+        .to include(keyword_sim:   a_collection_containing_exactly(*attributes[:keyword]),
                     subject_tesim: a_collection_containing_exactly(*attributes[:subject]),
                     subject_sim:   a_collection_containing_exactly(*attributes[:subject]))
     end
@@ -89,8 +102,8 @@ RSpec.shared_examples 'a Basic metadata indexer' do
 end
 
 RSpec.shared_examples 'a Collection indexer' do
-  subject(:indexer) { indexer_class.new(resource: resource) }
-  let(:resource)    { Hyrax::PcdmCollection.new }
+  subject(:indexer) { indexer_class.new(resource: the_resource) }
+  let(:the_resource) { defined?(resource) ? resource : FactoryBot.valkyrie_create(:hyrax_collection) }
 
   it_behaves_like 'a permission indexer'
   it_behaves_like 'a visibility indexer'
@@ -109,11 +122,12 @@ RSpec.shared_examples 'a Collection indexer' do
 end
 
 RSpec.shared_examples 'a Core metadata indexer' do
-  subject(:indexer) { indexer_class.new(resource: resource) }
+  subject(:indexer) { indexer_class.new(resource: the_resource) }
   let(:titles)      { ['Comet in Moominland', 'Finn Family Moomintroll'] }
-  let(:resource)    { Hyrax::Work.new(title: titles) }
+  let(:the_resource) { defined?(resource) ? resource : Hyrax::Work.new }
 
   describe '#to_solr' do
+    before { the_resource.title = titles }
     it 'indexes title as text' do
       expect(indexer.to_solr)
         .to include(title_tesim: a_collection_containing_exactly(*titles))

--- a/spec/hyrax/indexer_spec.rb
+++ b/spec/hyrax/indexer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Hyrax::Indexer do
   end
 
   context 'with core metadata schema' do
+    let(:resource) { work }
     it_behaves_like 'a Core metadata indexer'
   end
 

--- a/spec/indexers/hyrax/permission_indexer_spec.rb
+++ b/spec/indexers/hyrax/permission_indexer_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hyrax::PermissionIndexer do
       include Hyrax::PermissionIndexer
     end
   end
+  let(:resource) { FactoryBot.valkyrie_create(:hyrax_resource) }
 
   it_behaves_like 'a permission indexer'
 end

--- a/spec/indexers/hyrax/resource_indexer_spec.rb
+++ b/spec/indexers/hyrax/resource_indexer_spec.rb
@@ -3,6 +3,7 @@
 require 'hyrax/specs/shared_specs'
 
 RSpec.describe Hyrax::ResourceIndexer do
+  let(:resource) { Hyrax::Resource.new }
   let(:indexer_class) do
     Class.new(Hyrax::ValkyrieIndexer) do
       include Hyrax::ResourceIndexer

--- a/spec/indexers/hyrax/valkyrie_collection_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_collection_indexer_spec.rb
@@ -6,6 +6,5 @@ RSpec.describe Hyrax::ValkyrieCollectionIndexer do
   let(:resource) { FactoryBot.valkyrie_create(:hyrax_collection) }
   let(:indexer_class) { described_class }
 
-  it_behaves_like 'a Hyrax::Resource indexer'
   it_behaves_like 'a Collection indexer'
 end

--- a/spec/indexers/hyrax/valkyrie_collection_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_collection_indexer_spec.rb
@@ -3,7 +3,7 @@
 require 'hyrax/specs/shared_specs'
 
 RSpec.describe Hyrax::ValkyrieCollectionIndexer do
-  subject(:indexer) { described_class.new(resource: resource) }
+  let(:resource) { FactoryBot.valkyrie_create(:hyrax_collection) }
   let(:indexer_class) { described_class }
 
   it_behaves_like 'a Hyrax::Resource indexer'

--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -3,8 +3,6 @@
 require 'hyrax/specs/shared_specs'
 
 RSpec.describe Hyrax::ValkyrieWorkIndexer do
-  let(:indexer) { described_class.new(resource: resource) }
-  let(:resource) { FactoryBot.valkyrie_create(:hyrax_work) }
   let(:indexer_class) { described_class }
 
   it_behaves_like 'a Hyrax::Resource indexer'
@@ -20,5 +18,33 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
     end
 
     it_behaves_like 'a Basic metadata indexer'
+  end
+
+  context 'when extending with custom metadata' do
+    before do
+      module Hyrax::Test
+        module Custom
+          class Work < Hyrax::Work
+            attribute :broader, Valkyrie::Types::Array.of(Valkyrie::Types::String)
+          end
+          class WorkIndexer < Hyrax::ValkyrieWorkIndexer
+            def to_solr
+              super.tap do |solr_doc|
+                solr_doc['broader_ssim'] = resource.broader.first
+              end
+            end
+          end
+        end
+      end
+    end
+    after { Hyrax::Test.send(:remove_const, :Custom) }
+
+    let(:resource) { Hyrax.persister.save(resource: Hyrax::Test::Custom::Work.new(broader: ['term1', 'term2'])) }
+    let(:indexer_class) { Hyrax::Test::Custom::WorkIndexer }
+
+    it_behaves_like 'a Hyrax::Resource indexer'
+    it_behaves_like 'a Core metadata indexer'
+    it_behaves_like 'a permission indexer'
+    it_behaves_like 'a visibility indexer'
   end
 end

--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -3,18 +3,21 @@
 require 'hyrax/specs/shared_specs'
 
 RSpec.describe Hyrax::ValkyrieWorkIndexer do
+  let(:resource) { FactoryBot.valkyrie_create(:hyrax_work) }
   let(:indexer_class) { described_class }
 
-  it_behaves_like 'a Hyrax::Resource indexer'
-  it_behaves_like 'a Core metadata indexer'
-  it_behaves_like 'a permission indexer'
-  it_behaves_like 'a visibility indexer'
+  it_behaves_like 'a Work indexer'
 
   context 'when extending with basic metadata' do
     let(:indexer_class) do
       Class.new(described_class) do
         include Hyrax::Indexer(:basic_metadata)
       end
+    end
+    let(:resource) do
+      Class.new(Hyrax::Work) do
+        include Hyrax::Schema(:basic_metadata)
+      end.new
     end
 
     it_behaves_like 'a Basic metadata indexer'
@@ -42,9 +45,6 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
     let(:resource) { Hyrax.persister.save(resource: Hyrax::Test::Custom::Work.new(broader: ['term1', 'term2'])) }
     let(:indexer_class) { Hyrax::Test::Custom::WorkIndexer }
 
-    it_behaves_like 'a Hyrax::Resource indexer'
-    it_behaves_like 'a Core metadata indexer'
-    it_behaves_like 'a permission indexer'
-    it_behaves_like 'a visibility indexer'
+    it_behaves_like 'a Work indexer'
   end
 end

--- a/spec/indexers/hyrax/visibility_indexer_spec.rb
+++ b/spec/indexers/hyrax/visibility_indexer_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hyrax::VisibilityIndexer do
       include Hyrax::VisibilityIndexer
     end
   end
+  let(:resource) { Hyrax::Resource.new }
 
   it_behaves_like 'a visibility indexer'
 end

--- a/spec/support/book_resource.rb
+++ b/spec/support/book_resource.rb
@@ -7,11 +7,11 @@ module Hyrax
     # Use this for testing valkyrie models generically, with Hyrax assumptions
     # but no PCDM modelling behavior.
     class BookResource < Hyrax::Resource
-      attribute :author,   Valkyrie::Types::String
-      attribute :created,  Valkyrie::Types::Date
-      attribute :isbn,     Valkyrie::Types::String
-      attribute :pubisher, Valkyrie::Types::String
-      attribute :title,    Valkyrie::Types::String
+      attribute :author,    Valkyrie::Types::String
+      attribute :created,   Valkyrie::Types::Date
+      attribute :isbn,      Valkyrie::Types::String
+      attribute :publisher, Valkyrie::Types::String
+      attribute :title,     Valkyrie::Types::String
     end
 
     class Book < ActiveFedora::Base


### PR DESCRIPTION
Fixes #4464

### Description

Allow shared spec testing of indexers with customizations to #to_solr that depend on properties defined in the resource class that the indexer indexes.

### Resolution

Update shared indexers spec to have a valid resource passed in to the shared spec.  The shared spec sets values it depends on in a before block.  

@samvera/hyrax-code-reviewers
