### PR TITLE
use valkyrie to power collection member removal from Dashboard

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -384,7 +384,7 @@ module Hyrax
 
       def remove_members_from_collection
         batch.each do |pid|
-          work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: pid, use_valkyrie: false)
+          work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: pid, use_valkyrie: Hyrax.config.use_valkyrie?)
           work.member_of_collections.delete @collection
           work.save!
         end

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -385,8 +385,14 @@ module Hyrax
       def remove_members_from_collection
         batch.each do |pid|
           work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: pid, use_valkyrie: Hyrax.config.use_valkyrie?)
-          work.member_of_collections.delete @collection
-          work.save!
+          case work
+          when ActiveFedora::Base
+            work.member_of_collections.delete @collection
+            work.save!
+          when Valkyrie::Resource
+            work.member_of_collections_ids.delete @collection.id
+            Hyrax.persister.save(resource: work)
+          end
         end
       end
 

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -390,7 +390,7 @@ module Hyrax
             work.member_of_collections.delete @collection
             work.save!
           when Valkyrie::Resource
-            work.member_of_collections_ids.delete @collection.id
+            work.member_of_collection_ids.delete @collection.id
             Hyrax.persister.save(resource: work)
           end
         end


### PR DESCRIPTION
Fixes #4914 

This object has been updated to use Valkyrie when deleting collections. Instead of responding to #member_of_collections, it responds to #member_of_collection_ids. Then you can call delete using the id of the collection and then persist the valkyrie object.