### PR TITLE
docs: properly scope yard annotations for FindFileMetadata queries

### DIFF
--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
-# rubocop:disable Metrics/ClassLength
 module Hyrax
   module Forms
     # @abstract
-    class WorkForm
+    class WorkForm # rubocop:disable Metrics/ClassLength
       include HydraEditor::Form
       include HydraEditor::Form::Permissions
       attr_accessor :current_ability

--- a/app/helpers/hyrax/batch_edits_helper.rb
+++ b/app/helpers/hyrax/batch_edits_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
-# View Helpers for Hydra Batch Edit functionality
+
 module Hyrax
+  ##
+  # View Helpers for Hydra Batch Edit functionality
   module BatchEditsHelper
     # Displays the delete button for batch editing
     def batch_delete

--- a/app/models/concerns/hyrax/file_set/characterization.rb
+++ b/app/models/concerns/hyrax/file_set/characterization.rb
@@ -1,18 +1,24 @@
 # frozen_string_literal: true
-# This module points the FileSet to the location of the technical metadata.
-# By default, the file holding the metadata is :original_file and the terms
-# are listed under ::characterization_terms.
-# Implementations may define their own terms or use a different source file, but
-# any terms must be set on the ::characterization_proxy by the Hydra::Works::CharacterizationService
-#
-# class MyFileSet
-#   include Hyrax::FileSetBehavior
-# end
-#
-# MyFileSet.characterization_proxy = :master_file
-# MyFileSet.characterization_terms = [:term1, :term2, :term3]
+
 module Hyrax
   class FileSet
+    ##
+    # This module points the FileSet to the location of the technical metadata.
+    # By default, the file holding the metadata is +:original_file+ and the terms
+    # are listed under +.characterization_terms+.
+    #
+    # Implementations may define their own terms or use a different source file, but
+    # any terms must be set on the +.characterization_proxy+ by the
+    # +Hydra::Works::CharacterizationService+.
+    #
+    # @example
+    #   class MyFileSet
+    #     include Hyrax::FileSetBehavior
+    #   end
+    #
+    #   MyFileSet.characterization_proxy = :master_file
+    #   MyFileSet.characterization_terms = [:term1, :term2, :term3]
+    #
     module Characterization
       extend ActiveSupport::Concern
 

--- a/app/models/hyrax/virus_scanner.rb
+++ b/app/models/hyrax/virus_scanner.rb
@@ -1,23 +1,28 @@
 # frozen_string_literal: true
-# The default virus scanner Hyrax::Works, ported from hydra_works.
-# If ClamAV is present, it will be used to check for the presence of a virus. If ClamAV is not
-# installed or otherwise not available to your application, Hyrax::Works does no virus checking
-# add assumes files have no viruses.
-#
-# @example to use a virus checker other than Hyrax::VirusScanner:
-#   class MyScanner < Hyrax::Works::VirusScanner
-#     def infected?
-#       my_result = Scanner.check_for_viruses(file)
-#       [return true or false]
-#     end
-#   end
-#
-#   # Then set Hyrax::Works to use your scanner either in a config file or initializer:
-#   Hyrax.config.virus_scanner = MyScanner
+
 module Hyrax
+  ##
+  # The default virus scanner ported from +Hyrax::Works+.
+  #
+  # If ClamAV is present, it will be used to check for the presence of a virus.
+  # If ClamAV is not installed or otherwise not available to your application,
+  # +Hyrax::Works+ does no virus checking add assumes files have no viruses.
+  #
+  # @example to use a virus checker other than Hyrax::VirusScanner:
+  #   class MyScanner < Hyrax::Works::VirusScanner
+  #     def infected?
+  #       my_result = Scanner.check_for_viruses(file)
+  #       [return true or false]
+  #     end
+  #   end
+  #
+  #   # Then set Hyrax::Works to use your scanner either in a config file or initializer:
+  #   Hyrax.config.virus_scanner = MyScanner
+  #
   class VirusScanner
     attr_reader :file
 
+    ##
     # @api public
     # @param file [String]
     def self.infected?(file)
@@ -28,7 +33,9 @@ module Hyrax
       @file = file
     end
 
-    # Override this method to use your own virus checking software
+    ##
+    # @note Override this method to use your own virus checking software
+    #
     # @return [Boolean]
     def infected?
       defined?(ClamAV) ? clam_av_scanner : null_scanner
@@ -41,8 +48,10 @@ module Hyrax
       true
     end
 
