### PR TITLE
update collection ability to work with Hyrax::PcdmCollection

### DIFF
--- a/app/models/concerns/hyrax/ability/collection_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_ability.rb
@@ -2,22 +2,40 @@
 module Hyrax
   module Ability
     module CollectionAbility
-      def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         if admin?
-          can :manage, ::Collection
+          can :manage, [::Collection, Hyrax::PcdmCollection]
           can :manage_any, ::Collection
+          can :manage_any, Hyrax::PcdmCollection
           can :create_any, ::Collection
+          can :create_any, Hyrax::PcdmCollection
           can :view_admin_show_any, ::Collection
+          can :view_admin_show_any, Hyrax::PcdmCollection
         else
-          can :manage_any, ::Collection if Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
-          can :create_any, ::Collection if Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
-          can :view_admin_show_any, ::Collection if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_collection?(ability: self)
+          if Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
+            can :manage_any, ::Collection
+            can :manage_any, Hyrax::PcdmCollection
+          end
+          if Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
+            can :create_any, ::Collection
+            can :create_any, Hyrax::PcdmCollection
+          end
+          if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_collection?(ability: self)
+            can :view_admin_show_any, ::Collection
+            can :view_admin_show_any, Hyrax::PcdmCollection
+          end
 
           can [:edit, :update, :destroy], ::Collection do |collection| # for test by solr_doc, see solr_document_ability.rb
             test_edit(collection.id)
           end
+          can [:edit, :update, :destroy], Hyrax::PcdmCollection do |collection| # for test by solr_doc, see solr_document_ability.rb
+            test_edit(collection.id)
+          end
 
           can :deposit, ::Collection do |collection|
+            Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: collection.id)
+          end
+          can :deposit, Hyrax::PcdmCollection do |collection|
             Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: collection.id)
           end
           can :deposit, ::SolrDocument do |solr_doc|
@@ -27,11 +45,17 @@ module Hyrax
           can :view_admin_show, ::Collection do |collection| # admin show page
             Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: collection.id)
           end
+          can :view_admin_show, Hyrax::PcdmCollection do |collection| # admin show page
+            Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: collection.id)
+          end
           can :view_admin_show, ::SolrDocument do |solr_doc| # admin show page
             Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
           end
 
           can :read, ::Collection do |collection| # public show page  # for test by solr_doc, see solr_document_ability.rb
+            test_read(collection.id)
+          end
+          can :read, Hyrax::PcdmCollection do |collection| # public show page  # for test by solr_doc, see solr_document_ability.rb
             test_read(collection.id)
           end
         end

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -243,7 +243,7 @@ module Hyrax
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       def self.access_to_collection?(collection_id:, access:, ability:, exclude_groups: [])
         return false unless collection_id
-        template = Hyrax::PermissionTemplate.find_by!(source_id: collection_id)
+        template = Hyrax::PermissionTemplate.find_by!(source_id: collection_id.to_s)
         return true if ([ability.current_user.user_key] & template.agent_ids_for(agent_type: 'user', access: access)).present?
         return true if (ability.user_groups & (template.agent_ids_for(agent_type: 'group', access: access) - exclude_groups)).present?
         false

--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -1,164 +1,392 @@
 # frozen_string_literal: true
 require 'cancan/matchers'
 
-RSpec.describe Hyrax::Ability do
+RSpec.describe Hyrax::Ability, :clean_repo do
   subject { ability }
 
   let(:ability) { Ability.new(current_user) }
-  let(:user) { create(:user) }
+  let(:user) { create(:user, email: 'user@example.com') }
   let(:current_user) { user }
   let(:collection_type) { FactoryBot.create(:collection_type) }
+  let(:collection_type_gid) { collection_type.to_global_id }
 
   context 'when admin user' do
-    let(:user) { FactoryBot.create(:admin) }
-    let!(:collection) { FactoryBot.build(:collection_lw, id: 'col_au', with_permission_template: true, collection_type: collection_type) }
-    let!(:solr_document) { SolrDocument.new(collection.to_solr) }
+    let(:current_user) { admin }
+    let(:admin) { FactoryBot.create(:admin, email: 'admin@example.com') }
 
