### PR TITLE
create service to add/remove collection members

### DIFF
--- a/app/services/hyrax/collections/collection_member_service.rb
+++ b/app/services/hyrax/collections/collection_member_service.rb
@@ -108,14 +108,11 @@ module Hyrax
         # @param new_member [Hyrax::Resource] the new child collection or child work
         # @return [Hyrax::Resource] updated member resource
         def add_member(collection:, new_member:, user:)
-          message = Hyrax::MultipleMembershipChecker.new(item: new_member).check(collection_ids: collection.id, include_current_members: true)
-          if message
-            new_member.errors.add(:collections, message)
-          else
-            new_member.member_of_collection_ids += [collection.id] # only populate this direction
-            new_member = Hyrax.persister.save(resource: new_member)
-            Hyrax.publisher.publish('object.metadata.updated', object: new_member, user: user)
-          end
+          message = Hyrax::MultipleMembershipChecker.new(item: new_member).check(collection_ids: [collection.id], include_current_members: true)
+          raise Hyrax::SingleMembershipError, message if message
+          new_member.member_of_collection_ids += [collection.id] # only populate this direction
+          new_member = Hyrax.persister.save(resource: new_member)
+          Hyrax.publisher.publish('object.metadata.updated', object: new_member, user: user)
           new_member
         end
 

--- a/app/services/hyrax/collections/collection_member_service.rb
+++ b/app/services/hyrax/collections/collection_member_service.rb
@@ -67,6 +67,96 @@ module Hyrax
         end
         response
       end
+
+      class << self
+        # Check if a work or collection is already a member of a collection
+        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param member [Hyrax::Resource] the child collection and/or child work to check
+        # @return [Boolean] true if already in the member set; otherwise, false
+        def member?(collection:, member:)
+          member.member_of_collection_ids.include? collection.id
+        end
+
+        # Add works and/or collections as members of a collection
+        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param new_member_ids [Enumerable<Valkyrie::ID>] the ids of the new child collections and/or child works
+        # @return [Enumerable<Hyrax::Resource>] updated member resources
+        def add_members_by_ids(collection:, new_member_ids:, user:)
+          new_members = Hyrax.query_service.find_many_by_ids(ids: new_member_ids)
+          add_members(collection: collection, new_members: new_members, user: user)
+        end
+
+        # Add works and/or collections as members of a collection
+        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param new_members [Enumerable<Hyrax::Resource>] the new child collections and/or child works
+        # @return [Enumerable<Hyrax::Resource>] updated member resources
+        def add_members(collection:, new_members:, user:)
+          new_members.map { |new_member| add_member(collection: collection, new_member: new_member, user: user) }
+        end
+
+        # Add a work or collection as a member of a collection
+        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param new_member_id [Valkyrie::ID] the id of the new child collection or child work
+        # @return [Hyrax::Resource] updated member resource
+        def add_member_by_id(collection:, new_member_id:, user:)
+          new_member = Hyrax.query_service.find_by(id: new_member_id)
+          add_member(collection: collection, new_member: new_member, user: user)
+        end
+
+        # Add a work or collection as a member of a collection
+        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param new_member [Hyrax::Resource] the new child collection or child work
+        # @return [Hyrax::Resource] updated member resource
+        def add_member(collection:, new_member:, user:)
+          message = Hyrax::MultipleMembershipChecker.new(item: new_member).check(collection_ids: collection.id, include_current_members: true)
+          if message
+            new_member.errors.add(:collections, message)
+          else
+            new_member.member_of_collection_ids += [collection.id] # only populate this direction
+            new_member = Hyrax.persister.save(resource: new_member)
+            Hyrax.publisher.publish('object.metadata.updated', object: new_member, user: user)
+          end
+          new_member
+        end
+
+        # Remove collections and/or works from the members set of a collection
+        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param member_ids [Enumerable<Valkyrie::ID>] the ids of the child collections and/or child works to be removed
+        # @return [Enumerable<Hyrax::Resource>] updated member resources
+        def remove_members_by_ids(collection:, member_ids:, user:)
+          members = Hyrax.query_service.find_many_by_ids(ids: member_ids)
+          remove_members(collection: collection, members: members, user: user)
+        end
+
+        # Remove collections and/or works from the members set of a collection
+        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param members [Enumerable<Valkyrie::Resource>] the child collections and/or child works to be removed
+        # @return [Enumerable<Hyrax::Resource>] updated member resources
+        def remove_members(collection:, members:, user:)
+          members.map { |member| remove_member(collection: collection, member: member, user: user) }
+        end
+
+        # Remove collections and/or works from the members set of a collection
+        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param member_id [Valkyrie::ID] the id of the child collection or child work to be removed
+        # @return [Hyrax::Resource] updated member resource
+        def remove_member_by_id(collection:, member_id:, user:)
+          member = Hyrax.query_service.find_by(id: member_id)
+          remove_member(collection: collection, member: member, user: user)
+        end
+
+        # Remove a collection or work from the members set of a collection, also removing the inverse relationship
+        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param member [Hyrax::Resource] the child collection or child work to be removed
+        # @return [Hyrax::Resource] updated member resource
+        def remove_member(collection:, member:, user:)
+          return member unless member?(collection: collection, member: member)
+          member.member_of_collection_ids -= [collection.id]
+          member = Hyrax.persister.save(resource: member)
+          Hyrax.publisher.publish('object.metadata.updated', object: member, user: user)
+          member
+        end
+      end
     end
   end
 end

