### PR TITLE
add a listener for collection.metadata.updated to reindex collection

### DIFF
--- a/app/services/hyrax/collections/collection_member_service.rb
+++ b/app/services/hyrax/collections/collection_member_service.rb
@@ -155,8 +155,7 @@ module Hyrax
         private
 
         def publish_metadata_updated(member, user)
-          case member
-          when Hyrax::PcdmCollection
+          if member.collection?
             Hyrax.publisher.publish('collection.metadata.updated', collection: member, user: user)
           else
             Hyrax.publisher.publish('object.metadata.updated', object: member, user: user)

--- a/app/services/hyrax/collections/collection_member_service.rb
+++ b/app/services/hyrax/collections/collection_member_service.rb
@@ -110,7 +110,7 @@ module Hyrax
           raise Hyrax::SingleMembershipError, message if message.present?
           new_member.member_of_collection_ids << collection_id # only populate this direction
           new_member = Hyrax.persister.save(resource: new_member)
-          Hyrax.publisher.publish('object.metadata.updated', object: new_member, user: user)
+          publish_metadata_updated(new_member, user)
           new_member
         end
 
@@ -148,8 +148,19 @@ module Hyrax
           return member unless member?(collection_id: collection_id, member: member)
           member.member_of_collection_ids.delete(collection_id)
           member = Hyrax.persister.save(resource: member)
-          Hyrax.publisher.publish('object.metadata.updated', object: member, user: user)
+          publish_metadata_updated(member, user)
           member
+        end
+
+        private
+
+        def publish_metadata_updated(member, user)
+          case member
+          when Hyrax::PcdmCollection
+            Hyrax.publisher.publish('collection.metadata.updated', collection: member, user: user)
+          else
+            Hyrax.publisher.publish('object.metadata.updated', object: member, user: user)
+          end
         end
       end
     end

--- a/app/services/hyrax/listeners/metadata_index_listener.rb
+++ b/app/services/hyrax/listeners/metadata_index_listener.rb
@@ -15,11 +15,16 @@ module Hyrax
       # Re-index the resource.
       #
       # @param event [Dry::Event]
-      def on_object_metadata_updated(event)
-        log_non_resource(event) && return unless
-          event[:object].is_a?(Valkyrie::Resource)
+      def on_collection_metadata_updated(event)
+        metadata_updated(event, :collection)
+      end
 
-        Hyrax.index_adapter.save(resource: event[:object])
+      ##
+      # Re-index the resource.
+      #
+      # @param event [Dry::Event]
+      def on_object_metadata_updated(event)
+        metadata_updated(event, :object)
       end
 
       ##
@@ -35,9 +40,16 @@ module Hyrax
 
       private
 
-      def log_non_resource(event)
+      def log_non_resource(event, idx = :object)
         Hyrax.logger.info('Skipping object reindex because the object ' \
-                          "#{event[:object]} was not a Valkyrie::Resource.")
+                          "#{event[idx]} was not a Valkyrie::Resource.")
+      end
+
+      def metadata_updated(event, idx)
+        log_non_resource(event, idx) && return unless
+          event[idx].is_a?(Valkyrie::Resource)
+
+        Hyrax.index_adapter.save(resource: event[idx])
       end
     end
   end

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -96,6 +96,10 @@ module Hyrax
 
     # @since 3.0.0
     # @macro a_registered_event
+    register_event('collection.metadata.updated')
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('file.set.audited')
 
     # @since 3.0.0

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -38,12 +38,22 @@ module Hyrax
             unsaved.respond_to?(:permission_manager)
 
           user ||= ::User.find_by_user_key(saved.depositor)
-          Hyrax.publisher.publish('object.deposited', object: saved, user: user) if unsaved.new_record
-          Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
 
+          publish_changes(unsaved, saved, user)
           Success(saved)
         rescue StandardError => err
           Failure([err.message, change_set.resource])
+        end
+
+        private
+
+        def publish_changes(unsaved, saved, user)
+          if saved.collection?
+            Hyrax.publisher.publish('collection.metadata.updated', collection: saved, user: user)
+          else
+            Hyrax.publisher.publish('object.deposited', object: saved, user: user) if unsaved.new_record
+            Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
+          end
         end
       end
     end

--- a/spec/hyrax/transactions/steps/save_spec.rb
+++ b/spec/hyrax/transactions/steps/save_spec.rb
@@ -36,13 +36,30 @@ RSpec.describe Hyrax::Transactions::Steps::Save do
     end
 
     context 'when the caller passes a user' do
-      let(:resource) { build(:hyrax_work) }
-      let(:user)     { create(:user) }
+      let(:user) { create(:user) }
 
