### PR TITLE
Allow registrar to return nil for the identifier

### DIFF
--- a/app/services/hyrax/identifier/dispatcher.rb
+++ b/app/services/hyrax/identifier/dispatcher.rb
@@ -44,7 +44,7 @@ module Hyrax
       # @return [ActiveFedora::Base, Hyrax::Resource] object
       def assign_for(object:, attribute: :identifier)
         record = registrar.register!(object: object)
-        object.public_send("#{attribute}=".to_sym, [record.identifier])
+        object.public_send("#{attribute}=".to_sym, Array.wrap(record.identifier))
         object
       end
 


### PR DESCRIPTION
This is useful for when the registrar decides that the object shouldn't be registered but there hasn't been an error.

@samvera/hyrax-code-reviewers
