### PR TITLE
extract and minimize valkyrie fileset attachment behavior, add to change_set transaction(s)

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -187,8 +187,11 @@ module Hyrax
       else
         form = build_form
 
-        @curation_concern = form.validate(params[hash_key_for_curation_concern]) &&
-                            transactions['change_set.create_work'].call(form).value!
+        @curation_concern =
+          form.validate(params[hash_key_for_curation_concern]) &&
+          transactions['change_set.create_work']
+          .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files })
+          .call(form).value!
       end
     end
 
@@ -199,8 +202,11 @@ module Hyrax
       else
         form = build_form
 
-        @curation_concern = form.validate(params[hash_key_for_curation_concern]) &&
-                            transactions['change_set.update_work'].call(form).value!
+        @curation_concern =
+          form.validate(params[hash_key_for_curation_concern]) &&
+          transactions['change_set.update_work']
+          .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files })
+          .call(form).value!
       end
     end
 
@@ -411,6 +417,10 @@ module Hyrax
       else
         Hyrax.custom_queries.find_child_fileset_ids(resource: curation_concern).any?
       end
+    end
+
+    def uploaded_files
+      UploadedFile.find(params.fetch(:uploaded_files, []))
     end
   end
 end

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -10,7 +10,8 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
     when ActiveFedora::Base
       perform_af(work, uploaded_files, work_attributes)
     else
-      Hyrax::WorkUploadsHandler.new(work: work).add(files: uploaded_files).attach
+      Hyrax::WorkUploadsHandler.new(work: work).add(files: uploaded_files).attach ||
+        raise("Could not complete AttachFilesToWorkJob. Some of these are probably in an undesirable state: #{uploaded_files}")
     end
   end
 

--- a/app/jobs/inherit_permissions_job.rb
+++ b/app/jobs/inherit_permissions_job.rb
@@ -46,12 +46,11 @@ class InheritPermissionsJob < Hyrax::ApplicationJob
   #
   # @param work containing access level and filesets
   def valkyrie_perform(work)
-    work_permissions = Hyrax::AccessControlList.new(resource: work).permissions
+    work_acl = Hyrax::AccessControlList.new(resource: work)
 
     file_sets_for(work).each do |file_set|
-      acl = Hyrax::AccessControlList.new(resource: file_set)
-      acl.permissions = work_permissions
-      acl.save
+      Hyrax::AccessControlList
+        .copy_permissions(source: work_acl, target: file_set)
     end
   end
 end

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -4,6 +4,23 @@ module Hyrax
   ##
   # @api public
   #
+  # Cast an object to its AccessControlList
+  #
+  # @param [Object] an object to try to cast
+  #
+  # @return [Hyrax::AccessControlList]
+  def self.AccessControlList(obj)
+    case obj
+    when AccessControlList
+      obj
+    else
+      AccessControlList.new(resource: obj)
+    end
+  end
+
+  ##
+  # @api public
+  #
   # ACLs for `Hyrax::Resource` models
   #
   # Allows managing `Hyrax::Permission` entries referring to a specific
@@ -51,6 +68,19 @@ module Hyrax
       self.resource  = resource
       @persister     = persister
       @query_service = query_service
+    end
+
+    ##
+    # Copy and save permissions from source to target
+    #
+    # @param [Valkyrie::Resource, Hyrax::AccessControlList] source
+    # @param [Valkyrie::Resource, Hyrax::AccessControlList] target
+    #
+    # @return [Hyrax::AccessControlList] an acl for `target` with the updated permissions
+    def self.copy_permissions(source:, target:)
+      target = Hyrax::AccessControlList(target)
+      target.permissions = Hyrax::AccessControlList(source).permissions
+      target.save && target
     end
 
     ##

