### PR TITLE
Add ability to define custom change sets for resources

### DIFF
--- a/app/models/hyrax/change_set.rb
+++ b/app/models/hyrax/change_set.rb
@@ -7,10 +7,14 @@ module Hyrax
   # Build a changeset class for the given resource class. The ChangeSet will
   # have fields to match the resource class given.
   #
+  # To define a custom changeset with validations, use naming convention with "ChangeSet" appended to the end
+  # of the resource class name. (e.g. for BookResource, name the change set BookResourceChangeSet)
+  #
   # @example
   #   Hyrax::ChangeSet(Monograph)
   def self.ChangeSet(resource_class)
-    Class.new(Hyrax::ChangeSet) do
+    klass = (resource_class.to_s + "ChangeSet").safe_constantize || Hyrax::ChangeSet
+    Class.new(klass) do
       (resource_class.fields - resource_class.reserved_attributes).each do |field|
         property field, default: nil
       end

--- a/spec/models/hyrax/change_set_spec.rb
+++ b/spec/models/hyrax/change_set_spec.rb
@@ -48,4 +48,39 @@ RSpec.describe Hyrax::ChangeSet do
         .to have_attributes(title: contain_exactly(*titles))
     end
   end
+
+  describe ".for" do
+    context 'when custom change set does not exist' do
+      it 'returns an instance of described_class' do
+        expect(subject).to be_kind_of described_class
+      end
+    end
+
+    context 'when custom change set does exist' do
+      let(:resource) { Hyrax::Test::BookResource.new }
+
+      it 'returns an instance of custom change set' do
+        expect(subject).to be_kind_of Hyrax::Test::BookResourceChangeSet
+      end
+
+      context 'and value for custom validation is correct' do
+        let(:resource) do
+          book = Hyrax::Test::BookResource.new
+          book.isbn = '123-4-56-789123-0'
+          book
+        end
+        it 'passes validation' do
+          # NOTE isbn has validation presence: true
+          expect(subject.valid?).to eq true
+        end
+      end
+
+      context 'and value for custom validation is incorrect' do
+        it 'passes validation' do
+          # NOTE isbn has validation presence: true
+          expect(subject.valid?).to eq false
+        end
+      end
+    end
+  end
 end

--- a/spec/support/book_resource.rb
+++ b/spec/support/book_resource.rb
@@ -14,6 +14,15 @@ module Hyrax
       attribute :title,     Valkyrie::Types::String
     end
 
+    ##
+    # A simple Hyrax::ChangeSet with one custom validation.
+    #
+    # Hyrax::Test::BookResource will use this based on naming convention by adding `ChangeSet`
+    # to the end of the resource class name.
+    class BookResourceChangeSet < Hyrax::ChangeSet
+      validates :isbn, presence: true
+    end
+
     class Book < ActiveFedora::Base
       property :author,    predicate: ::RDF::URI('http://example.com/ns/author')
       property :created,   predicate: ::RDF::URI('http://example.com/ns/created')


### PR DESCRIPTION
The custom change set inherits from Hyrax::ChangeSet, so it still get properties generated based on resource attributes.

Validations can be added to the custom change set and will be part of what runs when `valid?` is called.
