### PR TITLE
Allow posting file visibility parameters from form

### DIFF
--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -95,7 +95,7 @@ module Hyrax
       def clean_attributes(attributes)
         attributes[:license] = Array(attributes[:license]) if attributes.key? :license
         attributes[:rights_statement] = Array(attributes[:rights_statement]) if attributes.key? :rights_statement
-        remove_blank_attributes!(attributes)
+        remove_blank_attributes!(attributes).except('file_set')
       end
 
       # If any attributes are blank remove them

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -179,7 +179,7 @@ module Hyrax
           },
           {
             file_set: [:visibility, :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
-                     :visibility_during_lease, :lease_expiration_date, :visibility_after_lease, :uploaded_file_id]
+                       :visibility_during_lease, :lease_expiration_date, :visibility_after_lease, :uploaded_file_id]
           }
         ]
       end

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -176,6 +176,10 @@ module Hyrax
             based_near_attributes: [:id, :_destroy],
             member_of_collections_attributes: [:id, :_destroy],
             work_members_attributes: [:id, :_destroy]
+          },
+          {
+            file_set: [:visibility, :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
+                     :visibility_during_lease, :lease_expiration_date, :visibility_after_lease, :uploaded_file_id]
           }
         ]
       end

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -25,15 +25,19 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
     work, work_permissions = create_permissions work, depositor
     uploaded_files.each do |uploaded_file|
       next if uploaded_file.file_set_uri.present?
-
-      actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
-      metadata = visibility_attributes(work_attributes, uploaded_file)
-      uploaded_file.add_file_set!(actor.file_set)
-      actor.file_set.permissions_attributes = work_permissions
-      actor.create_metadata(metadata)
-      actor.create_content(uploaded_file)
-      actor.attach_to_work(work, metadata)
+      attach_work(user, work, work_attributes, work_permissions, uploaded_file)
     end
+  end
+
+  def attach_work(user, work, work_attributes, work_permissions, uploaded_file)
+    actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
+    file_set_attributes = file_set_attrs(work_attributes, uploaded_file)
+    metadata = visibility_attributes(work_attributes, file_set_attributes)
+    uploaded_file.add_file_set!(actor.file_set)
+    actor.file_set.permissions_attributes = work_permissions
+    actor.create_metadata(metadata)
+    actor.create_content(uploaded_file)
+    actor.attach_to_work(work, metadata)
   end
 
   def create_permissions(work, depositor)
@@ -44,12 +48,16 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
   end
 
   # The attributes used for visibility - sent as initial params to created FileSets.
-  def visibility_attributes(attributes, uploaded_file = nil)
-    file_set_attributes = Array(attributes[:file_set]).find { |fs| fs[:uploaded_file_id] == uploaded_file&.id }
-    attributes.merge(Hash(file_set_attributes)).slice(:visibility, :visibility_during_lease,
+  def visibility_attributes(attributes, file_set_attributes)
+    attributes.merge(file_set_attributes).slice(:visibility, :visibility_during_lease,
                      :visibility_after_lease, :lease_expiration_date,
                      :embargo_release_date, :visibility_during_embargo,
                      :visibility_after_embargo)
+  end
+
+  def file_set_attrs(attributes, uploaded_file)
+    attrs = Array(attributes[:file_set]).find { |fs| fs[:uploaded_file_id].present? && (fs[:uploaded_file_id].to_i == uploaded_file&.id) }
+    Hash(attrs).symbolize_keys
   end
 
   def validate_files!(uploaded_files)

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -99,6 +99,8 @@ RSpec.describe Hyrax::Forms::WorkForm do
                                :version,
                                :on_behalf_of,
                                { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
+                               { file_set: [:visibility, :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
+                                            :visibility_during_lease, :lease_expiration_date, :visibility_after_lease, :uploaded_file_id] },
                                based_near_attributes: [:id, :_destroy],
                                member_of_collections_attributes: [:id, :_destroy],
                                work_members_attributes: [:id, :_destroy])

--- a/spec/jobs/attach_files_to_work_with_ordered_members_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_with_ordered_members_job_spec.rb
@@ -11,4 +11,24 @@ RSpec.describe AttachFilesToWorkWithOrderedMembersJob, perform_enqueued: [Attach
     expect(Hyrax::Actors::OrderedMembersActor).to receive(:attach_ordered_members_to_work).with(generic_work)
     described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
   end
+
+  context "with visibility different from parent work" do
+    let(:attributes) { { file_set: [{ uploaded_file_id: uploaded_file2.id, visibility: 'restricted' }] } }
+
+    before do
+      # Ensure uploaded files have ids
+      uploaded_file1.save
+      uploaded_file2.save
+    end
+
+    it "overrides the work's visibility", perform_enqueued: [described_class, IngestJob] do
+      expect(CharacterizeJob).to receive(:perform_later).twice
+      described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2], attributes)
+      generic_work.reload
+      expect(generic_work.file_sets.count).to eq 2
+      expect(generic_work.file_sets.find { |fs| fs.label == uploaded_file1.file.filename }.visibility).to eq 'open'
+      expect(generic_work.file_sets.find { |fs| fs.label == uploaded_file2.file.filename }.visibility).to eq 'restricted'
+      expect(uploaded_file1.reload.file_set_uri).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Small fixes and improvements building on #4992 to allow using this code from a controller by permitting the new parameters in the form and casting `uploaded_file_id` to an integer since it will be a string when posted by the form.

The job code was also refactored to appease rubocop's length requirements.

Follow on PR for submitting these parameters from the deposit form is #5022 

@samvera/hyrax-code-reviewers
