### PR TITLE
deprecate FindObjectsViaSolrService replaced by SolrQueryService#get_objects

### DIFF
--- a/app/services/hyrax/find_objects_via_solr_service.rb
+++ b/app/services/hyrax/find_objects_via_solr_service.rb
@@ -24,7 +24,7 @@ module Hyrax
         solr_query_builder.new
                           .with_model(model: model)
                           .with_field_pairs(field_pairs: field_pairs, join_with: join_with, type: type)
-                          .get_objects(use_valkyrie: use_valkyrie)
+                          .get_objects(use_valkyrie: use_valkyrie).to_a
       end
     end
   end

--- a/app/services/hyrax/find_objects_via_solr_service.rb
+++ b/app/services/hyrax/find_objects_via_solr_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  # This class is being replaced by Hyrax::SolrQueryService #get_objects method.
+  # @deprecated This class is being replaced by Hyrax::SolrQueryService #get_objects method.
   #
   # Methods in this class search solr to get the ids and then use the query service to find the objects.
   class FindObjectsViaSolrService

--- a/app/services/hyrax/find_objects_via_solr_service.rb
+++ b/app/services/hyrax/find_objects_via_solr_service.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 module Hyrax
+  # This class is being replaced by Hyrax::SolrQueryService #get_objects method.
+  #
   # Methods in this class search solr to get the ids and then use the query service to find the objects.
   class FindObjectsViaSolrService
     class_attribute :solr_query_builder, :solr_service, :query_service
-    self.solr_query_builder = Hyrax::SolrQueryBuilderService
+    self.solr_query_builder = Hyrax::SolrQueryService
     self.solr_service = Hyrax::SolrService
     self.query_service = Hyrax.query_service
 
@@ -14,13 +16,15 @@ module Hyrax
       # @param join_with [String] the value we're joining the clauses with (default: ' OR ' for backward compatibility with ActiveFedora where)
       # @param type [String] The type of query to run. Either 'raw' or 'field' (default: 'field')
       # @param use_valkyrie [Boolean] if true, return Valkyrie resource(s); otherwise, return ActiveFedora object(s)
-      # @return [Array<ActiveFedora|Valkyrie::Resource>] objects matching the query
+      # @return [Array<ActiveFedora::Base|Valkyrie::Resource>] objects matching the query
       def find_for_model_by_field_pairs(model:, field_pairs:, join_with: ' OR ', type: 'field', use_valkyrie: Hyrax.config.use_valkyrie?)
-        return model.where(field_pairs).to_a unless use_valkyrie
-        query = solr_query_builder.construct_query_for_model(model, field_pairs, join_with, type)
-        results = solr_service.query(query)
-        ids = results.map(&:id)
-        query_service.find_many_by_ids(ids: ids).to_a
+        Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
+                         "Instead, use 'Hyrax::SolrQueryService.new.with_model(...).with_field_pairs(...).get_objects'.")
+
+        solr_query_builder.new
+                          .with_model(model: model)
+                          .with_field_pairs(field_pairs: field_pairs, join_with: join_with, type: type)
+                          .get_objects(use_valkyrie: use_valkyrie)
       end
     end
   end

--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -55,9 +55,12 @@ module Hyrax
 
       field_pairs = {
         :id => collection_ids,
-        Hyrax.config.collection_type_index_field.to_sym => collection_type_gids_that_disallow_multiple_membership
+        Hyrax.config.collection_type_index_field.to_sym => collection_type_gids_that_disallow_multiple_membership&.map(&:to_s)
       }
-      Hyrax::FindObjectsViaSolrService.find_for_model_by_field_pairs(model: ::Collection, field_pairs: field_pairs, use_valkyrie: true)
+      Hyrax::SolrQueryService.new
+                             .with_model(model: ::Collection)
+                             .with_field_pairs(field_pairs: field_pairs, join_with: ' OR ')
+                             .get_objects(use_valkyrie: true)
     end
 
     def collection_type_gids_that_disallow_multiple_membership

