### PR TITLE
refactor specs for `NestCollectionForm`

### DIFF
--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
   describe '#save' do
     describe 'when not valid' do
       it 'does not even attempt to persist the relationship' do
-        expect(form).to receive(:valid?).and_return(false)
+        expect(form).to receive(:valid?).and_return(false) # rubocop:disable RSpec/SubjectStub
         expect(persistence_service).not_to receive(:persist_nested_collection_for)
 
         expect(form.save).to be_falsey
@@ -86,7 +86,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     end
 
     describe 'when valid' do
-      before { expect(form).to receive(:valid?).and_return(true) }
+      before { expect(form).to receive(:valid?).and_return(true) } # rubocop:disable RSpec/SubjectStub
 
       it "returns the result of the given persistence_service's call to persist_nested_collection_for" do
         expect(persistence_service)

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -1,14 +1,27 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
-  let(:parent) { double(nestable?: true) }
-  let(:child) { double(nestable?: true) }
-  let(:context) { double('Context') }
-  let(:nesting_depth_result) { true }
-  let(:query_service) { double('Query Service', valid_combined_nesting_depth?: nesting_depth_result) }
-  let(:persistence_service) { double('Persistence Service', persist_nested_collection: true) }
-  let(:form) { described_class.new(parent: parent, child: child, context: context, query_service: query_service, persistence_service: persistence_service) }
+  subject(:form) do
+    described_class.new(parent: parent,
+                        child: child,
+                        context: context,
+                        query_service: query_service,
+                        persistence_service: persistence_service)
+  end
 
-  subject { form }
+  let(:child)                { FactoryBot.create(:collection) }
+  let(:context)              { double('Context') }
+  let(:nesting_depth_result) { true }
+  let(:parent)               { FactoryBot.create(:collection) }
+
+  let(:persistence_service) do
+    double(Hyrax::Collections::NestedCollectionPersistenceService,
+           persist_nested_collection: true)
+  end
+
+  let(:query_service) do
+    double(Hyrax::Collections::NestedCollectionQueryService,
+           valid_combined_nesting_depth?: nesting_depth_result)
+  end
 
   it { is_expected.to validate_presence_of(:parent) }
   it { is_expected.to validate_presence_of(:child) }
@@ -22,7 +35,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     it { is_expected.to respond_to(:valid_combined_nesting_depth?) }
   end
 
-  describe '#default_query_service' do
+  describe '.default_persistence_service' do
     subject { described_class.default_persistence_service }
 
     it { is_expected.to respond_to(:persist_nested_collection_for) }
@@ -33,10 +46,12 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
 
     it 'is invalid if child cannot be nested within the parent' do
       expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child, scope: context).and_return(false)
-      subject.valid?
-      expect(subject.errors[:parent]).to eq(["cannot have child nested within it"])
-      expect(subject.errors[:child]).to eq(["cannot nest within parent"])
-      expect(subject.errors[:collection]).to eq(["nesting exceeds the allowed maximum nesting depth."])
+
+      expect { form.valid? }
+        .to change { form.errors.to_hash }
+        .to include parent: ["cannot have child nested within it"],
+                    child: ["cannot nest within parent"],
+                    collection: ["nesting exceeds the allowed maximum nesting depth."]
     end
   end
 
@@ -44,8 +59,9 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     let(:parent) { double(nestable?: false) }
 
     it 'is not valid' do
-      subject.valid?
-      expect(subject.errors[:parent]).to eq(["is not nestable"])
+      expect { form.valid? }
+        .to change { form.errors.to_hash }
+        .to include parent: ["is not nestable"]
     end
   end
 
@@ -53,49 +69,55 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     let(:child) { double(nestable?: false) }
 
     it 'is not valid' do
-      subject.valid?
-      expect(subject.errors[:child]).to eq(["is not nestable"])
+      expect { form.valid? }
+        .to change { form.errors.to_hash }
+        .to include child: ["is not nestable"]
     end
   end
 
   describe '#save' do
-    subject { form.save }
-
     describe 'when not valid' do
-      before do
-        expect(form).to receive(:valid?).and_return(false)
-      end
-      it { is_expected.to be_falsey }
       it 'does not even attempt to persist the relationship' do
