### PR TITLE
update NestedCollectionPersistenceService to use CollectionMemberService

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -202,8 +202,10 @@ module Hyrax
       end
 
       def link_parent_collection(parent_id)
-        parent = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: parent_id, use_valkyrie: false)
-        Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent, child: @collection)
+        child = collection.respond_to?(:valkyrie_resource) ? collection.valkyrie_resource : collection
+        Hyrax::Collections::CollectionMemberService.add_member(collection_id: parent_id,
+                                                               new_member: child,
+                                                               user: current_user)
       end
 
       def uploaded_files(uploaded_file_ids)

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -32,7 +32,7 @@ module Hyrax
 
         def save
           return false unless valid?
-          persistence_service.persist_nested_collection_for(parent: parent, child: child)
+          persistence_service.persist_nested_collection_for(parent: parent, child: child, user: context.current_user)
         end
 
         ##
@@ -83,7 +83,7 @@ module Hyrax
 
         def remove
           if context.can? :edit, parent
-            persistence_service.remove_nested_relationship_for(parent: parent, child: child)
+            persistence_service.remove_nested_relationship_for(parent: parent, child: child, user: context.current_user)
           else
             errors.add(:parent, :cannot_remove_relationship)
             false

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
             collection: collection_attrs, parent_id: parent_collection.id
           }
         end.to change { Collection.count }.by(1)
-        expect(assigns[:collection].member_of_collections).to eq [parent_collection]
+        expect(assigns[:collection].reload.member_of_collections).to eq [parent_collection]
       end
     end
 

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
   end
 
   let(:child)                { FactoryBot.create(:collection) }
-  let(:context)              { double('Context') }
+  let(:context)              { double('Context', current_user: user) }
   let(:nesting_depth_result) { true }
   let(:parent)               { FactoryBot.create(:collection) }
+  let(:user)                 { create(:user) }
 
   let(:persistence_service) do
     double(Hyrax::Collections::NestedCollectionPersistenceService,
@@ -91,7 +92,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
       it "returns the result of the given persistence_service's call to persist_nested_collection_for" do
         expect(persistence_service)
           .to receive(:persist_nested_collection_for)
-          .with(parent: parent, child: child)
+          .with(parent: parent, child: child, user: user)
           .and_return(:persisted)
 
         expect(form.save).to eq :persisted
@@ -173,7 +174,10 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
       end
 
       it "returns the result of the given persistence_service's call to remove_nested_relationship_for" do
-        expect(persistence_service).to receive(:remove_nested_relationship_for).with(parent: parent, child: child).and_return(:persisted)
+        expect(persistence_service)
+          .to receive(:remove_nested_relationship_for)
+          .with(parent: parent, child: child, user: user)
+          .and_return(:persisted)
 
         expect(form.remove).to eq :persisted
       end

--- a/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_persistence_service_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Collections::NestedCollectionPersistenceService, with_nested_reindexing: true do
-  let(:parent) { build(:collection_lw) }
-  let(:child) { create(:collection) }
+  let(:parent) { FactoryBot.valkyrie_create(:hyrax_collection) }
+  let(:child) { FactoryBot.valkyrie_create(:hyrax_collection) }
 
   describe '.persist_nested_collection_for' do
     subject { described_class.persist_nested_collection_for(parent: parent, child: child) }
 
     it 'creates the relationship between parent and child' do
       subject
-      expect(parent.member_objects).to eq([child])
-      expect(child.member_of_collections).to eq([parent])
+      expect(Hyrax.custom_queries.find_parent_collection_ids(resource: child)).to eq [parent.id]
+      expect(Hyrax.custom_queries.find_child_collection_ids(resource: parent)).to eq [child.id]
     end
   end
 
@@ -22,8 +22,8 @@ RSpec.describe Hyrax::Collections::NestedCollectionPersistenceService, with_nest
 
     it 'removes the relationship between parent and child' do
       subject
-      expect(parent.member_objects).to eq([])
-      expect(child.member_of_collections).to eq([])
+      expect(Hyrax.custom_queries.find_parent_collection_ids(resource: child)).to eq []
+      expect(Hyrax.custom_queries.find_child_collection_ids(resource: parent)).to eq []
     end
   end
 end


### PR DESCRIPTION
Since CollectionMemberService publishes `'object.metadata.updated'` and message published wants to attribute the action to a user, the persistence service methods added a `user:` parameter which defaults to nil for backwards compatibility.  Callers of these methods within Hyrax code were updated to pass a user or updated to call CollectionmemberService directly to avoid having to create an instance of the parent collection.

Partially addresses #5071

@samvera/hyrax-code-reviewers
