### PR TITLE
Allow for overriding the way form tab labels are created

### DIFF
--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -27,6 +27,29 @@ module Hyrax
     end
 
     ##
+    # This helper allows downstream applications and engines to change the label of tabs to be
+    # rendered on the work form.
+    #
+    # @example passing information from the form into the translations
+    #  Override this helper and ensure that it loads after Hyrax's helpers.
+    #  module WorksHelper
+    #    def form_tab_label_for(form:, tab:)
+    #      if tab == 'metadata'
+    #        t("hyrax.works.form.tab.#{tab}", title: form.model.title.first)
+    #      else
+    #        super
+    #      end
+    #    end
+    #  end
+    #
+    # @param form [Hyrax::Forms::WorkForm]
+    # @param tab [String]
+    # @return [String] the label of the tab to be rendered in the form
+    def form_tab_label_for(form:, tab:) # rubocop:disable Lint/UnusedMethodArgument
+      t("hyrax.works.form.tab.#{tab}")
+    end
+
+    ##
     # This helper allows downstream applications and engines to add additional sections to be
     # rendered after the visibility section in the Save Work panel on the work form.
     #

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -11,14 +11,14 @@
             <li role="presentation">
           <% end %>
               <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
-                <%= t("hyrax.works.form.tab.#{tab}") %>
+                <%= form_tab_label_for(form: f.object, tab: tab) %>
               </a>
             </li>
         <% end %>
 
         <li role="presentation" id="tab-share" class="hidden">
           <a href="#share" aria-controls="share" role="tab" data-toggle="tab">
-            <%= t("hyrax.works.form.tab.share") %>
+            <%= form_tab_label_for(form: f.object, tab: 'share') %>
           </a>
         </li>
       </ul>

--- a/spec/helpers/hyrax/work_form_helper_spec.rb
+++ b/spec/helpers/hyrax/work_form_helper_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe Hyrax::WorkFormHelper do
     end
   end
 
+  describe '.form_tab_label_for' do
+    let(:form) { double('form') }
+    let(:tab) { 'metadata' }
+
+    it 'returns the label' do
+      expect(form_tab_label_for(form: form, tab: tab)).to eq "Descriptions"
+    end
+  end
+
   describe '.form_progress_sections_for' do
     context 'with a change set style form' do
       let(:work) { build(:hyrax_work) }


### PR DESCRIPTION
This allows for downstream apps and engines to pass variables into translations based upon the form and tab.

The use case we have is to have a tab for collecting notes and to have the tab label include the number of notes present.

![image](https://user-images.githubusercontent.com/1053603/118706855-db545e80-b7e7-11eb-9448-b57e9853ea9a.png)

@samvera/hyrax-code-reviewers
