### PR TITLE
Adding feature test for Collection#destroy

### DIFF
--- a/spec/models/concerns/hyrax/collection_behavior_spec.rb
+++ b/spec/models/concerns/hyrax/collection_behavior_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::CollectionBehavior, clean_repo: true do
+  let(:collection) { create(:collection_lw) }
+  let(:work) { create(:work) }
+
+  describe "#destroy" do
+    it "removes the collection id from associated members" do
+      collection.add_member_objects([work.id])
+      collection.save
+
+      collection_via_query = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: collection.id, use_valkyrie: false)
+
+      expect { collection_via_query.destroy }
+        .to change { work.class.find(work.id).member_of_collection_ids }
+        .from([collection.id])
+        .to([])
+    end
+  end
+end


### PR DESCRIPTION
A little bit about this spec.  It's informed by #3762 which is why it
looks a bit odd.  When I wrote this spec it worked.  I suspect that some
prior change between the reported date of June 28, 2019 and
today (October 8, 2020) fixed this bug.

See [Hyrax::BatchEditsController#destroy_collection][1] for the related
code that informed the spec's implementation details.

I'm not prepared nor willing to bisect when this bug was fixed.  I also
understand that we need not merge this commit as the code-base already
works.  I do, however, think about some of the assumptions that we've
found to be broken; [Looking at you Embargo and Lease cascade behavior][2].

Closes #3872

[1]:https://github.com/samvera/hyrax/blob/0e6e7c4ff72fe508d2af0bb2eb22a1a532cf54b3/app/controllers/hyrax/batch_edits_controller.rb#L40-L47
[2]:https://github.com/samvera/hyrax/issue/4534

@samvera/hyrax-code-reviewers
