### PR TITLE
refactor Workflows::StatusListService to accept a user directly

### DIFF
--- a/app/controllers/hyrax/admin/workflows_controller.rb
+++ b/app/controllers/hyrax/admin/workflows_controller.rb
@@ -15,8 +15,8 @@ module Hyrax
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb t(:'hyrax.admin.sidebar.tasks'), '#'
       add_breadcrumb t(:'hyrax.admin.sidebar.workflow_review'), request.path
-      @status_list = Hyrax::Workflow::StatusListService.new(self, "-workflow_state_name_ssim:#{deposited_workflow_state_name}")
-      @published_list = Hyrax::Workflow::StatusListService.new(self, "workflow_state_name_ssim:#{deposited_workflow_state_name}")
+      @status_list = Hyrax::Workflow::StatusListService.new(current_user, "-workflow_state_name_ssim:#{deposited_workflow_state_name}")
+      @published_list = Hyrax::Workflow::StatusListService.new(current_user, "workflow_state_name_ssim:#{deposited_workflow_state_name}")
     end
 
     private

--- a/app/services/hyrax/workflow/status_list_service.rb
+++ b/app/services/hyrax/workflow/status_list_service.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 module Hyrax
   module Workflow
+    ##
     # Finds a list of works that we can perform a workflow action on
     class StatusListService
+      ##
       # @param context [#current_user, #logger]
       # @param filter_condition [String] a solr filter
       def initialize(context, filter_condition)
@@ -10,10 +12,14 @@ module Hyrax
         @filter_condition = filter_condition
       end
 
+      ##
+      # @!attribute [r] context
+      #   @return [#current_user]
       attr_reader :context
 
-      # TODO: We will want to paginate this
-      # @return [Array<StatusRow>] a list of results that the given user can take action on.
+      ##
+      # @todo We will want to paginate this
+      # @return [Enumerable<StatusRow>] a list of results that the given user can take action on.
       def each
         return enum_for(:each) unless block_given?
         solr_documents.each do |doc|
@@ -21,8 +27,11 @@ module Hyrax
         end
       end
 
-      # TODO: Make this private for version 1.0
+      ##
+      # @deprecated
       def user
+        Deprecation.warn('This method was always intended to be private. ' \
+                         'It will be removed in Hyrax 4.0')
         context.current_user
       end
 
@@ -37,7 +46,7 @@ module Hyrax
 
       def search_solr
         actionable_roles = roles_for_user
-        logger.debug("Actionable roles for #{user.user_key} are #{actionable_roles}")
+        logger.debug("Actionable roles for #{context.current_user.user_key} are #{actionable_roles}")
         return [] if actionable_roles.empty?
         WorkRelation.new.search_with_conditions(query(actionable_roles), method: :post)
       end
@@ -59,7 +68,7 @@ module Hyrax
       # @param workflow [Sipity::Workflow]
       # @return [ActiveRecord::Relation<Sipity::WorkflowRole>]
       def workflow_roles_for_user_and_workflow(workflow)
-        Hyrax::Workflow::PermissionQuery.scope_processing_workflow_roles_for_user_and_workflow(user: user, workflow: workflow)
+        Hyrax::Workflow::PermissionQuery.scope_processing_workflow_roles_for_user_and_workflow(user: context.current_user, workflow: workflow)
       end
     end
   end

--- a/app/services/hyrax/workflow/status_list_service.rb
+++ b/app/services/hyrax/workflow/status_list_service.rb
@@ -2,20 +2,34 @@
 module Hyrax
   module Workflow
     ##
-    # Finds a list of works that we can perform a workflow action on
+    # Finds a list of works that a given user can perform a workflow action on.
     class StatusListService
       ##
-      # @param context [#current_user]
+      # @param context_or_user [::User, #current_user]
       # @param filter_condition [String] a solr filter
-      def initialize(context, filter_condition)
-        @context = context
+      #
+      # @raise [ArgumentError] if th caller fails to provide a user
+      def initialize(context_or_user, filter_condition)
+        case context_or_user
+        when ::User
+          @user = context_or_user
+        when nil
+          raise ArgumentError, "A current user MUST be provided."
+        else
+          Deprecation.warn('Initializing StatusListService with a controller ' \
+                           '"context" is deprecated. Pass in a user instead.')
+          @context = context_or_user
+          @user = @context.current_user
+        end
         @filter_condition = filter_condition
       end
 
       ##
       # @!attribute [r] context
