### PR TITLE
Wait for redis in Chart worker initContainer

### DIFF
--- a/bin/db-worker-wait.sh
+++ b/bin/db-worker-wait.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -e
-
-db-wait.sh "$DB_HOST:$DB_PORT"
-if [ "$FCREPO_HOST" ]; then
-  db-wait.sh "$FCREPO_HOST:$FCREPO_PORT"
-fi
-db-wait.sh "$SOLR_HOST:$SOLR_PORT"

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -33,7 +33,7 @@ spec:
           command:
             - sh
             - -c
-            - db-worker-wait.sh
+            - db-wait.sh "$REDIS_HOST:6379"
       serviceAccountName: {{ include "hyrax.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}


### PR DESCRIPTION
The only database the sidekiq worker really needs to wait on is redis.

Note: I did not change the Chart version since this ultimately does a better job
of doing what my previous PR implemented. So we can publish that chart version
if/when we're happy with this alternative.

Screenshot:
db-wait container successfully waiting on redis:
![image](https://user-images.githubusercontent.com/67506/114075045-eebff180-9859-11eb-95c8-3f414ae776bd.png)

worker pod with a successful db-wait initContainer and a running sidekiq worker container:
![image](https://user-images.githubusercontent.com/67506/114075209-275fcb00-985a-11eb-998c-aa6fc61de6c0.png)


Changes proposed in this pull request:
* Remove the script to check solr and the database before starting the worker container
* Replace with a specific check against redis

@samvera/hyrax-code-reviewers
