### PR TITLE
centralize the list of collection classes

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -25,6 +25,13 @@ module Hyrax
     end
 
     ##
+    # @since 3.1.0
+    # @return [String] the css class for the collection model icon
+    def collection_model_icon
+      Hyrax::ModelIcon.css_class_for(Hyrax.config.collection_class)
+    end
+
+    ##
     # @since 3.0.0
     # @return [#to_s]
     def collection_metadata_label(collection, field)

--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -14,7 +14,7 @@ module Hyrax::FileSetHelper
   end
 
   def parent_path(parent)
-    if parent.is_a?(::Collection)
+    if parent.collection?
       main_app.collection_path(parent)
     else
       polymorphic_path([main_app, parent])

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -285,7 +285,7 @@ module Hyrax
 
     # Used by the gallery view
     def collection_thumbnail(_document, _image_options = {}, _url_options = {})
-      tag.span("", class: [Hyrax::ModelIcon.css_class_for(::Collection), "collection-icon-search"])
+      tag.span("", class: [Hyrax::ModelIcon.css_class_for(Hyrax.config.collection_class), "collection-icon-search"])
     end
 
     def collection_title_by_id(id)

--- a/app/models/concerns/hyrax/ability/collection_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_ability.rb
@@ -3,7 +3,7 @@ module Hyrax
   module Ability
     module CollectionAbility
       def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        models = [Hyrax::PcdmCollection, Hyrax.config.collection_class].uniq
+        models = Hyrax.collection_classes
         if admin?
           models.each do |collection_model|
             can :manage, collection_model

--- a/app/search_builders/hyrax/exposed_models_relation.rb
+++ b/app/search_builders/hyrax/exposed_models_relation.rb
@@ -3,7 +3,7 @@ module Hyrax
   # A relation that scopes to all user visible models (e.g. works + collections + file sets)
   class ExposedModelsRelation < AbstractTypeRelation
     def allowable_types
-      (Hyrax.config.curation_concerns + [Hyrax.config.collection_class, ::Collection, ::FileSet]).uniq
+      (Hyrax.config.curation_concerns + Hyrax.collection_classes + [::FileSet]).uniq
     end
   end
 end

--- a/app/search_builders/hyrax/filter_by_type.rb
+++ b/app/search_builders/hyrax/filter_by_type.rb
@@ -53,7 +53,7 @@ module Hyrax
 
     def collection_classes
       return [] if only_works?
-      [::Collection, Hyrax.config.collection_class].uniq
+      Hyrax.collection_classes
     end
   end
 end

--- a/app/views/hyrax/collections/_list_collections.html.erb
+++ b/app/views/hyrax/collections/_list_collections.html.erb
@@ -3,7 +3,7 @@
   <td></td>
   <td>
     <div class="media">
-      <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small pull-left"></span>
+      <span class="<%= Hyrax::ModelIcon.css_class_for(Hyrax.config.collection_class) %> collection-icon-small pull-left"></span>
       <div class="media-body">
         <div class="media-heading">
           <%= link_to collection_presenter.show_path do %>

--- a/app/views/hyrax/collections/_media_display.html.erb
+++ b/app/views/hyrax/collections/_media_display.html.erb
@@ -4,5 +4,5 @@
                 alt: "",
                 role: "presentation" %>
 <% else %>
-  <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-search" aria-hidden="true"></span>
+  <span class="<%= Hyrax::ModelIcon.css_class_for(Hyrax.config.collection_class) %> collection-icon-search" aria-hidden="true"></span>
 <% end %>

--- a/app/views/hyrax/collections/_media_display.html.erb
+++ b/app/views/hyrax/collections/_media_display.html.erb
@@ -4,5 +4,5 @@
                 alt: "",
                 role: "presentation" %>
 <% else %>
-  <span class="<%= Hyrax::ModelIcon.css_class_for(Hyrax.config.collection_class) %> collection-icon-search" aria-hidden="true"></span>
+  <span class="<%= collection_model_icon %> collection-icon-search" aria-hidden="true"></span>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -19,7 +19,7 @@
     <div class="thumbnail-title-wrapper">
       <div class="thumbnail-wrapper">
         <% if (collection_presenter.thumbnail_path == nil) %>
-          <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small"></span>
+          <span class="<%= Hyrax::ModelIcon.css_class_for(Hyrax.config.collection_class) %> collection-icon-small"></span>
         <% else %>
           <%= image_tag(collection_presenter.thumbnail_path, alt: "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
         <% end %>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -21,7 +21,7 @@
     <div class="thumbnail-title-wrapper">
       <div class="thumbnail-wrapper">
         <% if (collection_presenter.thumbnail_path == nil) %>
-          <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small"></span>
+          <span class="<%= Hyrax::ModelIcon.css_class_for(Hyrax.config.collection_class) %> collection-icon-small"></span>
         <% else %>
           <%= image_tag(collection_presenter.thumbnail_path, alt: "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
         <% end %>

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -140,4 +140,12 @@ module Hyrax
   def self.custom_queries
     query_service.custom_queries
   end
+
+  ##
+  # @return [Array<Class>] all possible collection classes
+  def self.collection_classes
+    klasses = [Hyrax.config.collection_class, Hyrax::PcdmCollection]
+    klasses << ::Collection if defined? ::Collection
+    klasses.uniq
+  end
 end

--- a/spec/lib/hyrax_spec.rb
+++ b/spec/lib/hyrax_spec.rb
@@ -7,4 +7,11 @@ RSpec.describe Hyrax do
       expect(described_class.logger).to respond_to :log
     end
   end
+
+  describe '.collection_classes' do
+    it 'returns all possible collection classes' do
+      expect(described_class.collection_classes)
+        .to match_array [::Collection, Hyrax::PcdmCollection]
+    end
+  end
 end

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hyrax::CollectionSearchBuilder do
   describe '#models' do
     its(:models) do
       is_expected
-        .to contain_exactly(*[::Collection, Hyrax.config.collection_class].uniq)
+        .to contain_exactly(*Hyrax.collection_classes)
     end
   end
 

--- a/spec/search_builders/hyrax/work_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/work_search_builder_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Hyrax::WorkSearchBuilder do
   end
 
   let(:class_filter_string) do
-    [Monograph, Collection, Hyrax.config.collection_class].uniq.join(',')
+    klasses = [Monograph] + Hyrax.collection_classes
+    klasses.join(',')
   end
 
   describe "#query" do


### PR DESCRIPTION
This centralizes the list of collection classes to `Hyrax.config.collection_classes`.

Places where any collection class could be input or processing occurs across all collection classes were updated to use `Hyrax.config.collection_classes`.  Remaining single references to `::Collection` were updated to `Hyrax.config.collection_class`.  These changes allow for almost all remaining uses of `::Collection` to be removed.

Exceptions:
* work_form which is only used with ActiveFedora
* `PermissionTemplate #collection` which is deprecated and only works with `::Collection`
* `Hyrax::Collections::MigrationService` which performs a migration dependent on reading in the collection as a `::Collection`

This PR does not update `CollectionAbiility` as it is being updated in PR #5206.  Whichever PR is merged first, there will be a small fix required to get abilities to reference the `collection_classes` config instead of creating the list in the `CollectionAbility` class.

@samvera/hyrax-code-reviewers
