### PR TITLE
Schemadocs

### DIFF
--- a/lib/hyrax/form_fields.rb
+++ b/lib/hyrax/form_fields.rb
@@ -14,7 +14,7 @@ module Hyrax
   ##
   # @api private
   #
-  # @see Hyrax.FormFields
+  # @see .FormFields
   class FormFields < Module
     attr_reader :name
 

--- a/lib/hyrax/schema.rb
+++ b/lib/hyrax/schema.rb
@@ -10,7 +10,7 @@ module Hyrax
   # `Dry::Type` types.
   #
   # For the default schema loader, configuration is loaded from
-  # `config/metadata/{name}.yaml`. Custom schema loaders can be provided
+  # `config/metadata/[name]}.yaml`. Custom schema loaders can be provided
   # for other types.
   #
   # @note `Valkyrie::Resources`/`Hyrax::Resources` are not required to use this
@@ -48,7 +48,7 @@ module Hyrax
   # applied to a `Valkyrie::Resource`. This provides the internals for the
   # recommended module builder syntax: `Hyrax::Schema(:schema_name)`
   #
-  # @see Hyrax.Schema
+  # @see .Schema
   class Schema < Module
     ##
     # @!attribute [r] name


### PR DESCRIPTION
this was linking to itself, instead of the class method. this is a big
difference because the class documented here is private, and the `Hyrax.Schema`
method is the appropriate interface devs are going to need to find.

@samvera/hyrax-code-reviewers
