### PR TITLE
in CollectionMembersController don't query for Collection to get id

### DIFF
--- a/app/controllers/hyrax/dashboard/collection_members_controller.rb
+++ b/app/controllers/hyrax/dashboard/collection_members_controller.rb
@@ -28,7 +28,7 @@ module Hyrax
 
         collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
         begin
-          Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection_id: collection.id,
+          Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection_id: collection_id,
                                                                          new_member_ids: batch_ids,
                                                                          user: current_user)
           after_update


### PR DESCRIPTION
this code was querying using the id, then using the result to find... the
id. oops.


@samvera/hyrax-code-reviewers
