### PR TITLE
write some tests for SolrDocumentBehavior; make #to_s return a string

### DIFF
--- a/.dassie/app/models/solr_document.rb
+++ b/.dassie/app/models/solr_document.rb
@@ -22,7 +22,7 @@ class SolrDocument
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
 
-  # Do content negotiation for AF models. 
+  # Do content negotiation for AF models.
 
   use_extension( Hydra::ContentNegotiation )
 end

--- a/app/models/concerns/hyrax/solr_document/characterization.rb
+++ b/app/models/concerns/hyrax/solr_document/characterization.rb
@@ -1,28 +1,39 @@
 # frozen_string_literal: true
 module Hyrax
   module SolrDocument
-    # TODO: aside from height and width, I don't think any of these other terms are indexed by default. - Justin 3/2016
     module Characterization
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def byte_order
         self["byte_order_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def capture_device
         self["capture_device_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def color_map
         self["color_map_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def color_space
         self["color_space_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def compression
         self["compression_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def gps_timestamp
         self["gps_timestamp_tesim"]
       end
@@ -31,30 +42,44 @@ module Hyrax
         self['height_is']
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def image_producer
         self["image_producer_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def latitude
         self["latitude_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def longitude
         self["longitude_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def orientation
         self["orientation_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def profile_name
         self["profile_name_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def profile_version
         self["profile_version_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def scanning_software
         self["scanning_software_tesim"]
       end
@@ -63,18 +88,24 @@ module Hyrax
         self['width_is']
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def format_label
         self["format_label_tesim"]
       end
 
       def file_size
-        self["file_size_tesim"]
+        self["file_size_lts"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def filename
         self["filename_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def well_formed
         self["well_formed_tesim"]
       end
@@ -95,6 +126,8 @@ module Hyrax
         self["sample_rate_tesim"]
       end
 
+      ##
+      # @todo this might not be indexed normally. deprecate?
       def last_modified
         self["last_modified_tesim"]
       end

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -23,8 +23,8 @@ module Hyrax
       id
     end
 
-    def to_s
-      title_or_label
+    def to_s # rubocop:disable Rails/Delegate
+      title_or_label.to_s
     end
 
     class ModelWrapper

--- a/spec/models/concerns/hyrax/solr_document_behavior_spec.rb
+++ b/spec/models/concerns/hyrax/solr_document_behavior_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::SolrDocumentBehavior do
+  subject(:solr_document) { solr_document_class.new(solr_hash) }
+  let(:solr_hash) { {} }
+
+  let(:solr_document_class) do
+    Class.new do
+      include Blacklight::Solr::Document
+      include Hyrax::SolrDocumentBehavior
+    end
+  end
+
+  describe '#itemtype' do
+    it 'defaults to CreativeWork' do
+      expect(solr_document.itemtype).to eq 'http://schema.org/CreativeWork'
+    end
+
+    context 'for a Video' do
+      let(:solr_hash) { { resource_type_tesim: 'Video' } }
+
+      it 'is of type Video' do
+        expect(solr_document.itemtype).to eq 'http://schema.org/VideoObject'
+      end
+    end
+  end
+
+  describe '#title_or_label' do
+    it 'defaults to nil' do
+      expect(solr_document.title_or_label).to be_nil
+    end
+
+    context 'with a label' do
+      let(:solr_hash) { { label_tesim: 'label' } }
+
+      it 'gives the label' do
+        expect(solr_document.title_or_label).to eq 'label'
+      end
+    end
+
+    context 'with a title' do
+      let(:solr_hash) { { title_tesim: 'title' } }
+
+      it 'gives the title' do
+        expect(solr_document.title_or_label).to eq 'title'
+      end
+
+      context 'and a label' do
+        let(:solr_hash) { { title_tesim: 'title', label_tesim: 'label' } }
+
+        it 'gives the title' do
+          expect(solr_document.title_or_label).to eq 'title'
+        end
+      end
+    end
+
+    context 'with several titles' do
+      let(:solr_hash) { { title_tesim: ['title1', 'title2'] } }
+
+      it 'gives the title' do
+        expect(solr_document.title_or_label).to eq 'title1, title2'
+      end
+    end
+  end
+
+  describe '#to_s' do
+    it 'defaults to empty string' do
+      expect(solr_document.to_s).to eq ''
+    end
+  end
+end


### PR DESCRIPTION
this very central module is missing unit tests. in poking at them, i quickly
found that its `#to_s` doesn't always return a string.

this adds a number of unit tests, and hopefully having some will encourage us to
write more.

@samvera/hyrax-code-reviewers
