### PR TITLE
move the valkyrie test adapter out of `wings/setup`

### DIFF
--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -13,12 +13,6 @@ Valkyrie::MetadataAdapter.register(
 )
 Valkyrie.config.metadata_adapter = :wings_adapter
 
-if ENV['RAILS_ENV'] == 'test'
-  Valkyrie::MetadataAdapter.register(
-    Valkyrie::Persistence::Memory::MetadataAdapter.new, :test_adapter
-  )
-end
-
 Valkyrie::StorageAdapter.register(
   Wings::Storage::ActiveFedora
     .new(connection: Ldp::Client.new(ActiveFedora.fedora.host), base_path: ActiveFedora.fedora.base_path),

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,9 @@ require 'database_cleaner'
 Hyrax::Schema
 # rubocop:enable Lint/Void
 
+Valkyrie::MetadataAdapter
+  .register(Valkyrie::Persistence::Memory::MetadataAdapter.new, :test_adapter)
+
 # Require supporting ruby files from spec/support/ and subdirectories.  Note: engine, not Rails.root context.
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 


### PR DESCRIPTION
this adapter is needed regardless of whether wings is in use---it tests
main-codebase functionality. moving it to `spec_helper` also avoids the need to
check a conditional in production.

@samvera/hyrax-code-reviewers