--- a/app/services/hyrax/work_uploads_handler.rb
+++ b/app/services/hyrax/work_uploads_handler.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Mediates uploads to a work.
+  #
+  # Given an existing Work object, `#add` some set of files, then call `#attach`
+  # to handle creation/attachment of File Sets, and trigger persistence of files
+  # to the storage backend.
+  #
+  # This class provides both an interface and a concrete implementation.
+  # Applications that want to handle file attachment differently (e.g. by making
+  # them completely synchronous, by attaching file sets to a different work
+  # attribute, by supporting another file/IO class, etc...) can use a different
+  # `Handler` implementation. The only guarantee made by the _interface_ is that
+  # the process of persisting the relationship between `work` and the provided
+  # `files` will start when `#attach` is called.
+  #
+  # This base implementation accepts only `Hyrax::UploadedFile` instances and,
+  # for each one, creates a `Hyrax::FileSet` with permissions matching those on
+  # `work`, and appends that FileSet to `member_ids`. The `FileSet` will be
+  # added in the order that the `UploadedFiles` are passed in. If the work has a
+  # `nil` `representative_id` and/or `thumbnail_id`, the first `FileSet` will be
+  # set to that value. An `IngestJob` will be equeued, for each `FileSet`. When
+  # all of the `files` have been processed, the work will be saved with the
+  # added members. While this is happening, we take a lock on the work via
+  # `Lockable` (Redis/Redlock).
+  #
+  # @example
+  #   Hyrax::WorkUploadsHandler.new(work: my_work)
+  #     .add(files: [file1, file2])
+  #     .attach
+  #
+  class WorkUploadsHandler
+    include Lockable
+
+    ##
+    # @!attribute [r] files
+    #   @return [Enumberable<Hyrax::UploadedFile>]
+    # @!attribute [r] work
+    #   @return [Hyrax::Work]
+    attr_reader :files, :work
+
+    ##
+    # @param [Hyrax::Work] work
+    # @param [#save] persister the valkyrie persister to use
+    def initialize(work:, persister: Hyrax.persister)
+      @work = work
+      @persister = persister
+    end
+
+    ##
+    # @param [Enumberable<Hyrax::UploadedFile>] files  files to add
+    #
+    # @return [WorkFileSetManager] self
+    # @raise [ArgumentError] if any of the uploaded files are not an
+    #   `UploadedFile`
+    def add(files:)
+      validate_files(files) &&
+        @files = Array.wrap(files).reject { |f| f.file_set_uri.present? }
+      self
+    end
+
+    ##
+    # Create filesets for each added file
+    #
+    # @return [Boolean] true if all requested files were attached
+    def attach
+      return true if Array.wrap(files).empty? # short circuit to avoid aquiring a lock we won't use
+
+      acquire_lock_for(work.id) do
+        files.each { |file| make_file_set_and_ingest(file) }
+        Hyrax.persister.save(resource: work)
+      end
+    end
+
+    private
+
+    def make_file_set_and_ingest(file)
+      file_set = @persister.save(resource: Hyrax::FileSet.new(file_set_args(file)))
+      file.add_file_set!(file_set)
+
+      # copy ACLs; should we also be propogating embargo/lease?
+      Hyrax::AccessControlList.copy_permissions(source: target_permissions, target: file_set)
+
+      work.member_ids << file_set.id
+      work.representative_id = file_set.id if work.representative_id.blank?
+      work.thumbnail_id = file_set.id if work.thumbnail_id.blank?
+      IngestJob.perform_later(wrap_file(file, file_set))
+    end
+
+    ##
+    # @api private
+    # @return [Hash{Symbol => Object}]
+    def file_set_args(file)
+      { depositor: file.user.user_key,
+        creator: file.user.user_key,
+        date_uploaded: file.created_at,
+        date_modified: Hyrax::TimeService.time_in_utc,
+        label: file.uploader.filename,
+        title: file.uploader.filename }
+    end
+
+    ##
+    # @note cache these per instance to avoid repeated lookups.
+    #
+    # @return [Hyrax::AccessControlList] permissions to set on created filesets
+    def target_permissions
+      @target_permissions ||= Hyrax::AccessControlList.new(resource: work)
+    end
+
+    ##
+    # @api private
+    # @return [JobIoWrapper]
+    def wrap_file(file, file_set)
+      JobIoWrapper.create_with_varied_file_handling!(user: file.user, file: file, relation: :original_file, file_set: file_set)
+    end
+
+    ##
+    # @api private
+    #
+    # @note ported from AttachFilesToWorkJob. do we need this? maybe we should
+    #   validate something other than type?
+    #
+    # @raise [ArgumentError] if any of the uploaded files aren't the right class
+    def validate_files(files)
+      files.each do |file|
+        next if file.is_a? Hyrax::UploadedFile
+        raise ArgumentError, "Hyrax::UploadedFile required, but #{file.class} received: #{file.inspect}"
+      end
+    end
+  end
+end

