### PR TITLE
Wrap riiif initializer in a Reloader

### DIFF
--- a/.dassie/config/initializers/riiif.rb
+++ b/.dassie/config/initializers/riiif.rb
@@ -1,27 +1,29 @@
 # frozen_string_literal: true
-Riiif::Image.file_resolver = Riiif::HttpFileResolver.new
-Riiif::Image.info_service = lambda do |id, _file|
-  # id will look like a path to a pcdm:file
-  # (e.g. rv042t299%2Ffiles%2F6d71677a-4f80-42f1-ae58-ed1063fd79c7)
-  # but we just want the id for the FileSet it's attached to.
+ActiveSupport::Reloader.to_prepare do
+  Riiif::Image.file_resolver = Riiif::HttpFileResolver.new
+  Riiif::Image.info_service = lambda do |id, _file|
+    # id will look like a path to a pcdm:file
+    # (e.g. rv042t299%2Ffiles%2F6d71677a-4f80-42f1-ae58-ed1063fd79c7)
+    # but we just want the id for the FileSet it's attached to.
 
-  # Capture everything before the first slash
-  fs_id = id.sub(/\A([^\/]*)\/.*/, '\1')
-  resp = Hyrax::SolrService.get("id:#{fs_id}")
-  doc = resp['response']['docs'].first
-  raise "Unable to find solr document with id:#{fs_id}" unless doc
-  { height: doc['height_is'], width: doc['width_is'], format: doc['mime_type_ssi'], channels: doc['alpha_channels_ssi'] }
-end
-
-Riiif::Image.file_resolver.id_to_uri = lambda do |id|
-  Hyrax::Base.id_to_uri(CGI.unescape(id)).tap do |url|
-    Rails.logger.info "Riiif resolved #{id} to #{url}"
+    # Capture everything before the first slash
+    fs_id = id.sub(/\A([^\/]*)\/.*/, '\1')
+    resp = Hyrax::SolrService.get("id:#{fs_id}")
+    doc = resp['response']['docs'].first
+    raise "Unable to find solr document with id:#{fs_id}" unless doc
+    { height: doc['height_is'], width: doc['width_is'], format: doc['mime_type_ssi'], channels: doc['alpha_channels_ssi'] }
   end
+
+  Riiif::Image.file_resolver.id_to_uri = lambda do |id|
+    Hyrax::Base.id_to_uri(CGI.unescape(id)).tap do |url|
+      Rails.logger.info "Riiif resolved #{id} to #{url}"
+    end
+  end
+
+  Riiif::Image.authorization_service = Hyrax::IIIFAuthorizationService
+
+  Riiif.not_found_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
+  Riiif.unauthorized_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
+
+  Riiif::Engine.config.cache_duration = 365.days
 end
-
-Riiif::Image.authorization_service = Hyrax::IIIFAuthorizationService
-
-Riiif.not_found_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
-Riiif.unauthorized_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
-
-Riiif::Engine.config.cache_duration = 365.days

--- a/lib/generators/hyrax/templates/config/initializers/riiif.rb
+++ b/lib/generators/hyrax/templates/config/initializers/riiif.rb
@@ -1,27 +1,29 @@
 # frozen_string_literal: true
-Riiif::Image.file_resolver = Riiif::HttpFileResolver.new
-Riiif::Image.info_service = lambda do |id, _file|
-  # id will look like a path to a pcdm:file
-  # (e.g. rv042t299%2Ffiles%2F6d71677a-4f80-42f1-ae58-ed1063fd79c7)
-  # but we just want the id for the FileSet it's attached to.
+ActiveSupport::Reloader.to_prepare do
+  Riiif::Image.file_resolver = Riiif::HttpFileResolver.new
+  Riiif::Image.info_service = lambda do |id, _file|
+    # id will look like a path to a pcdm:file
+    # (e.g. rv042t299%2Ffiles%2F6d71677a-4f80-42f1-ae58-ed1063fd79c7)
+    # but we just want the id for the FileSet it's attached to.
 
-  # Capture everything before the first slash
-  fs_id = id.sub(/\A([^\/]*)\/.*/, '\1')
-  resp = Hyrax::SolrService.get("id:#{fs_id}")
-  doc = resp['response']['docs'].first
-  raise "Unable to find solr document with id:#{fs_id}" unless doc
-  { height: doc['height_is'], width: doc['width_is'], format: doc['mime_type_ssi'], channels: doc['alpha_channels_ssi'] }
-end
-
-Riiif::Image.file_resolver.id_to_uri = lambda do |id|
-  Hyrax::Base.id_to_uri(CGI.unescape(id)).tap do |url|
-    Rails.logger.info "Riiif resolved #{id} to #{url}"
+    # Capture everything before the first slash
+    fs_id = id.sub(/\A([^\/]*)\/.*/, '\1')
+    resp = Hyrax::SolrService.get("id:#{fs_id}")
+    doc = resp['response']['docs'].first
+    raise "Unable to find solr document with id:#{fs_id}" unless doc
+    { height: doc['height_is'], width: doc['width_is'], format: doc['mime_type_ssi'], channels: doc['alpha_channels_ssi'] }
   end
+
+  Riiif::Image.file_resolver.id_to_uri = lambda do |id|
+    Hyrax::Base.id_to_uri(CGI.unescape(id)).tap do |url|
+      Rails.logger.info "Riiif resolved #{id} to #{url}"
+    end
+  end
+
+  Riiif::Image.authorization_service = Hyrax::IIIFAuthorizationService
+
+  Riiif.not_found_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
+  Riiif.unauthorized_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
+
+  Riiif::Engine.config.cache_duration = 365.days
 end
-
-Riiif::Image.authorization_service = Hyrax::IIIFAuthorizationService
-
-Riiif.not_found_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
-Riiif.unauthorized_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
-
-Riiif::Engine.config.cache_duration = 365.days


### PR DESCRIPTION
The configuration contained in an application's `config/initializers/riiif.rb` will (sometimes?) be lost at runtime in development mode causing an incorrect file_resolver to be used when requesting an image via riiif. This will explicitly reload that initializer when the application is reloading code.

Suggested in https://github.com/curationexperts/riiif/issues/119

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Working IIIF image requests in dassie.
* Should have no effect in production.

@samvera/hyrax-code-reviewers
