### PR TITLE
move parent collection JSON generator into helper 

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -123,6 +123,11 @@ module Hyrax
         collection_member_service.available_member_subcollections.documents
       end
 
+      ##
+      # @deprecated this implementation requires an extra db round trip, had a
+      #   buggy cacheing mechanism, and was largely duplicative of other code.
+      #   all versions of this code are replaced by
+      #   {CollectionsHelper#available_parent_collections_data}.
       def available_parent_collections(scope:)
         return @available_parents if @available_parents.present?
 
@@ -130,8 +135,7 @@ module Hyrax
         colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: scope, limit_to_id: nil)
         @available_parents = colls.map do |col|
           { "id" => col.id, "title_first" => col.title.first }
-        end
-        @available_parents.to_json
+        end.to_json
       end
 
       private

--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -10,6 +10,21 @@ module Hyrax
     end
 
     ##
+    # @since 3.1.0
+    #
+    # @note provides data for handleAddToCollection javascript
+    #
+    # @return [String] JSON document containing id/title pairs for eligible
+    #   parent collections to be displayed in an "Add to Collection" dropdown
+    def available_parent_collections_data(collection:)
+      Hyrax::Collections::NestedCollectionQueryService
+        .available_parent_collections(child: collection, scope: controller, limit_to_id: nil)
+        .map do |result|
+        { "id" => result.id, "title_first" => result.title.first }
+      end.to_json
+    end
+
+    ##
     # @since 3.0.0
     # @return [#to_s]
     def collection_metadata_label(collection, field)

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -155,14 +155,21 @@ module Hyrax
       create_work_presenter.first_model
     end
 
+    ##
+    # @deprecated this implementation requires an extra db round trip, had a
+    #   buggy cacheing mechanism, and was largely duplicative of other code.
+    #   all versions of this code are replaced by
+    #   {CollectionsHelper#available_parent_collections_data}.
     def available_parent_collections(scope:)
+      Deprecation.warn("#{self.class}#available_parent_collections is " \
+                       "deprecated. Use available_parent_collections_data " \
+                       "helper instead.")
       return @available_parents if @available_parents.present?
       collection = ::Collection.find(id)
       colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: scope, limit_to_id: nil)
       @available_parents = colls.map do |col|
         { "id" => col.id, "title_first" => col.title.first }
-      end
-      @available_parents.to_json
+      end.to_json
     end
 
     def subcollection_count=(total)

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -2,7 +2,7 @@
 <% id = collection_presenter.id %>
 <tr id="document_<%= id %>"
   data-id="<%= id %>"
-  data-colls-hash="<%= collection_presenter.available_parent_collections(scope: controller) %>"
+  data-colls-hash="<%= available_parent_collections_data(collection: collection_presenter) %>"
   data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
   data-post-delete-url="<%= is_admin_set ? hyrax.admin_admin_set_path(id) : hyrax.dashboard_collection_path(id) %>">
 

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -4,7 +4,7 @@
 <tr id="document_<%= id %>"
   data-source="my"
   data-id="<%= id %>"
-  data-colls-hash="<%= collection_presenter.available_parent_collections(scope: controller) %>"
+  data-colls-hash="<%= available_parent_collections_data(collection: collection_presenter) %>"
   data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
   data-post-delete-url="<%= is_admin_set ? hyrax.admin_admin_set_path(id) : hyrax.dashboard_collection_path(id) %>">
 

--- a/spec/views/hyrax/dashboard/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_list_collections.html.erb_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe 'hyrax/dashboard/collections/_list_collections.html.erb', type: :
     allow(presenter).to receive(:total_viewable_items).and_return(3)
     allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
 
+    allow(view)
+      .to receive(:available_parent_collections_data)
+      .with(collection: presenter)
+      .and_return([mock_model(Collection)])
+
     stub_template 'hyrax/my/_collection_action_menu.html.erb' => 'actions'
   end
 

--- a/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
@@ -37,7 +37,11 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
       allow(collection_presenter).to receive(:total_items).and_return(0)
       allow(collection_presenter).to receive(:collection_type_is_require_membership?).and_return(true)
       allow(collection_presenter).to receive(:collection_type_is_nestable?).and_return(true)
-      allow(collection_presenter).to receive(:available_parent_collections).and_return([mock_model(Collection)])
+
+      allow(view)
+        .to receive(:available_parent_collections_data)
+        .with(collection: collection_presenter)
+        .and_return([mock_model(Collection)])
 
       view.lookup_context.prefixes.push 'hyrax/my'
       render 'hyrax/my/collections/list_collections', collection_presenter: collection_presenter, is_admin_set: doc.admin_set?


### PR DESCRIPTION
the implementation of query for eligible parent collections had a handful of
problems.

first, it was awkwardly located in the presentation layer. since this code is
really about a business rule ("which parent collections are eligible for this
object?"), hiding it in presenters makes it hard to understand how to approach
changes. it was also duplicated across `CollectionForm` and
`CollectionPresenter`, compounding this problem. moving it to a helper doesn't
completely solve this problem, but it does give us a single point of focus for
continued refactors. as it stands, the business rule is tightly coupled to both
the JSON data generation and the underlying query. we'll probably want to loosen
that up before changing any of these three separate concerns.

second, the implementations retrieved a full object from Fedora. this is
particularly worrying because of how many collections are likely to be included
in a page. in general, we should avoid database access initiated by a
view (controllers should do this!). in the particular case, the called code
doesn't actually need the full object so we can just skip the query. there's
still a view-initiated solr query here, but baby steps.

lastly, there were some bugs in the specific existing implementations: they
cached and returned the wrong data type for repeated calls (Array<Hash>, vs JSON
String). i think this caching is completely unused, so i dropped it from the
helper's implementation.

@samvera/hyrax-code-reviewers
