### PR TITLE
WIP - Review Requested

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -140,11 +140,16 @@ module Hyrax
       # @param file_set [FileSet]
       # @return [ActiveFedora::Base]
       def parent_for(file_set:)
-        file_set.parent
+        case file_set
+        when ActiveFedora::Base
+          file_set.parent
+        else
+          Hyrax.query_service.find_parents(resource: file_set).first
+        end
       end
 
       def build_file_actor(relation)
-        fs = use_valkyrie ? file_set.valkyrie_resource : file_set
+        fs = object_to_act_on(file_set)
         file_actor_class.new(fs, relation, user, use_valkyrie: use_valkyrie)
       end
 

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -57,14 +57,14 @@ class ImportUrlJob < Hyrax::ApplicationJob
 
     # @todo Use Hydra::Works::AddExternalFileToFileSet instead of manually
     #       copying the file here. This will be gnarly.
-    copy_remote_file(name) do |f|
+    copy_remote_file(name) do |io_stream|
       # reload the FileSet once the data is copied since this is a long running task
       file_set.reload
 
       # FileSetActor operates synchronously so that this tempfile is available.
       # If asynchronous, the job might be invoked on a machine that did not have this temp file on its file system!
       # NOTE: The return status may be successful even if the content never attaches.
-      log_import_status(f)
+      log_import_status(io_stream)
     end
   end
 
@@ -101,14 +101,14 @@ class ImportUrlJob < Hyrax::ApplicationJob
   end
 
   # Write file to the stream
-  # @param f [IO] the stream to write to
-  def write_file(f)
+  # @param io_stream [IO] the stream to write to
+  def write_file(io_stream)
     retriever = BrowseEverything::Retriever.new
     uri_spec = ActiveSupport::HashWithIndifferentAccess.new(url: uri, headers: headers)
     retriever.retrieve(uri_spec) do |chunk|
-      f.write(chunk)
+      io_stream.write(chunk)
     end
-    f.rewind
+    io_stream.rewind
   end
 
   # Set the import operation status

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -24,10 +24,9 @@ class ImportUrlJob < Hyrax::ApplicationJob
   # @param [FileSet] file_set
   # @param [Hyrax::BatchCreateOperation] operation
   # @param [Hash] headers - header data to use in interaction with remote url
-  # @param [Boolean] use_valkyrie - a switch on whether or not to use Valkyrie processing
   #
   # @todo At present, this job works for ActiveFedora objects. The use_valkyrie is not complete.
-  def perform(file_set, operation, headers = {}, use_valkyrie: false)
+  def perform(file_set, operation, headers = {})
     @file_set = file_set
     @operation = operation
     @headers = headers
@@ -37,10 +36,11 @@ class ImportUrlJob < Hyrax::ApplicationJob
 
     return false unless can_retrieve_remote?
 
-    if use_valkyrie
-      # TODO
-    else
+    case file_set
+    when ActiveFedora::Base
       perform_af
+    else
+      # TODO
     end
   end
 

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -12,6 +12,53 @@ require 'browse_everything/retriever'
 #   {Hyrax::Actors::CreateWithRemoteFilesActor} when files are located in
 #   some other service.
 class ImportUrlJob < Hyrax::ApplicationJob
+  # This object is a shim to address the implementation details of the
+  # internal methods of the ImportUrlJob class.  Prior to adding this
+  # shim, the ImportUrlJob operated on a file_set, with the assumption
+  # that it had an `#errors` method and a `#reload` method.
+  class FileSetWrapper < SimpleDelegator
+    def initialize(object:)
+      @object = object
+      super(@object)
+      case object
+      when ActiveFedora::Base
+        @error_container_builder = ->(obj) { obj }
+        @reloader = ->(obj) { obj.reload }
+        @use_valkyrie = false
+      else
+        @error_container_builder = Hyrax::ChangeSet.method(:for)
+        @reloader = ->(obj) { Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: obj.id) }
+        @use_valkyrie = true
+      end
+      build_error_container!
+    end
+
+    def wrapped_object
+      @object
+    end
+
+    def reload
+      @object = @reloader.call(@object)
+      build_error_container!
+      @object
+    end
+
+    def errors
+      @error_container.errors
+    end
+
+    def use_valkyrie?
+      @use_valkyrie
+    end
+
+    private
+
+    def build_error_container!
+      @error_container = @error_container_builder.call(@object)
+    end
+  end
+  private_constant :FileSetWrapper
+
   queue_as Hyrax.config.ingest_queue_name
   attr_reader :file_set, :operation, :headers, :user, :uri
 
