### PR TITLE
Resources need to include the depositor to be included in search results

### DIFF
--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -16,6 +16,8 @@ module Hyrax
         solr_doc['admin_set_id_ssim'] = [resource.admin_set_id.to_s]
         solr_doc['member_of_collection_ids_ssim'] = resource.member_of_collection_ids.map(&:to_s)
         solr_doc['member_ids_ssim'] = resource.member_ids.map(&:to_s)
+        solr_doc['depositor_ssim'] = [resource.depositor]
+        solr_doc['depositor_tesim'] = [resource.depositor]
       end
     end
 

--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -58,17 +58,20 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
     let(:service) { described_class.new(resource: work) }
     subject(:solr_document) { service.to_solr }
 
+    let(:user) { create(:user) }
     let(:admin_set_title) { 'An Admin Set' }
     let(:admin_set) { create(:admin_set, title: [admin_set_title]) }
     let(:collection_title) { 'A Collection' }
     let(:col1) { valkyrie_create(:hyrax_collection, title: [collection_title]) }
-    let(:work) { valkyrie_create(:hyrax_work, :with_member_works, member_of_collection_ids: [col1.id], admin_set_id: admin_set.id) }
+    let(:work) { valkyrie_create(:hyrax_work, :with_member_works, member_of_collection_ids: [col1.id], admin_set_id: admin_set.id, depositor: user.email) }
 
     it 'includes attributes defined outside Hyrax::Schema include' do
       expect(solr_document.fetch('generic_type_sim')).to match_array ['Work']
       expect(solr_document.fetch('admin_set_id_ssim')).to match_array [admin_set.id]
       expect(solr_document.fetch('member_ids_ssim')).to match_array work.member_ids
       expect(solr_document.fetch('member_of_collection_ids_ssim')).to match_array [col1.id]
+      expect(solr_document.fetch('depositor_ssim')).to match_array [user.email]
+      expect(solr_document.fetch('depositor_tesim')).to match_array [user.email]
     end
 
     context 'when work is inactive' do


### PR DESCRIPTION
Fixes: #4786 

### Description

After adding a Monograph, which is a Valkyrie::Resource, through the UI, it was not included in the list of works on Dashboard -> Works.  This was caused by the indexer for Valkyrie based works not including the depositor in the solr doc.

This limiting part of the query that provides the list of works for Dashboard -> Works is…
```
"fq"=>["{!terms f=has_model_ssim}GenericWork,NamespacedWorks::NestedWork,Monograph", "_query_:\"{!raw f=depositor_ssim}example@hotmail.com\""]
```

So without the depositor in the solr doc, Monographs, which are were never returned in the search results.  Adding in the depositor, they are now included.

### Remaining Work

* The thumbnail image is not displayed in Dashboard -> Works, but is on the show page for the Monograph.

@samvera/hyrax-code-reviewers
