### PR TITLE
refactor and rework LeaseControllerBehavior #update for valkyrie

### DIFF
--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -23,6 +23,8 @@ module Hyrax
       end
     end
 
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def update
       filter_docs_with_edit_access!
       copy_visibility = []
@@ -35,11 +37,13 @@ module Hyrax
         else
           Hyrax::Actors::LeaseActor.new(resource).destroy
         end
-        Hyrax::VisibilityPropagator.for(source: resource).propagate if 
+        Hyrax::VisibilityPropagator.for(source: resource).propagate if
           copy_visibility.include?(resource.id)
       end
       redirect_to leases_path
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
 
     # This allows us to use the unauthorized template in curation_concerns/base
     def self.local_prefixes


### PR DESCRIPTION
Fixes #4912 

These proposed changes update the LeasesControllerBehavior to work with valkyrie. There was some duplicated code in the fileset propogation, so that was pulled out of the if statement and gets processed afterwords. The rest of it is similar to Embargoes. It uses the LeaseManager to expire the embargo, then utilizes the ACL to propogate those permissions down to the ActiveFedora Object.