### PR TITLE
update collection controller to process create with Hyrax::PcdmCollection

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -43,7 +43,7 @@ module Hyrax
       # The search builder to find the collections' members
       self.membership_service_class = Collections::CollectionMemberSearchService
 
-      load_and_authorize_resource except: [:index, :create], instance_name: :collection
+      load_and_authorize_resource except: [:index, :create, :new], instance_name: :collection
 
       def deny_collection_access(exception)
         if exception.action == :edit
@@ -57,14 +57,10 @@ module Hyrax
       end
 
       def new
-        # Coming from the UI, a collection type id should always be present.  Coming from the API, if a collection type id is not specified,
-        # use the default collection type (provides backward compatibility with versions < Hyrax 2.1.0)
-        collection_type_id = params[:collection_type_id].presence || default_collection_type.id
-        @collection.collection_type_gid = CollectionType.find(collection_type_id).to_global_id
+        authorize! :create_collection_of_type, collection_type
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
         add_breadcrumb t('.header', type_title: collection_type.title), request.path
-        @collection.apply_depositor_metadata(current_user.user_key)
         form
       end
 
@@ -82,42 +78,33 @@ module Hyrax
 
       def after_create
         form
-        set_default_permissions
         # if we are creating the new collection as a subcollection (via the nested collections controller),
         # we pass the parent_id through a hidden field in the form and link the two after the create.
-        link_parent_collection(params[:parent_id]) unless params[:parent_id].nil?
         respond_to do |format|
-          Hyrax::SolrService.commit
           format.html { redirect_to edit_dashboard_collection_path(@collection), notice: t('hyrax.dashboard.my.action.collection_create_success') }
           format.json { render json: @collection, status: :created, location: dashboard_collection_path(@collection) }
         end
       end
 
-      def after_create_error
-        form
+      def after_create_error(err_msg:)
+        flash[:error] = err_msg
         respond_to do |format|
           format.html { render action: 'new' }
-          format.json { render json: @collection.errors, status: :unprocessable_entity }
+          format.json { render json: err_msg, status: :unprocessable_entity }
         end
       end
 
       def create
-        # Manual load and authorize necessary because Cancan will pass in all
-        # form attributes. When `permissions_attributes` are present the
-        # collection is saved without a value for `has_model.`
-        @collection = ::Collection.new
-        authorize! :create, @collection
-        # Coming from the UI, a collection type gid should always be present.  Coming from the API, if a collection type gid is not specified,
-        # use the default collection type (provides backward compatibility with versions < Hyrax 2.1.0)
-        @collection.collection_type_gid = params[:collection_type_gid].presence || default_collection_type.to_global_id
-        @collection.attributes = collection_params.except(:members, :parent_id, :collection_type_gid)
-        @collection.apply_depositor_metadata(current_user.user_key)
-        @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE unless @collection.discoverable?
-        if @collection.save
+        authorize! :create_collection_of_type, collection_type
+        form
+        result = create_collection(form: @form,
+                                   user: current_user,
+                                   collection_type_gid: collection_type.to_global_id,
+                                   parent_id: params[:parent_id])
+        if result == true
           after_create
-          add_members_to_collection unless batch.empty?
         else
-          after_create_error
+          after_create_error(err_msg: result)
         end
       end
 
@@ -146,7 +133,7 @@ module Hyrax
         @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE unless @collection.discoverable?
         # we don't have to reindex the full graph when updating collection
         @collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
-        if @collection.update(collection_params.except(:members))
+        if @collection.update(collection_params_without_permissions.except(:members))
           after_update
         else
           after_update_error
@@ -197,12 +184,66 @@ module Hyrax
 
       private
 
