### PR TITLE
move indexing adapter registration to high-precedence

### DIFF
--- a/config/initializers/indexing_adapter_initializer.rb
+++ b/config/initializers/indexing_adapter_initializer.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
-require 'valkyrie/indexing_adapter'
-require 'valkyrie/indexing/solr/indexing_adapter'
-require 'valkyrie/indexing/null_indexing_adapter'
 
-Rails.application.config.to_prepare do
-  Valkyrie::IndexingAdapter.register(
-    Valkyrie::Indexing::Solr::IndexingAdapter.new,
-    :solr_index
-  )
-  Valkyrie::IndexingAdapter.register(
-    Valkyrie::Indexing::NullIndexingAdapter.new, :null_index
-  )
-end
+Valkyrie::IndexingAdapter.register(
+  Valkyrie::Indexing::Solr::IndexingAdapter.new,
+  :solr_index
+)
+Valkyrie::IndexingAdapter.register(
+  Valkyrie::Indexing::NullIndexingAdapter.new, :null_index
+)

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -21,6 +21,9 @@ require 'hyrax/inflections'
 require 'hyrax/name'
 require 'hyrax/valkyrie_can_can_adapter'
 require 'kaminari_route_prefix'
+require 'valkyrie/indexing_adapter'
+require 'valkyrie/indexing/solr/indexing_adapter'
+require 'valkyrie/indexing/null_indexing_adapter'
 
 module Hyrax
   extend ActiveSupport::Autoload


### PR DESCRIPTION
applications will probably want to do indexer setup in
initializers. registration of Hyrax's shipped adapters needs to be in place
before they do this. previously, this was the case only when the application
does setup in a letter after `'i'` (e.g. not `hyrax.rb`).

moving this up in precedence will make things more predictable for apps.

@samvera/hyrax-code-reviewers
