### PR TITLE
chart: use OCI published chart for fcrepo

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.11.0
+version: 0.12.0
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo
-    version: 0.6.0
-    repository: https://samvera-labs.github.com/fcrepo-charts
+    version: 0.6.1
+    repository: oci://ghcr.io/samvera
     condition: fcrepo.enabled
   - name: memcached
     version: 4.2.21


### PR DESCRIPTION
we've been getting 404 errors from the fcrepo chart, causing trouble on
builds. since Samvera is now publishing charts to the GitHub OCI registry, maybe
we want to just use that?

the tricky thing is that OCI support is "experimental" and requires
`HELM_EXPERIMENTAL_OCI=1` to be set in the environment.

@samvera/hyrax-code-reviewers