-    it 'allows all abilities' do # rubocop:disable RSpec/ExampleLength
-      is_expected.to be_able_to(:manage, Collection)
-      is_expected.to be_able_to(:manage_any, Collection)
-      is_expected.to be_able_to(:create_any, Collection)
-      is_expected.to be_able_to(:view_admin_show_any, Collection)
-      is_expected.to be_able_to(:edit, collection)
-      is_expected.to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:update, collection)
-      is_expected.to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:destroy, collection)
-      is_expected.to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:deposit, collection)
-      is_expected.to be_able_to(:deposit, solr_document)
-      is_expected.to be_able_to(:view_admin_show, collection)
-      is_expected.to be_able_to(:view_admin_show, solr_document)
-      is_expected.to be_able_to(:read, collection)
-      is_expected.to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
+    context 'and collection is an ActiveFedora::Base' do
+      let!(:collection) do
+        FactoryBot.build(:collection_lw, id: 'col_au',
+                                         user: user,
+                                         with_permission_template: true,
+                                         collection_type: collection_type)
+      end
+      let!(:solr_document) { SolrDocument.new(collection.to_solr) }
+
+      context 'for abilities open to admins' do
+        it { is_expected.to be_able_to(:manage, Collection) }
+        it { is_expected.to be_able_to(:manage_any, Collection) }
+        it { is_expected.to be_able_to(:create_any, Collection) }
+        it { is_expected.to be_able_to(:view_admin_show_any, Collection) }
+        it { is_expected.to be_able_to(:edit, collection) }
+        it { is_expected.to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:update, collection) }
+        it { is_expected.to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:destroy, collection) }
+        it { is_expected.to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:deposit, collection) }
+        it { is_expected.to be_able_to(:deposit, solr_document) }
+        it { is_expected.to be_able_to(:view_admin_show, collection) }
+        it { is_expected.to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.to be_able_to(:read, collection) }
+        it { is_expected.to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
+    end
+
+    context 'and collection is a valkyrie resource' do
+      let!(:collection) do
+        FactoryBot.valkyrie_create(:hyrax_collection,
+                                   user: user,
+                                   collection_type_gid: collection_type_gid)
+      end
+      let!(:solr_document) { SolrDocument.new(Hyrax::PcdmCollectionIndexer.new(resource: collection).to_solr) }
+
+      context 'for abilities open to admins' do
+        it { is_expected.to be_able_to(:manage, Hyrax::PcdmCollection) }
+        it { is_expected.to be_able_to(:manage_any, Hyrax::PcdmCollection) }
+        it { is_expected.to be_able_to(:create_any, Hyrax::PcdmCollection) }
+        it { is_expected.to be_able_to(:view_admin_show_any, Collection) }
+        it { is_expected.to be_able_to(:edit, collection) }
+        it { is_expected.to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:update, collection) }
+        it { is_expected.to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:destroy, collection) }
+        it { is_expected.to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:deposit, collection) }
+        it { is_expected.to be_able_to(:deposit, solr_document) }
+        it { is_expected.to be_able_to(:view_admin_show, collection) }
+        it { is_expected.to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.to be_able_to(:read, collection) }
+        it { is_expected.to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
     end
   end
 
   context 'when collection manager' do
-    let!(:collection) { FactoryBot.build(:collection_lw, id: 'col_mu', with_permission_template: true, collection_type: collection_type) }
-    let!(:solr_document) { SolrDocument.new(collection.to_solr) }
+    let(:current_user) { manager }
+    let(:manager) { create(:user, email: 'manager@example.com') }
 
-    before do
-      create(:permission_template_access,
-             :manage,
-             permission_template: collection.permission_template,
-             agent_type: 'user',
-             agent_id: user.user_key)
-      collection.reset_access_controls!
+    context 'and collection is an ActiveFedora::Base' do
+      let!(:collection) do
+        FactoryBot.build(:collection_lw, id: 'col_mu',
+                                         user: user,
+                                         with_permission_template: true,
+                                         collection_type: collection_type)
+      end
+      let!(:solr_document) { SolrDocument.new(collection.to_solr) }
+
+      before do
+        create(:permission_template_access,
+                 :manage,
+                 permission_template: collection.permission_template,
+                 agent_type: 'user',
+                 agent_id: manager.user_key)
+        collection.reset_access_controls!
+      end
+
+      context 'for abilities open to managers' do
+        it { is_expected.to be_able_to(:manage_any, Collection) }
+        it { is_expected.to be_able_to(:view_admin_show_any, Collection) }
+        it { is_expected.to be_able_to(:edit, collection) }
+        it { is_expected.to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:update, collection) }
+        it { is_expected.to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:destroy, collection) }
+        it { is_expected.to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:deposit, collection) }
+        it { is_expected.to be_able_to(:deposit, solr_document) }
+        it { is_expected.to be_able_to(:view_admin_show, collection) }
+        it { is_expected.to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.to be_able_to(:read, collection) } # edit access grants read and write
+        it { is_expected.to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
+
+      context 'for abilities NOT open to managers' do
+        it { is_expected.not_to be_able_to(:manage, Collection) }
+      end
     end
 
-    it 'allows most abilities' do # rubocop:disable RSpec/ExampleLength
-      is_expected.to be_able_to(:manage_any, Collection)
-      is_expected.to be_able_to(:view_admin_show_any, Collection)
-      is_expected.to be_able_to(:edit, collection)
-      is_expected.to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:update, collection)
-      is_expected.to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:destroy, collection)
-      is_expected.to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:deposit, collection)
-      is_expected.to be_able_to(:deposit, solr_document)
-      is_expected.to be_able_to(:view_admin_show, collection)
-      is_expected.to be_able_to(:view_admin_show, solr_document)
-      is_expected.to be_able_to(:read, collection) # edit access grants read and write
-      is_expected.to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
-    end
+    context 'and collection is a valkyrie resource' do
+      let!(:collection) do
+        FactoryBot.valkyrie_create(:hyrax_collection,
+                                   user: user,
+                                   collection_type_gid: collection_type_gid,
+                                   access_grants: grants)
+      end
+      let!(:solr_document) { SolrDocument.new(Hyrax::PcdmCollectionIndexer.new(resource: collection).to_solr) }
 
