### PR TITLE
Add indexing for Hyrax::FileSet through valkyrie indexing

### DIFF
--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -62,7 +62,8 @@ module Hyrax
       end
 
       def create_file_from_url(env, uri, file_name, auth_header)
-        if env.curation_concern.is_a? Valkyrie::Resource
+        case env.curation_concern
+        when Valkyrie::Resource
           create_file_from_url_through_valkyrie(env, uri, file_name, auth_header)
         else
           create_file_from_url_through_active_fedora(env, uri, file_name, auth_header)

--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -61,9 +61,17 @@ module Hyrax
         true
       end
 
+      def create_file_from_url(env, uri, file_name, auth_header)
+        if env.curation_concern.is_a? Valkyrie::Resource
+          create_file_from_url_through_valkyrie(env, uri, file_name, auth_header)
+        else
+          create_file_from_url_through_active_fedora(env, uri, file_name, auth_header)
+        end
+      end
+
       # Generic utility for creating FileSet from a URL
       # Used in to import files using URLs from a file picker like browse_everything
-      def create_file_from_url(env, uri, file_name, auth_header = {})
+      def create_file_from_url_through_active_fedora(env, uri, file_name, auth_header)
         import_url = URI.decode_www_form_component(uri.to_s)
         ::FileSet.new(import_url: import_url, label: file_name) do |fs|
           actor = Hyrax::Actors::FileSetActor.new(fs, env.user)
@@ -77,6 +85,23 @@ module Hyrax
           else
             ImportUrlJob.perform_later(fs, operation_for(user: actor.user), auth_header)
           end
+        end
+      end
+
+      # Generic utility for creating Hyrax::FileSet from a URL
+      # Used in to import files using URLs from a file picker like browse_everything
+      def create_file_from_url_through_valkyrie(env, uri, file_name, auth_header)
+        import_url = URI.decode_www_form_component(uri.to_s)
+        fs = Hyrax.persister.save(resource: Hyrax::FileSet.new(import_url: import_url, label: file_name))
+        actor = Hyrax::Actors::FileSetActor.new(fs, env.user, use_valkyrie: true)
+        actor.create_metadata(visibility: env.curation_concern.visibility)
+        actor.attach_to_work(env.curation_concern)
+        if uri.scheme == 'file'
+          # Turn any %20 into spaces.
+          file_path = CGI.unescape(uri.path)
+          IngestLocalFileJob.perform_later(fs, file_path, env.user)
+        else
+          ImportUrlJob.perform_later(fs, operation_for(user: actor.user), auth_header)
         end
       end
 

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -6,7 +6,7 @@ module Hyrax
       include Lockable
       attr_reader :file_set, :user, :attributes, :use_valkyrie
 
-      def initialize(file_set, user, use_valkyrie: false)
+      def initialize(file_set, user, use_valkyrie: Hyrax.config.query_index_from_valkyrie)
         @use_valkyrie = use_valkyrie
         @file_set = file_set
         @user = user
@@ -87,7 +87,7 @@ module Hyrax
       def attach_to_valkyrie_work(work, file_set_params)
         work = Hyrax.query_service.find_by(id: work.id) unless work.new_record
         file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
-        Hyrax.persister.save(resource: file_set)
+        @file_set = Hyrax.persister.save(resource: file_set)
         work.member_ids << file_set.id
         work.representative_id = file_set.id if work.representative_id.blank?
         work.thumbnail_id = file_set.id if work.thumbnail_id.blank?

