### PR TITLE
Query workflow status directly from DB

### DIFF
--- a/app/controllers/hyrax/admin/workflows_controller.rb
+++ b/app/controllers/hyrax/admin/workflows_controller.rb
@@ -15,14 +15,20 @@ module Hyrax
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb t(:'hyrax.admin.sidebar.tasks'), '#'
       add_breadcrumb t(:'hyrax.admin.sidebar.workflow_review'), request.path
-      @status_list = Hyrax::Workflow::StatusListService.new(current_user, "-workflow_state_name_ssim:#{deposited_workflow_state_name}")
-      @published_list = Hyrax::Workflow::StatusListService.new(current_user, "workflow_state_name_ssim:#{deposited_workflow_state_name}")
+
+      @status_list = actionable_objects.reject(&:published?)
+      @published_list = actionable_objects.select(&:published?)
     end
 
     private
 
     def ensure_authorized!
       authorize! :review, :submissions
+    end
+
+    def actionable_objects
+      @actionable_objects ||=
+        Hyrax::Workflow::ActionableObjects.new(user: current_user)
     end
   end
 end

--- a/app/services/hyrax/solr_query_service.rb
+++ b/app/services/hyrax/solr_query_service.rb
@@ -21,6 +21,12 @@ module Hyrax
     end
 
     ##
+    # @return [Enumerable<SolrDocument>]
+    def solr_documents
+      get['response']['docs'].map { |doc| ::SolrDocument.new(doc) }
+    end
+
+    ##
     # @return [Array<String>] ids of documents matching the current query
     def get_ids # rubocop:disable Naming/AccessorMethodName
       results = get

--- a/app/services/hyrax/workflow/actionable_objects.rb
+++ b/app/services/hyrax/workflow/actionable_objects.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+module Hyrax
+  module Workflow
+    ##
+    # Produces a list of workflow-ready objects for a given user. Results are
+    # given as a presenter objects with SolrDocument-like behavior, with added
+    # support for workflow states.
+    #
+    # @example
+    #   Hyrax::Workflow::ActionableObjects.new(user: current_user).each do |object|
+    #     puts object.title
+    #     puts object.workflow_state
+    #   end
+    #
+    # @see Hyrax::Workflow::ObjectInWorkflowDecorator
+    class ActionableObjects
+      include Enumerable
+
+      ##
+      # @!attribute [rw] user
+      #   @return [::User]
+      attr_accessor :user
+
+      ##
+      # @param [::User] user the user whose
+      def initialize(user:)
+        @user = user
+      end
+
+      ##
+      # @return [Hyrax::Workflow::ObjectInWorkflowDecorator]
+      def each
+        return enum_for(:each) unless block_given?
+        ids_and_states = id_state_pairs
+        return if ids_and_states.none?
+
+        docs = Hyrax::SolrQueryService.new.with_ids(ids: ids_and_states.map(&:first)).solr_documents
+
+        docs.each do |solr_doc|
+          object = ObjectInWorkflowDecorator.new(solr_doc)
+          _, state = ids_and_states.find { |id, _| id == object.id }
+
+          object.workflow_state = state
+
+          yield object
+        end
+      end
+
+      private
+
+      ##
+      # @api private
+      # @return [Array[String, Sipity::WorkflowState]]
+      def id_state_pairs
+        gids_and_states = PermissionQuery
+                          .scope_entities_for_the_user(user: user)
+                          .pluck(:proxy_for_global_id, :workflow_state_id)
+
+        return [] if gids_and_states.none?
+
+        all_states = Sipity::WorkflowState.find(gids_and_states.map(&:last).uniq)
+
+        gids_and_states.map do |str, state_id|
+          [GlobalID.new(str).model_id,
+           all_states.find { |state| state.id == state_id }]
+        end
+      end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/object_in_workflow_decorator.rb
+++ b/app/services/hyrax/workflow/object_in_workflow_decorator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Workflow
+    ##
+    # Decorates objects with attributes with their workflow state.
+    class ObjectInWorkflowDecorator < Draper::Decorator
+      delegate_all
+
+      ##
+      # @!attribute [w] workflow
+      #   @return [Sipity::Workflow]
+      # @!attribute [w] workflow_state
+      #   @return [Sipity::WorkflowState]
+      attr_writer :workflow, :workflow_state
+
+      ##
+      # @return [Boolean]
+      def published?
+        Hyrax::Admin::WorkflowsController.deposited_workflow_state_name ==
+          workflow_state
+      end
+
+      ##
+      # @return [String]
+      def workflow_state
+        @workflow_state&.name || 'unknown'
+      end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/status_list_service.rb
+++ b/app/services/hyrax/workflow/status_list_service.rb
@@ -2,6 +2,10 @@
 module Hyrax
   module Workflow
     ##
+    # @deprecated use the Hyrax::Workflow::ActionableObjects enumerator instead.
+    #   that service is designed as a more efficient and ergonomic replacement
+    #   for this one, and has fewer dependencies on specific indexing behavior.
+    #
     # Finds a list of works that a given user can perform a workflow action on.
     class StatusListService
       ##
