### PR TITLE
don't reload the collection to populate subcollection modal

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -417,7 +417,7 @@ module Hyrax
 
     def extract_subjects(subject)
       case subject
-      when Hyrax::WorkShowPresenter, FileSetPresenter
+      when Hyrax::WorkShowPresenter, FileSetPresenter, Hyrax::CollectionPresenter
         extract_subjects(subject.solr_document)
       when Draper::Decorator
         extract_subjects(subject.model)

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -28,6 +28,7 @@ module Hyrax
              :to_s, to: :solr_document
 
     delegate(*Hyrax::CollectionType.settings_attributes, to: :collection_type, prefix: :collection_type_is)
+    alias nestable? collection_type_is_nestable?
 
     def collection_type
       @collection_type ||= Hyrax::CollectionType.find_by_gid!(collection_type_gid)

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -96,7 +96,7 @@
 
 <% if @presenter.collection_type_is_nestable? && !collection_search_parameters? %>
   <%= render 'hyrax/my/collections/modal_add_to_collection', source: 'show' %>
-  <%= render 'hyrax/my/collections/modal_add_subcollection', id: @presenter.id, source: 'show' %>
+  <%= render 'hyrax/my/collections/modal_add_subcollection', id: @presenter.id, presenter: @presenter, source: 'show' %>
   <%= render 'hyrax/dashboard/collections/modal_parent_collection_remove_deny', source: 'show' %>
 <% end %>
 

--- a/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
@@ -1,5 +1,4 @@
 <div class="modal fade disable-unless-selected" id="add-subcollection-modal-<%= id %>" tabindex="-1" role="dialog" aria-labelledby="add-subcollection-label">
-<% collection = ::Collection.find id %>
   <div class="modal-dialog" role="document">
     <div class="modal-content">
 
@@ -14,7 +13,7 @@
         <input type="hidden" name="source" value="<%= source %>" />
         <select name="child_id">
           <option value="none"><%= t("hyrax.dashboard.my.action.select") %></option>
-          <% available_child_collections(collection: collection).each do |coll| %>
+          <% available_child_collections(collection: presenter).each do |coll| %>
             <option value="<%= coll.id %>"><%= coll.title.first %></option>
           <% end %>
         </select>
@@ -27,7 +26,7 @@
           disabled
           type="button"
           class="btn btn-primary modal-add-button modal-submit-button"
-          data-post-url="<%= dashboard_create_nest_collection_under_path(collection.id) %>"
+          data-post-url="<%= dashboard_create_nest_collection_under_path(presenter.id) %>"
           data-source="<%= source %>">
           <%= t('hyrax.collection.actions.nest_collections.button_label') %>
         </button>

--- a/spec/helpers/hyrax/collections_helper_spec.rb
+++ b/spec/helpers/hyrax/collections_helper_spec.rb
@@ -33,6 +33,21 @@ RSpec.describe Hyrax::CollectionsHelper do
       expect(helper.available_child_collections(collection: current_collection))
         .not_to be_empty
     end
+
+    context 'with a presenter' do
+      let(:collection) { FactoryBot.create(:collection) }
+      let(:presenter)  { Hyrax::CollectionPresenter.new(solr_doc, ability) }
+      let(:solr_doc)   { SolrDocument.new(collection.to_solr) }
+
+      before do
+        FactoryBot.create(:collection) # other collection
+      end
+
+      it 'gives a list of available collections' do
+        expect(helper.available_child_collections(collection: presenter))
+          .not_to be_empty
+      end
+    end
   end
 
   describe '#render_collection_links' do


### PR DESCRIPTION
this view used to call `#find` to retirieve a collection from an id. we already
have a presenter and a solr document, so there's no need for this.

instead, allow `Hyrax::Ability` to resolve `CollectionPresenter` to its
underlying `SolrDocument`. Add `CollectionPresenter#nestable?` as an alias to
the existing `#collection_type_is_nestable?` to match the `Collection`
interface, and pass the presenter through to the modal. we continue to pass the
id into the modal for backward compatibility.

Guidance for testing:
  * add a subcollection to an existing collection from the dashboard

@samvera/hyrax-code-reviewers
