### PR TITLE
Gh 4845 settinig lease date in past

### DIFF
--- a/app/helpers/hyrax/embargo_helper.rb
+++ b/app/helpers/hyrax/embargo_helper.rb
@@ -25,6 +25,10 @@ module Hyrax
     #   holder until we switch to Valkyrie::ChangeSet instead of Form
     #   objects
     def embargo_enforced?(resource)
+      # This is a guard; from the UI rendering perspective, there's no
+      # active embargo enforcement until the object is saved.
+      return false unless resource.persisted?
+
       case resource
       when Hydra::AccessControls::Embargoable
         !resource.embargo_release_date.nil?

--- a/app/helpers/hyrax/lease_helper.rb
+++ b/app/helpers/hyrax/lease_helper.rb
@@ -25,6 +25,10 @@ module Hyrax
     #   holder until we switch to Valkyrie::ChangeSet instead of Form
     #   objects
     def lease_enforced?(resource)
+      # This is a guard; from the UI rendering perspective, there's no
+      # active lease enforcement until the object is saved.
+      return false unless resource.persisted?
+
       case resource
       when Hydra::AccessControls::Embargoable
         !resource.lease_expiration_date.nil?

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -1,6 +1,6 @@
-<% if embargo_enforced?(f.object) %>
+<% if embargo_enforced?(f.object) && !f.object.new_record? %>
   <%= render 'form_permission_under_embargo', f: f %>
-<% elsif lease_enforced?(f.object) %>
+<% elsif lease_enforced?(f.object) && !f.object.new_record? %>
   <%= render 'form_permission_under_lease', f: f %>
 <% else %>
     <fieldset>

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -1,6 +1,6 @@
-<% if embargo_enforced?(f.object) && !f.object.new_record? %>
+<% if embargo_enforced?(f.object) %>
   <%= render 'form_permission_under_embargo', f: f %>
-<% elsif lease_enforced?(f.object) && !f.object.new_record? %>
+<% elsif lease_enforced?(f.object) %>
   <%= render 'form_permission_under_lease', f: f %>
 <% else %>
     <fieldset>

--- a/app/views/hyrax/base/_form_visibility_error.html.erb
+++ b/app/views/hyrax/base/_form_visibility_error.html.erb
@@ -1,3 +1,5 @@
 <%= f.full_error(:visibility) %>
 <%= f.full_error(:embargo_release_date) %>
 <%= f.full_error(:visibility_after_embargo) %>
+<%= f.full_error(:lease_expiration_date) %>
+<%= f.full_error(:visibility_after_lease) %>

--- a/spec/helpers/hyrax/embargo_helper_spec.rb
+++ b/spec/helpers/hyrax/embargo_helper_spec.rb
@@ -4,6 +4,21 @@ RSpec.describe Hyrax::EmbargoHelper do
   let(:resource) { build(:monograph) }
 
   describe 'embargo_enforced?' do
+    # Including this stub to preserve the spec structure before the #4845 change
+    before { allow(resource).to receive(:persisted?).and_return(true) }
+
+    context 'with a non-persisted object' do
+      let(:resource) { build(:hyrax_work, :under_embargo) }
+
+      before { Hyrax::EmbargoManager.apply_embargo_for!(resource: resource) }
+
+      it 'returns false' do
+        # Note: This spec echoes "embargo_enforced? with a Hyrax::Work when an embargo is enforced on the resource"
+        allow(resource).to receive(:persisted?).and_return false
+        expect(embargo_enforced?(resource)).to be false
+      end
+    end
+
     context 'with a Hyrax::Work' do
       let(:resource) { build(:hyrax_work) }
 
@@ -94,7 +109,8 @@ RSpec.describe Hyrax::EmbargoHelper do
     end
 
     context 'with a HydraEditor::Form' do
-      let(:resource) { Hyrax::GenericWorkForm.new(build(:work), ability, form_controller) }
+      let(:resource) { Hyrax::GenericWorkForm.new(model, ability, form_controller) }
+      let(:model) { build(:work) }
       let(:ability) { :FAKE_ABILITY }
       let(:form_controller) { :FAKE_CONTROLLER }
 
