### PR TITLE
[WIP] process collection create using Hyrax::PcdmCollection

### DIFF
--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -1,15 +1,34 @@
+##
 # frozen_string_literal: true
-
 module Hyrax
   module Forms
     ##
     # @api public
     # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
-    class PcdmCollectionForm < Valkyrie::ChangeSet
-      property :title, required: true, primary: true
+    class PcdmCollectionForm < Valkyrie::ChangeSet # rubocop:disable Metrics/ClassLength
+      include Hyrax::FormFields(:core_metadata)
+      include Hyrax::FormFields(:basic_metadata)
+      # include Hyrax::FormFields(:collection)
 
-      property :depositor
-      property :collection_type_gid
+      property :human_readable_type, writable: false
+      # property :visibility, default: VisibilityIntention::PRIVATE
+      property :date_modified, readable: false
+      property :date_uploaded, readable: false
+
+      # property :title, required: true
+      property :depositor, required: true
+      property :collection_type_gid, required: true
+
+      collection(:permissions,
+                 virtual: true,
+                 default: [],
+                 form: Hyrax::Forms::Permission,
+                 populator: :permission_populator,
+                 prepopulator: ->(_opts) { self.permissions = Hyrax::AccessControl.for(resource: model).permissions })
+
+      # pcdm relationships
+      property :member_ids, default: [], type: Valkyrie::Types::Array
+      property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 
       class << self
         def model_class
@@ -22,6 +41,10 @@ module Hyrax
           definitions
             .select { |_, definition| definition[:required] }
             .keys.map(&:to_sym)
+        end
+
+        def membership_service_class
+          Collections::CollectionMemberSearchService
         end
       end
 
@@ -48,10 +71,80 @@ module Hyrax
         secondary_terms.any?
       end
 
+      def banner_info
+        @banner_info ||= begin
+                           # Find Banner filename
+                           banner_info = CollectionBrandingInfo.where(collection_id: id, role: "banner")
+                           banner_file = File.split(banner_info.first.local_path).last unless banner_info.empty?
+                           alttext = banner_info.first.alt_text unless banner_info.empty?
+                           file_location = banner_info.first.local_path unless banner_info.empty?
+                           relative_path = "/" + banner_info.first.local_path.split("/")[-4..-1].join("/") unless banner_info.empty?
+                           { file: banner_file, full_path: file_location, relative_path: relative_path, alttext: alttext }
+                         end
+      end
+
+      def logo_info
+        @logo_info ||= begin
+                         # Find Logo filename, alttext, linktext
+                         logos_info = CollectionBrandingInfo.where(collection_id: id, role: "logo")
+
+                         logos_info.map do |logo_info|
+                           logo_file = File.split(logo_info.local_path).last
+                           relative_path = "/" + logo_info.local_path.split("/")[-4..-1].join("/")
+                           alttext = logo_info.alt_text
+                           linkurl = logo_info.target_url
+                           { file: logo_file, full_path: logo_info.local_path, relative_path: relative_path, alttext: alttext, linkurl: linkurl }
+                         end
+                       end
+      end
+
+      def list_parent_collections
+        collection.member_of_collections
+      end
+
+      def list_child_collections
+        collection_member_service.available_member_subcollections.documents
+      end
+
+      ##
+      # @deprecated this implementation requires an extra db round trip, had a
+      #   buggy cacheing mechanism, and was largely duplicative of other code.
+      #   all versions of this code are replaced by
+      #   {CollectionsHelper#available_parent_collections_data}.
+      def available_parent_collections(scope:)
+        return @available_parents if @available_parents.present?
+
+        collection = ::Collection.find(id)
+        colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: scope, limit_to_id: nil)
+        @available_parents = colls.map do |col|
+          { "id" => col.id, "title_first" => col.title.first }
+        end.to_json
+      end
+
       private
 
       def _form_field_definitions
         self.class.definitions
