### PR TITLE
deprecate passing an entire request object to `GraphExporter`

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -282,7 +282,7 @@ module Hyrax
     end
 
     def graph
-      GraphExporter.new(solr_document, request).fetch
+      GraphExporter.new(solr_document, hostname: request.host).fetch
     end
 
     # @return [Array<String>] member_of_collection_ids with current_ability access

--- a/app/services/hyrax/graph_exporter.rb
+++ b/app/services/hyrax/graph_exporter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Hyrax
   ##
+  # @api public
+  #
   # Retrieves the graph for an object with the internal triples removed
   # and the uris translated to external uris.
   class GraphExporter
@@ -30,6 +32,7 @@ module Hyrax
     attr_reader :solr_document, :request, :additional_resources, :hostname
     deprecation_deprecate :request
 
+    ##
     # @return [RDF::Graph]
     def fetch
       clean_graph_repository.find(solr_document.id).tap do |g|
@@ -74,10 +77,10 @@ module Hyrax
 
       if @visited_subresources.add?(resource_id)
         additional_resources << ListSourceExporter.new(
-          resource_id,
-          nil,
-          subject_replacer(parent_klass, parent_id),
-          hostname: hostname
+          id: resource_id,
+          parent_url: subject_replacer(parent_klass, parent_id),
+          hostname: hostname,
+          connection: connection
         ).fetch
       end
 
@@ -102,6 +105,46 @@ module Hyrax
     def object_replacer(id, _graph)
       id, anchor = id.split('/', 2)
       Rails.application.routes.url_helpers.solr_document_url(id, host: hostname, anchor: anchor)
+    end
+
+    ##
+    # @api private
+    class ListSourceExporter
+      def initialize(hostname:, id:, parent_url:, connection: CleanConnection.new(ActiveFedora.fedora.connection))
+        @connection = connection
+        @id = id
+        @hostname = hostname
+        @parent_url = parent_url
+      end
+
+      # @!attribute [r] hostname
+      #   @return [String]
+      # @!attribute [r] id
+      #   @return [String]
+      # @!attribute [r] parent_url
+      #   @return [String]
+      attr_reader :hostname, :id, :parent_url
+
+      ##
+      # @return [RDF::Graph]
+      def fetch
+        clean_graph_repository.find(id)
+      end
+
+      private
+
+      def clean_graph_repository
+        Hydra::ContentNegotiation::CleanGraphRepository.new(@connection, replacer)
+      end
+
+      # This method is called once for each statement in the graph.
+      def replacer
+        lambda do |resource_id, _graph|
+          parent_id = Hyrax::Base.uri_to_id(parent_url)
+          return parent_url + resource_id.sub(parent_id, '') if resource_id.start_with?(parent_id)
+          Rails.application.routes.url_helpers.solr_document_url(resource_id, host: hostname)
+        end
+      end
     end
   end
 end

--- a/app/services/hyrax/list_source_exporter.rb
+++ b/app/services/hyrax/list_source_exporter.rb
@@ -3,17 +3,32 @@ module Hyrax
   # Retrieves the graph for an object with the internal triples removed
   # and the uris translated to external uris.
   class ListSourceExporter
+    ##
     # @param [String] id
     # @param [ActionDispatch::Request] request the http request context
     # @param [String] parent_url
-    def initialize(id, request, parent_url)
+    # @param [String] hostname  the current http host
+    def initialize(id, request, parent_url, hostname: nil)
       @id = id
       @request = request
+      @hostname = hostname || request.host
       @parent_url = parent_url
     end
 
-    attr_reader :id, :request, :parent_url
+    ##
+    # @!attribute [r] id
+    #   @return [String]
+    # @!attribute [r] parent_url
+    #   @return [String]
+    # @!attribute [r] request
+    #   @deprecated use {#hostname} to access the host
+    #   @return [ActionDispatch::Request]
+    # @!attribute [r] hostname
+    #   @return [String]
+    attr_reader :id, :request, :parent_url, :hostname
+    deprecation_deprecate :request
 
+    ##
     # @return [RDF::Graph]
     def fetch
       clean_graph_repository.find(id)
@@ -36,10 +51,6 @@ module Hyrax
         return parent_url + resource_id.sub(parent_id, '') if resource_id.start_with?(parent_id)
         Rails.application.routes.url_helpers.solr_document_url(resource_id, host: hostname)
       end
-    end
-
-    def hostname
-      request.host
     end
   end
 end

