### PR TITLE
test that `WorkFormHelper.form_file_set_select_for` skips works

### DIFF
--- a/spec/helpers/hyrax/work_form_helper_spec.rb
+++ b/spec/helpers/hyrax/work_form_helper_spec.rb
@@ -105,6 +105,17 @@ RSpec.describe Hyrax::WorkFormHelper do
             .to include('moominpapa.jpg' => an_instance_of(String),
                         'snorkmaiden.jpg' => an_instance_of(String))
         end
+
+        context 'and work members' do
+          let(:work) { FactoryBot.build(:hyrax_work, member_ids: member_ids) }
+          let(:member_ids) { file_sets.map(&:id) + [member_work.id] }
+          let(:member_work) { FactoryBot.build(:hyrax_work) }
+
+          it 'gives labels => ids for file_sets only' do
+            expect(form_file_set_select_for(parent: form).values)
+              .not_to include member_work.id.to_s
+          end
+        end
       end
     end
 


### PR DESCRIPTION
i was worried this might not be working due to an unrelated error, so i wrote a
test. seems like it's okay, but might as well get this in the suite.

@samvera/hyrax-code-reviewers
