### PR TITLE
Update PcdmCollection metadata to match existing ::Collection metadata

### DIFF
--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -6,6 +6,9 @@ module Hyrax
     # @api public
     # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
     class PcdmCollectionForm < Valkyrie::ChangeSet # rubocop:disable Metrics/ClassLength
+      include Hyrax::FormFields(:collection_basic_metadata)
+      include Hyrax::FormFields(:collection_metadata)
+
       property :title, required: true, primary: true
 
       property :human_readable_type, writable: false

--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -6,6 +6,7 @@ module Hyrax
     # @api public
     # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
     class PcdmCollectionForm < Valkyrie::ChangeSet # rubocop:disable Metrics/ClassLength
+      include Hyrax::FormFields(:core_metadata)
       include Hyrax::FormFields(:collection_basic_metadata)
       include Hyrax::FormFields(:collection_metadata)
 
@@ -21,7 +22,6 @@ module Hyrax
 
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 
-      validates :title, presence: true
       validates :collection_type_gid, presence: true
 
       class << self

--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -7,8 +7,8 @@ module Hyrax
     include Hyrax::ResourceIndexer
     include Hyrax::PermissionIndexer
     include Hyrax::VisibilityIndexer
-    include Hyrax::Indexer(:core_metadata)
-    include Hyrax::Indexer(:basic_metadata)
+    include Hyrax::Indexer(:collection_basic_metadata)
+    include Hyrax::Indexer(:collection_metadata)
 
     def to_solr
       super.tap do |index_document|

--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -7,6 +7,7 @@ module Hyrax
     include Hyrax::ResourceIndexer
     include Hyrax::PermissionIndexer
     include Hyrax::VisibilityIndexer
+    include Hyrax::Indexer(:core_metadata)
     include Hyrax::Indexer(:collection_basic_metadata)
     include Hyrax::Indexer(:collection_metadata)
 

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -40,6 +40,7 @@ module Hyrax
   # @see Hyrax::CustomQueries::Navigators::CollectionMembers#find_members_of
   #
   class PcdmCollection < Hyrax::Resource
+    include Hyrax::Schema(:core_metadata)
     include Hyrax::Schema(:collection_basic_metadata)
     include Hyrax::Schema(:collection_metadata)
 

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -40,8 +40,8 @@ module Hyrax
   # @see Hyrax::CustomQueries::Navigators::CollectionMembers#find_members_of
   #
   class PcdmCollection < Hyrax::Resource
-    include Hyrax::Schema(:core_metadata)
-    include Hyrax::Schema(:basic_metadata)
+    include Hyrax::Schema(:collection_basic_metadata)
+    include Hyrax::Schema(:collection_metadata)
 
     attribute :collection_type_gid, Valkyrie::Types::String
     attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)

--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -76,7 +76,11 @@ module Hyrax
       ##
       # @return [Dry::Types::Type]
       def type
-        collection_type = config['multiple'] ? Valkyrie::Types::Array : Identity
+        collection_type = if config['multiple']
+                            Valkyrie::Types::Array.constructor { |v| Array(v).select(&:present?) }
+                          else
+                            Identity
+                          end
         collection_type.of(type_for(config['type']))
       end
 

--- a/config/metadata/collection_basic_metadata.yaml
+++ b/config/metadata/collection_basic_metadata.yaml
@@ -1,0 +1,105 @@
+attributes:
+  title:
+    type: string
+    multiple: true
+    index_keys:
+      - "title_sim"
+      - "title_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+  date_modified:
+    type: date_time
+  date_uploaded:
+    type: date_time
+  depositor:
+    type: string
+  description:
+    type: string
+    multiple: true
+    form:
+      primary: true
+  alternative_title:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  creator:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "creator_tesim"
+  contributor:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  keyword:
+    type: string
+    multiple: true
+    index_keys:
+      - "keyword_sim"
+      - "keyword_tesim"
+    form:
+      primary: false
+  license:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  publisher:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  date_created:
+    type: date_time
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "date_created_tesim"
+  subject:
+    type: string
+    multiple: true
+    index_keys:
+      - "subject_sim"
+      - "subject_tesim"
+    form:
+      primary: false
+  language:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  identifier:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  based_near:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "based_near_sim"
+      - "based_near_tesim"
+  related_url:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "related_url_tesim"
+  resource_type:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "resource_type_sim"
+      - "resource_type_tesim"

--- a/config/metadata/collection_basic_metadata.yaml
+++ b/config/metadata/collection_basic_metadata.yaml
@@ -1,20 +1,4 @@
 attributes:
