### PR TITLE
wings: generated Valkyrie::Resource classes route back to AF

### DIFF
--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -13,6 +13,8 @@ module Hyrax
   #
   # @see https://github.com/projectblacklight/blacklight/wiki/Understanding-Rails-and-Blacklight#models
   module SolrDocumentBehavior
+    ModelWrapper = ActiveFedoraDummyModel # alias for backward compatibility
+
     extend ActiveSupport::Concern
     include Hydra::Works::MimeTypes
     include Hyrax::Permissions::Readable
@@ -40,63 +42,12 @@ module Hyrax
     end
 
     ##
-    # Given a model class and an +id+, provides +ActiveModel+ style model methods.
-    #
-    # @note access this via {SolrDocumentBehavior#to_model}.
-    class ModelWrapper
-      ##
-      # @api private
-      #
-      # @param [Class] model
-      # @param [String, nil] id
-      def initialize(model, id)
-        @model = model
-        @id = id
-      end
-
-      ##
-      # @api public
-      def persisted?
-        true
-      end
-
-      ##
-      # @api public
-      def to_param
-        @id
-      end
-
-      ##
-      # @api public
-      def model_name
-        @model.model_name
-      end
-
-      ##
-      # @api public
-      #
-      # @note uses the @model's `._to_partial_path` if implemented, otherwise
-      #   constructs a default
-      def to_partial_path
-        return @model._to_partial_path if
-          @model.respond_to?(:_to_partial_path)
-
-        "hyrax/#{model_name.collection}/#{model_name.element}"
-      end
-
-      ##
-      # @api public
-      def to_global_id
-        URI::GID.build app: GlobalID.app, model_name: model_name.name, model_id: @id
-      end
-    end
-    ##
     # Offer the source model to Rails for some of the Rails methods (e.g. link_to).
     #
     # @example
     #   link_to '...', SolrDocument(:id => 'bXXXXXX5').new => <a href="/dams_object/bXXXXXX5">...</a>
     def to_model
-      @model ||= ModelWrapper.new(hydra_model, id)
+      @model ||= ActiveFedoraDummyModel.new(hydra_model, id)
     end
 
     ##

--- a/lib/hyrax/active_fedora_dummy_model.rb
+++ b/lib/hyrax/active_fedora_dummy_model.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # @api public
+  #
+  # Given a model class and an +id+, provides +ActiveModel+ style methods. This
+  # is a tool for providing route resolution and other +ActiveModel+ behavior
+  # for +ActiveFedora+ without loading the object from the fedora backend.
+  #
+  # @note this was originally implemented for +SolrDocument+ as
+  #   +Hyrax::SolrDocumentBehavior::ModelWrapper+, but is useful in the more
+  #   general case that we know the model class and id, but don't have a full
+  #   model object.
+  #
+  class ActiveFedoraDummyModel
+    ##
+    # @api public
+    #
+    # @param [Class] model
+    # @param [String, nil] id
+    def initialize(model, id)
+      @model = model
+      @id = id
+    end
+
+    ##
+    # @api public
+    def persisted?
+      true
+    end
+
+    ##
+    # @api public
+    def to_param
+      @id
+    end
+
+    ##
+    # @api public
+    def model_name
+      @model.model_name
+    end
+
+    ##
+    # @api public
+    #
+    # @note uses the @model's `._to_partial_path` if implemented, otherwise
+    #   constructs a default
+    def to_partial_path
+      return @model._to_partial_path if
+        @model.respond_to?(:_to_partial_path)
+
+      "hyrax/#{model_name.collection}/#{model_name.element}"
+    end
+
+    ##
+    # @api public
+    def to_global_id
+      URI::GID.build app: GlobalID.app, model_name: model_name.name, model_id: @id
+    end
+  end
+end

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -22,6 +22,7 @@ module Hyrax
     require 'valkyrie'
 
     require 'hydra/derivatives'
+    require 'hyrax/active_fedora_dummy_model'
     require 'hyrax/controller_resource'
     require 'hyrax/form_fields'
     require 'hyrax/indexer'

--- a/lib/wings/orm_converter.rb
+++ b/lib/wings/orm_converter.rb
@@ -41,6 +41,12 @@ module Wings
           end
 
           ##
+          # @return [String]
+          def to_s
+            internal_resource
+          end
+
+          ##
           # @api private
           def _canonical_valkyrie_model
             ancestors[1..-1].find { |parent| parent < ::Valkyrie::Resource }
@@ -49,10 +55,6 @@ module Wings
 
         def to_global_id
           URI::GID.build([GlobalID.app, internal_resource, id, {}])
-        end
-
-        def self.to_s
-          internal_resource
         end
 
         klass.properties.each_key do |property_name|

--- a/lib/wings/orm_converter.rb
+++ b/lib/wings/orm_converter.rb
@@ -53,8 +53,18 @@ module Wings
           end
         end
 
+        ##
+        # @return [URI::GID]
         def to_global_id
           URI::GID.build([GlobalID.app, internal_resource, id, {}])
+        end
+
+        ##
+        # @return [ActiveModel::Base]
+        def to_model
+          model_class = internal_resource.safe_constantize || self
+
+          Hyrax::ActiveFedoraDummyModel.new(model_class, id)
         end
 
         klass.properties.each_key do |property_name|

--- a/spec/wings/orm_converter_spec.rb
+++ b/spec/wings/orm_converter_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Wings::OrmConverter do
         it 'includes name in instance inspect' do
           expect(klass.new.inspect).to start_with '#<Hyrax::Work'
         end
+
+        it 'has a to_model for route resolution' do
+          expect(klass.new.to_model)
+            .to have_attributes(model_name: an_instance_of(Hyrax::Name),
+                                to_partial_path: 'hyrax/generic_works/generic_work')
+        end
       end
 
       context 'for a custom class' do
@@ -42,6 +48,12 @@ RSpec.describe Wings::OrmConverter do
 
         it 'includes name in instance inspect' do
           expect(klass.new.inspect).to start_with '#<Hyrax::Test::BookResource'
+        end
+
+        it 'has a to_model for route resolution' do
+          expect(klass.new.to_model)
+            .to have_attributes(model_name: an_instance_of(ActiveModel::Name),
+                                to_partial_path: 'hyrax/test/books/book')
         end
       end
     end


### PR DESCRIPTION
generated Valkyrie::Resource models should support ActiveModel-like behavior for
routing back to the ActiveFedora::Base objects they are based on.

we had an existing implementation of exactly this requirement for
`SolrDocument`, so that is extracted and reused in `Wings`.

@samvera/hyrax-code-reviewers
