### PR TITLE
Aligning batch size and page size enforcement

### DIFF
--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -53,7 +53,7 @@ module Hyrax
     # TODO: Extract a presenter object that wrangles all of these instance variables.
     def prepare_instance_variables_for_batch_control_display
       # set up some parameters for allowing the batch controls to show appropriately
-      max_batch_size = 80
+      max_batch_size = Hyrax.config.range_for_number_of_results_to_display_per_page.max
       count_on_page = @document_list.count { |doc| batch.index(doc.id) }
       @disable_select_all = @document_list.count > max_batch_size
       @result_set_size = @response.response["numFound"]

--- a/app/views/hyrax/my/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/my/_sort_and_per_page.html.erb
@@ -5,7 +5,7 @@
           <fieldset class="col-xs-12">
             <legend class="sr-only"><%= t('hyrax.dashboard.my.sr.results_per_page') %></legend>
             <%= label_tag :per_page do %>
-                Show <%= select_tag :per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])),
+                Show <%= select_tag :per_page, options_for_select(Hyrax.config.range_for_number_of_results_to_display_per_page.map(&:to_s), h(params[:per_page])),
                                     title: t(".number_of_results_to_display_per_page") %> per page
             <% end %>
             <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:per_page, :sort, :utf8)) %>

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -751,6 +751,19 @@ module Hyrax
       @identifier_registrars ||= {}
     end
 
+    # A configuration point for changing the available range for
+    # selecting per page results
+    #
+    # @!attribute [w] range_for_number_of_results_to_display_per_page
+    #   A configuration point for changing the available range for
+    #   selecting per page results
+    attr_writer :range_for_number_of_results_to_display_per_page
+
+    # @return [Array<Integer>]
+    def range_for_number_of_results_to_display_per_page
+      @number_of_results_to_display_per_page ||= [10, 20, 50, 100]
+    end
+
     private
 
     # @param [Symbol, #to_s] model_name - symbol representing the model


### PR DESCRIPTION
Closes #3242

Prior to this commit, there existed a ["magic number" in the
Hyrax::MyControllers][1].  This "magic number" was less than the largest
value in [the range for
`app/views/hyrax/my/_sort_and_per_page.html.erb`][2].

When a user selected a page size greater than the "magic number", then
they would see [a CSS overlay][3]. The CSS overlay is an 6 year old UI
implementation that provides a little bit of guidance were someone to
manufacture a URL with a custom `per_page` parameter.

Wit this commit, I'm aligning the "magic number" with the UI
constraint, and exposing a configuration option.  Enforcing the maximum
is likely a good idea to prevent (or maybe just discourage) custom
`per_page` parameters from over working the batch system.

[1]:https://github.com/samvera/hyrax/blob/0222988b13ddf03cb584c8c9168da7c8d826b674/app/controllers/hyrax/my_controller.rb#L56
[2]:https://github.com/samvera/hyrax/blob/0222988b13ddf03cb584c8c9168da7c8d826b674/app/views/hyrax/my/_sort_and_per_page.html.erb#L8
[3]:https://github.com/samvera/hyrax/blob/0222988b13ddf03cb584c8c9168da7c8d826b674/app/assets/stylesheets/hyrax/_file-listing.scss#L157

@samvera/hyrax-code-reviewers
