### PR TITLE
Fixed stray ul tag

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -35,9 +35,9 @@
               <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
                   data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
             </li>
-          <% end %>
+          </ul>
+        <% end %>
 
-        </ul>
       </div><!-- /.input-group-btn -->
     </div><!-- /.input-group -->
     


### PR DESCRIPTION
A simple PR to fix a stray ul tag in a search form.

This was noticed during a security audit and we were requested to fix it. We have done it locally, by overriding the file. It would be good to have it fixed upstream (in the 2.x branch though)

@samvera/hyrax-code-reviewers
