### PR TITLE
Re-rendering Work params for failed submit

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -53,12 +53,17 @@ module Hyrax
     end
 
     def create
+      # Caching the original input params in case the form is not valid
+      original_input_params_for_form = params[hash_key_for_curation_concern].deep_dup
       if create_work
         after_create_response
       else
         respond_to do |wants|
           wants.html do
             build_form
+            # Creating a form object that can re-render most of the
+            # submitted parameters
+            @form = Hyrax::Forms::FailedSubmissionFormWrapper.new(form: @form, input_params: original_input_params_for_form)
             render 'new', status: :unprocessable_entity
           end
           wants.json { render_json_response(response_type: :unprocessable_entity, options: { errors: curation_concern.errors }) }

--- a/app/forms/hyrax/forms/failed_submission_form_wrapper.rb
+++ b/app/forms/hyrax/forms/failed_submission_form_wrapper.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+module Hyrax
+  module Forms
+    # @deprecated This class should be removed when we switch to
+    #   Valkyrie::ChangeSet instead of Hydra::Forms.
+    #
+    # This object is responsible for exposing the user submitted
+    # params from a failed POST/PUT/PATCH.
+    #
+    # @see https://github.com/samvera/hyrax/issues/3978
+    class FailedSubmissionFormWrapper < SimpleDelegator
+      # @param form
+      # @param input_params [ActionController::Parameters]
+      #
+      # @param permitted_params [Hash] this likely comes from a class
+      #        method on the given form.  It's used for enforcing
+      #        strong parameters.  It's more of a schema for what the
+      #        input parameters should be.  Why not rely on the
+      #        form.class.permitted_params?  This is a violation of
+      #        the Law of Demeter, and due to object delegation, the
+      #        form.class may be a delegate class, and not the one
+      #        that has permitted_params.
+      #
+      # @see Hyrax::WorkForm.build_permitted_params
+      def initialize(form:, input_params:, permitted_params: nil)
+        @form = form
+        super(@form)
+        @input_params = input_params
+        @exposed_params = {}
+        @permitted_params = permitted_params || __default_permitted_params__(form: form)
+        build_exposed_params!
+      end
+
+      # Yes, I don't want to delegate class to the form, but based on
+      # past experiences, there are times where SimpleForm requests
+      # class.model_name and that had better align with the underlying
+      # form.
+      #
+      # Upon testing, when I don't have this method, the Javascript
+      # for "Requirements" on the new form will not properly
+      # acknowledge that we have re-filled the HTML form with the
+      # submitted non-file fields.
+      def class
+        @form.class
+      end
+
+      def model_name
+        @form.model_name
+      end
+
+      def to_model
+        self
+      end
+
+      def inspect
+        "Hyrax::Forms::FailedSubmissionFormWrapper(#{@form})"
+      end
+
+      def [](key)
+        if @exposed_params.key?(key)
+          @exposed_params.fetch(key)
+        else
+          super
+        end
+      end
+
+      private
+
+      def method_missing(method_name, *args, &block)
+        if @exposed_params.key?(method_name)
+          @exposed_params.fetch(method_name)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, *args)
+        return true if @exposed_params.key?(method_name)
+        super
+      end
+
+      def build_exposed_params!
+        @permitted_params.each do |permitted_param|
+          case permitted_param
+          when ::Symbol
+            @exposed_params[permitted_param] = @input_params.fetch(permitted_param) if @input_params.key?(permitted_param)
+          when ::Hash
+            permitted_param.each do |key, value_schema|
+              build_exposed_param_hash_element!(key: key, value_schema: value_schema)
+            end
+          end
+        end
+      end
+
+      def build_exposed_param_hash_element!(key:, value_schema:)
+        # The input may not include the given key, so don't attempt a fetch.
+        return unless @input_params.key?(key)
+        # I don't have a non-Array example of what this value_schema could be.
+        return unless value_schema.is_a?(::Array)
+        if value_schema.empty?
+          @exposed_params[key] = ::Array.wrap(@input_params.fetch(key))
+        elsif value_schema.is_a?(::Array)
+          # We're expecting nested attributes which will have the form:
+          # { "0" => <Hash with value_schema as keys>, "1" => <Hash with value_schema as keys> }
+          hash = {}
+          @input_params.fetch(key).each_pair do |nested_key, nested_value|
+            hash[nested_key] = nested_value.slice(*value_schema)
+          end
+          @exposed_params[key] = hash
+        end
+      end
+
+      # This method is specifically named __default_permitted_params__
+      # because the form object may well have a
+      # default_permitted_params; I know it's class most certainly
+      # does.
+      #
+      # In running tests, I'm seeing that in some cases a form object
+      # has an instance method for permitted_params, other times, a
+      # form object has a class method for permitted_params, and
+      # though I haven't seen it in specs, I do see that forms have a
+      # build_permitted_params method.
+      def __default_permitted_params__(form:)
+        if form.respond_to?(:permitted_params)
+          form.permitted_params
+        elsif form.class.respond_to?(:permitted_params)
+          form.class.permitted_params
+        elsif form.class.respond_to?(:build_permitted_params)
+          form.class.build_permitted_params
+        else
+          raise ArgumentError, "Unable to extract a suitable permitted_params from #{form.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/embargo_helper.rb
+++ b/app/helpers/hyrax/embargo_helper.rb
@@ -20,11 +20,15 @@ module Hyrax
     #
     # @return [Boolean] whether the resource has an embargo that is currently
     #   enforced (regardless of whether it has expired)
