### PR TITLE
provide NullUser for use when real user is not available

### DIFF
--- a/app/models/hyrax/null_user.rb
+++ b/app/models/hyrax/null_user.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module Hyrax
+  #
+  # This class supports passing a user or providing a default user when the currently
+  # logged in user is not available.  When adding the `user:` parameter to an existing
+  # method, the `Hyrax::NullUser` can be used as a default value to maintain backward
+  # compatibility. Whenever possible, calling methods should be updated to pass the
+  # real user through from a place where the user was available.
+  #
+  # Example:
+  # `Hyrax::Collections::NestedCollectionPersistenceService` methods use `Hyrax::NullUser.new`
+  # as the default for the `user:` parameter. `Hyrax::Forms::Dashboard::NestCollectionForm #save`
+  # method passes the current user to the service's `#persist_nested_collection_for` method.
+  # All callers of all methods in this service in Hyrax code pass in the real user.  Use
+  # of the `Hyrax::NullUser.new` provides backward compatibility for customizations.
+  #
+  class NullUser < ::User
+    ##
+    # @return [nil]
+    def id
+      '_NULL_USER_ID_'
+    end
+
+    ##
+    # @return [nil]
+    def user_key
+      nil
+    end
+  end
+end

--- a/app/services/hyrax/collections/nested_collection_persistence_service.rb
+++ b/app/services/hyrax/collections/nested_collection_persistence_service.rb
@@ -13,7 +13,7 @@ module Hyrax
       # @note There is odd permission arrangement based on the NestedCollectionQueryService:
       #       You can nest the child within a parent if you can edit the parent and read the child.
       #       See https://wiki.lyrasis.org/display/samvera/Samvera+Tech+Call+2017-08-23 for tech discussion.
-      def self.persist_nested_collection_for(parent:, child:, user: nil)
+      def self.persist_nested_collection_for(parent:, child:, user: Hyrax::NullUser.new)
         child_resource = child.respond_to?(:valkyrie_resource) ? child.valkyrie_resource : child
         Hyrax::Collections::CollectionMemberService.add_member(collection_id: parent.id, new_member: child_resource, user: user)
       end
@@ -21,7 +21,7 @@ module Hyrax
       # @param parent [Hyrax::PcdmCollection | ::Collection]
       # @param child [Hyrax::PcdmCollection | ::Collection]
       # @param user [::User] current logged in user (defaults=nil for backward compatibility)
-      def self.remove_nested_relationship_for(parent:, child:, user: nil)
+      def self.remove_nested_relationship_for(parent:, child:, user: Hyrax::NullUser.new)
         child_resource = child.respond_to?(:valkyrie_resource) ? child.valkyrie_resource : child
         Hyrax::Collections::CollectionMemberService.remove_member(collection_id: parent.id, member: child_resource, user: user)
         true

--- a/spec/models/hyrax/null_user_spec.rb
+++ b/spec/models/hyrax/null_user_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::NullUser do
+  subject(:null_user) { described_class.new }
+
+  describe '#id' do
+    it 'returns fake id' do
+      expect(subject.id).to eq '_NULL_USER_ID_'
+    end
+  end
+
+  describe '#user_key' do
+    it 'returns nil' do
+      expect(subject.user_key).to eq nil
+    end
+  end
+end


### PR DESCRIPTION
Primary usage is to provide backward compatibility for methods adding a `user:` parameter.  Whenever possible, a real user should be passed to methods with `user: NullUser.new` parameter.

Updates usage of `user: nil` added in PR #5076 

@samvera/hyrax-code-reviewers
