### PR TITLE
generate basic changesets for work resources

### DIFF
--- a/lib/generators/hyrax/work_resource/USAGE
+++ b/lib/generators/hyrax/work_resource/USAGE
@@ -9,9 +9,11 @@ Example:
     app/forms/monograph_form.rb
     app/indexers/monograph_indexer.rb
     app/models/monograph.rb
+    app/models/monograph_change_set.rb
     app/views/hyrax/monographs/_monograph.html.erb
     config/initializers/hyrax.rb
     config/metadata/monograph.yaml
     spec/models/monograph_spec.rb
+    spec/models/monograph_change_set_spec.rb
     spec/indexers/monograph_indexer_spec.rb
     spec/views/monographs/_monograph.html.erb_spec.rb

--- a/lib/generators/hyrax/work_resource/templates/change_set.rb.erb
+++ b/lib/generators/hyrax/work_resource/templates/change_set.rb.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:work_resource <%= class_name %>`
+class <%= class_name %>ChangeSet < Hyrax::ChangeSet
+  # add custom validations (e.g. validates :custom_field, presence: true)
+end

--- a/lib/generators/hyrax/work_resource/templates/change_set_spec.rb.erb
+++ b/lib/generators/hyrax/work_resource/templates/change_set_spec.rb.erb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:work_resource <%= class_name %>`
+require 'rails_helper'
+require 'hyrax/specs/shared_specs/hydra_works'
+
+RSpec.describe <%= class_name %>ChangeSet do
+  subject(:change_set) { described_class.for(resource) }
+  let(:resource) { <%= class_name %>.new }
+
+  it_behaves_like 'a Hyrax::ChangeSet'
+end

--- a/lib/generators/hyrax/work_resource/work_resource_generator.rb
+++ b/lib/generators/hyrax/work_resource/work_resource_generator.rb
@@ -49,6 +49,16 @@ class Hyrax::WorkResourceGenerator < Rails::Generators::NamedBase
     end
   end
 
+  def create_change_set
+    template('change_set.rb.erb', File.join('app/models/', class_path, "#{file_name}_change_set.rb"))
+  end
+
+  def create_change_set_spec
+    return unless rspec_installed?
+    filepath = File.join('spec/models/', class_path, "#{file_name}_change_set_spec.rb")
+    template('change_set_spec.rb.erb', filepath)
+  end
+
   def create_form
     template('form.rb.erb', File.join('app/forms/', class_path, "#{file_name}_form.rb"))
   end

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -290,3 +290,13 @@ RSpec.shared_examples 'a Hyrax::FileSet' do
     end
   end
 end
+
+RSpec.shared_examples 'a Hyrax::ChangeSet' do
+  before do
+    raise 'change_set creation requires `let(:resource)`' unless defined? resource
+  end
+
+  subject(:changeset)   { described_class.for(resource) }
+
+  it_behaves_like 'a Valkyrie::ChangeSet'
+end

--- a/spec/models/hyrax/change_set_spec.rb
+++ b/spec/models/hyrax/change_set_spec.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+require 'hyrax/specs/shared_specs/hydra_works'
+
 RSpec.describe Hyrax::ChangeSet do
   subject(:change_set) { described_class.for(resource) }
   let(:resource)       { build(:hyrax_work) }
   let(:titles)         { ['comet in moominland', 'finn family moomintroll'] }
+
+  it_behaves_like 'a Hyrax::ChangeSet'
 
   describe 'properties' do
     it 'changes when changed' do


### PR DESCRIPTION
### Description

Add a generator to create a basic change set and it's spec for work resources created through... 

```
rails generate hyrax:work_resource MyWorkResource
```

Added a shared spec for change sets to the hydra_works shared spec which calls the Valkyrie shared spec for change sets.  Updated Hyrax::ChangeSet's spec to also call the shared spec.

### Related Work

PR #4545 Add ability to define custom change sets for resources


@samvera/hyrax-code-reviewers