### PR TITLE
deprecate `WorkShowPresenter#member_presenters_for`

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -94,7 +94,7 @@ module Hyrax
       return nil if representative_id.blank?
       @representative_presenter ||=
         begin
-          result = member_presenters_for([representative_id]).first
+          result = member_presenters([representative_id]).first
           return nil if result.try(:id) == id
           result.try(:representative_presenter) || result
         end
@@ -181,9 +181,13 @@ module Hyrax
       paginated_item_list(page_array: authorized_item_ids)
     end
 
+    ##
+    # @deprecated use `#member_presenters(ids)` instead
+    #
     # @param [Array<String>] ids a list of ids to build presenters for
     # @return [Array<presenter_class>] presenters for the array of ids (not filtered by class)
     def member_presenters_for(an_array_of_ids)
+      Deprecation.warn("Use `#member_presenters` instead.")
       member_presenters(an_array_of_ids)
     end
 

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -239,19 +239,6 @@ RSpec.describe Hyrax::WorkShowPresenter do
     end
   end
 
-  describe "#member_presenters_for" do
-    let(:obj) { create(:work_with_file_and_work) }
-    let(:attributes) { obj.to_solr }
-    let(:items) { presenter.ordered_ids }
-    let(:subject) { presenter.member_presenters_for(items) }
-
-    it "returns appropriate classes for each item" do
-      expect(subject.size).to eq 2
-      expect(subject.first).to be_instance_of(Hyrax::FileSetPresenter)
-      expect(subject.last).to be_instance_of(described_class)
-    end
-  end
-
   describe "#list_of_item_ids_to_display" do
     let(:subject) { presenter.list_of_item_ids_to_display }
     let(:items_list) { (0..9).map { |i| "item#{i}" } }


### PR DESCRIPTION
this method delegates directly to another method with virtually the same name. use that instead.

@samvera/hyrax-code-reviewers
