### PR TITLE
bump container environment to Ruby 2.7.2, by default; test 2.7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,21 +163,21 @@ workflows:
           hyrax_valkyrie: "true"
           requires:
             - build
-  ruby2-7-1:
+  ruby2-7-2:
     jobs:
       - bundle:
-          ruby_version: "2.7.1"
+          ruby_version: "2.7.2"
           rails_version: "5.2.4.3"
           bundler_version: "2.1.4"
       - build:
-          ruby_version: "2.7.1"
+          ruby_version: "2.7.2"
           rails_version: "5.2.4.3"
           bundler_version: "2.1.4"
           requires:
             - bundle
       - test:
-          name: "ruby2-7-1"
-          ruby_version: "2.7.1"
+          name: "ruby2-7-2"
+          ruby_version: "2.7.2"
           bundler_version: "2.1.4"
           requires:
             - build

--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.4', '>= 5.2.4.3'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=2.7.1
+ARG RUBY_VERSION=2.7.2
 FROM ruby:$RUBY_VERSION-alpine as hyrax-base
 
 ARG DATABASE_APK_PACKAGE="postgresql-dev"


### PR DESCRIPTION
getting on the latest 2.7.

i was hoping this might help diagnose #4674, but it worked perfectly for me, so i guess we have Ruby 2.7.2 now(?).

@samvera/hyrax-code-reviewers
