### PR TITLE
remove errant default argument value from abstract ModeEditor

### DIFF
--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -156,7 +156,7 @@ module Hyrax
 
       private
 
-      def id_for(agent: user_or_group)
+      def id_for(agent:)
         case agent
         when Hyrax::Group
           "#{Hyrax::Group.name_prefix}#{agent.name}"


### PR DESCRIPTION
this method shouldn't have a default value, and the value specified is a bad
reference. including it just makes calls to this method harder to debug.

pretty sure this is just copy-paste cruft.

@samvera/hyrax-code-reviewers
