### PR TITLE
Publisher wiki and WorkflowListener autoload

### DIFF
--- a/app/services/hyrax/listeners.rb
+++ b/app/services/hyrax/listeners.rb
@@ -17,5 +17,6 @@ module Hyrax
     autoload :MetadataIndexListener
     autoload :ObjectLifecycleListener
     autoload :ProxyDepositListener
+    autoload :WorkflowListener
   end
 end

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -74,10 +74,14 @@ module Hyrax
   #
   # @see https://dry-rb.org/gems/dry-events/0.2/
   # @see Dry::Events::Publisher
+  # @see https://github.com/samvera/hyrax/wiki/Hyrax's-Event-Bus-(Hyrax::Publisher)
   class Publisher
     include Singleton
     include Dry::Events::Publisher[:hyrax]
 
+    # are you adding an event?
+    # make sure Hyrax is publishing events in the correct places (this is be non-trivial!)
+    # and add it to the list at https://github.com/samvera/hyrax/wiki/Hyrax's-Event-Bus-(Hyrax::Publisher)
     register_event('batch.created')
     register_event('file.set.audited')
     register_event('file.set.attached')


### PR DESCRIPTION
add links to wiki documentation on `Hyrax::Publisher`

oops: setup autoload for WorkflowListener 

@samvera/hyrax-code-reviewers
