### PR TITLE
only set reindex-extent on AF collections

### DIFF
--- a/app/controllers/hyrax/dashboard/collection_members_controller.rb
+++ b/app/controllers/hyrax/dashboard/collection_members_controller.rb
@@ -30,7 +30,7 @@ module Hyrax
         after_update_error(err_msg) if err_msg.present?
         return if err_msg.present?
 
-        @collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
+        @collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
         begin
           Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection_id: collection_id,
                                                                          new_member_ids: batch_ids,


### PR DESCRIPTION
Valkyrie models don't index automatically on save, so setting a "re-index
extent" on the model doesn't make much sense.

it's honestly not clear to me that this line does anything at all. the
collection doesn't appear to be saved (or indexed) as part of this controller's
logic.

whatever the case, it turns out that just not failing on this assignment makes
this controller's unit tests pass. we'll definitely want to look closer at
it, since the controller is doing `load_and_authorize_resource` on the whole
collection just to then pass through the id to a collaborator---do we need to
load the object, or just authorize based on id and move on?

@samvera/hyrax-code-reviewers
