### PR TITLE
apply more targeted handling for transactional save failures

### DIFF
--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -43,18 +43,18 @@ module Hyrax
 
           user ||= ::User.find_by_user_key(saved.depositor)
 
-          publish_changes(unsaved, saved, user)
+          publish_changes(resource: saved, user: user, new: unsaved.new_record)
           Success(saved)
         end
 
         private
 
-        def publish_changes(unsaved, saved, user)
-          if saved.collection?
-            Hyrax.publisher.publish('collection.metadata.updated', collection: saved, user: user)
+        def publish_changes(resource:, user:, new: false)
+          if resource.collection?
+            Hyrax.publisher.publish('collection.metadata.updated', collection: resource, user: user)
           else
-            Hyrax.publisher.publish('object.deposited', object: saved, user: user) if unsaved.new_record
-            Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
+            Hyrax.publisher.publish('object.deposited', object: resource, user: user) if new
+            Hyrax.publisher.publish('object.metadata.updated', object: resource, user: user)
           end
         end
       end


### PR DESCRIPTION
narrow the scope for failure message handling in the transactional save step.

this avoids blanket catching errors that arise due to listeners for published
events. treating all the possible errors from this method as exactly the same,
and squashing them to their `#message`, makes debugging hard (e.g. it's hard to
tell what is raising, exactly).

this change will cause errors from published events to raise eagerly, skipping
the `Success|Failure` `Result` monad pipeline. in theory, this should be okay,
since pub/sub listeners should generally not be raising uncaught exceptions. it
appears that some ARE at this point, at least in some cases. the hope is that
this change will help us get to the bottom of that.

@samvera/hyrax-code-reviewers
