### PR TITLE
support valkyrie in `SolrDocument::ModelWrapper#to_partial_path`

### DIFF
--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -74,8 +74,14 @@ module Hyrax
 
       ##
       # @api public
+      #
+      # @note uses the @model's `._to_partial_path` if implemented, otherwise
+      #   constructs a default
       def to_partial_path
-        @model._to_partial_path
+        return @model._to_partial_path if
+          @model.respond_to?(:_to_partial_path)
+
+        "hyrax/#{model_name.collection}/#{model_name.element}"
       end
 
       ##

--- a/lib/wings/active_fedora_converter/default_work.rb
+++ b/lib/wings/active_fedora_converter/default_work.rb
@@ -106,6 +106,10 @@ module Wings
       class << self
         delegate :human_readable_type, to: :valkyrie_class
 
+        def _to_partial_path
+          "hyrax/#{valkyrie_class.model_name.collection}/#{valkyrie_class.model_name.element}"
+        end
+
         def model_name(*)
           Hyrax::Name.new(valkyrie_class)
         end

--- a/spec/models/concerns/hyrax/solr_document_behavior_spec.rb
+++ b/spec/models/concerns/hyrax/solr_document_behavior_spec.rb
@@ -11,6 +11,32 @@ RSpec.describe Hyrax::SolrDocumentBehavior do
     end
   end
 
+  describe '#to_partial_path' do
+    context 'with an ActiveFedora model name' do
+      let(:solr_hash) { { 'has_model_ssim' => 'GenericWork' } }
+
+      it 'resolves the correct model name' do
+        expect(solr_document.to_model.to_partial_path).to eq 'hyrax/generic_works/generic_work'
+      end
+    end
+
+    context 'with a Valkyrie model name' do
+      let(:solr_hash) { { 'has_model_ssim' => 'Monograph' } }
+
+      it 'resolves the correct model name' do
+        expect(solr_document.to_model.to_partial_path).to eq 'hyrax/monographs/monograph'
+      end
+    end
+
+    context 'with a Wings model name' do
+      let(:solr_hash) { { 'has_model_ssim' => 'Wings(Monograph)' } }
+
+      it 'gives an appropriate generated ActiveFedora class' do
+        expect(solr_document.to_model.to_partial_path).to eq 'hyrax/monographs/monograph'
+      end
+    end
+  end
+
   describe '#hydra_model' do
     it 'gives ActiveFedora::Base by default' do
       expect(solr_document.hydra_model).to eq ActiveFedora::Base


### PR DESCRIPTION
since `Valkyrie::Resource` doesn't implement `ActiveModel`, we need default handling for SolrDocument partial paths.

@samvera/hyrax-code-reviewers
