### PR TITLE
enable expiration of embargoes when valkyrie is enabled

### DIFF
--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -28,7 +28,24 @@ module Hyrax
       filter_docs_with_edit_access!
       copy_visibility = []
       copy_visibility = params[:embargoes].values.map { |h| h[:copy_visibility] } if params[:embargoes]
-      af_objects = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
+      af_objects = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: Hyrax.config.use_valkyrie?)
+      if Hyrax.config.use_valkyrie? 
+        af_objects.each do |valkyrie_object|
+          manager = EmbargoManager.new(resource: valkyrie_object)
+          manager.release!
+          af = Wings::Valkyrie::ResourceFactory.new(adapter: Wings::Valkyrie::MetadataAdapter).from_resource(resource: valkyrie_object)
+          Hyrax::Actors::EmbargoActor.new(af).destroy
+        end
+      else
+        af_objects.each do |curation_concern|
+          Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
+          # if the concern is a FileSet, set its visibility and visibility propagation
+          if curation_concern.file_set?
+            curation_concern.visibility = curation_concern.to_solr["visibility_after_embargo_ssim"]
+            curation_concern.save!
+          elsif copy_visibility.include?(curation_concern.id)
+            Hyrax::VisibilityPropagator.for(source: curation_concern).propagate
+          end
       af_objects.each do |curation_concern|
         Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
         # if the concern is a FileSet, set its visibility and visibility propagation


### PR DESCRIPTION
This is a proposed fix for #4911

This allows for the expiration of embargoes when `use_valkyrie: true`. The main issue here is that when the persister is used, it tries to save the expired embargo. We really dont NEED to save the valkyrie object. The embargo is updated properly using the `EmbargoManager` and all we need to do is tell the AF Object that its embargo is expired too.

```
manager = EmbargoManager.new(resource: valkyrie_object)
manager.release!
af = Wings::Valkyrie::ResourceFactory.new(adapter: Wings::Valkyrie::MetadataAdapter).from_resource(resource: valkyrie_object)
Hyrax::Actors::EmbargoActor.new(af).destroy
```

This is the main bulk of the change. This transforms the valkyrie object back to an af object and then uses the embargo actor to expire it.

This is only a proposed change, and if this functionality needs to live elsewhere, then we can move this around to where it needs to go.