### PR TITLE
extend Helm chart with configurable liveness/readiness probes 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ Dockerfile
 
 artifacts/*
 coverage/*
+chart/*

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: 3.0.0-rc4
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -69,14 +69,30 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 5 }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold | default 3 }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 10}}
+            successThreshold: {{ .Values.livenessProbe.successThreshold | default 1 }}
             httpGet:
-              path: /
-              port: http
+              scheme: "HTTP"
+              path: {{ .Values.livenessProbe.path | default "/" }}
+              port: 3000
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 5 }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold | default 3 }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 10 }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold | default 1 }}
             httpGet:
-              path: /
-              port: http
+              scheme: "HTTP"
+              path: {{ .Values.readinessProbe.path | default "/" }}
+              port: 3000
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -50,6 +50,24 @@ ingress:
       paths: []
   tls: []
 
+livenessProbe:
+  enabled: true
+  # path: "/healthz"
+  # initialDelaySeconds: 0
+  # periodSeconds: 10
+  # timeoutSeconds: 10
+  # failureThreshold: 3
+  # successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  # path: "/healthz"
+  # initialDelaySeconds: 5
+  # periodSeconds: 10
+  # timeoutSeconds: 5
+  # failureThreshold: 6
+  # successThreshold: 1
+
 resources: {}
 
 fcrepo:


### PR DESCRIPTION
Uses some patterns borrowed from Bitnami for configuring liveness/readiness. Kubernetes uses these configurations to detect out of service pods.

@samvera/hyrax-code-reviewers
