### PR TITLE
make Valkyrie solr doc has_model_ssim instead of has_model_tesim

### DIFF
--- a/app/indexers/hyrax/resource_indexer.rb
+++ b/app/indexers/hyrax/resource_indexer.rb
@@ -6,7 +6,7 @@ module Hyrax
   module ResourceIndexer
     def to_solr
       super.tap do |index_document|
-        index_document[:has_model_tesim] = resource.class.name
+        index_document[:has_model_ssim] = resource.class.name
         index_document[:alternate_ids_sim] = resource.alternate_ids.map(&:to_s)
       end
     end

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples 'a Hyrax::Resource indexer' do
   describe '#to_solr' do
     it 'indexes base resource fields' do
       expect(indexer.to_solr)
-        .to include(has_model_tesim: resource.class.name,
+        .to include(has_model_ssim: resource.class.name,
                     alternate_ids_sim: a_collection_containing_exactly(*ids))
     end
   end


### PR DESCRIPTION
has_model was added to Valkyrie Hyrax::ResourceIndexer as has_model_tesim, but should have been has_model_ssim to be compatible with ActiveFedora solr doc.

See also PR #4489, Issue #4487

@samvera/hyrax-code-reviewers
