### PR TITLE
Test with Hyrax::Resources instead of Valkyrie::Resources

### DIFF
--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       before do
         module Hyrax::Test
           module Converter
-            class Resource < Valkyrie::Resource
+            class Resource < Hyrax::Resource
               attribute :title, Valkyrie::Types::Array.of(Valkyrie::Types::String)
               attribute :distant_relation, Valkyrie::Types::String
             end

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Wings::ModelTransformer, :clean_repo do
       before do
         module Hyrax::Test
           module Transformer
-            class Book < Valkyrie::Resource
+            class Book < Hyrax::Resource
             end
           end
         end


### PR DESCRIPTION
This PR is a quick fix to resolve the test failures encountered while testing a change in `hydra-access-controls` (see https://app.circleci.com/pipelines/github/samvera/hyrax/3935/workflows/9b0f1003-94f2-4f33-97a0-60997a60af42/jobs/27009)

While investigating the failures, I found that in these tests the test class was a `Valkyrie::Resource` subclass.  When it runs through the `ActiveFedoraConverter` it becomes a `DefaultWork` which includes the permissions modules.  This is odd since the original `Valkyrie::Resource` doesn't have any permissions.  I would have expected instead that a simpler `ActiveFedora::Base` subclass which doesn't include the permissions modules would have been returned.  But if the existing behavior is expected then I think `OrmConverter#base_for` must return `Hyrax::Resource` or a subclass instead of the test class which is a `Valkyrie::Resource`.  As it is now the converted class isn't really equivalent to the original.

The failed tests linked above go :boom: because the change in `hydra-access-controls` causes `access_control` to initialize in an `after_initialize` callback when it wasn't initialized before.  This in turn causes this check to fail: https://github.com/samvera/hyrax/blob/master/lib/wings/model_transformer.rb#L60

It seems to me that that guard clause was giving false positives before but is complicated by the inconsistencies between the original and converted classes.  So for now I'm proposing changing the two failing tests to use `Hyrax::Resource`.  Alternatively an additional check could be added to the guard clause: `resource.respond_to?(:permission_manager)`, but that might just be kicking the can down the road leading to failures later.  Ultimately I think that either `ActiveFedoraConverter` or `OrmConverter#base_for` needs to change to avoid the inconsistency or at least raise an exception.