### PR TITLE
introduce a listener to handle proxy deposits

### DIFF
--- a/app/actors/hyrax/actors/transfer_request_actor.rb
+++ b/app/actors/hyrax/actors/transfer_request_actor.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 module Hyrax
   module Actors
+    ##
+    # @deprecated transfer requests are now carried out in response to published
+    # 'object.deposited' events.
+    #
     # Notify the provided owner that their proxy wants to make a
     # deposit on their behalf
     class TransferRequestActor < AbstractActor
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if create was successful
       def create(env)
+        Deprecation.warn('Use Hyrax::Listeners::ProxyDepositListener instead.')
         next_actor.create(env) && create_proxy_deposit_request(env)
       end
 

--- a/app/models/hyrax/active_job_proxy.rb
+++ b/app/models/hyrax/active_job_proxy.rb
@@ -31,7 +31,7 @@ module Hyrax
     ##
     # @return [Valkyrie::Resource]
     def self.find(id)
-      Hyrax.query_adapter.find_by(id: id)
+      Hyrax.query_service.find_by(id: id)
     end
 
     ##

--- a/app/services/hyrax/default_middleware_stack.rb
+++ b/app/services/hyrax/default_middleware_stack.rb
@@ -32,9 +32,6 @@ module Hyrax
         # the model
         middleware.use Hyrax::Actors::InterpretVisibilityActor
 
-        # Handles transfering ownership of works from one user to another
-        middleware.use Hyrax::Actors::TransferRequestActor
-
         # Copies default permissions from the PermissionTemplate to the work
         middleware.use Hyrax::Actors::ApplyPermissionTemplateActor
 

--- a/app/services/hyrax/listeners.rb
+++ b/app/services/hyrax/listeners.rb
@@ -16,5 +16,6 @@ module Hyrax
     autoload :FileSetLifecycleNotificationListener
     autoload :MetadataIndexListener
     autoload :ObjectLifecycleListener
+    autoload :ProxyDepositListener
   end
 end

--- a/app/services/hyrax/listeners/proxy_deposit_listener.rb
+++ b/app/services/hyrax/listeners/proxy_deposit_listener.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Listens for deposit events, and checks for proxy situations. When a user
+    # deposits an item `on_behalf_of` another, ensures transfer is handled.
+    class ProxyDepositListener
+      ##
+      # @param event [Dry::Event]
+      def on_object_deposited(event)
+        return if event[:object].try(:on_behalf_of).blank? ||
+                  (event[:object].on_behalf_of == event[:object].depositor)
+
+        ContentDepositorChangeEventJob
+          .perform_later(event[:object], ::User.find_by_user_key(event[:object].on_behalf_of))
+      end
+    end
+  end
+end

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -6,6 +6,7 @@ Hyrax.publisher.subscribe(Hyrax::Listeners::BatchNotificationListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleNotificationListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::ProxyDepositListener.new)
 
 # Publish events from old style Hyrax::Callbacks to trigger the listeners
 # When callbacks are removed and replaced with direct event publication, drop these blocks

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -37,9 +37,8 @@ module Hyrax
           saved.permission_manager.acl.permissions = unsaved.permission_manager.acl.permissions if
             unsaved.respond_to?(:permission_manager)
 
-          Hyrax.publisher.publish('object.metadata.updated',
-                                  object: saved,
-                                  user: user)
+          Hyrax.publisher.publish('object.deposited', object: saved, user: user) if unsaved.new_record
+          Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
 
           Success(saved)
         rescue StandardError => err

--- a/spec/features/actor_stack_spec.rb
+++ b/spec/features/actor_stack_spec.rb
@@ -125,6 +125,20 @@ RSpec.describe Hyrax::DefaultMiddlewareStack, :clean_repo do
         expect(work.class.find(work.id).embargo_release_date).to be_present
       end
     end
+
+    describe 'when doing a proxy deposit' do
+      let(:target_user) { FactoryBot.create(:user) }
+      let(:attributes) do
+        { title: ['comet in moominland'],
+          on_behalf_of: target_user.user_key }
+      end
+
+      it 'enqueues exactly one ContentDepositorChangeEventJob' do
+        expect { actor.create(env) }
+          .to have_enqueued_job(ContentDepositorChangeEventJob)
+          .exactly(:once)
+      end
+    end
   end
 
   describe '#update' do

--- a/spec/jobs/visibility_copy_job_spec.rb
+++ b/spec/jobs/visibility_copy_job_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe VisibilityCopyJob do
     let(:resource) { FactoryBot.create(:work_with_files).valkyrie_resource }
     let(:queries)  { Hyrax.custom_queries }
 
