### PR TITLE
Long standing missing break, and spelling error

### DIFF
--- a/app/assets/javascripts/hyrax/autocomplete.es6
+++ b/app/assets/javascripts/hyrax/autocomplete.es6
@@ -19,7 +19,7 @@ export default class Autocomplete {
 
   byDataAttribute(element, url) {
     let type = element.data('autocomplete-type')
-    let exlude = element.data('exclude-work')
+    let exclude = element.data('exclude-work')
     if(type === 'resource' && exclude.length > 0) {
       new Resource(
         element,
@@ -53,6 +53,7 @@ export default class Autocomplete {
         break
       case 'based_near':
         new LinkedData(element, url)
+        break
       default:
         new Default(element, url)
         break


### PR DESCRIPTION
The missing `break` for based_near has existed for years, and causes issues when devs add new controlled vocabulary fields for their instances. More experienced devs know right away to add it but many newcomers don't know that it is required.

Also fixed a spelling error for the word `exclude`

@samvera/hyrax-code-reviewers
