### PR TITLE
make CollectionType#find_by_gid work with correct global id format

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -60,7 +60,7 @@ module Hyrax
         # Coming from the UI, a collection type id should always be present.  Coming from the API, if a collection type id is not specified,
         # use the default collection type (provides backward compatibility with versions < Hyrax 2.1.0)
         collection_type_id = params[:collection_type_id].presence || default_collection_type.id
-        @collection.collection_type_gid = CollectionType.find(collection_type_id).gid
+        @collection.collection_type_gid = CollectionType.find(collection_type_id).to_global_id
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
         add_breadcrumb t('.header', type_title: @collection.collection_type.title), request.path
@@ -111,7 +111,7 @@ module Hyrax
         authorize! :create, @collection
         # Coming from the UI, a collection type gid should always be present.  Coming from the API, if a collection type gid is not specified,
         # use the default collection type (provides backward compatibility with versions < Hyrax 2.1.0)
-        @collection.collection_type_gid = params[:collection_type_gid].presence || default_collection_type.gid
+        @collection.collection_type_gid = params[:collection_type_gid].presence || default_collection_type.to_global_id
         @collection.attributes = collection_params.except(:members, :parent_id, :collection_type_gid)
         @collection.apply_depositor_metadata(current_user.user_key)
         add_members_to_collection unless batch.empty?

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -47,7 +47,7 @@ module Hyrax
     end
 
     def collection_type=(new_collection_type)
-      self.collection_type_gid = new_collection_type.gid
+      self.collection_type_gid = new_collection_type.to_global_id
     end
 
     # Add members using the members association.

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -29,11 +29,11 @@ module Hyrax
       validates :collection_type_gid, presence: true
 
       # Need to define here in order to override setter defined by ActiveTriples
-      def collection_type_gid=(new_collection_type_gid)
+      def collection_type_gid=(new_collection_type_gid, force: false)
         new_collection_type_gid = new_collection_type_gid&.to_s
-        raise "Can't modify collection type of this collection" if persisted? && !collection_type_gid_was.nil? && collection_type_gid_was != new_collection_type_gid
+        raise "Can't modify collection type of this collection" if !force && persisted? && !collection_type_gid_was.nil? && collection_type_gid_was != new_collection_type_gid
         new_collection_type = Hyrax::CollectionType.find_by_gid!(new_collection_type_gid)
-        super
+        super(new_collection_type_gid)
         @collection_type = new_collection_type
         collection_type_gid
       end

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  class CollectionType < ActiveRecord::Base
+  class CollectionType < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
     # @!method id
     #   @return [Integer]
     # @!method description
@@ -197,5 +197,5 @@ module Hyrax
     def exists_for_machine_id?(machine_id)
       self.class.exists?(machine_id: machine_id)
     end
-  end
+  end # rubocop:enable Metrics/ClassLength
 end

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -75,6 +75,15 @@ module Hyrax
     # @return [Hyrax::CollectionType] an instance of Hyrax::CollectionType with id = the model_id portion of the gid (e.g. 3)
     # @raise [ActiveRecord::RecordNotFound] if record matching gid is not found
     def self.find_by_gid!(gid)
+      raise(URI::InvalidURIError) if gid.nil?
+      GlobalID::Locator.locate(gid)
+    rescue NameError
+      Rails.logger.warn "#{self.class}##{__method__} called with #{gid}, which is " \
+                        "a legacy collection type global id format. If this " \
+                        "collection type gid is attached to a collection in " \
+                        "your repository you'll want to run " \
+                        "`hyrax:collections:update_collection_type_global_ids` to " \
+                        "update references. see: https://github.com/samvera/hyrax/issues/4696"
       find(GlobalID.new(gid).model_id)
     end
 

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -95,18 +95,24 @@ module Hyrax
       SETTINGS_ATTRIBUTES
     end
 
+    ##
+    # @deprecation use #to_global_id
+    #
     # Return the Global Identifier for this collection type.
-    # @return [String] Global Identifier (gid) for this collection_type (e.g. gid://internal/hyrax-collectiontype/3)
+    # @return [String, nil] Global Identifier (gid) for this collection_type (e.g. gid://internal/hyrax-collectiontype/3)
+    #
+    # @see https://github.com/rails/globalid#usage
     def gid
-      URI::GID.build(app: GlobalID.app, model_name: model_name.name.parameterize.to_sym, model_id: id).to_s if id
+      Deprecation.warn('use #to_global_id.')
+      to_global_id.to_s if id
     end
 
     ##
     # @return [Enumerable<Collection, PcdmCollection>]
     def collections(use_valkyrie: false)
       return [] unless id
-      return Hyrax.custom_queries.find_collections_by_type(global_id: gid) if use_valkyrie
-      ActiveFedora::Base.where(Hyrax.config.collection_type_index_field.to_sym => gid.to_s)
+      return Hyrax.custom_queries.find_collections_by_type(global_id: to_global_id) if use_valkyrie
+      ActiveFedora::Base.where(Hyrax.config.collection_type_index_field.to_sym => to_global_id.to_s)
     end
 
     ##

--- a/app/services/hyrax/collections/migration_service.rb
+++ b/app/services/hyrax/collections/migration_service.rb
@@ -30,7 +30,7 @@ module Hyrax
       # @param collection [::Collection] collection object to be migrated
       def self.migrate_collection(collection)
         return if collection.collection_type_gid.present? # already migrated
-        collection.collection_type_gid = Hyrax::CollectionType.find_or_create_default_collection_type.gid
+        collection.collection_type_gid = Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id
         create_permissions(collection)
         collection.save
       end
@@ -74,8 +74,8 @@ module Hyrax
       #
       # @param collection [::Collection] collection object to be migrated/repaired
       def self.repair_migrated_collection(collection)
