### PR TITLE
use correct/configured user_key in Workflow::DepositedNotification

### DIFF
--- a/app/services/hyrax/workflow/abstract_notification.rb
+++ b/app/services/hyrax/workflow/abstract_notification.rb
@@ -39,9 +39,9 @@ module Hyrax
       # @option recipients [Array<Hyrax::User>] :to a list of users to which to send the notification
       # @option recipients [Array<Hyrax::User>] :cc a list of users to which to copy on the notification
       def initialize(entity, comment, user, recipients)
-        @work_id = entity.proxy_for_global_id.sub(/.*\//, '')
+        @work_id = entity.proxy_for.id
         @title = entity.proxy_for.title.first
-        @comment = comment.respond_to?(:comment) ? comment.comment.to_s : ''
+        @comment = comment&.comment.to_s
         # Convert to hash with indifferent access to allow both string and symbol keys
         @recipients = recipients.with_indifferent_access
         @user = user

--- a/app/services/hyrax/workflow/deposited_notification.rb
+++ b/app/services/hyrax/workflow/deposited_notification.rb
@@ -10,11 +10,11 @@ module Hyrax
 
       def message
         I18n.t('hyrax.notifications.workflow.deposited.message', title: title, link: (link_to work_id, document_path),
-                                                                 user: user.user_key, comment: comment)
+               user: user.user_key, comment: comment)
       end
 
       def users_to_notify
-        user_key = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: work_id).depositor
+        user_key = Hyrax.query_service.find_by(id: work_id).depositor
         super << ::User.find_by(email: user_key)
       end
     end

--- a/app/services/hyrax/workflow/deposited_notification.rb
+++ b/app/services/hyrax/workflow/deposited_notification.rb
@@ -9,13 +9,17 @@ module Hyrax
       end
 
       def message
-        I18n.t('hyrax.notifications.workflow.deposited.message', title: title, link: (link_to work_id, document_path),
-               user: user.user_key, comment: comment)
+        I18n.t('hyrax.notifications.workflow.deposited.message',
+               title: title,
+               link: (link_to work_id, document_path),
+               user: user.user_key,
+               comment: comment)
       end
 
       def users_to_notify
-        user_key = Hyrax.query_service.find_by(id: work_id).depositor
-        super << ::User.find_by(email: user_key)
+        user_key = @entity.proxy_for.depositor
+
+        super << ::User.find_by_user_key(user_key)
       end
     end
   end

--- a/spec/factories/sipity_entities.rb
+++ b/spec/factories/sipity_entities.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :sipity_entity, class: Sipity::Entity do
+    transient do
+      proxy_for { nil }
+    end
+
     proxy_for_global_id { 'gid://internal/Mock/1' }
     workflow { workflow_state.workflow }
     workflow_state
+
+    after(:build) do |entity, evaluator|
+      entity.proxy_for_global_id = Hyrax::GlobalID(evaluator.proxy_for).to_s if
+        evaluator.proxy_for
+    end
   end
 end

--- a/spec/services/hyrax/workflow/deposited_notification_spec.rb
+++ b/spec/services/hyrax/workflow/deposited_notification_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::Workflow::DepositedNotification do
   let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }
 
   describe ".send_notification" do
-    it 'sends a message to all users' do
+    it 'sends a message to all users' do # rubocop:disable RSpec/ExampleLength
       expect(approver)
         .to receive(:send_message)
         .with(anything,

--- a/spec/services/hyrax/workflow/deposited_notification_spec.rb
+++ b/spec/services/hyrax/workflow/deposited_notification_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Hyrax::Workflow::DepositedNotification do
   let(:depositor) { FactoryBot.create(:user) }
   let(:to_user) { FactoryBot.create(:user) }
   let(:cc_user) { FactoryBot.create(:user) }
-  let(:work) { FactoryBot.create(:generic_work, user: depositor) }
-  let(:entity) { FactoryBot.create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s) }
+  let(:work) { FactoryBot.create(:work, user: depositor) }
+  let(:entity) { FactoryBot.create(:sipity_entity, proxy_for: work) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
   let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }
 

--- a/spec/services/hyrax/workflow/deposited_notification_spec.rb
+++ b/spec/services/hyrax/workflow/deposited_notification_spec.rb
@@ -1,35 +1,49 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Workflow::DepositedNotification do
-  let(:approver) { create(:user) }
-  let(:depositor) { create(:user) }
-  let(:to_user) { create(:user) }
-  let(:cc_user) { create(:user) }
-  let(:work) { create(:generic_work, user: depositor) }
-  let(:entity) { create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s) }
+  let(:approver) { FactoryBot.create(:user) }
+  let(:depositor) { FactoryBot.create(:user) }
+  let(:to_user) { FactoryBot.create(:user) }
+  let(:cc_user) { FactoryBot.create(:user) }
+  let(:work) { FactoryBot.create(:generic_work, user: depositor) }
+  let(:entity) { FactoryBot.create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
   let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }
 
   describe ".send_notification" do
     it 'sends a message to all users' do
-      expect(approver).to receive(:send_message)
+      expect(approver)
+        .to receive(:send_message)
         .with(anything,
               "Test title (<a href=\"/concern/generic_works/#{work.id}\">#{work.id}</a>) " \
               "was approved by #{approver.user_key}. A pleasant read",
-              anything).exactly(3).times.and_call_original
+              anything)
+        .exactly(3)
+        .times
+        .and_call_original
 
       expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
-        .to change { depositor.mailbox.inbox.count }.by(1)
-                                                    .and change { to_user.mailbox.inbox.count }.by(1)
-                                                                                               .and change { cc_user.mailbox.inbox.count }.by(1)
+        .to change { depositor.mailbox.inbox.count }
+        .by(1)
+        .and change { to_user.mailbox.inbox.count }
+        .by(1)
+        .and change { cc_user.mailbox.inbox.count }
+        .by(1)
     end
+
     context 'without carbon-copied users' do
       let(:recipients) { { 'to' => [to_user] } }
 
       it 'sends a message to the to user(s)' do
-        expect(approver).to receive(:send_message).exactly(2).times.and_call_original
+        expect(approver)
+          .to receive(:send_message)
+          .exactly(2)
+          .times.and_call_original
+
         expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
-          .to change { depositor.mailbox.inbox.count }.by(1)
-                                                      .and change { to_user.mailbox.inbox.count }.by(1)
+          .to change { depositor.mailbox.inbox.count }
+          .by(1)
+          .and change { to_user.mailbox.inbox.count }
+          .by(1)
       end
     end
   end


### PR DESCRIPTION
we should look up the depositor based on the user key, since apps can configure
their keys.

also some refactors on specs and the abstract class.

@samvera/hyrax-code-reviewers
