### PR TITLE
don't override a ChangeSet's existing data with a generic default

### DIFF
--- a/lib/hyrax/transactions/steps/set_collection_type_gid.rb
+++ b/lib/hyrax/transactions/steps/set_collection_type_gid.rb
@@ -17,9 +17,10 @@ module Hyrax
         def call(change_set, collection_type_gid: default_collection_type_gid)
           return Failure[:no_collection_type_gid, collection] unless
             change_set.respond_to?(:collection_type_gid=)
+          return Success(change_set) if
+            change_set.collection_type_gid.present?
 
           change_set.collection_type_gid = collection_type_gid
-
           Success(change_set)
         end
 

--- a/spec/hyrax/transactions/steps/set_collection_type_gid_spec.rb
+++ b/spec/hyrax/transactions/steps/set_collection_type_gid_spec.rb
@@ -4,11 +4,15 @@ require 'hyrax/transactions'
 
 RSpec.describe Hyrax::Transactions::Steps::SetCollectionTypeGid do
   subject(:step)   { described_class.new }
-  let(:collection) { build(:hyrax_collection) }
+  let(:collection) { FactoryBot.build(:hyrax_collection, collection_type_gid: nil) }
   let(:change_set) { Hyrax::ChangeSet.for(collection) }
 
   describe '#call' do
-    let(:default_collection_type_gid) { Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id }
+    let(:default_collection_type_gid) do
+      Hyrax::CollectionType
+        .find_or_create_default_collection_type
+        .to_global_id
+    end
 
     it 'is success' do
       expect(step.call(change_set)).to be_success
@@ -17,24 +21,32 @@ RSpec.describe Hyrax::Transactions::Steps::SetCollectionTypeGid do
     context 'when a collection type gid is NOT passed in' do
       it 'sets the default collection type gid' do
         expect { step.call(change_set) }
-          .not_to change { change_set.collection_type_gid }
-          .from(default_collection_type_gid) # The default will always be assigned if one isn't give at create time.
+          .to change { change_set.collection_type_gid }
+          .to(default_collection_type_gid)
       end
     end
 
     context 'when a collection type gid is passed in' do
-      let(:collection_type) { create(:collection_type) }
+      let(:collection_type) { FactoryBot.create(:collection_type) }
       let(:collection_type_gid) { collection_type.to_global_id.to_s }
 
       it 'is success' do
-        expect(step.call(change_set, collection_type_gid: collection_type_gid)).to be_success
+        expect(step.call(change_set, collection_type_gid: collection_type_gid))
+          .to be_success
       end
 
       it 'sets the collection type gid' do
         expect { step.call(change_set, collection_type_gid: collection_type_gid) }
           .to change { change_set.collection_type_gid }
-          .from(default_collection_type_gid)
           .to(collection_type_gid)
+      end
+
+      it 'does not override an existing collection type' do
+        change_set.collection_type_gid = 'existing'
+
+        expect { step.call(change_set, collection_type_gid: collection_type_gid) }
+          .not_to change { change_set.collection_type_gid }
+          .from('existing')
       end
     end
   end


### PR DESCRIPTION
if a ChangeSet has a `#collection_type_gid` value, never override it with the default.

i'm honestly unsure whether this step is helpful at all (doesn't it reproduce Reform's `default:` argument?), but i think we definitely don't want to require you pass in the collection type via `with_step_args` if it's already set on the `change_set`.

@samvera/hyrax-code-reviewers
