### PR TITLE
use example metadata to trigger valkyrie test adapter

### DIFF
--- a/lib/hyrax/specs/shared_specs/factories/strategies/valkyrie_resource.rb
+++ b/lib/hyrax/specs/shared_specs/factories/strategies/valkyrie_resource.rb
@@ -19,14 +19,3 @@ class ValkyrieCreateStrategy
     Hyrax.persister
   end
 end
-
-# @see https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#custom-strategies
-# @example
-#   let(:resource) { FactoryBot.create_using_test_adapter(:hyrax_work) }
-class ValkyrieTestAdapterCreateStrategy < ValkyrieCreateStrategy
-  private
-
-  def persister
-    Valkyrie::MetadataAdapter.find(:test_adapter).persister
-  end
-end

--- a/spec/factories/hyrax_file_set.rb
+++ b/spec/factories/hyrax_file_set.rb
@@ -40,7 +40,6 @@ FactoryBot.define do
 
     trait :with_files do
       transient do
-        # assumes that the file set was also created with hyrax adapter or is not saved
         files { [valkyrie_create(:hyrax_file_metadata), valkyrie_create(:hyrax_file_metadata)] }
       end
     end

--- a/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_file_metadata_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
+RSpec.describe Hyrax::CustomQueries::FindFileMetadata, valkyrie_adapter: :test_adapter do
   let(:query_service) { Valkyrie::MetadataAdapter.find(:test_adapter).query_service }
   subject(:query_handler) { described_class.new(query_service: query_service) }
 
@@ -14,15 +14,15 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
 
   describe '.find_file_metadata_by' do
     context 'when id is for a file metadata resource' do
-      let!(:file_metadata1) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata) }
-      let!(:file_metadata2) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata) }
+      let!(:file_metadata1) { FactoryBot.valkyrie_create(:hyrax_file_metadata) }
+      let!(:file_metadata2) { FactoryBot.valkyrie_create(:hyrax_file_metadata) }
       it 'returns file metadata resource' do
         expect(query_handler.find_file_metadata_by(id: file_metadata1.id).id.to_s).to eq file_metadata1.id.to_s
       end
     end
 
     context 'when id for a non-file metadata resource' do
-      let!(:resource) { FactoryBot.create_using_test_adapter(:hyrax_resource) }
+      let!(:resource) { FactoryBot.valkyrie_create(:hyrax_resource) }
       it 'raises ObjectNotFound' do
         expect { query_handler.find_file_metadata_by(id: resource.id) }
           .to raise_error ::Valkyrie::Persistence::ObjectNotFoundError, "Result type Hyrax::Resource for id #{resource.id} is not a `Hyrax::FileMetadata`"
@@ -39,15 +39,15 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
 
   describe '.find_file_metadata_by_alternate_identifier' do
     context 'when file exists' do
-      let!(:file_metadata1) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, alternate_ids: ['fm1']) }
-      let!(:file_metadata2) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, alternate_ids: ['fm2']) }
+      let!(:file_metadata1) { FactoryBot.valkyrie_create(:hyrax_file_metadata, alternate_ids: ['fm1']) }
+      let!(:file_metadata2) { FactoryBot.valkyrie_create(:hyrax_file_metadata, alternate_ids: ['fm2']) }
       it 'returns file metadata resource' do
         expect(query_handler.find_file_metadata_by_alternate_identifier(alternate_identifier: 'fm2').id.to_s).to eq file_metadata2.id.to_s
       end
     end
 
     context 'when id for a non-file metadata resource' do
-      let!(:resource) { FactoryBot.create_using_test_adapter(:hyrax_resource, alternate_ids: ['r1']) }
+      let!(:resource) { FactoryBot.valkyrie_create(:hyrax_resource, alternate_ids: ['r1']) }
       it 'raises ObjectNotFound' do
         expect { query_handler.find_file_metadata_by_alternate_identifier(alternate_identifier: 'r1').id.to_s }
           .to raise_error ::Valkyrie::Persistence::ObjectNotFoundError, "Result type Hyrax::Resource for alternate_identifier #{resource.alternate_ids.first} is not a `Hyrax::FileMetadata`"
@@ -64,8 +64,8 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
 
   describe '.find_many_file_metadata_by_ids' do
     context 'when files exists' do
-      let!(:file_metadata1) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata) }
-      let!(:file_metadata2) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata) }
+      let!(:file_metadata1) { FactoryBot.valkyrie_create(:hyrax_file_metadata) }
+      let!(:file_metadata2) { FactoryBot.valkyrie_create(:hyrax_file_metadata) }
       let(:ids) { [file_metadata1.id, file_metadata2.id] }
       it 'returns file metadata resources' do
         expect(query_handler.find_many_file_metadata_by_ids(ids: ids).map { |fm| fm.id.to_s }).to match_array(ids.map(&:to_s))
@@ -73,9 +73,9 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
     end
 
     context 'when some ids are for non-file metadata resources' do
