### PR TITLE
refactor collection type permissions service spec

### DIFF
--- a/spec/services/hyrax/collection_types/permissions_service_spec.rb
+++ b/spec/services/hyrax/collection_types/permissions_service_spec.rb
@@ -1,36 +1,39 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::CollectionTypes::PermissionsService do
-  let(:user_cg) { create(:user, groups: 'create_group') }
-  let(:user_mg) { create(:user, groups: 'manage_group') }
-  let(:user_cu) { create(:user) }
-  let(:user_mu) { create(:user) }
-  let(:user_other) { create(:user) }
-  let(:user_admin) { create(:user, groups: 'admin') }
+  let(:user_cg) { FactoryBot.create(:user, groups: 'create_group') }
+  let(:user_mg) { FactoryBot.create(:user, groups: 'manage_group') }
+  let(:user_cu) { FactoryBot.create(:user) }
+  let(:user_mu) { FactoryBot.create(:user) }
+  let!(:user_collection_type) { FactoryBot.create(:user_collection_type) }
+  let!(:admin_set_collection_type) { FactoryBot.create(:admin_set_collection_type) }
 
-  let!(:user_collection_type) { create(:user_collection_type) }
-  let!(:admin_set_collection_type) { create(:admin_set_collection_type) }
-  let!(:collection_type) { create(:collection_type, creator_user: user_cu, creator_group: 'create_group', manager_user: user_mu, manager_group: 'manage_group') }
+  let!(:collection_type) do
+    FactoryBot.create(:collection_type,
+                      creator_user: user_cu,
+                      creator_group: 'create_group',
+                      manager_user: user_mu,
+                      manager_group: 'manage_group')
+  end
 
   describe '.collection_types_for_user' do # Also tests .collection_type_ids_for_user which is called by .collection_types_for_user
-    let!(:ability) { ::Ability.new(user) }
-
-    before { allow(ability).to receive(:current_user).and_return(user) }
-
-    subject { described_class.collection_types_for_user(user: user, roles: access).map(&:id) }
-
     context 'when user is a create user' do
       let(:user) { user_cu }
 
       context 'and create access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::CREATE_ACCESS }
+        it 'gives the collection types the user has create access for' do
+          access = Hyrax::CollectionTypeParticipant::CREATE_ACCESS
 
-        it { is_expected.to match_array [collection_type.id, user_collection_type.id] }
+          expect(described_class.collection_types_for_user(user: user, roles: access))
+            .to contain_exactly(collection_type, user_collection_type)
+        end
       end
 
       context 'and manage access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::MANAGE_ACCESS }
+        it 'is empty' do
+          access = Hyrax::CollectionTypeParticipant::MANAGE_ACCESS
 
-        it { is_expected.to match_array [] }
+          expect(described_class.collection_types_for_user(user: user, roles: access)).to be_empty
+        end
       end
     end
 
@@ -38,15 +41,20 @@ RSpec.describe Hyrax::CollectionTypes::PermissionsService do
       let(:user) { user_cg }
 
       context 'and create access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::CREATE_ACCESS }
+        it 'gives the collection types the user has create access for' do
+          access = Hyrax::CollectionTypeParticipant::CREATE_ACCESS
 
-        it { is_expected.to match_array [collection_type.id, user_collection_type.id] }
+          expect(described_class.collection_types_for_user(user: user, roles: access))
+            .to contain_exactly(collection_type, user_collection_type)
+        end
       end
 
       context 'and manage access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::MANAGE_ACCESS }
+        it 'is empty' do
+          access = Hyrax::CollectionTypeParticipant::MANAGE_ACCESS
 
-        it { is_expected.to match_array [] }
+          expect(described_class.collection_types_for_user(user: user, roles: access)).to be_empty
+        end
       end
     end
 
@@ -54,15 +62,21 @@ RSpec.describe Hyrax::CollectionTypes::PermissionsService do
       let(:user) { user_mu }
 
       context 'and create access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::CREATE_ACCESS }
