### PR TITLE
wings: handle single value fields for valkyrie native models

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -14,7 +14,7 @@ module Wings
   #
   # @note the `Valkyrie::Resource` object passed to this class **must** have an
   #   `#internal_resource` mapping it to an `ActiveFedora::Base` class.
-  class ActiveFedoraConverter
+  class ActiveFedoraConverter # rubocop:disable Metrics/ClassLength
     ##
     # Accesses the Class implemented for handling resource attributes
     # @return [Class]
@@ -47,7 +47,7 @@ module Wings
     # @return [Hash] attributes with values mapped for building an ActiveFedora model
     def attributes
       @attributes ||= attributes_class.mapped_attributes(attributes: resource.attributes).select do |attr|
-        attr == :permissions || attr.to_s.end_with?('_attributes') || active_fedora_class.properties.key?(attr.to_s) || active_fedora_class.reflections.key?(attr.to_sym)
+        active_fedora_class.supports_property?(attr)
       end
     end
 
@@ -203,7 +203,15 @@ module Wings
     def normal_attributes
       attributes.each_with_object({}) do |(attr, value), hash|
         property = active_fedora_class.properties[attr.to_s]
-        hash[attr] = property&.multiple? ? Array.wrap(value) : value
+        hash[attr] = if property.nil?
+                       value
+                     elsif property.multiple?
+                       Array.wrap(value)
+                     elsif Array.wrap(value).length < 2
+                       Array.wrap(value).first
+                     else
+                       value
+                     end
       end
     end
 

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -178,9 +178,10 @@ module Wings
       return unless resource.respond_to? :file_ids
 
       af_object.files = resource.file_ids.map do |fid|
+        next if fid.blank?
         pcdm_file = Hydra::PCDM::File.new(fid.id)
         assign_association_target(af_object, pcdm_file)
-      end
+      end.compact
     end
 
     def assign_association_target(af_object, pcdm_file)

--- a/lib/wings/orm_converter.rb
+++ b/lib/wings/orm_converter.rb
@@ -43,6 +43,7 @@ module Wings
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/BlockLength
     # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     # rubocop:disable Metrics/MethodLength because metaprogramming a class
     #   results in long methods
     def self.to_valkyrie_resource_class(klass:)
@@ -78,14 +79,22 @@ module Wings
         end
 
         klass.properties.each_key do |property_name|
-          attribute property_name.to_sym, ::Valkyrie::Types::String
+          next if fields.include?(property_name.to_sym)
+
+          if klass.properties[property_name].multiple?
+            attribute property_name.to_sym, ::Valkyrie::Types::Set.of(::Valkyrie::Types::Anything).optional
+          else
+            attribute property_name.to_sym, ::Valkyrie::Types::Anything.optional
+          end
         end
 
         relationship_keys.each do |linked_property_name|
+          next if fields.include?(linked_property_name.to_sym)
           attribute linked_property_name.to_sym, ::Valkyrie::Types::Set.of(::Valkyrie::Types::ID)
         end
 
         reflection_id_keys.each do |property_name|
+          next if fields.include?(property_name.to_sym)
           attribute property_name, ::Valkyrie::Types::ID
         end
 
@@ -100,3 +109,4 @@ end
 # rubocop:enable Metrics/BlockLength
 # rubocop:enable Metrics/MethodLength
 # rubocop:enable Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/PerceivedComplexity

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -20,6 +20,15 @@ module ActiveFedora
   def self.model_mapper
     ActiveFedora::DefaultModelMapper.new(classifier_class: Wings::ActiveFedoraClassifier)
   end
