### PR TITLE
support `#in_works_id` virtual property in (valkyrie) `ResourceForm`

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -45,6 +45,20 @@ module Hyrax
 
       ##
       # @api private
+      InWorksPopulator = lambda do |_options|
+        self.in_works_ids =
+          if persisted?
+            Hyrax.query_service
+                 .find_inverse_references_by(resource: model, property: :member_ids)
+                 .select(&:work?)
+                 .map(&:id)
+          else
+            []
+          end
+      end
+
+      ##
+      # @api private
       #
       # @note includes special handling for Wings, to support compatibility
       #   with `etag`-driven, application-side lock checks. for non-wings adapters
@@ -90,6 +104,7 @@ module Hyrax
 
       # pcdm relationships
       property :admin_set_id, prepopulator: ->(_opts) { self.admin_set_id = AdminSet::DEFAULT_ID }
+      property :in_works_ids, virtual: true, prepopulator: InWorksPopulator
       property :member_ids, default: [], type: Valkyrie::Types::Array
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -103,6 +103,50 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
   end
 
+  describe '#in_works_ids' do
+    context 'without membership' do
+      it 'is an empty array' do
+        form.prepopulate!
+
+        expect(form.in_works_ids).to eq []
+      end
+    end
+
+    context 'as a member of works' do
+      let(:work)   { Hyrax.query_service.find_by(id: parent.member_ids.first) }
+      let(:parent) { FactoryBot.valkyrie_create(:hyrax_work, :with_member_works) }
+
+      it 'lists the parent works' do
+        form.prepopulate!
+
+        expect(form.in_works_ids).to contain_exactly(parent.id)
+      end
+    end
+
+    context 'as a member of works and collections' do
+      let(:work)   { FactoryBot.valkyrie_create(:hyrax_work, :as_collection_member) }
+      let(:parent) { FactoryBot.valkyrie_create(:hyrax_work, :with_member_works, members: [work]) }
+
+      before { parent } # parent must be saved
+
+      it 'lists the parent works' do
+        form.prepopulate!
+
+        expect(form.in_works_ids).to contain_exactly(parent.id)
+      end
+    end
+
+    context 'as a member of collections' do
+      let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :as_member_of_multiple_collections) }
+
+      it 'is empty' do
+        form.prepopulate!
+
+        expect(form.in_works_ids).to eq []
+      end
+    end
+  end
+
   describe '#lease_expiration_date' do
     context 'without a lease' do
       it 'is nil' do

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe Hyrax::Forms::WorkForm do
     it { is_expected.to eq '123456' }
   end
 
+  describe '#in_works_ids' do
+    let(:work)   { parent.members.first }
+    let(:parent) { FactoryBot.create(:work_with_one_child) }
+
+    it 'gives the ids for parent works' do
+      expect(form.in_works_ids).to contain_exactly(parent.id)
+    end
+  end
+
   describe "#select_files" do
     let(:work) { create(:work_with_one_file) }
     let(:title) { work.file_sets.first.title.first }


### PR DESCRIPTION
Hyrax views use `#in_works_id` to handle membership in works. add an
implementation for `ResourceForm`, populated from a Valkyrie query.

This implementation pulls all the members just to get ids. Maybe we need a
"navigator" query for this purpose? `find_parent_works(resource:)`?

@samvera/hyrax-code-reviewers
