### PR TITLE
refactor collection members controller specs

### DIFF
--- a/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
@@ -6,18 +6,17 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
   before { sign_in(user) }
 
   describe '#update_members' do
-    let(:other_user) { FactoryBot.create(:user) }
     let(:owned_work_1) { FactoryBot.create(:work, user: user) }
     let(:owned_work_2) { FactoryBot.create(:work, user: user) }
     let(:owned_work_3) { FactoryBot.create(:work, user: user) }
-    let(:private_work) { FactoryBot.create(:work, user: other_user) }
+    let(:private_work) { FactoryBot.create(:work) }
 
     let(:editable_work) do
-      FactoryBot.create(:work, user: other_user, edit_users: [user])
+      FactoryBot.create(:work, edit_users: [user])
     end
 
     let(:readable_work) do
-      FactoryBot.create(:work, user: other_user, read_users: [user])
+      FactoryBot.create(:work, read_users: [user])
     end
 
     let(:owned_collection) do
@@ -33,20 +32,16 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
 
     let(:depositable_collection) do
       FactoryBot.create(:private_collection_lw,
-                        user: other_user,
                         with_permission_template: { deposit_users: [user] })
     end
 
     let(:viewable_collection) do
       FactoryBot.create(:private_collection_lw,
-                        user: other_user,
                         with_permission_template: { view_users: [user] })
     end
 
     let(:private_collection) do
-      FactoryBot.create(:private_collection_lw,
-                        user: other_user,
-                        with_permission_template: true)
+      FactoryBot.create(:private_collection_lw, with_permission_template: true)
     end
 
     let(:parameters) do

--- a/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
@@ -1,441 +1,530 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
-  routes { Hyrax::Engine.routes }
-  let(:user)  { create(:user) }
-  let(:other) { create(:user) }
+  routes     { Hyrax::Engine.routes }
+  let(:user) { FactoryBot.create(:user) }
 
-  let(:work_1_own) { create(:work, id: 'work-1-own', title: ['First of the Assets'], user: user) }
-  let(:work_2_own) { create(:work, id: 'work-2-own', title: ['Second of the Assets'], user: user) }
-  let(:work_3_own) { create(:work, id: 'work-3-own', title: ['Third of the Assets'], user: user) }
-  let(:work_4_edit) { create(:work, id: 'work-4-edit', title: ["Other's work with edit access"], user: other, edit_users: [user]) }
-  let(:work_5_read) { create(:work, id: 'work-5-read', title: ["Other's work with read access"], user: other, read_users: [user]) }
-  let(:work_6_noaccess) { create(:work, id: 'work-6-no_access', title: ["Other's work with no access"], user: other) }
-
-  let(:coll_1_own) { create(:private_collection_lw, id: 'col-1-own', title: ['User created'], user: user, with_permission_template: true) }
-  let(:coll_2_mgr) do
-    create(:private_collection_lw, id: 'col-2-mgr', title: ['User has manage access'], user: other,
-                                   with_permission_template: { manage_users: [user] })
-  end
-  let(:coll_3_dep) do
-    create(:private_collection_lw, id: 'col-3-dep', title: ['User has deposit access'], user: other,
-                                   with_permission_template: { deposit_users: [user] })
-  end
-  let(:coll_4_view) do
-    create(:private_collection_lw, id: 'col-4-dep', title: ['User has view access'], user: other,
-                                   with_permission_template: { view_users: [user] })
-  end
-  let(:coll_5_noaccess) do
-    create(:private_collection_lw, id: 'col-5-no_access', title: ['Other user created'],
-                                   user: other, with_permission_template: true)
-  end
+  before { sign_in(user) }
 
   describe '#update_members' do
