### PR TITLE
add `WorkShowPresenter#member_count`; avoid `#size`

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -223,6 +223,12 @@ module Hyrax
       end
     end
 
+    ##
+    # @return [Integer]
+    def member_count
+      @member_count ||= member_presenters.count
+    end
+
     # determine if the user can add this work to a collection
     # @param collections [Array<::Collection>] list of collections to which this user can deposit
     # @return true if the user can deposit to at least one collection OR if the user can create a collection; otherwise, false

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -27,7 +27,7 @@
   <div class="col-sm-6 text-right">
     <% if presenter.editor? && !workflow_restriction?(presenter) %>
       <%= link_to t('.edit'), edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
-      <% if presenter.member_presenters.size > 1 %>
+      <% if presenter.member_count > 1 %>
           <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
       <% end %>
       <% if presenter.valid_child_concerns.length > 0 %>

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -223,8 +223,25 @@ RSpec.describe Hyrax::WorkShowPresenter do
     let(:attributes) { obj.to_solr }
 
     it "filters out members that are file sets" do
-      expect(presenter.work_presenters.size).to eq 1
+      expect(presenter.work_presenters.count).to eq 1
       expect(presenter.work_presenters.first).to be_instance_of(described_class)
+    end
+  end
+
+  describe "#member_count" do
+    let(:obj) { FactoryBot.create(:work_with_file_and_work) }
+    let(:attributes) { obj.to_solr }
+
+    it "returns the member count" do
+      expect(presenter.member_count).to eq 2
+    end
+
+    context "with empty members" do
+      let(:obj) { FactoryBot.create(:work) }
+
+      it "returns 0" do
+        expect(presenter.member_count).to eq 0
+      end
     end
   end
 
@@ -233,7 +250,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
     let(:attributes) { obj.to_solr }
 
     it "returns appropriate classes for each" do
-      expect(presenter.member_presenters.size).to eq 2
+      expect(presenter.member_presenters.count).to eq 2
       expect(presenter.member_presenters.first).to be_instance_of(Hyrax::FileSetPresenter)
       expect(presenter.member_presenters.last).to be_instance_of(described_class)
     end

--- a/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
@@ -31,26 +31,34 @@ RSpec.describe 'hyrax/base/_show_actions.html.erb', type: :view do
       allow(presenter).to receive(:show_deposit_for?).with(anything).and_return(true)
       allow(presenter).to receive(:editor?).and_return(true)
     end
+
     context "when the work does not contain children" do
       before do
-        allow(presenter).to receive(:member_presenters).and_return([])
-        render 'hyrax/base/show_actions', presenter: presenter
+        allow(presenter).to receive(:member_presenters).and_return([].to_enum)
       end
+
       it "does not show file manager link" do
+        render 'hyrax/base/show_actions', presenter: presenter
+
         expect(rendered).not_to have_link 'File Manager'
       end
+
       it "shows edit / delete / Add to collection links" do
+        render 'hyrax/base/show_actions', presenter: presenter
+
         expect(rendered).to have_link 'Edit'
         expect(rendered).to have_link 'Delete'
         expect(rendered).to have_button 'Add to collection'
       end
     end
+
     context "when the work contains 1 child" do
       before do
-        allow(presenter).to receive(:member_presenters).and_return([member])
-        render 'hyrax/base/show_actions', presenter: presenter
+        allow(presenter).to receive(:member_presenters).and_return([member].to_enum)
       end
+
       it "does not show file manager link" do
+        render 'hyrax/base/show_actions', presenter: presenter
         expect(rendered).not_to have_link 'File Manager'
       end
     end
@@ -61,10 +69,11 @@ RSpec.describe 'hyrax/base/_show_actions.html.erb', type: :view do
       let(:file_attributes) { { id: '1234' } }
 
       before do
-        allow(presenter).to receive(:member_presenters).and_return([member, file_member])
-        render 'hyrax/base/show_actions', presenter: presenter
+        allow(presenter).to receive(:member_presenters).and_return([member, file_member].to_enum)
       end
+
       it "shows file manager link" do
+        render 'hyrax/base/show_actions', presenter: presenter
         expect(rendered).to have_link 'File Manager'
       end
     end


### PR DESCRIPTION
`#size` isn't available on all enumerables. to avoid the requirement to build
the full set to get a count, add a presenter method. this allows optimizations
like simply using `#member_ids` to provide the count.

@samvera/hyrax-code-reviewers
