### PR TITLE
verify work resource new form generates form according to metadata yaml fields

### DIFF
--- a/.dassie/config/metadata/monograph.yaml
+++ b/.dassie/config/metadata/monograph.yaml
@@ -23,4 +23,31 @@
 attributes:
   monograph_title:
     type: string
-
+  record_info:
+    type: string
+    form:
+      required: true
+      primary: true
+  place_of_publication:
+    type: string
+    form:
+      required: false
+      primary: true
+  genre:
+    type: string
+    form:
+      primary: true
+  series_title:
+    type: string
+    form:
+      primary: false
+  target_audience:
+    type: string
+    form:
+      multiple: true
+  table_of_contents:
+    type: string
+    form:
+      multiple: false
+  date_of_issuance:
+    type: string

--- a/.regen
+++ b/.regen
@@ -1,1 +1,1 @@
-30zoinks
+31zoinks

--- a/spec/features/create_work_resource_spec.rb
+++ b/spec/features/create_work_resource_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+RSpec.describe 'Creating a new Hyrax::Work Resource', :js, :workflow, :clean_repo, :feature do
+  let(:user) { create(:user) }
+  let!(:ability) { ::Ability.new(user) }
+  let(:file1) { File.open(fixture_path + '/world.png') }
+  let(:file2) { File.open(fixture_path + '/image.jp2') }
+  let!(:uploaded_file1) { Hyrax::UploadedFile.create(file: file1, user: user) }
+  let!(:uploaded_file2) { Hyrax::UploadedFile.create(file: file2, user: user) }
+
+  before do
+    visit root_path
+    # Grant the user access to deposit into an admin set.
+    create(:permission_template_access,
+           :deposit,
+           permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),
+           agent_type: 'user',
+           agent_id: user.user_key)
+    # stub out characterization. Travis doesn't have fits installed, and it's not relevant to the test.
+    allow(CharacterizeJob).to receive(:perform_later)
+  end
+
+  context "when the user is not a proxy" do
+    before do
+      sign_in user
+      click_link 'Works'
+      click_link "Add new work"
+      # Monograph is a Valkyrie resource
+      choose "payload_concern", option: "Monograph"
+      click_button 'Create work'
+    end
+
+    it 'generates the form based on the metadata yaml configs' do
+      # test required=true fields are marked with an asterisk (e.g. monograph record_info)
+      expect(page.find('div.monograph_record_info label', text: 'Record info')[:class]).to include('required')
+
+      # test required=false fields are not marked with an asterisk (e.g. monograph place_of_publication)
+      expect(page.find('div.monograph_place_of_publication label', text: 'Place of publication')[:class]).not_to include('required')
+
+      # test primary=true fields are above the fold (e.g. monograph genre)
+      expect(page).to have_content "Genre"
+
+      # test primary=false fields are below the fold (e.g. monograph series_title)
+      expect(page).not_to have_content "Series title"
+      click_link 'Additional fields' # show secondary fields
+      expect(page).to have_content "Series title"
+
+      # test multiple=true fields have '+ Add another ...' (e.g. monograph target_audience)
+      expect(page).to have_content "Add another Target audience"
+
+      # test multiple=false fields do not have '+ Add another ...' (e.g. monograph table_of_contents)
+      expect(page).not_to have_content "Add another Table of contents"
+
+      # test field without form configs (e.g. monograph date_of_issuance)
+      expect(page).not_to have_content "Date of issuance"
+    end
+  end
+end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -65,8 +65,41 @@ class TestAppGenerator < Rails::Generators::Base
 
   def create_work
     generate 'hyrax:work_resource Monograph monograph_title:string'
-  end
 
+    append_file 'config/metadata/monograph.yaml' do
+      <<-YAML
+  record_info:
+    type: string
+    form:
+      required: true
+      primary: true
+  place_of_publication:
+    type: string
+    form:
+      required: false
+      primary: true
+  genre:
+    type: string
+    form:
+      primary: true
+  series_title:
+    type: string
+    form:
+      primary: false
+  target_audience: 
+    type: string
+    form:
+      multiple: true
+  table_of_contents:
+    type: string
+    form:
+      multiple: false
+  date_of_issuance:
+    type: string
+YAML
+    end
+  end
+  
   def banner
     say_status("info", "ADDING OVERRIDES FOR TEST ENVIRONMENT", :blue)
   end


### PR DESCRIPTION
Fixes #4569

This tests that metadata fields are correctly generated in the new form for work resources.

Monograph was extended to includes attributes with the following form characteristics...
* requires: true
* required: false
* primary: true
* primary: false
* multiple: true
* multiple: false
* no form configs

Then the test verifies that each field was added to the form UI according to these configs.

@samvera/hyrax-code-reviewers