+      # @return <true | String> true if collection creation successful; otherwise, returns error message
+      def create_collection(form:, user:, collection_type_gid:, parent_id:)
+        result = create_form_validation(form: form)
+        return result unless result == true
+        create_form_result(form: form, user: user,
+                           collection_type_gid: collection_type_gid,
+                           parent_id: parent_id)
+      end
+
+      # @return <true | String> true if the form is valid; otherwise, returns validation error message
+      def create_form_validation(form:)
+        return true if @form.validate(collection_params)
+        err_msgs = []
+        form.errors.messages.each do |field, err|
+          err_msgs << "#{field.to_s.capitalize} #{err.first}."
+        end
+        err_msgs.join(' ')
+      end
+
+      # Process create form and set collection to results
+      # @return <true | String> true if the form is valid; otherwise, returns validation error message
+      def create_form_result(form:, user:, collection_type_gid:, parent_id:)
+        result = transactions['change_set.create_collection']
+                 .with_step_args(
+                   'change_set.set_user_as_depositor' => { user: user },
+                   'change_set.set_collection_type_gid' => { collection_type_gid: collection_type_gid },
+                   'change_set.add_to_collections' => { collection_ids: Array(parent_id) },
+                   'collection_resource.apply_collection_type_permissions' => { user: user }
+                 )
+                 .call(form)
+        return result.failure.first if result.failure?
+        @collection = result.value!
+        true
+      end
+
       def default_collection_type
         Hyrax::CollectionType.find_or_create_default_collection_type
       end
 
+      # The collection_type can be identified in several ways listed in order of precedence:
+      # * get id from @collection if it exists
+      # * get id from params[:collection_type_id], if it exists
+      # * get gid from params[:collection_type_gid], if it exists
+      # * otherwise, use default_collection_type
       def collection_type
-        @collection_type ||= CollectionType.find_by_gid!(collection.collection_type_gid)
+        return @collection_type if @collection_type
+        type_id = collection_type_id
+        @collection_type ||= Hyrax::CollectionType.find(type_id) if type_id
+        @collection_type ||= collection_type_from_gid
+      end
+
+      def collection_type_id
+        type_id = collection&.collection_type&.id || params[:collection_type_id]
+        type_id = default_collection_type.id if type_id.blank? && params[:collection_type_gid].blank?
+        type_id
+      end
+
+      def collection_type_from_gid
+        gid = params[:collection_type_gid]
+        Hyrax::CollectionType.find_by_gid!(gid) if gid
       end
 
       def link_parent_collection(parent_id)
@@ -345,6 +386,12 @@ module Hyrax
       deprecation_deprecate :single_item_search_builder
 
       def collection_params
+        # For backward compatibility, need to support params[:collection] for existing APIs
+        @collection_params = params[:collection]
+        @collection_params ||= params[:pcdm_collection]
+      end
+
+      def collection_params_without_permissions
         @participants = extract_old_style_permission_attributes(params[:collection])
         form_class.model_attributes(params[:collection])
       end
@@ -424,12 +471,13 @@ module Hyrax
       end
 
       def form
-        @form ||= form_class.new(@collection, current_ability, repository)
-      end
-
-      def set_default_permissions
-        additional_grants = @participants # Grants converted from older versions (< Hyrax 2.1.0) where share was edit or read access instead of managers, depositors, and viewers
-        Collections::PermissionsCreateService.create_default(collection: @collection, creating_user: current_user, grants: additional_grants)
+        @collection ||= Hyrax::PcdmCollection.new(collection_type_gid: collection_type.to_global_id)
+        @form ||= case collection
+                  when Hyrax::PcdmCollection
+                    Hyrax::Forms::PcdmCollectionForm.new(collection)
+                  else
+                    form_class.new(collection, current_ability, repository)
+                  end
       end
 
       def query_collection_members

--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -8,6 +8,7 @@ module Hyrax
     class PcdmCollectionForm < Valkyrie::ChangeSet # rubocop:disable Metrics/ClassLength
       include Hyrax::FormFields(:collection_core_metadata)
       include Hyrax::FormFields(:collection_basic_metadata)
+      include Hyrax::FormFields(:collection_metadata)
 
       property :human_readable_type, writable: false
       property :date_modified, readable: false

--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -5,11 +5,18 @@ module Hyrax
     ##
     # @api public
     # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
-    class PcdmCollectionForm < Valkyrie::ChangeSet
-      property :title, required: true, primary: true
+    class PcdmCollectionForm < Valkyrie::ChangeSet # rubocop:disable Metrics/ClassLength
+      include Hyrax::FormFields(:collection_core_metadata)
+      include Hyrax::FormFields(:collection_basic_metadata)
 
