### PR TITLE
refactor specs for permission template access deletion

### DIFF
--- a/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
@@ -1,26 +1,29 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
   routes { Hyrax::Engine.routes }
-  before do
-    sign_in create(:user)
-  end
   let(:hyrax) { Hyrax::Engine.routes.url_helpers }
-  let(:permission_template_access) { create(:permission_template_access) }
+  let(:permission_template_access) { FactoryBot.create(:permission_template_access) }
   let(:source_id) { permission_template_access.permission_template.source_id }
+
+  before { sign_in FactoryBot.create(:user) }
 
   describe "destroy" do
     context "without admin privleges" do
       before do
-        allow(controller.current_ability).to receive(:test_edit).with(source_id).and_return(false)
+        allow(controller.current_ability)
+          .to receive(:test_edit)
+          .with(source_id)
+          .and_return(false)
       end
+
       it "is unauthorized" do
         delete :destroy, params: { id: permission_template_access }
+
         expect(response).to be_unauthorized
       end
     end
 
     context "when signed in as an admin" do
-      # TODO: Need test that shows delete of admin group form depositors and viewers is allowed
       let(:permission_template_access) do
         create(:permission_template_access,
                :manage,
@@ -29,21 +32,49 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
                agent_id: agent_id)
       end
 
+      it 'can remove admin group from depositors'
+      it 'can remove admin group from viewers'
+
       context 'when source is an admin set' do
-        let(:permission_template) { create(:permission_template, source_id: admin_set.id) }
-        let(:admin_set) { create(:admin_set, edit_users: ['Liz']) }
+        let(:admin_set) { FactoryBot.create(:admin_set, edit_users: ['Liz']) }
+
+        let(:permission_template) do
+          FactoryBot.create(:permission_template, source_id: admin_set.id)
+        end
 
         context 'when deleting the admin users group' do
           let(:agent_type) { 'group' }
           let(:agent_id) { 'admin' }
 
-          it "is fails" do
-            expect(controller).to receive(:authorize!).with(:destroy, permission_template_access)
-            expect do
-              delete :destroy, params: { id: permission_template_access }
-            end.not_to change { Hyrax::PermissionTemplateAccess.count }
-            expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(source_id, locale: 'en', anchor: 'participants'))
-            expect(flash[:notice]).not_to eq I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
+          before do
+            allow(controller)
+              .to receive(:authorize!)
+              .with(:destroy, permission_template_access)
+          end
+
+          it "does not delete the permission template access" do
+            expect { delete :destroy, params: { id: permission_template_access } }
+              .not_to change { Hyrax::PermissionTemplateAccess.count }
+          end
+
+          it "does something" do
+            delete :destroy, params: { id: permission_template_access }
+
+            expect(response)
+              .to redirect_to(hyrax.edit_admin_admin_set_path(source_id,
+                                                              locale: 'en',
+                                                              anchor: 'participants'))
+          end
+
+          it "does not flash a notice" do
+            delete :destroy, params: { id: permission_template_access }
+
+            expect(flash[:notice]).not_to be_present
+          end
+
+          it "flashes an alert for failure" do
+            delete :destroy, params: { id: permission_template_access }
+
             expect(flash[:alert]).to eq 'The repository administrators group cannot be removed'
           end
         end
@@ -52,14 +83,38 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
           let(:agent_type) { 'user' }
           let(:agent_id) { 'Liz' }
 