-    it 'denies manage ability' do
-      is_expected.not_to be_able_to(:manage, Collection)
+      let(:grants) do
+        [
+          {
+            agent_type: Hyrax::PermissionTemplateAccess::USER,
+            agent_id: manager.user_key,
+            access: Hyrax::PermissionTemplateAccess::MANAGE
+          }
+        ]
+      end
+
+      context 'for abilities open to managers' do
+        it { is_expected.to be_able_to(:manage_any, Hyrax::PcdmCollection) }
+        it { is_expected.to be_able_to(:view_admin_show_any, Hyrax::PcdmCollection) }
+        it { is_expected.to be_able_to(:edit, collection) }
+        it { is_expected.to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:update, collection) }
+        it { is_expected.to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:destroy, collection) }
+        it { is_expected.to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:deposit, collection) }
+        it { is_expected.to be_able_to(:deposit, solr_document) }
+        it { is_expected.to be_able_to(:view_admin_show, collection) }
+        it { is_expected.to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.to be_able_to(:read, collection) } # edit access grants read and write
+        it { is_expected.to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
+
+      context 'for abilities NOT open to managers' do
+        it { is_expected.not_to be_able_to(:manage, Hyrax::PcdmCollection) }
+      end
     end
   end
 
   context 'when collection depositor' do
-    let!(:collection) { FactoryBot.build(:collection_lw, id: 'col_du', with_permission_template: true, collection_type: collection_type) }
-    let!(:solr_document) { SolrDocument.new(collection.to_solr) }
+    let(:current_user) { depositor }
+    let(:depositor) { create(:user, email: 'depositor@example.com') }
 
-    before do
-      create(:permission_template_access,
-             :deposit,
-             permission_template: collection.permission_template,
-             agent_type: 'user',
-             agent_id: user.user_key)
-      collection.reset_access_controls!
+    context 'and collection is an ActiveFedora::Base' do
+      let!(:collection) do
+        FactoryBot.build(:collection_lw, id: 'col_du',
+                                         user: user,
+                                         with_permission_template: true,
+                                         collection_type: collection_type)
+      end
+      let!(:solr_document) { SolrDocument.new(collection.to_solr) }
+
+      before do
+        create(:permission_template_access,
+               :deposit,
+               permission_template: collection.permission_template,
+               agent_type: 'user',
+               agent_id: depositor.user_key)
+        collection.reset_access_controls!
+      end
+
+      context 'for abilities open to depositor' do
+        it { is_expected.to be_able_to(:view_admin_show_any, Collection) }
+        it { is_expected.to be_able_to(:deposit, collection) }
+        it { is_expected.to be_able_to(:deposit, solr_document) }
+        it { is_expected.to be_able_to(:view_admin_show, collection) }
+        it { is_expected.to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.to be_able_to(:read, collection) }
+        it { is_expected.to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
+
+      context 'for abilities NOT open to depositor' do
+        it { is_expected.not_to be_able_to(:manage, Collection) }
+        it { is_expected.not_to be_able_to(:manage_any, Collection) }
+        it { is_expected.not_to be_able_to(:edit, collection) }
+        it { is_expected.not_to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:update, collection) }
+        it { is_expected.not_to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:destroy, collection) }
+        it { is_expected.not_to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+      end
     end
 
-    it 'allows deposit related abilities' do
-      is_expected.to be_able_to(:view_admin_show_any, Collection)
-      is_expected.to be_able_to(:deposit, collection)
-      is_expected.to be_able_to(:deposit, solr_document)
-      is_expected.to be_able_to(:view_admin_show, collection)
-      is_expected.to be_able_to(:view_admin_show, solr_document)
-    end
+    context 'and collection is a valkyrie resource' do
+      let!(:collection) do
+        FactoryBot.valkyrie_create(:hyrax_collection,
+                                   user: user,
+                                   collection_type_gid: collection_type_gid,
+                                   access_grants: grants)
+      end
+      let!(:solr_document) { SolrDocument.new(Hyrax::PcdmCollectionIndexer.new(resource: collection).to_solr) }
 
-    it 'denies non-deposit related abilities' do # rubocop:disable RSpec/ExampleLength
-      is_expected.not_to be_able_to(:manage, Collection)
-      is_expected.not_to be_able_to(:manage_any, Collection)
-      is_expected.not_to be_able_to(:edit, collection)
-      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:update, collection)
-      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:destroy, collection)
-      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:read, collection)
-      is_expected.not_to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
+      let(:grants) do
+        [
+          {
+            agent_type: Hyrax::PermissionTemplateAccess::USER,
+            agent_id: depositor.user_key,
+            access: Hyrax::PermissionTemplateAccess::DEPOSIT
+          }
+        ]
+      end
+
+      context 'for abilities open to depositor' do
+        it { is_expected.to be_able_to(:view_admin_show_any, Collection) }
+        it { is_expected.to be_able_to(:deposit, collection) }
+        it { is_expected.to be_able_to(:deposit, solr_document) }
+        it { is_expected.to be_able_to(:view_admin_show, collection) }
+        it { is_expected.to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.to be_able_to(:read, collection) }
+        it { is_expected.to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
+
+      context 'for abilities NOT open to depositor' do
+        it { is_expected.not_to be_able_to(:manage, Collection) }
+        it { is_expected.not_to be_able_to(:manage_any, Collection) }
+        it { is_expected.not_to be_able_to(:edit, collection) }
+        it { is_expected.not_to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:update, collection) }
+        it { is_expected.not_to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:destroy, collection) }
+        it { is_expected.not_to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+      end
     end
   end
 
   context 'when collection viewer' do
-    let!(:collection) { FactoryBot.build(:collection_lw, id: 'col_vu', with_permission_template: true, collection_type: collection_type) }
-    let!(:solr_document) { SolrDocument.new(collection.to_solr) }
+    let(:current_user) { viewer }
+    let(:viewer) { create(:user, email: 'viewer@example.com') }
 
-    before do
-      create(:permission_template_access,
-             :view,
-             permission_template: collection.permission_template,
-             agent_type: 'user',
-             agent_id: user.user_key)
-      collection.reset_access_controls!
+    context 'and collection is an ActiveFedora::Base' do
+      let!(:collection) do
+        FactoryBot.build(:collection_lw, id: 'col_vu',
+                                         user: user,
+                                         with_permission_template: true,
+                                         collection_type: collection_type)
+      end
+      let!(:solr_document) { SolrDocument.new(collection.to_solr) }
+
+      before do
+        create(:permission_template_access,
+               :view,
+               permission_template: collection.permission_template,
+               agent_type: 'user',
+               agent_id: viewer.user_key)
+        collection.reset_access_controls!
+      end
+
+      context 'for abilities open to viewer' do
+        it { is_expected.to be_able_to(:view_admin_show_any, Collection) }
+        it { is_expected.to be_able_to(:view_admin_show, collection) }
+        it { is_expected.to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.to be_able_to(:read, collection) }
+        it { is_expected.to be_able_to(:read, solr_document) }
+      end
+
+      context 'for abilities NOT open to viewer' do
+        it { is_expected.not_to be_able_to(:manage, Collection) }
+        it { is_expected.not_to be_able_to(:manage_any, Collection) }
+        it { is_expected.not_to be_able_to(:edit, collection) }
+        it { is_expected.not_to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:update, collection) }
+        it { is_expected.not_to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:destroy, collection) }
+        it { is_expected.not_to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:deposit, collection) }
+        it { is_expected.not_to be_able_to(:deposit, solr_document) }
+      end
     end
 
