### PR TITLE
Extend Valkyrie support in FileSetsController

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -107,8 +107,16 @@ module Hyrax
     # @note this is provided so that implementing application can override this
     #   behavior and map params to different attributes
     def update_metadata
-      file_attributes = form_class.model_attributes(attributes)
-      actor.update_metadata(file_attributes)
+      case file_set
+      when Hyrax::Resource
+        change_set = Hyrax::Forms::ResourceForm.for(file_set)
+
+        change_set.validate(attributes) &&
+          transactions['change_set.apply'].call(change_set).value_or { false }
+      else
+        file_attributes = form_class.model_attributes(attributes)
+        actor.update_metadata(file_attributes)
+      end
     end
 
     def parent(file_set: curation_concern)

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -44,8 +44,7 @@ module Hyrax
 
     # GET /concern/parent/:parent_id/file_sets/:id
     def show
-      presenter
-      guard_for_workflow_restriction_on!(parent: presenter.parent)
+      guard_for_workflow_restriction_on!(parent: parent(file_set: presenter))
       respond_to do |wants|
         wants.html
         wants.json
@@ -55,16 +54,17 @@ module Hyrax
 
     # DELETE /concern/file_sets/:id
     def destroy
-      parent = curation_concern.parent
       guard_for_workflow_restriction_on!(parent: parent)
+
       actor.destroy
-      redirect_to [main_app, parent], notice: view_context.t('hyrax.file_sets.asset_deleted_flash.message')
+      redirect_to [main_app, parent],
+                  notice: view_context.t('hyrax.file_sets.asset_deleted_flash.message')
     end
 
     # PATCH /concern/file_sets/:id
     def update
-      parent = curation_concern.parent
       guard_for_workflow_restriction_on!(parent: parent)
+
       if attempt_update
         after_update_response
       else
@@ -94,6 +94,16 @@ module Hyrax
     def update_metadata
       file_attributes = form_class.model_attributes(attributes)
       actor.update_metadata(file_attributes)
+    end
+
+    def parent(file_set: curation_concern)
+      @parent ||=
+        case file_set
+        when Hyrax::Resource
+          Hyrax.query_service.find_parents(resource: file_set).first
+        else
+          file_set.parent
+        end
     end
 
     def attempt_update
@@ -156,8 +166,8 @@ module Hyrax
     end
 
     def initialize_edit_form
-      @parent = @file_set.in_objects.first
-      guard_for_workflow_restriction_on!(parent: @parent)
+      guard_for_workflow_restriction_on!(parent: parent)
+
       @version_list = Hyrax::VersionListPresenter.for(file_set: @file_set)
       @groups = current_user.groups
     end

--- a/app/forms/hyrax/forms/file_set_form.rb
+++ b/app/forms/hyrax/forms/file_set_form.rb
@@ -5,6 +5,8 @@ module Hyrax
     ##
     # @api public
     class FileSetForm < Hyrax::ChangeSet
+      include Hyrax::FormFields(:core_metadata)
+
       class << self
         ##
         # @return [Array<Symbol>] list of required field names as symbols
@@ -15,7 +17,6 @@ module Hyrax
         end
       end
 
-      property :title, required: true
       property :creator, required: true
       property :license, required: true
 
@@ -29,6 +30,8 @@ module Hyrax
       property :publisher
       property :related_url
       property :subject
+
+      property :permissions, virtual: true
       property :visibility, default: VisibilityIntention::PRIVATE
 
       # virtual properties for embargo/lease;

--- a/app/forms/hyrax/forms/permission.rb
+++ b/app/forms/hyrax/forms/permission.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module Hyrax
+  module Forms
+    ##
+    # Nested form for permissions.
+    #
+    # @note due to historical oddities with Hydra::AccessControls and Hydra
+    #   Editor, Hyrax's views rely on `agent_name` and `access` as field
+    #   names. we provide these as virtual fields and prepopulate these from
+    #   `Hyrax::Permission`.
+    class Permission < Hyrax::ChangeSet
+      property :agent_name, virtual: true, prepopulator: ->(_opts) { self.agent_name = model.agent }
+      property :access, virtual: true, prepopulator: ->(_opts) { self.access = model.mode }
+
+      ##
+      # @note support a {#to_hash} method for compatibility with
+      #   {Hydra::AccessControl::Permissions}
+      def to_hash
+        { name: agent_name, access: access }
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -21,6 +21,7 @@ module Hyrax
       require 'hyrax/transactions/apply_change_set'
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/destroy_work'
+      require 'hyrax/transactions/file_set_destroy'
       require 'hyrax/transactions/work_create'
       require 'hyrax/transactions/work_destroy'
       require 'hyrax/transactions/update_work'
