### PR TITLE
refactor view dependency on AdminSetOptionsPresenter into a helper

### DIFF
--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -2,6 +2,16 @@
 module Hyrax
   module WorkFormHelper
     ##
+    # @todo this implementation hits database backends (solr) and is invoked
+    #   from views. refactor to avoid
+    # @return  [???]
+    def admin_set_options
+      service = Hyrax::AdminSetService.new(controller)
+
+      Hyrax::AdminSetOptionsPresenter.new(service).select_options
+    end
+
+    ##
     # This helper allows downstream applications and engines to add/remove/reorder the tabs to be
     # rendered on the work form.
     #

--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -4,7 +4,7 @@ module Hyrax
     ##
     # @todo this implementation hits database backends (solr) and is invoked
     #   from views. refactor to avoid
-    # @return  [???]
+    # @return  [Array<Array<String, String, Hash>] options for the admin set drop down.
     def admin_set_options
       service = Hyrax::AdminSetService.new(controller)
 

--- a/app/views/hyrax/base/_form_relationships.html.erb
+++ b/app/views/hyrax/base/_form_relationships.html.erb
@@ -1,8 +1,7 @@
 <% if Flipflop.assign_admin_set? %>
-  <%# TODO: avoid direct dependency on AdminSetService and AdminSetOptionsPresenter in the view!! make the controller provide the options! %>
   <%= f.input :admin_set_id, as: :select,
       include_blank: false,
-      collection: Hyrax::AdminSetOptionsPresenter.new(Hyrax::AdminSetService.new(controller)).select_options,
+      collection: admin_set_options,
       input_html: { class: 'form-control' } %>
 <% end %>
 


### PR DESCRIPTION
this is a straight extraction of the `_form_relationships` partial's dependency
on `AdminSetOptionsPresenter` and `AdminSetService` into a helper. none of the
actual behavior here is changed at all, but the extraction presents an idiomatic
seam for further reworking, and for downstream overrides.

@samvera/hyrax-code-reviewers
