### PR TITLE
Fixing broken configuration option

### DIFF
--- a/app/views/hyrax/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/collections/_sort_and_per_page.html.erb
@@ -7,7 +7,7 @@
       <%= select_tag(:sort, options_from_collection_for_select(collection_member_sort_fields, 'first', lambda {|field| field.last.label}, h(params[:sort]))) %>
       <%= label_tag(:per_page) do %>
         <span class="tiny-nudge"><%= t('.results_per_page') %></span>
-        <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: t('.number_of_results_to_display_per_page')) %>
+        <%= select_tag(:per_page, options_for_select(Hyrax.config.range_for_number_of_results_to_display_per_page, h(params[:per_page])), title: t('.number_of_results_to_display_per_page')) %>
       <% end %>
       <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:per_page, :sort)) %>
       &nbsp;<button class="btn btn-xs btn-default tiny-nudge"><span class="glyphicon glyphicon-refresh"></span> <%= t('helpers.action.refresh') %></button>

--- a/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
@@ -17,7 +17,7 @@
              <%= label_tag(:sort, t(".sort_by")) %>
              <%= select_tag(:sort, options_from_collection_for_select(collection_member_sort_fields, 'first', lambda {|field| field.last.label}, h(params[:sort]))) %>
              <%= label_tag(:per_page) do %>
-               <%= t(".show_par_page_html", select: select_tag(:per_page, options_for_select(['10', '20', '50', '100'], params[:per_page]), title: t('hyrax.dashboard.my.sr.results_per_page'))) %>
+               <%= t(".show_par_page_html", select: select_tag(:per_page, options_for_select(Hyrax.config.range_for_number_of_results_to_display_per_page, params[:per_page]), title: t('hyrax.dashboard.my.sr.results_per_page'))) %>
              <% end %>
              <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:per_page, :sort)) %>
              <button class="btn btn-info"><span class="glyphicon glyphicon-refresh"></span> <%= t('helpers.action.refresh') %></button>

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -757,11 +757,12 @@ module Hyrax
     # @!attribute [w] range_for_number_of_results_to_display_per_page
     #   A configuration point for changing the available range for
     #   selecting per page results
+    # @note This has no impact on the default page size of the controller.
     attr_writer :range_for_number_of_results_to_display_per_page
 
     # @return [Array<Integer>]
     def range_for_number_of_results_to_display_per_page
-      @number_of_results_to_display_per_page ||= [10, 20, 50, 100]
+      @range_for_number_of_results_to_display_per_page ||= [10, 20, 50, 100]
     end
 
     private

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -85,6 +85,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:upload_path) }
   it { is_expected.to respond_to(:registered_ingest_dirs) }
   it { is_expected.to respond_to(:registered_ingest_dirs=) }
+  it { is_expected.to respond_to(:range_for_number_of_results_to_display_per_page) }
+  it { is_expected.to respond_to(:range_for_number_of_results_to_display_per_page=) }
   it { is_expected.to respond_to(:work_requires_files?) }
 
   describe "#registered_ingest_dirs" do


### PR DESCRIPTION
Prior to this commit, the memoized instance variable did not match the
name of the associated writer method.  This meant things were not
configurable.

This also adds a spec to clarify intention.

I also tracked down a few places that had a copy of the "magical array".

Refs #3242

@samvera/hyrax-code-reviewers
