### PR TITLE
add embargo and lease expiry rake tasks; schedule  for helm deploys

### DIFF
--- a/chart/hyrax/templates/cron-embargo.yaml
+++ b/chart/hyrax/templates/cron-embargo.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.embargoRelease.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+metadata:
+  name: {{ include "hyrax.fullname" . }}-embargo-task
+  labels:
+    {{- include "hyrax.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.embargoRelease.schedule | default "*0 0 * * *" | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: embargo-release
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            command:
+            - /bin/sh
+            - -c
+            - bundle exec rake hyrax:embargo:deactivate_expired
+          restartPolicy: OnFailure
+{{- end }}

--- a/chart/hyrax/templates/cron-lease.yaml
+++ b/chart/hyrax/templates/cron-lease.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.leaseRelease.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+metadata:
+  name: {{ include "hyrax.fullname" . }}-lease-task
+  labels:
+    {{- include "hyrax.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.leaseRelease.schedule | default "0 0 * * *" | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: lease-release
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            command:
+            - /bin/sh
+            - -c
+            - bundle exec rake hyrax:lease:deactivate_expired
+          restartPolicy: OnFailure
+{{- end }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -31,6 +31,13 @@ externalPostgresql: {}
 #  password:
 #  database:
 
+embargoRelease:
+  enabled: true
+  schedule: "0 0 * * *"
+leaseRelease:
+  enabled: true
+  schedule: "0 0 * * *"
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/lib/tasks/embargo_lease.rake
+++ b/lib/tasks/embargo_lease.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+namespace :hyrax do
+  namespace :embargo do
+    desc 'Deactivate embargoes for which the lift date has past'
+    task deactivate_expired: :environment do
+      ids = Hyrax::EmbargoService.assets_with_expired_embargoes.map(&:id)
+
+      Hyrax.query_service.find_many_by_ids(ids: ids).each do |resource|
+        Hyrax::EmbargoManager.release_embargo_for(resource: resource) &&
+          Hyrax::AccessControlList(resource).save
+      end
+    end
+  end
+
+  namespace :lease do
+    desc 'Deactivate leases for which the expiration date has past'
+    task deactivate_expired: :environment do
+      ids = Hyrax::LeaseService.assets_with_expired_leases.map(&:id)
+
+      Hyrax.query_service.find_many_by_ids(ids: ids).each do |resource|
+        Hyrax::LeaseManager.release_lease_for(resource: resource) &&
+          Hyrax::AccessControlList(resource).save
+      end
+    end
+  end
+end


### PR DESCRIPTION
ensure embargo and lease expire daily (by default ) in Helm. adds a task to clear the current expired embargos and leases daily.
@samvera/hyrax-code-reviewers
