### PR TITLE
replace complex controller/blacklight scope stubs with a Fake

### DIFF
--- a/app/search_builders/hyrax/filter_by_type.rb
+++ b/app/search_builders/hyrax/filter_by_type.rb
@@ -30,7 +30,9 @@ module Hyrax
     end
 
     def models_to_solr_clause
-      models.map { |model| model.try(:to_rdf_representation) || model.name }.join(',')
+      models.map do |model|
+        model.respond_to?(:to_rdf_representation) ? model.to_rdf_representation : model.name
+      end.join(',')
     end
 
     def generic_type_field

--- a/spec/factory_tests/collections_factory_spec.rb
+++ b/spec/factory_tests/collections_factory_spec.rb
@@ -98,11 +98,9 @@ RSpec.describe 'Collections Factory' do # rubocop:disable RSpec/DescribeClass
     end
 
     context 'with_nesting_attributes' do
-      let(:collection_type) { create(:collection_type) }
-      let(:blacklight_config) { CatalogController.blacklight_config }
-      let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
+      let(:collection_type) { FactoryBot.create(:collection_type) }
       let(:current_ability) { instance_double(Ability, admin?: true) }
-      let(:scope) { double('Scope', can?: true, current_ability: current_ability, repository: repository, blacklight_config: blacklight_config) }
+      let(:scope) { FakeSearchBuilderScope.new(current_ability: current_ability) }
       let(:solr_doc) { Hyrax::SolrService.get("id:#{col.id}")["response"]["docs"].first }
       let(:nesting_attributes) do
         Hyrax::Collections::NestedCollectionQueryService::NestingAttributes.new(id: col.id, scope: scope)

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -1,57 +1,44 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::CollectionSearchBuilder do
-  let(:scope) do
-    double(blacklight_config: CatalogController.blacklight_config,
-           current_ability: ability)
-  end
-  let(:user) { create(:user) }
-  let(:ability) { ::Ability.new(user) }
-  let(:builder) { described_class.new(scope).with_access(access) }
+  subject(:builder) { described_class.new(scope).with_access(access) }
+  let(:access) { :read }
+  let(:user) { FactoryBot.create(:user) }
+  let(:scope) { FakeSearchBuilderScope.new(current_user: user) }
 
   describe '#sort_field' do
-    let(:access) { :read }
-
-    subject { builder.sort_field }
-
-    it { is_expected.to eq('title_si') }
+    its(:sort_field) { is_expected.to eq('title_si') }
   end
 
   describe '#models' do
-    let(:access) { :read }
-
-    subject { builder.models }
-
-    it { is_expected.to eq([Collection]) }
+    its(:models) { is_expected.to eq([Collection]) }
   end
 
   describe '#discovery_permissions' do
-    subject { builder.discovery_permissions }
-
     context 'when access is read' do
       let(:access) { :read }
 
-      it { is_expected.to eq %w[edit read] }
+      its(:discovery_permissions) { is_expected.to eq %w[edit read] }
     end
 
     context 'when access is edit' do
       let(:access) { :edit }
 
-      it { is_expected.to eq %w[edit] }
+      its(:discovery_permissions) { is_expected.to eq %w[edit] }
     end
 
     context 'when access is deposit' do
       let(:access) { :deposit }
 
-      it { is_expected.to eq %w[deposit] }
+      its(:discovery_permissions) { is_expected.to eq %w[deposit] }
     end
   end
 
   describe '#gated_discovery_filters' do
-    subject { builder.gated_discovery_filters(access, ability) }
+    subject { builder.gated_discovery_filters(access, ::Ability.new(user)) }
 
     context 'when access is :deposit' do
       let(:access) { "deposit" }
-      let!(:collection) { create(:collection_lw, with_permission_template: attributes) }
+      let!(:collection) { FactoryBot.create(:collection_lw, with_permission_template: attributes) }
 
       context 'and user has access' do
         let(:attributes) { { deposit_users: [user.user_key] } }

--- a/spec/search_builders/hyrax/my/shares_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/shares_search_builder_spec.rb
@@ -1,33 +1,19 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::My::SharesSearchBuilder do
-  let(:me) { create(:user) }
-  let(:config) { CatalogController.blacklight_config }
-  let(:scope) do
-    double('The scope',
-           blacklight_config: config,
-           params: {},
-           current_ability: Ability.new(me),
-           current_user: me)
-  end
-  let(:builder) { described_class.new(scope) }
+  subject(:builder) { described_class.new(scope) }
+  let(:me) { FactoryBot.create(:user) }
+  let(:scope) { FakeSearchBuilderScope.new(current_user: me) }
 
   before do
-    allow(builder).to receive(:gated_discovery_filters).and_return(["access_filter1", "access_filter2"])
-
-    # This prevents any generated classes from interfering with this test:
-    allow(builder).to receive(:work_classes).and_return([GenericWork])
-
     allow(ActiveFedora::SolrQueryBuilder).to receive(:construct_query_for_rel)
       .with(depositor: me.user_key)
       .and_return("depositor")
   end
 
