### PR TITLE
support Valkyrie in the TrophyPresenter 

### DIFF
--- a/app/presenters/hyrax/trophy_presenter.rb
+++ b/app/presenters/hyrax/trophy_presenter.rb
@@ -36,9 +36,10 @@ module Hyrax
     # @return [Array<TrophyPresenter>] a list of all the trophy presenters for the user
     def self.find_by_user(user)
       work_ids = user.trophies.pluck(:work_id)
-      query = Hyrax::SolrQueryBuilderService.construct_query_for_ids(work_ids)
-      results = Hyrax::WorkRelation.new.search_with_conditions(query)
-      results.map { |result| TrophyPresenter.new(document_model.new(result)) }
+      query    = Hyrax::SolrQueryBuilderService.construct_query_for_ids(work_ids)
+      results  = Hyrax::WorkRelation.new.search_with_conditions(query)
+
+      results.map { |result| new(document_model.new(result)) }
     rescue RSolr::Error::ConnectionRefused
       []
     end

--- a/app/presenters/hyrax/trophy_presenter.rb
+++ b/app/presenters/hyrax/trophy_presenter.rb
@@ -1,16 +1,38 @@
 # frozen_string_literal: true
+
 module Hyrax
+  ##
+  # @api public
+  #
+  # Presents works in context as "trophied" for a given user.
+  #
+  # @example
+  #   my_user = User.find(user_id)
+  #
+  #   trophies = Hyrax::TrophyPresenter.find_by_user(my_user)
+  #   trophies.each do |trophy|
+  #     puts "Object name/title: #{trophy}"
+  #     puts "Thumbnail path: #{trophy.thumbnail_path}"
+  #   end
   class TrophyPresenter
     include ModelProxy
+
+    ##
+    # @param solr_document [::SolrDocument]
     def initialize(solr_document)
       @solr_document = solr_document
     end
 
+    ##
+    # @!attribute [r] SolrDocument
+    #   @return [::SolrDocument]
     attr_reader :solr_document
 
     delegate :to_s, :thumbnail_path, to: :solr_document
 
+    ##
     # @param user [User] the user to find the TrophyPresentes for.
+    #
     # @return [Array<TrophyPresenter>] a list of all the trophy presenters for the user
     def self.find_by_user(user)
       work_ids = user.trophies.pluck(:work_id)
@@ -21,6 +43,8 @@ module Hyrax
       []
     end
 
+    ##
+    # @api private
     def self.document_model
       CatalogController.blacklight_config.document_model
     end

--- a/app/presenters/hyrax/trophy_presenter.rb
+++ b/app/presenters/hyrax/trophy_presenter.rb
@@ -35,18 +35,22 @@ module Hyrax
     #
     # @return [Array<TrophyPresenter>] a list of all the trophy presenters for the user
     def self.find_by_user(user)
-      work_ids = user.trophies.pluck(:work_id)
-      query    = Hyrax::SolrQueryBuilderService.construct_query_for_ids(work_ids)
-      results  = Hyrax::WorkRelation.new.search_with_conditions(query)
+      ids = user.trophies.pluck(:work_id)
+      return ids if ids.empty?
 
-      results.map { |result| new(document_model.new(result)) }
+      documents = Hyrax::SolrQueryService.new.with_ids(ids: ids).solr_documents
+
+      documents.map { |doc| new(doc) }
     rescue RSolr::Error::ConnectionRefused
       []
     end
 
     ##
     # @api private
+    # @deprecated use CatalogController.blacklight_config.document_model instead
     def self.document_model
+      Deprecation
+        .warn("Use CatalogController.blacklight_config.document_model instead.")
       CatalogController.blacklight_config.document_model
     end
     private_class_method :document_model

--- a/app/presenters/hyrax/user_profile_presenter.rb
+++ b/app/presenters/hyrax/user_profile_presenter.rb
@@ -1,16 +1,25 @@
 # frozen_string_literal: true
 module Hyrax
   class UserProfilePresenter
