### PR TITLE
precompile assets in container build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk --no-cache upgrade && \
   apk --no-cache add build-base \
   tzdata \
   nodejs \
+  yarn \
   $DATABASE_APK_PACKAGE \
   $EXTRA_APK_PACKAGES
 
@@ -35,6 +36,7 @@ ARG BUNDLE_WITHOUT="development test"
 
 ONBUILD COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 ONBUILD RUN bundle install --jobs "$(nproc)"
+ONBUILD RUN DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 
 
 FROM hyrax-base as hyrax-engine-dev
@@ -46,3 +48,4 @@ COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 COPY --chown=1001:101 . /app/samvera/hyrax-engine
 
 RUN cd /app/samvera/hyrax-engine; bundle install --jobs "$(nproc)"
+RUN DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile


### PR DESCRIPTION
ports the parts of #4496 that relate to container build. installs UV via rails
asset precompile.

this makes `.dassie` pass the one test that depends on UV's presence. it's also
needed generally for UV in the docker development and test environments.

@samvera/hyrax-code-reviewers