--- a/app/indexers/hyrax/valkyrie_file_set_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_file_set_indexer.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Indexes Hyrax::FileSet objects
+  class ValkyrieFileSetIndexer < Hyrax::ValkyrieIndexer
+    include Hyrax::ResourceIndexer
+    include Hyrax::PermissionIndexer
+    include Hyrax::VisibilityIndexer
+    include Hyrax::Indexer(:core_metadata)
+    include Hyrax::Indexer(:basic_metadata)
+
+    # include Hyrax::IndexesThumbnails # TODO: Is there a Valkyrie version of a thumbnail indexer?
+
+    def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      super.tap do |solr_doc| # rubocop:disable Metrics/BlockLength
+        # Metadata from the FileSet
+        solr_doc['file_ids_ssim']         = resource.file_ids&.map(&:to_s)
+        solr_doc['original_file_id_ssi']  = resource.original_file_id.to_s
+        solr_doc['thumbnail_id_ssi']      = resource.thumbnail_id.to_s
+        solr_doc['extracted_text_id_ssi'] = resource.extracted_text_id.to_s
+
+        # Add in metadata from the original file.
+        file_metadata = original_file
+        return solr_doc unless file_metadata
+
+        # Label is the actual file name. It's not editable by the user.
+        solr_doc['original_file_alternate_ids_tesim'] = file_metadata.alternate_ids&.map(&:to_s) if file_metadata.alternate_ids.present?
+
+        solr_doc['original_filename_tesi']  = file_metadata.original_filename if file_metadata.original_filename.present?
+        solr_doc['original_filename_ssi']   = file_metadata.original_filename if file_metadata.original_filename.present?
+        solr_doc['mime_type_tesi']          = file_metadata.mime_type if file_metadata.mime_type.present?
+        solr_doc['mime_type_ssi']           = file_metadata.mime_type if file_metadata.mime_type.present?
+
+        solr_doc['file_format_tesim']       = file_format(file_metadata)
+        solr_doc['file_format_sim']         = file_format(file_metadata)
+        solr_doc['file_size_lts']           = file_metadata.size[0]
+        solr_doc['type_tesim']              = file_metadata.type if file_metadata.type.present?
+
+        # attributes set by fits
+        solr_doc['format_label_tesim']      = file_metadata.format_label if file_metadata.format_label.present?
+        solr_doc['size_tesim']              = file_metadata.size if file_metadata.size.present?
+        solr_doc['well_formed_tesim']       = file_metadata.well_formed if file_metadata.well_formed.present?
+        solr_doc['valid_tesim']             = file_metadata.valid if file_metadata.valid.present?
+        solr_doc['fits_version_tesim']      = file_metadata.fits_version if file_metadata.fits_version.present?
+        solr_doc['exif_version_tesim']      = file_metadata.exif_version if file_metadata.exif_version.present?
+        solr_doc['checksum_tesim']          = file_metadata.checksum if file_metadata.checksum.present?
+
+        # shared attributes across multiple file types
+        solr_doc['frame_rate_tesim']        = file_metadata.frame_rate if file_metadata.frame_rate.present? # audio, video
+        solr_doc['bit_rate_tesim']          = file_metadata.bit_rate if file_metadata.bit_rate.present? # audio, video
+        solr_doc['duration_tesim']          = file_metadata.duration if file_metadata.duration.present? # audio, video
+        solr_doc['sample_rate_tesim']       = file_metadata.sample_rate if file_metadata.sample_rate.present? # audio, video
+
+        solr_doc['height_tesim']            = file_metadata.height if file_metadata.height.present? # image, video
+        solr_doc['width_tesim']             = file_metadata.width if file_metadata.width.present? # image, video
+
+        # attributes set by fits for audio files
+        solr_doc['bit_depth_tesim']         = file_metadata.bit_depth if file_metadata.bit_depth.present?
+        solr_doc['channels_tesim']          = file_metadata.channels if file_metadata.channels.present?
+        solr_doc['data_format_tesim']       = file_metadata.data_format if file_metadata.data_format.present?
+        solr_doc['offset_tesim']            = file_metadata.offset if file_metadata.offset.present?
+
+        # attributes set by fits for documents
+        solr_doc['file_title_tesim']        = file_metadata.file_title if file_metadata.file_title.present?
+        solr_doc['page_count_tesim']        = file_metadata.page_count if file_metadata.page_count.present?
+        solr_doc['language_tesim']          = file_metadata.language if file_metadata.language.present?
+        solr_doc['word_count_tesim']        = file_metadata.word_count if file_metadata.word_count.present?
+        solr_doc['character_count_tesim']   = file_metadata.character_count if file_metadata.character_count.present?
+        solr_doc['line_count_tesim']        = file_metadata.line_count if file_metadata.line_count.present?
+        solr_doc['character_set_tesim']     = file_metadata.character_set if file_metadata.character_set.present?
+        solr_doc['markup_basis_tesim']      = file_metadata.markup_basis if file_metadata.markup_basis.present?
+        solr_doc['paragraph_count_tesim']   = file_metadata.paragraph_count if file_metadata.paragraph_count.present?
+        solr_doc['markup_language_tesim']   = file_metadata.markup_language if file_metadata.markup_language.present?
+        solr_doc['table_count_tesim']       = file_metadata.table_count if file_metadata.table_count.present?
+        solr_doc['graphics_count_tesim']    = file_metadata.graphics_count if file_metadata.graphics_count.present?
+
+        # attributes set by fits for images
+        solr_doc['byte_order_tesim']        = file_metadata.byte_order if file_metadata.byte_order.present?
+        solr_doc['compression_tesim']       = file_metadata.compression if file_metadata.compression.present?
+        solr_doc['color_space_tesim']       = file_metadata.color_space if file_metadata.color_space.present?
+        solr_doc['profile_name_tesim']      = file_metadata.profile_name if file_metadata.profile_name.present?
+        solr_doc['profile_version_tesim']   = file_metadata.profile_version if file_metadata.profile_version.present?
+        solr_doc['orientation_tesim']       = file_metadata.orientation if file_metadata.orientation.present?
+        solr_doc['color_map_tesim']         = file_metadata.color_map if file_metadata.color_map.present?
+        solr_doc['image_producer_tesim']    = file_metadata.image_producer if file_metadata.image_producer.present?
+        solr_doc['capture_device_tesim']    = file_metadata.capture_device if file_metadata.capture_device.present?
+        solr_doc['scanning_software_tesim'] = file_metadata.scanning_software if file_metadata.scanning_software.present?
+        solr_doc['gps_timestamp_tesim']     = file_metadata.gps_timestamp if file_metadata.gps_timestamp.present?
+        solr_doc['latitude_tesim']          = file_metadata.latitude if file_metadata.latitude.present?
+        solr_doc['longitude_tesim']         = file_metadata.longitude if file_metadata.longitude.present?
+
+        # attributes set by fits for video
+        solr_doc['aspect_ratio_tesim']      = file_metadata.aspect_ratio if file_metadata.aspect_ratio.present?
+      end
+    end
+
+    private
+
+    def original_file
+      Hyrax.custom_queries.find_original_file(file_set: resource)
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      Hyrax.custom_queries.find_files(file_set: resource).first
+    end
+
+    def file_format(file)
+      if file.mime_type.present? && file.format_label.present?
+        "#{file.mime_type.split('/').last} (#{file.format_label.join(', ')})"
+      elsif file.mime_type.present?
+        file.mime_type.split('/').last
+      elsif file.format_label.present?
+        file.format_label
+      end
+    end
+  end
+end