--- a/app/services/hyrax/list_source_exporter.rb
+++ b/app/services/hyrax/list_source_exporter.rb
@@ -1,56 +1,27 @@
 # frozen_string_literal: true
 module Hyrax
+  ##
+  # @deprecated see Hyrax::GraphExporter::ListSourceExporter
+  #
   # Retrieves the graph for an object with the internal triples removed
   # and the uris translated to external uris.
-  class ListSourceExporter
+  class ListSourceExporter < GraphExporter::ListSourceExporter
     ##
     # @param [String] id
     # @param [ActionDispatch::Request] request the http request context
     # @param [String] parent_url
     # @param [String] hostname  the current http host
     def initialize(id, request, parent_url, hostname: nil)
-      @id = id
-      @request = request
-      @hostname = hostname || request.host
-      @parent_url = parent_url
+      Deprecation.warn("#{subject.class} is deprecated and replaced with the (private) Hyrax::GraphExporter::")
+      host = hostname || request.host
+      super(id: id, parent_url: parent_url, hostname: host)
     end
 
     ##
-    # @!attribute [r] id
-    #   @return [String]
-    # @!attribute [r] parent_url
-    #   @return [String]
     # @!attribute [r] request
     #   @deprecated use {#hostname} to access the host
     #   @return [ActionDispatch::Request]
-    # @!attribute [r] hostname
-    #   @return [String]
-    attr_reader :id, :request, :parent_url, :hostname
+    attr_reader :request
     deprecation_deprecate :request
-
-    ##
-    # @return [RDF::Graph]
-    def fetch
-      clean_graph_repository.find(id)
-    end
-
-    private
-
-    def clean_graph_repository
-      Hydra::ContentNegotiation::CleanGraphRepository.new(connection, replacer)
-    end
-
-    def connection
-      @connection ||= CleanConnection.new(ActiveFedora.fedora.connection)
-    end
-
-    # This method is called once for each statement in the graph.
-    def replacer
-      lambda do |resource_id, _graph|
-        parent_id = Hyrax::Base.uri_to_id(parent_url)
-        return parent_url + resource_id.sub(parent_id, '') if resource_id.start_with?(parent_id)
-        Rails.application.routes.url_helpers.solr_document_url(resource_id, host: hostname)
-      end
-    end
   end
 end

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "work show view" do
   let(:work_path) { "/concern/generic_works/#{work.id}" }
 
   before do
-    create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+    FactoryBot.create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
   end
 
   context "as the work owner" do
@@ -19,11 +19,11 @@ RSpec.describe "work show view" do
              ordered_members: [file_set],
              representative_id: file_set.id)
     end
-    let(:user) { create(:user) }
-    let(:file_set) { create(:file_set, user: user, title: ['A Contained FileSet'], content: file) }
+    let(:user) { FactoryBot.create(:user) }
+    let(:file_set) { FactoryBot.create(:file_set, user: user, title: ['A Contained FileSet'], content: file) }
     let(:file) { File.open(fixture_path + '/world.png') }
-    let(:multi_membership_type_1) { create(:collection_type, :allow_multiple_membership, title: 'Multi-membership 1') }
-    let!(:collection) { create(:collection_lw, user: user, collection_type_gid: multi_membership_type_1.gid) }
+    let(:multi_membership_type_1) { FactoryBot.create(:collection_type, :allow_multiple_membership, title: 'Multi-membership 1') }
+    let!(:collection) { FactoryBot.create(:collection_lw, user: user, collection_type_gid: multi_membership_type_1.gid) }
 
     before do
       sign_in user

--- a/spec/services/hyrax/graph_exporter_spec.rb
+++ b/spec/services/hyrax/graph_exporter_spec.rb
@@ -21,13 +21,8 @@ RSpec.describe Hyrax::GraphExporter do
       expect(graph.query([proxy, nil, nil]).count).to eq 2
     end
 
-    context "when a Ldp::NotFound is raised" do
-      before do
-        mock_repository_service = instance_double(Hydra::ContentNegotiation::CleanGraphRepository)
-        allow(mock_repository_service).to receive(:find).and_raise(Ldp::NotFound)
-
-        allow(service).to receive(:clean_graph_repository).and_return(mock_repository_service)
-      end
+    context "when the resource doesn't exist" do
+      let(:document) { double(id: 'a_missing_id') }
 
       it "raises a error that the controller catches and handles" do
         expect { service.fetch }.to raise_error ActiveFedora::ObjectNotFoundError


### PR DESCRIPTION
`GraphExporter` should only need to know about the `request.host`, not the entire request context.

@samvera/hyrax-code-reviewers