-    # Always return zero if there's nothing available to check for viruses. This means that
-    # we assume all files have no viruses because we can't conclusively say if they have or not.
+    ##
+    # Always return zero if there's nothing available to check for viruses.
+    # This means that we assume all files have no viruses because we can't
+    # conclusively say if they have or not.
     def null_scanner
       warning "Unable to check #{file} for viruses because no virus scanner is defined" unless
         Rails.env.test?

--- a/app/presenters/hyrax/file_usage.rb
+++ b/app/presenters/hyrax/file_usage.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
-# Called by the stats controller, it finds cached file pageview data,
-# and prepares it for visualization in /app/views/stats/file.html.erb
 module Hyrax
+  ##
+  # Called by the stats controller, it finds cached file pageview data,
+  # and prepares it for visualization in /app/views/stats/file.html.erb
   class FileUsage < StatsUsagePresenter
     def initialize(id)
       self.model = ::FileSet.find(id)

--- a/app/presenters/hyrax/stats_usage_presenter.rb
+++ b/app/presenters/hyrax/stats_usage_presenter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Hyrax
-  # Methods used by both WorkUsage and FileUsage
+  ##
+  # @abstract methods used by both {WorkUsage} and {FileUsage}
   class StatsUsagePresenter
     attr_accessor :id, :model
 

--- a/app/presenters/hyrax/work_usage.rb
+++ b/app/presenters/hyrax/work_usage.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
-# class WorkUsage follows the model established by FileUsage
-# Called by the stats controller, it finds cached work pageview data,
-# and prepares it for visualization in /app/views/stats/work.html.erb
+
 module Hyrax
+  # Follows the model established by {FileUsage}.
+  #
+  # Called by the stats controller, it finds cached work pageview data,
+  # and prepares it for visualization in /app/views/stats/work.html.erb
   class WorkUsage < StatsUsagePresenter
     def initialize(id)
       self.model = Hyrax::WorkRelation.new.find(id)

--- a/app/services/hyrax/custom_queries/find_file_metadata.rb
+++ b/app/services/hyrax/custom_queries/find_file_metadata.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
-# Provide custom queries for finding Hyrax::FileMetadata
-# @example
-#   Hyrax.custom_queries.find_file_metadata_by(id: valkyrie_id)
-#   Hyrax.custom_queries.find_file_metadata_by_alternate_identifier(alternate_identifier: alt_id)
-#   Hyrax.custom_queries.find_many_file_metadata_by_ids(ids: [valkyrie_id, valkyrie_id])
 module Hyrax
   module CustomQueries
