### PR TITLE
Make initContainers more flexible for downstream chart users

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.21.1
+version: 0.21.2
 appVersion: 3.0.2
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 0.21.2
+version: 0.22.0
 appVersion: 3.0.2
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -20,9 +20,6 @@ spec:
         {{- include "hyrax.selectorLabels" . | nindent 8 }}
     spec:
       initContainers:
-        {{- if .Values.worker.extraInitContainers }}
-        {{- toYaml .Values.worker.extraInitContainers | nindent 8 }}
-        {{- end }}
         - name: db-wait
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
@@ -37,6 +34,9 @@ spec:
             - sh
             - -c
             - db-wait.sh "$REDIS_HOST:6379"
+        {{- if .Values.worker.extraInitContainers }}
+        {{- toYaml .Values.worker.extraInitContainers | nindent 8 }}
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
               solrcloud-upload-configset.sh /app/samvera/hyrax-webapp/solr/conf &&
               solrcloud-assign-configset.sh
         {{- end }}
+        {{- if not .Values.skipDbMigrateSeed }}
         - name: db-setup
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -64,6 +65,7 @@ spec:
             - sh
             - -c
             - db-migrate-seed.sh
+        {{- end }}
         {{- if .Values.extraInitContainers }}
         {{- toYaml .Values.extraInitContainers | nindent 8 }}
         {{- end }}

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -21,9 +21,6 @@ spec:
         {{- include "hyrax.selectorLabels" . | nindent 8 }}
     spec:
       initContainers:
-        {{- if .Values.extraInitContainers }}
-        {{- toYaml .Values.extraInitContainers | nindent 8 }}
-        {{- end }}
         {{- if .Values.loadSolrConfigSet }}
         - name: load-solr-config
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -67,6 +64,9 @@ spec:
             - sh
             - -c
             - db-migrate-seed.sh
+        {{- if .Values.extraInitContainers }}
+        {{- toYaml .Values.extraInitContainers | nindent 8 }}
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -12,6 +12,9 @@ image:
 
 # use true to skip loading Hyrax engine database seed file
 skipHyraxEngineSeed: false
+# use true to skip running the `db-setup` initContainer
+# this may be desirable for downstream chart users to customize their database setup
+skipDbMigrateSeed: false
 
 # use false to skip the configset management init container
 loadSolrConfigSet: true


### PR DESCRIPTION

Downstream `extraInitContainers` may be dependent, in a way, on the
upstream `initContainers` running first.

For example, if one wants to add an additional Solr collection (say for
running tests against). If a local `extraInitContainer` is created to do
this, it may be implicitly dependent on the `load-solr-config`
`initContainer` having already ran (to reference the `configset`).

It may also be desirable for downstream users of the Hyrax chart to run their
own database setup `initContainers`, or potentially external to the Helm
process entirely.

This introduces the `skipDbMigrateSeed` value, which defaults to `false`
to preserve existing behavior. But provides a mechanism for downstream
users to opt-out.

Changes proposed in this pull request:
* Move `extraInitContainers` to the end of the `initContainers` section, which
	follows the general pattern of extras going at the end of definitions.
* Add `skipDbMigrateSeed` Helm chart value, defaulting to `false`, to allow
	downstream users to choose to opt-out of running the `db-setup`
	`initContainer` 

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* A `helm deploy` with the defaults should continue to work as-is
* A `helm deploy` setting `skipDbMigrateSeed: true` should skip the `db-setup`
	`initContainer`

@samvera/hyrax-code-reviewers