-  title:
-    type: string
-    multiple: true
-    index_keys:
-      - "title_sim"
-      - "title_tesim"
-    form:
-      required: true
-      primary: true
-      multiple: true
-  date_modified:
-    type: date_time
-  date_uploaded:
-    type: date_time
-  depositor:
-    type: string
   description:
     type: string
     multiple: true

--- a/config/metadata/collection_basic_metadata.yaml
+++ b/config/metadata/collection_basic_metadata.yaml
@@ -1,3 +1,24 @@
+# To change metadata used for Hyrax::PcdmCollections...
+#
+# add fields - see /config/metadata/collection_metadata.yaml
+#
+# remove or modify field
+# * copy this file to your app in the same location
+# * edit copied file
+# * remove the entire field definition to remove the field completely from collection resources
+# * modify any part of the field definition to change the characteristics of a field
+#
+# @note A definition in this file cannot be overridden by adding the same field to
+#   the collection_metadata.yaml.  This will cause an error.
+#
+# @note To remove all basic metadata, set this file to `attributes: {}`.
+#
+# @note ActiveFedora::Base Collections use a different process for metadata.
+#   In this case, a Collection class is generated when the Hyrax app generator
+#   is run.  In the generated class…
+# * includes `Hyrax::CollectionBehavior` which includes `Hyrax::CoreMetadata`
+# * includes `Hyrax::BasicMetadata`
+#
 attributes:
   description:
     type: string

--- a/config/metadata/collection_metadata.yaml
+++ b/config/metadata/collection_metadata.yaml
@@ -1,0 +1,1 @@
+attributes: {}

--- a/config/metadata/collection_metadata.yaml
+++ b/config/metadata/collection_metadata.yaml
@@ -1,1 +1,10 @@
+# To change metadata used for Hyrax::PcdmCollections...
+#
+# add fields
+# * copy this file to your app in the same location
+# * edit copied file
+# * add custom field definitions
+#
+# remove or modify field - see /config/metadata/collection_basic_metadata.yaml
+#
 attributes: {}

--- a/lib/generators/hyrax/templates/config/metadata/collection.yml
+++ b/lib/generators/hyrax/templates/config/metadata/collection.yml
@@ -1,0 +1,19 @@
+# Simple yaml config-driven schema which is used to define extensions to the
+# basic collection metadata attributes, index key names, and form properties.
+#
+# Attributes must have a type but all other configuration options are optional.
+#
+# attributes:
+#   attribute_name:
+#     type: string
+#     multiple: false
+#     index_keys:
+#       - "attribute_name_sim"
+#     form:
+#       required: true
+#       primary: true
+#       multiple: false
+#
+# @see config/metadata/collection_basic_metadata.yaml for an example configuration
+
+attributes: {}

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -134,7 +134,7 @@ RSpec.shared_examples 'a Hyrax::PcdmCollection' do
   it { is_expected.not_to be_work }
 
   it_behaves_like 'a Hyrax::Resource'
-  # it_behaves_like 'a model with core metadata'
+  it_behaves_like 'a model with core metadata'
   it_behaves_like 'a model with collection basic metadata'
   it_behaves_like 'has members'
 

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -134,8 +134,8 @@ RSpec.shared_examples 'a Hyrax::PcdmCollection' do
   it { is_expected.not_to be_work }
 
   it_behaves_like 'a Hyrax::Resource'
-  it_behaves_like 'a model with core metadata'
-  it_behaves_like 'a model with basic metadata'
+  # it_behaves_like 'a model with core metadata'
+  it_behaves_like 'a model with collection basic metadata'
   it_behaves_like 'has members'
 
   describe '#collection_type_gid' do

--- a/lib/hyrax/specs/shared_specs/metadata.rb
+++ b/lib/hyrax/specs/shared_specs/metadata.rb
@@ -96,28 +96,7 @@ end
 RSpec.shared_examples 'a model with collection basic metadata' do
   subject(:resource) { described_class.new }
   let(:date)         { Time.zone.today }
-
-  # from core metadata included in collection basic metadata
-  it 'has a date_modified' do
-    expect { resource.date_modified = date }
-      .to change { resource.date_modified }
-            .to eq date
-  end
-
-  # from core metadata included in collection basic metadata
-  it 'has a date_uploaded' do
-    expect { resource.date_uploaded = date }
-      .to change { resource.date_uploaded }
-            .to eq date
-  end
-
-  # from core metadata included in collection basic metadata
-  it 'has a depositor' do
-    expect { resource.depositor = 'userid' }
-      .to change { resource.depositor }
-            .to eq 'userid'
-  end
-
+  
   # from core metadata included in collection basic metadata
   # with multiple title override
   it 'has a title' do

--- a/lib/hyrax/specs/shared_specs/metadata.rb
+++ b/lib/hyrax/specs/shared_specs/metadata.rb
@@ -92,3 +92,91 @@ RSpec.shared_examples 'a model with core metadata' do
       .to contain_exactly('title')
   end
 end
