### PR TITLE
Make dassie sidekiq depend on services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,13 @@ services:
     env_file:
       - .env
       - .dassie/.env
+    depends_on:
+      - db_migrate
+      - fcrepo
+      - memcached
+      - postgres
+      - redis
+      - solr
     volumes:
       - .dassie:/app/samvera/hyrax-webapp:cached
       - .:/app/samvera/hyrax-engine:cached


### PR DESCRIPTION
When starting dassie with `docker-compose up` with empty volumes (perhaps after using `docker-compose down -v`) the sidekiq worker service would fail to come up with permission problems. This seems to be a race condition because starting the sidekiq service again manually works.

Adding some dependent services to the sidekiq service to match what is used by the app service should help address this by delaying its startup. It also makes bringing just the sidekiq service up (without the web server) easier.

This change will only affect dev environments using docker-compose.