### PR TITLE
switch call to deprecated presenter method with a helper call

### DIFF
--- a/app/views/hyrax/dashboard/collections/_collection_title.html.erb
+++ b/app/views/hyrax/dashboard/collections/_collection_title.html.erb
@@ -3,7 +3,7 @@
 <section class="collection-title-row-wrapper"
   data-source="my"
   data-id="<%= id %>"
-  data-colls-hash="<%= presenter.available_parent_collections(scope: controller) %>"
+  data-colls-hash="<%= available_parent_collections_data(collection: presenter) %>"
   data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
   data-post-delete-url="<%= hyrax.dashboard_collection_path(id) %>">
 


### PR DESCRIPTION
this presenter method was previously deprecated in favor of a helper. it looks
like this view got missed in that update.

@samvera/hyrax-code-reviewers