-  subject { builder.to_hash['fq'] }
-
   it "filters things we have access to in which we are not the depositor" do
-    expect(subject).to eq ["access_filter1 OR access_filter2",
-                           "{!terms f=has_model_ssim}GenericWork,Collection",
-                           "-suppressed_bsi:true",
-                           "-depositor"]
+    gated_access = builder.gated_discovery_filters.join(' OR ')
+
+    expect(builder.to_hash['fq'])
+      .to contain_exactly(gated_access, include('Collection'), "-suppressed_bsi:true", "-depositor")
   end
 end

--- a/spec/search_builders/hyrax/work_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/work_search_builder_spec.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::WorkSearchBuilder do
-  let(:me) { create(:user) }
-  let(:config) { CatalogController.blacklight_config }
-  let(:scope) do
-    double('The scope',
-           blacklight_config: config,
-           current_ability: Ability.new(me),
-           current_user: me)
-  end
+  let(:me) { FactoryBot.create(:user) }
+  let(:scope) { FakeSearchBuilderScope.new(current_user: me) }
   let(:builder) { described_class.new(scope).with(params) }
   let(:params) { { id: '123abc' } }
 

--- a/spec/services/hyrax/admin_set_member_service_spec.rb
+++ b/spec/services/hyrax/admin_set_member_service_spec.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::AdminSetMemberService, clean_repo: true do
-  let(:blacklight_config) { CatalogController.blacklight_config }
-  let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
+  subject(:builder) { described_class.new(scope: scope, collection: admin_set, params: { "id" => admin_set.id.to_s }) }
+  let(:admin_set) { FactoryBot.build(:admin_set) }
   let(:current_ability) { instance_double(Ability, admin?: true) }
-  let(:scope) { double('Scope', current_ability: current_ability, repository: repository, blacklight_config: blacklight_config) }
-
-  let(:admin_set) { build(:admin_set) }
-  let(:builder) { described_class.new(scope: scope, collection: admin_set, params: { "id" => admin_set.id.to_s }) }
-  let(:subject) { builder.available_member_works }
-  let(:ids) { subject.response[:docs].map { |col| col[:id] } }
+  let(:scope) { FakeSearchBuilderScope.new(current_ability: current_ability) }
 
   describe '#available_member_works' do
     let!(:work1) { create(:generic_work, admin_set: admin_set) }
@@ -16,6 +11,8 @@ RSpec.describe Hyrax::AdminSetMemberService, clean_repo: true do
     let!(:work3) { create(:generic_work, admin_set: admin_set) }
 
     it 'returns the members of the admin set' do
+      ids = builder.available_member_works.response[:docs].map { |col| col[:id] }
+
       expect(ids).to contain_exactly(work1.id, work3.id)
     end
   end

--- a/spec/services/hyrax/collections/collection_member_service_spec.rb
+++ b/spec/services/hyrax/collections/collection_member_service_spec.rb
@@ -1,50 +1,39 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Collections::CollectionMemberService, clean_repo: true do
-  let(:blacklight_config) { CatalogController.blacklight_config }
-  let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
-  let(:current_ability) { instance_double(Ability, admin?: true) }
-  let!(:nestable_collection) { create(:public_collection_lw, collection_type_settings: [:nestable]) }
-  let(:scope) { double('Scope', current_ability: current_ability, repository: repository, blacklight_config: blacklight_config, collection: nestable_collection) }
-  let!(:subcollection) { create(:public_collection_lw, member_of_collections: [nestable_collection], collection_type_settings: [:nestable]) }
-  let(:builder) { described_class.new(scope: scope, collection: nestable_collection, params: { "id" => nestable_collection.id.to_s }) }
+  subject(:builder) do
+    described_class.new(scope: scope, collection: nestable_collection, params: { "id" => nestable_collection.id.to_s })
+  end
 
+  let(:current_ability) { instance_double(Ability, admin?: true) }
+  let(:scope) { FakeSearchBuilderScope.new(current_ability: current_ability) }
+  let!(:subcollection) { create(:public_collection_lw, member_of_collections: [nestable_collection], collection_type_settings: [:nestable]) }
+
+  let!(:nestable_collection) { create(:public_collection_lw, collection_type_settings: [:nestable]) }
   let!(:work1) { create(:generic_work, member_of_collections: [nestable_collection]) }
   let!(:work2) { create(:generic_work) }
   let!(:work3) { create(:generic_work, member_of_collections: [nestable_collection]) }
 
   describe '#available_member_subcollections' do
-    let(:subject) { builder.available_member_subcollections }
-    let(:ids) { subject.response[:docs].map { |col| col[:id] } }
-
     it 'returns the members that are collections' do
-      expect(ids).to include(subcollection.id)
-      expect(ids).not_to include(work1.id)
-      expect(ids).not_to include(work3.id)
-      expect(ids).not_to include(work2.id)
+      ids = builder.available_member_subcollections.response[:docs].map { |col| col[:id] }
+
+      expect(ids).to contain_exactly(subcollection.id)
     end
   end
 
   describe '#available_member_works' do
