### PR TITLE
Gh 3356 maintain language support for profile

### DIFF
--- a/.dassie/config/locales/hyrax.es.yml
+++ b/.dassie/config/locales/hyrax.es.yml
@@ -19,6 +19,7 @@ es:
           date_created_tesim: Fecha de Creacion
           date_modified_dtsi: Fecha Modificada
           date_uploaded_dtsi: Fecha de Subida
+          depositor_tesim: Propietario
           description_tesim: Descripción
           file_format_tesim: Formato de Archivo
           identifier_tesim: Identificador
@@ -35,6 +36,7 @@ es:
           date_created_tesim: Fecha de Creacion
           date_modified_dtsi: Fecha Modificada
           date_uploaded_dtsi: Fecha de Subida
+          depositor_tesim: Propietario
           description_tesim: Descripción
           file_format_tesim: Formato de Archivo
           identifier_tesim: Identificador
@@ -51,7 +53,7 @@ es:
       suffix: "@example.org"
     footer:
       copyright_html: "<strong>Copyright &copy; 2018 Samvera</strong> bajo licencia de Apache, Version 2.0"
-      service_html: Un servicio de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera/a>.
+      service_html: Un servicio de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
     institution_name: institución
     institution_name_full: El nombre de la institución
     product_name: Hyrax

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -4,7 +4,7 @@
     <% doc_presenter = index_presenter(document) %>
     <% index_fields(document).each do |field_name, field| -%>
       <% if should_render_index_field? document, field %>
-          <dt><%= render_index_field_label document, field: field_name %></dt>
+          <dt data-solr-field-name="<%= field_name %>"><%= render_index_field_label document, field: field_name %></dt>
           <dd><%= doc_presenter.field_value field %></dd>
       <% end %>
     <% end %>

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -799,6 +799,7 @@ es:
         show_document_list_row:
           creator: 'Creador:'
           depositor: 'Depositor:'
+          owner: 'Propietario:'
           edit_access: 'Editar acceso:'
         sort_and_per_page:
           show_par_page_html: "%{select} Por página"
@@ -1111,6 +1112,7 @@ es:
         link: Ver todas las colecciones
         tab_label: Explorar Colecciones
         title: Explorar Colecciones
+        thumbnail: Miniatura
       featured_researcher:
         missing: No hay investigadores destacados
         tab_label: Investigador destacado
@@ -1570,6 +1572,7 @@ es:
         lease_expiration_date: hasta
         license: Licencia
         member_of_collection_ids: Añadir a la colección
+        owner: Propietario
         related_url: URL relacionada
         rights_notes: Notas de derechos
         rights_statement: Declaración de derechos

--- a/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
@@ -19,6 +19,7 @@ es:
           date_created_tesim: Fecha de Creacion
           date_modified_dtsi: Fecha Modificada
           date_uploaded_dtsi: Fecha de Subida
+          depositor_tesim: Propietario
           description_tesim: Descripción
           file_format_tesim: Formato de Archivo
           identifier_tesim: Identificador
@@ -35,6 +36,7 @@ es:
           date_created_tesim: Fecha de Creacion
           date_modified_dtsi: Fecha Modificada
           date_uploaded_dtsi: Fecha de Subida
+          depositor_tesim: Propietario
           description_tesim: Descripción
           file_format_tesim: Formato de Archivo
           identifier_tesim: Identificador


### PR DESCRIPTION
<img width="633" alt="Screen Shot 2021-02-04 at 8 39 51 AM" src="https://user-images.githubusercontent.com/2130/106900838-0269a300-66c5-11eb-8f0a-03cba8aa7891.png">

## Adding data attribute to aid troubleshooting

e0972b56741aa05d2c269b8970d0dc287a0969f0

In tracking down #3356, I first tried to translate `owner_tesim`;
However that didn't exist.  It turns out that we translate the field
`depositor_tesim` to "Owner".

I suspect that this will help others track down issues with translations.

## Adding missing "es" I18n translations

adb01ee607eb91f93c7a689ea841144c9b9c0c98

In troublshooting #3356 I noticed that we had the following for
spanish (notice the "Owner").

```
Descripción: test
Creador: test
Owner: your@email.com
```

This commit fixes that, and adds a missing translation for thumbnail on the homepage.

## Maintaining locale for links to profile

097bf5941fb6ddc46a7ef15532302c599bf3c657

Closes #3356

@samvera/hyrax-code-reviewers
