### PR TITLE
extend permission template to work with valkyrie

### DIFF
--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -35,6 +35,14 @@ module Hyrax
     has_one :active_workflow, -> { where(active: true) }, class_name: 'Sipity::Workflow', foreign_key: :permission_template_id
 
     ##
+    # @note this is a convenience method for +Hyrax.query_service.find_by(id: template.source_id)+
+    #
+    # @return [Hyrax::Resource] the collection this template is associated with
+    def source
+      Hyrax.query_service.find_by(id: source_id)
+    end
+
+    ##
     #
     # A bit of an analogue for a `belongs_to :source_model` as it crosses from Fedora to the DB
     # @return [AdminSet, ::Collection]

--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
+  ##
   # Defines behavior that is applied to objects added as members of an AdminSet
   #
   #  * access rights to stamp on each object
@@ -14,10 +15,14 @@ module Hyrax
     has_many :access_grants, class_name: 'Hyrax::PermissionTemplateAccess', dependent: :destroy
     accepts_nested_attributes_for :access_grants, reject_if: :all_blank
 
+    ##
     # @api public
+    #
     # Retrieve the agent_ids associated with the given agent_type and access
+    #
     # @param [String] agent_type
     # @param [String] access
+    #
     # @return [Array<String>] of agent_ids that match the given parameters
     def agent_ids_for(agent_type:, access:)
       access_grants.where(agent_type: agent_type, access: access).pluck(:agent_id)
@@ -29,6 +34,8 @@ module Hyrax
     # In a perfect world, there would be a join table that enforced uniqueness on the ID.
     has_one :active_workflow, -> { where(active: true) }, class_name: 'Sipity::Workflow', foreign_key: :permission_template_id
 
+    ##
+    #
     # A bit of an analogue for a `belongs_to :source_model` as it crosses from Fedora to the DB
     # @return [AdminSet, ::Collection]
     # @raise [Hyrax::ObjectNotFoundError] when neither an AdminSet or Collection is found

--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -43,7 +43,6 @@ module Hyrax
     end
 
     ##
-    #
     # A bit of an analogue for a `belongs_to :source_model` as it crosses from Fedora to the DB
     # @return [AdminSet, ::Collection]
     # @raise [Hyrax::ObjectNotFoundError] when neither an AdminSet or Collection is found

--- a/spec/models/hyrax/permission_template_spec.rb
+++ b/spec/models/hyrax/permission_template_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::PermissionTemplate, :clean_repo do
-  let(:admin_set) { create(:admin_set) }
-  let(:collection) { create(:collection) }
-  let(:permission_template) { described_class.new(attributes) }
-  let(:attributes) { { source_id: admin_set.id } }
+  subject(:permission_template) { described_class.new(attributes) }
 
-  subject { permission_template }
+  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:collection) { FactoryBot.create(:collection) }
+  let(:attributes) { { source_id: admin_set.id } }
 
   it { is_expected.to have_many(:available_workflows).dependent(:destroy) }
   it { is_expected.to have_one(:active_workflow).conditions(active: true).dependent(nil) }

--- a/spec/models/hyrax/permission_template_spec.rb
+++ b/spec/models/hyrax/permission_template_spec.rb
@@ -28,6 +28,31 @@ RSpec.describe Hyrax::PermissionTemplate, valkyrie_adapter: :test_adapter do
     end
   end
 
+  describe "#source" do
+    context 'when source is an AdminSet' do
+      it 'returns the source admin set' do
+        expect(permission_template.source).to eq admin_set
+      end
+    end
+
+    context 'when source is a Collection' do
+      let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection) }
+      let(:attributes) { { source_id: collection.id } }
+
+      it 'returns a Hyrax::PcdmCollection' do
+        expect(permission_template.source).to eq collection
+      end
+    end
+
+    context 'when source is any Resource' do
+      let(:admin_set) { FactoryBot.valkyrie_create(:hyrax_resource) }
+
+      it 'returns the source model' do
+        expect(permission_template.source).to eq admin_set
+      end
+    end
+  end
+
   describe "#source_model" do
     context 'when source is an AdminSet' do
       let(:admin_set) { FactoryBot.create(:admin_set) }