-      property :depositor
-      property :collection_type_gid
+      property :human_readable_type, writable: false
+      property :date_modified, readable: false
+      property :date_uploaded, readable: false
+
+      property :depositor, required: true
+      property :collection_type_gid, required: true
+
+      property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 
       class << self
         def model_class

--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -9,6 +9,7 @@ module Hyrax
     include Hyrax::VisibilityIndexer
     include Hyrax::Indexer(:collection_core_metadata)
     include Hyrax::Indexer(:collection_basic_metadata)
+    include Hyrax::Indexer(:collection_metadata)
 
     def to_solr
       super.tap do |index_document|

--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -7,8 +7,8 @@ module Hyrax
     include Hyrax::ResourceIndexer
     include Hyrax::PermissionIndexer
     include Hyrax::VisibilityIndexer
-    include Hyrax::Indexer(:core_metadata)
-    include Hyrax::Indexer(:basic_metadata)
+    include Hyrax::Indexer(:collection_core_metadata)
+    include Hyrax::Indexer(:collection_basic_metadata)
 
     def to_solr
       super.tap do |index_document|

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -8,6 +8,7 @@ module Hyrax
   class PcdmCollection < Hyrax::Resource
     include Hyrax::Schema(:collection_core_metadata)
     include Hyrax::Schema(:collection_basic_metadata)
+    include Hyrax::Schema(:collection_metadata)
 
     attribute :collection_type_gid, Valkyrie::Types::String
     attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -6,8 +6,8 @@ module Hyrax
   ##
   # Valkyrie model for Collection domain objects in the Hydra Works model.
   class PcdmCollection < Hyrax::Resource
-    include Hyrax::Schema(:core_metadata)
-    include Hyrax::Schema(:basic_metadata)
+    include Hyrax::Schema(:collection_core_metadata)
+    include Hyrax::Schema(:collection_basic_metadata)
 
     attribute :collection_type_gid, Valkyrie::Types::String
     attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1566,6 +1566,21 @@ en:
         resource_type: Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected.
         subject: Headings or index terms describing what the collection is about; these do need to conform to an existing vocabulary.
         title: A name to aid in identifying a collection.
+      pcdm_collection:
+        based_near: A place name related to the collection, such as its site of publication, or the city, state, or country the collection contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>.
+        contributor: A person or group you want to recognize for playing a role in the creation of the collection, but not the primary role.
+        creator: 'The person or group responsible for the collection. Usually this is the author of the content. Personal names should be entered with the last name first: Smith, John'
+        date_created: The date on which the collection was created.
+        description: Free-text notes about the collection. Examples include abstracts of a paper or citation information for a journal article.
+        identifier: A unique handle identifying the collection. An example would be a DOI for a journal article, or an ISBN or OCLC number for a book.
+        keyword: Words or phrases you select to describe what the collection is about. These are used to search for content.
+        language: The language of the collection's content.
+        license: Licensing and distribution information governing access to the collection. Select from the provided drop-down list.
+        publisher: The person or group making the collection available. Generally this is the institution.
+        related_url: A link to a website or other specific content (audio, video, PDF document) related to the collection. An example is the URL of a research project from which the collection was derived.
+        resource_type: Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected.
+        subject: Headings or index terms describing what the collection is about; these do need to conform to an existing vocabulary.
+        title: A name to aid in identifying a collection.
       collection_type:
         allow_multiple_membership: Allow works to belong to multiple collections of this type
         assigns_visibility: Allow collections of this type to assign initial visibility settings to a new work

--- a/config/metadata/collection_basic_metadata.yaml
+++ b/config/metadata/collection_basic_metadata.yaml
@@ -1,0 +1,86 @@
+attributes:
+  description:
+    type: string
+    multiple: true
+    form:
+      primary: true
+  alternative_title:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  creator:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "creator_tesim"
+  contributor:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  keyword:
+    type: string
+    multiple: true
+    index_keys:
+      - "keyword_sim"
+      - "keyword_tesim"
+    form:
+      primary: false
+  license:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  publisher:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  date_created:
+    type: date_time
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "date_created_tesim"
+  subject:
+    type: string
+    multiple: true
+    index_keys:
+      - "subject_sim"
+      - "subject_tesim"
+    form:
+      primary: false
+  language:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  identifier:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  location:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  related_url:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "related_url_tesim"
+  resource_type:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "resource_type_sim"
+      - "resource_type_tesim"

