### PR TITLE
Use response code from Hyrax::API

### DIFF
--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -52,7 +52,7 @@ module Hyrax::Controller
   # render a json response for +response_type+
   def render_json_response(response_type: :success, message: nil, options: {})
     json_body = Hyrax::API.generate_response_body(response_type: response_type, message: message, options: options)
-    render json: json_body, status: response_type
+    render json: json_body, status: Hyrax::API::DEFAULT_RESPONSES[response_type][:code]
   end
 
   # Called by Hydra::Controller::ControllerBehavior when CanCan::AccessDenied is caught


### PR DESCRIPTION
The response_type used for 500 errors is `:internal_error` which doesn't map to a valid rails response type (it should be `:internal_server_error`).  Instead of changing Hyrax::API just use the code set in Hyrax::API.  There is probably a better fix for this but this avoids errors for now.

@samvera/hyrax-code-reviewers