+    let(:other_user) { FactoryBot.create(:user) }
+    let(:owned_work_1) { FactoryBot.create(:work, user: user) }
+    let(:owned_work_2) { FactoryBot.create(:work, user: user) }
+    let(:owned_work_3) { FactoryBot.create(:work, user: user) }
+    let(:private_work) { FactoryBot.create(:work, user: other_user) }
+
+    let(:editable_work) do
+      FactoryBot.create(:work, user: other_user, edit_users: [user])
+    end
+
+    let(:readable_work) do
+      FactoryBot.create(:work, user: other_user, read_users: [user])
+    end
+
+    let(:owned_collection) do
+      FactoryBot.create(:private_collection_lw,
+                        user: user,
+                        with_permission_template: true)
+    end
+
+    let(:managed_collection) do
+      FactoryBot.create(:private_collection_lw,
+                        with_permission_template: { manage_users: [user] })
+    end
+
+    let(:depositable_collection) do
+      FactoryBot.create(:private_collection_lw,
+                        user: other_user,
+                        with_permission_template: { deposit_users: [user] })
+    end
+
+    let(:viewable_collection) do
+      FactoryBot.create(:private_collection_lw,
+                        user: other_user,
+                        with_permission_template: { view_users: [user] })
+    end
+
+    let(:private_collection) do
+      FactoryBot.create(:private_collection_lw,
+                        user: other_user,
+                        with_permission_template: true)
+    end
+
+    let(:parameters) do
+      { id: collection,
+        collection: { members: 'add' },
+        batch_document_ids: members_to_add.map(&:id) }
+    end
+
     context 'when user created the collection' do
+      let(:collection) { owned_collection }
+
       before do
-        sign_in user
-        [work_1_own, work_2_own].each do |asset|
-          asset.member_of_collections << coll_1_own
+        [owned_work_1, owned_work_2].each do |asset|
+          asset.member_of_collections << collection
           asset.save!
         end
       end
 
       context 'and user created the work' do
+        let(:members_to_add) { [owned_work_3] }
+
         it 'adds members to the collection' do
-          expect do
-            post :update_members, params: { id: coll_1_own,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_3_own.id] }
-          end.to change { coll_1_own.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_1_own, locale: 'en')
-          expect(coll_1_own.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .from(contain_exactly(owned_work_1, owned_work_2))
+            .to contain_exactly(owned_work_1, owned_work_2, owned_work_3)
+        end
+
+        it 'redirects to dashboard collection show' do
+          post :update_members, params: parameters
+
+          expect(response)
+            .to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
         end
       end
 
       context 'and user has edit access to works' do
+        let(:members_to_add) { [editable_work] }
+
         it 'adds members to the collection' do
-          expect do
-            post :update_members, params: { id: coll_1_own,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_4_edit.id] }
-          end.to change { coll_1_own.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_1_own, locale: 'en')
-          expect(coll_1_own.member_objects).to match_array [work_1_own, work_2_own, work_4_edit]
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .from(contain_exactly(owned_work_1, owned_work_2))
+            .to contain_exactly(owned_work_1, owned_work_2, editable_work)
         end
       end
 
       context 'and user has read access to works' do
+        let(:members_to_add) { [readable_work] }
+
         it 'adds members to the collection' do
-          expect do
-            post :update_members, params: { id: coll_1_own,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_5_read.id] }
-          end.to change { coll_1_own.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_1_own, locale: 'en')
-          expect(coll_1_own.member_objects).to match_array [work_1_own, work_2_own, work_5_read]
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .from(contain_exactly(owned_work_1, owned_work_2))
+            .to contain_exactly(owned_work_1, owned_work_2, readable_work)
         end
       end
 
-      context 'and user has no access to a work' do
+      context 'and user has no access to a some works' do
+        let(:members_to_add) { [owned_work_3, private_work] }
+
         it 'adds only members with read access' do
