### PR TITLE
wings: handle ActiveFedora associations/reflections deliberately

### DIFF
--- a/lib/wings/attribute_transformer.rb
+++ b/lib/wings/attribute_transformer.rb
@@ -15,27 +15,36 @@ module Wings
       end
     end
 
-    def self.run(obj)
-      reflections = OrmConverter.relationship_keys_for(reflections: obj.try(:reflections))
-      keys = (obj.class.delegated_attributes.keys + obj.class.association_attributes + reflections).uniq
-
-      attrs = keys.select { |k| k.to_s.end_with? '_ids' }.each_with_object({}) do |attr_name, mem|
-        mem[attr_name.to_sym] =
-          TransformerValueMapper.for(obj.try(attr_name)).result ||
-          TransformerValueMapper.for(attribute_ids_for(name: attr_name.chomp('_ids'), obj: obj)).result ||
-          TransformerValueMapper.for(attribute_ids_for(name: attr_name.chomp('_ids').pluralize, obj: obj)).result || []
+    def self.run(obj) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+      attrs = obj.reflections.each_with_object({}) do |(key, reflection), mem|
+        case reflection
+        when ActiveFedora::Reflection::HasManyReflection,
+             ActiveFedora::Reflection::HasAndBelongsToManyReflection,
+             ActiveFedora::Reflection::IndirectlyContainsReflection
+          mem[:"#{key.to_s.singularize}_ids"] =
+            obj.association(key).ids_reader
+        when ActiveFedora::Reflection::DirectlyContainsReflection
+          mem[:"#{key.to_s.singularize}_ids"] =
+            Array(obj.public_send(reflection.name)).map(&:id)
+        when ActiveFedora::Reflection::FilterReflection,
+             ActiveFedora::Reflection::OrdersReflection,
+             ActiveFedora::Reflection::HasSubresourceReflection,
+             ActiveFedora::Reflection::BelongsToReflection,
+             ActiveFedora::Reflection::BasicContainsReflection
+          :noop
+        when ActiveFedora::Reflection::DirectlyContainsOneReflection
+          mem[:"#{key.to_s.singularize}_id"] =
+            obj.public_send(reflection.name)&.id
+        else
+          mem[reflection.foreign_key.to_sym] =
+            obj.public_send(reflection.foreign_key.to_sym)
+        end
       end
 
-      keys.each_with_object(attrs) do |attr_name, mem|
+      obj.class.delegated_attributes.keys.each_with_object(attrs) do |attr_name, mem|
         next unless obj.respond_to?(attr_name) && !mem.key?(attr_name.to_sym)
         mem[attr_name.to_sym] = TransformerValueMapper.for(obj.public_send(attr_name)).result
       end
-    end
-
-    def self.attribute_ids_for(name:, obj:)
-      attribute_value = obj.try(name)
-      return if attribute_value.nil?
-      Array(attribute_value).map(&:id)
     end
   end
 

--- a/lib/wings/attribute_transformer.rb
+++ b/lib/wings/attribute_transformer.rb
@@ -15,9 +15,9 @@ module Wings
       end
     end
 
-    def self.run(obj, extra_keys = [])
+    def self.run(obj)
       reflections = OrmConverter.relationship_keys_for(reflections: obj.try(:reflections))
-      keys = (obj.class.delegated_attributes.keys + obj.class.association_attributes + reflections + extra_keys).uniq
+      keys = (obj.class.delegated_attributes.keys + obj.class.association_attributes + reflections).uniq
 
       attrs = keys.select { |k| k.to_s.end_with? '_ids' }.each_with_object({}) do |attr_name, mem|
         mem[attr_name.to_sym] =
@@ -40,8 +40,8 @@ module Wings
   end
 
   class FileAttributeTransformer
-    def run(obj, extra_keys = [])
-      keys = obj.metadata_node.class.fields + extra_keys
+    def run(obj)
+      keys = obj.metadata_node.class.fields
 
       attributes = keys.each_with_object({}) do |attr_name, mem|
         next unless obj.respond_to?(attr_name) && !mem.key?(attr_name.to_sym)

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
           binary = StringIO.new("hey")
           Hydra::Works::AddFileToFileSet.call(fileset1, binary, :original_file)
           expect(fileset1.original_file).not_to be_nil
-          expect(resource.original_file_ids.first.to_s).to eq file_id
+          expect(resource.original_file_id.to_s).to eq file_id
 
           converted_file_set = converter.convert
 

--- a/spec/wings/attribute_transformer_spec.rb
+++ b/spec/wings/attribute_transformer_spec.rb
@@ -2,10 +2,8 @@
 require 'wings/attribute_transformer'
 
 RSpec.describe Wings::AttributeTransformer do
-  let(:pcdm_object) { work }
-  let(:id)          { 'moomin123' }
-  let(:work)        { GenericWork.new(id: id, **attributes) }
-  let(:keys)        { attributes.keys }
+  let(:id)   { 'moomin123' }
+  let(:work) { GenericWork.new(id: id, **attributes) }
 
   let(:attributes) do
     {
@@ -15,16 +13,10 @@ RSpec.describe Wings::AttributeTransformer do
     }
   end
 
-  let(:uris) do
-    [RDF::URI('http://example.com/fake1'),
-     RDF::URI('http://example.com/fake2')]
-  end
-
-  subject { described_class.run(pcdm_object, keys) }
-
   it "transform the attributes" do
