### PR TITLE
wings: deprecate FileMetadataBuilder

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -47,7 +47,6 @@ module Hyrax
       def update_content(file, relation = :original_file)
         IngestJob.perform_later(wrapper!(file: file, relation: relation), notification: true)
       end
-
       # @!endgroup
 
       # Adds the appropriate metadata, visibility and relationships to file_set
@@ -138,7 +137,8 @@ module Hyrax
       end
 
       def build_file_actor(relation)
-        file_actor_class.new(file_set, relation, user, use_valkyrie: use_valkyrie)
+        fs = use_valkyrie ? file_set.valkyrie_resource : file_set
+        file_actor_class.new(fs, relation, user, use_valkyrie: use_valkyrie)
       end
 
       # uses create! because object must be persisted to serialize for jobs

--- a/lib/wings/services/file_metadata_builder.rb
+++ b/lib/wings/services/file_metadata_builder.rb
@@ -2,11 +2,14 @@
 
 module Wings
   # Stores a file and an associated Hyrax::FileMetadata
+  #
+  # @deprecated use `Hyrax.storage_adapter` instead
   class FileMetadataBuilder
     include Hyrax::Noid
 
     attr_reader :storage_adapter, :persister
     def initialize(storage_adapter:, persister:)
+      Deprecation.warn('This class is deprecated; use Wings::Valkyrie::Storage instead.')
       @storage_adapter = storage_adapter
       @persister = persister
     end
@@ -15,7 +18,11 @@ module Wings
     # @param file_metadata [Hyrax::FileMetadata] the metadata to represent the file
     # @param file_set [Valkyrie::Resouce, Hydra::Works::FileSet] the associated FileSet # TODO: WINGS - Remove Hydra::Works::FileSet as a potential type when valkyrization is complete.
     # @return [Hyrax::FileMetadata] the persisted metadata file_metadata that represents the file
+    #
+    # @deprecated use `Hyrax.storage_adapter` instead
     def create(io_wrapper:, file_metadata:, file_set:)
+      Deprecation.warn('Use storage_adapter.upload, Fedora creates a `FileMetadata` (describedBy) implictly. ' \
+                       'Query it with Hyrax.custom_queries.find_file_metadata_by(id: stored_file.id).')
       io_wrapper = build_file(io_wrapper, file_metadata.type)
       stored_file = storage_adapter.upload(file: io_wrapper,
                                            original_filename: io_wrapper.original_filename,


### PR DESCRIPTION
you can now use `storage_adapter.upload` to do all the work of
`FileMetadataBuilder`. Fedora creates the metadata node automatically, so it
just needs to be queried.

We may still want a Hyrax-layer abstraction for handling the assumption that
there will always be a `FileMetadata` model for every stored (pcdm) File. This
would need special handling for non-Wings adapters, but not for Wings.

@samvera/hyrax-code-reviewers