--- a/spec/models/hyrax/permission_template_spec.rb
+++ b/spec/models/hyrax/permission_template_spec.rb
@@ -1,228 +1,224 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::PermissionTemplate, :clean_repo do
+RSpec.describe Hyrax::PermissionTemplate, valkyrie_adapter: :test_adapter do
   subject(:permission_template) { described_class.new(attributes) }
-
-  let(:admin_set) { FactoryBot.create(:admin_set) }
-  let(:collection) { FactoryBot.create(:collection) }
   let(:attributes) { { source_id: admin_set.id } }
+  let(:admin_set) { FactoryBot.valkyrie_create(:hyrax_admin_set) }
 
   it { is_expected.to have_many(:available_workflows).dependent(:destroy) }
   it { is_expected.to have_one(:active_workflow).conditions(active: true).dependent(nil) }
   it { is_expected.to have_many(:access_grants).dependent(:destroy) }
 
   describe '#agent_ids_for' do
-    it 'queries the underlying access_grants' do
-      template = create(:permission_template)
-      to_find = template.access_grants.create!(agent_type: 'user', access: 'manage', agent_id: '123')
-      template.access_grants.create!(agent_type: 'user', access: 'view', agent_id: '456')
-      template.access_grants.create!(agent_type: 'group', access: 'manage', agent_id: '789')
+    subject(:permission_template) { FactoryBot.create(:permission_template) }
 
-      expect(template.agent_ids_for(agent_type: 'user', access: 'manage')).to eq([to_find.agent_id])
+    before do
+      permission_template.access_grants.create!(agent_type: 'user', access: 'manage', agent_id: '123')
+      permission_template.access_grants.create!(agent_type: 'user', access: 'manage', agent_id: 'abc')
+      permission_template.access_grants.create!(agent_type: 'user', access: 'view', agent_id: '456')
+      permission_template.access_grants.create!(agent_type: 'group', access: 'manage', agent_id: '789')
+    end
+
+    it 'queries the underlying access_grants' do
+      expect(permission_template.agent_ids_for(agent_type: 'user', access: 'manage'))
+        .to contain_exactly('123', 'abc')
+      expect(permission_template.agent_ids_for(agent_type: 'user', access: 'view'))
+        .to contain_exactly('456')
+      expect(permission_template.agent_ids_for(agent_type: 'group', access: 'manage'))
+        .to contain_exactly('789')
     end
   end
 
   describe "#source_model" do
     context 'when source is an AdminSet' do
-      let(:as_permission_template) { described_class.new(as_attributes) }
-      let(:as_attributes) { { source_id: admin_set.id } }
-
-      before do
-        allow(AdminSet).to receive(:find).with(as_permission_template.source_id).and_return(admin_set)
-      end
+      let(:admin_set) { FactoryBot.create(:admin_set) }
+      let(:attributes) { { source_id: admin_set.id } }
 
       it 'returns an AdminSet if the source_type is admin_set for the given permission_template' do
-        expect(as_permission_template.source_model).to be_kind_of(AdminSet)
-        expect(as_permission_template.source_model).to eq(admin_set)
+        expect(permission_template.source_model).to eq(admin_set)
       end
     end
 
     context 'when source is a Collection' do
-      let(:col_permission_template) { described_class.new(col_attributes) }
-      let(:col_attributes) { { source_id: collection.id } }
-
-      before do
-        allow(Collection).to receive(:find).with(col_permission_template.source_id).and_return(collection)
-      end
+      let(:collection) { FactoryBot.create(:collection) }
+      let(:attributes) { { source_id: collection.id } }
 
       it 'returns a Collection if the source_type is collection for the given permission_template' do
-        expect(col_permission_template.source_model).to be_kind_of(Collection)
-        expect(col_permission_template.source_model).to eq(collection)
+        expect(permission_template.source_model).to eq(collection)
       end
     end
   end
 
   describe "#release_fixed_date?" do
