### PR TITLE
Quote SKIP_HYRAX_ENGINE_SEED as it may be a bool

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.8.2
+version: 0.8.3
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -31,7 +31,7 @@ data:
   FCREPO_REST_PATH: {{ .Values.fcrepo.restPath | default "rest" }}
   {{- end }}
   REDIS_PROVIDER: SIDEKIQ_REDIS_URL
-  SKIP_HYRAX_ENGINE_SEED: {{  .Values.skipHyraxEngineSeed | default 0 }}
+  SKIP_HYRAX_ENGINE_SEED: {{  .Values.skipHyraxEngineSeed | default 0 | quote }}
   SOLR_ADMIN_USER: {{ template "hyrax.solr.username" . }}
   SOLR_ADMIN_PASSWORD: {{ template "hyrax.solr.password" . }}
   SOLR_COLLECTION_NAME: {{ template "hyrax.solr.collectionName" . }}


### PR DESCRIPTION
Environment variables in k8s have to ultimately be coerced into strings.
And this is not done automatically for integers and boolean values.

Without this, an error results parsing the ConfigMap when a value of
`true` or `false` (or their variants) is passed to skipHyraxEngineSeed.

```sh
Error: release dassie failed, and has been uninstalled due to atomic being set: ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects " or n, but found t, error found in #10 byte of ...|NE_SEED":true,"SOLR_|..., bigger context ...|ER":"SIDEKIQ_REDIS_URL","SKIP_HYRAX_ENGINE_SEED":true,"SOLR_ADMIN_PASSWORD":"admin","SOLR_ADMIN_USER|...
```

@samvera/hyrax-code-reviewers
