### PR TITLE
Closing A-tag in Spanish internationalization

### DIFF
--- a/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
@@ -51,7 +51,7 @@ es:
       suffix: "@example.org"
     footer:
       copyright_html: "<strong>Copyright &copy; 2018 Samvera</strong> bajo licencia de Apache, Version 2.0"
-      service_html: Un servicio de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera/a>.
+      service_html: Un servicio de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
     institution_name: institución
     institution_name_full: El nombre de la institución
     product_name: Hyrax


### PR DESCRIPTION
I also checked the other `hyrax.footer.service_html`
internationalization entries, all other langauges are correct.

Closes #4500

This should be back-ported to Hyrax 2.x

@samvera/hyrax-code-reviewers
