### PR TITLE
sipity: don't generate `true` comments

### DIFF
--- a/app/models/sipity/comment.rb
+++ b/app/models/sipity/comment.rb
@@ -11,4 +11,21 @@ module Sipity
       agent.proxy_for.to_s
     end
   end
+
+  ##
+  # A comment without a database record; always returns an empty string
+  class NullComment
+    attr_reader :agent, :entity
+
+    def initialize(agent:, entity:)
+      @agent = agent
+      @entity = entity
+    end
+
+    ##
+    # @return [String]
+    def comment
+      ''
+    end
+  end
 end

--- a/app/services/hyrax/workflow/workflow_action_service.rb
+++ b/app/services/hyrax/workflow/workflow_action_service.rb
@@ -31,7 +31,8 @@ module Hyrax
       end
 
       def create_sipity_comment
-        return true if comment_text.blank?
+        return Sipity::NullComment.new(entity: subject.entity, agent: subject.agent) if
+          comment_text.blank?
         Sipity::Comment.create!(entity: subject.entity, agent: subject.agent, comment: comment_text)
       end
 
@@ -44,7 +45,9 @@ module Hyrax
         )
       end
 
+      ##
       # Run any configured custom methods
+      #
       def handle_additional_sipity_workflow_action_processing(comment:)
         Hyrax::Workflow::ActionTakenService.handle_action_taken(
           target: subject.work,


### PR DESCRIPTION
handling `true` `nil` and `Sipity::Comment` values in all the action taken and
notification services isn't a great pattern. instead, go for `nil` if there`s no
comment.

@samvera/hyrax-code-reviewers
