### PR TITLE
Allow all ActiveFedora 12.x releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - samvera/install_solr_core:
-          solr_config_path: .internal_test_app/solr/config
+          solr_config_path: .internal_test_app/solr/conf
       # Rerun bundler in case this is a different ruby version than bundle and build steps
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -30,7 +30,7 @@ SUMMARY
   # http://guides.rubyonrails.org/maintenance_policy.html
   spec.add_dependency 'rails', '~> 5.0'
 
-  spec.add_dependency 'active-fedora', '>= 11.5.2', '< 12.2'
+  spec.add_dependency 'active-fedora', '>= 11.5.2', '< 13'
   spec.add_dependency 'almond-rails', '~> 0.1'
   spec.add_dependency 'awesome_nested_set', '~> 3.1'
   spec.add_dependency 'blacklight', '~> 6.14'

--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -34,7 +34,7 @@ module Hyrax
 
     def run_required_generators
       say_status('info', '[Hyrax] GENERATING BLACKLIGHT', :blue)
-      generate 'blacklight:install --devise'
+      generate 'blacklight:install --devise --skip-solr'
       say_status('info', '[Hyrax] GENERATING HYDRA-HEAD', :blue)
       generate 'hydra:head -f'
       generate "hyrax:models#{options[:force] ? ' -f' : ''}"

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -19,6 +19,7 @@ require 'hyrax/version'
 require 'hyrax/inflections'
 require 'kaminari_route_prefix'
 require 'solrizer'
+require 'retriable'
 
 module Hyrax
   extend ActiveSupport::Autoload


### PR DESCRIPTION
There are a number of improvements in the 12.2.x line of ActiveFedora that it would be great to be able to use in Hyrax 2.x.

@samvera/hyrax-code-reviewers
