### PR TITLE
chart: readd support for kubernetes versions before 1.19

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.15.0
+version: 0.16.0
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/ingress.yaml
+++ b/chart/hyrax/templates/ingress.yaml
@@ -1,7 +1,12 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "hyrax.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- $beta := semverCompare "<1.19-0" (default .Capabilities.KubeVersion.Version .Values.kubeVersion) -}}
+{{- if $beta }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -28,13 +33,18 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - path: {{ .path  }}
             pathType: {{ .pathType | default "ImplementationSpecific" }}
             backend:
+              {{- if $beta }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- else }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
support older style ingresses for Kubernetes versions from 1.14 to 1.19.

@samvera/hyrax-code-reviewers
