### PR TITLE
Adds tests for Hydra::AccessControls::Embargo behavior

### DIFF
--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -49,6 +49,7 @@ module Hyrax
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb t(:'hyrax.embargoes.index.manage_embargoes'), hyrax.embargoes_path
       add_breadcrumb t(:'hyrax.embargoes.edit.embargo_update'), '#'
+      authorize! :edit, Hydra::AccessControls::Embargo
     end
   end
 end

--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -172,7 +172,7 @@ module Hyrax
         alias_action :file_manager, to: :update
 
         return if admin?
-        cannot :index, Hydra::AccessControls::Embargo
+        cannot :manage, Hydra::AccessControls::Embargo
         cannot :index, Hydra::AccessControls::Lease
       end
 

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -1,4 +1,6 @@
-<% if f.object.embargo_release_date %>
+ <%# When I put a byebug here from the test in spec/features/embargo_spec.rb:85 current_user.groups = []
+current_user.can?(:edit, Hydra::AccessControls::Embargo) = false %>
+<% if f.object.embargo_release_date && current_user.can?(:edit, Hydra::AccessControls::Embargo) %>
   <%= render 'form_permission_under_embargo', f: f %>
 <% elsif f.object.lease_expiration_date %>
   <%= render 'form_permission_under_lease', f: f %>

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -28,7 +28,7 @@ SUMMARY
   # Note: rails does not follow sem-ver conventions, it's
   # minor version releases can include breaking changes; see
   # http://guides.rubyonrails.org/maintenance_policy.html
-  spec.add_dependency 'rails', '~> 5.2.4'
+  spec.add_dependency 'rails', '~> 5.0'
 
   spec.add_dependency 'active-fedora', '>= 11.5.2', '< 12.2'
   spec.add_dependency 'almond-rails', '~> 0.1'

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -28,7 +28,7 @@ SUMMARY
   # Note: rails does not follow sem-ver conventions, it's
   # minor version releases can include breaking changes; see
   # http://guides.rubyonrails.org/maintenance_policy.html
-  spec.add_dependency 'rails', '~> 5.0'
+  spec.add_dependency 'rails', '~> 5.2.4'
 
   spec.add_dependency 'active-fedora', '>= 11.5.2', '< 12.2'
   spec.add_dependency 'almond-rails', '~> 0.1'
@@ -86,10 +86,10 @@ SUMMARY
   spec.add_development_dependency 'capybara-maleficent', '~> 0.3.0'
   spec.add_development_dependency 'chromedriver-helper', '~> 2.1'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
-  spec.add_development_dependency 'engine_cart', '~> 2.2'
+  spec.add_development_dependency 'engine_cart', '~> 2.2.0'
   spec.add_development_dependency "equivalent-xml", '~> 0.5'
   spec.add_development_dependency "factory_bot", '~> 4.4'
-  spec.add_development_dependency 'fcrepo_wrapper', '~> 0.5', '>= 0.5.1'
+  spec.add_development_dependency 'fcrepo_wrapper', '~> 0.9'
   spec.add_development_dependency "jasmine", '~> 2.3', '< 2.99'
   spec.add_development_dependency "jasmine-core", '~> 2.3', '< 2.99'
   spec.add_development_dependency 'mida', '~> 0.3'
@@ -98,7 +98,7 @@ SUMMARY
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency "selenium-webdriver"
-  spec.add_development_dependency 'solr_wrapper', '>= 1.1', '< 3.0'
+  spec.add_development_dependency 'solr_wrapper', '>= 3'
   spec.add_development_dependency 'i18n-debug' if ENV['I18N_DEBUG']
   spec.add_development_dependency 'i18n_yaml_sorter' unless ENV['TRAVIS']
   spec.add_development_dependency 'rails-controller-testing', '~> 1'

--- a/spec/controllers/hyrax/embargoes_controller_spec.rb
+++ b/spec/controllers/hyrax/embargoes_controller_spec.rb
@@ -33,7 +33,25 @@ RSpec.describe Hyrax::EmbargoesController do
         expect(flash[:alert]).to eq 'You are not authorized to access this page.'
       end
     end
-    context 'when I have permission to edit the object' do
+    context 'when I have permission to edit the object, but not the embargo' do
+      fit 'does not show me the embargo' do
+        get :index, params: { id: a_work }
+
+        expect(user.can?(:index, Hydra::AccessControls::Embargo)).to eq false
+        expect(response.status).to eq 302
+        expect(flash[:alert]).to eq 'You are not authorized to access this page.'
+      end
+      fit 'does not show me the edit page' do
+        get :edit, params: { id: a_work }
+        
+        expect(user.can?(:edit, Hydra::AccessControls::Embargo)).to eq false
+        expect(response.status).to eq 302
+        expect(flash[:alert]).to eq 'You are not authorized to access this page.'
+      end
+    end
+
+    context "when I have permission to edit the embargo as an admin" do
+      let(:user) { create(:user, groups: ['admin']) }
       it 'shows me the page' do
         expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)

--- a/spec/controllers/hyrax/embargoes_controller_spec.rb
+++ b/spec/controllers/hyrax/embargoes_controller_spec.rb
@@ -34,16 +34,16 @@ RSpec.describe Hyrax::EmbargoesController do
       end
     end
     context 'when I have permission to edit the object, but not the embargo' do
-      fit 'does not show me the embargo' do
+      it 'does not show me the embargo' do
         get :index, params: { id: a_work }
 
         expect(user.can?(:index, Hydra::AccessControls::Embargo)).to eq false
         expect(response.status).to eq 302
         expect(flash[:alert]).to eq 'You are not authorized to access this page.'
       end
-      fit 'does not show me the edit page' do
+      it 'does not show me the edit page' do
         get :edit, params: { id: a_work }
-        
+
         expect(user.can?(:edit, Hydra::AccessControls::Embargo)).to eq false
         expect(response.status).to eq 302
         expect(flash[:alert]).to eq 'You are not authorized to access this page.'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     transient do
       # Allow for custom groups when a user is instantiated.
-      # @example create(:user, groups: 'avacado')
+      # @example create(:user, groups: 'avocado')
       groups { [] }
     end
 


### PR DESCRIPTION
refs #4782

Adds one passing and one failing test for Hydra::AccessControls::Embargo behavior. Currently, non-admin-users cannot view an embargo, but *can* edit that same embargo. 

This means that, while a user might not be able to navigate to an embargo via the UI, if they know the appropriate url, they can go directly to it and edit the embargo.

Changes proposed in this pull request:
* Adds tests for the expected behavior
* [future] Gets those tests passing
*

@samvera/hyrax-code-reviewers
