### PR TITLE
drop shx from .dassie

### DIFF
--- a/.dassie/package.json
+++ b/.dassie/package.json
@@ -8,10 +8,8 @@
 "scripts": {
   "preinstall": "rm -rf ./public/uv",
   "postinstall": "yarn run uv-install && yarn run uv-config",
-  "uv-install": "shx cp -r ./node_modules/universalviewer/dist ./public/uv",
-  "uv-config": "shx cp ./config/uv/uv.html ./public/uv/uv.html & shx cp ./config/uv/uv-config.json ./public/uv/"
+  "uv-install": "cp -r ./node_modules/universalviewer/dist ./public/uv",
+  "uv-config": "cp ./config/uv/uv.html ./public/uv/uv.html & cp ./config/uv/uv-config.json ./public/uv/"
   },
-  "devDependencies": {
-  "shx": "^0.3.2"
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
`shx` wasn't working in the alpine images; so much for portability(?). since it's not needed in that context, it's fine to just exclude it from `.dassie`.

should we also do this in the generator? or is `shx` providing a lot of value there?

@samvera/hyrax-code-reviewers
