### PR TITLE
correct accessibility issues form work view page.  Fixes #3967

### DIFF
--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-default navbar-static-top" role="navigation">
+<nav class="navbar navbar-default navbar-static-top" role="navigation" aria-label="Root Menu">
   <div class="container-fluid">
     <div class="row">
       <ul class="nav navbar-nav col-sm-5">

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -1,6 +1,6 @@
 <tr class="<%= dom_class(member) %> attributes">
   <td class="thumbnail">
-    <%= render_thumbnail_tag member %>
+    <%= render_thumbnail_tag member, { alt: "file details" } %>
   </td>
   <td class="attribute attribute-filename ensure-wrapped"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
   <td class="attribute attribute-date_uploaded"><%= member.try(:date_uploaded) %></td>

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -1,5 +1,5 @@
 <div class="viewer-wrapper">
-  <iframe
+  <iframe aria-label="image view" 
     src="<%= universal_viewer_base_url %>#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= universal_viewer_config_url %>" 
     allowfullscreen="true" 
     frameborder="0" 

--- a/lib/generators/hyrax/templates/uv.html
+++ b/lib/generators/hyrax/templates/uv.html
@@ -5,7 +5,7 @@
 
 <html>
     <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
         <link rel="icon" href="favicon.ico">
         <link rel="stylesheet" type="text/css" href="uv.css">
         <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>


### PR DESCRIPTION
Fixes #3967

With this PR I fixed some of the axe issues reported on issue #3967.  Because I don't have access to the universal viewer code I did not address the universal viewer issues.  Basically, axe complaint of landmarks missing the correct tagging.  This can be corrected by dosing something like this:

`role="menu" aria-label="Zoom In"`

This is a useful sight with info about this: https://www.washington.edu/accessibility/web/landmarks/

Also, there were warnings about color contrast. The axe tool said that they  `Element's background color could not be determined because it's partially obscured by another element` so for now I left the colors as is.  Also, I did not have access to correct the color issues within the universal viewer.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
*  Go to a work show page.
*  Run the axe tool.
*  You will see the errors that I did not address for the reasons stated above, but the other errors mentioned in the ticket will not show up.

@samvera/hyrax-code-reviewers
