### PR TITLE
Adding @since docs for Hyrax::Publisher events

### DIFF
--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 module Hyrax
@@ -79,18 +80,54 @@ module Hyrax
     include Singleton
     include Dry::Events::Publisher[:hyrax]
 
+    # @!group Registered Events
+    #
+    # 🛑 👀 ❓
     # are you adding an event?
     # make sure Hyrax is publishing events in the correct places (this is be non-trivial!)
     # and add it to the list at https://github.com/samvera/hyrax/wiki/Hyrax's-Event-Bus-(Hyrax::Publisher)
+
+    # @!macro [new] a_registered_event
+    #   @!attribute [r] $1
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('batch.created')
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('file.set.audited')
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('file.set.attached')
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('file.set.url.imported')
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('file.set.restored')
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('object.deleted')
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('object.failed_deposit')
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('object.deposited')
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('object.acl.updated')
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('object.metadata.updated')
   end
 end


### PR DESCRIPTION
This change adds documentation regarding the specific published events.
I spent a few hours poking around the yard `@!macro` and `@!attribute`
behavior to settle on this.  (Some of the documented behavior doesn't
quite work, and I wonder if its related to the two mixins).

Regardless the goal of this documentation is to help bring in line the
versions in which we started publishing each event.  These `@since`
declarations align with [the corresponding wiki entry][1]

Attached to this commit's associated pull request will be a
screen-capture of how this commit modifies the yard docs for `Hyrax::Publisher`.

<img width="492" alt="Screen Shot 2020-12-12 at 9 22 04 AM" src="https://user-images.githubusercontent.com/2130/101986516-393eb200-3c5c-11eb-89e9-96d2730435dd.png">

Note there are two sections: The "Registered Events" group and the Instance Attribute Details (which includes the @since declaration).

[1]:https://github.com/samvera/hyrax/wiki/Hyrax's-Event-Bus-(Hyrax::Publisher)

 In addition, I'm adding some emojies to the documentation, as I hope it draws the eye of future maintainers to say "Hmm, emojiis, that seems odd, I better check this out."

@samvera/hyrax-code-reviewers
