### PR TITLE
Trigger nurax-dev deploy on commits to hyrax/main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,17 @@ jobs:
           command: bundle exec rake app:db:migrate
       - samvera/parallel_rspec
 
+  deploy:
+    docker:
+      - image: ubuntu
+    steps:
+      - run:
+          name: Install curl
+          command: apt-get update && apt-get install -y curl
+      - run:
+          name: "Trigger Nurax deploy"
+          command: "curl -u ${CIRCLE_API_KEY}: -d build_parameters[CIRCLE_JOB]=start_workflows https://circleci.com/api/v1.1/project/github/curationexperts/nurax/tree/main"
+
 workflows:
   version: 2
   ruby2-5-8:
@@ -192,3 +203,11 @@ workflows:
           bundler_version: "2.1.4"
           requires:
             - build
+  nurax-dev_deploy:
+    jobs:
+      - deploy:
+          filters:
+            branches:
+              only:
+                - deploy_to_nurax # remove this once deploy is successful
+                - main


### PR DESCRIPTION
Fixes #issuenumber ; refs #issuenumber

Nurax is a testing environment for testing the state of Hyrax, hosted currently by Data Curation Experts (DCE). Currently, there are deploys to nurax-dev run on a cron job on the server once every 24 hours, and nurax-stable on each release. 

When Hyrax development is going faster, going to the test environment once every 24 hours may be too slow, and deploying to nurax-dev on every commit to hyrax/main might help speed development on Hyrax.

In order to deploy to nurax-dev on commit to hyrax/main using CircleCI, the hook has to be on the hyrax/main git repository, necessitating a change to the Hyrax CircleCI config. 

@samvera/hyrax-code-reviewers