+        it 'gives the collection types the user has create access for' do
+          access = Hyrax::CollectionTypeParticipant::CREATE_ACCESS
 
-        it { is_expected.to match_array [user_collection_type.id] }
+          expect(described_class.collection_types_for_user(user: user, roles: access))
+            .to contain_exactly(user_collection_type)
+        end
       end
 
       context 'and manage access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::MANAGE_ACCESS }
+        it 'gives the collection types the user has manage access for' do
+          access = Hyrax::CollectionTypeParticipant::MANAGE_ACCESS
 
-        it { is_expected.to match_array [collection_type.id] }
+          expect(described_class.collection_types_for_user(user: user, roles: access))
+            .to contain_exactly(collection_type)
+        end
       end
     end
 
@@ -70,229 +84,212 @@ RSpec.describe Hyrax::CollectionTypes::PermissionsService do
       let(:user) { user_mg }
 
       context 'and create access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::CREATE_ACCESS }
+        it 'gives the collection types the user has create access for' do
+          access = Hyrax::CollectionTypeParticipant::CREATE_ACCESS
 
-        it { is_expected.to match_array [user_collection_type.id] }
+          expect(described_class.collection_types_for_user(user: user, roles: access))
+            .to contain_exactly(user_collection_type)
+        end
       end
 
       context 'and manage access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::MANAGE_ACCESS }
+        it 'gives the collection types the user has manage access for' do
+          access = Hyrax::CollectionTypeParticipant::MANAGE_ACCESS
 
-        it { is_expected.to match_array [collection_type.id] }
+          expect(described_class.collection_types_for_user(user: user, roles: access))
+            .to contain_exactly(collection_type)
+        end
       end
     end
 
     context 'when user is an admin' do
-      let(:user) { user_admin }
+      let(:user) { FactoryBot.create(:user, groups: 'admin') }
 
       context 'and create access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::CREATE_ACCESS }
+        it 'gives all collection types' do
+          access = Hyrax::CollectionTypeParticipant::CREATE_ACCESS
 
-        it { is_expected.to match_array [collection_type.id, user_collection_type.id, admin_set_collection_type.id] }
+          expect(described_class.collection_types_for_user(user: user, roles: access))
+            .to contain_exactly(collection_type, user_collection_type, admin_set_collection_type)
+        end
       end
 
       context 'and manage access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::MANAGE_ACCESS }
+        it 'gives all collection types' do
+          access = Hyrax::CollectionTypeParticipant::MANAGE_ACCESS
 
-        it { is_expected.to match_array [collection_type.id, user_collection_type.id, admin_set_collection_type.id] }
+          expect(described_class.collection_types_for_user(user: user, roles: access))
+            .to contain_exactly(collection_type, user_collection_type, admin_set_collection_type)
+        end
       end
     end
 
     context 'when user with no access' do
-      let(:user) { user_other }
+      let(:user) { FactoryBot.create(:user) }
 
       context 'and create access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::CREATE_ACCESS }
+        it 'still grants access to the user collection types (user can create "user collections")' do
+          access = Hyrax::CollectionTypeParticipant::CREATE_ACCESS
 
-        it { is_expected.to match_array [user_collection_type.id] }
+          expect(described_class.collection_types_for_user(user: user, roles: access))
+            .to contain_exactly(user_collection_type)
+        end
       end
 
       context 'and manage access is queried' do
-        let(:access) { Hyrax::CollectionTypeParticipant::MANAGE_ACCESS }
+        it 'is empty' do
+          access = Hyrax::CollectionTypeParticipant::MANAGE_ACCESS
 
-        it { is_expected.to match_array [] }
+          expect(described_class.collection_types_for_user(user: user, roles: access)).to be_empty
+        end
       end
     end
   end
 
   describe '.can_create_any_collection_type?' do
-    let!(:ability) { ::Ability.new(user) }
-
-    before do
-      allow(ability).to receive(:current_user).and_return(user)
-    end
-
-    subject { described_class.can_create_any_collection_type?(user: user) }
-
     context 'when user is a create user' do
       let(:user) { user_cu }
 
