### PR TITLE
move view dependency on `Collection#collection_type` to a helper

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -120,6 +120,24 @@ module Hyrax
       single_item_action_form_fields(form, document, 'remove')
     end
 
+    ##
+    # @param [Object] collection
+    def collection_type_label_for(collection:)
+      case collection
+      when Valkyrie::Resource
+        CollectionType
+          .find_by_gid!(collection.collection_type_gid)
+          .title
+      else
+        collection.collection_type.title
+      end
+    end
+
+    ##
+    # @note this helper is primarily intended for use with blacklight facet
+    #   fields. it assumes we index a `collection_type_gid` and the helper
+    #   can be passed as as a `helper_method:` to `add_facet_field`.
+    #
     # @param collection_type_gid [String] The gid of the CollectionType to be looked up
     # @return [String] The CollectionType's title if found, else the gid
     def collection_type_label(collection_type_gid)

--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  module CollectionsHelper
+  module CollectionsHelper # rubocop:disable Metrics/ModuleLength
     ##
     # @since 3.1.0
     # @return [Array<SolrDocument>]
@@ -121,7 +121,7 @@ module Hyrax
     end
 
     ##
-    # @param [Object] collection
+    # @param collection [Object]
     def collection_type_label_for(collection:)
       case collection
       when Valkyrie::Resource
@@ -130,6 +130,51 @@ module Hyrax
           .title
       else
         collection.collection_type.title
+      end
+    end
+
+    ##
+    # @param collection [Object]
+    #
+    # @return [Boolean]
+    def collection_brandable?(collection:)
+      case collection
+      when Valkyrie::Resource
+        CollectionType
+          .find_by_gid!(collection.collection_type_gid)
+          .brandable?
+      else
+        collection.try(:brandable?)
+      end
+    end
+
+    ##
+    # @param collection [Object]
+    #
+    # @return [Boolean]
+    def collection_discoverable?(collection:)
+      case collection
+      when Valkyrie::Resource
+        CollectionType
+          .find_by_gid!(collection.collection_type_gid)
+          .discoverable?
+      else
+        collection.try(:discoverable?)
+      end
+    end
+
+    ##
+    # @param collection [Object]
+    #
+    # @return [Boolean]
+    def collection_sharable?(collection:)
+      case collection
+      when Valkyrie::Resource
+        CollectionType
+          .find_by_gid!(collection.collection_type_gid)
+          .sharable?
+      else
+        collection.try(:sharable?)
       end
     end
 
@@ -153,4 +198,4 @@ module Hyrax
       render 'hyrax/dashboard/collections/single_item_action_fields', form: form, document: document, action: action
     end
   end
-end
+end # rubocop:enable Metrics/ModuleLength

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -5,17 +5,17 @@
       <a href="#description" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.description') %></a>
     </li>
     <% if @form.persisted? %>
-      <% if @collection.brandable? %>
+      <% if collection_brandable?(collection: @collection) %>
       <li>
         <a href="#branding" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.branding') %></a>
       </li>
       <% end %>
-      <% if @collection.discoverable? %>
+      <% if collection_discoverable?(collection: @collection) %>
       <li>
         <a href="#discovery" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.discovery') %></a>
       </li>
       <% end %>
-      <% if @collection.sharable? %>
+      <% if collection_sharable?(collection: @collection) %>
       <li>
         <a href="#sharing" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t('.tabs.sharing') %></a>
       </li>

--- a/app/views/hyrax/dashboard/collections/edit.html.erb
+++ b/app/views/hyrax/dashboard/collections/edit.html.erb
@@ -1,7 +1,9 @@
-<% provide :page_title, construct_page_title( t('.header', type_title: @collection.collection_type.title, title: @form.title.first) ) %>
+<% type_title = collection_type_label_for(collection: @collection) %>
+
+<% provide :page_title, construct_page_title( t('.header', type_title: type_title, title: @form.title.first) ) %>
 
 <% provide :page_header do %>
-  <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t('.header', type_title: @collection.collection_type.title, title: @form.title.first) %></h1>
+  <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t('.header', type_title: type_title, title: @form.title.first) %></h1>
 <% end %>
 
 <div class="row">

--- a/app/views/hyrax/dashboard/collections/new.html.erb
+++ b/app/views/hyrax/dashboard/collections/new.html.erb
@@ -1,6 +1,8 @@
-<% provide :page_title, construct_page_title( t('.header', type_title: @collection.collection_type.title) ) %>
+<% type_title = collection_type_label_for(collection: @collection) %>
+
+<% provide :page_title, construct_page_title( t('.header', type_title: type_title)) %>
 <% provide :page_header do %>
-  <h1><span class="fa fa-edit" aria-hidden="true"></span> <%= t('.header', type_title: @collection.collection_type.title) %> </h1>
+  <h1><span class="fa fa-edit" aria-hidden="true"></span> <%= t('.header', type_title: type_title) %> </h1>
 <% end %>
 
 <div class="row">


### PR DESCRIPTION
extracts the dependency on `Collection#collection_type` to a helper, and
provides an alternate implementation for Valkyrie resources.

the older view relies on some specific knowledge about `collection_type`'s
implementation and caching behavior. the newer version offloads this to the
helper.

@samvera/hyrax-code-reviewers