+      end
+
+      def all_files_with_access
+        member_presenters(member_work_ids).flat_map(&:file_set_presenters).map { |x| [x.to_s, x.id] }
+      end
+
+      # Override this method if you have a different way of getting the member's ids
+      def member_work_ids
+        response = collection_member_service.available_member_work_ids.response
+        response.fetch('docs').map { |doc| doc['id'] }
+      end
+
+      def collection_member_service
+        @collection_member_service ||= membership_service_class.new(scope: scope, collection: collection, params: blacklight_config.default_solr_params)
+      end
+
+      def member_presenters(member_ids)
+        PresenterFactory.build_for(ids: member_ids,
+                                   presenter_class: WorkShowPresenter,
+                                   presenter_args: [nil])
       end
     end
   end

--- a/app/models/concerns/hyrax/ability/collection_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_ability.rb
@@ -2,15 +2,20 @@
 module Hyrax
   module Ability
     module CollectionAbility
-      def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         if admin?
           can :manage, [::Collection, Hyrax::PcdmCollection]
-          can :manage_any, [::Collection, Hyrax::PcdmCollection]
-          can :create_any, [::Collection, Hyrax::PcdmCollection]
-          can :view_admin_show_any, [::Collection, Hyrax::PcdmCollection]
+          can :manage_any, ::Collection
+          can :manage_any, Hyrax::PcdmCollection
+          can :create_any, ::Collection
+          can :create_any, Hyrax::PcdmCollection
+          can :view_admin_show_any, ::Collection
+          can :view_admin_show_any, Hyrax::PcdmCollection
         else
-          can :manage_any, [::Collection, Hyrax::PcdmCollection] if Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
-          can :create_any, [::Collection, Hyrax::PcdmCollection] if Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
+          can :manage_any, ::Collection if Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
+          can :manage_any, Hyrax::PcdmCollection if Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
+          can :create_any, ::Collection if Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
+          can :create_any, Hyrax::PcdmCollection if Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
           can :view_admin_show_any, ::Collection if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_collection?(ability: self)
 
           can [:edit, :update, :destroy], ::Collection do |collection| # for test by solr_doc, see solr_document_ability.rb

--- a/app/models/concerns/hyrax/ability/collection_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_ability.rb
@@ -4,13 +4,13 @@ module Hyrax
     module CollectionAbility
       def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         if admin?
-          can :manage, ::Collection
-          can :manage_any, ::Collection
-          can :create_any, ::Collection
-          can :view_admin_show_any, ::Collection
+          can :manage, [::Collection, Hyrax::PcdmCollection]
+          can :manage_any, [::Collection, Hyrax::PcdmCollection]
+          can :create_any, [::Collection, Hyrax::PcdmCollection]
+          can :view_admin_show_any, [::Collection, Hyrax::PcdmCollection]
         else
-          can :manage_any, ::Collection if Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
-          can :create_any, ::Collection if Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
+          can :manage_any, [::Collection, Hyrax::PcdmCollection] if Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
+          can :create_any, [::Collection, Hyrax::PcdmCollection] if Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
           can :view_admin_show_any, ::Collection if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_collection?(ability: self)
 
           can [:edit, :update, :destroy], ::Collection do |collection| # for test by solr_doc, see solr_document_ability.rb

--- a/app/models/concerns/hyrax/ability/collection_type_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_type_ability.rb
@@ -8,7 +8,7 @@ module Hyrax
           can :create_collection_type, CollectionType
         else
           can :create_collection_of_type, CollectionType do |collection_type|
-            Hyrax::CollectionTypes::PermissionsService.can_create_collection_of_type?(user: current_user, collection_type: collection_type)
+            Hyrax::CollectionTypes::PermissionsService.can_create_collection_of_type?(ability: self, collection_type: collection_type)
           end
         end
       end

--- a/app/services/hyrax/collection_types/permissions_service.rb
+++ b/app/services/hyrax/collection_types/permissions_service.rb
@@ -159,7 +159,7 @@ module Hyrax
       #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
       def self.access_to_collection_type?(collection_type:, access:, user: nil, ability: nil) # rubocop:disable Metrics/CyclomaticComplexity
         return false unless user.present? || ability.present?