-      it { is_expected.to be true }
+      it 'can create collection types' do
+        expect(described_class.can_create_any_collection_type?(user: user)).to be true
+      end
     end
 
     context 'when user is in create group' do
       let(:user) { user_cg }
 
-      it { is_expected.to be true }
+      it 'can create collection types' do
+        expect(described_class.can_create_any_collection_type?(user: user)).to be true
+      end
     end
 
     context 'when user is a manage user' do
       let(:user) { user_mu }
 
-      it { is_expected.to be true }
+      it 'can create collection types' do
+        expect(described_class.can_create_any_collection_type?(user: user)).to be true
+      end
     end
 
     context 'when user is in manage group' do
       let(:user) { user_mg }
 
-      it { is_expected.to be true }
+      it 'can create collection types' do
+        expect(described_class.can_create_any_collection_type?(user: user)).to be true
+      end
     end
 
     context 'when user is an admin' do
-      let(:user) { user_admin }
+      let(:user) { FactoryBot.create(:user, groups: 'admin') }
 
-      it { is_expected.to be true }
+      it 'can create collection types' do
+        expect(described_class.can_create_any_collection_type?(user: user)).to be true
+      end
     end
 
     context 'when user with no access' do
-      let(:user) { user_other }
+      let(:user) { FactoryBot.create(:user) }
 
-      # TODO: Fails for now becauser User Collection type is always created and it allows every logged in user to create one.
-      # Would require additional work to remove or change the User Collection participants so there are 0 collection types the
-      # user can create.
-      xit { is_expected.to be false }
+      it 'can create collection types' do
+        expect(described_class.can_create_any_collection_type?(user: user)).to be true
+      end
     end
   end
 
   describe '.can_create_admin_set?' do
-    let!(:ability) { ::Ability.new(user) }
-
-    before { allow(ability).to receive(:current_user).and_return(user) }
-
-    subject { described_class.can_create_admin_set_collection_type?(user: user) }
-
-    context 'when user is a create user' do
-      let(:user) { user_cu }
-
-      it { is_expected.to be false }
+    it 'create user cannot create admin sets' do
+      expect(described_class.can_create_admin_set_collection_type?(user: user_cu)).to be false
     end
 
-    context 'when user is in create group' do
-      let(:user) { user_cg }
-
-      it { is_expected.to be false }
+    it 'user in create group cannot create admin sets' do
+      expect(described_class.can_create_admin_set_collection_type?(user: user_cg)).to be false
     end
 
-    context 'when user is a manage user' do
-      let(:user) { user_mu }
-
-      it { is_expected.to be false }
+    it 'manage user cannot create admin sets' do
+      expect(described_class.can_create_admin_set_collection_type?(user: user_mu)).to be false
     end
 
-    context 'when user is in manage group' do
-      let(:user) { user_mg }
-
-      it { is_expected.to be false }
+    it 'user in manage group in cannot create admin sets' do
+      expect(described_class.can_create_admin_set_collection_type?(user: user_mg)).to be false
     end
 
-    context 'when user is an admin' do
-      let(:user) { user_admin }
-
-      it { is_expected.to be true }
+    it 'admin user can create admin sets' do
+      user = FactoryBot.create(:user, groups: 'admin')
+      expect(described_class.can_create_admin_set_collection_type?(user: user)).to be true
     end
 
-    context 'when user with no access' do
-      let(:user) { user_other }
-
-      it { is_expected.to be false }
+    it 'new user cannot create admin sets' do
+      user = FactoryBot.create(:user)
+      expect(described_class.can_create_admin_set_collection_type?(user: user)).to be false
     end
   end
 
   describe '.can_create_collection_types' do
