### PR TITLE
make collection gid index field configurable

### DIFF
--- a/app/controllers/hyrax/my/collections_controller.rb
+++ b/app/controllers/hyrax/my/collections_controller.rb
@@ -9,9 +9,9 @@ module Hyrax
       def self.configure_facets
         configure_blacklight do |config|
           # Name of pivot facet must match field name that uses helper_method
-          config.add_facet_field ::Collection.collection_type_gid_document_field_name,
+          config.add_facet_field Hyrax.config.collection_type_index_field,
                                  helper_method: :collection_type_label, limit: 5,
-                                 pivot: ['has_model_ssim', ::Collection.collection_type_gid_document_field_name],
+                                 pivot: ['has_model_ssim', Hyrax.config.collection_type_index_field],
                                  label: I18n.t('hyrax.dashboard.my.heading.collection_type')
           # This causes AdminSets to also be shown with the Collection Type label
           config.add_facet_field 'has_model_ssim',

--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -12,7 +12,7 @@ module Hyrax
 
     def to_solr
       super.tap do |index_document|
-        index_document[:collection_type_gid_ssim] = Array(resource.try(:collection_type_gid)&.to_s)
+        index_document[Hyrax.config.collection_type_index_field.to_sym] = Array(resource.try(:collection_type_gid)&.to_s)
         index_document[:generic_type_sim] = ['Collection']
         index_document[:thumbnail_path_ss] = Hyrax::CollectionThumbnailPathService.call(resource)
       end

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -101,7 +101,8 @@ module Hyrax
       end
 
       def collection_type_gid_document_field_name
-        "collection_type_gid_ssim"
+        Deprecation.warn('use Hyrax.config.collection_type_index_field instead')
+        Hyrax.config.collection_type_index_field
       end
     end
 

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -142,7 +142,7 @@ module Hyrax
     end
 
     def collection_type_gid
-      first('collection_type_gid_ssim')
+      first(Hyrax.config.collection_type_index_field)
     end
   end
 end

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -97,7 +97,7 @@ module Hyrax
     def collections(use_valkyrie: false)
       return [] unless id
       return Hyrax.custom_queries.find_collections_by_type(global_id: gid) if use_valkyrie
-      ActiveFedora::Base.where(collection_type_gid_ssim: gid.to_s)
+      ActiveFedora::Base.where(Hyrax.config.collection_type_index_field.to_sym => gid.to_s)
     end
 
     ##

--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -28,7 +28,7 @@ module Hyrax
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += [
           "-" + Hyrax::SolrQueryBuilderService.construct_query_for_ids([limit_ids]),
-          Hyrax::SolrQueryBuilderService.construct_query(::Collection.collection_type_gid_document_field_name => @collection.collection_type_gid)
+          Hyrax::SolrQueryBuilderService.construct_query(Hyrax.config.collection_type_index_field => @collection.collection_type_gid)
         ]
         solr_parameters[:fq] += limit_clause if limit_clause # add limits to prevent illegal nesting arrangements
       end

--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -52,7 +52,8 @@ module Hyrax
 
     def single_membership_collections(collection_ids)
       return [] if collection_ids.blank?
-      ::Collection.where(id: collection_ids, collection_type_gid_ssim: collection_type_gids_that_disallow_multiple_membership)
+
+      ::Collection.where(:id => collection_ids, Hyrax.config.collection_type_index_field.to_sym => collection_type_gids_that_disallow_multiple_membership)
     end
 
     def collection_type_gids_that_disallow_multiple_membership

--- a/app/views/hyrax/admin/collection_types/index.html.erb
+++ b/app/views/hyrax/admin/collection_types/index.html.erb
@@ -40,7 +40,7 @@
                  <% unless collection_type.admin_set? || collection_type.user_collection? %>
                   <button class="btn btn-danger btn-sm delete-collection-type"
                           data-collection-type="<%= collection_type.to_json %>"
-                          data-collection-type-index="<%= hyrax.dashboard_collections_path({ 'f[collection_type_gid_ssim][]' => collection_type.gid, 'f[has_model_ssim][]' => 'Collection' }) %>"
+                          data-collection-type-index="<%= hyrax.dashboard_collections_path({ "f[collection_type_gid_ssim][]" => collection_type.gid, 'f[has_model_ssim][]' => 'Collection' }) %>"
                           data-has-collections="<%= collection_type.collections? %>">
                     <%= t('helpers.action.delete') %>
                   </button>

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -633,6 +633,11 @@ module Hyrax
       @audit_user_key ||= 'audituser@example.com'
     end
 
+    attr_writer :collection_type_index_field
+    def collection_type_index_field
+      @collection_type_index_field ||= 'collection_type_gid_ssim'
+    end
+
     attr_writer :id_field
     def id_field
       @id_field || index_field_mapper.id_field

