### PR TITLE
add valkyrie handling for Dashboard::CollectionsController actions

### DIFF
--- a/lib/hyrax/transactions/collection_update.rb
+++ b/lib/hyrax/transactions/collection_update.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/transaction'
+
+module Hyrax
+  module Transactions
+    ##
+    # Creates a Collection from a ChangeSet
+    #
+    # @since 3.2.0
+    class CollectionUpdate < Transaction
+      DEFAULT_STEPS = ['change_set.apply'].freeze
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -20,6 +20,7 @@ module Hyrax
     class Container # rubocop:disable Metrics/ClassLength
       require 'hyrax/transactions/apply_change_set'
       require 'hyrax/transactions/collection_create'
+      require 'hyrax/transactions/collection_update'
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/destroy_work'
       require 'hyrax/transactions/file_set_destroy'
@@ -63,6 +64,10 @@ module Hyrax
 
         ops.register 'create_collection' do
           CollectionCreate.new
+        end
+
+        ops.register 'update_collection' do
+          CollectionUpdate.new
         end
 
         ops.register 'create_work' do

--- a/spec/hyrax/transactions/collection_update_spec.rb
+++ b/spec/hyrax/transactions/collection_update_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+require 'dry/container/stub'
+
+RSpec.describe Hyrax::Transactions::CollectionUpdate, valkyrie_adapter: :test_adapter do
+  subject(:tx) { described_class.new }
+
+  let(:change_set) { Hyrax::ChangeSet.for(resource) }
+  let(:resource)   { FactoryBot.valkyrie_create(:hyrax_collection) }
+
+  describe '#call' do
+    it 'is a success' do
+      expect(tx.call(change_set)).to be_success
+    end
+  end
+end


### PR DESCRIPTION
adds Valkyrie handling for `#create`, `#update` and `#destroy` actions on
`Dashboard::CollectionsController`.

these implementations are a bit simple, but pass all the controller level test
for these actions (the `#files` action remains unhandled). this handling is
invoked whenever `@collection` is a `Valkyrie::Resource`. the easiest way to
achieve this is to set `Hyrax.config.collection_model` to a Valkyrie model class
name.

@samvera/hyrax-code-reviewers
