### PR TITLE
Ensuring a wipe of data

### DIFF
--- a/spec/services/hyrax/custom_queries/find_ids_by_model_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_ids_by_model_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Hyrax::CustomQueries::FindIdsByModel, valkyrie_adapter: :test_ada
   subject(:query_handler) { described_class.new(query_service: Hyrax.query_service) }
 
   after { Hyrax.persister.wipe! }
+  before { Hyrax.persister.wipe! }
 
   describe '#find_ids_by_model' do
     let(:monographs) { [FactoryBot.valkyrie_create(:monograph), FactoryBot.valkyrie_create(:monograph), FactoryBot.valkyrie_create(:monograph)] }


### PR DESCRIPTION
Prior to this commit, I noticed that this [CircleCI build][1] failed.  I
suspect this is because there are other uses of
`FactoryBot.valkyrie_create(:monograph)` that don't tidy up after
themselves.

This should squash that particular problem.

[1]:https://app.circleci.com/pipelines/github/samvera/hyrax/4825/workflows/a7cb5d2d-bc5c-477b-afea-7f63c5837ba5/jobs/34868/parallel-runs/4

@samvera/hyrax-code-reviewers