--- a/lib/wings/services/custom_queries/find_collections_by_type.rb
+++ b/lib/wings/services/custom_queries/find_collections_by_type.rb
@@ -20,7 +20,7 @@ module Wings
       #
       # @return [Enumerable<PcdmCollection>]
       def find_collections_by_type(global_id:)
-        ::Collection.where(collection_type_gid_ssim: global_id.to_s).map(&:valkyrie_resource)
+        ::Collection.where(Hyrax.config.collection_type_index_field.to_sym => global_id.to_s).map(&:valkyrie_resource)
       end
     end
   end

--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
+
 RSpec.describe 'collection_type', type: :feature do
-  let(:admin_user) { create(:admin) }
-  let(:exhibit_title) { 'Exhibit' }
-  let(:exhibit_description) { 'Description for exhibit collection type.' }
-  let(:exhibit_collection_type) { create(:collection_type, title: exhibit_title, description: exhibit_description, creator_user: admin_user) }
-  let(:user_collection_type) { create(:user_collection_type) }
-  let(:admin_set_type) { create(:admin_set_collection_type) }
-  let(:solr_gid) { Collection.collection_type_gid_document_field_name }
+  let(:admin_user) { FactoryBot.create(:admin) }
+  let(:exhibit_collection_type) do
+    FactoryBot.create(:collection_type,
+                      title: 'Exhibit',
+                      description: 'Description for exhibit collection type.',
+                      creator_user: admin_user)
+  end
+  let(:user_collection_type) { FactoryBot.create(:user_collection_type) }
+  let(:admin_set_type) { FactoryBot.create(:admin_set_collection_type) }
+  let(:solr_gid) { Hyrax.config.collection_type_index_field }
 
   describe 'index' do
     before do
@@ -118,11 +122,6 @@ RSpec.describe 'collection_type', type: :feature do
 
   describe 'edit collection type' do
     context 'when there are no collections of this type' do
-      let(:title_old) { exhibit_title }
-      let(:description_old) { exhibit_description }
-      let(:title_new) { 'Exhibit modified' }
-      let(:description_new) { 'Change in description for exhibit collection type.' }
-
       before do
         exhibit_collection_type
         sign_in admin_user
@@ -130,7 +129,7 @@ RSpec.describe 'collection_type', type: :feature do
       end
 
       it 'modifies metadata values of a collection type', :js do
-        expect(page).to have_content "Edit Collection Type: #{title_old}"
+        expect(page).to have_content "Edit Collection Type: Exhibit"
 
         # confirm all tabs are visible
         expect(page).to have_link('Description', href: '#metadata')
@@ -138,20 +137,20 @@ RSpec.describe 'collection_type', type: :feature do
         expect(page).to have_link('Participants', href: '#participants')
 
         # confirm metadata fields have original values
-        expect(page).to have_selector "input#collection_type_title[value='#{title_old}']"
-        expect(page).to have_selector 'textarea#collection_type_description', text: description_old
+        expect(page).to have_selector "input#collection_type_title[value='Exhibit']"
+        expect(page).to have_selector 'textarea#collection_type_description', text: 'Description for exhibit collection type.'
 
         # set values and save
-        fill_in('Type name', with: title_new)
-        fill_in('Type description', with: description_new)
+        fill_in('Type name', with: 'Exhibit modified')
+        fill_in('Type description', with: 'Change in description for exhibit collection type.')
 
         click_button('Save changes')
 
-        expect(page).to have_content "Edit Collection Type: #{title_new}"
+        expect(page).to have_content "Edit Collection Type: Exhibit modified"
 
         # confirm values were set
-        expect(page).to have_selector "input#collection_type_title[value='#{title_new}']"
-        expect(page).to have_selector 'textarea#collection_type_description', text: description_new
+        expect(page).to have_selector "input#collection_type_title[value='Exhibit modified']"
+        expect(page).to have_selector 'textarea#collection_type_description', text: 'Change in description for exhibit collection type.'
 
         click_link('Settings', href: '#settings')
 

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   let(:admin_user) { create(:admin) }
   let(:collection_type) { create(:collection_type, creator_user: user) }
   let(:user_collection_type) { create(:user_collection_type) }
-  let(:solr_gid_field) { Collection.collection_type_gid_document_field_name }
+  let(:solr_gid_field) { Hyrax.config.collection_type_index_field }
   let(:solr_model_field) { 'has_model_ssim' }
 
   # Setting Title on admin sets to avoid false positive matches with collections.


### PR DESCRIPTION
this was partially configured at the `::Collection` class level, but not all
code respected it.

@samvera/hyrax-code-reviewers
