### PR TITLE
don't try to build breadcrumbs for nil parents

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -139,7 +139,7 @@ module Hyrax
       when 'edit'
         add_breadcrumb I18n.t("hyrax.file_set.browse_view"), main_app.hyrax_file_set_path(params["id"])
       when 'show'
-        add_breadcrumb presenter.parent.to_s, main_app.polymorphic_path(presenter.parent)
+        add_breadcrumb presenter.parent.to_s, main_app.polymorphic_path(presenter.parent) if presenter.parent.present?
         add_breadcrumb presenter.to_s, main_app.polymorphic_path(presenter)
       end
     end

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -83,6 +83,8 @@ module Hyrax
       Hyrax::FixityStatusPresenter.new(id).render_file_set_status
     end
 
+    ##
+    # @return [WorkShowPresenter, nil] +nil+ if no parent can be found
     def parent
       @parent_presenter ||= fetch_parent_presenter
     end

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -102,6 +102,7 @@ module Hyrax
     def fetch_parent_presenter
       ids = Hyrax::SolrService.query("{!field f=member_ids_ssim}#{id}", fl: Hyrax.config.id_field)
                               .map { |x| x.fetch(Hyrax.config.id_field) }
+      Hyrax.logger.warn("Couldn't find a parent work for FileSet: #{id}.") if ids.empty?
       Hyrax::PresenterFactory.build_for(ids: ids,
                                         presenter_class: WorkShowPresenter,
                                         presenter_args: current_ability).first

--- a/app/services/hyrax/listeners/workflow_listener.rb
+++ b/app/services/hyrax/listeners/workflow_listener.rb
@@ -7,14 +7,17 @@ module Hyrax
     # manages workflow accordingly.
     class WorkflowListener
       ##
-      # @!attribute [r] factory
-      #   @return [#create]
-      attr_reader :factory
-
-      ##
-      # @param [#create] factory
-      def initialize(factory: ::Hyrax::Workflow::WorkflowFactory)
-        @factory = factory
+      # @note respects class attribute configuration at
+      #   {Hyrax::Actors::InitializeWorkflowActor.workflow_factory}, but falls
+      #   back on {Hyrax::Workflow::WorkflowFactory} to prepare for removal of
+      #   Actors
+      # @return [#create] default: {Hyrax::Workflow::WorkflowFactory}
+      def factory
+        if defined?(Hyrax::Actors::InitializeWorkflowActor)
+          Hyrax::Actors::InitializeWorkflowActor.workflow_factory
+        else
+          Hyrax::Workflow::WorkflowFactory
+        end
       end
 
       ##

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -7,7 +7,7 @@ Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleNotificationListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ProxyDepositListener.new)
-Hyrax.publisher.subscribe(Hyrax::Listeners::WorkflowListener.new(factory: Hyrax::Actors::InitializeWorkflowActor.workflow_factory))
+Hyrax.publisher.subscribe(Hyrax::Listeners::WorkflowListener.new)
 
 # Publish events from old style Hyrax::Callbacks to trigger the listeners
 # When callbacks are removed and replaced with direct event publication, drop these blocks


### PR DESCRIPTION
`FileSetPresenter` runs a special solr query to find a file set's parent. this
logic is failure prone in cases where the index is out of step. the controller
shouldn't depend on it being present.

it's probably not great that we are running this query at all. if the `FileSet` is a member of more than one thing, it's going to return a random one. all of this is a bit silly, since the `parent` is given in the path. but this at least avoids failing hard on an out-of-sync index.

still working on fixing the main issue in #4647

@samvera/hyrax-code-reviewers
