### PR TITLE
Handle Visibility in Valkyrie Forms

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -36,7 +36,7 @@ module Hyrax
       #
       # @note due to historical oddities with Hydra::AccessControls and Hydra
       #   Editor, Hyrax's views rely on `agent_name` and `access` as field
-      #   names. we provide these as virtual fields andprepopulate these from
+      #   names. we provide these as virtual fields and prepopulate these from
       #   `Hyrax::Permission`.
       class Permission < Hyrax::ChangeSet
         property :agent_name, virtual: true, prepopulator: ->(_opts) { self.agent_name = model.agent }
@@ -71,7 +71,7 @@ module Hyrax
       property :on_behalf_of
       property :proxy_depositor
 
-      property :visibility # visibility has an accessor on the model
+      property :visibility, default: VisibilityIntention::PRIVATE
 
       property :date_modified, readable: false
       property :date_uploaded, readable: false

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -33,6 +33,7 @@ module Hyrax
       require 'hyrax/transactions/steps/ensure_permission_template'
       require 'hyrax/transactions/steps/save'
       require 'hyrax/transactions/steps/save_work'
+      require 'hyrax/transactions/steps/save_access_control'
       require 'hyrax/transactions/steps/set_default_admin_set'
       require 'hyrax/transactions/steps/set_modified_date'
       require 'hyrax/transactions/steps/set_uploaded_date_unless_present'
@@ -92,6 +93,10 @@ module Hyrax
       namespace 'work_resource' do |ops| # valkyrie works
         ops.register 'add_file_sets' do
           Steps::AddFileSets.new
+        end
+
+        ops.register 'save_acl' do
+          Steps::SaveAccessControl.new
         end
       end
 

--- a/lib/hyrax/transactions/steps/save_access_control.rb
+++ b/lib/hyrax/transactions/steps/save_access_control.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Saves the Hyrax::AccessControlList for any resource with a `#permission_manager`.
+      # If `#permission_manager` is undefined, succeeds.
+      #
+      # @see https://dry-rb.org/gems/dry-monads/1.0/result/
+      class SaveAccessControl
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Valkyrie::Resource] obj
+        #
+        # @return [Dry::Monads::Result]
+        def call(obj)
+          return Success(obj) unless obj.respond_to?(:permission_manager)
+          obj.permission_manager&.acl&.save ||
+            (return Failure[:failed_to_save_acl, acl])
+
+          Success(obj)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/update_work.rb
+++ b/lib/hyrax/transactions/update_work.rb
@@ -5,6 +5,7 @@ module Hyrax
     # @since 3.0.0
     class UpdateWork < Transaction
       DEFAULT_STEPS = ['change_set.apply',
+                       'work_resource.save_acl',
                        'work_resource.add_file_sets'].freeze
 
       ##

--- a/lib/hyrax/transactions/work_create.rb
+++ b/lib/hyrax/transactions/work_create.rb
@@ -13,6 +13,7 @@ module Hyrax
                        'change_set.set_user_as_depositor',
                        'change_set.add_to_collections',
                        'change_set.apply',
+                       'work_resource.save_acl',
                        'work_resource.add_file_sets'].freeze
 
       ##

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -73,6 +73,13 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
           expect(assigns[:curation_concern]).to have_attributes(visibility: 'open')
         end
+
+        it 'saves the visibility' do
+          post :create, params: { test_simple_work: create_params }
+
+          expect(Hyrax::AccessControlList(assigns[:curation_concern]).permissions)
+            .to include(have_attributes(mode: :read, agent: 'group/public'))
+        end
       end
 
       context 'and files' do
@@ -350,6 +357,13 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
           patch :update, params: { id: id, test_simple_work: update_params }
 
           expect(Hyrax::VisibilityReader.new(resource: assigns(:curation_concern)).read).to eq 'open'
+        end
+
+        it 'saves the visibility' do
+          patch :update, params: { id: id, test_simple_work: update_params }
+
+          expect(Hyrax::AccessControlList(assigns[:curation_concern]).permissions)
+            .to include(have_attributes(mode: :read, agent: 'group/public'))
         end
       end
     end

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -65,6 +65,16 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         expect(assigns[:curation_concern].depositor).to eq user.user_key
       end
 
