### PR TITLE
chart: teach PVCs to use specified storageclasses

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/branding-pvc.yaml
+++ b/chart/hyrax/templates/branding-pvc.yaml
@@ -10,4 +10,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.brandingVolume.size }}
+  storageClassName: {{ .Values.brandingVolume.storageClass }}
 {{- end }}

--- a/chart/hyrax/templates/derivatives-pvc.yaml
+++ b/chart/hyrax/templates/derivatives-pvc.yaml
@@ -10,4 +10,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.derivativesVolume.size }}
+  storageClassName: {{ .Values.derivativesVolume.storageClass }}
 {{- end }}

--- a/chart/hyrax/templates/uploads-pvc.yaml
+++ b/chart/hyrax/templates/uploads-pvc.yaml
@@ -10,4 +10,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.uploadsVolume.size }}
+  storageClassName: {{ .Values.uploadsVolume.storageClass }}
 {{- end }}


### PR DESCRIPTION
Currently any `storageClass` specified is ignored by the PVC

@samvera/hyrax-code-reviewers
