### PR TITLE
apply general curation_concerns permissions to configured collection

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -397,7 +397,7 @@ module Hyrax
     end
 
     def curation_concerns_models
-      [::FileSet, ::Collection] + Hyrax.config.curation_concerns
+      [::FileSet, Hyrax.config.collection_class] + Hyrax.config.curation_concerns
     end
 
     def can_review_submissions?


### PR DESCRIPTION
when using a collection class other than `::Collection`, apply Hyrax's
curation_concern permissions. (e.g. this allows `#create`).

@samvera/hyrax-code-reviewers
