### PR TITLE
wings: cache generated classes at the cache level

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -23,6 +23,14 @@ module Wings
     end
 
     ##
+    # A class level cache mapping from Valkyrie resource classes to generated
+    # ActiveFedora classes
+    # @return [Hash<Class, Class>]
+    def self.class_cache
+      @class_cache ||= {}
+    end
+
+    ##
     # @params [Valkyrie::Resource] resource
     #
     # @return [ActiveFedora::Base]
@@ -92,7 +100,7 @@ module Wings
     end
 
     def self.DefaultWork(resource_class)
-      Class.new(DefaultWork) do
+      class_cache[resource_class] ||= Class.new(DefaultWork) do
         self.valkyrie_class = resource_class
 
         # extract AF properties from the Valkyrie schema;

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
     it 'returns the ActiveFedora model' do
       expect(described_class.convert(resource: resource)).to eq work
     end
+
+    it 'gives equivilent classes' do
+      expect(described_class.convert(resource: Monograph.new).class <= described_class.convert(resource: Monograph.new).class)
+        .to eq true
+    end
   end
 
   describe '#convert' do

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
     end
 
     it 'gives equivilent classes' do
-      expect(described_class.convert(resource: Monograph.new).class <= described_class.convert(resource: Monograph.new).class)
-        .to eq true
+      first_class = described_class.convert(resource: Monograph.new).class
+      second_class = described_class.convert(resource: Monograph.new).class
+
+      expect(first_class <= second_class).to eq true
     end
   end
 


### PR DESCRIPTION
Original:
>  2.120  (± 0.0%) i/s -     11.000  in   5.196546s

With class level cache:
> 2.523  (± 0.0%) i/s -     13.000  in   5.164616s

but more importantly it ensures that classes generated by the AF classifier for the same valkyrie model are in the same class hierarchy (see test).
@samvera/hyrax-code-reviewers
