### PR TITLE
Split off hyrax-work-base image and bundle install from dassie

### DIFF
--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -4,7 +4,7 @@ if @sources.global_rubygems_source == Bundler::SourceList.new.global_rubygems_so
   Bundler.ui.info '[Dassie] Adding global rubygems source.'
   source 'https://rubygems.org'
 else
-  Bundler.ui.warn "[Dassie] Global rubygems source already set: #{@sources.global_rubygems_source.inspect}"
+  Bundler.ui.info "[Dassie] Global rubygems source already set: #{@sources.global_rubygems_source.inspect}"
 end
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 

--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Attempts to determine if a global gem source has ready been added by another Gemfile
 if @sources.global_rubygems_source == Bundler::SourceList.new.global_rubygems_source
-  Bundler.ui.warn '[Dassie] Adding global rubygems source.'
+  Bundler.ui.info '[Dassie] Adding global rubygems source.'
   source 'https://rubygems.org'
 else
   Bundler.ui.warn "[Dassie] Global rubygems source already set: #{@sources.global_rubygems_source.inspect}"

--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -1,4 +1,11 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+# Attempts to determine if a global gem source has ready been added by another Gemfile
+if @sources.global_rubygems_source == Bundler::SourceList.new.global_rubygems_source
+  Bundler.ui.warn '[Dassie] Adding global rubygems source.'
+  source 'https://rubygems.org'
+else
+  Bundler.ui.warn "[Dassie] Global rubygems source already set: #{@sources.global_rubygems_source.inspect}"
+end
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.2'
@@ -43,9 +50,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-begin # this is a hack to allow `eval_gemfile` to work correctly
-  gem 'hyrax', path: ENV.fetch('HYRAX_ENGINE_PATH', '..')
-rescue; end
+gemspec name: 'hyrax', path: ENV.fetch('HYRAX_ENGINE_PATH', '..')
 
 gem 'rsolr', '>= 1.0', '< 3'
 gem 'bootstrap-sass', '~> 3.0'

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,6 @@ Dockerfile
 artifacts/*
 coverage/*
 chart/*
+
+Gemfile.lock
+.dassie/Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ONBUILD RUN bundle install --jobs "$(nproc)"
 ONBUILD RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 
 
-FROM hyrax-base as hyrax-worker
+FROM hyrax-base as hyrax-worker-base
 
 ENV MALLOC_ARENA_MAX=2
 
@@ -64,14 +64,17 @@ RUN mkdir -p /app/fits && \
     chmod a+x /app/fits/fits.sh
 ENV PATH="${PATH}:/app/fits"
 
+CMD bundle exec sidekiq
+
+
+FROM hyrax-worker-base as hyrax-worker
+
 ARG APP_PATH=.
 ARG BUNDLE_WITHOUT="development test"
 
 ONBUILD COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 ONBUILD RUN bundle install --jobs "$(nproc)"
 ONBUILD RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
-
-CMD bundle exec sidekiq
 
 
 FROM hyrax-base as hyrax-engine-dev
@@ -84,11 +87,11 @@ ENV HYRAX_ENGINE_PATH /app/samvera/hyrax-engine
 COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 COPY --chown=1001:101 . /app/samvera/hyrax-engine
 
-RUN cd /app/samvera/hyrax-engine && bundle install --jobs "$(nproc)"
+RUN bundle install --jobs "$(nproc)"
 RUN RAILS_ENV=production SECRET_KEY_BASE='fakesecret1234' DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 
 
-FROM hyrax-worker as hyrax-engine-dev-worker
+FROM hyrax-worker-base as hyrax-engine-dev-worker
 
 ARG APP_PATH=.dassie
 ARG BUNDLE_WITHOUT=
@@ -98,4 +101,4 @@ ENV HYRAX_ENGINE_PATH /app/samvera/hyrax-engine
 COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 COPY --chown=1001:101 . /app/samvera/hyrax-engine
 
-RUN cd /app/samvera/hyrax-engine && bundle install --jobs "$(nproc)"
+RUN bundle install --jobs "$(nproc)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,12 +83,13 @@ ARG APP_PATH=.dassie
 ARG BUNDLE_WITHOUT=
 
 ENV HYRAX_ENGINE_PATH /app/samvera/hyrax-engine
-ENV IN_DASSIE_DOCKER_COMPOSE true
 
 COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 COPY --chown=1001:101 . /app/samvera/hyrax-engine
 
-RUN bundle install --jobs "$(nproc)" ; cd $HYRAX_ENGINE_PATH ; bundle install --jobs "$(nproc)"
+RUN gem update bundler && gem cleanup bundler && bundle -v && \
+  bundle install --jobs "$(nproc)" && \
+  cd $HYRAX_ENGINE_PATH && bundle install --jobs "$(nproc)"
 RUN RAILS_ENV=production SECRET_KEY_BASE='fakesecret1234' DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 
 
@@ -102,4 +103,5 @@ ENV HYRAX_ENGINE_PATH /app/samvera/hyrax-engine
 COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 COPY --chown=1001:101 . /app/samvera/hyrax-engine
 
-RUN bundle install --jobs "$(nproc)"
+RUN gem update bundler && gem cleanup bundler && bundle -v && \
+  bundle install --jobs "$(nproc)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,11 +83,12 @@ ARG APP_PATH=.dassie
 ARG BUNDLE_WITHOUT=
 
 ENV HYRAX_ENGINE_PATH /app/samvera/hyrax-engine
+ENV IN_DASSIE_DOCKER_COMPOSE true
 
 COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 COPY --chown=1001:101 . /app/samvera/hyrax-engine
 
-RUN bundle install --jobs "$(nproc)"
+RUN bundle install --jobs "$(nproc)" ; cd $HYRAX_ENGINE_PATH ; bundle install --jobs "$(nproc)"
 RUN RAILS_ENV=production SECRET_KEY_BASE='fakesecret1234' DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,9 @@ test_app_path = ENV['RAILS_ROOT'] ||
 test_app_gemfile = File.expand_path('Gemfile', test_app_path)
 
 # rubocop:disable Bundler/DuplicatedGem
-if File.exist?(test_app_gemfile)
+if File.exist?(test_app_gemfile) && !ENV.fetch('IN_DASSIE_DOCKER_COMPOSE', false)
   begin
+    Bundler.ui.warn "[Hyrax] Including test application dependencies from #{test_app_gemfile}"
     eval_gemfile test_app_gemfile
   rescue Bundler::GemfileError => e
     Bundler.ui.warn '[Hyrax] Skipping Rails application dependencies:'
@@ -32,5 +33,7 @@ elsif ENV['RAILS_VERSION'] == 'edge'
   ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks'
 elsif ENV['RAILS_VERSION']
   gem 'rails', ENV['RAILS_VERSION'], source: 'https://rubygems.org'
+else
+  Bundler.ui.warn '[Hyrax] Skipping all Rails dependency injection'
 end
 # rubocop:enable Bundler/DuplicatedGem

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ test_app_gemfile = File.expand_path('Gemfile', test_app_path)
 # rubocop:disable Bundler/DuplicatedGem
 if File.exist?(test_app_gemfile)
   begin
-    Bundler.ui.warn "[Hyrax] Including test application dependencies from #{test_app_gemfile}"
+    Bundler.ui.info "[Hyrax] Including test application dependencies from #{test_app_gemfile}"
     eval_gemfile test_app_gemfile
   rescue Bundler::GemfileError => e
     Bundler.ui.warn '[Hyrax] Skipping Rails application dependencies:'

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,17 @@
 # frozen_string_literal: true
-source 'https://rubygems.org' do
-  # Please see hyrax.gemspec for dependency information.
-  gemspec
+source 'https://rubygems.org'
+# Please see hyrax.gemspec for dependency information.
+gemspec
 
-  group :development, :test do
-    gem 'benchmark-ips'
-    gem 'easy_translate'
-    gem 'i18n-tasks'
-    gem 'okcomputer'
-    gem 'pry' unless ENV['CI']
-    gem 'pry-byebug' unless ENV['CI']
-    gem 'ruby-prof', require: false
-    gem "simplecov", require: false
-  end
+group :development, :test do
+  gem 'benchmark-ips'
+  gem 'easy_translate'
+  gem 'i18n-tasks'
+  gem 'okcomputer'
+  gem 'pry' unless ENV['CI']
+  gem 'pry-byebug' unless ENV['CI']
+  gem 'ruby-prof', require: false
+  gem "simplecov", require: false
 end
 
 test_app_path = ENV['RAILS_ROOT'] ||
@@ -20,7 +19,7 @@ test_app_path = ENV['RAILS_ROOT'] ||
 test_app_gemfile = File.expand_path('Gemfile', test_app_path)
 
 # rubocop:disable Bundler/DuplicatedGem
-if File.exist?(test_app_gemfile) && !ENV.fetch('IN_DASSIE_DOCKER_COMPOSE', false)
+if File.exist?(test_app_gemfile)
   begin
     Bundler.ui.warn "[Hyrax] Including test application dependencies from #{test_app_gemfile}"
     eval_gemfile test_app_gemfile


### PR DESCRIPTION
Fixes issues encountered when running `docker-compose build` without a Gemfile.lock in .dassie.

The bundle install command for the hyrax-engine-dev and hyrax-engine-dev-worker images was trying to resolve gem dependencies from the hyrax-engine directory instead of hyrax-webapp. This appeared to cause bundler to get into a circular dependency loop and eventually run out of stack space, or would cause bundler to not find some gems. ​

Problems also stemmed from the use of a scoped source in the hyrax engine Gemfile (from #4700).  

Changes proposed in this pull request:

* Bundle install gems using .dassie/Gemfile for dev docker images.
* Create hyrax-worker-base image that is the base for the other workers to avoid the onbuild bundle install in the dev worker.
* Have dassie load hyrax using `gemspec` instead of `gem` which allows the error catching hack to be removed.
* Undo the scoped source in hyrax's Gemfile and make dassie detect if a global source has already been loaded. This resolves bundler not being able to find compatible versions of gems.
* Update bundler in more places to ensure we have the latest version. Despite the hyrax-base image updating bundler, an old version could still be used if a cached image is used during the build.
  * The hyrax and hyrax-worker images still depend on hyrax-base to update bundler correctly. Should this be changed?
* Add the hyrax engine and dassie Gemfile.lock files to .dockerignore to avoid building with the host's gem environment.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* `docker-compose build` is successful
* The built images start without error using `docker-compose up`
* Able to run `docker-compose exec -w /app/samvera/hyrax-engine app sh -c "rubocop"` 
* Able to run `docker-compose exec -w /app/samvera/hyrax-engine app sh -c "rspec"` 

@samvera/hyrax-code-reviewers