### PR TITLE
remove superflouous `subject` definitions from SolrDocument specs

### DIFF
--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -6,34 +6,31 @@ RSpec.describe ::SolrDocument, type: :model do
   describe "#itemtype" do
     let(:attributes) { { resource_type_tesim: ['Article'] } }
 
+    its(:itemtype) { is_expected.to eq 'http://schema.org/Article' }
+
     it "delegates to the Hyrax::ResourceTypesService" do
       expect(Hyrax::ResourceTypesService).to receive(:microdata_type).with('Article')
-      subject
+      document.itemtype
     end
-    subject { document.itemtype }
-
-    it { is_expected.to eq 'http://schema.org/Article' }
 
     context 'with no resource_type' do
       let(:attributes) { {} }
 
-      it { is_expected.to eq 'http://schema.org/CreativeWork' }
+      its(:itemtype) { is_expected.to eq 'http://schema.org/CreativeWork' }
     end
   end
 
   describe "date_uploaded" do
     let(:attributes) { { 'date_uploaded_dtsi' => '2013-03-14T00:00:00Z' } }
 
-    subject { document.date_uploaded }
-
-    it { is_expected.to eq Date.parse('2013-03-14') }
+    its(:date_uploaded) { is_expected.to eq Date.parse('2013-03-14') }
 
     context "when an invalid type is provided" do
       let(:attributes) { { 'date_uploaded_dtsi' => 'Test' } }
 
       it "logs parse errors" do
         expect(Hyrax.logger).to receive(:info).with(/Unable to parse date.*/)
-        subject
+        document.date_uploaded
       end
     end
   end
@@ -44,6 +41,7 @@ RSpec.describe ::SolrDocument, type: :model do
     it "responds to rights_statement" do
       expect(document).to respond_to(:rights_statement)
     end
+
     it "returns the proper data" do
       expect(document.rights_statement).to eq ['A rights statement']
     end
@@ -52,16 +50,14 @@ RSpec.describe ::SolrDocument, type: :model do
   describe "create_date" do
     let(:attributes) { { 'system_create_dtsi' => '2013-03-14T00:00:00Z' } }
 
-    subject { document.create_date }
-
-    it { is_expected.to eq Date.parse('2013-03-14') }
+    its(:create_date) { is_expected.to eq Date.parse('2013-03-14') }
 
     context "when an invalid type is provided" do
       let(:attributes) { { 'system_create_dtsi' => 'Test' } }
 
       it "logs parse errors" do
         expect(Hyrax.logger).to receive(:info).with(/Unable to parse date.*/)
-        subject
+        document.create_date
       end
     end
   end
@@ -69,26 +65,20 @@ RSpec.describe ::SolrDocument, type: :model do
   describe "resource_type" do
     let(:attributes) { { 'resource_type_tesim' => ['Image'] } }
 
-    subject { document.resource_type }
-
-    it { is_expected.to eq ['Image'] }
+    its(:resource_type) { is_expected.to eq ['Image'] }
   end
 
   describe "thumbnail_path" do
     let(:attributes) { { 'thumbnail_path_ss' => ['/foo/bar'] } }
 
-    subject { document.thumbnail_path }
-
-    it { is_expected.to eq '/foo/bar' }
+    its(:thumbnail_path) { is_expected.to eq '/foo/bar' }
   end
 
   describe '#to_param' do
     let(:id) { '1v53kn56d' }
     let(:attributes) { { id: id } }
 
-    subject { document.to_param }
-
-    it { is_expected.to eq id }
+    its(:to_param) { is_expected.to eq id }
   end
 
   describe "#suppressed?" do
@@ -99,6 +89,7 @@ RSpec.describe ::SolrDocument, type: :model do
 
       it { is_expected.to be_suppressed }
     end
+
     context 'when false' do
       let(:suppressed_value) { false }
 
@@ -128,8 +119,6 @@ RSpec.describe ::SolrDocument, type: :model do
   end
 
   describe '#collection_ids' do
-    subject { document.collection_ids }
-
     context 'when the object belongs to collections' do
       let(:attributes) do
         { id: '123',
@@ -137,7 +126,7 @@ RSpec.describe ::SolrDocument, type: :model do
           collection_ids_tesim: ['123', '456', '789'] }
       end
 
-      it { is_expected.to eq ['123', '456', '789'] }
+      its(:collection_ids) { is_expected.to eq ['123', '456', '789'] }
     end
 
     context 'when the object does not belong to any collections' do
@@ -146,32 +135,26 @@ RSpec.describe ::SolrDocument, type: :model do
           title_tesim: ['A generic work'] }
       end
 
-      it { is_expected.to eq [] }
+      its(:collection_ids) { is_expected.to eq [] }
     end
   end
 
   describe "#height" do
     let(:attributes) { { height_is: '444' } }
 
-    subject { document.height }
-
-    it { is_expected.to eq '444' }
+    its(:height) { is_expected.to eq '444' }
   end
 
   describe "#width" do
     let(:attributes) { { width_is: '555' } }
 
-    subject { document.width }
-
-    it { is_expected.to eq '555' }
+    its(:width) { is_expected.to eq '555' }
   end
 
   context "when exporting in endnote format" do
     let(:attributes) { { id: "1234" } }
 
-    subject { document.endnote_filename }
-
-    it { is_expected.to eq("1234.endnote") }
+    its(:endnote_filename) { is_expected.to eq("1234.endnote") }
   end
 
   describe "#admin_set?" do
@@ -193,10 +176,12 @@ RSpec.describe ::SolrDocument, type: :model do
   end
 
   describe "#collection_type_gid?" do
-    let(:attributes) { { 'collection_type_gid_ssim' => 'gid://internal/hyrax-collectiontype/5' } }
+    let(:attributes) do
+      { 'collection_type_gid_ssim' => 'gid://internal/hyrax-collectiontype/5' }
+    end
 
-    subject { document.collection_type_gid }
-
-    it { is_expected.to eq 'gid://internal/hyrax-collectiontype/5' }
+    its(:collection_type_gid) do
+      is_expected.to eq 'gid://internal/hyrax-collectiontype/5'
+    end
   end
 end


### PR DESCRIPTION
these are just extra test setup and can be squashed down.

@samvera/hyrax-code-reviewers
