### PR TITLE
use titleized version of model as default for work type name

### DIFF
--- a/app/presenters/hyrax/select_type_presenter.rb
+++ b/app/presenters/hyrax/select_type_presenter.rb
@@ -16,7 +16,7 @@ module Hyrax
     end
 
     def name
-      translate('name')
+      translate('name', object_name.to_s.titleize)
     end
 
     def switch_to_new_work_path(route_set:, params:)
@@ -43,9 +43,10 @@ module Hyrax
       @object_name ||= concern.model_name.i18n_key
     end
 
-    def translate(key)
+    def translate(key, default = nil)
       defaults = []
       defaults << :"hyrax.select_type.#{object_name}.#{key}"
+      defaults << default
       defaults << :"hyrax.select_type.#{key}"
       defaults << ''
       I18n.t(defaults.shift, default: defaults)


### PR DESCRIPTION
Fixes #4593

When creating a new work, the user is presented with a list of work types.  Any work types that do not have a translation use a default name of `Work` which is confusing and does not allow the user to distinguish between work types.  The PR uses a titlelized version of the model name instead (e.g. `Monograph`).

NOTE: The translate method accepts a passed in default so that other keys (e.g. :description) that are translated with this method continue to have a default coming from the translation file 

BEFORE:

![image](https://user-images.githubusercontent.com/6855473/99309979-49639d00-2828-11eb-807f-ed39e9c13c0a.png)

AFTER:

![image](https://user-images.githubusercontent.com/6855473/99309905-2fc25580-2828-11eb-8d29-879bc5a46333.png)

@samvera/hyrax-code-reviewers
