### PR TITLE
don't show the "Add to collection" action when type isn't nestable

### DIFF
--- a/app/views/hyrax/my/_admin_set_action_menu.html.erb
+++ b/app/views/hyrax/my/_admin_set_action_menu.html.erb
@@ -41,16 +41,5 @@
         <%= t("hyrax.dashboard.my.action.delete_admin_set") %>
       <% end %>
     </li>
-    <% if Hyrax::CollectionType.any_nestable? %>
-        <li role="menuitem" tabindex="-1">
-          <%= link_to "#",
-                      class: 'itemicon add-to-collection',
-                      title: t("hyrax.dashboard.my.action.add_to_collection"),
-                      data: { nestable: false,
-                              hasaccess: (can?(:deposit, admin_set_presenter.solr_document)) } do %>
-              <%= t("hyrax.dashboard.my.action.add_to_collection") %>
-          <% end %>
-        </li>
-    <% end %>
   </ul>
 </div>

--- a/app/views/hyrax/my/_collection_action_menu.html.erb
+++ b/app/views/hyrax/my/_collection_action_menu.html.erb
@@ -6,7 +6,6 @@
     <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
     <%= t("hyrax.dashboard.my.action.select") %> <span class="caret" aria-hidden="true"></span>
   </button>
-
   <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= id %>">
     <li role="menuitem" tabindex="-1">
       <%= link_to hyrax.dashboard_collection_path(id),
@@ -43,7 +42,7 @@
       <% end %>
     </li>
 
-    <% if Hyrax::CollectionType.any_nestable? %>
+    <% if collection_presenter.collection_type_is_nestable? %>
       <% # The user should have deposit access to the parent we are adding, and read access to the child (the collection we are linking here). %>
       <li role="menuitem" tabindex="-1">
         <%= link_to "#",

--- a/spec/views/hyrax/my/_collection_action_menu.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_collection_action_menu.html.erb_spec.rb
@@ -44,22 +44,22 @@ RSpec.describe 'hyrax/my/_collection_action_menu.html.erb' do
     end
   end
 
-  context "when any_nestable?" do
+  context "when nestable" do
     before do
-      allow(Hyrax::CollectionType).to receive(:any_nestable?).and_return(true)
-      render 'hyrax/my/collection_action_menu', collection: collection_doc
+      allow(collection_presenter)
+        .to receive(:collection_type_is_nestable?)
+        .and_return(true)
     end
+
     it "shows add to collection action " do
+      render 'hyrax/my/collection_action_menu', collection: collection_doc
       expect(rendered).to have_link 'Add to collection'
     end
   end
 
-  context "when not any_nestable?" do
-    before do
-      allow(Hyrax::CollectionType).to receive(:any_nestable?).and_return(false)
-      render 'hyrax/my/collection_action_menu', collection: collection_doc
-    end
+  context "when not nestable" do
     it "hides add to collection action " do
+      render 'hyrax/my/collection_action_menu', collection: collection_doc
       expect(rendered).not_to have_link 'Add to collection'
     end
   end


### PR DESCRIPTION
the previous guard skipped showing this button only if no collection types were
nestable (checking this involved a solr query). it would then base the actual
behavior on the current collection type's nestability. in the case of admin
sets, it was even hard coded to false!

instead, check whether the current type is nestable. this avoids the most common
case where the user might push this button only to be given a deny popup. since
none of the data is loaded in dynamically in response to the button push,
there's no reason we can't remove that modal implementation altogether.

@samvera/hyrax-code-reviewers
