### PR TITLE
don't lookup `Sipity::Workflow` instances from their own ids

### DIFF
--- a/app/presenters/hyrax/admin_set_options_presenter.rb
+++ b/app/presenters/hyrax/admin_set_options_presenter.rb
@@ -59,16 +59,9 @@ module Hyrax
       # > remove files from a work, and add new works to the set.
       return true if @current_ability.can?(:manage, permission_template)
 
-      # Otherwise, we check if the workflow was setup, active, and
-      # allows_access_grants.
-      wf = workflow(permission_template: permission_template)
-      return false unless wf
-      wf.allows_access_grant?
-    end
-
-    def workflow(permission_template:)
-      return unless permission_template.active_workflow
-      Sipity::Workflow.find_by!(id: permission_template.active_workflow.id)
+      # Otherwise, we check if the workflow active workflow allows access
+      # grants.
+      !!permission_template.active_workflow&.allows_access_grant?
     end
   end
 end

--- a/app/presenters/hyrax/admin_set_options_presenter.rb
+++ b/app/presenters/hyrax/admin_set_options_presenter.rb
@@ -59,8 +59,7 @@ module Hyrax
       # > remove files from a work, and add new works to the set.
       return true if @current_ability.can?(:manage, permission_template)
 
-      # Otherwise, we check if the workflow active workflow allows access
-      # grants.
+      # Otherwise, we check if the active workflow allows access grants
       !!permission_template.active_workflow&.allows_access_grant?
     end
   end

--- a/spec/presenters/hyrax/admin_set_options_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_options_presenter_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe Hyrax::AdminSetOptionsPresenter do
 
       let(:workflow) { instance_double(Sipity::Workflow, allows_access_grant?: allow_access_grant) }
       let(:permission_template) { build(:permission_template, source_id: solr_doc.id, visibility: 'open') }
+
       before do
         expect(Hyrax::PermissionTemplate).to receive(:find_by).and_return(permission_template)
-        allow(presenter).to receive(:workflow) { workflow }
-        allow(permission_template).to receive(:active_workflow).and_return(true)
+        allow(permission_template).to receive(:active_workflow).and_return(workflow)
       end
 
       context 'current ability can manage the workflow though the the template does not allow access grants' do


### PR DESCRIPTION
`PermissionTemplate#active_workflow` returns a `Sipity::Workflow`. the older
code used its id to retrieve it from the database again. instead we can simply
use it as-is.


@samvera/hyrax-code-reviewers