-        return false unless user && collection_type
+        return false unless collection_type
         return true if ([user_id(user, ability)] & agent_ids_for(collection_type: collection_type, agent_type: 'user', access: access)).present?
         return true if (user_groups(user, ability) & agent_ids_for(collection_type: collection_type, agent_type: 'group', access: access)).present?
         false

--- a/app/services/hyrax/collections/collection_member_service.rb
+++ b/app/services/hyrax/collections/collection_member_service.rb
@@ -110,7 +110,7 @@ module Hyrax
           raise Hyrax::SingleMembershipError, message if message.present?
           new_member.member_of_collection_ids << collection_id # only populate this direction
           new_member = Hyrax.persister.save(resource: new_member)
-          Hyrax.publisher.publish('object.metadata.updated', object: new_member, user: user)
+          publish_metadata_updated(new_member, user)
           new_member
         end
 
@@ -148,8 +148,19 @@ module Hyrax
           return member unless member?(collection_id: collection_id, member: member)
           member.member_of_collection_ids.delete(collection_id)
           member = Hyrax.persister.save(resource: member)
-          Hyrax.publisher.publish('object.metadata.updated', object: member, user: user)
+          publish_metadata_updated(member, user)
           member
+        end
+
+        private
+
+        def publish_metadata_updated(member, user)
+          case member
+          when Hyrax::PcdmCollection
+            Hyrax.publisher.publish('collection.metadata.updated', object: member, user: user)
+          else
+            Hyrax.publisher.publish('object.metadata.updated', object: member, user: user)
+          end
         end
       end
     end

--- a/app/services/hyrax/listeners/metadata_index_listener.rb
+++ b/app/services/hyrax/listeners/metadata_index_listener.rb
@@ -15,11 +15,16 @@ module Hyrax
       # Re-index the resource.
       #
       # @param event [Dry::Event]
-      def on_object_metadata_updated(event)
-        log_non_resource(event) && return unless
-          event[:object].is_a?(Valkyrie::Resource)
+      def on_collection_metadata_updated(event)
+        metadata_updated(event, :collection)
+      end
 
-        Hyrax.index_adapter.save(resource: event[:object])
+      ##
+      # Re-index the resource.
+      #
+      # @param event [Dry::Event]
+      def on_object_metadata_updated(event)
+        metadata_updated(event, :object)
       end
 
       ##
@@ -38,6 +43,13 @@ module Hyrax
       def log_non_resource(event)
         Hyrax.logger.info('Skipping object reindex because the object ' \
                           "#{event[:object]} was not a Valkyrie::Resource.")
+      end
+
+      def metadata_updated(event, idx)
+        log_non_resource(event) && return unless
+          event[idx].is_a?(Valkyrie::Resource)
+
+        Hyrax.index_adapter.save(resource: event[idx])
       end
     end
   end

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -129,5 +129,9 @@ module Hyrax
     # @since 3.0.0
     # @macro a_registered_event
     register_event('object.metadata.updated')
+
+    # @since 3.0.0
+    # @macro a_registered_event
+    register_event('collection.metadata.updated')
   end
 end

--- a/lib/hyrax/transactions/collection_create.rb
+++ b/lib/hyrax/transactions/collection_create.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/transaction'
+
+module Hyrax
+  module Transactions
+    ##
+    # Creates a Collection from a ChangeSet
+    #
+    # @since 3.0.0
+    class CollectionCreate < Transaction
+      DEFAULT_STEPS = ['change_set.set_user_as_depositor',
+                       # 'change_set.set_user_as_editor',
+                       'change_set.set_collection_type_gid',
+                       'change_set.apply',
+                       'collection_resource.apply_collection_type_permissions',
+                       'collection_resource.save_acl'].freeze
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/collection_create.rb
+++ b/lib/hyrax/transactions/collection_create.rb
@@ -9,10 +9,10 @@ module Hyrax
     # @since 3.0.0
     class CollectionCreate < Transaction
       DEFAULT_STEPS = ['change_set.set_user_as_depositor',
-                       # 'change_set.set_user_as_editor',
                        'change_set.set_collection_type_gid',
                        'change_set.apply',
                        'collection_resource.apply_collection_type_permissions',
+                       'collection_resource.set_user_as_editor',
                        'collection_resource.save_acl'].freeze
 
       ##

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -19,6 +19,7 @@ module Hyrax
     # @see https://dry-rb.org/gems/dry-container/
     class Container # rubocop:disable Metrics/ClassLength
       require 'hyrax/transactions/apply_change_set'
