### PR TITLE
Don't warn or use Gemfile.extra when not using engine_cart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,6 @@ if File.exist?(test_app_gemfile)
     Bundler.ui.warn e.message
   end
 else
-  Bundler.ui.warn "[Hyrax] Unable to find test application dependencies in #{test_app_gemfile}, using placeholder dependencies"
-
   # rubocop:disable Bundler/DuplicatedGem
   if ENV['RAILS_VERSION']
     if ENV['RAILS_VERSION'] == 'edge'
@@ -39,6 +37,4 @@ else
     end
   end
   # rubocop:enable Bundler/DuplicatedGem
-
-  eval_gemfile File.expand_path('spec/test_app_templates/Gemfile.extra', File.dirname(__FILE__))
 end

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ test_app_path = ENV['RAILS_ROOT'] ||
                 ENV.fetch('ENGINE_CART_DESTINATION', File.expand_path('.internal_test_app', File.dirname(__FILE__)))
 test_app_gemfile = File.expand_path('Gemfile', test_app_path)
 
+# rubocop:disable Bundler/DuplicatedGem
 if File.exist?(test_app_gemfile)
   begin
     eval_gemfile test_app_gemfile
@@ -26,13 +27,10 @@ if File.exist?(test_app_gemfile)
     Bundler.ui.warn '[Hyrax] Skipping Rails application dependencies:'
     Bundler.ui.warn e.message
   end
-else
-  # rubocop:disable Bundler/DuplicatedGem
-  if ENV['RAILS_VERSION'] == 'edge'
-    gem 'rails', github: 'rails/rails', source: 'https://rubygems.org'
-    ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks'
-  elsif ENV['RAILS_VERSION']
-    gem 'rails', ENV['RAILS_VERSION'], source: 'https://rubygems.org'
-  end
-  # rubocop:enable Bundler/DuplicatedGem
+elsif ENV['RAILS_VERSION'] == 'edge'
+  gem 'rails', github: 'rails/rails', source: 'https://rubygems.org'
+  ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks'
+elsif ENV['RAILS_VERSION']
+  gem 'rails', ENV['RAILS_VERSION'], source: 'https://rubygems.org'
 end
+# rubocop:enable Bundler/DuplicatedGem

--- a/Gemfile
+++ b/Gemfile
@@ -28,13 +28,11 @@ if File.exist?(test_app_gemfile)
   end
 else
   # rubocop:disable Bundler/DuplicatedGem
-  if ENV['RAILS_VERSION']
-    if ENV['RAILS_VERSION'] == 'edge'
-      gem 'rails', github: 'rails/rails', source: 'https://rubygems.org'
-      ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks'
-    else
-      gem 'rails', ENV['RAILS_VERSION'], source: 'https://rubygems.org'
-    end
+  if ENV['RAILS_VERSION'] == 'edge'
+    gem 'rails', github: 'rails/rails', source: 'https://rubygems.org'
+    ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks'
+  elsif ENV['RAILS_VERSION']
+    gem 'rails', ENV['RAILS_VERSION'], source: 'https://rubygems.org'
   end
   # rubocop:enable Bundler/DuplicatedGem
 end


### PR DESCRIPTION
When doing a fresh checkout of hyrax and not generating the internal test app, I ran into errors running the first `bundle install`:
```
[Hyrax] Unable to find test application dependencies in /home/cjcolvar/Code/samvera/hyrax/.internal_test_app/Gemfile, using placeholder dependencies
Your Gemfile lists the gem okcomputer (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
Warning: the running version of Bundler (2.2.14) is older than the version that created the lockfile (2.2.17). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.2.17`.
Fetching gem metadata from https://rubygems.org/........
Could not find gem 'better_errors' in locally installed gems.
The source does not contain any versions of 'better_errors'
```
`better_errors` is coming from `spec/test_app_templates/Gemfile.extra` used by `engine_cart`.

Because using docker and dassie instead of engine_cart is the preferred dev environment now I think we can skip warning the user and skip trying to load Gemfile.extra when the internal test app isn't present.

@samvera/hyrax-code-reviewers
