### PR TITLE
chart: define a fallback/dummy fcrepo host

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.21.0
+version: 0.21.1
 appVersion: 3.0.2
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -74,7 +74,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- if .Values.fcrepo.enabled }}
 {{- include "hyrax.fcrepo.fullname" . }}
 {{- else }}
-{{- .Values.externalFcrepoHost }}
+{{- .Values.externalFcrepoHost | default "NO_FCREPO_HOST_DEFINED" }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
helm doesn't accept nil values, so some dummy value is needed in the case that
no fcrepo host is defined (e.g. because we don't intend to deploy one). an empty
string or similar would be fine, but we prefer a more communicative and verbose
value.

@samvera/hyrax-code-reviewers
