### PR TITLE
Bumping regen to fix rubocop-ast caching issue

### DIFF
--- a/.regen
+++ b/.regen
@@ -1,1 +1,1 @@
-29omg
+30zoinks

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -105,7 +105,7 @@ SUMMARY
   spec.add_development_dependency 'i18n_yaml_sorter'
   spec.add_development_dependency 'rails-controller-testing', '~> 1'
   # the hyrax style guide is based on `bixby`. see `.rubocop.yml`
-  spec.add_development_dependency 'bixby', '~> 3.0'
+  spec.add_development_dependency 'bixby', '~> 3.0', ">= 3.0.2"
   spec.add_development_dependency 'shoulda-callback-matchers', '~> 1.1.1'
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
   spec.add_development_dependency 'webdrivers', '~> 3.0'


### PR DESCRIPTION
Prior to this commit, the CI environment of Hyrax went wonky.  This, we
hope, is addressed in our Bixby implementation (see
https://github.com/samvera-labs/bixby/pull/47).  However, we need to
invalidate the cache.

@samvera/hyrax-code-reviewers
