### PR TITLE
test that valkyrie work deletion is functional at browser level

### DIFF
--- a/app/services/hyrax/listeners.rb
+++ b/app/services/hyrax/listeners.rb
@@ -14,6 +14,7 @@ module Hyrax
     autoload :BatchNotificationListener
     autoload :FileSetLifecycleListener
     autoload :FileSetLifecycleNotificationListener
+    autoload :MemberCleanupListener
     autoload :MetadataIndexListener
     autoload :ObjectLifecycleListener
     autoload :ProxyDepositListener

--- a/app/services/hyrax/listeners/member_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/member_cleanup_listener.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Listens for object deleted events and cleans up associated members
+    class MemberCleanupListener
+      def on_object_deleted(event)
+        return unless event.payload.key?(:object) # legacy callback
+        return if event[:object].is_a?(ActiveFedora::Base) # handled by legacy code
+
+        Hyrax.custom_queries.find_child_filesets(resource: event[:object]).each do |file_set|
+          begin
+            Hyrax.persister.delete(resource: file_set)
+            Hyrax.publisher
+                 .publish('object.deleted', object: file_set, id: file_set.id, user: user)
+          rescue StandardError # we don't uncaught errors looping filesets
+            Hyrax.logger.warn "Failed to delete #{file_set.class}:#{file_set.id} " \
+                              "during cleanup for resource: #{event[:object]}. " \
+                              'This member may now be orphaned.'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/hyrax/listeners/object_lifecycle_listener.rb
+++ b/app/services/hyrax/listeners/object_lifecycle_listener.rb
@@ -8,7 +8,7 @@ module Hyrax
       ##
       # @param event [Dry::Event]
       def on_object_deleted(event)
-        ContentDeleteEventJob.perform_later(event[:id], event[:user])
+        ContentDeleteEventJob.perform_later(event[:id].to_s, event[:user])
       end
 
       ##

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -2,6 +2,7 @@
 
 Hyrax.publisher.subscribe(Hyrax::Listeners::AclIndexListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ActiveFedoraAclIndexListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::MemberCleanupListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::MetadataIndexListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::BatchNotificationListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)

--- a/spec/features/delete_resource_spec.rb
+++ b/spec/features/delete_resource_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe 'Deleting a valkyrie work', type: :feature do
       .to include(id: work.id.to_s, user: user)
 
     # deletes all members
-    # work.member_ids.each do |file_set_id|
-    #   expect { Hyrax.query_service.find_by(id: file_set_id) }
-    #     .to raise_error Hyrax::ObjectNotFoundError
-    # end
+    work.member_ids.each do |file_set_id|
+      expect { Hyrax.query_service.find_by(id: file_set_id) }
+        .to raise_error Hyrax::ObjectNotFoundError
+    end
   end
 end

--- a/spec/features/delete_resource_spec.rb
+++ b/spec/features/delete_resource_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'hyrax/specs/spy_listener'
+
+RSpec.describe 'Deleting a valkyrie work', type: :feature do
+  let(:work) do
+    FactoryBot.valkyrie_create(:monograph,
+                               :as_member_of_multiple_collections,
+                               :with_admin_set,
+                               :with_member_file_sets,
+                               title: 'babys first monograph',
+                               edit_users: [user.user_key])
+  end
+
+  let(:listener) { Hyrax::Specs::SpyListener.new }
+  let(:user)     { FactoryBot.create(:user) }
+
+  before do
+    sign_in user
+    Hyrax.publisher.subscribe(listener)
+  end
+
+  after { Hyrax.publisher.unsubscribe(listener) }
+
+  it 'deletes the work' do
+    visit hyrax_monograph_path(work)
+    click_on('Delete', match: :first)
+    expect(page).to have_current_path(hyrax.my_works_path, ignore_query: true)
+    expect(page).to have_content 'Deleted babys first monograph'
+
+    expect { Hyrax.query_service.find_by(id: work.id) }
+      .to raise_error Hyrax::ObjectNotFoundError
+
+    # publishes object.deleted
+    expect(listener.object_deleted&.payload)
+      .to include(id: work.id.to_s, user: user)
+
+    # deletes all members
+    # work.member_ids.each do |file_set_id|
+    #   expect { Hyrax.query_service.find_by(id: file_set_id) }
+    #     .to raise_error Hyrax::ObjectNotFoundError
+    # end
+  end
+end


### PR DESCRIPTION
test that valkyrie work deletion works.

delete the FileSet members when a work is deleted. the actor stack only does this cleanup for FileSet members, not for member works, and doesn't perform any authorization. 

related to #4585.

@samvera/hyrax-code-reviewers