-        return if collection.collection_type_gid.present? && collection.collection_type_gid != Hyrax::CollectionType.find_or_create_default_collection_type.gid
-        collection.collection_type_gid = Hyrax::CollectionType.find_or_create_default_collection_type.gid
+        return if collection.collection_type_gid.present? && collection.collection_type_gid != Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id
+        collection.collection_type_gid = Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id
         permission_template = Hyrax::PermissionTemplate.find_by(source_id: collection.id)
         if permission_template.present?
           collection.reset_access_controls!

--- a/app/views/hyrax/admin/collection_types/index.html.erb
+++ b/app/views/hyrax/admin/collection_types/index.html.erb
@@ -40,7 +40,7 @@
                  <% unless collection_type.admin_set? || collection_type.user_collection? %>
                   <button class="btn btn-danger btn-sm delete-collection-type"
                           data-collection-type="<%= collection_type.to_json %>"
-                          data-collection-type-index="<%= hyrax.dashboard_collections_path({ "f[collection_type_gid_ssim][]" => collection_type.gid, 'f[has_model_ssim][]' => 'Collection' }) %>"
+                          data-collection-type-index="<%= hyrax.dashboard_collections_path({ 'f[collection_type_gid_ssim][]' => collection_type.to_global_id.to_s, 'f[has_model_ssim][]' => 'Collection' }) %>"
                           data-has-collections="<%= collection_type.collections? %>">
                     <%= t('helpers.action.delete') %>
                   </button>

--- a/lib/generators/hyrax/templates/db/seeds.rb
+++ b/lib/generators/hyrax/templates/db/seeds.rb
@@ -114,14 +114,15 @@ create_user('vw2@example.com', 'pppppp')
 genuser = create_user('general_user@example.com', 'pppppp')
 
 puts 'Create collection types for QA'
-_discoverable_gid = create_collection_type('discoverable_collection_type', title: 'Discoverable', description: 'Sample collection type allowing collections to be discovered.', discoverable: true).gid
-_sharable_gid = create_collection_type('sharable_collection_type', title: 'Sharable', description: 'Sample collection type allowing collections to be shared.', sharable: true).gid
+_discoverable_gid = create_collection_type('discoverable_collection_type', title: 'Discoverable', description: 'Sample collection type allowing collections to be discovered.', discoverable: true)
+                    .to_global_id
+_sharable_gid = create_collection_type('sharable_collection_type', title: 'Sharable', description: 'Sample collection type allowing collections to be shared.', sharable: true).to_global_id
 options = { title: 'Multi-membership', description: 'Sample collection type allowing works to belong to multiple collections.', allow_multiple_membership: true }
 _multi_membership_gid = create_collection_type('multi_membership_collection_type', options)
-_nestable_1_gid = create_collection_type('nestable_1_collection_type', title: 'Nestable 1', description: 'A sample collection type allowing nesting.', nestable: true).gid
-_nestable_2_gid = create_collection_type('nestable_2_collection_type', title: 'Nestable 2', description: 'Another sample collection type allowing nesting.', nestable: true).gid
-_empty_gid = create_collection_type('empty_collection_type', title: 'Test Empty Collection Type', description: 'A collection type with 0 collections of this type').gid
-inuse_gid = create_collection_type('inuse_collection_type', title: 'Test In-Use Collection Type', description: 'A collection type with at least one collection of this type').gid
+_nestable_1_gid = create_collection_type('nestable_1_collection_type', title: 'Nestable 1', description: 'A sample collection type allowing nesting.', nestable: true).to_global_id
+_nestable_2_gid = create_collection_type('nestable_2_collection_type', title: 'Nestable 2', description: 'Another sample collection type allowing nesting.', nestable: true).to_global_id
+_empty_gid = create_collection_type('empty_collection_type', title: 'Test Empty Collection Type', description: 'A collection type with 0 collections of this type').to_global_id
+inuse_gid = create_collection_type('inuse_collection_type', title: 'Test In-Use Collection Type', description: 'A collection type with at least one collection of this type').to_global_id
 
 puts 'Create collections for QA'
 inuse_col = create_public_collection(genuser, inuse_gid, 'inuse_col1', title: ['Public Collection of type In-Use'], description: ['Public collection of the type Test In-Use Collection Type.'])
@@ -158,11 +159,11 @@ user = create_user('foo@example.com', 'foobarbaz')
 puts 'Create collection types for collection nesting ad hoc testing'
 options = { title: 'Nestable Collection', description: 'Sample collection type that allows nesting of collections.',
             nestable: true, discoverable: true, sharable: true, allow_multiple_membership: true }
-nestable_gid = create_collection_type('nestable_collection', options).gid
+nestable_gid = create_collection_type('nestable_collection', options).to_global_id
 
 options = { title: 'Non-Nestable Collection', description: 'Sample collection type that DOES NOT allow nesting of collections.',
             nestable: false, discoverable: true, sharable: true, allow_multiple_membership: true }
-_nonnestable_gid = create_collection_type('nonnestable_collection', options).gid
+_nonnestable_gid = create_collection_type('nonnestable_collection', options).to_global_id
 
 puts 'Create collections for collection nesting ad hoc testing'
 pnc = create_public_collection(user, nestable_gid, 'public_nestable', title: ['Public Nestable Collection'], description: ['Public nestable collection for use in ad hoc tests.'])

--- a/lib/tasks/collection_type_global_id.rake
+++ b/lib/tasks/collection_type_global_id.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+namespace :hyrax do
+  namespace :collections do
+    desc 'Update CollectionType global id references for Hyrax 3.0.0'
+    task :update_collection_type_global_ids do
+      puts 'Updating collection -> collection type GlobalId references.'
+
+      count = 0
+
+      Collection.all.each do |collection|
+        next if collection.collection_type_gid == collection.collection_type.to_global_id.to_s
+
+        collection.public_send(:collection_type_gid=, collection.collection_type.to_global_id, force: true)
+
+        collection.save &&
+          count += 1
+      end
+
+      puts "Updated #{count} collections."
+    end
+  end
+end

--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Hyrax::Ability do
   let(:ability) { Ability.new(current_user) }
   let(:user) { create(:user) }
   let(:current_user) { user }
