### PR TITLE
add an the AdminSetOptionsPresenter alternative that avoids queries

### DIFF
--- a/app/presenters/hyrax/admin_set_selection_presenter.rb
+++ b/app/presenters/hyrax/admin_set_selection_presenter.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # @api public
+  # @since 3.1.0
+  #
+  # Presents select options for admin sets.
+  #
+  # @note this supersedes the older +Hyrax::AdminSetOptionsPresenter+, which
+  #   actied more like a "service" sending database queries to Solr and
+  #   ActiveRecord.  this version seeks only to present the input data and
+  #   relies on its caller to pass in the right data.
+  class AdminSetSelectionPresenter
+    ##
+    # @param [Array<#id>]
+    def initialize(admin_sets:)
+      @admin_sets = admin_sets
+    end
+
+    ##
+    # @return [Array<Array<String, String, Hash>>] an array suitable for  a form
+    #   input `collection:` parameter. it should contain a label, an id, and a
+    #   hash of HTML5  data attributes.
+    def select_options
+      @admin_sets.map do |admin_set|
+        case admin_set
+        when OptionsEntry
+          admin_set.result
+        else
+          OptionsEntry.new(admin_set: admin_set).result
+        end
+      end
+    end
+
+    ##
+    # @api public
+    class OptionsEntry
+      ##
+      # @!attribute [rw] admin_set
+      #   @return [AdministrativeSet, SolrDocument]
+      attr_accessor :admin_set
+
+      ##
+      # @param [AdministrativeSet, SolrDocument] admin_set
+      def initialize(admin_set:)
+        @admin_set = admin_set
+      end
+
+      ##
+      # @return [Array<String, String, Hash>]
+      def result
+        [label, id, data]
+      end
+
+      ##
+      # @return [String]
+      def label
+        Array(admin_set.title).first || admin_set.to_s
+      end
+
+      ##
+      # @return [String]
+      def id
+        admin_set.id.to_s
+      end
+
+      ##
+      # @return [Hash{String => Object}]
+      def data
+        {}.tap do |data|
+          data['data-release-no-delay'] = true
+          data['data-visibility'] = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/hyrax/admin_set_selection_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_selection_presenter_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::AdminSetSelectionPresenter do
+  subject(:presenter) { described_class.new(admin_sets: admin_sets) }
+
+  let(:admin_sets) do
+    [FactoryBot.valkyrie_create(:hyrax_admin_set, title: 'first'),
+     FactoryBot.valkyrie_create(:hyrax_admin_set, title: 'second'),
+     FactoryBot.valkyrie_create(:hyrax_admin_set, title: 'third')]
+  end
+
+  describe '#select_options' do
+    it 'builds out the options for a select dropdown' do
+      expect(presenter.select_options)
+        .to contain_exactly ["first", admin_sets[0].id, an_instance_of(Hash)],
+                            ["second", admin_sets[1].id, an_instance_of(Hash)],
+                            ["third", admin_sets[2].id, an_instance_of(Hash)]
+    end
+  end
+
+  describe described_class::OptionsEntry do
+    subject(:entry) { described_class.new(admin_set: admin_set) }
+
+    let(:admin_set) do
+      FactoryBot.valkyrie_create(:hyrax_admin_set, title: 'first')
+    end
+
+    its(:id) { is_expected.to eq admin_set.id }
+
+    describe '#data' do
+      it 'is a hash' do
+        expect(entry.data)
+          .to include 'data-release-no-delay' => true,
+                      'data-visibility' => 'restricted'
+      end
+    end
+
+    describe '#label' do
+      it 'is the title' do
+        expect(entry.label).to eq 'first'
+      end
+    end
+  end
+end


### PR DESCRIPTION
`AdminSetOptionsPersenter` does extensive querying: first of admin sets, and
their permissions then of `PermissionTemplates` and lastly of the
`#active_workflow`. in the existing architecture, this is all initiated by view
code (recently, it has moved to a helper). ideally the Controller should broker
the querying and simply provide the relevant data to the view.

in order to achive this, we need a new presenter that accepts the needed input.
`AdminSetSelectionPresenter` in designed to fill this role and eventually
replace `AdminSetOptionsPresenter` completely. it accepts an enum of
`admin_sets` on initialization, and uses them to build the underlying data. the
plan from here is:

  - extend `AdminSetSelectionPresenter::OptionsEntry` to accept a
    `PermissionTemplate` and generate `#data` according to its settings.
  - refactor the `admin_set_options` helper to use a prepopulated presenter if
    provided by the controller.
  - implement the controller behavior to query the data eagerly.
  - optimize queries.

@samvera/hyrax-code-reviewers
