### PR TITLE
create an initial Form object for Valkyrie collections support

### DIFF
--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Forms
+    ##
+    # @api public
+    # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
+    class PcdmCollectionForm < Valkyrie::ChangeSet
+      property :title, required: true, primary: true
+
+      property :depositor
+      property :collection_type_gid
+
+      class << self
+        def model_class
+          Hyrax::PcdmCollection
+        end
+
+        ##
+        # @return [Array<Symbol>] list of required field names as symbols
+        def required_fields
+          definitions
+            .select { |_, definition| definition[:required] }
+            .keys.map(&:to_sym)
+        end
+      end
+
+      ##
+      # @return [Array<Symbol>] terms for display 'above-the-fold', or in the most
+      #   prominent form real estate
+      def primary_terms
+        _form_field_definitions
+          .select { |_, definition| definition[:primary] }
+          .keys.map(&:to_sym)
+      end
+
+      ##
+      # @return [Array<Symbol>] terms for display 'below-the-fold'
+      def secondary_terms
+        _form_field_definitions
+          .select { |_, definition| definition[:display] && !definition[:primary] }
+          .keys.map(&:to_sym)
+      end
+
+      ##
+      # @return [Boolean] whether there are terms to display 'below-the-fold'
+      def display_additional_fields?
+        secondary_terms.any?
+      end
+
+      private
+
+      def _form_field_definitions
+        self.class.definitions
+      end
+    end
+  end
+end

--- a/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Forms::PcdmCollectionForm do
+  subject(:form)   { described_class.new(collection) }
+  let(:collection) { Hyrax::PcdmCollection.new }
+
+  describe '.required_fields' do
+    it 'lists required fields' do
+      expect(described_class.required_fields)
+        .to contain_exactly :title
+    end
+  end
+
+  describe '#primary_terms' do
+    it 'gives "title" as a primary term' do
+      expect(form.primary_terms).to contain_exactly(:title)
+    end
+  end
+end


### PR DESCRIPTION
some of this code is duplicated from `ResourceForm`, but i think there's a need
to develop this on an independant line for a while before refactoring
similiarities out.

we'll need this to read collection configuration from a `SimpleSchemaLoader`
style config.

for now, we just want something we can use to develop other collection behavior
around. the design of the form can come from pressure as we adapt the
controllers.

@samvera/hyrax-code-reviewers
