### PR TITLE
make ffmpeg path configurable with an ENV

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -74,7 +74,7 @@ module Hyrax
 
     attr_writer :ffmpeg_path
     def ffmpeg_path
-      @ffmpeg_path ||= 'ffmpeg'
+      @ffmpeg_path ||= ENV.fetch('HYRAX_FFMPEG_PATH', 'ffmpeg')
     end
 
     attr_writer :fits_message_length


### PR DESCRIPTION
since the ffmpeg install path may vary across deployment environments, it's
helpful (and 12-factorish) to provide an environment hook for path
configuration.

@samvera/hyrax-code-reviewers
