### PR TITLE
Prevent generation of a work resource with name 'Work'. Fixes #4567.

### DIFF
--- a/lib/generators/hyrax/work_resource/work_resource_generator.rb
+++ b/lib/generators/hyrax/work_resource/work_resource_generator.rb
@@ -13,6 +13,17 @@ class Hyrax::WorkResourceGenerator < Rails::Generators::NamedBase
 
   argument :attributes, type: :array, default: [], banner: 'field:type field:type'
 
+  def self.exit_on_failure?
+    true
+  end
+
+  def validate_name
+    return unless name.strip.casecmp("work").zero?
+    raise Thor::MalformattedArgumentError,
+          set_color("Error: A work resource with the name '#{name}' would cause name-space clashes. "\
+                    "Please use a different name.", :red)
+  end
+
   def banner
     if revoking?
       say_status("info", "DESTROYING VALKYRIE WORK MODEL: #{class_name}", :blue)


### PR DESCRIPTION
Fixes #4567 

Adds a new method to the work_resource generator which raises an error if the name is equal to 'work', using a case insensitive match.

@samvera/hyrax-code-reviewers