### PR TITLE
get a grip on the id vs alternate_ids situation in valkyrie

### DIFF
--- a/lib/hyrax/valkyrie_can_can_adapter.rb
+++ b/lib/hyrax/valkyrie_can_can_adapter.rb
@@ -19,6 +19,7 @@ module Hyrax
     #
     # @raise Hyrax::ObjectNotFoundError
     def self.find(_model_class, id)
+      return Hyrax.query_service.find_by(id: id) unless Hyrax.config.enable_noids?
       Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: id)
     rescue Valkyrie::Persistence::ObjectNotFoundError => err
       raise Hyrax::ObjectNotFoundError, err.message

--- a/spec/hyrax/valkyrie_can_can_adapter_spec.rb
+++ b/spec/hyrax/valkyrie_can_can_adapter_spec.rb
@@ -13,6 +13,24 @@ RSpec.describe Hyrax::ValkyrieCanCanAdapter do
       expect(described_class.find(work.class, work.id).id)
         .to eq work.id
     end
+
+    context 'with assigned ids, noids disabled', valkyrie_adapter: :test_adapter do
+      it 'finds the work' do
+        expect(described_class.find(work.class, work.id).id).to eq work.id
+      end
+    end
+
+    context 'with assigned ids, noids enabled', valkyrie_adapter: :test_adapter do
+      let(:work) do
+        FactoryBot.valkyrie_create(:hyrax_work, alternate_ids: ['a_noid'])
+      end
+
+      before { allow(Hyrax.config).to receive(:enable_noids?).and_return(true) }
+
+      it 'finds the work' do
+        expect(described_class.find(work.class, 'a_noid').id).to eq work.id
+      end
+    end
   end
 
   describe '.for_class' do


### PR DESCRIPTION
only query alternate_ids if the noid minter is enabled. the idea is that Hyrax
should resolve `alternate_ids` from user queries (i.e. via controllers), when
it mints noids into this field.

@samvera/hyrax-code-reviewers
