### PR TITLE
wings: fix serveral shared example specs for Valkyrie persister

### DIFF
--- a/lib/wings/converter_value_mapper.rb
+++ b/lib/wings/converter_value_mapper.rb
@@ -73,7 +73,7 @@ module Wings
     end
 
     def result
-      collections = value.last.map { |id| ActiveFedora::Base.find(id.id) }
+      collections = value.last.map { |id| ActiveFedora::Base.find(id.to_s) }
       [:member_of_collections, collections]
     end
   end
@@ -86,7 +86,7 @@ module Wings
     end
 
     def result
-      members = value.last.map { |id| ActiveFedora::Base.find(id.id) }
+      members = value.last.map { |id| ActiveFedora::Base.find(id.to_s) }
       [:members, members]
     end
   end

--- a/lib/wings/valkyrie/persister.rb
+++ b/lib/wings/valkyrie/persister.rb
@@ -41,9 +41,10 @@ module Wings
       # @param [Valkyrie::Resource] resource
       # @return [Valkyrie::Resource] the persisted/updated resource
       def save_all(resources:)
-        resources.map do |resource|
-          save(resource: resource)
-        end
+        resources.map { |resource| save(resource: resource) }
+      rescue ::Valkyrie::Persistence::StaleObjectError => _err
+        raise(::Valkyrie::Persistence::StaleObjectError,
+              "One or more resources have been updated by another process.")
       end
 
       # Deletes a resource persisted using ActiveFedora
@@ -51,7 +52,7 @@ module Wings
       # @return [Valkyrie::Resource] the deleted resource
       def delete(resource:)
         af_object = ActiveFedora::Base.new
-        af_object.id = resource.alternate_ids.first.to_s
+        af_object.id = resource.id
         af_object.delete
         resource
       end
@@ -84,7 +85,8 @@ module Wings
           etag_lock_token_valid?(af_object: af_object, resource: resource) &&
           last_modified_lock_token_valid?(af_object: af_object, resource: resource)
 
-        raise(::Valkyrie::Persistence::StaleObjectError, resource.id.to_s)
+        raise(::Valkyrie::Persistence::StaleObjectError,
+              "The object #{resource.id} has been updated by another process.")
       end
 
       ##

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Wings::Valkyrie::Persister do
     let(:resource_class) { Wings::OrmConverter.to_valkyrie_resource_class(klass: af_resource_class) }
     let(:resource) { resource_class.new(title: ['Foo']) }
 
-    # it_behaves_like "a Valkyrie::Persister", :no_deep_nesting, :no_mixed_nesting
+    # it_behaves_like "a Valkyrie::Persister"
 
     it { is_expected.to respond_to(:save).with_keywords(:resource) }
     it { is_expected.to respond_to(:save_all).with_keywords(:resources) }


### PR DESCRIPTION
this reduces the space of shared example failures to type issues, order
issues, and nesting issues. 22 tests fail in total.

RDF.rb and ActiveFedora cast many RDF types to Ruby objects, which is mostly
helpful, and we don't have plans to circumvent this to pass Valkyrie tests.

ordered attribute support is forthcoming, and nesting is to be explored.

@samvera/hyrax-code-reviewers
