### PR TITLE
add hyrax-valkyrie-dev solr core to dassie test app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,7 +120,7 @@ services:
     command:
       - sh
       - "-c"
-      - "precreate-core hyrax_test /opt/solr/server/configsets/hyraxconf; precreate-core hyrax-valkyrie-test /opt/solr/server/configsets/hyraxconf; solr-precreate hyrax /opt/solr/server/configsets/hyraxconf"
+      - "precreate-core hyrax_test /opt/solr/server/configsets/hyraxconf; precreate-core hyrax-valkyrie-test /opt/solr/server/configsets/hyraxconf; precreate-core hyrax-valkyrie-dev /opt/solr/server/configsets/hyraxconf; solr-precreate hyrax /opt/solr/server/configsets/hyraxconf"
     volumes:
       - solr_home:/var/solr/data:cached
       - .dassie/solr/conf:/opt/solr/server/configsets/hyraxconf


### PR DESCRIPTION
This is the core that Hyrax writes to when Valkyrie indexing is enabled in `.dassie/config/initializers/hyrax.rb` and accessing the app through a browser.

@samvera/hyrax-code-reviewers
