### PR TITLE
helperize resolution of thumbnail labels

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -296,6 +296,15 @@ module Hyrax
       solr_field.first
     end
 
+    ##
+    # @param [Object] an object that might have a thumbnail
+    #
+    # @return [String] a label for the object's thumbnail
+    def thumbnail_label_for(object:)
+      object.try(:thumbnail_title).presence ||
+        ""
+    end
+
     private
 
     def user_agent

--- a/app/views/hyrax/admin/admin_sets/_form.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form.html.erb
@@ -26,7 +26,7 @@
                 <% if f.object.persisted? && f.object.member_ids.present? %>
                   <%# we're loading these values dynamically to speed page load %>
                   <%= f.input :thumbnail_id,
-                              input_html: { data: { text: f.object.thumbnail_title } } %>
+                              input_html: { data: { text: thumbnail_label_for(object: f.object) } } %>
                 <% end %>
 
               </div>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -37,7 +37,7 @@
               <% if f.object.persisted? %>
                 <%# we're loading these values dynamically to speed page load %>
                 <%= f.input :thumbnail_id,
-                            input_html: { data: { text: f.object.thumbnail_title } } %>
+                    input_html: { data: { text: thumbnail_label_for(object: f.object) } } %>
               <% end %>
             </div>
             <% if f.object.display_additional_fields? %>

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -388,4 +388,32 @@ RSpec.describe HyraxHelper, type: :helper do
       expect(helper.collection_title_by_id("bad-id")).to eq nil
     end
   end
+
+  describe "#thumbnail_label_for" do
+    it "gives a string even if no thumbnail label can be found" do
+      expect(helper.thumbnail_label_for(object: Object.new)).to be_a String
+    end
+
+    it 'interoperates with CollectionForm' do
+      collection = ::Collection.new
+      collection.thumbnail = ::FileSet.create(title: ["thumbnail"])
+
+      form = Hyrax::Forms::CollectionForm.new(collection,
+                                              :FAKE_ABILITY,
+                                              :FAKE_BLACKLIGHT_REPOSITORY)
+
+      expect(helper.thumbnail_label_for(object: form)).to eq 'thumbnail'
+    end
+
+    it 'interoperates with AdminSetForm' do
+      admin_set = AdminSet.new
+      admin_set.thumbnail = ::FileSet.create(title: ["thumbnail"])
+
+      form = Hyrax::Forms::AdminSetForm.new(admin_set,
+                                            :FAKE_ABILITY,
+                                            :FAKE_BLACKLIGHT_REPOSITORY)
+
+      expect(helper.thumbnail_label_for(object: form)).to eq 'thumbnail'
+    end
+  end
 end


### PR DESCRIPTION
extract dependency on Form level `#thumbnail_title` methods to a helper, avoid
NoMethodError that breaks the entire page if this method isn't present in an
application's form implementation.

@samvera/hyrax-code-reviewers
