### PR TITLE
use a button for FS actions when only download action is available

### DIFF
--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,4 +1,13 @@
 <% if (can?(:download, file_set.id) || can?(:destroy, file_set.id) || can?(:edit, file_set.id)) && !workflow_restriction?(file_set.parent) %>
+  <% if can?(:download, file_set.id) && !(can?(:edit, file_set.id) || can?(:destroy, file_set.id)) %>
+  <%= link_to t('.download'),
+              hyrax.download_path(file_set),
+              class: 'btn btn-default btn-sm',
+              title: t('.download_title', file_set: file_set),
+              target: "_blank",
+              id: "file_download",
+              data: { label: file_set.id } %>
+  <% else %>
   <div class="btn-group">
     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
       <span class="sr-only"><%= t('.press_to') %> </span>
@@ -40,4 +49,5 @@
 
     </ul>
   </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
don't display a dropdown for filesets in the common case where the only action
is a download button.

closes #147.

reaching way back into the vault, here.

Guidance for testing:
  * create a public new work, with a file/fileset
  * log out
  * browse to the work
  * scroll to the file display at the bottom of the work show page
  * confirm that there is a "dowload" button, not a dropdown with only one option.

@samvera/hyrax-code-reviewers


![button](https://user-images.githubusercontent.com/1361776/112440035-11ed8b80-8d07-11eb-85f7-1c82ceeaaacf.png)