-    let!(:ability) { ::Ability.new(user) }
-
-    before { allow(ability).to receive(:current_user).and_return(user) }
-
-    subject { described_class.can_create_collection_types(user: user).map(&:id) }
-
-    context 'when user is a create user' do
-      let(:user) { user_cu }
-
-      it { is_expected.to match_array [collection_type.id, user_collection_type.id] }
+    it 'lists collection types user can create collections for' do
+      expect(described_class.can_create_collection_types(user: user_cu))
+        .to contain_exactly(collection_type, user_collection_type)
     end
 
-    context 'when user is in create group' do
-      let(:user) { user_cg }
-
-      it { is_expected.to match_array [collection_type.id, user_collection_type.id] }
+    it 'lists collection types user groups can create collections for' do
+      expect(described_class.can_create_collection_types(user: user_cg))
+        .to contain_exactly(collection_type, user_collection_type)
     end
 
-    context 'when user is a manage user' do
-      let(:user) { user_mu }
-
-      it { is_expected.to match_array [collection_type.id, user_collection_type.id] }
+    it 'includes collection types user can manage' do
+      expect(described_class.can_create_collection_types(user: user_mu))
+        .to contain_exactly(collection_type, user_collection_type)
     end
 
-    context 'when user is in manage group' do
-      let(:user) { user_mg }
-
-      it { is_expected.to match_array [collection_type.id, user_collection_type.id] }
+    it 'includes collection types user groups can manage' do
+      expect(described_class.can_create_collection_types(user: user_mg))
+        .to contain_exactly(collection_type, user_collection_type)
     end
 
-    context 'when user is an admin' do
-      let(:user) { user_admin }
+    it 'includes all collection types for admin user' do
+      admin = FactoryBot.create(:user, groups: 'admin')
 
-      it { is_expected.to match_array [collection_type.id, user_collection_type.id, admin_set_collection_type.id] }
+      expect(described_class.can_create_collection_types(user: admin))
+        .to contain_exactly(collection_type, user_collection_type, admin_set_collection_type)
     end
 
-    context 'when user with no access' do
-      let(:user) { user_other }
-
-      it { is_expected.to match_array [user_collection_type.id] }
+    it 'includes only user collection type for new user' do
+      user = FactoryBot.create(:user)
+      expect(described_class.can_create_collection_types(user: user))
+        .to contain_exactly(user_collection_type)
     end
   end
 
   describe '.user_edit_grants_for_collection_of_type' do
-    subject { described_class.user_edit_grants_for_collection_of_type(collection_type: coltype) }
-
-    context 'for user collection type' do
-      let(:coltype) { user_collection_type }
-
-      it { is_expected.to match_array [] }
+    it 'is empty for user collection type' do
+      expect(described_class.user_edit_grants_for_collection_of_type(collection_type: user_collection_type))
+        .to be_empty
     end
 
-    context 'for admin set collection type' do
-      let(:coltype) { admin_set_collection_type }
-
-      it { is_expected.to match_array [] }
+    it 'is empty for admin set collection type' do
+      expect(described_class.user_edit_grants_for_collection_of_type(collection_type: admin_set_collection_type))
+        .to be_empty
     end
 
-    context 'for collection type' do
-      let(:coltype) { collection_type }
-
-      it { is_expected.to match_array [user_mu.user_key] }
+    it 'gives configured manage users' do
+      expect(described_class.user_edit_grants_for_collection_of_type(collection_type: collection_type))
+        .to contain_exactly(user_mu.user_key)
     end
   end
 
   describe '.group_edit_grants_for_collection_of_type' do
-    subject { described_class.group_edit_grants_for_collection_of_type(collection_type: coltype) }
-
-    context 'for user collection type' do
-      let(:coltype) { user_collection_type }
-
-      it { is_expected.to match_array ['admin'] }
+    it 'user collection type grants edit to admin group' do
+      expect(described_class.group_edit_grants_for_collection_of_type(collection_type: user_collection_type))
+        .to contain_exactly('admin')
     end
 
-    context 'for admin set collection type' do
-      let(:coltype) { admin_set_collection_type }
-
-      it { is_expected.to match_array ['admin'] }
+    it 'admin set type grants edit to admin group' do
+      expect(described_class.group_edit_grants_for_collection_of_type(collection_type: admin_set_collection_type))
+        .to contain_exactly('admin')
     end
 
