### PR TITLE
serialize and deserialize classes in Wings::ModelRegistry

### DIFF
--- a/lib/wings/model_registry.rb
+++ b/lib/wings/model_registry.rb
@@ -37,18 +37,19 @@ module Wings
     end
 
     def register(valkyrie, active_fedora)
-      @map[valkyrie] = active_fedora
+      @map[valkyrie.name] = active_fedora.name
     end
 
     def lookup(valkyrie)
       valkyrie = valkyrie._canonical_valkyrie_model if
         valkyrie.respond_to?(:_canonical_valkyrie_model)
 
-      @map.fetch(valkyrie) { ActiveFedoraConverter::DefaultWork(valkyrie) }
+      @map[valkyrie.name]&.safe_constantize ||
+        ActiveFedoraConverter::DefaultWork(valkyrie)
     end
 
     def reverse_lookup(active_fedora)
-      @map.rassoc(active_fedora)&.first
+      @map.rassoc(active_fedora.name)&.first&.safe_constantize
     end
   end
 end

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -415,7 +415,6 @@ RSpec.describe Wings::Valkyrie::Persister do
     # internal_resource="Wings::ActiveFedoraConverter::DefaultWork"
     # so the CustomResource defined above will not be persisted as such.
     it "can find that resource again" do
-      Wings::ModelRegistry.register(resource_class, Custom)
       id = persister.save(resource: resource).id
       item = query_service.find_by(id: id)
       expect(item).to be_kind_of resource_class


### PR DESCRIPTION
storing classes for later lookup isn't reliable in Rails development mode, maybe
we should get rid of a regsitry altogether(?) and do class resolution some other
way. for now, this helps ensure processes that reload constants can still find
classes in the registry.

fixes #4647.

@samvera/hyrax-code-reviewers