@@ -21,50 +68,46 @@ class ImportUrlJob < Hyrax::ApplicationJob
   end
 
   ##
-  # @param [FileSet] file_set
-  # @param [Hyrax::BatchCreateOperation] operation
-  # @param [Hash] headers - header data to use in interaction with remote url
+  # @param file_set [Hyrax::FileSet, FileSet] a persisted file_set object
+  # @param operation [Hyrax::BatchCreateOperation]
+  # @param headers [Hash] header data to use in interaction with remote url
   #
   # @todo At present, this job works for ActiveFedora objects. The use_valkyrie is not complete.
   def perform(file_set, operation, headers = {})
     @file_set = file_set
+    wrapper = FileSetWrapper.new(object: @file_set)
     @operation = operation
     @headers = headers
     operation.performing!
     @user = User.find_by_user_key(file_set.depositor)
     @uri = URI(file_set.import_url)
 
-    return false unless can_retrieve_remote?
+    return false unless can_retrieve_remote?(wrapper: wrapper)
 
-    case file_set
-    when ActiveFedora::Base
-      perform_af
-    else
-      # TODO
-    end
+    __perform(wrapper: wrapper)
   end
 
   private
 
-  def can_retrieve_remote?
+  def can_retrieve_remote?(wrapper:)
     return true if BrowseEverything::Retriever.can_retrieve?(uri, headers)
-    send_error('Expired URL')
+    send_error(message: 'Expired URL', wrapper: wrapper)
     false
   end
 
-  def perform_af
-    name = file_set.label
+  def __perform(wrapper:)
+    name = wrapper.label
 
     # @todo Use Hydra::Works::AddExternalFileToFileSet instead of manually
     #       copying the file here. This will be gnarly.
-    copy_remote_file(name) do |io_stream|
+    copy_remote_file(name: name, wrapper: wrapper) do |io_stream|
       # reload the FileSet once the data is copied since this is a long running task
-      file_set.reload
+      wrapper.reload
 
       # FileSetActor operates synchronously so that this tempfile is available.
       # If asynchronous, the job might be invoked on a machine that did not have this temp file on its file system!
       # NOTE: The return status may be successful even if the content never attaches.
-      log_import_status(io_stream)
+      log_import_status(io_stream: io_stream, wrapper: wrapper)
     end
   end
 
@@ -73,8 +116,9 @@ class ImportUrlJob < Hyrax::ApplicationJob
   # because when the file in added into Fedora the file name will get persisted in the
   # metadata.
   # @param name [String] the human-readable name of the file
+  # @param wrapper [FileSetWrapper]
   # @yield [IO] the stream to write to
-  def copy_remote_file(name)
+  def copy_remote_file(name:, wrapper:)
     filename = File.basename(name)
     dir = Dir.mktmpdir
     Rails.logger.debug("ImportUrlJob: Copying <#{uri}> to #{dir}")
@@ -84,7 +128,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
         write_file(f)
         yield f
       rescue StandardError => e
-        send_error(e.message)
+        send_error(message: e.message, wrapper: wrapper)
       end
     end
     Rails.logger.debug("ImportUrlJob: Closing #{File.join(dir, filename)}")
@@ -93,11 +137,16 @@ class ImportUrlJob < Hyrax::ApplicationJob
   ##
   # Send message to user on download failure
   #
-  # @param error_message [String] the download error message
-  def send_error(error_message)
-    file_set.errors.add('Error:', error_message)
-    Hyrax.config.callback.run(:after_import_url_failure, file_set, user, warn: false)
-    operation.fail!(file_set.errors.full_messages.join(' '))
+  # @param message [String] the download error message
+  # @param wrapper [FileSetWrapper]
+  def send_error(message:, wrapper:)
+    wrapper.errors.add('Error:', message)
+
+    # I'm a little concerned about passing the wrapped object instead
+    # of the wrapper; Namely because there was a presupposition about
+    # the original wrapped_object having an `errors` method.
+    Hyrax.config.callback.run(:after_import_url_failure, wrapper, user, warn: false)
+    operation.fail!(wrapper.errors.full_messages)
   end
 
   # Write file to the stream
@@ -112,12 +161,13 @@ class ImportUrlJob < Hyrax::ApplicationJob
   end
 
   # Set the import operation status
-  # @param f [IO] the stream to write to
-  def log_import_status(f)
-    if Hyrax::Actors::FileSetActor.new(file_set, user).create_content(f, from_url: true)
+  # @param io_stream [IO] the stream to write to
+  # @param wrapper [FileSetWrapper]
+  def log_import_status(io_stream:, wrapper:)
+    if Hyrax::Actors::FileSetActor.new(wrapper.wrapped_object, user, use_valkyrie: wrapper.use_valkyrie?).create_content(io_stream, from_url: true)
       operation.success!
     else
