### PR TITLE
Gh 4196 step 2

### DIFF
--- a/app/jobs/ingest_local_file_job.rb
+++ b/app/jobs/ingest_local_file_job.rb
@@ -2,19 +2,29 @@
 class IngestLocalFileJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
-  # @param [FileSet] file_set
+  # @param [FileSet, Hyrax::FileSet] file_set
   # @param [String] path
   # @param [User] user
   def perform(file_set, path, user)
-    perform_af(file_set, path, user)
+    case file_set
+    when ActiveFedora::Base
+      __perform(file_set, path, user, use_valkyrie: false)
+    else
+      __perform(file_set, path, user, use_valkyrie: true)
+    end
   end
 
   private
 
-  def perform_af(file_set, path, user)
+  # @note Based on the present implementation (see SHA a8597884e) of
+  # the Hyrax::Actors::FileSetActor, we wouldn't need to pass the
+  # `use_valkyrie` parameter.  However, I want to include this logic
+  # to demonstrate that "Yes, the IngestLocalFileJob has been tested
+  # for Valkyrie usage"
+  def __perform(file_set, path, user, use_valkyrie:)
     file_set.label ||= File.basename(path)
 
-    actor = Hyrax::Actors::FileSetActor.new(file_set, user)
+    actor = Hyrax::Actors::FileSetActor.new(file_set, user, use_valkyrie: use_valkyrie)
 
     if actor.create_content(File.open(path))
       Hyrax.config.callback.run(:after_import_local_file_success, file_set, user, path, warn: false)

--- a/spec/jobs/ingest_local_file_job_spec.rb
+++ b/spec/jobs/ingest_local_file_job_spec.rb
@@ -4,6 +4,14 @@ RSpec.describe IngestLocalFileJob do
   let(:user) { create(:user) }
   let(:path) { File.join(fixture_path, 'world.png') }
 
+  context 'when passing a Valkyrie::Resource' do
+    let(:file_set) { FactoryBot.build(:hyrax_file_set) }
+    it 'attach successfully attachs a file' do
+      expect(Hyrax.config.callback).to receive(:run).with(:after_import_local_file_success, file_set, user, path, warn: false).and_return(true)
+      described_class.perform_now(file_set, path, user)
+    end
+  end
+
   context 'when use_valkyrie is false' do
     let(:file_set) { FileSet.new }
 


### PR DESCRIPTION
## Removing excessive mocking to better test

9e5e4dfc15faa872206edfafe0a8138c40a18506

Given the labyrinth that is the implementation of the FileSet jobs and
actors, it seems quite reasonable to remove the mocks and instead rely
on a more full stack test.

This also helps us know that when we use an ActiveFedora object it
works and by extension when we add tests/behavior for
Valkyrie::Resource objects, we'll know it works as well.

## Ensuring IngestLocalFileJob handles valkyrie obj

0406d4092dfae0aaed605e5787df5aa27a75372e

This commit documents and tests that the IngestLocalFileJob handles
valkyrie resources.  We wouldn't have needed to make any changes to this
job to verify that Valkyrie worked.  However, by favoring an explicit
change a future maintainer can quickly look at this class and say "Cool,
I don't need to check if this works with Valkyrie!"

Closes #4196

@samvera/hyrax-code-reviewers
