### PR TITLE
Add administrative set form with minimal metadata

### DIFF
--- a/app/forms/hyrax/forms/administrative_set_form.rb
+++ b/app/forms/hyrax/forms/administrative_set_form.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Forms
+    ##
+    # @api public
+    # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
+    class AdministrativeSetForm < Valkyrie::ChangeSet
+      property :title, required: true, primary: true
+      property :description, primary: true
+
+      property :human_readable_type, writable: false
+      property :date_modified, readable: false
+      property :date_uploaded, readable: false
+
+      property :depositor
+
+      class << self
+        def model_class
+          Hyrax::AdministrativeSet
+        end
+
+        ##
+        # @return [Array<Symbol>] list of required field names as symbols
+        def required_fields
+          definitions
+            .select { |_, definition| definition[:required] }
+            .keys.map(&:to_sym)
+        end
+      end
+
+      ##
+      # @return [Array<Symbol>] terms for display 'above-the-fold', or in the most
+      #   prominent form real estate
+      def primary_terms
+        _form_field_definitions
+          .select { |_, definition| definition[:primary] }
+          .keys.map(&:to_sym)
+      end
+
+      ##
+      # @return [Array<Symbol>] terms for display 'below-the-fold'
+      def secondary_terms
+        _form_field_definitions
+          .select { |_, definition| definition[:display] && !definition[:primary] }
+          .keys.map(&:to_sym)
+      end
+
+      ##
+      # @return [Boolean] whether there are terms to display 'below-the-fold'
+      def display_additional_fields?
+        secondary_terms.any?
+      end
+
+      private
+
+      def _form_field_definitions
+        self.class.definitions
+      end
+    end
+  end
+end

--- a/spec/forms/hyrax/forms/administrative_set_form_spec.rb
+++ b/spec/forms/hyrax/forms/administrative_set_form_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Forms::AdministrativeSetForm do
+  subject(:form)   { described_class.new(collection) }
+  let(:collection) { Hyrax::PcdmCollection.new }
+
+  describe '.required_fields' do
+    it 'lists required fields' do
+      expect(described_class.required_fields)
+        .to contain_exactly :title
+    end
+  end
+
+  describe '#primary_terms' do
+    it 'gives "title" as a primary term' do
+      expect(form.primary_terms).to contain_exactly(:title, :description)
+    end
+  end
+end


### PR DESCRIPTION
This adds Hyrax::AdministrativeSetForm to support creating and editing admin sets that are Hyrax::AdministrativeSet. This is part of the work to address Issue #5130 (Val MVP: Create AdministrativeSet as a valkyrie resource through UI ) and #5131 (Val MVP: Edit AdministrativeSet as a valkyrie resource through UI).

@samvera/hyrax-code-reviewers
