### PR TITLE
implement a fallback visibility badge class

### DIFF
--- a/app/presenters/hyrax/permission_badge.rb
+++ b/app/presenters/hyrax/permission_badge.rb
@@ -24,7 +24,7 @@ module Hyrax
     private
 
     def dom_label_class
-      VISIBILITY_LABEL_CLASS.fetch(@visibility.to_sym)
+      VISIBILITY_LABEL_CLASS.fetch(@visibility.to_sym, 'label-info')
     end
 
     def text


### PR DESCRIPTION
if for some reason (app customization, most likely), the `#visibility` of an
object is not one of the configured options, fallback on `'label-info'` as the
class.

@samvera/hyrax-code-reviewers
