### PR TITLE
add a rake task to regenerate derivatives

### DIFF
--- a/lib/tasks/regenerate_derivatives.rake
+++ b/lib/tasks/regenerate_derivatives.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :hyrax do
+  namespace :file_sets do
+    desc 'Regenerate derivatives for all FileSets in the repository'
+    task :regenerate_derivatives do
+      FileSet.all.each do |fs|
+        fs.files.each { |fi| CreateDerivativesJob.perform_later(fs, fi) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
it's a common pitfall in deploying Hyrax apps to misconfigure
thumbnail/derivatives path. when the configuration changes, the thumbnails will
be missing. depending on whether the storage medium they were originally
generated to still exists, it can be impossible to recover the old thumbnails.

adding a task to regen the derivatives completely seems of high utility.

@samvera/hyrax-code-reviewers
