### PR TITLE
Extracting class as interstitial refactor

### DIFF
--- a/app/actors/hyrax/actors/create_with_remote_files_ordered_members_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_ordered_members_actor.rb
@@ -39,54 +39,19 @@ module Hyrax
     # url property, it may have spaces, and not be a valid URI.
     class CreateWithRemoteFilesOrderedMembersActor < CreateWithRemoteFilesActor
       attr_reader :ordered_members
+      self.file_set_actor_class = Hyrax::Actors::FileSetOrderedMembersActor
 
       # @param [HashWithIndifferentAccess] remote_files
       # @return [TrueClass]
       def attach_files(env, remote_files)
-        return true unless remote_files
         @ordered_members = env.curation_concern.ordered_members.to_a
-        remote_files.each do |file_info|
-          next if file_info.blank? || file_info[:url].blank?
-          # Escape any space characters, so that this is a legal URI
-          uri = URI.parse(Addressable::URI.escape(file_info[:url]))
-          unless validate_remote_url(uri)
-            Rails.logger.error "User #{env.user.user_key} attempted to ingest file from url #{file_info[:url]}, which doesn't pass validation"
-            return false
-          end
-          auth_header = file_info.fetch(:auth_header, {})
-          create_file_from_url(env, uri, file_info[:file_name], auth_header)
-        end
-        add_ordered_members(env.user, env.curation_concern)
-        true
+        ingest_remote_files_service_class.new(user: env.user,
+                                              curation_concern: env.curation_concern,
+                                              remote_files: remote_files,
+                                              ordered_members: @ordered_members,
+                                              ordered: true,
+                                              file_set_actor_class: file_set_actor_class).attach!
       end
-
-      # Generic utility for creating FileSet from a URL
-      # Used in to import files using URLs from a file picker like browse_everything
-      def create_file_from_url(env, uri, file_name, auth_header = {})
-        ::FileSet.new(import_url: uri.to_s, label: file_name) do |fs|
-          actor = file_set_actor_class.new(fs, env.user)
-          actor.create_metadata(visibility: env.curation_concern.visibility)
-          actor.attach_to_work(env.curation_concern)
-          fs.save!
-          ordered_members << fs
-          if uri.scheme == 'file'
-            # Turn any %20 into spaces.
-            file_path = CGI.unescape(uri.path)
-            IngestLocalFileJob.perform_later(fs, file_path, env.user)
-          else
-            ImportUrlJob.perform_later(fs, operation_for(user: actor.user), auth_header)
-          end
-        end
-      end
-
-      # Add all file_sets as ordered_members in a single action
-      def add_ordered_members(user, work)
-        actor = Hyrax::Actors::OrderedMembersActor.new(ordered_members, user)
-        actor.attach_ordered_members_to_work(work)
-      end
-
-      class_attribute :file_set_actor_class
-      self.file_set_actor_class = Hyrax::Actors::FileSetOrderedMembersActor
     end
   end
 end

--- a/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
@@ -97,7 +97,6 @@ RSpec.describe Hyrax::Actors::CreateWithRemoteFilesActor do
       let(:file) { "file:///local/otherdir/test.txt" }
 
       it "doesn't attach files" do
-        expect(actor).to receive(:validate_remote_url).and_call_original
         expect(IngestLocalFileJob).not_to receive(:perform_later)
         expect(actor.create(environment)).to be false
       end
@@ -113,25 +112,27 @@ RSpec.describe Hyrax::Actors::CreateWithRemoteFilesActor do
     end
   end
 
-  describe "#validate_remote_url" do
+  describe "IngestRemoteFilesService.validate_remote_url" do
     before do
       allow(Hyrax.config).to receive(:registered_ingest_dirs).and_return(['/test/', '/local/file/'])
     end
 
+    let(:service_class) { described_class::IngestRemoteFilesService }
+
     it "accepts file: urls in registered directories" do