+      require 'hyrax/transactions/collection_create'
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/destroy_work'
       require 'hyrax/transactions/file_set_destroy'
@@ -29,11 +30,13 @@ module Hyrax
       require 'hyrax/transactions/steps/add_to_collections'
       require 'hyrax/transactions/steps/add_to_parent'
       require 'hyrax/transactions/steps/apply_collection_permission_template'
+      require 'hyrax/transactions/steps/apply_collection_type_permissions'
       require 'hyrax/transactions/steps/apply_permission_template'
       require 'hyrax/transactions/steps/apply_visibility'
       require 'hyrax/transactions/steps/delete_resource'
       require 'hyrax/transactions/steps/destroy_work'
       require 'hyrax/transactions/steps/ensure_admin_set'
+      require 'hyrax/transactions/steps/set_collection_type_gid'
       require 'hyrax/transactions/steps/ensure_permission_template'
       require 'hyrax/transactions/steps/remove_file_set_from_work'
       require 'hyrax/transactions/steps/save'
@@ -43,6 +46,7 @@ module Hyrax
       require 'hyrax/transactions/steps/set_modified_date'
       require 'hyrax/transactions/steps/set_uploaded_date_unless_present'
       require 'hyrax/transactions/steps/set_user_as_depositor'
+      require 'hyrax/transactions/steps/set_user_as_editor'
       require 'hyrax/transactions/steps/validate'
 
       extend Dry::Container::Mixin
@@ -58,12 +62,20 @@ module Hyrax
           ApplyChangeSet.new
         end
 
+        ops.register 'create_collection' do
+          CollectionCreate.new
+        end
+
         ops.register 'create_work' do
           WorkCreate.new
         end
 
         ops.register 'ensure_admin_set' do
           Steps::EnsureAdminSet.new
+        end
+
+        ops.register 'set_collection_type_gid' do
+          Steps::SetCollectionTypeGid.new
         end
 
         ops.register 'save' do
@@ -86,6 +98,10 @@ module Hyrax
           Steps::SetUserAsDepositor.new
         end
 
+        ops.register 'set_user_as_editor' do
+          Steps::SetUserAsEditor.new
+        end
+
         ops.register 'update_work' do
           UpdateWork.new
         end
@@ -106,6 +122,16 @@ module Hyrax
 
         ops.register 'remove_from_work' do
           Steps::RemoveFileSetFromWork.new
+        end
+      end
+
+      namespace 'collection_resource' do |ops| # valkyrie collection
+        ops.register 'apply_collection_type_permissions' do
+          Steps::ApplyCollectionTypePermissions.new
+        end
+
+        ops.register 'save_acl' do
+          Steps::SaveAccessControl.new
         end
       end
 

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -74,12 +74,12 @@ module Hyrax
           Steps::EnsureAdminSet.new
         end
 
-        ops.register 'set_collection_type_gid' do
-          Steps::SetCollectionTypeGid.new
-        end
-
         ops.register 'save' do
           Steps::Save.new
+        end
+
+        ops.register 'set_collection_type_gid' do
+          Steps::SetCollectionTypeGid.new
         end
 
         ops.register 'set_default_admin_set' do
@@ -96,10 +96,6 @@ module Hyrax
 
         ops.register 'set_user_as_depositor' do
           Steps::SetUserAsDepositor.new
-        end
-
-        ops.register 'set_user_as_editor' do
-          Steps::SetUserAsEditor.new
         end
 
         ops.register 'update_work' do
@@ -132,6 +128,10 @@ module Hyrax
 
         ops.register 'save_acl' do
           Steps::SaveAccessControl.new
+        end
+
+        ops.register 'set_user_as_editor' do
+          Steps::SetUserAsEditor.new
         end
       end
 

