### PR TITLE
add a db:create step to the helm deployment process

### DIFF
--- a/bin/db-migrate-seed.sh
+++ b/bin/db-migrate-seed.sh
@@ -2,8 +2,10 @@
 set -e
 
 db-wait.sh "$DB_HOST:$DB_PORT"
+bundle exec rails db:create
+bundle exec rails db:migrate
+
 db-wait.sh "$FCREPO_HOST:$FCREPO_PORT"
 db-wait.sh "$SOLR_HOST:$SOLR_PORT"
 
-bundle exec rails db:migrate
 bundle exec rails db:seed


### PR DESCRIPTION
ensures that the configured database exists by adding a `rake db:create`
invocation to the `db-setup` initContainer.

in the event we're trying to deploy hyrax against a database engine that it has
permissions for, but where the configured database doesn't exist, this will
ensure it gets added before we try to run the migrations.

see also #4792

@samvera/hyrax-code-reviewers