+      #   @deprecated
       #   @return [#current_user]
       attr_reader :context
+      deprecation_deprecate :context
 
       ##
       # @todo We will want to paginate this
@@ -33,11 +47,12 @@ module Hyrax
       def user
         Deprecation.warn('This method was always intended to be private. ' \
                          'It will be removed in Hyrax 4.0')
-        context.current_user
+        @user
       end
 
       private
 
+      ##
       # @return [Hash<String,SolrDocument>] a hash of id to solr document
       def solr_documents
         search_solr.map { |result| ::SolrDocument.new(result) }
@@ -45,7 +60,7 @@ module Hyrax
 
       def search_solr
         actionable_roles = roles_for_user
-        Hyrax.logger.debug("Actionable roles for #{context.current_user.user_key} are #{actionable_roles}")
+        Hyrax.logger.debug("Actionable roles for #{@user.user_key} are #{actionable_roles}")
         return [] if actionable_roles.empty?
         WorkRelation.new.search_with_conditions(query(actionable_roles), method: :post)
       end
@@ -67,7 +82,7 @@ module Hyrax
       # @param workflow [Sipity::Workflow]
       # @return [ActiveRecord::Relation<Sipity::WorkflowRole>]
       def workflow_roles_for_user_and_workflow(workflow)
-        Hyrax::Workflow::PermissionQuery.scope_processing_workflow_roles_for_user_and_workflow(user: context.current_user, workflow: workflow)
+        Hyrax::Workflow::PermissionQuery.scope_processing_workflow_roles_for_user_and_workflow(user: @user, workflow: workflow)
       end
     end
   end

--- a/app/services/hyrax/workflow/status_list_service.rb
+++ b/app/services/hyrax/workflow/status_list_service.rb
@@ -5,7 +5,7 @@ module Hyrax
     # Finds a list of works that we can perform a workflow action on
     class StatusListService
       ##
-      # @param context [#current_user, #logger]
+      # @param context [#current_user]
       # @param filter_condition [String] a solr filter
       def initialize(context, filter_condition)
         @context = context
@@ -22,6 +22,7 @@ module Hyrax
       # @return [Enumerable<StatusRow>] a list of results that the given user can take action on.
       def each
         return enum_for(:each) unless block_given?
+
         solr_documents.each do |doc|
           yield doc
         end
@@ -37,8 +38,6 @@ module Hyrax
 
       private
 
-      delegate :logger, to: :context
-
       # @return [Hash<String,SolrDocument>] a hash of id to solr document
       def solr_documents
         search_solr.map { |result| ::SolrDocument.new(result) }
@@ -46,7 +45,7 @@ module Hyrax
 
       def search_solr
         actionable_roles = roles_for_user
-        logger.debug("Actionable roles for #{context.current_user.user_key} are #{actionable_roles}")
+        Hyrax.logger.debug("Actionable roles for #{context.current_user.user_key} are #{actionable_roles}")
         return [] if actionable_roles.empty?
         WorkRelation.new.search_with_conditions(query(actionable_roles), method: :post)
       end

--- a/spec/controllers/hyrax/admin/workflows_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/workflows_controller_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Admin::WorkflowsController do
   describe "#index" do
-    before do
-      expect(controller).to receive(:authorize!).with(:review, :submissions).and_return(true)
-    end
+    let(:user) { FactoryBot.create(:admin) }
+
+    before { sign_in user }
+
     it "is successful" do
       expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
       expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)

--- a/spec/services/hyrax/workflow/status_list_service_spec.rb
+++ b/spec/services/hyrax/workflow/status_list_service_spec.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Workflow::StatusListService do
-  subject(:service) { described_class.new(context, "workflow_state_name_ssim:initial") }
-  let(:context) { double(current_user: user, logger: double(debug: nil)) }
+  subject(:service) { described_class.new(user, "workflow_state_name_ssim:initial") }
   let!(:sipity_entity) { FactoryBot.create(:sipity_entity) }
   let(:user) { FactoryBot.create(:user) }
 
-  context 'using valkyrie models' do
+  context 'using valkyrie models',
+          index_adapter: :solr_index,
+          valkyrie_adapter: :test_adapter do
     let(:work) { FactoryBot.valkyrie_create(:hyrax_work) }
 
