### PR TITLE
Gh 3175 sharing tab hidden

### DIFF
--- a/app/presenters/hyrax/admin_set_options_presenter.rb
+++ b/app/presenters/hyrax/admin_set_options_presenter.rb
@@ -4,8 +4,9 @@ module Hyrax
   class AdminSetOptionsPresenter
     ##
     # @param [Hyrax::AdminSetService] service
-    def initialize(service)
+    def initialize(service, current_ability: service.context.current_ability)
       @service = service
+      @current_ability = current_ability
     end
 
     # Return AdminSet selectbox options based on access type
@@ -49,6 +50,17 @@ module Hyrax
 
     # Does the workflow for the currently selected permission template allow sharing?
     def sharing?(permission_template:)
+      # This short-circuit builds on a stated "promise" in the UI of
+      # editing an admin set:
+      #
+      # > Managers of this administrative set can edit the set
+      # > metadata, participants, and release and visibility
+      # > settings. Managers can also edit work metadata, add to or
+      # > remove files from a work, and add new works to the set.
+      return true if @current_ability.can?(:manage, permission_template)
+
+      # Otherwise, we check if the workflow was setup, active, and
+      # allows_access_grants.
       wf = workflow(permission_template: permission_template)
       return false unless wf
       wf.allows_access_grant?

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -4,7 +4,7 @@
     <div class="panel panel-default tabs" role="main">
       <!-- Nav tabs -->
       <ul class="nav nav-tabs" role="tablist">
-        <% tabs.each_with_index do | tab, i | %>
+        <% (tabs - ['share']).each_with_index do | tab, i | %>
           <% if i == 0 %>
             <li role="presentation" class="active">
           <% else %>

--- a/spec/presenters/hyrax/admin_set_options_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_options_presenter_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::AdminSetOptionsPresenter do
   let(:service) { instance_double(Hyrax::AdminSetService) }
-  let(:presenter) { described_class.new(service) }
+  let(:current_ability) { double('an abilitiy', can?: false) }
+  let(:presenter) { described_class.new(service, current_ability: current_ability) }
 
   describe "#select_options" do
     subject { presenter.select_options }
@@ -26,6 +27,30 @@ RSpec.describe Hyrax::AdminSetOptionsPresenter do
       it do
         is_expected.to eq [['Public Set', '123', { 'data-sharing' => false, 'data-visibility' => 'open' }],
                            ['Private Set', '345', { 'data-sharing' => false, 'data-visibility' => 'restricted' }]]
+      end
+    end
+
+    context "with permission_template and workflow" do
+      let(:solr_doc) { instance_double(SolrDocument, id: '123', to_s: 'Doc') }
+      let(:results) { [solr_doc] }
+
+      let(:workflow) { instance_double(Sipity::Workflow, allows_access_grant?: allow_access_grant) }
+      let(:permission_template) { build(:permission_template, source_id: solr_doc.id, visibility: 'open') }
+      before do
+        expect(Hyrax::PermissionTemplate).to receive(:find_by).and_return(permission_template)
+        allow(presenter).to receive(:workflow) { workflow }
+        allow(permission_template).to receive(:active_workflow).and_return(true)
+      end
+
+      context 'current ability can manage the workflow though the the template does not allow access grants' do
+        let(:allow_access_grant) { false }
+        before do
+          expect(current_ability).to receive(:can?).with(:manage, permission_template).and_return(true)
+        end
+
+        it 'allows sharing' do
+          is_expected.to eq [[solr_doc.to_s, solr_doc.id, { 'data-sharing' => true, 'data-visibility' => 'open' }]]
+        end
       end
     end
 


### PR DESCRIPTION
## Ensuring admins can manage participants

e7c9f08f18ff653e4db6780352605d8a2b19b269

Based on the descriptive text in the [_form_participants][3] (see
below), the application describes that a manager of an admin set should
have the rights to manage the participants of objects deposited into the
admin set.

> Managers of this administrative set can edit the set metadata,
> participants, and release and visibility settings. Managers can also
> edit work metadata, add to or remove files from a work, and add new
> works to the set.

The implemented solution favors an initial check that the given ability
can manage the associate permission template.  The admin set form
partials ([panel navigation][1], [renderinig panel content][2], and
[panel content][3]) support this short-circuit.  A more conservative
approach would be to first check that we have an active workflow, then
test the ability, and finally if the workflow allows for access
granting.

I chose to go with the path that extends more privileges to the
administrator.

Closes #3175

[1]:https://github.com/samvera/hyrax/blob/a8e1d84e48d7444d4f5dce4ada7a82dd1dad7737/app/views/hyrax/admin/admin_sets/_form.html.erb#L43
[2]:https://github.com/samvera/hyrax/blob/a8e1d84e48d7444d4f5dce4ada7a82dd1dad7737/app/views/hyrax/admin/admin_sets/_form.html.erb#L8-L10
[3]:https://github.com/samvera/hyrax/blob/a8e1d84e48d7444d4f5dce4ada7a82dd1dad7737/app/views/hyrax/admin/admin_sets/_form_participants.html.erb#L1

## Echoing tab rendering selection logic

2de06c000690860470277fbf1b98b9b375ca6757

Given that later logic in this view partial has `(tabs - ['share'])` it
makes sense to echo that concern here.  Also, given that we are
explicitly including a share navigation LI, it would be confusing to
have two 'share' elements show up.  This change aligns the rendering
logic of both the navigation and content.
