### PR TITLE
improve google scholar meta tag presentation

### DIFF
--- a/app/presenters/hyrax/google_scholar_presenter.rb
+++ b/app/presenters/hyrax/google_scholar_presenter.rb
@@ -4,6 +4,12 @@ module Hyrax
   ##
   # Handles presentation for google scholar meta tags.
   #
+  # @example
+  #   my_book = Monograph.new(title: ['On Moomins'], creator: ['Tove', 'Lars'])
+  #   scholar = GoogleScholarPresenter.new(my_book)
+  #
+  #   scholar.title => 'On Moomins'
+  #
   # @see https://scholar.google.com/intl/en/scholar/inclusion.html#overview
   class GoogleScholarPresenter < Draper::Decorator
     ##
@@ -21,6 +27,60 @@ module Hyrax
       return object.scholarly? if object.respond_to?(:scholarly?)
 
       true
+    end
+
+    ##
+    # @note Google Scholar cares about author order. when possible, this should
+    #   return the othors in order. delegates to `#ordered_authors` when
+    #   available.
+    #
+    # @return [Array<String>] an ordered array of author names
+    def authors
+      return object.ordered_authors if object.respond_to?(:ordered_authors)
+
+      Array(object.creator)
+    end
+
+    ##
+    # @note falls back on {#title} if no description can be found. this
+    #   probably isn't great.
+    #
+    # @return [String] a description
+    def description
+      (Array(object.try(:description)).first || title).truncate(200)
+    end
+
+    ##
+    # @return [String] the keywords
+    def keywords
+      Array(object.try(:keyword)).join('; ')
+    end
+
+    ##
+    # @todo this should probably only return a present value if a PDF is
+    #   available!
+    #
+    # @return [#to_s]
+    def pdf_url
+      object.try(:download_url)
+    end
+
+    ##
+    # @return [String] the publication date
+    def publication_date
+      Array(object.try(:date_created)).first || ''
+    end
+
+    ##
+    # @return [String] a string representing the publisher
+    def publisher
+      Array(object.try(:publisher)).join('; ')
+    end
+
+    ##
+    # @return [String] exactly one title; the same one every time
+    def title
+      Array(object.try(:title)).sort.first || ""
     end
   end
 end

--- a/app/presenters/hyrax/google_scholar_presenter.rb
+++ b/app/presenters/hyrax/google_scholar_presenter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Handles presentation for google scholar meta tags.
+  #
+  # @see https://scholar.google.com/intl/en/scholar/inclusion.html#overview
+  class GoogleScholarPresenter < Draper::Decorator
+    ##
+    # @note Scholar content inclusion docs indicate we should embed metadata
+    #   for "scholarly articles - journal papers, conference papers,
+    #   technical reports, or their drafts, dissertations, pre-prints,
+    #   post-prints, or abstracts." Implementations should try to return
+    #   `false` for other content.
+    #
+    # @return [Boolean] whether this content is "scholarly" for Google Scholar's
+    #   purposes. delegates to decorated object if possible.
+    #
+    # @see https://scholar.google.com/intl/en/scholar/inclusion.html#content
+    def scholarly?
+      return object.scholarly? if object.respond_to?(:scholarly?)
+
+      true
+    end
+  end
+end

--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -14,31 +14,31 @@
   <meta name="twitter:label2" content="Rights Statement" />
 <% end %>
 
-<% gscholar_presenter = Hyrax::GoogleScholarPresenter.new(@presenter) %>
+<% gscholar = Hyrax::GoogleScholarPresenter.new(@presenter) %>
 
-<% if gscholar_presenter.scholarly? %>
+<% if gscholar.scholarly? %>
 <% content_for(:gscholar_meta) do %>
-  <meta name="description" content="<%= @presenter.description.first.truncate(200) rescue @presenter.title.first %>" />
-  <meta name="citation_title" content="<%= @presenter.title.first %>" />
+  <meta name="description" content="<%= gscholar.description %>" />
+  <meta name="citation_title" content="<%= gscholar.title %>" />
 
-  <% gscholar_presenter.each do |creator| %>
-  <meta name="citation_author" content="<%= creator %>" />
+  <% gscholar.authors.each do |author| %>
+  <meta name="citation_author" content="<%= author %>" />
   <% end %>
 
-  <% unless @presenter.date_created.blank? %>
-  <meta name="citation_publication_date" content="<%= @presenter.date_created.first %>" />
+  <% if gscholar.publication_date.present? %>
+  <meta name="citation_publication_date" content="<%= gscholar.publication_date %>" />
   <% end %>
 
-  <% unless @presenter.download_url.blank? %>
-  <meta name="citation_pdf_url" content="<%= @presenter.download_url %>" />
+  <% if gscholar.pdf_url.present? %>
+  <meta name="citation_pdf_url" content="<%= gscholar.pdf_url %>" />
   <% end %>
 
-  <% unless @presenter.keyword.blank? %>
-  <meta name="citation_keywords" content="<%= @presenter.keyword.join('; ') %>" />
+  <% if gscholar.keywords.present? %>
+  <meta name="citation_keywords" content="<%= gscholar.keywords %>" />
   <% end %>
 
