### PR TITLE
refactor and unskip ownership transfer tests

### DIFF
--- a/app/views/hyrax/transfers/_received.html.erb
+++ b/app/views/hyrax/transfers/_received.html.erb
@@ -26,13 +26,13 @@
               <button class="btn btn-sm dropdown-toggle accept" data-toggle="dropdown" href="#"><span class="caret"></span></button>
               <ul class="dropdown-menu">
                 <li>
-                  <%= link_to t(".allow_depositor_to_retain_edit_access"), hyrax.accept_transfer_path(req), method: :put, class: 'accept-retain', title: t(".accept_the_file_and_allow_the_original_depositor_to_retain_access_to_edit_the_file_and_metadata") %>
+                  <%= link_to t(".allow_depositor_to_retain_edit_access"), hyrax.accept_transfer_path(req), method: :put, class: 'accept-retain', id: 'accept-retain', title: t(".accept_the_file_and_allow_the_original_depositor_to_retain_access_to_edit_the_file_and_metadata") %>
                 </li>
                 <li>
-                  <%= link_to t(".remove_depositor_access"), hyrax.accept_transfer_path(req, reset: true), method: :put, class: 'accept-reset', title: t(".accept_the_file_remove_access_from_the_original_depositor") %>
+                  <%= link_to t(".remove_depositor_access"), hyrax.accept_transfer_path(req, reset: true), method: :put, class: 'accept-reset', id: 'accept-reset', title: t(".accept_the_file_remove_access_from_the_original_depositor") %>
                 </li>
                 <li>
-                  <%= link_to t(".authorize_depositor_as_proxy"), hyrax.accept_transfer_path(req, sticky: true), method: :put, class: 'accept-stick', title: t(".accept_the_file_and_allow_the_original_depositor_to_retain_access_and_authorize") %>
+                  <%= link_to t(".authorize_depositor_as_proxy"), hyrax.accept_transfer_path(req, sticky: true), method: :put, class: 'accept-stick', id: 'accept-stick', title: t(".accept_the_file_and_allow_the_original_depositor_to_retain_access_and_authorize") %>
                 </li>
               </ul>
             </div>

--- a/spec/features/ownership_transfer_spec.rb
+++ b/spec/features/ownership_transfer_spec.rb
@@ -4,55 +4,40 @@ RSpec.describe 'Transferring work ownership:', type: :feature do
   include Selectors::NewTransfers
   include Selectors::Transfers
 
-  let(:original_owner) { create(:user) }
-  let(:new_owner) { create(:user) }
-  let!(:work) do
-    create(:public_work,
-           title: ['little_generic_work'],
-           creator: ['little_generic_work.creator'],
-           resource_type: ["stuff"],
-           user: original_owner)
+  let(:original_owner) { FactoryBot.create(:user) }
+  let(:new_owner) { FactoryBot.create(:user) }
+  let(:work) do
+    FactoryBot.create(:public_work,
+                      title: ['little_generic_work'],
+                      creator: ['little_generic_work.creator'],
+                      resource_type: ["stuff"],
+                      user: original_owner)
   end
 
-  describe 'When I request a work transfer:', :js do
-    before do
-      sign_in original_owner
-    end
+  describe 'when I request a work transfer', :js do
+    before { sign_in(original_owner) }
 
     context 'To myself' do
       before { transfer_ownership_of_work work, original_owner }
+
       it 'displays an appropriate error message' do
         expect(page).to have_content 'Specify a different user to receive the work'
       end
     end
 
-    context 'To someone else' do
-      before { transfer_ownership_of_work work, new_owner }
+    it 'if the new owner accepts it I should see it was accepted' do
+      transfer_ownership_of_work(work, new_owner)
+      expect(page).to have_content('Transfer request created')
+      new_owner.proxy_deposit_requests.last.transfer!
+      # refresh the page
+      visit '/dashboard'
+      expect(page.find('#outgoing-transfers')).to have_content 'Accepted'
+    end
 
-      it 'Creates a transfer request' do
-        expect(page).to have_content 'Transfer request created'
-      end
-
-      context 'If the new owner accepts it' do
-        before do
-          expect(page).to have_content('Transfer request created')
-          new_owner.proxy_deposit_requests.last.transfer!
-          # refresh the page
-          visit '/dashboard'
-        end
-        it 'I should see it was accepted' do
-          expect(page.find('#outgoing-transfers')).to have_content 'Accepted'
-        end
-      end
-
-      context 'If I cancel it' do
-        before do
-          accept_confirm { first_sent_cancel_button.click }
-        end
-        it 'I should see it was cancelled' do
-          expect(page).to have_content 'Transfer canceled'
-        end
-      end
+    it 'if I cancel it I should see it was cancelled' do
+      transfer_ownership_of_work(work, new_owner)
+      accept_confirm { first_sent_cancel_button.click }
+      expect(page).to have_content 'Transfer canceled'
     end
   end
 
@@ -65,21 +50,22 @@ RSpec.describe 'Transferring work ownership:', type: :feature do
 
       # Become the new_owner so we can manage transfers sent to us
       sign_in new_owner
-      visit '/dashboard'
-      expect(page).to have_content 'Transfers of Ownership'
     end
 
     it 'I should be able to accept it' do
-      skip if ci_build?
+      visit '/dashboard'
+
       within('#notifications') do
         expect(page).to have_content "#{original_owner.name} wants to transfer a work to you"
       end
       first_received_accept_dropdown.click
-      click_link 'Allow depositor to retain edit access'
+      click_link 'accept-retain'
       expect(page).to have_content 'Transfer complete'
     end
 
     it 'I should be able to reject it' do
+      visit '/dashboard'
+
       within('#notifications') do
         expect(page).to have_content "#{original_owner.name} wants to transfer a work to you"
       end


### PR DESCRIPTION
remove at least one unneeded repetition of this test setup. unskip test skipped in CI.

@samvera/hyrax-code-reviewers
