### PR TITLE
deprecate `CollectionType.collection_type_settings_methods`

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -101,7 +101,7 @@ module Hyrax
     # @return [String] The CollectionType's title if found, else the gid
     def collection_type_label(collection_type_gid)
       CollectionType.find_by_gid!(collection_type_gid).title
-    rescue ActiveRecord::RecordNotFound, URI::BadURIError
+    rescue ActiveRecord::RecordNotFound, URI::InvalidURIError, URI::BadURIError
       CollectionType.find_or_create_default_collection_type.title
     end
 

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -40,7 +40,7 @@ module Hyrax
       end
     end
 
-    delegate(*Hyrax::CollectionType.collection_type_settings_methods, to: :collection_type)
+    delegate(*Hyrax::CollectionType.settings_attributes, to: :collection_type)
 
     # Get the collection_type when accessed
     def collection_type

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -81,7 +81,7 @@ module Hyrax
     ##
     # @return [Enumerable<Collection, PcdmCollection>]
     def collections(use_valkyrie: false)
-      return [] unless gid
+      return [] unless id
       return Hyrax.custom_queries.find_collections_by_type(global_id: gid) if use_valkyrie
       ActiveFedora::Base.where(collection_type_gid_ssim: gid.to_s)
     end
@@ -149,15 +149,13 @@ module Hyrax
     end
 
     def ensure_no_settings_changes_for_admin_set_type
-      return true unless admin_set? && exists_for_machine_id?(ADMIN_SET_MACHINE_ID)
-      return true unless collection_type_settings_changed?
+      return true unless admin_set? && collection_type_settings_changed? && exists_for_machine_id?(ADMIN_SET_MACHINE_ID)
       errors[:base] << I18n.t('hyrax.admin.collection_types.errors.no_settings_change_for_admin_sets')
       throw :abort
     end
 
     def ensure_no_settings_changes_for_user_collection_type
-      return true unless user_collection? && exists_for_machine_id?(USER_COLLECTION_MACHINE_ID)
-      return true unless collection_type_settings_changed?
+      return true unless user_collection? && collection_type_settings_changed? && exists_for_machine_id?(USER_COLLECTION_MACHINE_ID)
       errors[:base] << I18n.t('hyrax.admin.collection_types.errors.no_settings_change_for_user_collections')
       throw :abort
     end
@@ -170,8 +168,7 @@ module Hyrax
     end
 
     def collection_type_settings_changed?
-      (changes.keys & ['nestable', 'brandable', 'discoverable', 'sharable', 'share_applies_to_new_works', 'allow_multiple_membership',
-                       'require_membership', 'assigns_workflow', 'assigns_visibility']).any?
+      (changes.keys & ['nestable', 'brandable', 'discoverable', 'sharable', 'share_applies_to_new_works', 'allow_multiple_membership', 'require_membership', 'assigns_workflow', 'assigns_visibility']).any?
     end
 
     def exists_for_machine_id?(machine_id)

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -27,7 +27,7 @@ module Hyrax
     delegate :stringify_keys, :human_readable_type, :collection?, :representative_id,
              :to_s, to: :solr_document
 
-    delegate(*Hyrax::CollectionType.collection_type_settings_methods, to: :collection_type, prefix: :collection_type_is)
+    delegate(*Hyrax::CollectionType.settings_attributes, to: :collection_type, prefix: :collection_type_is)
 
     def collection_type
       @collection_type ||= Hyrax::CollectionType.find_by_gid!(collection_type_gid)

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -148,11 +148,11 @@ RSpec.describe ::Collection, type: :model do
 
     it 'throws ActiveRecord::RecordNotFound if cannot find collection type for the gid' do
       gid = 'gid://internal/hyrax-collectiontype/999'
-      expect { collection.collection_type_gid = gid }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID '#{gid}'")
+      expect { collection.collection_type_gid = gid }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'throws ActiveRecord::RecordNotFound if set to nil' do
-      expect { collection.collection_type_gid = nil }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID ''")
+      expect { collection.collection_type_gid = nil }.to raise_error(URI::InvalidURIError)
     end
 
     it 'updates the collection_type instance variable' do

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -1,33 +1,43 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::CollectionType, type: :model do
-  let(:collection_type) { build(:collection_type) }
+  subject(:collection_type) { FactoryBot.build(:collection_type) }
 
   shared_context 'with a collection' do
-    let(:collection_type) { create(:collection_type) }
-
-    before do
-      FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.gid)
-    end
+    let(:collection_type) { FactoryBot.create(:collection_type) }
+    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.gid) }
   end
 
   describe '.collection_type_settings_methods' do
-    subject { described_class.collection_type_settings_methods }
-
-    it { is_expected.to be_a(Array) }
+    it 'lists collection settings methods' do # deprecated
+      expect(described_class.collection_type_settings_methods)
+        .to include(:nestable?, :discoverable?, :brandable?)
+    end
   end
 
   describe '#collection_type_settings_methods' do
-    subject { described_class.new.collection_type_settings_methods }
-
-    it { is_expected.to be_a(Array) }
+    it 'lists collection settings methods' do # deprecated
+      expect(collection_type.collection_type_settings_methods)
+        .to include(:nestable?, :discoverable?, :brandable?)
+    end
   end
 
-  it "has basic metadata" do
-    expect(collection_type).to respond_to(:title)
-    expect(collection_type.title).not_to be_empty
-    expect(collection_type).to respond_to(:description)
+  describe '.settings_attributes' do
+    it 'lists collection settings methods' do
+      expect(described_class.settings_attributes)
+        .to include(:nestable?, :discoverable?, :brandable?)
+    end
+  end
+
+  it 'has a description' do
     expect(collection_type.description).not_to be_empty
-    expect(collection_type).to respond_to(:machine_id)
+  end
+
+  it 'has a machine_id' do
+    expect(collection_type.machine_id).not_to be_empty
+  end
+
+  it 'has a title' do
+    expect(collection_type.title).not_to be_empty
   end
 
   it "has configuration properties with defaults" do
@@ -143,11 +153,12 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     end
 
     it 'raises error if collection type with gid does NOT exist' do
-      expect { described_class.find_by_gid!(nonexistent_gid) }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID '#{nonexistent_gid}'")
+      expect { described_class.find_by_gid!(nonexistent_gid) }
+        .to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'raises error if passed nil' do
-      expect { described_class.find_by_gid!(nil) }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Hyrax::CollectionType matching GID ''")
+      expect { described_class.find_by_gid!(nil) }.to raise_error(URI::InvalidURIError)
     end
   end
 

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -206,9 +206,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   describe '#save' do
-    before do
-      allow(collection_type).to receive(:changes).and_return('nestable' => false)
-    end
+    before { collection_type.nestable = !collection_type.nestable }
 
     context 'for non-special collection type' do
       include_context 'with a collection'


### PR DESCRIPTION
these settings flag methods should be aligned with migrated database tables. the
old setup allowed us to override them at the class level with an attribute
setter. it might be nice to refine this further, but we should definitely be
more conservative about this than `class_attribute` allows.

@samvera/hyrax-code-reviewers
