### PR TITLE
Adding documention on located_near attribute

### DIFF
--- a/spec/indexers/hyrax/generic_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/generic_work_indexer_spec.rb
@@ -99,11 +99,18 @@ RSpec.describe GenericWorkIndexer do
   end
 
   describe "with a remote resource (based near)" do
+    # You can get the original RDF+XML here:
+    # https://sws.geonames.org/5037649/about.rdf Note: in this RDF+XML
+    # document, the only "English readable" identifying attributes are
+    # the nodes: `gn:name` and `gn:countryCode`.  In other words the
+    # helpful administrative container (e.g. Minnesota) is not in this
+    # document.
     mpls = <<RDFXML.strip_heredoc
       <?xml version="1.0" encoding="UTF-8" standalone="no"?>
           <rdf:RDF xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gn="http://www.geonames.org/ontology#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
           <gn:Feature rdf:about="http://sws.geonames.org/5037649/">
           <gn:name>Minneapolis</gn:name>
+          <gn:countryCode>US</gn:countryCode>
           </gn:Feature>
           </rdf:RDF>
 RDFXML


### PR DESCRIPTION
As I'm working through #1065, I needed to understand the default
behavior.  I also wanted to look and see if there were more attributes
on the RDF document that I could add to the label.

I'm also considering that #1956 required a change in implementation;
moving away from RDF and towards the JSON response document.

At present, I'm uncertain on the best approach to proceed with resolving
issue #1065.  I'll be bringing this up in the hyrax-wg channel and
during stand up.

@samvera/hyrax-code-reviewers
