### PR TITLE
use a real "fake" group_service implementation to manage test groups

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -20,6 +20,12 @@ module Hyrax
     include Hyrax::WorkFormHelper
     include Hyrax::WorkflowsHelper
 
+    ##
+    # @return [Array<String>] the list of all user groups
+    def available_user_groups
+      ::User.group_service.role_names
+    end
+
     # Which translations are available for the user to select
     # @return [Hash{String => String}] locale abbreviations as keys and flags as values
     def available_translations

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -22,8 +22,10 @@ module Hyrax
 
     ##
     # @return [Array<String>] the list of all user groups
-    def available_user_groups
-      ::User.group_service.role_names
+    def available_user_groups(ability:)
+      return ::User.group_service.role_names if ability.admin?
+
+      ability.user_groups
     end
 
     # Which translations are available for the user to select

--- a/app/views/hyrax/base/_form_share.html.erb
+++ b/app/views/hyrax/base/_form_share.html.erb
@@ -19,7 +19,7 @@
   <div class="col-sm-9 form-inline">
     <label for="new_group_name_skel" class="sr-only"><%= t(".group") %></label>
     <% if current_ability.admin? %>
-      <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.group_service.map.keys), class: 'form-control' %>
+      <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + available_user_groups), class: 'form-control' %>
     <% else %>
       <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>
     <% end %>

--- a/app/views/hyrax/base/_form_share.html.erb
+++ b/app/views/hyrax/base/_form_share.html.erb
@@ -18,11 +18,7 @@
   </legend>
   <div class="col-sm-9 form-inline">
     <label for="new_group_name_skel" class="sr-only"><%= t(".group") %></label>
-    <% if current_ability.admin? %>
-      <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + available_user_groups), class: 'form-control' %>
-    <% else %>
-      <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>
-    <% end %>
+    <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + available_user_groups(ability: current_ability)), class: 'form-control' %>
     <label for="new_group_permission_skel" class="sr-only"><%= t(".access_type_to_grant") %></label>
     <%= select_tag 'new_group_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
 

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Hyrax::GenericWorksController do
     end
 
     context 'when I am a repository manager' do
-      before { allow(::User.group_service).to receive(:byname).and_return(user.user_key => ['admin']) }
+      before { ::User.group_service.add(user: user, groups: ['admin']) }
       let(:work) { create(:private_generic_work) }
 
       it 'someone elses private work should show me the page' do
@@ -436,7 +436,8 @@ RSpec.describe Hyrax::GenericWorksController do
     end
 
     context 'when I am a repository manager' do
-      before { allow(::User.group_service).to receive(:byname).and_return(user.user_key => ['admin']) }
+      before { ::User.group_service.add(user: user, groups: ['admin']) }
+
       let(:work) { create(:private_generic_work) }
 
       it 'someone elses private work should show me the page' do
@@ -520,8 +521,7 @@ RSpec.describe Hyrax::GenericWorksController do
     end
 
     context 'when I am a repository manager' do
-      before { allow(::User.group_service).to receive(:byname).and_return(user.user_key => ['admin']) }
-
+      before { ::User.group_service.add(user: user, groups: ['admin']) }
       let(:work) { create(:private_generic_work) }
 
       it 'someone elses private work should update the work' do
@@ -578,7 +578,8 @@ RSpec.describe Hyrax::GenericWorksController do
     context 'when I am a repository manager' do
       let(:work_to_be_deleted) { create(:private_generic_work) }
 
-      before { allow(::User.group_service).to receive(:byname).and_return(user.user_key => ['admin']) }
+      before { ::User.group_service.add(user: user, groups: ['admin']) }
+
       it 'someone elses private work should delete the work' do
         delete :destroy, params: { id: work_to_be_deleted }
         expect(GenericWork).not_to exist(work_to_be_deleted.id)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,16 +10,8 @@ FactoryBot.define do
       groups { [] }
     end
 
-    # TODO: Register the groups for the given user key such that we can remove the following from other specs:
-    #   `allow(::User.group_service).to receive(:byname).and_return(user.user_key => ['admin'])``
     after(:build) do |user, evaluator|
-      # In case we have the instance but it has not been persisted
-      ::RSpec::Mocks.allow_message(user, :groups).and_return(Array.wrap(evaluator.groups))
-      # Given that we are stubbing the class, we need to allow for the original to be called
-      ::RSpec::Mocks.allow_message(user.class.group_service, :fetch_groups).and_call_original
-      # We need to ensure that each instantiation of the admin user behaves as expected.
-      # This resolves the issue of both the created object being used as well as re-finding the created object.
-      ::RSpec::Mocks.allow_message(user.class.group_service, :fetch_groups).with(user: user).and_return(Array.wrap(evaluator.groups))
+      User.group_service.add(user: user, groups: evaluator.groups)
     end
 
     factory :admin do

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
   let!(:file_set)    { create(:file_set) }
 
   before do
-    RoleMapper.byname[current_user.user_key] << 'donor'
+    ::User.group_service.add(user: current_user, groups: ['donor'])
     sign_in current_user
     visit '/dashboard/my/works'
     check 'check_all'

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 RSpec.describe 'Editing a work', type: :feature do
-  let(:user) { create(:user, groups: 'librarians') }
-  let(:user_admin) { create(:user, groups: 'admin') }
-  let(:work) { build(:work, user: user, admin_set: another_admin_set) }
+  let(:user) { FactoryBot.create(:user, groups: 'librarians') }
+  let(:user_admin) { FactoryBot.create(:user, groups: 'admin') }
+  let(:work) { FactoryBot.build(:work, user: user, admin_set: another_admin_set) }
   let(:default_admin_set) do