+    ##
+    # @param user [::User]
+    # @param ability [::Ability]
     def initialize(user, ability)
       @user = user
       @ability = ability
     end
 
+    ##
+    # @!attribute [r] ability
+    #   @return [::Ability]
+    # @!attribute [r] user
+    #   @return [::User]
     attr_reader :user, :ability
 
     delegate :name, to: :user
 
-    # @return true if the presenter is for the logged in user
+    ##
+    # @return [Boolean] true if the presenter is for the logged in user
     def current_user?
       user == ability.current_user
     end
@@ -23,6 +32,7 @@ module Hyrax
                   end
     end
 
+    ##
     # @return [Array<TrophyPresenter>] list of TrophyPresenters for this profile.
     def trophies
       @trophies ||= Hyrax::TrophyPresenter.find_by_user(user)

--- a/app/services/hyrax/solr_query_service.rb
+++ b/app/services/hyrax/solr_query_service.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 module Hyrax
   ##
-  # Methods in this class are providing functionality previously supported by ActiveFedora::SolrQueryBuilder.
-  # It includes methods to build and execute a query.
+  # Supports building and executing a solr query.
+  #
+  # @note Methods in this class are providing functionality previously supported by
+  #   ActiveFedora::SolrQueryBuilder.
   class SolrQueryService < ::SearchBuilder # rubocop:disable Metrics/ClassLength
     class_attribute :query_service
     self.query_service = Hyrax.query_service
@@ -15,6 +17,15 @@ module Hyrax
     end
 
     ##
+    # @api private
+    # @see Blacklight::Configuration#document_model
+    #
+    # @return [Class] the model class to use for solr documents
+    def self.document_model
+      CatalogController.blacklight_config.document_model
+    end
+
+    ##
     # @return [Hash] the results returned from solr for the current query
     def get
       solr_service.get(build)
@@ -23,7 +34,7 @@ module Hyrax
     ##
     # @return [Enumerable<SolrDocument>]
     def solr_documents
-      get['response']['docs'].map { |doc| ::SolrDocument.new(doc) }
+      get['response']['docs'].map { |doc| self.class.document_model.new(doc) }
     end
 
     ##

--- a/spec/presenters/hyrax/trophy_presenter_spec.rb
+++ b/spec/presenters/hyrax/trophy_presenter_spec.rb
@@ -18,22 +18,28 @@ RSpec.describe Hyrax::TrophyPresenter do
 
   describe ".find_by_user" do
     let(:user)  { FactoryBot.create(:user) }
-    let(:work1) { FactoryBot.create(:work, user: user) }
-    let(:work2) { FactoryBot.create(:work, user: user) }
-    let(:work3) { FactoryBot.create(:work, user: user) }
+    let(:work1) { FactoryBot.valkyrie_create(:hyrax_work, depositor: user.user_key) }
+    let(:work2) { FactoryBot.valkyrie_create(:hyrax_work, depositor: user.user_key) }
+    let(:work3) { FactoryBot.valkyrie_create(:hyrax_work, depositor: user.user_key) }
 
-    before do
-      user.trophies.create!(work_id: work1.id)
-      user.trophies.create!(work_id: work2.id)
-      user.trophies.create!(work_id: work3.id)
-      user.trophies.create!(work_id: 'fake_id')
+    it 'is empty' do
+      expect(described_class.find_by_user(user)).to be_empty
     end
 
-    it "returns presenters for trophied works" do
-      expect(described_class.find_by_user(user))
-        .to contain_exactly(be_kind_of(described_class),
-                            be_kind_of(described_class),
-                            be_kind_of(described_class))
+    context 'with trophies' do
+      before do
+        user.trophies.create!(work_id: work1.id)
+        user.trophies.create!(work_id: work2.id)
+        user.trophies.create!(work_id: work3.id)
+        user.trophies.create!(work_id: 'fake_id')
+      end
+
+      it "returns presenters for trophied works" do
+        expect(described_class.find_by_user(user))
+          .to contain_exactly(be_kind_of(described_class),
+                              be_kind_of(described_class),
+                              be_kind_of(described_class))
+      end
     end
   end
 end

