### PR TITLE
backport: Update skip_to_content.js

### DIFF
--- a/app/assets/javascripts/hyrax/skip_to_content.js
+++ b/app/assets/javascripts/hyrax/skip_to_content.js
@@ -4,7 +4,7 @@ Blacklight.onLoad(function () {
   $(".skip-to-content").click(function(event) {
     event.preventDefault();
     // element to focus on
-    let skipTo = '#' + $(this)[0].firstElementChild.hash.split('#')[1];
+    var skipTo = '#' + $(this)[0].firstElementChild.hash.split('#')[1];
 
     // Setting 'tabindex' to -1 takes an element out of normal
     // tab flow but allows it to be focused via javascript


### PR DESCRIPTION
Remove ES6 dependency from 2.x stable.

Fixes #4705 

This commit removes the offending ES6 `let` syntax.

This does not address any potential changes desired in CI build that would have triggered this bug.

@samvera/hyrax-code-reviewers
