### PR TITLE
use redis configuration for ActionCable in `.dassie`

### DIFF
--- a/.dassie/config/cable.yml
+++ b/.dassie/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDIS_URL") { "redis://:#{ENV.fetch('REDIS_PASSWORD')}@#{ENV.fetch('REDIS_HOST', 'localhost')}:#{ENV.fetch('REDIS_PORT', '6379')}/1" } %>
   channel_prefix: _dassie_production

--- a/.dassie/config/redis.yml
+++ b/.dassie/config/redis.yml
@@ -7,3 +7,4 @@ test:
 production:
   host: <%= ENV.fetch('REDIS_HOST', 'localhost') %>
   port: <%= ENV.fetch('REDIS_PORT', 6379) %>
+  password: <%= ENV.fetch('REDIS_PASSWORD', 'mysecret') %>

--- a/chart/hyrax/templates/secrets.yaml
+++ b/chart/hyrax/templates/secrets.yaml
@@ -10,3 +10,6 @@ data:
   {{- if .Values.postgresql.enabled }}
   DATABASE_URL: {{ printf "postgresql://%s:%s@%s/%s?pool=5" .Values.postgresql.postgresqlUsername .Values.postgresql.postgresqlPassword (include "hyrax.postgresql.fullname" .) .Values.postgresql.postgresqlDatabase | b64enc }}
   {{- end }}
+  {{- if .Values.redis.enabled }}
+  REDIS_PASSWORD: {{ .Values.redis.password }}
+  {{- end }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -109,6 +109,7 @@ postgresql:
 
 redis:
   enabled: true
+  password: mysecret
 
 solr:
   enabled: true


### PR DESCRIPTION
`ActionCable` has its own redis configuration, and the whole app explodes in the dashboard if it's misconfigured. make it configurable with environment variables.

@samvera/hyrax-code-reviewers
