### PR TITLE
fix an unreliable test in ActionableObjects specs

### DIFF
--- a/spec/services/hyrax/workflow/actionable_objects_spec.rb
+++ b/spec/services/hyrax/workflow/actionable_objects_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hyrax::Workflow::ActionableObjects, :clean_repo do
+RSpec.describe Hyrax::Workflow::ActionableObjects do
   subject(:service) { described_class.new(user: user) }
   let(:user) { FactoryBot.create(:user) }
 
@@ -77,8 +77,8 @@ RSpec.describe Hyrax::Workflow::ActionableObjects, :clean_repo do
           agent = Sipity::Agent(user)
 
           Sipity::WorkflowRole.where(workflow_id: workflow.id).each do |wf_role|
-            Sipity::WorkflowResponsibility.find_or_create_by!(agent_id: agent.id, workflow_role_id: wf_role.role_id)
-            Sipity::WorkflowResponsibility.find_or_create_by!(agent_id: agent.id, workflow_role_id: wf_role.role_id)
+            Sipity::WorkflowResponsibility.find_or_create_by!(agent_id: agent.id, workflow_role_id: wf_role.id)
+            Sipity::WorkflowResponsibility.find_or_create_by!(agent_id: agent.id, workflow_role_id: wf_role.id)
           end
         end
 


### PR DESCRIPTION
this test only worked if the Sipity::Roles and Sipity::WorkflowRoles are 1:1,
which they aren't if another workflow exists with different WorkflowRole
definitions/ids. using the Sipity::WorkflowRole id instead of the one for
Sipity::Role guarantees the correct result.

with this fix in, there's no longer a need to clean the repo between runs.

@samvera/hyrax-code-reviewers
