### PR TITLE
Adding permision_populator to change set

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -91,7 +91,12 @@ module Hyrax
       property :date_uploaded, readable: false
       property :agreement_accepted, virtual: true, default: false, prepopulator: ->(_opts) { self.agreement_accepted = !model.new_record }
 
-      collection :permissions, virtual: true, default: [], form: Permission, prepopulator: ->(_opts) { self.permissions = Hyrax::AccessControl.for(resource: model).permissions }
+      collection(:permissions,
+                 virtual: true,
+                 default: [],
+                 form: Permission,
+                 populator: :permission_populator,
+                 prepopulator: ->(_opts) { self.permissions = Hyrax::AccessControl.for(resource: model).permissions })
 
       # virtual properties for embargo/lease;
       property :embargo_release_date, virtual: true, prepopulator: ->(_opts) { self.embargo_release_date = model.embargo&.embargo_release_date }
@@ -200,6 +205,11 @@ module Hyrax
       end
 
       private
+
+      # https://trailblazer.to/2.1/docs/reform.html#reform-populators-populator-collections
+      def permission_populator(collection:, index:, **)
+        Permission.new(collection[index])
+      end
 
       def _form_field_definitions
         self.class.definitions

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -204,6 +204,15 @@ RSpec.describe Hyrax::Forms::ResourceForm do
         .from(be_empty)
     end
 
+    # Github Issue #4900
+    it 'validates an empty nested value' do
+      form.validate(
+        "permissions_attributes" => {
+          "1" => { "type" => "person", "name" => "basic_user@example.com", "access" => "edit" }
+        }
+      )
+    end
+
     context 'with existing permissions' do
       let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :public) }
 


### PR DESCRIPTION
Prior to this commit, if we were to add the spec from
`spec/forms/hyrax/forms/resource_form_spec.rb` but not the change to
`app/forms/hyrax/forms/resource_form.rb`, the spec would raise the
following error:

```console
RuntimeError:
  [Reform] Your :populator did not return a Reform::Form instance
  for `permissions`.
```

Building on the documentation from
https://trailblazer.to/2.1/docs/reform.html#reform-populators-populator-collections,
this change ensures that we cast the raw hash attributes into a Reform
compliant object.

Closes #4900

Note: There are some appeasements of Rubocop

@samvera/hyrax-code-reviewers
