### PR TITLE
support ::Ability (can? style) checks for WorkShowPresenter and FileSetPresenter

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -417,8 +417,10 @@ module Hyrax
 
     def extract_subjects(subject)
       case subject
+      when Hyrax::WorkShowPresenter, FileSetPresenter
+        extract_subjects(subject.solr_document)
       when Draper::Decorator
-        super(subject.model)
+        extract_subjects(subject.model)
       else
         super
       end

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -57,8 +57,13 @@ module Hyrax
       current_ability.can?(:read, id) ? first_title : 'File'
     end
 
+    ##
+    # @deprecated use `::Ability.can?(:edit, presenter)`. Hyrax views calling
+    #   presenter {#editor} methods will continue to call them until Hyrax
+    #   4.0.0. The deprecation time horizon for the presenter methods themselves
+    #   is 5.0.0.
     def editor?
-      current_ability.can?(:edit, solr_document)
+      current_ability.can?(:edit, self)
     end
 
     def tweeter

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -132,8 +132,13 @@ module Hyrax
       graph.dump(:ttl)
     end
 
+    ##
+    # @deprecated use `::Ability.can?(:edit, presenter)`. Hyrax views calling
+    #   presenter {#editor} methods will continue to call them until Hyrax
+    #   4.0.0. The deprecation time horizon for the presenter methods themselves
+    #   is 5.0.0.
     def editor?
-      current_ability.can?(:edit, solr_document)
+      current_ability.can?(:edit, self)
     end
 
     def tweeter

--- a/spec/models/concerns/hyrax/ability_spec.rb
+++ b/spec/models/concerns/hyrax/ability_spec.rb
@@ -65,4 +65,25 @@ RSpec.describe Hyrax::Ability do
       its(:registered_user?) { is_expected.to be false }
     end
   end
+
+  context 'with a WorkShowPresenter' do
+    # we want to stub the object under test here, because we want to ensure it
+    # is calling another method on itself to resolve these authorizations
+    # rubocop:disable RSpec/SubjectStub
+    let(:attributes)    { { id: 'my_solr_doc_id' } }
+    let(:presenter)     { Hyrax::WorkShowPresenter.new(solr_document, ability, :NULL_REQUEST) }
+    let(:solr_document) { SolrDocument.new(attributes) }
+
+    describe 'can?(:edit)' do
+      it 'defers strictly to the presenter solr_document ' do
+        expect(ability)
+          .to receive(:test_edit)
+          .with('my_solr_doc_id')
+          .and_return(true)
+
+        expect(ability.can?(:edit, presenter)).to eq true
+      end
+    end
+    # rubocop:enable RSpec/SubjectStub
+  end
 end

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
                      publisher_tesim: ['French Press'])
   end
 
-  let(:decorated_work_solr_document) { Hyrax::SolrDocument::OrderedMembers.decorate(work_solr_document) }
-
   let(:file_set_solr_document) do
     SolrDocument.new(id: '123',
                      title_tesim: ['My FileSet'],
@@ -48,7 +46,8 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
   end
 
   before do
-    allow(ability).to receive(:can?).with(:edit, decorated_work_solr_document).and_return(false)
+    allow(view).to receive(:workflow_restriction?).and_return(false)
+    allow(ability).to receive(:can?).with(:edit, presenter).and_return(false)
     allow(presenter).to receive(:workflow).and_return(workflow_presenter)
     allow(presenter).to receive(:representative_presenter).and_return(representative_presenter)
     allow(presenter).to receive(:representative_id).and_return(representative_presenter&.id)

--- a/spec/views/hyrax/file_sets/show.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/show.html.erb_spec.rb
@@ -28,10 +28,7 @@ RSpec.describe 'hyrax/file_sets/show.html.erb', type: :view do
   before do
     allow(view).to receive(:workflow_restriction?).and_return(false)
     view.lookup_context.prefixes.push 'hyrax/base'
-    allow(view).to receive(:can?).with(:edit, Hyrax::SolrDocument::OrderedMembers).and_return(false)
-    allow(ability).to receive(:can?).with(:edit, Hyrax::SolrDocument::OrderedMembers).and_return(false)
-    allow(view).to receive(:can?).with(:edit, SolrDocument).and_return(false)
-    allow(ability).to receive(:can?).with(:edit, SolrDocument).and_return(false)
+    allow(ability).to receive(:can?).with(:edit, presenter).and_return(false)
     allow(presenter).to receive(:fixity_status).and_return(mock_metadata)
     assign(:presenter, presenter)
     assign(:parent_presenter, parent_presenter)


### PR DESCRIPTION
this is to deprecate presenter `#editor?` methods.

we're in a bit of a bind, re: deprecation. our views use these methods, which
means application-side presenters will have been reasonable to use this as a
hook to drive view behavior.

the proposed deprecation path is:

now: mark these methods deprecated now, encourage calling `can?(:edit)`
directly.

4.0.0: remove existing calls to #editor? from the Hyrax codebase. add
deprecation warnings to the methods.

5.0.0: remove #editor? methods.

@samvera/hyrax-code-reviewers
