### PR TITLE
Removes upper limit on QA

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -69,7 +69,7 @@ SUMMARY
   spec.add_dependency 'oauth2', '~> 1.2'
   spec.add_dependency 'posix-spawn'
   spec.add_dependency 'power_converter', '~> 0.1', '>= 0.1.2'
-  spec.add_dependency 'qa', '>= 2', '< 4' # questioning_authority
+  spec.add_dependency 'qa', '~> 5.5', '>= 5.5.1' # questioning_authority
   spec.add_dependency 'rails_autolink', '~> 1.1'
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
   spec.add_dependency 'rdf-vocab', '< 3.1.5'


### PR DESCRIPTION
Fixes #4479- Library of Congress authorities broken in QA versions less than 5.5.0.

Looking at release notes for QA 4+, I didn't see an obvious need for the pin. Dependabot introduced the pin in #3439, so it feels safe to remove.