### PR TITLE
Updating readme to reflect Hyrax 3.0.0.pre.rc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Hyrax requires Rails 5. We recommend the latest Rails 5.2 release.
 
 ```
 # If you don't already have Rails at your disposal...
-gem install rails -v 5.2.3
+gem install rails -v 5.2.4.3
 ```
 
 ### JavaScript runtime
@@ -155,7 +155,7 @@ NOTE: The steps need to be done in order to create a new Hyrax based app.
 Generate a new Rails application using the template.
 
 ```
-rails _5.2.4.3_ new my_app -m https://raw.githubusercontent.com/samvera/hyrax/v3.0.0-rc2/template.rb
+rails _5.2.4.3_ new my_app -m https://raw.githubusercontent.com/samvera/hyrax/v3.0.0.pre.rc2/template.rb
 ```
 
 Generating a new Rails application using Hyrax's template above takes cares of a number of steps for you, including:

--- a/template.rb
+++ b/template.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Hack for https://github.com/rails/rails/issues/35153
 gsub_file 'Gemfile', /^gem ["']sqlite3["']$/, 'gem "sqlite3", "~> 1.3.0"'
-gem 'hyrax', '3.0.0-rc2'
+gem 'hyrax', '3.0.0.pre.rc2'
 run 'bundle install'
 generate 'hyrax:install', '-f'
 rails_command 'db:migrate'


### PR DESCRIPTION
The preliminary documentation for Hyrax 3.0.0.pre.rc2 assumed one
gemfile structure.  However, running `rake release` I got the following:

```console
hyrax 3.0.0.pre.rc2 built to pkg/hyrax-3.0.0.pre.rc2.gem.
Tagged v3.0.0.pre.rc2.
Pushed git commits and tags.
Pushing gem to https://rubygems.org...
You have enabled multi-factor authentication. Please enter OTP code.
Code:   ******
Successfully registered gem: hyrax (3.0.0.pre.rc2)
Pushed hyrax 3.0.0.pre.rc2 to rubygems.org
```

This commit ensures our documentation aligns with what Rubygems and
Github have.

@samvera/hyrax-code-reviewers