-      it 'publishes an event with a user' do
-        expect { step.call(change_set, user: user) }
-          .to change { listener.object_metadata_updated&.payload }
-          .to match object: an_instance_of(resource.class), user: user
+      context 'and resource is a hyrax work' do
+        let(:resource) { build(:hyrax_work) }
+        it 'publishes object.metadata.updated with a user' do
+          expect { step.call(change_set, user: user) }
+            .to change { listener.object_metadata_updated&.payload }
+            .to match object: an_instance_of(resource.class), user: user
+        end
+
+        it 'publishes object.deposited with a user' do
+          expect { step.call(change_set, user: user) }
+            .to change { listener.object_deposited&.payload }
+            .to match object: an_instance_of(resource.class), user: user
+        end
+      end
+
+      context 'and resource is a hyrax pcdm collection' do
+        let(:resource) { build(:hyrax_collection) }
+        it 'publishes collection.metadata.updated with a user' do
+          expect { step.call(change_set, user: user) }
+            .to change { listener.collection_metadata_updated&.payload }
+            .to match collection: an_instance_of(resource.class), user: user
+        end
       end
     end
 

--- a/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
@@ -49,4 +49,24 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
       end
     end
   end
+
+  describe '#on_collection_metadata_updated' do
+    let(:event_type) { :on_collection_metadata_updated }
+    let(:data)       { { collection: resource } }
+
+    it 'reindexes the collection on the configured adapter' do
+      expect { listener.on_collection_metadata_updated(event) }
+        .to change { fake_adapter.saved_resources }
+        .to contain_exactly(resource)
+    end
+
+    context 'when it gets a non-resource as payload' do
+      let(:resource) { ActiveFedora::Base.new }
+
+      it 'returns as a no-op' do
+        expect { listener.on_collection_metadata_updated(event) }
+          .not_to change { fake_adapter.saved_resources }
+      end
+    end
+  end
 end

--- a/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
@@ -7,15 +7,18 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
   let(:fake_adapter) { FakeIndexingAdapter.new }
   let(:resource)     { FactoryBot.valkyrie_create(:hyrax_resource) }
 
+  let(:skipping_message) { /Skipping (object|collection) reindex because the (object|collection) .*/ }
+
   # the listener should always use the currently configured Hyrax Index Adapter
   before do
     allow(Hyrax).to receive(:index_adapter).and_return(fake_adapter)
   end
 
   describe '#on_object_deleted' do
-    let(:event_type) { :on_object_delted }
+    let(:event_type) { :on_object_deleted }
 
     it 'reindexes the object on the configured adapter' do
+      expect(Hyrax.logger).not_to receive(:info).with(skipping_message)
       expect { listener.on_object_deleted(event) }
         .to change { fake_adapter.deleted_resources }
         .to contain_exactly(resource)
@@ -25,6 +28,7 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
       let(:resource) { ActiveFedora::Base.new }
 
       it 'returns as a no-op' do
+        expect(Hyrax.logger).to receive(:info).with(skipping_message)
         expect { listener.on_object_deleted(event) }
           .not_to change { fake_adapter.deleted_resources }
       end
@@ -35,6 +39,7 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
     let(:event_type) { :on_object_metadata_updated }
 
     it 'reindexes the object on the configured adapter' do
+      expect(Hyrax.logger).not_to receive(:info).with(skipping_message)
       expect { listener.on_object_metadata_updated(event) }
         .to change { fake_adapter.saved_resources }
         .to contain_exactly(resource)
@@ -44,6 +49,7 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
       let(:resource) { ActiveFedora::Base.new }
 
       it 'returns as a no-op' do
+        expect(Hyrax.logger).to receive(:info).with(skipping_message)
         expect { listener.on_object_metadata_updated(event) }
           .not_to change { fake_adapter.saved_resources }
       end
@@ -55,6 +61,7 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
     let(:data)       { { collection: resource } }
 
     it 'reindexes the collection on the configured adapter' do
+      expect(Hyrax.logger).not_to receive(:info).with(skipping_message)
       expect { listener.on_collection_metadata_updated(event) }
         .to change { fake_adapter.saved_resources }
         .to contain_exactly(resource)
@@ -64,6 +71,7 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
       let(:resource) { ActiveFedora::Base.new }
 
       it 'returns as a no-op' do
+        expect(Hyrax.logger).to receive(:info).with(skipping_message)
         expect { listener.on_collection_metadata_updated(event) }
           .not_to change { fake_adapter.saved_resources }
       end


### PR DESCRIPTION
Adds listener for collection.metadata.updated that is separate from object.metadata.updated.  When it is published, the collection metadata will be reindexed.  

Members of collections can be works or collections.  The collection membership service was updated to publish the correct message depending on the type of object updated.

@samvera/hyrax-code-reviewers