--- a/spec/presenters/hyrax/user_profile_presenter_spec.rb
+++ b/spec/presenters/hyrax/user_profile_presenter_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Hyrax::UserProfilePresenter do
   its(:current_user?) { is_expected.to be true }
 
   describe "#trophies" do
-    let(:work1) { FactoryBot.create(:work, user: user) }
-    let(:work2) { FactoryBot.create(:work, user: user) }
-    let(:work3) { FactoryBot.create(:work, user: user) }
+    let(:work1) { FactoryBot.valkyrie_create(:hyrax_work, depositor: user.user_key) }
+    let(:work2) { FactoryBot.valkyrie_create(:hyrax_work, depositor: user.user_key) }
+    let(:work3) { FactoryBot.valkyrie_create(:hyrax_work, depositor: user.user_key) }
 
     before do
       user.trophies.create!(work_id: work1.id)

--- a/spec/presenters/hyrax/user_profile_presenter_spec.rb
+++ b/spec/presenters/hyrax/user_profile_presenter_spec.rb
@@ -1,29 +1,32 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::UserProfilePresenter do
-  let(:user) { create(:user) }
-  let(:ability) { Ability.new(user) }
-  let(:presenter) { described_class.new(user, ability) }
+  subject(:presenter) { described_class.new(user, ability) }
+  let(:ability)       { Ability.new(user) }
+  let(:user)          { FactoryBot.create(:user) }
 
-  describe "current_user?" do
-    subject { presenter.current_user? }
+  its(:current_user?) { is_expected.to be true }
 
-    it { is_expected.to be true }
-  end
+  describe "#trophies" do
+    let(:work1) { FactoryBot.create(:work, user: user) }
+    let(:work2) { FactoryBot.create(:work, user: user) }
+    let(:work3) { FactoryBot.create(:work, user: user) }
 
-  describe "trophies" do
-    let(:work1) { create(:work, user: user) }
-    let(:work2) { create(:work, user: user) }
-    let(:work3) { create(:work, user: user) }
-    let!(:trophy1) { user.trophies.create!(work_id: work1.id) }
-    let!(:trophy2) { user.trophies.create!(work_id: work2.id) }
-    let!(:trophy3) { user.trophies.create!(work_id: work3.id) }
-    let!(:badtrophy) { user.trophies.create!(work_id: 'not_a_generic_work') }
-
-    subject { presenter.trophies }
+    before do
+      user.trophies.create!(work_id: work1.id)
+      user.trophies.create!(work_id: work2.id)
+      user.trophies.create!(work_id: work3.id)
+      user.trophies.create!(work_id: 'not_a_generic_work')
+    end
 
     it "has an array of presenters" do
-      expect(subject).to all(be_kind_of Hyrax::TrophyPresenter)
-      expect(subject.map(&:id)).to match_array [work1.id, work2.id, work3.id]
+      expect(presenter.trophies).to all(be_kind_of Hyrax::TrophyPresenter)
+    end
+
+    it "matches only the trophied works" do
+      FactoryBot.create(:work, user: user) # not trophied
+
+      expect(presenter.trophies.map(&:id))
+        .to match_array [work1.id, work2.id, work3.id]
     end
   end
 end


### PR DESCRIPTION
remove the dependency on `Hyrax::WorkRelation` from the
`TrophyPresenter`. there's no need for this presenter to filter on registered
work types, since the trophies already know the exact ids for the trophied
objects. we can do a simple search for the ids and build the results without
further complication.

some refactors (mainly in specs) and documentation additions precede the more substantive changes, which are in f70281a

@samvera/hyrax-code-reviewers
