### PR TITLE
use valkyrie to handle branding storage

### DIFF
--- a/config/initializers/valkryrie_storage.rb
+++ b/config/initializers/valkryrie_storage.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Valkyrie::StorageAdapter.register(
+  Valkyrie::Storage::Disk.new(base_path: Hyrax.config.branding_path,
+                              path_generator: Hyrax::ValkyrieSimplePathGenerator),
+  :branding_disk
+)

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -386,6 +386,18 @@ module Hyrax
     # @!group Valkyrie
 
     ##
+    # @return [Valkyrie::StorageAdapter]
+    def branding_storage_adapter
+      @branding_storage_adapter ||= Valkyrie::StorageAdapter.find(:branding_disk)
+    end
+
+    ##
+    # @param [#to_sym] adapter
+    def branding_storage_adapter=(adapter)
+      @branding_storage_adapter = Valkyrie::StorageAdapter.find(adapter.to_sym)
+    end
+
+    ##
     # @return [#save, #save_all, #delete, #wipe!] an indexing adapter
     def index_adapter
       @index_adapter ||= Valkyrie::IndexingAdapter.find(:null_index)

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -31,6 +31,7 @@ module Hyrax
     require 'hyrax/search_state'
     require 'hyrax/transactions'
     require 'hyrax/errors'
