### PR TITLE
update admin set ability to work with Hyrax::AdministrativeSet

### DIFF
--- a/app/models/concerns/hyrax/ability/admin_set_ability.rb
+++ b/app/models/concerns/hyrax/ability/admin_set_ability.rb
@@ -2,27 +2,51 @@
 module Hyrax
   module Ability
     module AdminSetAbility
-      def admin_set_abilities # rubocop:disable Metrics/MethodLength
+      def admin_set_abilities # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         if admin?
-          can :manage, AdminSet
+          can :manage, [AdminSet, Hyrax::AdministrativeSet]
           can :manage_any, AdminSet
+          can :manage_any, Hyrax::AdministrativeSet
           can :create_any, AdminSet
+          can :create_any, Hyrax::AdministrativeSet
           can :view_admin_show_any, AdminSet
+          can :view_admin_show_any, Hyrax::AdministrativeSet
         else
-          can :manage_any, AdminSet if Hyrax::Collections::PermissionsService.can_manage_any_admin_set?(ability: self)
-          can [:create_any, :create], AdminSet if Hyrax::CollectionTypes::PermissionsService.can_create_admin_set_collection_type?(ability: self)
-          can :view_admin_show_any, AdminSet if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_admin_set?(ability: self)
-
-          can [:edit, :update, :destroy], AdminSet do |admin_set| # for test by solr_doc, see solr_document_ability.rb
+          if Hyrax::Collections::PermissionsService.can_manage_any_admin_set?(ability: self)
+            can :manage_any, AdminSet
+            can :manage_any, Hyrax::AdministrativeSet
+          end
+          if Hyrax::CollectionTypes::PermissionsService.can_create_admin_set_collection_type?(ability: self)
+            can :create, [AdminSet, Hyrax::AdministrativeSet]
+            can :create_any, AdminSet
+            can :create_any, Hyrax::AdministrativeSet
+          end
+          if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_admin_set?(ability: self)
+            can :view_admin_show_any, AdminSet
+            can :view_admin_show_any, Hyrax::AdministrativeSet
+          end
+          # [:edit, :update, :destroy] for AdminSet is controlled by Hydra::Ability #edit_permissions
+          can [:edit, :update, :destroy], Hyrax::AdministrativeSet do |admin_set| # for test by solr_doc, see solr_document_ability.rb
             test_edit(admin_set.id)
           end
 
           can :deposit, AdminSet do |admin_set| # for test by solr_doc, see collection_ability.rb
             Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: admin_set.id)
           end
+          can :deposit, Hyrax::AdministrativeSet do |admin_set| # for test by solr_doc, see collection_ability.rb
+            Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: admin_set.id)
+          end
 
           can :view_admin_show, AdminSet do |admin_set| # admin show page # for test by solr_doc, see collection_ability.rb
             Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: admin_set.id)
+          end
+          can :view_admin_show, Hyrax::AdministrativeSet do |admin_set| # admin show page # for test by solr_doc, see collection_ability.rb
+            Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: admin_set.id)
+          end
+
+          # [:read] for AdminSet is controlled by Hydra::Ability #read_permissions
+          can :read, Hyrax::AdministrativeSet do |admin_set| # admin show page # for test by solr_doc, see collection_ability.rb
+            test_read(admin_set.id)
           end
         end
 

--- a/spec/abilities/admin_set_ability_spec.rb
+++ b/spec/abilities/admin_set_ability_spec.rb
@@ -1,178 +1,212 @@
 # frozen_string_literal: true
 require 'cancan/matchers'
 
-RSpec.describe Hyrax::Ability do
+RSpec.describe Hyrax::Ability, :clean_repo do
   subject { ability }
 
   let(:ability) { Ability.new(current_user) }
-  let(:user) { create(:user) }
+  let(:user) { create(:user, email: 'user@example.com') }
   let(:current_user) { user }
-  let(:admin_set) { create(:admin_set, edit_users: [user], with_permission_template: true) }
 
   context 'when user who created the admin set' do
-    it 'allows the edit_users to edit and read' do
-      is_expected.to be_able_to(:read, admin_set)
-      is_expected.to be_able_to(:edit, admin_set)
+    context 'and admin set is an ActiveFedora::Base' do
+      let(:admin_set) { create(:adminset_lw, user: user, with_permission_template: true) }
+
+      it { is_expected.to be_able_to(:read, admin_set) }
+      it { is_expected.to be_able_to(:edit, admin_set) }
     end
   end
 
   context 'when admin user' do