--- a/app/services/hyrax/work_uploads_handler.rb
+++ b/app/services/hyrax/work_uploads_handler.rb
@@ -84,8 +84,8 @@ module Hyrax
       Hyrax::AccessControlList.copy_permissions(source: target_permissions, target: file_set)
 
       work.member_ids << file_set.id
-      work.representative_id = file_set.id if work.representative_id.blank?
-      work.thumbnail_id = file_set.id if work.thumbnail_id.blank?
+      work.representative_id = file_set.id if work.respond_to?(:representative_id) && work.representative_id.blank?
+      work.thumbnail_id = file_set.id if work.respond_to?(:thumbnail_id) && work.thumbnail_id.blank?
       IngestJob.perform_later(wrap_file(file, file_set))
     end
 

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -40,6 +40,7 @@ module Hyrax
     autoload :Listeners
   end
 
+  ##
   # @api public
   #
   # Exposes the Hyrax configuration

--- a/lib/hyrax/specs/spy_listener.rb
+++ b/lib/hyrax/specs/spy_listener.rb
@@ -42,5 +42,24 @@ module Hyrax
         end
       end
     end
+
+    ##
+    # A spy listener that accumulates events, so multiple events published by
+    # one unit-under-test can be collected for inspection.
+    class AppendingSpyListener
+      Hyrax::Publisher.events.each_value do |registered_event|
+        listener_method = registered_event.listener_method
+        attr_name = registered_event.listener_method.to_s.sub(/^on_/, '')
+
+        define_method attr_name.to_sym do
+          instance_variable_get("@#{attr_name}") ||
+            instance_variable_set("@#{attr_name}", [])
+        end
+
+        define_method listener_method do |published_event|
+          send(attr_name.to_sym) << published_event
+        end
+      end
+    end
   end
 end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -23,6 +23,7 @@ module Hyrax
       require 'hyrax/transactions/destroy_work'
       require 'hyrax/transactions/work_create'
       require 'hyrax/transactions/update_work'
+      require 'hyrax/transactions/steps/add_file_sets'
       require 'hyrax/transactions/steps/add_to_collections'
       require 'hyrax/transactions/steps/apply_collection_permission_template'
       require 'hyrax/transactions/steps/apply_permission_template'
@@ -88,7 +89,13 @@ module Hyrax
         end
       end
 
-      namespace 'work' do |ops|
+      namespace 'work_resource' do |ops| # valkyrie works
+        ops.register 'add_file_sets' do
+          Steps::AddFileSets.new
+        end
+      end
+
+      namespace 'work' do |ops| # legacy AF works
         ops.register 'apply_collection_permission_template' do
           Steps::ApplyCollectionPermissionTemplate.new
         end

--- a/lib/hyrax/transactions/steps/add_file_sets.rb
+++ b/lib/hyrax/transactions/steps/add_file_sets.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Adds a Hyrax::FileSet
+      #
+      # @see https://wiki.lyrasis.org/display/samvera/Hydra::Works+Shared+Modeling
+      class AddFileSets
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Class] handler
+        def initialize(handler: Hyrax::WorkUploadsHandler)
+          @handler = handler
+        end
+
+        ##
+        # @param [Hyrax::Work] obj
+        # @param [Enumerable<UploadedFile>] uploaded_files
+        #
+        # @return [Dry::Monads::Result]
+        def call(obj, uploaded_files: [])
+          if @handler.new(work: obj).add(files: uploaded_files).attach
+            Success(obj)
+          else
+            Failure[:failed_to_attach_file_sets, uploaded_files]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/update_work.rb
+++ b/lib/hyrax/transactions/update_work.rb
@@ -4,7 +4,8 @@ module Hyrax
     ##
     # @since 3.0.0
     class UpdateWork < Transaction
