### PR TITLE
Remove issue type hard-coding within #issue_types_for_locale

### DIFF
--- a/app/models/hyrax/contact_form.rb
+++ b/app/models/hyrax/contact_form.rb
@@ -24,13 +24,7 @@ module Hyrax
     end
 
     def self.issue_types_for_locale
-      [
-        I18n.t('hyrax.contact_form.issue_types.depositing'),
-        I18n.t('hyrax.contact_form.issue_types.changing'),
-        I18n.t('hyrax.contact_form.issue_types.browsing'),
-        I18n.t('hyrax.contact_form.issue_types.reporting'),
-        I18n.t('hyrax.contact_form.issue_types.general')
-      ]
+      I18n.t('hyrax.contact_form.issue_types').values.select(&:present?)
     end
   end
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -647,11 +647,11 @@ en:
       email_label: Your Email
       header: Contact Form
       issue_types:
-        browsing: Browsing and searching
-        changing: Making changes to my content
         depositing: Depositing content
-        general: General inquiry or request
+        changing: Making changes to my content
+        browsing: Browsing and searching
         reporting: Reporting a problem
+        general: General inquiry or request
       message_label: Message
       name_label: Your Name
       notice: Please use the contact form to submit inquiries about this system; to report a problem you are experiencing with the system; to request assistance using the system; or to provide general feedback. See the Help page for additional information about this system.


### PR DESCRIPTION
Changes pulling issue types for the Contact form from a hard-coded list to whatever non-blank values are provided.

This has effectively no change on the output within stock Hyrax, but makes customizing the issue types in Hyrax-based projects doable solely via config locale changes, instead of necessitating code changes.

@samvera/hyrax-code-reviewers
