### PR TITLE
add engine seeds for admin set and collection types

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,11 @@
+puts "\n== Creating default collection types"
+Hyrax::CollectionType.find_or_create_default_collection_type
+Hyrax::CollectionType.find_or_create_admin_set_type
+
+puts "\n== Loading workflows"
+Hyrax::Workflow::WorkflowImporter.load_workflows
+errors = Hyrax::Workflow::WorkflowImporter.load_errors
+abort("Failed to process all workflows:\n  #{errors.join('\n  ')}") unless errors.empty?
+
+puts "\n== Creating default admin set"
+AdminSet.find_or_create_default_admin_set_id

--- a/lib/generators/hyrax/templates/db/seeds.rb
+++ b/lib/generators/hyrax/templates/db/seeds.rb
@@ -16,8 +16,9 @@
 #     ActiveFedora::Cleaner.clean!
 #     exit
 #   rake db:drop db:create db:migrate
-#   bin/rails hyrax:default_admin_set:create
 #   rake db:seed
+
+Hyrax::Engine.load_seed
 
 # ---------------------------------
 # methods to create various objects


### PR DESCRIPTION
introduces seeds for admin set and collection types. this new approach is a
candidate to replace the related rake tasks as the recommended approach for app
setup: i.e. those tasks would be replaced by `rake/rails db:seed`.

motivated in part by #4483.

@samvera/hyrax-code-reviewers
