### PR TITLE
do not adjust routing if name is already ‘Collection’

### DIFF
--- a/lib/hyrax/collection_name.rb
+++ b/lib/hyrax/collection_name.rb
@@ -7,7 +7,7 @@ module Hyrax
   class CollectionName < Name
     def initialize(klass, namespace = nil, name = nil)
       super
-
+      return if @name == 'Collection'
       @route_key          = Collection.model_name.route_key
       @singular_route_key = Collection.model_name.singular_route_key
     end


### PR DESCRIPTION
Without the check for `@name == 'Collection'`, a resource named `Collection` will enter an infinite loop as `Hyrax::CollectionName` attempts to update routes..

@samvera/hyrax-code-reviewers
