### PR TITLE
use both `::Collection` and any configured class for filter queries

### DIFF
--- a/app/search_builders/hyrax/filter_by_type.rb
+++ b/app/search_builders/hyrax/filter_by_type.rb
@@ -53,8 +53,7 @@ module Hyrax
 
     def collection_classes
       return [] if only_works?
-      # to_class_uri is deprecated in AF 11
-      [Hyrax.config.collection_class]
+      [::Collection, Hyrax.config.collection_class].uniq
     end
   end
 end

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Hyrax::CollectionSearchBuilder do
 
   describe '#models' do
     its(:models) do
-      is_expected.to contain_exactly(Hyrax.config.collection_class)
+      is_expected
+        .to contain_exactly(*[::Collection, Hyrax.config.collection_class].uniq)
     end
   end
 


### PR DESCRIPTION
existing collections indexed as `'Collection'` and those created with `Wings`
should still turn up in queries.

probably we should be using the indexed `generic_type` for these filters instead
of a list of models, but this keeps compatibility until we can work that out.

@samvera/hyrax-code-reviewers
