### PR TITLE
Ensuring non-parseable date bubbles up to UI

### DIFF
--- a/app/services/hyrax/visibility_intention.rb
+++ b/app/services/hyrax/visibility_intention.rb
@@ -54,7 +54,7 @@ module Hyrax
     ##
     # @return [Boolean]
     def valid_embargo?
-      wants_embargo? && release_date.present?
+      wants_embargo? && release_date.present? && a_valid_date?(release_date)
     end
 
     ##
@@ -66,13 +66,31 @@ module Hyrax
     ##
     # @return [Boolean]
     def valid_lease?
-      wants_lease? && release_date.present?
+      wants_lease? && release_date.present? && a_valid_date?(release_date)
     end
 
     ##
     # @return [Boolean]
     def wants_lease?
       visibility == LEASE_REQUEST
+    end
+
+    private
+
+    ##
+    # @param date [Object]
+    # @return [Boolean]
+    # @note If we don't have a valid date, we really can't have a
+    # valid release_date
+    def a_valid_date?(date)
+      return true if date.is_a?(Date)
+      return true if date.is_a?(Time)
+      Date.parse(date)
+      # In Ruby 2.7.x, Date::Error descends from ArgumentError; Once
+      # we stop supporting pre-2.7, we can switch this to the more
+      # narrow Date::Error
+    rescue ArgumentError
+      false
     end
   end
 end

--- a/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
+++ b/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
@@ -94,6 +94,20 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
           expect(attributes).to eq(visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE)
         end
       end
+
+      context 'when lease_expiration_date is not a parseable date' do
+        let(:attributes) do
+          { visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE,
+            visibility_during_lease: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE,
+            visibility_after_lease: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+            lease_expiration_date: "you can't parse this (as a date)" }
+        end
+
+        it 'sets error on curation_concern and return false' do
+          expect(subject.create(env)).to be false
+          expect(curation_concern.errors[:visibility].first).to eq 'When setting visibility to "lease" you must also specify lease expiration date.'
+        end
+      end
     end
   end
 

--- a/spec/services/hyrax/visibility_intention_spec.rb
+++ b/spec/services/hyrax/visibility_intention_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe Hyrax::VisibilityIntention do
       end
     end
 
+    context 'when an embargo is requested with a release date that is not a date' do
+      let(:attributes) do
+        { visibility: described_class::EMBARGO_REQUEST,
+          release_date: "you can't parse this (as a date)" }
+      end
+
+      it 'raises an error' do
+        expect { intention.embargo_params }.to raise_error ArgumentError
+      end
+    end
+
     context 'when an embargo is requested with valid release date' do
       let(:attributes) do
         { visibility: described_class::EMBARGO_REQUEST, release_date: date }
@@ -54,6 +65,17 @@ RSpec.describe Hyrax::VisibilityIntention do
 
     context 'when an lease is requested with no release date' do
       let(:attributes) { { visibility: described_class::LEASE_REQUEST } }
+
+      it 'raises an error' do
+        expect { intention.lease_params }.to raise_error ArgumentError
+      end
+    end
+
+    context 'when a lease is requested with a release date that is not a date' do
+      let(:attributes) do
+        { visibility: described_class::LEASE_REQUEST,
+          release_date: "you can't parse this (as a date)" }
+      end
 
       it 'raises an error' do
         expect { intention.lease_params }.to raise_error ArgumentError


### PR DESCRIPTION
## Release Notes

Fixes #4757, when creating a work and you enter a non-date string (e.g., "This is Not a Date") into the lease expiration date field, this fix now bubbles up a meaningful error message to the UI.

## Ensuring non-parseable date bubbles up to UI

c689eda6a6804a8c5447f7613589d71aca4fd50e

Prior to this commit, we were not verifying that a user's input for a
release_date was in fact a parseable date.  Chrome and Firefox apply a
date picker "widget" that enforces entries for a `type="date"`.
However, Safari does not.

Closes #4757

Note, to test this in the UI requires a fix for #4833.  That fix, at the
time of crafting this commit message, can be seen at PR #4885.

@samvera/hyrax-code-reviewers
