### PR TITLE
Enable feature specs to pass with HUB_URL/Selenium

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,3 @@
-CAPYBARA_SERVER=http://app:3010
 CHROME_HEADLESS_MODE=false
 DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
 DATABASE_TEST_URL=postgresql://hyrax_user:hyrax_password@postgres/hyrax_test?pool=5

--- a/lib/hyrax/specs/capybara.rb
+++ b/lib/hyrax/specs/capybara.rb
@@ -40,7 +40,9 @@ if ENV['IN_DOCKER'].present? || ENV['HUB_URL'].present?
 
   Capybara.server_host = '0.0.0.0'
   Capybara.server_port = 3010
-  Capybara.app_host = ENV['CAPYBARA_SERVER'] || 'http://127.0.0.1:3010'
+
+  ip = IPSocket.getaddress(Socket.gethostname)
+  Capybara.app_host = "http://#{ip}:#{Capybara.server_port}"
 else
   TEST_HOST = 'localhost:3000'.freeze
   # @note In January 2018, TravisCI disabled Chrome sandboxing in its Linux

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe "work show view" do
   include Selectors::Dashboard
 
   let(:work_path) { "/concern/generic_works/#{work.id}" }
+  let(:app_host) { Capybara.app_host || 'http://www.example.com' }
 
   before do
     FactoryBot.create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
@@ -50,13 +51,11 @@ RSpec.describe "work show view" do
         expect(page).to have_selector '.attribute-filename', text: 'A Contained FileSet'
       end
 
-      server_host = ENV.fetch('CAPYBARA_SERVER', 'http://www.example.com')
-
       # IIIF manifest does not include locale query param
       expect(find('div.viewer-wrapper iframe')['src']).to eq(
-        "#{server_host}/uv/uv.html#?manifest=" \
-        "#{server_host}/concern/generic_works/#{work.id}/manifest&" \
-        "config=#{server_host}/uv/uv-config.json"
+        "#{app_host}/uv/uv.html#?manifest=" \
+        "#{app_host}/concern/generic_works/#{work.id}/manifest&" \
+        "config=#{app_host}/uv/uv-config.json"
       )
     end
 
@@ -142,7 +141,7 @@ RSpec.describe "work show view" do
       expect(page).not_to have_selector "form#fileupload"
 
       # has some social media buttons
-      expect(page).to have_link '', href: "https://twitter.com/intent/tweet/?#{page_title}&url=http%3A%2F%2Fwww.example.com%2Fconcern%2Fgeneric_works%2F#{work.id}"
+      expect(page).to have_link '', href: "https://twitter.com/intent/tweet/?#{page_title}&url=#{CGI.escape(app_host)}%2Fconcern%2Fgeneric_works%2F#{work.id}"
 
       # exports EndNote
       expect(page).to have_link 'EndNote'


### PR DESCRIPTION
Changes proposed in this pull request:
* Remove `CAPYBARA_SERVER` env var
* Replace `CAPYBARA_SERVER` usage with `IPSocket.getaddress`
* Replace hard-coded `example.com` reference in twitter feature spec assertion
	with `Capybara.app_host`

Locally, in the `docker-compose` environment, if I run all the feature specs
via:

```sh
% docker-compose exec -w /app/samvera/hyrax-engine app sh -c "bundle exec rspec spec/features"
```

I can get all test to pass:

```sh
Finished in 10 minutes 50 seconds (files took 5.67 seconds to load)
157 examples, 0 failures, 4 pending
```

@samvera/hyrax-code-reviewers
