### PR TITLE
Fixing closing header tag

### DIFF
--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -47,7 +47,7 @@
           </div>
       <% end %>
 
-      </header>
+      </div>
 
     </div>
   </div>


### PR DESCRIPTION
In the commit 2f880a6a63f686e459bd8ea97c561e6813952de0, we changed from
opening a HEADER tag to opening a DIV tag.  However, we did not changing
the matching closing HEADER to a closing DIV.  This commit fixes that.

Closes #4518

Related to #4150

@samvera/hyrax-code-reviewers
