### PR TITLE
Cn 2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+./tmp
+./log
+.internal_test_app/*
+
+*.rdb
+
+artifacts/*
+coverage/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+ARG RUBY_VERSION=2.6.6
+FROM ruby:$RUBY_VERSION-alpine
+
+ARG RAILS_ENV=production
+ARG APP_PATH=.hyrax_app
+ARG BUNDLE_WITHOUT=development:test
+ARG EXTRA_APK_PACKAGES="git sqlite-dev"
+
+RUN apk --no-cache upgrade && \
+  apk --no-cache add build-base \
+  tzdata \
+  nodejs \
+  $EXTRA_APK_PACKAGES
+
+RUN gem update bundler
+
+ENV RAILS_ENV $RAILS_ENV
+ENV RACK_ENV $RAILS_ENV
+ENV BUNDLE_WITHOUT $BUNDLE_WITHOUT
+
+ENV APP_HOME /app-data/samvera/$APP_PATH
+RUN mkdir -p APP_HOME
+
+ENV BUNDLE_PATH /usr/local/bundle
+ENV BUNDLE_GEMFILE $APP_HOME/Gemfile
+ENV BUNDLE_JOBS 4
+
+COPY $APP_PATH $APP_HOME
+WORKDIR $APP_HOME
+
+RUN bundle install
+
+ADD https://time.is/just /app-data/build-time
+
+CMD ["bundle", "exec", "puma", "-v", "-b", "tcp://0.0.0.0:3000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ WORKDIR $APP_HOME
 
 RUN bundle install
 
+COPY bin/db-wait.sh db-wait.sh
+
 ADD https://time.is/just /app-data/build-time
 
 CMD ["bundle", "exec", "puma", "-v", "-b", "tcp://0.0.0.0:3000"]

--- a/bin/db-wait.sh
+++ b/bin/db-wait.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+host=$(printf "%s\n" "$1"| cut -d : -f 1)
+port=$(printf "%s\n" "$1"| cut -d : -f 2)
+
+shift 1
+
+while ! nc -z "$host" "$port"
+do
+  echo "waiting for $host:$port"
+  sleep 1
+done
+
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,142 @@
+# rails _5.2.4.3_ new .hyrax_app -m ./template.rb --database=postgresql
+# rm .hyrax_app/config/database.yml # use ENV for database configuration
+# docker-compose build
+# docker-compose up
+version: '3.5'
+services:
+  app: &app
+    build:
+      context: .
+      args:
+        RAILS_ENV: development
+        BUNDLE_WITHOUT: test
+        EXTRA_APK_PACKAGES: 'git postgresql-dev'
+    stdin_open: true
+    tty: true
+    environment:
+      - DATABASE_URL=postgresql://hyrax_user:hyrax_password@postgres/hyrax?pool=5
+      - FCREPO_PORT=8080
+      - FCREPO_HOST=fcrepo
+      - REDIS_HOST=redis
+      - SOLR_URL=http://solr:8983/solr/hyrax
+    depends_on:
+      # - create_admin_set
+      - create_collection_types
+      - db_migrate
+      - fcrepo
+      - memcached
+      - postgres
+      - redis
+      - solr
+    ports:
+      - 3000:3000
+    volumes:
+      - .hyrax_app:/data
+
+  # create_admin_set:
+  #   <<: *app
+  #   environment:
+  #     - DATABASE_URL=postgresql://hyrax_user:hyrax_password@postgres/hyrax?pool=5
+  #     - FCREPO_PORT=8080
+  #     - FCREPO_HOST=fcrepo
+  #     - REDIS_HOST=redis
+  #     - SOLR_URL=http://solr:8983/solr/hyrax
+  #   command:
+  #     - bundle
+  #     - exec
+  #     - rake
+  #     - hyrax:default_admin_set:create
+  #   depends_on:
+  #     - fcrepo
+  #     - solr
+  #     - postgres
+  #   ports: []
+
+  create_collection_types:
+    <<: *app
+    environment:
+      - DATABASE_URL=postgresql://hyrax_user:hyrax_password@postgres/hyrax?pool=5
+      - FCREPO_PORT=8080
+      - FCREPO_HOST=fcrepo
+      - REDIS_HOST=redis
+      - SOLR_URL=http://solr:8983/solr/hyrax
+    command:
+      - bundle
+      - exec
+      - rake
+      - hyrax:default_collection_types:create
+    depends_on:
+      - postgres
+    ports: []
+    volumes:
+      - .hyrax_app:/data
+
+  db_migrate:
+    <<: *app
+    environment:
+      - DATABASE_URL=postgresql://hyrax_user:hyrax_password@postgres/hyrax?pool=5
+      - FCREPO_PORT=8080
+      - FCREPO_HOST=fcrepo
+      - REDIS_HOST=redis
+      - SOLR_URL=http://solr:8983/solr/hyrax
+    command:
+      - bundle
+      - exec
+      - rails
+      - db:create
+      - db:migrate
+    depends_on:
+      - postgres
+    ports: []
+    volumes:
+      - .hyrax_app:/data
+
+  postgres:
+    image: postgres:latest
+    restart: always
+    environment:
+      - POSTGRES_USER=hyrax_user
+      - POSTGRES_PASSWORD=hyrax_password
+      - POSTGRES_DB=hyrax
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    ports:
+      - "5432:5432"
+    volumes:
+      - db:/var/lib/postgresql/data
+
+  fcrepo:
+    image: cbeer/fcrepo4:4.7
+    volumes:
+      - fcrepo:/data
+    ports:
+      - 8080:8080
+    environment:
+      - JAVA_OPTS=${JAVA_OPTS} -Dfcrepo.modeshape.configuration="classpath:/config/file-simple/repository.json" -Dfcrepo.object.directory="/data/objects" -Dfcrepo.binary.directory="/data/binaries"
+
+  memcached:
+    image: bitnami/memcached
+    ports:
+      - '11211:11211'
+
+  redis:
+    image: redis:5-alpine
+    volumes:
+      - redis:/data
+
+  solr: &solr
+    image: solr:7
+    ports:
+      - 8983:8983
+    command:
+      - solr-precreate
+      - hyrax
+      - /opt/solr/server/configsets/hyraxconf
+    volumes:
+      - solr_home:/opt/solr/server/solr
+      - .hyrax_app/solr/conf:/opt/solr/server/configsets/hyraxconf
+
+volumes:
+  db:
+  fcrepo:
+  redis:
+  solr_home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - REDIS_HOST=redis
       - SOLR_URL=http://solr:8983/solr/hyrax
     depends_on:
-      # - create_admin_set
+      - create_admin_set
       - create_collection_types
       - db_migrate
       - fcrepo
@@ -33,26 +33,7 @@ services:
     volumes:
       - .hyrax_app:/data
 
-  # create_admin_set:
-  #   <<: *app
-  #   environment:
-  #     - DATABASE_URL=postgresql://hyrax_user:hyrax_password@postgres/hyrax?pool=5
-  #     - FCREPO_PORT=8080
-  #     - FCREPO_HOST=fcrepo
-  #     - REDIS_HOST=redis
-  #     - SOLR_URL=http://solr:8983/solr/hyrax
-  #   command:
-  #     - bundle
-  #     - exec
-  #     - rake
-  #     - hyrax:default_admin_set:create
-  #   depends_on:
-  #     - fcrepo
-  #     - solr
-  #     - postgres
-  #   ports: []
-
-  create_collection_types:
+  create_admin_set:
     <<: *app
     environment:
       - DATABASE_URL=postgresql://hyrax_user:hyrax_password@postgres/hyrax?pool=5
@@ -61,6 +42,31 @@ services:
       - REDIS_HOST=redis
       - SOLR_URL=http://solr:8983/solr/hyrax
     command:
+      - ./db-wait.sh
+      - postgres:5432
+      - ./db-wait.sh
+      - fcrepo:8080
+      - ./db-wait.sh
+      - solr:8983
+      - bundle
+      - exec
+      - rake
+      - hyrax:default_admin_set:create
+    depends_on:
+      - fcrepo
+      - solr
+      - postgres
+    ports: []
+
+  create_collection_types:
+    <<: *app
+    environment:
+      - DATABASE_URL=postgresql://hyrax_user:hyrax_password@postgres/hyrax?pool=5
+      - REDIS_HOST=redis
+      - SOLR_URL=http://solr:8983/solr/hyrax
+    command:
+      - ./db-wait.sh
+      - postgres:5432
       - bundle
       - exec
       - rake
@@ -75,11 +81,9 @@ services:
     <<: *app
     environment:
       - DATABASE_URL=postgresql://hyrax_user:hyrax_password@postgres/hyrax?pool=5
-      - FCREPO_PORT=8080
-      - FCREPO_HOST=fcrepo
-      - REDIS_HOST=redis
-      - SOLR_URL=http://solr:8983/solr/hyrax
     command:
+      - ./db-wait.sh
+      - postgres:5432
       - bundle
       - exec
       - rails


### PR DESCRIPTION


our normal development stack involves Postgres, Fedora, Solr, and Redis; rather
than put it on the developer to configure all of this, we can provide containers
configured to run the app.

this creates a parallel approach to .internal_test_app, with .hyrax_app as
the application path by default and engine_cart replaced with rails new as
the preferred way to generate it.

the included Dockerfile is intended to grow to support downstream
applications; to this end it offers arguments for Ruby version, app path, and a
mechanism to inject system dependencies.

all of this could probably use some work; especially:

  - some Hyrax system dependencies are missing,
  - there's no support for live code updates, because:
  -      the engine isn't mounted in the dev containers,
  -      the mounted .:/data volume isn't updating either (for reasons unknown).

...but this is progress.

@samvera/hyrax-code-reviewers
