### PR TITLE
chart: allow an existing PVC to be used to host the web application

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -174,3 +174,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "hyrax.redis.url" -}}
 {{- printf "redis://:%s@%s:%s" .Values.redis.password (include "hyrax.redis.host" .) "6379/0" -}}
 {{- end -}}
+
+{{- define "hyrax.sharedPvcAccessModes" -}}
+{{- if .Values.worker.enabled }}
+accessModes:
+  - ReadWriteMany
+{{- else }}
+accessModes:
+  - ReadWriteOnce
+{{- end }}
+{{- end -}}

--- a/chart/hyrax/templates/branding-pvc.yaml
+++ b/chart/hyrax/templates/branding-pvc.yaml
@@ -6,8 +6,7 @@ metadata:
   labels:
     {{- include "hyrax.labels" . | nindent 4 }}
 spec:
-  accessModes:
-    - ReadWriteMany
+  {{ include "hyrax.sharedPvcAccessModes" . | nindent 2 }}
   resources:
     requests:
       storage: {{ .Values.brandingVolume.size }}

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.worker.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,6 +55,10 @@ spec:
             - name: uploads
               subPath: uploads
               mountPath: /app/samvera/uploads
+            {{- if .Values.applicationExistingClaim }}
+            - name: application
+              mountPath: /app/samvera/hyrax-webapp
+            {{- end }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
       volumes:
@@ -77,7 +82,11 @@ spec:
           {{ else }}
           emptyDir: {}
           {{ end }}
-
+        {{- if .Values.applicationExistingClaim }}
+        - name: "application"
+          persistentVolumeClaim:
+            claimName: {{ .Values.applicationExistingClaim }}
+        {{- end }}
       {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -90,3 +99,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -106,6 +106,10 @@ spec:
             - name: uploads
               subPath: uploads
               mountPath: /app/samvera/uploads
+            {{- if .Values.applicationExistingClaim }}
+            - name: application
+              mountPath: /app/samvera/hyrax-webapp
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -139,6 +143,11 @@ spec:
           {{ else }}
           emptyDir: {}
           {{ end }}
+        {{- if .Values.applicationExistingClaim }}
+        - name: "application"
+          persistentVolumeClaim:
+            claimName: {{ .Values.applicationExistingClaim }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/hyrax/templates/derivatives-pvc.yaml
+++ b/chart/hyrax/templates/derivatives-pvc.yaml
@@ -6,8 +6,7 @@ metadata:
   labels:
     {{- include "hyrax.labels" . | nindent 4 }}
 spec:
-  accessModes:
-    - ReadWriteMany
+  {{ include "hyrax.sharedPvcAccessModes" . | nindent 2 }}
   resources:
     requests:
       storage: {{ .Values.derivativesVolume.size }}

--- a/chart/hyrax/templates/uploads-pvc.yaml
+++ b/chart/hyrax/templates/uploads-pvc.yaml
@@ -6,8 +6,7 @@ metadata:
   labels:
     {{- include "hyrax.labels" . | nindent 4 }}
 spec:
-  accessModes:
-    - ReadWriteMany
+  {{ include "hyrax.sharedPvcAccessModes" . | nindent 2 }}
   resources:
     requests:
       storage: {{ .Values.uploadsVolume.size }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -19,20 +19,27 @@ externalSolrUser: ""
 externalSolrPassword: ""
 externalSolrCollection: "hyrax"
 
+# an existing volume containing a Hyrax-based application
+# must be a ReadWriteMany volume if worker is enabled
+applicationExistingClaim: ""
+
 brandingVolume:
   enabled: true
+  # the name of an existing volume claim; must be an ReadWriteMany volume
   existingClaim: ""
   size: 2Gi
   storageClass: ""
 
 derivativesVolume:
   enabled: true
+  # the name of an existing volume claim; must be an ReadWriteMany volume
   existingClaim: ""
   size: 10Gi
   storageClass: ""
 
 uploadsVolume:
   enabled: true
+  # the name of an existing volume claim; must be an ReadWriteMany volume
   existingClaim: ""
   size: 20Gi
   storageClass: ""
@@ -117,6 +124,7 @@ readinessProbe:
 resources: {}
 
 worker:
+  enabled: true
   replicaCount: 3
   image:
     repository: samveralabs/dassie-worker


### PR DESCRIPTION
this is useful in the case that an adopter would like to deploy without building an image that already contains the application. users can create a PVC with their application code, and mount the volume to the `hyrax-webapp` directory.

@samvera/hyrax-code-reviewers
