### PR TITLE
Allow active-fedora 12.2 

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -30,7 +30,7 @@ SUMMARY
   # http://guides.rubyonrails.org/maintenance_policy.html
   spec.add_dependency 'rails', '~> 5.0'
 
-  spec.add_dependency 'active-fedora', '>= 11.5.2', '< 12.2'
+  spec.add_dependency 'active-fedora', '>= 11.5.2', '< 13'
   spec.add_dependency 'almond-rails', '~> 0.1'
   spec.add_dependency 'awesome_nested_set', '~> 3.1'
   spec.add_dependency 'blacklight', '~> 6.14'


### PR DESCRIPTION
This unblocks pulling in newer hydra-derivatives.

@samvera/hyrax-code-reviewers
