### PR TITLE
Pin docker solr to 8.6.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - redis:/data
 
   solr:
-    image: solr:8
+    image: solr:8.6.2
     ports:
       - 8983:8983
     command:


### PR DESCRIPTION
refs #4542 

Pin SOLR version to 8.6.2 in docker-compose file to address solr schema that is invalid in solr 8.6.3.

@samvera/hyrax-code-reviewers
