### PR TITLE
Gh 4515 and 4516 batch deactivate

### DIFF
--- a/app/views/hyrax/batch_select/_add_button.html.erb
+++ b/app/views/hyrax/batch_select/_add_button.html.erb
@@ -1,3 +1,3 @@
 <div data-behavior="batch-add-button">
-  <%= check_box_tag "batch_document_#{document.id}", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}", checks: "active" %>
+  <%= check_box_tag "batch_document_ids[]", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}", checks: "active" %>
 </div>

--- a/app/views/hyrax/collections/_default_group.html.erb
+++ b/app/views/hyrax/collections/_default_group.html.erb
@@ -1,3 +1,4 @@
+<fieldset>
 <table class="table table-striped">
   <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
   <thead>
@@ -20,3 +21,4 @@
   <% end %>
   </tbody>
 </table>
+</fieldset>

--- a/app/views/hyrax/dashboard/works/_default_group.html.erb
+++ b/app/views/hyrax/dashboard/works/_default_group.html.erb
@@ -1,3 +1,4 @@
+<fieldset>
 <table class="table table-striped works-list">
   <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
   <thead>
@@ -18,3 +19,4 @@
   <% end %>
   </tbody>
 </table>
+</fieldset>

--- a/app/views/hyrax/leases/_list_expired_active_leases.html.erb
+++ b/app/views/hyrax/leases/_list_expired_active_leases.html.erb
@@ -17,6 +17,7 @@
 <% else %>
 
   <%= form_tag leases_path, method: :patch do %>
+    <fieldset>
     <%= submit_tag t('.deactivate_selected'), class: 'btn btn-primary' %>
     <table class="leases table">
       <thead>
@@ -49,5 +50,5 @@
       </tbody>
     </table>
   <% end %>
-
+  </fieldset>
 <% end %>

--- a/app/views/hyrax/my/works/_default_group.html.erb
+++ b/app/views/hyrax/my/works/_default_group.html.erb
@@ -1,3 +1,4 @@
+<fieldset>
 <table class="table table-striped works-list">
   <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
   <thead>
@@ -16,3 +17,4 @@
   <% end %>
   </tbody>
 </table>
+</fieldset>

--- a/spec/views/hyrax/batch_select/_add_button.html.erb_spec.rb
+++ b/spec/views/hyrax/batch_select/_add_button.html.erb_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/batch_select/_add_button.html.erb', type: :view do
+  let(:document) { double(id: 123) }
+  before do
+    render 'hyrax/batch_select/add_button.html.erb', document: document
+  end
+
+  it 'renders a checkbox named "batch_document_ids[]"' do
+    # See ./app/controllers/concerns/hyrax/collections/accepts_batches.rb
+    # for how we expect the input fields to have a name "batch_document_ids[]"
+    expect(rendered).to have_selector(%([data-behavior="batch-add-button"] .batch_document_selector#batch_document_#{document.id}[name="batch_document_ids[]"][value=#{document.id}][type=checkbox]))
+  end
+end


### PR DESCRIPTION
## Restoring HTML form field name.

a09812ce728afad4ca30ff5edf619dfd485678f4

In 241cbed1df4ad416b8d44763ae321e642443ed88 we introduced changes to
address accessibility issues reported in #3966.  However, the introduced
change broke the HTML form field names and the assumed parameters for
the [batch processing][1].

This commit reverts that change, but it does not address the
accessibility concern raised in #3966.  That is for another commit, as I
don't know if that other commit is the correct path forward.

Closes #4516
Closes #4515

[1]:https://github.com/samvera/hyrax/blob/3c7258c95c1fe6f0fe1537078f3f5f458f211989/app/controllers/concerns/hyrax/collections/accepts_batches.rb#L20-L28

## Adding fieldset to address like named form inputs

b152637e1ad9a01a6b3a09d909d6ad6dd62e1ef2

In consultation with @dananji and following the [guidance of W3.org][1],
this commit wraps the forms (or controls) that render the
[add_buttom partial][2].  I don't believe that I have access to the
accessibility testing software, so this is a bit of a stab in the dark.

Note, in some cases I render the fieldset as a direct child of the form,
in other cases, I render the fieldset as a container for the table used
to present the elements that render the add button partial.

This relates to work done in #4160 to address #3966.

[1]:https://www.w3.org/WAI/tutorials/forms/grouping/
[2]:https://github.com/samvera/hyrax/blob/d5aa2f9ca802fe670687bb4f7c14ad242c1bacf6/app/views/hyrax/batch_select/_add_button.html.erb#L2

@samvera/hyrax-code-reviewers