-  let(:collection_type_gid) { create(:collection_type).gid }
+  let(:collection_type) { FactoryBot.create(:collection_type) }
 
   context 'when admin user' do
     let(:user) { FactoryBot.create(:admin) }
-    let!(:collection) { build(:collection_lw, id: 'col_au', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { FactoryBot.build(:collection_lw, id: 'col_au', with_permission_template: true, collection_type: collection_type) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     it 'allows all abilities' do # rubocop:disable RSpec/ExampleLength
@@ -35,7 +35,7 @@ RSpec.describe Hyrax::Ability do
   end
 
   context 'when collection manager' do
-    let!(:collection) { build(:collection_lw, id: 'col_mu', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { FactoryBot.build(:collection_lw, id: 'col_mu', with_permission_template: true, collection_type: collection_type) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do
@@ -70,7 +70,7 @@ RSpec.describe Hyrax::Ability do
   end
 
   context 'when collection depositor' do
-    let!(:collection) { build(:collection_lw, id: 'col_du', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { FactoryBot.build(:collection_lw, id: 'col_du', with_permission_template: true, collection_type: collection_type) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do
@@ -105,7 +105,7 @@ RSpec.describe Hyrax::Ability do
   end
 
   context 'when collection viewer' do
-    let!(:collection) { build(:collection_lw, id: 'col_vu', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { FactoryBot.build(:collection_lw, id: 'col_vu', with_permission_template: true, collection_type: collection_type) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     before do
@@ -140,7 +140,7 @@ RSpec.describe Hyrax::Ability do
   end
 
   context 'when user has no special access' do
-    let!(:collection) { create(:collection_lw, id: 'as', with_permission_template: true, collection_type_gid: collection_type_gid) }
+    let!(:collection) { FactoryBot.create(:collection_lw, id: 'as', with_permission_template: true, collection_type: collection_type) }
     let!(:solr_document) { SolrDocument.new(collection.to_solr) }
 
     it 'denies all abilities' do # rubocop:disable RSpec/ExampleLength

--- a/spec/abilities/permission_template_ability_spec.rb
+++ b/spec/abilities/permission_template_ability_spec.rb
@@ -5,9 +5,8 @@ RSpec.describe Hyrax::Ability do
   subject(:ability) { Ability.new(current_user) }
   let(:user) { create(:user) }
   let(:current_user) { user }
-  let(:collection_type_gid) { create(:collection_type).gid }
-
-  let!(:collection) { create(:collection_lw, with_permission_template: true, collection_type_gid: collection_type_gid) }
+  let(:collection_type) { FactoryBot.create(:collection_type) }
+  let!(:collection) { create(:collection_lw, with_permission_template: true, collection_type: collection_type) }
   let(:permission_template) { collection.permission_template }
   let!(:permission_template_access) do
     create(:permission_template_access,

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
 
     context "updates env" do
       let!(:collection_type) { create(:collection_type) }
-      let!(:collection) { create(:collection_lw, collection_type_gid: collection_type.gid, with_permission_template: true) }
+      let!(:collection) { FactoryBot.create(:collection_lw, collection_type: collection_type, with_permission_template: true) }
 
       subject(:middleware) do
         stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|

--- a/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller, clean
       end
 
       context "when collections exist of this type" do
-        let!(:collection) { create(:collection_lw, collection_type_gid: collection_type_to_destroy.gid) }
+        let!(:collection) { FactoryBot.create(:collection_lw, collection_type: collection_type_to_destroy) }
 
         it "doesn't delete the collection type or collection" do
           delete :destroy, params: { id: collection_type_to_destroy }

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   routes { Hyrax::Engine.routes }
   let(:user)  { create(:user) }
   let(:other) { build(:user) }
-  let(:collection_type_gid) { create(:user_collection_type).gid }
+  let(:collection_type_gid) { FactoryBot.create(:user_collection_type).to_global_id.to_s }
 
   let(:collection) do
     create(:public_collection_lw, title: ["My collection"],
@@ -105,10 +105,11 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       it "creates a Collection of specified type" do
         expect do
           post :create, params: {
-            collection: collection_attrs, collection_type_gid: collection_type.gid
+            collection: collection_attrs, collection_type_gid: collection_type.to_global_id.to_s
           }
         end.to change { Collection.count }.by(1)
-        expect(assigns[:collection].collection_type_gid).to eq collection_type.gid
+
+        expect(assigns[:collection].collection_type_gid).to eq collection_type.to_global_id.to_s
       end
     end
 

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -87,14 +87,13 @@ FactoryBot.define do
   factory :user_collection, class: Collection do
     transient do
       user { create(:user) }
+      collection_type { create(:user_collection_type) }
     end
 
     sequence(:title) { |n| ["User Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
-      collection_type = create(:user_collection_type)
-      collection.collection_type_gid = collection_type.gid
     end
   end
 

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     collection_type_gid { Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id }
 
     transient do
+      collection_type { nil }
       edit_groups { [] }
       edit_users { [] }
       read_groups { [] }
@@ -16,6 +17,7 @@ FactoryBot.define do
     end
 
     after(:build) do |collection, evaluator|
+      collection.collection_type_gid ||= evaluator.collection_type.to_global_id if evaluator.collection_type&.id.present?
       collection.member_ids = evaluator.members.map(&:id) if evaluator.members
       collection.permission_manager.edit_groups = evaluator.edit_groups
       collection.permission_manager.edit_users = evaluator.edit_users

--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, js: true
   end
 
   describe 'when both collections support multiple membership' do
-    let(:old_collection) { build(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_1.gid, title: ['OldCollectionTitle']) }
+    let(:old_collection) { FactoryBot.build(:collection_lw, user: admin_user, collection_type: multi_membership_type_1, title: ['OldCollectionTitle']) }
     let!(:work) { create(:generic_work, user: admin_user, member_of_collections: [old_collection], title: ['The highly valued work that everyone wants in their collection']) }
 
     context 'and are of different types' do
-      let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_2.gid, title: ['NewCollectionTitle']) }
+      let!(:new_collection) { FactoryBot.create(:collection_lw, user: admin_user, collection_type: multi_membership_type_2, title: ['NewCollectionTitle']) }
 
       it 'then the work is added to both collections' do
         # Add to second multi-membership collection of a different type
@@ -35,7 +35,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, js: true
     end
 
     context 'and are of the same type' do
-      let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_1.gid, title: ['NewCollectionTitle']) }
+      let!(:new_collection) { FactoryBot.create(:collection_lw, user: admin_user, collection_type: multi_membership_type_1, title: ['NewCollectionTitle']) }
 
       it 'then the work is added to both collections' do
         # Add to second multi-membership collection of a different type
@@ -55,7 +55,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, js: true
   end
 
   describe 'when both collections require single membership' do
-    let(:old_collection) { build(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_1.gid, title: ['OldCollectionTitle']) }
+    let(:old_collection) { FactoryBot.build(:collection_lw, user: admin_user, collection_type: single_membership_type_1, title: ['OldCollectionTitle']) }
     let!(:work) do
       create(:generic_work,
              user: admin_user,
@@ -66,7 +66,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, js: true
     end
 
     context 'and are of different types' do
-      let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_2.gid, title: ['NewCollectionTitle']) }
+      let!(:new_collection) { FactoryBot.create(:collection_lw, user: admin_user, collection_type: single_membership_type_2, title: ['NewCollectionTitle']) }
 
       it 'then the work is added to both collections' do
         # Add to second single-membership collection of a different type
@@ -85,7 +85,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, js: true
     end
 
     context 'and are of the same type' do
-      let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_1.gid, title: ['NewCollectionTitle']) }
+      let!(:new_collection) { FactoryBot.create(:collection_lw, user: admin_user, collection_type: single_membership_type_1, title: ['NewCollectionTitle']) }
 
       context 'then the work fails to add to the second collection' do
         it 'from the dashboard->works batch add to collection' do
@@ -156,7 +156,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, js: true
     let!(:work) { create(:generic_work, user: admin_user, member_of_collections: [old_collection], title: ['The highly valued work that everyone wants in their collection']) }
 
     context 'allowing multi-membership' do
-      let(:old_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_1.gid, title: ['CollectionTitle']) }
+      let(:old_collection) { FactoryBot.create(:collection_lw, user: admin_user, collection_type: multi_membership_type_1, title: ['CollectionTitle']) }
       let!(:new_collection) { old_collection }
 
       it 'then the add is treated as a success' do
@@ -176,7 +176,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, js: true
     end
 
     context 'requiring single-membership' do
-      let(:old_collection) { create(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_1.gid, title: ['CollectionTitle']) }
+      let(:old_collection) { FactoryBot.create(:collection_lw, user: admin_user, collection_type: single_membership_type_1, title: ['CollectionTitle']) }
       let!(:new_collection) { old_collection }
 
       it 'then the add is treated as a success' do

--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -292,7 +292,9 @@ RSpec.describe 'collection_type', type: :feature do
     end
 
     context 'when collections exist of this type' do
-      let!(:collection1) { create(:public_collection_lw, user: build(:user), collection_type_gid: exhibit_collection_type.gid) }
+      let!(:collection1) do
+        FactoryBot.create(:public_collection_lw, user: build(:user), collection_type: exhibit_collection_type)
+      end
 
       before do
         exhibit_collection_type
@@ -352,7 +354,7 @@ RSpec.describe 'collection_type', type: :feature do
 
     context 'when collections exist of this type' do
       let!(:not_empty_collection_type) { FactoryBot.create(:collection_type, title: 'Not Empty Type', creator_user: admin_user) }
-      let!(:collection1) { FactoryBot.create(:public_collection_lw, user: admin_user, collection_type_gid: not_empty_collection_type.gid) }
+      let!(:collection1) { FactoryBot.create(:public_collection_lw, user: admin_user, collection_type: not_empty_collection_type) }
 
       let(:deny_delete_modal_text) do
         'You cannot delete this collection type because one or more collections of this type have already been created. ' \

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   # Setting Title on admin sets to avoid false positive matches with collections.
   let(:admin_set_a) { create(:admin_set, creator: [admin_user.user_key], title: ['Set A'], with_permission_template: true) }
   let(:admin_set_b) { create(:admin_set, creator: [user.user_key], title: ['Set B'], edit_users: [user.user_key], with_permission_template: true) }
-  let(:collection1) { create(:public_collection_lw, user: user, collection_type_gid: collection_type.gid, with_permission_template: true) }
-  let(:collection2) { create(:public_collection_lw, user: user, collection_type_gid: collection_type.gid, with_permission_template: true) }
-  let(:collection3) { create(:public_collection_lw, user: admin_user, collection_type_gid: collection_type.gid, with_permission_template: true) }
-  let(:collection4) { create(:public_collection_lw, user: admin_user, collection_type_gid: user_collection_type.gid, with_permission_template: true) }
+  let(:collection1) { FactoryBot.create(:public_collection_lw, user: user, collection_type: collection_type, with_permission_template: true) }
+  let(:collection2) { FactoryBot.create(:public_collection_lw, user: user, collection_type: collection_type, with_permission_template: true) }
+  let(:collection3) { FactoryBot.create(:public_collection_lw, user: admin_user, collection_type: collection_type, with_permission_template: true) }
+  let(:collection4) { FactoryBot.create(:public_collection_lw, user: admin_user, collection_type: user_collection_type, with_permission_template: true) }
 
   describe 'Your Collections tab' do
     context 'when non-admin user' do
@@ -57,11 +57,11 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
                                   href: /visibility_ssi.+#{Regexp.escape(CGI.escape(collection3.visibility))}/
         expect(page).to have_button 'Collection Type'
         expect(page).to have_link collection_type.title,
-                                  href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(collection_type.gid))}/
+                                  href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(collection_type.to_global_id.to_s))}/
         expect(page).to have_link 'AdminSet',
                                   href: /#{solr_model_field}.+#{Regexp.escape('AdminSet')}/
         expect(page).not_to have_link user_collection_type.title,
-                                      href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(user_collection_type.gid))}/
+                                      href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(user_collection_type.to_global_id.to_s))}/
         expect(page).not_to have_link 'Collection',
                                       href: /#{solr_model_field}.+#{Regexp.escape('Collection')}/
       end