+    require 'hyrax/valkyrie_simple_path_generator'
 
     # Force these models to be added to Legato's registry in development mode
     config.eager_load_paths += %W[

--- a/lib/hyrax/valkyrie_simple_path_generator.rb
+++ b/lib/hyrax/valkyrie_simple_path_generator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # Provide "simple", paths for the valkyrie disk storage adapter.
+  #
+  # By default, Valkyrie does bucketed/pairtree style paths. Since some of our
+  # older on-disk file storage does not do this, we need this to provide
+  # backward compatibility.
+  class ValkyrieSimplePathGenerator
+    attr_reader :base_path
+
+    def initialize(base_path:)
+      @base_path = base_path
+    end
+
+    def generate(resource:, file:, original_filename:) # rubocop:disable Lint/UnusedMethodArgument
+      Pathname.new(base_path).join(resource.id, original_filename)
+    end
+  end
+end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -257,83 +257,68 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
     end
 
     context "updating a collections branding metadata" do
+      let(:uploaded) { FactoryBot.create(:uploaded_file) }
+
       it "saves banner metadata" do
-        val = double("/public/banner.gif")
-        allow(val).to receive(:file_url).and_return("/public/banner.gif")
-        allow(Hyrax::UploadedFile).to receive(:find).with(["1"]).and_return([val])
+        put :update, params: { id: collection, banner_files: [uploaded.id], collection: { creator: ['Emily'] }, update_collection: true }
 
-        allow(File).to receive(:split).with(any_args).and_return(["banner.gif"])
-        allow(FileUtils).to receive(:cp).with(any_args).and_return(nil)
-
-        put :update, params: { id: collection, banner_files: [1], collection: { creator: ['Emily'] }, update_collection: true }
-        collection.reload
-        expect(CollectionBrandingInfo.where(collection_id: collection.id, role: "banner").where("local_path LIKE '%banner.gif'")).to exist
+        expect(CollectionBrandingInfo
+                 .where(collection_id: collection.id, role: "banner")
+                 .where("local_path LIKE '%#{uploaded.file.filename}'"))
+          .to exist
       end
 
       it "don't save banner metadata" do
-        val = double("/public/banner.gif")
-        allow(val).to receive(:file_url).and_return("/public/banner.gif")
-        allow(Hyrax::UploadedFile).to receive(:find).with(["1"]).and_return([val])
-
-        allow(File).to receive(:split).with(any_args).and_return(["banner.gif"])
-        allow(FileUtils).to receive(:cp).with(any_args).and_return(nil)
-
-        put :update, params: { id: collection, banner_files: [1], collection: { creator: ['Emily'] } }
-        collection.reload
-        expect(CollectionBrandingInfo.where(collection_id: collection.id, role: "banner").where("local_path LIKE '%banner.gif'")).not_to exist
+        put :update, params: { id: collection, banner_files: [uploaded.id], collection: { creator: ['Emily'] } }
+        expect(CollectionBrandingInfo
+                 .where(collection_id: collection.id, role: "banner")
+                 .where("local_path LIKE '%#{uploaded.file.filename}'"))
+          .not_to exist
       end
 
       it "saves logo metadata" do
-        val = double(["/public/logo.gif"])
-        allow(val).to receive(:file_url).and_return("/public/logo.gif")
-        allow(Hyrax::UploadedFile).to receive(:find).with("1").and_return(val)
+        put :update, params: { id: collection,
+                               logo_files: [uploaded.id],
+                               alttext: ["Logo alt Text"],
+                               linkurl: ["http://abc.com"],
+                               collection: { creator: ['Emily'] },
+                               update_collection: true }
 
-        allow(File).to receive(:split).with(any_args).and_return(["logo.gif"])
-        allow(FileUtils).to receive(:cp).with(any_args).and_return(nil)
-
-        put :update, params: { id: collection, logo_files: [1], alttext: ["Logo alt Text"], linkurl: ["http://abc.com"], collection: { creator: ['Emily'] }, update_collection: true }
-        collection.reload
-
-        expect(CollectionBrandingInfo.where(collection_id: collection.id, role: "logo", alt_text: "Logo alt Text", target_url: "http://abc.com").where("local_path LIKE '%logo.gif'")).to exist
+        expect(CollectionBrandingInfo
+                 .where(collection_id: collection.id, role: "logo", alt_text: "Logo alt Text", target_url: "http://abc.com")
+                 .where("local_path LIKE '%#{uploaded.file.filename}'"))
+          .to exist
       end
 
       context 'where the linkurl is not a valid http|http link' do
+        let(:uploaded) { FactoryBot.create(:uploaded_file) }
+
         it "does not save linkurl containing html; target_url is empty" do
-          val = double(["/public/logo.gif"])
-          allow(val).to receive(:file_url).and_return("/public/logo.gif")
-          allow(Hyrax::UploadedFile).to receive(:find).with("1").and_return(val)
-
-          allow(File).to receive(:split).with(any_args).and_return(["logo.gif"])
-          allow(FileUtils).to receive(:cp).with(any_args).and_return(nil)
-
-          put :update, params: { id: collection, logo_files: [1], alttext: ["Logo alt Text"], linkurl: ["<script>remove_me</script>"], collection: { creator: ['Emily'] }, update_collection: true }
-          collection.reload
+          put :update, params: { id: collection,
+                                 logo_files: [uploaded.id],
+                                 alttext: ["Logo alt Text"], linkurl: ["<script>remove_me</script>"],
+                                 collection: { creator: ['Emily'] },
+                                 update_collection: true }
 
           expect(
             CollectionBrandingInfo.where(
               collection_id: collection.id,
-              role: "logo",
-              alt_text: "Logo alt Text",
               target_url: "<script>remove_me</script>"
             ).where("target_url LIKE '%remove_me%)'")
           ).not_to exist
         end
 
         it "does not save linkurl containing dodgy protocol; target_url is empty" do
-          val = double(["/public/logo.gif"])
-          allow(val).to receive(:file_url).and_return("/public/logo.gif")
-          allow(Hyrax::UploadedFile).to receive(:find).with("1").and_return(val)
+          put :update, params: { id: collection,
+                                 logo_files: [uploaded.id],
+                                 alttext: ["Logo alt Text"],
+                                 linkurl: ['javascript:alert("remove_me")'],
+                                 collection: { creator: ['Emily'] },
+                                 update_collection: true }
 
-          allow(File).to receive(:split).with(any_args).and_return(["logo.gif"])
-          allow(FileUtils).to receive(:cp).with(any_args).and_return(nil)
-
-          put :update, params: { id: collection, logo_files: [1], alttext: ["Logo alt Text"], linkurl: ['javascript:alert("remove_me")'], collection: { creator: ['Emily'] }, update_collection: true }
-          collection.reload
           expect(
             CollectionBrandingInfo.where(
               collection_id: collection.id,
-              role: "logo",
-              alt_text: "Logo alt Text",
               target_url: 'javascript:alert("remove_me")'
             ).where("target_url LIKE '%remove_me%)'")
           ).not_to exist

--- a/spec/models/collection_branding_info_spec.rb
+++ b/spec/models/collection_branding_info_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe CollectionBrandingInfo, type: :model do
+  let(:storage_adapter) { Hyrax.config.branding_storage_adapter }
+
   let(:banner_info) do
     described_class.new(
       collection_id: "123",
@@ -20,13 +22,11 @@ RSpec.describe CollectionBrandingInfo, type: :model do
     )
   end
 
-  describe "save banner and logo info" do
+  let(:file) { Tempfile.new('my_branding.jpg') }
+
+  describe '#save' do
     it "saves the banner info, copy banner to public area, and remove it from temp area" do
-      expect(FileUtils).to receive(:mkdir_p).with(banner_info.find_local_dir_name('123', 'banner')).and_return("/public/123/banner/")
-      expect(FileUtils).to receive(:cp).with('/tmp/12/34/56', banner_info.find_local_dir_name('123', 'banner') + "/banner.gif")
-      expect(FileUtils).to receive(:remove_file).with('/tmp/12/34/56')
-      expect(File).to receive(:exist?).and_return(true)
-      banner_info.save("/tmp/12/34/56")
+      banner_info.save(file.path)
 
       expect(banner_info.local_path).to eq(banner_info.find_local_dir_name('123', 'banner') + "/banner.gif")
       expect(banner_info.alt_text).to eq("banner alt txt")
@@ -34,11 +34,7 @@ RSpec.describe CollectionBrandingInfo, type: :model do
     end
 
     it "saves the logo info, copy logo to public area, and remove it from temp area" do
-      expect(FileUtils).to receive(:mkdir_p).with(logo_info.find_local_dir_name('123', 'logo')).and_return("/public/123/logo/")
-      expect(FileUtils).to receive(:cp).with('/tmp/12/34/56', logo_info.find_local_dir_name('123', 'logo') + "/logo.gif")
-      expect(FileUtils).to receive(:remove_file).with('/tmp/12/34/56')
-      expect(File).to receive(:exist?).and_return(true)
-      logo_info.save("/tmp/12/34/56")
+      logo_info.save(file.path)
 
       expect(logo_info.local_path).to eq(logo_info.find_local_dir_name('123', 'logo') + "/logo.gif")
       expect(logo_info.alt_text).to eq("This is the logo")
@@ -46,17 +42,21 @@ RSpec.describe CollectionBrandingInfo, type: :model do
     end
   end
 
-  describe "remove banner and log files from the public directroy" do
+  describe '#delete' do
     it "removes banner file from public directory" do
-      expect(FileUtils).to receive(:remove_file).with(banner_info.find_local_dir_name('123', 'banner') + "/banner.gif")
-      expect(File).to receive(:exist?).and_return(true)
+      banner_info.save(file.path)
       banner_info.delete(banner_info.find_local_dir_name('123', 'banner') + "/banner.gif")
+
+      expect { storage_adapter.find_by(id: banner_info.local_path) }
+        .to raise_error Valkyrie::StorageAdapter::FileNotFound
     end
 
     it "removes logo file from public directory" do
-      expect(FileUtils).to receive(:remove_file).with(logo_info.find_local_dir_name('123', 'logo') + "/logo.gif")
-      expect(File).to receive(:exist?).and_return(true)
+      logo_info.save(file.path)
       logo_info.delete(logo_info.find_local_dir_name('123', 'logo') + "/logo.gif")
+
+      expect { storage_adapter.find_by(id: logo_info.local_path) }
+        .to raise_error Valkyrie::StorageAdapter::FileNotFound
     end
   end
 end


### PR DESCRIPTION
drop direct file and fileutils calls for storage of collection branding
images. use valkyrie instead.

because valkyrie's disk storage adapter defaults to pair tree style paths, we
need a custom path handler to ensure branding files are stored in the same place
as before.

@samvera/hyrax-code-reviewers
