### PR TITLE
index valkyrie work attributes consistent with AF

### DIFF
--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -11,35 +11,21 @@ module Hyrax
 
     def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
       super.tap do |solr_doc|
-        admin_set_label = admin_set_title(resource.admin_set_id)
-        solr_doc['admin_set_sim'] = admin_set_label
-        solr_doc['admin_set_tesim'] = admin_set_label
-        solr_doc['member_ids_ssim'] = resource.member_ids
-        solr_doc['member_of_collections_ssim']    = collection_titles(resource.member_of_collection_ids)
+        solr_doc['generic_type_sim'] = ['Work']
+        solr_doc['admin_set_id_ssim'] = [resource.admin_set_id]
         solr_doc['member_of_collection_ids_ssim'] = resource.member_of_collection_ids
+        solr_doc['member_ids_ssim'] = resource.member_ids
 
         # attributes from Hyrax::Work not defined by Hyrax::Schema includes
         # solr_doc['on_behalf_of'] = ''
         # solr_doc['proxy_depositor'] = ''
         # solr_doc['state'] = ''
 
-        solr_doc['generic_type_sim'] = ['Work']
-
         # This enables us to return a Work when we have a FileSet that matches
         # the search query.  While at the same time allowing us not to return Collections
         # when a work in the collection matches the query.
         # solr_doc['file_set_ids_ssim'] = solr_doc['member_ids_ssim'] # TODO: Doesn't this return child works too?
       end
-    end
-
-    private
-
-    def admin_set_title(id)
-      id.present? ? Hyrax.query_service.find_by(id: id)&.title : ""
-    end
-
-    def collection_titles(ids)
-      Hyrax.query_service.find_many_by_ids(ids: ids).map { |col| col.title&.first }
     end
   end
 end

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -8,5 +8,38 @@ module Hyrax
     include Hyrax::PermissionIndexer
     include Hyrax::VisibilityIndexer
     include Hyrax::Indexer(:core_metadata)
+
+    def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+      super.tap do |solr_doc|
+        admin_set_label = admin_set_title(resource.admin_set_id)
+        solr_doc['admin_set_sim'] = admin_set_label
+        solr_doc['admin_set_tesim'] = admin_set_label
+        solr_doc['member_ids_ssim'] = resource.member_ids
+        solr_doc['member_of_collections_ssim']    = collection_titles(resource.member_of_collection_ids)
+        solr_doc['member_of_collection_ids_ssim'] = resource.member_of_collection_ids
+
+        # attributes from Hyrax::Work not defined by Hyrax::Schema includes
+        # solr_doc['on_behalf_of'] = ''
+        # solr_doc['proxy_depositor'] = ''
+        # solr_doc['state'] = ''
+
+        solr_doc['generic_type_sim'] = ['Work']
+
+        # This enables us to return a Work when we have a FileSet that matches
+        # the search query.  While at the same time allowing us not to return Collections
+        # when a work in the collection matches the query.
+        # solr_doc['file_set_ids_ssim'] = solr_doc['member_ids_ssim'] # TODO: Doesn't this return child works too?
+      end
+    end
+
+    private
+
+    def admin_set_title(id)
+      id.present? ? Hyrax.query_service.find_by(id: id)&.title : ""
+    end
+
+    def collection_titles(ids)
+      Hyrax.query_service.find_many_by_ids(ids: ids).map { |col| col.title&.first }
+    end
   end
 end

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -12,20 +12,17 @@ module Hyrax
     def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
       super.tap do |solr_doc|
         solr_doc['generic_type_sim'] = ['Work']
+        solr_doc['suppressed_bsi'] = suppressed?(resource)
         solr_doc['admin_set_id_ssim'] = [resource.admin_set_id]
         solr_doc['member_of_collection_ids_ssim'] = resource.member_of_collection_ids
         solr_doc['member_ids_ssim'] = resource.member_ids
-
-        # attributes from Hyrax::Work not defined by Hyrax::Schema includes
-        # solr_doc['on_behalf_of'] = ''
-        # solr_doc['proxy_depositor'] = ''
-        # solr_doc['state'] = ''
-
-        # This enables us to return a Work when we have a FileSet that matches
-        # the search query.  While at the same time allowing us not to return Collections
-        # when a work in the collection matches the query.
-        # solr_doc['file_set_ids_ssim'] = solr_doc['member_ids_ssim'] # TODO: Doesn't this return child works too?
       end
