### PR TITLE
skip CollectionForm specs if ActiveFedora isn't used for Collections

### DIFF
--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Forms::CollectionForm do
+RSpec.describe Hyrax::Forms::CollectionForm, skip: !(Hyrax.config.collection_class < ActiveFedora::Base) do
   let(:collection) { build(:collection_lw) }
   let(:ability) { Ability.new(create(:user)) }
   let(:repository) { double }


### PR DESCRIPTION
this form should only be used if an ActiveFedora `Collection` model is
used. otherwise simply skip the specs in CI.

@samvera/hyrax-code-reviewers