--- a/lib/hyrax/transactions/steps/apply_collection_type_permissions.rb
+++ b/lib/hyrax/transactions/steps/apply_collection_type_permissions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # A `dry-transcation` step that applies permission templates from a
+      # collection type on a given collection.
+      #
+      # @since 3.0.0
+      class ApplyCollectionTypePermissions
+        include Dry::Transaction::Operation
+
+        ##
+        # @param [Hyrax::PcdmCollection] collection with a collection type gid
+        # @param user [User] the user that created the collection
+        #
+        # @return [Dry::Monads::Result]
+        def call(collection, user: nil)
+          Hyrax::Collections::PermissionsCreateService.create_default(collection: collection,
+                                                                      creating_user: user)
+          Success(collection)
+        rescue ActiveRecord::RecordNotFound => err
+          # will be raised if the collection_type_gid isn't set or doesn't exist
+          Failure(err)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -38,8 +38,12 @@ module Hyrax
             unsaved.respond_to?(:permission_manager)
 
           user ||= ::User.find_by_user_key(saved.depositor)
-          Hyrax.publisher.publish('object.deposited', object: saved, user: user) if unsaved.new_record
-          Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
+          if saved.collection?
+            Hyrax.publisher.publish('collection.metadata.updated', collection: saved, user: user)
+          else
+            Hyrax.publisher.publish('object.deposited', object: saved, user: user) if unsaved.new_record
+            Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
+          end
 
           Success(saved)
         rescue StandardError => err

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -36,7 +36,7 @@ module Hyrax
           # we want to resync changes that we had in progress so we can persist them later.
           saved.permission_manager.acl.permissions = unsaved.permission_manager.acl.permissions if
             unsaved.respond_to?(:permission_manager)
-
+byebug
           user ||= ::User.find_by_user_key(saved.depositor)
           if saved.collection?
             Hyrax.publisher.publish('collection.metadata.updated', collection: saved, user: user)

--- a/lib/hyrax/transactions/steps/set_collection_type_gid.rb
+++ b/lib/hyrax/transactions/steps/set_collection_type_gid.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # A step that sets the `#collection_type_gid` in the change set.
+      #
+      # @since 2.4.0
+      class SetCollectionTypeGid
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Hyrax::ChangeSet] change_set
+        # @param collection_type_gid [URI::GID] global id for the collection type
+        # @return [Dry::Monads::Result] `Failure` if there is no `collection_type_gid` or
+        #   it can't be set to the default for the input; `Success(input)`, otherwise.
+        def call(change_set, collection_type_gid: default_collection_type_gid)
+          return Failure[:no_collection_type_gid, collection] unless
+            change_set.respond_to?(:collection_type_gid=)
+
+          change_set.collection_type_gid = collection_type_gid
+
+          Success(change_set)
+        end
+
+        private
+
+        def default_collection_type_gid
+          Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/set_user_as_editor.rb
+++ b/lib/hyrax/transactions/steps/set_user_as_editor.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Add a given `::User` as an `#editor` via a ChangeSet.
+      #
+      # If no user is given, simply passes as a `Success`.
+      #
+      # @since 3.0.0
+      class SetUserAsEditor
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Hyrax::ChangeSet] change_set
+        # @param [#user_key] user
+        #
+        # @return [Dry::Monads::Result]
+        def call(change_set, user: NullUser.new)
+          # TODO: This doesn't work.  Need to figure out how to set
+          #       permissions on a changeset
+          change_set.edit_users += [user.user_key] if user.user_key
+
+          Success(change_set)
+        rescue NoMethodError => err
+          Failure([err.message, change_set])
+        end
+
+        ##
+        # @api private
+        class NullUser
+          ##
+          # @return [nil]
+          def user_key
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/set_user_as_editor.rb
+++ b/lib/hyrax/transactions/steps/set_user_as_editor.rb
@@ -14,28 +14,18 @@ module Hyrax
         include Dry::Monads[:result]
 
         ##
-        # @param [Hyrax::ChangeSet] change_set
+        # @param [Hyrax::Resource] obj
         # @param [#user_key] user
         #
         # @return [Dry::Monads::Result]