@@ -109,9 +109,9 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
                                   href: /visibility_ssi.+#{Regexp.escape(CGI.escape(collection3.visibility))}/
         expect(page).to have_button 'Collection Type'
         expect(page).to have_link collection_type.title,
-                                  href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(collection_type.gid))}/
+                                  href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(collection_type.to_global_id.to_s))}/
         expect(page).to have_link user_collection_type.title,
-                                  href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(user_collection_type.gid))}/
+                                  href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(user_collection_type.to_global_id.to_s))}/
         expect(page).to have_link 'AdminSet',
                                   href: /#{solr_model_field}.+#{Regexp.escape('AdminSet')}/
         expect(page).not_to have_link 'Collection',
@@ -153,9 +153,9 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
                                 href: /visibility_ssi.+#{Regexp.escape(CGI.escape(collection1.visibility))}/
       expect(page).to have_button 'Collection Type'
       expect(page).to have_link collection_type.title,
-                                href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(collection_type.gid))}/
+                                href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(collection_type.to_global_id.to_s))}/
       expect(page).to have_link user_collection_type.title,
-                                href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(user_collection_type.gid))}/
+                                href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(user_collection_type.to_global_id.to_s))}/
       expect(page).to have_link 'AdminSet',
                                 href: /#{solr_model_field}.+#{Regexp.escape('AdminSet')}/
       expect(page).not_to have_link 'Collection',
