### PR TITLE
extend FileSetAttachedEventJob to work with Valkyrie

### DIFF
--- a/app/jobs/file_set_attached_event_job.rb
+++ b/app/jobs/file_set_attached_event_job.rb
@@ -30,6 +30,11 @@ class FileSetAttachedEventJob < ContentEventJob
   end
 
   def curation_concern
-    repo_object.in_works.first
+    case repo_object
+    when ActiveFedora::Base
+      repo_object.in_works.first
+    else
+      Hyrax.query_service.find_parents(resource: repo_object).first
+    end
   end
 end

--- a/spec/factories/hyrax_file_set.rb
+++ b/spec/factories/hyrax_file_set.rb
@@ -43,5 +43,16 @@ FactoryBot.define do
         files { [valkyrie_create(:hyrax_file_metadata), valkyrie_create(:hyrax_file_metadata)] }
       end
     end
+
+    trait :in_work do
+      transient do
+        work { build(:hyrax_work) }
+      end
+
+      after(:create) do |file_set, evaluator|
+        evaluator.work.member_ids += [file_set.id]
+        Hyrax.persister.save(resource: evaluator.work)
+      end
+    end
   end
 end

--- a/spec/jobs/file_set_attached_event_job_spec.rb
+++ b/spec/jobs/file_set_attached_event_job_spec.rb
@@ -1,24 +1,25 @@
 # frozen_string_literal: true
 RSpec.describe FileSetAttachedEventJob do
-  let(:user) { create(:user) }
+  let(:user) { FactoryBot.create(:user) }
   let(:mock_time) { Time.zone.at(1) }
+
+  let(:event) do
+    {
+      action: "User <a href=\"/users/#{user.to_param}\">#{user.user_key}</a> " \
+              "has attached <a href=\"/concern/file_sets/#{file_set.id}\">A Contained FileSet</a> " \
+              "to <a href=\"/concern/#{curation_concern.model_name.collection}/#{curation_concern.id}\">MacBeth</a>",
+      timestamp: '1'
+    }
+  end
 
   before do
     allow_any_instance_of(User).to receive(:can?).and_return(true)
-    allow(Time).to receive(:now).at_least(:once).and_return(mock_time)
+    allow(Hyrax::TimeService).to receive(:time_in_utc).at_least(:once).and_return(mock_time)
   end
 
   context 'with a FileSet' do
     let(:file_set) { curation_concern.file_sets.first }
     let(:curation_concern) { create(:work_with_one_file, title: ['MacBeth'], user: user) }
-    let(:event) do
-      {
-        action: "User <a href=\"/users/#{user.to_param}\">#{user.user_key}</a> " \
-                "has attached <a href=\"/concern/file_sets/#{file_set.id}\">A Contained FileSet</a> " \
-                "to <a href=\"/concern/generic_works/#{curation_concern.id}\">MacBeth</a>",
-        timestamp: '1'
-      }
-    end
 
     it "logs the event to the right places" do
       expect do
@@ -30,6 +31,27 @@ RSpec.describe FileSetAttachedEventJob do
       expect(user.profile_events.first).to eq(event)
       expect(curation_concern.events.first).to eq(event)
       expect(file_set.events.first).to eq(event)
+    end
+  end
+
+  context 'with a Hyrax::FileSet (valkyrie)' do
+    let(:file_set) do
+      FactoryBot.valkyrie_create(:hyrax_file_set, :in_work, work: curation_concern, title: 'A Contained FileSet')
+    end
+
+    let(:curation_concern) { FactoryBot.valkyrie_create(:monograph, title: ['MacBeth']) }
+
+    it 'logs events to user profile, file_set, and work' do
+      expect { described_class.perform_now(file_set, user) }
+        .to change { user.profile_events.length }
+        .by(1)
+        .and change { file_set.events.length }
+        .by(1)
+        .and change { curation_concern.events.length }.by(1)
+
+      expect(user.profile_events).to contain_exactly(event)
+      expect(curation_concern.events).to contain_exactly(event)
+      expect(file_set.events).to contain_exactly(event)
     end
   end
 end


### PR DESCRIPTION
support valkyrie style lookup of parent works for the event job. there's good
reason to think this job could be quicly converted to valkyrie-only by removing
the switch statement and possibly using an id-based inverse relation lookup for
membership instead of `find_parents`. for now, it seemed best to leave the
behavior for ActiveFedora totally fixed.

@samvera/hyrax-code-reviewers