-        def call(change_set, user: NullUser.new)
-          # TODO: This doesn't work.  Need to figure out how to set
-          #       permissions on a changeset
-          change_set.edit_users += [user.user_key] if user.user_key
+        def call(obj, user:)
+          # ignore empty user
+          return Success(obj) if user&.user_key.blank?
+          obj.permission_manager.edit_users += [user.user_key]
 
-          Success(change_set)
+          Success(obj)
         rescue NoMethodError => err
-          Failure([err.message, change_set])
-        end
-
-        ##
-        # @api private
-        class NullUser
-          ##
-          # @return [nil]
-          def user_key
-            nil
-          end
+          Failure([err.message, obj])
         end
       end
     end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
 
     it 'assigns @collection' do
       get :new
-      expect(assigns(:collection)).to be_kind_of(Collection)
+      expect(assigns(:collection)).to be_kind_of(Hyrax::PcdmCollection)
     end
   end
 

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -21,8 +21,14 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   let(:unowned_asset)  { create(:work, user: other) }
 
   let(:collection_attrs) do
-    { title: ['My First Collection'], description: ["The Description\r\n\r\nand more"], collection_type_gid: [collection_type_gid] }
+    {
+    title: ['My First Collection'],
+      description: ["The Description\r\n\r\nand more"],
+      collection_type_gid: [collection_type_gid]
+    }
   end
+
+  let(:listener) { Hyrax::Specs::SpyListener.new }
 
   describe '#new' do
     before { sign_in user }
@@ -36,64 +42,91 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   describe '#create' do
     before { sign_in user }
 
-    # rubocop:disable RSpec/ExampleLength
-    it "creates a Collection" do
+    it 'creates a Collection with metadata' do
       expect do
         post :create, params: {
-          collection: collection_attrs.merge(
-            visibility: 'open',
-            # TODO: Tests with old approach to sharing a collection which is deprecated and
-            # will be removed in 3.0.  New approach creates a PermissionTemplate with
-            # source_id = the collection's id.
-            permissions_attributes: [{ type: 'person',
-                                       name: 'archivist1',
-                                       access: 'edit' }]
-          )
+          collection_type_gid: collection_type_gid,
+          pcdm_collection: collection_attrs
         }
       end.to change { Collection.count }.by(1)
-      expect(assigns[:collection].visibility).to eq 'open'
-      expect(assigns[:collection].edit_users).to contain_exactly "archivist1", user.email
+      expect(assigns(:collection)).to be_kind_of(Hyrax::PcdmCollection)
+      expect(assigns[:collection].visibility).to eq 'restricted'
+      expect(assigns[:collection].depositor).to eq user.user_key
+      expect(assigns[:collection].permission_manager.edit_users).to contain_exactly user.user_key
       expect(flash[:notice]).to eq "Collection was successfully created."
     end
 
-    it "removes blank strings from params before creating Collection" do
+    it "publishes collection.metadata.updated" do
       expect do
         post :create, params: {
-          collection: collection_attrs.merge(creator: [''])
+          collection_type_gid: collection_type_gid,
+          pcdm_collection: collection_attrs
         }
-      end.to change { Collection.count }.by(1)
-      expect(assigns[:collection].title).to eq ["My First Collection"]
-      expect(assigns[:collection].creator).to eq []
+      end
+        .to change { listener.collection_metadata_updated&.payload }
+              .to match(collection: have_attributes(id: collection.id), user: user)
     end
 
