### PR TITLE
Allow for setting of file visibility independent of work visibility

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -203,7 +203,7 @@ module Hyrax
         @curation_concern =
           form.validate(params[hash_key_for_curation_concern]) &&
           transactions['change_set.create_work']
-          .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files },
+          .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
                           'change_set.set_user_as_depositor' => { user: current_user })
           .call(form).value!
       end
@@ -219,7 +219,7 @@ module Hyrax
         @curation_concern =
           form.validate(params[hash_key_for_curation_concern]) &&
           transactions['change_set.update_work']
-          .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files })
+          .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] })
           .call(form).value!
       end
     end

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -23,16 +23,16 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
     user = User.find_by_user_key(depositor)
 
     work, work_permissions = create_permissions work, depositor
-    metadata = visibility_attributes(work_attributes)
     uploaded_files.each do |uploaded_file|
       next if uploaded_file.file_set_uri.present?
 
       actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
+      metadata = visibility_attributes(work_attributes, uploaded_file)
       uploaded_file.add_file_set!(actor.file_set)
       actor.file_set.permissions_attributes = work_permissions
       actor.create_metadata(metadata)
       actor.create_content(uploaded_file)
-      actor.attach_to_work(work)
+      actor.attach_to_work(work, metadata)
     end
   end
 
@@ -44,8 +44,9 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
   end
 
   # The attributes used for visibility - sent as initial params to created FileSets.
-  def visibility_attributes(attributes)
-    attributes.slice(:visibility, :visibility_during_lease,
+  def visibility_attributes(attributes, uploaded_file = nil)
+    file_set_attributes = Array(attributes[:file_set]).find { |fs| fs[:uploaded_file_id] == uploaded_file&.id }
+    attributes.merge(Hash(file_set_attributes)).slice(:visibility, :visibility_during_lease,
                      :visibility_after_lease, :lease_expiration_date,
                      :embargo_release_date, :visibility_during_embargo,
                      :visibility_after_embargo)

--- a/lib/hyrax/transactions/steps/add_file_sets.rb
+++ b/lib/hyrax/transactions/steps/add_file_sets.rb
@@ -20,10 +20,11 @@ module Hyrax
         ##
         # @param [Hyrax::Work] obj
         # @param [Enumerable<UploadedFile>] uploaded_files
+        # @param [Enumerable<Hash>] file_set_params
         #
         # @return [Dry::Monads::Result]
-        def call(obj, uploaded_files: [])
-          if @handler.new(work: obj).add(files: uploaded_files).attach
+        def call(obj, uploaded_files: [], file_set_params: [])
+          if @handler.new(work: obj).add(files: uploaded_files, file_set_params: file_set_params).attach
             Success(obj)
           else
             Failure[:failed_to_attach_file_sets, uploaded_files]

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -147,6 +147,17 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
           expect(response.status).to eq 422
         end
+
+        it 'sets the file visibility' do
+          params = { test_simple_work: { title: 'comet in moominland',
+                                         file_set: [{ uploaded_file_id: uploads.first.id, visibility: 'open' },
+                                                    { uploaded_file_id: uploads.second.id, visibility: 'open' }] },
+                     uploaded_files: uploads.map(&:id) }
+
+          get :create, params: params
+
+          expect(assigns(:curation_concern)).to have_file_set_members(have_attributes(visibility: 'open'), have_attributes(visibility: 'open'))
+        end
       end
 
       context 'with invalid form data' do
@@ -408,6 +419,17 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
           get :update, params: params
           expect(assigns(:curation_concern)).to have_file_set_members(be_persisted, be_persisted)
+        end
+
+        it 'sets the file visibility' do
+          params = { id: id,
+                     test_simple_work: { title: 'comet in moominland',
+                                         file_set: [{ uploaded_file_id: uploads.first.id, visibility: 'open' },
+                                                    { uploaded_file_id: uploads.second.id, visibility: 'open' }] },
+                     uploaded_files: uploads.map(&:id) }
+
+          get :update, params: params
+          expect(assigns(:curation_concern)).to have_file_set_members(have_attributes(visibility: 'open'), have_attributes(visibility: 'open'))
         end
       end
 


### PR DESCRIPTION
We have many cases where a work is open but a file within it is private or embargoed.  It is tedious and potentially problematic to have to attach a file then edit that file to set the correct visibility.  In the case of bulkrax it would have to be done post import.   This PR is a first step to allowing editing of a file's permissions as part of adding files in the deposit form and correctly setting file permissions in a bulkrax import.

The create/update request to the works controller needs an array of file set param hashes for this to work.  Each file set param hash is identified by the uploaded file id.  For example:
```
{ generic_work: { file_set: [{ uploaded_file_id: 1, visibility: 'restricted' },
                             { uploaded_file_id: 2, visibility: 'institution' }],
                  visibility: 'open' } }
```

@samvera/hyrax-code-reviewers
