### PR TITLE
chart: re-instate external fcrepo hostname support

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.20.0
+version: 0.20.1
 appVersion: 3.0.2
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -25,12 +25,10 @@ data:
   {{- if .Values.redis.enabled }}
   REDIS_HOST: {{ template "hyrax.redis.host" . }}
   {{- end }}
-  {{- if .Values.fcrepo.enabled }}
-  FCREPO_BASE_PATH: {{ .Values.fcrepoBasePathOverride | default (printf "/%s" (include "hyrax.fullname" .)) | quote }}
   FCREPO_HOST: {{ template "hyrax.fcrepo.host" . }}
+  FCREPO_BASE_PATH: {{ .Values.fcrepoBasePathOverride | default (printf "/%s" (include "hyrax.fullname" .)) | quote }}
   FCREPO_PORT: {{ .Values.fcrepo.servicePort | default 8080 | quote }}
   FCREPO_REST_PATH: {{ .Values.fcrepo.restPath | default "rest" }}
-  {{- end }}
   REDIS_PROVIDER: SIDEKIQ_REDIS_URL
   {{- if .Values.minio.enabled }}
   MINIO_ENDPOINT: {{ template "hyrax.minio.fullname" . }}


### PR DESCRIPTION
when the fcrepo chart is disabled, still set the `FCREPO_HOST` and
`FCREPO_BASE_PATH` and other environment variables. the templates and variable
logic should (and already do?) handle all cases.

i think this regressed because of UC work to make it possible to simply skip
fcrepo. setting the environment variables is harmless in this case though. i
think we just got a bit overzealous.


@samvera/hyrax-code-reviewers
