### PR TITLE
Do not precompile assets in hyrax-engine-dev image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 COPY --chown=1001:101 . /app/samvera/hyrax-engine
 
 RUN cd /app/samvera/hyrax-engine; bundle install --jobs "$(nproc)"
-RUN DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
+RUN DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake yarn:install
 
 
 FROM hyrax-engine-dev as hyrax-engine-dev-worker


### PR DESCRIPTION
Do not precompile assets in hyrax-engine-dev image

While updating a gem that includes breaking JS changes, the old JS mysteriously persisted being served up. It was discovered that the old code was living on as compiled assets in the hyrax-public volume which is mounted over the image's public directory. That outdated compiled JS is then used despite not matching the source.

To avoid this, we should not precompile assets in dev. However `yarn install` is being run as part of the precompile, and that behavior needs to be retained.

Changes proposed in this pull request:
* Do not precompile assets in the hyrax-engine-dev image

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Should have no effect in production

@samvera/hyrax-code-reviewers