-    it 'allows viewing only ability' do
-      is_expected.to be_able_to(:view_admin_show_any, Collection)
-      is_expected.to be_able_to(:view_admin_show, collection)
-      is_expected.to be_able_to(:view_admin_show, solr_document)
-      is_expected.to be_able_to(:read, collection)
-      is_expected.to be_able_to(:read, solr_document)
-    end
+    context 'and collection is a valkyrie resource' do
+      let!(:collection) do
+        FactoryBot.valkyrie_create(:hyrax_collection,
+                                   user: user,
+                                   collection_type_gid: collection_type_gid,
+                                   access_grants: grants)
+      end
+      let!(:solr_document) { SolrDocument.new(Hyrax::PcdmCollectionIndexer.new(resource: collection).to_solr) }
 
-    it 'denies most abilities' do # rubocop:disable RSpec/ExampleLength
-      is_expected.not_to be_able_to(:manage, Collection)
-      is_expected.not_to be_able_to(:manage_any, Collection)
-      is_expected.not_to be_able_to(:edit, collection)
-      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:update, collection)
-      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:destroy, collection)
-      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:deposit, collection)
-      is_expected.not_to be_able_to(:deposit, solr_document)
+      let(:grants) do
+        [
+          {
+            agent_type: Hyrax::PermissionTemplateAccess::USER,
+            agent_id: viewer.user_key,
+            access: Hyrax::PermissionTemplateAccess::VIEW
+          }
+        ]
+      end
+
+      context 'for abilities open to viewer' do
+        it { is_expected.to be_able_to(:view_admin_show_any, Hyrax::PcdmCollection) }
+        it { is_expected.to be_able_to(:view_admin_show, collection) }
+        it { is_expected.to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.to be_able_to(:read, collection) }
+        it { is_expected.to be_able_to(:read, solr_document) }
+      end
+
+      context 'for abilities NOT open to viewer' do
+        it { is_expected.not_to be_able_to(:manage, Hyrax::PcdmCollection) }
+        it { is_expected.not_to be_able_to(:manage_any, Hyrax::PcdmCollection) }
+        it { is_expected.not_to be_able_to(:edit, collection) }
+        it { is_expected.not_to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:update, collection) }
+        it { is_expected.not_to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:destroy, collection) }
+        it { is_expected.not_to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:deposit, collection) }
+        it { is_expected.not_to be_able_to(:deposit, solr_document) }
+      end
     end
   end
 
   context 'when user has no special access' do