-      send_error(uri.path)
+      send_error(message: uri.path, wrapper: wrapper)
     end
   end
 end

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ImportUrlJob do
   context 'when using a Valkyrie::Resource file_set' do
     context 'happy path' do
       let(:file_set) do
-        build(:hyrax_file_set, label: label, import_url: import_url)
+        FactoryBot.valkyrie_create(:hyrax_file_set, label: label, import_url: import_url, depositor: user.user_key)
       end
 
       it 'notifies the operation of success' do
@@ -72,7 +72,7 @@ RSpec.describe ImportUrlJob do
 
       before do
         file_set.id = 'abc123'
-        allow(file_set).to receive(:reload)
+        allow(file_set).to receive(:reload).and_return(file_set)
 
         FileUtils.mkdir_p(tmpdir)
         allow(Dir).to receive(:mktmpdir).and_return(tmpdir)
@@ -83,7 +83,6 @@ RSpec.describe ImportUrlJob do
       end
 
       it 'creates the content and updates the associated operation' do
-        # expect(actor).to receive(:create_content).with(File, from_url: true).and_return(true)
         described_class.perform_now(file_set, operation)
         expect(operation).to be_success
       end

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -5,23 +5,11 @@ RSpec.describe ImportUrlJob do
   let(:file_path) { fixture_path + '/world.png' }
   let(:file_hash) { '/673467823498723948237462429793840923582' }
   let(:label) { file_path }
-
-  let(:file_set) do
-    FileSet.new(import_url: "http://example.org#{file_hash}",
-                label: label) do |f|
-      f.apply_depositor_metadata(user.user_key)
-    end
-  end
-
   let(:operation) { create(:operation) }
-  let(:actor) { instance_double(Hyrax::Actors::FileSetActor, create_content: true) }
-
   let(:mock_retriever) { double }
   let(:inbox) { user.mailbox.inbox }
 
   before do