+    ##
+    # Provide custom queries for finding Hyrax::FileMetadata
+    #
+    # @example
+    #   Hyrax.custom_queries.find_file_metadata_by(id: valkyrie_id)
+    #   Hyrax.custom_queries.find_file_metadata_by_alternate_identifier(alternate_identifier: alt_id)
+    #   Hyrax.custom_queries.find_many_file_metadata_by_ids(ids: [valkyrie_id, valkyrie_id])
     class FindFileMetadata
       def self.queries
         [:find_file_metadata_by,

--- a/app/services/hyrax/edit_permissions_service.rb
+++ b/app/services/hyrax/edit_permissions_service.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 module Hyrax
+  ##
+  # @api public
+  #
   # Encapsulates the logic to determine which object permissions may be edited by a given user
-  #  - user is permitted to update any work permissions coming ONLY from collections they manage
-  #  - user is not permitted to update a work permission if it comes from a collection they do not manage, even if also from a managed collection
-  #  - user is permitted to update only non-manager permissions from any Collections
-  #  - user is permitted to update any non-collection permissions
+  # * user is permitted to update any work permissions coming ONLY from collections they manage
+  # * user is not permitted to update a work permission if it comes from a collection they do not manage, even if also from a managed collection
+  # * user is permitted to update only non-manager permissions from any Collections
+  # * user is permitted to update any non-collection permissions
   class EditPermissionsService
+    ##
     # @api public
     # @since v3.0.0
     #
@@ -14,15 +18,15 @@ module Hyrax
     # @return [Hyrax::EditPermissionService]
     #
     # @note
-    #   form object.class = SimpleForm::FormBuilder
-    #     For works (i.e. GenericWork):
-    #     - form object.object = Hyrax::GenericWorkForm
-    #     - form object.object.model = GenericWork
-    #     - use the work itself
-    #     For file_sets:
-    #     - form object.object.class = FileSet
-    #     - use work the file_set is in
-    #     No other object types are supported by this view. %>
+    #   +form object.class = SimpleForm::FormBuilder+
+    #    For works (i.e. GenericWork):
+    #    * form object.object = Hyrax::GenericWorkForm
+    #    * form object.object.model = GenericWork
+    #    * use the work itself
+    #    For file_sets:
+    #    * form object.object.class = FileSet
+    #    * use work the file_set is in
+    #    No other object types are supported by this view.
     def self.build_service_object_from(form:, ability:)
       if form.object.respond_to?(:model) && form.object.model.work?
         new(object: form.object, ability: ability)
@@ -33,7 +37,9 @@ module Hyrax
 
     attr_reader :depositor, :unauthorized_collection_managers
 
-    # @param object [#depositor, #admin_set_id, #member_of_collection_ids] GenericWorkForm (if called for object) or GenericWork (if called for file set)
+    ##
+    # @param object [#depositor, #admin_set_id, #member_of_collection_ids]
+    #   +GenericWorkForm+ (if called for object) or +GenericWork+ (if called for file set)
     # @param ability [Ability] user's current_ability
     def initialize(object:, ability:)
       @object = object
@@ -47,7 +53,7 @@ module Hyrax
     # @api private
     # @todo refactor this code to use "can_edit?"; Thinking in negations can be challenging.
     #
-    # @param permission_hash [Hash] one set of permission fields for object {:name, :access}
+    # @param permission_hash [Hash] one set of permission fields for object +:name+, :access}
     # @return [Boolean] true if user cannot edit the given permissions
     def cannot_edit_permissions?(permission_hash)
       permission_hash.fetch(:access) == "edit" && @unauthorized_managers.include?(permission_hash.fetch(:name))
@@ -55,7 +61,7 @@ module Hyrax
 
     # @api private
     #
-    # @param permission_hash [Hash] one set of permission fields for object {:name, :access}
+    # @param permission_hash [Hash] one set of permission fields for object +:name+, +:access+
     # @return [Boolean] true if given permissions are one of fixed exclusions
     def excluded_permission?(permission_hash)
       exclude_from_display.include? permission_hash.fetch(:name).downcase
@@ -68,9 +74,10 @@ module Hyrax
     # * returns false if the given permission_hash is part of the fixed exclusions.
     # * yields a PermissionPresenter to provide additional logic and text for rendering
     #
-    # @param permission_hash [Hash<:name, :access>]
-    # @return false if the given permission_hash is a fixed exclusion
-    # @yield PermissionPresenter
+    # @param permission_hash [Hash{Symbol => Object}]
+    #
+    # @return [Boolean] +false+ if the given +permission_hash+ is a fixed exclusion
+    # @yield [PermissionPresenter]
     #
     # @see #excluded_permission?
     def with_applicable_permission(permission_hash:)
@@ -81,7 +88,7 @@ module Hyrax
     # @api private
     #
     # A helper class to contain specific presentation logic related to
-    # the EditPermissionsService
+    # the {EditPermissionsService}
     class PermissionPresenter
       # @param service [Hyrax::EditPermissionsService]
       # @param permission_hash [Hash]

--- a/app/services/hyrax/search_service.rb
+++ b/app/services/hyrax/search_service.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-# SearchService returns search results from the repository
 module Hyrax
-  # Copied from Blacklight 7
+  ##
+  # Returns search results from the repository.
+  #
+  # @note Adapted from Blacklight 7
   class SearchService
     def initialize(config:, user_params: nil, search_builder_class: config.search_builder_class, **context)
       @blacklight_config = config

--- a/app/services/hyrax/statistics/depositors/summary.rb
+++ b/app/services/hyrax/statistics/depositors/summary.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
-# Gather information about the depositors who have contributed to the repository
 module Hyrax
   module Statistics
     module Depositors
+      ##
+      # Gather information about the depositors who have contributed to the repository
       class Summary
         include Blacklight::SearchHelper
 

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -25,6 +25,13 @@ require 'valkyrie/indexing_adapter'
 require 'valkyrie/indexing/solr/indexing_adapter'
 require 'valkyrie/indexing/null_indexing_adapter'
 
+##
+# Hyrax is a Ruby on Rails Engine built by the Samvera community. The engine
+# provides a foundation for creating many different digital repository
+# applications.
+#
+# @see https://samvera.org Samvera Community
+# @see https://guides.rubyonrails.org/engines.html Rails Guides: Getting Started with Engines
 module Hyrax
   extend ActiveSupport::Autoload
 


### PR DESCRIPTION
fixes an issue where this docstring is erroneously applied to the whole of `module Hyrax`.

@samvera/hyrax-code-reviewers