-    let(:user) { FactoryBot.create(:admin) }
-    let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
+    let(:current_user) { admin }
+    let(:admin) { FactoryBot.create(:admin, email: 'admin@example.com') }
 
-    it 'allows all abilities' do # rubocop:disable RSpec/ExampleLength
-      is_expected.to be_able_to(:manage, AdminSet)
-      is_expected.to be_able_to(:manage_any, AdminSet)
-      is_expected.to be_able_to(:create_any, AdminSet)
-      is_expected.to be_able_to(:create, AdminSet)
-      is_expected.to be_able_to(:view_admin_show_any, AdminSet)
-      is_expected.to be_able_to(:edit, admin_set)
-      is_expected.to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:update, admin_set)
-      is_expected.to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:destroy, admin_set)
-      is_expected.to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:deposit, admin_set)
-      is_expected.to be_able_to(:deposit, solr_document)
-      is_expected.to be_able_to(:view_admin_show, admin_set)
-      is_expected.to be_able_to(:view_admin_show, solr_document)
-      is_expected.to be_able_to(:read, admin_set) # admins can do everything
-      is_expected.to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
+    context 'and admin set is an ActiveFedora::Base' do
+      let(:admin_set) { create(:adminset_lw, user: user, with_permission_template: true) }
+      let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
+
+      context 'for abilities open to admins' do
+        it { is_expected.to be_able_to(:manage, AdminSet) }
+        it { is_expected.to be_able_to(:manage_any, AdminSet) }
+        it { is_expected.to be_able_to(:create_any, AdminSet) }
+        it { is_expected.to be_able_to(:create, AdminSet) }
+        it { is_expected.to be_able_to(:view_admin_show_any, AdminSet) }
+        it { is_expected.to be_able_to(:edit, admin_set) }
+        it { is_expected.to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:update, admin_set) }
+        it { is_expected.to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:destroy, admin_set) }
+        it { is_expected.to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:deposit, admin_set) }
+        it { is_expected.to be_able_to(:deposit, solr_document) }
+        it { is_expected.to be_able_to(:view_admin_show, admin_set) }
+        it { is_expected.to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.to be_able_to(:read, admin_set) } # admins can do everything
+        it { is_expected.to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
     end
   end
 
   context 'when admin set manager' do
-    let!(:admin_set) { create(:admin_set, id: 'as_mu', with_permission_template: true) }
-    let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
+    let(:current_user) { manager }
+    let(:manager) { create(:user, email: 'manager@example.com') }
 
-    before do
-      create(:permission_template_access,
-             :manage,
-             permission_template: admin_set.permission_template,
-             agent_type: 'user',
-             agent_id: user.user_key)
-      admin_set.reset_access_controls!
-    end
+    context 'and admin set is an ActiveFedora::Base' do
+      let!(:admin_set) { create(:adminset_lw, id: 'as_mu', user: user, with_permission_template: true) }
+      let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
 
-    it 'allows most abilities' do # rubocop:disable RSpec/ExampleLength
-      is_expected.to be_able_to(:manage_any, AdminSet)
-      is_expected.to be_able_to(:view_admin_show_any, AdminSet)
-      is_expected.to be_able_to(:edit, admin_set) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:edit, solr_document)
-      is_expected.to be_able_to(:update, admin_set) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:update, solr_document)
-      is_expected.to be_able_to(:destroy, admin_set) # defined in solr_document_ability.rb
-      is_expected.to be_able_to(:destroy, solr_document)
-      is_expected.to be_able_to(:deposit, admin_set)
-      is_expected.to be_able_to(:deposit, solr_document)
-      is_expected.to be_able_to(:view_admin_show, admin_set)
-      is_expected.to be_able_to(:view_admin_show, solr_document)
-      is_expected.to be_able_to(:read, admin_set) # edit access grants read and write
-      is_expected.to be_able_to(:read, solr_document) # edit access grants read and write # defined in solr_document_ability.rb
-    end
+      before do
+        create(:permission_template_access,
+               :manage,
+               permission_template: admin_set.permission_template,
+               agent_type: 'user',
+               agent_id: manager.user_key)
+        admin_set.reset_access_controls!
+      end
 
