### PR TITLE
Allow an admin to transfer a work to themself

### DIFF
--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -42,7 +42,7 @@ class ProxyDepositRequest < ActiveRecord::Base
 
   validates :sending_user, :work_id, presence: true
   validate :transfer_to_should_be_a_valid_username
-  validate :sending_user_should_not_be_receiving_user
+  validate :sending_user_should_not_be_receiving_user, unless: :sender_is_admin?
   validate :should_not_be_already_part_of_a_transfer
 
   after_save :send_request_transfer_message
@@ -73,6 +73,10 @@ class ProxyDepositRequest < ActiveRecord::Base
   def should_not_be_already_part_of_a_transfer
     transfers = ProxyDepositRequest.where(work_id: work_id, status: PENDING)
     errors.add(:open_transfer, 'must close open transfer on the work before creating a new one') unless transfers.blank? || (transfers.count == 1 && transfers[0].id == id)
+  end
+
+  def sender_is_admin?
+    sending_user.ability.admin?
   end
 
   public

--- a/spec/models/proxy_deposit_request_spec.rb
+++ b/spec/models/proxy_deposit_request_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ProxyDepositRequest, type: :model do
   let(:sender) { create(:user) }
   let(:receiver) { create(:user) }
   let(:receiver2) { create(:user) }
+  let(:admin) { create(:admin) }
   let(:work_id) { '123abc' }
   let(:stubbed_work_query_service_class) { double(new: work_query_service) }
   let(:work_query_service) { double(work: work) }
@@ -140,6 +141,17 @@ RSpec.describe ProxyDepositRequest, type: :model do
         subject.transfer_to = sender.user_key
         expect(subject).not_to be_valid
         expect(subject.errors[:transfer_to]).to eq(['specify a different user to receive the work'])
+      end
+
+      context 'but they are an admin' do
+        subject do
+          described_class.new(work_id: work_id, sending_user: admin,
+                              receiving_user: admin, sender_comment: "admin is taking this")
+        end
+
+        it 'does not raise an error' do
+          expect(subject).to be_valid
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #3176

Lets an admin create a ProxyDepositRequest where they are the receiving user. Normally this is not allowed.

Changes proposed in this pull request:
* Add a condition to the relevant validation that checks if the sender is an admin.

Guidance for testing, such as acceptance criteria or new user interface behaviors:

Copied from the issue:
1. Log in as a regular user and create a public work
2. Log in as a repo-admin, navigate to the works dashboard and find the work that was created in step 1
3. Select "transfer ownership of work" from the drop-down menu
4. Try to transfer ownership to your repo-admin account

@samvera/hyrax-code-reviewers