@@ -214,9 +214,9 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
                                 href: /visibility_ssi.+#{Regexp.escape(CGI.escape(collection1.visibility))}/
       expect(page).to have_button 'Collection Type'
       expect(page).to have_link collection_type.title,
-                                href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(collection_type.gid))}/
+                                href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(collection_type.to_global_id.to_s))}/
       expect(page).to have_link user_collection_type.title,
-                                href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(user_collection_type.gid))}/
+                                href: /#{solr_gid_field}.+#{Regexp.escape(CGI.escape(user_collection_type.to_global_id.to_s))}/
       expect(page).not_to have_link 'AdminSet',
                                     href: /#{solr_model_field}.+#{Regexp.escape('AdminSet')}/
       expect(page).not_to have_link 'Collection',

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "work show view" do
     let(:file_set) { FactoryBot.create(:file_set, user: user, title: ['A Contained FileSet'], content: file) }
     let(:file) { File.open(fixture_path + '/world.png') }
     let(:multi_membership_type_1) { FactoryBot.create(:collection_type, :allow_multiple_membership, title: 'Multi-membership 1') }
-    let!(:collection) { FactoryBot.create(:collection_lw, user: user, collection_type_gid: multi_membership_type_1.gid) }
+    let!(:collection) { FactoryBot.create(:collection_lw, user: user, collection_type: multi_membership_type_1) }
 
     before do
       sign_in user
@@ -61,7 +61,7 @@ RSpec.describe "work show view" do
       click_button "Add to collection" # opens the modal
       # Really ensure that this Collection model is persisted
       Collection.all.map(&:destroy!)
-      persisted_collection = create(:collection_lw, user: user, collection_type_gid: multi_membership_type_1.gid)
+      persisted_collection = FactoryBot.create(:collection_lw, user: user, collection_type: multi_membership_type_1)
       select_member_of_collection(persisted_collection)
       click_button 'Save changes'
 
@@ -88,7 +88,7 @@ RSpec.describe "work show view" do
     let(:file_set) { create(:file_set, user: user, title: ['A Contained FileSet'], content: file) }
     let(:file) { File.open(fixture_path + '/world.png') }
     let(:multi_membership_type_1) { create(:collection_type, :allow_multiple_membership, title: 'Multi-membership 1') }
-    let!(:collection) { create(:collection_lw, user: viewer, collection_type_gid: multi_membership_type_1.gid) }
+    let!(:collection) { FactoryBot.create(:collection_lw, user: viewer, collection_type: multi_membership_type_1) }
 
     before do
       sign_in viewer

--- a/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
+++ b/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm, :clean_repo do
     let(:collection_type) { FactoryBot.create(:collection_type) }
 
     before do
-      FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.gid)
+      FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id)
     end
   end
 

--- a/spec/helpers/hyrax/collections_helper_spec.rb
+++ b/spec/helpers/hyrax/collections_helper_spec.rb
@@ -131,7 +131,8 @@ RSpec.describe Hyrax::CollectionsHelper do
       let(:test_collection_type) { FactoryBot.create(:collection_type) }
 
       it "returns the CollectionType title" do
-        expect(collection_type_label(test_collection_type.gid)).to eq test_collection_type.title
+        expect(collection_type_label(test_collection_type.to_global_id))
+          .to eq test_collection_type.title
       end
     end
 

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
 
   shared_context 'with a collection' do
     let(:collection_type) { FactoryBot.create(:collection_type) }
-    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.gid) }
+    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id) }
   end
 
   describe '.collection_type_settings_methods' do
@@ -55,7 +55,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   describe '#gid' do
     it 'returns the gid when id exists' do
       collection_type.id = 5
-      expect(collection_type.gid.to_s).to eq "gid://#{GlobalID.app}/hyrax-collectiontype/5"
+      expect(collection_type.gid.to_s).to eq "gid://#{GlobalID.app}/#{described_class}/5"
     end
 
     it 'returns nil when id is nil' do
@@ -66,7 +66,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
 
   describe ".any_nestable?" do
     context "when there is a nestable collection type" do
-      let!(:collection_type) { create(:collection_type, nestable: true) }
+      let!(:collection_type) { FactoryBot.create(:collection_type, nestable: true) }
 
       it 'returns true' do
         expect(described_class.any_nestable?).to be true
