### PR TITLE
don't break on UrlHelper load if models aren't ActiveModel conformant

### DIFF
--- a/app/helpers/hyrax/url_helper.rb
+++ b/app/helpers/hyrax/url_helper.rb
@@ -4,7 +4,10 @@ module Hyrax
     # generated models get registered as curation concerns and need a
     # track_model_path to render Blacklight-related views
     (['FileSet', 'Collection'] + Hyrax.config.registered_curation_concern_types).each do |concern|
-      define_method("track_#{concern.constantize.model_name.singular_route_key}_path") { |*args| main_app.track_solr_document_path(*args) }
+      model = concern.safe_constantize
+      model_name = model.respond_to?(:model_name) && model.model_name
+      next unless model_name
+      define_method("track_#{model_name.singular_route_key}_path") { |*args| main_app.track_solr_document_path(*args) }
     end
   end
 end


### PR DESCRIPTION
not all possible `registered_curation_concern_types` (or `FileSet`s or
`Collection`s) have a model name. likewise, `registered_curation_concern_types`
contains strings, which might not be constantizable by mistake. if the rest of
the application works under these conditions, just skip defining track paths.

note that this module is eagerly loaded and run (only in production, for usual
app configurations!) even if it's not included anywhere in the downstream
application. this is a bad time to break someone's app on startup over code they
didn't load themselves.

@samvera/hyrax-code-reviewers