--- a/config/metadata/collection_basic_metadata.yaml
+++ b/config/metadata/collection_basic_metadata.yaml
@@ -87,3 +87,8 @@ attributes:
     index_keys:
       - "resource_type_sim"
       - "resource_type_tesim"
+  source:
+    type: string
+    multiple: true
+    form:
+      primary: false

--- a/config/metadata/collection_basic_metadata.yaml
+++ b/config/metadata/collection_basic_metadata.yaml
@@ -64,11 +64,14 @@ attributes:
     multiple: true
     form:
       primary: false
-  location:
+  based_near:
     type: string
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "based_near_sim"
+      - "based_near_tesim"
   related_url:
     type: string
     multiple: true

--- a/config/metadata/collection_core_metadata.yaml
+++ b/config/metadata/collection_core_metadata.yaml
@@ -1,0 +1,17 @@
+attributes:
+  title:
+    type: string
+    multiple: true
+    index_keys:
+      - "title_sim"
+      - "title_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+  date_modified:
+    type: date_time
+  date_uploaded:
+    type: date_time
+  depositor:
+    type: string

--- a/lib/generators/hyrax/templates/config/metadata/collection.yml
+++ b/lib/generators/hyrax/templates/config/metadata/collection.yml
@@ -1,0 +1,19 @@
+# Simple yaml config-driven schema which is used to define extensions to the
+# basic collection metadata attributes, index key names, and form properties.
+#
+# Attributes must have a type but all other configuration options are optional.
+#
+# attributes:
+#   attribute_name:
+#     type: string
+#     multiple: false
+#     index_keys:
+#       - "attribute_name_sim"
+#     form:
+#       required: true
+#       primary: true
+#       multiple: false
+#
+# @see config/metadata/collection_basic_metadata.yaml for an example configuration
+
+attributes: {}

--- a/lib/hyrax/form_fields.rb
+++ b/lib/hyrax/form_fields.rb
@@ -49,6 +49,7 @@ module Hyrax
 
       form_field_definitions.each do |field_name, options|
         descendant.property field_name.to_sym, options.merge(display: true, default: [])
+        descendant.validates field_name.to_sym, presence: true if options.fetch(:required, false)
       end
     end
   end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -21,12 +21,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   let(:unowned_asset)  { create(:work, user: other) }
 
   let(:collection_attrs) do
-    {
-      title: ['My First Collection'],
-      description: ["The Description\r\n\r\nand more"],
-      creator: ["Skippyjon Jones"],
-      collection_type_gid: [collection_type_gid]
-    }
+    { title: ['My First Collection'], description: ["The Description\r\n\r\nand more"], collection_type_gid: [collection_type_gid] }
   end
 
   let(:listener) { Hyrax::Specs::SpyListener.new }

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
   factory :hyrax_collection, class: 'Hyrax::PcdmCollection' do
     title               { ['The Tove Jansson Collection'] }
     collection_type_gid { Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id }
+    creator             { 'Skippyjon Jones' }
 
     transient do
       with_permission_template { true }
@@ -56,5 +57,10 @@ FactoryBot.define do
         members { [valkyrie_create(:hyrax_collection), valkyrie_create(:hyrax_collection)] }
       end
     end
+  end
+
+  factory :invalid_hyrax_collection, class: 'Hyrax::PcdmCollection' do
+    # Title and creator are required based on core and basic metadata definitions.
+    # Without title and creator, the collection is invalid.
   end
 end

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
   factory :hyrax_collection, class: 'Hyrax::PcdmCollection' do
     title               { ['The Tove Jansson Collection'] }
     collection_type_gid { Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id }
-    creator             { 'Skippyjon Jones' }
 
     transient do
       with_permission_template { true }
@@ -60,7 +59,7 @@ FactoryBot.define do
   end
 
   factory :invalid_hyrax_collection, class: 'Hyrax::PcdmCollection' do
