### PR TITLE
only skip loading resource for ActiveFedora in CollectionsController

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -43,9 +43,12 @@ module Hyrax
       # The search builder to find the collections' members
       self.membership_service_class = Collections::CollectionMemberSearchService
 
-      load_and_authorize_resource except: [:index, :create],
+      load_and_authorize_resource except: [:index],
                                   instance_name: :collection,
                                   class: Hyrax.config.collection_model
+
+      skip_load_resource only: :create if
+        Hyrax.config.collection_class < ActiveFedora::Base
 
       def deny_collection_access(exception)
         if exception.action == :edit


### PR DESCRIPTION
`Dashboard::CollectionsController#create` has some behavior to avoid CanCan's
load_resource hook. the reasons for avoiding this are a bit opaque, but we
definitely don't want to carry this forward. disabling it immediately does
actually fail some tests, so instead limit the skip to cases where an
ActiveFedora collection class is in use.

@samvera/hyrax-code-reviewers
