### PR TITLE
deprecate `Suppressible#suppressed?`

### DIFF
--- a/app/models/concerns/hyrax/suppressible.rb
+++ b/app/models/concerns/hyrax/suppressible.rb
@@ -10,6 +10,11 @@ module Hyrax
     end
 
     ##
+    # @deprecated use `Hyrax::ResourceStatus` instead. in most cases,
+    #   {#suppressed?} is being called on a {SolrDocumentBehavior}. we continue
+    #   to index `suppressed_bsi` and expose its value as an attribute on solr
+    #   document objects.
+    #
     # Used to restrict visibility on search results for a work that is inactive. If the state is not set, the
     # default behavior is to consider the work not to be suppressed.
     #

--- a/app/services/hyrax/resource_status.rb
+++ b/app/services/hyrax/resource_status.rb
@@ -37,6 +37,13 @@ module Hyrax
     end
 
     ##
+    # @param [#state] resource
+    # @return [Boolean]
+    def self.inactive?(resource:)
+      new(resource: resource).inactive?
+    end
+
+    ##
     # @return [Boolean]
     # @raise [NoMethodError] if the resource doesn't have a state attribute
     def active?

--- a/spec/services/hyrax/resource_status_spec.rb
+++ b/spec/services/hyrax/resource_status_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe Hyrax::ResourceStatus do
     end
   end
 
+  describe '.inactive?' do
+    let(:resource) { fake_with_status.new(Hyrax::ResourceStatus::ACTIVE) }
+
+    it { expect(described_class.inactive?(resource: resource)).to eq false }
+
+    context 'when inactive' do
+      let(:resource) { fake_with_status.new(Hyrax::ResourceStatus::INACTIVE) }
+
+      it { expect(described_class.inactive?(resource: resource)).to eq true }
+    end
+  end
+
   describe '#active?' do
     it { is_expected.not_to be_active }
 


### PR DESCRIPTION
this behavior has been extracted to `Hyrax::ResourceStatus.new(resource:
self).inactive?`. since it won't be used on models going forward it's important
to stop calling it. since we've encouraged folks to override this method with
custom behavior, we can't stop calling it from some key places in Hyrax yet,
mainly the indexers.

`#suppressed?` is still used on `SolrDocument`, and we'll continue to index
`suppressed_bsi` and provide `#suppressed?` for `SolrDocumentBehavior` and
presenters.

@samvera/hyrax-code-reviewers
