### PR TITLE
File manager form

### DIFF
--- a/app/forms/hyrax/forms/file_manager_form.rb
+++ b/app/forms/hyrax/forms/file_manager_form.rb
@@ -6,10 +6,17 @@ module Hyrax
       self.terms = []
       delegate :id, :thumbnail_id, :representative_id, :to_s, to: :model
       attr_reader :current_ability, :request
-      def initialize(work, ability)
+
+      ##
+      # @param work [Object] a work with members
+      # @param ability [::Ability] the current ability
+      # @param member_factory [Class] the member_presenter factory object to use
+      #   when constructing presenters
+      def initialize(work, ability, member_factory: MemberPresenterFactory)
         super(work)
         @current_ability = ability
         @request = nil
+        @member_factory = member_factory
       end
 
       def version
@@ -21,7 +28,7 @@ module Hyrax
       private
 
       def member_presenter_factory
-        MemberPresenterFactory.new(model, current_ability)
+        @member_factory.new(model, current_ability)
       end
     end
   end

--- a/spec/forms/hyrax/forms/file_manager_form_spec.rb
+++ b/spec/forms/hyrax/forms/file_manager_form_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Forms::FileManagerForm do
   subject(:form) { described_class.new(work, ability) }
-  let(:work) { FactoryBot.build(:work) }
+  let(:work) { FactoryBot.build(:generic_work) }
   let(:ability) { :FAKE_ABILITY }
 
   describe "#member_presenters" do
@@ -18,6 +18,16 @@ RSpec.describe Hyrax::Forms::FileManagerForm do
 
       it "is delegated to the MemberPresenterFactory" do
         expect(form.member_presenters).to eq [:some, :member, :presenters]
+      end
+    end
+
+    context 'with an AF::Base work' do
+      let(:work) { FactoryBot.create(:work_with_files) }
+
+      it 'gives file set presenters' do
+        expect(form.member_presenters)
+          .to contain_exactly(an_instance_of(Hyrax::FileSetPresenter),
+                              an_instance_of(Hyrax::FileSetPresenter))
       end
     end
   end

--- a/spec/forms/hyrax/forms/file_manager_form_spec.rb
+++ b/spec/forms/hyrax/forms/file_manager_form_spec.rb
@@ -1,20 +1,24 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Forms::FileManagerForm do
-  let(:work) { create(:work) }
-  let(:ability) { instance_double Ability }
-  let(:form) { described_class.new(work, ability) }
+  subject(:form) { described_class.new(work, ability) }
+  let(:work) { FactoryBot.build(:work) }
+  let(:ability) { :FAKE_ABILITY }
 
   describe "#member_presenters" do
-    subject { form.member_presenters }
+    context 'with a custom member presenter factory' do
+      subject(:form) { described_class.new(work, ability, member_factory: member_factory) }
 
-    let(:factory) { instance_double(Hyrax::MemberPresenterFactory, member_presenters: result) }
-    let(:result) { double }
+      let(:member_factory) do
+        Class.new(Hyrax::MemberPresenterFactory) do
+          def member_presenters
+            [:some, :member, :presenters]
+          end
+        end
+      end
 
-    before do
-      allow(Hyrax::MemberPresenterFactory).to receive(:new).with(work, ability).and_return(factory)
-    end
-    it "is delegated to the MemberPresenterFactory" do
-      expect(subject).to eq result
+      it "is delegated to the MemberPresenterFactory" do
+        expect(form.member_presenters).to eq [:some, :member, :presenters]
+      end
     end
   end
 end


### PR DESCRIPTION
use named subject; avoid indirection in test logic. these tests don't exercise any of the real behavior of this module; from their perspective, it's not much more than a wrapper for the member factory. since the tests want to inject a PresenterFactory, we can guess that others might too (will we need custom ones for valkyrie?), so we extend the class to support factory injection.

iest the existing default case. i initially staged a failing test for Valkyrie, but after getting this far, i think a new form for the FileManager views is going to be the better approach.

@samvera/hyrax-code-reviewers