-    context 'for collection type' do
-      let(:coltype) { collection_type }
-
-      it { is_expected.to match_array ['manage_group', 'admin'] }
+    it 'grants edit to provided manage and admin groups' do
+      expect(described_class.group_edit_grants_for_collection_of_type(collection_type: collection_type))
+        .to contain_exactly('manage_group', 'admin')
     end
   end
 end

--- a/spec/services/hyrax/collections/permissions_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_service_spec.rb
@@ -1,18 +1,16 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Collections::PermissionsService do
-  let(:user) { create(:user, email: 'user@example.com') }
-
+  let(:user) { FactoryBot.create(:user) }
   let(:ability) { Ability.new(user) }
 
   context 'collection specific methods' do
-    let(:collection) { build(:collection_lw, id: 'collection_1') }
-    let(:admin_set) { build(:admin_set, id: 'adminset_1') }
-    let(:col_permission_template) { create(:permission_template, source_id: collection.id) }
-    let(:as_permission_template) { create(:permission_template, source_id: admin_set.id) }
+    let(:collection) { FactoryBot.build(:collection_lw, id: 'collection_1') }
+    let(:admin_set) { FactoryBot.build(:admin_set, id: 'adminset_1') }
+    let(:col_permission_template) { FactoryBot.create(:permission_template, source_id: collection.id) }
+    let(:as_permission_template) { FactoryBot.create(:permission_template, source_id: admin_set.id) }
 
     before do
       allow(Hyrax::PermissionTemplate).to receive(:find_by!).with(source_id: collection.id).and_return(col_permission_template)
-      allow(ability).to receive(:user_groups).and_return(['public', 'registered'])
     end
 
     context 'when manage user' do
@@ -25,13 +23,12 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
       end
 
-      subject { described_class }
-
       it '.can_deposit_in_collection? returns true' do
