### PR TITLE
ValkyrieIndexer.for - use `class.name` instead of `class` to avoid issues with wings generated classes

### DIFF
--- a/app/indexers/hyrax/valkyrie_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_indexer.rb
@@ -56,17 +56,6 @@ module Hyrax
     attr_reader :resource
 
     ##
-    # @api public
-    # @param [Valkyrie::Resource] resource
-    #
-    # @return [#to_solr]
-    def self.for(resource:)
-      indexer_class = "#{resource.class.name}Indexer".safe_constantize || ValkyrieIndexer
-
-      indexer_class.new(resource: resource)
-    end
-
-    ##
     # @api private
     # @param [Valkyrie::Resource] resource
     def initialize(resource:)
@@ -82,6 +71,31 @@ module Hyrax
         "created_at_dtsi": resource.created_at,
         "updated_at_dtsi": resource.updated_at
       }
+    end
+
+    class << self
+      ##
+      # @api public
+      # @param resource [Valkyrie::Resource] an instance of a Valkyrie::Resource or an inherited class
+      # @note This will attempt to return an indexer following a naming convention where the indexer for a resource
+      #       class is expected to be the class name appended with 'Indexer'.  It will return default ValkyrieIndexer
+      #       if an indexer following the naming convention is not found or the resource is the reserved Hyrax::Resource
+      #       which should use ValkyrieIndexer instead of the base implementation in Hyrax::ResourceIndexer.
+      # @example
+      #     resource class:  Book
+      #     indexer class:   BookIndexer
+      # @return [Valkyrie::Indexer] an instance of ValkyrieIndexer or an inherited class based on naming convention
+      #
+      def for(resource:)
+        indexer_class = resource.class.name == 'Hyrax::Resource' ? ValkyrieIndexer : indexer_from_classname(resource)
+        indexer_class.new(resource: resource)
+      end
+
+      private
+
+      def indexer_from_classname(resource)
+        "#{resource.class.name}Indexer".safe_constantize || ValkyrieIndexer
+      end
     end
   end
 end

--- a/app/indexers/hyrax/valkyrie_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_indexer.rb
@@ -61,7 +61,7 @@ module Hyrax
     #
     # @return [#to_solr]
     def self.for(resource:)
-      indexer_class = "#{resource.class}Indexer".safe_constantize || ValkyrieIndexer
+      indexer_class = "#{resource.class.name}Indexer".safe_constantize || ValkyrieIndexer
 
       indexer_class.new(resource: resource)
     end

--- a/spec/indexers/hyrax/valkyrie_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_indexer_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Hyrax::ValkyrieIndexer do
         expect(described_class.for(resource: resource))
           .to be_a indexer_class
       end
+
+      context 'and resource was converted using wings' do
+        let(:resource) { valkyrie_create(:monograph) }
+
+        it 'gives an instance of MonographIndexer for Monograph' do
+          expect(described_class.for(resource: resource))
+            .to be_a indexer_class
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Descriptive summary

Getting the indexer for a resource depends on naming convention by appending Indexer to the end of the classname (e.g. MyWork has indexer MyWorkIndexer).  Classname before using wings will match the resource class name (e.g. w = MyWork.new; puts w.classname # "MyWork").  Classname after persisting with wings adapter has a Wings generated class and classname (e.g. w2 = Hyrax.persister.save(resource: w); puts w2.classname # "Wings(MyWork)").  If it cannot find a matching indexer, it defaults to Valkyrie::Indexer

### Solution

Use class.name instead of class.  It returns the correct string for creating the indexer from the resource.

```
>> w = Hyrax::Work.new
#<Hyrax::Work id=nil internal_resource="Hyrax::Work" ...>
>> puts w.class
Hyrax::Work
nil
>> w.class.name
Hyrax::Work

>> w2 = Hyrax.persister.save(resource: w)
#<Hyrax::Work id=#<Valkyrie::ID:0x00007fb23ed54ab0 @id="1831cj92z"> internal_resource="#<Class:0x00007fb23ecf7428>" ...>
>> puts w2.class
Wings(Hyrax::Work)
nil
>> w2.class.name
Hyrax::Work
```

NOTE: The spec that was added fails with the original code and passes with the updated code.


@samvera/hyrax-code-reviewers
