### PR TITLE
Move Hydra:AccessControl conversion to a valkyrie resource into ModelTransformer

### DIFF
--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -98,27 +98,6 @@ require 'wings/valkyrie/persister'
 require 'wings/valkyrie/storage'
 require 'wings/valkyrie/query_service'
 
-Hydra::AccessControl.send(:define_method, :valkyrie_resource) do
-  attrs = attributes.symbolize_keys
-  attrs[:new_record]  = new_record?
-  attrs[:created_at]  = create_date
-  attrs[:updated_at]  = modified_date
-
-  attrs[:permissions] = permissions.map do |permission|
-    agent = permission.type == 'group' ? "group/#{permission.agent_name}" : permission.agent_name
-
-    Hyrax::Permission.new(id: permission.id,
-                          mode: permission.access.to_sym,
-                          agent: agent,
-                          access_to: Valkyrie::ID.new(permission.access_to_id),
-                          new_record: permission.new_record?)
-  end
-
-  attrs[:access_to] = attrs[:permissions].find { |p| p.access_to&.id&.present? }&.access_to
-
-  Hyrax::AccessControl.new(**attrs)
-end
-
 begin
   require 'wings/setup'
 rescue NameError, Hyrax::SimpleSchemaLoader::UndefinedSchemaError => err

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -2,6 +2,7 @@
 
 ActiveFedora::Base.include Wings::Valkyrizable
 ActiveFedora::File.include Wings::Valkyrizable
+Hydra::AccessControl.include Wings::Valkyrizable
 
 module ActiveTriples
   class NodeConfig

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -363,4 +363,23 @@ RSpec.describe Wings::ModelTransformer, :clean_repo do
       end
     end
   end
+
+  context 'build for access control' do
+    let(:af_object) { ActiveFedora::Base.create }
+    let(:permission) { { name: "admin@example.com", access: :edit.to_s, type: :person } }
+    let(:access_control) do
+      Hydra::AccessControl.create.tap do |ac|
+        ac.owner = af_object
+        ac.permissions.create(permission)
+      end
+    end
+    let(:pcdm_object) { access_control }
+    subject(:resource) { factory.build }
+
+    it 'sets permissions' do
+      expect(resource.permissions.first.access_to).to eq pcdm_object.permissions.first.access_to_id
+      expect(resource.permissions.first.mode.to_s).to eq pcdm_object.permissions.first.access
+      expect(resource.permissions.first.agent).to eq pcdm_object.permissions.first.agent_name
+    end
+  end
 end


### PR DESCRIPTION
wings.rb was defining #valkyrie_resource directly on
Hydra::AccessControl but the query service is attempting to convert
using ModelTransformer which doesn't know how to handle AccessControl
objects.  Getting rid of the direct method declaration in favor of
Valkyrizable standardizes and solves this problem.

Fixes #4901

@samvera/hyrax-code-reviewers
