### PR TITLE
Add :environment to rake tasks that are missing it

### DIFF
--- a/lib/tasks/collection_type_global_id.rake
+++ b/lib/tasks/collection_type_global_id.rake
@@ -2,7 +2,7 @@
 namespace :hyrax do
   namespace :collections do
     desc 'Update CollectionType global id references for Hyrax 3.0.0'
-    task :update_collection_type_global_ids do
+    task update_collection_type_global_ids: :environment do
       puts 'Updating collection -> collection type GlobalId references.'
 
       count = 0

--- a/lib/tasks/regenerate_derivatives.rake
+++ b/lib/tasks/regenerate_derivatives.rake
@@ -3,7 +3,7 @@
 namespace :hyrax do
   namespace :file_sets do
     desc 'Regenerate derivatives for all FileSets in the repository'
-    task :regenerate_derivatives do
+    task regenerate_derivatives: :environment do
       FileSet.all.each do |fs|
         fs.files.each { |fi| CreateDerivativesJob.perform_later(fs, fi) }
       end


### PR DESCRIPTION
Rake tasks should include `:environment` in the line naming the task.  Otherwise, `Undefined constant` errors occur when referencing classes defined under `app`.

This was reported in Slack as a bug in rake task `collection_type_global_id.rake` in a release 3.0.2 install.  I checked all other tasks and found it missing in only one other.  Rake task `regenerate_derivatirves.rake` is also repaired in this PR.

@samvera/hyrax-code-reviewers