-    allow(Hyrax::Actors::FileSetActor).to receive(:new).with(file_set, user).and_return(actor)
-
     response_headers = {
       'Content-Type' => 'image/png',
       'Content-Length' => 1,
@@ -40,142 +28,155 @@ RSpec.describe ImportUrlJob do
     allow(mock_retriever).to receive(:retrieve)
   end
 
-  context 'before enqueueing the job' do
-    before do
-      file_set.id = 'fsid123'
-    end
-
-    describe '.operation' do
-      it 'fetches the operation' do
-        described_class.perform_later(file_set, operation)
-        expect { subject.operation.to eq Hyrax::Operation }
-      end
-    end
-  end
-
-  context 'after running the job' do
-    let!(:tmpdir) { Rails.root.join("tmp/spec/#{Process.pid}") }
-
-    before do
-      file_set.id = 'abc123'
-      allow(file_set).to receive(:reload)
-
-      FileUtils.mkdir_p(tmpdir)
-      allow(Dir).to receive(:mktmpdir).and_return(tmpdir)
-    end
-
-    after do
-      FileUtils.remove_entry(tmpdir)
-    end
-
-    it 'creates the content and updates the associated operation' do
-      expect(actor).to receive(:create_content).with(File, from_url: true).and_return(true)
-      described_class.perform_now(file_set, operation)
-      expect(operation).to be_success
-    end
-
-    it 'leaves the temp directory in place' do
-      described_class.perform_now(file_set, operation)
-      file_name = File.basename(file_set.label)
-      expect(File.exist?(File.join(tmpdir, file_name))).to be true
-    end
-
-    context 'when the FileSet has an existing label' do
-      let(:label) { "example.tif" }
-      before do
-        allow(Rails.logger).to receive(:debug)
-      end
-      it 'uses the FileSet label' do
-        described_class.perform_now(file_set, operation)
-        tmp_file_path = Rails.root.join(tmpdir, label)
-        expect(Rails.logger).to have_received(:debug).with("ImportUrlJob: Closing #{tmp_file_path}")
-        expect(File.exist?(tmp_file_path.to_s)).to be true
-      end
-    end
-  end
-
-  context "when a batch update job is running too" do
-    let(:title) { { file_set.id => ['File One'] } }
-    let(:file_set_id) { file_set.id }
-
-    before do
-      file_set.save!
-      allow(ActiveFedora::Base).to receive(:find).and_call_original
-      allow(ActiveFedora::Base).to receive(:find).with(file_set_id).and_return(file_set)
-      # run the batch job to set the title
-      file_set.update(title: ['File One'])
-    end
-
-    it "does not kill all the metadata set by other processes" do
-      # run the import job
-      described_class.perform_now(file_set, operation)
-      # import job should not override the title set another process
-      file = FileSet.find(file_set_id)
-      expect(file.title).to eq(['File One'])
-    end
-  end
-
-  context 'when the remote file is unavailable' do
-    before do
-      stub_request(:get, "http://example.org#{file_hash}").with(headers: { 'Range' => 'bytes=0-0' }).to_return(
-        body: '', status: 406, headers: {}
-      )
-    end
-
-    it 'sends error message' do
-      expect(operation).to receive(:fail!)
-      expect(file_set.original_file).to be_nil
-      described_class.perform_now(file_set, operation)
-      expect(inbox.count).to eq(1)
-      last_message = inbox[0].last_message
-      expect(last_message.subject).to eq('File Import Error')
-      expect(last_message.body).to eq("Error: Expired URL")
-    end
-  end
-
-  context 'when retrieval fails' do
-    before { allow(mock_retriever).to receive(:retrieve).and_raise(StandardError, 'Timeout') }
-
-    it 'sends error message' do
-      expect(operation).to receive(:fail!)
-      expect(file_set.original_file).to be_nil
-      described_class.perform_now(file_set, operation)
-      expect(inbox.count).to eq(1)
-      last_message = inbox[0].last_message
-      expect(last_message.subject).to eq('File Import Error')
-      expect(last_message.body).to eq("Error: Timeout")
-    end
-  end
-
-  context 'when the URL to the remote file has headers' do
-    let(:import_url) { "http://example.org#{file_hash}" }
-    let(:headers) do
-      {
-        "Authorization" => "OAuth <ACCESS_TOKEN>"
-      }
-    end
+  context 'when use_valkyrie is false' do
     let(:file_set) do
-      FileSet.new(import_url: import_url, label: file_path) do |f|
+      FileSet.new(import_url: "http://example.org#{file_hash}",
+                  label: label) do |f|
         f.apply_depositor_metadata(user.user_key)
       end
     end
-    let(:operation) { create(:operation) }
-    let(:import_uri) { URI(import_url) }
-
+    let(:actor) { instance_double(Hyrax::Actors::FileSetActor, create_content: true) }
     before do
-      allow(BrowseEverything::Retriever).to receive(:can_retrieve?).and_return(true)
-      described_class.perform_now(file_set, operation, headers)
+      allow(Hyrax::Actors::FileSetActor).to receive(:new).with(file_set, user).and_return(actor)
     end
 
-    it 'submits a request to the cloud server with auth headers' do
-      expect(BrowseEverything::Retriever).to have_received(:can_retrieve?).with(import_uri, headers)
+    context 'before enqueueing the job' do
+      before do
+        file_set.id = 'fsid123'
+      end
+
+      describe '.operation' do
+        it 'fetches the operation' do
+          described_class.perform_later(file_set, operation)
+          expect { subject.operation.to eq Hyrax::Operation }
+        end
+      end
     end
 
-    it 'retrieves the cloud server resources with the auth headers' do
-      expect(mock_retriever).to have_received(:retrieve).with(
-        "url" => import_uri,
-        "headers" => headers
-      )
+    context 'after running the job' do
+      let!(:tmpdir) { Rails.root.join("tmp/spec/#{Process.pid}") }
+
+      before do
+        file_set.id = 'abc123'
+        allow(file_set).to receive(:reload)
+
+        FileUtils.mkdir_p(tmpdir)
+        allow(Dir).to receive(:mktmpdir).and_return(tmpdir)
+      end
+
+      after do
+        FileUtils.remove_entry(tmpdir)
+      end
+
+      it 'creates the content and updates the associated operation' do
+        expect(actor).to receive(:create_content).with(File, from_url: true).and_return(true)
+        described_class.perform_now(file_set, operation)
+        expect(operation).to be_success
+      end
+
+      it 'leaves the temp directory in place' do
+        described_class.perform_now(file_set, operation)
+        file_name = File.basename(file_set.label)
+        expect(File.exist?(File.join(tmpdir, file_name))).to be true
+      end
+
+      context 'when the FileSet has an existing label' do
+        let(:label) { "example.tif" }
+        before do
+          allow(Rails.logger).to receive(:debug)
+        end
+        it 'uses the FileSet label' do
+          described_class.perform_now(file_set, operation)
+          tmp_file_path = Rails.root.join(tmpdir, label)
+          expect(Rails.logger).to have_received(:debug).with("ImportUrlJob: Closing #{tmp_file_path}")
+          expect(File.exist?(tmp_file_path.to_s)).to be true
+        end
+      end
+    end
+
+    context "when a batch update job is running too" do
+      let(:title) { { file_set.id => ['File One'] } }
+      let(:file_set_id) { file_set.id }
+
+      before do
+        file_set.save!
+        allow(ActiveFedora::Base).to receive(:find).and_call_original
+        allow(ActiveFedora::Base).to receive(:find).with(file_set_id).and_return(file_set)
+        # run the batch job to set the title
+        file_set.update(title: ['File One'])
+      end
+
+      it "does not kill all the metadata set by other processes" do
+        # run the import job
+        described_class.perform_now(file_set, operation)
+        # import job should not override the title set another process
+        file = FileSet.find(file_set_id)
+        expect(file.title).to eq(['File One'])
+      end
+    end
+
+    context 'when the remote file is unavailable' do
+      before do
+        stub_request(:get, "http://example.org#{file_hash}").with(headers: { 'Range' => 'bytes=0-0' }).to_return(
+          body: '', status: 406, headers: {}
+        )
+      end
+
+      it 'sends error message' do
+        expect(operation).to receive(:fail!)
+        expect(file_set.original_file).to be_nil
+        described_class.perform_now(file_set, operation)
+        expect(inbox.count).to eq(1)
+        last_message = inbox[0].last_message
+        expect(last_message.subject).to eq('File Import Error')
+        expect(last_message.body).to eq("Error: Expired URL")
+      end
+    end
+
+    context 'when retrieval fails' do
+      before { allow(mock_retriever).to receive(:retrieve).and_raise(StandardError, 'Timeout') }
+
+      it 'sends error message' do
+        expect(operation).to receive(:fail!)
+        expect(file_set.original_file).to be_nil
+        described_class.perform_now(file_set, operation)
+        expect(inbox.count).to eq(1)
+        last_message = inbox[0].last_message
+        expect(last_message.subject).to eq('File Import Error')
+        expect(last_message.body).to eq("Error: Timeout")
+      end
+    end
+
+    context 'when the URL to the remote file has headers' do
+      let(:import_url) { "http://example.org#{file_hash}" }
+      let(:headers) do
+        {
+          "Authorization" => "OAuth <ACCESS_TOKEN>"
+        }
+      end
+      let(:file_set) do
+        FileSet.new(import_url: import_url, label: file_path) do |f|
+          f.apply_depositor_metadata(user.user_key)
+        end
+      end
+      let(:operation) { create(:operation) }
+      let(:import_uri) { URI(import_url) }
+
+      before do
+        allow(BrowseEverything::Retriever).to receive(:can_retrieve?).and_return(true)
+        described_class.perform_now(file_set, operation, headers)
+      end
+
+      it 'submits a request to the cloud server with auth headers' do
+        expect(BrowseEverything::Retriever).to have_received(:can_retrieve?).with(import_uri, headers)
+      end
+
+      it 'retrieves the cloud server resources with the auth headers' do
+        expect(mock_retriever).to have_received(:retrieve).with(
+                                    "url" => import_uri,
+                                    "headers" => headers
+                                  )
+      end
     end
   end
 end


### PR DESCRIPTION
## Refactoring to make an easier change

d5dec6eac99fe656c33fdef7d95dc650d4bd175e

This is code change is a simple restructuring to enable an easier review
for future work on #4196.  _I know I struggle reviewing a code change
that both wraps a chunk of code with a containing block AND changes the
logic of that block._

Related to #4196

## Renaming variable for better clarity

28408b1e42a06570e16e1a99f87c6c1ba0ec0204

Prior to this commit, when I was reading the code I saw "f" and
"file_set" in the same context.  That "f" is then passed to another
method which clarifies what it's type.

This commit looks to separate the "f" (which implies "file") from the
"FileSet" which is the container of a "file".

## Favor case instead of `use_valkyrie` switch

3f4618f99ac42e84f9cb809dae805a363a8fd50e

Aside from the `file_set.reload`, all other collaborators with the
ImportUrlJob can handle a Valkyrie::Resource or ActiveFedora::Base
object.

That change will be a future commit.

## Refactoring to provide switch for parent

30f41515dbfc9ff2cbff11eb2e4cd51f17da4402

A FileSet responds to "#parent", but a Hyrax::FileSet does not.  This
refactor helps with a future change.

## WIP

d44fcd552ca8da660a0c306084965a96043db666

Adding a possible approach to resolving #4196; I want to put this up for
comment before I proceed with further tests.

@samvera/hyrax-code-reviewers