-          expect do
-            post :update_members, params: { id: coll_1_own,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_3_own.id, work_6_noaccess.id] }
-          end.to change { coll_1_own.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_1_own, locale: 'en')
-          expect(coll_1_own.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
+          expect { post :update_members, params: parameters }
+            .to change { collection.reload.member_objects }
+            .from(contain_exactly(owned_work_1, owned_work_2))
+            .to contain_exactly(owned_work_1, owned_work_2, owned_work_3)
+        end
+      end
+
+      context 'and user has no access to selected works' do
+        let(:members_to_add) { [private_work] }
+
+        it 'does not change membership' do
+          expect { post(:update_members, params: parameters) }
+            .not_to change { collection.reload.member_objects.count }
+
+          expect(flash[:alert])
+            .to eq 'You do not have sufficient privileges to any of the selected members'
         end
 
-        it 'displays error message if none of the members have read access' do
-          expect do
-            post :update_members, params: { id: coll_1_own,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_6_noaccess.id] }
-          end.to change { coll_1_own.reload.member_objects.size }.by(0)
-          expect(flash[:alert]).to eq 'You do not have sufficient privileges to any of the selected members'
-          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
-          expect(coll_1_own.member_objects).to match_array [work_1_own, work_2_own]
+        it 'flashes an error' do
+          post :update_members, params: parameters
+
+          expect(flash[:alert])
+            .to eq 'You do not have sufficient privileges to any of the selected members'
         end
       end
 
       context 'and user adds a subcollection' do
-        let(:parent_collection) { create(:private_collection_lw, id: 'pcol', title: ['User created another'], user: user, with_permission_template: true) }
+        let(:members_to_add) { [owned_collection] }
 
         it 'adds collection user created' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_1_own.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_1_own]
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .to contain_exactly(owned_work_1, owned_work_2, owned_collection)
         end
 
-        it 'adds collection with manage access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_2_mgr.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_2_mgr]
+        it 'redirects to the dashboard collection show' do
+          post(:update_members, params: parameters)
+
+          expect(response)
+            .to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
+        end
+      end
+
+      context 'and user adds a collection with manage access' do
+        let(:members_to_add) { [managed_collection] }
+
+        it 'adds collection to members' do
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .to contain_exactly(owned_work_1, owned_work_2, managed_collection)
+        end
+      end
+
+      context 'and user adds a collection with deposit access' do
+        let(:members_to_add) { [depositable_collection] }
+
+        it 'adds collection to members' do
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .to contain_exactly(owned_work_1, owned_work_2, depositable_collection)
+        end
+      end
+
+      context 'and user adds a collection with view access' do
+        let(:members_to_add) { [viewable_collection] }
+
+        it 'adds collection' do
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .to contain_exactly(owned_work_1, owned_work_2, viewable_collection)
+        end
+      end
+
+      context 'and user adds collection for which they have no access' do
+        let(:members_to_add) { [private_collection] }
+
+        it 'does not change membership ' do
+          expect { post(:update_members, params: parameters) }
+            .not_to change { collection.reload.member_objects.count }
         end
 
-        it 'adds collection with deposit access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_3_dep.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_3_dep]
-        end
+        it 'displays error message ' do
+          post(:update_members, params: parameters)
 
-        it 'adds collection with view access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_4_view.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_4_view]
-        end
-
-        it 'displays error message for collection with no access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_5_noaccess.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(0)
           expect(flash[:alert]).to eq 'You do not have sufficient privileges to any of the selected members'
           expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