--- a/app/indexers/hyrax/valkyrie_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_indexer.rb
@@ -95,7 +95,12 @@ module Hyrax
       # @example
       #     ValkyrieIndexer.for(resource: Book.new) # => #<BookIndexer ...>
       def for(resource:)
-        indexer_class_for(resource).new(resource: resource)
+        case resource
+        when Hyrax::FileSet
+          Hyrax::ValkyrieFileSetIndexer.new(resource: resource)
+        else
+          indexer_class_for(resource).new(resource: resource)
+        end
       end
 
       private

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -7,6 +7,7 @@ module Hyrax
   # @see https://wiki.duraspace.org/display/samvera/Hydra%3A%3AWorks+Shared+Modeling
   class FileSet < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
+    include Hyrax::Schema(:basic_metadata)
 
     attribute :file_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID) # id for FileMetadata resources
     attribute :original_file_id, Valkyrie::Types::ID # id for FileMetadata resource

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -14,6 +14,8 @@ module Hyrax
     attribute :on_behalf_of,             Valkyrie::Types::String
     attribute :proxy_depositor,          Valkyrie::Types::String
     attribute :state,                    Valkyrie::Types::URI.default(Hyrax::ResourceStatus::ACTIVE)
+    attribute :representative_id,        Valkyrie::Types::ID
+    attribute :thumbnail_id,             Valkyrie::Types::ID
 
     ##
     # @return [Boolean] true

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -63,7 +63,7 @@ class JobIoWrapper < ApplicationRecord
     nil # unable to determine
   end
 
-  def file_set(use_valkyrie: false)
+  def file_set(use_valkyrie: Hyrax.config.query_index_from_valkyrie)
     return FileSet.find(file_set_id) unless use_valkyrie
     Hyrax.query_service.find_by(id: Valkyrie::ID.new(file_set_id))
   end

