### PR TITLE
provide a generic pattern for test app names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ db/schema.rb
 
 ## PROJECT::SPECIFIC
 
-.internal_test_app
+.*_app
 .byebug_history
 
 ## Carried over from hyrax-models (RIP)


### PR DESCRIPTION
sometimes, it's helpful to have multiple test apps, or to name them in ways that
are useful for development. to support this, extend git's ignores to target
`.*_app` instead of narrowly ignoring `.internal_test_app`. this makes it easy
to create ignored apps with a naming convention.

@samvera/hyrax-code-reviewers
