### PR TITLE
add basic view test for the file_sets/edit template

### DIFF
--- a/spec/views/hyrax/file_sets/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/edit.html.erb_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/file_sets/edit.html.erb', type: :view do
+  let(:ability)  { Ability.new(user) }
+  let(:file_set) { stub_model(FileSet) }
+  let(:parent)   { stub_model(GenericWork) }
+  let(:form)     { Hyrax::Forms::FileSetEditForm.new(file_set) }
+  let(:user)     { FactoryBot.build(:user) }
+  let(:versions) { [] }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(view).to receive(:curation_concern).and_return(file_set)
+    allow(view).to receive(:form).and_return(form)
+    assign(:version_list, versions)
+
+    stub_template "hyrax/file_sets/_form.html.erb" => "Form for File Set"
+    stub_template "hyrax/file_sets/_permission.html.erb" => "Permissions for File Set"
+  end
+
+  it 'renders the page without preview by default' do
+    render
+
+    expect(rendered).to include "No preview available"
+  end
+end


### PR DESCRIPTION
this key view was completely untested, and requires quite a bit of careful setup
to work correctly!

this is a very basic test that stubs most of the later partials. getting this in
should help us scale down the setup required for the view and later partials.

@samvera/hyrax-code-reviewers
