### PR TITLE
Allowing passed label option to be used

### DIFF
--- a/app/renderers/hyrax/renderers/attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer.rb
@@ -14,6 +14,9 @@ module Hyrax
       # @param [Symbol] field
       # @param [Array] values
       # @param [Hash] options
+      # @option options [String] :label The field label to render
+      # @option options [String] :include_empty Do we render if if the values are empty?
+      # @option options [String] :work_type Used for some I18n logic
       def initialize(field, values, options = {})
         @field = field
         @values = values
@@ -53,16 +56,23 @@ module Hyrax
         markup.html_safe
       end
 
+      # Defaults to the label provided in the options, otherwise, it
+      # fallsback to the inner logic of the method.
+      #
       # @return The human-readable label for this field.
       # @note This is a central location for determining the label of a field
       #   name. Can be overridden if more complicated logic is needed.
       def label
-        translate(
-          :"blacklight.search.fields.#{work_type_label_key}.show.#{field}",
-          default: [:"blacklight.search.fields.show.#{field}",
-                    :"blacklight.search.fields.#{field}",
-                    options.fetch(:label, field.to_s.humanize)]
-        )
+        if options&.key?(:label)
+          options.fetch(:label)
+        else
+          translate(
+            :"blacklight.search.fields.#{work_type_label_key}.show.#{field}",
+            default: [:"blacklight.search.fields.show.#{field}",
+                      :"blacklight.search.fields.#{field}",
+                      field.to_s.humanize]
+          )
+        end
       end
 
       private

--- a/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
@@ -95,6 +95,14 @@ RSpec.describe Hyrax::Renderers::AttributeRenderer do
 
   describe "#label" do
     subject { renderer }
+    context 'with label provided as an option' do
+      let(:given_label) { "Peeps we know" }
+      let(:renderer) { described_class.new(field, ['Bob', 'Jessica'], label: given_label) }
+
+      it 'renders the provided label' do
+        expect(subject.label).to eq(given_label)
+      end
+    end
 
     context 'with work type option' do
       let(:work_type) { "GenericWork".underscore }


### PR DESCRIPTION
Prior to this commit, we didn't expose `options[:label]` as a valid
option.

The following quote comes from #3456

> While using the `_attribute_rows.html.erb` partial, I expected that
> any value I passed to the `label` key value would override any other
> label value.

With this change, you can now do something similar to what the original
issue reporter requested:

```erb
<% if presenter.model.model_name.name == "OralHistory" %>
  <%= presenter.attribute_to_html(:creator, render_as: :faceted, label: t('hyrax.labels.oral_history.creator')) %>
  <%= presenter.attribute_to_html(:contributor, render_as: :faceted, label: t('hyrax.labels.oral_history.contributor')) %>
<% else %>
```

Closes #3456

@samvera/hyrax-code-reviewers
