### PR TITLE
Verifying round trip AF conversion validation

### DIFF
--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -24,6 +24,25 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
   end
 
   describe '#convert' do
+    context 'with an invalid GenericWork object' do
+      it 'round trip converts to an GenericWork object this is also invalid' do
+        work = GenericWork.new(title: nil)
+        expect(work).not_to be_valid
+        converted_work = described_class.new(resource: work.valkyrie_resource).convert
+        expect(converted_work).not_to be_valid
+        expect(work.errors.full_messages).to eq(converted_work.errors.full_messages)
+      end
+    end
+    context 'with an invalid FileSet object' do
+      it 'round trip converts to an FileSet object this is also invalid' do
+        file_set = ::FileSet.new(lease_expiration_date: 1.day.ago)
+        expect(file_set).not_to be_valid
+        converted_file_set = described_class.new(resource: file_set.valkyrie_resource).convert
+        expect(converted_file_set).not_to be_valid
+        expect(file_set.errors.full_messages).to eq(converted_file_set.errors.full_messages)
+      end
+    end
+
     it 'returns the ActiveFedora model' do
       expect(converter.convert).to eq work
     end


### PR DESCRIPTION
The desired behavior is as follows:

Given `x` is an ActiveFedora object which responds to `x.valid?` and returns `false`
And `f(x)` converts `x` to a `Valkyrie::Resource` (which doesn't respond to `valid?`)
And `g(f(x))` converts `f(x)` resource back to an ActiveFedora object that responds to `valid?`
Then `g(f(x))` responds to `valid?` and returns `false`

This spec tests that behavior.  However, I'm not able to duplicate the
error.  Perhaps it's a matter of the specific parameters?  I'm adding
this spec as a placeholder for what could be the specific
attributes/values that trigger a failing scenario.

Closes #3917 as I'm unable to duplicate the error

@samvera/hyrax-code-reviewers
