### PR TITLE
Add valkyrie support to Hyrax::Workflow::RevokeEditFromDepositor

### DIFF
--- a/app/services/hyrax/workflow/revoke_edit_from_depositor.rb
+++ b/app/services/hyrax/workflow/revoke_edit_from_depositor.rb
@@ -5,7 +5,11 @@ module Hyrax
     # removes the creators the ability to alter it.
     module RevokeEditFromDepositor
       def self.call(target:, **)
-        target.edit_users -= [target.depositor]
+        return true unless target.try(:depositor)
+        target.edit_users = target.edit_users.to_a - Array.wrap(target.depositor)
+
+        target.try(:permission_manager)&.acl&.save
+
         # If there are a lot of members, revoking access from each could take a
         # long time. Do this work in the background.
         RevokeEditFromMembersJob.perform_later(target, target.depositor)

--- a/spec/factories/hyrax_file_set.rb
+++ b/spec/factories/hyrax_file_set.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
       extracted_text     { nil }
       thumbnail          { nil }
       visibility_setting { nil }
+      edit_users         { [] }
+      edit_groups        { [] }
+      read_users         { [] }
+      read_groups        { [] }
     end
 
     after(:build) do |file_set, evaluator|
@@ -22,6 +26,11 @@ FactoryBot.define do
       file_set.original_file_id = evaluator.original_file.id if evaluator.original_file
       file_set.extracted_text_id = evaluator.extracted_text.id if evaluator.extracted_text
       file_set.thumbnail_id = evaluator.thumbnail.id if evaluator.thumbnail
+
+      file_set.permission_manager.edit_groups = evaluator.edit_groups
+      file_set.permission_manager.edit_users  = evaluator.edit_users
+      file_set.permission_manager.read_users  = evaluator.read_users
+      file_set.permission_manager.read_users  = evaluator.read_groups
     end
 
     after(:create) do |file_set, evaluator|
@@ -30,6 +39,13 @@ FactoryBot.define do
         writer.assign_access_for(visibility: evaluator.visibility_setting)
         writer.permission_manager.acl.save
       end
+
+      file_set.permission_manager.edit_groups = evaluator.edit_groups
+      file_set.permission_manager.edit_users  = evaluator.edit_users
+      file_set.permission_manager.read_users  = evaluator.read_users
+      file_set.permission_manager.read_users  = evaluator.read_groups
+
+      file_set.permission_manager.acl.save
     end
 
     trait :public do

--- a/spec/services/hyrax/workflow/revoke_edit_from_depositor_spec.rb
+++ b/spec/services/hyrax/workflow/revoke_edit_from_depositor_spec.rb
@@ -2,47 +2,58 @@
 require 'hyrax/specs/shared_specs'
 
 RSpec.describe Hyrax::Workflow::RevokeEditFromDepositor do
-  let(:depositor) { create(:user) }
+  subject(:workflow_method) { described_class }
+  let(:depositor) { FactoryBot.create(:user) }
+  let(:editors) { [depositor.user_key] }
   let(:user) { User.new }
 
-  let(:workflow_method) { described_class }
+  let(:work) do
+    FactoryBot.valkyrie_create(:monograph,
+                               depositor: depositor.user_key,
+                               edit_users: editors)
+  end
 
   it_behaves_like 'a Hyrax workflow method'
 
   describe ".call" do
-    subject do
-      described_class.call(target: work,
-                           comment: "A pleasant read",
-                           user: user)
-    end
-
     context "with no additional editors" do
-      let(:work) { create(:work_without_access, depositor: depositor.user_key, edit_users: [depositor.user_key]) }
-
       it "removes edit access" do
-        expect { subject }.to change { work.edit_users }.from([depositor.user_key]).to([])
-        expect(work).to be_valid
+        expect { described_class.call(target: work, comment: "A pleasant read", user: user) }
+          .to change { Hyrax::PermissionManager.new(resource: work).edit_users }
+          .from(contain_exactly(depositor.user_key))
+          .to be_none
       end
     end
 
     context "with an additional editor" do
-      let(:editor) { create(:user) }
-      let(:work) { create(:work_without_access, depositor: depositor.user_key, edit_users: [depositor.user_key, editor.user_key]) }
+      let(:editor) { FactoryBot.create(:user) }
+      let(:editors) { [depositor, editor].map(&:user_key) }
 
       it "removes edit access" do
-        expect { subject }.to change { work.edit_users }.from([depositor.user_key, editor.user_key]).to([editor.user_key])
-        expect(work).to be_valid
+        expect { described_class.call(target: work, comment: "A pleasant read", user: user) }
+          .to change { Hyrax::PermissionManager.new(resource: work).edit_users }
+          .from(contain_exactly(*editors))
+          .to contain_exactly(editor.user_key)
       end
     end
 
     context "with attached FileSets", perform_enqueued: [Hyrax::RevokeEditFromMembersJob] do
-      let(:work) { create(:work_with_one_file, user: depositor) }
-      let(:file_set) { work.members.first }
+      let(:work) do
+        FactoryBot.valkyrie_create(:monograph,
+                                   members: [file_set],
+                                   depositor: depositor.user_key)
+      end
+
+      let(:file_set) do
+        FactoryBot
+          .valkyrie_create(:hyrax_file_set, edit_users: [depositor.user_key])
+      end
 
       it "removes edit access" do
-        # We need to reload, because this work happens in a background job
-        expect { subject }.to change { file_set.reload.edit_users }.from([depositor.user_key]).to([])
-        expect(work).to be_valid
+        expect { described_class.call(target: work, comment: "A pleasant read", user: user) }
+          .to change { Hyrax::PermissionManager.new(resource: file_set).edit_users }
+          .from(contain_exactly(depositor.user_key))
+          .to be_none
       end
     end
   end


### PR DESCRIPTION
following the pattern in GrantEditToDepositor, add valkyrie support to
RevokeEditFromDepositor.

@samvera/hyrax-code-reviewers
