### PR TITLE
Solr chart

### DIFF
--- a/.dassie/config/environments/development.rb
+++ b/.dassie/config/environments/development.rb
@@ -60,6 +60,8 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  config.assets.prefix = '/dev-assets'
+
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
 

--- a/.dassie/config/environments/production.rb
+++ b/.dassie/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ARG BUNDLE_WITHOUT="development test"
 
 ONBUILD COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 ONBUILD RUN bundle install --jobs "$(nproc)"
-ONBUILD RUN DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
+ONBUILD RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 
 FROM hyrax-base as hyrax-engine-dev
 
@@ -52,7 +52,7 @@ COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 COPY --chown=1001:101 . /app/samvera/hyrax-engine
 
 RUN cd /app/samvera/hyrax-engine && bundle install --jobs "$(nproc)"
-RUN DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake yarn:install
+RUN RAILS_ENV=production SECRET_KEY_BASE='fakesecret1234' DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 
 
 FROM hyrax-engine-dev as hyrax-engine-dev-worker

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,12 @@ ARG EXTRA_APK_PACKAGES="git"
 
 RUN apk --no-cache upgrade && \
   apk --no-cache add build-base \
+  curl \
   imagemagick \
   tzdata \
   nodejs \
   yarn \
+  zip \
   $DATABASE_APK_PACKAGE \
   $EXTRA_APK_PACKAGES
 

--- a/bin/solrcloud-assign-configset.sh
+++ b/bin/solrcloud-assign-configset.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+COUNTER=0;
+
+if [ "$SOLR_ADMIN_USER" ]; then
+  solr_user_settings="--user $SOLR_ADMIN_USER:$SOLR_ADMIN_PASSWORD"
+fi
+
+# Solr Cloud Collection API URLs
+solr_collection_list_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=LIST"
+solr_collection_modify_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=MODIFYCOLLECTION&collection=hyrax&collection.configName=solrconfig"
+
+while [ $COUNTER -lt 30 ]; do
+  if nc -z "${SOLR_HOST}" "${SOLR_PORT}"; then
+    if curl --silent $solr_user_settings "$solr_collection_list_url" | grep -q "hyrax"; then
+      echo "-- Collection hyrax exists; setting Hyrax ConfigSet ..."
+      echo $solr_collection_modify_url
+      curl $solr_user_settings "$solr_collection_modify_url"
+      exit
+    fi
+  fi
+  echo "-- Looking for Solr (${SOLR_HOST}:${SOLR_PORT})..."
+  COUNTER=$(( COUNTER+1 ));
+  sleep 5s
+done
+
+echo "--- ERROR: failed to create/update Solr collection after 5 minutes";
+exit 1

--- a/bin/solrcloud-upload-configset.sh
+++ b/bin/solrcloud-upload-configset.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+
+COUNTER=0;
+# /app/samvera/hyrax-webapp/solr/conf
+CONFDIR="${1}"
+
+if [ "$SOLR_ADMIN_USER" ]; then
+  solr_user_settings="--user $SOLR_ADMIN_USER:$SOLR_ADMIN_PASSWORD"
+fi
+
+# Solr Cloud ConfigSet API URLs
+solr_config_list_url="http://$SOLR_HOST:$SOLR_PORT/api/cluster/configs?omitHeader=true"
+solr_config_upload_url="http://$SOLR_HOST:$SOLR_PORT/solr/admin/configs?action=UPLOAD&name=solrconfig"
+
+while [ $COUNTER -lt 30 ]; do
+  echo "-- Looking for Solr (${SOLR_HOST}:${SOLR_PORT})..."
+  if nc -z "${SOLR_HOST}" "${SOLR_PORT}"; then
+    if curl --silent $solr_user_settings "$solr_config_list_url" | grep -q 'solrconfig'; then
+      echo "-- ConfigSet already exists; skipping creation ...";
+    else
+      echo "-- ConfigSet for ${CONFDIR} does not exist; creating ..."
+      (cd "$CONFDIR" && zip -r - *) | curl -X POST $solr_user_settings --header "Content-Type:application/octet-stream" --data-binary @- "$solr_config_upload_url"
+    fi
+    exit
+  fi
+  COUNTER=$(( COUNTER+1 ));
+  sleep 5s
+done
+
+echo "--- ERROR: failed to create Solr ConfigSet after 5 minutes";
+exit 1

--- a/chart/fcrepo/Chart.yaml
+++ b/chart/fcrepo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fcrepo
 description: Fedora Commons Repository 4
 type: application
-version: 0.4.1
+version: 0.5.0
 appVersion: 4.7
 dependencies:
   - name: postgresql

