### PR TITLE
chart: add an optional minio

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo
@@ -13,6 +13,10 @@ dependencies:
     version: 4.2.21
     repository: https://charts.bitnami.com/bitnami
     condition: memcached.enabled
+  - name: minio
+    version: 6.7.2
+    repository: https://charts.bitnami.com/bitnami
+    condition: minio.enabled
   - name: postgresql
     version: 10.3.13
     repository: https://charts.bitnami.com/bitnami

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -188,6 +188,15 @@ fcrepo:
 memcached:
   enabled: false
 
+minio:
+  enabled: false
+  accessKey:
+    password: hyrax-access-key
+  secretKey:
+    password: hyrax-secret-key
+  persistence:
+    enabled: false
+
 postgresql:
   enabled: true
   image:


### PR DESCRIPTION
deploying Minio provides for S3-compatible object storage. this is useful for
development and disposable applications, where using a persistent bucket might
not be the best idea. it also provides some additional flexibility in
production.

@samvera/hyrax-code-reviewers
