### PR TITLE
chart: add worker securityContext configuration

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.16.0
+version: 0.17.0
 appVersion: 3.0.1
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -43,9 +43,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "hyrax.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-worker
+          securityContext:
+            {{- toYaml .Values.worker.securityContext | nindent 12 }}
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           envFrom:


### PR DESCRIPTION
adds support for a container securityContext specific to the worker container.

container security context (as opposed to podSecurityContext) is useful for
setting, e.g. linux capabilities.  https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container

@samvera/hyrax-code-reviewers
