### PR TITLE
make fits.sh path configurable with an ENV

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -139,7 +139,7 @@ module Hyrax
 
     attr_writer :fits_path
     def fits_path
-      @fits_path ||= 'fits.sh'
+      @fits_path ||= ENV.fetch('HYRAX_FITS_PATH', 'fits.sh')
     end
 
     # Override characterization runner


### PR DESCRIPTION
since the fits install path may vary across deployment environments, it's
helpful (and 12-factorish) to provide an environment hook for path
configuration.

@samvera/hyrax-code-reviewers