+
+  class Base
+    def self.supports_property?(property)
+      property == :permissions ||
+        property.to_s.end_with?('_attributes') ||
+        properties.key?(property.to_s) ||
+        reflections.key?(property.to_sym)
+    end
+  end
 end
 
 Valkyrie::MetadataAdapter.register(

--- a/lib/wings/transformer_value_mapper.rb
+++ b/lib/wings/transformer_value_mapper.rb
@@ -72,6 +72,7 @@ module Wings
     ##
     # @return [Enumerable<Object>]
     def result
+      return calling_mapper.for(value.first).result if value.length < 2
       value.map { |v| calling_mapper.for(v).result }
     end
   end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -135,7 +135,8 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       end
 
       it 'has the given collection type' do
-        expect(converter.convert.collection_type.to_global_id.to_s).to eq resource.collection_type_gid
+        expect(converter.convert.collection_type.to_global_id.to_s)
+          .to eq resource.collection_type_gid
       end
 
       context 'with work members' do

--- a/spec/wings/attribute_transformer_spec.rb
+++ b/spec/wings/attribute_transformer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Wings::AttributeTransformer do
 
   it "transform the attributes" do
     expect(subject).to include title: work.title,
-                               contributor: work.contributor,
-                               description: work.description
+                               contributor: work.contributor.first,
+                               description: work.description.first
   end
 end

--- a/spec/wings/services/file_metadata_builder_spec.rb
+++ b/spec/wings/services/file_metadata_builder_spec.rb
@@ -3,7 +3,7 @@ require 'wings_helper'
 require 'wings/services/file_metadata_builder'
 
 RSpec.describe Wings::FileMetadataBuilder do
-  subject do
+  subject(:builder) do
     described_class.new(storage_adapter: Hyrax.storage_adapter,
                         persister: Hyrax.persister)
   end
@@ -26,7 +26,7 @@ RSpec.describe Wings::FileMetadataBuilder do
 
   describe '#create(io_wrapper:, file_metadata:, file_set:)' do
     it 'creates file metadata' do
-      built_file_metadata = subject.create(io_wrapper: io_wrapper, file_metadata: original_file_metadata, file_set: file_set)
+      built_file_metadata = builder.create(io_wrapper: io_wrapper, file_metadata: original_file_metadata, file_set: file_set)
       expect(built_file_metadata).to be_kind_of Hyrax::FileMetadata
       expect(built_file_metadata.original_file?).to be true
       expect(built_file_metadata.file_set_id.id).to eq file_set.id.id

--- a/spec/wings/transformer_value_mapper_spec.rb
+++ b/spec/wings/transformer_value_mapper_spec.rb
@@ -50,10 +50,10 @@ RSpec.describe Wings::TransformerValueMapper do
     context 'with a numeric value'
 
     context 'with an enumerable value' do
-      let(:value) { ['a value'] }
+      let(:value) { ['a value', 'another value'] }
 
-      it 'maps internal values' do
-        expect(mapper.result).to eq value
+      it 'maps single values' do
+        expect(mapper.result).to contain_exactly(*value)
       end
     end
   end

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe Wings::Valkyrie::Persister do
         attribute :depositor, Valkyrie::Types::String.optional
         attribute :ordered_authors, Valkyrie::Types::Array.of(Valkyrie::Types::Anything).meta(ordered: true)
         attribute :ordered_nested, Valkyrie::Types::Array.of(CustomResource).meta(ordered: true)
+        attribute :single_value, Valkyrie::Types::String.optional
       end
 
       class Custom < ActiveFedora::Base
@@ -180,17 +181,17 @@ RSpec.describe Wings::Valkyrie::Persister do
     end
 
     it "can persist single values" do
-      resource.depositor = "user@institution.edu"
+      resource.single_value = "user@institution.edu"
 
       output = persister.save(resource: resource)
 
-      expect(output.depositor).to eq "user@institution.edu"
+      expect(output.single_value).to eq "user@institution.edu"
     end
 
     it "returns nil for an unset single value" do
       output = persister.save(resource: resource_class.new)
 
-      expect(output.depositor).to be_nil
+      expect(output.single_value).to be_nil
     end
 
     it "stores created_at/updated_at" do


### PR DESCRIPTION
make TransformerValueMapper/OrmConverter treat single value arrays as singular
value objects by default. change the generated fields for ad-hoc valkyrie models
to be Set.of(Anything), by default. don't override existing fields when
generating valkyrie models.

related to #4556

Co-authored-by: Trey Pendragon <tpendragon@princeton.edu>


@samvera/hyrax-code-reviewers
