### PR TITLE
deprecate CollectionBehavior #add_member_objects and replace with CollectionMemberService.add_members

### DIFF
--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -51,27 +51,22 @@ module Hyrax
     end
 
     # Add members using the members association.
-    # TODO: Confirm if this is ever used.  I believe all relationships are done through
-    #       add_member_objects using the member_of_collections relationship.  Deprecate?
     def add_members(new_member_ids)
-      return if new_member_ids.blank?
-      members << Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: new_member_ids, use_valkyrie: false)
+      Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
+                         "Instead, use Hyrax::Collections::CollectionMemberService.add_members_by_ids.")
+      Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection: valkyrie_resource,
+                                                                     new_member_ids: new_member_ids,
+                                                                     user: nil)
     end
 
     # Add member objects by adding this collection to the objects' member_of_collection association.
     # @param [Enumerable<String>] the ids of the new child collections and works collection ids
     def add_member_objects(new_member_ids)
-      Array(new_member_ids).collect do |member_id|
-        member = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: member_id, use_valkyrie: false)
-        message = Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
-        if message
-          member.errors.add(:collections, message)
-        else
-          member.member_of_collections << self
-          member.save!
-        end
-        member
-      end
+      Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
+                         "Instead, use Hyrax::Collections::CollectionMemberService.add_members_by_ids.")
+      Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection: valkyrie_resource,
+                                                                     new_member_ids: new_member_ids,
+                                                                     user: nil)
     end
 
     # @return [Enumerable<ActiveFedora::Base>] an enumerable over the children of this collection

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -4,7 +4,7 @@ require 'hyrax/specs/spy_listener'
 RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   routes { Hyrax::Engine.routes }
   let(:user)  { create(:user) }
-  let(:other) { build(:user) }
+  let(:other) { create(:user) }
   let(:collection_type_gid) { FactoryBot.create(:user_collection_type).to_global_id.to_s }
 
   let(:collection) do

--- a/spec/models/concerns/hyrax/collection_behavior_spec.rb
+++ b/spec/models/concerns/hyrax/collection_behavior_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Hyrax::CollectionBehavior, clean_repo: true do
 
   describe "#destroy" do
     it "removes the collection id from associated members" do
-      collection.add_member_objects([work.id])
+      Hyrax::Collections::CollectionMemberService.add_members(collection: collection.valkyrie_resource,
+                                                              new_members: [work],
+                                                              user: nil)
       collection.save
 
       collection_via_query = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: collection.id, use_valkyrie: false)


### PR DESCRIPTION
Partially addresses Issue #4920 

_NOTE: The issue says to update to support Valkyrie objects, but instead methods are being deprecated in favor of services in order to keep the Valkyrie resource object light weight._

* deprecates `Hyrax::CollectionBehavior#add_member_objects`
* updates all places that call it to `Hyrax::Collections::CollectionMemberService.add_members`

@samvera/hyrax-code-reviewers