--- a/app/services/hyrax/work_uploads_handler.rb
+++ b/app/services/hyrax/work_uploads_handler.rb
@@ -64,7 +64,7 @@ module Hyrax
     # @note we immediately and silently discard uploads with an existing
     #   file_set_uri, in a half-considered attempt at supporting idempotency
     #   (for job retries). this is for legacy/AttachFilesToWorkJob
-    #   compatibility, but could stand for a roubst reimplementation.
+    #   compatibility, but could stand for a robust reimplementation.
     #
     # @param [Enumberable<Hyrax::UploadedFile>] files  files to add
     #
@@ -106,6 +106,7 @@ module Hyrax
       Hyrax::AccessControlList.copy_permissions(source: target_permissions, target: file_set)
       append_to_work(file_set)
       IngestJob.perform_later(wrap_file(file, file_set))
+      Hyrax.publisher.publish('object.metadata.updated', object: file_set, user: file.user)
       { file_set: file_set, user: file.user }
     end
 

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -19,10 +19,12 @@ end
 
 Hyrax.config.callback.set(:after_create_fileset, warn: false) do |file_set, user|
   Hyrax.publisher.publish('file.set.attached', file_set: file_set, user: user)
+  Hyrax.publisher.publish('object.metadata.updated', object: file_set, user: user)
 end
 
 Hyrax.config.callback.set(:after_revert_content, warn: false) do |file_set, user, revision|
   Hyrax.publisher.publish('file.set.restored', file_set: file_set, user: user, revision: revision)
+  Hyrax.publisher.publish('object.metadata.updated', object: file_set, user: user)
 end
 
 Hyrax.config.callback.set(:after_update_metadata, warn: false) do |curation_concern, user|

--- a/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
@@ -134,4 +134,114 @@ RSpec.describe Hyrax::Actors::CreateWithRemoteFilesActor do
       expect(actor.send(:validate_remote_url, URI('https://example.com/test.txt'))).to be true
     end
   end
+
+  context 'when work is a valkyrie resource' do
+    let(:work) { valkyrie_create(:monograph) }
+
+    context "with source uris that are remote" do
+      let(:remote_files) do
+        [{ url: url1,
+           expires: "2014-03-31T20:37:36.214Z",
+           file_name: "filepicker-demo.txt.txt" },
+         { url: url2,
+           expires: "2014-03-31T20:37:36.731Z",
+           file_name: "Getting+Started.pdf" }]
+      end
+
+      it "attaches files" do
+        expect(ImportUrlJob).to receive(:perform_later).with(Hyrax::FileSet, Hyrax::Operation, {}).twice
+        expect(actor.create(environment)).to be true
+      end
+    end
+
+    context "with source URIs that are remote and contain encoded parameters" do
+      let(:url1) { "https://dl.dropbox.com/fake/file?param1=%28example%29&param2=%5Bexample2%5D" }
+
+      before do
+        allow(Hyrax::FileSet).to receive(:new).and_call_original
+      end
+
+      it "preserves the encoded parameters in the URIs" do
+        expect(ImportUrlJob).to receive(:perform_later).with(Hyrax::FileSet, Hyrax::Operation, {}).twice
+        expect(actor.create(environment)).to be true
+        expect(Hyrax::FileSet).to have_received(:new).with(import_url: "https://dl.dropbox.com/fake/file?param1=%28example%29&param2=%5Bexample2%5D", label: "filepicker-demo.txt.txt")
+      end
+    end
+
+    context "with source uris that are remote bearing auth headers" do
+      let(:remote_files) do
+        [{ url: url1,
+           expires: "2014-03-31T20:37:36.214Z",
+           file_name: "filepicker-demo.txt.txt",
+           auth_header: { 'Authorization' => 'Bearer access-token' } },
+         { url: url2,
+           expires: "2014-03-31T20:37:36.731Z",
+           file_name: "Getting+Started.pdf",
+           auth_header: { 'Authorization' => 'Bearer access-token' } }]
+      end
+
+      it "attaches files" do
+        expect(ImportUrlJob).to receive(:perform_later).with(Hyrax::FileSet, Hyrax::Operation, 'Authorization' => 'Bearer access-token').twice
+        expect(actor.create(environment)).to be true
+      end
+    end
+
+    context "with source uris that are local files" do
+      let(:remote_files) do
+        [{ url: file,
+           expires: "2014-03-31T20:37:36.214Z",
+           file_name: "here.txt" }]
+      end
+
+      before do
+        allow(Hyrax.config).to receive(:registered_ingest_dirs).and_return(["/local/file/"])
+      end
+
+      it "attaches files" do
+        expect(IngestLocalFileJob).to receive(:perform_later).with(Hyrax::FileSet, "/local/file/here.txt", user)
+        expect(actor.create(environment)).to be true
+      end
+
+      context "with files from non-registered directories" do
+        let(:file) { "file:///local/otherdir/test.txt" }
+
+        it "doesn't attach files" do
+          expect(actor).to receive(:validate_remote_url).and_call_original
+          expect(IngestLocalFileJob).not_to receive(:perform_later)
+          expect(actor.create(environment)).to be false
+        end
+      end
+
+      context "with spaces" do
+        let(:file) { "file:///local/file/ pigs .txt" }
+
+        it "attaches files" do
+          expect(IngestLocalFileJob).to receive(:perform_later).with(Hyrax::FileSet, "/local/file/ pigs .txt", user)
+          expect(actor.create(environment)).to be true
+        end
+      end
+    end
+
+    describe "#validate_remote_url" do
+      before do
+        allow(Hyrax.config).to receive(:registered_ingest_dirs).and_return(['/test/', '/local/file/'])
+      end
+
+      it "accepts file: urls in registered directories" do
+        expect(actor.send(:validate_remote_url, URI('file:///local/file/test.txt'))).to be true
+        expect(actor.send(:validate_remote_url, URI('file:///local/file/subdirectory/test.txt'))).to be true
+        expect(actor.send(:validate_remote_url, URI('file:///test/test.txt'))).to be true
+      end
+
+      it "rejects file: urls outside registered directories" do
+        expect(actor.send(:validate_remote_url, URI('file:///tmp/test.txt'))).to be false
+        expect(actor.send(:validate_remote_url, URI('file:///test/../tmp/test.txt'))).to be false
+        expect(actor.send(:validate_remote_url, URI('file:///test/'))).to be false
+      end
+
+      it "accepts other types of urls" do
+        expect(actor.send(:validate_remote_url, URI('https://example.com/test.txt'))).to be true
+      end
+    end
+  end
 end