-          it "is successful" do
-            expect(controller).to receive(:authorize!).with(:destroy, permission_template_access)
-            expect do
-              delete :destroy, params: { id: permission_template_access }
-            end.to change { Hyrax::PermissionTemplateAccess.count }.by(-1)
-            expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(source_id, locale: 'en', anchor: 'participants'))
-            expect(flash[:notice]).to eq(I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
-            expect(admin_set.reload.edit_users).to be_empty
+          before do
+            allow(controller)
+              .to receive(:authorize!)
+              .with(:destroy, permission_template_access)
+          end
+
+          it "deletes the permission template access" do
+            expect { delete :destroy, params: { id: permission_template_access } }
+              .to change { Hyrax::PermissionTemplateAccess.count }
+              .by(-1)
+          end
+
+          it "redirects to the admin dashboard's admin set edit path" do
+            delete :destroy, params: { id: permission_template_access }
+
+            expect(response)
+              .to redirect_to(hyrax.edit_admin_admin_set_path(source_id,
+                                                                   locale: 'en',
+                                                                   anchor: 'participants'))
+          end
+
+          it "flashes a notice" do
+            delete :destroy, params: { id: permission_template_access }
+
+            expect(flash[:notice])
+              .to eq "The administrative set's participant rights have been updated"
+          end
+
+          it "empties the admin set's edit users" do
+            expect { delete :destroy, params: { id: permission_template_access } }
+              .to change { admin_set.reload.edit_users.to_a }
+              .to be_empty
           end
         end
       end
@@ -72,28 +127,70 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
           let(:agent_type) { 'group' }
           let(:agent_id) { 'admin' }
 
-          it "fails" do
-            expect(controller).to receive(:authorize!).with(:destroy, permission_template_access)
-            expect do
-              delete :destroy, params: { id: permission_template_access }
-            end.not_to change { Hyrax::PermissionTemplateAccess.count }
-            expect(response).to redirect_to(hyrax.edit_dashboard_collection_path(source_id, locale: 'en', anchor: 'sharing'))
-            expect(flash[:notice]).not_to eq I18n.t('sharing', scope: 'hyrax.dashboard.collections.form.permission_update_notices')
-            expect(flash[:alert]).to eq 'The repository administrators group cannot be removed'
+          before do
+            allow(controller)
+              .to receive(:authorize!)
+              .with(:destroy, permission_template_access)
+          end
+
+          it "does not delete the permission template access" do
+            expect { delete :destroy, params: { id: permission_template_access } }
+              .not_to change { Hyrax::PermissionTemplateAccess.count }
+          end
+
+          it "redirects to the dashboard collection edit path" do
+            delete :destroy, params: { id: permission_template_access }
+
+            expect(response)
+              .to redirect_to(hyrax.edit_dashboard_collection_path(source_id,
+                                                                   locale: 'en',
+                                                                   anchor: 'sharing'))
+          end
+
+          it "does not flash a notice" do
+            delete :destroy, params: { id: permission_template_access }
+
+            expect(flash[:notice]).not_to be_present
+          end
+
+          it "flashes an alert showing failure status" do
+            delete :destroy, params: { id: permission_template_access }
+
+            expect(flash[:alert])
+              .to eq 'The repository administrators group cannot be removed'
           end
         end
 
-        context 'with deleting any agent other than the admin users group' do
+        context 'as an agent not in the admin users group' do
           let(:agent_type) { 'user' }
           let(:agent_id) { 'Liz' }
 
-          it "is successful" do
-            expect(controller).to receive(:authorize!).with(:destroy, permission_template_access)
-            expect do
-              delete :destroy, params: { id: permission_template_access }
-            end.to change { Hyrax::PermissionTemplateAccess.count }.by(-1)
-            expect(response).to redirect_to(hyrax.edit_dashboard_collection_path(source_id, locale: 'en', anchor: 'sharing'))
-            expect(flash[:notice]).to eq(I18n.t('sharing', scope: 'hyrax.dashboard.collections.form.permission_update_notices'))
+          before do
+            allow(controller)
+              .to receive(:authorize!)
+              .with(:destroy, permission_template_access)
+          end
+
+          it "deletes the permission template access" do
+            expect { delete :destroy, params: { id: permission_template_access } }
+              .to change { Hyrax::PermissionTemplateAccess.count }
+              .by(-1)
+          end
+
+          it "redirects to the dashboard collection edit path" do
+            delete :destroy, params: { id: permission_template_access }
+
+            expect(response)
+              .to redirect_to(hyrax.edit_dashboard_collection_path(source_id,
+                                                                   locale: 'en',
+                                                                   anchor: 'sharing'))
+          end
+
+          it "flashes a notice" do
+            delete :destroy, params: { id: permission_template_access }
+
+            expect(flash[:notice])
+              .to eq "The collection's sharing options have been updated."
           end
         end
       end


### PR DESCRIPTION
the tests for this controller were not sufficiently granular to make debugging
easy. i encountered this working on Collection support for Valkyrie (where these
tests are failing seemingly due to #5214). it took me some time to understand
what was going wrong, so i wanted to make the tests clearer by following the
one-expectation-per-spec-block pattern.

@samvera/hyrax-code-reviewers