-    context "with files I can access" do
-      it "creates a collection using only the accessible files" do
-        expect do
-          post :create, params: {
-            collection: collection_attrs,
-            batch_document_ids: [asset1.id, asset2.id, unowned_asset.id]
-          }
-        end.to change { Collection.count }.by(1)
-        collection = assigns(:collection)
-        expect(collection.member_objects).to match_array [asset1, asset2]
-      end
-
-      it "adds docs to the collection and adds the collection id to the documents in the collection" do
-        post :create, params: {
-          batch_document_ids: [asset1.id, unowned_asset.id],
-          collection: collection_attrs
-        }
-
-        expect(assigns[:collection].member_objects).to eq [asset1]
-        asset_results = Hyrax::SolrService.get(fq: ["id:\"#{asset1.id}\""], fl: ['id', "collection_tesim"])
-        expect(asset_results["response"]["numFound"]).to eq 1
-        doc = asset_results["response"]["docs"].first
-        expect(doc["id"]).to eq asset1.id
-      end
-    end
+    # # rubocop:disable RSpec/ExampleLength
+    # it "creates a Collection with extra settings not supported in the form" do
+    #   expect do
+    #     post :create, params: {
+    #       collection_type_gid: collection_type_gid,
+    #       pcdm_collection: collection_attrs.merge(
+    #         visibility: 'open',
+    #         # TODO: Tests with old approach to sharing a collection which is deprecated and
+    #         # will be removed in 3.0.  New approach creates a PermissionTemplate with
+    #         # source_id = the collection's id.
+    #         permissions_attributes: [{ type: 'person',
+    #                                    name: 'archivist1',
+    #                                    access: 'edit' }]
+    #       )
+    #     }
+    #   end.to change { Collection.count }.by(1)
+    #   expect(assigns[:collection].visibility).to eq 'open'
+    #   expect(assigns[:collection].edit_users).to contain_exactly "archivist1", user.email
+    #   expect(flash[:notice]).to eq "Collection was successfully created."
+    # end
+    #
+    # it "removes blank strings from params before creating Collection" do
+    #   expect do
+    #     post :create, params: {
+    #       collection: collection_attrs.merge(creator: [''])
+    #     }
+    #   end.to change { Collection.count }.by(1)
+    #   expect(assigns[:collection].title).to eq ["My First Collection"]
+    #   expect(assigns[:collection].creator).to eq []
+    # end
+    #
+    # context "with files I can access" do
+    #   it "creates a collection using only the accessible files" do
+    #     expect do
+    #       post :create, params: {
+    #         collection: collection_attrs,
+    #         batch_document_ids: [asset1.id, asset2.id, unowned_asset.id]
+    #       }
+    #     end.to change { Collection.count }.by(1)
+    #     collection = assigns(:collection)
+    #     expect(collection.member_objects).to match_array [asset1, asset2]
+    #   end
+    #
+    #   it "adds docs to the collection and adds the collection id to the documents in the collection" do
+    #     post :create, params: {
+    #       batch_document_ids: [asset1.id, unowned_asset.id],
+    #       collection: collection_attrs
+    #     }
+    #
+    #     expect(assigns[:collection].member_objects).to eq [asset1]
+    #     asset_results = Hyrax::SolrService.get(fq: ["id:\"#{asset1.id}\""], fl: ['id', "collection_tesim"])
+    #     expect(asset_results["response"]["numFound"]).to eq 1
+    #     doc = asset_results["response"]["docs"].first
+    #     expect(doc["id"]).to eq asset1.id
+    #   end
+    # end
 
     context 'when setting collection type' do
-      let(:collection_type) { create(:collection_type) }
+      let(:collection_type_gid) { create(:collection_type, creator_user: user.user_key).to_global_id.to_s }
+      let(:default_collection_type_gid) { create(:user_collection_type).to_global_id.to_s }
 
       it "creates a Collection of default type when type is nil" do
         expect do
@@ -101,17 +134,17 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
             collection: collection_attrs
           }
         end.to change { Collection.count }.by(1)
-        expect(assigns[:collection].collection_type.machine_id).to eq Hyrax::CollectionType::USER_COLLECTION_MACHINE_ID
+        expect(assigns[:collection].collection_type_gid).to eq default_collection_type_gid
       end
 
       it "creates a Collection of specified type" do
         expect do
           post :create, params: {
-            collection: collection_attrs, collection_type_gid: collection_type.to_global_id.to_s
+            collection: collection_attrs, collection_type_gid: collection_type_gid
           }
         end.to change { Collection.count }.by(1)
 
