### PR TITLE
use Valkyrie-based Hyrax::PcdmCollection when `use_valkyrie?` is on

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -705,7 +705,12 @@ module Hyrax
     # @return [#constantize] a string representation of the collection
     #   model
     def collection_model
-      @collection_model ||= '::Collection'
+      @collection_model ||=
+        if use_valkyrie?
+          'Hyrax::PcdmCollection'
+        else
+          '::Collection'
+        end
     end
 
     ##


### PR DESCRIPTION
forcing a build using the Valkyrie collection model. expecting a lot of failures, and a lot of new information.

@samvera/hyrax-code-reviewers
