### PR TITLE
support valkyrie in WorkflowActionsController

### DIFF
--- a/app/controllers/hyrax/workflow_actions_controller.rb
+++ b/app/controllers/hyrax/workflow_actions_controller.rb
@@ -11,7 +11,7 @@ module Hyrax
       else
         respond_to do |wants|
           wants.html { render 'hyrax/base/unauthorized', status: :unauthorized }
-          wants.json { render_json_response(response_type: :unprocessable_entity, options: { errors: curation_concern.errors }) }
+          wants.json { render_json_response(response_type: :unprocessable_entity, options: { errors: workflow_action_form.errors }) }
         end
       end
     end
@@ -19,7 +19,8 @@ module Hyrax
     private
 
     def curation_concern
-      @curation_concern ||= Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id], use_valkyrie: false)
+      @curation_concern ||=
+        Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id])
     end
 
     def workflow_action_form

--- a/spec/controllers/hyrax/workflow_actions_controller_spec.rb
+++ b/spec/controllers/hyrax/workflow_actions_controller_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Hyrax::WorkflowActionsController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   let(:generic_work) { FactoryBot.create(:work) }
-  let(:form) { instance_double(described_class::DEFAULT_FORM_CLASS) }
+  let(:form) { instance_double(described_class::DEFAULT_FORM_CLASS, errors: {}) }
 
   routes { Rails.application.routes }
 

--- a/spec/controllers/hyrax/workflow_actions_controller_spec.rb
+++ b/spec/controllers/hyrax/workflow_actions_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::WorkflowActionsController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
-  let(:generic_work) { FactoryBot.create(:work) }
+  let(:work) { FactoryBot.valkyrie_create(:monograph) }
   let(:form) { instance_double(described_class::DEFAULT_FORM_CLASS, errors: {}) }
 
   routes { Rails.application.routes }
@@ -12,7 +12,7 @@ RSpec.describe Hyrax::WorkflowActionsController, type: :controller do
 
   describe '#update' do
     it 'will redirect to login path if user not authenticated' do
-      put :update, params: { id: generic_work.to_param, workflow_action: { name: 'advance', comment: '' } }
+      put :update, params: { id: work.to_param, workflow_action: { name: 'advance', comment: '' } }
       expect(response).to redirect_to(main_app.user_session_path)
     end
 
@@ -20,7 +20,7 @@ RSpec.describe Hyrax::WorkflowActionsController, type: :controller do
       expect(form).to receive(:save).and_return(false)
       sign_in(user)
 
-      put :update, params: { id: generic_work.to_param, workflow_action: { name: 'advance', comment: '' } }
+      put :update, params: { id: work.to_param, workflow_action: { name: 'advance', comment: '' } }
       expect(response).to be_unauthorized
     end
 
@@ -28,8 +28,8 @@ RSpec.describe Hyrax::WorkflowActionsController, type: :controller do
       expect(form).to receive(:save).and_return(true)
       sign_in(user)
 
-      put :update, params: { id: generic_work.to_param, workflow_action: { name: 'advance', comment: '' } }
-      expect(response).to redirect_to(main_app.hyrax_generic_work_path(generic_work, locale: 'en'))
+      put :update, params: { id: work.to_param, workflow_action: { name: 'advance', comment: '' } }
+      expect(response).to redirect_to(main_app.hyrax_monograph_path(work, locale: 'en'))
     end
 
     context 'when responding to json' do
@@ -37,7 +37,7 @@ RSpec.describe Hyrax::WorkflowActionsController, type: :controller do
         expect(form).to receive(:save).and_return(true)
         sign_in(user)
 
-        put :update, params: { id: generic_work.to_param, workflow_action: { name: 'advance', comment: '' } }, format: :json
+        put :update, params: { id: work.to_param, workflow_action: { name: 'advance', comment: '' } }, format: :json
         expect(response.status).to eq 200
       end
 
@@ -45,7 +45,7 @@ RSpec.describe Hyrax::WorkflowActionsController, type: :controller do
         expect(form).to receive(:save).and_return(false)
         sign_in(user)
 
-        put :update, params: { id: generic_work.to_param, workflow_action: { name: 'advance', comment: '' } }, format: :json
+        put :update, params: { id: work.to_param, workflow_action: { name: 'advance', comment: '' } }, format: :json
         expect(response.status).to eq 422
       end
     end


### PR DESCRIPTION
allows `WorkflowActionsController` to use any Valkyrie adapter.

the main collaborator is a Form object (`WorkflowActionForm`) implemented as an
`ActiveModel::Validations`. this object already supports and is tested against
Valkyrie.

the only things stopping us from having Valkyrie support here is the use of the
`curation_concern.errors` method (which may have been wrong all along? the
errors are collected on the Form object, not the curation_concern). after fixing
this, removing the `use_valkyrie:` flag (which isn't adapter portable) switches
us to using valkyrie throughout.

@samvera/hyrax-code-reviewers
