### PR TITLE
Replace ActiveFedora construct_query_for_rel with Valkyrized

### DIFF
--- a/app/search_builders/hyrax/abstract_type_relation.rb
+++ b/app/search_builders/hyrax/abstract_type_relation.rb
@@ -15,7 +15,7 @@ module Hyrax
 
     def search_model_clause
       clauses = allowable_types.map do |k|
-        ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: k.to_s)
+        Hyrax::SolrQueryBuilderService.construct_query_for_rel(has_model: k.to_s)
       end
       # empty array returns nil, AF finder method handles it properly, see hyrax issue #2844
       clauses.size <= 1 ? clauses.first : "(#{clauses.join(' OR ')})"

--- a/app/search_builders/hyrax/dashboard/collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/collections_search_builder.rb
@@ -18,8 +18,8 @@ module Hyrax
       def show_only_managed_collections_for_non_admins(solr_parameters)
         return if current_ability.admin?
         clauses = [
-          '-' + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key),
-          '-' + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::AdminSet.to_s, creator: current_user_key)
+          '-' + Hyrax::SolrQueryBuilderService.construct_query_for_rel(depositor: current_user_key),
+          '-' + Hyrax::SolrQueryBuilderService.construct_query_for_rel(has_model: ::AdminSet.to_s, creator: current_user_key)
         ]
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += ["(#{clauses.join(' OR ')})"]

--- a/app/search_builders/hyrax/dashboard/works_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/works_search_builder.rb
@@ -12,7 +12,7 @@ module Hyrax
       def show_only_managed_works_for_non_admins(solr_parameters)
         return if current_ability.admin?
         solr_parameters[:fq] ||= []
-        solr_parameters[:fq] << '-' + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key)
+        solr_parameters[:fq] << '-' + Hyrax::SolrQueryBuilderService.construct_query_for_rel(depositor: current_user_key)
       end
     end
   end

--- a/app/search_builders/hyrax/my/collections_search_builder.rb
+++ b/app/search_builders/hyrax/my/collections_search_builder.rb
@@ -11,8 +11,8 @@ class Hyrax::My::CollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
   # @param [Hash] solr_parameters
   def show_only_collections_deposited_by_current_user(solr_parameters)
     clauses = [
-      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key),
-      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::AdminSet.to_s, creator: current_user_key)
+      Hyrax::SolrQueryBuilderService.construct_query_for_rel(depositor: current_user_key),
+      Hyrax::SolrQueryBuilderService.construct_query_for_rel(has_model: ::AdminSet.to_s, creator: current_user_key)
     ]
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] += ["(#{clauses.join(' OR ')})"]

--- a/app/search_builders/hyrax/my/search_builder.rb
+++ b/app/search_builders/hyrax/my/search_builder.rb
@@ -14,7 +14,7 @@ module Hyrax
       def show_only_resources_deposited_by_current_user(solr_parameters)
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += [
-          ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key)
+          Hyrax::SolrQueryBuilderService.construct_query_for_rel(depositor: current_user_key)
         ]
       end
     end

--- a/app/search_builders/hyrax/my/shares_search_builder.rb
+++ b/app/search_builders/hyrax/my/shares_search_builder.rb
@@ -8,7 +8,7 @@ class Hyrax::My::SharesSearchBuilder < Hyrax::SearchBuilder
   def show_only_shared_files(solr_parameters)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] += [
-      "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key)
+      "-" + Hyrax::SolrQueryBuilderService.construct_query_for_rel(depositor: current_user_key)
     ]
   end
 end

--- a/spec/search_builders/hyrax/my/shares_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/shares_search_builder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hyrax::My::SharesSearchBuilder do
   let(:scope) { FakeSearchBuilderScope.new(current_user: me) }
 
   before do
-    allow(ActiveFedora::SolrQueryBuilder).to receive(:construct_query_for_rel)
+    allow(Hyrax::SolrQueryBuilderService).to receive(:construct_query_for_rel)
       .with(depositor: me.user_key)
       .and_return("depositor")
   end

--- a/spec/search_builders/hyrax/my/works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/works_search_builder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::My::WorksSearchBuilder do
 
   describe "#to_hash" do
     before do
-      allow(ActiveFedora::SolrQueryBuilder).to receive(:construct_query_for_rel)
+      allow(Hyrax::SolrQueryBuilderService).to receive(:construct_query_for_rel)
         .with(depositor: me.user_key)
         .and_return("depositor")
     end


### PR DESCRIPTION
Adds, uses a `Hyrax::SolrQueryBuilderService` version of `ActiveFedora::SolrQueryBuilder`'s `construct_query_for_rel`
