### PR TITLE
speed up grant_read_to_members_job_spec; don't stub unit under test

### DIFF
--- a/spec/jobs/hyrax/grant_read_to_members_job_spec.rb
+++ b/spec/jobs/hyrax/grant_read_to_members_job_spec.rb
@@ -1,33 +1,30 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::GrantReadToMembersJob do
-  let(:depositor) { create(:user) }
+RSpec.describe Hyrax::GrantReadToMembersJob, perform_enqueued: [Hyrax::GrantReadToMembersJob] do
+  let(:depositor) { FactoryBot.create(:user) }
 
   context "when using active fedora" do
-    let(:work) { create(:work) }
-    let(:file_set_ids) { ['xyz123abc', 'abc789zyx'] }
-
-    before do
-      allow_any_instance_of(described_class).to receive(:file_set_ids).with(work).and_return(file_set_ids)
-    end
+    let(:work) { FactoryBot.create(:work_with_files) }
 
     it 'loops over FileSet IDs, spawning a job for each' do
-      file_set_ids.each do |file_set_id|
+      work.member_ids.each do |file_set_id|
         expect(Hyrax::GrantReadJob).to receive(:perform_now).with(file_set_id, depositor.user_key, use_valkyrie: false).once
       end
-      described_class.perform_now(work, depositor.user_key)
+
+      described_class.perform_later(work, depositor.user_key)
     end
   end
 
-  context "when using valkyrie" do
-    let(:file_set1) { valkyrie_create(:hyrax_file_set) }
-    let(:file_set2) { valkyrie_create(:hyrax_file_set) }
-    let(:work) { valkyrie_create(:hyrax_work, member_ids: [file_set1.id, file_set2.id]) }
+  context "when using valkyrie", valkyrie_adapter: :test_adapter  do
+    let(:file_set1) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+    let(:file_set2) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work, member_ids: [file_set1.id, file_set2.id]) }
 
     it 'loops over FileSet IDs, spawning a job for each' do
       work.member_ids.each do |file_set_id|
         expect(Hyrax::GrantReadJob).to receive(:perform_now).with(file_set_id, depositor.user_key, use_valkyrie: true).once
       end
-      described_class.perform_now(work, depositor.user_key)
+
+      described_class.perform_later(work, depositor.user_key)
     end
   end
 end


### PR DESCRIPTION
use the test ActiveJob adapter for this test set; don't stub the unit under
test for ActiveFedora tests; use the memory valkyrie adapter for valkyrie unit
tests.

@samvera/hyrax-code-reviewers
