### PR TITLE
Pinning Hyrax internal-test-app to SOLR 8.6.2

### DIFF
--- a/.regen
+++ b/.regen
@@ -1,1 +1,1 @@
-30zoinks
+31solr-bleck

--- a/lib/generators/hyrax/config_generator.rb
+++ b/lib/generators/hyrax/config_generator.rb
@@ -13,6 +13,7 @@ class Hyrax::ConfigGenerator < Rails::Generators::Base
     * TinyMCE
     * i18n
     * Valkyrie index
+    * SOLR wrapper shims
        """
 
   source_root File.expand_path('../templates', __FILE__)
@@ -36,6 +37,14 @@ class Hyrax::ConfigGenerator < Rails::Generators::Base
   def configure_redis
     copy_file 'config/redis.yml'
     copy_file 'config/initializers/redis_config.rb'
+  end
+
+  # @note We added these to address the fact that the SOLR schema we
+  # use broke in the SOLR 8.6.3 release.  We envision this to be a
+  # stop-gap.
+  def configure_solr_wrappers
+    copy_file 'config/solr_wrapper_test.yml', force: true
+    copy_file 'config/solr_wrapper_dev.yml', force: true
   end
 
   def configure_valkyrie_index

--- a/lib/generators/hyrax/templates/config/solr_wrapper_dev.yml
+++ b/lib/generators/hyrax/templates/config/solr_wrapper_dev.yml
@@ -1,0 +1,8 @@
+#config/solr_wrapper_test.yml
+version: 8.6.2
+port: 8983
+instance_dir: tmp/solr-development
+collection:
+    persist: false
+    dir: solr/conf
+    name: hydra-development

--- a/lib/generators/hyrax/templates/config/solr_wrapper_test.yml
+++ b/lib/generators/hyrax/templates/config/solr_wrapper_test.yml
@@ -1,0 +1,8 @@
+#config/solr_wrapper_test.yml
+version: 8.6.2
+port: 8985
+instance_dir: tmp/solr-test
+collection:
+    persist: false
+    dir: solr/conf
+    name: hydra-test

--- a/lib/generators/hyrax/templates/config/solr_wrapper_valkyrie_test.yml
+++ b/lib/generators/hyrax/templates/config/solr_wrapper_valkyrie_test.yml
@@ -1,4 +1,5 @@
 # config/solr_wrapper_valkyrie_test.yml
+version: 8.6.2
 port: 8987
 instance_dir: tmp/solr-valkyrie-test
 collection:


### PR DESCRIPTION
Prior to this commit, the internal test app would build against the
latest version of SOLR.  With SOLR 8.6.3, the upstream maintainers of
SOLR introduced a breaking change.  The schema that we use does not work
in 8.6.3.

We envision this commit to be a work-around.

@samvera/hyrax-code-reviewers
