### PR TITLE
refactor specs GrantReadToDepositor workflow action

### DIFF
--- a/spec/services/hyrax/workflow/grant_read_to_depositor_spec.rb
+++ b/spec/services/hyrax/workflow/grant_read_to_depositor_spec.rb
@@ -2,47 +2,46 @@
 require 'hyrax/specs/shared_specs'
 
 RSpec.describe Hyrax::Workflow::GrantReadToDepositor do
-  let(:depositor) { create(:user) }
+  let(:depositor) { FactoryBot.create(:user) }
   let(:user) { User.new }
 
-  let(:workflow_method) { described_class }
+  subject(:workflow_method) { described_class }
 
   it_behaves_like 'a Hyrax workflow method'
 
   describe ".call" do
-    subject do
-      described_class.call(target: work,
-                           comment: "A pleasant read",
-                           user: user)
-    end
-
     context "with no additional viewers" do
-      let(:work) { create(:work_without_access, depositor: depositor.user_key) }
+      let(:work) { FactoryBot.create(:work_without_access, depositor: depositor.user_key) }
 
       it "adds read access" do
-        expect { subject }.to change { work.read_users }.from([]).to([depositor.user_key])
-        expect(work).to be_valid
+        expect { workflow_method.call(target: work, comment: "A pleasant read", user: user) }
+          .to change { work.read_users }
+          .from(be_empty)
+          .to contain_exactly(depositor.user_key)
       end
     end
 
     context "with an additional viewers" do
-      let(:viewer) { create(:user) }
-      let(:work) { create(:work_without_access, depositor: depositor.user_key, read_users: [viewer.user_key]) }
+      let(:viewer) { FactoryBot.create(:user) }
+      let(:work) { FactoryBot.create(:work_without_access, depositor: depositor.user_key, read_users: [viewer.user_key]) }
 
       it "adds read access" do
-        expect { subject }.to change { work.read_users }.from([viewer.user_key]).to([viewer.user_key, depositor.user_key])
-        expect(work).to be_valid
+        expect { workflow_method.call(target: work, comment: "A pleasant read", user: user) }
+          .to change { work.read_users }
+          .from(contain_exactly(viewer.user_key))
+          .to contain_exactly(viewer.user_key, depositor.user_key)
       end
     end
 
     context "with attached FileSets", perform_enqueued: [Hyrax::GrantReadToMembersJob] do
-      let(:work) { create(:work_with_one_file, user: depositor) }
+      let(:work) { FactoryBot.create(:work_with_one_file, user: depositor) }
       let(:file_set) { work.members.first }
 
       it "grants read access" do
-        # We need to reload, because this work happens in a background job
-        expect { subject }.to change { file_set.reload.read_users }.from([]).to([depositor.user_key])
-        expect(work).to be_valid
+        expect { workflow_method.call(target: work, comment: "A pleasant read", user: user) }
+          .to change { file_set.reload.read_users }
+          .from(be_empty)
+          .to contain_exactly(depositor.user_key)
       end
     end
   end


### PR DESCRIPTION
cleaning these specs up:

  - don't exercise tested code in `subject`; subject should be the object under
    test.
  - use `FactoryBot` explictly.
  - add newlines for readability.
  - use collection matchers instead of strict array equality

@samvera/hyrax-code-reviewers
