### PR TITLE
implement a generic query for finding ids by model

### DIFF
--- a/app/services/hyrax/custom_queries/find_ids_by_model.rb
+++ b/app/services/hyrax/custom_queries/find_ids_by_model.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module Hyrax
+  module CustomQueries
+    ##
+    # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
+    class FindIdsByModel
+      def self.queries
+        [:find_ids_by_model]
+      end
+
+      def initialize(query_service:)
+        @query_service = query_service
+      end
+
+      attr_reader :query_service
+      delegate :resource_factory, to: :query_service
+
+      ##
+      # @note this is an unoptimized default implementation of this custom
+      #   query. it's Hyrax's policy to provide such implementations of custom
+      #   queries in use for cross-compatibility of Valkyrie query services.
+      #   it's advisable to provide an optimized query for the specific adapter.
+      #
+      # @param model [Class]
+      # @param ids [Enumerable<#to_s>, Symbol]
+      #
+      # @return [Enumerable<Valkyrie::ID>]
+      def find_ids_by_model(model:, ids: :all)
+        return query_service.find_all_of_model(model: model).map(&:id) if ids == :all
+
+        query_service.find_many_by_ids(ids: ids).select do |resource|
+          resource.is_a?(model)
+        end.map(&:id)
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/custom_queries/find_ids_by_model_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_ids_by_model_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::CustomQueries::FindIdsByModel, valkyrie_adapter: :test_adapter do
+  subject(:query_handler) { described_class.new(query_service: Hyrax.query_service) }
+
+  after { Hyrax.persister.wipe! }
+
+  describe '#find_ids_by_model' do
+    let(:monographs) { [FactoryBot.valkyrie_create(:monograph), FactoryBot.valkyrie_create(:monograph), FactoryBot.valkyrie_create(:monograph)] }
+
+    before { [FactoryBot.valkyrie_create(:hyrax_work), FactoryBot.valkyrie_create(:hyrax_work)] }
+
+    it 'for a model without resources is empty' do
+      expect(query_handler.find_ids_by_model(model: Monograph)).to be_empty
+    end
+
+    it 'finds ids matching the model' do
+      monographs # create
+      expect(query_handler.find_ids_by_model(model: Monograph)).to contain_exactly(*monographs.map(&:id))
+    end
+
+    context 'with ids to filter' do
+      let(:ids) { ['first_id', 'second_id'] }
+
+      it 'for a model without resources is empty' do
+        expect(query_handler.find_ids_by_model(model: Monograph, ids: ids)).to be_empty
+      end
+
+      it 'finds ids matching the model' do
+        monograph_ids = monographs.map(&:id)
+        query_ids = monograph_ids.take(2) + ['fake_id']
+
+        expect(query_handler.find_ids_by_model(model: Monograph, ids: query_ids)).to contain_exactly(*monograph_ids.take(2))
+      end
+    end
+  end
+end


### PR DESCRIPTION
this makes it possible to query Valkyrie adapters to filter a set of ids down to
those matching a model. if no ids are passed, all ids matching the model are
returned.

this default implementation follows our policy of providing an implementation of
all custom queries that works for Hyrax using only Valkyrie's built-in
queries. follow-up work will implement for Wings.

@samvera/hyrax-code-reviewers
