### PR TITLE
chart: support extra ENV variables

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -28,6 +28,8 @@ spec:
                 name: {{ include "hyrax.fullname" . }}-env
             - secretRef:
                 name: {{ template "hyrax.fullname" . }}
+          env:
+            {{- toYaml .Values.worker.extraEnvVars | nindent 12 }}
           command:
             - sh
             - -c
@@ -46,6 +48,8 @@ spec:
                 name: {{ include "hyrax.fullname" . }}-env
             - secretRef:
                 name: {{ template "hyrax.fullname" . }}
+          env:
+            {{- toYaml .Values.worker.extraEnvVars | nindent 12 }}
           volumeMounts:
             - name: derivatives
               mountPath: /app/samvera/derivatives

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
                 name: {{ include "hyrax.fullname" . }}-env
             - secretRef:
                 name: {{ include "hyrax.fullname" . }}
+          env:
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
           command:
             - sh
             - -c
@@ -45,6 +47,8 @@ spec:
                 name: {{ include "hyrax.fullname" . }}-env
             - secretRef:
                 name: {{ template "hyrax.fullname" . }}
+          env:
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
           command:
             - sh
             - -c
@@ -67,6 +71,8 @@ spec:
                 name: {{ include "hyrax.fullname" . }}-env
             - secretRef:
                 name: {{ template "hyrax.fullname" . }}
+          env:
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
           ports:
             - name: http
               containerPort: 3000

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -19,6 +19,15 @@ externalSolrUser: ""
 externalSolrPassword: ""
 externalSolrCollection: "hyrax"
 
+# additional environment variables, evaluated as a template. e.g.
+#
+#  extraEnvVars:
+#    - name: RAILS_SERVE_STATIC_FILES
+#      value: "1"
+#    - name: GOOGLE_OAUTH_APP_NAME
+#      value: "my_hyrax_app"
+extraEnvVars: []
+
 # an existing volume containing a Hyrax-based application
 # must be a ReadWriteMany volume if worker is enabled
 applicationExistingClaim: ""


### PR DESCRIPTION
applications will want to pass in arbitrary environment variables to support
their local configuration. this provides a hook to do that extensibly with a
variable evaluated as a template.

we should probably support a secret version of this,
too (i.e. `.Values.existingSecretEnvVars` or some such).


@samvera/hyrax-code-reviewers
