### PR TITLE
chart: move solr admin password to Secrets! support existing secrets

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.12.0
+version: 0.13.0
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -34,7 +34,6 @@ data:
   REDIS_PROVIDER: SIDEKIQ_REDIS_URL
   SKIP_HYRAX_ENGINE_SEED: {{  .Values.skipHyraxEngineSeed | default 0 | quote }}
   SOLR_ADMIN_USER: {{ template "hyrax.solr.username" . }}
-  SOLR_ADMIN_PASSWORD: {{ template "hyrax.solr.password" . }}
   SOLR_COLLECTION_NAME: {{ template "hyrax.solr.collectionName" . }}
   SOLR_CONFIGSET_NAME: {{ template "hyrax.fullname" . }}
   SOLR_HOST: {{ template "hyrax.solr.host" . }}

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -53,6 +53,10 @@ spec:
                 name: {{ include "hyrax.fullname" . }}-env
             - secretRef:
                 name: {{ template "hyrax.fullname" . }}
+            {{- if .Values.solrExistingSecret }}
+            - secretRef:
+                name: {{ include .Values.solrExistingSecret . }}
+            {{- end }}
           env:
             {{- toYaml .Values.worker.extraEnvVars | nindent 12 }}
           volumeMounts:

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
                 name: {{ include "hyrax.fullname" . }}-env
             - secretRef:
                 name: {{ include "hyrax.fullname" . }}
+            {{- if .Values.solrExistingSecret }}
+            - secretRef:
+                name: {{ include .Values.solrExistingSecret . }}
+            {{- end }}
           env:
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
           command:
@@ -50,6 +54,10 @@ spec:
                 name: {{ include "hyrax.fullname" . }}-env
             - secretRef:
                 name: {{ template "hyrax.fullname" . }}
+            {{- if .Values.solrExistingSecret }}
+            - secretRef:
+                name: {{ include .Values.solrExistingSecret . }}
+            {{- end }}
           env:
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
           command:
@@ -74,6 +82,10 @@ spec:
                 name: {{ include "hyrax.fullname" . }}-env
             - secretRef:
                 name: {{ template "hyrax.fullname" . }}
+            {{- if .Values.solrExistingSecret }}
+            - secretRef:
+                name: {{ include .Values.solrExistingSecret . }}
+            {{- end }}
           env:
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
           ports:

--- a/chart/hyrax/templates/secrets.yaml
+++ b/chart/hyrax/templates/secrets.yaml
@@ -9,6 +9,9 @@ data:
   SECRET_KEY_BASE: {{ randAlphaNum 20 | b64enc | quote }}
   DB_PASSWORD: {{ include "hyrax.postgresql.password" . | b64enc }}
   DATABASE_URL: {{ printf "postgresql://%s:%s@%s/%s?pool=5" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) | b64enc }}
+  {{- if not .Values.solrExistingSecret }}
+  SOLR_ADMIN_PASSWORD: {{ include "hyrax.solr.password" . | quote | b64enc }}
+  {{- end }}
   {{- if .Values.redis.enabled }}
   REDIS_PASSWORD: {{ .Values.redis.password | b64enc}}
   SIDEKIQ_REDIS_URL: {{ include "hyrax.redis.url" . | b64enc }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -17,6 +17,7 @@ skipHyraxEngineSeed: false
 loadSolrConfigSet: true
 # the host and auth details for an external solr service;
 #   ignored if `solr.enabled` is true
+solrExistingSecret: ""
 externalSolrHost: ""
 externalSolrUser: ""
 externalSolrPassword: ""


### PR DESCRIPTION
the solr admin password should be a secret!

also support existing secrets. if i want to deliver my secrets by putting them
directly in kubernetes, or having some automated process outside of helm do
this, then i should expect to be able to do that.

@samvera/hyrax-code-reviewers
