### PR TITLE
adjust stubs in WorkShowPresenter specs

### DIFF
--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -595,7 +595,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
         before do
           allow(ability)
             .to receive(:can?)
-            .with(:create_any, Hyrax.collection.collection_class)
+            .with(:create_any, Hyrax.config.collection_class)
             .and_return(false)
         end
 


### PR DESCRIPTION
we want these stubs to apply for whatever collection class is in use in the test
suite.

@samvera/hyrax-code-reviewers
