### PR TITLE
Enable debugging in Hyrax chart deployments

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.18.0
+version: 0.19.0
 appVersion: 3.0.2
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -82,6 +82,9 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
+          {{- with .Values.extraContainerConfiguration }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       volumes:
         - name: "derivatives"
           {{- if and .Values.derivativesVolume.enabled .Values.derivativesVolume.existingClaim }}

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -142,6 +142,9 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.extraContainerConfiguration }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       volumes:
         - name: "branding"
           {{- if and .Values.brandingVolume.enabled .Values.brandingVolume.existingClaim }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -53,6 +53,15 @@ extraInitContainers: []
 #
 extraEnvFrom: []
 
+# Extra container spec configuration
+# Example: (enabling pry debugging for local development)
+# Note: with this enabled, one can `kubectl attach` to a running container with a binding.pry breakpoint
+#
+#extraContainerConfiguration:
+# stdin: true
+# tty: true
+extraContainerConfiguration: []
+
 # an existing volume containing a Hyrax-based application
 # must be a ReadWriteMany volume if worker is enabled
 applicationExistingClaim: ""


### PR DESCRIPTION
In order to use the `kubectl attach`[1] command for pry debugging, we
need to enable `stdin` and `tty` debugging flags for the container,
which are disabled by default[2].

To enable this, and potentially other container configuration additions,
we add an `extraContainerConfiguration` section which will support this
in a way that mirrors `extraVolumeMounts` and other related yaml hooks.

1. https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#attach
2. https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#debugging


@samvera/hyrax-code-reviewers