### PR TITLE
Temporarily pin Bundler to v 2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN addgroup -S --gid 101 app && \
   adduser -S -G app -u 1001 -s /bin/sh -h /app app
 USER app
 
-RUN gem update bundler
+# temporarily locked to 2.1 as 2.2 introduces bundle install issues
+RUN gem install bundler -v 2.1
 
 RUN mkdir -p /app/samvera/hyrax-webapp
 WORKDIR /app/samvera/hyrax-webapp


### PR DESCRIPTION
There seems to be an issue building/bundling with Bundler version 2.2 with the `Dockerfile` and `docker-compose` environment.

The errors manifest as some version of:

```sh
Bundler could not find compatible versions for gem "listen":
  In Gemfile:
    listen (>= 3.0.5, < 3.2)

    spring-watcher-listen (~> 2.0.0) was resolved to 2.0.1, which depends on
      listen (< 4.0, >= 2.7)

Bundler could not find compatible versions for gem "rails":
  In Gemfile:
    rails (~> 5.2.4, >= 5.2.4.4)

    engine_cart (~> 2.2) was resolved to 2.3.0, which depends on
      rails

    hyrax was resolved to 3.0.2, which depends on
      rails (~> 5.0)

Bundler could not find compatible versions for gem "rubocop-rails":
  In Gemfile:
    bixby (~> 3.0, >= 3.0.2) was resolved to 3.0.2, which depends on
      rubocop-rails

Could not find gem 'rubocop-rails', which is required by gem 'bixby (~> 3.0, >=
3.0.2)', in rubygems repository https://rubygems.org/ or installed locally.

Bundler could not find compatible versions for gem "thread":
  In Gemfile:
    easy_translate was resolved to 0.5.1, which depends on
      thread

Could not find gem 'thread', which is required by gem 'easy_translate', in
rubygems repository https://rubygems.org/ or installed locally.
The command '/bin/sh -c cd /app/samvera/hyrax-engine && bundle install --jobs "$(nproc)"' returned a non-zero code: 6
ERROR: Service 'sidekiq' failed to build : Build failed
```

Forcing Bundler to use `2.1` allows the bundle installation to
successfully complete. I've been unable to target an upstream related
issue, but hopefully this is something we can soon revert.


@samvera/hyrax-code-reviewers
