### PR TITLE
use AdminSetCreateService to create default admin set

### DIFF
--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -22,8 +22,8 @@ class AdminSet < ActiveFedora::Base
   include Hyrax::HumanReadableType
   include Hyrax::HasRepresentative
 
-  DEFAULT_ID = 'admin_set/default'
-  DEFAULT_TITLE = ['Default Admin Set'].freeze
+  DEFAULT_ID = Hyrax::AdminSetCreateService::DEFAULT_ID
+  DEFAULT_TITLE = Hyrax::AdminSetCreateService::DEFAULT_TITLE
   DEFAULT_WORKFLOW_NAME = Hyrax.config.default_active_workflow_name
 
   validates_with Hyrax::HasOneTitleValidator
@@ -42,17 +42,22 @@ class AdminSet < ActiveFedora::Base
   after_destroy :destroy_permission_template
 
   def self.default_set?(id)
-    id == DEFAULT_ID
+    Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
+                     "Instead, use 'Hyrax::AdminSetCreateService.default_admin_set?(id:)'.")
+    Hyrax::AdminSetCreateService.default_admin_set?(id: id)
   end
 
   def default_set?
+    Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
+                     "Instead, use 'Hyrax::AdminSetCreateService.default_admin_set?(id:)'.")
     self.class.default_set?(id)
   end
 
   # Creates the default AdminSet and an associated PermissionTemplate with workflow
   def self.find_or_create_default_admin_set_id
-    Hyrax::AdminSetCreateService.create_default_admin_set(admin_set_id: DEFAULT_ID, title: DEFAULT_TITLE) unless exists?(DEFAULT_ID)
-    DEFAULT_ID
+    Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
+                     "Instead, use 'Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id'.")
+    Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
   end
 
   def to_s

--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -21,13 +21,12 @@ module Hyrax
 
     # AdminSet cannot be deleted if default set or non-empty
     def disable_delete?
-      AdminSet.default_set?(id) || any_items?
+      default_set? || any_items?
     end
 
     # Message to display if deletion is disabled
     def disabled_message
-      return I18n.t('hyrax.admin.admin_sets.delete.error_default_set') if AdminSet.default_set?(id)
-
+      return I18n.t('hyrax.admin.admin_sets.delete.error_default_set') if default_set?
       I18n.t('hyrax.admin.admin_sets.delete.error_not_empty') if any_items?
     end
 
@@ -62,6 +61,12 @@ module Hyrax
     def allow_batch?
       return false unless current_ability.can?(:edit, solr_document)
       !disable_delete?
+    end
+
+    private
+
+    def default_set?
+      Hyrax::AdminSetCreateService.default_admin_set?(id: id)
     end
   end
 end

--- a/app/services/hyrax/ensure_well_formed_admin_set_service.rb
+++ b/app/services/hyrax/ensure_well_formed_admin_set_service.rb
@@ -14,12 +14,12 @@ module Hyrax
     #
     # @param admin_set_id [String, nil]
     #
-    # @return [String] an admin_set_id; if you provide a "present"
+    # @return [#to_s] an admin_set_id; if you provide a "present"
     #   admin_set_id, this service will return that.
     #
-    # @see AdminSet.find_or_create_default_admin_set_id
+    # @see Hyrax::AdminSetCreateService.find_or_create_default_admin_set
     def self.call(admin_set_id: nil)
-      admin_set_id = admin_set_id.presence || AdminSet.find_or_create_default_admin_set_id
+      admin_set_id = admin_set_id.presence&.to_s || Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
       Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id)
       admin_set_id
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,7 @@ errors = Hyrax::Workflow::WorkflowImporter.load_errors
 abort("Failed to process all workflows:\n  #{errors.join('\n  ')}") unless errors.empty?
 
 puts "\n== Creating default admin set"
-admin_set_id = AdminSet.find_or_create_default_admin_set_id
+admin_set_id = Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
 
 # I have found that when I come back to a development
 # environment, that I may have an AdminSet in Fedora, but it is

--- a/lib/generators/hyrax/work/templates/feature_spec.rb.erb
+++ b/lib/generators/hyrax/work/templates/feature_spec.rb.erb
@@ -12,7 +12,7 @@ RSpec.feature 'Create a <%= class_name %>', js: false do
     let(:user) do
       User.new(user_attributes) { |u| u.save(validate: false) }
     end
-    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:admin_set_id) { Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s }
     let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
     let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
 