-      DEFAULT_STEPS = ['change_set.apply'].freeze
+      DEFAULT_STEPS = ['change_set.apply',
+                       'work_resource.add_file_sets'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/work_create.rb
+++ b/lib/hyrax/transactions/work_create.rb
@@ -12,7 +12,8 @@ module Hyrax
                        'change_set.ensure_admin_set',
                        'change_set.set_user_as_depositor',
                        'change_set.add_to_collections',
-                       'change_set.apply'].freeze
+                       'change_set.apply',
+                       'work_resource.add_file_sets'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
           expect(flash[:notice]).to eq "Your files are being processed by Hyrax in the background. " \
                                        "The metadata and access controls you specified are being applied. " \
                                        "You may need to refresh this page to see these updates."
-          expect(assigns(:curation_concern)).to have_file_set_members
+          expect(assigns(:curation_concern)).to have_file_set_members(be_persisted, be_persisted)
         end
 
         let(:uploads) { FactoryBot.create_list(:uploaded_file, 2, user: user) }

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         let(:uploads) { FactoryBot.create_list(:uploaded_file, 2, user: user) }
 
         it 'attaches the files' do
-          pending 'it should actually attach the files'
           params = { test_simple_work: { title: 'comet in moominland' },
                      uploaded_files: uploads.map(&:id) }
 
@@ -314,6 +313,18 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
         expect(Hyrax.query_service.find_by(id: id))
           .to have_attributes title: contain_exactly('new title')
+      end
+
+      context 'and files' do
+        let(:uploads) { FactoryBot.create_list(:uploaded_file, 2, user: user) }
+
+        it 'attaches the files' do
+          params = { id: id, test_simple_work: { title: 'comet in moominland' },
+                     uploaded_files: uploads.map(&:id) }
+
+          get :update, params: params
+          expect(assigns(:curation_concern)).to have_file_set_members(be_persisted, be_persisted)
+        end
       end
     end
   end

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -60,6 +60,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_member_file_sets do
+      transient do
+        members { [valkyrie_create(:hyrax_file_set), valkyrie_create(:hyrax_file_set)] }
+      end
+    end
+
     trait :as_collection_member do
       member_of_collection_ids { [valkyrie_create(:hyrax_collection).id] }
     end

--- a/spec/hyrax/transactions/steps/add_file_sets_spec.rb
+++ b/spec/hyrax/transactions/steps/add_file_sets_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::AddFileSets, valkyrie_adapter: :test_adapter do
+  subject(:step) { described_class.new }
+  let(:work)     { FactoryBot.valkyrie_create(:hyrax_work) }
+
+  it 'gives success' do
+    expect(step.call(work)).to be_success
+  end
+
+  context 'with uploaded files' do
+    let(:uploaded_files) { FactoryBot.create_list(:uploaded_file, 4) }
+
+    it 'attaches file_sets for the files' do
+      expect(step.call(work, uploaded_files: uploaded_files).value!)
+        .to have_file_set_members(be_persisted, be_persisted,
+                                  be_persisted, be_persisted)
+    end
+  end
+end

--- a/spec/hyrax/transactions/work_create_spec.rb
+++ b/spec/hyrax/transactions/work_create_spec.rb
@@ -58,5 +58,16 @@ RSpec.describe Hyrax::Transactions::WorkCreate do
           .to have_attributes member_of_collection_ids: contain_exactly(*collection_ids)
       end
     end
+
+    context 'when attaching uploaded files' do
+      let(:uploaded_files) { FactoryBot.create_list(:uploaded_file, 4) }
+
+      it 'adds uploaded files' do
+        tx.with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files })
+
+        expect(tx.call(change_set).value!)
+          .to have_file_set_members(be_persisted, be_persisted, be_persisted, be_persisted)
+      end
+    end
   end
 end

--- a/spec/services/hyrax/work_uploads_handler_spec.rb
+++ b/spec/services/hyrax/work_uploads_handler_spec.rb
@@ -45,5 +45,20 @@ RSpec.describe Hyrax::WorkUploadsHandler do
                                     be_a_resource_with_permissions(have_attributes(mode: :read, agent: 'group/public')))
       end
     end
+
+    context 'with existing file_sets' do
+      let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :public, :with_member_file_sets) }
+
+      it 'appends the new file sets' do
+        first_id, second_id = work.member_ids
+
+        service.add(files: uploads).attach
+        expect(work).to have_file_set_members(have_attributes(id: first_id),
+                                              have_attributes(id: second_id),
+                                              be_persisted,
+                                              be_persisted,
+                                              be_persisted)
+      end
+    end
   end
 end

