### PR TITLE
Allow ExposedModelsRelation to support Valkryie collections

### DIFF
--- a/app/search_builders/hyrax/exposed_models_relation.rb
+++ b/app/search_builders/hyrax/exposed_models_relation.rb
@@ -3,7 +3,7 @@ module Hyrax
   # A relation that scopes to all user visible models (e.g. works + collections + file sets)
   class ExposedModelsRelation < AbstractTypeRelation
     def allowable_types
-      Hyrax.config.curation_concerns + [::Collection, ::FileSet]
+      (Hyrax.config.curation_concerns + [Hyrax.config.collection_class, ::Collection, ::FileSet]).uniq
     end
   end
 end


### PR DESCRIPTION
via the `Hyrax.config.collection_class`

I noticed this while reading up on the ResourceSync code in https://github.com/samvera/hyrax/pull/5199
