### PR TITLE
Fixing Works Created Count Discrepency - #3478

### DIFF
--- a/app/helpers/hyrax/dashboard_helper_behavior.rb
+++ b/app/helpers/hyrax/dashboard_helper_behavior.rb
@@ -5,7 +5,11 @@ module Hyrax
       params[:controller].match(%r{^hyrax/dashboard|hyrax/my})
     end
 
-    def number_of_works(user = current_user, where: {})
+    # @param user [User]
+    # @param where [Hash] applied as the where clause when querying the Hyrax::WorkRelation
+    #
+    # @see Hyrax::WorkRelation
+    def number_of_works(user = current_user, where: { generic_type_sim: "Work" })
       where_clause = where.merge(DepositSearchBuilder.depositor_field => user.user_key)
       Hyrax::WorkRelation.new.where(where_clause).count
     rescue RSolr::Error::ConnectionRefused

--- a/app/helpers/hyrax/dashboard_helper_behavior.rb
+++ b/app/helpers/hyrax/dashboard_helper_behavior.rb
@@ -5,8 +5,9 @@ module Hyrax
       params[:controller].match(%r{^hyrax/dashboard|hyrax/my})
     end
 
-    def number_of_works(user = current_user)
-      Hyrax::WorkRelation.new.where(DepositSearchBuilder.depositor_field => user.user_key).count
+    def number_of_works(user = current_user, where: {})
+      where_clause = where.merge(DepositSearchBuilder.depositor_field => user.user_key)
+      Hyrax::WorkRelation.new.where(where_clause).count
     rescue RSolr::Error::ConnectionRefused
       'n/a'
     end

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -306,7 +306,9 @@ module Hyrax
     # rubocop:enable Metrics/MethodLength
 
     # @param [ActionController::Parameters] params first argument for Blacklight::SearchState.new
-    # @param [Hash] facet
+    # @param [Hash] facet(s)
+    # @return [Hash]
+    #
     # @note Assumes one facet is passed in. If a second facet is passed, then it must be the depositor
     # facet used by the Profile page.
     def search_state_with_facets(params, facet = {})

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -105,7 +105,11 @@ module Hyrax
     # @see Blacklight::SearchState#initialize
     def link_to_field(name, value, label = nil, facet_hash = {})
       label ||= value
-      params = { search_field: name, q: "\"#{value}\"" } if name != ''
+      params = {}
+      if name.present?
+        params[:search_field] = name
+        params[:q] = "\"#{value}\""
+      end
       state = search_state_with_facets(params, facet_hash)
       link_to(label, main_app.search_catalog_path(state))
     end

--- a/app/views/hyrax/users/_vitals.html.erb
+++ b/app/views/hyrax/users/_vitals.html.erb
@@ -8,8 +8,7 @@
 </div>
 
 <div class="list-group-item">
-  <%# "Note the `{ generic_type_sim: "Work" }` for number_of_works aligns with the link_to_field's {generic_type: 'Work'} key/value pair." %>
-  <span class="badge"><%= number_of_works(user, where: { generic_type_sim: "Work" }) %></span>
+  <span class="badge"><%= number_of_works(user) %></span>
   <span class="glyphicon glyphicon-upload" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.works"), {generic_type: "Work", depositor: user.to_s}) %>
 
   <ul class="views-downloads-dashboard list-unstyled">

--- a/app/views/hyrax/users/_vitals.html.erb
+++ b/app/views/hyrax/users/_vitals.html.erb
@@ -8,7 +8,8 @@
 </div>
 
 <div class="list-group-item">
-  <span class="badge"><%= number_of_works(user) %></span>
+  <%# "Note the `{ generic_type_sim: "Work" }` for number_of_works aligns with the link_to_field's {generic_type: 'Work'} key/value pair." %>
+  <span class="badge"><%= number_of_works(user, where: { generic_type_sim: "Work" }) %></span>
   <span class="glyphicon glyphicon-upload" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.works"), {generic_type: "Work", depositor: user.to_s}) %>
 
   <ul class="views-downloads-dashboard list-unstyled">

--- a/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
+++ b/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe Hyrax::DashboardHelperBehavior, type: :helper do
     it "finds 3 works" do
       expect(helper.number_of_works(user1)).to eq(3)
     end