--- a/lib/tasks/default_admin_set.rake
+++ b/lib/tasks/default_admin_set.rake
@@ -3,24 +3,25 @@ namespace :hyrax do
   namespace :default_admin_set do
     desc "Create the Default Admin Set"
     task create: :environment do
-      id = AdminSet.find_or_create_default_admin_set_id
-      # I have found that when I come back to a development
-      # environment, that I may have an AdminSet in Fedora, but it is
-      # not indexed in Solr.  This remediates that situation by
-      # ensuring we have an indexed AdminSet
-      AdminSet.find(id).update_index
-      if Hyrax::PermissionTemplate.find_by(source_id: id)
+      id = Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id
+      if Hyrax::PermissionTemplate.find_by(source_id: id.to_s)
         puts "Successfully created default admin set"
       else
         warn "ERROR: Default admin set exists but it does not have an " \
           "associated permission template.\n\nThis may happen if you cleared your " \
-          "database but you did not clear out Fedora and Solr.\n\n" \
+          "database but you did not clear out metadata datasource (e.g. Fedora, Postgres) " \
+          "and Solr.\n\n" \
           "You could manually create the permission template in the rails console" \
           " (non-destructive):\n\n" \
-          "    Hyrax::PermissionTemplate.create!(source_id: AdminSet::DEFAULT_ID)\n\n" \
-          "OR you could start fresh by clearing Fedora and Solr (destructive):\n\n" \
+          "    Hyrax::PermissionTemplate.create!(source_id: Hyrax::AdminSetCreateService::DEFAULT_ID)\n\n" \
+          "OR you could start fresh by clearing the metadata datasource and Solr (destructive):\n\n" \
+          "  For ActiveFedora or Wings Valkryie adapter (default), use...\n" \
           "    require 'active_fedora/cleaner'\n" \
-          "    ActiveFedora::Cleaner.clean!\n\n"
+          "    ActiveFedora::Cleaner.clean!\n\n" \
+          "  For Valkyrie, use...\n" \
+          "    conn = Hyrax.index_adapter.connection\n" \
+          "    conn.delete_by_query('*:*', params: { 'softCommit' => true })\n" \
+          "    Hyrax.persister.wipe!\n"
       end
     end
   end

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     context 'with a logged in user' do
       include_context 'with a logged in user'
 
-      before { AdminSet.find_or_create_default_admin_set_id }
+      before { Hyrax::AdminSetCreateService.find_or_create_default_admin_set }
 
       it 'redirects to a new work' do
         get :create, params: { test_simple_work: { title: 'comet in moominland' } }
@@ -344,13 +344,13 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
       end
 
       it 'populates allowed admin sets' do
-        admin_set = AdminSet.find_or_create_default_admin_set_id
+        admin_set_id = Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
         FactoryBot.valkyrie_create(:hyrax_admin_set) # one without deposit access
 
         get :new
 
         expect(assigns['admin_set_options'].select_options)
-          .to contain_exactly(["Default Admin Set", admin_set, { "data-release-no-delay" => true, "data-sharing" => false }])
+          .to contain_exactly(["Default Admin Set", admin_set_id, { "data-release-no-delay" => true, "data-sharing" => false }])
       end
     end
   end
@@ -433,7 +433,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     context 'when the user has edit access' do
       include_context 'with a user with edit access'
 
-      before { AdminSet.find_or_create_default_admin_set_id }
+      before { Hyrax::AdminSetCreateService.find_or_create_default_admin_set }
 
       it 'redirects to updated work' do
         patch :update, params: { id: id, test_simple_work: { title: 'new title' } }

--- a/spec/hyrax/transactions/create_work_spec.rb
+++ b/spec/hyrax/transactions/create_work_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::Transactions::CreateWork do
 
   before do
     Hyrax::PermissionTemplate
-      .find_or_create_by(source_id: AdminSet.find_or_create_default_admin_set_id)
+      .find_or_create_by(source_id: Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s)
   end
 
   describe '#call' do
@@ -49,7 +49,7 @@ RSpec.describe Hyrax::Transactions::CreateWork do
     it 'sets the default admin set' do
       expect { transaction.call(work) }
         .to change { work.admin_set&.id }
-        .to AdminSet.find_or_create_default_admin_set_id
+        .to Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
     end
 
     it 'sets the modified time using Hyrax::TimeService' do

--- a/spec/hyrax/transactions/steps/set_default_admin_set_spec.rb
+++ b/spec/hyrax/transactions/steps/set_default_admin_set_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Hyrax::Transactions::Steps::SetDefaultAdminSet do
   let(:change_set) { Hyrax::ChangeSet.for(work) }
 
   describe '#call' do