@@ -33,6 +34,7 @@ module Hyrax
       require 'hyrax/transactions/steps/destroy_work'
       require 'hyrax/transactions/steps/ensure_admin_set'
       require 'hyrax/transactions/steps/ensure_permission_template'
+      require 'hyrax/transactions/steps/remove_file_set_from_work'
       require 'hyrax/transactions/steps/save'
       require 'hyrax/transactions/steps/save_work'
       require 'hyrax/transactions/steps/save_access_control'
@@ -89,6 +91,20 @@ module Hyrax
 
         ops.register 'validate' do
           Steps::Validate.new
+        end
+      end
+
+      namespace 'file_set' do |ops| # Hyrax::FileSet
+        ops.register 'delete' do
+          Steps::DeleteResource.new
+        end
+
+        ops.register 'destroy' do
+          FileSetDestroy.new
+        end
+
+        ops.register 'remove_from_work' do
+          Steps::RemoveFileSetFromWork.new
         end
       end
 

--- a/lib/hyrax/transactions/file_set_destroy.rb
+++ b/lib/hyrax/transactions/file_set_destroy.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/transaction'
+
+module Hyrax
+  module Transactions
+    ##
+    # destroys a FileSet resource.
+    #
+    # @since 3.1.0
+    class FileSetDestroy < Transaction
+      DEFAULT_STEPS = ['file_set.remove_from_work',
+                       'file_set.delete'].freeze
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
+++ b/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # removes the file set from all its parents, returning a
+      # `Dry::Monads::Result` (`Success`|`Failure`).
+      #
+      # there should normally be only one parent for a FileSet, but in the case
+      # that there are multiple, this step will remove the file set from all
+      # parents.
+      #
+      # if no user is provided to attribute the removal to, the step fails
+      # immediately.
+      #
+      # @see https://dry-rb.org/gems/dry-monads/1.0/result/
+      class RemoveFileSetFromWork
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Valkyrie::QueryService] query_service
+        def initialize(query_service: Hyrax.query_service, persister: Hyrax.persister)
+          @persister     = persister
+          @query_service = query_service
+        end
+
+        ##
+        # @param [Hyrax::FileSet] file_set
+        #
+        # @return [Dry::Monads::Result]
+        def call(file_set, user: nil)
+          return Failure('No user provided.') if user.nil?
+
+          @query_service.find_parents(resource: file_set).each do |parent|
+            parent.member_ids -= [file_set.id]
+            saved = @persister.save(resource: parent)
+            Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
+          end
+
+          Success(file_set)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -1,25 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe Hyrax::FileSetsController do
-  routes { Rails.application.routes }
-  let(:user) { create(:user) }
+  routes      { Rails.application.routes }
+  let(:user)  { FactoryBot.create(:user) }
   let(:actor) { controller.send(:actor) }
 
   context "when signed in" do
-    before do
-      sign_in user
-    end
+    before { sign_in user }
 
     describe "#destroy" do
       context "file_set with a parent" do
-        let(:file_set) do
-          create(:file_set, user: user)
-        end
-        let(:work) do
-          create(:work, title: ['test title'], user: user)
-        end
-
-        let(:delete_message) { double('delete message') }
+        let(:file_set) { FactoryBot.create(:file_set, user: user) }
+        let(:work) { FactoryBot.create(:work, title: ['test title'], user: user) }
 
         before do
           work.ordered_members << file_set
@@ -28,20 +20,22 @@ RSpec.describe Hyrax::FileSetsController do
 
         it "deletes the file" do
           expect(ContentDeleteEventJob).to receive(:perform_later).with(file_set.id, user)
-          expect do
-            delete :destroy, params: { id: file_set }
-          end.to change { FileSet.exists?(file_set.id) }.from(true).to(false)
+
+          expect { delete :destroy, params: { id: file_set } }
+            .to change { FileSet.exists?(file_set.id) }
+            .from(true)
+            .to(false)
+
           expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
         end
       end
     end
 
     describe "#edit" do
-      let(:parent) do
-        create(:work, :public, user: user)
-      end
+      let(:parent) { FactoryBot.create(:work, :public, user: user) }
+
       let(:file_set) do
