### PR TITLE
Default to ValkyrieWorkIndexer when resource is a Hyrax::Work

### DIFF
--- a/app/indexers/hyrax/valkyrie_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_indexer.rb
@@ -114,7 +114,7 @@ module Hyrax
 
         return indexer_class if indexer_class.is_a?(Class) &&
                                 indexer_class.instance_methods.include?(:to_solr)
-        ValkyrieIndexer
+        resource.try(:work?) ? Hyrax::ValkyrieWorkIndexer : ValkyrieIndexer
       end
     end
   end

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -117,6 +117,12 @@ module Hyrax
       hydra_model == ::AdminSet
     end
 
+    ##
+    # @return [Boolean]
+    def work?
+      Hyrax.config.curation_concerns.include? hydra_model
+    end
+
     # Method to return the model
     def hydra_model(classifier: ActiveFedora.model_mapper)
       "::#{first('has_model_ssim')}".safe_constantize ||

--- a/spec/controllers/hyrax/homepage_controller_spec.rb
+++ b/spec/controllers/hyrax/homepage_controller_spec.rb
@@ -46,11 +46,9 @@ RSpec.describe Hyrax::HomepageController, type: :controller do
       expect(titles).not_to include('Test Private Document')
     end
 
-    it "includes only GenericWork objects in recent documents" do
+    it "includes only Work objects in recent documents" do
       get :index
-      assigns(:recent_documents).each do |doc|
-        expect(doc["has_model_ssim"]).to eql ["GenericWork"]
-      end
+      expect(assigns(:recent_documents).all?(&:work?)).to eq true
     end
 
     context "with a document not created this second", clean_repo: true do

--- a/spec/indexers/hyrax/valkyrie_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_indexer_spec.rb
@@ -9,6 +9,15 @@ RSpec.describe Hyrax::ValkyrieIndexer do
         .to eq described_class
     end
 
+    context 'for a work' do
+      let(:resource) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+      it 'gives an instance of ValkyrieWorkIndexer' do
+        expect(described_class.for(resource: resource))
+          .to be_a Hyrax::ValkyrieWorkIndexer
+      end
+    end
+
     context 'for a collection' do
       let(:resource) { build(:hyrax_collection) }
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -196,6 +196,14 @@ RSpec.describe ::SolrDocument, type: :model do
     it { is_expected.to be_collection }
   end
 
+  describe "#work?" do
+    let(:attributes) { { 'has_model_ssim' => 'GenericWork' } }
+
+    subject { document }
+
+    it { is_expected.to be_work }
+  end
+
   describe "#collection_type_gid?" do
     let(:attributes) { { 'collection_type_gid_ssim' => 'gid://internal/hyrax-collectiontype/5' } }
 


### PR DESCRIPTION
When working on #4928 I noticed that `Hyrax::Test::SimpleWork` wasn't having it's permissions indexed because it doesn't have an indexer following the naming conventions.  Instead it was getting assigned `ValkyrieIndexer` which doesn't have the work specific includes.  This PR changes the default for `Hyrax::Work` resources to be `Hyrax::ValkyrieWorkIndexer` as a more helpful default.