### PR TITLE
Remove row limit

### DIFF
--- a/app/services/hyrax/workflow/status_list_service.rb
+++ b/app/services/hyrax/workflow/status_list_service.rb
@@ -39,7 +39,7 @@ module Hyrax
         actionable_roles = roles_for_user
         logger.debug("Actionable roles for #{user.user_key} are #{actionable_roles}")
         return [] if actionable_roles.empty?
-        WorkRelation.new.search_with_conditions(query(actionable_roles), rows: 1000, method: :post)
+        WorkRelation.new.search_with_conditions(query(actionable_roles), method: :post)
       end
 
       def query(actionable_roles)


### PR DESCRIPTION
This limit prevented the review submission dashboard from showing accurate result totals.

 refs #3171

This fixes the issue currently seen on nurax and other systems with large amounts of works. There may be further inaccuracies to be discovered after this limit is removed.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* The total amount of works reported in the review submissions dashboard agrees with the amount shown on the works dashboard.

@samvera/hyrax-code-reviewers
