### PR TITLE
make VersionPresenterList an Enumerable; extract creation to factory

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -154,8 +154,7 @@ module Hyrax
     def initialize_edit_form
       @parent = @file_set.in_objects.first
       guard_for_workflow_restriction_on!(parent: @parent)
-      original = @file_set.original_file
-      @version_list = Hyrax::VersionListPresenter.new(original ? original.versions.all : [])
+      @version_list = Hyrax::VersionListPresenter.for(file_set: @file_set)
       @groups = current_user.groups
     end
 

--- a/app/presenters/hyrax/version_list_presenter.rb
+++ b/app/presenters/hyrax/version_list_presenter.rb
@@ -1,8 +1,27 @@
 # frozen_string_literal: true
 module Hyrax
+  ##
+  # @api public
   class VersionListPresenter
+    include Enumerable
+
+    ##
+    # @param version_list [Array<#created>]
     def initialize(version_list)
       @raw_list = version_list
+    end
+
+    ##
+    # @param [Object] an object representing the File Set
+    #
+    # @return [Enumerable<Hyrax::VersionPresenter>] an enumerable of presenters
+    #   for the relevant file versions.
+    #
+    # @raise [ArugumentError] if we can't build an enu
+    def self.for(file_set:)
+      new(file_set.original_file&.versions&.all.to_a)
+    rescue NoMethodError
+      raise ArgumentError
     end
 
     delegate :each, to: :wrapped_list

--- a/spec/presenters/hyrax/version_list_presenter_spec.rb
+++ b/spec/presenters/hyrax/version_list_presenter_spec.rb
@@ -16,15 +16,47 @@ RSpec.describe Hyrax::VersionListPresenter do
     end
   end
 
-  subject { described_class.new([resource_version, resource_version2]) }
+  subject(:enum) { described_class.new([resource_version, resource_version2]) }
+
+  describe ".for" do
+    context "with an ActiveFedora::Base" do
+      it "gives an empty enumerable" do
+        file_set = FactoryBot.create(:file_set)
+
+        expect(described_class.for(file_set: file_set)).to be_none
+      end
+
+      it "enumerates over version presenters for original_file" do
+        file_set   = FactoryBot.create(:file_set)
+        binary     = StringIO.new("hey")
+        new_binary = StringIO.new("hey2")
+
+        Hydra::Works::AddFileToFileSet
+          .call(file_set, binary, :original_file, versioning: true)
+        Hydra::Works::AddFileToFileSet
+          .call(file_set, new_binary, :original_file, versioning: true)
+
+        expect(described_class.for(file_set: file_set).count).to eq 2
+      end
+    end
+
+    context "with a bad argument" do
+      it "raises an error" do
+        expect { described_class.for(file_set: nil) }
+          .to raise_error ArgumentError
+      end
+    end
+  end
 
   describe "#each" do
     it "yields version_presenters" do
       versions_descending = []
-      subject.each do |v|
+
+      enum.each do |v|
         expect(v).to be_kind_of Hyrax::VersionPresenter
         versions_descending.push(v.label)
       end
+
       expect(versions_descending).to eq ['version2', 'version1']
     end
   end


### PR DESCRIPTION
`VersionPresenterList` is effectively an `Enumerable` (responds only to
`#each`), extending it with `include Enumerable` makes it more
versitile (perhaps we should consider a rename?). the current implementation
relies on loading each member up-front and then sorting, but this might not be
necessary for all backends. `Enumerable` also provides some guidance about how
to do this kind of loading lazily.

move the generation to a factory so the details of how to resolve an object to a
list of versions are encapsulated.

@samvera/hyrax-code-reviewers
