### PR TITLE
wings: versions for fcrepo

### DIFF
--- a/lib/hyrax/specs/shared_specs/valkyrie_storage_versions.rb
+++ b/lib/hyrax/specs/shared_specs/valkyrie_storage_versions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a Valkyrie::StorageAdapter with versioning support' do
+  describe '#supports?' do
+    it 'supports versions' do
+      expect(storage_adapter.supports?(:versions)).to eq true
+    end
+  end
+end


### PR DESCRIPTION
support a versions interface for the valkyrie storage adapter. the interface
developed here only applies to the access side---not to explicit version
creation. since `fcrepo` creates the versions for us in the normal
configuration, we can just rely on that for this adapter.

further work is needed to validate that this interface is sufficient for Hyrax,
and that some version of it can be implemented for other versioning storage
layers (e.g. S3).

@samvera/hyrax-code-reviewers