-    let(:subject) { builder.available_member_works }
-    let(:ids) { subject.response[:docs].map { |col| col[:id] } }
-
     it 'returns the members that are collections' do
-      expect(ids).to include(work1.id)
-      expect(ids).to include(work3.id)
-      expect(ids).not_to include(work2.id)
-      expect(ids).not_to include(subcollection.id)
+      ids = builder.available_member_works.response[:docs].map { |col| col[:id] }
+
+      expect(ids).to contain_exactly(work1.id, work3.id)
     end
   end
 
   describe '#available_member_work_ids' do
-    let(:subject) { builder.available_member_work_ids }
-    let(:ids) { subject.response[:docs].map { |col| col[:id] } }
-
     it 'returns the members ids that are works' do
-      expect(ids).to include(work1.id)
-      expect(ids).to include(work3.id)
-      expect(ids).not_to include(work2.id)
-      expect(ids).not_to include(subcollection.id)
+      ids = builder.available_member_work_ids.response[:docs].map { |col| col[:id] }
+
+      expect(ids).to contain_exactly(work1.id, work3.id)
     end
   end
 end

--- a/spec/services/hyrax/collections/managed_collections_service_spec.rb
+++ b/spec/services/hyrax/collections/managed_collections_service_spec.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Collections::ManagedCollectionsService, clean_repo: true do
-  let(:blacklight_config) { CatalogController.blacklight_config }
-  let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
-
   let(:current_ability) { instance_double(Ability, admin?: true) }
-  let(:scope) { double('Scope', can?: true, current_ability: current_ability, repository: repository, blacklight_config: blacklight_config) }
+  let(:scope) { FakeSearchBuilderScope.new(current_ability: current_ability) }
 
   describe '.managed_collections_count' do
-    subject { described_class.managed_collections_count(scope: scope) }
-
-    let!(:collection) { create(:public_collection) }
+    let!(:collection) { FactoryBot.create(:public_collection) }
 
     it 'returns number of collections that can be managed' do
-      expect(subject).to eq(1)
+      expect(described_class.managed_collections_count(scope: scope)).to eq(1)
     end
   end
 end

--- a/spec/services/hyrax/works/managed_works_service_spec.rb
+++ b/spec/services/hyrax/works/managed_works_service_spec.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Works::ManagedWorksService, clean_repo: true do
-  let(:blacklight_config) { CatalogController.blacklight_config }
-  let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
-
   let(:current_ability) { instance_double(Ability, admin?: true) }
-  let(:scope) { double('Scope', params: {}, can?: true, current_ability: current_ability, repository: repository, blacklight_config: blacklight_config) }
+  let(:scope) { FakeSearchBuilderScope.new(current_ability: current_ability) }
 
   describe '.managed_works_count' do
-    subject { described_class.managed_works_count(scope: scope) }
-
-    let!(:work) { create(:public_work) }
+    let!(:work) { FactoryBot.create(:public_work) }
 
     it 'returns number of works that can be managed' do
-      expect(subject).to eq(1)
+      expect(described_class.managed_works_count(scope: scope)).to eq(1)
     end
   end
 end

--- a/spec/support/fakes/fake_search_builder_scope.rb
+++ b/spec/support/fakes/fake_search_builder_scope.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+##
+# +Blacklight::SearchBuilder+ requires a 'scope' object, which its documentation
+# describes as "the scope where the filter methods reside in."
+#
+# Often (usually?) this is a Controller with:
+#   - +#blacklight_config+
+#   - +#current_ability+
+#   - +#current_user+
+#   - +#params+
+#   - +#repository+
+#
+# This provides a fake scope with more control than a generic RSpec double.
+class FakeSearchBuilderScope
+  ##
+  # @!attribute [r] blacklight_config
+  #   @return [Blacklight::Configuration]
+  # @!attribute [r] current_ability
+  #   @return [::Ability]
+  # @!attribute [r] current_user
+  #   @return [::User, nil]
+  # @!attribute [r] params
+  #   @return [Hash]
+  # @!attribute [r] repository
+  #   @return [Blacklight::AbstractRepository]
+  attr_reader :blacklight_config, :current_ability, :current_user, :params, :repository
+
+  ##
+  # @param [Blacklight::Configuration] blacklight_config
+  # @param [::Ability, nil] current_ability
+  # @param [::User, nil] current_user
+  def initialize(blacklight_config: CatalogController.blacklight_config, current_ability: nil, current_user: nil)
+    @blacklight_config = blacklight_config
+    @current_user = current_user
+    @current_ability = current_ability || ::Ability.new(current_user)
+    @params = {} # all existing tests explitly pass in an empty hash, real controller params are used in practice?
+    @repository = Blacklight::Solr::Repository.new(blacklight_config)
+  end
+end


### PR DESCRIPTION
using a 'fake' here instead of stubs targets tests on the direct
collaborator. we can have a realistic implementation of the
Blacklight::SearchBuilder's `scope` collaborator, and avoid complex and repeated
setup.

@samvera/hyrax-code-reviewers
