### PR TITLE
drop docker-compose file version to 3.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '3.8'
+version: '3.7'
+
 services:
   app: &app
     build:


### PR DESCRIPTION
3.8 wasn't added until this February, so users on slower release channels will
see an error: https://github.com/docker/compose/blob/master/CHANGELOG.md#features-3

@samvera/hyrax-code-reviewers
