### PR TITLE
allow ResourceForm`s `#for` factory method to find Collection forms

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -134,6 +134,8 @@ module Hyrax
           case resource
           when Hyrax::FileSet
             Hyrax::Forms::FileSetForm.new(resource)
+          when Hyrax::PcdmCollection
+            Hyrax::Forms::PcdmCollectionForm.new(resource)
           else
             Hyrax::Forms::ResourceForm(resource.class).new(resource)
           end


### PR DESCRIPTION
map `Hyrax::PcdmCollection` to `Hyrax::Forms::PcdmCollectionForm` for the
factory method's purposes.

@samvera/hyrax-code-reviewers