+    end
+
+    private
+
+    def suppressed?(resource)
+      Hyrax::ResourceStatus.new(resource: resource).inactive?
     end
   end
 end

--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -70,5 +70,19 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
       expect(solr_document.fetch('member_ids_ssim')).to match_array work.member_ids
       expect(solr_document.fetch('member_of_collection_ids_ssim')).to match_array [col1.id]
     end
+
+    context 'when work is inactive' do
+      before { allow(work).to receive(:state).and_return(Hyrax::ResourceStatus::INACTIVE) }
+      it 'sets suppressed to true' do
+        expect(solr_document.fetch('suppressed_bsi')).to be true
+      end
+    end
+
+    context 'when work is active' do
+      before { allow(work).to receive(:state).and_return(Hyrax::ResourceStatus::ACTIVE) }
+      it 'sets suppressed to false' do
+        expect(solr_document.fetch('suppressed_bsi')).to be false
+      end
+    end
   end
 end

--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -53,4 +53,24 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
 
     it_behaves_like 'a Work indexer'
   end
+
+  describe '#to_solr' do
+    let(:service) { described_class.new(resource: work) }
+    subject(:solr_document) { service.to_solr }
+
+    let(:admin_set_title) { 'An Admin Set' }
+    let(:admin_set) { create(:admin_set, title: [admin_set_title]) }
+    let(:collection_title) { 'A Collection' }
+    let(:col1) { valkyrie_create(:hyrax_collection, title: [collection_title]) }
+    let(:work) { valkyrie_create(:hyrax_work, :with_member_works, member_of_collection_ids: [col1.id], admin_set_id: admin_set.id) }
+
+    it 'includes attributes defined outside Hyrax::Schema include' do
+      expect(solr_document.fetch('generic_type_sim')).to match_array ['Work']
+      expect(solr_document.fetch('admin_set_sim')).to match_array [admin_set_title]
+      expect(solr_document.fetch('admin_set_tesim')).to match_array [admin_set_title]
+      expect(solr_document.fetch('member_ids_ssim')).to match_array work.member_ids
+      expect(solr_document.fetch('member_of_collections_ssim')).to match_array [collection_title]
+      expect(solr_document.fetch('member_of_collection_ids_ssim')).to match_array [col1.id]
+    end
+  end
 end

--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -66,10 +66,8 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
 
     it 'includes attributes defined outside Hyrax::Schema include' do
       expect(solr_document.fetch('generic_type_sim')).to match_array ['Work']
-      expect(solr_document.fetch('admin_set_sim')).to match_array [admin_set_title]
-      expect(solr_document.fetch('admin_set_tesim')).to match_array [admin_set_title]
+      expect(solr_document.fetch('admin_set_id_ssim')).to match_array [admin_set.id]
       expect(solr_document.fetch('member_ids_ssim')).to match_array work.member_ids
-      expect(solr_document.fetch('member_of_collections_ssim')).to match_array [collection_title]
       expect(solr_document.fetch('member_of_collection_ids_ssim')).to match_array [col1.id]
     end
   end


### PR DESCRIPTION
### Related Issue

Partially addresses Issue #4487 - Solr docs generated by ActiveFedora and Hyrax::ValkyrieWorkIndexer are not compatible

### Description

Most attributes for Hyrax::Work are defined using `Hyrax::Schema` includes.  A few are defined with `attribute` statements.  Some of these attributes were indexed by ActiveFedora.  Adding in indexing for these to be consistent with ActiveFedora’s indexing.

### Additional Differences

Looking for confirmation on how to handle additional attributes not covered by this PR.

Indexed in AF, but not in ValkyrieWorkIndexer…
* generic_type_sim
* file_set_ids_ssim

Defined as attribute in Hyrax::Work, but not indexed
* on_behalf_of
* proxy_depositor
* state

### Observations

The updates in this PR handle the attributes the same way as in AF.  For admin_set and member_of_collections, this involves getting the title from the related resources.  Will we still need the labels going forward?  I am guessing they are used by show pages to avoid needing to instantiate the related objects as those pages are generated.

Looking for confirmation on this as well.


