### PR TITLE
Set user to root for sidekiq compose service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
       context: .
       target: hyrax-engine-dev-worker
     image: ghcr.io/samvera/dassie-worker
+    user: root
     env_file:
       - .env
       - .dassie/.env


### PR DESCRIPTION
I was having issues using the compose development environment locally. I
believe the issues I experienced were along the lines of:

```sh
sidekiq_1     | There was an error while trying to write to
sidekiq_1     | `/app/samvera/hyrax-webapp/Gemfile.lock`. It is likely that you need to grant
sidekiq_1     | write permissions for that path.
```

And I believe this is due to the `sidekiq` service needing to run as
`root` like the `app` and `db_migrate` services.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* `docker-compose down -v`
* `docker-compose build`
* `docker-compose up`

@samvera/hyrax-code-reviewers