### PR TITLE
add logging/warnings when we don't know how to propagate visibility

### DIFF
--- a/app/services/hyrax/visibility_propagator.rb
+++ b/app/services/hyrax/visibility_propagator.rb
@@ -2,7 +2,7 @@
 module Hyrax
   ##
   # @abstract Propagates visibility from a provided object (e.g. a Work) to some
-  # group of its members (e.g. file_sets).
+  #   group of its members (e.g. file_sets).
   class VisibilityPropagator
     ##
     # @param source [#visibility] the object to propagate visibility from
@@ -14,6 +14,35 @@ module Hyrax
         FileSetVisibilityPropagator.new(source: source)
       when Hyrax::Resource # Valkyrie
         ResourceVisibilityPropagator.new(source: source)
+      else
+        NullVisibilityPropogator.new(source: source)
+      end
+    end
+
+    ##
+    # Provides a null/logging implementation of the visibility propogator.
+    class NullVisibilityPropogator
+      ##
+      # @!attribute [rw] source
+      #   @return [#visibility]
+      attr_accessor :source
+
+      ##
+      # @param source [#visibility] the object to propagate visibility from
+      def initialize(source:)
+        self.source = source
+      end
+
+      ##
+      # @return [void]
+      # @raise [RuntimeError] if we're in development mode
+      def propogate
+        message =  "Tried to propogate visibility to members of #{source} " \
+                   "but didn't know what kind of object it is. Model " \
+                   "name #{source.try(:model_name)}. Called from #{caller[0]}."
+
+        Hyrax.logger.warn(message)
+        Rails.env.development? ? raise(message) : :noop
       end
     end
   end


### PR DESCRIPTION
in a follow-up to #4516, it became clear that in some cases objects that are
neither `WorkBehavior` nor `Hyrax::Resource` are being passed to the visibility
propagator.

when, and what kinds of objects? this should help us find out.

@samvera/hyrax-code-reviewers
