### PR TITLE
Ensuring AdminSet properly indexed during seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,3 +11,10 @@ abort("Failed to process all workflows:\n  #{errors.join('\n  ')}") unless error
 
 puts "\n== Creating default admin set"
 AdminSet.find_or_create_default_admin_set_id
+
+# I have found that when I come back to a development
+# environment, that I may have an AdminSet in Fedora, but it is
+# not indexed in Solr.  This remediates that situation by
+# ensuring we have an indexed AdminSet
+puts "\n== Ensuring the found or created admin set is indexed"
+AdminSet.find(id).update_index


### PR DESCRIPTION
I have found that when I come back to a development environment, that I
may have an AdminSet in Fedora, but it is not indexed in Solr.  This
remediates that situation by ensuring we have an indexed AdminSet.

We [merged this change merged][1] into `rake
hyrax:default_admin_set:create` but it was not part of the db:seeds.

[1]:https://github.com/samvera/hyrax/commit/940e1003e35b55a1aab69cdc2a231269fe7f29bf

@samvera/hyrax-code-reviewers