--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -52,9 +52,8 @@ module Hyrax
 
     def single_membership_collections(collection_ids)
       return [] if collection_ids.blank?
-
       field_pairs = {
-        :id => collection_ids,
+        :id => Array(collection_ids).map(&:to_s),
         Hyrax.config.collection_type_index_field.to_sym => collection_type_gids_that_disallow_multiple_membership&.map(&:to_s)
       }
       Hyrax::SolrQueryService.new

--- a/lib/hyrax/errors.rb
+++ b/lib/hyrax/errors.rb
@@ -12,5 +12,7 @@ module Hyrax
 
   class SingleUseError < HyraxError; end
 
+  class SingleMembershipError < HyraxError; end
+
   class ObjectNotFoundError < ActiveFedora::ObjectNotFoundError; end
 end

--- a/spec/services/hyrax/collections/collection_member_service_spec.rb
+++ b/spec/services/hyrax/collections/collection_member_service_spec.rb
@@ -36,4 +36,306 @@ RSpec.describe Hyrax::Collections::CollectionMemberService, clean_repo: true do
       expect(ids).to contain_exactly(work1.id, work3.id)
     end
   end
+
+  let(:custom_query_service) { Hyrax.custom_queries }
+  let(:user) { create(:user) }
+
+  describe '.member?' do
+    let(:non_member) { FactoryBot.valkyrie_create(:hyrax_work) }
+    context 'when no members' do
+      let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection) }
+      it 'returns false' do
+        expect(described_class.member?(collection: collection, member: non_member)).to eq false
+      end
+    end
+    context 'when has members' do
+      let(:work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+      let(:work2) { FactoryBot.valkyrie_create(:hyrax_work) }
+      let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, members: [work1, work2]) }
+      it "returns false if member isn't in member set" do
+        expect(described_class.member?(collection: collection, member: non_member)).to eq false
+      end
+      it "returns true if member is in member set" do
+        expect(described_class.member?(collection: collection, member: work1)).to eq true
+      end
+    end
+  end
+
+  describe '.add_members_by_ids' do
+    let(:work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let(:work2) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, members: existing_members) }
+    let(:existing_members) { [] }
+    let(:existing_member_ids) { existing_members.map(&:id) }
+    let(:new_member_ids) { [work1.id, work2.id] }
+
+    before { described_class.add_members_by_ids(collection: collection, new_member_ids: new_member_ids, user: user) }
+
+    context 'when no members' do
+      it "updates the collection member set to contain only the new members" do
+        expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array new_member_ids
+      end
+    end
+    context 'when has members' do
+      let(:existing_work) { FactoryBot.valkyrie_create(:hyrax_work) }
+      let(:existing_members) { [existing_work] }
+      context 'and one of the new members already exists in the member set' do
+        let(:new_member_ids) { [work1.id, work2.id, existing_work.id] }
+        it "updates the collection member set adding only resources not already in the member set" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array new_member_ids
+        end
+      end
+      context 'and none of the new members exist in the member set' do
+        it "updates the collection member set adding the new members" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids + new_member_ids
+        end
+      end
+    end
+  end
+
+  describe '.add_members' do
+    let(:work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let(:work2) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, members: existing_members) }
+    let(:existing_members) { [] }
+    let(:existing_member_ids) { existing_members.map(&:id) }
+    let(:new_members) { [work1, work2] }
+    let(:new_member_ids) { [work1.id, work2.id] }
+
+    before { described_class.add_members(collection: collection, new_members: new_members, user: user) }
+
+    context 'when no members' do
+      it "updates the collection member set to contain only the new members" do
+        expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array new_member_ids
+      end
+    end
+    context 'when has members' do
+      let(:existing_work) { FactoryBot.valkyrie_create(:hyrax_work) }
+      let(:existing_members) { [existing_work] }
+      context 'and a members already exists in the member set' do
+        let(:new_members) { [work1, work2, existing_work] }
+        let(:new_member_ids) { [work1.id, work2.id, existing_work.id] }
+        it "updates the collection member set adding only resources not already in the member set" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array new_member_ids
+        end
+      end
+      context 'and none of the new members exist in the member set' do
+        it "updates the collection member set adding the new members" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids + new_member_ids
+        end
+      end
+    end
+  end
+
+  describe '.add_member_by_id' do
+    let(:work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, members: existing_members) }
+    let(:existing_members) { [] }
+    let(:existing_member_ids) { existing_members.map(&:id) }
+    let(:new_member_id) { work1.id }
+
+    before { described_class.add_member_by_id(collection: collection, new_member_id: new_member_id, user: user) }
+
+    context 'when no members' do
+      it "updates the collection member set to contain only the new members" do
+        expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array [new_member_id]
+      end
+    end
+    context 'when has members' do
+      let(:existing_work) { FactoryBot.valkyrie_create(:hyrax_work) }
+      let(:existing_members) { [existing_work] }
+      context 'and the new member already exists in the member set' do
+        let(:new_member_id) { existing_work.id }
+        it "the collection member set remains unchanged" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+        end
+      end
+      context 'and the new member does not exist in the member set' do
+        it "updates the collection member set adding the new member" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids + [new_member_id]
+        end
+      end
+    end
+  end
+
+  describe '.add_member' do
+    let(:work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, members: existing_members) }
+    let(:existing_members) { [] }
+    let(:existing_member_ids) { existing_members.map(&:id) }
+    let(:new_member) { work1 }
+
+    before { described_class.add_member(collection: collection, new_member: new_member, user: user) }
+
+    context 'when no members' do
+      it "updates the collection member set to contain only the new members" do
+        expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array [new_member.id]
+      end
+    end
+    context 'when has members' do
+      let(:existing_work) { FactoryBot.valkyrie_create(:hyrax_work) }
+      let(:existing_members) { [existing_work] }
+      context 'and the new member already exists in the member set' do
+        let(:new_member) { existing_work }
+        it "the collection member set remains unchanged" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+        end
+      end
+      context 'and the new member does not exist in the member set' do
+        it "updates the collection member set adding the new member" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids + [new_member.id]
+        end
+      end
+    end
+  end
+
+  describe '.remove_members_by_ids' do
+    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, members: existing_members) }
+    let(:existing_members) { [work1, work2] }
+    let(:existing_member_ids) { existing_members.map(&:id) }
+    let(:work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let(:work2) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let(:members_to_remove_ids) { [work1.id, work2.id] }
+
+    context 'when no members' do
+      let(:existing_members) { [] }
+      it "collection member remains empty" do
+        expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to eq []
+        described_class.remove_members_by_ids(collection: collection, member_ids: members_to_remove_ids, user: user)
+        expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to eq []
+      end
+    end
+    context 'when has members' do
+      context 'and none of the members to remove exist in the member set' do
+        let(:non_existing_work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+        let(:non_existing_work2) { FactoryBot.valkyrie_create(:hyrax_work) }
+        let(:members_to_remove_ids) { [non_existing_work1.id, non_existing_work2.id] }
+        it "collection members remain unchanged" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+          described_class.remove_members_by_ids(collection: collection, member_ids: members_to_remove_ids, user: user)
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+        end
+      end
+      context 'and the members to remove exist in the member set' do
+        let(:work3) { FactoryBot.valkyrie_create(:hyrax_work) }
+        let(:existing_members) { [work1, work2, work3] }
+        it "updates the collection member set removing the members" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+          described_class.remove_members_by_ids(collection: collection, member_ids: members_to_remove_ids, user: user)
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array [work3.id]
+        end
+      end
+    end
+
+    describe '.remove_members' do
+      let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, members: existing_members) }
+      let(:existing_members) { [work1, work2] }
+      let(:existing_member_ids) { existing_members.map(&:id) }
+      let(:work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+      let(:work2) { FactoryBot.valkyrie_create(:hyrax_work) }
+      let(:members_to_remove) { [work1, work2] }
+
+      context 'when no members' do
+        let(:existing_members) { [] }
+        it "collection member remains empty" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to eq []
+          described_class.remove_members(collection: collection, members: members_to_remove, user: user)
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to eq []
+        end
+      end
+      context 'when has members' do
+        context 'and none of the members to remove exist in the member set' do
+          let(:non_existing_work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+          let(:non_existing_work2) { FactoryBot.valkyrie_create(:hyrax_work) }
+          let(:members_to_remove) { [non_existing_work1, non_existing_work2] }
+          it "collection members remain unchanged" do
+            expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+            described_class.remove_members(collection: collection, members: members_to_remove, user: user)
+            expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+          end
+        end
+        context 'and the members to remove exist in the member set' do
+          let(:work3) { FactoryBot.valkyrie_create(:hyrax_work) }
+          let(:existing_members) { [work1, work2, work3] }
+          it "updates the collection member set removing the members" do
+            expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+            described_class.remove_members(collection: collection, members: members_to_remove, user: user)
+            expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array [work3.id]
+          end
+        end
+      end
+    end
+  end
+
+  describe '.remove_member_by_id' do
+    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, members: existing_members) }
+    let(:existing_members) { [work1, work2] }
+    let(:existing_member_ids) { existing_members.map(&:id) }
+    let(:work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let(:work2) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let(:member_to_remove_id) { work1.id }
+
+    context 'when no members' do
+      let(:existing_members) { [] }
+      it "collection member remains empty" do
+        expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to eq []
+        described_class.remove_member_by_id(collection: collection, member_id: member_to_remove_id, user: user)
+        expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to eq []
+      end
+    end
+    context 'when has members' do
+      context 'and the member to remove does not exist in the member set' do
+        let(:non_existing_work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+        let(:member_to_remove_id) { non_existing_work1.id }
+        it "collection members remain unchanged" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+          described_class.remove_member_by_id(collection: collection, member_id: member_to_remove_id, user: user)
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+        end
+      end
+      context 'and the member to remove exists in the member set' do
+        it "updates the collection member set removing the members" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+          described_class.remove_member_by_id(collection: collection, member_id: member_to_remove_id, user: user)
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array [work2.id]
+        end
+      end
+    end
+  end
+
+  describe '.remove_member' do
+    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, members: existing_members) }
+    let(:existing_members) { [work1, work2] }
+    let(:existing_member_ids) { existing_members.map(&:id) }
+    let(:work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let(:work2) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let(:member_to_remove) { work1 }
+
+    context 'when no members' do
+      let(:existing_members) { [] }
+      it "collection member remains empty" do
+        expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to eq []
+        described_class.remove_member(collection: collection, member: member_to_remove, user: user)
+        expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to eq []
+      end
+    end
+    context 'when has members' do
+      context 'and the member to remove does not exist in the member set' do
+        let(:non_existing_work1) { FactoryBot.valkyrie_create(:hyrax_work) }
+        let(:member_to_remove) { non_existing_work1 }
+        it "collection members remain unchanged" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+          described_class.remove_member(collection: collection, member: member_to_remove, user: user)
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+        end
+      end
+      context 'and the member to remove exists in the member set' do
+        it "updates the collection member set removing the members" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids
+          described_class.remove_member(collection: collection, member: member_to_remove, user: user)
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array [work2.id]
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #5031

Centralizes the code to add and remove collection members to avoid confusion about which relationship to use (i.e. child's `member_of_collection_ids` and collection's `member_ids`) and to handle pre-processing (e.g. multiple collection membership check).

Also updates the Valkyrie collection factory with the following changes:

* Updated the relationship being used for collection membership to `member_of_collection_ids`.  Since the collection id must exist, the processing of members was moved to `after :create`

* Remove `collection_type` as an attribute.  Before this change you could pass in `collection_type` and/or `collection_type_gid`.  The change removes the confusion of what should happen if both are passed in and represent different types.  Since only `collection_type_gid` was in use, `collection_type` was removed.

NOTE: Issue #5031 stated that Issue #5030 was a prerequisite, but the identified deprecations are happening after addressing Issue #5031.

@samvera/hyrax-code-reviewers
