### PR TITLE
docker: add network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - hyrax-uploads:/app/samvera/hyrax-webapp/uploads
       - rails-public:/app/samvera/hyrax-webapp/public
       - rails-tmp:/app/samvera/hyrax-webapp/tmp
+    networks:
+      - hyrax
 
   chrome:
     image: selenium/standalone-chrome:3.141
@@ -44,6 +46,8 @@ services:
     ports:
       - "4444:4444"
       - "5959:5900"
+    networks:
+      - hyrax
 
   db_migrate:
     image: ghcr.io/samvera/dassie
@@ -59,6 +63,8 @@ services:
       - .:/app/samvera/hyrax-engine:cached
       - rails-public:/app/samvera/hyrax-webapp/public
       - rails-tmp:/app/samvera/hyrax-webapp/tmp
+    networks:
+      - hyrax
 
   postgres:
     image: postgres:latest
@@ -72,6 +78,8 @@ services:
       - "5432:5432"
     volumes:
       - db:/var/lib/postgresql/data
+    networks:
+      - hyrax
 
   fcrepo:
     image: ghcr.io/samvera/fcrepo4:4.7.5
@@ -79,16 +87,22 @@ services:
       - fcrepo:/data:cached
     ports:
       - 8080:8080
+    networks:
+      - hyrax
 
   memcached:
     image: bitnami/memcached
     ports:
       - '11211:11211'
+    networks:
+      - hyrax
 
   redis:
     image: redis:5-alpine
     volumes:
       - redis:/data
+    networks:
+      - hyrax
 
   sidekiq:
     build:
@@ -112,6 +126,8 @@ services:
       - hyrax-uploads:/app/samvera/hyrax-webapp/uploads
       - sidekiq-public:/app/samvera/hyrax-webapp/public
       - sidekiq-tmp:/app/samvera/hyrax-webapp/tmp
+    networks:
+      - hyrax
 
   solr:
     image: solr:8.7
@@ -124,6 +140,8 @@ services:
     volumes:
       - solr_home:/var/solr/data:cached
       - .dassie/solr/conf:/opt/solr/server/configsets/hyraxconf
+    networks:
+      - hyrax
 
 volumes:
   db:
@@ -136,3 +154,9 @@ volumes:
   sidekiq-public:
   sidekiq-tmp:
   solr_home:
+
+networks:
+  hyrax:
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.name: br-hyrax


### PR DESCRIPTION
without this I'm seeing 
```
db_migrate_1  | waiting for solr:8983
db_migrate_1  | nc: bad address 'solr'
```
during startup

https://docs.docker.com/network/bridge/

@samvera/hyrax-code-reviewers
