### PR TITLE
collection membership service uses collection id instead of collection resource

### DIFF
--- a/app/controllers/hyrax/dashboard/collection_members_controller.rb
+++ b/app/controllers/hyrax/dashboard/collection_members_controller.rb
@@ -28,7 +28,7 @@ module Hyrax
 
         collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
         begin
-          Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection: collection.valkyrie_resource,
+          Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection_id: collection.id,
                                                                          new_member_ids: batch_ids,
                                                                          user: current_user)
           after_update

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -379,18 +379,15 @@ module Hyrax
 
       def add_members_to_collection(collection = nil)
         collection ||= @collection
-        Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection: collection.valkyrie_resource,
+        Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection_id: collection.id,
                                                                        new_member_ids: batch,
                                                                        user: current_user)
       end
 
       def remove_members_from_collection
-        batch.each do |member_id|
-          work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: member_id)
-          work.member_of_collection_ids.delete @collection.id
-          Hyrax.persister.save(resource: work) &&
-            Hyrax.publisher.publish('object.metadata.updated', object: work, user: current_user)
-        end
+        Hyrax::Collections::CollectionMemberService.remove_members_by_ids(collection_id: @collection.id,
+                                                                          member_ids: batch,
+                                                                          user: current_user)
       end
 
       def move_members_between_collections

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -54,7 +54,7 @@ module Hyrax
     def add_members(new_member_ids)
       Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
                          "Instead, use Hyrax::Collections::CollectionMemberService.add_members_by_ids.")
-      Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection: valkyrie_resource,
+      Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection_id: id,
                                                                      new_member_ids: new_member_ids,
                                                                      user: nil)
     end
@@ -64,7 +64,7 @@ module Hyrax
     def add_member_objects(new_member_ids)
       Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
                          "Instead, use Hyrax::Collections::CollectionMemberService.add_members_by_ids.")
-      Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection: valkyrie_resource,
+      Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection_id: id,
                                                                      new_member_ids: new_member_ids,
                                                                      user: nil)
     end

--- a/app/services/hyrax/collections/collection_member_service.rb
+++ b/app/services/hyrax/collections/collection_member_service.rb
@@ -60,31 +60,31 @@ module Hyrax
 
       class << self
         # Check if a work or collection is already a member of a collection
-        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param collection_id [Valkyrie::ID] the id of the parent collection
         # @param member [Hyrax::Resource] the child collection and/or child work to check
         # @return [Boolean] true if already in the member set; otherwise, false
-        def member?(collection:, member:)
-          member.member_of_collection_ids.include? collection.id
+        def member?(collection_id:, member:)
+          member.member_of_collection_ids.include? collection_id
         end
 
         # Add works and/or collections as members of a collection
-        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param collection_id [Valkyrie::ID] the id of the parent collection
         # @param new_member_ids [Enumerable<Valkyrie::ID>] the ids of the new child collections and/or child works
         # @return [Enumerable<Hyrax::Resource>] updated member resources
-        def add_members_by_ids(collection:, new_member_ids:, user:)
+        def add_members_by_ids(collection_id:, new_member_ids:, user:)
           new_members = Hyrax.query_service.find_many_by_ids(ids: new_member_ids)
-          add_members(collection: collection, new_members: new_members, user: user)
+          add_members(collection_id: collection_id, new_members: new_members, user: user)
         end
 
         # Add works and/or collections as members of a collection
-        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param collection_id [Valkyrie::ID] the id of the parent collection
         # @param new_members [Enumerable<Hyrax::Resource>] the new child collections and/or child works
         # @return [Enumerable<Hyrax::Resource>] updated member resources
-        def add_members(collection:, new_members:, user:)
+        def add_members(collection_id:, new_members:, user:)
           messages = []
           new_members.map do |new_member|
             begin
-              add_member(collection: collection, new_member: new_member, user: user)
+              add_member(collection_id: collection_id, new_member: new_member, user: user)
             rescue Hyrax::SingleMembershipError => err
               messages += [err.message]
             end
@@ -93,60 +93,60 @@ module Hyrax
         end
 
         # Add a work or collection as a member of a collection
-        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param collection_id [Valkyrie::ID] the id of the parent collection
         # @param new_member_id [Valkyrie::ID] the id of the new child collection or child work
         # @return [Hyrax::Resource] updated member resource
-        def add_member_by_id(collection:, new_member_id:, user:)
+        def add_member_by_id(collection_id:, new_member_id:, user:)
           new_member = Hyrax.query_service.find_by(id: new_member_id)
-          add_member(collection: collection, new_member: new_member, user: user)
+          add_member(collection_id: collection_id, new_member: new_member, user: user)
         end
 
         # Add a work or collection as a member of a collection
-        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param collection_id [Valkyrie::ID] the id of the parent collection
         # @param new_member [Hyrax::Resource] the new child collection or child work
         # @return [Hyrax::Resource] updated member resource
-        def add_member(collection:, new_member:, user:)
-          message = Hyrax::MultipleMembershipChecker.new(item: new_member).check(collection_ids: [collection.id], include_current_members: true)
+        def add_member(collection_id:, new_member:, user:)
+          message = Hyrax::MultipleMembershipChecker.new(item: new_member).check(collection_ids: [collection_id], include_current_members: true)
           raise Hyrax::SingleMembershipError, message if message.present?
-          new_member.member_of_collection_ids += [collection.id] # only populate this direction
+          new_member.member_of_collection_ids << collection_id # only populate this direction
           new_member = Hyrax.persister.save(resource: new_member)
           Hyrax.publisher.publish('object.metadata.updated', object: new_member, user: user)
           new_member
         end
 
         # Remove collections and/or works from the members set of a collection
