### PR TITLE
Extend helm chart solr configuration

### DIFF
--- a/bin/solrcloud-assign-configset.sh
+++ b/bin/solrcloud-assign-configset.sh
@@ -7,12 +7,12 @@ fi
 
 # Solr Cloud Collection API URLs
 solr_collection_list_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=LIST"
-solr_collection_modify_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=MODIFYCOLLECTION&collection=hyrax&collection.configName=solrconfig"
+solr_collection_modify_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=MODIFYCOLLECTION&collection=$SOLR_COLLECTION_NAME&collection.configName=$SOLR_CONFIGSET_NAME"
 
 while [ $COUNTER -lt 30 ]; do
   if nc -z "${SOLR_HOST}" "${SOLR_PORT}"; then
-    if curl --silent $solr_user_settings "$solr_collection_list_url" | grep -q "hyrax"; then
-      echo "-- Collection hyrax exists; setting Hyrax ConfigSet ..."
+    if curl --silent $solr_user_settings "$solr_collection_list_url" | grep -q "$SOLR_COLLECTION_NAME"; then
+      echo "-- Collection ${SOLR_COLLECTION_NAME} exists; setting ${SOLR_CONFIGSET_NAME} ConfigSet ..."
       echo $solr_collection_modify_url
       curl $solr_user_settings "$solr_collection_modify_url"
       exit

--- a/bin/solrcloud-upload-configset.sh
+++ b/bin/solrcloud-upload-configset.sh
@@ -10,12 +10,12 @@ fi
 
 # Solr Cloud ConfigSet API URLs
 solr_config_list_url="http://$SOLR_HOST:$SOLR_PORT/api/cluster/configs?omitHeader=true"
-solr_config_upload_url="http://$SOLR_HOST:$SOLR_PORT/solr/admin/configs?action=UPLOAD&name=solrconfig"
+solr_config_upload_url="http://$SOLR_HOST:$SOLR_PORT/solr/admin/configs?action=UPLOAD&name=$SOLR_CONFIGSET_NAME"
 
 while [ $COUNTER -lt 30 ]; do
   echo "-- Looking for Solr (${SOLR_HOST}:${SOLR_PORT})..."
   if nc -z "${SOLR_HOST}" "${SOLR_PORT}"; then
-    if curl --silent $solr_user_settings "$solr_config_list_url" | grep -q 'solrconfig'; then
+    if curl --silent $solr_user_settings "$solr_config_list_url" | grep -q "$SOLR_CONFIGSET_NAME"; then
       echo "-- ConfigSet already exists; skipping creation ...";
     else
       echo "-- ConfigSet for ${CONFDIR} does not exist; creating ..."

--- a/chart/hyrax/README.md
+++ b/chart/hyrax/README.md
@@ -42,10 +42,32 @@ The chart populates the following environment variables:
 | FCREPO_HOST       | Fedora Commons host            | `fcrepo.enabled`       |
 | FCREPO_PORT       | Fedora Commons port            | `fcrepo.enabled`       |
 | FCREPO_REST_PATH  | Fedora Commons REST endpoint   | `fcrepo.enabled`       |
-| SOLR_HOST         | Solr service host              | `solr.enabled`         |
-| SOLR_PORT         | Solr service port              | `solr.enabled`         |
-| SOLR_URL          | Solr service full URL          | `solr.enabled`         |
+| SOLR_ADMIN_USER   | Solr user for basic auth       | n/a                    |
+| SOLR_ADMIN_PASSWORD | Solr password for basic auth | n/a                    |
+| SOLR_COLLECTION_NAME | The name of the solr collection to use | n/a         |
+| SOLR_CONFIGSET_NAME | The name of the solr configset to use for config management tasks | n/a |
+| SOLR_HOST         | Solr service host              | n/a                    |
+| SOLR_PORT         | Solr service port              | n/a                    |
+| SOLR_URL          | Solr service full URL          | n/a                    |
 |----------------- -|--------------------------------|------------------------|
+
+## With an external SolrCloud
+
+To use an existing or externally managed SolrCloud, use the chart values:
+
+  - `solr.enabled`: true
+  - `solr.externalSolrHost`: "mySolr.hostname.example.com"
+  - `solr.externalSolrUser`: "admin"
+  - `solr.externalSolrPassword`: "the_admin_password"
+  - `solr.externalSolrCollection`: "a_collection_name"
+
+By default, the chart will attempt to upload a ConfigSet for Hyrax matching the
+deployment's `hyrax.fullname` and assign it to the collection. This is achieved
+through the Solr Collections API, and authentication _must_ be enabled in the
+external Solr for this to work.
+
+If you want to manage your ConfigSet manually, disable this behavior with
+`--set loadSolrConfigSet=false`.
 
 ## For DevOps:
 

