### PR TITLE
don't have a hard dependency on Wings in Hyrax::ResourceName

### DIFF
--- a/lib/hyrax/resource_name.rb
+++ b/lib/hyrax/resource_name.rb
@@ -7,6 +7,7 @@ module Hyrax
   class ResourceName < Name
     def initialize(klass, namespace = nil, name = nil)
       super
+      return unless defined?(Wings::ModelRegistry)
 
       legacy_model = Wings::ModelRegistry.lookup(klass)
       return unless legacy_model


### PR DESCRIPTION
`ResourceName` provides name resolution in the case of registered Wings legacy
models, but it shouldn't have a hard coded dependency on Wings.

@samvera/hyrax-code-reviewers