-    subject { permission_template.release_fixed_date? }
-
     context "with release_period='fixed'" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_release_fixed_date }
     end
+
     context "with other release_period" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
 
-      it { is_expected.to be false }
+      it { is_expected.not_to be_release_fixed_date }
     end
   end
 
   describe "#release_no_delay?" do
-    subject { permission_template.release_no_delay? }
-
     context "with release_period='now'" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_release_no_delay }
     end
+
     context "with other release_period" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
 
-      it { is_expected.to be false }
+      it { is_expected.not_to be_release_no_delay }
     end
   end
 
   describe "#release_before_date?" do
-    subject { permission_template.release_before_date? }
-
     context "with release_period='before'" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE } }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_release_before_date }
     end
+
     context "with maximum embargo period (release_period of 1 year)" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR } }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_release_before_date }
     end
+
     context "with other release_period" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
 
-      it { is_expected.to be false }
+      it { is_expected.not_to be_release_before_date }
     end
   end
 
   describe "#release_max_embargo?" do
-    subject { permission_template.release_max_embargo? }
-
     context "with release_period of 1 year" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR } }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_release_max_embargo }
     end
+
     context "with release_period of 2 years" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_2_YEARS } }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_release_max_embargo }
     end
+
     context "with other release_period" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
 
-      it { is_expected.to be false }
+      it { is_expected.not_to be_release_max_embargo }
     end
   end
 
   describe "#release_date" do
-    subject { permission_template.release_date }
-
-    let(:today) { Time.zone.today }
-
     context "with today and release_fixed_date?" do
-      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: today } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: Time.zone.today } }
 
-      it { is_expected.to eq today }
+      its(:release_date) { is_expected.to eq Time.zone.today }
     end
+
     context "with today and release_before_date?" do
-      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: today } }
+      let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: Time.zone.today } }
 
-      it { is_expected.to eq today }
+      its(:release_date) { is_expected.to eq Time.zone.today }
     end
+
     context "with release_period of 6 months" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_6_MONTHS } }
 
-      it { is_expected.to eq today + 6.months }
+      its(:release_date) { is_expected.to eq Time.zone.today + 6.months }
     end
+
     context "with release_period of 1 year" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR } }
 
-      it { is_expected.to eq today + 1.year }
+      its(:release_date) { is_expected.to eq Time.zone.today + 1.year }
     end
+
     context "with release_no_delay?" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
 
-      it { is_expected.to eq today }
+      its(:release_date) { is_expected.to eq Time.zone.today }
     end
   end
 
   describe "#valid_release_date?" do
     let(:date) { Time.zone.today + 6.months }
 
-    subject { permission_template.valid_release_date?(date) }
-
     context "with any release date and one is not required" do
       let(:attributes) { { source_id: admin_set.id } }
 
-      it { is_expected.to eq true }
+      it { expect(permission_template.valid_release_date?(date)).to eq true }
     end
+
     context "with matching date and release_fixed_date?" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: date } }
 
-      it { is_expected.to eq true }
+      it { expect(permission_template.valid_release_date?(date)).to eq true }
     end
+
     context "with non-matching date and release_fixed_date?" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, release_date: date + 1.day } }
 
-      it { is_expected.to eq false }
+      it { expect(permission_template.valid_release_date?(date)).to eq false }
     end
+
     context "with exact match date and release_before_date?" do
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: date } }
 
-      it { is_expected.to eq true }
+      it { expect(permission_template.valid_release_date?(date)).to eq true }
     end
+
     context "with future, valid date and release_before_date?" do
-      let(:date) { Time.zone.today + 1.day }
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: Time.zone.today + 1.month } }
 
-      it { is_expected.to eq true }
+      it { expect(permission_template.valid_release_date?(Time.zone.today + 1.day)).to eq true }
     end
+
     context "with future, invalid date and release_before_date?" do
-      let(:date) { Time.zone.today + 1.year }
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE, release_date: Time.zone.today + 1.month } }
 
