### PR TITLE
add transactions related to creating collections

### DIFF
--- a/lib/hyrax/transactions/collection_create.rb
+++ b/lib/hyrax/transactions/collection_create.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/transaction'
+
+module Hyrax
+  module Transactions
+    ##
+    # Creates a Collection from a ChangeSet
+    #
+    # @since 3.0.0
+    class CollectionCreate < Transaction
+      DEFAULT_STEPS = ['change_set.set_user_as_depositor',
+                       'change_set.set_collection_type_gid',
+                       'change_set.add_to_collections',
+                       'change_set.apply',
+                       'collection_resource.apply_collection_type_permissions',
+                       'collection_resource.save_acl'].freeze
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/collection_create.rb
+++ b/lib/hyrax/transactions/collection_create.rb
@@ -6,7 +6,7 @@ module Hyrax
     ##
     # Creates a Collection from a ChangeSet
     #
-    # @since 3.0.0
+    # @since 3.2.0
     class CollectionCreate < Transaction
       DEFAULT_STEPS = ['change_set.set_user_as_depositor',
                        'change_set.set_collection_type_gid',

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -19,6 +19,7 @@ module Hyrax
     # @see https://dry-rb.org/gems/dry-container/
     class Container # rubocop:disable Metrics/ClassLength
       require 'hyrax/transactions/apply_change_set'
+      require 'hyrax/transactions/collection_create'
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/destroy_work'
       require 'hyrax/transactions/file_set_destroy'
@@ -29,11 +30,13 @@ module Hyrax
       require 'hyrax/transactions/steps/add_to_collections'
       require 'hyrax/transactions/steps/add_to_parent'
       require 'hyrax/transactions/steps/apply_collection_permission_template'
+      require 'hyrax/transactions/steps/apply_collection_type_permissions'
       require 'hyrax/transactions/steps/apply_permission_template'
       require 'hyrax/transactions/steps/apply_visibility'
       require 'hyrax/transactions/steps/delete_resource'
       require 'hyrax/transactions/steps/destroy_work'
       require 'hyrax/transactions/steps/ensure_admin_set'
+      require 'hyrax/transactions/steps/set_collection_type_gid'
       require 'hyrax/transactions/steps/ensure_permission_template'
       require 'hyrax/transactions/steps/remove_file_set_from_work'
       require 'hyrax/transactions/steps/save'
@@ -58,6 +61,10 @@ module Hyrax
           ApplyChangeSet.new
         end
 
+        ops.register 'create_collection' do
+          CollectionCreate.new
+        end
+
         ops.register 'create_work' do
           WorkCreate.new
         end
@@ -68,6 +75,10 @@ module Hyrax
 
         ops.register 'save' do
           Steps::Save.new
+        end
+
+        ops.register 'set_collection_type_gid' do
+          Steps::SetCollectionTypeGid.new
         end
 
         ops.register 'set_default_admin_set' do
@@ -106,6 +117,16 @@ module Hyrax
 
         ops.register 'remove_from_work' do
           Steps::RemoveFileSetFromWork.new
+        end
+      end
+
+      namespace 'collection_resource' do |ops| # valkyrie collection
+        ops.register 'apply_collection_type_permissions' do
+          Steps::ApplyCollectionTypePermissions.new
+        end
+
+        ops.register 'save_acl' do
+          Steps::SaveAccessControl.new
         end
       end
 

--- a/lib/hyrax/transactions/steps/apply_collection_type_permissions.rb
+++ b/lib/hyrax/transactions/steps/apply_collection_type_permissions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # A `dry-transcation` step that applies permission templates from a
+      # collection type on a given collection.
+      #
+      # @since 3.0.0
+      class ApplyCollectionTypePermissions
+        include Dry::Transaction::Operation
+
+        ##
+        # @param [Hyrax::PcdmCollection] collection with a collection type gid
+        # @param user [User] the user that created the collection
+        #
+        # @return [Dry::Monads::Result]
+        def call(collection, user: nil)
+          Hyrax::Collections::PermissionsCreateService.create_default(collection: collection,
+                                                                      creating_user: user)
+          Success(collection)
+        rescue URI::InvalidURIError => err
+          # will be raised if the collection_type_gid is invalid or doesn't exist
+          Failure(err)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/apply_collection_type_permissions.rb
+++ b/lib/hyrax/transactions/steps/apply_collection_type_permissions.rb
@@ -6,9 +6,9 @@ module Hyrax
       # A `dry-transcation` step that applies permission templates from a
       # collection type on a given collection.
       #
-      # @since 3.0.0
+      # @since 3.2.0
       class ApplyCollectionTypePermissions
-        include Dry::Transaction::Operation
+        include Dry::Monads[:result]
 
         ##
         # @param [Hyrax::PcdmCollection] collection with a collection type gid

--- a/lib/hyrax/transactions/steps/set_collection_type_gid.rb
+++ b/lib/hyrax/transactions/steps/set_collection_type_gid.rb
@@ -5,7 +5,7 @@ module Hyrax
       ##
       # A step that sets the `#collection_type_gid` in the change set.
       #
-      # @since 2.4.0
+      # @since 3.2.0
       class SetCollectionTypeGid
         include Dry::Monads[:result]
 

--- a/lib/hyrax/transactions/steps/set_collection_type_gid.rb
+++ b/lib/hyrax/transactions/steps/set_collection_type_gid.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # A step that sets the `#collection_type_gid` in the change set.
+      #
+      # @since 2.4.0
+      class SetCollectionTypeGid
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Hyrax::ChangeSet] change_set
+        # @param collection_type_gid [URI::GID] global id for the collection type
+        # @return [Dry::Monads::Result] `Failure` if there is no `collection_type_gid` or
+        #   it can't be set to the default for the input; `Success(input)`, otherwise.
+        def call(change_set, collection_type_gid: default_collection_type_gid)
+          return Failure[:no_collection_type_gid, collection] unless
+            change_set.respond_to?(:collection_type_gid=)
+
+          change_set.collection_type_gid = collection_type_gid
+
+          Success(change_set)
+        end
+
+        private
+
+        def default_collection_type_gid
+          Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id
+        end
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/collection_create_spec.rb
+++ b/spec/hyrax/transactions/collection_create_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+require 'dry/container/stub'
+
+RSpec.describe Hyrax::Transactions::CollectionCreate, :clean_repo do
+  subject(:tx)     { described_class.new }
+  let(:change_set) { Hyrax::ChangeSet.for(resource) }
+  let(:resource)   { Hyrax::PcdmCollection.new(title: "My Resource") }
+
+  let(:default_collection_type_gid) { create(:user_collection_type).to_global_id.to_s }
+  let(:collection_type_gid) { create(:collection_type).to_global_id.to_s }
+
+  describe '#call' do
+    it 'is a success' do
+      expect(tx.call(change_set)).to be_success
+    end
+
+    it 'wraps a saved collection' do
+      expect(tx.call(change_set).value!).to be_persisted
+    end
+
+    context 'when providing a depositor' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'sets the given user as the depositor' do
+        tx.with_step_args('change_set.set_user_as_depositor' => { user: user })
+
+        expect(tx.call(change_set).value!)
+          .to have_attributes depositor: user.user_key
+      end
+    end
+
+    context 'when collection type is not passed in' do
+      it 'sets the collection type to the default collection type gid' do
+        expect(tx.call(change_set).value!)
+          .to have_attributes collection_type_gid: default_collection_type_gid
+      end
+    end
+
+    context 'when collection type is passed in' do
+      it 'sets the collection type to the passed in gid' do
+        tx.with_step_args('change_set.set_collection_type_gid' => { collection_type_gid: collection_type_gid })
+        expect(tx.call(change_set).value!)
+          .to have_attributes collection_type_gid: collection_type_gid
+      end
+    end
+
+    context 'when adding to collections' do
+      let(:collections) do
+        [FactoryBot.valkyrie_create(:hyrax_collection),
+         FactoryBot.valkyrie_create(:hyrax_collection)]
+      end
+
+      let(:collection_ids) { collections.map(&:id) }
+
+      it 'adds to the collections' do
+        tx.with_step_args('change_set.add_to_collections' => { collection_ids: collection_ids })
+
+        expect(tx.call(change_set).value!)
+          .to have_attributes member_of_collection_ids: contain_exactly(*collection_ids)
+      end
+    end
+
+    context 'when collection type has permissions' do
+      let(:manager) { create(:user) }
+      let(:creator) { create(:user) }
+      let(:user)    { create(:user) }
+
+      let(:collection_type) do
+        create(:collection_type,
+          creator_user: creator.user_key,
+          creator_group: 'creator_group',
+          manager_user: manager.user_key,
+          manager_group: 'manager_group')
+      end
+      let(:collection_type_gid) { collection_type.to_global_id.to_s }
+
+      it 'sets permissions on collection through Hyrax::Collections::PermissionsCreateService.create_default' do
+        tx.with_step_args('change_set.set_collection_type_gid' => { collection_type_gid: collection_type_gid },
+                          'collection_resource.apply_collection_type_permissions' => { user: user })
+
+        expect(Hyrax::Collections::PermissionsCreateService)
+          .to receive(:create_default).with(any_args).and_call_original
+        updated_resource = tx.call(change_set).value!
+        expect(updated_resource.permission_manager.edit_users).to match_array [manager.user_key, user.user_key]
+        expect(updated_resource.permission_manager.edit_groups).to match_array ['admin', 'manager_group']
+        expect(updated_resource.permission_manager.read_users).to match_array []
+        expect(updated_resource.permission_manager.read_groups).to match_array []
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/add_to_collections_spec.rb
+++ b/spec/hyrax/transactions/steps/add_to_collections_spec.rb
@@ -42,5 +42,16 @@ RSpec.describe Hyrax::Transactions::Steps::AddToCollections do
           .to have_attributes(member_of_collection_ids: contain_exactly(*expected))
       end
     end
