### PR TITLE
support Valkyrie in `WorksControllerBehavior#destroy`

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -37,6 +37,7 @@ module Hyrax
       self.registered_group_name = Hyrax.config.registered_user_group_name
       self.public_group_name = Hyrax.config.public_user_group_name
       self.ability_logic += [:admin_permissions,
+                             :edit_resources,
                              :curation_concerns_permissions,
                              :operation_abilities,
                              :add_to_collection,
@@ -105,6 +106,16 @@ module Hyrax
       can :download, SolrDocument do |obj|
         cache.put(obj.id, obj)
         test_download(obj.id)
+      end
+    end
+
+    ##
+    # @api public
+    #
+    # Allows
+    def edit_resources
+      can [:edit, :update, :destroy], Hyrax::Resource do |resource|
+        test_edit(resource.id)
       end
     end
 

--- a/app/services/hyrax/listeners/metadata_index_listener.rb
+++ b/app/services/hyrax/listeners/metadata_index_listener.rb
@@ -16,9 +16,26 @@ module Hyrax
       #
       # @param event [Dry::Event]
       def on_object_metadata_updated(event)
-        return Hyrax.index_adapter.save(resource: event[:object]) if
+        log_non_resource(event) && return unless
           event[:object].is_a?(Valkyrie::Resource)
 
+        Hyrax.index_adapter.save(resource: event[:object])
+      end
+
+      ##
+      # Remove the resource from the index.
+      #
+      # @param event [Dry::Event]
+      def on_object_deleted(event)
+        log_non_resource(event.payload) && return unless
+          event.payload[:object].is_a?(Valkyrie::Resource)
+
+        Hyrax.index_adapter.delete(resource: event[:object])
+      end
+
+      private
+
+      def log_non_resource(event)
         Hyrax.logger.info('Skipping object reindex because the object ' \
                           "#{event[:object]} was not a Valkyrie::Resource.")
       end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -17,17 +17,19 @@ module Hyrax
     # @since 2.4.0
     #
     # @see https://dry-rb.org/gems/dry-container/
-    class Container
+    class Container # rubocop:disable Metrics/ClassLength
       require 'hyrax/transactions/apply_change_set'
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/destroy_work'
       require 'hyrax/transactions/work_create'
+      require 'hyrax/transactions/work_destroy'
       require 'hyrax/transactions/update_work'
       require 'hyrax/transactions/steps/add_file_sets'
       require 'hyrax/transactions/steps/add_to_collections'
       require 'hyrax/transactions/steps/apply_collection_permission_template'
       require 'hyrax/transactions/steps/apply_permission_template'
       require 'hyrax/transactions/steps/apply_visibility'
+      require 'hyrax/transactions/steps/delete_resource'
       require 'hyrax/transactions/steps/destroy_work'
       require 'hyrax/transactions/steps/ensure_admin_set'
       require 'hyrax/transactions/steps/ensure_permission_template'
@@ -93,6 +95,14 @@ module Hyrax
       namespace 'work_resource' do |ops| # valkyrie works
         ops.register 'add_file_sets' do
           Steps::AddFileSets.new
+        end
+
+        ops.register 'delete' do
+          Steps::DeleteResource.new
+        end
+
+        ops.register 'destroy' do
+          WorkDestroy.new
         end
 
         ops.register 'save_acl' do

--- a/lib/hyrax/transactions/steps/delete_resource.rb
+++ b/lib/hyrax/transactions/steps/delete_resource.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Deletes a resource from the persister, returning a `Dry::Monads::Result`
+      # (`Success`|`Failure`).
+      #
+      # @see https://dry-rb.org/gems/dry-monads/1.0/result/
+      class DeleteResource
+        include Dry::Monads[:result]
+
+        ##
+        # @params [#save] persister
+        def initialize(persister: Hyrax.persister)
+          @persister = persister
+        end
+
+        ##
+        # @param [Valkyrie::Resource] resource
+        # @param [::User] the user resposible for the delete action
+        #
+        # @return [Dry::Monads::Result]
+        def call(resource, user: nil)
+          return Failure(:resource_not_persisted) unless resource.persisted?
+
+          @persister.delete(resource: resource)
+          Hyrax.publisher
+               .publish('object.deleted', object: resource, id: resource.id.id, user: user)
+
+          Success(resource)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/destroy_work.rb
+++ b/lib/hyrax/transactions/steps/destroy_work.rb
@@ -6,6 +6,7 @@ module Hyrax
       # A `dry-transcation` step that destroys a Work.
       #
       # @since 3.0.0
+      # @deprecated
       class DestroyWork
         include Dry::Transaction::Operation
 

--- a/lib/hyrax/transactions/work_destroy.rb
+++ b/lib/hyrax/transactions/work_destroy.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/transaction'
+
+module Hyrax
+  module Transactions
+    ##
+    # Destroys a work resource
+    #
+    # @since 3.0.0
+    class WorkDestroy < Transaction
+      DEFAULT_STEPS = ['work_resource.delete'].freeze
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/lib/wings/valkyrie/persister.rb
+++ b/lib/wings/valkyrie/persister.rb
@@ -53,6 +53,7 @@ module Wings
         af_object = ActiveFedora::Base.new
         af_object.id = resource.alternate_ids.first.to_s
         af_object.delete
+        resource
       end
 
       # Deletes all resources from Fedora and Solr

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -51,10 +51,9 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
       FactoryBot.valkyrie_create(:hyrax_work,
                                  alternate_ids: [id],
                                  title: title,
-                                 edit_users: [user] )
+                                 edit_users: [user])
     end
   end