-          expect(parent_collection.member_objects).to match_array []
+        end
+      end
+    end
+
+    context 'when user is a depositor on collection' do
+      let(:collection) { depositable_collection }
+
+      before do
+        [owned_work_1, owned_work_2].each do |asset|
+          asset.member_of_collections << collection
+          asset.save!
+        end
+      end
+
+      context 'and user created the work' do
+        let(:members_to_add) { [owned_work_3] }
+
+        it 'adds members to the collection' do
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .from(contain_exactly(owned_work_1, owned_work_2))
+            .to contain_exactly(owned_work_1, owned_work_2, owned_work_3)
+        end
+
+        it 'redirects to dashboard collection show' do
+          post :update_members, params: parameters
+
+          expect(response)
+            .to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
+        end
+      end
+
+      context 'and user has edit access to works' do
+        let(:members_to_add) { [editable_work] }
+
+        it 'adds members to the collection' do
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .from(contain_exactly(owned_work_1, owned_work_2))
+            .to contain_exactly(owned_work_1, owned_work_2, editable_work)
+        end
+      end
+
+      context 'and user has read access to works' do
+        let(:members_to_add) { [readable_work] }
+
+        it 'adds members to the collection' do
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .from(contain_exactly(owned_work_1, owned_work_2))
+            .to contain_exactly(owned_work_1, owned_work_2, readable_work)
+        end
+      end
+
+      context 'and user has no access to a some works' do
+        let(:members_to_add) { [owned_work_3, private_work] }
+
+        it 'adds only members with read access' do
+          expect { post :update_members, params: parameters }
+            .to change { collection.reload.member_objects }
+            .from(contain_exactly(owned_work_1, owned_work_2))
+            .to contain_exactly(owned_work_1, owned_work_2, owned_work_3)
+        end
+      end
+
+      context 'and user has no access to selected works' do
+        let(:members_to_add) { [private_work] }
+
+        it 'does not change membership' do
+          expect { post(:update_members, params: parameters) }
+            .not_to change { collection.reload.member_objects.count }
+
+          expect(flash[:alert])
+            .to eq 'You do not have sufficient privileges to any of the selected members'
+        end
+
+        it 'flashes an error' do
+          post :update_members, params: parameters
+
+          expect(flash[:alert])
+            .to eq 'You do not have sufficient privileges to any of the selected members'
+        end
+      end
+
+      context 'and user adds a subcollection' do
+        let(:members_to_add) { [owned_collection] }
+
+        it 'adds collection user created' do
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .to contain_exactly(owned_work_1, owned_work_2, owned_collection)
+        end
+
+        it 'redirects to the dashboard collection show' do
+          post(:update_members, params: parameters)
+
+          expect(response)
+            .to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
+        end
+      end
+
+      context 'and user adds a collection with manage access' do
+        let(:members_to_add) { [managed_collection] }
+
+        it 'adds collection to members' do
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .to contain_exactly(owned_work_1, owned_work_2, managed_collection)
+        end
+      end
+
+      context 'and user adds a collection with deposit access' do
+        let(:members_to_add) { [depositable_collection] }
+
+        it 'adds collection to members' do
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .to contain_exactly(owned_work_1, owned_work_2, depositable_collection)
+        end
+      end
+
+      context 'and user adds a collection with view access' do
+        let(:members_to_add) { [viewable_collection] }
+
+        it 'adds collection' do
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .to contain_exactly(owned_work_1, owned_work_2, viewable_collection)
+        end
+      end
+
+      context 'and user adds collection for which they have no access' do
+        let(:members_to_add) { [private_collection] }
+
+        it 'does not change membership ' do
+          expect { post(:update_members, params: parameters) }
+            .not_to change { collection.reload.member_objects.count }
+        end
+
+        it 'displays error message ' do
+          post(:update_members, params: parameters)
+
+          expect(flash[:alert]).to eq 'You do not have sufficient privileges to any of the selected members'
+          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
         end
       end
     end
 
     context 'when user is manager of the collection' do
-      before do
-        sign_in user
-        [work_1_own, work_2_own].each do |asset|
-          asset.member_of_collections << coll_2_mgr
-          asset.save!
-        end
-      end
+      let(:collection) { managed_collection }
 
       context 'and user created the work' do
+        let(:members_to_add) { [owned_collection] }
+
         it 'adds members to the collection' do
-          expect do
-            post :update_members, params: { id: coll_2_mgr,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_3_own.id] }
-          end.to change { coll_2_mgr.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_2_mgr, locale: 'en')
-          expect(coll_2_mgr.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .to contain_exactly(owned_collection)
         end
       end
 
       context 'and user has edit access to works' do
+        let(:members_to_add) { [editable_work] }
+
         it 'adds members to the collection' do
-          expect do
-            post :update_members, params: { id: coll_2_mgr,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_4_edit.id] }
-          end.to change { coll_2_mgr.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_2_mgr, locale: 'en')
-          expect(coll_2_mgr.member_objects).to match_array [work_1_own, work_2_own, work_4_edit]
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .to contain_exactly(editable_work)
         end
       end
 
       context 'and user has read access to works' do
