### PR TITLE
base64 encode redis password

### DIFF
--- a/chart/hyrax/templates/secrets.yaml
+++ b/chart/hyrax/templates/secrets.yaml
@@ -9,5 +9,5 @@ data:
   SECRET_KEY_BASE: {{ randAlphaNum 20 | b64enc | quote }}
   DATABASE_URL: {{ printf "postgresql://%s:%s@%s/%s?pool=5" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) | b64enc }}
   {{- if .Values.redis.enabled }}
-  REDIS_PASSWORD: {{ .Values.redis.password }}
+  REDIS_PASSWORD: {{ .Values.redis.password | b64enc}}
   {{- end }}


### PR DESCRIPTION
kubernetes doesn't like to be passed cleartext secrets.

@samvera/hyrax-code-reviewers