-    # Title and creator are required based on core and basic metadata definitions.
-    # Without title and creator, the collection is invalid.
+    # Title and collection_type_gid are required based on core and basic collection
+    # metadata definitions. Without either of these fields, the collection is invalid.
   end
 end

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe 'Creating a new Admin Set', :js, :workflow, :clean_repo do
+RSpec.describe 'Creating a new Collection', :js, :workflow, :clean_repo do
   let(:admin) { create(:admin, email: 'admin@example.com') }
   let(:manager) { create(:user, email: 'manager@example.com') }
   let(:creator) { create(:user, email: 'creator@example.com') }
@@ -18,14 +18,14 @@ RSpec.describe 'Creating a new Admin Set', :js, :workflow, :clean_repo do
   end
 
   context "when the user is not an admin" do
-    context "and user does not have permissions to create managed collection type" do
+    context "and user does not have permissions to create Managed Collection type" do
       before do
         sign_in user
         click_link 'Collections'
       end
 
       it 'user is not offered the option to create that type of collection' do
-        # try and create the new admin set
+        # try and create the new collection
         click_button "New Collection"
         expect(page).to have_xpath("//h4", text: "User Collection")
         expect(page).to have_xpath("//h4", text: "Other")
@@ -33,7 +33,7 @@ RSpec.describe 'Creating a new Admin Set', :js, :workflow, :clean_repo do
       end
     end
 
-    context "and user is a creator for managed collection type" do
+    context "and user is a creator for Managed Collection type" do
       before do
         sign_in creator
         click_link 'Collections'
@@ -48,6 +48,8 @@ RSpec.describe 'Creating a new Admin Set', :js, :workflow, :clean_repo do
         choose "collection_type", option: "ManagedCollection"
         click_button 'Create collection'
         fill_in('Title', with: 'A Managed Collection')
+        fill_in('Creator', with: 'Skippyjon Jones')
+        click_link 'Additional fields'
         fill_in('Description', with: "This collection was created by #{creator.user_key}")
         click_on('Save')
         expect(page).to have_content("Collection was successfully created.")
@@ -84,7 +86,7 @@ RSpec.describe 'Creating a new Admin Set', :js, :workflow, :clean_repo do
       end
     end
 
-    context "and user is a manager for managed collection type" do
+    context "and user is a manager for Managed Collection type" do
       before do
         sign_in manager
         click_link 'Collections'
@@ -99,6 +101,8 @@ RSpec.describe 'Creating a new Admin Set', :js, :workflow, :clean_repo do
         choose "collection_type", option: "ManagedCollection"
         click_button 'Create collection'
         fill_in('Title', with: 'A Managed Collection')
+        fill_in('Creator', with: 'Skippyjon Jones')
+        click_link 'Additional fields'
         fill_in('Description', with: "This collection was created by #{manager.user_key}")
         click_on('Save')
         expect(page).to have_content("Collection was successfully created.")
@@ -148,6 +152,8 @@ RSpec.describe 'Creating a new Admin Set', :js, :workflow, :clean_repo do
       choose "collection_type", option: "ManagedCollection"
       click_button 'Create collection'
       fill_in('Title', with: 'A Managed Collection')
+      fill_in('Creator', with: 'Skippyjon Jones')
+      click_link 'Additional fields'
       fill_in('Description', with: "This collection was created by #{admin.user_key}")
       click_on('Save')
       expect(page).to have_content("Collection was successfully created.")

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -48,8 +48,6 @@ RSpec.describe 'Creating a new Collection', :js, :workflow, :clean_repo do
         choose "collection_type", option: "ManagedCollection"
         click_button 'Create collection'
         fill_in('Title', with: 'A Managed Collection')
-        fill_in('Creator', with: 'Skippyjon Jones')
-        click_link 'Additional fields'
         fill_in('Description', with: "This collection was created by #{creator.user_key}")
         click_on('Save')
         expect(page).to have_content("Collection was successfully created.")
@@ -101,8 +99,6 @@ RSpec.describe 'Creating a new Collection', :js, :workflow, :clean_repo do
         choose "collection_type", option: "ManagedCollection"
         click_button 'Create collection'
         fill_in('Title', with: 'A Managed Collection')
