### PR TITLE
loosen RDF::Vocab dependency

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -72,7 +72,7 @@ SUMMARY
   spec.add_dependency 'qa', '~> 5.5', '>= 5.5.1' # questioning_authority
   spec.add_dependency 'rails_autolink', '~> 1.1'
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
-  spec.add_dependency 'rdf-vocab', '< 3.1.5'
+  spec.add_dependency 'rdf-vocab', '~> 3.0'
   spec.add_dependency 'redis-namespace', '~> 1.5'
   spec.add_dependency 'redlock', '>= 0.1.2'
   spec.add_dependency 'reform', '~> 2.3'


### PR DESCRIPTION
ActiveFedora now manages the needed vocabulary terms itself.

@samvera/hyrax-code-reviewers
