### PR TITLE
add Hydra::AccessControls::Permissions to CollectionBehavior once

### DIFF
--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -4,7 +4,6 @@ module Hyrax
     extend ActiveSupport::Concern
     include Hydra::AccessControls::WithAccessRight
     include Hydra::WithDepositor # for access to apply_depositor_metadata
-    include Hydra::AccessControls::Permissions
     include Hyrax::CoreMetadata
     include Hydra::Works::CollectionBehavior
     include Hyrax::Noid


### PR DESCRIPTION
`Hydra::AccessControls::WithAccessRight` already includes
`Hydra::AccessControls::Permissions` as its own dependency. avoid including it
explictly later.

@samvera/hyrax-code-reviewers
