### PR TITLE
Use correct solr field for file_size

### DIFF
--- a/app/models/concerns/hyrax/solr_document/characterization.rb
+++ b/app/models/concerns/hyrax/solr_document/characterization.rb
@@ -67,7 +67,7 @@ module Hyrax
       end
 
       def file_size
-        self[Solrizer.solr_name("file_size")]
+        self["file_size_lts"]
       end
 
       def filename


### PR DESCRIPTION
`solr_name` returns `file_size_tesim` but the data is being indexes as `file_size_lts`

This is already fixed in the default branch.  It would probably be good to do a review between the two branches and backport any fixes.

@samvera/hyrax-code-reviewers
