### PR TITLE
Refactoring DefaultAdminSetActor

### DIFF
--- a/app/actors/hyrax/actors/default_admin_set_actor.rb
+++ b/app/actors/hyrax/actors/default_admin_set_actor.rb
@@ -24,6 +24,10 @@ module Hyrax
 
       private
 
+      # This method:
+      #
+      # - ensures that the env.attributes[:admin_set_id] is set
+      # - ensures that the permission template for the admin set is correct
       def ensure_admin_set_attribute!(env)
         if env.attributes[:admin_set_id].present?
           ensure_permission_template!(admin_set_id: env.attributes[:admin_set_id])
@@ -36,16 +40,11 @@ module Hyrax
       end
 
       def ensure_permission_template!(admin_set_id:)
-        Hyrax::PermissionTemplate.find_by(source_id: admin_set_id) || create_permission_template!(source_id: admin_set_id)
+        Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id)
       end
 
       def default_admin_set_id
         AdminSet.find_or_create_default_admin_set_id
-      end
-
-      # Creates a Hyrax::PermissionTemplate for the given AdminSet
-      def create_permission_template!(source_id:)
-        Hyrax::PermissionTemplate.create!(source_id: source_id)
       end
     end
   end

--- a/app/services/hyrax/ensure_well_formed_admin_set_service.rb
+++ b/app/services/hyrax/ensure_well_formed_admin_set_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+module Hyrax
+  # This "service" ensures that we have a well formed AdminSet.
+  #
+  # @note For historical reasons, we lazily apply the default admin
+  #   set to curation concerns that don't already have an admin set.
+  #
+  # @see AdminSet
+  # @see Hyrax::PermissionTemplate
+  # @see Hyrax::Actors::DefaultAdminSetActor
+  module EnsureWellFormedAdminSetService
+    # @api public
+    # @since v3.0.0
+    #
+    # @param admin_set_id [String, nil]
+    #
+    # @return [String] an admin_set_id; if you provide a "present"
+    #   admin_set_id, this service will return that.
+    #
+    # @see AdminSet.find_or_create_default_admin_set_id
+    def self.call(admin_set_id: nil)
+      admin_set_id = admin_set_id.presence || AdminSet.find_or_create_default_admin_set_id
+      Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id)
+      admin_set_id
+    end
+  end
+end

--- a/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
-  let(:depositor) { create(:user) }
+  let(:depositor) { build(:user) }
   let(:depositor_ability) { ::Ability.new(depositor) }
   let(:work) { build(:generic_work) }
   let(:admin_set) { build(:admin_set, id: 'admin_set_1') }
@@ -55,7 +55,7 @@ RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
       let(:attributes) { { title: 'new title' } }
       let(:default_id) { AdminSet::DEFAULT_ID }
 
-      it "gets the admin set id fro the work" do
+      it "gets the admin set id for the work" do
         expect(terminator).to receive(:update).with(Hyrax::Actors::Environment) do |k|
           expect(k.attributes).to eq('title' => 'new title', 'admin_set_id' => admin_set.id)
           true

--- a/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
           expect(k.attributes).to eq("admin_set_id" => default_id)
           true
         end
-        expect(AdminSet).to receive(:find_or_create_default_admin_set_id).and_return(default_id)
+        expect(Hyrax::EnsureWellFormedAdminSetService).to receive(:call).with(admin_set_id: nil).and_return(default_id)
         middleware.create(env)
       end
     end
@@ -34,15 +34,13 @@ RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
     context "when admin_set_id is provided" do
       let(:attributes) { { admin_set_id: admin_set.id } }
 
-      it "uses the provided id, ensures a permission template, and returns true" do
+      it "uses the provided id, ensures a well formed admin set, and returns true" do
         expect(terminator).to receive(:create).with(Hyrax::Actors::Environment) do |k|
           expect(k.attributes).to eq("admin_set_id" => admin_set.id)
           true
         end
-        expect(AdminSet).not_to receive(:find_or_create_default_admin_set_id)
-        expect do
-          expect(middleware.create(env)).to be true
-        end.to change { Hyrax::PermissionTemplate.count }.by(1)
+        expect(Hyrax::EnsureWellFormedAdminSetService).to receive(:call).with(admin_set_id: admin_set.id).and_return(admin_set.id)
+        expect(middleware.create(env)).to be true
       end
     end
   end
@@ -60,7 +58,7 @@ RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
           expect(k.attributes).to eq('title' => 'new title', 'admin_set_id' => admin_set.id)
           true
         end
