### PR TITLE
Addressing "removed from the module tree" error

### DIFF
--- a/app/services/hyrax/listeners.rb
+++ b/app/services/hyrax/listeners.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module Hyrax
+  # @note
+  #    Did you encounter an exception similar to the following:
+  #
+  #    "A copy of Hyrax::Listeners::ObjectLifecycleListener has been removed from the module tree but is still active!"
+  #
+  #    You may need to register a listener as autoload.  See
+  #    ./app/services/hyrax/listeners.rb
+  module Listeners
+    extend ActiveSupport::Autoload
+
+    autoload :AclIndexListener
+    autoload :BatchNotificationListener
+    autoload :FileSetLifecycleListener
+    autoload :FileSetLifecycleNotificationListener
+    autoload :MetadataIndexListener
+    autoload :ObjectLifecycleListener
+  end
+end

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -37,6 +37,7 @@ module Hyrax
     autoload :RedisEventStore
     autoload :ResourceSync
     autoload :Zotero
+    autoload :Listeners
   end
 
   # @api public


### PR DESCRIPTION
Previously, when I ran the container version of local Hyrax development,
I (and others), encountered the following exception:

```sh
ArgumentError in Hyrax::GenericWorksController#create

A copy of Hyrax::Listeners::ObjectLifecycleListener has been removed
from the module tree but is still active!
```

[As reported by others][1], it is often unclear what to do.  I attempted
to add the `autoload` directive, and it appears to work.  Here's hoping
it works for you as well.

[1]:https://discuss.rubyonrails.org/t/yet-another-a-copy-of-xxx-has-been-removed-from-the-module-tree-but-is-still-active-can-we-add-an-example/75744

@samvera/hyrax-code-reviewers
