### PR TITLE
extract view dependency on NestedCollectionQueryService to helper

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -2,6 +2,14 @@
 module Hyrax
   module CollectionsHelper
     ##
+    # @since 3.1.0
+    # @return [Array<SolrDocument>]
+    def available_child_collections(collection:)
+      Hyrax::Collections::NestedCollectionQueryService
+        .available_child_collections(parent: collection, scope: controller, limit_to_id: nil)
+    end
+
+    ##
     # @since 3.0.0
     # @return [#to_s]
     def collection_metadata_label(collection, field)

--- a/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
@@ -14,10 +14,9 @@
         <input type="hidden" name="source" value="<%= source %>" />
         <select name="child_id">
           <option value="none"><%= t("hyrax.dashboard.my.action.select") %></option>
-          <% colls = Hyrax::Collections::NestedCollectionQueryService.available_child_collections(parent: collection, scope: controller, limit_to_id: nil) %>
-          <% colls.each {|coll| %>
+          <% available_child_collections(collection: collection).each do |coll| %>
             <option value="<%= coll.id %>"><%= coll.title.first %></option>
-          <% } %>
+          <% end %>
         </select>
       </div>
 

--- a/spec/helpers/hyrax/collections_helper_spec.rb
+++ b/spec/helpers/hyrax/collections_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::CollectionsHelper do
-  let(:user) { create(:user, groups: ['admin']) }
+  let(:user) { FactoryBot.create(:user, groups: ['admin']) }
   let(:ability) { Ability.new(user) }
 
   before do
@@ -9,6 +9,29 @@ RSpec.describe Hyrax::CollectionsHelper do
     allow(view).to receive(:collection_path) do |collection|
       id = collection.respond_to?(:id) ? collection.id : collection
       "/collections/#{id}"
+    end
+  end
+
+  describe '#available_child_collections' do
+    let(:repository) { Blacklight::Solr::Repository.new(bl_config) }
+    let(:bl_config) { CatalogController.blacklight_config }
+
+    before do
+      allow(controller).to receive(:blacklight_config).and_return(bl_config)
+      allow(controller).to receive(:repository).and_return(repository)
+      allow(controller).to receive(:current_ability).and_return(ability)
+    end
+
+    it 'gives an empty set for a missing collection' do
+      expect(helper.available_child_collections(collection: nil)).to be_empty
+    end
+
+    it 'gives a list of available collections' do
+      FactoryBot.create(:collection) # other collection
+      current_collection = FactoryBot.create(:collection)
+
+      expect(helper.available_child_collections(collection: current_collection))
+        .not_to be_empty
     end
   end
 


### PR DESCRIPTION
the subcollection modal had a hard coded dependency on
`NestedCollectionQueryService`, which depends on very specific indexing behavior
for collections. extracting that dependency to a helper makes it easier to
control the specific behavior.

in writing tests for this new helper, i tried to analyze the behavior of the
downstream method. the current tests there are heavily stubbed, and it's not
clear which collections are *supposed* to be included in this list (apparently
something to do with the collection type?). the current tests are therefore
minimal, and test the current behavior (which is suprising to me; a collection
can be added as a subcollection of itself?).

@samvera/hyrax-code-reviewers