-      expect(actor.send(:validate_remote_url, URI('file:///local/file/test.txt'))).to be true
-      expect(actor.send(:validate_remote_url, URI('file:///local/file/subdirectory/test.txt'))).to be true
-      expect(actor.send(:validate_remote_url, URI('file:///test/test.txt'))).to be true
+      expect(service_class.validate_remote_url(URI('file:///local/file/test.txt'))).to be true
+      expect(service_class.validate_remote_url(URI('file:///local/file/subdirectory/test.txt'))).to be true
+      expect(service_class.validate_remote_url(URI('file:///test/test.txt'))).to be true
     end
 
     it "rejects file: urls outside registered directories" do
-      expect(actor.send(:validate_remote_url, URI('file:///tmp/test.txt'))).to be false
-      expect(actor.send(:validate_remote_url, URI('file:///test/../tmp/test.txt'))).to be false
-      expect(actor.send(:validate_remote_url, URI('file:///test/'))).to be false
+      expect(service_class.validate_remote_url(URI('file:///tmp/test.txt'))).to be false
+      expect(service_class.validate_remote_url(URI('file:///test/../tmp/test.txt'))).to be false
+      expect(service_class.validate_remote_url(URI('file:///test/'))).to be false
     end
 
     it "accepts other types of urls" do
-      expect(actor.send(:validate_remote_url, URI('https://example.com/test.txt'))).to be true
+      expect(service_class.validate_remote_url(URI('https://example.com/test.txt'))).to be true
     end
   end
 
@@ -206,7 +207,6 @@ RSpec.describe Hyrax::Actors::CreateWithRemoteFilesActor do
         let(:file) { "file:///local/otherdir/test.txt" }
 
         it "doesn't attach files" do
-          expect(actor).to receive(:validate_remote_url).and_call_original
           expect(IngestLocalFileJob).not_to receive(:perform_later)
           expect(actor.create(environment)).to be false
         end
@@ -227,20 +227,22 @@ RSpec.describe Hyrax::Actors::CreateWithRemoteFilesActor do
         allow(Hyrax.config).to receive(:registered_ingest_dirs).and_return(['/test/', '/local/file/'])
       end
 
+      let(:service_class) { described_class::IngestRemoteFilesService }
+
       it "accepts file: urls in registered directories" do
-        expect(actor.send(:validate_remote_url, URI('file:///local/file/test.txt'))).to be true
-        expect(actor.send(:validate_remote_url, URI('file:///local/file/subdirectory/test.txt'))).to be true
-        expect(actor.send(:validate_remote_url, URI('file:///test/test.txt'))).to be true
+        expect(service_class.validate_remote_url(URI('file:///local/file/test.txt'))).to be true
+        expect(service_class.validate_remote_url(URI('file:///local/file/subdirectory/test.txt'))).to be true
+        expect(service_class.validate_remote_url(URI('file:///test/test.txt'))).to be true
       end
 
       it "rejects file: urls outside registered directories" do
-        expect(actor.send(:validate_remote_url, URI('file:///tmp/test.txt'))).to be false
-        expect(actor.send(:validate_remote_url, URI('file:///test/../tmp/test.txt'))).to be false
-        expect(actor.send(:validate_remote_url, URI('file:///test/'))).to be false
+        expect(service_class.validate_remote_url(URI('file:///tmp/test.txt'))).to be false
+        expect(service_class.validate_remote_url(URI('file:///test/../tmp/test.txt'))).to be false
+        expect(service_class.validate_remote_url(URI('file:///test/'))).to be false
       end
 
       it "accepts other types of urls" do
-        expect(actor.send(:validate_remote_url, URI('https://example.com/test.txt'))).to be true
+        expect(service_class.validate_remote_url(URI('https://example.com/test.txt'))).to be true
       end
     end
   end


### PR DESCRIPTION
I'm continuing to work on #4195.  This change extracts a class that can
be called outside the ActorStack.  The goal being to leverage this
class's logic to ingest remote URLs.

This change looks to remove lots of repeated logic and instead provide a
singular point of entry for associating a remote file with a work.

@samvera/hyrax-code-reviewers