+        let(:members_to_add) { [readable_work] }
+
         it 'adds members to the collection' do
-          expect do
-            post :update_members, params: { id: coll_2_mgr,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_5_read.id] }
-          end.to change { coll_2_mgr.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_2_mgr, locale: 'en')
-          expect(coll_2_mgr.member_objects).to match_array [work_1_own, work_2_own, work_5_read]
+          expect { post(:update_members, params: parameters) }
+            .to change { collection.reload.member_objects }
+            .to contain_exactly(readable_work)
         end
       end
 
       context 'and user has no access to a work' do
-        it 'adds only members with read access' do
-          expect do
-            post :update_members, params: { id: coll_2_mgr,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_3_own.id, work_6_noaccess.id] }
-          end.to change { coll_2_mgr.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_2_mgr, locale: 'en')
-          expect(coll_2_mgr.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
+        let(:members_to_add) { [private_work] }
+
+        it 'declines to add members' do
+          expect { post(:update_members, params: parameters) }
+            .not_to change { collection.reload.member_objects.to_a }
+            .from be_none
         end
       end
 
       context 'and user adds a subcollection' do
-        let(:parent_collection) do
-          create(:private_collection_lw, id: 'pcol-mgr', title: ['User has manage access to another'], user: other,
-                                         with_permission_template: { manage_users: [user] })
+        context 'created by the user' do
+          let(:members_to_add) { [owned_collection] }
+
+          it 'adds collection' do
+            expect { post(:update_members, params: parameters) }
+              .to change { collection.reload.member_objects }
+              .to contain_exactly(owned_collection)
+          end
         end
 
-        it 'adds collection user created' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_1_own.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_1_own]
+        context 'with manage access' do
+          let(:members_to_add) { [managed_collection] }
+
+          it 'adds collection' do
+            expect { post(:update_members, params: parameters) }
+              .to change { collection.reload.member_objects }
+              .to contain_exactly(managed_collection)
+          end
         end
 
-        it 'adds collection with manage access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_2_mgr.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_2_mgr]
+        context 'with manage access' do
+          let(:members_to_add) { [managed_collection] }
+
+          it 'adds collection' do
+            expect { post(:update_members, params: parameters) }
+              .to change { collection.reload.member_objects }
+              .to contain_exactly(managed_collection)
+          end
         end
 
-        it 'adds collection with deposit access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_3_dep.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_3_dep]
+        context 'with deposit access' do
+          let(:members_to_add) { [depositable_collection] }
+
+          it 'adds collection' do
+            expect { post(:update_members, params: parameters) }
+              .to change { collection.reload.member_objects }
+              .to contain_exactly(depositable_collection)
+          end
         end
 
-        it 'adds collection with view access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_4_view.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_4_view]
+        context 'with view access' do
+          let(:members_to_add) { [viewable_collection] }
+
+          it 'adds collection' do
+            expect { post(:update_members, params: parameters) }
+              .to change { collection.reload.member_objects }
+              .to contain_exactly(viewable_collection)
+          end
         end
 
-        it 'displays error message for collection with no access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_5_noaccess.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(0)
-          expect(flash[:alert]).to eq 'You do not have sufficient privileges to any of the selected members'
-          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
-          expect(parent_collection.member_objects).to match_array []
+        context 'with no access' do
+          let(:members_to_add) { [private_collection] }
+
+          it 'does not add members' do
+            expect { post(:update_members, params: parameters) }
+              .not_to change { collection.reload.member_objects.to_a }
+              .from be_none
+          end
+
+          it 'displays error' do
+            post(:update_members, params: parameters)
+
+            expect(flash[:alert])
+              .to eq 'You do not have sufficient privileges to any of the selected members'
+            expect(response)
+              .to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
+          end
         end
       end
     end
 