-  <% unless @presenter.publisher.blank? %>
-  <meta name="citation_publisher" content="<%= @presenter.publisher.join('; ') %>" />
+  <% if gscholar.publisher.present? %>
+  <meta name="citation_publisher" content="<%= gscholar.publisher %>" />
   <% end %>
 
   <!-- Hyrax does not yet support these metadata -->

--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -14,11 +14,14 @@
   <meta name="twitter:label2" content="Rights Statement" />
 <% end %>
 
+<% gscholar_presenter = Hyrax::GoogleScholarPresenter.new(@presenter) %>
+
+<% if gscholar_presenter.scholarly? %>
 <% content_for(:gscholar_meta) do %>
   <meta name="description" content="<%= @presenter.description.first.truncate(200) rescue @presenter.title.first %>" />
   <meta name="citation_title" content="<%= @presenter.title.first %>" />
 
-  <% @presenter.creator.each do |creator| %>
+  <% gscholar_presenter.each do |creator| %>
   <meta name="citation_author" content="<%= creator %>" />
   <% end %>
 
@@ -46,4 +49,5 @@
     <meta name="citation_firstpage" content=""/>
     <meta name="citation_lastpage" content=""/>
   -->
+<% end %>
 <% end %>

--- a/spec/presenters/hyrax/google_scholar_presenter_spec.rb
+++ b/spec/presenters/hyrax/google_scholar_presenter_spec.rb
@@ -2,15 +2,84 @@
 
 RSpec.describe Hyrax::GoogleScholarPresenter do
   subject(:presenter) { described_class.new(work) }
-  let(:work) { FactoryBot.build(:monograph) }
+  let(:work) { FactoryBot.build(:monograph, title: 'On Moomins') }
 
   describe '#scholarly?' do
     it { is_expected.to be_scholarly }
 
     context 'when the decorated object says it is not scholarly' do
-      let(:work) { double(:scholarly? => false) }
+      let(:work) { double('scholarly?': false) }
 
       it { is_expected.not_to be_scholarly }
+    end
+  end
+
+  describe '#authors' do
+    let(:work) { FactoryBot.build(:monograph, creator: ['Tove', 'Lars']) }
+
+    it 'gives an array of the authors' do
+      expect(presenter.authors).to eq ['Tove', 'Lars']
+    end
+
+    context 'if the object provides ordered authors' do
+      let(:work) { double(ordered_authors: ['Tove', 'Lars']) }
+
+      it 'gives an array of the authors' do
+        expect(presenter.authors).to eq ['Tove', 'Lars']
+      end
+    end
+  end
+
+  describe '#description' do
+    it 'gives the title' do # why?
+      expect(presenter.description).to eq 'On Moomins'
+    end
+
+    context 'with a description' do
+      let(:work) { FactoryBot.build(:monograph, description: ['a short abstract']) }
+
+      it 'gives the title' do # why?
+        expect(presenter.description).to eq 'a short abstract'
+      end
+    end
+
+    context 'with a long description' do
+      let(:work) { FactoryBot.build(:monograph, description: [description]) }
+      let(:description) { Array.new(1000) { 'a' }.join('') }
+
+      it 'truncates the description' do
+        expect(presenter.description.length).to eq 200
+      end
+    end
+  end
+
+  describe '#keywords' do
+    let(:work) { FactoryBot.build(:monograph, keyword: ['one', 'two', 'three']) }
+
+    it 'lists the keywords semicolon delimeted' do
+      expect(presenter.keywords).to eq 'one; two; three'
+    end
+  end
+
+  describe '#publication_date' do
+    let(:work) { FactoryBot.build(:monograph, date_created: ['2021', '2024']) }
+
+    it 'gives exactly one publication date' do
+      expect(presenter.publication_date).to eq '2021'
+    end
+  end
+
+  describe '#publisher' do
+    let(:work) { FactoryBot.build(:monograph, publisher: ['Knopf', 'Macmillan', 'Sage']) }
+
+    it 'lists the publishers semicolon delimeted' do
+      expect(presenter.publisher).to eq 'Knopf; Macmillan; Sage'
+    end
+  end
+
+  describe '#title' do
+    it 'gives title as a string' do
+      expect(presenter.title).to eq 'On Moomins'
     end
   end
 end

--- a/spec/presenters/hyrax/google_scholar_presenter_spec.rb
+++ b/spec/presenters/hyrax/google_scholar_presenter_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::GoogleScholarPresenter do
+  subject(:presenter) { described_class.new(work) }
+  let(:work) { FactoryBot.build(:monograph) }
+
+  describe '#scholarly?' do
+    it { is_expected.to be_scholarly }
+
+    context 'when the decorated object says it is not scholarly' do
+      let(:work) { double(:scholarly? => false) }
+
+      it { is_expected.not_to be_scholarly }
+    end
+  end
+end


### PR DESCRIPTION
Changes proposed in this pull request:
* move view logic for tag value presentation into a presenter
* create a hook for suppressing google scholar meta tags for non-scholarly content
* guarantee author order:
  * use `#ordered_authors` for author content, if present (i.e. add a hook for applicaitons)
  * use and sort `BasicMetadata#creator` otherwise

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* make sure google scholar meta tags still appear in `<head>` for work show views

@samvera/hyrax-code-reviewers
