### PR TITLE
add HTML5 data for javastript to AdminSetSelectionPresenter

### DIFF
--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -5,6 +5,14 @@ FactoryBot.define do
     # with a unique index on the source_id, I don't want to have duplication in source_id
     sequence(:source_id) { |n| format("%010d", n) }
 
+    trait :with_immediate_release do
+      release_period { Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY }
+    end
+
+    trait :with_delayed_release do
+      release_period { Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_6_MONTHS }
+    end
+
     before(:create) do |permission_template, evaluator|
       if evaluator.with_admin_set
         source_id = permission_template.source_id

--- a/spec/presenters/hyrax/admin_set_selection_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_selection_presenter_spec.rb
@@ -28,10 +28,40 @@ RSpec.describe Hyrax::AdminSetSelectionPresenter do
     its(:id) { is_expected.to eq admin_set.id }
 
     describe '#data' do
-      it 'is a hash' do
+      it 'is a hash with no releose delay and restricted visibility' do
         expect(entry.data)
-          .to include 'data-release-no-delay' => true,
-                      'data-visibility' => 'restricted'
+          .to include 'data-release-no-delay' => true
+      end
+
+      context 'with a permission template' do
+        subject(:entry) do
+          described_class
+            .new(admin_set: admin_set, permission_template: permission_template)
+        end
+
+        let(:permission_template) do
+          FactoryBot.create(:permission_template,
+                            :with_immediate_release,
+                            source_id: admin_set.id.to_s)
+        end
+
+        it 'indicates no release delay' do
+          expect(entry.data).to include 'data-release-no-delay' => true
+        end
+
+        context 'and delayed release' do
+          let(:permission_template) do
+            FactoryBot.create(:permission_template,
+                              :with_delayed_release,
+                              source_id: admin_set.id.to_s)
+          end
+
+          it 'indicates a release delay' do
+            expect(entry.data)
+              .to include 'data-release-before-date' => true,
+                          'data-release-date' => permission_template.release_date
+          end
+        end
       end
     end
 


### PR DESCRIPTION
the selected Admin Set is used to decide which embargo/lease options are
allowable. visibility_component javascript updates the visibility selection
partial according to the values provided. these changes add feature pairty with
the older `AdminSetOptionsPresenter`.

@samvera/hyrax-code-reviewers