@@ -10,6 +14,9 @@ module Hyrax
       #
       # @raise [ArgumentError] if th caller fails to provide a user
       def initialize(context_or_user, filter_condition)
+        Deprecation
+          .warn("Use the Hyrax::Workflow::ActionableObjects enumerator instead.")
+
         case context_or_user
         when ::User
           @user = context_or_user

--- a/spec/controllers/hyrax/admin/workflows_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/workflows_controller_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Hyrax::Admin::WorkflowsController do
 
       get :index
       expect(response).to be_successful
-      expect(assigns[:status_list]).to be_kind_of Hyrax::Workflow::StatusListService
-      expect(assigns[:published_list]).to be_kind_of Hyrax::Workflow::StatusListService
+      expect(assigns[:status_list]).to respond_to(:each)
+      expect(assigns[:published_list]).to respond_to(:each)
     end
   end
 end

--- a/spec/services/hyrax/workflow/actionable_objects_spec.rb
+++ b/spec/services/hyrax/workflow/actionable_objects_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Workflow::ActionableObjects, :clean_repo do
+  subject(:service) { described_class.new(user: user) }
+  let(:user) { FactoryBot.create(:user) }
+
+  describe '#each' do
+    it 'is empty by default' do
+      expect(service.each).to be_none
+    end
+
+    context 'with objects in workflow' do
+      let(:admin_set) { FactoryBot.valkyrie_create(:hyrax_admin_set) }
+      let(:objects) do
+        [FactoryBot.valkyrie_create(:hyrax_work, admin_set_id: admin_set.id),
+         FactoryBot.valkyrie_create(:hyrax_work, admin_set_id: admin_set.id),
+         FactoryBot.valkyrie_create(:hyrax_work, admin_set_id: admin_set.id)]
+      end
+
+      let(:permission_template) do
+        Hyrax::PermissionTemplate
+          .find_or_create_by(source_id: admin_set.id.to_s)
+      end
+
+      let(:workflow) do
+        Hyrax::Workflow::WorkflowImporter
+          .generate_from_hash(data: workflow_spec.as_json,
+                              permission_template: permission_template)
+        Sipity::Workflow.last
+      end
+
+      let(:workflow_spec) do
+        {
+          workflows: [
+            {
+              name: "go_with_the_floe",
+              label: "Testing out the workflow ",
+              description: "A single-step workflow for the test suite",
+              actions: [
+                {
+                  name: "ingest",
+                  from_states: [],
+                  transition_to: "needs_attention"
+                },
+                {
+                  name: "two_step",
+                  from_states: [
+                    {
+                      names: ["needs_attention"],
+                      roles: ["disapproving"]
+                    }
+                  ],
+                  transition_to: "not_the_magic_name",
+                  methods: [
+                    "Hyrax::Workflow::ActivateObject"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      before do
+        Sipity::Workflow.activate!(permission_template: permission_template,
+                                   workflow_id: workflow.id)
+
+        objects.each { |o| Hyrax::Workflow::WorkflowFactory.create(o, {}, user) }
+      end
+
+      it 'is empty with no user actions' do
+        expect(service.each).to be_none
+      end
+
+      context 'and user available actions' do
+        before do
+          agent = Sipity::Agent(user)
+
+          Sipity::WorkflowRole.where(workflow_id: workflow.id).each do |wf_role|
+            Sipity::WorkflowResponsibility.find_or_create_by!(agent_id: agent.id, workflow_role_id: wf_role.role_id)
+            Sipity::WorkflowResponsibility.find_or_create_by!(agent_id: agent.id, workflow_role_id: wf_role.role_id)
+          end
+        end
+
+        it 'lists the objects' do
+          expect(service.map(&:id)).to contain_exactly(*objects.map(&:id))
+        end
+
+        it 'includes the workflow states' do
+          expect(service.map(&:workflow_state))
+            .to contain_exactly('needs_attention',
+                                'needs_attention',
+                                'needs_attention')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/workflow/object_in_workflow_decorator_spec.rb
+++ b/spec/services/hyrax/workflow/object_in_workflow_decorator_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::Workflow::ObjectInWorkflowDecorator do
+  subject(:decorator) { described_class.new(resource) }
+  let(:resource) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+  it { is_expected.not_to be_published }
+
+  describe '#workflow_state' do
+    it 'is unknown' do
+      expect(decorator.workflow_state).to eq 'unknown'
+    end
+  end
+end


### PR DESCRIPTION
working on querying sipity entities directly from the database. once we have a
list of ids, we pull their documents from Solr.

with those in hand, we probably want to get data into a presenter next and add
the workflow states in alongside. the presenter should be able to determine if
the workflow state is `#published?` for some definition thereof within the
workflow.

aside: is it a good assumption that workflows have a `#published` status? the
workflow use cases seem to extend far beyond publication workflows. do we like
the tabs?

@samvera/hyrax-code-reviewers
