### PR TITLE
remove chowns from image entrypoint

### DIFF
--- a/bin/hyrax-entrypoint.sh
+++ b/bin/hyrax-entrypoint.sh
@@ -1,20 +1,6 @@
 #!/bin/sh
 set -e
 
-# Make sure common volume points have the app permission
-chown -fR app:app /app/samvera/hyrax-webapp/tmp
-chown -fR app:app /app/samvera/hyrax-webapp/public
-
-if [ -n "${HYRAX_DERIVITIVES_PATH+x}" ]; then
-  mkdir -p "${HYRAX_DERIVITIVES_PATH}"
-  chown -f -R app:app "${HYRAX_DERIVATIVES_PATH}"
-fi
-
-if [ -n "${HYRAX_UPLOAD_PATH+x}" ]; then
-  mkdir -p "${HYRAX_UPLOAD_PATH}"
-  chown -f -R app:app "${HYRAX_UPLOAD_PATH}"
-fi
-
 mkdir -p /app/samvera/hyrax-webapp/tmp/pids
 rm -f /app/samvera/hyrax-webapp/tmp/pids/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       target: hyrax-engine-dev
       args:
         - EXTRA_APK_PACKAGES=git less
-    image: hyrax-engine-dev
+    image: ghcr.io/samvera/dassie
     stdin_open: true
     tty: true
     user: root
@@ -46,7 +46,7 @@ services:
       - "5959:5900"
 
   db_migrate:
-    image: hyrax-engine-dev
+    image: ghcr.io/samvera/dassie
     user: root
     env_file:
       - .env
@@ -74,7 +74,7 @@ services:
       - db:/var/lib/postgresql/data
 
   fcrepo:
-    image: samvera/fcrepo4:4.7.5
+    image: ghcr.io/samvera/fcrepo4:4.7.5
     volumes:
       - fcrepo:/data:cached
     ports:
@@ -94,6 +94,7 @@ services:
     build:
       context: .
       target: hyrax-engine-dev-worker
+    image: ghcr.io/samvera/dassie-worker
     env_file:
       - .env
       - .dassie/.env


### PR DESCRIPTION
these `chown` calls seemed useful to ensure that mounted volumes come in with
the correct permissions. they don't really work out in practice. deployment
platforms have their own mechanisms for setting volume permissions at mount
time. it's best to use them.

@samvera/hyrax-code-reviewers
