### PR TITLE
chart: support extra volumes/mounts evaluated as a template

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -59,6 +59,9 @@ spec:
             - name: application
               mountPath: /app/samvera/hyrax-webapp
             {{- end }}
+            {{- with .Values.worker.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
       volumes:
@@ -86,6 +89,9 @@ spec:
         - name: "application"
           persistentVolumeClaim:
             claimName: {{ .Values.applicationExistingClaim }}
+        {{- end }}
+        {{- with .Values.worker.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.worker.nodeSelector }}
       nodeSelector:

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -110,6 +110,9 @@ spec:
             - name: application
               mountPath: /app/samvera/hyrax-webapp
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -147,6 +150,9 @@ spec:
         - name: "application"
           persistentVolumeClaim:
             claimName: {{ .Values.applicationExistingClaim }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -44,6 +44,19 @@ uploadsVolume:
   size: 20Gi
   storageClass: ""
 
+# additional volumes and volume mounts, evaluated as a template, e.g.
+#
+#  extraVolumeMounts
+#    - name: local-app
+#      mountPath: /app/samvera/hyrax-webapp
+#  extraVolumes:
+#    - name: local-app
+#      hostPath:
+#        path: /src
+#        type: DirectoryOrCreate
+extraVolumeMounts: []
+extraVolumes: []
+
 # configuration for an external/existing fcrepo service;
 #   ignored if `fcrepo.enabled` is true
 externalFcrepoHost: ""
@@ -130,6 +143,8 @@ worker:
     repository: samveralabs/dassie-worker
     pullPolicy: IfNotPresent
     tag: ""
+  extraVolumeMounts: []
+  extraVolumes: []
   imagePullSecrets: []
   podSecurityContext: {}
   nodeSelector: {}


### PR DESCRIPTION
in the case a particular application needs to add/mount extra volumes, these
values provide a hook for it to do so both on the rails application deployments,
and on the worker pods.

@samvera/hyrax-code-reviewers
