### PR TITLE
find legacy collections in CollectionsSearchBuilder

### DIFF
--- a/app/search_builders/hyrax/dashboard/collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/collections_search_builder.rb
@@ -9,7 +9,7 @@ module Hyrax
 
       # This overrides the models in FilterByType
       def models
-        [::AdminSet, Hyrax.config.collection_model.safe_constantize].compact
+        [::AdminSet, ::Collection, Hyrax.config.collection_model.safe_constantize].uniq.compact
       end
 
       # adds a filter to exclude collections and admin sets created by the

--- a/spec/search_builders/hyrax/dashboard/collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/collections_search_builder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsSearchBuilder do
   describe '#models' do
     subject { builder.models }
 
-    it { is_expected.to eq([AdminSet, Hyrax.config.collection_class]) }
+    it { is_expected.to eq([AdminSet, ::Collection, Hyrax.config.collection_class].uniq) }
   end
 
   describe ".default_processor_chain" do

--- a/spec/services/hyrax/collections/managed_collections_service_spec.rb
+++ b/spec/services/hyrax/collections/managed_collections_service_spec.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Collections::ManagedCollectionsService, clean_repo: true do
-  let(:current_ability) { instance_double(Ability, admin?: true) }
+RSpec.describe Hyrax::Collections::ManagedCollectionsService do
   let(:scope) { FakeSearchBuilderScope.new(current_ability: current_ability) }
+  let(:current_ability) { instance_double(Ability, admin?: true) }
 
   describe '.managed_collections_count' do
-    before do
-      FactoryBot.valkyrie_create(:hyrax_collection, :public)
-    end
-
     it 'returns number of collections that can be managed' do
-      expect(described_class.managed_collections_count(scope: scope)).to eq(1)
+      expect { FactoryBot.valkyrie_create(:hyrax_collection, :public) }
+        .to change { described_class.managed_collections_count(scope: scope) }
+        .by 1
     end
   end
 end


### PR DESCRIPTION
even when using Valkyrie (and Hyrax::PcdmCollection), we expect Wings to index
to the ActiveFedora Solr core using `::Collection`. for this reason, searches
should continue to resolve legacy `::Collection` references for the moment.


@samvera/hyrax-code-reviewers
