### PR TITLE
add accessible_by to SolrQueryService

### DIFF
--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -12,7 +12,11 @@ module Hyrax
     end
 
     def total_viewable_items
-      ActiveFedora::Base.where("isPartOf_ssim:#{id}").accessible_by(current_ability).count
+      field_pairs = { "isPartOf_ssim" => id.to_s }
+      SolrQueryService.new
+                      .with_field_pairs(field_pairs: field_pairs)
+                      .accessible_by(ability: current_ability)
+                      .count
     end
 
     # AdminSet cannot be deleted if default set or non-empty

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -78,19 +78,36 @@ module Hyrax
     end
 
     def total_items
-      Hyrax::SolrService.new.count("member_of_collection_ids_ssim:#{id}")
+      field_pairs = { "member_of_collection_ids_ssim" => id.to_s }
+      SolrQueryService.new
+                      .with_field_pairs(field_pairs: field_pairs)
+                      .count
     end
 
     def total_viewable_items
-      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}").accessible_by(current_ability).count
+      field_pairs = { "member_of_collection_ids_ssim" => id.to_s }
+      SolrQueryService.new
+                      .with_field_pairs(field_pairs: field_pairs)
+                      .accessible_by(ability: current_ability)
+                      .count
     end
 
     def total_viewable_works
-      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id} AND generic_type_sim:Work").accessible_by(current_ability).count
+      field_pairs = { "member_of_collection_ids_ssim" => id.to_s }
+      SolrQueryService.new
+                      .with_field_pairs(field_pairs: field_pairs)
+                      .with_generic_type(generic_type: "Work")
+                      .accessible_by(ability: current_ability)
+                      .count
     end
 
     def total_viewable_collections
-      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id} AND generic_type_sim:Collection").accessible_by(current_ability).count
+      field_pairs = { "member_of_collection_ids_ssim" => id.to_s }
+      SolrQueryService.new
+                      .with_field_pairs(field_pairs: field_pairs)
+                      .with_generic_type(generic_type: "Collection")
+                      .accessible_by(ability: current_ability)
+                      .count
     end
 
     def collection_type_badge

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -112,7 +112,11 @@ RSpec.describe Hyrax::CollectionPresenter do
 
   describe "#total_items", :clean_repo do
     context "empty collection" do
+      let(:ability) { double(::Ability, user_groups: ['public'], current_user: user) }
+      let(:user) { create(:user) }
       let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection) }
+
+      before { allow(ability).to receive(:admin?).and_return(false) }
 
       it 'returns 0' do
         expect(presenter.total_items).to eq 0
@@ -143,6 +147,8 @@ RSpec.describe Hyrax::CollectionPresenter do
     let(:user) { create(:user) }
     let(:collection) { FactoryBot.create(:collection_lw) }
     let(:solr_hash) { collection.to_solr }
+
+    before { allow(ability).to receive(:admin?).and_return(false) }
 
     context "empty collection" do
       it { is_expected.to eq 0 }
@@ -193,6 +199,8 @@ RSpec.describe Hyrax::CollectionPresenter do
     let(:collection) { FactoryBot.create(:collection_lw) }
     let(:solr_hash) { collection.to_solr }
 
+    before { allow(ability).to receive(:admin?).and_return(false) }
+
     context "empty collection" do
       it { is_expected.to eq 0 }
     end
@@ -229,6 +237,8 @@ RSpec.describe Hyrax::CollectionPresenter do
     let(:user) { create(:user) }
     let(:collection) { FactoryBot.create(:collection_lw) }
     let(:solr_hash) { collection.to_solr }
+
+    before { allow(ability).to receive(:admin?).and_return(false) }
 
     context "empty collection" do
       it { is_expected.to eq 0 }


### PR DESCRIPTION
Partially addresses Issue #3820 by removing use of `ActiveFedora::Base #where` method when using `#accessible_by` method.

See original [`#accessible_by`](https://github.com/samvera/hydra-head/blob/main/hydra-access-controls/lib/active_fedora/accessible_by.rb) method defined in hydra-access-controls.

See Hyrax override of [`#gated_discovery_filters`](https://github.com/samvera/hyrax/blob/b034218b89dde7df534e32d1e5ade9161e129a1d/app/search_builders/hyrax/search_filters.rb#L16-L21).  Note: To have access to this method, the SolrQueryService needs to inherit from `::SearchBuilder`.

@samvera/hyrax-code-reviewers
