### PR TITLE
Fix solr_home dir in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       - "-c"
       - "precreate-core hyrax_test /opt/solr/server/configsets/hyraxconf; precreate-core hyrax-valkyrie-test /opt/solr/server/configsets/hyraxconf; solr-precreate hyrax /opt/solr/server/configsets/hyraxconf"
     volumes:
-      - solr_home:/opt/solr/server/solr
+      - solr_home:/var/solr/data:cached
       - .dassie/solr/conf:/opt/solr/server/configsets/hyraxconf
 
 volumes:


### PR DESCRIPTION
Fixes the solr_home docker volume mount location that changed in solr 8.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Dassie's solr index is not lost when restarting the docker-compose stack.

@samvera/hyrax-code-reviewers
