### PR TITLE
support `depositor` in `ResourceForm`

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -190,7 +190,8 @@ module Hyrax
         @curation_concern =
           form.validate(params[hash_key_for_curation_concern]) &&
           transactions['change_set.create_work']
-          .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files })
+          .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files },
+                          'change_set.set_user_as_depositor' => { user: current_user })
           .call(form).value!
       end
     end

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -65,7 +65,9 @@ module Hyrax
 
       class_attribute :model_class
 
-      delegate :depositor, :human_readable_type, :on_behalf_of, :proxy_depositor, to: :model
+      delegate :depositor, :on_behalf_of, :proxy_depositor, to: :model
+
+      property :human_readable_type, writable: false
 
       property :visibility # visibility has an accessor on the model
 

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -65,9 +65,11 @@ module Hyrax
 
       class_attribute :model_class
 
-      delegate :depositor, :on_behalf_of, :proxy_depositor, to: :model
-
       property :human_readable_type, writable: false
+
+      property :depositor
+      property :on_behalf_of
+      property :proxy_depositor
 
       property :visibility # visibility has an accessor on the model
 

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
           .to redirect_to paths.hyrax_test_simple_work_legacy_path(id: assigns(:curation_concern).id, locale: :en)
       end
 
+      it 'sets current user as depositor' do
+        post :create, params: { test_simple_work: { title: 'comet in moominland' } }
+
+        expect(assigns[:curation_concern].depositor).to eq user.user_key
+      end
+
       context 'and files' do
         let(:uploads) { FactoryBot.create_list(:uploaded_file, 2, user: user) }
 
@@ -324,6 +330,16 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
           get :update, params: params
           expect(assigns(:curation_concern)).to have_file_set_members(be_persisted, be_persisted)
+        end
+      end
+
+      context 'and editing visibility' do
+        let(:update_params) { { title: 'new title', visibility: 'open' } }
+
+        xit 'can make work public' do
+          patch :update, params: { id: id, test_simple_work: update_params }
+
+          expect(Hyrax::VisibilityReader.new(resource: assigns(:curation_concern)).read).to eq 'open'
         end
       end
     end

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -172,8 +172,14 @@ RSpec.describe Hyrax::Forms::ResourceForm do
   end
 
   describe '#human_readable_type' do
-    it 'delegates to model' do
+    it 'reads from model' do
       expect(form.human_readable_type).to eq work.human_readable_type
+    end
+
+    it 'cannot be overwritten' do
+      form.human_readable_type = 'NOPE'
+
+      expect { form.sync }.not_to change { work.human_readable_type }
     end
   end
 
@@ -181,6 +187,7 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     let(:user1) { FactoryBot.create(:user).to_s }
     let(:user2) { FactoryBot.create(:user).to_s }
     let(:work) { FactoryBot.valkyrie_create(:hyrax_work, on_behalf_of: user2, proxy_depositor: user1) }
+
     it 'delegates to model' do
       expect(form.proxy_depositor).to eq user1
     end
@@ -190,6 +197,7 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     let(:user1) { create(:user).to_s }
     let(:user2) { create(:user).to_s }
     let(:work) { FactoryBot.valkyrie_create(:hyrax_work, on_behalf_of: user2, proxy_depositor: user1) }
+
     it 'delegates to model' do
       expect(form.on_behalf_of).to eq user2
     end


### PR DESCRIPTION
some improvements to `ResourceForm`, especially to get `:depositor` behavior via `WorkFormBehavior`

@samvera/hyrax-code-reviewers
