### PR TITLE
skip ActiveFedora indexing if Wings is disabled

### DIFF
--- a/app/services/hyrax/listeners/active_fedora_acl_index_listener.rb
+++ b/app/services/hyrax/listeners/active_fedora_acl_index_listener.rb
@@ -13,6 +13,7 @@ module Hyrax
       #
       # @param event [Dry::Event]
       def on_object_acl_updated(event)
+        return if Hyrax.config.disable_wings
         return unless event[:result] == :success # do nothing on failure
 
         if Hyrax.metadata_adapter.is_a?(Wings::Valkyrie::MetadataAdapter)

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 Hyrax.publisher.subscribe(Hyrax::Listeners::AclIndexListener.new)
-Hyrax.publisher.subscribe(Hyrax::Listeners::ActiveFedoraAclIndexListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::ActiveFedoraAclIndexListener.new) unless
+  Hyrax.config.disable_wings
 Hyrax.publisher.subscribe(Hyrax::Listeners::MemberCleanupListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::MetadataIndexListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::BatchNotificationListener.new)


### PR DESCRIPTION
this whole module requires type checking on Wings, so just don't include it if
Wings is disabled.

@samvera/hyrax-code-reviewers
