### PR TITLE
Add seeded admin user to admin role

### DIFF
--- a/.dassie/config/role_map.yml
+++ b/.dassie/config/role_map.yml
@@ -1,4 +1,6 @@
 development:
+  admin:
+    - admin@example.com
   archivist:
     - archivist1@example.com
 


### PR DESCRIPTION
A user (admin@example.com) is currently created in dassie when running db:seed, but does not actually have the admin role. This PR makes them an admin out of the box.

Changes proposed in this pull request:
* Add admin@example.com to admin role

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* In dev dassie, Admin dashboard is available to the generated admin user.

@samvera/hyrax-code-reviewers
