### PR TITLE
chart: remove errant quote

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/secrets.yaml
+++ b/chart/hyrax/templates/secrets.yaml
@@ -10,7 +10,7 @@ data:
   DB_PASSWORD: {{ include "hyrax.postgresql.password" . | b64enc }}
   DATABASE_URL: {{ printf "postgresql://%s:%s@%s/%s?pool=5" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) | b64enc }}
   {{- if not .Values.solrExistingSecret }}
-  SOLR_ADMIN_PASSWORD: {{ include "hyrax.solr.password" . | quote | b64enc }}
+  SOLR_ADMIN_PASSWORD: {{ include "hyrax.solr.password" . | b64enc }}
   {{- end }}
   {{- if .Values.redis.enabled }}
   REDIS_PASSWORD: {{ .Values.redis.password | b64enc}}


### PR DESCRIPTION
this quote led to the wrong secret being deployed, e.g. `"admin"` vs `admin`.

@samvera/hyrax-code-reviewers