+    #
+    # @note Hyrax::Forms::Failedsubmissionformwrapper is a place
+    #   holder until we switch to Valkyrie::ChangeSet instead of Form
+    #   objects
     def embargo_enforced?(resource)
       case resource
       when Hydra::AccessControls::Embargoable
         !resource.embargo_release_date.nil?
-      when HydraEditor::Form
+      when HydraEditor::Form, Hyrax::Forms::FailedSubmissionFormWrapper
         embargo_enforced?(resource.model)
       when Valkyrie::ChangeSet
         Hyrax::EmbargoManager.new(resource: resource.model).enforced?

--- a/app/helpers/hyrax/lease_helper.rb
+++ b/app/helpers/hyrax/lease_helper.rb
@@ -20,11 +20,15 @@ module Hyrax
     #
     # @return [Boolean] whether the resource has an lease that is currently
     #   enforced (regardless of whether it has expired)
+    #
+    # @note Hyrax::Forms::Failedsubmissionformwrapper is a place
+    #   holder until we switch to Valkyrie::ChangeSet instead of Form
+    #   objects
     def lease_enforced?(resource)
       case resource
       when Hydra::AccessControls::Embargoable
         !resource.lease_expiration_date.nil?
-      when HydraEditor::Form
+      when HydraEditor::Form, Hyrax::Forms::FailedSubmissionFormWrapper
         lease_enforced?(resource.model)
       when Valkyrie::ChangeSet
         Hyrax::LeaseManager.new(resource: resource.model).enforced?

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe Hyrax::GenericWorksController do
       it 'draws the form again' do
         post :create, params: { generic_work: { title: ['a title'] } }
         expect(response.status).to eq 422
-        expect(assigns[:form]).to be_kind_of Hyrax::GenericWorkForm
+        expect(assigns[:form]).to be_kind_of Hyrax::Forms::FailedSubmissionFormWrapper
         expect(response).to render_template 'new'
       end
     end

--- a/spec/forms/hyrax/forms/failed_submission_form_wrapper_spec.rb
+++ b/spec/forms/hyrax/forms/failed_submission_form_wrapper_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::Forms::FailedSubmissionFormWrapper do
+  let(:form) { instance_double(Hyrax::Forms::WorkForm, **form_attributes) }
+  let(:form_attributes) { { title: ["Form's Title"], description: ["Form's description"] } }
+  # I would love to use Hyrax::Forms::WorkForm, but I encountered an
+  # exception when I do Hyrax::Forms::WorkForm.permitted_params.  In
+  # this spec, things fail, however in
+  # ./spec/forms/hyrax/forms/work_form_spec.rb it works.
+  let(:permitted_params) do
+    [
+      { title: [] },
+      :representative_id,
+      { description: [] },
+      { based_near_attributes: [:id, :_destroy], member_of_collections_attributes: [:id, :_destroy], work_members_attributes: [:id, :_destroy] },
+      { permissions_attributes: [:type, :name, :access, :id, :_destroy] }
+    ]
+  end
+  let(:input_params) do
+    ActionController::Parameters.new(
+      title: ["Title"],
+      representative_id: "123",
+      obviously_missing_attribute: "One",
+      member_of_collections_attributes: { "0" => { id: "1" }, "2" => { id: "2", _destroy: "1" } }
+    )
+  end
+
+  subject(:wrapper) { described_class.new(form: form, input_params: input_params, permitted_params: permitted_params) }
+
+  describe "input param key is part of permitted params" do
+    it "exposes the given input params" do
+      expect(wrapper.representative_id).to eq(input_params.fetch(:representative_id))
+      expect(wrapper[:representative_id]).to eq(input_params.fetch(:representative_id))
+
+      expect(wrapper.title).to eq(input_params.fetch(:title))
+      expect(wrapper[:title]).to eq(input_params.fetch(:title))
+
+      expect(wrapper.member_of_collections_attributes).to eq(input_params.fetch(:member_of_collections_attributes))
+      expect(wrapper[:member_of_collections_attributes]).to eq(input_params.fetch(:member_of_collections_attributes))
+
+      expect { wrapper.obviously_missing_attribute }.to raise_error(NoMethodError)
+    end
+
+    it "delegates to the underlying form when an input param is not given" do
+      expect(wrapper.description).to eq(form.description)
+      allow(form).to receive(:[]).with(:description).and_return(form_attributes.fetch(:description))
+      expect(wrapper[:description]).to eq(form.description)
+    end
+  end
+
+  describe "when no permitted params are given" do
+    let(:form) { double(**form_attributes) } # Need to get around some constraints of instance_double, so I'm loosening requirements
+    subject(:wrapper) { described_class.new(form: form, input_params: input_params) }
+    it "uses the form's #permitted_params" do
+      allow(form).to receive(:respond_to?).with(:permitted_params).and_return(true)
+      expect(form).to receive(:permitted_params).and_return(permitted_params)
+      expect(wrapper.instance_variable_get("@permitted_params")).to eq(permitted_params)
+    end
+
+    it "uses form.permitted_params when form does not respond to #permitted_params" do
+      allow(form).to receive(:respond_to?).with(:permitted_params).and_return(false)
+      allow(form.class).to receive(:respond_to?).with(:permitted_params).and_return(true)
+      expect(form.class).to receive(:permitted_params).and_return(permitted_params)
+      expect(wrapper.instance_variable_get("@permitted_params")).to eq(permitted_params)
+    end
+
+    it "uses form.build_permitted_params when form does not respond to #permitted_params nor .permitted_params" do
+      allow(form).to receive(:respond_to?).with(:permitted_params).and_return(false)
+      allow(form.class).to receive(:respond_to?).with(:permitted_params).and_return(false)
+      allow(form.class).to receive(:respond_to?).with(:build_permitted_params).and_return(true)
+      expect(form.class).to receive(:build_permitted_params).and_return(permitted_params)
+      expect(wrapper.instance_variable_get("@permitted_params")).to eq(permitted_params)
+    end
+
+    it "raises an error when it can't find a suitable permitted params" do
+      expect { wrapper }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/helpers/hyrax/embargo_helper_spec.rb
+++ b/spec/helpers/hyrax/embargo_helper_spec.rb
@@ -110,5 +110,24 @@ RSpec.describe Hyrax::EmbargoHelper do
         end
       end
     end