-    context 'when user is depositor of the collection' do
-      before do
-        sign_in user
-        [work_1_own, work_2_own].each do |asset|
-          asset.member_of_collections << coll_3_dep
-          asset.save!
-        end
+    context 'when user only a viewer of the collection' do
+      let(:collection) { viewable_collection }
+      let(:members_to_add) { [owned_work_3] }
+
+      it 'does not add the work' do
+        expect { post(:update_members, params: parameters) }
+          .not_to change { collection.reload.member_objects.to_a }
+          .from be_none
       end
 
-      context 'and user created the work' do
-        it 'adds members to the collection' do
-          expect do
-            post :update_members, params: { id: coll_3_dep,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_3_own.id] }
-          end.to change { coll_3_dep.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_3_dep, locale: 'en')
-          expect(coll_3_dep.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
-        end
-      end
+      it 'displays error' do
+        post(:update_members, params: parameters)
 
-      context 'and user has edit access to works' do
-        it 'adds members to the collection' do
-          expect do
-            post :update_members, params: { id: coll_3_dep,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_4_edit.id] }
-          end.to change { coll_3_dep.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_3_dep, locale: 'en')
-          expect(coll_3_dep.member_objects).to match_array [work_1_own, work_2_own, work_4_edit]
-        end
-      end
-
-      context 'and user has read access to works' do
-        it 'adds members to the collection' do
-          expect do
-            post :update_members, params: { id: coll_3_dep,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_5_read.id] }
-          end.to change { coll_3_dep.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_3_dep, locale: 'en')
-          expect(coll_3_dep.member_objects).to match_array [work_1_own, work_2_own, work_5_read]
-        end
-      end
-
-      context 'and user has no access to a work' do
-        it 'adds only members with read access' do
-          expect do
-            post :update_members, params: { id: coll_3_dep,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_3_own.id, work_6_noaccess.id] }
-          end.to change { coll_3_dep.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_3_dep, locale: 'en')
-          expect(coll_3_dep.member_objects).to match_array [work_1_own, work_2_own, work_3_own]
-        end
-      end
-
-      context 'and user adds a subcollection' do
-        let(:parent_collection) do
-          create(:private_collection_lw, id: 'pcol-dep', title: ['User has deposit access to another'], user: other,
-                                         with_permission_template: { deposit_users: [user] })
-        end
-
-        it 'adds collection user created' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_1_own.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_1_own]
-        end
-
-        it 'adds collection with manage access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_2_mgr.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_2_mgr]
-        end
-
-        it 'adds collection with deposit access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_3_dep.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_3_dep]
-        end
-
-        it 'adds collection with view access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_4_view.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(1)
-          expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(parent_collection, locale: 'en')
-          expect(parent_collection.member_objects).to match_array [coll_4_view]
-        end
-
-        it 'displays error message for collection with no access' do
-          expect do
-            post :update_members, params: { id: parent_collection,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [coll_5_noaccess.id] }
-          end.to change { parent_collection.reload.member_objects.size }.by(0)
-          expect(flash[:alert]).to eq 'You do not have sufficient privileges to any of the selected members'
-          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
-          expect(parent_collection.member_objects).to match_array []
-        end
-      end
-    end
-
-    context 'when user is viewer of the collection' do
-      before do
-        sign_in user
-        [work_1_own, work_2_own].each do |asset|
-          asset.member_of_collections << coll_4_view
-          asset.save!
-        end
-      end
-
-      context 'and user created the work' do
-        it "displays error message if user can't deposit to collection" do
-          expect do
-            post :update_members, params: { id: coll_4_view,
-                                            collection: { members: 'add' },
-                                            batch_document_ids: [work_3_own.id] }
-          end.to change { coll_4_view.reload.member_objects.size }.by(0)
-          expect(flash[:alert]).to eq 'You do not have sufficient privileges to add members to the collection'
-          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
-          expect(coll_4_view.member_objects).to match_array [work_1_own, work_2_own]
-        end
+        expect(flash[:alert])
+          .to eq 'You do not have sufficient privileges to add members to the collection'
+        expect(response)
+          .to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
       end
     end
 
     context 'when members violate the multi-membership checker for single membership collections' do
