### PR TITLE
respect new collection model configuration throughout

### DIFF
--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -37,7 +37,7 @@ module Hyrax
       # @return [Boolean] true if destroy was successful
       def destroy(env)
         env.curation_concern.in_collection_ids.each do |id|
-          destination_collection = ::Collection.find(id)
+          destination_collection = Hyrax.config.collection_class.find(id)
           destination_collection.members.delete(env.curation_concern)
           destination_collection.update_index
         end

--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -69,7 +69,7 @@ module Hyrax
       # Adds the item to the ordered members so that it displays in the items
       # along side the FileSets on the show page
       def add(env, id)
-        collection = ::Collection.find(id)
+        collection = Hyrax.config.collection_class.find(id)
         collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
 
         return unless env.current_ability.can?(:deposit, collection)
@@ -78,7 +78,7 @@ module Hyrax
 
       # Remove the object from the members set and the ordered members list
       def remove(curation_concern, id)
-        collection = ::Collection.find(id)
+        collection = Hyrax.config.collection_class.find(id)
         curation_concern.member_of_collections.delete(collection)
       end
 
@@ -107,7 +107,7 @@ module Hyrax
         collection_id = attributes_collection.first.second['id']
 
         # Do not apply permissions to work if collection type is configured not to
-        collection = ::Collection.find(collection_id)
+        collection = Hyrax.config.collection_class.find(collection_id)
         return unless collection.share_applies_to_new_works?
 
         # Save the collection id in env for use in apply_permission_template_actor

--- a/app/controllers/hyrax/collections_controller.rb
+++ b/app/controllers/hyrax/collections_controller.rb
@@ -6,7 +6,7 @@ module Hyrax
     with_themed_layout :decide_layout
     load_and_authorize_resource except: [:index, :create],
                                 instance_name: :collection,
-                                class: Hyrax.config.collection_class
+                                class: Hyrax.config.collection_model
 
     # Renders a JSON response with a list of files in this collection
     # This is used by the edit form to populate the thumbnail_id dropdown

--- a/app/controllers/hyrax/dashboard/collection_members_controller.rb
+++ b/app/controllers/hyrax/dashboard/collection_members_controller.rb
@@ -64,7 +64,7 @@ module Hyrax
       end
 
       def collection
-        @collection ||= ::Collection.find(collection_id)
+        @collection ||= Hyrax.config.collection_class.find(collection_id)
       end
 
       def batch_ids

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -45,7 +45,7 @@ module Hyrax
 
       load_and_authorize_resource except: [:index, :create],
                                   instance_name: :collection,
-                                  class: Hyrax.config.collection_class
+                                  class: Hyrax.config.collection_model
 
       def deny_collection_access(exception)
         if exception.action == :edit
@@ -107,7 +107,7 @@ module Hyrax
         # Manual load and authorize necessary because Cancan will pass in all
         # form attributes. When `permissions_attributes` are present the
         # collection is saved without a value for `has_model.`
-        @collection = ::Collection.new
+        @collection = Hyrax.config.collection_class.new
         authorize! :create, @collection
         # Coming from the UI, a collection type gid should always be present.  Coming from the API, if a collection type gid is not specified,
         # use the default collection type (provides backward compatibility with versions < Hyrax 2.1.0)
@@ -399,7 +399,7 @@ module Hyrax
       end
 
       def move_members_between_collections
-        destination_collection = ::Collection.find(params[:destination_collection_id])
+        destination_collection = Hyrax.config.collection_class.find(params[:destination_collection_id])
         remove_members_from_collection
         add_members_to_collection(destination_collection)
         if destination_collection.save
@@ -465,7 +465,7 @@ module Hyrax
       end
 
       def collection_object
-        action_name == 'show' ? ::Collection.find(collection.id) : collection
+        action_name == 'show' ? Hyrax.config.collection_class.find(collection.id) : collection
       end
 
       # You can override this method if you need to provide additional

--- a/app/controllers/hyrax/dashboard/nest_collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/nest_collections_controller.rb
@@ -64,28 +64,28 @@ module Hyrax
       private
 
       def build_within_form
