### PR TITLE
Bumping to Hydra::Editor v5.0.4

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -51,7 +51,7 @@ SUMMARY
   spec.add_dependency 'flot-rails', '~> 0.0.6'
   spec.add_dependency 'font-awesome-rails', '~> 4.2'
   spec.add_dependency 'hydra-derivatives', '~> 3.3'
-  spec.add_dependency 'hydra-editor', '~> 5.0'
+  spec.add_dependency 'hydra-editor', '~> 5.0', ">= 5.0.4"
   spec.add_dependency 'hydra-head', '~> 11.0', ">= 11.0.1"
   spec.add_dependency 'hydra-works', '>= 0.16', '< 2.0'
   spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'


### PR DESCRIPTION
This bump brings the following (from
https://github.com/samvera/hydra-editor/commit/bb7946dd5190d2cf7d12f1b87abf000268c00d84):

Closes #3526 
---

Hiding the link that could remove required input

With the following CSS

```css
.multi_value .listing li:first-of-type .remove { display: none; }
.multi_value .listing li:first-of-type { width: 83.333333%; }
```

I get the ![following UI](https://user-images.githubusercontent.com/2130/106814035-c8a28900-663f-11eb-8d33-fc9b1d641de7.png)

I spent some time working through the javascript, and it's a rather
nasty labyrinth.  First, all multi-values are written by JS (see the
[field_manager.es6 file in
Hydra::Editor](https://github.com/samvera/hydra-editor/blob/b0d0eee963ebff8d5769b7e535542ab48f252c07/app/assets/javascripts/hydra-editor/field_manager.es6#L1)).
My hope was to be able to discard the "X Remove" button from the HTML of
the first element.  However, that proved difficult as there's an
assumption that that HTML will be around when we click the "Add another
Title" link.

It would be possible to "store that" somewhere, but that felt like some
complicated changes.  Instead I went down the path of CSS and settled on
the above.  It's not quite perfect but it does things a little better.
Yes, you could disable stylesheets and thus see the button again. Yes
you could inspect element and do nefarious things.  But at the root,
this solution preserves the "required" input field AND helps avoid
POSTing the form.

Related to samvera/hyrax#3526

@samvera/hyrax-code-reviewers