-        expect(AdminSet).not_to receive(:find_or_create_default_admin_set_id)
+        expect(Hyrax::EnsureWellFormedAdminSetService).to receive(:call).with(admin_set_id: admin_set.id).and_return(admin_set.id)
         expect(middleware.update(env)).to be true
       end
     end
@@ -69,12 +67,12 @@ RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
       let(:admin_set2) { build(:admin_set, id: 'admin_set_2') }
       let(:attributes) { { title: 'new title', admin_set_id: admin_set2.id } }
 
-      it "uses the provided id, ensures a permission template, and returns true" do
+      it "uses the provided id, ensures ensures a well formed admin set, and returns true" do
         expect(terminator).to receive(:update).with(Hyrax::Actors::Environment) do |k|
           expect(k.attributes).to eq('title' => 'new title', 'admin_set_id' => admin_set2.id)
           true
         end
-        expect(AdminSet).not_to receive(:find_or_create_default_admin_set_id)
+        expect(Hyrax::EnsureWellFormedAdminSetService).to receive(:call).with(admin_set_id: admin_set2.id).and_return(admin_set2.id)
         expect(middleware.update(env)).to be true
       end
     end

--- a/spec/hyrax/transactions/steps/set_default_admin_set_spec.rb
+++ b/spec/hyrax/transactions/steps/set_default_admin_set_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Hyrax::Transactions::Steps::SetDefaultAdminSet do
 
       it 'sets the default admin_set' do
         expect { step.call(work) }
-          .to change { work.admin_set&.id }
+          .to change { work.admin_set_id }
           .from(nil)
           .to(admin_set_id)
       end

--- a/spec/services/hyrax/ensure_well_formed_admin_set_service_spec.rb
+++ b/spec/services/hyrax/ensure_well_formed_admin_set_service_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::EnsureWellFormedAdminSetService do
+  let(:default_id) { AdminSet::DEFAULT_ID }
+  describe ".call" do
+    subject { described_class.call(admin_set_id: given_admin_set_id) }
+    context "with admin_set_id: nil" do
+      let(:given_admin_set_id) { nil }
+      it 'uses the default admin set and conditionally creates the associated permission template' do
+        expect(AdminSet).to receive(:find_or_create_default_admin_set_id).and_return(default_id)
+        expect(Hyrax::PermissionTemplate).to receive(:find_or_create_by!).with(source_id: default_id)
+        expect(subject).to eq(default_id)
+      end
+    end
+    context "with admin_set_id: <not nil>" do
+      let(:given_admin_set_id) { 'admin_set/mine' }
+      it 'uses the given admin_set_id and conditionally creates the associated permission template' do
+        expect(AdminSet).not_to receive(:find_or_create_default_admin_set_id)
+        expect(Hyrax::PermissionTemplate).to receive(:find_or_create_by!).with(source_id: given_admin_set_id)
+        expect(subject).to eq(given_admin_set_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Minor refactoring of DefaultAdminSetActor

a6336febd7b8ae801ad4437cd4779a9547e43734

I'm beginning to poke at the logic in the actor stack.  On my first
pass, I'm looking for candidates that I could extract a service class.

This commit compresses some logic, leaning on Rails `find_or_create_by!`
instead of two separate methods and `||` logic.

In addition, this commit fixes a typo in the specs, and moves from a
`create(:user)` to `build(:user)`.  Anecdotally, the move from create to
build shaved 0.5 seconds from these specs, or dropped the test time to
75% of the original.

As my comments indicate, I'm currently unpacking the
`ensure_admin_set_attribute!` method.

## Extracting "Service" from ActorStack object

ae87c08076d965af3f9b682acccbd38808c50034

The extracted code is something easily repurposible, and could be easily
repurposed in the Hyrax::Transactions.

## Switching spec to reflect behavior

f219ee3491dc7faee8c316666d1645db80b519a2

Prior to this change, when running this spec in isolation, it does not
succeed.  I believe at issue is the fact that specs do not reload the
object.

```console
bundle exec rspec
./spec/hyrax/transactions/steps/set_default_admin_set_spec.rb:46

Failures:

  1) Hyrax::Transactions::Steps::SetDefaultAdminSet#call with an active fedora object sets the default admin_set
     Failure/Error:
       expect { step.call(work) }
         .to change { work.admin_set&.id }
         .from(nil)
         .to(admin_set_id)

       expected `work.admin_set&.id` to have changed from nil to
       "admin_set/default", but did not change
```

I verified that the above spec fails for SHA 08ffa5aa7 (a commit from a Sept 4, 2020).