-    it 'converts resource to proxy when enqueuing' do
+    it 'serializes and deserailizes resource transparently' do
       expect { described_class.perform_later(resource) }
-        .to have_enqueued_job.with("_aj_globalid" => proxy.to_global_id.to_s)
+        .to have_enqueued_job
+        .with(resource)
     end
 
     it 'copies visibility to file sets' do

--- a/spec/services/hyrax/default_middleware_stack_spec.rb
+++ b/spec/services/hyrax/default_middleware_stack_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Hyrax::DefaultMiddlewareStack do
         Hyrax::Actors::ApplyOrderActor,
         Hyrax::Actors::DefaultAdminSetActor,
         Hyrax::Actors::InterpretVisibilityActor,
-        Hyrax::Actors::TransferRequestActor,
         Hyrax::Actors::ApplyPermissionTemplateActor,
         Hyrax::Actors::CleanupFileSetsActor,
         Hyrax::Actors::CleanupTrophiesActor,

--- a/spec/services/hyrax/listeners/proxy_deposit_listener_spec.rb
+++ b/spec/services/hyrax/listeners/proxy_deposit_listener_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Listeners::ProxyDepositListener do
+  subject(:listener) { described_class.new }
+  let(:data)         { { object: resource, user: depositor } }
+  let(:depositor)    { FactoryBot.create(:user) }
+  let(:event)        { Dry::Events::Event.new(event_type, data) }
+  let(:proxied_to)   { FactoryBot.create(:user) }
+  let(:resource)     { FactoryBot.valkyrie_create(:hyrax_resource) }
+
+  describe 'on_object_deposited' do
+    let(:event_type) { :on_object_deposited }
+
+    it 'with no on_behalf_of' do
+      expect { listener.on_object_deposited(event) }
+        .not_to have_enqueued_job
+    end
+
+    context 'when object has been deposited as proxy for another user' do
+      let(:resource) { FactoryBot.valkyrie_create(:hyrax_work, on_behalf_of: proxied_to.user_key) }
+
+      it 'enqueues a ContentDepositorChangeEventJob' do
+        expect { listener.on_object_deposited(event) }
+          .to have_enqueued_job(ContentDepositorChangeEventJob)
+          .with(resource, proxied_to)
+      end
+    end
+
+    context 'if user has mangaed to proxy to self' do
+      let(:resource) { FactoryBot.valkyrie_create(:hyrax_work, on_behalf_of: depositor.user_key, depositor: depositor.user_key) }
+
+      it 'does not enqueue' do
+        expect { listener.on_object_deposited(event) }
+          .not_to have_enqueued_job(ContentDepositorChangeEventJob)
+      end
+    end
+
+    context 'if proxying to a missing user' do
+      let(:resource) { FactoryBot.valkyrie_create(:hyrax_work, on_behalf_of: 'uncreated_proxy_target_user', depositor: depositor.user_key) }
+
+      it 'enqueues the job (this facilitates remediation)' do
+        expect { listener.on_object_deposited(event) }
+          .to have_enqueued_job(ContentDepositorChangeEventJob)
+          .with(resource, nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
in the past, we've enqueued `ContentDepositorChangeEventJob` from an
actor (`TransferRequestActor`). this is pretty limited, since it means any proxy
deposit MUST go through the actor stack, and that actor MUST be triggered.

since this behavior is a reaction do an object's deposit, it's a good candidate
for a listener. we already promise to publish events for
`'object.deposited'`. adding a listener as the handler means we are able to
respond to any deposit. since listeners are "dead ends", with no downstream
contract, creating a custom listener with different behavior (e.g. handle this
transfer synchronously, trigger application-specific events or notifications,
etc...) should be easier than creating a custom actor.

we choose to enqueue a job if the depositor has deposited "on behalf of" a
non-existent user. this is a choice, to be sure, but it seems better than either
panicking, or just logging. the job will (presumably) fail (unless the missing
user was a fleeting error), and in most deployments get queued for retry. this
gives local maintainers a chance to create the user, if that's what should have
happened, or remove the job from the queue if they prefer a no-op.

**breaking change**: this DEPRECATES `TransferRequestActor` and REMOVES it from
  the default actor stack. existing default actor stack behavior isn't changed (since the actor's
  responsibilities are taken up by the listener) but downstream customization to 
  `TransferRequestActor` require application-side action to retain. applications can either
  port their customization to the listener, or defer by unsubscribing the listener and
  re-inserting the deprecated actor.

@samvera/hyrax-code-reviewers
