### PR TITLE
display real alt text for banners in the form

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -82,9 +82,10 @@ module Hyrax
           # Find Banner filename
           banner_info = CollectionBrandingInfo.where(collection_id: id).where(role: "banner")
           banner_file = File.split(banner_info.first.local_path).last unless banner_info.empty?
+          alttext = banner_info.first.alt_text unless banner_info.empty?
           file_location = banner_info.first.local_path unless banner_info.empty?
           relative_path = "/" + banner_info.first.local_path.split("/")[-4..-1].join("/") unless banner_info.empty?
-          { file: banner_file, full_path: file_location, relative_path: relative_path }
+          { file: banner_file, full_path: file_location, relative_path: relative_path, alttext: alttext }
         end
       end
 

--- a/app/views/hyrax/dashboard/collections/_form_branding.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_branding.html.erb
@@ -60,7 +60,7 @@
             <div class="banner-image">
               <i><%= image_tag(f.object.banner_info[:relative_path],
                                size: "800x100",
-                               alt: "Unable to display banner: #{f.object.banner_info[:file]}") %></i>
+                               alt: f.object.banner_info[:alttext].presence || f.object.banner_info[:file]) %></i>
             </div>
             <% end %>
           </div> <!-- end banner -->


### PR DESCRIPTION
it's really not okay for the alt text to read "unable to display". the
activerecord object stores alt text, so display it if its present, otherwise use
the filename.

@samvera/hyrax-code-reviewers
