### PR TITLE
Use blank? instead of nil? for parent_collections in CollectionPresenter

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -116,13 +116,13 @@ module Hyrax
 
     # The total number of parents that this collection belongs to, visible or not.
     def total_parent_collections
-      parent_collections.nil? ? 0 : parent_collections.response['numFound']
+      parent_collections.blank? ? 0 : parent_collections.response['numFound']
     end
 
     # The number of parent collections shown on the current page. This will differ from total_parent_collections
     # due to pagination.
     def parent_collection_count
-      parent_collections.nil? ? 0 : parent_collections.documents.size
+      parent_collections.blank? ? 0 : parent_collections.documents.size
     end
 
     def user_can_nest_collection?


### PR DESCRIPTION
The `CollectionPresenter` determines the `total_parent_collections` and
`parent_collection_count` by doing a conditional check on the response
from a call to `parent_collections`

The `nil?` check is problematic because if the `child` is not `nestable?` then
[the response from `NestedCollectionQueryService.parent_collections` is an empty `[]`](https://github.com/samvera/hyrax/blob/main/app/services/hyrax/collections/nested_collection_query_service.rb#L72), not `nil`.

This causes the `total_parent_collections` and `parent_collection_count` methods to try and call `#response` and `#documents` , respectively, against an empty `[]`, throwing errors.

So, change the check to use `blank?`

@samvera/hyrax-code-reviewers
