### PR TITLE
ensure we set Hyrax::Permission to Symbol

### DIFF
--- a/app/models/hyrax/permission.rb
+++ b/app/models/hyrax/permission.rb
@@ -14,6 +14,6 @@ module Hyrax
 
     attribute :access_to, Valkyrie::Types::ID
     attribute :agent,     Valkyrie::Types::String
-    attribute :mode,      Valkyrie::Types::String
+    attribute :mode,      Valkyrie::Types::Symbol
   end
 end

--- a/app/services/hyrax/permission_manager.rb
+++ b/app/services/hyrax/permission_manager.rb
@@ -143,7 +143,7 @@ module Hyrax
     def groups_for(mode:)
       Enumerator.new do |yielder|
         acl.permissions.each do |permission|
-          next unless permission.mode == mode
+          next unless permission.mode.to_sym == mode
           next unless permission.agent.starts_with?(Hyrax::Group.name_prefix)
           yielder << permission.agent.gsub(Hyrax::Group.name_prefix, '')
         end
@@ -154,7 +154,7 @@ module Hyrax
       groups = groups.map(&:to_s)
 
       acl.permissions.each do |permission|
-        next unless permission.mode == mode
+        next unless permission.mode.to_sym == mode
         next unless permission.agent.starts_with?(Hyrax::Group.name_prefix)
 
         group_name = permission.agent.gsub(Hyrax::Group.name_prefix, '')
@@ -175,7 +175,7 @@ module Hyrax
       end
 
       acl.permissions.each do |permission|
-        next unless permission.mode == mode
+        next unless permission.mode.to_sym == mode
         next if permission.agent.starts_with?(Hyrax::Group.name_prefix)
         next if users.include? permission.agent
 
@@ -189,7 +189,7 @@ module Hyrax
     def users_for(mode:)
       Enumerator.new do |yielder|
         acl.permissions.each do |permission|
-          next unless permission.mode == mode
+          next unless permission.mode.to_sym == mode
           next if permission.agent.starts_with?(Hyrax::Group.name_prefix)
           yielder << permission.agent
         end


### PR DESCRIPTION
we rely on Symbol data coming back for equality checks, especially in
Hydra::AccessControlList. the type mismatch can lead to phantom permissions for
certain adapters (where types are cast on reserialization).

the specs for this file SHOULD fail, but the Valkyrie Memory adapter doesn't do
type casting in a way that's consistent with other adapters (should it? this
seems like a problem).

since Wings has special handling for this class, this should only impact apps
on the bleeding edge that are manually disabling Wings.

@samvera/hyrax-code-reviewers