--- a/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::ValkyrieFileSetIndexer do
+  include Hyrax::FactoryHelpers
+
+  let(:fileset_id) { 'fs1' }
+  let(:file_set) do
+    Hyrax::FileSet.new(
+      id: fileset_id,
+      file_ids: [mock_file.id, mock_text.id],
+      original_file_id: mock_file.id,
+      extracted_text_id: mock_text.id,
+      contributor: ['Rogers, Jacqueline'],
+      creator: ['Cleary, Beverly'],
+      title: ['Ramona Quimby, age 8'],
+      description: ["Ramona's life as an 8 year old."],
+      publisher: ['HarperCollins'],
+      date_created: ['1981-01-01'],
+      date_uploaded: Date.parse('2011-01-01'),
+      date_modified: Date.parse('2012-01-01'),
+      subject: ['Family life'],
+      language: ['English'],
+      license: ['In Copyright'],
+      rights_statement: ['Known Copyright'],
+      resource_type: ['Book'],
+      identifier: ['urn:isbn:1234567890'],
+      based_near: ['Oakland, California'],
+      related_url: ['https://id.loc.gov/resources/works/17452360.html']
+    )
+  end
+
+  let(:file_name) { 'mock_file.jpg' }
+  let(:original_file_id) { 'mf1' }
+  let(:mock_file) do
+    # attributes as defined in Hyrax::FileMetadata
+    mock_file_metadata_factory(
+      file_identifier: 'VALFILEID1',
+      alternate_ids: ['AFFILEID1'],
+      file_set_id: fileset_id,
+
+      label: [file_name],
+      original_filename: file_name,
+      mime_type: 'image/jpeg',
+      type: ['jpg'],
+
+      # attributes set by fits
+      format_label: ['JPEG Image'],
+      size: ['2904'],
+      well_formed: ['true'],
+      valid: ['true'],
+      date_created: ['1981-01-01'],
+      fits_version: ['1.5'],
+      exif_version: ['2.32'],
+      checksum: ['C0H9E8CfK6SbUcMd'],
+
+      # shared attributes across multiple file types
+      frame_rate: ['30/s'],
+      bit_rate: ['1 Mbit/s'],
+      duration: ['6:18'],
+      sample_rate: ['48 kHz'],
+
+      height: ['500'],
+      width: ['600'],
+
+      # attributes set by fits for audio files
+      bit_depth: ['32'],
+      channels: ['4'],
+      data_format: ['mp3'],
+      offset: ['7:33'],
+
+      # attributes set by fits for documents
+      file_title: ['Ramona Quimby, age 8'],
+      creator: ['Cleary, Beverly'],
+      page_count: ['1'],
+      language: ['en'],
+      word_count: ['20'],
+      character_count: ['200'],
+      line_count: ['4'],
+      character_set: ['latin1'],
+      markup_basis: ['md basis'],
+      paragraph_count: ['2'],
+      markup_language: ['md'],
+      table_count: ['3'],
+      graphics_count: ['5'],
+
+      # attributes set by fits for images
+      byte_order: ['AVR32'],
+      compression: ['lossy'],
+      color_space: ['sRGB'],
+      profile_name: ['ESXi-7.0.2-17630552-standard'],
+      profile_version: ['17630552'],
+      orientation: ['landscape'],
+      color_map: ['autumn'],
+      image_producer: ['MemoryImageSource'],
+      capture_device: ['Nikon 35mm'],
+      scanning_software: [''],
+      gps_timestamp: ['2021:03:11 09:35:02'],
+      latitude: ['38.8951'],
+      longitude: ['-77.0365'],
+
+      # attributes set by fits for video
+      aspect_ratio: ['5:4']
+    )
+  end
+
+  let(:mock_text) do
+    mock_file_factory(content: "abcxyz")
+  end
+
+  let(:indexer) { described_class.new(resource: file_set) }
+
+  describe '#to_solr' do
+    before do
+      allow(file_set).to receive(:persisted?).and_return(true)
+      allow(file_set).to receive(:label).and_return('CastoriaAd.tiff')
+      allow(Hyrax::ThumbnailPathService).to receive(:call).and_return('/downloads/foo12345?file=thumbnail')
+      allow(Hyrax.custom_queries).to receive(:find_original_file).with(file_set: file_set).and_return(mock_file)
+      allow(mock_file).to receive(:file_name).and_return(file_name)
+    end
+    subject { indexer.generate_solr_document }
+
+    it 'has fields' do # rubocop:disable RSpec/ExampleLength
+      # from core metadata
+      expect(subject['title_sim']).to eq ['Ramona Quimby, age 8']
+      expect(subject['title_tesim']).to eq ['Ramona Quimby, age 8']
+
+      # from basic metadata
+      expect(subject['based_near_sim']).to eq ['Oakland, California']
+      expect(subject['based_near_tesim']).to eq ['Oakland, California']
+      expect(subject['creator_tesim']).to eq ['Cleary, Beverly']
+      expect(subject['date_created_tesim']).to eq ['1981-01-01']
+      expect(subject['related_url_tesim']).to eq ['https://id.loc.gov/resources/works/17452360.html']
+      expect(subject['resource_type_sim']).to eq ['Book']
+      expect(subject['resource_type_tesim']).to eq ['Book']
+      expect(subject['subject_sim']).to eq ['Family life']
+      expect(subject['subject_tesim']).to eq ['Family life']
+
+      # from FileSet metadata
+      expect(subject['file_ids_ssim']).to match_array [mock_file.id.to_s, mock_text.id.to_s]
+      expect(subject['original_file_id_ssi']).to eq mock_file.id.to_s
+      expect(subject['thumbnail_id_ssi']).to eq ""
+      expect(subject['extracted_text_id_ssi']).to eq mock_text.id.to_s
+
+      # from FileMetadata
+      expect(subject['original_file_alternate_ids_tesim']).to eq mock_file['alternate_ids']
+      expect(subject['original_filename_tesi']).to eq mock_file['original_filename']
+      expect(subject['original_filename_ssi']).to eq mock_file['original_filename']
+      expect(subject['mime_type_tesi']).to eq mock_file['mime_type']
+      expect(subject['mime_type_ssi']).to eq mock_file['mime_type']
+
+      expect(subject['file_format_tesim']).to eq 'jpeg (JPEG Image)'
+      expect(subject['file_format_sim']).to eq 'jpeg (JPEG Image)'
+      expect(subject['file_size_lts']).to eq mock_file.size[0]
+      expect(subject['type_tesim']).to eq mock_file['type']
+
+      # attributes set by fits
+      expect(subject['format_label_tesim']).to eq mock_file['format_label']
+      expect(subject['size_tesim']).to eq mock_file['size']
+      expect(subject['well_formed_tesim']).to eq mock_file['well_formed']
+      expect(subject['valid_tesim']).to eq mock_file['valid']
+      expect(subject['date_created_tesim']).to eq mock_file['date_created']
+      expect(subject['fits_version_tesim']).to eq mock_file['fits_version']
+      expect(subject['exif_version_tesim']).to eq mock_file['exif_version']
+      expect(subject['checksum_tesim']).to eq mock_file['checksum']
+
+      # shared attributes across multiple file types
+      expect(subject['frame_rate_tesim']).to eq mock_file['frame_rate']
+      expect(subject['bit_rate_tesim']).to eq mock_file['bit_rate']
+      expect(subject['duration_tesim']).to eq mock_file['duration']
+      expect(subject['sample_rate_tesim']).to eq mock_file['sample_rate']
+
+      expect(subject['height_tesim']).to eq mock_file['height']
+      expect(subject['width_tesim']).to eq mock_file['width']
+
+      # attributes set by fits for audio files
+      expect(subject['bit_depth_tesim']).to eq mock_file['bit_depth']
+      expect(subject['channels_tesim']).to eq mock_file['channels']
+      expect(subject['data_format_tesim']).to eq mock_file['data_format']
+      expect(subject['offset_tesim']).to eq mock_file['offset']
+
+      # attributes set by fits for documents
+      expect(subject['file_title_tesim']).to eq mock_file['file_title']
+      expect(subject['creator_tesim']).to eq mock_file['creator']
+      expect(subject['page_count_tesim']).to eq mock_file['page_count']
+      expect(subject['language_tesim']).to eq mock_file['language']
+      expect(subject['word_count_tesim']).to eq mock_file['word_count']
+      expect(subject['character_count_tesim']).to eq mock_file['character_count']
+      expect(subject['line_count_tesim']).to eq mock_file['line_count']
+      expect(subject['character_set_tesim']).to eq mock_file['character_set']
+      expect(subject['markup_basis_tesim']).to eq mock_file['markup_basis']
+      expect(subject['paragraph_count_tesim']).to eq mock_file['paragraph_count']
+      expect(subject['markup_language_tesim']).to eq mock_file['markup_language']
+      expect(subject['table_count_tesim']).to eq mock_file['table_count']
+      expect(subject['graphics_count_tesim']).to eq mock_file['graphics_count']
+
+      # attributes set by fits for images
+      expect(subject['byte_order_tesim']).to eq mock_file['byte_order']
+      expect(subject['compression_tesim']).to eq mock_file['compression']
+      expect(subject['color_space_tesim']).to eq mock_file['color_space']
+      expect(subject['profile_name_tesim']).to eq mock_file['profile_name']
+      expect(subject['profile_version_tesim']).to eq mock_file['profile_version']
+      expect(subject['orientation_tesim']).to eq mock_file['orientation']
+      expect(subject['color_map_tesim']).to eq mock_file['color_map']
+      expect(subject['image_producer_tesim']).to eq mock_file['image_producer']
+      expect(subject['capture_device_tesim']).to eq mock_file['capture_device']
+      expect(subject['scanning_software_tesim']).to eq mock_file['scanning_software']
+      expect(subject['gps_timestamp_tesim']).to eq mock_file['gps_timestamp']
+      expect(subject['latitude_tesim']).to eq mock_file['latitude']
+      expect(subject['longitude_tesim']).to eq mock_file['longitude']
+
+      # attributes set by fits for video
+      expect(subject['aspect_ratio_tesim']).to eq mock_file['aspect_ratio']
+    end
+
+    context "when original_file is not versioned" do
+      # before do
+      #   allow(version_graph).to receive(:fedora_versions).and_return([])
+      # end
+
+      it "does not have version info indexed" do
+        expect(subject['original_file_id_ssi']).to eq file_set.original_file_id
+      end
+    end
+  end
+
+  describe '#file_format' do
+    subject { indexer.send(:file_format, mock_file) }
+
+    context 'when both mime and format_label are present' do
+      before do
+        allow(mock_file).to receive(:mime_type).and_return('image/png')
+        allow(mock_file).to receive(:format_label).and_return(['Portable Network Graphics'])
+      end
+      it { is_expected.to eq 'png (Portable Network Graphics)' }
+    end
+
+    context 'when just mime type is present' do
+      before do
+        allow(mock_file).to receive(:mime_type).and_return('image/png')
+        allow(mock_file).to receive(:format_label).and_return([])
+      end
+      it { is_expected.to eq 'png' }
+    end
+
+    context 'when just format_label is present' do
+      before do
+        allow(mock_file).to receive(:mime_type).and_return('')
+        allow(mock_file).to receive(:format_label).and_return(['Portable Network Graphics'])
+      end
+      it { is_expected.to eq ['Portable Network Graphics'] }
+    end
+  end
+end

