### PR TITLE
Gh 4833 depositing a work with past embargo gives no id error

### DIFF
--- a/app/services/hyrax/edit_permissions_service.rb
+++ b/app/services/hyrax/edit_permissions_service.rb
@@ -183,13 +183,7 @@ module Hyrax
     # find all of the collection ids an object is a member of
     # @return [Array] array of collection ids
     def object_member_of_ids
-      @object_member_of_ids ||= begin
-                              belongs_to = []
-                              # get all of work's collection ids from the form
-                              belongs_to += @object.member_of_collection_ids
-                              belongs_to << @object.admin_set_id if @object.admin_set_id.present?
-                              belongs_to
-                            end
+      @object_member_of_ids ||= (@object.member_of_collection_ids + [@object.admin_set_id]).select(&:present?)
     end
 
     # The list of all collections this user has manage rights on

--- a/app/services/hyrax/edit_permissions_service.rb
+++ b/app/services/hyrax/edit_permissions_service.rb
@@ -170,7 +170,7 @@ module Hyrax
     # @todo Refactor code to remove explicit ActiveFedora::Base call (see method implementation for details)
     def object_unauthorized_collection_ids
       @object_unauthorized_collection_ids ||= begin
-                                                limited_access = []
+                                                limited_access_ids = []
                                                 unauthorized_collection_ids = object_member_of_ids - object_managed_collection_ids
                                                 unauthorized_collection_ids.each do |id|
                                                   # TODO: Refactor to remove ActiveFedora::Base
@@ -193,9 +193,9 @@ module Hyrax
                                                   #           object to the collection type); We'd also need to account for AdminSet and
                                                   #           Hyrax::AdministrativeSet.
                                                   collection = ActiveFedora::Base.find(id)
-                                                  limited_access << id if (collection.instance_of? AdminSet) || collection.share_applies_to_new_works?
+                                                  limited_access_ids << id if (collection.instance_of? AdminSet) || collection.share_applies_to_new_works?
                                                 end
-                                                limited_access
+                                                limited_access_ids
                                               end
     end
 

--- a/app/services/hyrax/edit_permissions_service.rb
+++ b/app/services/hyrax/edit_permissions_service.rb
@@ -168,13 +168,11 @@ module Hyrax
       @object_unauthorized_collection_ids ||= begin
                                                 limited_access = []
                                                 unauthorized_collection_ids = object_member_of_ids - object_managed_collection_ids
-                                                if unauthorized_collection_ids.any?
-                                                  unauthorized_collection_ids.each do |id|
-                                                    # TODO: Can we instead use a SOLR query?  This seems to be somewhat expensive.  However, as this is
-                                                    # used in administration instead of user front-end displays, I'm not as concerned.
-                                                    collection = ActiveFedora::Base.find(id)
-                                                    limited_access << id if (collection.instance_of? AdminSet) || collection.share_applies_to_new_works?
-                                                  end
+                                                unauthorized_collection_ids.each do |id|
+                                                  # TODO: Can we instead use a SOLR query?  This seems to be somewhat expensive.  However, as this is
+                                                  # used in administration instead of user front-end displays, I'm not as concerned.
+                                                  collection = ActiveFedora::Base.find(id)
+                                                  limited_access << id if (collection.instance_of? AdminSet) || collection.share_applies_to_new_works?
                                                 end
                                                 limited_access
                                               end

--- a/app/services/hyrax/edit_permissions_service.rb
+++ b/app/services/hyrax/edit_permissions_service.rb
@@ -158,7 +158,7 @@ module Hyrax
     # find all of the work's collections a user can manage
     # @return [Array] of collection ids
     def object_managed_collection_ids
-      @object_managed_collection_ids ||= object_member_of & managed_collection_ids
+      @object_managed_collection_ids ||= object_member_of_ids & managed_collection_ids
     end
 
     # find all of the work's collections a user cannot manage
@@ -167,7 +167,7 @@ module Hyrax
     def object_unauthorized_collection_ids
       @object_unauthorized_collection_ids ||= begin
                                                 limited_access = []
-                                                unauthorized_collection_ids = object_member_of - object_managed_collection_ids
+                                                unauthorized_collection_ids = object_member_of_ids - object_managed_collection_ids
                                                 if unauthorized_collection_ids.any?
                                                   unauthorized_collection_ids.each do |id|
                                                     # TODO: Can we instead use a SOLR query?  This seems to be somewhat expensive.  However, as this is
@@ -182,8 +182,8 @@ module Hyrax
 
     # find all of the collection ids an object is a member of
     # @return [Array] array of collection ids
-    def object_member_of
-      @object_member_of ||= begin
+    def object_member_of_ids
+      @object_member_of_ids ||= begin
                               belongs_to = []
                               # get all of work's collection ids from the form
                               belongs_to += @object.member_of_collection_ids


### PR DESCRIPTION
## Release Notes:

Fixes #4833: Ensures that no exception is raised when giving an embargo date set in the past;  This relates to introducing the improved permission handling from #3166 and how form data is passed in.

## Renaming method to better reflect return value

76c68fb1fdb7950c22985ff7ec02066464f1f9e0

Given that we're working with an array of IDs, I want the private method
name to better reflect the expected behavior.  The previous name ain't
wrong, this just nudges the comprehendability in a slightly better
direction.

## Compacting array building logic

c97c31fc6cbc5393565f03597ef9c848cd65b7d9

This commit serves two purposes:

1) First, and most important, it fixes #4833
2) Second, it unifies the logic for determining the ids

More on 4833 (in case you don't have access to Github)

The observed error is as follows:

> Depositing a work with past embargo gives no id error
>
> Depositing a work with an embargo date in the past gives an "No ID
> provided for ActiveFedora::Base" error.
>
> Expected Behavior: Depositing a work with a past embargo should fail
> to be created and entered information should be preserved

In debugging the application, the `@object.member_of_collection_ids` was
the following: `["", "admin_set/default"]`

That appears to come from the form submitting a select box that has no
selected value (e.g., the `""` value).  I verified this logic change by
UI interaction.

## Removing redundant `.any?` check

696da5dbb1afb128f2d97151e83b91f48e0cb935

The guard of `.any?` prevented us from iterating via the `.each`.  In
the case of an empty Array, this new implementation is logically
equivalent.  And ini the case of a non-empty Array, we're saving a
method invocation.

## Documenting spot to remove ActiveFedora::Base call

657ef7c83ba3b08cc9fc0e9446268876409ee3df

This documentation reflects some of what I worked through when testing
a bug fix for #4833.  My intention is to continue working on this code,
but only after a consultation.

## Renaming local variable for clarity

d2ddfd793cedd7cc6d1254fff802376193ff112c

The variable name is of minor importance, but highlighting that its an
array of IDs helps set expectations (which of course map to the @return
documentation).

## Factoring from ActiveFedora::Base to query_service

22c888138a783f0976ee5fe3356a38aff765e78a

This commit builds on a TODO item and implements the minimum viable
change.  It highlights that there's considerable branching logic, and
this may not be the best place to encode that branching logic.

## Refactoring to extract inner block logic

35af65db1c1370d734c053f91526a69a0fde43d6

This commit appeases two Rubocop violations.  More importantly it
isolates the logic related to a single resource and whether or not it is
something the given user can or cannot manage.
