### PR TITLE
Wait until Solr auth is on before uploading config

### DIFF
--- a/bin/solrcloud-upload-configset.sh
+++ b/bin/solrcloud-upload-configset.sh
@@ -15,13 +15,18 @@ solr_config_upload_url="http://$SOLR_HOST:$SOLR_PORT/solr/admin/configs?action=U
 while [ $COUNTER -lt 30 ]; do
   echo "-- Looking for Solr (${SOLR_HOST}:${SOLR_PORT})..."
   if nc -z "${SOLR_HOST}" "${SOLR_PORT}"; then
-    if curl --silent $solr_user_settings "$solr_config_list_url" | grep -q "$SOLR_CONFIGSET_NAME"; then
-      echo "-- ConfigSet already exists; skipping creation ...";
-    else
-      echo "-- ConfigSet for ${CONFDIR} does not exist; creating ..."
-      (cd "$CONFDIR" && zip -r - *) | curl -X POST $solr_user_settings --header "Content-Type:application/octet-stream" --data-binary @- "$solr_config_upload_url"
+    # shellcheck disable=SC2143,SC2086
+    if curl --silent --user 'fake:fake' "$solr_config_list_url" | grep -q '401'; then
+      # the solr pods come up and report available before they are ready to accept trusted configs
+      # only try to upload the config if auth is on.
+      if curl --silent $solr_user_settings "$solr_config_list_url" | grep -q "$SOLR_CONFIGSET_NAME"; then
+        echo "-- ConfigSet already exists; skipping creation ...";
+      else
+        echo "-- ConfigSet for ${CONFDIR} does not exist; creating ..."
+        (cd "$CONFDIR" && zip -r - *) | curl -X POST $solr_user_settings --header "Content-Type:application/octet-stream" --data-binary @- "$solr_config_upload_url"
+      fi
+      exit
     fi
-    exit
   fi
   COUNTER=$(( COUNTER+1 ));
   sleep 5s


### PR DESCRIPTION
This is a race/timing issue that can happen intermittently. Adding the
check for a `401` response has proved to address this in local projects.

Changes proposed in this pull request:
* Add an additional check before trying to upload the solr configset to ensure
	that auth is enabled/available

@samvera/hyrax-code-reviewers
