### PR TITLE
allow Hyrax::PcdmCollection to use the existing Collection i18n

### DIFF
--- a/lib/hyrax/collection_name.rb
+++ b/lib/hyrax/collection_name.rb
@@ -9,6 +9,7 @@ module Hyrax
       super
 
       @human              = 'Collection'
+      @i18n_key           = :collection
       @route_key          = 'collections'
       @singular_route_key = 'collection'
     end

--- a/spec/models/hyrax/pcdm_collection_spec.rb
+++ b/spec/models/hyrax/pcdm_collection_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe Hyrax::PcdmCollection do
 
   it_behaves_like 'a Hyrax::PcdmCollection'
 
+  describe '#name' do
+    it 'uses a Collection-like name' do
+      expect(subject.model_name)
+        .to have_attributes(human: "Collection",
+                            i18n_key: :collection,
+                            route_key: "collections",
+                            singular_route_key: "collection")
+    end
+  end
+
   describe '#human_readable_type' do
     it 'has a human readable type' do
       expect(collection.human_readable_type).to eq 'Collection'


### PR DESCRIPTION
map the class name's i18n_key to `:collection`

@samvera/hyrax-code-reviewers