-        expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
+        expect(described_class.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
       end
+
       it '.can_view_admin_show_for_collection? returns true' do
-        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
+        expect(described_class.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
       end
     end
 
@@ -45,13 +42,12 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
       end
 
-      subject { described_class }
-
       it '.can_deposit_in_collection? returns true' do
-        expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
+        expect(described_class.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
       end
+
       it '.can_view_admin_show_for_collection? returns true' do
-        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
+        expect(described_class.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
       end
     end
 
@@ -65,18 +61,17 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
       end
 
-      subject { described_class }
-
       it '.can_deposit_in_collection? returns false' do
-        expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
+        expect(described_class.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
       end
+
       it '.can_view_admin_show_for_collection? returns true' do
-        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
+        expect(described_class.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
       end
     end
 
     context 'when deposit user' do
-      context 'thru membership in public group' do
+      context 'through membership in public group' do
         before do
           allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
           allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
@@ -96,7 +91,7 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         end
       end
 
-      context 'thru membership in registered group' do
+      context 'through membership in registered group' do
         before do
           allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
           allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
@@ -106,19 +101,18 @@ RSpec.describe Hyrax::Collections::PermissionsService do
           allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return([])
         end
 
-        subject { described_class }
-
         it '.can_deposit_in_collection? returns true' do
-          expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
+          expect(described_class.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
         end
+
         it '.can_view_admin_show_for_collection? returns false' do
-          expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+          expect(described_class.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
         end
       end
     end
 
     context 'when view user' do
-      context 'thru membership in public group' do
+      context 'through membership in public group' do
         before do
           allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
           allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
@@ -128,17 +122,15 @@ RSpec.describe Hyrax::Collections::PermissionsService do
           allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return(['public'])
         end
 
-        subject { described_class }
-
         it '.can_deposit_in_collection? returns false' do
-          expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
+          expect(described_class.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
         end
         it '.can_view_admin_show_for_collection? returns false' do
-          expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+          expect(described_class.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
         end
       end
 
-      context 'thru membership in registered group' do
+      context 'through membership in registered group' do
         before do
           allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'manage').and_return([])
           allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'user', access: 'deposit').and_return([])
@@ -148,64 +140,62 @@ RSpec.describe Hyrax::Collections::PermissionsService do
           allow(col_permission_template).to receive(:agent_ids_for).with(agent_type: 'group', access: 'view').and_return(['registered'])
         end
 
-        subject { described_class }
-
         it '.can_deposit_in_collection? returns false' do
-          expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
+          expect(described_class.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
         end
+
         it '.can_view_admin_show_for_collection? returns false' do
-          expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+          expect(described_class.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
         end
       end
     end
 
     context 'when user without access' do
-      subject { described_class }
-
       it '.can_deposit_in_collection? returns false' do
-        expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
+        expect(described_class.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
       end
+
       it '.can_view_admin_show_for_collection? returns false' do
-        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+        expect(described_class.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
       end
     end
   end
 
   context 'methods returning ids' do
-    let(:user1) { create(:user, email: 'user1@example.com') }
-    let(:user2) { create(:user, email: 'user2@example.com') }
+    let(:user1) { FactoryBot.create(:user) }
+    let(:user2) { FactoryBot.create(:user) }
 
     let!(:col_vu) do
-      build(:collection_lw, id: 'collection_vu', user: user1, with_solr_document: true,
-                            with_permission_template: { view_users: [user] })
+      FactoryBot.build(:collection_lw, id: 'collection_vu', user: user1, with_solr_document: true,
+                                       with_permission_template: { view_users: [user] })
     end
     let!(:col_vg) do
-      build(:collection_lw, id: 'collection_vg', user: user1, with_solr_document: true,
-                            with_permission_template: { view_groups: ['view_group'] })
+      FactoryBot.build(:collection_lw, id: 'collection_vg', user: user1, with_solr_document: true,
+                                       with_permission_template: { view_groups: ['view_group'] })
     end
     let!(:col_mu) do
-      build(:collection_lw, id: 'collection_mu', user: user1, with_solr_document: true,
-                            with_permission_template: { manage_users: [user] })
+      FactoryBot.build(:collection_lw, id: 'collection_mu', user: user1, with_solr_document: true,
+                                       with_permission_template: { manage_users: [user] })
     end
     let!(:col_mg) do
-      build(:collection_lw, id: 'collection_mg', user: user1, with_solr_document: true,
-                            with_permission_template: { manage_groups: ['manage_group'] })
+      FactoryBot.build(:collection_lw, id: 'collection_mg', user: user1, with_solr_document: true,
+                                       with_permission_template: { manage_groups: ['manage_group'] })
     end
     let!(:col_du) do
-      build(:collection_lw, id: 'collection_du', user: user1, with_solr_document: true,
-                            with_permission_template: { deposit_users: [user] })
+      FactoryBot.build(:collection_lw, id: 'collection_du', user: user1, with_solr_document: true,
+                                       with_permission_template: { deposit_users: [user] })
     end
     let!(:col_dg) do
-      build(:collection_lw, id: 'collection_dg', user: user1, with_solr_document: true,
-                            with_permission_template: { deposit_groups: ['deposit_group'] })
+      FactoryBot.build(:collection_lw, id: 'collection_dg', user: user1, with_solr_document: true,
+                                       with_permission_template: { deposit_groups: ['deposit_group'] })
     end
 
-    let(:as_vu) { create(:admin_set, id: 'adminset_vu', with_permission_template: true) }
-    let(:as_vg) { create(:admin_set, id: 'adminset_vg', with_permission_template: true) }
-    let(:as_mu) { create(:admin_set, id: 'adminset_mu', with_permission_template: true) }
-    let(:as_mg) { create(:admin_set, id: 'adminset_mg', with_permission_template: true) }
-    let(:as_du) { create(:admin_set, id: 'adminset_du', with_permission_template: true) }
-    let(:as_dg) { create(:admin_set, id: 'adminset_dg', with_permission_template: true) }
+    let(:as_vu) { FactoryBot.create(:admin_set, id: 'adminset_vu', with_permission_template: true) }
+    let(:as_vg) { FactoryBot.create(:admin_set, id: 'adminset_vg', with_permission_template: true) }
+    let(:as_mu) { FactoryBot.create(:admin_set, id: 'adminset_mu', with_permission_template: true) }
+    let(:as_mg) { FactoryBot.create(:admin_set, id: 'adminset_mg', with_permission_template: true) }
+    let(:as_du) { FactoryBot.create(:admin_set, id: 'adminset_du', with_permission_template: true) }
+    let(:as_dg) { FactoryBot.create(:admin_set, id: 'adminset_dg', with_permission_template: true) }
 
     before do
       source_access(as_vu.permission_template, 'user', user.user_key, :view)
@@ -222,23 +212,23 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       it 'returns collection ids where user has manage access' do
         expect(described_class.collection_ids_for_user(access: 'manage', ability: ability)).to match_array [col_mu.id, col_mg.id]
       end
+
       it 'returns collection ids where user has deposit access' do
         expect(described_class.collection_ids_for_user(access: 'deposit', ability: ability)).to match_array [col_du.id, col_dg.id]
       end
+
       it 'returns collection ids where user has view access' do
         expect(described_class.collection_ids_for_user(access: 'view', ability: ability)).to match_array [col_vu.id, col_vg.id]
       end
+
       it 'returns collection ids where user has manage, deposit, or view access' do
         all = [col_mu.id, col_mg.id, col_du.id, col_dg.id, col_vu.id, col_vg.id]
         expect(described_class.collection_ids_for_user(access: ['manage', 'deposit', 'view'], ability: ability)).to match_array all
       end
 
-      context 'when user has no access' do
-        let(:ability) { Ability.new(user2) }
-
-        it 'returns empty array' do
-          expect(described_class.collection_ids_for_user(access: ['manage', 'deposit', 'view'], ability: ability)).to match_array []
-        end
+      it 'returns empty arraywhen user has no access' do
+        expect(described_class.collection_ids_for_user(access: ['manage', 'deposit', 'view'], ability: Ability.new(user2)))
+          .to be_empty
       end
     end
 
@@ -246,18 +236,18 @@ RSpec.describe Hyrax::Collections::PermissionsService do
       it 'returns collection and admin set ids where user has manage access' do
         expect(described_class.source_ids_for_manage(ability: ability)).to match_array [col_mu.id, col_mg.id, as_mu.id, as_mg.id]
       end
+
       it 'returns collection ids where user has manage access' do
         expect(described_class.source_ids_for_manage(ability: ability, source_type: 'collection')).to match_array [col_mu.id, col_mg.id]
       end
+
       it 'returns admin set ids where user has manage access' do
         expect(described_class.source_ids_for_manage(ability: ability, source_type: 'admin_set')).to match_array [as_mu.id, as_mg.id]
       end
 
       context 'when user has no access' do
-        let(:ability) { Ability.new(user2) }
-
         it 'returns empty array' do
-          expect(described_class.source_ids_for_manage(ability: ability)).to match_array []
+          expect(described_class.source_ids_for_manage(ability: Ability.new(user2))).to be_empty
         end
       end
     end
@@ -277,12 +267,8 @@ RSpec.describe Hyrax::Collections::PermissionsService do
           .to match_array [as_du.id, as_mu.id, as_mg.id]
       end
 
-      context 'when user has no access' do
-        let(:ability) { Ability.new(user2) }
-
-        it 'returns empty array' do
-          expect(described_class.source_ids_for_deposit(ability: ability)).to match_array []
-        end
+      it 'returns empty array when user has no access' do
+        expect(described_class.source_ids_for_deposit(ability: Ability.new(user2))).to be_empty
       end
     end
 
@@ -291,12 +277,8 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         expect(described_class.collection_ids_for_deposit(ability: ability)).to match_array [col_du.id, col_dg.id, col_mu.id, col_mg.id]
       end
 
-      context 'when user has no access' do
-        let(:ability) { Ability.new(user2) }
-
-        it 'returns empty array' do
-          expect(described_class.collection_ids_for_deposit(ability: ability)).to match_array []
-        end
+      it 'returns empty array' do
+        expect(described_class.collection_ids_for_deposit(ability: Ability.new(user2))).to be_empty
       end
     end
 
@@ -305,12 +287,8 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         expect(described_class.collection_ids_for_view(ability: ability)).to match_array [col_du.id, col_dg.id, col_mu.id, col_mg.id, col_vu.id, col_vg.id]
       end
 
-      context 'when user has no access' do
-        let(:ability) { Ability.new(user2) }
-
-        it 'returns empty array' do
-          expect(described_class.collection_ids_for_view(ability: ability)).to match_array []
-        end
+      it 'returns empty array when user has no access' do
+        expect(described_class.collection_ids_for_view(ability: Ability.new(user2))).to be_empty
       end
     end
 
@@ -319,12 +297,8 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         expect(described_class.can_manage_any_collection?(ability: ability)).to be true
       end
 
-      context 'when user has no access' do
-        let(:ability) { Ability.new(user2) }
-
-        it 'returns false' do
-          expect(described_class.can_manage_any_collection?(ability: ability)).to be false
-        end
+      it 'returns false when user has no access' do
+        expect(described_class.can_manage_any_collection?(ability: Ability.new(user2))).to be false
       end
     end
 
@@ -333,12 +307,8 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         expect(described_class.can_manage_any_admin_set?(ability: ability)).to be true
       end
 
-      context 'when user has no access' do
-        let(:ability) { Ability.new(user2) }
-
-        it 'returns false' do
-          expect(described_class.can_manage_any_admin_set?(ability: ability)).to be false
-        end
+      it 'returns false when user has no access' do
+        expect(described_class.can_manage_any_admin_set?(ability: Ability.new(user2))).to be false
       end
     end
 
@@ -347,12 +317,8 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         expect(described_class.can_view_admin_show_for_any_collection?(ability: ability)).to be true
       end
 
-      context 'when user has no access' do
-        let(:ability) { Ability.new(user2) }
-
-        it 'returns false' do
-          expect(described_class.can_view_admin_show_for_any_collection?(ability: ability)).to be false
-        end
+      it 'returns false when user has no access' do
+        expect(described_class.can_view_admin_show_for_any_collection?(ability: Ability.new(user2))).to be false
       end
     end
 
@@ -361,21 +327,17 @@ RSpec.describe Hyrax::Collections::PermissionsService do
         expect(described_class.can_view_admin_show_for_any_admin_set?(ability: ability)).to be true
       end
 
-      context 'when user has no access' do
-        let(:ability) { Ability.new(user2) }
-
-        it 'returns false' do
-          expect(described_class.can_view_admin_show_for_any_admin_set?(ability: ability)).to be false
-        end
+      it 'returns false when user has no access' do
+        expect(described_class.can_view_admin_show_for_any_admin_set?(ability: Ability.new(user2))).to be false
       end
     end
   end
 
   def source_access(permission_template, agent_type, agent_id, access)
-    create(:permission_template_access,
-           access,
-           permission_template: permission_template,
-           agent_type: agent_type,
-           agent_id: agent_id)
+    FactoryBot.create(:permission_template_access,
+                      access,
+                      permission_template: permission_template,
+                      agent_type: agent_type,
+                      agent_id: agent_id)
   end
 end


### PR DESCRIPTION
these specs don't test the bulk of the code branches in the
PermissionsService (see also: https://github.com/samvera/hyrax/issues/4686)

in the interest of fixing that, and clarifying the permissions service
contracts, clean up the tests by removing unused/misleading `:ability` variables
and removing `subject` memos that don't represent the unit under test.

@samvera/hyrax-code-reviewers
