### PR TITLE
prepare release 2.9.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The Samvera community is here to help. Please see our [support guide](./.github/
 # Getting started
 
 This document contains instructions specific to setting up an app with __Hyrax
-v2.5.0__. If you are looking for instructions on installing a different
+v2.9.6__. If you are looking for instructions on installing a different
 version, be sure to select the appropriate branch or tag from the drop-down
 menu above.
 
@@ -158,7 +158,7 @@ NOTE: The steps need to be done in order to create a new Hyrax based app.
 Generate a new Rails application using the template.
 
 ```
-rails _5.2.6_ new my_app -m https://raw.githubusercontent.com/samvera/hyrax/v2.9.5/template.rb
+rails _5.2.6_ new my_app -m https://raw.githubusercontent.com/samvera/hyrax/v2.9.6/template.rb
 ```
 
 Generating a new Rails application using Hyrax's template above takes cares of a number of steps for you, including:

--- a/lib/hyrax/version.rb
+++ b/lib/hyrax/version.rb
@@ -1,3 +1,3 @@
 module Hyrax
-  VERSION = '2.9.5'.freeze
+  VERSION = '2.9.6'.freeze
 end

--- a/template.rb
+++ b/template.rb
@@ -1,6 +1,6 @@
 # Hack for https://github.com/rails/rails/issues/35153
 gsub_file 'Gemfile', /^gem ["']sqlite3["']$/, 'gem "sqlite3", "~> 1.3.0"'
-gem 'hyrax', '2.9.5'
+gem 'hyrax', '2.9.6'
 run 'bundle install'
 generate 'hyrax:install', '-f'
 rails_command 'db:migrate'


### PR DESCRIPTION
Prepare v2.9.6 release against 2.x-stable branch, proposed release text below

```
Bug Fixes:
--------------
  - Allow all ActiveFedora 12.x releases (#4959)
  - Skip blacklight generating solr config because active-fedora handles it (#4959)
  - Use new solr conf location in CI (#4959)
  - Add missing require (#4959 )
  - Check FlipFlop for caching manifest configuration at runtime (#5095; backports #4718)
```