### PR TITLE
document and test Hyrax::ContextualPath

### DIFF
--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -9,6 +9,12 @@ module Hyrax
     include Hyrax::Schema(:core_metadata)
     include Hyrax::Schema(:basic_metadata)
 
+    def self.model_name(name_class: Hyrax::Name)
+      @_model_name ||= begin
+        name_class.new(self, nil, 'FileSet')
+      end
+    end
+
     attribute :file_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID) # id for FileMetadata resources
     attribute :original_file_id, Valkyrie::Types::ID # id for FileMetadata resource
     attribute :thumbnail_id, Valkyrie::Types::ID # id for FileMetadata resource

--- a/app/services/hyrax/contextual_path.rb
+++ b/app/services/hyrax/contextual_path.rb
@@ -1,14 +1,37 @@
 # frozen_string_literal: true
 module Hyrax
+  ##
+  # @api public
+  #
+  # Provides a polymorphic path for a target object (presenter) nested under the
+  # path of the parent, if given.
+  #
+  # @see WorkShowPresenter#contextual_path
+  #
+  # @example
+  #   Hyrax::ContextualPath.new(my_file_set, parent_object).show
+  #   # => "/concerns/parent/id4parent/file_sets/id4file_set"
+  #
+  # @example with a nil parent
+  #   Hyrax::ContextualPath.new(my_file_set, nil).show
+  #   # => "/concerns/file_sets/id4file_set"
+  #
   class ContextualPath
     include Rails.application.routes.url_helpers
     include ActionDispatch::Routing::PolymorphicRoutes
     attr_reader :presenter, :parent_presenter
+
+    ##
+    # @param presenter [#model_name] an ActiveModel-like target object
+    # @param parent_presenter [#id, nil] an ActiveModel-like presenter for the
+    #   target's parent
     def initialize(presenter, parent_presenter)
       @presenter = presenter
       @parent_presenter = parent_presenter
     end
 
+    ##
+    # @return [String]
     def show
       if parent_presenter
         polymorphic_path([:hyrax, :parent, presenter.model_name.singular.to_sym],

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -1215,7 +1215,7 @@ de:
         subject: Stapelweises Hochladen abgeschlossen
         title: Dateien erfolgreich hochgeladen
     models:
-      hyrax/file_set: Dateisatz
+      file_set: Dateisatz
       hyrax/pcdm_collection: Sammlung
       hyrax/work: Arbeit
     my:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1221,7 +1221,7 @@ en:
         subject: Batch upload complete
         title: Files uploaded successfully
     models:
-      hyrax/file_set: File Set
+      file_set: File Set
       hyrax/pcdm_collection: Collection
       hyrax/work: Work
     my:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1222,7 +1222,7 @@ es:
         subject: Subida en lote completa
         title: Archivos cargados satisfactoriamente
     models:
-      hyrax/file_set: Conjunto de archivos
+      file_set: Conjunto de archivos
       hyrax/pcdm_collection: Colección
       hyrax/work: Trabaja
     my:

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -1221,7 +1221,7 @@ fr:
         subject: Téléchargement par lots complet
         title: Fichiers téléchargés avec succès
     models:
-      hyrax/file_set: Ensemble de fichiers
+      file_set: Ensemble de fichiers
       hyrax/pcdm_collection: Collection
       hyrax/work: Travailler
     my:

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -1220,7 +1220,7 @@ it:
         subject: Caricamento batch completato
         title: I file sono stati caricati correttamente
     models:
-      hyrax/file_set: Set di file
+      file_set: Set di file
       hyrax/pcdm_collection: Collezione
       hyrax/work: Opera
     my:

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -1215,7 +1215,7 @@ pt-BR:
         subject: Carga em lote completo
         title: Arquivos carregados com sucesso
     models:
-      hyrax/file_set: Conjunto de arquivos
+      file_set: Conjunto de arquivos
       hyrax/pcdm_collection: Coleção
       hyrax/work: Trabalhar
     my:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -1218,7 +1218,7 @@ zh:
         subject: 批量上传完成
         title: 文件上传成功
     models:
-      hyrax/file_set: 文件集
+      file_set: 文件集
       hyrax/pcdm_collection: 收藏
       hyrax/work: 工作
     my:

--- a/spec/presenters/hyrax/pcdm_member_presenter_factory_spec.rb
+++ b/spec/presenters/hyrax/pcdm_member_presenter_factory_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::PcdmMemberPresenterFactory, index_adapter: :solr_index, va
     match do |actual|
       actual.id == expected.id &&
         (actual.solr_document['has_model_ssim'].first ==
-         expected.model_name.name)
+         expected.class.name)
     end
   end
 

--- a/spec/services/hyrax/contextual_path_spec.rb
+++ b/spec/services/hyrax/contextual_path_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::ContextualPath, valkyrie_adapter: :test_adapter do
+  subject(:contextual_path) { described_class.new(object, parent) }
+  let(:object) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+  let(:parent) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+  describe '#show' do
+    it 'gives the path nested under a parent' do
+      expect(contextual_path.show)
+        .to eq "/concern/parent/#{parent.id}/file_sets/#{object.id}"
+    end
+
+    context 'with nil parent' do
+      let(:parent) { nil }
+
+      it 'gives just the path for the object' do
+        expect(contextual_path.show).to eq "/concern/file_sets/#{object.id}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
add tests and documentation for Hyrax::ContextualPath.

add a `Hyrax::FileSet.model_name` implementation for compatibility with
`FileSet`. the change in model name/namespaceing shouldn't change our paths.

@samvera/hyrax-code-reviewers
