### PR TITLE
chart: add `extraEnvFrom` to allow extra existing secrets/configmaps

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.13.2
+version: 0.14.0
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -57,6 +57,9 @@ spec:
             - secretRef:
                 name: {{ .Values.solrExistingSecret }}
             {{- end }}
+            {{- with .Values.worker.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             {{- toYaml .Values.worker.extraEnvVars | nindent 12 }}
           volumeMounts:

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
             - secretRef:
                 name: {{ .Values.solrExistingSecret }}
             {{- end }}
+            {{- with .Values.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
           command:
@@ -85,6 +88,9 @@ spec:
             {{- if .Values.solrExistingSecret }}
             - secretRef:
                 name: {{ .Values.solrExistingSecret }}
+            {{- end }}
+            {{- with .Values.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
             {{- toYaml .Values.extraEnvVars | nindent 12 }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -42,6 +42,17 @@ extraEnvVars: []
 ##
 extraInitContainers: []
 
+# Extra envFrom (secrets/configmaps)
+# Example
+#
+# extraEnvFrom:
+#   - configMapRef:
+#       name: existingConfigMap
+#   - secretRef:
+#       name: existingSecret
+#
+extraEnvFrom: []
+
 # an existing volume containing a Hyrax-based application
 # must be a ReadWriteMany volume if worker is enabled
 applicationExistingClaim: ""


### PR DESCRIPTION
add another evaluate-as-template hook for additional secrets & configmaps.

@samvera/hyrax-code-reviewers
