### PR TITLE
Some realignment of FileSetsController

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -156,9 +156,10 @@ module Hyrax
     end
 
     def initialize_edit_form
-      @parent = @file_set.in_objects.first
+      @form = form_class.new(curation_concern).prepopulate!
+      @parent = @form.parent
       guard_for_workflow_restriction_on!(parent: @parent)
-      @version_list = Hyrax::VersionListPresenter.for(file_set: @file_set)
+      @version_list = @form.versions
       @groups = current_user.groups
     end
 

--- a/app/forms/hyrax/forms/file_set_edit_form.rb
+++ b/app/forms/hyrax/forms/file_set_edit_form.rb
@@ -16,5 +16,19 @@ module Hyrax::Forms
                   :visibility_during_embargo, :visibility_after_embargo, :embargo_release_date,
                   :visibility_during_lease, :visibility_after_lease, :lease_expiration_date,
                   :visibility]
+
+    def parent
+      model.in_objects.first
+    end
+
+    ##
+    # @note for compatibility with Valkyrie::ChangeSet
+    def prepopulate!
+      self
+    end
+
+    def versions
+      @versions ||= Hyrax::VersionListPresenter.for(file_set: model)
+    end
   end
 end

--- a/app/forms/hyrax/forms/file_set_edit_form.rb
+++ b/app/forms/hyrax/forms/file_set_edit_form.rb
@@ -4,7 +4,7 @@ module Hyrax::Forms
     include HydraEditor::Form
     include HydraEditor::Form::Permissions
 
-    delegate :depositor, :permissions, to: :model
+    delegate :depositor, :id, :permissions, to: :model
 
     self.required_fields = [:title, :creator, :license]
 

--- a/app/forms/hyrax/forms/file_set_edit_form.rb
+++ b/app/forms/hyrax/forms/file_set_edit_form.rb
@@ -3,6 +3,7 @@ module Hyrax::Forms
   class FileSetEditForm
     include HydraEditor::Form
     include HydraEditor::Form::Permissions
+    include Hydra::Works::MimeTypes
 
     delegate :depositor, :id, :permissions, to: :model
 
@@ -22,9 +23,19 @@ module Hyrax::Forms
     end
 
     ##
-    # @note for compatibility with Valkyrie::ChangeSet
+    # Frontload queries for supplementary data, avoiding database calls from
+    # views.
+    #
+    # @note "#prepopulate!" is named for compatibility with Valkyrie::ChangeSet.
     def prepopulate!
+      @mime_type = CatalogController.new.fetch(model.id).last.mime_type
       self
+    end
+
+    ##
+    # @return [String]
+    def mime_type
+      @mime_type || ""
     end
 
     def versions

--- a/app/forms/hyrax/forms/file_set_form.rb
+++ b/app/forms/hyrax/forms/file_set_form.rb
@@ -38,6 +38,12 @@ module Hyrax
       property :lease_expiration_date, virtual: true
       property :visibility_after_lease, virtual: true
       property :visibility_during_lease, virtual: true
+
+      # virtual properties for pcdm membership
+      property :parent, virtual: true, prepopulator: ->(_opts) { self.parent = Hyrax.query_service.find_parents(resource: model).first }
+
+      # virtual properties for versions
+      property :versions, virtual: true, prepopulator: ->(_opts) { self.versions = Hyrax::VersionListPresenter.for(file_set: model) }
     end
   end
 end

--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -37,25 +37,21 @@ module Hyrax::FileSetHelper
   end
 
   def media_display_partial(file_set) # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
-    slug = case file_set
-           when ActiveFedora::Base
-             return media_display_partial(CatalogController.new.fetch(file_set.id).last)
-           else
-             if file_set.image?
-               'image'
-             elsif file_set.video?
-               'video'
-             elsif file_set.audio?
-               'audio'
-             elsif file_set.pdf?
-               'pdf'
-             elsif file_set.office_document?
-               'office_document'
-             else
-               'default'
-             end
-           end
+    type = Hyrax::FileSetTypeService.for(file_set: file_set)
 
