### PR TITLE
make the stats/analytics displays responsive

### DIFF
--- a/app/assets/stylesheets/hyrax/_usage-stats.scss
+++ b/app/assets/stylesheets/hyrax/_usage-stats.scss
@@ -4,7 +4,7 @@
 
 .stats-container {
   box-sizing: border-box;
-  width: 850px;
+  max-width: 850px;
   height: 450px;
   padding: 20px 15px 15px 15px;
   margin: 15px auto 30px auto;


### PR DESCRIPTION
this addresses (part of) #4530.

analytics graphs were lacking device responsivity because width was hard
coded. shifting to `max-width` allows the graphs to generate for the appropriate
screen size.

@samvera/hyrax-code-reviewers
