### PR TITLE
allow the SolrCloud assign-configset utility to create collections

### DIFF
--- a/bin/solrcloud-assign-configset.sh
+++ b/bin/solrcloud-assign-configset.sh
@@ -16,6 +16,11 @@ while [ $COUNTER -lt 30 ]; do
       echo $solr_collection_modify_url
       curl $solr_user_settings "$solr_collection_modify_url"
       exit
+    else
+      echo "-- Collection ${SOLR_COLLECTION_NAME} does not exist; creating and setting ${SOLR_CONFIGSET_NAME} ConfigSet ..."
+      solr_collection_create_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=CREATE&name=$SOLR_COLLECTION_NAME&collection.configName=$SOLR_CONFIGSET_NAME&numShards=1"
+      curl $solr_user_settings "$solr_collection_create_url"
+      exit
     fi
   fi
   echo "-- Looking for Solr (${SOLR_HOST}:${SOLR_PORT})..."


### PR DESCRIPTION
many solr images provide an easy way to create an inital collection via the
entrypoint, so this script was originally written with the assumption that the
collection would already exist.

in practice, it's nice to be able to create multiple collections (e.g. to add a
test collection) or to create one that doesn't exist (e.g. because the solrcloud
instance is preexisting and has other collections, but not ours). this work
extends the script to allow creating the collection in the init container if it
doesn't already exist.

this also fixes an issue where the init container would loop and timeout when
the collection is missing. it will now try to create the collection instead.

@samvera/hyrax-code-reviewers
