### PR TITLE
add validations for required fields

### DIFF
--- a/lib/hyrax/form_fields.rb
+++ b/lib/hyrax/form_fields.rb
@@ -49,6 +49,7 @@ module Hyrax
 
       form_field_definitions.each do |field_name, options|
         descendant.property field_name.to_sym, options.merge(display: true, default: [])
+        descendant.validates field_name.to_sym, presence: true if options.fetch(:required, false)
       end
     end
   end

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -311,6 +311,31 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
   end
 
+  describe '#valid?' do
+    subject(:form) { form_class.new(work) }
+
+    let(:form_class) do
+      Class.new(Hyrax::Forms::ResourceForm(work.class)) do
+        property :non_required, virtual: true
+      end
+    end
+
+    context 'when any required field is missing' do
+      before { form.title = [] }
+      it 'fails validation' do
+        expect(form.valid?).to be false
+      end
+    end
+
+    context 'when all required fields are present' do
+      # ResourceForm only includes core_metadata which has only title as a required field
+      before { form.title = ['My Title'] }
+      it 'passes validation' do
+        expect(form.valid?).to be true
+      end
+    end
+  end
+
   describe '#secondary_terms' do
     it 'is empty with only core metadata' do
       expect(form.secondary_terms)


### PR DESCRIPTION
Required fields were not getting validated.  The tests in this PR both return true for `valid?` without the addition to set `validates`.

See this gotcha described in [Dive into Valkyrie](https://github.com/samvera/valkyrie/wiki/Validating-change-sets#resource-attribute-with-required-true-passes-validation-when-missing).

@samvera/hyrax-code-reviewers
