### PR TITLE
Update solrcloud scripts variable interpolation syntax

### DIFF
--- a/bin/solrcloud-assign-configset.sh
+++ b/bin/solrcloud-assign-configset.sh
@@ -5,20 +5,23 @@ if [ "$SOLR_ADMIN_USER" ]; then
   solr_user_settings="--user $SOLR_ADMIN_USER:$SOLR_ADMIN_PASSWORD"
 fi
 
+solr_config_name="${SOLR_CONFIGSET_NAME:-solrconfig}"
+solr_collection_name="${SOLR_COLLECTION_NAME:-hyrax}"
+
 # Solr Cloud Collection API URLs
 solr_collection_list_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=LIST"
-solr_collection_modify_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=MODIFYCOLLECTION&collection=$SOLR_COLLECTION_NAME&collection.configName=$SOLR_CONFIGSET_NAME"
+solr_collection_modify_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=MODIFYCOLLECTION&collection=${solr_collection_name}&collection.configName=${solr_config_name}"
 
 while [ $COUNTER -lt 30 ]; do
   if nc -z "${SOLR_HOST}" "${SOLR_PORT}"; then
-    if curl --silent $solr_user_settings "$solr_collection_list_url" | grep -q "$SOLR_COLLECTION_NAME"; then
-      echo "-- Collection ${SOLR_COLLECTION_NAME} exists; setting ${SOLR_CONFIGSET_NAME} ConfigSet ..."
+    if curl --silent $solr_user_settings "$solr_collection_list_url" | grep -q "$solr_collection_name"; then
+      echo "-- Collection ${solr_collection_name} exists; setting ${solr_config_name} ConfigSet ..."
       echo $solr_collection_modify_url
       curl $solr_user_settings "$solr_collection_modify_url"
       exit
     else
-      echo "-- Collection ${SOLR_COLLECTION_NAME} does not exist; creating and setting ${SOLR_CONFIGSET_NAME} ConfigSet ..."
-      solr_collection_create_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=CREATE&name=$SOLR_COLLECTION_NAME&collection.configName=$SOLR_CONFIGSET_NAME&numShards=1"
+      echo "-- Collection ${solr_collection_name} does not exist; creating and setting ${solr_config_name} ConfigSet ..."
+      solr_collection_create_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=CREATE&name=${solr_collection_name}&collection.configName=${solr_config_name}&numShards=1"
       curl $solr_user_settings "$solr_collection_create_url"
       exit
     fi

--- a/bin/solrcloud-upload-configset.sh
+++ b/bin/solrcloud-upload-configset.sh
@@ -8,9 +8,11 @@ if [ "$SOLR_ADMIN_USER" ]; then
   solr_user_settings="--user $SOLR_ADMIN_USER:$SOLR_ADMIN_PASSWORD"
 fi
 
+solr_config_name="${SOLR_CONFIGSET_NAME:-solrconfig}"
+
 # Solr Cloud ConfigSet API URLs
 solr_config_list_url="http://$SOLR_HOST:$SOLR_PORT/api/cluster/configs?omitHeader=true"
-solr_config_upload_url="http://$SOLR_HOST:$SOLR_PORT/solr/admin/configs?action=UPLOAD&name=$SOLR_CONFIGSET_NAME"
+solr_config_upload_url="http://$SOLR_HOST:$SOLR_PORT/solr/admin/configs?action=UPLOAD&name=${solr_config_name}"
 
 while [ $COUNTER -lt 30 ]; do
   echo "-- Looking for Solr (${SOLR_HOST}:${SOLR_PORT})..."
@@ -19,7 +21,7 @@ while [ $COUNTER -lt 30 ]; do
     if curl --silent --user 'fake:fake' "$solr_config_list_url" | grep -q '401'; then
       # the solr pods come up and report available before they are ready to accept trusted configs
       # only try to upload the config if auth is on.
-      if curl --silent $solr_user_settings "$solr_config_list_url" | grep -q "$SOLR_CONFIGSET_NAME"; then
+      if curl --silent $solr_user_settings "$solr_config_list_url" | grep -q "$solr_config_name"; then
         echo "-- ConfigSet already exists; skipping creation ...";
       else
         echo "-- ConfigSet for ${CONFDIR} does not exist; creating ..."


### PR DESCRIPTION
The existing scripts, particularly for URLs such as
`solr_collection_create_url`, `solr_collection_modify_url`, etc. are somehow
getting null values of the environment variables even though they are
defined.

This changes the interpolation strategy and syntax a bit, and in local
testing in both a raw Hyrax chart and our Comet application, I'm now
about to get a passing `load-solr-config` `initContainer`.

@samvera/hyrax-code-reviewers
