### PR TITLE
Adding title attribute for visibility link

### DIFF
--- a/app/helpers/hyrax/ability_helper.rb
+++ b/app/helpers/hyrax/ability_helper.rb
@@ -36,7 +36,8 @@ module Hyrax
         visibility_badge(document.visibility),
         path,
         id: "permission_#{document.id}",
-        class: 'visibility-link'
+        class: 'visibility-link',
+        title: "#{t('hyrax.works.form.tab.share')}: #{document.title_or_label}"
       )
     end
 


### PR DESCRIPTION
Given that we're linking to the "share" tab, I opted to include the I18n
translation of the [Share tab][#1].  I'm including it as a prefix for
the title.  To do much else would require another translation entry.  I
believe this is adequate to provide enough differentiation in the titles.

Related to #4753

[1]:https://github.com/samvera/hyrax/blob/001bb7ad73300a2183ed681c0b4e917f25199b67/app/views/hyrax/base/_guts4form.html.erb#L21

@samvera/hyrax-code-reviewers
