### PR TITLE
build CollectionType GlobalID for Admin Sets without db lookup

### DIFF
--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -62,8 +62,7 @@ class AdminSet < ActiveFedora::Base
   end
 
   def collection_type_gid
-    # allow AdminSet to behave more like a regular Collection
-    Hyrax::CollectionType.find_or_create_admin_set_type.to_global_id
+    Hyrax::AdministrativeSet.collection_type_gid
   end
 
   def to_s

--- a/app/models/hyrax/administrative_set.rb
+++ b/app/models/hyrax/administrative_set.rb
@@ -10,9 +10,20 @@ module Hyrax
     attribute :creator,           Valkyrie::Types::Set.of(Valkyrie::Types::String)
     attribute :description,       Valkyrie::Types::Set.of(Valkyrie::Types::String)
 
+    ##
+    # @note all admin sets have the same collection type, so we don't store
+    #   this data. however, we want a reader so type lookup behaves the same
+    #   as for other collections.
+    # @return [GlobalID]
     def collection_type_gid
-      # allow AdministrativeSet to behave more like a regular PcdmCollection
-      Hyrax::CollectionType.find_or_create_admin_set_type.to_global_id
+      self.class.collection_type_gid
+    end
+
+    def self.collection_type_gid
+      GlobalID.new(URI::GID.build([GlobalID.app,
+                                   Hyrax::CollectionType.name,
+                                   Hyrax.admin_set_collection_type_id,
+                                   {}]))
     end
   end
 end

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -140,4 +140,11 @@ module Hyrax
   def self.custom_queries
     query_service.custom_queries
   end
+
+  ##
+  # @return [String] the primary key for the admin set collection type
+  def self.admin_set_collection_type_id
+    @_admin_set_collection_type_id ||=
+      Hyrax::CollectionType.find_or_create_admin_set_type.id
+  end
 end

--- a/spec/models/hyrax/administrative_set_spec.rb
+++ b/spec/models/hyrax/administrative_set_spec.rb
@@ -5,4 +5,8 @@ require 'hyrax/specs/shared_specs/hydra_works'
 
 RSpec.describe Hyrax::AdministrativeSet do
   it_behaves_like 'a Hyrax::AdministrativeSet'
+
+  it do
+    subject.collection_type_gid
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,6 +105,7 @@ ActiveJob::Base.queue_adapter = :test
 
 def clean_active_fedora_repository
   ActiveFedora::Cleaner.clean!
+  Hyrax.instance_variable_set(:@_admin_set_collection_type_id, nil)
   # The JS is executed in a different thread, so that other thread
   # may think the root path has already been created:
   ActiveFedora.fedora.connection.send(:init_base_path)


### PR DESCRIPTION
don't depend on a database lookup to find the collection type gid for admin
sets. we are normally planning to use this for collection type lookup, and it's
circular (and a bit comical) to lookup the collection type just to find the ID.
maybe this is a step toward removing `CollectionType#machine_id`, too.

@samvera/hyrax-code-reviewers
