### PR TITLE
Test calling update_work multiple times

### DIFF
--- a/spec/hyrax/transactions/update_work_spec.rb
+++ b/spec/hyrax/transactions/update_work_spec.rb
@@ -34,5 +34,23 @@ RSpec.describe Hyrax::Transactions::UpdateWork, valkyrie_adapter: :test_adapter 
 
       expect(tx.call(change_set).value!).to have_attributes(date_uploaded: uploaded)
     end
+
+    context 'when called multiple times' do
+      let(:monograph) { Monograph.new }
+
+      it 'is a success every time' do
+        monograph.title = "Monograph"
+        1.upto(3) do |idx|
+          new_title = "#{monograph.title.first}#{idx}"
+          change_set = MonographChangeSet.for(monograph)
+          change_set.monograph_title = new_title
+          result = tx.call(change_set)
+          expect(result.success?).to eq true
+          monograph = result.value!
+          expect(monograph.title).to eq [new_title]
+        end
+        expect(monograph.title).to eq ["Monograph123"]
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description

When calling transaction update_work, the work returned by result.value! does not have the updated attribute value.

### Expected

```
change_set.attr = new_value
result = Hyrax::Transactions::UpdateWork.new.call(change_set)
result.value!.attr # new_value
```

attr should have new_value

### Actual

```
change_set.attr = new_value
result = Hyrax::Transactions::UpdateWork.new.call(change_set)
result.value!.attr # old_value
```

attr should has old_value

### To reproduce

* Run test: spec/hyrax/transactions/update_work_spec.rb:41

This is the new test added in this PR to test calling update_work multiple times for the same work.  It can be used to test for the expected behavior.

@samvera/hyrax-code-reviewers