-    create(:admin_set, id: AdminSet::DEFAULT_ID,
-                       title: ["Default Admin Set"],
-                       description: ["A description"],
-                       edit_users: [user.user_key])
+    FactoryBot.create(:admin_set, id: AdminSet::DEFAULT_ID,
+                                  title: ["Default Admin Set"],
+                                  description: ["A description"],
+                                  edit_users: [user.user_key])
   end
   let(:another_admin_set) do
-    create(:admin_set, title: ["Another Admin Set"],
-                       description: ["A description"],
-                       edit_users: [user.user_key])
+    FactoryBot.create(:admin_set, title: ["Another Admin Set"],
+                                  description: ["A description"],
+                                  edit_users: [user.user_key])
   end
 
   before do
@@ -71,9 +71,11 @@ RSpec.describe 'Editing a work', type: :feature do
     end
 
     it 'selects group all available groups' do
+      FactoryBot.create(:user, groups: 'donor')
+
       visit edit_hyrax_generic_work_path(work)
       click_link "Sharing" # switch tab
-      expect(page).to have_selector('#new_group_name_skel', text: 'archivist admin_policy_object_editor donor researcher patron')
+      expect(page).to have_selector('#new_group_name_skel', text: 'librarians admin donor')
     end
   end
 end

--- a/spec/features/workflow_state_changes_spec.rb
+++ b/spec/features/workflow_state_changes_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe "Workflow state changes", type: :feature do
   let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
 
   before do
-    allow(::User.group_service).to receive(:byname).and_return(depositing_user.user_key => ['admin'], approving_user.user_key => ['admin'])
     Hyrax::Workflow::WorkflowImporter.generate_from_hash(data: one_step_workflow, permission_template: permission_template)
     permission_template.available_workflows.first.update!(active: true)
     Hyrax::Workflow::PermissionGenerator.call(roles: 'approving', workflow: workflow, agents: approving_user)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -131,6 +131,8 @@ RSpec.configure do |config|
     Hyrax.config.enable_noids = false
     # Don't use the nested relationship reindexer. Null is much faster
     Hyrax.config.nested_relationship_reindexer = ->(id:, extent:) {}
+    # setup a test group service
+    User.group_service = TestHydraGroupService.new
   end
 
   config.before do |example|
@@ -143,7 +145,7 @@ RSpec.configure do |config|
 
     # using :workflow is preferable to :clean_repo, use the former if possible
     # It's important that this comes after DatabaseCleaner.start
-    ensure_deposit_available_for(user) if example.metadata[:workflow]
+    ensure_deposit_available_for(user) if example.metadata[:workflow] && defined?(user)
   end
 
   config.include(ControllerLevelHelpers, type: :view)
@@ -179,6 +181,7 @@ RSpec.configure do |config|
     # Ensuring we have a clear queue between each spec.
     ActiveJob::Base.queue_adapter.enqueued_jobs  = []
     ActiveJob::Base.queue_adapter.performed_jobs = []
+    User.group_service.clear
   end
 
   # If true, the base class of anonymous controllers will be inferred

--- a/spec/support/fakes/test_hydra_group_service.rb
+++ b/spec/support/fakes/test_hydra_group_service.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+##
+# A fake group service implementation for use in test suites as a drop-in
+# replacement for `RoleMapper` or the `hydra-role-management` gem, allowing
+# dynamic group assignment backed by in-memory data structures.
+#
+# @example setup the group service for an rspec test suite
+#   config.before(:suite) do
+#     ::User.group_service = TestHydraGroupService.new
+#   end
+#
+# @example adding a user to a group
+#   ::User.group_service.add(user: my_user, groups: ['a_group'])
+#
+# @example clearing the user -> group map
+#   ::User.group_service.clear
+#
+# @see Hydra::User.group_service
+class TestHydraGroupService
+  ##
+  # @param group_map [Hash{String, Array<String>}] map user keys to group names
+  def initialize(group_map: {})
+    @group_map = group_map
+  end
+
+  ##
+  # @param user [::User]
+  # @param groups [Array<String>, String]
+  #
+  # @return [void]
+  def add(user:, groups:)
+    @group_map[user.user_key] = fetch_groups(user: user) + Array(groups)
+  end
+
+  ##
+  # @return [void]
+  def clear
+    @group_map = {}
+  end
+
+  ##
+  # @param user [::User]
+  #
+  # @return [Array<String>]
+  def fetch_groups(user:)
+    @group_map.fetch(user.user_key) { [] }
+  end
+
+  ##
+  # @return [Array<String>] a list of all known group names
+  def role_names
+    @group_map.values.flatten.uniq
+  end
+end


### PR DESCRIPTION
instead of stubbing in hacked parts of a group service implementation for
dynamic group assignment during test, provide a "fake" group service
implementation for testing, and store the group membership mappings in-memory.

this fixes an issue where admin users created by the users factories don't have
admin group membership on reload (e.g. when loaded by a controller after being
created in a feature spec setup).

@samvera/hyrax-code-reviewers
