### PR TITLE
use AccessControlList#permissions= in InheritPermissionsJob

### DIFF
--- a/app/jobs/inherit_permissions_job.rb
+++ b/app/jobs/inherit_permissions_job.rb
@@ -16,26 +16,11 @@ class InheritPermissionsJob < Hyrax::ApplicationJob
 
   private
 
-  # Return array of hashes representing permissions without their :access_to objects
-  # @param permissions [Permission]
-  # @return [Array<Hash>]
-  def permissions_map(permissions)
-    permissions.collect { |p| { agent: agent_object(p.agent), mode: p.mode } }
-  end
-
   # Returns a list of member file_sets for a work
   # @param work [Resource]
   # @return [Array<Hyrax::File_Set>]
   def file_sets_for(work)
-    Hyrax.query_service.custom_queries.find_child_filesets(resource: work)
-  end
-
-  # Converts string representation of Permission.agent to either User or Hyrax::Group
-  # @param agent [String]
-  # @return [User] or [Hyrax::Group]
-  def agent_object(agent)
-    return Hyrax::Group.new(agent.sub(Hyrax::Group.name_prefix, '')) if agent.starts_with?(Hyrax::Group.name_prefix)
-    User.find_by_user_key(agent)
+    Hyrax.custom_queries.find_child_filesets(resource: work)
   end
 
   # Perform the copy from the work to the contained filesets
@@ -61,14 +46,12 @@ class InheritPermissionsJob < Hyrax::ApplicationJob
   #
   # @param work containing access level and filesets
   def valkyrie_perform(work)
-    work_permissions = permissions_map(work.permission_manager.acl.permissions)
+    work_permissions = Hyrax::AccessControlList.new(resource: work).permissions
+
     file_sets_for(work).each do |file|
       file_acl = Hyrax::AccessControlList.new(resource: file)
-      file_permissions = permissions_map(file_acl.permissions)
-      # grant new work permissions to member file_sets
-      (work_permissions - file_permissions).each { |perm| file_acl.grant(perm[:mode]).to(perm[:agent]).save }
-      # remove permissions that are not on work from member file_sets
-      (file_permissions - work_permissions).each { |perm| file_acl.revoke(perm[:mode]).from(perm[:agent]).save }
+      file_acl.permissions = []
+      work_permissions.each { |permission| file_acl << permission }
       file_acl.save
     end
   end

--- a/app/jobs/inherit_permissions_job.rb
+++ b/app/jobs/inherit_permissions_job.rb
@@ -48,11 +48,10 @@ class InheritPermissionsJob < Hyrax::ApplicationJob
   def valkyrie_perform(work)
     work_permissions = Hyrax::AccessControlList.new(resource: work).permissions
 
-    file_sets_for(work).each do |file|
-      file_acl = Hyrax::AccessControlList.new(resource: file)
-      file_acl.permissions = []
-      work_permissions.each { |permission| file_acl << permission }
-      file_acl.save
+    file_sets_for(work).each do |file_set|
+      acl = Hyrax::AccessControlList.new(resource: file_set)
+      acl.permissions = work_permissions
+      acl.save
     end
   end
 end

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -112,7 +112,8 @@ module Hyrax
     #
     # @return [Array<Hyrax::Permission>]
     def permissions=(new_permissions)
-      change_set.permissions = new_permissions.to_a
+      change_set.permissions = []
+      new_permissions.each { |p| self << p }
     end
 
     ##

--- a/spec/services/hyrax/access_control_list_spec.rb
+++ b/spec/services/hyrax/access_control_list_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hyrax::AccessControlList do
                         query_service: query_service)
   end
 
-  let(:permission)    { build(:permission) }
+  let(:permission)    { FactoryBot.build(:permission) }
   let(:adapter)       { Valkyrie::MetadataAdapter.find(:test_adapter) }
   let(:persister)     { adapter.persister }
   let(:query_service) { adapter.query_service }
@@ -59,6 +59,20 @@ RSpec.describe Hyrax::AccessControlList do
   describe '#permissions' do
     it 'is empty by default' do
       expect(acl.permissions).to be_empty
+    end
+  end
+
+  describe '#permissions=' do
+    let(:group) { Hyrax::Group.new('public') }
+
+    before { acl.grant(:read).to(group) }
+
+    it 'sets the permissions with access_to' do
+      expect { acl.permissions = [permission] }
+        .to change { acl.permissions }
+        .to contain_exactly(have_attributes(mode: permission.mode,
+                                            agent: permission.agent,
+                                            access_to: resource.id))
     end
   end
 


### PR DESCRIPTION
avoid complicated diffing logic in favor of a wipe and replace strategy.

ACL has an internal ChangeSet, so manipulating it inline has a low cost.

a slight change to `ACL#permissions=` is included to make the interface for this kind of permission copying a bit cleaner.

@samvera/hyrax-code-reviewers
