### PR TITLE
make the Collection model class to use configurable

### DIFF
--- a/app/controllers/hyrax/collections_controller.rb
+++ b/app/controllers/hyrax/collections_controller.rb
@@ -4,7 +4,9 @@ module Hyrax
     include CollectionsControllerBehavior
     include BreadcrumbsForCollections
     with_themed_layout :decide_layout
-    load_and_authorize_resource except: [:index, :show, :create], instance_name: :collection
+    load_and_authorize_resource except: [:index, :show, :create],
+                                instance_name: :collection,
+                                class: Hyrax.config.collection_class
 
     # Renders a JSON response with a list of files in this collection
     # This is used by the edit form to populate the thumbnail_id dropdown

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -43,7 +43,9 @@ module Hyrax
       # The search builder to find the collections' members
       self.membership_service_class = Collections::CollectionMemberSearchService
 
-      load_and_authorize_resource except: [:index, :create], instance_name: :collection
+      load_and_authorize_resource except: [:index, :create],
+                                  instance_name: :collection,
+                                  class: Hyrax.config.collection_class
 
       def deny_collection_access(exception)
         if exception.action == :edit

--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -27,7 +27,9 @@ module Hyrax
     configure_facets
 
     before_action :authenticate_user!
-    load_and_authorize_resource only: :show, instance_name: :collection
+    load_and_authorize_resource only: :show,
+                                instance_name: :collection,
+                                class: Hyrax.config.collection_class
 
     # include the render_check_all view helper method
     helper Hyrax::BatchEditsHelper

--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -131,7 +131,7 @@ module Hyrax
       def available_parent_collections(scope:)
         return @available_parents if @available_parents.present?
 
-        collection = ::Collection.find(id)
+        collection = model_class.find(id)
         colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: scope, limit_to_id: nil)
         @available_parents = colls.map do |col|
           { "id" => col.id, "title_first" => col.title.first }

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -53,7 +53,7 @@ module Hyrax
     ##
     # @return [Boolean]
     def collection?
-      hydra_model == ::Collection
+      hydra_model == ::Collection || hydra_model.try(:collection?)
     end
 
     ##

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -248,7 +248,8 @@ module Hyrax
     # @return [Boolean] a flag indicating whether to display collection deposit
     #   options.
     def show_deposit_for?(collections:)
-      collections.present? || current_ability.can?(:create_any, ::Collection)
+      collections.present? ||
+        current_ability.can?(:create_any, Hyrax.config.collection_class.constantize)
     end
 
     ##

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -666,6 +666,11 @@ module Hyrax
       @collection_type_index_field ||= 'collection_type_gid_ssim'
     end
 
+    attr_writer :collection_class
+    def collection_class
+      @collection_class = '::Collection'
+    end
+
     attr_writer :id_field
     def id_field
       @id_field || index_field_mapper.id_field

--- a/lib/hyrax/resource_sync/change_list_writer.rb
+++ b/lib/hyrax/resource_sync/change_list_writer.rb
@@ -62,7 +62,7 @@ module Hyrax
       def build_resources(xml, doc_set)
         doc_set.each do |doc|
           model = doc.fetch('has_model_ssim', []).first.constantize
-          if model == ::Collection
+          if model == ::Collection || model.try(:collection?)
             build_resource(xml, doc, model, hyrax_routes)
           else
             build_resource(xml, doc, model, main_app_routes)


### PR DESCRIPTION
introduce `Hyrax.config.collection_class` to allow applications to choose what
model class to use for collections. many existing hard-coded refernces to
`::Collection`, are kept in this commit.

this is targeted at adding a hook for turning use of the Valkyrie-based
collection class, but it could also be useful for using an ActiveFedora
Collection class with another name (e.g. because your application has some other
model/class/module named `::Collection`).

@samvera/hyrax-code-reviewers
