### PR TITLE
open AdminSetSearchBuilder to post-Wings model scope

### DIFF
--- a/app/search_builders/hyrax/admin_set_search_builder.rb
+++ b/app/search_builders/hyrax/admin_set_search_builder.rb
@@ -14,7 +14,7 @@ module Hyrax
 
     # This overrides the models in FilterByType
     def models
-      [::AdminSet]
+      [::AdminSet, Hyrax::AdministrativeSet]
     end
 
     # Overrides Hydra::AccessControlsEnforcement

--- a/app/search_builders/hyrax/my/collections_search_builder.rb
+++ b/app/search_builders/hyrax/my/collections_search_builder.rb
@@ -21,6 +21,6 @@ class Hyrax::My::CollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
   # This overrides the models in FilterByType
   # @return [Array<Class>] a list of classes to include
   def models
-    [::AdminSet, ::Collection]
+    [::AdminSet, ::Collection, Hyrax::AdministrativeSet]
   end
 end

--- a/spec/search_builders/hyrax/admin_set_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/admin_set_search_builder_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Hyrax::AdminSetSearchBuilder do
         expect(subject['fq']).to eq ["edit_access_person_ssim:#{user.user_key} OR " \
                                        "discover_access_person_ssim:#{user.user_key} OR " \
                                        "read_access_person_ssim:#{user.user_key}",
-                                     "{!terms f=has_model_ssim}AdminSet"]
+                                     "{!terms f=has_model_ssim}AdminSet,Hyrax::AdministrativeSet"]
       end
     end
 
@@ -72,7 +72,7 @@ RSpec.describe Hyrax::AdminSetSearchBuilder do
       end
 
       it 'is successful' do
-        expect(subject['fq']).to eq ["{!terms f=id}7,8", "{!terms f=has_model_ssim}AdminSet"]
+        expect(subject['fq']).to eq ["{!terms f=id}7,8", "{!terms f=has_model_ssim}AdminSet,Hyrax::AdministrativeSet"]
       end
     end
   end

--- a/spec/search_builders/hyrax/my/collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/collections_search_builder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::My::CollectionsSearchBuilder do
   describe '#models' do
     subject { builder.models }
 
-    it { is_expected.to eq([AdminSet, Collection]) }
+    it { is_expected.to eq([AdminSet, Collection, Hyrax::AdministrativeSet]) }
   end
 
   describe ".default_processor_chain" do

--- a/spec/search_builders/hyrax/single_admin_set_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/single_admin_set_search_builder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::SingleAdminSetSearchBuilder do
 
     it do
       is_expected.to match_array ["",
-                                  "{!terms f=has_model_ssim}AdminSet"]
+                                  "{!terms f=has_model_ssim}AdminSet,Hyrax::AdministrativeSet"]
     end
   end
 end


### PR DESCRIPTION
this search builder should find objects of class `AdminSet` and
`Hyrax::AdministrativeSet`. with Wings enabled, `AdministrativeSet` already
resolves its `internal_resource` as `AdminSet`. for apps without wings, its
desirable for this service to find objects indexed with `has_model_ssim` of
`Hyrax::AdministrativeSet`.

maybe we also want to move this builder toward using the "generic type" index?
that would require a broad reindex from downstream apps, because the legacy
admin sets don't seem to include any generic type data.

@samvera/hyrax-code-reviewers
