### PR TITLE
move resolution of available admin sets to controller

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,10 @@ Metrics/BlockLength:
 Style/AsciiComments:
   Enabled: false
 
+# rubocop suggests !thing.nil? instead, but that is NOT equivalent
+Style/DoubleNegation:
+  Enabled: false
+
 Style/CollectionMethods:
   PreferredMethods:
     collect: 'map'

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -47,6 +47,7 @@ module Hyrax
     end
 
     def new
+      @admin_set_options = available_admin_sets
       # TODO: move these lines to the work form builder in Hyrax
       curation_concern.depositor = current_user.user_key
       curation_concern.admin_set_id = admin_set_id_for_new
@@ -95,6 +96,7 @@ module Hyrax
     # rubocop:enable Metrics/AbcSize
 
     def edit
+      @admin_set_options = available_admin_sets
       build_form
     end
 
@@ -436,6 +438,22 @@ module Hyrax
 
     def uploaded_files
       UploadedFile.find(params.fetch(:uploaded_files, []))
+    end
+
+    def available_admin_sets
+      admin_set_results = Hyrax::AdminSetService.new(self).search_results(:deposit)
+      # get all the templates at once, reducing query load
+      templates = PermissionTemplate.where(id: admin_set_results.map(&:id)).to_a
+
+      admin_sets = admin_set_results.map do |admin_set_doc|
+        template = templates.find { |temp| temp.source_id == admin_set_doc.id.to_s }
+        sharing = can?(:manage, template) || !!template&.active_workflow&.allows_access_grant?
+
+        AdminSetSelectionPresenter::OptionsEntry
+          .new(admin_set: admin_set_doc, permission_template: template, permit_sharing: sharing)
+      end
+
+      AdminSetSelectionPresenter.new(admin_sets: admin_sets)
     end
   end
 end

--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -6,8 +6,9 @@ module Hyrax
     #   from views. refactor to avoid
     # @return  [Array<Array<String, String, Hash>] options for the admin set drop down.
     def admin_set_options
-      service = Hyrax::AdminSetService.new(controller)
+      return @admin_set_options.select_options if @admin_set_options
 
+      service = Hyrax::AdminSetService.new(controller)
       Hyrax::AdminSetOptionsPresenter.new(service).select_options
     end
 

--- a/app/presenters/hyrax/admin_set_selection_presenter.rb
+++ b/app/presenters/hyrax/admin_set_selection_presenter.rb
@@ -47,14 +47,18 @@ module Hyrax
       #   @return [AdministrativeSet, SolrDocument]
       # @!attribute [rw] permission_template
       #   @return [PermissionTemplate]
-      attr_accessor :admin_set, :permission_template
+      # @!attribute [rw] permit_sharing
+      #   @return [Boolean]
+      attr_accessor :admin_set, :permission_template, :permit_sharing
 
       ##
       # @param [AdministrativeSet, SolrDocument] admin_set
       # @param [PermissionTemplate] permission_template
-      def initialize(admin_set:, permission_template: nil)
+      # @param [Boolean] permit_sharing
+      def initialize(admin_set:, permission_template: nil, permit_sharing: false)
         @admin_set = admin_set
         @permission_template = permission_template
+        @permit_sharing = permit_sharing
       end
 
       ##
@@ -79,6 +83,8 @@ module Hyrax
       # @return [Hash{String => Object}]
       def data
         {}.tap do |data|
+          data['data-sharing'] = permit_sharing
+
           if permission_template
             data.merge!(data_for(permission_template))
           else

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -342,6 +342,16 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
         expect(controller).to render_template('hyrax/base/new')
       end
+
+      it 'populates allowed admin sets' do
+        admin_set = AdminSet.find_or_create_default_admin_set_id
+        FactoryBot.valkyrie_create(:hyrax_admin_set) # one without deposit access
+
+        get :new
+
+        expect(assigns['admin_set_options'].select_options)
+          .to contain_exactly(["Default Admin Set", admin_set, { "data-release-no-delay" => true, "data-sharing" => false }])
+      end
     end
   end
 

--- a/spec/presenters/hyrax/admin_set_selection_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_selection_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Hyrax::AdminSetSelectionPresenter do
     its(:id) { is_expected.to eq admin_set.id }
 
     describe '#data' do
-      it 'is a hash with no releose delay and restricted visibility' do
+      it 'is a hash with no release delay and restricted visibility' do
         expect(entry.data)
           .to include 'data-release-no-delay' => true
       end


### PR DESCRIPTION
reduces the queries needed to build the work form by retrieving the data needed
to determine admin set behavior directly from the controller and all at once.

the older implementation looped over the admin sets and pulled the
`PermissionTemplate` for each. this version uses Solr to retrieve the admin set
solr documents, then gets the permission templates matching them all at once
before grouping the two sets together in-memory.

giving the controller direct responsibility for the query behavior should be
more flexible and open the door to other optimizations.

Co-authored-by: Matthew Critchlow <matt.critchlow@gmail.com>
Co-authored-by: Alexandra Dunn <adunn@ucsb.edu>

@samvera/hyrax-code-reviewers
