### PR TITLE
Adding `aria-hidden=true` for thumbnail tag

### DIFF
--- a/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
@@ -8,7 +8,7 @@
   </td>
   <td>
     <div class="media">
-      <%= link_to [main_app, document], class: "media-left" do %>
+      <%= link_to [main_app, document], "class" => "media-left", "aria-hidden" => "true" do %>
         <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -7,7 +7,7 @@
   </td>
   <td>
     <div class="media">
-      <%= link_to [main_app, document], class: "media-left" do %>
+      <%= link_to [main_app, document], "class" => "media-left", "aria-hidden" => "true" do %>
         <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail", alt: "#{document.title_or_label} #{t('hyrax.homepage.admin_sets.thumbnail')}" }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -7,7 +7,7 @@
   </td>
   <td>
     <div class="media">
-      <%= link_to [main_app, document], class: "media-left" do %>
+      <%= link_to [main_app, document], "class" => "media-left", "aria-hidden" => "true" do %>
         <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail", alt: document.title_or_label }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">


### PR DESCRIPTION
Prior to this commit, there existed two URLs that linked to the same
resource.  One A tag wrapped a thumbnail, the other A tag wrapped the
title of the work.

From an accessibility stand-point, there need only be one link to the
document (two links to the same URL can be confounding).

By setting aria-hidden, we're telling assistive devices that this link
isn't of importance.  We include the link as a courtesy for those
relying on the non-assistive rendering.

Related to #4753

@samvera/hyrax-code-reviewers
