### PR TITLE
support ID as a type in metadata schema

### DIFF
--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -108,6 +108,8 @@ module Hyrax
       # @return [Dry::Types::Type]
       def type_for(type)
         case type
+        when 'id'
+          Valkyrie::Types::ID
         when 'uri'
           Valkyrie::Types::URI
         when 'date_time'


### PR DESCRIPTION
Add support for an attribute that holds a Valkyrie::ID to another resource.  To be able to define this through the SchemaLoader, the `id` type needs to have a special case to set Valkryie type to `Valkyrie::Types::ID`.

### Expected

In config/metadata/my_resource.yaml, defining an attribute with

```
type: id
```

should produce

```
Valkyrie::Types::ID
```

### Actual

In config/metadata/my_resource.yaml, defining an attribute with

```
type: id
```

produces

```
Valkyrie::Types::Id
```

which doesn't exist causing exception

```
uninitialized constant Valkyrie::Types::Id
```

@samvera/hyrax-code-reviewers
