### PR TITLE
add param_key and plural to `Hyrax::CollectionName`

### DIFF
--- a/lib/hyrax/collection_name.rb
+++ b/lib/hyrax/collection_name.rb
@@ -10,6 +10,8 @@ module Hyrax
 
       @human              = 'Collection'
       @i18n_key           = :collection
+      @param_key          = 'collection'
+      @plural             = 'collections'
       @route_key          = 'collections'
       @singular_route_key = 'collection'
     end

--- a/spec/models/hyrax/pcdm_collection_spec.rb
+++ b/spec/models/hyrax/pcdm_collection_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Hyrax::PcdmCollection do
       expect(subject.model_name)
         .to have_attributes(human: "Collection",
                             i18n_key: :collection,
+                            param_key: "collection",
+                            plural: "collections",
                             route_key: "collections",
                             singular_route_key: "collection")
     end


### PR DESCRIPTION
we want the collection form data to be the same regardless of the model
used. ActiveModel naming is the right place to handle this.

@samvera/hyrax-code-reviewers