-    it 'without any roles is empty'
+    before { Hyrax.index_adapter.save(resource: work) }
+
+    it 'without any roles is empty' do
+      expect(service.each).to be_none
+    end
   end
 
   describe "#each" do

--- a/spec/services/hyrax/workflow/status_list_service_spec.rb
+++ b/spec/services/hyrax/workflow/status_list_service_spec.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Workflow::StatusListService do
+  subject(:service) { described_class.new(context, "workflow_state_name_ssim:initial") }
+  let(:context) { double(current_user: user, logger: double(debug: nil)) }
+  let!(:sipity_entity) { FactoryBot.create(:sipity_entity) }
+  let(:user) { FactoryBot.create(:user) }
+
+  context 'using valkyrie models' do
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+    it 'without any roles is empty'
+  end
+
   describe "#each" do
-    let(:user) { create(:user) }
-    let(:context) { double(current_user: user, logger: double(debug: nil)) }
-    let(:service) { described_class.new(context, "workflow_state_name_ssim:initial") }
-    let!(:sipity_entity) { create(:sipity_entity) }
     let(:document) do
       { id: '33333',
         has_model_ssim: ['GenericWork'],
@@ -12,21 +19,21 @@ RSpec.describe Hyrax::Workflow::StatusListService do
         workflow_state_name_ssim: ["initial"],
         title_tesim: ['Hey dood!'] }
     end
-    let(:ability) do
+    let(:bad_document) do
       { id: '44444',
         has_model_ssim: ['GenericWork'],
         title_tesim: ['bad result'] }
     end
-    let(:workflow_role) { instance_double(Sipity::Role, name: 'approving') }
-    let(:workflow_roles) { [instance_double(Sipity::WorkflowRole, role: workflow_role)] }
-    let(:results) { service.each.to_a }
 
     before do
-      Hyrax::SolrService.add([document, ability], commit: true)
+      Hyrax::SolrService.add([document, bad_document], commit: true)
     end
 
     context "when user has roles" do
       let(:template) { double('template', source_id: 'foobar') }
+      let(:workflow_role) { instance_double(Sipity::Role, name: 'approving') }
+      let(:workflow_roles) { [instance_double(Sipity::WorkflowRole, role: workflow_role)] }
+
       let(:workflow) do
         instance_double(Sipity::Workflow, name: 'generic_work', permission_template: template)
       end
@@ -37,10 +44,10 @@ RSpec.describe Hyrax::Workflow::StatusListService do
       end
 
       it "returns status rows" do
-        expect(results.size).to eq 1
-        expect(results.first).to be_kind_of(SolrDocument)
-        expect(results.first.to_s).to eq 'Hey dood!'
-        expect(results.first.workflow_state).to eq 'initial'
+        expect(service.each.count).to eq 1
+        expect(service.each.first).to be_kind_of(SolrDocument)
+        expect(service.each.first.to_s).to eq 'Hey dood!'
+        expect(service.each.first.workflow_state).to eq 'initial'
       end
     end
 
@@ -48,8 +55,9 @@ RSpec.describe Hyrax::Workflow::StatusListService do
       before do
         allow(Hyrax::Workflow::PermissionQuery).to receive(:scope_processing_workflow_roles_for_user_and_workflow).and_return([])
       end
+
       it "returns nothing" do
-        expect(results).to be_empty
+        expect(service.each).to be_none
       end
     end
   end

--- a/spec/services/hyrax/workflow/status_list_service_spec.rb
+++ b/spec/services/hyrax/workflow/status_list_service_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Workflow::StatusListService do
   subject(:service) { described_class.new(user, "workflow_state_name_ssim:initial") }
-  let!(:sipity_entity) { FactoryBot.create(:sipity_entity) }
   let(:user) { FactoryBot.create(:user) }
 
   context 'using valkyrie models',


### PR DESCRIPTION
this service had a highly bidirectional dependency on its calling
controller. this kind of dependency makes testing harder, and limits reuse. in
practice, all this service really needs is a `::User` and the set of filters for
the workflow query (can this be abstracted?). refactor to allow the service to
accept just a user instead of a search context/controller, and deprecate the
controller arugemnt.

moving toward valkyrie support for `Workflows::StatusListService`.

@samvera/hyrax-code-reviewers
