### PR TITLE
suppress null virus scanner warning in the test environment

### DIFF
--- a/app/models/hyrax/virus_scanner.rb
+++ b/app/models/hyrax/virus_scanner.rb
@@ -44,7 +44,8 @@ module Hyrax
     # Always return zero if there's nothing available to check for viruses. This means that
     # we assume all files have no viruses because we can't conclusively say if they have or not.
     def null_scanner
-      warning "Unable to check #{file} for viruses because no virus scanner is defined"
+      warning "Unable to check #{file} for viruses because no virus scanner is defined" unless
+        Rails.env.test?
       false
     end
 

--- a/spec/models/hyrax/virus_scanner_spec.rb
+++ b/spec/models/hyrax/virus_scanner_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Hyrax::VirusScanner do
   context 'when ClamAV is not defined' do
     before { Object.send(:remove_const, :ClamAV) if defined?(ClamAV) }
 
-    it 'returns false with a warning' do
-      expect(Hyrax.logger).to receive(:warn).with(kind_of(String))
+    it 'returns false' do
+      # we used to test the warning here, but we suppress it for the test env now
       is_expected.not_to be_infected
     end
   end


### PR DESCRIPTION
if the null virus scanner is used in test, don't overwhelm the user with
warnings. this is a good intended usage.

@samvera/hyrax-code-reviewers
