### PR TITLE
Fixing broken seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,11 +10,11 @@ errors = Hyrax::Workflow::WorkflowImporter.load_errors
 abort("Failed to process all workflows:\n  #{errors.join('\n  ')}") unless errors.empty?
 
 puts "\n== Creating default admin set"
-AdminSet.find_or_create_default_admin_set_id
+admin_set_id = AdminSet.find_or_create_default_admin_set_id
 
 # I have found that when I come back to a development
 # environment, that I may have an AdminSet in Fedora, but it is
 # not indexed in Solr.  This remediates that situation by
 # ensuring we have an indexed AdminSet
 puts "\n== Ensuring the found or created admin set is indexed"
-AdminSet.find(id).update_index
+AdminSet.find(admin_set_id).update_index


### PR DESCRIPTION
This is Jeremy; I copied the code from another location, but didn't
really pay attention to what I copied.  Prior to this commit, the code
referenced an undeclared `id` variable.  This fixes that and renames
`id` into something more meaningful.

@samvera/hyrax-code-reviewers
