### PR TITLE
Contact form text

### DIFF
--- a/app/helpers/hyrax/contact_form_helper.rb
+++ b/app/helpers/hyrax/contact_form_helper.rb
@@ -17,8 +17,7 @@ module Hyrax
     #
     # @see https://apidock.com/rails/ActionView/Helpers/FormOptionsHelper/options_for_select
     def contact_form_issue_type_options
-      types = Hyrax::ContactForm.issue_types_for_locale.dup
-      types.unshift([t('hyrax.contact_form.select_type'), nil])
+      Hyrax::ContactForm.issue_types_for_locale.dup
     end
   end
 end

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -22,7 +22,7 @@
   <div class="form-group">
     <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
-      <%= f.select 'category', options_for_select(contact_form_issue_type_options), {}, {class: 'form-control', required: true } %>
+      <%= f.select 'category', options_for_select(contact_form_issue_type_options), { include_blank: t('hyrax.contact_form.select_type') }, {class: 'form-control', required: true } %>
     </div>
   </div>
 

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,3 +1,5 @@
+<% provide :page_title, I18n.t('hyrax.contact_form.title') %>
+
 <div class="alert alert-info">
   <%= render 'directions' %>
 </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -657,6 +657,7 @@ en:
       notice: Please use the contact form to submit inquiries about this system; to report a problem you are experiencing with the system; to request assistance using the system; or to provide general feedback. See the Help page for additional information about this system.
       select_type: Select an Issue Type
       subject_label: Subject
+      title: Contact Us
       type_label: Issue Type
     content_blocks:
       cancel: Cancel

--- a/spec/helpers/hyrax/contact_form_helper_spec.rb
+++ b/spec/helpers/hyrax/contact_form_helper_spec.rb
@@ -2,10 +2,6 @@
 
 RSpec.describe Hyrax::ContactFormHelper, type: :helper do
   describe '#contact_form_issue_type_options' do
-    it 'has a nil (label) option first' do
-      expect(helper.contact_form_issue_type_options.first).to match([an_instance_of(String), nil])
-    end
-
     it 'has string options' do
       expect(helper.contact_form_issue_type_options[1..-1]).to all(be_an_instance_of(String))
     end


### PR DESCRIPTION
Two proposed changes to the Contact form:
* Make the page title for the Contact page directly configurable; it currently assumes default title generation
* Moves the blank value text from the form helper into the f.select call; this fixes having both a blankline entry _and_ a "Select..." entry, and also feels a little cleaner

@samvera/hyrax-code-reviewers
