### PR TITLE
Correcting heading hierarchy on search page

### DIFF
--- a/app/assets/stylesheets/hyrax/_catalog.scss
+++ b/app/assets/stylesheets/hyrax/_catalog.scss
@@ -37,6 +37,7 @@
     .search-result-title {
       display: inline-block;
       margin: 0 15px;
+      font-size: 18px;
     }
 
     @media (max-width: 768px) {

--- a/app/views/catalog/_index_header_list_collection.html.erb
+++ b/app/views/catalog/_index_header_list_collection.html.erb
@@ -1,4 +1,4 @@
 <div class="search-results-title-row">
-  <h4 class="search-result-title"><%= link_to document.title_or_label, [hyrax, document] %></h4>
+  <h3 class="search-result-title"><%= link_to document.title_or_label, [hyrax, document] %></h3>
   <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
 </div>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,3 +1,3 @@
 <div class="search-results-title-row">
-  <h4 class="search-result-title"><%= link_to document.title_or_label, document %></h4>
+  <h3 class="search-result-title"><%= link_to document.title_or_label, document %></h3>
 </div>


### PR DESCRIPTION
For testing this, I disabled the page's stylesheet.  This helps me see
the heading structure and better orient.  Below is what I found

```
H1 - Page Title
H2 - Search Constraints
H2 - Search Results
H4 - Result 2
H4 - Result 2
etc.
```

The result is changing `h4.search-result-title` should be
`h3.search-result-title`.

Closes #1263

@samvera/hyrax-code-reviewers
