### PR TITLE
Fix accessibility issues on work view page.

### DIFF
--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -5,5 +5,5 @@
     <%= media_display presenter.representative_presenter %>
   <% end %>
 <% else %>
-  <%= image_tag 'default.png', class: "canonical-image" %>
+  <%= image_tag 'default.png', class: "canonical-image", alt: 'default representative image' %>
 <% end %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -33,7 +33,7 @@
 
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title"><%= t('hyrax.base.show.relationships') %></h3>
+        <h1 class="panel-title"><%= t('hyrax.base.show.relationships') %></h1>
       </div>
       <div class="panel-body">
         <%= render 'relationships', presenter: @presenter %>
@@ -42,7 +42,7 @@
 
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title"><%= t('.items') %></h3>
+        <h1 class="panel-title"><%= t('.items') %></h1>
       </div>
       <div class="panel-body">
         <%= render 'items', presenter: @presenter %>


### PR DESCRIPTION
Fixes #3966 

Adds alt text to representative image tag.
Changes H3s to H1s for Relations and Items panes. The panel-title class overrides the only style difference between the two heading styles (font-size).

@samvera/hyrax-code-reviewers
