### PR TITLE
(Backport of 4634) make default translate_uri_to_id 2x faster

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -479,10 +479,14 @@ module Hyrax
     attr_writer :translate_uri_to_id
 
     def translate_uri_to_id
-      @translate_uri_to_id ||= lambda do |uri|
-        baseparts = 2 + [(::Noid::Rails.config.template.gsub(/\.[rsz]/, '').length.to_f / 2).ceil, 4].min
-        uri.to_s.sub("#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}", '').split('/', baseparts).last
-      end
+      @translate_uri_to_id ||=
+        begin
+          baseparts = 2 + [(::Noid::Rails.config.template.gsub(/\.[rsz]/, '').length.to_f / 2).ceil, 4].min
+
+          lambda do |uri|
+            uri.to_s.split(ActiveFedora.fedora.base_path).last.split('/', baseparts).last
+          end
+        end
     end
 
     attr_writer :translate_id_to_uri

--- a/spec/indexers/hyrax/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/file_set_indexer_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Hyrax::FileSetIndexer do
 
   let(:file_set) do
     FileSet.new(
-      id: 'foo123',
+      id: 'foo12345',
       contributor: ['Mohammad'],
       creator: ['Allah'],
       title: ['The Work'],
@@ -50,15 +50,15 @@ RSpec.describe Hyrax::FileSetIndexer do
       # https://github.com/samvera/active_fedora/issues/1251
       allow(file_set).to receive(:persisted?).and_return(true)
       allow(file_set).to receive(:label).and_return('CastoriaAd.tiff')
-      allow(Hyrax::ThumbnailPathService).to receive(:call).and_return('/downloads/foo123?file=thumbnail')
+      allow(Hyrax::ThumbnailPathService).to receive(:call).and_return('/downloads/foo12345?file=thumbnail')
       allow(file_set).to receive(:original_file).and_return(mock_file)
       allow(file_set).to receive(:extracted_text).and_return(mock_text)
     end
     subject { indexer.generate_solr_document }
 
     it 'has fields' do
-      expect(subject['hasRelatedMediaFragment_ssim']).to eq 'foo123'
-      expect(subject['hasRelatedImage_ssim']).to eq 'foo123'
+      expect(subject['hasRelatedMediaFragment_ssim']).to eq 'foo12345'
+      expect(subject['hasRelatedImage_ssim']).to eq 'foo12345'
       expect(subject['date_uploaded_tesim']).to be_nil
       expect(subject['date_modified_tesim']).to be_nil
       expect(subject['date_uploaded_dtsi']).to eq '2011-01-01T00:00:00Z'
@@ -82,7 +82,7 @@ RSpec.describe Hyrax::FileSetIndexer do
       expect(subject['identifier_tesim']).to eq ['urn:isbn:1234567890']
       expect(subject['based_near_tesim']).to eq ['Medina, Saudi Arabia']
       expect(subject['mime_type_ssi']).to eq 'image/jpeg'
-      expect(subject['thumbnail_path_ss']).to eq '/downloads/foo123?file=thumbnail'
+      expect(subject['thumbnail_path_ss']).to eq '/downloads/foo12345?file=thumbnail'
       expect(subject['all_text_timv']).to eq('abcxyz')
       expect(subject['height_is']).to eq 500
       expect(subject['width_is']).to eq 600


### PR DESCRIPTION
make default translate_uri_to_id 2x faster

this code is called very frequently. the old implementation was slow in two
places:

first, it calculated `baseparts` for every call. this inloved a memory
lookup (`Noid::Rails.config.template`) and several computations (most notably
`String#gsub`). since lambdas are closures, we can do this just once and have
the value (an Integer) passed around with the lambda. this maybe introduces a
cache invalidation problem (if `Noid::Rails.config` changes during execution,
we'll have the wrong number for `baseparts`). however, `Noid::Rails.config`
shouldn't change during execution; it seems safe for now to not worry about
invalidating this cache.

second, it ran `String#sub` on a long string match. `#split` on
`ActiveFedora.fedora.base_path` is more resilient (e.g. it's not protocol
dependent) and just a whole bunch faster.

in all, i saw a > 2x improvement on this code that's called, in some cases,
dozens of times for relatively simple AF operations.

Warming up --------------------------------------
       translate uri    35.111k i/100ms
Calculating -------------------------------------
       translate uri    356.748k (± 4.8%) i/s -      1.791M in   5.030930s

Fixes #issuenumber ; refs #issuenumber

Present tense short summary (50 characters or less)

More detailed description, if necessary. Try to be as descriptive as you can: even if you think that the PR content is obvious, it may not be obvious to others. Include tracebacks if helpful, and be sure to call out any bits of the PR that may be work-in-progress.

Description can have multiple paragraphs and you can use code examples inside:

``` ruby
class PostsController
  def index
    respond_with Post.limit(10)
  end
end
```

Changes proposed in this pull request:
*
*
*

Guidance for testing, such as acceptance criteria or new user interface behaviors:
*
*
*

@samvera/hyrax-code-reviewers
