### PR TITLE
docker: fix entrypoint script for sh

### DIFF
--- a/bin/hyrax-entrypoint.sh
+++ b/bin/hyrax-entrypoint.sh
@@ -5,14 +5,14 @@ set -e
 chown -fR app:app /app/samvera/hyrax-webapp/tmp
 chown -fR app:app /app/samvera/hyrax-webapp/public
 
-if [ -v HYRAX_DERIVITIVES_PATH ]; then
-  mkdir -p $HYRAX_DERIVITIVES_PATH
-  chown -f -R app:app $HYRAX_DERIVATIVES_PATH
+if [ -n "${HYRAX_DERIVITIVES_PATH+x}" ]; then
+  mkdir -p "${HYRAX_DERIVITIVES_PATH}"
+  chown -f -R app:app "${HYRAX_DERIVATIVES_PATH}"
 fi
 
-if [ -v HYRAX_UPLOAD_PATH ]; then
-  mkdir -p $HYRAX_UPLOAD_PATH
-  chown -f -R app:app $HYRAX_UPLOAD_PATH
+if [ -n "${HYRAX_UPLOAD_PATH+x}" ]; then
+  mkdir -p "${HYRAX_UPLOAD_PATH}"
+  chown -f -R app:app "${HYRAX_UPLOAD_PATH}"
 fi
 
 mkdir -p /app/samvera/hyrax-webapp/tmp/pids


### PR DESCRIPTION
see
```
In POSIX sh, unary -v (in place of [ -n "${var+x}" ]) is undefined. [SC2039]
```

@samvera/hyrax-code-reviewers
