### PR TITLE
dassie: turn on iiif configuration

### DIFF
--- a/.dassie/config/initializers/hyrax.rb
+++ b/.dassie/config/initializers/hyrax.rb
@@ -2,6 +2,9 @@
 Hyrax.config do |config|
   # Injected via `rails g hyrax:work GenericWork`
   config.register_curation_concern :generic_work
+
+  config.iiif_image_server = true
+
   # Returns a URL that resolves to an image provided by a IIIF image server
   config.iiif_image_url_builder = lambda do |file_id, base_url, size, format|
     Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size)


### PR DESCRIPTION
`dassie` already has RIIIF, but was missing `config.iiif_image_server =
true`. turn it on so we resolve images to the server.

@samvera/hyrax-code-reviewers
