### PR TITLE
safely skip indexing when events are published w/ ActiveFedora::Base

### DIFF
--- a/app/services/hyrax/listeners/metadata_index_listener.rb
+++ b/app/services/hyrax/listeners/metadata_index_listener.rb
@@ -16,7 +16,11 @@ module Hyrax
       #
       # @param event [Dry::Event]
       def on_object_metadata_updated(event)
-        Hyrax.index_adapter.save(resource: event[:object])
+        return Hyrax.index_adapter.save(resource: event[:object]) if
+          event[:object].is_a?(Valkyrie::Resource)
+
+        Hyrax.logger.info('Skipping object reindex because the object ' \
+                          "#{event[:object]} was not a Valkyrie::Resource.")
       end
     end
   end

--- a/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
@@ -20,5 +20,14 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
         .to change { fake_adapter.saved_resources }
         .to contain_exactly(resource)
     end
+
+    context 'when it gets a non-resource as payload' do
+      let(:resource) { ActiveFedora::Base.new }
+
+      it 'returns as a no-op' do
+        expect { listener.on_object_metadata_updated(event) }
+          .not_to change { fake_adapter.saved_resources }
+      end
+    end
   end
 end


### PR DESCRIPTION
when metadata updated events are published with `ActiveFedora::Base` objects,
don't try to index them to valkyrie. trust that AF has already indexed to its
own solr core.

Fixes #4775.

@samvera/hyrax-code-reviewers
