### PR TITLE
add parent collections navigator

### DIFF
--- a/app/services/hyrax/custom_queries/navigators/parent_collections_navigator.rb
+++ b/app/services/hyrax/custom_queries/navigators/parent_collections_navigator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module CustomQueries
+    module Navigators
+      ##
+      # Navigate from a resource to the parent collections of the resource.
+      #
+      # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
+      # @since 3.0.0
+      class ParentCollectionsNavigator
+        # Define the queries that can be fulfilled by this navigator.
+        def self.queries
+          [:find_parent_collections, :find_parent_collection_ids]
+        end
+
+        attr_reader :query_service
+
+        def initialize(query_service:)
+          @query_service = query_service
+        end
+
+        ##
+        # Find parent collections of a given resource, and map to Valkyrie Resources
+        #
+        # @param [Valkyrie::Resource] resource
+        #
+        # @return [Array<Valkyrie::Resource>]
+        def find_parent_collections(resource:)
+          query_service
+            .find_many_by_ids(ids: find_parent_collection_ids(resource: resource))
+        end
+
+        ##
+        # Find the ids of parent collections of a given resource, and map to Valkyrie Resources IDs
+        #
+        # @param [Valkyrie::Resource] resource
+        #
+        # @return [Array<Valkyrie::ID>]
+        def find_parent_collection_ids(resource:)
+          resource.member_of_collection_ids
+        end
+      end
+    end
+  end
+end

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -77,6 +77,7 @@ Valkyrie.config.storage_adapter = :active_fedora
 #       A refactor is needed to add the default implementations to hyrax.rb and only handle the wings specific overrides here.
 custom_queries = [Hyrax::CustomQueries::Navigators::CollectionMembers,
                   Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator,
+                  Hyrax::CustomQueries::Navigators::ParentCollectionsNavigator,
                   Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator,
                   Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
                   Hyrax::CustomQueries::Navigators::FindFiles,

--- a/spec/services/hyrax/custom_queries/navigators/parent_collections_navigator_spec.rb
+++ b/spec/services/hyrax/custom_queries/navigators/parent_collections_navigator_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::CustomQueries::Navigators::ParentCollectionsNavigator, :clean_repo do
+  let(:custom_query_service) { Hyrax.custom_queries }
+
+  let!(:collection1) do
+    FactoryBot.valkyrie_create(:hyrax_collection, id: 'col1',
+                                                  title: ['Parent Collection 1'],
+                                                  members: [collection3, work1, work2])
+  end
+  let!(:collection2) do
+    FactoryBot.valkyrie_create(:hyrax_collection, id: 'col2',
+                                                  title: ['Parent Collection 1'],
+                                                  members: [collection3, work1, work2])
+  end
+  let(:collection3) { FactoryBot.valkyrie_create(:hyrax_collection, id: 'col3', title: ['Child Collection 3']) }
+  let(:work1) { FactoryBot.valkyrie_create(:hyrax_work, id: 'wk1', title: ['Child Work 1']) }
+  let(:work2) { FactoryBot.valkyrie_create(:hyrax_work, id: 'wk2', title: ['Child Work 2']) }
+
+  describe '#find_parent_collections' do
+    it 'returns parent collections as Valkyrie resources' do
+      parent_collections = custom_query_service.find_parent_collections(resource: collection3)
+      expect(parent_collections.map(&:id)).to match_array([collection1.id, collection2.id])
+    end
+  end
+
+  describe '#find_parent_collection_ids' do
+    it 'returns Valkyrie ids for parent collections' do
+      parent_collection_ids = custom_query_service.find_parent_collection_ids(resource: work1)
+      expect(parent_collection_ids).to match_array([collection1.id, collection2.id])
+    end
+  end
+end


### PR DESCRIPTION
This follows the established navigator pattern.  It will be used as part of the process for replacing uses of ActiveFedora relationship `member_of_collections`.

@samvera/hyrax-code-reviewers
