### PR TITLE
add a ChangeSet-based form for file sets 

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -86,7 +86,11 @@ module Hyrax
 
     private
 
-    # this is provided so that implementing application can override this behavior and map params to different attributes
+    ##
+    # @api public
+    #
+    # @note this is provided so that implementing application can override this
+    #   behavior and map params to different attributes
     def update_metadata
       file_attributes = form_class.model_attributes(attributes)
       actor.update_metadata(file_attributes)

--- a/app/forms/hyrax/forms/file_set_form.rb
+++ b/app/forms/hyrax/forms/file_set_form.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Forms
+    ##
+    # @api public
+    class FileSetForm < Hyrax::ChangeSet
+      class << self
+        ##
+        # @return [Array<Symbol>] list of required field names as symbols
+        def required_fields
+          definitions
+            .select { |_, definition| definition[:required] }
+            .keys.map(&:to_sym)
+        end
+      end
+
+      property :title, required: true
+      property :creator, required: true
+      property :license, required: true
+
+      property :based_near
+      property :contributor
+      property :date_created
+      property :description
+      property :identifier
+      property :keyword
+      property :language
+      property :publisher
+      property :related_url
+      property :subject
+      property :visibility, default: VisibilityIntention::PRIVATE
+
+      # virtual properties for embargo/lease;
+      property :embargo_release_date, virtual: true
+      property :visibility_after_embargo, virtual: true
+      property :visibility_during_embargo, virtual: true
+      property :lease_expiration_date, virtual: true
+      property :visibility_after_lease, virtual: true
+      property :visibility_during_lease, virtual: true
+    end
+  end
+end

--- a/spec/forms/hyrax/forms/file_set_form_spec.rb
+++ b/spec/forms/hyrax/forms/file_set_form_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Forms::FileSetForm do
+  subject(:form) { described_class.new(file_set) }
+  let(:file_set) { Hyrax::FileSet.new }
+
+  describe '.fields' do
+    # rubocop:disable RSpec/RepeatedDescription (these aren't repeated, rubocop)
+    its(:fields) { is_expected.to have_key('based_near') }
+    its(:fields) { is_expected.to have_key('creator') }
+    its(:fields) { is_expected.to have_key('contributor') }
+    its(:fields) { is_expected.to have_key('date_created') }
+    its(:fields) { is_expected.to have_key('description') }
+    its(:fields) { is_expected.to have_key('identifier') }
+    its(:fields) { is_expected.to have_key('keyword') }
+    its(:fields) { is_expected.to have_key('language') }
+    its(:fields) { is_expected.to have_key('license') }
+    its(:fields) { is_expected.to have_key('publisher') }
+    its(:fields) { is_expected.to have_key('related_url') }
+    its(:fields) { is_expected.to have_key('subject') }
+    its(:fields) { is_expected.to have_key('title') }
+    its(:fields) { is_expected.to have_key('visibility') }
+    # rubocop:enable RSpec/RepeatedDescription
+  end
+
+  describe '.required_fields' do
+    it 'lists the fields tagged required' do
+      expect(described_class.required_fields)
+        .to contain_exactly(:title, :creator, :license)
+    end
+  end
+
+  describe '#embargo_release_date' do
+    context 'without an embargo' do
+      it 'is nil' do
+        expect { form.prepopulate! }
+          .not_to change { form.embargo_release_date }
+          .from(nil)
+      end
+    end
+  end
+
+  describe '#lease_expiration_date' do
+    context 'without a lease' do
+      it 'is nil' do
+        expect { form.prepopulate! }
+          .not_to change { form.lease_expiration_date }
+          .from(nil)
+      end
+    end
+  end
+
+  describe '#required' do
+    it 'requires title' do
+      expect(form.required?(:title)).to eq true
+    end
+  end
+
+  describe '#visibility_after_embargo' do
+    context 'without an embargo' do
+      it 'is nil' do
+        expect { form.prepopulate! }
+          .not_to change { form.visibility_after_embargo }
+          .from(nil)
+      end
+    end
+  end
+
+  describe '#visibility_during_embargo' do
+    context 'without an embargo' do
+      it 'is nil' do
+        expect { form.prepopulate! }
+          .not_to change { form.visibility_during_embargo }
+          .from(nil)
+      end
+    end
+  end
+
+  describe '#visibility_after_lease' do
+    context 'without a lease' do
+      it 'is nil' do
+        expect { form.prepopulate! }
+          .not_to change { form.visibility_after_lease }
+          .from(nil)
+      end
+    end
+  end
+
+  describe '#visibility_during_lease' do
+    context 'without a lease' do
+      it 'is nil' do
+        expect { form.prepopulate! }
+          .not_to change { form.visibility_during_lease }
+          .from(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
this is the beginning of a drop-in replacement for the existing `FileSetEditForm` supporting valkyrie. it's possible that this form could be adapted to work for `ActiveFedora` objects as well.

@samvera/hyrax-code-reviewers
