### PR TITLE
add factories for invalid admin set and default admin set

### DIFF
--- a/spec/factories/administrative_sets.rb
+++ b/spec/factories/administrative_sets.rb
@@ -3,4 +3,13 @@ FactoryBot.define do
   factory :hyrax_admin_set, class: 'Hyrax::AdministrativeSet' do
     title { ['My Admin Set'] }
   end
+
+  factory :invalid_hyrax_admin_set, class: 'Hyrax::AdministrativeSet' do
+    # Title is required.  Without title, the admin set is invalid.
+  end
+
+  factory :default_hyrax_admin_set, class: 'Hyrax::AdministrativeSet' do
+    id { Hyrax::AdminSetCreateService::DEFAULT_ID }
+    title { Hyrax::AdminSetCreateService::DEFAULT_TITLE }
+  end
 end


### PR DESCRIPTION
The factories are for the valkyrie version of admin set.  They set the stage for PRs for admin set controller and admin set create service coming soon.

@samvera/hyrax-code-reviewers
