### PR TITLE
[backport] ensure iiif manifest order

### DIFF
--- a/app/models/concerns/hyrax/solr_document/ordered_members.rb
+++ b/app/models/concerns/hyrax/solr_document/ordered_members.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+module Hyrax
+  module SolrDocument
+    ##
+    # Decorates an object responding to `#id` with an `#ordered_member_ids` method.
+    #
+    # @note this decorator is intended for use with data representations other
+    #   than the core model objects, as an alternative to a direct query of the
+    #   canonical database. for example, it can be used with `SolrDocument` to
+    #   quickly retrieve member order in a way that is compatible with the
+    #   fast access required in Blacklight's search contexts.
+    #
+    # @example
+    #   base_document = SolrDocument.new(my_work.to_solr)
+    #   solr_document = Hyrax::SolrDocument::OrderedMembers.decorate(base_document)
+    #
+    #   solr_document.ordered_member_ids # => ['abc', '123']
+    #
+    class OrderedMembers < Draper::Decorator
+      delegate_all
+
+      ##
+      # @note the purpose of this method is to provide fast access to member
+      #   order. currently this is achieved by accessing indexed list proxies
+      #   from Solr. however, this strategy may change in the future.
+      #
+      # @return [Enumerable<String>] ids in the order of their membership,
+      #   only includes ids of ordered members.
+      def ordered_member_ids
+        return [] if id.blank?
+        @ordered_member_ids ||= query_for_ordered_ids
+      end
+
+      private
+
+        def query_for_ordered_ids(limit: 10_000,
+                                  proxy_field: 'proxy_in_ssi',
+                                  target_field: 'ordered_targets_ssim')
+          ActiveFedora::SolrService
+            .query("#{proxy_field}:#{id}", rows: limit, fl: target_field)
+            .flat_map { |x| x.fetch(target_field, nil) }
+            .compact
+        end
+    end
+  end
+end

--- a/app/presenters/hyrax/iiif_manifest_presenter.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter.rb
@@ -87,7 +87,7 @@ module Hyrax
     ##
     # @return [Array<#to_s>]
     def member_ids
-      Array(model.try(:member_ids))
+      Hyrax::SolrDocument::OrderedMembers.decorate(model).ordered_member_ids
     end
 
     ##

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -36,14 +36,8 @@ module Hyrax
       @work_presenters ||= member_presenters(ordered_ids - file_set_ids, work_presenter_class)
     end
 
-    # TODO: Extract this to ActiveFedora::Aggregations::ListSource
     def ordered_ids
-      @ordered_ids ||= begin
-                         ActiveFedora::SolrService.query("proxy_in_ssi:#{id}",
-                                                         rows: 10_000,
-                                                         fl: "ordered_targets_ssim")
-                                                  .flat_map { |x| x.fetch("ordered_targets_ssim", []) }
-                       end
+      @ordered_ids ||= Hyrax::SolrDocument::OrderedMembers.decorate(@work).ordered_member_ids
     end
 
     private

--- a/spec/features/iiif_manifest_spec.rb
+++ b/spec/features/iiif_manifest_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'building a IIIF Manifest' do
 
   before do
     work.ordered_members += file_sets
-    work.members += member_works
+    work.ordered_members += member_works
     work.save
 
     sign_in user

--- a/spec/models/concerns/hyrax/solr_document/ordered_members_spec.rb
+++ b/spec/models/concerns/hyrax/solr_document/ordered_members_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::SolrDocument::OrderedMembers do
+  subject(:decorated) { described_class.decorate(document) }
+  let(:data) { { id: parent_id } }
+  let(:document) { SolrDocument.new(data) }
+  let(:parent_id) { '1' }
+
+  describe '#ordered_member_ids' do
+    context 'with no id' do
+      let(:data) { {} }
+
+      it 'is empty' do
+        expect(decorated.ordered_member_ids).to be_empty
+      end
+    end
+
+    context 'with no members' do
+      it 'is empty' do
+        expect(decorated.ordered_member_ids).to be_empty
+      end
+    end
+
+    context 'with ordered members' do
+      let(:parent) { create(:work_with_ordered_files) }
+      let(:parent_id) { parent.id.to_s }
+
+      it 'has the file ids in exact order' do
+        expect(decorated.ordered_member_ids).to eq parent.ordered_member_ids
+      end
+    end
+  end
+end

--- a/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Hyrax::IiifManifestPresenter do
 
         it 'includes items with read permissions' do
           readable = FactoryBot.create(:file_set, :image, user: user)
-          work.members << readable
+          work.ordered_members << readable
           work.save
 
           expect(builder_service.manifest_for(presenter: presenter)['sequences'].first['canvases'].count)
@@ -112,7 +112,7 @@ RSpec.describe Hyrax::IiifManifestPresenter do
 
           it 'has file sets the user can read' do
             readable = FactoryBot.create(:file_set, :image, user: user)
-            work.members << readable
+            work.ordered_members << readable
             work.save
 
             expect(presenter.file_set_presenters)


### PR DESCRIPTION
reinstates careful ordering for IIIF manifests.

backports #4447 and #4455 
supersedes #4448 

@samvera/hyrax-code-reviewers
