### PR TITLE
publish events when adding valkyrie objects to work membership

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -203,7 +203,7 @@ module Hyrax
         @curation_concern =
           form.validate(params[hash_key_for_curation_concern]) &&
           transactions['change_set.create_work']
-          .with_step_args('work_resource.add_to_parent' => { parent_id: params[:parent_id] },
+          .with_step_args('work_resource.add_to_parent' => { parent_id: params[:parent_id], user: current_user },
                           'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
                           'change_set.set_user_as_depositor' => { user: current_user })
           .call(form).value!

--- a/lib/hyrax/transactions/steps/add_to_parent.rb
+++ b/lib/hyrax/transactions/steps/add_to_parent.rb
@@ -16,12 +16,15 @@ module Hyrax
         # @param [#to_s] parent_id
         #
         # @return [Dry::Monads::Result]
-        def call(obj, parent_id: nil)
+        def call(obj, parent_id: nil, user: nil)
           return Success(obj) if parent_id.blank?
 
           parent = Hyrax.query_service.find_by(id: parent_id)
           parent.member_ids << obj.id
           Hyrax.persister.save(resource: parent)
+
+          user ||= ::User.find_by_user_key(obj.depositor)
+          Hyrax.publisher.publish('object.metadata.updated', object: parent, user: user)
 
           Success(obj)
         rescue Valkyrie::Persistence::ObjectNotFoundError => _err

--- a/spec/hyrax/transactions/steps/add_to_parent_spec.rb
+++ b/spec/hyrax/transactions/steps/add_to_parent_spec.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 require 'spec_helper'
 require 'hyrax/transactions'
+require 'hyrax/specs/spy_listener'
 
 RSpec.describe Hyrax::Transactions::Steps::AddToParent, valkyrie_adapter: :test_adapter do
   subject(:step) { described_class.new }
+  let(:listener) { Hyrax::Specs::SpyListener.new }
   let(:work)     { FactoryBot.valkyrie_create(:hyrax_work) }
+
+  before { Hyrax.publisher.subscribe(listener) }
+  after  { Hyrax.publisher.unsubscribe(listener) }
 
   it 'gives success' do
     expect(step.call(work)).to be_success
@@ -30,6 +35,12 @@ RSpec.describe Hyrax::Transactions::Steps::AddToParent, valkyrie_adapter: :test_
         .to change { Hyrax.query_service.custom_queries.find_child_works(resource: parent) }
         .from(be_empty)
         .to contain_exactly(work)
+    end
+
+    it 'publishes a metadata change event for the parent work' do
+      expect { step.call(work, parent_id: parent.id) }
+        .to change { listener.object_metadata_updated&.payload }
+        .to match(object: parent, user: nil)
     end
   end
 end


### PR DESCRIPTION
ensures metadata update listeners trigger when the membership changes. we use
this to update indexes, and also it's just part of our aspirational contract
with users.

pass the current user to the step so the listeners will know what user updated
the object.

@samvera/hyrax-code-reviewers
