### PR TITLE
allow resetting the configured valkyrie index adapter

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -491,7 +491,7 @@ module Hyrax
     ##
     # @param [#to_sym] adapter
     def index_adapter=(adapter)
-      @index_adapter ||= Valkyrie::IndexingAdapter.find(adapter.to_sym)
+      @index_adapter = Valkyrie::IndexingAdapter.find(adapter.to_sym)
     end
 
     attr_writer :index_field_mapper


### PR DESCRIPTION
there was a bug causing `Hyrax.config.index_adapter=` to be a no-op if the index
adapter is already set. this patches it, allowing applications to change their
configured indexing behavior at runtime.

@samvera/hyrax-code-reviewers
