### PR TITLE
chart: don't try to evaluate `solrExistingSecret` as a template

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.13.1
+version: 0.13.2
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -55,7 +55,7 @@ spec:
                 name: {{ template "hyrax.fullname" . }}
             {{- if .Values.solrExistingSecret }}
             - secretRef:
-                name: {{ include .Values.solrExistingSecret . }}
+                name: {{ .Values.solrExistingSecret }}
             {{- end }}
           env:
             {{- toYaml .Values.worker.extraEnvVars | nindent 12 }}

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
                 name: {{ include "hyrax.fullname" . }}
             {{- if .Values.solrExistingSecret }}
             - secretRef:
-                name: {{ include .Values.solrExistingSecret . }}
+                name: {{ .Values.solrExistingSecret }}
             {{- end }}
           env:
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
@@ -56,7 +56,7 @@ spec:
                 name: {{ template "hyrax.fullname" . }}
             {{- if .Values.solrExistingSecret }}
             - secretRef:
-                name: {{ include .Values.solrExistingSecret . }}
+                name: {{ .Values.solrExistingSecret }}
             {{- end }}
           env:
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
@@ -84,7 +84,7 @@ spec:
                 name: {{ template "hyrax.fullname" . }}
             {{- if .Values.solrExistingSecret }}
             - secretRef:
-                name: {{ include .Values.solrExistingSecret . }}
+                name: {{ .Values.solrExistingSecret }}
             {{- end }}
           env:
             {{- toYaml .Values.extraEnvVars | nindent 12 }}


### PR DESCRIPTION
fix usage of "solrExistingSecret". this value shouldn't be evaluated as a
template, it can just be interpreted as a straight value.

@samvera/hyrax-code-reviewers
