### PR TITLE
remove sleep from `collection_type` feature specs

### DIFF
--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe 'collection_type', type: :feature, clean_repo: true do
+RSpec.describe 'collection_type', type: :feature do
   let(:admin_user) { create(:admin) }
   let(:exhibit_title) { 'Exhibit' }
   let(:exhibit_description) { 'Description for exhibit collection type.' }
@@ -352,8 +352,9 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
     end
 
     context 'when collections exist of this type' do
-      let!(:not_empty_collection_type) { create(:collection_type, title: 'Not Empty Type', creator_user: admin_user) }
-      let!(:collection1) { create(:public_collection_lw, user: admin_user, collection_type_gid: not_empty_collection_type.gid) }
+      let!(:not_empty_collection_type) { FactoryBot.create(:collection_type, title: 'Not Empty Type', creator_user: admin_user) }
+      let!(:collection1) { FactoryBot.create(:public_collection_lw, user: admin_user, collection_type_gid: not_empty_collection_type.gid) }
+
       let(:deny_delete_modal_text) do
         'You cannot delete this collection type because one or more collections of this type have already been created. ' \
         'To delete this collection type, first ensure that all collections of this type have been deleted.'
@@ -374,7 +375,6 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
           expect(page).to have_content(:all, deny_delete_modal_text)
           click_link('View collections of this type')
         end
-        sleep 3
 
         # forwards to Dashboard -> Collections -> All Collections
         within('li.active') do

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe "work show view" do
       click_button 'Save changes'
 
       # forwards to collection show page
-      sleep 5
       expect(page).to have_content persisted_collection.title.first
       expect(page).to have_content work.title.first
       expect(page).to have_selector '.alert-success', text: 'Collection was successfully updated.'


### PR DESCRIPTION
sleeping in tests is... :(

this one seems to pass just fine without the sleep, so let's not do it.

@samvera/hyrax-code-reviewers
