### PR TITLE
allow collection_type_ability to pass ability to PermissionsService

### DIFF
--- a/app/models/concerns/hyrax/ability/collection_type_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_type_ability.rb
@@ -8,7 +8,7 @@ module Hyrax
           can :create_collection_type, CollectionType
         else
           can :create_collection_of_type, CollectionType do |collection_type|
-            Hyrax::CollectionTypes::PermissionsService.can_create_collection_of_type?(user: current_user, collection_type: collection_type)
+            Hyrax::CollectionTypes::PermissionsService.can_create_collection_of_type?(ability: self, collection_type: collection_type)
           end
         end
       end

--- a/app/services/hyrax/collection_types/permissions_service.rb
+++ b/app/services/hyrax/collection_types/permissions_service.rb
@@ -159,7 +159,7 @@ module Hyrax
       #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
       def self.access_to_collection_type?(collection_type:, access:, user: nil, ability: nil) # rubocop:disable Metrics/CyclomaticComplexity
         return false unless user.present? || ability.present?
-        return false unless user && collection_type
+        return false unless collection_type
         return true if ([user_id(user, ability)] & agent_ids_for(collection_type: collection_type, agent_type: 'user', access: access)).present?
         return true if (user_groups(user, ability) & agent_ids_for(collection_type: collection_type, agent_type: 'group', access: access)).present?
         false

--- a/spec/services/hyrax/collection_types/permissions_service_spec.rb
+++ b/spec/services/hyrax/collection_types/permissions_service_spec.rb
@@ -259,6 +259,50 @@ RSpec.describe Hyrax::CollectionTypes::PermissionsService do
     end
   end
 
+  describe '.can_create_collection_of_type?' do
+    let(:ability) { instance_double(Ability, admin?: false, current_user: user, user_groups: []) }
+    let(:user) { create(:user) }
+    let(:collection_type) { create(:collection_type) }
+
+    context 'when user has no priviledges for the collection type' do
+      it 'returns false' do
+        expect(described_class.can_create_collection_of_type?(collection_type: collection_type, user: user)).to be false
+      end
+
+      context 'and identity is passed as an ability' do
+        it 'returns false' do
+          expect(described_class.can_create_collection_of_type?(collection_type: collection_type, ability: ability)).to be false
+        end
+      end
+    end
+
+    context 'when user is a manager for the collection type' do
+      let(:collection_type) { create(:collection_type, manager_user: user) }
+      it 'returns true' do
+        expect(described_class.can_create_collection_of_type?(collection_type: collection_type, user: user)).to be true
+      end
+
+      context 'and identity is passed as an ability' do
+        it 'returns true' do
+          expect(described_class.can_create_collection_of_type?(collection_type: collection_type, ability: ability)).to be true
+        end
+      end
+    end
+
+    context 'when user is a creator for the collection type' do
+      let(:collection_type) { create(:collection_type, creator_user: user) }
+      it 'returns true' do
+        expect(described_class.can_create_collection_of_type?(collection_type: collection_type, user: user)).to be true
+      end
+
+      context 'and identity is passed as an ability' do
+        it 'returns true' do
+          expect(described_class.can_create_collection_of_type?(collection_type: collection_type, ability: ability)).to be true
+        end
+      end
+    end
+  end
+
   describe '.user_edit_grants_for_collection_of_type' do
     it 'is empty for user collection type' do
       expect(described_class.user_edit_grants_for_collection_of_type(collection_type: user_collection_type))


### PR DESCRIPTION
Calls to the collection_type and collection permission services should pass ability instead of current_user to allow for check of user_groups the user may be in.  The collection_type_ability to see if a user can create a collection of a certain type was passing the user.   Updating this to ability revealed an error in the permission service that was returning false if the user was not passed in.  This was fixed and tests were added to be sure that ability and user are both allowed as parameters.

This can probably be refactored at some point to remove the ability to pass either or both.  You can get the user from the ability (i.e. `ability.current_user`) and vice_versa (i.e. `user.ability`).  Would need to verify that this is always the case before refactoring.  This would change the method signature of the public methods requiring deprecation of the `ability` parameter.

@samvera/hyrax-code-reviewers
