### PR TITLE
sipity: add debug-level logging to #Entity

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -2,6 +2,10 @@ Security/MarshalLoad:
   Exclude:
     - 'app/models/concerns/hyrax/user.rb'
 
+Metrics/AbcSize:
+  Exclude:
+    - 'app/models/sipity.rb'
+
 Metrics/ClassLength:
   Exclude:
     - 'app/controllers/hyrax/dashboard/collections_controller.rb'

--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -2,10 +2,6 @@ Security/MarshalLoad:
   Exclude:
     - 'app/models/concerns/hyrax/user.rb'
 
-Metrics/AbcSize:
-  Exclude:
-    - 'app/models/sipity.rb'
-
 Metrics/ClassLength:
   Exclude:
     - 'app/controllers/hyrax/dashboard/collections_controller.rb'

--- a/app/models/sipity.rb
+++ b/app/models/sipity.rb
@@ -56,7 +56,7 @@ module Sipity
   #
   # @return [Sipity::Entity]
   # rubocop:disable Naming/MethodName, Metrics/CyclomaticComplexity, Metrics/MethodLength
-  def Entity(input, &block)
+  def Entity(input, &block) # rubocop:disable Metrics/AbcSize
     Rails.logger.debug("Trying to make an Entity for #{input.inspect}")
 
     result = case input
@@ -86,7 +86,7 @@ module Sipity
     handle_conversion(input, result, :to_sipity_entity, &block)
   rescue URI::GID::MissingModelIdError
     Entity(nil)
-  end
+  end # rubocop:enable Metrics/AbcSize
   module_function :Entity
   # rubocop:enable Naming/MethodName, Metrics/CyclomaticComplexity, Metrics/MethodLength
 


### PR DESCRIPTION
Because it's a recursive method, debugging entity creation can be difficult.
This helps trace the method flow when it's not clear how the input is being
transformed during the iterations.

@samvera/hyrax-code-reviewers
