### PR TITLE
add `less` to `docker-compose` environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       target: hyrax-engine-dev
+      args:
+        - EXTRA_APK_PACKAGES=git less
     image: hyrax-engine-dev
     stdin_open: true
     tty: true


### PR DESCRIPTION
`pry` wants to use `less` for output paging. the default `busybox` version doesn't support the GNU
arguments and ENV variables it counts on. installing `less` manually ought to
fix it.

@samvera/hyrax-code-reviewers
