### PR TITLE
skip CollectionsMembershipActor specs if using Valkyrie collections

### DIFF
--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
+RSpec.describe Hyrax::Actors::CollectionsMembershipActor, skip: !(Hyrax.config.collection_class < ActiveFedora::Base) do
   let(:user) { create(:user) }
   let(:ability) { ::Ability.new(user) }
   let(:curation_concern) { build(:work, user: user) }


### PR DESCRIPTION
this actor won't be updated for compatibility with Valkyrie-based collection
models. skip its tests in the case that Valkyrie is in use for Collection.

@samvera/hyrax-code-reviewers
