### PR TITLE
Restoring anonymous resource declaration in specs

### DIFF
--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -9,23 +9,22 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
   it_behaves_like 'a Work indexer'
 
   context 'when extending with basic metadata' do
-    before do
-      module Hyrax::Test
-        module Basic
-          class Work < Hyrax::Work
-            include Hyrax::Schema(:basic_metadata)
-          end
-        end
-      end
-    end
-    after { Hyrax::Test.send(:remove_const, :Basic) }
-
     let(:indexer_class) do
       Class.new(described_class) do
         include Hyrax::Indexer(:basic_metadata)
       end
     end
-    let(:resource) { Hyrax::Test::Basic::Work.new }
+    let(:resource) do
+      Class.new(Hyrax::Work) do
+        # Included to address a `ArgumentError: Class name cannot be
+        # blank. You need to supply a name argument when anonymous
+        # class given`"
+        def self.model_name
+          ActiveModel::Name.new(self, nil, "TemporaryResource")
+        end
+        include Hyrax::Schema(:basic_metadata)
+      end.new
+    end
 
     it_behaves_like 'a Basic metadata indexer'
   end


### PR DESCRIPTION
At issue is "human_readable_type" leverages the resource's model name,
which, by default, uses ActiveModel::Name.  By adding `.model_name` that
returns an instance of ActiveModel::Name, the tests now pass.

I could imagine adding a spec helper method for generating an anonymous
resource.  This method would encapsulate the behavior.  If we were to go
this route, we'd want to update all of our existing `Class.new` declarations.

```ruby
module Hyrax::SpecSupport
  def self.build_anonymous_resource_class(klass, name: "Anonymous", &block)
     Class.new(klass) do
       def self.model_name
         ActiveModel::Name.new(self, nil, name)
       end
       instance_exec(&block)
     end
  end
end

Hyrax::SpecSupport.build_anonymous_resource_class(Hyrax::Work, name: "Anonymouse") do
  include Hyrax::Schema(:basic_metadata)
end
```

@samvera/hyrax-code-reviewers