-    it 'denies manage ability' do
-      is_expected.not_to be_able_to(:manage, AdminSet)
-      is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
-      is_expected.not_to be_able_to(:create, AdminSet)
+      context 'for abilities open to managers' do
+        it { is_expected.to be_able_to(:manage_any, AdminSet) }
+        it { is_expected.to be_able_to(:view_admin_show_any, AdminSet) }
+        it { is_expected.to be_able_to(:edit, admin_set) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:edit, solr_document) }
+        it { is_expected.to be_able_to(:update, admin_set) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:update, solr_document) }
+        it { is_expected.to be_able_to(:destroy, admin_set) } # defined in solr_document_ability.rb
+        it { is_expected.to be_able_to(:destroy, solr_document) }
+        it { is_expected.to be_able_to(:deposit, admin_set) }
+        it { is_expected.to be_able_to(:deposit, solr_document) }
+        it { is_expected.to be_able_to(:view_admin_show, admin_set) }
+        it { is_expected.to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.to be_able_to(:read, admin_set) } # edit access grants read and write
+        it { is_expected.to be_able_to(:read, solr_document) } # edit access grants read and write # defined in solr_document_ability.rb
+      end
+
+      context 'for abilities NOT open to managers' do
+        it { is_expected.not_to be_able_to(:manage, AdminSet) }
+        it { is_expected.not_to be_able_to(:create_any, AdminSet) } # granted by collection type, not collection
+        it { is_expected.not_to be_able_to(:create, AdminSet) }
+      end
     end
   end
 
   context 'when admin set depositor' do
-    let!(:admin_set) { create(:admin_set, id: 'as_du', with_permission_template: true) }
-    let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
+    let(:current_user) { depositor }
+    let(:depositor) { create(:user, email: 'depositor@example.com') }
 
-    before do
-      create(:permission_template_access,
-             :deposit,
-             permission_template: admin_set.permission_template,
-             agent_type: 'user',
-             agent_id: user.user_key)
-      admin_set.reset_access_controls!
-    end
+    context 'and admin set is an ActiveFedora::Base' do
+      let!(:admin_set) { create(:adminset_lw, id: 'as_du', user: user, with_permission_template: true) }
+      let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
 
-    it 'allows deposit related abilities' do
-      is_expected.to be_able_to(:view_admin_show_any, AdminSet)
-      is_expected.to be_able_to(:deposit, admin_set)
-      is_expected.to be_able_to(:deposit, solr_document)
-      is_expected.to be_able_to(:view_admin_show, admin_set)
-      is_expected.to be_able_to(:view_admin_show, solr_document)
-    end
+      before do
+        create(:permission_template_access,
+               :deposit,
+               permission_template: admin_set.permission_template,
+               agent_type: 'user',
+               agent_id: depositor.user_key)
+        admin_set.reset_access_controls!
+      end
 
