### PR TITLE
Allow Hyrax Helm chart to disable fcrepo

### DIFF
--- a/.dassie/db/seeds.rb
+++ b/.dassie/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-Hyrax::Engine.load_seed
+Hyrax::Engine.load_seed unless ActiveModel::Type::Boolean.new.cast(ENV["SKIP_HYRAX_ENGINE_SEED"])
 
 puts "\n== Loading users"
 User.where(email: 'admin@example.com').first_or_create do |f|

--- a/bin/db-migrate-seed.sh
+++ b/bin/db-migrate-seed.sh
@@ -5,7 +5,9 @@ db-wait.sh "$DB_HOST:$DB_PORT"
 bundle exec rails db:create
 bundle exec rails db:migrate
 
-db-wait.sh "$FCREPO_HOST:$FCREPO_PORT"
+if [ "$FCREPO_HOST" ]; then
+  db-wait.sh "$FCREPO_HOST:$FCREPO_PORT"
+fi
 db-wait.sh "$SOLR_HOST:$SOLR_PORT"
 
 bundle exec rails db:seed

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.8.1
+version: 0.8.2
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/README.md
+++ b/chart/hyrax/README.md
@@ -43,6 +43,7 @@ The chart populates the following environment variables:
 | FCREPO_HOST       | Fedora Commons host            | n/a                    |
 | FCREPO_PORT       | Fedora Commons port            | n/a                    |
 | FCREPO_REST_PATH  | Fedora Commons REST endpoint   | n/a                    |
+| SKIP_HYRAX_ENGINE_SEED   | Flag to load Hyrax engine seed file | n/a                    |
 | SOLR_ADMIN_USER   | Solr user for basic auth       | n/a                    |
 | SOLR_ADMIN_PASSWORD | Solr password for basic auth | n/a                    |
 | SOLR_COLLECTION_NAME | The name of the solr collection to use | n/a         |

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -24,11 +24,14 @@ data:
   {{- if .Values.redis.enabled }}
   REDIS_HOST: {{ template "hyrax.redis.host" . }}
   {{- end }}
+  {{- if .Values.fcrepo.enabled }}
   FCREPO_BASE_PATH: {{ .Values.fcrepoBasePathOverride | default (printf "/%s" (include "hyrax.fullname" .)) | quote }}
   FCREPO_HOST: {{ template "hyrax.fcrepo.host" . }}
   FCREPO_PORT: {{ .Values.fcrepo.servicePort | default 8080 | quote }}
   FCREPO_REST_PATH: {{ .Values.fcrepo.restPath | default "rest" }}
+  {{- end }}
   REDIS_PROVIDER: SIDEKIQ_REDIS_URL
+  SKIP_HYRAX_ENGINE_SEED: {{  .Values.skipHyraxEngineSeed | default 0 }}
   SOLR_ADMIN_USER: {{ template "hyrax.solr.username" . }}
   SOLR_ADMIN_PASSWORD: {{ template "hyrax.solr.password" . }}
   SOLR_COLLECTION_NAME: {{ template "hyrax.solr.collectionName" . }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -10,6 +10,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# use true to skip loading Hyrax engine database seed file
+skipHyraxEngineSeed: false
+
 # use false to skip the configset management init container
 loadSolrConfigSet: true
 # the host and auth details for an external solr service;


### PR DESCRIPTION
This adds support in the Hyrax helm chart to disable an `fcrepo` chart dependency installation.

Changes proposed in this pull request:
* Add gate around looking for fedora in the `db-seed-migrate.sh` script used in
	the chart's `initContainer`
* Add a new environment variable, disabled by default, to determine whether to
	load the Hyrax engine seed file.
* Add gate around defining fedora env vars in the Chart ConfigMap for
	environment variables.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* `docker build --target hyrax-engine-dev --tag k3d-registry.localhost:41906/dassie:nofedora .`
* `docker push k3d-registry.localhost:41906/dassie:nofedora`
* `helm upgrade --timeout 30m0s --atomic --install --namespace=hyrax-nofedora
--values=hyrax.yaml dassie chart/hyrax`

Values of `hyrax.yaml` were:

```yaml
image:
  repository: k3d-registry.localhost:41906/dassie
  tag: "nofedora"
ingress:
  enabled: false
brandingVolume:
  enabled: false
derivativesVolume:
  enabled: false
uploadsVolume:
  enabled: false
fcrepo:
  enabled: false
loadSolrConfigSet: false
solr:
  enabled: true
livenessProbe:
  enabled: false
readinessProbe:
  enabled: false
worker:
  enabled: false
```

Screenshot of deployment with the values/settings as described above:

![image](https://user-images.githubusercontent.com/67506/113900303-87833e00-9782-11eb-8ab2-8dd0ceb49b18.png)


@samvera/hyrax-code-reviewers
