### PR TITLE
Use Ingress apiVersion 1 for Helm Chart

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.10.2
+version: 0.11.0
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/ingress.yaml
+++ b/chart/hyrax/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "hyrax.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,10 +28,13 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -135,7 +135,9 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: hyrax.local
-      paths: []
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls: []
 
 livenessProbe:


### PR DESCRIPTION
Changes proposed in this pull request:
* Update chart version to `0.11.0`
* Upgrade the `ingress.yaml` template to use the `apiVersion` `1`. And update
	configuration accordingly.

Potential Concerns:
* Deployments on clusters with older versions of k8s could break on this change. We could be more conservative and wrap some conditionals into the `ingress.yaml` template around k8s versions. I'm starting with this proposal, as I don't _think_ there are many deployments of the chart in the wild (yet).

I tested with the following configuration:
```yaml
ingress:
  enabled: true
  hosts:
    - host: hyrax.k3d.localhost
      paths:
       - path: /
```

![image](https://user-images.githubusercontent.com/67506/114940383-9f983480-9df6-11eb-9d9e-1ee18b8629af.png)


@samvera/hyrax-code-reviewers
