### PR TITLE
remove duplicate `okcomputer` gem requires

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ source 'https://rubygems.org' do
     gem 'benchmark-ips'
     gem 'easy_translate'
     gem 'i18n-tasks'
-    gem 'okcomputer'
     gem 'pry' unless ENV['CI']
     gem 'pry-byebug' unless ENV['CI']
     gem 'ruby-prof', require: false

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,6 +1,7 @@
 # Use this file to reference specific commits of gems.
 
 group :development do
+  gem 'okcomputer'
   gem 'better_errors'
   gem 'binding_of_caller'
 end


### PR DESCRIPTION
`okcomputer` is is the hyrax gemspec as a development dependency. it shouldn't
be necessary here.

@samvera/hyrax-code-reviewers
