### PR TITLE
support indexing Collections using Valkyrie 

### DIFF
--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -8,9 +8,11 @@ module Hyrax
     include Hyrax::PermissionIndexer
     include Hyrax::VisibilityIndexer
     include Hyrax::Indexer(:core_metadata)
+    include Hyrax::Indexer(:basic_metadata)
 
     def to_solr
       super.tap do |index_document|
+        index_document[:collection_type_gid_ssim] = Array(resource.try(:collection_type_gid)&.to_s)
         index_document[:generic_type_sim] = ['Collection']
         index_document[:thumbnail_path_ss] = Hyrax::CollectionThumbnailPathService.call(resource)
       end

--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Indexes properties common to PCDM Collections
+  class PcdmCollectionIndexer < Hyrax::ValkyrieIndexer
+    include Hyrax::ResourceIndexer
+    include Hyrax::PermissionIndexer
+    include Hyrax::VisibilityIndexer
+    include Hyrax::Indexer(:core_metadata)
+
+    def to_solr
+      super.tap do |index_document|
+        index_document[:generic_type_sim] = ['Collection']
+        index_document[:thumbnail_path_ss] = Hyrax::CollectionThumbnailPathService.call(resource)
+      end
+    end
+  end
+end

--- a/app/indexers/hyrax/valkyrie_collection_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_collection_indexer.rb
@@ -3,17 +3,8 @@
 module Hyrax
   ##
   # Indexes properties common to PCDM Collections
-  class ValkyrieCollectionIndexer < Hyrax::ValkyrieIndexer
-    include Hyrax::ResourceIndexer
-    include Hyrax::PermissionIndexer
-    include Hyrax::VisibilityIndexer
-    include Hyrax::Indexer(:core_metadata)
-
-    def to_solr
-      super.tap do |index_document|
-        index_document[:generic_type_sim] = ['Collection']
-        index_document[:thumbnail_path_ss] = Hyrax::CollectionThumbnailPathService.call(resource)
-      end
-    end
+  #
+  # @deprecated use Hyrax::PcdmCollectionIndexer instead
+  class ValkyrieCollectionIndexer < Hyrax::PcdmCollectionIndexer
   end
 end

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -7,6 +7,7 @@ module Hyrax
   # Valkyrie model for Collection domain objects in the Hydra Works model.
   class PcdmCollection < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
+    include Hyrax::Schema(:basic_metadata)
 
     attribute :collection_type_gid, Valkyrie::Types::String
     attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)

--- a/config/metadata/basic_metadata.yaml
+++ b/config/metadata/basic_metadata.yaml
@@ -19,6 +19,9 @@ attributes:
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "based_near_sim"
+      - "based_near_tesim"
   bibliographic_citation:
     type: string
     multiple: true
@@ -38,6 +41,8 @@ attributes:
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "date_created_tesim"
   description:
     type: string
     multiple: true
@@ -55,6 +60,7 @@ attributes:
     multiple: true
     index_keys:
       - "keyword_sim"
+      - "keyword_tesim"
     form:
       primary: false
   publisher:
@@ -83,11 +89,16 @@ attributes:
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "related_url_tesim"
   resource_type:
     type: string
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "resource_type_sim"
+      - "resource_type_tesim"
   rights_notes:
     type: string
     multiple: true

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -130,6 +130,7 @@ RSpec.shared_examples 'a Hyrax::PcdmCollection' do
 
   it_behaves_like 'a Hyrax::Resource'
   it_behaves_like 'a model with core metadata'
+  it_behaves_like 'a model with basic metadata'
   it_behaves_like 'has members'
 
   describe '#collection_type_gid' do

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -119,7 +119,11 @@ RSpec.shared_examples 'a Basic metadata indexer' do
 
   let(:attributes) do
     {
+      based_near: ['helsinki', 'finland'],
+      date_created: ['tuesday'],
       keyword: ['comic strip'],
+      related_url: ['http://example.com/moomin'],
+      resource_type: ['book'],
       subject: ['moomins', 'snorks']
     }
   end
@@ -127,9 +131,15 @@ RSpec.shared_examples 'a Basic metadata indexer' do
   describe '#to_solr' do
     it 'indexes basic metadata' do
       expect(indexer.to_solr)
-        .to include(keyword_sim:   a_collection_containing_exactly(*attributes[:keyword]),
+        .to include(based_near_tesim: a_collection_containing_exactly(*attributes[:based_near]),
+                    based_near_sim: a_collection_containing_exactly(*attributes[:based_near]),
+                    date_created_tesim: a_collection_containing_exactly(*attributes[:date_created]),
+                    keyword_sim: a_collection_containing_exactly(*attributes[:keyword]),
+                    related_url_tesim: a_collection_containing_exactly(*attributes[:related_url]),
+                    resource_type_tesim: a_collection_containing_exactly(*attributes[:resource_type]),
+                    resource_type_sim: a_collection_containing_exactly(*attributes[:resource_type]),
                     subject_tesim: a_collection_containing_exactly(*attributes[:subject]),
-                    subject_sim:   a_collection_containing_exactly(*attributes[:subject]))
+                    subject_sim: a_collection_containing_exactly(*attributes[:subject]))
     end
   end
 end
@@ -164,6 +174,11 @@ RSpec.shared_examples 'a Collection indexer' do
   it_behaves_like 'a visibility indexer'
 
   describe '#to_solr' do
