### PR TITLE
deprecate methods in CollectionMemberService; moved to CollectionMemberSearchService

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -22,7 +22,7 @@ module Hyrax
       # The search builder to find the collection
       self.single_item_search_builder_class = SingleCollectionSearchBuilder
       # The search builder to find the collections' members
-      self.membership_service_class = Collections::CollectionMemberService
+      self.membership_service_class = Collections::CollectionMemberSearchService
     end
 
     def show

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -41,7 +41,7 @@ module Hyrax
       # The search builder to find the collection
       self.single_item_search_builder_class = SingleCollectionSearchBuilder
       # The search builder to find the collections' members
-      self.membership_service_class = Collections::CollectionMemberService
+      self.membership_service_class = Collections::CollectionMemberSearchService
 
       load_and_authorize_resource except: [:index, :create], instance_name: :collection
 

--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -18,7 +18,7 @@ module Hyrax
 
       self.model_class = ::Collection
 
-      self.membership_service_class = Collections::CollectionMemberService
+      self.membership_service_class = Collections::CollectionMemberSearchService
 
       delegate :blacklight_config, to: Hyrax::CollectionsController
 

--- a/app/services/hyrax/collections/collection_member_search_service.rb
+++ b/app/services/hyrax/collections/collection_member_search_service.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+module Hyrax
+  module Collections
+    ##
+    # Retrieves collection members
+    class CollectionMemberSearchService < Hyrax::SearchService
+      ##
+      # @param scope [#repository] Typically a controller object which responds to :repository
+      # @param [::Collection] collection
+      # @param [ActionController::Parameters] params the query params
+      # @param [ActionController::Parameters] user_params
+      # @param [::Ability] current_ability
+      # @param [Class] search_builder_class a {::SearchBuilder}
+      def initialize(scope:, collection:, params:, user_params: nil, current_ability: nil, search_builder_class: Hyrax::CollectionMemberSearchBuilder) # rubocop:disable Metrics/ParameterLists
+        super(
+          config: scope.blacklight_config,
+          user_params: user_params || params,
+          collection: collection,
+          scope: scope,
+          current_ability: current_ability || scope.current_ability,
+          search_builder_class: search_builder_class
+        )
+      end
+
+      ##
+      # @api public
+      #
+      # Collections which are members of the given collection
+      #
+      # @return [Blacklight::Solr::Response] (up to 50 solr documents)
+      def available_member_subcollections
+        response, _docs = search_results do |builder|
+          # To differentiate current page for works vs subcollections, we have to use a sub_collection_page
+          # param. Map this to the page param before querying for subcollections, if it's present
+          builder.page(user_params[:sub_collection_page])
+          builder.search_includes_models = :collections
+          builder
+        end
+        response
+      end
+
+      ##
+      # @api public
+      #
+      # Works which are members of the given collection
+      #
+      # @return [Blacklight::Solr::Response]
+      def available_member_works
+        response, _docs = search_results do |builder|
+          builder.search_includes_models = :works
+          builder
+        end
+        response
+      end
+
+      ##
+      # @api public
+      #
+      # Work ids of the works which are members of the given collection
+      #
+      # @return [Blacklight::Solr::Response]
+      def available_member_work_ids
+        response, _docs = search_results do |builder|
+          builder.search_includes_models = :works
+          builder.merge(fl: 'id')
+          builder
+        end
+        response
+      end
+    end
+  end
+end

--- a/app/services/hyrax/collections/collection_member_service.rb
+++ b/app/services/hyrax/collections/collection_member_service.rb
@@ -3,7 +3,7 @@ module Hyrax
   module Collections
     ##
     # Retrieves collection members
-    class CollectionMemberService < Hyrax::SearchService
+    class CollectionMemberService
       ##
       # @param scope [#repository] Typically a controller object which responds to :repository
       # @param [::Collection] collection
@@ -12,14 +12,14 @@ module Hyrax
       # @param [::Ability] current_ability
       # @param [Class] search_builder_class a {::SearchBuilder}
       def initialize(scope:, collection:, params:, user_params: nil, current_ability: nil, search_builder_class: Hyrax::CollectionMemberSearchBuilder) # rubocop:disable Metrics/ParameterLists
-        super(
-          config: scope.blacklight_config,
-          user_params: user_params || params,
-          collection: collection,
-          scope: scope,
-          current_ability: current_ability || scope.current_ability,
-          search_builder_class: search_builder_class
-        )
+        Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
+                         "Instead, use the same method in 'Hyrax::Collections::CollectionMemberSearchService'.")
+        @member_search_service = Hyrax::Collections::CollectionMemberSearchService(scope: scope,
+                                                                                   collection: collection,
+                                                                                   params: params,
+                                                                                   user_params: user_params,
+                                                                                   current_ability: current_ability,
+                                                                                   search_builder_class: search_builder_class)
       end
 
       ##
@@ -29,14 +29,9 @@ module Hyrax
       #
       # @return [Blacklight::Solr::Response] (up to 50 solr documents)
       def available_member_subcollections
