### PR TITLE
breaking: use `Hydra::AccessControls::Permissions` for AdminSet

### DIFF
--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -17,7 +17,7 @@
 # @see Hyrax::DefaultAdminSetActor
 # @see Hyrax::ApplyPermissionTemplateActor
 class AdminSet < ActiveFedora::Base
-  include Hydra::AccessControls::WithAccessRight
+  include Hydra::AccessControls::Permissions
   include Hyrax::Noid
   include Hyrax::HumanReadableType
   include Hyrax::HasRepresentative


### PR DESCRIPTION
`AdminSet` used `WithAccessRight` which included `:open_access?`,
`:authenticated_only_access?`, etc...

these methods aren't needed for `AdminSet`, so we can reduce its API footprint
in 3.0.0 by using a more targeted mixin.

@samvera/hyrax-code-reviewers