+    it 'indexes collection type gid' do
+      expect(indexer.to_solr)
+        .to include(collection_type_gid_ssim: a_collection_containing_exactly(an_instance_of(String)))
+    end
+
     it 'indexes generic type' do
       expect(indexer.to_solr)
         .to include(generic_type_sim: a_collection_containing_exactly('Collection'))

--- a/lib/hyrax/specs/shared_specs/metadata.rb
+++ b/lib/hyrax/specs/shared_specs/metadata.rb
@@ -1,5 +1,69 @@
 # frozen_string_literal: true
 
+RSpec.shared_examples 'a model with basic metadata' do
+  subject(:resource) { described_class.new }
+
+  it 'has abstracts' do
+    expect { resource.abstract = ['lorem ipsum', 'a story about moomins'] }
+      .to change { resource.abstract }
+      .to contain_exactly 'lorem ipsum', 'a story about moomins'
+  end
+
+  it 'has a label' do
+    expect { resource.label = 'one single label' }
+      .to change { resource.label }
+      .to eq 'one single label'
+  end
+
+  it 'has language' do
+    expect { resource.language = ['en', 'fi'] }
+      .to change { resource.language }
+      .to contain_exactly 'en', 'fi'
+  end
+
+  it 'has licenses' do
+    expect { resource.license = ['http://example.com/li1', 'http://example.com/li2'] }
+      .to change { resource.license }
+      .to contain_exactly 'http://example.com/li1', 'http://example.com/li2'
+  end
+
+  it 'has a relative path' do
+    expect { resource.relative_path = 'hamburger' }
+      .to change { resource.relative_path }
+      .to eq 'hamburger'
+  end
+
+  it 'has resource types' do
+    expect { resource.resource_type = ['book', 'image'] }
+      .to change { resource.resource_type }
+      .to contain_exactly 'book', 'image'
+  end
+
+  it 'has rights notes' do
+    expect { resource.rights_notes = ['secret', 'do not use'] }
+      .to change { resource.rights_notes }
+      .to contain_exactly 'secret', 'do not use'
+  end
+
+  it 'has rights statements' do
+    expect { resource.rights_statement = ['http://example.com/rs1', 'http://example.com/rs2'] }
+      .to change { resource.rights_statement }
+      .to contain_exactly 'http://example.com/rs1', 'http://example.com/rs2'
+  end
+
+  it 'has sources' do
+    expect { resource.source = ['first', 'second'] }
+      .to change { resource.source }
+      .to contain_exactly 'first', 'second'
+  end
+
+  it 'has subjects' do
+    expect { resource.subject = ['moomin', 'snork'] }
+      .to change { resource.subject }
+      .to contain_exactly 'moomin', 'snork'
+  end
+end
+
 RSpec.shared_examples 'a model with core metadata' do
   subject(:resource) { described_class.new }
   let(:date)         { Time.zone.today }

--- a/spec/indexers/hyrax/pcdm_collection_indexer_spec.rb
+++ b/spec/indexers/hyrax/pcdm_collection_indexer_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'hyrax/specs/shared_specs'
+
+RSpec.describe Hyrax::PcdmCollectionIndexer do
+  let(:resource) { FactoryBot.valkyrie_create(:hyrax_collection) }
+  let(:indexer_class) { described_class }
+
+  it_behaves_like 'a Collection indexer'
+end

--- a/spec/indexers/hyrax/valkyrie_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_indexer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hyrax::ValkyrieIndexer do
     context 'for a collection' do
       let(:resource) { build(:hyrax_collection) }
 
-      it 'gives an instance of ValkyrieCollectionIndexer' do
+      it 'gives an instance of PcdmCollectionIndexer' do
         expect(described_class.for(resource: resource))
           .to be_a Hyrax::PcdmCollectionIndexer
       end

--- a/spec/indexers/hyrax/valkyrie_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_indexer_spec.rb
@@ -9,6 +9,15 @@ RSpec.describe Hyrax::ValkyrieIndexer do
         .to eq described_class
     end
 
+    context 'for a collection' do
+      let(:resource) { build(:hyrax_collection) }
+
+      it 'gives an instance of ValkyrieCollectionIndexer' do
+        expect(described_class.for(resource: resource))
+          .to be_a Hyrax::PcdmCollectionIndexer
+      end
+    end
+
     context 'with a matching indexer by naming convention' do
       let(:resource) { build(:monograph) }
       let(:indexer_class) { MonographIndexer }


### PR DESCRIPTION
wires `Hyrax::PcdmCollection` generated solr documents into presenter tests
using `SolrDocument`. this serves as a fulcrum to add some support for new
valkyrie style collections at the presenter layer.

adds basic metadata to collections and their `Valkyrie::Indexer`. adds index
keys for basic metadata where they are needed to pass collection presenter
tests. adds (some) share specs for basic metadata; there's still more to add
here.

the only presenter behavior left behind are the `#total_viewable_*` methods,
which still depend on `ActiveFedora::Relation#accessible_by`. this is a major
remaining hard `ActiveFedora` dependency, and the specific behavior of
`#accessible_by` continues to get more confusing. in this case, it doesn't seem
to work with Wings at all. this could use some digging into.

@samvera/hyrax-code-reviewers
