### PR TITLE
support providing no redis password

### DIFF
--- a/.dassie/config/cable.yml
+++ b/.dassie/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://:#{ENV.fetch('REDIS_PASSWORD')}@#{ENV.fetch('REDIS_HOST', 'localhost')}:#{ENV.fetch('REDIS_PORT', '6379')}/1" } %>
+  url: <%= ENV.fetch("REDIS_URL") { sprintf "redis://%s%s:%s/1", (ENV['REDIS_PASSWORD'].present? ? ":#{ENV['REDIS_PASSWORD']}@" : ''), ENV.fetch('REDIS_HOST', 'localhost'), ENV.fetch('REDIS_PORT', '6379') }
   channel_prefix: _dassie_production

--- a/.dassie/config/redis.yml
+++ b/.dassie/config/redis.yml
@@ -7,4 +7,4 @@ test:
 production:
   host: <%= ENV.fetch('REDIS_HOST', 'localhost') %>
   port: <%= ENV.fetch('REDIS_PORT', 6379) %>
-  password: <%= ENV.fetch('REDIS_PASSWORD', 'mysecret') %>
+  password: <%= ENV['REDIS_PASSWORD'] %>


### PR DESCRIPTION
the previous addition of the redis password broke dassie environments where no
password is called for.

@samvera/hyrax-code-reviewers
