### PR TITLE
filter collections permissions on the application side

### DIFF
--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -22,15 +22,15 @@ module Hyrax
 
       def self.filter_source(source_type:, ids:)
         return [] if ids.empty?
-        id_clause = "{!terms f=id}#{ids.join(',')}"
+
         query = case source_type
                 when 'admin_set'
                   "_query_:\"{!raw f=has_model_ssim}AdminSet\""
                 when 'collection'
                   "_query_:\"{!raw f=has_model_ssim}Collection\""
                 end
-        query += " AND #{id_clause}"
-        Hyrax::SolrService.query(query, fl: 'id', rows: ids.count).map { |hit| hit['id'] }
+
+        Hyrax::SolrService.query(query, fl: 'id', rows: 100_000).map { |hit| hit['id'] } & ids
       end
       private_class_method :filter_source
 


### PR DESCRIPTION
`Collections::PermissionsService` formerly added a list of candidate collection
ids to a solr query. this caused a scaleing issue when thousads of collections
exist. even for a small handful of collections, it's probably best not to pass
so many id arguments to Solr. instead, get the full list of ids that are
Collections or AdminSet and do `Array` intersection.

this proposal has a different scaling problem: if there are a very large number
of Collections or AdminSets (not associated with the user) it's possible they'd
get missed.

honestly, the next step is probably to rewrite this to not use `SolrService` at
all. our various model abstraction layers should be able to tell us whether a
list of ids are of a certain model class quickly and reliably.

but this is for consideration as a short-term fix.

@samvera/hyrax-code-reviewers
