### PR TITLE
Docker Build Improvements

### DIFF
--- a/bin/hyrax-entrypoint.sh
+++ b/bin/hyrax-entrypoint.sh
@@ -5,8 +5,15 @@ set -e
 chown -fR app:app /app/samvera/hyrax-webapp/tmp
 chown -fR app:app /app/samvera/hyrax-webapp/public
 
-chown -fR app:app $HYRAX_DERIVATIVES_PATH
-chown -fR app:app $HYRAX_UPLOAD_PATH
+if [ -v HYRAX_DERIVITIVES_PATH ]; then
+  mkdir -p $HYRAX_DERIVITIVES_PATH
+  chown -f -R app:app $HYRAX_DERIVATIVES_PATH
+fi
+
+if [ -v HYRAX_UPLOAD_PATH ]; then
+  mkdir -p $HYRAX_UPLOAD_PATH
+  chown -f -R app:app $HYRAX_UPLOAD_PATH
+fi
 
 mkdir -p /app/samvera/hyrax-webapp/tmp/pids
 rm -f /app/samvera/hyrax-webapp/tmp/pids/*


### PR DESCRIPTION
Lock base at alpine3.12 and update fits to a url that still resolves, skip chown of paths if vars are not set

FITS is no longer available at the Harvard URL. When I switched to the Github url, it would not resolve due to a bug in Alpine 3.13.  In order to debug, I wanted to run individual build steps, but could not due to the entry point vars.  These were all "on the way to fix something else" issues, but I wanted to capture them so others don't have to figure it out.

@samvera/hyrax-code-reviewers