--- a/spec/services/hyrax/work_uploads_handler_spec.rb
+++ b/spec/services/hyrax/work_uploads_handler_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::WorkUploadsHandler do
+  subject(:service) { described_class.new(work: work) }
+
+  let(:uploads) { FactoryBot.create_list(:uploaded_file, 3) }
+  let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :public) }
+
+  describe '#attach' do
+    it 'when no files are added returns uneventfully' do
+      expect { service.attach }
+        .not_to change { work.member_ids }
+        .from be_empty
+    end
+
+    context 'after adding files' do
+      before { service.add(files: uploads) }
+
+      it 'assigns FileSet ids synchronously' do
+        expect { service.attach }
+          .to change { work.member_ids }
+          .to contain_exactly(an_instance_of(Valkyrie::ID),
+                              an_instance_of(Valkyrie::ID),
+                              an_instance_of(Valkyrie::ID))
+      end
+
+      it 'creates persisted filesets' do
+        service.attach
+        expect(work).to have_file_set_members(be_persisted, be_persisted, be_persisted)
+      end
+
+      it 'creates filesets with metadata' do
+        service.attach
+        expect(work)
+          .to have_file_set_members(have_attributes(title: ['image.jp2'], depositor: an_instance_of(String), visibility: 'open'),
+                                    have_attributes(title: ['image.jp2'], depositor: an_instance_of(String), visibility: 'open'),
+                                    have_attributes(title: ['image.jp2'], depositor: an_instance_of(String), visibility: 'open'))
+      end
+
+      it 'propagates work permissions to file_sets' do
+        service.attach
+        expect(work)
+          .to have_file_set_members(be_a_resource_with_permissions(have_attributes(mode: :read, agent: 'group/public')),
+                                    be_a_resource_with_permissions(have_attributes(mode: :read, agent: 'group/public')),
+                                    be_a_resource_with_permissions(have_attributes(mode: :read, agent: 'group/public')))
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/work_uploads_handler_spec.rb
+++ b/spec/services/hyrax/work_uploads_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'hyrax/specs/spy_listener'
 
-RSpec.describe Hyrax::WorkUploadsHandler do
+RSpec.describe Hyrax::WorkUploadsHandler, valkyrie_adapter: :test_adapter do
   subject(:service) { described_class.new(work: work) }
 
   let(:uploads) { FactoryBot.create_list(:uploaded_file, 3) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,6 +90,7 @@ end
 query_registration_target =
   Valkyrie::MetadataAdapter.find(:test_adapter).query_service.custom_queries
 [Hyrax::CustomQueries::Navigators::CollectionMembers,
+ Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator,
  Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
  Hyrax::CustomQueries::FindAccessControl,
  Hyrax::CustomQueries::FindCollectionsByType,

--- a/spec/support/matchers/pcdm_matchers.rb
+++ b/spec/support/matchers/pcdm_matchers.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
-RSpec::Matchers.define :have_file_set_members do
-  match do |actual|
-    expect(Hyrax.custom_queries.find_child_filesets(resource: actual)).not_to be_empty
+RSpec::Matchers.define :have_file_set_members do |*expected_file_sets|
+  match do |actual_work|
+    actual_file_sets = Hyrax.custom_queries.find_child_filesets(resource: actual_work)
+
+    expect(actual_file_sets).to contain_exactly(*expected_file_sets)
+  end
+end
+
+RSpec::Matchers.define :be_a_resource_with_permissions do |*expected_permissions|
+  match do |actual_resource|
+    expect(Hyrax::AccessControlList.new(resource: actual_resource).permissions)
+      .to include(*expected_permissions)
   end
 end


### PR DESCRIPTION
makes uploads passed to the controller lead to files attached to the work.
 
this is the simplest version of valkyrie driven fileset attachment that i could come up with
that passes the current tests.

i fear that passing the current tests may not be enough. but i think the
preferred strategy at this point is to get an end-to-end implementation from the
`WorksControllerBehavior` tests so we can avoid duplicating the byzantine
processes involved in FileSetActor, FileActor, AttachFileToWorkJob, etc...

@samvera/hyrax-code-reviewers
