### PR TITLE
don't fall through to 204 No Content when unsure of model type

### DIFF
--- a/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
+++ b/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
@@ -35,7 +35,7 @@ module Hyrax
           redirect_to hyrax.edit_admin_admin_set_path(source_id,
                                                       anchor: 'participants'),
                       notice: translate('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
-        elsif source.collection?
+        else
           redirect_to hyrax.edit_dashboard_collection_path(source_id,
                                                            anchor: 'sharing'),
                       notice: translate('sharing', scope: 'hyrax.dashboard.collections.form.permission_update_notices')
@@ -47,7 +47,7 @@ module Hyrax
           redirect_to hyrax.edit_admin_admin_set_path(source_id,
                                                       anchor: 'participants'),
                       alert: @permission_template_access.errors.full_messages.to_sentence
-        elsif source.collection?
+        else
           redirect_to hyrax.edit_dashboard_collection_path(source_id,
                                                            anchor: 'sharing'),
                       alert: @permission_template_access.errors.full_messages.to_sentence
@@ -56,6 +56,9 @@ module Hyrax
 
       delegate :source_id, to: :permission_template
 
+      ##
+      # @todo can we avoid querying solr to deciede where to redirect? we
+      #   otherwise don't need this data at all.
       def source
         @source ||= ::SolrDocument.find(source_id)
       end


### PR DESCRIPTION
`PermissionTemplateAccessesController` decides where to redirect based on the
SolrDocument's model type, but falls through to a 204 No Content if the
SolrDocument isn't sure what it is.

this is probably okay for successes, even if it's a bit user unfriendly, but is
a serious problem for failures where we don't want to be returning a Successful
response status code!

even for successes, it's hard to see the downside of redirecting to the
collection edit path by default. can't be worse than redirecting to a blank
page.

@samvera/hyrax-code-reviewers
