### PR TITLE
ObjectInWorkflowDecorator: inherit from our decorator class

### DIFF
--- a/app/services/hyrax/workflow/object_in_workflow_decorator.rb
+++ b/app/services/hyrax/workflow/object_in_workflow_decorator.rb
@@ -4,7 +4,7 @@ module Hyrax
   module Workflow
     ##
     # Decorates objects with attributes with their workflow state.
-    class ObjectInWorkflowDecorator < Draper::Decorator
+    class ObjectInWorkflowDecorator < Hyrax::ModelDecorator
       delegate_all
 
       ##


### PR DESCRIPTION
inheriting directly from `Draper::Decorator` doesn't give us the correct
`#to_model` behavior

@samvera/hyrax-code-reviewers