@@ -74,7 +74,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     end
 
     context "when there are no nestable collection types" do
-      let!(:collection_type) { create(:collection_type, nestable: false) }
+      let!(:collection_type) { FactoryBot.create(:collection_type, nestable: false) }
 
       it 'returns false' do
         expect(described_class.any_nestable?).to be false
@@ -92,12 +92,13 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   describe ".gids_that_do_not_allow_multiple_membership" do
-    let!(:type_allows_multiple_membership) { create(:collection_type, allow_multiple_membership: true) }
-    let!(:type_disallows_multiple_membership) { create(:collection_type, allow_multiple_membership: false) }
+    let!(:type_allows_multiple_membership) { FactoryBot.create(:collection_type, allow_multiple_membership: true) }
+    let!(:type_disallows_multiple_membership) { FactoryBot.create(:collection_type, allow_multiple_membership: false) }
 
-    subject { described_class.gids_that_do_not_allow_multiple_membership }
-
-    it { is_expected.to match_array(type_disallows_multiple_membership.gid) }
+    it 'lists the single membership gids' do
+      expect(described_class.gids_that_do_not_allow_multiple_membership)
+        .to match_array(type_disallows_multiple_membership.to_global_id.to_s)
+    end
   end
 
   describe ".find_or_create_admin_set_type" do
@@ -112,7 +113,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   describe "validations", :clean_repo do
-    let(:collection_type) { create(:collection_type) }
+    let(:collection_type) { FactoryBot.create(:collection_type) }
 
     it "ensures the required fields have values" do
       collection_type.title = nil
@@ -128,7 +129,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   describe '.find_by_gid' do
-    let(:collection_type) { create(:collection_type) }
+    let(:collection_type) { FactoryBot.create(:collection_type) }
 
     it 'returns the same collection type the gid exists' do
       expect(described_class.find_by_gid(collection_type.gid)).to eq collection_type
@@ -169,8 +170,8 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   describe "collections" do
-    let!(:collection) { create(:collection_lw, collection_type_gid: collection_type.gid.to_s) }
-    let(:collection_type) { create(:collection_type) }
+    let!(:collection) { FactoryBot.create(:collection_lw, collection_type_gid: collection_type.gid.to_s) }
+    let(:collection_type) { FactoryBot.create(:collection_type) }
 
     it 'returns collections of this collection type' do
       expect(collection_type.collections.to_a).to include collection
@@ -183,10 +184,10 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   describe "collections?", :clean_repo do
-    let(:collection_type) { create(:collection_type) }
+    let(:collection_type) { FactoryBot.create(:collection_type) }
 
     it 'returns true if there are any collections of this collection type' do
-      create(:collection_lw, collection_type_gid: collection_type.gid.to_s)
+      FactoryBot.create(:collection_lw, collection_type: collection_type)
       expect(collection_type).to have_collections
     end
     it 'returns false if there are not any collections of this collection type' do
@@ -235,7 +236,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     end
 
     context 'for admin set collection type' do
-      let(:collection_type) { create(:admin_set_collection_type) }
+      let(:collection_type) { FactoryBot.create(:admin_set_collection_type) }
 
       it 'fails if settings are changed' do
         expect(collection_type.save).to be false
@@ -244,7 +245,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     end
 
     context 'for user collection type' do
-      let(:collection_type) { create(:user_collection_type) }
+      let(:collection_type) { FactoryBot.create(:user_collection_type) }
 
       it 'fails if settings are changed' do
         expect(collection_type.save).to be false

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -129,14 +129,17 @@ RSpec.describe Hyrax::CollectionType, type: :model do
 
   describe '.find_by_gid' do
     let(:collection_type) { create(:collection_type) }
-    let(:nonexistent_gid) { 'gid://internal/hyrax-collectiontype/NO_EXIST' }
 
-    it 'returns instance of collection type when one with the gid exists' do
+    it 'returns the same collection type the gid exists' do
       expect(described_class.find_by_gid(collection_type.gid)).to eq collection_type
     end
 
+    it 'returns the same collection type with `#to_global_id`' do
+      expect(described_class.find_by_gid(collection_type.to_global_id)).to eq collection_type
+    end
+
     it 'returns false if collection type with gid does NOT exist' do
-      expect(described_class.find_by_gid(nonexistent_gid)).to eq false
+      expect(described_class.find_by_gid('gid://internal/hyrax-collectiontype/NO_EXIST')).to eq false
     end
 
     it 'returns false if gid is nil' do
@@ -145,15 +148,18 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   describe '.find_by_gid!' do
-    let(:collection_type) { create(:collection_type) }
-    let(:nonexistent_gid) { 'gid://internal/hyrax-collectiontype/NO_EXIST' }
+    let(:collection_type) { FactoryBot.create(:collection_type) }
 
     it 'returns instance of collection type when one with the gid exists' do
       expect(described_class.find_by_gid(collection_type.gid)).to eq collection_type
     end
 
+    it 'returns the same collection type with `#to_global_id`' do
+      expect(described_class.find_by_gid!(collection_type.to_global_id)).to eq collection_type
+    end
+
     it 'raises error if collection type with gid does NOT exist' do
-      expect { described_class.find_by_gid!(nonexistent_gid) }
+      expect { described_class.find_by_gid!('gid://internal/hyrax-collectiontype/NO_EXIST') }
         .to raise_error(ActiveRecord::RecordNotFound)
     end
 

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     let(:collection_type) { create(:collection_type) }
 
     describe 'when solr_document#collection_type_gid exists' do
-      let(:collection) { build(:collection_lw, collection_type_gid: collection_type.gid) }
+      let(:collection) { FactoryBot.build(:collection_lw, collection_type: collection_type) }
       let(:solr_doc) { SolrDocument.new(collection.to_solr) }
 
       it 'finds the collection type based on the solr_document#collection_type_gid if one exists' do

