### PR TITLE
cleanup trophies for valkyrie works

### DIFF
--- a/app/services/hyrax/listeners.rb
+++ b/app/services/hyrax/listeners.rb
@@ -17,6 +17,7 @@ module Hyrax
     autoload :MetadataIndexListener
     autoload :ObjectLifecycleListener
     autoload :ProxyDepositListener
+    autoload :TrophyCleanupListener
     autoload :WorkflowListener
   end
 end

--- a/app/services/hyrax/listeners/trophy_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/trophy_cleanup_listener.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Listens for object deleted events and cleans up associated members
+    class TrophyCleanupListener
+      def on_object_deleted(event)
+        Trophy.where(work_id: event[:id]).destroy_all
+      rescue StandardError => err
+        Hyrax.logger.warn "Failed to delete trophies for #{event[:id]}. " \
+                          'These trophies might be orphaned.' \
+                          "\n\t#{err.message}"
+      end
+    end
+  end
+end

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -8,6 +8,7 @@ Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleNotificationListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ProxyDepositListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::TrophyCleanupListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::WorkflowListener.new)
 
 # Publish events from old style Hyrax::Callbacks to trigger the listeners

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -203,6 +203,16 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
         expect(flash[:notice]).to include work.title.first
       end
+
+      context 'with trophies' do
+        before { 3.times { Trophy.create(work_id: work.id) } }
+
+        it 'deletes the trophies' do
+          delete :destroy, params: { id: work.id }
+
+          expect(Trophy.where(work_id: work.id.to_s)).to be_empty
+        end
+      end
     end
   end
 


### PR DESCRIPTION
add trophy cleanup when valkyrie works are deleted.

this listener code will likely also cleanly replace the existing trophy cleanup
actor stack behavior, with less risk of unwanted/unimportant errors.

we should consider deprecating the actor stack version in favor of this.

@samvera/hyrax-code-reviewers