-      let!(:file_metadata1) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata) }
-      let!(:file_metadata2) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata) }
-      let!(:non_file_metadata_resource) { FactoryBot.create_using_test_adapter(:hyrax_resource) }
+      let!(:file_metadata1) { FactoryBot.valkyrie_create(:hyrax_file_metadata) }
+      let!(:file_metadata2) { FactoryBot.valkyrie_create(:hyrax_file_metadata) }
+      let!(:non_file_metadata_resource) { FactoryBot.valkyrie_create(:hyrax_resource) }
       let!(:non_existent_id) { ::Valkyrie::ID.new('BOGUS') }
       let(:ids) { [file_metadata1.id, file_metadata2.id, non_file_metadata_resource.id, non_existent_id] }
       it 'only includes file metadata resources' do
@@ -84,7 +84,7 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
     end
 
     context 'when not passed any valid ids' do
-      let!(:non_file_metadata_resource) { FactoryBot.create_using_test_adapter(:hyrax_resource) }
+      let!(:non_file_metadata_resource) { FactoryBot.valkyrie_create(:hyrax_resource) }
       let!(:non_existent_id) { ::Valkyrie::ID.new('BOGUS') }
       let(:ids) { [non_file_metadata_resource.id, non_existent_id] }
       it 'result is empty' do
@@ -101,16 +101,16 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
   end
 
   describe '.find_file_metadata_by_use' do
-    let!(:of_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, type: original_file_use) }
-    let!(:et_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, type: extracted_text_use) }
-    let!(:th_file_metadata) { FactoryBot.create_using_test_adapter(:hyrax_file_metadata, type: thumbnail_use) }
+    let!(:of_file_metadata) { FactoryBot.valkyrie_create(:hyrax_file_metadata, type: original_file_use) }
+    let!(:et_file_metadata) { FactoryBot.valkyrie_create(:hyrax_file_metadata, type: extracted_text_use) }
+    let!(:th_file_metadata) { FactoryBot.valkyrie_create(:hyrax_file_metadata, type: thumbnail_use) }
 
     let(:original_file_use)  { Hyrax::FileMetadata::Use::ORIGINAL_FILE }
     let(:extracted_text_use) { Hyrax::FileMetadata::Use::EXTRACTED_TEXT }
     let(:thumbnail_use)      { Hyrax::FileMetadata::Use::THUMBNAIL }
 
     context 'when file set has files of the requested use' do
-      let!(:file_set) { FactoryBot.create_using_test_adapter(:hyrax_file_set, files: [of_file_metadata, et_file_metadata, th_file_metadata]) }
+      let!(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set, files: [of_file_metadata, et_file_metadata, th_file_metadata]) }
 
       it 'returns Hyrax::FileMetadata resources matching use' do
         result = query_handler.find_many_file_metadata_by_use(resource: file_set, use: extracted_text_use)
@@ -121,7 +121,7 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
     end
 
     context 'when file set has no files of the requested use' do
-      let!(:file_set) { FactoryBot.create_using_test_adapter(:hyrax_file_set, files: [of_file_metadata, th_file_metadata]) }
+      let!(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set, files: [of_file_metadata, th_file_metadata]) }
 
       it 'result is empty' do
         result = query_handler.find_many_file_metadata_by_use(resource: file_set, use: extracted_text_use)
@@ -130,7 +130,7 @@ RSpec.describe Hyrax::CustomQueries::FindFileMetadata do
     end
 
     context 'when file set has no files' do
-      let!(:file_set) { FactoryBot.create_using_test_adapter(:hyrax_file_set) }
+      let!(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
       it 'result is empty' do
         result = query_handler.find_many_file_metadata_by_use(resource: file_set, use: original_file_use)
         expect(result).to be_empty

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,7 +74,6 @@ require 'byebug' unless ci_build?
 require 'hyrax/specs/shared_specs/factories/strategies/json_strategy'
 require 'hyrax/specs/shared_specs/factories/strategies/valkyrie_resource'
 FactoryBot.register_strategy(:valkyrie_create, ValkyrieCreateStrategy)
-FactoryBot.register_strategy(:create_using_test_adapter, ValkyrieTestAdapterCreateStrategy)
 FactoryBot.register_strategy(:json, JsonStrategy)
 FactoryBot.definition_file_paths = [File.expand_path("../factories", __FILE__)]
 FactoryBot.find_definitions

--- a/spec/support/simple_work.rb
+++ b/spec/support/simple_work.rb
@@ -10,7 +10,6 @@ module Hyrax
     #
     # @example creating with FactoryBot
     #   work = FactoryBot.valkyrie_create(:hyrax_work, :public, title: ['Comet in Moominland'])
-    #   work = FactoryBot.create_using_test_adapter(:hyrax_work, :public, title: ['Comet in Moominland'])
     class SimpleWork < Hyrax::Work; end
 
     class SimpleWorkLegacy < ActiveFedora::Base


### PR DESCRIPTION
drop specialized test adapter FactoryBot create strategy; use example metadata to control this across the examples instead.

@samvera/hyrax-code-reviewers
