### PR TITLE
use correct/configured user_key in Workflow::ChangesRequiredNotification

### DIFF
--- a/app/services/hyrax/workflow/changes_required_notification.rb
+++ b/app/services/hyrax/workflow/changes_required_notification.rb
@@ -9,14 +9,15 @@ module Hyrax
       end
 
       def message
-        I18n.t('hyrax.notifications.workflow.changes_required.message', title: title,
-                                                                        link: (link_to work_id, document_path),
-                                                                        comment: comment)
+        I18n.t('hyrax.notifications.workflow.changes_required.message',
+               title: title,
+               link: (link_to work_id, document_path),
+               comment: comment)
       end
 
       def users_to_notify
         user_key = document.depositor
-        super << ::User.find_by(email: user_key)
+        super << ::User.find_by_user_key(user_key)
       end
     end
   end

--- a/spec/services/hyrax/workflow/changes_required_notification_spec.rb
+++ b/spec/services/hyrax/workflow/changes_required_notification_spec.rb
@@ -1,35 +1,50 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Workflow::ChangesRequiredNotification do
-  let(:approver) { create(:user) }
-  let(:depositor) { create(:user) }
-  let(:to_user) { create(:user) }
-  let(:cc_user) { create(:user) }
-  let(:work) { create(:generic_work, user: depositor) }
-  let(:entity) { create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s) }
+  let(:approver) { FactoryBot.create(:user) }
+  let(:depositor) { FactoryBot.create(:user) }
+  let(:to_user) { FactoryBot.create(:user) }
+  let(:cc_user) { FactoryBot.create(:user) }
+  let(:work) { FactoryBot.create(:work, user: depositor) }
+  let(:entity) { FactoryBot.create(:sipity_entity, proxy_for_global_id: work.to_global_id) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
   let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }
 
   describe ".send_notification" do
-    it 'sends a message to all users' do
-      expect(approver).to receive(:send_message)
+    it 'sends a message to all users' do # rubocop:disable RSpec/ExampleLength
+      expect(approver)
+        .to receive(:send_message)
         .with(anything,
               "Test title (<a href=\"/concern/generic_works/#{work.id}\">#{work.id}</a>) " \
               "requires additional changes before approval.\n 'A pleasant read'",
-              anything).exactly(3).times.and_call_original
+              anything)
+        .exactly(3)
+        .times
+        .and_call_original
 
       expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
-        .to change { depositor.mailbox.inbox.count }.by(1)
-                                                    .and change { to_user.mailbox.inbox.count }.by(1)
-                                                                                               .and change { cc_user.mailbox.inbox.count }.by(1)
+        .to change { depositor.mailbox.inbox.count }
+        .by(1)
+        .and change { to_user.mailbox.inbox.count }
+        .by(1)
+        .and change { cc_user.mailbox.inbox.count }
+        .by(1)
     end
+
     context 'without carbon-copied users' do
       let(:recipients) { { 'to' => [to_user] } }
 
-      it 'sends a message to the to user(s)' do
-        expect(approver).to receive(:send_message).exactly(2).times.and_call_original
+      it 'sends a message to the to user(s)' do # rubocop:disable RSpec/ExampleLength
+        expect(approver)
+          .to receive(:send_message)
+          .exactly(2)
+          .times
+          .and_call_original
+
         expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
-          .to change { depositor.mailbox.inbox.count }.by(1)
-                                                      .and change { to_user.mailbox.inbox.count }.by(1)
+          .to change { depositor.mailbox.inbox.count }
+          .by(1)
+          .and change { to_user.mailbox.inbox.count }
+          .by(1)
       end
     end
   end


### PR DESCRIPTION
we should look up the depositor based on the user key, since apps can configure
their keys.

see also #5120 
@samvera/hyrax-code-reviewers