-        create(:file_set, user: user).tap do |file_set|
+        FactoryBot.create(:file_set, user: user).tap do |file_set|
           parent.ordered_members << file_set
           parent.save!
         end
@@ -54,10 +48,22 @@ RSpec.describe Hyrax::FileSetsController do
       end
 
       it "sets the breadcrumbs and versions presenter" do
-        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.file_set.browse_view'), Rails.application.routes.url_helpers.hyrax_file_set_path(file_set, locale: 'en'))
+        app_helpers    = Rails.application.routes.url_helpers
+        engine_helpers = Hyrax::Engine.routes.url_helpers
+
+        expect(controller)
+          .to receive(:add_breadcrumb)
+          .with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+        expect(controller)
+          .to receive(:add_breadcrumb)
+          .with(I18n.t('hyrax.dashboard.title'), engine_helpers.dashboard_path(locale: 'en'))
+        expect(controller)
+          .to receive(:add_breadcrumb)
+          .with(I18n.t('hyrax.dashboard.my.works'), engine_helpers.my_works_path(locale: 'en'))
+        expect(controller)
+          .to receive(:add_breadcrumb)
+          .with(I18n.t('hyrax.file_set.browse_view'), app_helpers.hyrax_file_set_path(file_set, locale: 'en'))
+
         get :edit, params: { id: file_set }
 
         expect(response).to be_successful
@@ -70,11 +76,10 @@ RSpec.describe Hyrax::FileSetsController do
     end
 
     describe "#update" do
-      let(:parent) do
-        create(:work, :public, user: user)
-      end
+      let(:parent) { FactoryBot.create(:work, :public, user: user) }
+
       let(:file_set) do
-        create(:file_set, user: user, title: ['test title']).tap do |file_set|
+        FactoryBot.create(:file_set, user: user, title: ['test title']).tap do |file_set|
           parent.ordered_members << file_set
           parent.save!
         end
@@ -82,7 +87,10 @@ RSpec.describe Hyrax::FileSetsController do
 
       context "when updating metadata" do
         it "spawns a content update event job" do
-          expect(ContentUpdateEventJob).to receive(:perform_later).with(file_set, user)
+          expect(ContentUpdateEventJob)
+            .to receive(:perform_later)
+            .with(file_set, user)
+
           post :update, params: {
             id: file_set,
             file_set: {
@@ -93,8 +101,10 @@ RSpec.describe Hyrax::FileSetsController do
                                          access: 'edit' }]
             }
           }
-          expect(response).to redirect_to main_app.hyrax_file_set_path(file_set, locale: 'en')
-          expect(assigns[:file_set].modified_date).not_to be file_set.modified_date
+          expect(response)
+            .to redirect_to main_app.hyrax_file_set_path(file_set, locale: 'en')
+          expect(assigns[:file_set].modified_date)
+            .not_to be file_set.modified_date
         end
       end
 
@@ -115,20 +125,31 @@ RSpec.describe Hyrax::FileSetsController do
       end
 
       context "when updating the attached file already uploaded" do
-        let(:actor) { double }
+        let(:actor) { double(Hyrax::Actors::FileActor) }
 
         before do
           allow(Hyrax::Actors::FileActor).to receive(:new).and_return(actor)
         end
 
         it "spawns a ContentNewVersionEventJob", perform_enqueued: [IngestJob] do
-          expect(actor).to receive(:ingest_file).with(JobIoWrapper).and_return(true)
-          expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
+          expect(actor)
+            .to receive(:ingest_file)
+            .with(JobIoWrapper)
+            .and_return(true)
+          expect(ContentNewVersionEventJob)
+            .to receive(:perform_later)
+            .with(file_set, user)
+
           file = fixture_file_upload('/world.png', 'image/png')
-          allow(Hyrax::UploadedFile).to receive(:find).with(["1"]).and_return([file])
+          allow(Hyrax::UploadedFile)
+            .to receive(:find)
+            .with(["1"])
+            .and_return([file])
 
           post :update, params: { id: file_set, files_files: ["1"] }
-          expect(assigns[:file_set].modified_date).not_to be file_set.modified_date
+
+          expect(assigns[:file_set].modified_date)
+            .not_to be file_set.modified_date
           expect(assigns[:file_set].title).to eq file_set.title
         end
       end
@@ -164,14 +185,13 @@ RSpec.describe Hyrax::FileSetsController do
               expect(restored_content.original_name).to eq file1
               expect(versions.all.count).to eq 3
               expect(versions.last.label).to eq latest_version.label