--- a/chart/fcrepo/templates/deployment.yaml
+++ b/chart/fcrepo/templates/deployment.yaml
@@ -49,8 +49,10 @@ spec:
           command:
             - sh
             - -c
-            - export PGPASSWORD=$DATABASE_PASSWORD PGHOST=$DATABASE_HOST PGUSER=$DATABASE_USER;
-            - psql -tc "SELECT 1 FROM pg_database WHERE datname = '$DATABASE_NAME'" | grep -q 1 || createdb -e -w $DATABASE_NAME
+            - >
+              PGPASSWORD=$DATABASE_PASSWORD PGHOST=$DATABASE_HOST PGUSER=$DATABASE_USER; export PGPASSWORD PGHOST PGUSER;
+              psql -tc "SELECT 1 FROM pg_database WHERE datname = '$DATABASE_NAME'" | grep -q 1 ||
+              createdb -e -w $DATABASE_NAME
           envFrom:
             - configMapRef:
                 name: {{ include "fcrepo.fullname" . }}-env

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.5.0
 appVersion: 3.0.0-rc4
 dependencies:
   - name: fcrepo
-    version: 0.4.1
+    version: 0.5.0
     repository: file://../fcrepo
   - name: memcached
     version: 4.2.21
@@ -21,7 +21,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: solr
-    version: 1.5.2
-    repository: http://storage.googleapis.com/kubernetes-charts-incubator
+    version: 0.2.2
+    repository: https://charts.bitnami.com/bitnami
     condition: solr.enabled
   # need something for fcrepo

--- a/chart/hyrax/templates/NOTES.txt
+++ b/chart/hyrax/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -87,6 +87,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "hyrax.solr.fullname" -}}
 {{- printf "%s-%s" .Release.Name "solr" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "hyrax.solr.url" -}}
+{{- printf "http://%s:%s@%s:%s/solr/%s" .Values.solr.authentication.adminUsername .Values.solr.authentication.adminPassword (include "hyrax.solr.fullname" .) "8983" "hyrax" -}}
+{{- end -}}
+
 {{- define "hyrax.zk.fullname" -}}
 {{- printf "%s-%s" .Release.Name "zookeeper" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -26,7 +26,9 @@ data:
   FCREPO_REST_PATH: {{ .Values.fcrepo.restPath | default "fcrepo/rest" }}
   {{- end }}
   {{- if .Values.solr.enabled }}
-  SOLR_HOST: {{ template "hyrax.solr.fullname" . }}-svc
+  SOLR_HOST: {{ template "hyrax.solr.fullname" . }}
   SOLR_PORT: "8983"
-  SOLR_URL: http://{{ template "hyrax.solr.fullname" . }}-svc:8983/solr/hyrax
+  SOLR_URL: {{ template "hyrax.solr.url" . }}
+  SOLR_ADMIN_USER: {{ .Values.solr.authentication.adminUsername }}
+  SOLR_ADMIN_PASSWORD: {{ .Values.solr.authentication.adminPassword }}
   {{- end }}

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -21,6 +21,20 @@ spec:
         {{- include "hyrax.selectorLabels" . | nindent 8 }}
     spec:
       initContainers:
+        - name: load-solr-config
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "hyrax.fullname" . }}-env
+            - secretRef:
+                name: {{ include "hyrax.fullname" . }}
+          command:
+            - sh
+            - -c
+            - >
+              solrcloud-upload-configset.sh /app/samvera/hyrax-webapp/solr/conf &&
+              solrcloud-assign-configset.sh
         - name: db-setup
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -59,6 +59,9 @@ fcrepo:
   servicePort: 8080
   postgresql:
     enabled: false
+    image:
+      repository: bitnami/postgresql
+      tag: 12.3.0
 
 memcached:
   enabled: false
@@ -82,6 +85,23 @@ redis:
 
 solr:
   enabled: true
+  image:
+    repository: bitnami/solr
+    tag: 8.8.1
+  authentication:
+    enabled: true
+    adminUsername: admin
+    adminPassword: admin
+  coreName: hyrax
+  collection: hyrax
+  cloudBootstrap: true
+  cloudEnabled: true
+  persistence:
+    enabled: true
+  zookeeper:
+    enabled: true
+    persistence:
+      enabled: true
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
for deploying Zookeeper and SolrCloud with Helm, use Bitnami's charts which are much more robust than the older helm incubator ones.

Changes proposed in this pull request:
* Fixes helm chart to successfully deploy and configure Solr
* Fixes Postgresql authentication issues in FCRepo chart, these changes should be ported to the `samvera-labs` chart.
* Reinstates production asset pipeline for `.dassie` docker images.

@samvera/hyrax-code-reviewers
