### PR TITLE
pass `base_url`, not just `hostname` through to manifest generation

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -147,7 +147,7 @@ module Hyrax
 
     def iiif_manifest_presenter
       IiifManifestPresenter.new(search_result_document(id: params[:id])).tap do |p|
-        p.hostname = request.hostname
+        p.hostname = request.base_url
         p.ability = current_ability
       end
     end


### PR DESCRIPTION
this change realigns with older Hyrax behavior that used the protocol
from the current controller's request as part of the argument to the IIIF image
URI generator.

related to #4572.

@samvera/hyrax-code-reviewers