-              expect(Hyrax::VersionCommitter.where(version_id: versions.last.uri).pluck(:committer_login)).to eq [user.user_key]
+              expect(Hyrax::VersionCommitter.where(version_id: versions.last.uri).pluck(:committer_login))
+                .to eq [user.user_key]
             end
           end
 
           context "as a user without edit access" do
-            before do
-              sign_in second_user
-            end
+            before { sign_in second_user }
 
             it "is unauthorized" do
               post :update, params: { id: file_set, revision: version1 }
@@ -193,13 +213,15 @@ RSpec.describe Hyrax::FileSetsController do
                       ] }
         }
 
-        expect(assigns[:file_set].read_groups).to eq ["group1"]
-        expect(assigns[:file_set].edit_users).to include("user1", user.user_key)
+        expect(assigns[:file_set])
+          .to have_attributes(read_groups: contain_exactly("group1"),
+                              edit_users: include("user1", user.user_key))
       end
 
       it "updates existing groups and users" do
         file_set.edit_groups = ['group3']
         file_set.save
+
         post :update, params: {
           id: file_set,
           file_set: { keyword: [''],
@@ -212,19 +234,17 @@ RSpec.describe Hyrax::FileSetsController do
       end
 
       context "when there's an error saving" do
-        let(:parent) do
-          create(:work, :public, user: user)
-        end
+        let(:parent) { FactoryBot.create(:work, :public, user: user) }
+
         let(:file_set) do
-          create(:file_set, user: user).tap do |file_set|
+          FactoryBot.create(:file_set, user: user).tap do |file_set|
             parent.ordered_members << file_set
             parent.save!
           end
         end
 
-        before do
-          allow(FileSet).to receive(:find).and_return(file_set)
-        end
+        before { allow(FileSet).to receive(:find).and_return(file_set) }
+
         it "draws the edit page" do
           expect(file_set).to receive(:valid?).and_return(false)
           post :update, params: { id: file_set, file_set: { keyword: [''] } }
@@ -237,18 +257,15 @@ RSpec.describe Hyrax::FileSetsController do
     end
 
     describe "#edit" do
-      let(:file_set) do
-        create(:file_set, read_groups: ['public'])
-      end
+      let(:file_set) { FactoryBot.create(:file_set, read_groups: ['public']) }
 
       let(:file) do
-        Hydra::Derivatives::IoDecorator.new(File.open(fixture_path + '/world.png'),
-                                            'image/png', 'world.png')
+        Hydra::Derivatives::IoDecorator
+          .new(File.open(fixture_path + '/world.png'),
+               'image/png', 'world.png')
       end
 
-      before do
-        Hydra::Works::UploadFileToFileSet.call(file_set, file)
-      end
+      before { Hydra::Works::UploadFileToFileSet.call(file_set, file) }
 
       context "someone else's files" do
         it "sets flash error" do
@@ -262,13 +279,13 @@ RSpec.describe Hyrax::FileSetsController do
 
     describe "#show" do
       let(:work) do
-        create(:generic_work, :public,
-               title: ['test title'],
-               user: user)
+        FactoryBot.create(:generic_work, :public,
+                          title: ['test title'],
+                          user: user)
       end
 
       let(:file_set) do
-        create(:file_set, title: ['test file'], user: user).tap do |file_set|
+        FactoryBot.create(:file_set, title: ['test file'], user: user).tap do |file_set|
           work.ordered_members << file_set
           work.save!
         end
@@ -281,9 +298,9 @@ RSpec.describe Hyrax::FileSetsController do
 
       context "without a referer" do
         let(:work) do
-          create(:generic_work, :public,
-                 title: ['test title'],
-                 user: user)
+          FactoryBot.create(:generic_work, :public,
+                            title: ['test title'],
+                            user: user)
         end
 
         before do
@@ -329,19 +346,23 @@ RSpec.describe Hyrax::FileSetsController do
     end
 
     context 'someone elses (public) files' do
-      let(:creator) { create(:user, email: 'archivist1@example.com') }
-      let(:parent) do
-        create(:work, :public, user: creator, read_groups: ['public'])
+      let(:creator) do
+        FactoryBot.create(:user, email: 'archivist1@example.com')
       end
+
+      let(:parent) do
+        FactoryBot.create(:work, :public, user: creator, read_groups: ['public'])
+      end
+
       let(:public_file_set) do
-        create(:file_set, user: creator, read_groups: ['public']).tap do |file_set|
+        FactoryBot.create(:file_set, user: creator, read_groups: ['public']).tap do |file_set|
           parent.ordered_members << file_set
           parent.save!
         end
       end
 
       let(:work) do
-        create(:generic_work, :public,
+        FactoryBot.create(:generic_work, :public,
                title: ['test title'],
                user: user)
       end
@@ -356,6 +377,7 @@ RSpec.describe Hyrax::FileSetsController do
       describe '#edit' do
         it 'gives me the unauthorized page' do
           get :edit, params: { id: public_file_set }
+
           expect(response.code).to eq '401'
           expect(response).to render_template(:unauthorized)
           expect(response).to render_template('dashboard')
@@ -365,6 +387,7 @@ RSpec.describe Hyrax::FileSetsController do
       describe '#show' do
         it 'allows access to the file' do
           get :show, params: { id: public_file_set }
+
           expect(response).to be_successful
         end
       end
@@ -372,14 +395,14 @@ RSpec.describe Hyrax::FileSetsController do
   end
 
   context 'when not signed in' do
-    let(:work) { create(:work, :public, user: user) }
-    let(:private_file_set) { create(:file_set) }
-    let(:public_file_set) { create(:file_set, read_groups: ['public']) }
+    let(:work) { FactoryBot.create(:work, :public, user: user) }
+    let(:private_file_set) { FactoryBot.create(:file_set) }
+    let(:public_file_set) { FactoryBot.create(:file_set, read_groups: ['public']) }
 
     let(:work) do
-      create(:generic_work, :public,
-             title: ['test title'],
-             user: user)
+      FactoryBot.create(:generic_work, :public,
+                        title: ['test title'],
+                        user: user)
     end
 
     before do
@@ -392,53 +415,75 @@ RSpec.describe Hyrax::FileSetsController do
     describe '#edit' do
       it 'requires login' do
         get :edit, params: { id: public_file_set }
-        expect(response).to fail_redirect_and_flash(main_app.new_user_session_path, 'You need to sign in or sign up before continuing.')
+
+        expect(response)
+          .to fail_redirect_and_flash(main_app.new_user_session_path,
+                                      'You need to sign in or sign up before continuing.')
       end
     end
 
     describe '#show' do
       it 'denies access to private files' do
         get :show, params: { id: private_file_set }
-        expect(response).to fail_redirect_and_flash(main_app.new_user_session_path(locale: 'en'), 'You are not authorized to access this page.')
+
+        expect(response)
+          .to fail_redirect_and_flash(main_app.new_user_session_path(locale: 'en'),
+                                      'You are not authorized to access this page.')
       end
 
       it 'allows access to public files' do
-        expect(controller).to receive(:additional_response_formats).with(ActionController::MimeResponds::Collector)
+        expect(controller)
+          .to receive(:additional_response_formats)
+          .with(ActionController::MimeResponds::Collector)
+
         get :show, params: { id: public_file_set }
+
         expect(response).to be_successful
       end
     end
 
     describe '#show' do
       let(:parent_work_active) do
-        create(:work, :public, state: ::RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#active'))
+        FactoryBot
+          .create(:work, :public, state: Vocab::FedoraResourceStatus.active)
       end
+
       let(:file_set_active) do
-        create(:file_set, read_groups: ['public']).tap do |file_set|
+        FactoryBot.create(:file_set, read_groups: ['public']).tap do |file_set|
           parent_work_active.ordered_members << file_set
           parent_work_active.save!
         end
       end
+
       let(:parent_work_inactive) do
-        create(:work, :public, state: ::RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#inactive'))
+        FactoryBot
+          .create(:work, :public, state: Vocab::FedoraResourceStatus.inactive)
       end
+
       let(:file_set_inactive) do
-        create(:file_set, read_groups: ['public']).tap do |file_set|
+        FactoryBot.create(:file_set, read_groups: ['public']).tap do |file_set|
           parent_work_inactive.ordered_members << file_set
           parent_work_inactive.save!
         end
       end
 
       it "shows active parent" do
-        expect(controller).to receive(:additional_response_formats).with(ActionController::MimeResponds::Collector)
+        expect(controller)
+          .to receive(:additional_response_formats)
+          .with(ActionController::MimeResponds::Collector)
+
         get :show, params: { id: file_set_active }
+
         expect(response).to be_successful
       end
 
       it "shows not currently available for inactive parent" do
         get :show, params: { id: file_set_inactive }
+
         expect(response).to render_template 'unavailable'
-        expect(flash[:notice]).to eq 'The file is not currently available because its parent work has not yet completed the approval process'
+        expect(flash[:notice])
+          .to eq 'The file is not currently available because its parent work ' \
+                 'has not yet completed the approval process'
         expect(response.status).to eq 401
       end
     end
@@ -446,10 +491,12 @@ RSpec.describe Hyrax::FileSetsController do
 
   describe 'integration test for suppressed documents' do
     let(:work) do
-      create(:work, :public, state: Vocab::FedoraResourceStatus.inactive)
+      FactoryBot
+        .create(:work, :public, state: Vocab::FedoraResourceStatus.inactive)
     end
+
     let(:file_set) do
-      create(:file_set, read_groups: ['public']).tap do |file_set|
+      FactoryBot.create(:file_set, read_groups: ['public']).tap do |file_set|
         work.ordered_members << file_set
         work.save!
       end
@@ -458,11 +505,13 @@ RSpec.describe Hyrax::FileSetsController do
     before do
       work.ordered_members << file_set
       work.save!
-      create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+
+      FactoryBot.create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
     end
 
     it 'renders the unavailable message because it is in workflow' do
       get :show, params: { id: file_set }
+
       expect(response.code).to eq '401'
       expect(response).to render_template(:unavailable)
       expect(assigns[:presenter]).to be_instance_of Hyrax::FileSetPresenter

--- a/spec/hyrax/transactions/file_set_destroy_spec.rb
+++ b/spec/hyrax/transactions/file_set_destroy_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+require 'dry/container/stub'
+
+RSpec.describe Hyrax::Transactions::FileSetDestroy do
+  subject(:transaction) { described_class.new }
+  let(:file_set)        { FactoryBot.valkyrie_create(:hyrax_file_set) }
+
+  describe '#call' do
+    let(:user) { FactoryBot.create(:user) }
+
+    context 'without a user' do
+      it 'is a failure' do
+        expect(transaction.call(file_set)).to be_failure
+      end
+    end
+
+    it 'succeeds' do
+      expect(transaction.with_step_args('file_set.remove_from_work' => { user: user }).call(file_set))
+        .to be_success
+    end
+
+    it 'deletes the file set' do
+      transaction.with_step_args('file_set.remove_from_work' => { user: user }).call(file_set)
+
+      expect { Hyrax.query_service.find_by(id: file_set.id) }
+        .to raise_error Valkyrie::Persistence::ObjectNotFoundError
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/remove_file_set_from_work_spec.rb
+++ b/spec/hyrax/transactions/steps/remove_file_set_from_work_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions/steps/add_to_collections'
+require 'hyrax/specs/spy_listener'
+
+RSpec.describe Hyrax::Transactions::Steps::RemoveFileSetFromWork do
+  subject(:step) { described_class.new }
+  let(:file_set) { FactoryBot.build(:hyrax_file_set) }
+
+  describe '#call' do
+    it 'is a Failure' do
+      expect(step.call(file_set)).to be_failure
+    end
+
+    context 'with a user' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'succeeds' do
+        expect(step.call(file_set, user: user)).to be_success
+      end
+
+      context 'and with a parent' do
+        let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set, :in_work) }
+        let(:listener) { Hyrax::Specs::SpyListener.new }
+
+        before { Hyrax.publisher.subscribe(listener) }
+        after  { Hyrax.publisher.unsubscribe(listener) }
+
+        it 'removes the file set from the parent' do
+          expect { step.call(file_set, user: user) }
+            .to change { Hyrax.query_service.find_parents(resource: file_set).to_a }
+            .to be_empty
+        end
+
+        it 'publishes an update of the parent' do
+          expect { step.call(file_set, user: user) }
+            .to change { listener.object_metadata_updated&.payload }
+            .to match object: be_a(Hyrax::Resource), user: user
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
adds some support for Valkyrie based `Hyrax::FileSet` objects to `Hyrax::FileSetsController`. so far this support is experimental, and is missing handling for versioning, permissions, and file content updates.

there's still work to do here, but adopters can switch to using this support by changing the reference to `::FileSet` `load_and_authorize_resource class: ::FileSet, except: :show` to `Hyrax::FileSet`

@samvera/hyrax-code-reviewers
