### PR TITLE
Backport "check FlipFlop for caching manifest configuration at runtime"

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -10,11 +10,12 @@ module Hyrax
       with_themed_layout :decide_layout
       copy_blacklight_config_from(::CatalogController)
 
-      class_attribute :_curation_concern_type, :show_presenter, :work_form_service, :search_builder_class, :iiif_manifest_builder
+      class_attribute :_curation_concern_type, :show_presenter, :work_form_service, :search_builder_class
+      class_attribute :iiif_manifest_builder, instance_accessor: false
       self.show_presenter = Hyrax::WorkShowPresenter
       self.work_form_service = Hyrax::WorkFormService
       self.search_builder_class = WorkSearchBuilder
-      self.iiif_manifest_builder = (Flipflop.cache_work_iiif_manifest? ? Hyrax::CachingIiifManifestBuilder.new : Hyrax::ManifestBuilderService.new)
+      self.iiif_manifest_builder = nil
       attr_accessor :curation_concern
       helper_method :curation_concern, :contextual_path
 
@@ -140,7 +141,8 @@ module Hyrax
     private
 
       def iiif_manifest_builder
-        self.class.iiif_manifest_builder
+        self.class.iiif_manifest_builder ||
+          (Flipflop.cache_work_iiif_manifest? ? Hyrax::CachingIiifManifestBuilder.new : Hyrax::ManifestBuilderService.new)
       end
 
       def iiif_manifest_presenter


### PR DESCRIPTION
See https://github.com/samvera/hyrax/commit/88aebb3321ac905d02fb838d191dcf733f2c67cb 

Backporting to v2.9.4 version for patch version release

Quote from that commit:
### check FlipFlop for caching manifest configuration at runtime
checking FlipFlop at app startup can be problematic if the database isn't
present. it also causes issues if this configuration gets flipped while the app
is running (the normal use case for FlipFlop).

probably this whole configuration should be deprecated in favor of an
environment flag.