### PR TITLE
Rework Hyrax's `spec_helper`

### DIFF
--- a/lib/hyrax/specs/clamav.rb
+++ b/lib/hyrax/specs/clamav.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+if defined?(ClamAV)
+  ClamAV.instance.loaddb
+else
+  class ClamAV
+    include Singleton
+    def scanfile(_f)
+      0
+    end
+
+    def loaddb
+      nil
+    end
+  end
+end

--- a/lib/hyrax/specs/engine_routes.rb
+++ b/lib/hyrax/specs/engine_routes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module EngineRoutes
+  def self.included(base)
+    base.routes { Hyrax::Engine.routes }
+  end
+
+  def main_app
+    Rails.application.class.routes.url_helpers
+  end
+end

--- a/lib/hyrax/specs/shared_specs/factories/strategies/json_strategy.rb
+++ b/lib/hyrax/specs/shared_specs/factories/strategies/json_strategy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class JsonStrategy
+  def initialize
+    @strategy = FactoryBot.strategy_by_name(:create).new
+  end
+
+  delegate :association, to: :@strategy
+
+  def result(evaluation)
+    @strategy.result(evaluation).to_json
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -124,6 +124,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before :suite do
+    Hyrax::RedisEventStore.instance.redis.flushdb
     DatabaseCleaner.clean_with(:truncation)
     # Noid minting causes extra LDP requests which slow the test suite.
     Hyrax.config.enable_noids = false
@@ -132,12 +133,6 @@ RSpec.configure do |config|
   end
 
   config.before do |example|
-    # Many of the specs push data into Redis. This ensures that we
-    # have a clean slate when processing.  It is possible that we
-    # could narrow the call for this method to be done for clean_repo
-    # or feature specs.
-    Hyrax::RedisEventStore.instance.redis.flushdb
-
     if example.metadata[:type] == :feature && Capybara.current_driver != :rack_test
       DatabaseCleaner.strategy = :truncation
     else
@@ -235,6 +230,7 @@ RSpec.configure do |config|
 
   config.before(:example, :clean_repo) do
     clean_active_fedora_repository
+    Hyrax::RedisEventStore.instance.redis.flushdb
   end
 
   # Use this example metadata when you want to perform jobs inline during testing.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,7 @@ require 'equivalent-xml'
 require 'equivalent-xml/rspec_matchers'
 require 'database_cleaner'
 require 'hyrax/specs/capybara'
+require 'hyrax/specs/clamav'
 
 # ensure Hyrax::Schema gets loaded is resolvable for `support/` models
 Hyrax::Schema # rubocop:disable Lint/Void
@@ -71,21 +72,6 @@ require 'byebug' unless ci_build?
 # HttpLogger.logger = Logger.new(STDOUT)
 # HttpLogger.ignore = [/localhost:8983\/solr/]
 # HttpLogger.colorize = false
-
-if defined?(ClamAV)
-  ClamAV.instance.loaddb
-else
-  class ClamAV
-    include Singleton
-    def scanfile(_f)
-      0
-    end
-
-    def loaddb
-      nil
-    end
-  end
-end
 
 class JsonStrategy
   def initialize

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,18 +73,6 @@ require 'byebug' unless ci_build?
 # HttpLogger.ignore = [/localhost:8983\/solr/]
 # HttpLogger.colorize = false
 
-class JsonStrategy
-  def initialize
-    @strategy = FactoryBot.strategy_by_name(:create).new
-  end
-
-  delegate :association, to: :@strategy
-
-  def result(evaluation)
-    @strategy.result(evaluation).to_json
-  end
-end
-
 require 'hyrax/specs/shared_specs/factories/strategies/valkyrie_resource'
 FactoryBot.register_strategy(:valkyrie_create, ValkyrieCreateStrategy)
 FactoryBot.register_strategy(:create_using_test_adapter, ValkyrieTestAdapterCreateStrategy)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-$VERBOSE = nil # silence loud Ruby 2.7 deprecations
+$VERBOSE = nil unless ENV['RUBY_LOUD'] # silence loud Ruby 2.7 deprecations
 ENV['RAILS_ENV'] = 'test'
 ENV['DATABASE_URL'] = ENV['DATABASE_TEST_URL'] if ENV['DATABASE_TEST_URL']
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -192,12 +192,7 @@ RSpec.configure do |config|
 
   config.include Shoulda::Matchers::Independent
 
-  if Devise::VERSION >= '4.2'
-    config.include Devise::Test::ControllerHelpers, type: :controller
-  else
-    config.include Devise::TestHelpers, type: :controller
-  end
-
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.include EngineRoutes, type: :controller
   config.include Warden::Test::Helpers, type: :request
   config.include Warden::Test::Helpers, type: :feature

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,8 +49,10 @@ require 'rspec/active_model/mocks'
 require 'equivalent-xml'
 require 'equivalent-xml/rspec_matchers'
 require 'database_cleaner'
+
 require 'hyrax/specs/capybara'
 require 'hyrax/specs/clamav'
+require 'hyrax/specs/engine_routes'
 
 # ensure Hyrax::Schema gets loaded is resolvable for `support/` models
 Hyrax::Schema # rubocop:disable Lint/Void
@@ -73,22 +75,13 @@ require 'byebug' unless ci_build?
 # HttpLogger.ignore = [/localhost:8983\/solr/]
 # HttpLogger.colorize = false
 
+require 'hyrax/specs/shared_specs/factories/strategies/json_strategy'
 require 'hyrax/specs/shared_specs/factories/strategies/valkyrie_resource'
 FactoryBot.register_strategy(:valkyrie_create, ValkyrieCreateStrategy)
 FactoryBot.register_strategy(:create_using_test_adapter, ValkyrieTestAdapterCreateStrategy)
 FactoryBot.register_strategy(:json, JsonStrategy)
 FactoryBot.definition_file_paths = [File.expand_path("../factories", __FILE__)]
 FactoryBot.find_definitions
-
-module EngineRoutes
-  def self.included(base)
-    base.routes { Hyrax::Engine.routes }
-  end
-
-  def main_app
-    Rails.application.class.routes.url_helpers
-  end
-end
 
 require 'shoulda/matchers'
 require 'shoulda/callback/matchers'


### PR DESCRIPTION
move a bunch of utility code to places where apps can reuse. refactor `spec_helper` to use RSpec features instead of hand-written branching logic.

@samvera/hyrax-code-reviewers
