### PR TITLE
remove `Collection` dependency from `Hyrax::CollectionName`

### DIFF
--- a/lib/hyrax/collection_name.rb
+++ b/lib/hyrax/collection_name.rb
@@ -8,8 +8,9 @@ module Hyrax
     def initialize(klass, namespace = nil, name = nil)
       super
 
-      @route_key          = Collection.model_name.route_key
-      @singular_route_key = Collection.model_name.singular_route_key
+      @human              = 'Collection'
+      @route_key          = 'collections'
+      @singular_route_key = 'collection'
     end
   end
 end


### PR DESCRIPTION
this class is intended to provide compatibilty with `::Collection` classes for
routing. the original implementation creates a hard dependency between
`Hyrax::PcdmCollection` and `::Collection`. since our goal is to get rid of AF
and `::Collection`, we don't want that.

instead, just use the route keys we want explictly.

this is an alternative to #5104 

@samvera/hyrax-code-reviewers
