### PR TITLE
Only admins should be able to edit embargoes

### DIFF
--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -52,6 +52,7 @@ module Hyrax
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb t(:'hyrax.embargoes.index.manage_embargoes'), hyrax.embargoes_path
       add_breadcrumb t(:'hyrax.embargoes.edit.embargo_update'), '#'
+      authorize! :edit, Hydra::AccessControls::Embargo
     end
   end
 end

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -20,6 +20,14 @@ module Hyrax
     include Hyrax::WorkFormHelper
     include Hyrax::WorkflowsHelper
 
+    ##
+    # @return [Array<String>] the list of all user groups
+    def available_user_groups(ability:)
+      return ::User.group_service.role_names if ability.admin?
+
+      ability.user_groups
+    end
+
     # Which translations are available for the user to select
     # @return [Hash{String => String}] locale abbreviations as keys and flags as values
     def available_translations

--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -309,9 +309,8 @@ module Hyrax
       # user can version if they can edit
       alias_action :versions, to: :update
       alias_action :file_manager, to: :update
-
       return if admin?
-      cannot :index, Hydra::AccessControls::Embargo
+      cannot :manage, Hydra::AccessControls::Embargo
       cannot :index, Hydra::AccessControls::Lease
     end
 

--- a/app/views/hyrax/base/_form_share.html.erb
+++ b/app/views/hyrax/base/_form_share.html.erb
@@ -18,11 +18,7 @@
   </legend>
   <div class="col-sm-9 form-inline">
     <label for="new_group_name_skel" class="sr-only"><%= t(".group") %></label>
-    <% if current_ability.admin? %>
-      <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.group_service.map.keys), class: 'form-control' %>
-    <% else %>
-      <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>
-    <% end %>
+    <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + available_user_groups(ability: current_ability)), class: 'form-control' %>
     <label for="new_group_permission_skel" class="sr-only"><%= t(".access_type_to_grant") %></label>
     <%= select_tag 'new_group_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
 

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -1,4 +1,8 @@
-<% if embargo_enforced?(f.object) %>
+<% puts "user can edit Embargoes? from form: #{current_user.can?(:edit, Hydra::AccessControls::Embargo)}"
+   puts "user groups from form: #{current_user.groups}" # Locally from test spec/features/embargo_spec.rb:106 is [], expecting ["admin"]
+   puts "User display name from form: #{current_user.display_name}"
+%>
+<% if embargo_enforced?(f.object) && current_user.can?(:edit, Hydra::AccessControls::Embargo) %>
   <%= render 'form_permission_under_embargo', f: f %>
 <% elsif lease_enforced?(f.object) %>
   <%= render 'form_permission_under_lease', f: f %>

--- a/spec/controllers/hyrax/embargoes_controller_spec.rb
+++ b/spec/controllers/hyrax/embargoes_controller_spec.rb
@@ -34,7 +34,25 @@ RSpec.describe Hyrax::EmbargoesController do
         expect(flash[:alert]).to eq 'You are not authorized to access this page.'
       end
     end
-    context 'when I have permission to edit the object' do
+    context 'when I have permission to edit the object, but not the embargo' do
+      it 'does not show me the embargo' do
+        get :index, params: { id: a_work }
+
+        expect(user.can?(:index, Hydra::AccessControls::Embargo)).to eq false
+        expect(response.status).to eq 302
+        expect(flash[:alert]).to eq 'You are not authorized to access this page.'
+      end
+      it 'does not show me the edit page' do
+        get :edit, params: { id: a_work }
+
+        expect(user.can?(:edit, Hydra::AccessControls::Embargo)).to eq false
+        expect(response.status).to eq 302
+        expect(flash[:alert]).to eq 'You are not authorized to access this page.'
+      end
+    end
+
+    context "when I have permission to edit the embargo as an admin" do
+      let(:user) { create(:user, groups: ['admin']) }
       it 'shows me the page' do
         expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)

--- a/spec/features/embargo_spec.rb
+++ b/spec/features/embargo_spec.rb
@@ -1,57 +1,83 @@
 # frozen_string_literal: true
 RSpec.describe 'embargo' do
-  let(:user) { create(:user) }
-
-  before do
-    sign_in user
-  end
   describe 'creating an embargoed object' do
     let(:future_date) { 5.days.from_now }
     let(:later_future_date) { 10.days.from_now }
 
