### PR TITLE
support adding a work into a parent work with valkyrie models

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -203,7 +203,8 @@ module Hyrax
         @curation_concern =
           form.validate(params[hash_key_for_curation_concern]) &&
           transactions['change_set.create_work']
-          .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
+          .with_step_args('work_resource.add_to_parent' => { parent_id: params[:parent_id] },
+                          'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
                           'change_set.set_user_as_depositor' => { user: current_user })
           .call(form).value!
       end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -27,6 +27,7 @@ module Hyrax
       require 'hyrax/transactions/update_work'
       require 'hyrax/transactions/steps/add_file_sets'
       require 'hyrax/transactions/steps/add_to_collections'
+      require 'hyrax/transactions/steps/add_to_parent'
       require 'hyrax/transactions/steps/apply_collection_permission_template'
       require 'hyrax/transactions/steps/apply_permission_template'
       require 'hyrax/transactions/steps/apply_visibility'
@@ -111,6 +112,10 @@ module Hyrax
       namespace 'work_resource' do |ops| # valkyrie works
         ops.register 'add_file_sets' do
           Steps::AddFileSets.new
+        end
+
+        ops.register 'add_to_parent' do
+          Steps::AddToParent.new
         end
 
         ops.register 'delete' do

--- a/lib/hyrax/transactions/steps/add_to_parent.rb
+++ b/lib/hyrax/transactions/steps/add_to_parent.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Adds a work to a parent work
+      #
+      # @see https://wiki.lyrasis.org/display/samvera/Hydra::Works+Shared+Modeling
+      class AddToParent
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Hyrax::Work] obj
+        # @param [#to_s] parent_id
+        #
+        # @return [Dry::Monads::Result]
+        def call(obj, parent_id: nil)
+          return Success(obj) if parent_id.blank?
+
+          parent = Hyrax.query_service.find_by(id: parent_id)
+          parent.member_ids << obj.id
+          Hyrax.persister.save(resource: parent)
+
+          Success(obj)
+        rescue Valkyrie::Persistence::ObjectNotFoundError => _err
+          Failure[:parent_object_not_found, parent_id]
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/work_create.rb
+++ b/lib/hyrax/transactions/work_create.rb
@@ -14,7 +14,8 @@ module Hyrax
                        'change_set.add_to_collections',
                        'change_set.apply',
                        'work_resource.save_acl',
-                       'work_resource.add_file_sets'].freeze
+                       'work_resource.add_file_sets',
+                       'work_resource.add_to_parent'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -160,6 +160,20 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         end
       end
 
+      context 'and a parent work' do
+        let(:parent) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+        it 'adds the new work as a member of the parent' do
+          params = { test_simple_work: { title: 'comet in moominland' },
+                     parent_id: parent.id }
+
+          post :create, params: params
+
+          expect(Hyrax.query_service.find_by(id: parent.id).member_ids)
+            .to contain_exactly(assigns(:curation_concern).id)
+        end
+      end
+
       context 'with invalid form data' do
         let(:work) { FactoryBot.build(:hyrax_work) }
 

--- a/spec/hyrax/transactions/steps/add_to_parent_spec.rb
+++ b/spec/hyrax/transactions/steps/add_to_parent_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::AddToParent, valkyrie_adapter: :test_adapter do
+  subject(:step) { described_class.new }
+  let(:work)     { FactoryBot.valkyrie_create(:hyrax_work) }
+
+  it 'gives success' do
+    expect(step.call(work)).to be_success
+  end
+
+  context 'when the parent does not exist' do
+    it 'is a failure' do
+      expect(step.call(work, parent_id: 'NOT_A_REAL_ID'))
+        .to be_failure
+    end
+  end
+
+  context 'with a valid parent id' do
+    let(:parent) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+    it 'is a success' do
+      expect(step.call(work, parent_id: parent.id))
+        .to be_success
+    end
+
+    it 'adds work to parent work' do
+      expect { step.call(work, parent_id: parent.id) }
+        .to change { Hyrax.query_service.custom_queries.find_child_works(resource: parent) }
+        .from(be_empty)
+        .to contain_exactly(work)
+    end
+  end
+end


### PR DESCRIPTION
when submitting a work form with a `parent_id` argument, add the work to a
parent work.

this adds valkyrie native support for this feature, which is long standing for
ActiveFedora models.

@samvera/hyrax-code-reviewers