+      context 'when setting visibility' do
+        let(:create_params) { { title: 'comet in moominland', visibility: 'open' } }
+
+        it 'can set work to public' do
+          post :create, params: { test_simple_work: create_params }
+
+          expect(assigns[:curation_concern]).to have_attributes(visibility: 'open')
+        end
+      end
+
       context 'and files' do
         let(:uploads) { FactoryBot.create_list(:uploaded_file, 2, user: user) }
 
@@ -336,7 +346,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
       context 'and editing visibility' do
         let(:update_params) { { title: 'new title', visibility: 'open' } }
 
-        xit 'can make work public' do
+        it 'can make work public' do
           patch :update, params: { id: id, test_simple_work: update_params }
 
           expect(Hyrax::VisibilityReader.new(resource: assigns(:curation_concern)).read).to eq 'open'

--- a/spec/hyrax/transactions/steps/save_access_control_spec.rb
+++ b/spec/hyrax/transactions/steps/save_access_control_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::SaveAccessControl, valkyrie_adapter: :test_adapter do
+  subject(:step) { described_class.new }
+  let(:work)     { FactoryBot.valkyrie_create(:hyrax_work) }
+
+  it 'gives Success(obj) in basic case' do
+    expect(step.call(work).value!).to eql(work)
+  end
+
+  context 'when editing permissions' do
+    let(:user) { FactoryBot.create(:user) }
+
+    before { work.permission_manager.acl.grant(:read).to(user) }
+
+    it 'persists the new permissions' do
+      expect { step.call(work) }
+        .to change { Hyrax::AccessControlList(work).permissions }
+        .to contain_exactly(have_attributes(mode: :read, agent: user.user_key))
+    end
+  end
+
+  context 'when the resource has no permission_manager' do
+    before do
+      module Hyrax
+        module Test
+          module SaveAccessControlStep
+            class SimpleResource < Valkyrie::Resource
+            end
+          end
+        end
+      end
+    end
+
+    after { Hyrax::Test.send(:remove_const, :SaveAccessControlStep) }
+
+    let(:resource) { Hyrax.persister.save(resource: Hyrax::Test::SaveAccessControlStep::SimpleResource.new) }
+
+    it 'succeeds happily' do
+      expect(step.call(work).value!).to eql(work)
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/save_spec.rb
+++ b/spec/hyrax/transactions/steps/save_spec.rb
@@ -46,6 +46,25 @@ RSpec.describe Hyrax::Transactions::Steps::Save do
       end
     end
 
+    context 'when setting visibility' do
+      let(:change_set_class) do
+        Class.new(Hyrax::ChangeSet) { self.fields = [:title, :visibility] }
+      end
+
+      before { change_set.visibility = 'open' }
+
+      # visibility is special because, though it's modeled in terms of an
+      # inverse relation (a Hyrax::AccessControl, pointing at this object),
+      # for historical reasons we edit it as an attribute. if the change_set
+      # has a `visibility`, it wants to set permissions on the AccessControl.
+      # when we save the model, we *never* save those permissions, but we need
+      # to make sure we repopulate our changes to the saved work's in-memory
+      # copy. here's a test to make sure that happens.
+      it 'retains visibility changes on unwrapped work' do
+        expect(step.call(change_set).value!).to have_attributes(visibility: 'open')
+      end
+    end
+
     context 'when the save fails' do
       before do
         allow(persister)


### PR DESCRIPTION
ensure transactions save ACLs. the `AccessControlList` mediator service handles
the details: publishing events for ACLs, resolving to the correct Valkyrie
persister, etc...

one part of this is arbitrary: when updating, we choose to save access controls
only (but immediately) after the work's save has completed. we do this for
symmetry with the create transaction, which needs a saved work/id to
reference. on update, we could choose to save the ACLs immediately, eliminating
risk of a metadata update going through without its accompanying permission
changes. we forego that in favor of the symmetry, at least for now.

@samvera/hyrax-code-reviewers