@@ -103,9 +119,12 @@ RSpec.describe Hyrax::EmbargoHelper do
       end
 
       context 'when the wrapped work is under embargo' do
-        let(:resource) { Hyrax::GenericWorkForm.new(build(:embargoed_work), ability, form_controller) }
+        let(:model) { build(:embargoed_work) }
 
         it 'returns true' do
+          # This allow call is a tweak to preserve spec for pre #4845 patch
+          allow(model).to receive(:persisted?).and_return(true)
+
           expect(embargo_enforced?(resource)).to be true
         end
       end
@@ -113,7 +132,8 @@ RSpec.describe Hyrax::EmbargoHelper do
 
     context 'with a Hyrax::Forms::FailedSubmissionFormWrapper' do
       let(:resource) { Hyrax::Forms::FailedSubmissionFormWrapper.new(form: form, input_params: {}, permitted_params: {}) }
-      let(:form) { Hyrax::GenericWorkForm.new(build(:work), ability, form_controller) }
+      let(:form) { Hyrax::GenericWorkForm.new(model, ability, form_controller) }
+      let(:model) { build(:work) }
       let(:ability) { :FAKE_ABILITY }
       let(:form_controller) { :FAKE_CONTROLLER }
 
@@ -122,9 +142,11 @@ RSpec.describe Hyrax::EmbargoHelper do
       end
 
       context 'when the wrapped work is under embargo' do
-        let(:form) { Hyrax::GenericWorkForm.new(build(:embargoed_work), ability, form_controller) }
+        let(:model) { build(:embargoed_work) }
 
         it 'returns true' do
+          # This allow call is a tweak to preserve spec for pre #4845 patch
+          allow(model).to receive(:persisted?).and_return(true)
           expect(embargo_enforced?(resource)).to be true
         end
       end


### PR DESCRIPTION
## Release Notes

Fixes #4845.  This fix adds both a meaningful error message and renders the correct form controls when you enter an invalid lease date.

## Fixing rendering logic for visibility component

e1fd2244d8747deb0365a69a6f34a92fda87fe3a

Fixes #4845

Prior to this fix, if we had a new record that either set an embargo or
a lease, we would narrow our rendering of the visibility component to
only a partial related to the embargo or lease.

```gherkin
Given a form that set an embargo (or release date)
And that form had invalid data
When I submitted the form
Then the response form would inidicate there was invalid data
And would render only the portion of the visibility related to
  embargo (or release date if set)
```

With this change, the form renders the entire visibility component,
letting the user change their visibility options (e.g., go from with
Lease to Public or what have you).  However, the error messaging is not
providing insight into the problem; That is to say there's a red flash
error, but the content is empty; and there is no indicator on the lease
field that there existed an error.  This warrants further work, and will
be a commit that builds on this change.

## Adding rendering of lease related error messages

9511dce400382a9d17c92465d71e2645c40af0a5

Prior to this commit, the `form_visibility_error` partial did not
include the errors for the `:lease_expiration_date` nor the
`:visibility_after_lease`.  Per convention of Hyrax, we place the error
messages on the form and not in close DOM proximity to the HTML field
in which we encountered the error.

This relates to #4845

## Adjusting lease/embargo_enforced helper logic

adb14ecf08747d3a16d4fb9cacb7c70f0db30128

This reflects moving the change from e1fd2244d — "Fixing rendering logic
for visibility component" into the helper method.  This suggestion comes
from [no_reply's review comment][1], and makes sense.  I don't think we
want to push the logic further down the stack, as there's a case
statement that would add complexity, as well as it may have unintended
consequences.  The change at this level (e.g., a helper method) makes it
more clear that this is for rendering UI components.

Related to #4845.

[1]:https://github.com/samvera/hyrax/pull/4889/files#r625466486

@samvera/hyrax-repo-managers 
