### PR TITLE
extract view dependency on `WorkForm#select_files` to a helper

### DIFF
--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -50,10 +50,18 @@ module Hyrax
     #
     # @param form [Object]
     #
-    # @return [Hash{String => String}] a map from file set labels to ids for
+    # @return [Array<Hash{String => String}>] a map from file set labels to ids for
     #   the parent object
     def form_file_set_select_for(parent:)
-      parent.select_files
+      return parent.select_files if parent.respond_to?(:select_files)
+      return {} unless parent.respond_to?(:member_ids)
+
+      file_sets =
+        Hyrax::PcdmMemberPresenterFactory.new(parent, nil).file_set_presenters
+
+      file_sets.each_with_object({}) do |presenter, hash|
+        hash[presenter.title_or_label] = presenter.id
+      end
     end
   end
 end

--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -44,5 +44,16 @@ module Hyrax
     def form_progress_sections_for(*)
       []
     end
+
+    ##
+    # Constructs a hash for a form `select`.
+    #
+    # @param form [Object]
+    #
+    # @return [Hash{String => String}] a map from file set labels to ids for
+    #   the parent object
+    def form_file_set_select_for(parent:)
+      parent.select_files
+    end
   end
 end

--- a/app/views/hyrax/base/_form_rendering.html.erb
+++ b/app/views/hyrax/base/_form_rendering.html.erb
@@ -7,7 +7,7 @@
       <div class="form-group">
         <span class="help-block"><%= t("hyrax.base.form_rendering.help_html") %></span>
         <%= f.select :rendering_ids,
-                    f.object.select_files,
+                    form_file_set_select_for(parent: f.object),
                     { include_blank: true },
                     { class: 'form-control', multiple: true } %>
       </div>

--- a/app/views/hyrax/base/_form_representative.html.erb
+++ b/app/views/hyrax/base/_form_representative.html.erb
@@ -6,7 +6,7 @@
         </legend>
         <div class="form-group">
           <span class="help-block"><%= t("hyrax.base.form_representative.help_html") %></span>
-          <%= f.select :representative_id, @form.select_files, {}, { class: 'form-control' } %>
+          <%= f.select :representative_id, form_file_set_select_for(parent: @form), {}, { class: 'form-control' } %>
         </div>
       </fieldset>
     </div>

--- a/app/views/hyrax/base/_form_thumbnail.html.erb
+++ b/app/views/hyrax/base/_form_thumbnail.html.erb
@@ -6,7 +6,7 @@
         </legend>
         <div class="form-group">
           <span class="help-block"><%= t("hyrax.base.form_thumbnail.help_html") %></span>
-          <%= f.select :thumbnail_id, @form.select_files, {}, { class: 'form-control' } %>
+          <%= f.select :thumbnail_id, form_file_set_select_for(parent: @form), {}, { class: 'form-control' } %>
         </div>
       </fieldset>
     </div>

--- a/spec/helpers/hyrax/work_form_helper_spec.rb
+++ b/spec/helpers/hyrax/work_form_helper_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Hyrax::WorkFormHelper do
-  describe 'form_tabs_for' do
+  describe '.form_tabs_for' do
     context 'with a change set style form' do
       let(:work) { build(:hyrax_work) }
       let(:form) { Hyrax::Forms::ResourceForm.for(work) }
@@ -32,7 +32,7 @@ RSpec.describe Hyrax::WorkFormHelper do
     end
   end
 
-  describe 'form_progress_sections_for' do
+  describe '.form_progress_sections_for' do
     context 'with a change set style form' do
       let(:work) { build(:hyrax_work) }
       let(:form) { Hyrax::Forms::ResourceForm.for(work) }
@@ -59,6 +59,34 @@ RSpec.describe Hyrax::WorkFormHelper do
 
       it 'returns an empty list' do
         expect(form_progress_sections_for(form: form)).to eq []
+      end
+    end
+  end
+
+  describe '.form_file_set_select_for' do
+    context 'with a legacy GenericWork form' do
+      let(:work) { stub_model(GenericWork, id: '456', member_ids: file_set_ids) }
+      let(:ability) { double }
+      let(:file_set_ids) { [] }
+      let(:form) { Hyrax::GenericWorkForm.new(work, ability, controller) }
+
+      it 'returns an empty hash' do
+        expect(form_file_set_select_for(parent: form)).to eq({})
+      end
+
+      context 'with file_set members' do
+        let(:file_set_ids) { file_sets.map(&:id) }
+
+        let(:file_sets) do
+          [FactoryBot.create(:file_set, label: 'moomin.jpg'),
+           FactoryBot.create(:file_set, label: 'snork.jpg')]
+        end
+
+        it 'gives labels => ids' do
+          expect(form_file_set_select_for(parent: form))
+            .to include('moomin.jpg' => an_instance_of(String),
+                        'snork.jpg' => an_instance_of(String))
+        end
       end
     end
   end


### PR DESCRIPTION
the Form objects probably don't *need* to know about SimpleForm's hash
arguments. extracting this dependency to a helper gives us more flexibility in
handling the view dependency.

our goal here is to avoid reimplementing this hash constructor for Valkyrie in
`ResourceForm`.

---

2351bf2 adds support for valkyrie ChangeSet-style forms.

this implementation assumes any editor of a work can read the titles of the file
sets. is that correct? should this be more stringent?

@samvera/hyrax-code-reviewers