--- a/spec/indexers/hyrax/valkyrie_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_indexer_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe Hyrax::ValkyrieIndexer do
       end
     end
 
+    context 'for a Hyrax::FileSet' do
+      let(:resource) { build(:hyrax_file_set) }
+
+      it 'gives an instance of ValkyrieFileSetIndexer' do
+        expect(described_class.for(resource: resource))
+          .to be_a Hyrax::ValkyrieFileSetIndexer
+      end
+    end
+
     context 'with a matching indexer by naming convention' do
       let(:resource) { build(:monograph) }
       let(:indexer_class) { MonographIndexer }

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -28,5 +28,67 @@ module Hyrax
 
       mock_model('MockOriginal', fields)
     end
+
+    # as defined in Hyrax::FileMetadata
+    HYRAX_FILE_METADATA_FIELDS = { file_identifier: '',
+                                   alternate_ids: [],
+                                   file_set_id: '',
+                                   label: [''],
+                                   original_filename: '',
+                                   mime_type: 'text/plain',
+                                   type: [],
+                                   format_label: [],
+                                   size: [],
+                                   well_formed: [],
+                                   valid: [],
+                                   date_created: [],
+                                   fits_version: [],
+                                   exif_version: [],
+                                   checksum: [],
+                                   frame_rate: [],
+                                   bit_rate: [],
+                                   duration: [],
+                                   sample_rate: [],
+                                   height: [],
+                                   width: [],
+                                   bit_depth: [],
+                                   channels: [],
+                                   data_format: [],
+                                   offset: [],
+                                   file_title: [],
+                                   creator: [],
+                                   page_count: [],
+                                   language: [],
+                                   word_count: [],
+                                   character_count: [],
+                                   line_count: [],
+                                   character_set: [],
+                                   markup_basis: [],
+                                   markup_language: [],
+                                   paragraph_count: [],
+                                   table_count: [],
+                                   graphics_count: [],
+                                   byte_order: [],
+                                   compression: [],
+                                   color_space: [],
+                                   profile_name: [],
+                                   profile_version: [],
+                                   orientation: [],
+                                   color_map: [],
+                                   image_producer: [],
+                                   capture_device: [],
+                                   scanning_software: [],
+                                   gps_timestamp: [],
+                                   latitude: [],
+                                   longitude: [],
+                                   aspect_ratio: [] }.freeze
+
+    def mock_file_metadata_factory(opts = {})
+      fields = HYRAX_FILE_METADATA_FIELDS.each_with_object({}) do |(name, default), hsh|
+        hsh[name] = opts.fetch(name, default)
+      end
+
+      mock_model('MockFileMetadata', fields)
+    end
   end
 end


### PR DESCRIPTION
Fixes #4766

### Description

This creates indexing for [Hyrax::FileSet](https://github.com/samvera/hyrax/blob/master/app/models/hyrax/file_set.rb), which is a `Valkyrie::Resource`, using the Valkyrie indexing process called from the [MetadataIndexListener](https://github.com/samvera/hyrax/blob/master/app/services/hyrax/listeners/metadata_index_listener.rb#L18-L24).

### Questions
There are two questions posed in the comments in the file changes.
* Is the refactor of `Hyrax::FileSetIndexer` to `Hyrax::ActiveFedoraFileSetIndexer` acceptable?  It is necessary for Valkyrie indexing naming conventions, but does represent a public API change.
* Do we want to index all file metadata?

### Known remaining issues

Jobs that need to add support for Valkyrie
* CharacterizationJob (#4100)
* CreateDerivativesJob (#4191)
* possible others as well

Valkyrie works do not include FileSets as members in solr docs.

@samvera/hyrax-code-reviewers
