### PR TITLE
add proxy_depositor and on_behalf_off to resource_form

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -65,7 +65,7 @@ module Hyrax
 
       class_attribute :model_class
 
-      delegate :depositor, :human_readable_type, to: :model
+      delegate :depositor, :human_readable_type, :on_behalf_of, :proxy_depositor, to: :model
 
       property :visibility # visibility has an accessor on the model
 

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -177,6 +177,24 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
   end
 
+  describe '#proxy_depositor' do
+    let(:user1) { FactoryBot.create(:user).to_s }
+    let(:user2) { FactoryBot.create(:user).to_s }
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work, on_behalf_of: user2, proxy_depositor: user1) }
+    it 'delegates to model' do
+      expect(form.proxy_depositor).to eq user1
+    end
+  end
+
+  describe '#on_behalf_of' do
+    let(:user1) { create(:user).to_s }
+    let(:user2) { create(:user).to_s }
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work, on_behalf_of: user2, proxy_depositor: user1) }
+    it 'delegates to model' do
+      expect(form.on_behalf_of).to eq user2
+    end
+  end
+
   describe '#primary_terms' do
     it 'lists the core metadata primary terms' do
       expect(form.primary_terms).to contain_exactly(:title)


### PR DESCRIPTION
Fixes #4596

AF work forms delegated proxy_depositor and on_behalf_off to the AF model.  Similarly, this PR delegates those to the Valkyrie resource work model.  There are several other fields that are delegated to the Valkyrie resource work (e.g. :depositor, :human_readable_type).

Coming soon will be a feature test that allows proxy depositors that will demonstrate this change in the context of the UI.  The feature test related to this change already works, but a PR with those changes is awaiting a bug fix unrelated to this PR.

@samvera/hyrax-code-reviewers
