### PR TITLE
add basic required metadata to the pcdm collection form

### DIFF
--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -5,11 +5,17 @@ module Hyrax
     ##
     # @api public
     # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
-    class PcdmCollectionForm < Valkyrie::ChangeSet
+    class PcdmCollectionForm < Valkyrie::ChangeSet # rubocop:disable Metrics/ClassLength
       property :title, required: true, primary: true
 
-      property :depositor
-      property :collection_type_gid
+      property :human_readable_type, writable: false
+      property :date_modified, readable: false
+      property :date_uploaded, readable: false
+
+      property :depositor, required: true
+      property :collection_type_gid, required: true
+
+      property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 
       class << self
         def model_class

--- a/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::Forms::PcdmCollectionForm do
   describe '.required_fields' do
     it 'lists required fields' do
       expect(described_class.required_fields)
-        .to contain_exactly :title
+        .to contain_exactly(:title, :collection_type_gid, :depositor)
     end
   end
 


### PR DESCRIPTION
This updated the Hyrax::PcdmCollectionForm to support creating and editing collections that are Hyrax::PcdmCollection.  This is part of the work to address Issue #5132 (Val MVP: Create PcdmCollection as a valkyrie resource through UI ) and #5133 (Val MVP: Edit PcdmCollection as a valkyrie resource through UI).

@samvera/hyrax-code-reviewers
