### PR TITLE
Use db-worker-wait.sh in chart worker template

### DIFF
--- a/bin/db-worker-wait.sh
+++ b/bin/db-worker-wait.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+db-wait.sh "$DB_HOST:$DB_PORT"
+if [ "$FCREPO_HOST" ]; then
+  db-wait.sh "$FCREPO_HOST:$FCREPO_PORT"
+fi
+db-wait.sh "$SOLR_HOST:$SOLR_PORT"

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.8.3
+version: 0.8.4
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -33,9 +33,7 @@ spec:
           command:
             - sh
             - -c
-            - db-wait.sh "$DB_HOST:$DB_PORT"
-            - db-wait.sh "$FCREPO_HOST:$FCREPO_PORT"
-            - db-wait.sh "$SOLR_HOST:$SOLR_PORT"
+            - db-worker-wait.sh
       serviceAccountName: {{ include "hyrax.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}


### PR DESCRIPTION
This allows us to optionally skip Fedora waiting.

Changes proposed in this pull request:
* Rely on a new `db-worker-wait.sh` script in worker template initContainer rather than individual call to the `db-wait.sh` script

@samvera/hyrax-code-reviewers
