### PR TITLE
Gh 3260 work transfer reset edits on file sets

### DIFF
--- a/app/services/hyrax/change_content_depositor_service.rb
+++ b/app/services/hyrax/change_content_depositor_service.rb
@@ -18,6 +18,7 @@ module Hyrax
       work.permissions = [] if reset
       work.apply_depositor_metadata(user)
       work.file_sets.each do |f|
+        f.permissions = [] if reset
         f.apply_depositor_metadata(user)
         f.save!
       end

--- a/app/services/hyrax/change_content_depositor_service.rb
+++ b/app/services/hyrax/change_content_depositor_service.rb
@@ -35,6 +35,8 @@ module Hyrax
     end
     private_class_method :call_af
 
+    # @todo Should this include some dependency injection regarding
+    # the Hyrax.persister and Hyrax.custom_queries?
     def self.call_valkyrie(work, user, reset)
       if reset
         work.permission_manager.acl.permissions = []
@@ -44,10 +46,9 @@ module Hyrax
       work.proxy_depositor = work.depositor
       apply_depositor_metadata(work, user)
 
-      Hyrax.custom_queries.find_child_filesets(resource: work).each do |f|
-        apply_depositor_metadata(f, user)
-      end
+      apply_valkyrie_changes_to_file_sets(work: work, user: user, reset: reset)
 
+      Hyrax.persister.save(resource: work)
       work
     end
     private_class_method :call_valkyrie
@@ -58,5 +59,17 @@ module Hyrax
       Hyrax::AccessControlList.new(resource: resource).grant(:edit).to(::User.find_by_user_key(depositor_id)).save
     end
     private_class_method :apply_depositor_metadata
+
+    def self.apply_valkyrie_changes_to_file_sets(work:, user:, reset:)
+      Hyrax.custom_queries.find_child_filesets(resource: work).each do |f|
+        if reset
+          f.permission_manager.acl.permissions = []
+          f.permission_manager.acl.save
+        end
+        apply_depositor_metadata(f, user)
+        Hyrax.persister.save(resource: f)
+      end
+    end
+    private_class_method :apply_valkyrie_changes_to_file_sets
   end
 end

--- a/app/services/hyrax/change_content_depositor_service.rb
+++ b/app/services/hyrax/change_content_depositor_service.rb
@@ -54,7 +54,7 @@ module Hyrax
 
     def self.apply_depositor_metadata(resource, depositor)
       depositor_id = depositor.respond_to?(:user_key) ? depositor.user_key : depositor
-      resource.depositor = depositor_id if resource.respond_to? :depositor
+      resource.depositor = depositor_id if resource.respond_to? :depositor=
       Hyrax::AccessControlList.new(resource: resource).grant(:edit).to(::User.find_by_user_key(depositor_id)).save
     end
     private_class_method :apply_depositor_metadata

--- a/app/services/hyrax/change_content_depositor_service.rb
+++ b/app/services/hyrax/change_content_depositor_service.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 module Hyrax
   class ChangeContentDepositorService
-    # @param [ActiveFedora::Base, Valkyrie::Resource] work
-    # @param [User] user
-    # @param [TrueClass, FalseClass] reset
+    # Set the given `user` as the depositor of the given `work`; If
+    # `reset` is true, first remove all previous permissions.
+    #
+    # @param work [ActiveFedora::Base, Valkyrie::Resource] the work
+    #             that is receiving a change of depositor
+    # @param user [User] the user that will "become" the depositor of
+    #             the given work
+    # @param reset [TrueClass, FalseClass] when true, first clear
+    #              permissions for the given work and contained file
+    #              sets; regardless of true/false make the given user
+    #              the depositor of the given work
     def self.call(work, user, reset)
       case work
       when ActiveFedora::Base

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -70,13 +70,23 @@ FactoryBot.define do
 
     trait :with_member_works do
       transient do
-        members { [valkyrie_create(:hyrax_work), valkyrie_create(:hyrax_work)] }
+        members do
+          # If you set a depositor on the containing work, propogate that into these members
+          additional_attributes = {}
+          additional_attributes[:depositor] = depositor if depositor
+          [valkyrie_create(:hyrax_work, additional_attributes), valkyrie_create(:hyrax_work, additional_attributes)]
+        end
       end
     end
 
     trait :with_member_file_sets do
       transient do
-        members { [valkyrie_create(:hyrax_file_set), valkyrie_create(:hyrax_file_set)] }
+        members do
+          # If you set a depositor on the containing work, propogate that into these members
+          additional_attributes = {}
+          additional_attributes[:depositor] = depositor if depositor
+          [valkyrie_create(:hyrax_file_set, additional_attributes), valkyrie_create(:hyrax_file_set, additional_attributes)]
+        end
       end
     end
 

--- a/spec/services/hyrax/change_content_depositor_service_spec.rb
+++ b/spec/services/hyrax/change_content_depositor_service_spec.rb
@@ -2,49 +2,52 @@
 RSpec.describe Hyrax::ChangeContentDepositorService do
   let!(:depositor) { create(:user) }
   let!(:receiver) { create(:user) }
-  let!(:file) do
-    create(:file_set, user: depositor)
-  end
-  let!(:work) do
-    create(:work, title: ['Test work'], user: depositor)
-  end
 
-  before do
-    work.members << file
-    described_class.call(work, receiver, reset)
-  end
-
-  context "by default, when permissions are not reset" do
-    let(:reset) { false }
-
-    it "changes the depositor and records an original depositor" do
-      work.reload
-      expect(work.depositor).to eq receiver.user_key
-      expect(work.proxy_depositor).to eq depositor.user_key
-      expect(work.edit_users).to include(receiver.user_key, depositor.user_key)
+  context "for Active Fedora objects" do
+    let!(:file) do
+      create(:file_set, user: depositor)
+    end
+    let!(:work) do
+      create(:work, title: ['Test work'], user: depositor)
     end
 
