### PR TITLE
make default translate_uri_to_id 2x faster

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -542,10 +542,14 @@ module Hyrax
     attr_writer :translate_uri_to_id
 
     def translate_uri_to_id
-      @translate_uri_to_id ||= lambda do |uri|
-        baseparts = 2 + [(::Noid::Rails.config.template.gsub(/\.[rsz]/, '').length.to_f / 2).ceil, 4].min
-        uri.to_s.sub("#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}", '').split('/', baseparts).last
-      end
+      @translate_uri_to_id ||=
+        begin
+          baseparts = 2 + [(::Noid::Rails.config.template.gsub(/\.[rsz]/, '').length.to_f / 2).ceil, 4].min
+
+          lambda do |uri|
+            uri.to_s.split(ActiveFedora.fedora.base_path).last.split('/', baseparts).last
+          end
+        end
     end
 
     attr_writer :translate_id_to_uri

--- a/spec/indexers/hyrax/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/file_set_indexer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hyrax::FileSetIndexer do
 
   let(:file_set) do
     FileSet.new(
-      id: 'foo123',
+      id: 'foo12345',
       contributor: ['Mohammad'],
       creator: ['Allah'],
       title: ['The Work'],
@@ -43,7 +43,7 @@ RSpec.describe Hyrax::FileSetIndexer do
 
   let(:resource_version) do
     ActiveFedora::VersionsGraph::ResourceVersion.new.tap do |v|
-      v.uri = "http://test.example/rest/example/foo123/files/#{mock_file.id}/fcr:versions/version1"
+      v.uri = "#{file_set.uri}/files/#{mock_file.id}/fcr:versions/version1"
       v.label = 'version1'
       v.created = '2019-08-07T06:05:43.210Z'
     end
@@ -64,7 +64,7 @@ RSpec.describe Hyrax::FileSetIndexer do
       # https://github.com/samvera/active_fedora/issues/1251
       allow(file_set).to receive(:persisted?).and_return(true)
       allow(file_set).to receive(:label).and_return('CastoriaAd.tiff')
-      allow(Hyrax::ThumbnailPathService).to receive(:call).and_return('/downloads/foo123?file=thumbnail')
+      allow(Hyrax::ThumbnailPathService).to receive(:call).and_return('/downloads/foo12345?file=thumbnail')
       allow(file_set).to receive(:original_file).and_return(mock_file)
       allow(file_set).to receive(:extracted_text).and_return(mock_text)
       allow(version_graph).to receive(:fedora_versions) { [resource_version] }
@@ -72,8 +72,8 @@ RSpec.describe Hyrax::FileSetIndexer do
     subject { indexer.generate_solr_document }
 
     it 'has fields' do
-      expect(subject['hasRelatedMediaFragment_ssim']).to eq 'foo123'
-      expect(subject['hasRelatedImage_ssim']).to eq 'foo123'
+      expect(subject['hasRelatedMediaFragment_ssim']).to eq 'foo12345'
+      expect(subject['hasRelatedImage_ssim']).to eq 'foo12345'
       expect(subject['date_uploaded_tesim']).to be_nil
       expect(subject['date_modified_tesim']).to be_nil
       expect(subject['date_uploaded_dtsi']).to eq '2011-01-01T00:00:00Z'
@@ -97,7 +97,7 @@ RSpec.describe Hyrax::FileSetIndexer do
       expect(subject['identifier_tesim']).to eq ['urn:isbn:1234567890']
       expect(subject['based_near_tesim']).to eq ['Medina, Saudi Arabia']
       expect(subject['mime_type_ssi']).to eq 'image/jpeg'
-      expect(subject['thumbnail_path_ss']).to eq '/downloads/foo123?file=thumbnail'
+      expect(subject['thumbnail_path_ss']).to eq '/downloads/foo12345?file=thumbnail'
       expect(subject['all_text_timv']).to eq('abcxyz')
       expect(subject['height_is']).to eq 500
       expect(subject['width_is']).to eq 600
@@ -107,7 +107,7 @@ RSpec.describe Hyrax::FileSetIndexer do
       expect(subject['file_title_tesim']).to eq ['title']
       expect(subject['duration_tesim']).to eq ['0:1']
       expect(subject['sample_rate_tesim']).to eq ['sample rate']
-      expect(subject['original_file_id_ssi']).to eq "foo123/files/#{file_set.original_file.id}/fcr:versions/version1"
+      expect(subject['original_file_id_ssi']).to eq "foo12345/files/#{file_set.original_file.id}/fcr:versions/version1"
     end
 
     context "when original_file is not versioned" do


### PR DESCRIPTION
this code is called very frequently. the old implementation was slow in two
places:

first, it calculated `baseparts` for every call. this involved a memory
lookup (`Noid::Rails.config.template`) and several computations (most notably
`String#gsub`). since lambdas are closures, we can do this just once and have
the value (an Integer) passed around with the lambda. this maybe introduces a
cache invalidation problem (if `Noid::Rails.config` changes during execution,
we'll have the wrong number for `baseparts`). however, `Noid::Rails.config`
shouldn't change during execution; it seems safe for now to not worry about
invalidating this cache.

second, it ran `String#sub` on a long string match. `#split` on
`ActiveFedora.fedora.base_path` is more resilient (e.g. it's not protocol
dependent) and just a whole bunch faster.

in all, i saw a > 2x improvement on this code that's called, in some cases,
dozens of times for relatively simple AF operations.

Warming up --------------------------------------
       translate uri    35.111k i/100ms
Calculating -------------------------------------
       translate uri    356.748k (± 4.8%) i/s -      1.791M in   5.030930s

(i didn't capture the baseline, but it was about `14k` / `145k`)

@samvera/hyrax-code-reviewers
