### PR TITLE
refactor embargo and lease expiry jobs to use valkyrie

### DIFF
--- a/app/jobs/embargo_expiry_job.rb
+++ b/app/jobs/embargo_expiry_job.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 class EmbargoExpiryJob < Hyrax::ApplicationJob
   def perform
-    records_with_expired_embargos.each do |id|
-      work = ActiveFedora::Base.find(id)
-      Hyrax::Actors::EmbargoActor.new(work).destroy
+    records_with_expired_embargos.each do |resource|
+      Hyrax::EmbargoManager.release_embargo_for(resource: resource) &&
+        Hyrax::AccessControlList(resource).save
     end
   end
 
   ##
-  # @return [Enumerator<String>] ids for all the objects that have expired active embargoes
+  # @return [Enumerator<Valkyrie::Resource>] ids for all the objects that have expired active embargoes
   def records_with_expired_embargos
-    Hyrax::EmbargoService.assets_with_expired_embargoes.map(&:id)
+    ids = Hyrax::EmbargoService.assets_with_expired_embargoes.map(&:id)
+
+    Hyrax.query_service.find_many_by_ids(ids: ids)
   end
 end

--- a/app/jobs/lease_expiry_job.rb
+++ b/app/jobs/lease_expiry_job.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 class LeaseExpiryJob < Hyrax::ApplicationJob
   def perform
-    records_with_expired_leases.each do |id|
-      work = ActiveFedora::Base.find(id)
-      Hyrax::Actors::LeaseActor.new(work).destroy
+    records_with_expired_leases.each do |resource|
+      Hyrax::LeaseManager.release_lease_for(resource: resource) &&
+        Hyrax::AccessControlList(resource).save
     end
   end
 
   ##
   # @return [Enumerator<String>] ids for all the objects that have expired active leases
   def records_with_expired_leases
-    Hyrax::LeaseService.assets_with_expired_leases.map(&:id)
+    ids = Hyrax::LeaseService.assets_with_expired_leases.map(&:id)
+
+    Hyrax.query_service.find_many_by_ids(ids: ids)
   end
 end

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -14,7 +14,7 @@ module Hyrax
     when AccessControlList
       obj
     else
-      AccessControlList.new(resource: obj)
+      obj.try(:permission_manager)&.acl || AccessControlList.new(resource: obj)
     end
   end
 

--- a/spec/hyrax/transactions/steps/save_access_control_spec.rb
+++ b/spec/hyrax/transactions/steps/save_access_control_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hyrax::Transactions::Steps::SaveAccessControl, valkyrie_adapter: 
 
     it 'persists the new permissions' do
       expect { step.call(work) }
-        .to change { Hyrax::AccessControlList(work).permissions }
+        .to change { Hyrax::AccessControlList.new(resource: work).permissions }
         .to contain_exactly(have_attributes(mode: :read, agent: user.user_key))
     end
   end

--- a/spec/jobs/embargo_expiry_job_spec.rb
+++ b/spec/jobs/embargo_expiry_job_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe EmbargoExpiryJob, :clean_repo do
   subject { described_class }
-
   let(:past_date) { 2.days.ago }
-
   let(:embargoed_work) { create(:embargoed_work) }
 
   let!(:work_with_expired_embargo) do
@@ -21,8 +19,10 @@ RSpec.describe EmbargoExpiryJob, :clean_repo do
   describe '#records_with_expired_embargos' do
     it 'returns all records with expired embargos' do
       records = described_class.new.records_with_expired_embargos
-      expect(records).to include work_with_expired_embargo.id, file_set_with_expired_embargo.id
-      expect(records).not_to include embargoed_work.id
+
+      expect(records.map(&:id))
+        .to contain_exactly(work_with_expired_embargo.id,
+                            file_set_with_expired_embargo.id)
     end
   end
 

--- a/spec/jobs/lease_expiry_job_spec.rb
+++ b/spec/jobs/lease_expiry_job_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe LeaseExpiryJob, :clean_repo do
   describe '#records_with_expired_leases' do
     it 'returns all records with expired leases' do
       records = described_class.new.records_with_expired_leases
-      expect(records).to include work_with_expired_lease.id, file_set_with_expired_lease.id
-      expect(records).not_to include leased_work.id
+      expect(records.map(&:id))
+        .to contain_exactly(work_with_expired_lease.id,
+                            file_set_with_expired_lease.id)
     end
   end
 


### PR DESCRIPTION
these jobs were recently written using ActiveFedora. these versions retain the existing API and behavior, but use Valkyrie for the implementation.

@samvera/hyrax-code-reviewers