+        expect(form).to receive(:valid?).and_return(false)
         expect(persistence_service).not_to receive(:persist_nested_collection_for)
-        subject
+
+        expect(form.save).to be_falsey
       end
     end
+
     describe 'when valid' do
-      before do
-        expect(form).to receive(:valid?).and_return(true)
-      end
+      before { expect(form).to receive(:valid?).and_return(true) }
+
       it "returns the result of the given persistence_service's call to persist_nested_collection_for" do
-        expect(persistence_service).to receive(:persist_nested_collection_for).with(parent: parent, child: child).and_return(:persisted)
-        subject
+        expect(persistence_service)
+          .to receive(:persist_nested_collection_for)
+          .with(parent: parent, child: child)
+          .and_return(:persisted)
+
+        expect(form.save).to eq :persisted
       end
     end
   end
 
   describe '#available_child_collections' do
-    subject { form.available_child_collections }
-
     it 'delegates to the underlying query_service' do
-      expect(query_service).to receive(:available_child_collections).with(parent: parent, scope: context).and_return(:results)
-      expect(subject).to eq(:results)
+      expect(query_service)
+        .to receive(:available_child_collections)
+        .with(parent: parent, scope: context)
+        .and_return(:results)
+
+      expect(form.available_child_collections).to eq(:results)
     end
   end
-  describe '#available_parent_collections' do
-    subject { form.available_parent_collections }
 
+  describe '#available_parent_collections' do
     it 'delegates to the underlying query_service' do
-      expect(query_service).to receive(:available_parent_collections).with(child: child, scope: context).and_return(:results)
-      expect(subject).to eq(:results)
+      expect(query_service)
+        .to receive(:available_parent_collections)
+        .with(child: child, scope: context)
+        .and_return(:results)
+
+      expect(form.available_parent_collections).to eq(:results)
     end
   end
 
@@ -104,8 +126,9 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
       let(:parent) { double(nestable?: false) }
 
       it 'validates the parent cannnot contain nested subcollections' do
-        subject.validate_add
-        expect(subject.errors[:parent]).to eq(["cannot have child nested within it"])
+        expect { form.validate_add }
+          .to change { form.errors.to_hash }
+          .to include parent: ["cannot have child nested within it"]
       end
     end
 
@@ -115,8 +138,9 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
         let(:nesting_depth_result) { false }
 
         it 'validates the parent cannot have additional files nested' do
-          subject.validate_add
-          expect(subject.errors[:collection]).to eq(["nesting exceeds the allowed maximum nesting depth."])
+          expect { form.validate_add }
+            .to change { form.errors.to_hash }
+            .to include collection: ["nesting exceeds the allowed maximum nesting depth."]
         end
       end
 
@@ -124,16 +148,13 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
         let(:parent) { double(nestable?: true) }
 
         it 'validates the parent can contain nested subcollections' do
-          subject.validate_add
-          expect(subject.validate_add).to eq true
+          expect(form.validate_add).to eq true
         end
       end
     end
   end
 
   describe '#remove' do
-    subject { form.remove }
-
     describe 'when not authorized' do
       before do
         expect(context).to receive(:can?).with(:edit, parent).and_return(false)
@@ -141,7 +162,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
 
       it 'does not even attempt to persist the relationship' do
         expect(persistence_service).not_to receive(:remove_nested_relationship_for)
-        subject
+        form.remove
         expect(form.errors[:parent]).to eq(["permission is inadequate for removal of nesting relationship"])
       end
     end
@@ -153,7 +174,8 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
 
       it "returns the result of the given persistence_service's call to remove_nested_relationship_for" do
         expect(persistence_service).to receive(:remove_nested_relationship_for).with(parent: parent, child: child).and_return(:persisted)
-        subject
+
+        expect(form.remove).to eq :persisted
       end
     end
   end


### PR DESCRIPTION
reduce stubbing and use verifying mocks for these specs. use `subject` for the
object under test, not to run the exercised code. use `expect { }.to change { }`
where it can help ensure the desired state change was caused by the test (not in
setup).

i was trying to understand this module, and rewrote the specs to get there.

@samvera/hyrax-code-reviewers