-    it 'can be created, displayed and updated', :clean_repo, :workflow do
-      visit '/concern/generic_works/new'
-      fill_in 'Title', with: 'Embargo test'
-      choose 'Embargo'
-      fill_in 'generic_work_embargo_release_date', with: future_date
-      select 'Private', from: 'Restricted to'
-      select 'Public', from: 'then open it up to'
-      click_button 'Save'
-
-      # chosen embargo date is on the show page
-      expect(page).to have_content(future_date.to_date.to_formatted_s(:standard))
-
-      click_link 'Edit'
-      click_link 'Embargo Management Page'
-
-      expect(page).to have_content('This Generic Work is under embargo.')
-      expect(page).to have_xpath("//input[@name='generic_work[embargo_release_date]' and @value='#{future_date.to_datetime.iso8601}']") # current embargo date is pre-populated in edit field
-
-      fill_in 'until', with: later_future_date.to_s
-
-      click_button 'Update Embargo'
-      expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard))
-
-      click_link 'Edit'
-      fill_in 'Title', with: 'Embargo test CHANGED'
-      click_button 'Save'
-
-      expect(page).to have_content('CHANGED')
-
-      click_link 'Edit'
-      click_link "Files" # switch tab
-      expect(page).to have_content "Add files"
-      expect(page).to have_content "Add folder"
-      within('div#add-files') do
-        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
+    context 'as an admin user' do
+      let(:admin) { create(:admin) }
+      before do
+        sign_in admin
       end
 
-      click_button 'Save' # Save the work
-      expect(page).to have_content('CHANGED')
+      it 'can be created, displayed and updated', :clean_repo, :workflow do
+        visit '/concern/generic_works/new'
+        fill_in 'Title', with: 'Embargo test'
+        choose 'Embargo'
+        fill_in 'generic_work_embargo_release_date', with: future_date
+        select 'Private', from: 'Restricted to'
+        select 'Public', from: 'then open it up to'
+        click_button 'Save'
+
+        # chosen embargo date is on the show page
+        expect(page).to have_content(future_date.to_date.to_formatted_s(:standard))
+
+        click_link 'Edit'
+        click_link 'Embargo Management Page'
+
+        expect(page).to have_content('This Generic Work is under embargo.')
+        expect(page).to have_xpath("//input[@name='generic_work[embargo_release_date]' and @value='#{future_date.to_datetime.iso8601}']") # current embargo date is pre-populated in edit field
+
+        fill_in 'until', with: later_future_date.to_s
+
+        click_button 'Update Embargo'
+        expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard))
+
+        click_link 'Edit'
+        fill_in 'Title', with: 'Embargo test CHANGED'
+        click_button 'Save'
+
+        expect(page).to have_content('CHANGED')
+
+        click_link 'Edit'
+        click_link "Files" # switch tab
+        expect(page).to have_content "Add files"
+        expect(page).to have_content "Add folder"
+        within('div#add-files') do
+          attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
+        end
+
+        click_button 'Save' # Save the work
+        expect(page).to have_content('CHANGED')
+      end
+    end
+
+    context 'as a regular user' do
+      let(:user) { create(:user) }
+      before do
+        sign_in user
+      end
+
+      it 'can be created and displayed, and not updated', :clean_repo, :workflow do
+        visit '/concern/generic_works/new'
+        fill_in 'Title', with: 'Embargo test'
+        choose 'Embargo'
+        fill_in 'generic_work_embargo_release_date', with: future_date
+        select 'Private', from: 'Restricted to'
+        select 'Public', from: 'then open it up to'
+        click_button 'Save'
+
+        # chosen embargo date is on the show page
+        expect(page).to have_content(future_date.to_date.to_formatted_s(:standard))
+
+        click_link 'Edit'
+        expect(page).not_to have_link('Embargo Management Page')
+      end
     end
   end
 
-  describe 'updating embargoed object' do
+  describe 'updating embargoed object as an admin' do
+    let(:user) { create(:admin, display_name: "Real live admin") }
     let(:my_admin_set) do
       create(:admin_set,
              title: ['admin set with embargo range'],
@@ -73,8 +99,14 @@ RSpec.describe 'embargo' do
                     admin_set_id: my_admin_set.id,
                     edit_users: [user])
     end
+    before do
+      sign_in user
+    end
 
     it 'can be updated with a valid date' do
+      puts "User can edit Embargoes? from test: #{user.can?(:edit, Hydra::AccessControls::Embargo)}"
+      puts "User groups from test: #{user.groups}" # Locally is ["admin"]
+      puts "User display name from test: #{user.display_name}"
       visit "/concern/generic_works/#{work.id}"
 
       click_link 'Edit'


### PR DESCRIPTION
refs #4782

Currently, non-admin-users cannot view an embargo, but *can* edit that same embargo. This is counter-intuitive - "can :index" is usually the most conservative permission *granted*; however, if you are *removing* permissions, which the "cannot" code does, the ability does not flow to restrict more-permissive restrictions from `:index`, so removing the ability to `:index` only removes that ability, not any others.

This means that, while a user might not be able to navigate to an embargo via the UI, if they know the appropriate url, they can go directly to it and edit the embargo.

Previously opened this as a PR against 2.x, and was asked to do it against master for future back porting instead. (see https://github.com/samvera/hyrax/pull/4789)

Changes proposed in this pull request:
* Adds tests for the expected behavior
* [future] Gets those tests passing
  * First commit adds temporary "puts" to explain confusion with test - it seems that somehow the user groups are not available or have been deleted in the form context, and I don't know why

@samvera/hyrax-code-reviewers
