### PR TITLE
docker: run assets precompile on worker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ ARG BUNDLE_WITHOUT="development test"
 
 ONBUILD COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 ONBUILD RUN bundle install --jobs "$(nproc)"
+ONBUILD RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 
 CMD bundle exec sidekiq
 


### PR DESCRIPTION
workers need precompiled assets too, even though they won't serve them, because
use of `ActionController::Base.helpers` in ThumbnailPathService (and perhaps
elsewhere).

@samvera/hyrax-code-reviewers