-        fill_in('Creator', with: 'Skippyjon Jones')
-        click_link 'Additional fields'
         fill_in('Description', with: "This collection was created by #{manager.user_key}")
         click_on('Save')
         expect(page).to have_content("Collection was successfully created.")
@@ -152,8 +148,6 @@ RSpec.describe 'Creating a new Collection', :js, :workflow, :clean_repo do
       choose "collection_type", option: "ManagedCollection"
       click_button 'Create collection'
       fill_in('Title', with: 'A Managed Collection')
-      fill_in('Creator', with: 'Skippyjon Jones')
-      click_link 'Additional fields'
       fill_in('Description', with: "This collection was created by #{admin.user_key}")
       click_on('Save')
       expect(page).to have_content("Collection was successfully created.")

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -227,6 +227,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   describe 'create collection' do
     let(:title) { "Test Collection" }
     let(:description) { "Description for collection we are testing." }
+    let(:creator) { "Skippyjon Jones" }
 
     context 'when user can create collections of multiple types' do
       before do
@@ -252,6 +253,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         fill_in('Title', with: title)
         fill_in('Description', with: description)
+        fill_in('Creator', with: creator)
         fill_in('Related URL', with: 'http://example.com/')
 
         click_button("Save")
@@ -283,6 +285,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         fill_in('Title', with: title)
         fill_in('Description', with: description)
+        fill_in('Creator', with: creator)
         fill_in('Related URL', with: 'http://example.com/')
 
         click_button("Save")

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -227,7 +227,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   describe 'create collection' do
     let(:title) { "Test Collection" }
     let(:description) { "Description for collection we are testing." }
-    let(:creator) { "Skippyjon Jones" }
 
     context 'when user can create collections of multiple types' do
       before do
@@ -253,7 +252,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         fill_in('Title', with: title)
         fill_in('Description', with: description)
-        fill_in('Creator', with: creator)
         fill_in('Related URL', with: 'http://example.com/')
 
         click_button("Save")
@@ -285,7 +283,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         fill_in('Title', with: title)
         fill_in('Description', with: description)
-        fill_in('Creator', with: creator)
         fill_in('Related URL', with: 'http://example.com/')
 
         click_button("Save")

--- a/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::Forms::PcdmCollectionForm do
   describe '.required_fields' do
     it 'lists required fields' do
       expect(described_class.required_fields)
-        .to contain_exactly(:title)
+        .to contain_exactly(:title, :collection_type_gid, :depositor)
     end
   end
 

--- a/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Hyrax::Forms::PcdmCollectionForm do
   describe '.required_fields' do
     it 'lists required fields' do
       expect(described_class.required_fields)
-        .to contain_exactly :title
+        .to contain_exactly(:title, :collection_type_gid, :creator, :depositor)
     end
   end
 
   describe '#primary_terms' do
     it 'gives "title" as a primary term' do
-      expect(form.primary_terms).to contain_exactly(:title)
+      expect(form.primary_terms).to contain_exactly(:title, :creator, :rights_statement)
     end
   end
 end

--- a/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Hyrax::Forms::PcdmCollectionForm do
   describe '.required_fields' do
     it 'lists required fields' do
       expect(described_class.required_fields)
-        .to contain_exactly(:title, :collection_type_gid, :creator, :depositor)
+        .to contain_exactly(:title)
     end
   end
 
   describe '#primary_terms' do
     it 'gives "title" as a primary term' do
-      expect(form.primary_terms).to contain_exactly(:title, :creator, :rights_statement)
+      expect(form.primary_terms).to contain_exactly(:title, :description)
     end
   end
 end


### PR DESCRIPTION
Fixes #5132

Includes changes to Hyrax::Forms::PcdmCollectionForm that support creating collections through the UI.

There are a few changes in the presentation to users with the change to Hyrax::PcdmCollection based on the way metadata is defined in that class.  See comments in changed files for more information.

NOTE: This was confirmed in the UI that a collection can be created with `Hyrax:PcdmCollection` and then edited using `::Collection`.  Edit will also be updated in a later PR.

@samvera/hyrax-code-reviewers