-    it 'denies non-deposit related abilities' do # rubocop:disable RSpec/ExampleLength
-      is_expected.not_to be_able_to(:manage, AdminSet)
-      is_expected.not_to be_able_to(:manage_any, AdminSet)
-      is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
-      is_expected.not_to be_able_to(:create, AdminSet)
-      is_expected.not_to be_able_to(:edit, admin_set)
-      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:update, admin_set)
-      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:destroy, admin_set)
-      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:read, admin_set) # no public page for admin sets
-      is_expected.not_to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
+      context 'for abilities open to depositor' do
+        it { is_expected.to be_able_to(:view_admin_show_any, AdminSet) }
+        it { is_expected.to be_able_to(:deposit, admin_set) }
+        it { is_expected.to be_able_to(:deposit, solr_document) }
+        it { is_expected.to be_able_to(:view_admin_show, admin_set) }
+        it { is_expected.to be_able_to(:view_admin_show, solr_document) }
+
+        # There isn't a public show page for admin_sets, but since the user has
+        # permission to view the admin show page, they have permission to view
+        # the non-existent public show page.
+        it { is_expected.to be_able_to(:read, admin_set) } # no public page for admin sets
+        it { is_expected.to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
+
+      context 'for abilities NOT open to depositor' do
+        it { is_expected.not_to be_able_to(:manage, AdminSet) }
+        it { is_expected.not_to be_able_to(:manage_any, AdminSet) }
+        it { is_expected.not_to be_able_to(:create_any, AdminSet) } # granted by collection type, not collection
+        it { is_expected.not_to be_able_to(:create, AdminSet) }
+        it { is_expected.not_to be_able_to(:edit, admin_set) }
+        it { is_expected.not_to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:update, admin_set) }
+        it { is_expected.not_to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:destroy, admin_set) }
+        it { is_expected.not_to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+      end
     end
   end
 
   context 'when admin set viewer' do
-    let!(:admin_set) { create(:admin_set, id: 'as_vu', with_permission_template: true) }
-    let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
+    let(:current_user) { viewer }
+    let(:viewer) { create(:user, email: 'viewer@example.com') }
 
-    before do
-      create(:permission_template_access,
-             :view,
-             permission_template: admin_set.permission_template,
-             agent_type: 'user',
-             agent_id: user.user_key)
-      admin_set.reset_access_controls!
-    end
+    context 'and admin set is an ActiveFedora::Base' do
+      let!(:admin_set) { create(:adminset_lw, id: 'as_vu', user: user, with_permission_template: true) }
+      let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
 
-    it 'allows viewing only ability' do
-      is_expected.to be_able_to(:view_admin_show_any, AdminSet)
-      is_expected.to be_able_to(:view_admin_show, admin_set)
-    end
+      before do
+        create(:permission_template_access,
+               :view,
+               permission_template: admin_set.permission_template,
+               agent_type: 'user',
+               agent_id: viewer.user_key)
+        admin_set.reset_access_controls!
+      end
 
-    it 'denies most abilities' do # rubocop:disable RSpec/ExampleLength
-      is_expected.not_to be_able_to(:manage, AdminSet)
-      is_expected.not_to be_able_to(:manage_any, AdminSet)
-      is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
-      is_expected.not_to be_able_to(:create, AdminSet)
-      is_expected.not_to be_able_to(:edit, admin_set)
-      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:update, admin_set)
-      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:destroy, admin_set)
-      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:deposit, admin_set)
-      is_expected.not_to be_able_to(:deposit, solr_document)
-      is_expected.not_to be_able_to(:read, admin_set) # no public page for admin sets
-      is_expected.not_to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
+      context 'for abilities open to viewer' do
+        it { is_expected.to be_able_to(:view_admin_show_any, AdminSet) }
+        it { is_expected.to be_able_to(:view_admin_show, admin_set) }
+
+        # There isn't a public show page for admin_sets, but since the user has
+        # permission to view the admin show page, they have permission to view
+        # the non-existent public show page.
+        it { is_expected.to be_able_to(:read, admin_set) } # no public page for admin sets
+        it { is_expected.to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
+
+      context 'for abilities NOT open to viewer' do
+        it { is_expected.not_to be_able_to(:manage, AdminSet) }
+        it { is_expected.not_to be_able_to(:manage_any, AdminSet) }
+        it { is_expected.not_to be_able_to(:create_any, AdminSet) } # granted by collection type, not collection
+        it { is_expected.not_to be_able_to(:create, AdminSet) }
+        it { is_expected.not_to be_able_to(:edit, admin_set) }
+        it { is_expected.not_to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:update, admin_set) }
+        it { is_expected.not_to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:destroy, admin_set) }
+        it { is_expected.not_to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:deposit, admin_set) }
+        it { is_expected.not_to be_able_to(:deposit, solr_document) }
+      end
     end
   end
 
   context 'when user has no special access' do
-    let(:admin_set) { create(:admin_set, id: 'as', with_permission_template: true) }
-    let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
+    let(:current_user) { other_user }
+    let(:other_user) { create(:user, email: 'other_user@example.com') }
 
