### PR TITLE
chart: add environment variables/secret for the db username and pass

### DIFF
--- a/chart/hyrax/README.md
+++ b/chart/hyrax/README.md
@@ -30,11 +30,12 @@ production environments.
 
 The chart populates the following environment variables:
 
-|-------------------|--------------------------------|------------------------|
 | Variable          | Description                    | Condition              |
 |-------------------|--------------------------------|------------------------|
-| DB_HOST           | Postgresql hostname            | `postgresql.enabled`   |
-| DB_PORT           | Postgresql service port        | `postgresql.enabled`   |
+| DB_PASSWORD       | Postgresql password            | n/a                    |
+| DB_PORT           | Postgresql service port        | n/a                    |
+| DB_HOST           | Postgresql hostname            | n/a                    |
+| DB_USERNAME       | Postgresql username            | n/a                    |
 | MEMCACHED_HOST    | Memcached host                 | `memcached.enabled`    |
 | RACK_ENV          | app environment ('production') | n/a                    |
 | RAILS_ENV         | app environment ('production') | n/a                    |
@@ -51,7 +52,6 @@ The chart populates the following environment variables:
 | SOLR_HOST         | Solr service host              | n/a                    |
 | SOLR_PORT         | Solr service port              | n/a                    |
 | SOLR_URL          | Solr service full URL          | n/a                    |
-|----------------- -|--------------------------------|------------------------|
 
 ## With an external SolrCloud
 

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -10,6 +10,7 @@ metadata:
 data:
   DB_HOST: {{ template "hyrax.postgresql.host" . }}
   DB_PORT: "5432"
+  DB_USERNAME: {{ template "hyrax.postgresql.database" . }}
   {{- if .Values.memcached.enabled }}
   MEMCACHED_HOST: {{ template "hyrax.memcached.fullname" . }}
   {{- end }}

--- a/chart/hyrax/templates/secrets.yaml
+++ b/chart/hyrax/templates/secrets.yaml
@@ -7,7 +7,7 @@ metadata:
 type: Opaque
 data:
   SECRET_KEY_BASE: {{ randAlphaNum 20 | b64enc | quote }}
-  DATABASE_PASSWORD: {{ include "hyrax.postgresql.password" . | b64enc }}
+  DB_PASSWORD: {{ include "hyrax.postgresql.password" . | b64enc }}
   DATABASE_URL: {{ printf "postgresql://%s:%s@%s/%s?pool=5" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) | b64enc }}
   {{- if .Values.redis.enabled }}
   REDIS_PASSWORD: {{ .Values.redis.password | b64enc}}

--- a/chart/hyrax/templates/secrets.yaml
+++ b/chart/hyrax/templates/secrets.yaml
@@ -7,6 +7,7 @@ metadata:
 type: Opaque
 data:
   SECRET_KEY_BASE: {{ randAlphaNum 20 | b64enc | quote }}
+  DATABASE_PASSWORD: {{ include "hyrax.postgresql.password" . | b64enc }}
   DATABASE_URL: {{ printf "postgresql://%s:%s@%s/%s?pool=5" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) | b64enc }}
   {{- if .Values.redis.enabled }}
   REDIS_PASSWORD: {{ .Values.redis.password | b64enc}}


### PR DESCRIPTION
in the case that an application wants to connect to the postgresql instance
outside the database configured with `DATABASE_URL` it's handy to have these
values. all this information is already exposed to the application via the
`DATABASE_URL` secret entry, so passing this along shouldn't have any security
implications.

@samvera/hyrax-code-reviewers
