### PR TITLE
3998 readme documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ This software has been developed by and is brought to you by the Samvera communi
 
 ## License
 
-Hyrax is available under [the Apache 2.0 license](LICENSE.md).
+Hyrax is available under [the Apache 2.0 license](LICENSE).

--- a/documentation/developing-your-hyrax-based-app.md
+++ b/documentation/developing-your-hyrax-based-app.md
@@ -190,7 +190,7 @@ end
 **After** Fedora and Solr are running, create the default administrative set -- into which all works will be deposited unless assigned to other administrative sets -- by running the following command:
 
 ```
-bin/rails hyrax:default_admin_set:create
+rails hyrax:default_admin_set:create
 ```
 
 This command also makes sure that Hyrax's built-in workflows are loaded for your application and available for the default administrative set.
@@ -204,19 +204,19 @@ Using Hyrax requires generating at least one type of repository object, or "work
 Pass a (CamelCased) model name to Hyrax's work generator to get started, e.g.:
 
 ```
-bin/rails generate hyrax:work Work
+rails generate hyrax:work Work
 ```
 
 or
 
 ```
-bin/rails generate hyrax:work MovingImage
+rails generate hyrax:work MovingImage
 ```
 
 If your applications requires your work type to be namespaced, namespaces can be included by adding a slash to the model name which creates a new class called `MovingImage` within the `My` namespace:
 
 ```
-bin/rails generate hyrax:work My/MovingImage
+rails generate hyrax:work My/MovingImage
 ```
 
 You may wish to [customize your work type](https://github.com/samvera/hyrax/wiki/Customizing-your-work-types) now that it's been generated.

--- a/documentation/developing-your-hyrax-based-app.md
+++ b/documentation/developing-your-hyrax-based-app.md
@@ -99,7 +99,7 @@ Hyrax supports Ruby 2.5, 2.6, and 2.7. When starting a new project, we recommend
 
 ## Redis
 
-[Redis](http://redis.io/) is a key-value store that Hyrax uses to provide activity streams on repository objects and users, and to prevent race conditions as a global mutex when modifying order-persisting objects.
+[Redis](http://redis.io/) is a key-value store that Hyrax uses to provide activity streams on repository objects and users, and helps when modifying order-persisting objects by managing multi-threaded actions on data (preventing race conditions as a global mutex).
 
 Starting up Redis will depend on your operating system, and may in fact already be started on your system. You may want to consult the [Redis documentation](http://redis.io/documentation) for help doing this.
 
@@ -116,7 +116,7 @@ gem install rails -v 5.2.4.3
 
 Rails requires that you have a JavaScript runtime installed (e.g. nodejs or rubyracer). Either install nodejs or uncomment the `rubyracer` line in your Gemfile and run `bundle install` before running Hyrax's install generator.
 
-NOTE: nodejs is preinstalled on most Mac computers and doesn't require a gem.  To test if nodejs is already installed, execute `node -v` in the terminal and the version of nodejs will be displayed if it is installed.
+NOTE: [nodejs](https://nodejs.org/en/) is preinstalled on most Mac computers and doesn't require a gem.  To test if nodejs is already installed, execute `node -v` in the terminal and the version of nodejs will be displayed if it is installed.
 
 ## Creating a Hyrax-based app
 
@@ -204,19 +204,19 @@ Using Hyrax requires generating at least one type of repository object, or "work
 Pass a (CamelCased) model name to Hyrax's work generator to get started, e.g.:
 
 ```
-rails generate hyrax:work Work
+bin/rails generate hyrax:work Work
 ```
 
 or
 
 ```
-rails generate hyrax:work MovingImage
+bin/rails generate hyrax:work MovingImage
 ```
 
-If your applications requires your work type to be namespaced, namespaces can be included in the by adding a slash to the model name which creates a new class called `MovingImage` within the `My` namespace:
+If your applications requires your work type to be namespaced, namespaces can be included by adding a slash to the model name which creates a new class called `MovingImage` within the `My` namespace:
 
 ```
-rails generate hyrax:work My/MovingImage
+bin/rails generate hyrax:work My/MovingImage
 ```
 
 You may wish to [customize your work type](https://github.com/samvera/hyrax/wiki/Customizing-your-work-types) now that it's been generated.

--- a/documentation/developing-your-hyrax-based-app.md
+++ b/documentation/developing-your-hyrax-based-app.md
@@ -27,7 +27,7 @@ A Hyrax-based application includes lots of dependencies. We provide a [Docker im
 
 <aside><p><em><strong>Note:</em></strong> The Docker image describes the canonical dependencies. In a way, it is executable documentation. The following documentation is our best effort to transcribe that executable documentation into a narrative. In other words, this documentation may drift away from the Docker details.</p></aside>
 
-You can also try [Running Hyrax-based application in local VM](https://github.com/samvera/hyrax/wiki/Hyrax-Development-Guide#running-hyrax-based-application-in-local-vm) using Ubuntu.
+You can also try [Running Hyrax-based application in local VM](https://github.com/samvera/hyrax/wiki/Hyrax-Development-Guide#running-hyrax-based-application-in-local-vm) which uses Ubuntu.
 
 This document contains instructions specific to setting up an app with __Hyrax
 v3.0.0-rc2__. If you are looking for instructions on installing a different

--- a/documentation/developing-your-hyrax-based-app.md
+++ b/documentation/developing-your-hyrax-based-app.md
@@ -25,9 +25,9 @@
 
 A Hyrax-based application includes lots of dependencies. We provide a [Docker image for getting started with your Hyrax-based application](/CONTAINERS.md#docker-image-for-hyrax-based-applications).
 
-_**TODO:** Write the instructions for generating a new Hyrax-based application using the Docker Image for Hyrax-based Applications._
-
 <aside><p><em><strong>Note:</em></strong> The Docker image describes the canonical dependencies. In a way, it is executable documentation. The following documentation is our best effort to transcribe that executable documentation into a narrative. In other words, this documentation may drift away from the Docker details.</p></aside>
+
+You can also try [Running Hyrax-based application in local VM](https://github.com/samvera/hyrax/wiki/Hyrax-Development-Guide#running-hyrax-based-application-in-local-vm) using Ubuntu.
 
 This document contains instructions specific to setting up an app with __Hyrax
 v3.0.0-rc2__. If you are looking for instructions on installing a different


### PR DESCRIPTION
Fixes #3998 

README.md update:

Fix link to Apache 2 license (https://github.com/samvera/hyrax/blob/master/LICENSE)

developing-your-hyrax-based-app.md updates:

Add link to Nodejs (https://nodejs.org/en/)

Change path for rails commands from `bin/rails` to just `rails`

Correct typo to remove extra "in the" from "If your applications require..." sentence

Applied suggested edit to jargon-y sentence about "race conditions as a global mutex"

Introduction: Removed TODO note about writing Docker instructions and added link to wiki for Ubuntu VM install instructions

@samvera/hyrax-code-reviewers