-
 
   describe '#create' do
     it 'redirects to new user login' do
@@ -168,7 +167,6 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     end
   end
 
-
   describe '#destroy' do
     it 'redirect to user login' do
       delete :destroy, params: { id: work.id }
@@ -184,20 +182,26 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
       end
     end
 
-    xcontext 'when the user has edit access' do
+    context 'when the user has edit access' do
       include_context 'with a user with edit access'
 
       it 'is a success' do
         delete :destroy, params: { id: work.id }
 
-        expect(response).to be_successful
+        expect(response.status).to eq 302 # redirect on success
       end
 
       it 'deletes the work' do
-        expect { delete :destroy, params: { id: work.id } }
-          .to change { work.persisted? }
-          .from(true)
-          .to false
+        delete :destroy, params: { id: work.id }
+
+        expect { Hyrax.query_service.find_by(id: work.id) }
+          .to raise_error Hyrax::ObjectNotFoundError
+      end
+
+      it 'tells the user what they deleted' do
+        delete :destroy, params: { id: work.id }
+
+        expect(flash[:notice]).to include work.title.first
       end
     end
   end

--- a/spec/hyrax/transactions/steps/delete_resource_spec.rb
+++ b/spec/hyrax/transactions/steps/delete_resource_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions/steps/delete_resource'
+require 'hyrax/specs/spy_listener'
+
+RSpec.describe Hyrax::Transactions::Steps::DeleteResource, valkyrie_adapter: :test_adapter do
+  subject(:step) { described_class.new }
+  let(:work)     { FactoryBot.valkyrie_create(:hyrax_work) }
+  let(:listener) { Hyrax::Specs::SpyListener.new }
+
+  before { Hyrax.publisher.subscribe(listener) }
+  after  { Hyrax.publisher.unsubscribe(listener) }
+
+  describe '#call' do
+    it 'gives success' do
+      expect(step.call(work)).to be_success
+    end
+
+    it 'publishes object.deleted' do
+      step.call(work)
+
+      expect(listener.object_deleted&.payload)
+        .to include(id: work.id, object: work, user: nil)
+    end
+
+    context 'with a resource that is not saved' do
+      let(:work) { FactoryBot.build(:hyrax_work) }
+
+      it 'is a failure' do
+        expect(step.call(work)).to be_failure
+      end
+
+      it 'does not publish' do
+        step.call(work)
+
+        expect(listener.object_deleted).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
@@ -12,6 +12,25 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
     allow(Hyrax).to receive(:index_adapter).and_return(fake_adapter)
   end
 
+  describe '#on_object_deleted' do
+    let(:event_type) { :on_object_delted }
+
+    it 'reindexes the object on the configured adapter' do
+      expect { listener.on_object_deleted(event) }
+        .to change { fake_adapter.deleted_resources }
+        .to contain_exactly(resource)
+    end
+
+    context 'when it gets a non-resource as payload' do
+      let(:resource) { ActiveFedora::Base.new }
+
+      it 'returns as a no-op' do
+        expect { listener.on_object_deleted(event) }
+          .not_to change { fake_adapter.deleted_resources }
+      end
+    end
+  end
+
   describe '#on_object_metadata_updated' do
     let(:event_type) { :on_object_metadata_updated }
 

--- a/spec/support/fakes/indexing_adapter.rb
+++ b/spec/support/fakes/indexing_adapter.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 class FakeIndexingAdapter
-  attr_reader :saved_resources
+  attr_reader :deleted_resources, :saved_resources
 
   def initialize
+    @deleted_resources = []
     @saved_resources = []
   end
 
   def save(resource:)
     @saved_resources << resource
+  end
+
+  def delete(resource:)
+    @deleted_resources << resource
   end
 end


### PR DESCRIPTION
adds transactional support for the destroy action. publishes the `object.deleted` event when destroying the object. this replaces
the older `:after_destroy` callback. the callback has been merely a wrapper to the publisher/listner event for some time.

to support this, add edit abilities for `Hyrax::Resource`. the edit rules for `Hyrax::Resource` should be the same as those used for
`ActiveFedora::Base`.

@samvera/hyrax-code-reviewers