+
+    context 'with a Hyrax::Forms::FailedSubmissionFormWrapper' do
+      let(:resource) { Hyrax::Forms::FailedSubmissionFormWrapper.new(form: form, input_params: {}, permitted_params: {}) }
+      let(:form) { Hyrax::GenericWorkForm.new(build(:work), ability, form_controller) }
+      let(:ability) { :FAKE_ABILITY }
+      let(:form_controller) { :FAKE_CONTROLLER }
+
+      it 'returns false' do
+        expect(embargo_enforced?(resource)).to be false
+      end
+
+      context 'when the wrapped work is under embargo' do
+        let(:form) { Hyrax::GenericWorkForm.new(build(:embargoed_work), ability, form_controller) }
+
+        it 'returns true' do
+          expect(embargo_enforced?(resource)).to be true
+        end
+      end
+    end
   end
 end

--- a/spec/helpers/hyrax/lease_helper_spec.rb
+++ b/spec/helpers/hyrax/lease_helper_spec.rb
@@ -108,5 +108,24 @@ RSpec.describe Hyrax::LeaseHelper do
         end
       end
     end
+
+    context 'with a Hyrax::Forms::FailedSubmissionFormWrapper' do
+      let(:resource) { Hyrax::Forms::FailedSubmissionFormWrapper.new(form: form, input_params: {}, permitted_params: {}) }
+      let(:form) { Hyrax::GenericWorkForm.new(build(:work), ability, form_controller) }
+      let(:ability) { :FAKE_ABILITY }
+      let(:form_controller) { :FAKE_CONTROLLER }
+
+      it 'returns false' do
+        expect(lease_enforced?(resource)).to be false
+      end
+
+      context 'when the wrapped work is under embargo' do
+        let(:form) { Hyrax::GenericWorkForm.new(build(:leased_work), ability, form_controller) }
+
+        it 'returns true' do
+          expect(lease_enforced?(resource)).to be true
+        end
+      end
+    end
   end
 end

--- a/spec/support/form_with_validations.rb
+++ b/spec/support/form_with_validations.rb
@@ -5,6 +5,11 @@ module Hyrax
       property :title
 
       validates :title, presence: true
+
+      # Added to comply with Hyrax::Forms::FailedSubmissionFormWrapper
+      def permitted_params
+        { title: [] }
+      end
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, when I would submit an invalid work create form,
the re-rendered form would have blank input values.  With this change
all non-file attributes are re-loaded with the submitted values.

Please note, this needs a bit more time to put full polish on, but I
want to make sure its a path worth pursuing.  If this is a reasonable
path, I'm happy to add the additional specs and inline comments to get
this working.

I'm presently dissatisfied with the changes I needed to make to the case
statement, and would appreciate guidance on how to correct that.

Related to #3978

@samvera/hyrax-code-reviewers
