### PR TITLE
Helm charts for Hyrax and FCRepo

### DIFF
--- a/.dassie/values.stage.yaml
+++ b/.dassie/values.stage.yaml
@@ -1,0 +1,7 @@
+ingress:
+  enabled: true
+  annotations: {}
+  hosts:
+    - host: "staging.dassie.dld.library.ucsb.edu"
+      paths: ["/"]
+  tls: []

--- a/.dassie/values.yaml
+++ b/.dassie/values.yaml
@@ -1,0 +1,15 @@
+image:
+  repository: samveralabs/dassie
+  pullPolicy: IfNotPresent
+  tag: "stable"
+
+ingress:
+  enabled: true
+  annotations: {}
+  hosts:
+    - host: "dassie.dld.library.ucsb.edu"
+      paths: ["/"]
+  tls: []
+
+memcached:
+  enabled: true

--- a/CONTAINERS.md
+++ b/CONTAINERS.md
@@ -66,4 +66,17 @@ docker push samveralabs/dassie:(git rev-parse HEAD)
 docker push samveralabs/dassie:$HYRAX_VERSION
 ```
 
+## Helm Chart
+
+Also under development is a Helm chart, which we are developing into a robust,
+configurable production environment for Hyrax applications.
+
+If you have a Kubernetes cluster configured (`kubectl cluster-info`), you can
+deploy the `dassie` test applications with:
+
+```sh
+helm dependency update chart/hyrax
+helm install -n hyrax --set image.repository=samveralabs/dassie --set image.tag=(git rev-parse HEAD) dassie chart/hyrax
+```
+
 [dockerhub-samveralabs]: https://hub.docker.com/r/samveralabs

--- a/CONTAINERS.md
+++ b/CONTAINERS.md
@@ -76,7 +76,7 @@ deploy the `dassie` test applications with:
 
 ```sh
 helm dependency update chart/hyrax
