### PR TITLE
Make collection-related search builders inherit from the base hyrax collection search builder

### DIFF
--- a/app/search_builders/hyrax/collection_member_search_builder.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Hyrax
   # This search builder requires that a accessor named "collection" exists in the scope
-  class CollectionMemberSearchBuilder < ::SearchBuilder
+  class CollectionMemberSearchBuilder < ::Hyrax::CollectionSearchBuilder
     include Hyrax::FilterByType
     attr_writer :collection, :search_includes_models
 

--- a/app/search_builders/hyrax/collection_member_search_builder.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder.rb
@@ -41,6 +41,11 @@ module Hyrax
       solr_parameters[:fq] << "#{collection_membership_field}:#{collection.id}"
     end
 
+    # This overrides the models in FilterByType
+    def models
+      work_classes + collection_classes
+    end
+
     private
 
     def only_works?

--- a/app/search_builders/hyrax/collection_search_builder.rb
+++ b/app/search_builders/hyrax/collection_search_builder.rb
@@ -23,11 +23,6 @@ module Hyrax
       "title_si"
     end
 
-    # This overrides the models in FilterByType
-    def models
-      collection_classes
-    end
-
     def with_access(access)
       @access = access
       super(access)

--- a/app/search_builders/hyrax/collection_search_builder.rb
+++ b/app/search_builders/hyrax/collection_search_builder.rb
@@ -23,6 +23,11 @@ module Hyrax
       "title_si"
     end
 
+    # This overrides the models in FilterByType
+    def models
+      collection_classes
+    end
+
     def with_access(access)
       @access = access
       super(access)

--- a/app/search_builders/hyrax/my/collections_search_builder.rb
+++ b/app/search_builders/hyrax/my/collections_search_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # Added to allow for the My controller to show only things I have edit access to
-class Hyrax::My::CollectionsSearchBuilder < ::SearchBuilder
+class Hyrax::My::CollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
   include Hyrax::My::SearchBuilderBehavior
   include Hyrax::FilterByType
 

--- a/app/search_builders/hyrax/nested_collections_parent_search_builder.rb
+++ b/app/search_builders/hyrax/nested_collections_parent_search_builder.rb
@@ -2,7 +2,7 @@
 module Hyrax
   ##
   # Searches for all collections that are parents of a given collection.
-  class NestedCollectionsParentSearchBuilder < ::SearchBuilder
+  class NestedCollectionsParentSearchBuilder < ::Hyrax::CollectionSearchBuilder
     include Hyrax::FilterByType
     attr_reader :child, :page, :limit
 

--- a/app/search_builders/hyrax/single_collection_search_builder.rb
+++ b/app/search_builders/hyrax/single_collection_search_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  class SingleCollectionSearchBuilder < ::SearchBuilder
+  class SingleCollectionSearchBuilder < ::Hyrax::CollectionSearchBuilder
     include SingleResult
   end
 end


### PR DESCRIPTION
This changes all Collection-related `SearchBuilder`s to inherit from the "base" `Hyrax::CollectionSearchBuilder`. This allows for consistent behavior across Collection queries as well as less repeated code. 

@samvera/hyrax-code-reviewers 