### PR TITLE
rename FileMetadata#file_identifiers attribute to #file_identifier

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -87,7 +87,7 @@ module Hyrax
         end
         Hyrax::VersioningService.create(saved_file_metadata, user)
         pathhint = io.uploaded_file.uploader.path if io.uploaded_file # in case next worker is on same filesystem
-        id = Hyrax.config.translate_uri_to_id.call saved_file_metadata.file_identifiers.first
+        id = Hyrax.config.translate_uri_to_id.call saved_file_metadata.file_identifier
         CharacterizeJob.perform_later(file_set, id, pathhint || io.path)
       end
 

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -34,7 +34,7 @@ module Hyrax
       module_function :uri_for
     end
 
-    attribute :file_identifiers, ::Valkyrie::Types::Set # id of the file stored by the storage adapter
+    attribute :file_identifier, Valkyrie::Types::ID # id of the file stored by the storage adapter
     attribute :alternate_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID) # id of the Hydra::PCDM::File which holds metadata and the file in ActiveFedora
     attribute :file_set_id, ::Valkyrie::Types::ID # id of parent file set resource
 
@@ -141,7 +141,7 @@ module Hyrax
     end
 
     def file
-      Hyrax.storage_adapter.find_by(id: file_identifiers.first)
+      Hyrax.storage_adapter.find_by(id: file_identifier)
     end
   end
 end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -558,7 +558,7 @@ module Hyrax
     attr_writer :resource_id_to_uri_transformer
     def resource_id_to_uri_transformer
       @resource_id_to_uri_transformer ||= lambda do |resource, base_url|
-        file_id = CGI.escape(resource.file_identifiers.first.to_s)
+        file_id = CGI.escape(resource.file_identifier.to_s)
         fs_id = CGI.escape(resource.file_set_id.to_s)
         "#{base_url}#{::Noid::Rails.treeify(fs_id)}/files/#{file_id}"
       end

--- a/lib/wings/services/file_converter_service.rb
+++ b/lib/wings/services/file_converter_service.rb
@@ -29,7 +29,7 @@ module Wings
         id = ::Valkyrie::ID.new(af_file.id)
         { id: id,
           alternate_ids: [id],
-          file_identifiers: [id],
+          file_identifier: id,
           created_at: af_file.create_date,
           updated_at: af_file.modified_date,
           content: af_file.content,

--- a/lib/wings/services/file_metadata_builder.rb
+++ b/lib/wings/services/file_metadata_builder.rb
@@ -26,7 +26,7 @@ module Wings
                                            content_type: io_wrapper.content_type,
                                            resource: file_metadata,
                                            resource_uri_transformer: Hyrax.config.resource_id_to_uri_transformer)
-      file_metadata.file_identifiers = [stored_file.id]
+      file_metadata.file_identifier = stored_file.id
       attach_file_metadata(file_metadata: file_metadata, file_set: file_set)
     end
 

--- a/spec/wings/services/file_converter_service_spec.rb
+++ b/spec/wings/services/file_converter_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Wings::FileConverterService do
     it 'copies attributes to resource' do # rubocop:disable RSpec/ExampleLength
       expect(subject.id.to_s).to eq af_file_id
       expect(subject.alternate_ids).to match_valkyrie_ids_with_active_fedora_ids [af_file_id]
-      expect(subject.file_identifiers).to match_valkyrie_ids_with_active_fedora_ids [af_file_id]
+      expect(subject.file_identifier).to eq af_file_id
       expect(subject.created_at).to eq af_file.create_date
       expect(subject.updated_at).to eq af_file.modified_date
       expect(subject.type).to match_array af_file.metadata_node.type
@@ -44,7 +44,7 @@ RSpec.describe Wings::FileConverterService do
     let(:valkyrie_attrs) { plain_text_valkyrie_attrs }
     let(:file_metadata) do
       valkyrie_attrs[:alternate_ids] = valkyrie_id
-      valkyrie_attrs[:file_identifiers] = valkyrie_id
+      valkyrie_attrs[:file_identifier] = valkyrie_id
       valkyrie_attrs[:word_count] = plain_text_valkyrie_attrs[:content].split(' ').count
       valkyrie_attrs[:size] = plain_text_valkyrie_attrs[:content].size
       valkyrie_attrs[:character_count] = plain_text_valkyrie_attrs[:content].size


### PR DESCRIPTION
there should only ever be one file per metadata node. this is connected to `describedBy` in LDP/fcrepo.

this is a first step to clearing the issues blocking #4628.

@samvera/hyrax-code-reviewers