-    it 'denies all abilities' do # rubocop:disable RSpec/ExampleLength
-      is_expected.not_to be_able_to(:manage, AdminSet)
-      is_expected.not_to be_able_to(:manage_any, AdminSet)
-      is_expected.not_to be_able_to(:create_any, AdminSet) # granted by collection type, not collection
-      is_expected.not_to be_able_to(:create, AdminSet)
-      is_expected.not_to be_able_to(:view_admin_show_any, AdminSet)
-      is_expected.not_to be_able_to(:edit, admin_set)
-      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:update, admin_set)
-      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:destroy, admin_set)
-      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:deposit, admin_set)
-      is_expected.not_to be_able_to(:deposit, solr_document) # defined in solr_document_ability.rb
-      is_expected.not_to be_able_to(:view_admin_show, admin_set)
-      is_expected.not_to be_able_to(:view_admin_show, solr_document)
-      is_expected.not_to be_able_to(:read, admin_set) # no public page for admin sets
-      is_expected.not_to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
+    context 'and admin set is an ActiveFedora::Base' do
+      let(:admin_set) { create(:adminset_lw, id: 'as', user: user, with_permission_template: true) }
+      let!(:solr_document) { SolrDocument.new(admin_set.to_solr) }
+
+      context 'for abilities NOT open to general user' do
+        it { is_expected.not_to be_able_to(:manage, AdminSet) }
+        it { is_expected.not_to be_able_to(:manage_any, AdminSet) }
+        it { is_expected.not_to be_able_to(:create_any, AdminSet) } # granted by collection type, not collection
+        it { is_expected.not_to be_able_to(:create, AdminSet) }
+        it { is_expected.not_to be_able_to(:view_admin_show_any, AdminSet) }
+        it { is_expected.not_to be_able_to(:edit, admin_set) }
+        it { is_expected.not_to be_able_to(:edit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:update, admin_set) }
+        it { is_expected.not_to be_able_to(:update, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:destroy, admin_set) }
+        it { is_expected.not_to be_able_to(:destroy, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:deposit, admin_set) }
+        it { is_expected.not_to be_able_to(:deposit, solr_document) } # defined in solr_document_ability.rb
+        it { is_expected.not_to be_able_to(:view_admin_show, admin_set) }
+        it { is_expected.not_to be_able_to(:view_admin_show, solr_document) }
+        it { is_expected.not_to be_able_to(:read, admin_set) } # no public page for admin sets
+        it { is_expected.not_to be_able_to(:read, solr_document) } # defined in solr_document_ability.rb
+      end
     end
   end
 end

--- a/spec/factories/administrative_sets.rb
+++ b/spec/factories/administrative_sets.rb
@@ -2,6 +2,33 @@
 FactoryBot.define do
   factory :hyrax_admin_set, class: 'Hyrax::AdministrativeSet' do
     title { ['My Admin Set'] }
+
+    transient do
+      with_permission_template { false }
+      user { create(:user) }
+      access_grants { [] }
+    end
+
+    after(:build) do |adminset, evaluator|
+      adminset.creator = [evaluator.user.user_key]
+    end
+
+    after(:create) do |admin_set, evaluator|
+      if evaluator.with_permission_template
+        template = Hyrax::PermissionTemplate.find_or_create_by(source_id: admin_set.id.to_s)
+        evaluator.access_grants.each do |grant|
+          Hyrax::PermissionTemplateAccess.find_or_create_by(permission_template_id: template.id,
+                                                            agent_type: grant[:agent_type],
+                                                            agent_id: grant[:agent_id],
+                                                            access: grant[:access])
+        end
+        Hyrax::PermissionTemplateAccess.find_or_create_by(permission_template_id: template.id,
+                                                          agent_type: Hyrax::PermissionTemplateAccess::USER,
+                                                          agent_id: evaluator.user.user_key,
+                                                          access: Hyrax::PermissionTemplateAccess::MANAGE)
+        template.reset_access_controls_for(collection: admin_set)
+      end
+    end
   end
 
   factory :invalid_hyrax_admin_set, class: 'Hyrax::AdministrativeSet' do


### PR DESCRIPTION
This is in preparation for using Hyrax::AdministrativeSets for new/create in the collections controller. Partially addresses Issue #5130 Val MVP: Create AdministrativeSets as a valkyrie resource through UI.

Updates admin_set_ability to allow/disallow the same abilities when the object is an ActiveFedora::Base AdminSet or a Valkyrie::Resource Hyrax::AdministrativeSets. The same tests are run for both object classes.

@samvera/hyrax-code-reviewers