-    expect(subject).to include title: work.title,
-                               contributor: work.contributor.first,
-                               description: work.description.first
+    expect(described_class.run(work))
+      .to include title: work.title,
+                  contributor: work.contributor.first,
+                  description: work.description.first
   end
 end

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -28,12 +28,11 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
     context 'and requesting original file' do
       subject { described_class.call(file_set: file_set, file: pdf_file, type: original_file_use) }
       it "builds and uses the association's target" do
-        ids = subject.original_file_ids
-        expect(ids.size).to eq 1
-        expect(ids.first).to be_a Valkyrie::ID
-        expect(ids.first.to_s).to start_with "#{file_set.id}/files/"
+        id = subject.original_file_id
+        expect(id).to be_a Valkyrie::ID
+        expect(id.to_s).to start_with "#{file_set.id}/files/"
 
-        file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: ids.first)
+        file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: id)
         expect(file_metadata.mime_type).to eq pdf_mimetype
       end
     end
@@ -41,25 +40,24 @@ RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
     context 'and requesting extracted text' do
       subject { described_class.call(file_set: file_set, file: text_file, type: [extracted_text_use]) }
       it "builds and uses the association's target" do
-        ids = subject.extracted_text_ids
-        expect(ids.size).to eq 1
-        expect(ids.first).to be_a Valkyrie::ID
-        expect(ids.first.to_s).to start_with "#{file_set.id}/files/"
+        id = subject.extracted_text_id
+        expect(id).to be_a Valkyrie::ID
+        expect(id.to_s).to start_with "#{file_set.id}/files/"
 
-        file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: ids.first)
+        file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: id)
         expect(file_metadata.mime_type).to eq text_mimetype
       end
     end
 
     context 'and requesting thumbnail' do
       subject { described_class.call(file_set: file_set, file: image_file, type: thumbnail_use) }
-      it "builds and uses the association's target" do
-        ids = subject.thumbnail_ids
-        expect(ids.size).to eq 1
-        expect(ids.first).to be_a Valkyrie::ID
-        expect(ids.first.to_s).to start_with "#{file_set.id}/files/"
 
-        file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: ids.first)
+      it "builds and uses the association's target" do
+        id = subject.thumbnail_id
+        expect(id).to be_a Valkyrie::ID
+        expect(id.to_s).to start_with "#{file_set.id}/files/"
+
+        file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: id)
         expect(file_metadata.mime_type).to eq image_mimetype
       end
     end

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -191,9 +191,9 @@ RSpec.describe Wings::ModelTransformer, :clean_repo do
       it 'has the correct reflection ids' do
         resource = described_class.new(pcdm_object: file_set).build
         expect(resource.file_ids).to match_valkyrie_ids_with_active_fedora_ids(file_set.files.map(&:id))
-        expect(resource.original_file_ids).to match_valkyrie_ids_with_active_fedora_ids([file_set.original_file.id])
-        expect(resource.thumbnail_ids).to match_valkyrie_ids_with_active_fedora_ids([file_set.thumbnail.id])
-        expect(resource.extracted_text_ids).to match_valkyrie_ids_with_active_fedora_ids([file_set.extracted_text.id])
+        expect(resource.original_file_id).to eq file_set.original_file.id
+        expect(resource.thumbnail_id).to eq file_set.thumbnail.id
+        expect(resource.extracted_text_id).to eq file_set.extracted_text.id
       end
     end
 
@@ -324,14 +324,14 @@ RSpec.describe Wings::ModelTransformer, :clean_repo do
           .to have_attributes title: book.title,
                               contributor: book.contributor,
                               description: book.description
-        expect(subject.build.active_fedora_page_ids).to match_valkyrie_ids_with_active_fedora_ids(['pg1', 'pg2'])
+        expect(subject.build.active_fedora_page_ids).to eq(['pg1', 'pg2'])
       end
     end
   end
 
   context 'build for file' do
     let(:id)       { '123' }
-    let(:file_set) { create(:file_set, id: id) }
+    let(:file_set) { FactoryBot.create(:file_set, id: id) }
     let(:file) { file_set.build_original_file }
     let(:pcdm_object) { file_set }
 
@@ -341,7 +341,7 @@ RSpec.describe Wings::ModelTransformer, :clean_repo do
       end
 
       it 'sets file id in file set resource' do
-        expect(subject.build.original_file_ids).to match_valkyrie_ids_with_active_fedora_ids([file.id])
+        expect(subject.build.original_file_id).to eq file.id
       end
     end
 
@@ -351,7 +351,7 @@ RSpec.describe Wings::ModelTransformer, :clean_repo do
       end
 
       it 'sets file id in file set resource' do
-        expect(subject.build.original_file_ids).to match_valkyrie_ids_with_active_fedora_ids([file.id])
+        expect(factory.build.original_file_id).to eq file.id
       end
     end
 
@@ -359,7 +359,7 @@ RSpec.describe Wings::ModelTransformer, :clean_repo do
       let(:file_set) { create(:file_set) }
 
       it 'does not set file id in file set resource' do
-        expect(subject.build.original_file_ids).to eq []
+        expect(factory.build.original_file_id).to be_empty
       end
     end
   end


### PR DESCRIPTION
the older approach was a little bit too trial-and-error for real use cases. this attempts to handle the reflection types used in typical Hyrax usage specifically. there are probably performance gains to be had by optimizing handling for the individual branches.

@samvera/hyrax-code-reviewers