-    it "changes the depositor of the child file sets" do
-      file.reload
-      expect(file.depositor).to eq receiver.user_key
-      expect(file.edit_users).to include(receiver.user_key, depositor.user_key)
-    end
-  end
-
-  context "when permissions are reset" do
-    let(:reset) { true }
-
-    it "excludes the depositor from the edit users" do
-      work.reload
-      expect(work.depositor).to eq receiver.user_key
-      expect(work.proxy_depositor).to eq depositor.user_key
-      expect(work.edit_users).to contain_exactly(receiver.user_key)
+    before do
+      work.members << file
+      described_class.call(work, receiver, reset)
     end
 
-    it "changes the depositor of the child file sets" do
-      file.reload
-      expect(file.depositor).to eq receiver.user_key
-      expect(file.edit_users).to contain_exactly(receiver.user_key)
+    context "by default, when permissions are not reset" do
+      let(:reset) { false }
+
+      it "changes the depositor and records an original depositor" do
+        work.reload
+        expect(work.depositor).to eq receiver.user_key
+        expect(work.proxy_depositor).to eq depositor.user_key
+        expect(work.edit_users).to include(receiver.user_key, depositor.user_key)
+      end
+
+      it "changes the depositor of the child file sets" do
+        file.reload
+        expect(file.depositor).to eq receiver.user_key
+        expect(file.edit_users).to include(receiver.user_key, depositor.user_key)
+      end
+    end
+
+    context "when permissions are reset" do
+      let(:reset) { true }
+
+      it "excludes the depositor from the edit users" do
+        work.reload
+        expect(work.depositor).to eq receiver.user_key
+        expect(work.proxy_depositor).to eq depositor.user_key
+        expect(work.edit_users).to contain_exactly(receiver.user_key)
+      end
+
+      it "changes the depositor of the child file sets" do
+        file.reload
+        expect(file.depositor).to eq receiver.user_key
+        expect(file.edit_users).to contain_exactly(receiver.user_key)
+      end
     end
   end
 end

--- a/spec/services/hyrax/change_content_depositor_service_spec.rb
+++ b/spec/services/hyrax/change_content_depositor_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
     it "changes the depositor of the child file sets" do
       file.reload
       expect(file.depositor).to eq receiver.user_key
-      expect(file.edit_users).to include(receiver.user_key, depositor.user_key)
+      expect(file.edit_users).to contain_exactly(receiver.user_key)
     end
   end
 end


### PR DESCRIPTION
_**NOTE:** This is "complete" for ActiveFedora, but there's no tests for the complimentary Valkyrie logic path.  I'm going to build from this branch to test valkyrie.  The reason for separating commits and PRs is because of the second commit in this PR.  That commit reworks the structure of the specs._

_From a reviewers perspective, I encourage you to look at the first commit to see what substantively changed. Then review the entire change as a whole._

## Conditionally reseting fileset depositor for AF

0dc6207704e74621a5de6224f63cd2b7ccd20501

Starting with the [change_content_depositor_service_spec.rb][1], we have
a test that asserts the current behavior.

(awead) [introduce the spec in a 2015 commit][2], I found this commit by (grosscol) [that subtly removed the expected behavior][3]

So, my analysis is that one commit introduced the bug and a later spec
asserted the bug as expected behavior.

This commit addresses the ActiveFedora bug.  I add this as a separate
commit, because I'm about to add a spec for Valkyrie that will
structurally change spec I updated in this commit.

Ref #3260

[1]:https://github.com/samvera/hyrax/blob/508e7381d9b5cfce4cd27c40406141df47876eca/spec/services/hyrax/change_content_depositor_service_spec.rb#L34:L49
[2]:https://github.com/samvera/hyrax/commit/468929845f2989913617a297af801bbda6bd8e45
[3]:https://github.com/samvera/hyrax/commit/0cb55bf46092bbb72c1803e7341074e1ea903a5b#diff-bfac0ce58388b8031096668717616b32e0edbeaf3707ca4cde388ee859dcdd35L20-L24

## Reworking spec structure (no changes otherwise)

8bcf23aee43168991960a2c9e336f4db269fd2d7

This is a reworking of the structure of a spec.  As written the spec
doesn't make much space for a sibling Valkyrie spec.

This commit helps a reviewer see the step and, I hope "move along".

## Documenting ChangeContentDepositorService

14f07f5b382652b6735b41afae74b56107805527


## Propogating depositor attr in hyrax_work factory

3a1a9c0bd98f0a5d87792dc5d9811ec815cc1269

I wanted a quick way to do this for testing the transfer of a Valkyrie
work (and file set) to another user.  This change enables a lightweight
assignment of depositor.

Ref #3260

## Adjusting respond_to test for better accuracy

0d4df08efe11c9c449876c9adb2d0582cec009c8

Prior to this, we were checking if the object responded to `depositor`
but then called `depositor=`.  That's not as precise.

This tidies that up.

## Conditionally reset fileset depositor for Valkyrie

8ed959fcffe9c4ce93f5453c3865a734bc58d316

This commit closes the loop on an untested portion of code.  With the
commit, the Valkyrie and ActiveFedora paths have the same conceptual
logic applied.

Closes #3260, Ref #4745 (in particular 0dc620770)

@samvera/hyrax-code-reviewers