-        response, _docs = search_results do |builder|
-          # To differentiate current page for works vs subcollections, we have to use a sub_collection_page
-          # param. Map this to the page param before querying for subcollections, if it's present
-          builder.page(user_params[:sub_collection_page])
-          builder.search_includes_models = :collections
-          builder
-        end
-        response
+        Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
+                         "Instead, use the same method in 'Hyrax::Collections::CollectionMemberSearchService'.")
+        @member_search_service.available_member_subcollections
       end
 
       ##
@@ -46,11 +41,9 @@ module Hyrax
       #
       # @return [Blacklight::Solr::Response]
       def available_member_works
-        response, _docs = search_results do |builder|
-          builder.search_includes_models = :works
-          builder
-        end
-        response
+        Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
+                         "Instead, use the same method in 'Hyrax::Collections::CollectionMemberSearchService'.")
+        @member_search_service.available_member_works
       end
 
       ##
@@ -60,12 +53,9 @@ module Hyrax
       #
       # @return [Blacklight::Solr::Response]
       def available_member_work_ids
-        response, _docs = search_results do |builder|
-          builder.search_includes_models = :works
-          builder.merge(fl: 'id')
-          builder
-        end
-        response
+        Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
+                         "Instead, use the same method in 'Hyrax::Collections::CollectionMemberSearchService'.")
+        @member_search_service.available_member_work_ids
       end
 
       class << self

--- a/spec/services/hyrax/collections/collection_member_search_service_spec.rb
+++ b/spec/services/hyrax/collections/collection_member_search_service_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::Collections::CollectionMemberSearchService, clean_repo: true do
+  subject(:builder) do
+    described_class.new(scope: scope, collection: nestable_collection, params: { "id" => nestable_collection.id.to_s })
+  end
+
+  let(:current_ability) { instance_double(Ability, admin?: true) }
+  let(:scope) { FakeSearchBuilderScope.new(current_ability: current_ability) }
+  let!(:subcollection) { create(:public_collection_lw, member_of_collections: [nestable_collection], collection_type_settings: [:nestable]) }
+
+  let!(:nestable_collection) { create(:public_collection_lw, collection_type_settings: [:nestable]) }
+  let!(:work1) { create(:generic_work, member_of_collections: [nestable_collection]) }
+  let!(:work2) { create(:generic_work) }
+  let!(:work3) { create(:generic_work, member_of_collections: [nestable_collection]) }
+
+  describe '#available_member_subcollections' do
+    it 'returns the members that are collections' do
+      ids = builder.available_member_subcollections.response[:docs].map { |col| col[:id] }
+
+      expect(ids).to contain_exactly(subcollection.id)
+    end
+  end
+
+  describe '#available_member_works' do
+    it 'returns the members that are collections' do
+      ids = builder.available_member_works.response[:docs].map { |col| col[:id] }
+
+      expect(ids).to contain_exactly(work1.id, work3.id)
+    end
+  end
+
+  describe '#available_member_work_ids' do
+    it 'returns the members ids that are works' do
+      ids = builder.available_member_work_ids.response[:docs].map { |col| col[:id] }
+
+      expect(ids).to contain_exactly(work1.id, work3.id)
+    end
+  end
+end

--- a/spec/services/hyrax/collections/collection_member_service_spec.rb
+++ b/spec/services/hyrax/collections/collection_member_service_spec.rb
@@ -2,43 +2,6 @@
 require 'hyrax/specs/spy_listener'
 
 RSpec.describe Hyrax::Collections::CollectionMemberService, clean_repo: true do
-  subject(:builder) do
-    described_class.new(scope: scope, collection: nestable_collection, params: { "id" => nestable_collection.id.to_s })
-  end
-
-  let(:current_ability) { instance_double(Ability, admin?: true) }
-  let(:scope) { FakeSearchBuilderScope.new(current_ability: current_ability) }
-  let!(:subcollection) { create(:public_collection_lw, member_of_collections: [nestable_collection], collection_type_settings: [:nestable]) }
-
-  let!(:nestable_collection) { create(:public_collection_lw, collection_type_settings: [:nestable]) }
-  let!(:work1) { create(:generic_work, member_of_collections: [nestable_collection]) }
-  let!(:work2) { create(:generic_work) }
-  let!(:work3) { create(:generic_work, member_of_collections: [nestable_collection]) }
-
-  describe '#available_member_subcollections' do
-    it 'returns the members that are collections' do
-      ids = builder.available_member_subcollections.response[:docs].map { |col| col[:id] }
-
-      expect(ids).to contain_exactly(subcollection.id)
-    end
-  end
-
-  describe '#available_member_works' do
-    it 'returns the members that are collections' do
-      ids = builder.available_member_works.response[:docs].map { |col| col[:id] }
-
-      expect(ids).to contain_exactly(work1.id, work3.id)
-    end
-  end
-
-  describe '#available_member_work_ids' do
-    it 'returns the members ids that are works' do
-      ids = builder.available_member_work_ids.response[:docs].map { |col| col[:id] }
-
-      expect(ids).to contain_exactly(work1.id, work3.id)
-    end
-  end
-
   let(:custom_query_service) { Hyrax.custom_queries }
   let(:user) { create(:user) }
   let(:listener) { Hyrax::Specs::SpyListener.new }


### PR DESCRIPTION
Fixes #5030

This sets the stage to use CollectionMemberService for non-search related member services.

@samvera/hyrax-code-reviewers
