### PR TITLE
bump solr support to 8.7

### DIFF
--- a/.dassie/solr/conf/schema.xml
+++ b/.dassie/solr/conf/schema.xml
@@ -84,7 +84,7 @@
     <!-- A PointField based date field for faster date range queries and date faceting. -->
     <fieldType name="tdate" class="solr.DatePointField" docValues="true"/>
     <!-- A DateRange based date field for truly faster date range queries. -->
-    <fieldType name="dateRange" class="solr.DateRangeField"/>
+    <fieldType name="dateRange" class="solr.DateRangeField" omitNorms="true" omitTermFreqAndPositions="true"/>
 
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
@@ -261,10 +261,10 @@
     <!-- date range (_dr...) (for faster AND better range queries) -->
     <dynamicField name="*_dri" type="dateRange" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_drim" type="dateRange" stored="false" indexed="true" multiValued="true"/>
-    <dynamicField name="*_drs" type="dateRange" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_drsm" type="dateRange" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_drsi" type="dateRange" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_drsim" type="dateRange" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_drs" type="dateRange" stored="true" indexed="true" multiValued="false"/> <!-- indexed anyway because DateRangeField errors otherwise -->
+    <dynamicField name="*_drsm" type="dateRange" stored="true" indexed="true" multiValued="true"/> <!-- indexed anyway because DateRangeField errors otherwise -->
 
     <!-- long (_l...) -->
     <dynamicField name="*_li" type="long" stored="false" indexed="true" multiValued="false"/>

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Prerequisites are required for both creating a Hyrax\-based app and contributing
 
 Hyrax requires the following software to work:
 
-1. [Solr](http://lucene.apache.org/solr/) version >= 5.x (tested up to 7.0.0)
+1. [Solr](http://lucene.apache.org/solr/) version >= 5.x (tested up to 8.7.0)
 1. [Fedora Commons](http://www.fedora-commons.org/) digital repository version >= 4.5.1 (tested up to 4.7.5)
 1. A SQL RDBMS (MySQL, PostgreSQL), though **note** that SQLite will be used by default if you're looking to get up and running quickly
 1. [Redis](http://redis.io/), a key-value store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - redis:/data
 
   solr:
-    image: solr:8
+    image: solr:8.7
     ports:
       - 8983:8983
     command:


### PR DESCRIPTION
test Hyrax on solr 8.7 in `docker-compose`. the version used in CI is set by the samvera orb, and doesn't seem like it can be overridden from here.

change the `.dassie` solr schema to use `omitNorms="true"` on dateRange. from 8.6.3 Solr fails aggressively on the default behavior(!) https://issues.apache.org/jira/browse/SOLR-14859

for new apps, this needs to be merged into ActiveFedora https://github.com/samvera/active_fedora/pull/1439

supersedes #4579 and #4542 

@samvera/hyrax-code-reviewers