+
+    context 'when work already belongs to a single membership collection' do
+      before do
+        allow_any_instance_of(Hyrax::MultipleMembershipChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:check).with(any_args).and_return('VIOLATION')
+      end
+
+      it 'is a failure' do
+        expect(step.call(change_set, collection_ids: collection_ids)).to be_failure
+      end
+    end
   end
 end

--- a/spec/hyrax/transactions/steps/apply_collection_type_permissions_spec.rb
+++ b/spec/hyrax/transactions/steps/apply_collection_type_permissions_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::ApplyCollectionTypePermissions do
+  subject(:step) { described_class.new }
+  let(:collection) do
+    FactoryBot.valkyrie_create(:hyrax_collection,
+                               title: "My Resource",
+                               collection_type_gid: collection_type_gid)
+  end
+
+  let(:collection_type) { create(:collection_type) }
+  let(:collection_type_gid) { collection_type.to_global_id.to_s }
+  let(:default_collection_type_gid) { create(:user_collection_type).to_global_id.to_s }
+
+  let(:manager_groups) { ['manage_group_1', 'manage_group_2'] }
+  let(:manager_users)  { create_list(:user, 2) }
+  let(:creator_groups) { ['create_group_1', 'create_group_2'] }
+  let(:creator_users)  { create_list(:user, 2) }
+  let(:user) { create(:user) }
+
+  context 'without a collection type' do
+    let(:collection) { Hyrax::PcdmCollection.new(title: "My Resource") }
+
+    it 'is a failure' do
+      expect(step.call(collection)).to be_failure
+    end
+  end
+
+  context 'with a collection type' do
+    it 'is a success' do
+      expect(step.call(collection)).to be_success
+    end
+
+    context 'with users and groups' do
+      let(:collection_type) do
+        create(:collection_type,
+          creator_user: creator_users,
+          creator_group: creator_groups,
+          manager_user: manager_users,
+          manager_group: manager_groups)
+      end
+
+      it 'assigns edit users from collection type participants' do
+        expect { step.call(collection) }
+          .to change { collection.permission_manager.edit_users }
+          .to include(*manager_users.map(&:user_key))
+      end
+
+      it 'assigns creating user to edit users' do
+        expect { step.call(collection, user: user) }
+          .to change { collection.permission_manager.edit_users }
+          .to include(user.user_key)
+      end
+
+      it 'assigns edit groups from collection type participants' do
+        expect { step.call(collection) }
+          .to change { collection.permission_manager.edit_groups }
+          .to include(*manager_groups)
+      end
+
+      it 'assigns admins to edit groups' do
+        expect { step.call(collection) }
+          .to change { collection.permission_manager.edit_groups }
+          .to include('admin')
+      end
+
+      it 'does not assigns read users from collection type participants' do
+        expect { step.call(collection) }
+          .not_to change { collection.permission_manager.read_users.count }
+      end
+
+      it 'does not assigns read groups from collection type participants' do
+        expect { step.call(collection) }
+          .not_to change { collection.permission_manager.read_groups.count }
+      end
+    end
+
+    context 'missing Participants record' do
+      let(:collection_type) { create(:collection_type) }
+
+      it 'assigns creating user to edit users' do
+        expect { step.call(collection, user: user) }
+          .to change { collection.permission_manager.edit_users }
+          .to include(user.user_key)
+      end
+
+      it 'assigns admins to edit group' do
+        # Hyrax::Collections::PermissionService handles this gracefully
+        expect { step.call(collection) }
+          .to change { collection.permission_manager.edit_groups }
+          .to include('admin')
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/set_collection_type_gid_spec.rb
+++ b/spec/hyrax/transactions/steps/set_collection_type_gid_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::SetCollectionTypeGid do
+  subject(:step)   { described_class.new }
+  let(:collection) { build(:hyrax_collection) }
+  let(:change_set) { Hyrax::ChangeSet.for(collection) }
+
+  describe '#call' do
+    let(:default_collection_type_gid) { Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id }
+
+    it 'is success' do
+      expect(step.call(change_set)).to be_success
+    end
+
+    context 'when a collection type gid is NOT passed in' do
+      it 'sets the default collection type gid' do
+        expect { step.call(change_set) }
+          .not_to change { change_set.collection_type_gid }
+          .from(default_collection_type_gid) # The default will always be assigned if one isn't give at create time.
+      end
+    end
+
+    context 'when a collection type gid is passed in' do
+      let(:collection_type) { create(:collection_type) }
+      let(:collection_type_gid) { collection_type.to_global_id.to_s }
+
+      it 'is success' do
+        expect(step.call(change_set, collection_type_gid: collection_type_gid)).to be_success
+      end
+
+      it 'sets the collection type gid' do
+        expect { step.call(change_set, collection_type_gid: collection_type_gid) }
+          .to change { change_set.collection_type_gid }
+          .from(default_collection_type_gid)
+          .to(collection_type_gid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is in preparation for using `Hyrax::PcdmCollection` for new/create in the collections controller.  Partially addresses Issue #5132 Val MVP: Create PcdmCollection as a valkyrie resource through UI.

@samvera/hyrax-code-reviewers