-    "hyrax/file_sets/media_display/#{slug}"
+    "hyrax/file_sets/media_display/" +
+      if type.image?
+        'image'
+      elsif type.video?
+        'video'
+      elsif type.audio?
+        'audio'
+      elsif type.pdf?
+        'pdf'
+      elsif type.office_document?
+        'office_document'
+      else
+        'default'
+      end
   end
 end

--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -36,20 +36,26 @@ module Hyrax::FileSetHelper
     render(media_display_partial(presenter), locals.merge(file_set: presenter))
   end
 
-  def media_display_partial(file_set)
-    'hyrax/file_sets/media_display/' +
-      if file_set.image?
-        'image'
-      elsif file_set.video?
-        'video'
-      elsif file_set.audio?
-        'audio'
-      elsif file_set.pdf?
-        'pdf'
-      elsif file_set.office_document?
-        'office_document'
-      else
-        'default'
-      end
+  def media_display_partial(file_set) # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+    slug = case file_set
+           when ActiveFedora::Base
+             return media_display_partial(CatalogController.new.fetch(file_set.id).last)
+           else
+             if file_set.image?
+               'image'
+             elsif file_set.video?
+               'video'
+             elsif file_set.audio?
+               'audio'
+             elsif file_set.pdf?
+               'pdf'
+             elsif file_set.office_document?
+               'office_document'
+             else
+               'default'
+             end
+           end
+
+    "hyrax/file_sets/media_display/#{slug}"
   end
 end

--- a/app/models/concerns/hyrax/file_set_behavior.rb
+++ b/app/models/concerns/hyrax/file_set_behavior.rb
@@ -33,8 +33,17 @@ module Hyrax
       to_param
     end
 
+    ##
+    # @deprecated
+    #
     # Cast to a SolrDocument by querying from Solr
     def to_presenter
+      Deprecation.warn "#to_presenter makes duplicative calls to Solr. " \
+                       "if you are reaching this message from a custom " \
+                       "file_sets/edit template, we recommend calling " \
+                       "media_display_partial directly on the " \
+                       "`curation_concern` local."
+
       CatalogController.new.fetch(id).last
     end
   end

--- a/app/presenters/hyrax/version_list_presenter.rb
+++ b/app/presenters/hyrax/version_list_presenter.rb
@@ -19,6 +19,7 @@ module Hyrax
     #
     # @raise [ArgumentError] if we can't build an enu
     def self.for(file_set:)
+      return new([]) if file_set.is_a?(Valkyrie::Resource)
       new(file_set.original_file&.versions&.all.to_a)
     rescue NoMethodError
       raise ArgumentError

--- a/app/services/hyrax/file_set_type_service.rb
+++ b/app/services/hyrax/file_set_type_service.rb
@@ -50,9 +50,13 @@ module Hyrax
     # @return [#audio?, #image?, #office_document?, #pdf?, #video?]
     def self.for(file_set:, characterization_proxy: ::FileSet.characterization_proxy, **opts)
       case file_set
-      when ActiveFedora::Base, HydraEditor::Form
+      when ActiveFedora::Base
+        Deprecation.warn("Resolving FileSet mime type from an" \
+                         "ActiveFedora::Base requires a Solr query. " \
+                         "Pass in a SolrDocument or form object to avoid " \
+                         "triggering this query unnecessarily.")
         CatalogController.new.fetch(file_set.id).last
-      when SolrDocument
+      when HydraEditor::Form, SolrDocument
         file_set
       else
         new(file_set: file_set, characterization_proxy: characterization_proxy, **opts)

--- a/app/services/hyrax/file_set_type_service.rb
+++ b/app/services/hyrax/file_set_type_service.rb
@@ -4,12 +4,27 @@ module Hyrax
   ##
   # Resolves file sets to a mime type. Provides a series of utility methods for
   # figuring out what a file set is all about.
-  #
-  # @note this service is for `Hyrax::FileSet` Valkyrie Resources. for
-  #   ActiveFedora file sets see Hydra::Works::MimeTypes
   class FileSetTypeService
     DEFAULT_AUDIO_TYPES = ['audio/mp3', 'audio/mpeg', 'audio/wav',
                            'audio/x-wave', 'audio/x-wav', 'audio/ogg'].freeze
