### PR TITLE
Wrap stringy sql in Arel.sql for pluck calls

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -73,7 +73,7 @@ module Hyrax
         ids = PermissionTemplateAccess.for_user(ability: self,
                                                 access: ['deposit', 'manage'])
                                       .joins(:permission_template)
-          .pluck(Arel.sql('DISTINCT source_id'))
+                                      .pluck(Arel.sql('DISTINCT source_id'))
         query = "_query_:\"{!raw f=has_model_ssim}AdminSet\" AND {!terms f=id}#{ids.join(',')}"
         ActiveFedora::SolrService.count(query).positive?
       end

--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -73,7 +73,7 @@ module Hyrax
         ids = PermissionTemplateAccess.for_user(ability: self,
                                                 access: ['deposit', 'manage'])
                                       .joins(:permission_template)
-                                      .pluck('DISTINCT source_id')
+          .pluck(Arel.sql('DISTINCT source_id'))
         query = "_query_:\"{!raw f=has_model_ssim}AdminSet\" AND {!terms f=id}#{ids.join(',')}"
         ActiveFedora::SolrService.count(query).positive?
       end

--- a/app/services/hyrax/collection_types/permissions_service.rb
+++ b/app/services/hyrax/collection_types/permissions_service.rb
@@ -21,7 +21,7 @@ module Hyrax
                                           Hyrax::CollectionTypeParticipant.where(agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE,
                                                                                  agent_id: user_groups(user, ability),
                                                                                  access: roles)
-        ).pluck(Arel.sql('DISTINCT hyrax_collection_type_id'))
+                                        ).pluck(Arel.sql('DISTINCT hyrax_collection_type_id'))
       end
 
       # @api public

--- a/app/services/hyrax/collection_types/permissions_service.rb
+++ b/app/services/hyrax/collection_types/permissions_service.rb
@@ -13,7 +13,7 @@ module Hyrax
       #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
       def self.collection_type_ids_for_user(roles:, user: nil, ability: nil)
         return false unless user.present? || ability.present?
-        return Hyrax::CollectionType.all.pluck('DISTINCT id') if user_admin?(user, ability)
+        return Hyrax::CollectionType.all.pluck(Arel.sql('DISTINCT id')) if user_admin?(user, ability)
         Hyrax::CollectionTypeParticipant.where(agent_type: Hyrax::CollectionTypeParticipant::USER_TYPE,
                                                agent_id: user_id(user, ability),
                                                access: roles)
@@ -21,7 +21,7 @@ module Hyrax
                                           Hyrax::CollectionTypeParticipant.where(agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE,
                                                                                  agent_id: user_groups(user, ability),
                                                                                  access: roles)
-                                        ).pluck('DISTINCT hyrax_collection_type_id')
+        ).pluck(Arel.sql('DISTINCT hyrax_collection_type_id'))
       end
 
       # @api public
@@ -174,7 +174,7 @@ module Hyrax
       def self.agent_ids_for(collection_type:, agent_type:, access:)
         Hyrax::CollectionTypeParticipant.where(hyrax_collection_type_id: collection_type.id,
                                                agent_type: agent_type,
-                                               access: access).pluck('DISTINCT agent_id')
+                                               access: access).pluck(Arel.sql('DISTINCT agent_id'))
       end
       private_class_method :agent_ids_for
 

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -13,7 +13,7 @@ module Hyrax
       def self.source_ids_for_user(access:, ability:, source_type: nil, exclude_groups: [])
         scope = PermissionTemplateAccess.for_user(ability: ability, access: access, exclude_groups: exclude_groups)
                                         .joins(:permission_template)
-        ids = scope.pluck('DISTINCT source_id')
+        ids = scope.pluck(Arel.sql('DISTINCT source_id'))
         return ids unless source_type
         filter_source(source_type: source_type, ids: ids)
       end


### PR DESCRIPTION
Fixes "dangerous query" warnings


AR  warns when passing strings into queries, as a way to prod developers into paying attention to SQL injection.


Description can have multiple paragraphs and you can use code examples inside:

``` ruby
.pluck('DISTINCT source_id')
```

becomes

``` ruby
.pluck(Arel.sql('DISTINCT source_id'))
```

Changes proposed in this pull request:
* Wrap bare strings passed into pluck calls in Area.sql() as noted in the warning.


Guidance for testing, such as acceptance criteria or new user interface behaviors:
*  Observe if Arel warnings are still occurring.


@samvera/hyrax-code-reviewers
