### PR TITLE
use uploaded_file for new versions

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -85,11 +85,16 @@ module Hyrax
           actor.revert_content(params[:revision])
         elsif params.key?(:file_set)
           if params[:file_set].key?(:files)
-            actor.update_content(params[:file_set][:files].first)
+            actor.update_content(uploaded_file_from_path)
           else
             update_metadata
           end
         end
+      end
+
+      def uploaded_file_from_path
+        uploaded_file = CarrierWave::SanitizedFile.new(params[:file_set][:files].first)
+        Hyrax::UploadedFile.create(user_id: current_user.id, file: uploaded_file)
       end
 
       def after_update_response


### PR DESCRIPTION
Please note, this is a clean cherry-pick of @1283bbeb5b737141f1ebefd48e050d05c94bef8e onto the 2.x-stable branch.  This will be part of a v2.9.4 release.  (I am not planning to patch earlier versions, but I'm not opposed to doing so)

Thank you:

* @dchandekstark for tracking down the issue and diving into the stack
* @no-reply for authoring the fix.
* @geekscruff for committing the change (you are missed).
* @K8Sewell (v2.?.?), @scherztc, (v2.6.x), and @cjcolvar (v2.9.3) for verifying the break across different installs
* And @orangewolf for delegating to your team.

All of these actions really help move our code-base forward.

Closes #4747.  