-        child = ::Collection.find(params.fetch(:child_id))
+        child = Hyrax.config.collection_class.find(params.fetch(:child_id))
         authorize! :read, child
-        parent = params.key?(:parent_id) ? ::Collection.find(params[:parent_id]) : nil
+        parent = params.key?(:parent_id) ? Hyrax.config.collection_class.find(params[:parent_id]) : nil
         form_class.new(child: child, parent: parent, context: self)
       end
 
       def build_under_form
-        parent = ::Collection.find(params.fetch(:parent_id))
+        parent = Hyrax.config.collection_class.find(params.fetch(:parent_id))
         authorize! :deposit, parent
-        child = params.key?(:child_id) ? ::Collection.find(params[:child_id]) : nil
+        child = params.key?(:child_id) ? Hyrax.config.collection_class.find(params[:child_id]) : nil
         form_class.new(child: child, parent: parent, context: self)
       end
 
       def build_create_collection_form
-        parent = ::Collection.find(params.fetch(:parent_id))
+        parent = Hyrax.config.collection_class.find(params.fetch(:parent_id))
         authorize! :deposit, parent
         form_class.new(child: nil, parent: parent, context: self)
       end
 
       def build_remove_form
-        child = ::Collection.find(params.fetch(:child_id))
-        parent = ::Collection.find(params.fetch(:parent_id))
+        child = Hyrax.config.collection_class.find(params.fetch(:child_id))
+        parent = Hyrax.config.collection_class.find(params.fetch(:parent_id))
         authorize! :edit, parent
         form_class.new(child: child, parent: parent, context: self)
       end

--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -29,7 +29,7 @@ module Hyrax
     before_action :authenticate_user!
     load_and_authorize_resource only: :show,
                                 instance_name: :collection,
-                                class: Hyrax.config.collection_class
+                                class: Hyrax.config.collection_model
 
     # include the render_check_all view helper method
     helper Hyrax::BatchEditsHelper

--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -16,7 +16,7 @@ module Hyrax
       # Required for search builder (FIXME)
       alias collection model
 
-      self.model_class = ::Collection
+      self.model_class = Hyrax.config.collection_class
 
       self.membership_service_class = Collections::CollectionMemberSearchService
 

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -53,7 +53,8 @@ module Hyrax
     ##
     # @return [Boolean]
     def collection?
-      hydra_model == ::Collection || hydra_model.try(:collection?)
+      hydra_model.try(:collection?) ||
+        hydra_model == Hyrax.config.collection_class
     end
 
     ##

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -182,7 +182,7 @@ module Hyrax
                        "deprecated. Use available_parent_collections_data " \
                        "helper instead.")
       return @available_parents if @available_parents.present?
-      collection = ::Collection.find(id)
+      collection = Hyrax.config.collection_class.find(id)
       colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: scope, limit_to_id: nil)
       @available_parents = colls.map do |col|
         { "id" => col.id, "title_first" => col.title.first }

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -249,7 +249,7 @@ module Hyrax
     #   options.
     def show_deposit_for?(collections:)
       collections.present? ||
-        current_ability.can?(:create_any, Hyrax.config.collection_class.constantize)
+        current_ability.can?(:create_any, Hyrax.config.collection_class)
     end
 
     ##

--- a/app/search_builders/hyrax/dashboard/collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/collections_search_builder.rb
@@ -9,7 +9,7 @@ module Hyrax
 
       # This overrides the models in FilterByType
       def models
-        [::AdminSet, ::Collection]
+        [::AdminSet, Hyrax.config.collection_model.safe_constantize].compact
       end
 
       # adds a filter to exclude collections and admin sets created by the

--- a/app/search_builders/hyrax/filter_by_type.rb
+++ b/app/search_builders/hyrax/filter_by_type.rb
@@ -54,7 +54,7 @@ module Hyrax
     def collection_classes
       return [] if only_works?
       # to_class_uri is deprecated in AF 11
-      [::Collection]
+      [Hyrax.config.collection_class]
     end
   end
 end

--- a/app/search_builders/hyrax/my/collections_search_builder.rb
+++ b/app/search_builders/hyrax/my/collections_search_builder.rb
@@ -21,6 +21,6 @@ class Hyrax::My::CollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
   # This overrides the models in FilterByType
   # @return [Array<Class>] a list of classes to include
   def models
