### PR TITLE
prepopulate the default admin set in ResourceForm

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -85,7 +85,7 @@ module Hyrax
       property :visibility_during_lease, virtual: true, prepopulator: ->(_opts) { self.visibility_during_lease = model.lease&.visibility_during_lease }
 
       # pcdm relationships
-      property :admin_set_id
+      property :admin_set_id, prepopulator: ->(_opts) { self.admin_set_id = AdminSet::DEFAULT_ID }
       property :member_ids, default: [], type: Valkyrie::Types::Array
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     context 'with a logged in user' do
       include_context 'with a logged in user'
 
+      before { AdminSet.find_or_create_default_admin_set_id }
+
       it 'redirects to a new work' do
         get :create, params: { test_simple_work: { title: 'comet in moominland' } }
 
@@ -155,6 +157,14 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         expect(assigns[:form]).to be_a Valkyrie::ChangeSet
       end
 
+      it 'prepopulates depositor and admin set' do
+        get :new
+
+        expect(assigns[:form])
+          .to have_attributes(depositor: user.user_key,
+                              admin_set_id: AdminSet::DEFAULT_ID)
+      end
+
       it 'renders form' do
         get :new
 
@@ -254,6 +264,8 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
       include_context 'with a logged in user'
 
       before do
+        AdminSet.find_or_create_default_admin_set_id
+
         allow(controller.current_ability)
           .to receive(:can?)
           .with(any_args)

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
   end
 
+  describe '#admin_set_id' do
+    it 'is nil' do
+      expect(form.admin_set_id).to be_nil
+    end
+
+    it 'prepopulates to the default admin set' do
+      expect { form.prepopulate! }
+        .to change { form.admin_set_id }
+        .to AdminSet::DEFAULT_ID
+    end
+  end
+
   describe '#agreement_accepted' do
     it { is_expected.to have_attributes(agreement_accepted: false) }
 


### PR DESCRIPTION
ensure ResourceForm implements prepopulation as handled by the existing
controller.

the old controller logic set some values on `#new` directly on the
`curation_concern`. instead of recreating this for `ResourceForm` in valkyrie,
use the `#prepopulate!` method. this is more extensible, since custom forms can
provide their own prepopulation logic.

@samvera/hyrax-code-reviewers
