### PR TITLE
Feature/expire leases for valkyrie

### DIFF
--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -28,24 +28,17 @@ module Hyrax
       filter_docs_with_edit_access!
       copy_visibility = []
       copy_visibility = params[:embargoes].values.map { |h| h[:copy_visibility] } if params[:embargoes]
-      af_objects = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: Hyrax.config.use_valkyrie?)
-      if Hyrax.config.use_valkyrie? 
-        af_objects.each do |valkyrie_object|
-          manager = EmbargoManager.new(resource: valkyrie_object)
-          manager.release!
-          af = Wings::Valkyrie::ResourceFactory.new(adapter: Wings::Valkyrie::MetadataAdapter).from_resource(resource: valkyrie_object)
-          Hyrax::Actors::EmbargoActor.new(af).destroy
-        end
-      else
-        af_objects.each do |curation_concern|
-          Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
-          # if the concern is a FileSet, set its visibility and visibility propagation
-          if curation_concern.file_set?
-            curation_concern.visibility = curation_concern.to_solr["visibility_after_embargo_ssim"]
-            curation_concern.save!
-          elsif copy_visibility.include?(curation_concern.id)
-            Hyrax::VisibilityPropagator.for(source: curation_concern).propagate
-          end
+      resources = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: Hyrax.config.use_valkyrie?)
+      resources.each do |resource|
+        EmbargoManager.new(resource: resource).release! if Hyrax.config.use_valkyrie?
+        curation_concern = Wings::Valkyrie::ResourceFactory.new(adapter: Wings::Valkyrie::MetadataAdapter).from_resource(resource: resource) if Hyrax.config.use_valkyrie?
+        Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
+        # if the concern is a FileSet, set its visibility and visibility propagation
+        if curation_concern.file_set?
+          curation_concern.visibility = curation_concern.to_solr["visibility_after_embargo_ssim"]
+          curation_concern.save!
+        elsif copy_visibility.include?(curation_concern.id)
+          Hyrax::VisibilityPropagator.for(source: curation_concern).propagate
         end
       end
       redirect_to embargoes_path, notice: t('.embargo_deactivated')

--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -24,6 +24,8 @@ module Hyrax
     end
 
     # Updates a batch of embargos
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def update
       filter_docs_with_edit_access!
       copy_visibility = []
@@ -43,6 +45,8 @@ module Hyrax
       end
       redirect_to embargoes_path, notice: t('.embargo_deactivated')
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
 
     # This allows us to use the unauthorized template in curation_concerns/base
     def self.local_prefixes

--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -46,14 +46,6 @@ module Hyrax
           elsif copy_visibility.include?(curation_concern.id)
             Hyrax::VisibilityPropagator.for(source: curation_concern).propagate
           end
-      af_objects.each do |curation_concern|
-        Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
-        # if the concern is a FileSet, set its visibility and visibility propagation
-        if curation_concern.file_set?
-          curation_concern.visibility = curation_concern.to_solr["visibility_after_embargo_ssim"]
-          curation_concern.save!
-        elsif copy_visibility.include?(curation_concern.id)
-          Hyrax::VisibilityPropagator.for(source: curation_concern).propagate
         end
       end
       redirect_to embargoes_path, notice: t('.embargo_deactivated')

--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -28,7 +28,24 @@ module Hyrax
       filter_docs_with_edit_access!
       copy_visibility = []
       copy_visibility = params[:embargoes].values.map { |h| h[:copy_visibility] } if params[:embargoes]
-      af_objects = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
+      af_objects = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: Hyrax.config.use_valkyrie?)
+      if Hyrax.config.use_valkyrie? 
+        af_objects.each do |valkyrie_object|
+          manager = EmbargoManager.new(resource: valkyrie_object)
+          manager.release!
+          af = Wings::Valkyrie::ResourceFactory.new(adapter: Wings::Valkyrie::MetadataAdapter).from_resource(resource: valkyrie_object)
+          Hyrax::Actors::EmbargoActor.new(af).destroy
+        end
+      else
+        af_objects.each do |curation_concern|
+          Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
+          # if the concern is a FileSet, set its visibility and visibility propagation
+          if curation_concern.file_set?
+            curation_concern.visibility = curation_concern.to_solr["visibility_after_embargo_ssim"]
+            curation_concern.save!
+          elsif copy_visibility.include?(curation_concern.id)
+            Hyrax::VisibilityPropagator.for(source: curation_concern).propagate
+          end
       af_objects.each do |curation_concern|
         Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
         # if the concern is a FileSet, set its visibility and visibility propagation

