### PR TITLE
remove dependency injection from WorkflowListener

### DIFF
--- a/app/services/hyrax/listeners/workflow_listener.rb
+++ b/app/services/hyrax/listeners/workflow_listener.rb
@@ -7,14 +7,17 @@ module Hyrax
     # manages workflow accordingly.
     class WorkflowListener
       ##
-      # @!attribute [r] factory
-      #   @return [#create]
-      attr_reader :factory
-
-      ##
-      # @param [#create] factory
-      def initialize(factory: ::Hyrax::Workflow::WorkflowFactory)
-        @factory = factory
+      # @note respects class attribute configuration at
+      #   {Hyrax::Actors::InitializeWorkflowActor.workflow_factory}, but falls
+      #   back on {Hyrax::Workflow::WorkflowFactory} to prepare for removal of
+      #   Actors
+      # @return [#create] default: {Hyrax::Workflow::WorkflowFactory}
+      def factory
+        if defined?(Hyrax::Actors::InitializeWorkflowActor)
+          Hyrax::Actors::InitializeWorkflowActor.workflow_factory
+        else
+          Hyrax::Workflow::WorkflowFactory
+        end
       end
 
       ##

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -7,7 +7,7 @@ Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleNotificationListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ProxyDepositListener.new)
-Hyrax.publisher.subscribe(Hyrax::Listeners::WorkflowListener.new(factory: Hyrax::Actors::InitializeWorkflowActor.workflow_factory))
+Hyrax.publisher.subscribe(Hyrax::Listeners::WorkflowListener.new)
 
 # Publish events from old style Hyrax::Callbacks to trigger the listeners
 # When callbacks are removed and replaced with direct event publication, drop these blocks


### PR DESCRIPTION
listeners struggle with dependency injection because they need to be initialized
on app startup. Rails tries to reload their collaborator objects, which leads to
`ArgumentError (A copy of Hyrax::Workflow::WorkflowFactory has been removed
from the module tree but is still active!)`

pending a better fix, we just need to ban DI for listeners and hard code their
collaborators.

@samvera/hyrax-code-reviewers
