### PR TITLE
reindex ActiveFedora objects when valkyrie ACLs are updated

### DIFF
--- a/app/services/hyrax/listeners/active_fedora_acl_index_listener.rb
+++ b/app/services/hyrax/listeners/active_fedora_acl_index_listener.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Reindexes resources when their ACLs are updated
+    #
+    # Hyrax's `Ability` behavior depends on the index being up-to-date as
+    # concerns-their read/write users/groups, and visibility.
+    class ActiveFedoraAclIndexListener
+      ##
+      # Re-index the resource for the updated ACL.
+      #
+      # @param event [Dry::Event]
+      def on_object_acl_updated(event)
+        return unless event[:result] == :success # do nothing on failure
+
+        if Hyrax.metadata_adapter.is_a?(Wings::Valkyrie::MetadataAdapter)
+          Wings::ActiveFedoraConverter.convert(resource: event[:acl].resource).update_index
+        else
+          Hyrax.logger.info('Skipping ActiveFedora object reindex because the Wings adapter is not in use.')
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Hyrax.publisher.subscribe(Hyrax::Listeners::AclIndexListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::ActiveFedoraAclIndexListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::MetadataIndexListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::BatchNotificationListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)

--- a/spec/controllers/concerns/hyrax/collections_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/collections_controller_behavior_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::CollectionsControllerBehavior, :clean_repo, type: :controller do
+  let(:paths) { controller.main_app }
+
+  controller(ApplicationController) do
+    include Hyrax::CollectionsControllerBehavior # rubocop:disable RSpec/DescribedClass
+  end
+
+  shared_context 'with a logged in user' do
+    let(:user) { FactoryBot.create(:user) }
+
+    before { sign_in user }
+  end
+
+  describe '#show' do
+    context 'with a public collection' do
+      let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, :public) }
+
+      it 'shows the collection' do
+        get :show, params: { id: collection.id }
+
+        expect(response).to be_successful
+      end
+
+      context 'with a logged in user' do
+        include_context 'with a logged in user'
+
+        it 'shows the collection' do
+          get :show, params: { id: collection.id }
+
+          expect(response).to be_successful
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -300,13 +300,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     end
 
     context 'when indexed as public' do
-      let(:index_document) do
-        Wings::ActiveFedoraConverter.convert(resource: work).to_solr.tap do |doc|
-          doc[Hydra.config.permissions.read.group] = 'public'
-        end
-      end
-
-      before { ActiveFedora::SolrService.add(index_document, softCommit: true) }
+      let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :public, alternate_ids: [id], title: title) }
 
       it_behaves_like 'allows show access'
     end
@@ -314,13 +308,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     context 'when the user has read access' do
       include_context 'with a logged in user'
 
-      let(:index_document) do
-        Wings::ActiveFedoraConverter.convert(resource: work).to_solr.tap do |doc|
-          doc[Hydra.config.permissions.read.individual] = [user.user_key]
-        end
-      end
-
-      before { ActiveFedora::SolrService.add(index_document, softCommit: true) }
+      let(:work) { FactoryBot.valkyrie_create(:hyrax_work, alternate_ids: [id], title: title, read_users: [user]) }
 
       it_behaves_like 'allows show access'
     end

--- a/spec/search_builders/hyrax/single_collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/single_collection_search_builder_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::SingleCollectionSearchBuilder do
+  subject(:builder) { described_class.new(scope) }
+  let(:scope) { FakeSearchBuilderScope.new }
+
+  shared_context 'with search params' do
+    let(:params) { { id: 'a_collection_id' } }
+
+    before { builder.with(params) }
+  end
+
+  describe 'Hyrax::SearchService collaboration' do
+    let(:search_service) do
+      Hyrax::SearchService.new(config: scope.blacklight_config,
+                               user_params: params,
+                               scope: scope,
+                               search_builder_class: described_class)
+    end
+
+    include_context 'with search params'
+
+    it 'finds none' do
+      expect(search_service.search_results[0].documents).to be_empty
+    end
+
+    context 'with an indexed public collection' do
+      let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, :public) }
+      let(:params) { { id: collection.id } }
+
+      before { collection } # index it
+
+      it 'finds one' do
+        expect(search_service.search_results[0].documents)
+          .to contain_exactly(have_attributes(id: collection.id))
+      end
+    end
+  end
+
+  describe "#to_hash" do
+    it 'with no parameters raises an error eagerly' do
+      expect { builder.to_hash }.to raise_error KeyError
+    end
+
+    context 'with parameters' do
+      include_context 'with search params'
+
+      it 'includes collection in type filter' do
+        expect(builder.to_hash['fq']).to include(/f\=has_model_ssim\}.*Collection/)
+      end
+
+      it 'searches for the provided id' do
+        expect(builder.to_hash['fq']).to include '{!raw f=id}a_collection_id'
+      end
+
+      it 'filters suppressed' do
+        expect(builder.to_hash['fq']).to include '-suppressed_bsi:true'
+      end
+    end
+  end
+end


### PR DESCRIPTION
this is a bit tricky...

Valkyrie models treat ACLs as separate, first class resources that refer to the
resource they grant access on. this means, a work/file_set, etc... must exist in
order to create an ACL and grant permissions. in our Valkyrie usage, we don't
normally want to set ACLs directly via the object, we work through
`Hyrax::AccessControl` and the service-level tooling `Hyrax::AccessControlList`
instead.

so, normally, we create a Resource, then update the ACLs and the resource
independently. `Blacklight::AccessControls` and  `Hyrax::Ability` generally
count on the index being up-to-date, so we have a listener to watch for ACL
updates and update the index.

the tricky bit is that with Wings, our indexer is generally a no-op, since
updating indexes is handled as part of the persister (ActiveFedora::Base#save
does both metadata persistence and index updating). calling `#save` via
`ActiveFedora` does in fact update the index's ACL data to the current
state. but we can update the ACL at any time, and we don't necessarily update
the resource at the same time!

this is especially an issue on object creation: we can't persist the ACL before
we create the object. we could add a bunch of special handling to Wings to make
sure ACLs are added in the way `Hydra::AccessControls` wants. but this special
handling makes ensuring that we get the end state we want a bit complicated. so
the propasal here is to avoid special handlind and instead introduce a special
listener, just for Wings, that updates the (ActiveFedora) object index whenever
the ACL is up-to-date.

this encourages us to follow the new pattern, and code written to play nice with
this should also play nice when the Valkyrie indexer isn't a no-op.

@samvera/hyrax-code-reviewers