--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -30,7 +30,7 @@ module Hyrax
       resources = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: true)
       resources.each do |resource|
         if true
-          EmbargoManager.new(resource: resource).release!
+          LeaseManager.new(resource: resource).release!
           Hyrax.persister.save(resource: resource)
         else
           Hyrax::Actors::LeaseActor.new(resource).destroy

--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -27,11 +27,16 @@ module Hyrax
       filter_docs_with_edit_access!
       copy_visibility = []
       copy_visibility = params[:leases].values.map { |h| h[:copy_visibility] } if params[:leases]
-      af_objects = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
-      af_objects.each do |curation_concern|
-        Hyrax::Actors::LeaseActor.new(curation_concern).destroy
-        Hyrax::VisibilityPropagator.for(source: curation_concern).propagate if
-          copy_visibility.include?(curation_concern.id)
+      resources = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: true)
+      resources.each do |resource|
+        if true
+          EmbargoManager.new(resource: resource).release!
+          Hyrax.persister.save(resource: resource)
+        else
+          Hyrax::Actors::LeaseActor.new(resource).destroy
+          Hyrax::VisibilityPropagator.for(source: resource).propagate if
+            copy_visibility.include?(resource.id)
+        end
       end
       redirect_to leases_path
     end

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -45,6 +45,26 @@ RSpec.describe Wings::Valkyrie::Persister do
       expect(saved.id).not_to be_blank
     end
 
+    let(:release_date) { Time.zone.today - 1 }
+    let(:a_work) { create(:generic_work, user: user) }
+    let(:user) { create(:user) }
+
+    before do
+      a_work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      a_work.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      a_work.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      a_work.embargo_release_date = release_date.to_s
+      a_work.embargo.save(validate: false)
+      a_work.save(validate: false)
+    end
+
+    it "can save a resource with an embargo" do
+      resources = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: [a_work.id], use_valkyrie: true)
+      saved = persister.save(resource: resources.first)
+      expect(saved).to be_persisted
+      expect(saved.id).not_to be_blank
+    end
+
     it "stores created_at/updated_at" do
       book = persister.save(resource: resource)
       book.title = ["test"]

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -8,6 +8,28 @@ RSpec.describe Wings::Valkyrie::Persister do
   let(:adapter) { Wings::Valkyrie::MetadataAdapter.new }
   let(:query_service) { adapter.query_service }
 
+  context "When an AF work exists with an embargo" do
+    let(:release_date) { Time.zone.today - 1 }
+    let(:a_work) { create(:generic_work, user: user) }
+    let(:user) { create(:user) }
+
+    before do
+      a_work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      a_work.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      a_work.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      a_work.embargo_release_date = release_date.to_s
+      a_work.embargo.save(validate: false)
+      a_work.save(validate: false)
+    end
+
+    it "can save a resource with an embargo" do
+      resources = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: [a_work.id], use_valkyrie: true)
+      saved = persister.save(resource: resources.first)
+      expect(saved).to be_persisted
+      expect(saved.id).not_to be_blank
+    end
+  end
+
   context "When passing a Valkyrie::Resource converted from an ActiveFedora::Base" do
     before do
       module Hyrax::Test
@@ -41,26 +63,6 @@ RSpec.describe Wings::Valkyrie::Persister do
     it "can save a resource" do
       expect(resource).not_to be_persisted
       saved = persister.save(resource: resource)
-      expect(saved).to be_persisted
-      expect(saved.id).not_to be_blank
-    end
-
-    let(:release_date) { Time.zone.today - 1 }
-    let(:a_work) { create(:generic_work, user: user) }
-    let(:user) { create(:user) }
-
-    before do
-      a_work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-      a_work.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-      a_work.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-      a_work.embargo_release_date = release_date.to_s
-      a_work.embargo.save(validate: false)
-      a_work.save(validate: false)
-    end
-
-    it "can save a resource with an embargo" do
-      resources = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: [a_work.id], use_valkyrie: true)
-      saved = persister.save(resource: resources.first)
       expect(saved).to be_persisted
       expect(saved.id).not_to be_blank
     end


### PR DESCRIPTION
Fixes #4912 

This code is currently based off the fixes for the embargoes. This is subject to change depending on how we want the embargo code to look.

This code is also dependent on the changes to hydra-head found here: https://github.com/samvera/hydra-head/pull/533 and an update found here: https://github.com/samvera/hyrax/pull/4939

What this does is allows for the setting of the hyrax config to enable valkyrie. Expiring leases looks different for valkyrie objects as they can use the LeaseManager to do so. This enables the code to make the choice between Valkyrie and AF.

This code is reliant on the changes to the Persister getting pushed through.