-        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param collection_id [Valkyrie::ID] the id of the parent collection
         # @param member_ids [Enumerable<Valkyrie::ID>] the ids of the child collections and/or child works to be removed
         # @return [Enumerable<Hyrax::Resource>] updated member resources
-        def remove_members_by_ids(collection:, member_ids:, user:)
+        def remove_members_by_ids(collection_id:, member_ids:, user:)
           members = Hyrax.query_service.find_many_by_ids(ids: member_ids)
-          remove_members(collection: collection, members: members, user: user)
+          remove_members(collection_id: collection_id, members: members, user: user)
         end
 
         # Remove collections and/or works from the members set of a collection
-        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param collection_id [Valkyrie::ID] the id of the parent collection
         # @param members [Enumerable<Valkyrie::Resource>] the child collections and/or child works to be removed
         # @return [Enumerable<Hyrax::Resource>] updated member resources
-        def remove_members(collection:, members:, user:)
-          members.map { |member| remove_member(collection: collection, member: member, user: user) }
+        def remove_members(collection_id:, members:, user:)
+          members.map { |member| remove_member(collection_id: collection_id, member: member, user: user) }
         end
 
         # Remove collections and/or works from the members set of a collection
-        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param collection_id [Valkyrie::ID] the id of the parent collection
         # @param member_id [Valkyrie::ID] the id of the child collection or child work to be removed
         # @return [Hyrax::Resource] updated member resource
-        def remove_member_by_id(collection:, member_id:, user:)
+        def remove_member_by_id(collection_id:, member_id:, user:)
           member = Hyrax.query_service.find_by(id: member_id)
-          remove_member(collection: collection, member: member, user: user)
+          remove_member(collection_id: collection_id, member: member, user: user)
         end
 
         # Remove a collection or work from the members set of a collection, also removing the inverse relationship
-        # @param collection [Hyrax::PcdmCollection] the collection
+        # @param collection_id [Valkyrie::ID] the id of the parent collection
         # @param member [Hyrax::Resource] the child collection or child work to be removed
         # @return [Hyrax::Resource] updated member resource
-        def remove_member(collection:, member:, user:)
-          return member unless member?(collection: collection, member: member)
-          member.member_of_collection_ids -= [collection.id]
+        def remove_member(collection_id:, member:, user:)
+          return member unless member?(collection_id: collection_id, member: member)
+          member.member_of_collection_ids.delete(collection_id)
           member = Hyrax.persister.save(resource: member)
           Hyrax.publisher.publish('object.metadata.updated', object: member, user: user)
           member

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
       before do
         sign_in user
         if collection.is_a? Valkyrie::Resource
-          Hyrax::Collections::CollectionMemberService.add_members(collection: collection,
+          Hyrax::Collections::CollectionMemberService.add_members(collection_id: collection.id,
                                                                   new_members: [asset1, asset2, asset3, asset4, asset5],
                                                                   user: user)
         else

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ::Collection, type: :model do
       let(:work3) { valkyrie_create(:hyrax_work, title: 'Work 3') }
 
       it "allows multiple works to be added" do
-        Hyrax::Collections::CollectionMemberService.add_members(collection: collection.valkyrie_resource,
+        Hyrax::Collections::CollectionMemberService.add_members(collection_id: collection.id,
                                                                 new_members: [work1, work2],
                                                                 user: nil)
         expect(collection.reload.member_objects.map(&:id)).to match_array [work1.id.to_s, work2.id.to_s]
@@ -81,7 +81,7 @@ RSpec.describe ::Collection, type: :model do
 
         it 'fails to add the member' do
           begin
-            Hyrax::Collections::CollectionMemberService.add_members(collection: collection.valkyrie_resource,
+            Hyrax::Collections::CollectionMemberService.add_members(collection_id: collection.id,
                                                                     new_members: [work1, work2, work3],
                                                                     user: nil)
           rescue; end # rubocop:disable Lint/SuppressedException
@@ -92,11 +92,11 @@ RSpec.describe ::Collection, type: :model do
   end
 
   describe "#destroy", clean_repo: true do
-    let(:collection) { build(:collection_lw) }
+    let(:collection) { create(:collection_lw) }
     let(:work1) { valkyrie_create(:hyrax_work) }
 
     before do
-      Hyrax::Collections::CollectionMemberService.add_members(collection: collection.valkyrie_resource,
+      Hyrax::Collections::CollectionMemberService.add_members(collection_id: collection.id,
                                                               new_members: [work1],
                                                               user: nil)
       collection.destroy
@@ -117,7 +117,7 @@ RSpec.describe ::Collection, type: :model do
         include Hydra::Works::WorkBehavior
       end
 
-      Hyrax::Collections::CollectionMemberService.add_members(collection: collection.valkyrie_resource,
+      Hyrax::Collections::CollectionMemberService.add_members(collection_id: collection.id,
                                                               new_members: [member.valkyrie_resource],
                                                               user: nil)
     end

--- a/spec/models/concerns/hyrax/collection_behavior_spec.rb
+++ b/spec/models/concerns/hyrax/collection_behavior_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::CollectionBehavior, clean_repo: true do
 
   describe "#destroy" do
     it "removes the collection id from associated members" do
-      Hyrax::Collections::CollectionMemberService.add_members(collection: collection.valkyrie_resource,
+      Hyrax::Collections::CollectionMemberService.add_members(collection_id: collection.id,
                                                               new_members: [work],
                                                               user: nil)
       collection.save


### PR DESCRIPTION
Refactor: Since none of the methods in this service need the collection resource, there is no reason to require a collection resource.  It is more efficient to pass and use the collection’s id when that is all that is needed.

@samvera/hyrax-code-reviewers
