### PR TITLE
alternate ids should be string-indexed-multivalue

### DIFF
--- a/app/indexers/hyrax/resource_indexer.rb
+++ b/app/indexers/hyrax/resource_indexer.rb
@@ -6,7 +6,7 @@ module Hyrax
   module ResourceIndexer
     def to_solr
       super.tap do |index_document|
-        index_document[:alternate_ids_sm] = resource.alternate_ids.map(&:to_s)
+        index_document[:alternate_ids_sim] = resource.alternate_ids.map(&:to_s)
       end
     end
   end

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples 'a Hyrax::Resource indexer' do
   describe '#to_solr' do
     it 'indexes alternate_ids' do
       expect(indexer.to_solr)
-        .to include(alternate_ids_sm: a_collection_containing_exactly(*ids))
+        .to include(alternate_ids_sim: a_collection_containing_exactly(*ids))
     end
   end
 end


### PR DESCRIPTION
### Description

Solr documents generated through valkyrie indexing cannot be saved. Fails with `"ERROR: [doc=02870v844] unknown field 'alternate_ids_sm'"`

### Expected

#to_solr for valkyrie indexers in Hyrax should add field `alternate_ids_sim`.

Extension `_sim` makes the field a searchable multi-valued string.  With this extension, it will not be part of the returned solrdoc in search results.  Assuming that is the desired behavior, then the _sim extension is the correct one to use.

### Actual

#to_solr for valkyrie indexers in Hyrax adds field `alternate_ids_sm`.

This produces an `"ERROR: [doc=02870v844] unknown field 'alternate_ids_sm'"` when trying to save since the Hyrax default schema does not define extension `_sm`.

@samvera/hyrax-code-reviewers