-    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:admin_set_id) { Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s }
 
     it 'is success' do
       expect(step.call(change_set)).to be_success

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -143,19 +143,16 @@ RSpec.describe AdminSet, type: :model do
   describe ".find_or_create_default_admin_set_id" do
     subject { described_class.find_or_create_default_admin_set_id }
 
-    describe 'if it already exists' do
-      before { expect(described_class).to receive(:exists?).and_return(true) }
-      it 'returns the DEFAULT_ID without creating the admin set' do
-        expect(Hyrax::AdminSetCreateService).not_to receive(:create_default_admin_set)
-        expect(subject).to eq(described_class::DEFAULT_ID)
-      end
+    let(:default_admin_set) { build(:default_hyrax_admin_set) }
+
+    before do
+      allow(Hyrax::AdminSetCreateService).to receive(:find_or_create_default_admin_set)
+        .and_return(default_admin_set)
     end
-    describe 'if it does not already exist' do
-      before { expect(described_class).to receive(:exists?).and_return(false) }
-      it 'returns the DEFAULT_ID and creates the admin set' do
-        expect(Hyrax::AdminSetCreateService).to receive(:create_default_admin_set).with(admin_set_id: described_class::DEFAULT_ID, title: described_class::DEFAULT_TITLE)
-        expect(subject).to eq(described_class::DEFAULT_ID)
-      end
+
+    it 'gets the default admin set from the create service and returns the DEFAULT_ID' do
+      expect(Hyrax::AdminSetCreateService).to receive(:find_or_create_default_admin_set)
+      expect(subject).to eq(described_class::DEFAULT_ID)
     end
   end
 

--- a/spec/services/hyrax/ensure_well_formed_admin_set_service_spec.rb
+++ b/spec/services/hyrax/ensure_well_formed_admin_set_service_spec.rb
@@ -1,21 +1,28 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::EnsureWellFormedAdminSetService do
-  let(:default_id) { AdminSet::DEFAULT_ID }
+  let(:default_id) { Hyrax::AdminSetCreateService::DEFAULT_ID }
   describe ".call" do
     subject { described_class.call(admin_set_id: given_admin_set_id) }
     context "with admin_set_id: nil" do
       let(:given_admin_set_id) { nil }
       it 'uses the default admin set and conditionally creates the associated permission template' do
-        expect(AdminSet).to receive(:find_or_create_default_admin_set_id).and_return(default_id)
-        expect(Hyrax::PermissionTemplate).to receive(:find_or_create_by!).with(source_id: default_id)
+        expect(Hyrax::AdminSetCreateService)
+          .to receive_message_chain(:find_or_create_default_admin_set, :id) # rubocop:disable RSpec/MessageChain
+          .and_return(default_id)
+        expect(Hyrax::PermissionTemplate)
+          .to receive(:find_or_create_by!)
+          .with(source_id: default_id)
         expect(subject).to eq(default_id)
       end
     end
     context "with admin_set_id: <not nil>" do
       let(:given_admin_set_id) { 'admin_set/mine' }
       it 'uses the given admin_set_id and conditionally creates the associated permission template' do
-        expect(AdminSet).not_to receive(:find_or_create_default_admin_set_id)
-        expect(Hyrax::PermissionTemplate).to receive(:find_or_create_by!).with(source_id: given_admin_set_id)
+        expect(Hyrax::AdminSetCreateService)
+          .not_to receive(:find_or_create_default_admin_set)
+        expect(Hyrax::PermissionTemplate)
+          .to receive(:find_or_create_by!)
+          .with(source_id: given_admin_set_id)
         expect(subject).to eq(given_admin_set_id)
       end
     end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       end
 
       context 'as Admin Set member' do
-        let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+        let(:admin_set_id) { Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id }
 
         before { resource.admin_set_id = admin_set_id }
 


### PR DESCRIPTION
The process for creating the default admin set is moved from the ActiveFedora AdminSet to Hyrax::AdminSetCreateService.  All calls to the AF AdminSet method were updated to call the create service method.  This moves AdminSets one step closer to moving to the valkyrie version Hyrax::AdministrativeSets.

Additionally, the check to see if an admin set is the default was also moved to Hyrax::AdminSetCreateService.  All calls that used `AdminSet.default_set?` were updated to use the create service instead.

Deprecates methods in AdminSet:
* #default_set?
* .default_set?
* .find_or_create_default_admin_set

@samvera/hyrax-code-reviewers