-    let!(:collection) { FactoryBot.create(:collection_lw, id: 'as', with_permission_template: true, collection_type: collection_type) }
-    let!(:solr_document) { SolrDocument.new(collection.to_solr) }
+    let(:current_user) { other_user }
+    let(:other_user) { create(:user, email: 'other_user@example.com') }
 
-    it 'denies all abilities' do # rubocop:disable RSpec/ExampleLength
-      is_expected.not_to be_able_to(:manage, Collection)
-      is_expected.not_to be_able_to(:manage_any, Collection)
-      is_expected.not_to be_able_to(:view_admin_show_any, Collection)
-      is_expected.not_to be_able_to(:edit, collection)
-      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:update, collection)
-      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:destroy, collection)
-      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:deposit, collection)
-      is_expected.not_to be_able_to(:deposit, solr_document)
-      is_expected.not_to be_able_to(:view_admin_show, collection)
-      is_expected.not_to be_able_to(:view_admin_show, solr_document)
-      is_expected.not_to be_able_to(:read, collection)
-      is_expected.not_to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
+    context 'and collection is an ActiveFedora::Base' do
+      let!(:collection) do
+        FactoryBot.create(:collection_lw, id: 'as',
+                                          user: user,
+                                          with_permission_template: true,
+                                          collection_type: collection_type)
+      end
+      let!(:solr_document) { SolrDocument.new(collection.to_solr) }
+
+      context 'for abilities NOT open to general user' do
+        it { is_expected.not_to be_able_to(:manage, Collection) }
+        it { is_expected.not_to be_able_to(:manage_any, Collection) }
+        it { is_expected.not_to be_able_to(:view_admin_show_any, Collection) }
+        it { is_expected.not_to be_able_to(:edit, collection) }
+        it { is_expected.not_to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:update, collection) }
+        it { is_expected.not_to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:destroy, collection) }
+        it { is_expected.not_to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:deposit, collection) }
+        it { is_expected.not_to be_able_to(:deposit, solr_document) }
+        it { is_expected.not_to be_able_to(:view_admin_show, collection) }
+        it { is_expected.not_to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.not_to be_able_to(:read, collection) }
+        it { is_expected.not_to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
+    end
+
+    context 'and collection is a valkyrie resource' do
+      let!(:collection) do
+        FactoryBot.valkyrie_create(:hyrax_collection,
+                                   user: user,
+                                   collection_type_gid: collection_type_gid)
+      end
+      let!(:solr_document) { SolrDocument.new(Hyrax::PcdmCollectionIndexer.new(resource: collection).to_solr) }
+
+      context 'for abilities NOT open to general user' do
+        it { is_expected.not_to be_able_to(:manage, Collection) }
+        it { is_expected.not_to be_able_to(:manage_any, Collection) }
+        it { is_expected.not_to be_able_to(:view_admin_show_any, Collection) }
+        it { is_expected.not_to be_able_to(:edit, collection) }
+        it { is_expected.not_to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:update, collection) }
+        it { is_expected.not_to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:destroy, collection) }
+        it { is_expected.not_to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:deposit, collection) }
+        it { is_expected.not_to be_able_to(:deposit, solr_document) }
+        it { is_expected.not_to be_able_to(:view_admin_show, collection) }
+        it { is_expected.not_to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.not_to be_able_to(:read, collection) }
+        it { is_expected.not_to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
     end
   end
 
@@ -183,9 +411,7 @@ RSpec.describe Hyrax::Ability do
     end
 
     context 'when there are collection types that have create access' do
-      before do
-        create(:user_collection_type)
-      end
+      before { create(:user_collection_type) }
 
       it 'allows create_any' do
         is_expected.to be_able_to(:create_any, Collection)

--- a/spec/hyrax/transactions/steps/apply_collection_type_permissions_spec.rb
+++ b/spec/hyrax/transactions/steps/apply_collection_type_permissions_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Hyrax::Transactions::Steps::ApplyCollectionTypePermissions do
   let(:collection) do
     FactoryBot.valkyrie_create(:hyrax_collection,
                                title: "My Resource",
-                               collection_type_gid: collection_type_gid)
+                               collection_type_gid: collection_type_gid,
+                               with_permission_template: false)
   end
 
   let(:collection_type) { create(:collection_type) }


### PR DESCRIPTION
This is in preparation for using Hyrax::PcdmCollection for new/create in the collections controller. Partially addresses Issue #5132 Val MVP: Create PcdmCollection as a valkyrie resource through UI.

Updates collection_ability to allow/disallow the same abilities when the object is an `ActiveFedora::Base` `::Collection` or a `Valkyrie::Resource` `Hyrax::PcdmCollection`.  The same tests are run for both object classes.

Notable changes:
* The ActiveFedora tests were refactored to have each ability check run separately to allow all failing abilities to be identified.  Otherwise, only the first failure is reported.  I believe it was original written as a single test for performance reasons.  With CircleCI running tests in parallel, this seems less critical.
* There was an error in the Depositor tests that denied read access to the public show page, but allowed access to the more restricted admin show page.  This was an error in the test and not in the code.  A slight rewrite of the test shows the abilities for Depositor behaving as expected.



@samvera/hyrax-code-reviewers