### PR TITLE
remove call to deprecated method

### DIFF
--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -36,9 +36,7 @@ module Hyrax
 
     def index
       @user = current_user
-      Deprecation.silence(Hyrax::MyController) do
-        (@response, @document_list) = query_solr
-      end
+      (@response, @document_list) = search_service.search_results
       prepare_instance_variables_for_batch_control_display
 
       respond_to do |format|

--- a/app/views/hyrax/dashboard/collections/_collection_title.html.erb
+++ b/app/views/hyrax/dashboard/collections/_collection_title.html.erb
@@ -3,7 +3,7 @@
 <section class="collection-title-row-wrapper"
   data-source="my"
   data-id="<%= id %>"
-  data-colls-hash="<%= presenter.available_parent_collections(scope: controller) %>"
+  data-colls-hash="<%= available_parent_collections_data(collection: presenter) %>"
   data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
   data-post-delete-url="<%= hyrax.dashboard_collection_path(id) %>">
 


### PR DESCRIPTION
`#available_parent_collections` was deprecated in 0c0b08e0, but remained in this
view. use the helper implementation of this method.

@samvera/hyrax-code-reviewers
