### PR TITLE
allow search filter to find `Hyrax::PcdmCollection` for searches

### DIFF
--- a/app/search_builders/hyrax/filter_by_type.rb
+++ b/app/search_builders/hyrax/filter_by_type.rb
@@ -53,8 +53,7 @@ module Hyrax
 
     def collection_classes
       return [] if only_works?
-      # to_class_uri is deprecated in AF 11
-      [::Collection]
+      [::Collection, Hyrax::PcdmCollection]
     end
   end
 end

--- a/spec/search_builders/hyrax/admin_admin_set_member_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/admin_admin_set_member_search_builder_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hyrax::AdminAdminSetMemberSearchBuilder do
     let(:solr_params) { { fq: [] } }
 
     it 'searches for valid work types' do
-      expect(solr_params[:fq].first).to include('{!terms f=has_model_ssim}GenericWork,Collection')
+      expect(solr_params[:fq].first).to include('{!terms f=has_model_ssim}GenericWork,Collection,Hyrax::PcdmCollection')
     end
     it 'does not limit to active only' do
       expect(solr_params[:fq].first).not_to include('-suppressed_bsi:true')

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::CollectionSearchBuilder do
   end
 
   describe '#models' do
-    its(:models) { is_expected.to eq([Collection]) }
+    its(:models) { is_expected.to eq([Collection, Hyrax::PcdmCollection]) }
   end
 
   describe '#discovery_permissions' do

--- a/spec/search_builders/hyrax/single_collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/single_collection_search_builder_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::SingleCollectionSearchBuilder do
+  subject(:builder) { described_class.new(scope) }
+  let(:scope) { FakeSearchBuilderScope.new }
+
+  shared_context 'with search params' do
+    let(:params) { { id: 'a_collection_id' } }
+
+    before { builder.with(params) }
+  end
+
+  describe "#to_hash" do
+    it 'with no parameters raises an error eagerly' do
+      expect { builder.to_hash }.to raise_error KeyError
+    end
+
+    context 'with parameters' do
+      include_context 'with search params'
+
+      it 'includes collection and pcdmcollection in type filter' do
+        expect(builder.to_hash['fq']).to include(/f\=has_model_ssim\}.*Collection,Hyrax::PcdmCollection/)
+      end
+
+      it 'searches for the provided id' do
+        expect(builder.to_hash['fq']).to include '{!raw f=id}a_collection_id'
+      end
+
+      it 'filters suppressed' do
+        expect(builder.to_hash['fq']).to include '-suppressed_bsi:true'
+      end
+    end
+  end
+end

--- a/spec/search_builders/hyrax/work_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/work_search_builder_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Hyrax::WorkSearchBuilder do
 
         it "filters for id, access, suppressed and type" do
           expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                      "{!terms f=has_model_ssim}GenericWork,Collection",
+                                      "{!terms f=has_model_ssim}GenericWork,Collection,Hyrax::PcdmCollection",
                                       "{!raw f=id}123abc"]
         end
       end
@@ -46,7 +46,7 @@ RSpec.describe Hyrax::WorkSearchBuilder do
 
           it "filters for id, access, suppressed and type" do
             expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                        "{!terms f=has_model_ssim}GenericWork,Collection",
+                                        "{!terms f=has_model_ssim}GenericWork,Collection,Hyrax::PcdmCollection",
                                         "-suppressed_bsi:true",
                                         "{!raw f=id}123abc"]
           end
@@ -59,7 +59,7 @@ RSpec.describe Hyrax::WorkSearchBuilder do
 
           it "filters for id, access, suppressed and type" do
             expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                        "{!terms f=has_model_ssim}GenericWork,Collection",
+                                        "{!terms f=has_model_ssim}GenericWork,Collection,Hyrax::PcdmCollection",
                                         "{!raw f=id}123abc"]
           end
         end
@@ -79,7 +79,7 @@ RSpec.describe Hyrax::WorkSearchBuilder do
 
         it "filters for id, access, suppressed and type" do
           expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                      "{!terms f=has_model_ssim}GenericWork,Collection",
+                                      "{!terms f=has_model_ssim}GenericWork,Collection,Hyrax::PcdmCollection",
                                       "-suppressed_bsi:true",
                                       "{!raw f=id}123abc"]
         end
@@ -92,7 +92,7 @@ RSpec.describe Hyrax::WorkSearchBuilder do
 
         it "filters for id, access, suppressed and type" do
           expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
-                                      "{!terms f=has_model_ssim}GenericWork,Collection",
+                                      "{!terms f=has_model_ssim}GenericWork,Collection,Hyrax::PcdmCollection",
                                       "{!raw f=id}123abc"]
         end
       end


### PR DESCRIPTION
when searches should find a collection model, allow them to find
`Hyrax::PcdmCollection`.

@samvera/hyrax-code-reviewers
