### PR TITLE
use `ActiveRecord::Base#find_by` instead of `#where` for versions

### DIFF
--- a/app/presenters/hyrax/version_presenter.rb
+++ b/app/presenters/hyrax/version_presenter.rb
@@ -20,8 +20,9 @@ module Hyrax
     end
 
     def committer
-      vc = Hyrax::VersionCommitter.where(version_id: @version.uri)
-      vc.empty? ? nil : vc.first.committer_login
+      Hyrax::VersionCommitter
+        .find_by(version_id: @version.uri)
+        &.committer_login
     end
   end
 end


### PR DESCRIPTION
`#find_by` is a more efficient query and using it simplifies the method.

@samvera/hyrax-code-reviewers
