### PR TITLE
Allow 4.0.x versions of select2-rails

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -79,7 +79,7 @@ SUMMARY
   spec.add_dependency 'reform-rails', '~> 0.2.0'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'samvera-nesting_indexer', '~> 2.0'
-  spec.add_dependency 'select2-rails', '~> 3.5'
+  spec.add_dependency 'select2-rails', '>= 3.5', '< 4.1'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
   spec.add_dependency 'valkyrie', '>= 2.1.1', "< 3.0"


### PR DESCRIPTION
Relaxing the dependency on select2-rails allows a 4.0.x version of select2-rails to be brought in.  The latest select2-rails 3.x depends on thor ~> 0.14 so allowing a newer select2-rails allows for thor 1.0+.

I kept select2-rails below 4.1 since the [unreleased notes](https://github.com/select2/select2/blob/develop/CHANGELOG.md#410-unreleased) mention breaking changes. That being said select2-rails 4.0 also has breaking changes.  Do we think the feature tests will test these adequately or should there be some manual testing?

#### Related work
This is part of my quest to allow thor 1.0+ with hyrax:
- [x] hydra-editor - fixed in 5.0.3
- [ ] browse-everything - change merged but unreleased
- [ ] select2-rails - this PR

I think that these are the only dependencies blocking thor 1.0. 

@samvera/hyrax-code-reviewers