-      let!(:sm_collection_type) { create(:collection_type, title: 'Single Membership', allow_multiple_membership: false) }
-      let(:coll_1_sm) { create(:collection_lw, id: 'coll_1_sm', title: ['SM1'], collection_type: sm_collection_type, user: user) }
-      let!(:coll_2_sm) { create(:collection_lw, id: 'coll_2_sm', title: ['SM2'], collection_type: sm_collection_type, user: user) }
-      let(:base_errmsg) { "Error: You have specified more than one of the same single-membership collection type" }
-      let(:regexp) { /#{base_errmsg} \(type: Single Membership, collections: (SM1 and SM2|SM2 and SM1)\)/ }
+      let(:members_to_add) { [owned_work_1, owned_work_2, owned_work_3] }
 
-      before do
-        sign_in user
-        [work_1_own, work_2_own].each do |asset|
-          asset.member_of_collections << coll_1_sm
-          asset.save!
-          Hyrax.publisher.publish('object.metadata.updated', object: asset.valkyrie_resource, user: user)
-        end
-        Hyrax.publisher.publish('object.metadata.updated', object: coll_1_sm.valkyrie_resource, user: user)
-        Hyrax.publisher.publish('object.metadata.updated', object: coll_2_sm.valkyrie_resource, user: user)
+      let(:single_membership_type) do
+        FactoryBot.create(:collection_type, allow_multiple_membership: false)
       end
 
-      it "displays error message and deposits works not in violation" do
-        expect do
-          post :update_members, params: { id: coll_2_sm,
-                                          collection: { members: 'add' },
-                                          batch_document_ids: [work_1_own.id, work_2_own.id, work_3_own.id] }
-        end.to change { coll_2_sm.reload.member_objects.size }.by(1)
-        expect(flash[:error]).to match regexp
-        expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(coll_2_sm, locale: 'en')
-        expect(coll_2_sm.member_objects).to match_array [work_3_own]
+      let(:collection) do
+        FactoryBot.create(:collection_lw,
+                          collection_type: single_membership_type,
+                          user: user)
+      end
+
+      let(:other_collection_of_type) do
+        FactoryBot.create(:collection_lw,
+                          collection_type: single_membership_type,
+                          user: user)
+      end
+
+      before do
+        [owned_work_1, owned_work_2].each do |asset|
+          asset.member_of_collections << other_collection_of_type
+          asset.save!
+        end
+      end
+
+      it "deposits works not in violation" do
+        expect { post(:update_members, params: parameters) }
+          .to change { collection.reload.member_objects }
+          .to contain_exactly(owned_work_3)
+      end
+
+      it "displays an error message" do
+        post :update_members, params: parameters
+
+        expect(flash[:error])
+          .to match %r{Error\:\sYou\shave\sspecified\smore\sthan\sone\sof\sthe\s
+                       same\ssingle-membership\scollection\stype\s\(type:\s
+                       #{single_membership_type.title.gsub(' ', '\s')},\s
+                       collections:\s
+                       (#{other_collection_of_type.title.first.gsub(' ', '\s')}\s
+                       and\s#{collection.title.first.gsub(' ', '\s')}|
+                       #{collection.title.first.gsub(' ', '\s')}\sand\s
+                       #{other_collection_of_type.title.first.gsub(' ', '\s')})}x
+
+        expect(response)
+          .to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
       end
     end
   end


### PR DESCRIPTION
these specs were really challenging to read, had a lot of duplication and
had many specs with multiple expectations.

this provides clearer naming, consistent indentation style, and deduplicated
parameters. it also removes much unneeded setup code (e.g. providing cryptic ids
and titles for each example object).

interestingly, though the tests here are split out, these seem to run quite a bit faster.
once this is in, i'm hoping to further refactor the whole file to take advantage of valkyrie's
in-memory adapter and further speed up test times.

@samvera/hyrax-code-reviewers
