### PR TITLE
map SolrDocument#collection? to configured class

### DIFF
--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -53,8 +53,7 @@ module Hyrax
     ##
     # @return [Boolean]
     def collection?
-      hydra_model.try(:collection?) ||
-        hydra_model == Hyrax.config.collection_class
+      hydra_model == Hyrax.config.collection_class
     end
 
     ##
@@ -77,7 +76,7 @@ module Hyrax
 
     # Method to return the model
     def hydra_model(classifier: ActiveFedora.model_mapper)
-      "::#{first('has_model_ssim')}".safe_constantize ||
+      first('has_model_ssim')&.safe_constantize ||
         classifier.classifier(self).best_model
     end
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe ::SolrDocument, type: :model do
   end
 
   describe "#collection?" do
-    let(:attributes) { { 'has_model_ssim' => 'Collection' } }
+    let(:attributes) { { 'has_model_ssim' => Hyrax.config.collection_model } }
 
     it { is_expected.to be_collection }
   end


### PR DESCRIPTION
using `#collection?` on the `hydra_model` turns out to be useless, since
`hydra_model` is actually a Class, not a model instance.

instead just respect whatever model is configured. trust that
`SolrDocument#hydra_model` will get resolved to the configured class.

@samvera/hyrax-code-reviewers
