### PR TITLE
chart: bump fcrepo dependency

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.19.0
+version: 0.20.0
 appVersion: 3.0.2
 dependencies:
   - name: fcrepo
-    version: 0.6.1
+    version: 0.8.0
     repository: oci://ghcr.io/samvera
     condition: fcrepo.enabled
   - name: memcached


### PR DESCRIPTION
the fcrepo chart now deploys a samvera ghcr.io image by default. we want to do
that too, so bump the chart version.

@samvera/hyrax-code-reviewers
