### PR TITLE
[Backport] Relaxes upper limit on QA

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -68,7 +68,7 @@ SUMMARY
   spec.add_dependency 'posix-spawn'
   spec.add_dependency 'power_converter', '~> 0.1', '>= 0.1.2'
   spec.add_dependency 'pul_uv_rails', '~> 2.0'
-  spec.add_dependency 'qa', '~> 2.0' # questioning_authority
+  spec.add_dependency 'qa', '>= 2.0', '< 6.0' # questioning_authority
   spec.add_dependency 'rails_autolink', '~> 1.1'
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
   spec.add_dependency 'rdf-vocab', '< 3.1.5'


### PR DESCRIPTION
Fixes #4479, backports #4480.

Library of Congress authorities broken in QA versions less than 5.5.1, although backports of the fix may come for earlier 3.x and 4.x versions.