### PR TITLE
Apply skip_to_content javascript across app not just client pages

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -105,6 +105,7 @@
 //= require hyrax/turbolinks_events
 //= require hyrax/i18n_helper
 //= require hyrax/collapse
+//= require hyrax/skip_to_content
 
 // this needs to be after batch_select so that the form ids get setup correctly
 //= require hyrax/batch_edit

--- a/app/assets/javascripts/hyrax/skip_to_content.js
+++ b/app/assets/javascripts/hyrax/skip_to_content.js
@@ -1,0 +1,15 @@
+// This code is to implement skip_to_content
+
+Blacklight.onLoad(function () {
+  $(".skip-to-content").click(function(event) {
+    event.preventDefault();
+    // element to focus on
+    let skipTo = '#' + $(this)[0].firstElementChild.hash.split('#')[1];
+
+    // Setting 'tabindex' to -1 takes an element out of normal
+    // tab flow but allows it to be focused via javascript
+    $(skipTo).attr('tabindex', -1).on('blur focusout', function () {
+      $(this).removeAttr('tabindex');
+    }).focus();
+  });
+});

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -29,19 +29,4 @@
     <%= render 'shared/footer' %>
     <%= render 'shared/ajax_modal' %>
   </body>
-  <script type="text/javascript">
-    $( document ).ready(function() {
-      $(".skip-to-content").click(function(event) {
-        event.preventDefault();
-        // element to focus on
-        let skipTo = '#' + $(this)[0].firstElementChild.hash.split('#')[1];
-
-        // Setting 'tabindex' to -1 takes an element out of normal 
-        // tab flow but allows it to be focused via javascript
-        $(skipTo).attr('tabindex', -1).on('blur focusout', function () {
-          $(this).removeAttr('tabindex');
-        }).focus();
-      });
-    });
-  </script>
 </html>


### PR DESCRIPTION
Fixes #3774 

Skip_to_content javascript code was only used on the client-facing page layouts, not dashboard pages.
This PR applies the javascript to all pages.

@samvera/hyrax-code-reviewers