+
+    DEFAULT_IMAGE_TYPES = ["image/png", "image/jpeg", "image/jpg", "image/jp2",
+                           "image/bmp", "image/gif", "image/tiff"].freeze
+
+    DEFAULT_OFFICE_TYPES =
+      ["text/rtf", "application/msword",
+       "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+       "application/vnd.oasis.opendocument.text", "application/vnd.ms-excel",
+       "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+       "application/vnd.ms-powerpoint",
+       "application/vnd.openxmlformats-officedocument.presentationml.presentation"]
+      .freeze
+
+    DEFAULT_PDF_TYPES = ["application/pdf"].freeze
+
+    DEFAULT_VIDEO_TYPES = ["video/mpeg", "video/mp4", "video/webm",
+                           "video/x-msvideo", "video/avi", "video/quicktime",
+                           "application/mxf"].freeze
 
     ##
     # @!attribute [r] file_set
@@ -29,6 +44,21 @@ module Hyrax
       @queries = query_service
     end
 
+    ##
+    # @param [Hyrax::FileSet] file_set
+    #
+    # @return [#audio?, #image?, #office_document?, #pdf?, #video?]
+    def self.for(file_set:, characterization_proxy: ::FileSet.characterization_proxy, **opts)
+      case file_set
+      when ActiveFedora::Base, HydraEditor::Form
+        CatalogController.new.fetch(file_set.id).last
+      when SolrDocument
+        file_set
+      else
+        new(file_set: file_set, characterization_proxy: characterization_proxy, **opts)
+      end
+    end
+
     def metadata
       @metadata ||= @queries.find_many_file_metadata_by_use(resource: file_set, use: @proxy_use).first
     end
@@ -45,11 +75,55 @@ module Hyrax
       audio_types.include?(mime_type)
     end
 
+    ##
+    # @return [Boolean]
+    def image?
+      image_types.include?(mime_type)
+    end
+
+    ##
+    # @return [Boolean]
+    def office_document?
+      office_types.include?(mime_type)
+    end
+
+    ##
+    # @return [Boolean]
+    def pdf?
+      pdf_types.include?(mime_type)
+    end
+
+    ##
+    # @return [Boolean]
+    def video?
+      video_types.include?(mime_type)
+    end
+
     private
 
     def audio_types
       return ::FileSet.audio_mime_types if defined?(::FileSet)
       DEFAULT_AUDIO_TYPES
+    end
+
+    def image_types
+      return ::FileSet.image_mime_types if defined?(::FileSet)
+      DEFAULT_IMAGE_TYPES
+    end
+
+    def office_types
+      return ::FileSet.office_document_mime_types if defined?(::FileSet)
+      DEFAULT_OFFICE_TYPES
+    end
+
+    def pdf_types
+      return ::FileSet.pdf_mime_types if defined?(::FileSet)
+      DEFAULT_PDF_TYPES
+    end
+
+    def video_types
+      return ::FileSet.video_mime_types if defined?(::FileSet)
+      DEFAULT_VIDEO_TYPES
     end
   end
 end

--- a/app/views/hyrax/file_sets/edit.html.erb
+++ b/app/views/hyrax/file_sets/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="row">
   <div class="col-xs-12 col-sm-4">
-    <%= render media_display_partial(curation_concern), file_set: curation_concern %>
+    <%= render media_display_partial(form), file_set: curation_concern %>
   </div>
   <div class="col-xs-12 col-sm-8">
     <div class="panel panel-default tabs">

--- a/app/views/hyrax/file_sets/edit.html.erb
+++ b/app/views/hyrax/file_sets/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="row">
   <div class="col-xs-12 col-sm-4">
-    <%= render media_display_partial(curation_concern.to_presenter), file_set: curation_concern.to_presenter %>
+    <%= render media_display_partial(curation_concern), file_set: curation_concern %>
   </div>
   <div class="col-xs-12 col-sm-8">
     <div class="panel panel-default tabs">

--- a/spec/helpers/hyrax/file_set_helper_spec.rb
+++ b/spec/helpers/hyrax/file_set_helper_spec.rb
@@ -46,42 +46,50 @@ RSpec.describe Hyrax::FileSetHelper do
   describe '#media_display_partial' do
     subject { helper.media_display_partial(file_set) }
 