+
+    context "with a :where clause" do
+      it "limits to those matching the where clause" do
+        expect(helper.number_of_works(user1, where: { "generic_type_sim" => "Big Work" })).to eq(1)
+      end
+    end
   end
 
   describe "#number_of_files" do
@@ -61,10 +67,12 @@ RSpec.describe Hyrax::DashboardHelperBehavior, type: :helper do
     solr_service = Hyrax::SolrService
 
     # deposited by the first user
-    3.times do |t|
+    2.times do |t|
       solr_service.add id: "199#{t}", "depositor_tesim" => user1.user_key, "has_model_ssim" => [model],
-                       "depositor_ssim" => user1.user_key
+                       "depositor_ssim" => user1.user_key, "generic_type_sim" => "Work"
     end
+
+    solr_service.add id: "1993", "depositor_tesim" => user1.user_key, "generic_type_sim" => "Big Work", "has_model_ssim" => [model], "depositor_ssim" => user1.user_key
 
     # deposited by the second user, but editable by the first
     solr_service.add id: "1994", "depositor_tesim" => user2.user_key, "has_model_ssim" => [model],

--- a/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
+++ b/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
@@ -26,11 +26,15 @@ RSpec.describe Hyrax::DashboardHelperBehavior, type: :helper do
       create_models("GenericWork", user1, user2)
     end
 
-    it "finds 3 works" do
-      expect(helper.number_of_works(user1)).to eq(3)
+    it "finds 2 works" do
+      expect(helper.number_of_works(user1)).to eq(2)
     end
 
-    context "with a :where clause" do
+    context "with an over-riddent :where clause" do
+      it "finds 3 works when passed an empty where" do
+        expect(helper.number_of_works(user1, where: {})).to eq(3)
+      end
+
       it "limits to those matching the where clause" do
         expect(helper.number_of_works(user1, where: { "generic_type_sim" => "Big Work" })).to eq(1)
       end


### PR DESCRIPTION
## Adjusting logic to ensure use of local variable

b0b5dc46b6f143406ee3259032b8e0abb00a8d96

Prior to this commit, we could be passing the application controller's
`params` instead of of the local variable `params`.  This could result
in some unexpected behavior.

Note, in SHA @b04c41d2772505d8a548c3fd48774a5642d3ac90 we went from:

```ruby
params = { search_field: name, q: "\"#{value}\"" }
state = search_state_with_facets(params, facet_hash)
```

to

```ruby
params = { search_field: name, q: "\"#{value}\"" } if name != ''
state = search_state_with_facets(params, facet_hash)
```

The prior change meant that instead of always having the local variable
named `params`, we would sometimes fallback to the application's
`params` method.

I don't think this is a major issue, but one that could introduce some
unexpected results.

Related to #4322, #3478

## Introducing where clause for number_of_works()

980dc92ce0611222c3facb0285446fba4832b8f1

Based on some investigation around #3478, I suspect that the
`Hyrax::WorkRelation#where` call that uses only a depositor field and
user key is finding more results than the query run on the catalog
search page.

By adding the where clause, I hope to align the query logic of the
`number_of_works` and the `link_to_field` on the [_vitals.html.erb][1] partial.

Related to #3478

[1]: https://github.com/samvera/hyrax/blob/b04c41d2772505d8a548c3fd48774a5642d3ac90/app/views/hyrax/users/_vitals.html.erb#L11-L12

## Adding where clause to align counts on two pages

212cf164410dbe5c301ba5525a71c320c36a6c91

On the "vitals" page, there is a count that we derive from
`number_of_works`.  When you click on the `link_to_field` that new page
also as a count based on the provided facets.  Prior to this commit, I
believe the underlying queries were not using the same logic.

With this change, I hope to bring this in alignment.

Please note, I don't have tests to confirm this, nor a data state that
would help confirm it.  So, I'm pushing up a change that I believe
should work.

My plan is to write some helper tests at a later date, but for now am
drawing to the end of my work day.

Related to #3478

## Moving where clause into helper

7abf7578d4a01a136aae273a72a5f5e351813bc6

Per discussion on https://github.com/samvera/hyrax/pull/4494, a view
likely should not know about the Solr document field names.  This is
better served in a helper.
