### PR TITLE
use AbstractTypeRelation for collection stats

### DIFF
--- a/app/search_builders/hyrax/abstract_type_relation.rb
+++ b/app/search_builders/hyrax/abstract_type_relation.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 module Hyrax
   class AbstractTypeRelation < ActiveFedora::Relation
-    def initialize(opts = {})
+    def initialize(allowable_types: nil, **opts)
+      @allowable_types = allowable_types
       super(DummyModel, opts)
     end
 
     def allowable_types
-      raise NotImplementedException, "Implement allowable_types in a subclass"
+      @allowable_types ||
+        raise(NotImplementedException, "Implement allowable_types in a subclass")
     end
 
     def equivalent_class?(klass)

--- a/app/services/hyrax/statistics/collections/over_time.rb
+++ b/app/services/hyrax/statistics/collections/over_time.rb
@@ -6,7 +6,8 @@ module Hyrax
         private
 
         def relation
-          Hyrax.config.collection_class
+          AbstractTypeRelation
+            .new(allowable_types: [Hyrax.config.collection_class])
         end
       end
     end

--- a/spec/services/hyrax/statistics/collections/over_time_spec.rb
+++ b/spec/services/hyrax/statistics/collections/over_time_spec.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Statistics::Collections::OverTime do
-  let(:service) { described_class.new }
+  subject(:service) { described_class.new }
 
   describe "#points", :clean_repo do
-    before do
-      create(:collection)
-    end
-
-    subject { service.points }
+    before { FactoryBot.valkyrie_create(:hyrax_collection) }
 
     it "is a list of points" do
-      expect(subject.size).to eq 5
-      expect(subject.first[1]).to eq 0
-      expect(subject.to_a.last[1]).to eq 1
+      expect(service.points.size).to eq 5
+      expect(service.points.first[1]).to eq 0
+      expect(service.points.to_a.last[1]).to eq 1
     end
   end
 end


### PR DESCRIPTION
don't rely on ActiveFedora's solr queries for `Collections::OverTime`, use
`AbstractTypeRelation` instead.

first we open `AbstractTypeRelation` to concretized instances, then we create
one to use for queries in `Collections::OverTime`.

@samvera/hyrax-code-reviewers
