### PR TITLE
bootstrap mixin level ability tests

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -114,6 +114,9 @@ module Hyrax
     # Add this to your {.ability_logic} if you want all logged in users to be able
     # to submit content.
     #
+    # @note this is normally injected into an application +::Ability+ by the
+    #   hyrax install generator.
+    #
     # @example
     #   self.ability_logic += [:everyone_can_create_curation_concerns]
     def everyone_can_create_curation_concerns

--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 module Hyrax
+  ##
+  # Provides Hyrax's engine level user/group permissions.
+  #
+  # @note This is intended as a mixin layered over
+  # +Blacklight::AccessControls::Ability+ and +Hydra::AccessControls+. Its
+  # implementation may depend in part on behavioral details of either of those
+  # two mixins. As of Hyrax 3.0.0 there's an ongoing effort to clarify and
+  # document the specific dependencies.
+  #
+  # @example creating an application Ability
+  #
+  # # app/models/ability.rb
+  # class Ability
+  #   include Hydra::Ability
+  #   include Hyrax::Ability
+  # end
+  #
+  # @see https://www.rubydoc.info/github/CanCanCommunity/cancancan
+  # @see https://www.rubydoc.info/gems/blacklight-access_controls/
   module Ability
     extend ActiveSupport::Concern
 

--- a/spec/models/concerns/hyrax/ability_spec.rb
+++ b/spec/models/concerns/hyrax/ability_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'cancan/matchers'
+
+RSpec.describe Hyrax::Ability do
+  subject(:ability) { ability_class.new(user) }
+  let(:user) { FactoryBot.create(:user) }
+
+  shared_context 'with guest user' do
+    let(:user) { FactoryBot.create(:user, :guest) }
+  end
+
+  shared_context 'with deposit access on an admin set' do
+    let(:permission_template) { FactoryBot.create(:permission_template, with_admin_set: true) }
+
+    before do
+      FactoryBot.create(:permission_template_access,
+                        :deposit,
+                        permission_template: permission_template,
+                        agent_type: 'user',
+                        agent_id: user.user_key)
+    end
+  end
+
+  shared_context 'with create access on a work type' do
+    let(:work_model) { Monograph }
+
+    before { ability.can(:create, work_model) }
+  end
+
+  let(:ability_class) do
+    module Hyrax
+      module Test
+        module AbilityMixin
+          class Ability
+            include Blacklight::AccessControls::Ability
+            include Hyrax::Ability
+          end
+        end
+      end
+    end
+  end
+
+  after { Hyrax::Test.send(:remove_const, :AbilityMixin) }
+
+  describe '#can_create_any_work?' do
+    its(:can_create_any_work?) { is_expected.to be false }
+
+    context 'when user can deposit to an admin set' do
+      include_context 'with deposit access on an admin set'
+
+      its(:can_create_any_work?) { is_expected.to be false }
+
+      context 'and user can create a work type' do
+        include_context 'with create access on a work type'
+
+        its(:can_create_any_work?) { is_expected.to be true }
+      end
+    end
+  end
+
+  describe '#registered_user?' do
+    context 'with a guest user' do
+      include_context 'with guest user'
+
+      its(:registered_user?) { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
historically we've tested `Hyrax::Ability` only in the context of the generated
application `Ability`. this makes isolating dependencies very hard, which
results in a less clear interface. as we move toward supporting `Valkyrie` here,
we need to get some real unit level tests in place.

@samvera/hyrax-code-reviewers