--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -88,8 +88,40 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name "solr" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "hyrax.solr.host" -}}
+{{- if .Values.solr.enabled }}
+{{- include "hyrax.solr.fullname" . }}
+{{- else }}
+{{- .Values.externalSolrHost }}
+{{- end }}
+{{- end -}}
+
+{{- define "hyrax.solr.collectionName" -}}
+{{- if .Values.solr.enabled }}
+{{- .Values.solr.collection | default "hyrax" }}
+{{- else }}
+{{- .Values.externalSolrCollection | default "hyrax" }}
+{{- end }}
+{{- end -}}
+
+{{- define "hyrax.solr.username" -}}
+{{- if .Values.solr.enabled }}
+{{- .Values.solr.authentication.adminUsername }}
+{{- else }}
+{{- .Values.externalSolrUser }}
+{{- end }}
+{{- end -}}
+
+{{- define "hyrax.solr.password" -}}
+{{- if .Values.solr.enabled }}
+{{- .Values.solr.authentication.adminPassword }}
+{{- else }}
+{{- .Values.externalSolrPassword }}
+{{- end }}
+{{- end -}}
+
 {{- define "hyrax.solr.url" -}}
-{{- printf "http://%s:%s@%s:%s/solr/%s" .Values.solr.authentication.adminUsername .Values.solr.authentication.adminPassword (include "hyrax.solr.fullname" .) "8983" "hyrax" -}}
+{{- printf "http://%s:%s@%s:%s/solr/%s" (include "hyrax.solr.username" .) (include "hyrax.solr.password" .) (include "hyrax.solr.host" .) "8983" (include "hyrax.solr.collectionName" .)  -}}
 {{- end -}}
 
 {{- define "hyrax.zk.fullname" -}}

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -28,6 +28,7 @@ data:
   SOLR_ADMIN_USER: {{ template "hyrax.solr.username" . }}
   SOLR_ADMIN_PASSWORD: {{ template "hyrax.solr.password" . }}
   SOLR_COLLECTION_NAME: {{ template "hyrax.solr.collectionName" . }}
+  SOLR_CONFIGSET_NAME: {{ template "hyrax.fullname" . }}
   SOLR_HOST: {{ template "hyrax.solr.host" . }}
   SOLR_PORT: "8983"
   SOLR_URL: {{ template "hyrax.solr.url" . }}

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -25,10 +25,9 @@ data:
   FCREPO_HOST: {{ template "hyrax.fcrepo.fullname" . }}
   FCREPO_REST_PATH: {{ .Values.fcrepo.restPath | default "fcrepo/rest" }}
   {{- end }}
-  {{- if .Values.solr.enabled }}
-  SOLR_HOST: {{ template "hyrax.solr.fullname" . }}
+  SOLR_ADMIN_USER: {{ template "hyrax.solr.username" . }}
+  SOLR_ADMIN_PASSWORD: {{ template "hyrax.solr.password" . }}
+  SOLR_COLLECTION_NAME: {{ template "hyrax.solr.collectionName" . }}
+  SOLR_HOST: {{ template "hyrax.solr.host" . }}
   SOLR_PORT: "8983"
   SOLR_URL: {{ template "hyrax.solr.url" . }}
-  SOLR_ADMIN_USER: {{ .Values.solr.authentication.adminUsername }}
-  SOLR_ADMIN_PASSWORD: {{ .Values.solr.authentication.adminPassword }}
-  {{- end }}

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         {{- include "hyrax.selectorLabels" . | nindent 8 }}
     spec:
       initContainers:
+        {{- if .Values.loadSolrConfigSet }}
         - name: load-solr-config
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -35,6 +36,7 @@ spec:
             - >
               solrcloud-upload-configset.sh /app/samvera/hyrax-webapp/solr/conf &&
               solrcloud-assign-configset.sh
+        {{- end }}
         - name: db-setup
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -10,6 +10,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# use false to skip the configset management init container
+loadSolrConfigSet: true
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -12,6 +12,12 @@ image:
 
 # use false to skip the configset management init container
 loadSolrConfigSet: true
+# the host and auth details for an external solr service;
+#   ignored if `solr.enabled` is true
+externalSolrHost: ""
+externalSolrUser: ""
+externalSolrPassword: ""
+externalSolrCollection: "hyrax"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
support configuring an external SolrCloud instance in the helm chart. the new features are documented in `chart/hyrax/README.md`.

this config option is being used to deploy http://dassie.samvera-community.notch8.cloud/

@samvera/hyrax-code-reviewers