-      it { is_expected.to eq false }
+      it { expect(permission_template.valid_release_date?(Time.zone.today + 1.year)).to eq false }
     end
+
     context "with today release and release_no_delay?" do
-      let(:date) { Time.zone.today }
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
 
-      it { is_expected.to eq true }
+      it { expect(permission_template.valid_release_date?(Time.zone.today)).to eq true }
     end
+
     context "with tomorrow release and release_no_delay?" do
-      let(:date) { Time.zone.today + 1.day }
       let(:attributes) { { source_id: admin_set.id, release_period: Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
 
-      it { is_expected.to eq false }
+      it { expect(permission_template.valid_release_date?(Time.zone.today + 1.day)).to eq false }
     end
   end
 
   describe "#valid_visibility?" do
     let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
 
-    subject { permission_template.valid_visibility?(visibility) }
-
     context "with matching visibility" do
       let(:attributes) { { source_id: admin_set.id, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC } }
 
-      it { is_expected.to eq true }
+      it { expect(permission_template.valid_visibility?(visibility)).to eq true }
     end
+
     context "with non-matching visibility" do
       let(:attributes) { { source_id: admin_set.id, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED } }
 
-      it { is_expected.to eq false }
+      it { expect(permission_template.valid_visibility?(visibility)).to eq false }
     end
+
     context "with visibility when none required" do
       let(:attributes) { { source_id: admin_set.id } }
 
-      it { is_expected.to eq true }
+      it { expect(permission_template.valid_visibility?(visibility)).to eq true }
     end
   end
 end

--- a/spec/models/hyrax/permission_template_spec.rb
+++ b/spec/models/hyrax/permission_template_spec.rb
@@ -10,48 +10,6 @@ RSpec.describe Hyrax::PermissionTemplate, :clean_repo do
   it { is_expected.to have_one(:active_workflow).conditions(active: true).dependent(nil) }
   it { is_expected.to have_many(:access_grants).dependent(:destroy) }
 
-  describe 'factories' do
-    context 'with_admin_set parameter' do
-      it 'will create an AdminSet when true' do
-        permission_template = create(:permission_template, with_admin_set: true)
-        expect(permission_template.source_model).to be_persisted
-      end
-      it 'will not persist an AdminSet when false (or not given)' do
-        permission_template = create(:permission_template, with_admin_set: false)
-        expect { permission_template.source_model }.to raise_error(Hyrax::ObjectNotFoundError)
-      end
-    end
-
-    context 'with_collection parameter' do
-      it 'will create an Collection when true' do
-        permission_template = create(:permission_template, with_collection: true)
-        expect(permission_template.source_model).to be_persisted
-      end
-      it 'will not persist an Collection when false (or not given)' do
-        permission_template = create(:permission_template, with_collection: false)
-        expect { permission_template.source_model }.to raise_error(Hyrax::ObjectNotFoundError)
-      end
-    end
-
-    context 'with_workflows parameter' do
-      it 'will create the workflow when set true' do
-        expect { create(:permission_template, with_workflows: true) }.to change { Sipity::Workflow.count }
-      end
-      it 'will not create the workflow when false (or not given)' do
-        expect { create(:permission_template, with_workflows: false) }.not_to change { Sipity::Workflow.count }
-      end
-    end
-
-    context 'with_active_workflow parameter' do
-      it 'will create the workflow when set true' do
-        expect { create(:permission_template, with_active_workflow: true) }.to change { Sipity::Workflow.count }.by(1)
-      end
-      it 'will not create the workflow when false (or not given)' do
-        expect { create(:permission_template, with_active_workflow: false) }.not_to change { Sipity::Workflow.count }
-      end
-    end
-  end
-
   describe '#agent_ids_for' do
     it 'queries the underlying access_grants' do
       template = create(:permission_template)


### PR DESCRIPTION
add `PermissionTemplate#source` to act as the new source_id relationship
resolver. we don't deprecate the old `#source_model` here; it will hang around
until we start phasing out AF support.

@samvera/hyrax-code-reviewers
