### PR TITLE
Update TinyMCE and fix configuration loading

### DIFF
--- a/.dassie/config/tinymce.yml
+++ b/.dassie/config/tinymce.yml
@@ -3,10 +3,11 @@ default: &default
 content_block:
   <<: *default
   menubar: false
-  toolbar1: styleselect | bold italic | link image | undo redo
-  toolbar2: table | fullscreen | uploadimage
+  toolbar1: styleselect | bold italic | undo redo
+  toolbar2: table | fullscreen | image
   plugins:
     - table
     - fullscreen
+    - image
 custom:
   <<: *default

--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -30,6 +30,7 @@
 //= require morris/morris.min
 
 //= require clipboard
+//= require tinymce
 
 // This is required for Jasmine tests, specifically to polyfill the Symbol() function
 //= require babel/polyfill

--- a/app/assets/javascripts/hyrax/app.js.erb
+++ b/app/assets/javascripts/hyrax/app.js.erb
@@ -18,20 +18,10 @@ Hyrax = {
         this.collectionTypeEditor();
         this.collectionUtilities();
         this.adminStatisticsGraphs();
-        this.tinyMCE();
         this.sortAndPerPage();
         this.sidebar();
         this.batchSelect();
         this.internationalizationHelper();
-    },
-
-    // Add WYSIWYG editor functionality to editable content blocks
-    tinyMCE: function() {
-        if (typeof tinyMCE === "undefined")
-            return;
-        tinyMCE.init({
-            selector: 'textarea.tinymce'
-        });
     },
 
     // The AdminSet edit page

--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -22,7 +22,7 @@ signed in %>
 
 <!-- application js -->
 <%= javascript_include_tag 'application' %>
-<%= tinymce_assets if can? :update, ContentBlock %>
+
 <%= render 'shared/appearance_styles' %>
 
 <!-- Google Analytics -->

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -81,7 +81,7 @@ SUMMARY
   spec.add_dependency 'samvera-nesting_indexer', '~> 2.0'
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
-  spec.add_dependency 'tinymce-rails', '~> 4.1'
+  spec.add_dependency 'tinymce-rails'
   spec.add_dependency 'valkyrie', '>= 2.1.1', "< 3.0"
 
   spec.add_development_dependency "capybara", '~> 3.29'

--- a/lib/generators/hyrax/templates/config/tinymce.yml
+++ b/lib/generators/hyrax/templates/config/tinymce.yml
@@ -3,10 +3,11 @@ default: &default
 content_block:
   <<: *default
   menubar: false
-  toolbar1: styleselect | bold italic | link image | undo redo
-  toolbar2: table | fullscreen | uploadimage
+  toolbar1: styleselect | bold italic | undo redo
+  toolbar2: table | fullscreen | image
   plugins:
     - table
     - fullscreen
+    - image
 custom:
   <<: *default

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -17,6 +17,7 @@ module Hyrax
     require 'flipflop'
     require 'qa'
     require 'clipboard/rails'
+    require 'tinymce-rails'
     require 'legato'
     require 'valkyrie'
 


### PR DESCRIPTION
Fixes #2273

Updates tinymce-rails gem and fixes broken config loading.

This updates the TinyMCE gem that has been pinned at an older version for several years. It also was not loading the application's tinymce config file, instead using defaults. This PR addresses both of those issues.

Changes proposed in this pull request:
* Remove version pin on tinymce-rails gem
* Modify how its JS is loaded according to the gem's install docs.
* Update the provided config file.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* The TinyMCE editor loads without error and functions when editing Pages and Content Blocks in the dashboard.
*
*

@samvera/hyrax-code-reviewers