-helm install -n hyrax --set image.repository=samveralabs/dassie --set image.tag=(git rev-parse HEAD) dassie chart/hyrax
+helm install -n hyrax --set image.tag=(git rev-parse HEAD) dassie chart/hyrax
 ```
 
 [dockerhub-samveralabs]: https://hub.docker.com/r/samveralabs

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ ONBUILD COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 ONBUILD RUN bundle install --jobs "$(nproc)"
 ONBUILD RUN DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 
-
 FROM hyrax-base as hyrax-engine-dev
 
 ARG APP_PATH=.dassie

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /app/samvera/hyrax-webapp
 COPY --chown=1001:101 ./bin /app/samvera
 ENV PATH="/app/samvera:$PATH"
 ENV RAILS_ROOT="/app/samvera/hyrax-webapp"
+ENV RAILS_SERVE_STATIC_FILES="1"
 
 ENTRYPOINT ["hyrax-entrypoint.sh"]
 CMD ["bundle", "exec", "puma", "-v", "-b", "tcp://0.0.0.0:3000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ FROM hyrax-base as hyrax-engine-dev
 ARG APP_PATH=.dassie
 ARG BUNDLE_WITHOUT=
 
+ENV HYRAX_ENGINE_PATH /app/samvera/hyrax-engine
+
 COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 COPY --chown=1001:101 . /app/samvera/hyrax-engine
 

--- a/chart/fcrepo/.gitignore
+++ b/chart/fcrepo/.gitignore
@@ -1,0 +1,2 @@
+charts/*
+Chart.lock

--- a/chart/fcrepo/.helmignore
+++ b/chart/fcrepo/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/fcrepo/Chart.yaml
+++ b/chart/fcrepo/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: fcrepo
+description: Fedora Commons Repository 4
+type: application
+version: 0.1.7
+appVersion: 4.7
+dependencies:
+  - name: postgresql
+    version: 9.3.3
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled

--- a/chart/fcrepo/Chart.yaml
+++ b/chart/fcrepo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fcrepo
 description: Fedora Commons Repository 4
 type: application
-version: 0.1.7
+version: 0.2.5
 appVersion: 4.7
 dependencies:
   - name: postgresql

--- a/chart/fcrepo/Chart.yaml
+++ b/chart/fcrepo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fcrepo
 description: Fedora Commons Repository 4
 type: application
-version: 0.2.5
+version: 0.4.0
 appVersion: 4.7
 dependencies:
   - name: postgresql

--- a/chart/fcrepo/README.md
+++ b/chart/fcrepo/README.md
@@ -1,0 +1,50 @@
+Fedora Commons Helm Chart
+=========================
+
+Fedora is the flexible, modular, open source repository platform with native
+linked data support.
+
+## Installation
+
+```sh
+helm dep up chart/fcrepo
+helm install fcrepo chart/fcrepo
+```
+
+## Configuration
+
+By default, this chart deploys with Postgresql as the backend for Fedora.
+Without other configuration, it will deploy a new Postgresql instance/database
+as a service available to the `fcrepo` deployment.
+
+In practice, users may want to forego installing postgres for two reasons:
+
+_First_, when you are deploying Fedora into a more complex application
+environment you may wish to reuse an existing Postgres instance already
+maintained with that environment.
+
+In this case, `fcrepo` should be deployed with postgresql explictly disabled, an
+`exernalDatabaseUsername`, and an `fcrepoSecretName`. `fcrepoSecretName` must
+correspond to an existing secret providing `DATABASE_PASSWORD`, `DATABASE_HOST`,
+and `JAVA_OPTS`.
+
+Optionally, a `externalDatabaseName` may be given to avoid collissions in the
+case that the default `fcrepo` is not an acceptable database name.
+
+This is usually done in the context of a parent chart which provides the postgresql instance, for example:
+
+```yaml
+fcrepo:
+  enabled: true
+  fcrepoSecretName: "mychart.fcrepo.fullname"
+  externalDatabaseUsername: "mydbuser"
+  servicePort: 8080
+  postgresql:
+    enabled: false
+```
+
+_Second_, because they want to use another backend for Fedora. This use case is broadly unsupported here. In theory, you can get a default (Infinispan) configuration by setting `postgresql.enabled` to `false`. **THIS CONFIGURATION IS UNTESTED AND UNSUPPORTED**:
+
+```sh
+helm install --set postgresql.enabled=false fcrepo-test chart/fcrepo
+```

--- a/chart/fcrepo/templates/NOTES.txt
+++ b/chart/fcrepo/templates/NOTES.txt
@@ -13,9 +13,9 @@
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "fcrepo.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "fcrepo.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+  echo http://$SERVICE_IP:{{ .Values.servicePort | default .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "fcrepo.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:{{ .Values.servicePort | default .Values.service.port }}
 {{- end }}

--- a/chart/fcrepo/templates/NOTES.txt
+++ b/chart/fcrepo/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "fcrepo.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "fcrepo.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "fcrepo.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "fcrepo.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/chart/fcrepo/templates/_helpers.tpl
+++ b/chart/fcrepo/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "hyrax.name" -}}
+{{- define "fcrepo.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -11,7 +11,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "hyrax.fullname" -}}
+{{- define "fcrepo.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -27,16 +27,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "hyrax.chart" -}}
+{{- define "fcrepo.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "hyrax.labels" -}}
-helm.sh/chart: {{ include "hyrax.chart" . }}
-{{ include "hyrax.selectorLabels" . }}
+{{- define "fcrepo.labels" -}}
+helm.sh/chart: {{ include "fcrepo.chart" . }}
+{{ include "fcrepo.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -46,47 +46,23 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "hyrax.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "hyrax.name" . }}
+{{- define "fcrepo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fcrepo.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "hyrax.serviceAccountName" -}}
+{{- define "fcrepo.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "hyrax.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "fcrepo.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 
-{{/*
-Create default fully qualified service names.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "hyrax.fcrepo.fullname" -}}
-{{- printf "%s-%s" .Release.Name "fcrepo" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "hyrax.memcached.fullname" -}}
-{{- printf "%s-%s" .Release.Name "memcached" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "hyrax.postgresql.fullname" -}}
-{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-
-{{- define "hyrax.redis.fullname" -}}
-{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-
-{{- define "hyrax.solr.fullname" -}}
-{{- printf "%s-%s" .Release.Name "solr" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- define "hyrax.zk.fullname" -}}
-{{- printf "%s-%s" .Release.Name "zookeeper" | trunc 63 | trimSuffix "-" -}}
+{{- define "fcrepo.postgresql.fullname" -}}
+{{- $name := default .Values.postgresql.nameOverride "postgresql" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/chart/fcrepo/templates/_helpers.tpl
+++ b/chart/fcrepo/templates/_helpers.tpl
@@ -63,6 +63,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "fcrepo.postgresql.fullname" -}}
-{{- $name := default .Values.postgresql.nameOverride "postgresql" -}}
+{{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/chart/fcrepo/templates/configmap-env.yaml
+++ b/chart/fcrepo/templates/configmap-env.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fcrepo.fullname" . }}-env
+  labels:
+    app.kubernetes.io/name: {{ include "fcrepo.name" . }}
+    helm.sh/chart: {{ include "fcrepo.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  DATABASE_NAME: {{ .Values.postgresql.postgresqlDatabase }}
+  DATABASE_USER: {{ .Values.postgresql.postgresqlUsername }}

--- a/chart/fcrepo/templates/configmap-env.yaml
+++ b/chart/fcrepo/templates/configmap-env.yaml
@@ -8,5 +8,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
+  {{- if .Values.postgresql.enabled }}
   DATABASE_NAME: {{ .Values.postgresql.postgresqlDatabase }}
   DATABASE_USER: {{ .Values.postgresql.postgresqlUsername }}
+  {{- else }}
+  DATABASE_NAME: {{ .Values.externalDatabaseName | default "fcrepo" }}
+  DATABASE_USER: {{ .Values.externalDatabaseUsername }}
+  {{- end }}

--- a/chart/fcrepo/templates/configmap-env.yaml
+++ b/chart/fcrepo/templates/configmap-env.yaml
@@ -12,6 +12,8 @@ data:
   DATABASE_NAME: {{ .Values.postgresql.postgresqlDatabase }}
   DATABASE_USER: {{ .Values.postgresql.postgresqlUsername }}
   {{- else }}
+  {{- if .Values.externalDatabaseUsername }}
   DATABASE_NAME: {{ .Values.externalDatabaseName | default "fcrepo" }}
   DATABASE_USER: {{ .Values.externalDatabaseUsername }}
+  {{- end }}
   {{- end }}

--- a/chart/fcrepo/templates/deployment.yaml
+++ b/chart/fcrepo/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             claimName: {{ template "fcrepo.fullname" . }}
       initContainers:
         - name: "remove-lost-found"
-          image: "busybox:1.25.0"
+          image: "busybox:1.32.0"
           command:
             - rm
             - -fr
@@ -49,7 +49,8 @@ spec:
           command:
             - sh
             - -c
-            - PGPASSWORD=$DATABASE_PASSWORD PGHOST=$DATABASE_HOST PGUSER=$DATABASE_USER psql -tc "SELECT 1 FROM pg_database WHERE datname = '$DATABASE_NAME'" | grep -q 1 || createdb -e -w $DATABASE_NAME
+            - export PGPASSWORD=$DATABASE_PASSWORD PGHOST=$DATABASE_HOST PGUSER=$DATABASE_USER
+            - psql -tc "SELECT 1 FROM pg_database WHERE datname = '$DATABASE_NAME'" | grep -q 1 || createdb -e -w $DATABASE_NAME
           envFrom:
             - configMapRef:
                 name: {{ include "fcrepo.fullname" . }}-env

--- a/chart/fcrepo/templates/deployment.yaml
+++ b/chart/fcrepo/templates/deployment.yaml
@@ -42,6 +42,19 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+        {{- if not .Values.postgresql.enabled }}
+        - name: "init-db"
+          image: {{ .Values.postgresql.image.repository | default "bitnami/postgresql" }}:{{ .Values.postgresql.image.tag | default "latest" }}
+          command:
+            - sh
+            - -c
+            - PGPASSWORD=$DATABASE_PASSWORD PGHOST=$DATABASE_HOST PGUSER=$DATABASE_USER psql -tc "SELECT 1 FROM pg_database WHERE datname = '$DATABASE_NAME'" | grep -q 1 || createdb -e -w $DATABASE_NAME
+          envFrom:
+            - configMapRef:
+                name: {{ include "fcrepo.fullname" . }}-env
+            - secretRef:
+                name: {{ include .Values.fcrepoSecretName . }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -52,7 +65,11 @@ spec:
             - configMapRef:
                 name: {{ include "fcrepo.fullname" . }}-env
             - secretRef:
+                {{- if .Values.postgresql.enabled }}
                 name: {{ template "fcrepo.fullname" . }}
+                {{- else }}
+                name: {{ include .Values.fcrepoSecretName . }}
+                {{- end }}
           ports:
             - name: http
               containerPort: 8080
@@ -64,12 +81,12 @@ spec:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: {{ default .Values.healthCheck.initialDelay 15 }}
+            initialDelaySeconds: {{ default 15 .Values.healthCheck.initialDelay }}
           readinessProbe:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: {{ default .Values.healthCheck.initialDelay 15 }}
+            initialDelaySeconds: {{ default 15 .Values.healthCheck.initialDelay }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/chart/fcrepo/templates/deployment.yaml
+++ b/chart/fcrepo/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
             - name: data
               mountPath: /data
         {{- if not .Values.postgresql.enabled }}
+        {{- if .Values.fcrepoSecretName }}
         - name: "init-db"
           image: {{ .Values.postgresql.image.repository | default "bitnami/postgresql" }}:{{ .Values.postgresql.image.tag | default "latest" }}
           command:
@@ -55,6 +56,7 @@ spec:
             - secretRef:
                 name: {{ include .Values.fcrepoSecretName . }}
         {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -64,12 +66,15 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "fcrepo.fullname" . }}-env
+            {{- if .Values.postgresql.enabled }}
             - secretRef:
-                {{- if .Values.postgresql.enabled }}
                 name: {{ template "fcrepo.fullname" . }}
-                {{- else }}
+            {{- else }}
+            {{- if .Values.fcrepoSecretName }}
+            - secretRef:
                 name: {{ include .Values.fcrepoSecretName . }}
-                {{- end }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/chart/fcrepo/templates/deployment.yaml
+++ b/chart/fcrepo/templates/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fcrepo.fullname" . }}
+  labels:
+    {{- include "fcrepo.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fcrepo.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "fcrepo.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+      serviceAccountName: {{ include "fcrepo.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ template "fcrepo.fullname" . }}
+      initContainers:
+        - name: "remove-lost-found"
+          image: "busybox:1.25.0"
+          command:
+            - rm
+            - -fr
+            - /data/lost+found
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "fcrepo.fullname" . }}-env
+            - secretRef:
+                name: {{ template "fcrepo.fullname" . }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ default .Values.healthCheck.initialDelay 15 }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ default .Values.healthCheck.initialDelay 15 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/fcrepo/templates/ingress.yaml
+++ b/chart/fcrepo/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "fcrepo.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "fcrepo.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/chart/fcrepo/templates/pvc.yaml
+++ b/chart/fcrepo/templates/pvc.yaml
@@ -1,0 +1,20 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fcrepo.fullname" . }}
+  labels:
+    app: {{ template "fcrepo.name" . }}
+    chart: {{ template "fcrepo.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: fcrepo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ default .Values.storage.size "1Gi" }}
+  {{- if .Values.storage.className }}
+  storageClassName: "{{ .Values.storage.ClassName }}"
+  {{- end }}

--- a/chart/fcrepo/templates/secret.yaml
+++ b/chart/fcrepo/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fcrepo.fullname" . }}
+  labels:
+{{ include "fcrepo.labels" . | indent 4 }}
+type: Opaque
+data:
+  DATABASE_PASSWORD: {{ .Values.postgresql.postgresqlPassword | b64enc }}
+  JAVA_OPTS: {{ printf "-Dfcrepo.modeshape.configuration=\"classpath:/config/jdbc-postgresql/repository.json\" -Dfcrepo.postgresql.host=\"%s\" -Dfcrepo.postgresql.username=\"%s\" -Dfcrepo.postgresql.password=\"%s\" -Dfcrepo.object.directory=\"/data/objects\" -Dfcrepo.binary.directory=\"/data/binaries\"" ( include "fcrepo.postgresql.fullname" . ) .Values.postgresql.postgresqlUsername .Values.postgresql.postgresqlPassword | b64enc }}

--- a/chart/fcrepo/templates/service.yaml
+++ b/chart/fcrepo/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.servicePort | default .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/chart/fcrepo/templates/service.yaml
+++ b/chart/fcrepo/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fcrepo.fullname" . }}
+  labels:
+    {{- include "fcrepo.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "fcrepo.selectorLabels" . | nindent 4 }}

--- a/chart/fcrepo/templates/serviceaccount.yaml
+++ b/chart/fcrepo/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fcrepo.serviceAccountName" . }}
+  labels:
+    {{- include "fcrepo.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/fcrepo/templates/tests/test-connection.yaml
+++ b/chart/fcrepo/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "fcrepo.fullname" . }}-test-connection"
+  labels:
+    {{- include "fcrepo.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "fcrepo.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/chart/fcrepo/values.yaml
+++ b/chart/fcrepo/values.yaml
@@ -11,6 +11,8 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 
+fcrepoSecretName: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -52,7 +54,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: fcrepo.local
-      paths: []
+      paths: ['/']
   tls: []
   #  - secretName: fcrepo-tls
   #    hosts:

--- a/chart/fcrepo/values.yaml
+++ b/chart/fcrepo/values.yaml
@@ -1,13 +1,14 @@
-# Default values for hyrax.
+# Default values for fcrepo.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
 
+storage: {}
+
 image:
-  repository: samveralabs/dassie
+  repository: ualbertalib/docker-fcrepo4
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 imagePullSecrets: []
@@ -22,6 +23,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+healthCheck: {}
 
 podAnnotations: {}
 
@@ -46,48 +49,24 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: hyrax.local
+    - host: fcrepo.local
       paths: []
   tls: []
-
-resources: {}
-
-fcrepo:
-  enabled: true
-  postgresql:
-    nameOverride: fcrepo-psql
-  healthCheck:
-    initialDelay: 1000
-
-memcached:
-  enabled: false
+  #  - secretName: fcrepo-tls
+  #    hosts:
+  #      - chart-example.local
 
 postgresql:
   enabled: true
   image:
     repository: bitnami/postgresql
     tag: 12.3.0
-  postgresqlUsername: hyrax
-  postgresqlPassword: hyrax_pass
-  postgresqlDatabase: hyrax
+  postgresqlUsername: fcrepo
+  postgresqlPassword: fcrepo_pass
+  postgresqlDatabase: fcrepo
   servicePort: 5432
-  # cpu: 1000m
-  # memory: 1Gi
-  # persistence:
-  #   size: 10Gi
 
-redis:
-  enabled: true
-
-solr:
-  enabled: true
-
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
+resources: {}
 
 nodeSelector: {}
 

--- a/chart/fcrepo/values.yaml
+++ b/chart/fcrepo/values.yaml
@@ -39,9 +39,11 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+servicePort: 8080
+
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
 
 ingress:
   enabled: false

--- a/chart/hyrax/.gitignore
+++ b/chart/hyrax/.gitignore
@@ -1,0 +1,2 @@
+charts/*
+Chart.lock

--- a/chart/hyrax/.helmignore
+++ b/chart/hyrax/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -5,6 +5,9 @@ type: application
 version: 0.2.0
 appVersion: 3.0.0-rc2
 dependencies:
+  - name: fcrepo
+    version: 0.1.6
+    repository: file://../fcrepo
   - name: memcached
     version: 4.2.21
     repository: https://charts.bitnami.com/bitnami

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -1,23 +1,6 @@
 apiVersion: v2
 name: hyrax
-description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+description: An open-source, Samvera-powered digital repository system
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+version: 0.2.0
+appVersion: 3.0.0-rc2

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.2.0
+version: 0.4.0
 appVersion: 3.0.0-rc2
 dependencies:
   - name: fcrepo
-    version: 0.2.5
+    version: 0.4.0
     repository: file://../fcrepo
   - name: memcached
     version: 4.2.21

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.0
 appVersion: 3.0.0-rc2
 dependencies:
   - name: fcrepo
-    version: 0.1.6
+    version: 0.2.5
     repository: file://../fcrepo
   - name: memcached
     version: 4.2.21

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -4,3 +4,21 @@ description: An open-source, Samvera-powered digital repository system
 type: application
 version: 0.2.0
 appVersion: 3.0.0-rc2
+dependencies:
+  - name: memcached
+    version: 4.2.21
+    repository: https://charts.bitnami.com/bitnami
+    condition: memcached.enabled
+  - name: postgresql
+    version: 9.3.3
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+  - name: redis
+    version: 10.7.16
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
+  - name: solr
+    version: 1.5.2
+    repository: http://storage.googleapis.com/kubernetes-charts-incubator
+    condition: solr.enabled
+  # need something for fcrepo

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: hyrax
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/chart/hyrax/README.md
+++ b/chart/hyrax/README.md
@@ -1,0 +1,69 @@
+Hyrax Helm
+==========
+
+This [Helm][helm] chart provides configurable deployments for Hyrax applications
+to [Kubernetes][k8s] clusters. It seeks to be a complete but flexible
+production-ready setup for Hyrax applications. By default it deploys:
+
+  - A Hyrax-based Rails application
+  - Fedora Commons v4.7
+  - Postgresql
+  - Solr (in a cloud configuration, including Apache Zookeeper)
+  - Redis
+
+## A base Hyrax deployment
+
+Because Hyrax is a [Rails Engine][engine]---not a stand-alone application---
+deploying it requires us to have a specific application. This chart assumes that
+the user has a container image based on `samveralabs/hyrax` (see:
+[CONTAINERS.md][containers]) that includes their application. Point the chart at
+your image by setting the `image.repository` and `image.tag` values.
+
+By default, the chart deploys [images][dassie-images] for Hyrax's development
+application, [`dassie`][dassie].
+
+For application configuration, we take our queues from [12-factor][twelve]
+methodology. Applications using environment variables to manage their
+configuration can be easily reconfigured across different releases using this
+chart; e.g. the same chart can be used to deploy sandbox, staging, and
+production environments.
+
+The chart populates the following environment variables:
+
+|-------------------|--------------------------------|------------------------|
+| Variable          | Description                    | Condition              |
+|-------------------|--------------------------------|------------------------|
+| DB_HOST           | Postgresql hostname            | `postgresql.enabled`   |
+| DB_PORT           | Postgresql service port        | `postgresql.enabled`   |
+| MEMCACHED_HOST    | Memcached host                 | `memcached.enabled`    |
+| RACK_ENV          | app environment ('production') | n/a                    |
+| RAILS_ENV         | app environment ('production') | n/a                    |
+| REDIS_HOST        | Redis service host             | `redis.enabled`        |
+| FCREPO_HOST       | Fedora Commons host            | `fcrepo.enabled`       |
+| FCREPO_PORT       | Fedora Commons port            | `fcrepo.enabled`       |
+| FCREPO_REST_PATH  | Fedora Commons REST endpoint   | `fcrepo.enabled`       |
+| SOLR_HOST         | Solr service host              | `solr.enabled`         |
+| SOLR_PORT         | Solr service port              | `solr.enabled`         |
+| SOLR_URL          | Solr service full URL          | `solr.enabled`         |
+|----------------- -|--------------------------------|------------------------|
+
+## For DevOps:
+
+For those interested in trying out or contributing to this Chart, it's helpful
+to setup a simple cluster locally. Various projects exist to make this easy; we
+recommend [`k3d`][k3d] or [minikube][minikube].
+
+For example, with `k3d`:
+
+```sh
+k3d cluster create dev-cluster --api-port 6550 -p 80:80@loadbalancer --agents 3
+```
+
+[containers]: ../../CONTAINERS.md#hyrax-image
+[dassie]: ../../.dassie/README.md
+[dassie-image]: https://hub.docker.com/r/samveralabs/dassie
+[engine]: https://guides.rubyonrails.org/engines.html
+[helm]: https://helm.sh
+[k3d]: https://k3d.io
+[k8s]: https://kubernetes.io
+[minikube]: https://minikube.sigs.k8s.io/docs/

--- a/chart/hyrax/templates/NOTES.txt
+++ b/chart/hyrax/templates/NOTES.txt
@@ -17,5 +17,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "hyrax.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:3000
 {{- end }}

--- a/chart/hyrax/templates/NOTES.txt
+++ b/chart/hyrax/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "hyrax.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "hyrax.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "hyrax.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "hyrax.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hyrax.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hyrax.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hyrax.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hyrax.labels" -}}
+helm.sh/chart: {{ include "hyrax.chart" . }}
+{{ include "hyrax.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hyrax.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hyrax.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "hyrax.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "hyrax.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -61,3 +61,28 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create default fully qualified service names.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "hyrax.memcached.fullname" -}}
+{{- printf "%s-%s" .Release.Name "memcached" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "hyrax.postgresql.fullname" -}}
+{{- printf "%s-%s" "dassie" "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{- define "hyrax.redis.fullname" -}}
+{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{- define "hyrax.solr.fullname" -}}
+{{- printf "%s-%s" .Release.Name "solr" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- define "hyrax.zk.fullname" -}}
+{{- printf "%s-%s" .Release.Name "zookeeper" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -24,8 +24,9 @@ data:
   {{- if .Values.fcrepo.enabled }}
   FCREPO_PORT: "80"
   FCREPO_HOST: {{ template "hyrax.fcrepo.fullname" . }}
-  FCREPO_REST_PATH: {{ default .Values.fcrepo.restPath "fcrepo/rest" }}
+  FCREPO_REST_PATH: {{ default "fcrepo/rest" .Values.fcrepo.restPath }}
   {{- end }}
+  FCREPO_BASE_PATH: {{ default "hyrax" .Values.fcrepo.basePath }}
   {{- if .Values.solr.enabled }}
   SOLR_HOST: {{ template "hyrax.solr.fullname" . }}-svc
   SOLR_PORT: "8983"

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   {{- if .Values.postgresql.enabled }}
-  DATABASE_URL: postgresql://{{ .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ template "hyrax.postgresql.fullname" }}/{{ .Values.postgresql.postgresqlDatabase }}?pool=5
-  DB_HOST: {{ template "hyrax.postgresql.fullname" }}
+  DATABASE_URL: postgresql://{{ .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ template "hyrax.postgresql.fullname" . }}/{{ .Values.postgresql.postgresqlDatabase }}?pool=5
+  DB_HOST: {{ template "hyrax.postgresql.fullname" . }}
   DB_PORT: "5432"
   {{- end }}
   {{- if .Values.memcached.enabled }}
@@ -20,6 +20,11 @@ data:
   RAILS_ENV: production
   {{- if .Values.redis.enabled }}
   REDIS_HOST: {{ template "hyrax.redis.fullname" . }}-master
+  {{- end }}
+  {{- if .Values.fcrepo.enabled }}
+  FCREPO_PORT: "80"
+  FCREPO_HOST: {{ template "hyrax.fcrepo.fullname" . }}
+  FCREPO_REST_PATH: {{ default .Values.fcrepo.restPath "fcrepo/rest" }}
   {{- end }}
   {{- if .Values.solr.enabled }}
   SOLR_HOST: {{ template "hyrax.solr.fullname" . }}-svc

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hyrax.fullname" . }}-env
+  labels:
+    app.kubernetes.io/name: {{ include "hyrax.name" . }}
+    helm.sh/chart: {{ include "hyrax.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  {{- if .Values.postgresql.enabled }}
+  DATABASE_URL: postgresql://{{ .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ template "hyrax.postgresql.fullname" }}/{{ .Values.postgresql.postgresqlDatabase }}?pool=5
+  DB_HOST: {{ template "hyrax.postgresql.fullname" }}
+  DB_PORT: "5432"
+  {{- end }}
+  {{- if .Values.memcached.enabled }}
+  MEMCACHED_HOST: {{ template "hyrax.memcached.fullname" . }}
+  {{- end }}
+  RACK_ENV: production
+  RAILS_ENV: production
+  {{- if .Values.redis.enabled }}
+  REDIS_HOST: {{ template "hyrax.redis.fullname" . }}-master
+  {{- end }}
+  {{- if .Values.solr.enabled }}
+  SOLR_HOST: {{ template "hyrax.solr.fullname" . }}-svc
+  SOLR_PORT: "8983"
+  SOLR_URL: http://{{ template "hyrax.solr.fullname" . }}-svc:8983/solr/hyrax
+  {{- end }}

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   {{- if .Values.postgresql.enabled }}
-  DATABASE_URL: postgresql://{{ .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ template "hyrax.postgresql.fullname" . }}/{{ .Values.postgresql.postgresqlDatabase }}?pool=5
   DB_HOST: {{ template "hyrax.postgresql.fullname" . }}
   DB_PORT: "5432"
   {{- end }}
@@ -22,11 +21,10 @@ data:
   REDIS_HOST: {{ template "hyrax.redis.fullname" . }}-master
   {{- end }}
   {{- if .Values.fcrepo.enabled }}
-  FCREPO_PORT: "80"
+  FCREPO_PORT: {{ .Values.fcrepo.servicePort | default 8080 | quote }}
   FCREPO_HOST: {{ template "hyrax.fcrepo.fullname" . }}
-  FCREPO_REST_PATH: {{ default "fcrepo/rest" .Values.fcrepo.restPath }}
+  FCREPO_REST_PATH: {{ .Values.fcrepo.restPath | default "fcrepo/rest" }}
   {{- end }}
-  FCREPO_BASE_PATH: {{ default "hyrax" .Values.fcrepo.basePath }}
   {{- if .Values.solr.enabled }}
   SOLR_HOST: {{ template "hyrax.solr.fullname" . }}-svc
   SOLR_PORT: "8983"

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hyrax.fullname" . }}
+  labels:
+    {{- include "hyrax.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "hyrax.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "hyrax.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "hyrax.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -20,6 +20,19 @@ spec:
       labels:
         {{- include "hyrax.selectorLabels" . | nindent 8 }}
     spec:
+      initContainers:
+        - name: db-setup
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "hyrax.fullname" . }}-env
+            - secretRef:
+                name: {{ template "hyrax.fullname" . }}
+          command:
+            - sh
+            - -c
+            - db-migrate-seed.sh
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -33,9 +46,14 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "hyrax.fullname" . }}-env
+            - secretRef:
+                name: {{ template "hyrax.fullname" . }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 3000
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/chart/hyrax/templates/fcrepo-secret.yaml
+++ b/chart/hyrax/templates/fcrepo-secret.yaml
@@ -1,12 +1,13 @@
-{{- if .Values.postgresql.enabled }}
+{{- if .Values.fcrepo.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "fcrepo.fullname" . }}
+  name: {{ include "hyrax.fcrepo.fullname" . }}
   labels:
-{{ include "fcrepo.labels" . | indent 4 }}
+{{ include "hyrax.labels" . | indent 4 }}
 type: Opaque
 data:
   DATABASE_PASSWORD: {{ .Values.postgresql.postgresqlPassword | b64enc }}
+  DATABASE_HOST: {{ include "fcrepo.postgresql.fullname" . | b64enc }}
   JAVA_OPTS: {{ printf "-Dfcrepo.modeshape.configuration=\"classpath:/config/jdbc-postgresql/repository.json\" -Dfcrepo.postgresql.host=\"%s\" -Dfcrepo.postgresql.username=\"%s\" -Dfcrepo.postgresql.password=\"%s\" -Dfcrepo.object.directory=\"/data/objects\" -Dfcrepo.binary.directory=\"/data/binaries\"" ( include "fcrepo.postgresql.fullname" . ) .Values.postgresql.postgresqlUsername .Values.postgresql.postgresqlPassword | b64enc }}
 {{- end }}

--- a/chart/hyrax/templates/hpa.yaml
+++ b/chart/hyrax/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hyrax.fullname" . }}
+  labels:
+    {{- include "hyrax.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "hyrax.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/chart/hyrax/templates/ingress.yaml
+++ b/chart/hyrax/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "hyrax.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "hyrax.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/chart/hyrax/templates/secrets.yaml
+++ b/chart/hyrax/templates/secrets.yaml
@@ -7,3 +7,6 @@ metadata:
 type: Opaque
 data:
   SECRET_KEY_BASE: {{ randAlphaNum 20 | b64enc | quote }}
+  {{- if .Values.postgresql.enabled }}
+  DATABASE_URL: {{ printf "postgresql://%s:%s@%s/%s?pool=5" .Values.postgresql.postgresqlUsername .Values.postgresql.postgresqlPassword (include "hyrax.postgresql.fullname" .) .Values.postgresql.postgresqlDatabase | b64enc }}
+  {{- end }}

--- a/chart/hyrax/templates/secrets.yaml
+++ b/chart/hyrax/templates/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "hyrax.fullname" . }}
+  labels:
+{{ include "hyrax.labels" . | indent 4 }}
+type: Opaque
+data:
+  SECRET_KEY_BASE: {{ randAlphaNum 20 | b64enc | quote }}

--- a/chart/hyrax/templates/service.yaml
+++ b/chart/hyrax/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hyrax.fullname" . }}
+  labels:
+    {{- include "hyrax.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "hyrax.selectorLabels" . | nindent 4 }}

--- a/chart/hyrax/templates/serviceaccount.yaml
+++ b/chart/hyrax/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hyrax.serviceAccountName" . }}
+  labels:
+    {{- include "hyrax.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/hyrax/templates/tests/test-connection.yaml
+++ b/chart/hyrax/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "hyrax.fullname" . }}-test-connection"
+  labels:
+    {{- include "hyrax.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "hyrax.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -1,0 +1,79 @@
+# Default values for hyrax.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: nginx
+  repository: samveralabs/dassie
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -64,6 +64,29 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+memcached:
+  enabled: false
+
+postgresql:
+  enabled: true
+  image:
+    repository: bitnami/postgresql
+    tag: 12.3.0
+  postgresqlUsername: hyrax
+  postgresqlPassword: hyrax_pass
+  postgresqlDatabase: hyrax
+  servicePort: 5432
+  # cpu: 1000m
+  # memory: 1Gi
+  # persistence:
+  #   size: 10Gi
+
+redis:
+  enabled: true
+
+solr:
+  enabled: true
 
 autoscaling:
   enabled: false

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -54,10 +54,11 @@ resources: {}
 
 fcrepo:
   enabled: true
+  fcrepoSecretName: "hyrax.fcrepo.fullname"
+  externalDatabaseUsername: "hyrax"
+  servicePort: 8080
   postgresql:
-    nameOverride: fcrepo-psql
-  healthCheck:
-    initialDelay: 1000
+    enabled: false
 
 memcached:
   enabled: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+ActiveFedora.fedora.connection.send(:init_base_path)
+
 puts "\n== Creating default collection types"
 Hyrax::CollectionType.find_or_create_default_collection_type
 Hyrax::CollectionType.find_or_create_admin_set_type


### PR DESCRIPTION
http://dassie.dld.library.ucsb.edu is deployed from this chart.

This [Helm][helm] chart provides configurable deployments for Hyrax applications
to [Kubernetes][k8s] clusters. It seeks to be a complete but flexible
production-ready setup for Hyrax applications. By default it deploys:

  - A Hyrax-based Rails application
  - Fedora Commons v4.7
  - Postgresql
  - Solr (in a cloud configuration, including Apache Zookeeper)
  - Redis

## A base Hyrax deployment

Because Hyrax is a [Rails Engine][engine]---not a stand-alone application---
deploying it requires us to have a specific application. This chart assumes that
the user has a container image based on `samveralabs/hyrax` (see:
[CONTAINERS.md][containers]) that includes their application. Point the chart at
your image by setting the `image.repository` and `image.tag` values.

By default, the chart deploys [images][dassie-images] for Hyrax's development
application, [`dassie`][dassie].

For application configuration, we take our queues from [12-factor][twelve]
methodology. Applications using environment variables to manage their
configuration can be easily reconfigured across different releases using this
chart; e.g. the same chart can be used to deploy sandbox, staging, and
production environments.

The chart populates the following environment variables:

|-------------------|--------------------------------|------------------------|
| Variable          | Description                    | Condition              |
|-------------------|--------------------------------|------------------------|
| DB_HOST           | Postgresql hostname            | `postgresql.enabled`   |
| DB_PORT           | Postgresql service port        | `postgresql.enabled`   |
| MEMCACHED_HOST    | Memcached host                 | `memcached.enabled`    |
| RACK_ENV          | app environment ('production') | n/a                    |
| RAILS_ENV         | app environment ('production') | n/a                    |
| REDIS_HOST        | Redis service host             | `redis.enabled`        |
| FCREPO_HOST       | Fedora Commons host            | `fcrepo.enabled`       |
| FCREPO_PORT       | Fedora Commons port            | `fcrepo.enabled`       |
| FCREPO_REST_PATH  | Fedora Commons REST endpoint   | `fcrepo.enabled`       |
| SOLR_HOST         | Solr service host              | `solr.enabled`         |
| SOLR_PORT         | Solr service port              | `solr.enabled`         |
| SOLR_URL          | Solr service full URL          | `solr.enabled`         |
|----------------- -|--------------------------------|------------------------|

## For DevOps:

For those interested in trying out or contributing to this Chart, it's helpful
to setup a simple cluster locally. Various projects exist to make this easy; we
recommend [`k3d`][k3d] or [minikube][minikube].

For example, with `k3d`:

```sh
k3d cluster create dev-cluster --api-port 6550 -p 80:80@loadbalancer --agents 3
```

[containers]: ../../CONTAINERS.md#hyrax-image
[dassie]: ../../.dassie/README.md
[dassie-image]: https://hub.docker.com/r/samveralabs/dassie
[engine]: https://guides.rubyonrails.org/engines.html
[helm]: https://helm.sh
[k3d]: https://k3d.io
[k8s]: https://kubernetes.io
[minikube]: https://minikube.sigs.k8s.io/docs/

@samvera/hyrax-code-reviewers
