### PR TITLE
bump alpine linux to 3.14 to fix imagemagick pyramidal tiffs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,21 +189,21 @@ workflows:
           hyrax_valkyrie: "true"
           requires:
             - build
-  ruby2-7-2:
+  ruby2-7-4:
     jobs:
       - bundle:
-          ruby_version: "2.7.2"
+          ruby_version: "2.7.4"
           rails_version: "5.2.6"
           bundler_version: "2.1.4"
       - build:
-          ruby_version: "2.7.2"
+          ruby_version: "2.7.4"
           rails_version: "5.2.6"
           bundler_version: "2.1.4"
           requires:
             - bundle
       - test:
-          name: "ruby2-7-2"
-          ruby_version: "2.7.2"
+          name: "ruby2-7-4"
+          ruby_version: "2.7.4"
           bundler_version: "2.1.4"
           requires:
             - build

--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -8,7 +8,7 @@ else
 end
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
+ruby '2.7.4'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.4', '>= 5.2.4.4'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-ARG RUBY_VERSION=2.7.2
-# lock at alpine3.12 because 3.13 has dns resolver problems
-FROM ruby:$RUBY_VERSION-alpine3.12 as hyrax-base
+ARG RUBY_VERSION=2.7.4
+FROM ruby:$RUBY_VERSION-alpine3.14 as hyrax-base
 
 ARG DATABASE_APK_PACKAGE="postgresql-dev"
 ARG EXTRA_APK_PACKAGES="git"

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -165,6 +165,8 @@ module Hyrax
         elsif file_set.import_url.present?
           # This path is taken when file is a Tempfile (e.g. from ImportUrlJob)
           File.basename(Addressable::URI.unencode(file.file_url))
+        elsif file.respond_to?(:original_filename) # e.g. Rack::Test::UploadedFile
+          file.original_filename
         else
           File.basename(file)
         end


### PR DESCRIPTION
Some tiffs thumbnails are broken in the version of ImageMagick that Alpine 3.12 ships with.  Updating here and picking up the latest Ruby patch version seems like a win.

@samvera/hyrax-code-reviewers