-    [::AdminSet, ::Collection, Hyrax::AdministrativeSet]
+    [::AdminSet, Hyrax::AdministrativeSet, Hyrax.config.collection_model.safe_constantize].compact
   end
 end

--- a/app/services/hyrax/collections/permissions_create_service.rb
+++ b/app/services/hyrax/collections/permissions_create_service.rb
@@ -31,7 +31,7 @@ module Hyrax
       #       access: Hyrax::PermissionTemplateAccess::DEPOSIT } ]
       # @see Hyrax::PermissionTemplateAccess for valid values for agent_type and access
       def self.add_access(collection_id:, grants:)
-        collection = ::Collection.find(collection_id)
+        collection = Hyrax.config.collection_class.find(collection_id)
         template = Hyrax::PermissionTemplate.find_by!(source_id: collection_id)
         grants.each do |grant|
           Hyrax::PermissionTemplateAccess.find_or_create_by(permission_template_id: template.id,

--- a/app/services/hyrax/statistics/collections/over_time.rb
+++ b/app/services/hyrax/statistics/collections/over_time.rb
@@ -6,7 +6,7 @@ module Hyrax
         private
 
         def relation
-          ::Collection
+          Hyrax.config.collection_class
         end
       end
     end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -666,9 +666,18 @@ module Hyrax
       @collection_type_index_field ||= 'collection_type_gid_ssim'
     end
 
-    attr_writer :collection_class
+    attr_writer :collection_model
+    ##
+    # @return [#constantize] a string representation of the collection
+    #   model
+    def collection_model
+      @collection_model ||= '::Collection'
+    end
+
+    ##
+    # @return [Class] the configured collection model class
     def collection_class
-      @collection_class ||= '::Collection'
+      collection_model.constantize
     end
 
     attr_writer :id_field

--- a/lib/hyrax/resource_sync/change_list_writer.rb
+++ b/lib/hyrax/resource_sync/change_list_writer.rb
@@ -61,8 +61,8 @@ module Hyrax
 
       def build_resources(xml, doc_set)
         doc_set.each do |doc|
-          model = doc.fetch('has_model_ssim', []).first.constantize
-          if model == ::Collection || model.try(:collection?)
+          model = doc.fetch('has_model_ssim', []).first.safe_constantize
+          if model.try(:collection?) || model == Hyrax.config.collection_class
             build_resource(xml, doc, model, hyrax_routes)
           else
             build_resource(xml, doc, model, main_app_routes)

--- a/lib/hyrax/resource_sync/resource_list_writer.rb
+++ b/lib/hyrax/resource_sync/resource_list_writer.rb
@@ -32,8 +32,8 @@ module Hyrax
         end
       end
 
-      def build_collections(xml)
-        ::Collection.search_in_batches(public_access) do |doc_set|
+      def build_collections(xml, searcher: Hyrax.config.collection_class)
+        searcher.search_in_batches(public_access) do |doc_set|
           build_resources(xml, doc_set, hyrax_routes)
         end
       end

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::CollectionSearchBuilder do
   end
 
   describe '#models' do
-    its(:models) { is_expected.to eq([Collection]) }
+    its(:models) { is_expected.to contain_exactly(Collection) }
   end
 
   describe '#discovery_permissions' do

--- a/spec/search_builders/hyrax/my/collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/collections_search_builder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::My::CollectionsSearchBuilder do
   describe '#models' do
     subject { builder.models }
 
-    it { is_expected.to eq([AdminSet, Collection, Hyrax::AdministrativeSet]) }
+    it { is_expected.to contain_exactly(AdminSet, Collection, Hyrax::AdministrativeSet) }
   end
 
   describe ".default_processor_chain" do


### PR DESCRIPTION
replace hard coded references to `::Collection` with a constantized version of
the configured model.

the constantize dance is needed to avoid autoloading issues: if `::Collection`
is reloaded, we don't want to be holding references to it in `./lib` code like
`Hyrax::Configuration`.

@samvera/hyrax-code-reviewers
