### PR TITLE
deprecate `media_display` helper

### DIFF
--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -21,12 +21,19 @@ module Hyrax::FileSetHelper
     end
   end
 
-  # REVIEW: Since this media display could theoretically work for
-  #         any object that inplements to_s and the Mime Type methos (image? audio? ...),
-  #         Should this really be in file_set or could it be in it's own helper class like media_helper?
+  ##
+  # @deprecated use render(media_display_partial(file_set), file_set: file_set)
+  #   instead
+  #
+  # @param presenter [Object]
+  # @param locals [Hash{Symbol => Object}]
   def media_display(presenter, locals = {})
-    render media_display_partial(presenter),
-           locals.merge(file_set: presenter)
+    Deprecation.warn("the helper `media_display` renders a partial name " \
+                     "provided by `media_display_partial`. Callers " \
+                     "should render `media_display_partial(file_set) directly
+                     instead.")
+
+    render(media_display_partial(presenter), locals.merge(file_set: presenter))
   end
 
   def media_display_partial(file_set)
@@ -45,5 +52,4 @@ module Hyrax::FileSetHelper
         'default'
       end
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -2,7 +2,7 @@
   <% if defined?(viewer) && viewer %>
     <%= iiif_viewer_display presenter %>
   <% else %>
-    <%= media_display presenter.representative_presenter %>
+    <%= render media_display_partial(presenter.representative_presenter), file_set: presenter.representative_presenter  %>
   <% end %>
 <% else %>
   <%= image_tag 'default.png', class: "canonical-image", alt: 'default representative image' %>

--- a/app/views/hyrax/file_sets/edit.html.erb
+++ b/app/views/hyrax/file_sets/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="row">
   <div class="col-xs-12 col-sm-4">
-    <%= media_display curation_concern.to_presenter %>
+    <%= render media_display_partial(curation_concern.to_presenter), file_set: curation_concern.to_presenter %>
   </div>
   <div class="col-xs-12 col-sm-8">
     <div class="panel panel-default tabs">

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -2,7 +2,7 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-xs-12 col-sm-4">
-      <%= media_display @presenter %>
+      <%= render media_display_partial(@presenter), file_set: @presenter %>
       <%= render 'show_actions', presenter: @presenter %>
       <%= render 'single_use_links', presenter: @presenter if @presenter.editor? %>
     </div>


### PR DESCRIPTION
this partial exists only to call `render`. the indirection isn't helpful, so we
inline its code and encourage callers to render the partial directly from the
view.

@samvera/hyrax-code-reviewers
