### PR TITLE
add a publishable event for collection membership changes

### DIFF
--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -100,6 +100,10 @@ module Hyrax
 
     # @since 3.0.0
     # @macro a_registered_event
+    register_event('collection.membership.updated')
+
+    # @since 3.0.0
+    # @macro a_registered_event
     register_event('file.set.audited')
 
     # @since 3.0.0


### PR DESCRIPTION
we want to be able to take actions (e.g. to log, or send timeseries data), when
a collection changes its membership. add a hook for this.

@samvera/hyrax-code-reviewers
