### PR TITLE
fix typo in embargo manager

### DIFF
--- a/app/services/hyrax/embargo_manager.rb
+++ b/app/services/hyrax/embargo_manager.rb
@@ -175,7 +175,7 @@ module Hyrax
 
     ##
     # @return [void]
-    # @raise [NotEnforcableError] when trying to release an embargo that
+    # @raise [NotReleasableError] when trying to release an embargo that
     #   is currently active
     def release!
       release || raise(NotReleasableError)


### PR DESCRIPTION
these docs reflected the wrong error type

@samvera/hyrax-code-reviewers