+
+RSpec.shared_examples 'a model with collection basic metadata' do
+  subject(:resource) { described_class.new }
+  let(:date)         { Time.zone.today }
+
+  # from core metadata included in collection basic metadata
+  it 'has a date_modified' do
+    expect { resource.date_modified = date }
+      .to change { resource.date_modified }
+            .to eq date
+  end
+
+  # from core metadata included in collection basic metadata
+  it 'has a date_uploaded' do
+    expect { resource.date_uploaded = date }
+      .to change { resource.date_uploaded }
+            .to eq date
+  end
+
+  # from core metadata included in collection basic metadata
+  it 'has a depositor' do
+    expect { resource.depositor = 'userid' }
+      .to change { resource.depositor }
+            .to eq 'userid'
+  end
+
+  # from core metadata included in collection basic metadata
+  # with multiple title override
+  it 'has a title' do
+    expect { resource.title = ['title', 'title 2'] }
+      .to change { resource.title }
+            .to contain_exactly 'title', 'title 2'
+  end
+
+  it 'description' do
+    expect { resource.description = ['lorem ipsum', 'another description'] }
+      .to change { resource.description }
+            .to contain_exactly 'lorem ipsum', 'another description'
+  end
+
+  it 'has alternative title' do
+    expect { resource.alternative_title = ['lorem ipsum', 'a story about moomins'] }
+      .to change { resource.alternative_title }
+            .to contain_exactly 'lorem ipsum', 'a story about moomins'
+  end
+
+  it 'has a creator' do
+    expect { resource.creator = ['Creator, Joe', 'Creator, Jane'] }
+      .to change { resource.creator }
+            .to contain_exactly 'Creator, Joe', 'Creator, Jane'
+  end
+
+  it 'has licenses' do
+    expect { resource.license = ['http://example.com/li1', 'http://example.com/li2'] }
+      .to change { resource.license }
+            .to contain_exactly 'http://example.com/li1', 'http://example.com/li2'
+  end
+
+  it 'has subjects' do
+    expect { resource.subject = ['moomin', 'snork'] }
+      .to change { resource.subject }
+            .to contain_exactly 'moomin', 'snork'
+  end
+
+  it 'has language' do
+    expect { resource.language = ['en', 'fi'] }
+      .to change { resource.language }
+            .to contain_exactly 'en', 'fi'
+  end
+
+  it 'has based near' do
+    expect { resource.based_near = ['Ithaca (US)', 'New York (US)'] }
+      .to change { resource.based_near }
+            .to contain_exactly 'Ithaca (US)', 'New York (US)'
+  end
+
+  it 'has a related url' do
+    expect { resource.related_url = ['http://example.com/info', 'http://example.com/contact'] }
+      .to change { resource.related_url }
+            .to contain_exactly 'http://example.com/info', 'http://example.com/contact'
+  end
+
+  it 'has resource types' do
+    expect { resource.resource_type = ['book', 'image'] }
+      .to change { resource.resource_type }
+            .to contain_exactly 'book', 'image'
+  end
+end

--- a/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyrax::Forms::PcdmCollectionForm do
 
   describe '#primary_terms' do
     it 'gives "title" as a primary term' do
-      expect(form.primary_terms).to contain_exactly(:title)
+      expect(form.primary_terms).to contain_exactly(:title, :description)
     end
   end
 


### PR DESCRIPTION
This is in preparation for using `Hyrax::PcdmCollection` for new/create in the collections controller. Partially addresses Issue #5132 Val MVP: Create PcdmCollection as a valkyrie resource through UI.

This issue update the metadata for `Hyrax::PcdmCollection` to match that currently provided through `::Collection`.

Possible follow-on work:
* Currently, core metadata is included in `collection_basic_metadata` to allow title to have multiple values specified in the form.  If there was support for overriding metadata with the last reference to an attribute taking precedence, then `core_metadata` can be included and an override for just `title` can happen in `collection_basic_metadata`.
* `collection_metadata` is an empty metadata file that allows sites to add additional metadata for collections by adding this file to their app and adding custom metadata definitions.  This may need additional testing and may be dependent on override functionality being in place first.
* `collection_basic_metadata` does not bring in thumbnail selection into the form.
* Locations, driven by the `based_near` attribute, is not connecting to `GeoNames` for auto-complete.  It is possible that there is some outside configuration that has to happen in the app for this to work and does not represent additional work in Hyrax.  Testing needs to happen to confirm this.
* There is a larger question about what metadata should be included as collection metadata.  This will require community input to determine if we want to make a change.

@samvera/hyrax-code-reviewers