--- a/spec/services/hyrax/collections/migration_service_spec.rb
+++ b/spec/services/hyrax/collections/migration_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::Collections::MigrationService, clean_repo: true do
   let(:depositor2) { create(:user) }
   let(:viewer1) { create(:user) }
   let(:viewer2) { create(:user) }
-  let(:default_gid) { create(:user_collection_type).gid }
+  let(:default_gid) { FactoryBot.create(:user_collection_type).to_global_id.to_s }
 
   describe ".migrate_all_collections" do
     context 'when legacy collections are found (e.g. collections created before Hyrax 2.1.0)' do

--- a/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   let(:coll_a) do
     build(:public_collection,
           id: 'Collection_A',
-          collection_type_gid: collection_type.gid,
+          collection_type: collection_type,
           with_nesting_attributes:
           { ancestors: [],
             parent_ids: [],
@@ -23,7 +23,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   let(:coll_b) do
     build(:public_collection,
           id: 'Collection_B',
-          collection_type_gid: collection_type.gid,
+          collection_type: collection_type,
           member_of_collections: [coll_a],
           with_nesting_attributes:
           { ancestors: ['Collection_A'],
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   let(:coll_c) do
     build(:public_collection,
           id: 'Collection_C',
-          collection_type_gid: collection_type.gid,
+          collection_type: collection_type,
           member_of_collections: [coll_b],
           with_nesting_attributes:
           { ancestors: ["Collection_A",
@@ -46,7 +46,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   let(:coll_d) do
     build(:public_collection,
           id: 'Collection_D',
-          collection_type_gid: collection_type.gid,
+          collection_type: collection_type,
           member_of_collections: [coll_c],
           with_nesting_attributes:
           { ancestors: ["Collection_A",
@@ -59,7 +59,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   let(:coll_e) do
     build(:public_collection,
           id: 'Collection_E',
-          collection_type_gid: collection_type.gid,
+          collection_type: collection_type,
           member_of_collections: [coll_d],
           with_nesting_attributes:
           { ancestors: ["Collection_A",
@@ -73,7 +73,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   let(:another) do
     build(:public_collection,
           id: 'Another_One',
-          collection_type_gid: collection_type.gid,
+          collection_type: collection_type,
           with_nesting_attributes:
           { ancestors: [],
             parent_ids: [],
@@ -83,7 +83,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   let(:wrong) do
     build(:public_collection,
           id: 'Wrong_Type',
-          collection_type_gid: another_collection_type.gid,
+          collection_type: another_collection_type,
           with_nesting_attributes:
           { ancestors: [],
             parent_ids: [],
@@ -156,14 +156,14 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
         let(:coll_a) do
           build(:public_collection_lw,
                 id: 'Collection_A',
-                collection_type_gid: collection_type.gid,
+                collection_type: collection_type,
                 user: user,
                 with_permission_template: true)
         end
         let(:coll_b) do
           build(:public_collection_lw,
                 id: 'Collection_B',
-                collection_type_gid: collection_type.gid,
+                collection_type: collection_type,
                 user: user,
                 with_permission_template: true,
                 member_of_collections: [coll_a])
@@ -171,7 +171,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
         let(:coll_c) do
           build(:public_collection_lw,
                 id: 'Collection_C',
-                collection_type_gid: collection_type.gid,
+                collection_type: collection_type,
                 user: user,
                 with_permission_template: true,
                 member_of_collections: [coll_b])
@@ -179,7 +179,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
         let(:coll_d) do
           build(:public_collection_lw,
                 id: 'Collection_D',
-                collection_type_gid: collection_type.gid,
+                collection_type: collection_type,
                 user: user,
                 with_permission_template: true,
                 member_of_collections: [coll_c])
@@ -187,7 +187,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
         let(:coll_e) do
           create(:public_collection_lw,
                  id: 'Collection_E',
-                 collection_type_gid: collection_type.gid,
+                 collection_type: collection_type,
                  user: user,
                  with_permission_template: true,
                  member_of_collections: [coll_d])
@@ -195,14 +195,14 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
         let(:another) do
           create(:public_collection_lw,
                  id: 'Another_One',
-                 collection_type_gid: collection_type.gid,
+                 collection_type: collection_type,
                  user: user,
                  with_permission_template: true)
         end
         let(:wrong) do
           build(:public_collection_lw,
                 id: 'Wrong_Type',
-                collection_type_gid: another_collection_type.gid,
+                collection_type: another_collection_type,
                 user: user,
                 with_permission_template: true)
         end
@@ -248,14 +248,14 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
         let!(:parent) do
           create(:public_collection_lw,
                  id: 'Parent_Collecton',
-                 collection_type_gid: collection_type.gid,
+                 collection_type: collection_type,
                  user: user,
                  with_permission_template: true)
         end
         let!(:child) do
           create(:public_collection_lw,
                  id: 'Child_Collection',
-                 collection_type_gid: collection_type.gid,
+                 collection_type: collection_type,
                  user: user,
                  with_permission_template: true)
         end
@@ -326,12 +326,13 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
 
   describe 'nesting attributes object', with_nested_reindexing: true do
     let(:user) { create(:user) }
-    let!(:parent) { build(:collection_lw, id: 'Parent_Coll', collection_type_gid: collection_type.gid, user: user) }
-    let!(:child) { create(:user_collection_lw, id: 'Child_Coll', collection_type_gid: collection_type.gid, user: user) }
+    let(:parent) { FactoryBot.build(:collection_lw, id: 'Parent_Coll', collection_type: collection_type, user: user) }
+    let(:child) { FactoryBot.create(:collection_lw, id: 'Child_Coll', collection_type: collection_type, user: user) }
     let(:nesting_attributes) { Hyrax::Collections::NestedCollectionQueryService::NestingAttributes.new(id: child.id, scope: scope) }
 
     before do
-      Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent, child: child)
+      Hyrax::Collections::NestedCollectionPersistenceService
+        .persist_nested_collection_for(parent: parent, child: child)
     end
 
     it 'will respond to expected methods' do

--- a/spec/services/hyrax/collections/permissions_create_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_create_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::Collections::PermissionsCreateService do
     end
     let!(:collection_type_participant) { create(:collection_type_participant, user_manage_attributes) }
     let!(:collection_type_participant2) { create(:collection_type_participant, group_manage_attributes) }
-    let(:collection) { build(:collection_lw, id: 'collection1', collection_type_gid: collection_type.gid) }
+    let(:collection) { FactoryBot.build(:collection_lw, id: 'collection1', collection_type: collection_type) }
 
     before do
       subject

--- a/spec/services/hyrax/multiple_membership_checker_spec.rb
+++ b/spec/services/hyrax/multiple_membership_checker_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
 
       context 'with multiple single membership collection types' do
         let!(:collection_type_2) { create(:collection_type, title: 'Doc', allow_multiple_membership: false) }
-        let(:collection_type_gids) { [collection_type.gid, collection_type_2.gid] }
+        let(:collection_type_gids) { [collection_type.to_global_id, collection_type_2.to_global_id] }
 
         it 'returns an error' do
           expect(item).not_to receive(:member_of_collection_ids)
@@ -110,7 +110,7 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
 
       context 'with multiple single membership collection types' do
         let!(:collection_type_2) { create(:collection_type, title: 'Doc', allow_multiple_membership: false) }
-        let(:collection_type_gids) { [collection_type.gid, collection_type_2.gid] }
+        let(:collection_type_gids) { [collection_type.to_global_id, collection_type_2.to_global_id] }
 
         it 'returns an error' do
           expect(item).to receive(:member_of_collection_ids)
@@ -127,7 +127,7 @@ RSpec.describe Hyrax::MultipleMembershipChecker, :clean_repo do
       let(:collections) { [collection1, collection2] }
       let(:collection_ids) { collections.map(&:id) }
       let(:collection_type_2) { create(:collection_type, title: 'Doc', allow_multiple_membership: false) }
-      let(:collection_type_gids) { [collection_type.gid, collection_type_2.gid] }
+      let(:collection_type_gids) { [collection_type.to_global_id, collection_type_2.to_global_id] }
 
       it 'returns nil' do
         expect(item).not_to receive(:member_of_collection_ids)

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -25,4 +25,39 @@ RSpec.describe "Rake tasks" do
       File.delete("abc123.txt")
     end
   end
+
+  describe 'hyrax:collections', :clean_repo do
+    describe ':update_collection_type_global_ids' do
+      before do
+        load_rake_environment [File.expand_path('../../../lib/tasks/collection_type_global_id.rake', __FILE__)]
+      end
+
+      context 'with no collections' do
+        it 'outputs that 0 collections were updated' do
+          run_task 'hyrax:collections:update_collection_type_global_ids'
+        end
+      end
+
+      context 'with collections' do
+        let(:collection_type) { FactoryBot.create(:collection_type) }
+        let(:other_collection_type) { FactoryBot.create(:collection_type) }
+
+        let(:collections_with_legacy_gids) do
+          [FactoryBot.create(:collection, collection_type_gid: "gid://internal/sometext/#{collection_type.id}"),
+           FactoryBot.create(:collection, collection_type_gid: "gid://internal/sometext/#{other_collection_type.id}")]
+        end
+
+        before do
+          FactoryBot.create_list(:collection, 3, collection_type_gid: collection_type.to_global_id)
+          FactoryBot.create_list(:collection, 3, collection_type_gid: other_collection_type.to_global_id)
+        end
+
+        it 'updates collections to use standard GlobalId URI' do
+          expect { run_task 'hyrax:collections:update_collection_type_global_ids' }
+            .to change { collections_with_legacy_gids.map { |col| col.reload.collection_type_gid } }
+            .to eq [collection_type.to_global_id.to_s, other_collection_type.to_global_id.to_s]
+        end
+      end
+    end
+  end
 end

--- a/spec/views/hyrax/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/show.html.erb_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe 'hyrax/collections/show.html.erb', type: :view do
   let(:document) do
     SolrDocument.new(id: 'xyz123z4',
-                     'collection_type_gid_ssim' => [collection_type.gid],
+                     'collection_type_gid_ssim' => [collection_type.to_global_id.to_s],
                      'title_tesim' => ['Make Collections Great Again'],
                      'rights_tesim' => ["http://creativecommons.org/licenses/by-sa/3.0/us/"])
   end

--- a/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
         "title_tesim" => ["Collection Title"],
         "description_tesim" => ["Collection Description"],
         "thumbnail_path_ss" => Hyrax::CollectionIndexer.thumbnail_path_service.default_image,
-        "collection_type_gid_ssim" => [collection_type.gid],
+        "collection_type_gid_ssim" => [collection_type.to_global_id.to_s],
         "system_modified_dtsi" => modified_date
       }
     end
 
     let(:doc) { SolrDocument.new(attributes) }
-    let(:collection_type) { build(:collection_type) }
+    let(:collection_type) { FactoryBot.build(:collection_type, id: 'coltype_id') }
     let(:collection_presenter) { Hyrax::CollectionPresenter.new(doc, Ability.new(build(:user)), nil) }
 
     before do
@@ -67,7 +67,7 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
         "title_tesim" => ["AdminSet Title"],
         "description_tesim" => ["Admin Description"],
         "thumbnail_path_ss" => Hyrax::AdminSetIndexer.thumbnail_path_service.default_image,
-        "collection_type_gid_ssim" => [collection_type.gid],
+        "collection_type_gid_ssim" => [collection_type.to_global_id.to_s],
         "system_modified_dtsi" => modified_date
       }
     end


### PR DESCRIPTION
addresses #4696 by:

  - allowing `CollectionType#find_by_gid` to find "real" GlobalID objects and matching strings.
  - providing a rake task to convert existing references to the new syntax
  - deprecating `#gid` in favor of `#to_global_id`

to move away from the old custom format, we'll need to provide a data migration/rake task that can fix existing references.

@samvera/hyrax-code-reviewers
