### PR TITLE
make Hyrax's user groups configurable

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -11,9 +11,9 @@ module Hyrax
       include Hyrax::Ability::SolrDocumentAbility
 
       class_attribute :admin_group_name, :registered_group_name, :public_group_name
-      self.admin_group_name = 'admin'
-      self.registered_group_name = 'registered'
-      self.public_group_name = 'public' # TODO: find hard coded values and replace with this
+      self.admin_group_name = Hyrax.config.admin_user_group_name
+      self.registered_group_name = Hyrax.config.registered_user_group_name
+      self.public_group_name = Hyrax.config.public_user_group_name
       self.ability_logic += [:admin_permissions,
                              :curation_concerns_permissions,
                              :operation_abilities,

--- a/app/models/concerns/hyrax/permissions/writable.rb
+++ b/app/models/concerns/hyrax/permissions/writable.rb
@@ -14,8 +14,8 @@ module Hyrax
         class_attribute :paranoid_edit_permissions
         self.paranoid_edit_permissions =
           [
-            { key: :edit_groups, message: 'Public cannot have edit access', condition: ->(obj) { obj.edit_groups.include?('public') } },
-            { key: :edit_groups, message: 'Registered cannot have edit access', condition: ->(obj) { obj.edit_groups.include?('registered') } }
+            { key: :edit_groups, message: 'Public cannot have edit access', condition: ->(obj) { obj.edit_groups.include?(::Ability.public_group_name) } },
+            { key: :edit_groups, message: 'Registered cannot have edit access', condition: ->(obj) { obj.edit_groups.include?(::Ability.registered_group_name) } }
           ]
       end
 

--- a/app/search_builders/hyrax/dashboard/managed_search_filters.rb
+++ b/app/search_builders/hyrax/dashboard/managed_search_filters.rb
@@ -15,7 +15,7 @@ module Hyrax
         return [] if groups.empty?
         permission_types.map do |type|
           field = solr_field_for(type, 'group')
-          user_groups = type == 'read' ? groups - ['public', 'registered'] : groups
+          user_groups = type == 'read' ? groups - [::Ability.public_group_name, ::Ability.registered_group_name] : groups
           next if user_groups.empty?
           "({!terms f=#{field}}#{user_groups.join(',')})" # parens required to properly OR the clauses together.
         end

--- a/lib/generators/hyrax/templates/db/seeds.rb
+++ b/lib/generators/hyrax/templates/db/seeds.rb
@@ -253,7 +253,7 @@ end
 
 puts 'Create Expired, Authenticated Embargo works'
 1.times do |i|
-  GenericWork.create(title: ["Expired Authenticated #{i}"], read_groups: ['registered']) do |work|
+  GenericWork.create(title: ["Expired Authenticated #{i}"], read_groups: [Hyrax.config.registered_user_group_name]) do |work|
     work.apply_depositor_metadata(user)
     work.apply_embargo(Date.yesterday.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
   end
@@ -261,7 +261,7 @@ end
 
 puts 'Create Expired, Public Embargo works'
 3.times do |i|
-  GenericWork.create(title: ["Expired Public #{i}"], read_groups: ['public']) do |work|
+  GenericWork.create(title: ["Expired Public #{i}"], read_groups: [Hyrax.config.public_user_group_name]) do |work|
     work.apply_depositor_metadata(user)
     work.apply_embargo(Date.yesterday.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
   end
@@ -269,7 +269,7 @@ end
 
 puts 'Create Active, Public Lease works'
 3.times do |i|
-  GenericWork.create(title: ["Active Public #{i}"], read_groups: ['public']) do |work|
+  GenericWork.create(title: ["Active Public #{i}"], read_groups: [Hyrax.config.public_user_group_name]) do |work|
     work.apply_depositor_metadata(user)
     work.apply_lease(Date.tomorrow.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE)
   end
@@ -277,7 +277,7 @@ end
 
 puts 'Create Active, Authenticated Lease works'
 2.times do |i|
-  GenericWork.create(title: ["Active Authenticated #{i}"], read_groups: ['registered']) do |work|
+  GenericWork.create(title: ["Active Authenticated #{i}"], read_groups: [Hyrax.config.registered_user_group_name]) do |work|
     work.apply_depositor_metadata(user)
     work.apply_lease(Date.tomorrow.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE)
   end
@@ -285,7 +285,7 @@ end
 
 puts 'Create Expired, Authenticated Lease works'
 1.times do |i|
-  GenericWork.create(title: ["Expired Authenticated #{i}"], read_groups: ['registered']) do |work|
+  GenericWork.create(title: ["Expired Authenticated #{i}"], read_groups: [Hyrax.config.registered_user_group_name]) do |work|
     work.apply_depositor_metadata(user)
     work.apply_lease(Date.yesterday.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
   end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -48,6 +48,42 @@ module Hyrax
       true
     end
 
+    # @!group Hyrax Group Configuration
+
+    ##
+    # @!attribute [w] admin_user_group_name
+    #   @return [String]
+    # @!attribute [w] public_user_group_name
+    #   @return [String]
+    # @!attribute [w] registered_user_group_name
+    #   @return [String]
+    attr_writer :admin_user_group_name
+    attr_writer :public_user_group_name
+    attr_writer :registered_user_group_name
+
+    ##
+    # @api public
+    # @return [String]
+    def admin_user_group_name
+      @admin_user_group_name ||= 'admin'
+    end
+
+    ##
+    # @api public
+    # @return [String]
+    def public_user_group_name
+      @public_user_group_name ||= 'public'
+    end
+
+    ##
+    # @api public
+    # @return [String]
+    def registered_user_group_name
+      @registered_user_group_name ||= 'registered'
+    end
+
+    # @!endgroup
+
     # Path on the local file system where derivatives will be stored
     attr_writer :derivatives_path
     def derivatives_path

--- a/lib/hyrax/resource_sync/change_list_writer.rb
+++ b/lib/hyrax/resource_sync/change_list_writer.rb
@@ -95,7 +95,7 @@ module Hyrax
       delegate :collection_url, to: :routes
 
       def public_access
-        { Hydra.config.permissions.read.group => 'public' }
+        { Hydra.config.permissions.read.group => Hyrax.config.public_user_group_name }
       end
     end
   end

--- a/lib/hyrax/resource_sync/resource_list_writer.rb
+++ b/lib/hyrax/resource_sync/resource_list_writer.rb
@@ -78,7 +78,7 @@ module Hyrax
       delegate :collection_url, to: :routes
 
       def public_access
-        { Hydra.config.permissions.read.group => 'public' }
+        { Hydra.config.permissions.read.group => Hyrax.config.public_user_group_name }
       end
     end
   end

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -45,7 +45,7 @@ RSpec.shared_examples 'a permission indexer' do
   describe '#to_solr' do
     it 'indexes read permissions' do
       expect(indexer.to_solr)
-        .to include(Hydra.config.permissions.read.group => ['public'],
+        .to include(Hydra.config.permissions.read.group => [Hyrax.config.public_user_group_name],
                     Hydra.config.permissions.read.individual => read_users.map(&:user_key))
     end
 


### PR DESCRIPTION
Hyrax has special handling built in for three user groups: admins, registered
users, and the general public. behavior specific to each of these
groups (especially in `Hyrax::Ability` and related mixins) is keyed off the
group name.

in the past, we've provided a kind of configuration at the class level on
`::Ability` (or any application class which mixes in `Hyrax::Ability`), but
centralizing this at Hyrax configuration makes it easier to use across the
application, and easier to understand. it also reduces the risk of inheritance
confusion.

the class level configuration is retained. at least for now, i think it's best
not to deprecate the associated class attributes.

@samvera/hyrax-code-reviewers
