### PR TITLE
stop stubbing to reach otherwise unreachable code path; deprecate

### DIFF
--- a/app/controllers/hyrax/permissions_controller.rb
+++ b/app/controllers/hyrax/permissions_controller.rb
@@ -6,6 +6,7 @@ module Hyrax
     def confirm
       # intentional noop to display default view
     end
+    deprecation_deprecate confirm: "Use the #confirm_access action instead."
 
     def copy
       authorize! :edit, curation_concern

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -476,8 +476,6 @@ RSpec.describe Hyrax::GenericWorksController do
       end
 
       describe 'changing rights' do
-        let(:visibility_changed) { true }
-
         context 'when the work has file sets attached' do
           before do
             allow(GenericWork).to receive(:find).and_return(work)
@@ -485,8 +483,8 @@ RSpec.describe Hyrax::GenericWorksController do
           end
 
           it 'prompts to change the files access' do
-            patch :update, params: { id: work, generic_work: {} }
-            expect(response).to redirect_to main_app.confirm_hyrax_permission_path(controller.curation_concern, locale: 'en')
+            patch :update, params: { id: work, generic_work: { visibility: 'restricted' } }
+            expect(response).to redirect_to hyrax.confirm_access_permission_path(controller.curation_concern, locale: 'en')
           end
         end
 


### PR DESCRIPTION
since `#visibility` is a projection on `#permissions` we never need to confirm
propogation of visibility changes if permissions haven't changed. the stub
created an artificial scenario where the work's `visibility_will_change!` flag
is set, even though we've never changed the permissions. fix the test to edit
visibility through user parameters, then remove the unreachable/unreached code
path. deprecate the related controller action.

the only other way this artificial scenario is achievable is by editing the
visibility, and then editing it back. we don't want to confirm edits in this
case, since neither permissions nor vizibility have really changed.

@samvera/hyrax-code-reviewers