-    let(:file_set) { SolrDocument.new(mime_type_ssi: mime_type) }
-
-    context "with an image" do
-      let(:mime_type) { 'image/tiff' }
+    context 'with an ActiveFedora file set' do
+      let(:file_set) { FactoryBot.create(:file_set, :image) }
 
       it { is_expected.to eq 'hyrax/file_sets/media_display/image' }
     end
 
-    context "with a video" do
-      let(:mime_type) { 'video/webm' }
+    context 'with a solr document' do
+      let(:file_set) { SolrDocument.new(mime_type_ssi: mime_type) }
 
-      it { is_expected.to eq 'hyrax/file_sets/media_display/video' }
-    end
+      context "with an image" do
+        let(:mime_type) { 'image/tiff' }
 
-    context "with an audio" do
-      let(:mime_type) { 'audio/wav' }
+        it { is_expected.to eq 'hyrax/file_sets/media_display/image' }
+      end
 
-      it { is_expected.to eq 'hyrax/file_sets/media_display/audio' }
-    end
+      context "with a video" do
+        let(:mime_type) { 'video/webm' }
 
-    context "with a pdf" do
-      let(:mime_type) { 'application/pdf' }
+        it { is_expected.to eq 'hyrax/file_sets/media_display/video' }
+      end
 
-      it { is_expected.to eq 'hyrax/file_sets/media_display/pdf' }
-    end
+      context "with an audio" do
+        let(:mime_type) { 'audio/wav' }
 
-    context "with a word document" do
-      let(:mime_type) { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+        it { is_expected.to eq 'hyrax/file_sets/media_display/audio' }
+      end
 
-      it { is_expected.to eq 'hyrax/file_sets/media_display/office_document' }
-    end
+      context "with a pdf" do
+        let(:mime_type) { 'application/pdf' }
 
-    context "with anything else" do
-      let(:mime_type) { 'application/binary' }
+        it { is_expected.to eq 'hyrax/file_sets/media_display/pdf' }
+      end
 
-      it { is_expected.to eq 'hyrax/file_sets/media_display/default' }
+      context "with a word document" do
+        let(:mime_type) { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+
+        it { is_expected.to eq 'hyrax/file_sets/media_display/office_document' }
+      end
+
+      context "with anything else" do
+        let(:mime_type) { 'application/binary' }
+
+        it { is_expected.to eq 'hyrax/file_sets/media_display/default' }
+      end
     end
   end
 end

--- a/spec/views/hyrax/file_sets/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/edit.html.erb_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/file_sets/edit.html.erb', type: :view do
+  let(:ability)  { Ability.new(user) }
+  let(:file_set) { stub_model(FileSet) }
+  let(:parent)   { stub_model(GenericWork) }
+  let(:form)     { Hyrax::Forms::FileSetEditForm.new(file_set) }
+  let(:user)     { FactoryBot.build(:user) }
+  let(:versions) { [] }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(view).to receive(:curation_concern).and_return(file_set)
+    allow(view).to receive(:form).and_return(form)
+    assign(:version_list, versions)
+
+    stub_template "hyrax/file_sets/_form.html.erb" => "Form for File Set"
+    stub_template "hyrax/file_sets/_permission.html.erb" => "Permissions for File Set"
+  end
+
+  it 'renders the page without preview by default' do
+    render
+
+    expect(rendered).to include "No preview available"
+  end
+end


### PR DESCRIPTION
this is work toward opening `FileSetsController` and the view templates it uses to Valkyrie::Resource & ChangeSet objects. some compatibility behavior is added to `FileSetEditForm` to improve interchangeability with the ChangeSet-based form. some view tests are added as well.

the main chunk of work here is to extract a Solr query that used to be triggered from the view (via `#to_presenter`) down into the controller. the thinking here is that the controller should supply the data needed to satisfy the user's request. that will mean that if we can provide the data in another way (without the extra Solr query) when using a different data interface, we won't be forced to continue making the Solr call because of the view code. i.e. we want a clean separation of concerns: the controller resolves the user's request; the view renders the data.

@samvera/hyrax-code-reviewers