--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -60,7 +60,7 @@ module Hyrax
       Hyrax::SolrQueryService.new
                              .with_model(model: ::Collection)
                              .with_field_pairs(field_pairs: field_pairs, join_with: ' OR ')
-                             .get_objects(use_valkyrie: true)
+                             .get_objects(use_valkyrie: true).to_a
     end
 
     def collection_type_gids_that_disallow_multiple_membership

--- a/app/services/hyrax/solr_query_service.rb
+++ b/app/services/hyrax/solr_query_service.rb
@@ -31,8 +31,8 @@ module Hyrax
     # @return [Array<Valkyrie::Resource|ActiveFedora::Base>] objects matching the current query
     def get_objects(use_valkyrie: Hyrax.config.use_valkyrie?)
       ids = get_ids
-      return ids.map { |id| ActiveFedora::Base.find(id) }.to_a unless use_valkyrie
-      query_service.find_many_by_ids(ids: ids).to_a
+      return ids.map { |id| ActiveFedora::Base.find(id) } unless use_valkyrie
+      query_service.find_many_by_ids(ids: ids)
     end
 
     ##

--- a/spec/services/hyrax/solr_query_service_spec.rb
+++ b/spec/services/hyrax/solr_query_service_spec.rb
@@ -25,6 +25,48 @@ RSpec.describe Hyrax::SolrQueryService do
     end
   end
 
+  describe '#get_ids' do
+    let!(:work1) { create(:work, id: 'wk1', creator: ['Mark']) }
+    let!(:work2) { create(:work, id: 'wk2', creator: ['Fred']) }
+    let!(:work3) { create(:work, id: 'wk3', creator: ['Mark']) }
+    subject(:solr_query_service) { described_class.new }
+
+    before { solr_query_service.with_field_pairs(field_pairs: { creator_tesim: 'Mark' }) }
+
+    it 'get ids for solr document matching the query' do
+      ids = solr_query_service.get_ids
+      expect(ids.count).to eq 2
+      expect(ids).to match_array ['wk1', 'wk3']
+    end
+  end
+
+  describe '#get_objects' do
+    let!(:work1) { create(:work, id: 'wk1', creator: ['Mark']) }
+    let!(:work2) { create(:work, id: 'wk2', creator: ['Fred']) }
+    let!(:work3) { create(:work, id: 'wk3', creator: ['Mark']) }
+    subject(:solr_query_service) { described_class.new }
+
+    before { solr_query_service.with_field_pairs(field_pairs: { creator_tesim: 'Mark' }) }
+
+    context "when use_valkyrie is false" do
+      it 'get ActiveFedora::Base objects matching the query' do
+        objects = solr_query_service.get_objects(use_valkyrie: false)
+        expect(objects.count).to eq 2
+        expect(objects.first).to be_kind_of ActiveFedora::Base
+        expect(objects.map(&:id)).to match_array ['wk1', 'wk3']
+      end
+    end
+
+    context "when use_valkyrie is true" do
+      it 'get Valkyrie::Resource objects matching the query' do
+        objects = solr_query_service.get_objects(use_valkyrie: true)
+        expect(objects.count).to eq 2
+        expect(objects.first).to be_kind_of Valkyrie::Resource
+        expect(objects.map(&:id)).to match_array ['wk1', 'wk3']
+      end
+    end
+  end
+
   describe '#count' do
     let!(:work1) { create(:work, id: 'wk1', creator: ['Mark']) }
     let!(:work2) { create(:work, id: 'wk2', creator: ['Fred']) }


### PR DESCRIPTION
Use `SolrQueryService#get_objects` instead of `FindObjectsViaSolrService` when objects are required.  If solr documents are sufficient, then just use `SolrQueryService#get`.

By using `SolrQueryService`, this allows for the construction of more complex queries even when objects are being returned.

Also updated `MultipleMembershipChecker` to use `SolrQueryService` instead of `FindObjectViaSolrService`.  This was the only use of `FindObjectViaSolrService`.

Related to: Issue #3820 which is replacing ActiveFedora::Base.where calls.

@samvera/hyrax-code-reviewers