-        expect(assigns[:collection].collection_type_gid).to eq collection_type.to_global_id.to_s
+        expect(assigns[:collection].collection_type_gid).to eq collection_type_gid
       end
     end
 
@@ -125,17 +158,19 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
             collection: collection_attrs, parent_id: parent_collection.id
           }
         end.to change { Collection.count }.by(1)
-        expect(assigns[:collection].reload.member_of_collections).to eq [parent_collection]
+        expect(assigns[:collection].member_of_collection_ids).to eq [parent_collection.id]
       end
     end
 
     context "when create fails" do
-      let(:collection) { Collection.new }
+      # let(:collection) { Hyrax::PcdmCollection.new }
+      let(:collection) { build(:hyrax_collection) }
+      let(:persister) { Hyrax.persister }
 
       before do
         allow(controller).to receive(:authorize!)
-        allow(Collection).to receive(:new).and_return(collection)
-        allow(collection).to receive(:save).and_return(false)
+        allow(Hyrax::PcdmCollection).to receive(:new).and_return(collection)
+        allow(persister).to receive(:save).with(resource: collection).and_raise(Exception, 'Bad Collection')
       end
 
       it "renders the form again" do
@@ -147,7 +182,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   end
 
   describe "#update" do
-    let(:listener) { Hyrax::Specs::SpyListener.new }
 
     before do
       Hyrax.publisher.subscribe(listener)

--- a/spec/services/hyrax/collections/collection_member_service_spec.rb
+++ b/spec/services/hyrax/collections/collection_member_service_spec.rb
@@ -160,10 +160,22 @@ RSpec.describe Hyrax::Collections::CollectionMemberService, clean_repo: true do
         it "updates the collection member set adding the new member" do
           expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids + [new_member.id]
         end
-        it "publishes metadata updated event for member" do
+        it "publishes object metadata updated event for work member" do
           updated_work = described_class.add_member(collection_id: collection.id, new_member: new_member, user: user)
           expect(listener.object_metadata_updated&.payload)
             .to eq object: updated_work, user: user
+        end
+      end
+      context 'and the new member is a collection' do
+        let(:child_collection) { FactoryBot.valkyrie_create(:hyrax_collection) }
+        let(:new_member) { child_collection }
+        it "updates the collection member set adding the child collection" do
+          expect(custom_query_service.find_members_of(collection: collection).map(&:id)).to match_array existing_member_ids + [new_member.id]
+        end
+        it "publishes collection metadata updated event for collection member" do
+          updated_collection = described_class.add_member(collection_id: collection.id, new_member: new_member, user: user)
+          expect(listener.collection_metadata_updated&.payload)
+            .to eq collection: updated_collection, user: user
         end
       end
     end

--- a/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
@@ -49,4 +49,23 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
       end
     end
   end
+
+  describe '#on_collection_metadata_updated' do
+    let(:event_type) { :on_collection_metadata_updated }
+
+    it 'reindexes the collection on the configured adapter' do
+      expect { listener.on_collection_metadata_updated(event) }
+        .to change { fake_adapter.saved_resources }
+        .to contain_exactly(resource)
+    end
+
+    context 'when it gets a non-resource as payload' do
+      let(:resource) { ActiveFedora::Base.new }
+
+      it 'returns as a no-op' do
+        expect { listener.on_collection_metadata_updated(event) }
+          .not_to change { fake_adapter.saved_resources }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Updates several key components that work together during the create process:
* CollectionsController - update new and create method to use Hyrax::PcdmCollection
* add transactions to perform the steps for the create process
* updates the PcdmCollectionForm to more closely match the existing CollectionForm
* adds listener for collection metadata change to run collection valkyrie indexing

### REMAINING WORK

* need to confirm that extra methods in CollectionForm still operate the same in Hyrax::PcdmCollectionForm
* need to confirm that extra methods in CollectionController related to new/create still operate the same prior to changes
* need to explore disallowed collection create ability for non-admins
* need tests of new behavior
* may be able to move some functionality out of the controller and into the transactions

This only addresses new/create.  It does not change the edit process.

Fixes #5132

@samvera/hyrax-code-reviewers
