### PR TITLE
Support dynamic initContainers in Helm chart

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.8.5
+version: 0.9.0
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -20,6 +20,9 @@ spec:
         {{- include "hyrax.selectorLabels" . | nindent 8 }}
     spec:
       initContainers:
+        {{- if .Values.worker.extraInitContainers }}
+        {{- toYaml .Values.worker.extraInitContainers | nindent 8 }}
+        {{- end }}
         - name: db-wait
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         {{- include "hyrax.selectorLabels" . | nindent 8 }}
     spec:
       initContainers:
+        {{- if .Values.extraInitContainers }}
+        {{- toYaml .Values.extraInitContainers | nindent 8 }}
+        {{- end }}
         {{- if .Values.loadSolrConfigSet }}
         - name: load-solr-config
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -31,6 +31,16 @@ externalSolrCollection: "hyrax"
 #      value: "my_hyrax_app"
 extraEnvVars: []
 
+## Extra init containers
+## Example
+##
+## extraInitContainers:
+##   - name: do-something
+##     image: busybox
+##     command: ['echo', 'Hello, Hyrax.']
+##
+extraInitContainers: []
+
 # an existing volume containing a Hyrax-based application
 # must be a ReadWriteMany volume if worker is enabled
 applicationExistingClaim: ""
@@ -155,6 +165,7 @@ worker:
     repository: samveralabs/dassie-worker
     pullPolicy: IfNotPresent
     tag: ""
+  extraInitContainers: []
   extraVolumeMounts: []
   extraVolumes: []
   imagePullSecrets: []


### PR DESCRIPTION
For both the main application deployment as well as the worker
deployment, this adds the capability for downstream chart users to
include their own initContainers.

A use case for this might be waiting on an additional database not
natively monitored by the chart, but is required to be up and running
for the application to start.

Screenshot of a sample deployment using an `extraInitContainer` in both deployments:

Main app:

![image](https://user-images.githubusercontent.com/67506/114241049-674bae80-993d-11eb-9766-c688f72d6b6a.png)

Worker:

![image](https://user-images.githubusercontent.com/67506/114241114-834f5000-993d-11eb-8ecc-48382f654da5.png)

`values.yaml` used in the deployment referenced above:

```yaml
extraInitContainers:
  - name: hyrax-extra-init
	image: busybox
	command: ["echo", "hello hyrax"]
ingress:
  enabled: false
brandingVolume:
  enabled: false
derivativesVolume:
  enabled: false
uploadsVolume:
  enabled: false
fcrepo:
  enabled: false
loadSolrConfigSet: false
skipHyraxEngineSeed: "yes"
solr:
  enabled: true
livenessProbe:
  enabled: false
readinessProbe:
  enabled: false
worker:
  enabled: true
  replicaCount: 1
  image:
	tag: 3.0.1
  extraInitContainers:
	- name: hyrax-extra-init
	  image: busybox
	  command: ["echo", "hello hyrax worker"]
```


Changes proposed in this pull request:
* Add an `extraInitContainers` option for both the application and worker
	deployments
* Bump Chart version to take this change into account

@samvera/hyrax-code-reviewers
