### PR TITLE
helperize download link display flag

### DIFF
--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 module Hyrax::FileSetHelper
+  ##
+  # @todo inline the "workflow restriction" into the `can?(:download)` check.
+  #
+  # @param file_set [#id]
+  #
+  # @return [Boolean] whether to display the download link for the given file
+  #   set
+  def display_media_download_link?(file_set:)
+    Hyrax.config.display_media_download_link? &&
+      can?(:download, file_set) &&
+      !workflow_restriction?(file_set.try(:parent))
+  end
+
   def parent_path(parent)
     if parent.is_a?(::Collection)
       main_app.collection_path(parent)

--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.try(:parent)) %>
+<% if display_media_download_link?(file_set: file_set) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,6 +1,6 @@
 <div class="no-preview">
   <%= t('hyrax.works.show.no_preview') %>
-  <% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.try(:parent)) %>
+  <% if display_media_download_link?(file_set: file_set) %>
     <p /><%= link_to t('hyrax.file_set.show.download'),
       hyrax.download_path(file_set),
       id: "file_download",

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) && !workflow_restriction?(file_set.try(:parent)) %>
+<% if display_media_download_link?(file_set: file_set) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.try(:parent)) %>
+<% if display_media_download_link?(file_set: file_set) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.try(:parent)) %>
+<% if display_media_download_link?(file_set: file_set) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,4 +1,4 @@
-<% if Hyrax.config.display_media_download_link? && !workflow_restriction?(file_set.try(:parent)) %>
+<% if display_media_download_link?(file_set: file_set) %>
   <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">

--- a/spec/helpers/hyrax/file_set_helper_spec.rb
+++ b/spec/helpers/hyrax/file_set_helper_spec.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::FileSetHelper do
+  describe '#display_media_download_link?' do
+    let(:ability)  { double(Ability) }
+    let(:file_set) { FactoryBot.create(:file_set) }
+
+    before do
+      allow(controller).to receive(:current_ability).and_return(ability)
+    end
+
+    it 'does not allow download when permissions restrict it' do
+      allow(ability).to receive(:can?).with(:download, file_set).and_return(false)
+
+      expect(helper.display_media_download_link?(file_set: file_set)).to eq false
+    end
+
+    it 'allows download when permissions allow it ' do
+      allow(ability).to receive(:can?).with(:download, file_set).and_return(true)
+
+      expect(helper.display_media_download_link?(file_set: file_set)).to eq true
+    end
+  end
+
   describe '#media_display' do
     let(:file_set) { SolrDocument.new(mime_type_ssi: mime_type) }
     let(:mime_type) { 'image/tiff' }

--- a/spec/views/hyrax/file_sets/media_display/_audio.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_audio.html.erb_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/file_sets/media_display/_audio.html.erb', type: :view do
+  let(:ability)  { double(Ability) }
   let(:file_set) { stub_model(FileSet, parent: parent) }
-  let(:config) { double }
   let(:parent) { double }
   let(:link) { true }
 
   before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:can?).with(:download, file_set).and_return(true)
     allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
     render 'hyrax/file_sets/media_display/audio', file_set: file_set

--- a/spec/views/hyrax/file_sets/media_display/_default.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_default.html.erb_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/file_sets/media_display/_default.html.erb', type: :view do
+  let(:ability)  { double(Ability) }
   let(:file_set) { stub_model(FileSet, parent: parent) }
   let(:parent) { double }
-  let(:config) { double }
   let(:link) { true }
 
   before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:can?).with(:download, file_set).and_return(true)
     allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
     render 'hyrax/file_sets/media_display/default', file_set: file_set

--- a/spec/views/hyrax/file_sets/media_display/_video.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_video.html.erb_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/file_sets/media_display/_video.html.erb', type: :view do
+  let(:ability)  { double(Ability) }
   let(:file_set) { stub_model(FileSet, parent: parent) }
   let(:parent) { double }
-  let(:config) { double }
   let(:link) { true }
 
   before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:can?).with(:download, file_set).and_return(true)
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
     allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
     render 'hyrax/file_sets/media_display/video', file_set: file_set

--- a/spec/views/hyrax/file_sets/show.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/show.html.erb_spec.rb
@@ -26,8 +26,10 @@ RSpec.describe 'hyrax/file_sets/show.html.erb', type: :view do
   let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
 
   before do
+    allow(controller).to receive(:current_ability).and_return(ability)
     allow(view).to receive(:workflow_restriction?).and_return(false)
     view.lookup_context.prefixes.push 'hyrax/base'
+    allow(ability).to receive(:can?).with(:download, presenter).and_return(true)
     allow(ability).to receive(:can?).with(:edit, presenter).and_return(false)
     allow(presenter).to receive(:fixity_status).and_return(mock_metadata)
     assign(:presenter, presenter)


### PR DESCRIPTION
move some repeated (and incorrect in some places!) view logic into a helper.

this reduces duplication, aligning the behavior and hopefully preventing future drift.

## Guidance for Testing
  - it would be good to confirm that the download links are displaying on the file set show pages

@samvera/hyrax-code-reviewers
