### PR TITLE
refactor CollectionPresenter branding logic to simplify

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -69,10 +69,8 @@ module Hyrax
       end
 
       def show
-        if @collection.collection_type.brandable?
-          banner_info = CollectionBrandingInfo.where(collection_id: @collection.id.to_s).where(role: "banner")
-          @banner_file = "/" + banner_info.first.local_path.split("/")[-4..-1].join("/") unless banner_info.empty?
-        end
+        # @todo: remove this unused assignment in 4.0.0
+        @banner_file = presenter.banner_file if @collection.collection_type.brandable?
 
         presenter
         query_collection_members

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -119,25 +119,21 @@ module Hyrax
       Hyrax::Engine.routes.url_helpers.dashboard_collection_path(id, locale: I18n.locale)
     end
 
+    ##
+    # @return [#to_s, nil] a download path for the banner file
     def banner_file
-      # Find Banner filename
-      ci = CollectionBrandingInfo.where(collection_id: id, role: "banner")
-      "/" + ci[0].local_path.split("/")[-4..-1].join("/") unless ci.empty?
+      banner = CollectionBrandingInfo.find_by(collection_id: id, role: "banner")
+      "/" + banner.local_path.split("/")[-4..-1].join("/") if banner
     end
 
     def logo_record
-      logo_info = []
-      # Find Logo filename, alttext, linktext
-      cis = CollectionBrandingInfo.where(collection_id: id, role: "logo")
-      return if cis.empty?
-      cis.each do |coll_info|
-        logo_file = File.split(coll_info.local_path).last
-        file_location = "/" + coll_info.local_path.split("/")[-4..-1].join("/") unless logo_file.empty?
-        alttext = coll_info.alt_text
-        linkurl = coll_info.target_url
-        logo_info << { file: logo_file, file_location: file_location, alttext: alttext, linkurl: linkurl }
+      CollectionBrandingInfo.where(collection_id: id, role: "logo")
+                            .select(:local_path, :alt_text, :target_url).map do |logo|
+        { alttext: logo.alt_text,
+          file: File.split(logo.local_path).last,
+          file_location: "/#{logo.local_path.split('/')[-4..-1].join('/')}",
+          linkurl: logo.target_url }
       end
-      logo_info
     end
 
     # A presenter for selecting a work type to create

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -3,7 +3,7 @@
   <div class="row hyc-header">
     <div class="col-md-12">
 
-      <% unless @presenter.banner_file.blank? %>
+      <% if @presenter.banner_file.present? %>
           <div class="hyc-banner" style="background-image:url(<%= @presenter.banner_file %>)">
       <% else %>
           <div class="hyc-generic">

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -353,18 +353,15 @@ RSpec.describe Hyrax::CollectionPresenter do
       )
     end
 
-    before do
-      allow(CollectionBrandingInfo).to receive(:where).with(collection_id: '123', role: 'banner').and_return([banner_info])
-      allow(banner_info).to receive(:local_path).and_return("/temp/public/branding/123/banner/banner.gif")
-      allow(CollectionBrandingInfo).to receive(:where).with(collection_id: '123', role: 'logo').and_return([logo_info])
-      allow(logo_info).to receive(:local_path).and_return("/temp/public/branding/123/logo/logo.gif")
-    end
-
     it "banner check" do
+      tempfile = Tempfile.new('my_file')
+      banner_info.save(tempfile.path)
       expect(presenter.banner_file).to eq("/branding/123/banner/banner.gif")
     end
 
     it "logo check" do
+      tempfile = Tempfile.new('my_file')
+      logo_info.save(tempfile.path)
       expect(presenter.logo_record).to eq([{ file: "logo.gif", file_location: "/branding/123/logo/logo.gif", alttext: "This is the logo", linkurl: "http://logo.com" }])
     end
   end


### PR DESCRIPTION
the `CollectionPresenter` had unduly complicated branding logic. squash it down
into something simpler.

our real goal here is to get rid of the `local_path.split('/')...` logic, to
allow these branding files to be served even if the static file isn't on disk at
every server instance: e.g. by allowing content to be served from a public S3
bucket. for now, this is just a straight refactor to get a grip on some
complicated logic.

@samvera/hyrax-code-reviewers
