### PR TITLE
remove `sleep` from collection membership specs

### DIFF
--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
         visit '/dashboard/my/works'
         check 'check_all'
         click_button 'Add to collection' # opens the modal
-        sleep 5
         select_member_of_collection(new_collection)
         click_button 'Save changes'
 
@@ -119,9 +118,7 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
 
           select_collection(new_collection)
           check('agreement')
-          sleep 3
           choose('generic_work_visibility_open')
-          sleep 3
 
           within('div#savewidget') do
             element = nil

--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_repo: true, js: true do
+RSpec.describe 'Adding a work to multiple collections', type: :feature, js: true do
   include Selectors::Dashboard
   let(:admin_user) { create(:admin, email: 'admin@example.com') }
   let(:single_membership_type_1) { create(:collection_type, :not_allow_multiple_membership, title: 'Single-membership 1') }
@@ -19,7 +19,6 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
       let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_2.gid, title: ['NewCollectionTitle']) }
 
       it 'then the work is added to both collections' do
-        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
         # Add to second multi-membership collection of a different type
         visit '/dashboard/my/works'
         check 'check_all'
@@ -39,7 +38,6 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
       let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: multi_membership_type_1.gid, title: ['NewCollectionTitle']) }
 
       it 'then the work is added to both collections' do
-        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
         # Add to second multi-membership collection of a different type
         visit '/dashboard/my/works'
         check 'check_all'
@@ -71,7 +69,6 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
       let!(:new_collection) { create(:collection_lw, user: admin_user, collection_type_gid: single_membership_type_2.gid, title: ['NewCollectionTitle']) }
 
       it 'then the work is added to both collections' do
-        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
         # Add to second single-membership collection of a different type
         visit '/dashboard/my/works'
         check 'check_all'
@@ -92,7 +89,6 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
 
       context 'then the work fails to add to the second collection' do
         it 'from the dashboard->works batch add to collection' do
-          optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
           # Attempt to add to second single-membership collection of the same type
           visit '/dashboard/my/works'
           check 'check_all'
@@ -164,7 +160,6 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
       let!(:new_collection) { old_collection }
 
       it 'then the add is treated as a success' do
-        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
         # Re-add to same multi-membership collection
         visit '/dashboard/my/works'
         check 'check_all'
@@ -185,7 +180,6 @@ RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_re
       let!(:new_collection) { old_collection }
 
       it 'then the add is treated as a success' do
-        optional 'ability to get capybara to find css select2-result (see Issue #3038)' if ci_build?
         # Re-add to same single-membership collection
         visit '/dashboard/my/works'
         check 'check_all'

--- a/spec/support/selectors.rb
+++ b/spec/support/selectors.rb
@@ -43,17 +43,15 @@ module Selectors
     def select_member_of_collection(collection) # rubocop:disable Metrics/MethodLength
       find('#s2id_member_of_collection_ids').click
       find('.select2-input').set(collection.title.first)
+
       # Crude way of waiting for the AJAX response
-      select2_results = []
-      time_elapsed = 0
-      while select2_results.empty? && time_elapsed < 60
-        begin_time = Time.now.to_f
-        doc = Nokogiri::XML.parse(page.body)
-        select2_results = doc.xpath('//html:li[contains(@class,"select2-result")]', html: 'http://www.w3.org/1999/xhtml')
-        end_time = Time.now.to_f
-        time_elapsed += end_time - begin_time
+      select2_results = false
+      begin_time = current_time = Time.now.to_f
+      while !select2_results && (current_time - begin_time) < 3
+        select2_results = page.has_css?('li.select2-result')
+        current_time = Time.now.to_f
       end
-      expect(page).to have_css('.select2-result')
+
       within ".select2-result" do
         find("span", text: collection.title.first).click
       end


### PR DESCRIPTION
these sleep statements add clock time to the tests and are hopefully not needed.

~~these tests are slow enough as is!~~

this also now includes a removal of some imprecise wait code:

> this code was *always* waiting 60 seconds. instead let's wait a maximum of 3, and actually quit when the results appear.

fixing:

> Slowest examples                                                                                                                                                                                                                                                                 
>   Adding a work to multiple collections when adding a work already in a collection requiring single-membership then the add is treated as a success                                                                                                                              
>     ./spec/features/collection_multi_membership_spec.rb:187                                                                                                                                                                                                                      
>     69.549399448 seconds                                                                                                                                                                                                                                                         
>   Adding a work to multiple collections when both collections support multiple membership and are of different types then the work is added to both collections                                                                                                                  
>     ./spec/features/collection_multi_membership_spec.rb:21                                                                                                                                                                                                                       
>     67.607107951 seconds                                                                                                                                                                                                                                                         
>   Adding a work to multiple collections when both collections require single membership and are of different types then the work is added to both collections                                                                                                                    
>     ./spec/features/collection_multi_membership_spec.rb:73                                                                                                                                                                                                                       
>     67.538731979 seconds                                                                                                                                                                                                                                                         
>   Adding a work to multiple collections when both collections support multiple membership and are of the same type then the work is added to both collections                                                                                                                    
>     ./spec/features/collection_multi_membership_spec.rb:41                                                                                                                                                                                                                       
>     66.623338903 seconds                                                                                                                                                                                                                                                         
>   Adding a work to multiple collections when adding a work already in a collection allowing multi-membership then the add is treated as a success                                                                                                                                
>     ./spec/features/collection_multi_membership_spec.rb:166                                                                                                                                                                                                                      
>     66.28511291 seconds                                                                                                                                                                                                                                                          
>   Adding a work to multiple collections when both collections require single membership and are of the same type then the work fails to add to the second collection from the dashboard->works batch add to collection                                                           
>     ./spec/features/collection_multi_membership_spec.rb:94                                                                                                                                                                                                                       
>     66.234296793 seconds                                                                                                                                                                                                                                                         
>   Adding a work to multiple collections when both collections require single membership and are of the same type then the work fails to add to the second collection from the work's edit form Relationships tab                                                                 
>     ./spec/features/collection_multi_membership_spec.rb:114                                                                                                                                                                                                                      
>     7.185194964 seconds                                                                                                                                                                                                                                                          
>   Adding a work to multiple collections when both collections require single membership and are of the same type then the work fails to add to the second collection from the collection's show page Add to collection                                                           
>     ./spec/features/collection_multi_membership_spec.rb:134                                                                                                                                                                                                                      
>     6.19967933 seconds                                                                                                                                                                                                                                                           

@samvera/hyrax-code-reviewers
