### PR TITLE
always use valkyrie for collection member removal from dashboard

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -383,16 +383,11 @@ module Hyrax
       end
 
       def remove_members_from_collection
-        batch.each do |pid|
-          work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: pid, use_valkyrie: Hyrax.config.use_valkyrie?)
-          case work
-          when ActiveFedora::Base
-            work.member_of_collections.delete @collection
-            work.save!
-          when Valkyrie::Resource
-            work.member_of_collection_ids.delete @collection.id
-            Hyrax.persister.save(resource: work)
-          end
+        batch.each do |member_id|
+          work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: member_id)
+          work.member_of_collection_ids.delete @collection.id
+          Hyrax.persister.save(resource: work) &&
+            Hyrax.publisher.publish('object.metadata.updated', object: work, user: current_user)
         end
       end
 


### PR DESCRIPTION
use valkyrie to handle removal of objects from collections. ensure the update controller action publishes events for object metadata updates on save.

@samvera/hyrax-code-reviewers
