### PR TITLE
limit lifecycle deposit and metadata updated events

### DIFF
--- a/app/services/hyrax/listeners/object_lifecycle_listener.rb
+++ b/app/services/hyrax/listeners/object_lifecycle_listener.rb
@@ -14,13 +14,23 @@ module Hyrax
       ##
       # @param event [Dry::Event]
       def on_object_deposited(event)
+        return unless run_jobs(event)
         ContentDepositEventJob.perform_later(event[:object], event[:user])
       end
 
       ##
       # @param event [Dry::Event]
       def on_object_metadata_updated(event)
+        return unless run_jobs(event)
         ContentUpdateEventJob.perform_later(event[:object], event[:user])
+      end
+
+      private
+
+      def run_jobs(event)
+        # TODO: Jobs should run for all model types, but currently fails for
+        #       anything but works and file sets. Pending resolution of Issue #5085
+        event[:object].work? || event[:object].file_set?
       end
     end
   end


### PR DESCRIPTION
Issue #5085 describes a problem with polymorphic paths causing some event jobs to fail for anything but works and filesets.  For now, these jobs will be skipped for other object types.  Having this allows these messages to be published for all object types.  There are other listeners that perform other actions that do work properly for all object types and that need to be run when these messages are published.

@samvera/hyrax-code-reviewers
