### PR TITLE
coerce `Hyrax::Permission#mode` to Symbol

### DIFF
--- a/app/models/hyrax/permission.rb
+++ b/app/models/hyrax/permission.rb
@@ -14,6 +14,6 @@ module Hyrax
 
     attribute :access_to, Valkyrie::Types::ID
     attribute :agent,     Valkyrie::Types::String
-    attribute :mode,      Valkyrie::Types::Symbol
+    attribute :mode,      Valkyrie::Types::Coercible::Symbol
   end
 end


### PR DESCRIPTION
we always want this value to be a symbol token, so coerce it using the
`dry-types` system.

@samvera/hyrax-code-reviewers
