### PR TITLE
refactor NestedCollectionQueryService specs

### DIFF
--- a/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   let(:coll_a) do
     FactoryBot.build(:public_collection,
                      id: 'Collection_A',
-                    collection_type: collection_type,
+                     collection_type: collection_type,
                      with_nesting_attributes:
                        { ancestors: [],
                          parent_ids: [],
@@ -130,10 +130,10 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
 
       describe 'and can deposit to the parent' do
         before do
-            allow(scope)
-              .to receive(:can?)
-              .with(:deposit, coll_c)
-              .and_return(true)
+          allow(scope)
+            .to receive(:can?)
+            .with(:deposit, coll_c)
+            .and_return(true)
         end
 
         describe 'it prevents circular nesting' do
@@ -257,7 +257,6 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
                             user: user,
                             with_permission_template: true)
         end
-
 
         it 'is true' do
           expect(described_class.parent_and_child_can_nest?(parent: collection, child: member, scope: scope))

--- a/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
+++ b/spec/services/hyrax/collections/nested_collection_query_service_spec.rb
@@ -1,108 +1,108 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: true do
-  let(:blacklight_config) { CatalogController.blacklight_config }
-  let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
-  let(:user) { create(:user) }
-  let(:ability) { ::Ability.new(user) }
-  let(:current_ability) { ability }
-  let(:scope) { double('Scope', can?: true, current_ability: current_ability, repository: repository, blacklight_config: blacklight_config) }
-
-  let(:collection_type) { create(:collection_type) }
-  let(:another_collection_type) { create(:collection_type) }
+  let(:collection_type) { FactoryBot.create(:collection_type) }
+  let(:collection_type_other) { FactoryBot.create(:collection_type) }
+  let(:scope) { FakeSearchBuilderScope.new(current_user: user) }
+  let(:user) { FactoryBot.create(:user) }
 
   let(:coll_a) do
-    build(:public_collection,
-          id: 'Collection_A',
-          collection_type: collection_type,
-          with_nesting_attributes:
-          { ancestors: [],
-            parent_ids: [],
-            pathnames: ['Collection_A'],
-            depth: 1 })
+    FactoryBot.build(:public_collection,
+                     id: 'Collection_A',
+                    collection_type: collection_type,
+                     with_nesting_attributes:
+                       { ancestors: [],
+                         parent_ids: [],
+                         pathnames: ['Collection_A'],
+                         depth: 1 })
   end
+
   let(:coll_b) do
-    build(:public_collection,
-          id: 'Collection_B',
-          collection_type: collection_type,
-          member_of_collections: [coll_a],
-          with_nesting_attributes:
-          { ancestors: ['Collection_A'],
-            parent_ids: ['Collection_A'],
-            pathnames: ['Collection_A/Collection_B'],
-            depth: 2 })
+    FactoryBot.build(:public_collection,
+                     id: 'Collection_B',
+                     collection_type: collection_type,
+                     member_of_collections: [coll_a],
+                     with_nesting_attributes:
+                       { ancestors: ['Collection_A'],
+                         parent_ids: ['Collection_A'],
+                         pathnames: ['Collection_A/Collection_B'],
+                         depth: 2 })
   end
+
   let(:coll_c) do
-    build(:public_collection,
-          id: 'Collection_C',
-          collection_type: collection_type,
-          member_of_collections: [coll_b],
-          with_nesting_attributes:
-          { ancestors: ["Collection_A",
-                        "Collection_A/Collection_B"],
-            parent_ids: ['Collection_B'],
-            pathnames: ['Collection_A/Collection_B/Collection_C'],
-            depth: 3 })
+    FactoryBot.build(:public_collection,
+                     id: 'Collection_C',
+                     collection_type: collection_type,
+                     member_of_collections: [coll_b],
+                     with_nesting_attributes:
+                       { ancestors: ["Collection_A",
+                                     "Collection_A/Collection_B"],
+                         parent_ids: ['Collection_B'],
+                         pathnames: ['Collection_A/Collection_B/Collection_C'],
+                         depth: 3 })
   end
+
   let(:coll_d) do
-    build(:public_collection,
-          id: 'Collection_D',
-          collection_type: collection_type,
-          member_of_collections: [coll_c],
-          with_nesting_attributes:
-          { ancestors: ["Collection_A",
-                        "Collection_A/Collection_B",
-                        "Collection_A/Collection_B/Collection_C"],
-            parent_ids: ['Collection_C'],
-            pathnames: ["Collection_A/Collection_B/Collection_C/Collection_D"],
-            depth: 4 })
+    FactoryBot.build(:public_collection,
+                     id: 'Collection_D',
+                     collection_type: collection_type,
+                     member_of_collections: [coll_c],
+                     with_nesting_attributes:
+                       { ancestors: ["Collection_A",
+                                     "Collection_A/Collection_B",
+                                     "Collection_A/Collection_B/Collection_C"],
+                         parent_ids: ['Collection_C'],
+                         pathnames: ["Collection_A/Collection_B/Collection_C/Collection_D"],
+                         depth: 4 })
   end
+
   let(:coll_e) do
-    build(:public_collection,
-          id: 'Collection_E',
-          collection_type: collection_type,
-          member_of_collections: [coll_d],
-          with_nesting_attributes:
-          { ancestors: ["Collection_A",
-                        "Collection_A/Collection_B",
-                        "Collection_A/Collection_B/Collection_C",
-                        "Collection_A/Collection_B/Collection_C/Collection_D"],
-            parent_ids: ['Collection_D'],
-            pathnames: ['Collection_A/Collection_B/Collection_C/Collection_D/Collection_E'],
-            depth: 5 })
+    FactoryBot.build(:public_collection,
+                     id: 'Collection_E',
+                     collection_type: collection_type,
+                     member_of_collections: [coll_d],
+                     with_nesting_attributes:
+                       { ancestors: ["Collection_A",
+                                     "Collection_A/Collection_B",
+                                     "Collection_A/Collection_B/Collection_C",
+                                     "Collection_A/Collection_B/Collection_C/Collection_D"],
+                         parent_ids: ['Collection_D'],
+                         pathnames: ['Collection_A/Collection_B/Collection_C/Collection_D/Collection_E'],
+                         depth: 5 })
   end
+
   let(:another) do
-    build(:public_collection,
-          id: 'Another_One',
-          collection_type: collection_type,
-          with_nesting_attributes:
-          { ancestors: [],
-            parent_ids: [],
-            pathnames: ['Another_One'],
-            depth: 1 })
+    FactoryBot.build(:public_collection,
+                     id: 'Another_One',
+                     collection_type: collection_type,
+                     with_nesting_attributes:
+                       { ancestors: [],
+                         parent_ids: [],
+                         pathnames: ['Another_One'],
+                         depth: 1 })
   end
+
   let(:wrong) do
-    build(:public_collection,
-          id: 'Wrong_Type',
-          collection_type: another_collection_type,
-          with_nesting_attributes:
-          { ancestors: [],
-            parent_ids: [],
-            pathnames: ['Wrong_Type'],
-            depth: 1 })
+    FactoryBot.build(:public_collection,
+                     id: 'Wrong_Type',
+                     collection_type: collection_type_other,
+                     with_nesting_attributes:
+                       { ancestors: [],
+                         parent_ids: [],
+                         pathnames: ['Wrong_Type'],
+                         depth: 1 })
   end
 
   describe '.available_child_collections' do
-    describe 'given parent is not nestable?' do
-      subject { described_class.available_child_collections(parent: parent_double, scope: scope) }
+    context 'when parent is not nestable?' do
+      let(:collection) { double(nestable?: false) }
 
-      let(:parent_double) { double(nestable?: false) }
-
-      it { is_expected.to eq([]) }
+      it 'is empty' do
+        expect(described_class.available_child_collections(parent: collection, scope: scope))
+          .to be_empty
+      end
     end
 
-    describe 'given parent is nestable?' do
-      subject { described_class.available_child_collections(parent: coll_c, scope: scope) }
-
+    context 'when parent is nestable?' do
       before do
         coll_e # this will also build coll_a through coll_d
         another
@@ -110,19 +110,37 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
       end
 
       describe 'and cannot deposit to the parent' do
+        before do
+          allow(scope)
+            .to receive(:can?)
+            .with(:deposit, coll_c)
+            .and_return(false)
+        end
+
         it 'returns an empty array' do
-          expect(scope).to receive(:can?).with(:deposit, coll_c).and_return(false)
+          expect(described_class.available_child_collections(parent: coll_c, scope: scope))
+            .to be_empty
+        end
+
+        it 'does not query for subcollections' do
           expect(described_class).not_to receive(:query_solr)
-          expect(subject).to eq([])
+          described_class.available_child_collections(parent: coll_c, scope: scope)
         end
       end
 
       describe 'and can deposit to the parent' do
+        before do
+            allow(scope)
+              .to receive(:can?)
+              .with(:deposit, coll_c)
+              .and_return(true)
+        end
+
         describe 'it prevents circular nesting' do
           it 'returns an array of valid collections of the same collection type' do
-            expect(scope).to receive(:can?).with(:deposit, coll_c).and_return(true)
-            expect(described_class).to receive(:query_solr).with(collection: coll_c, access: :read, scope: scope, limit_to_id: nil, nest_direction: :as_child).and_call_original
-            expect(subject.map(&:id)).to contain_exactly(another.id, coll_e.id)
+            expect(described_class.available_child_collections(parent: coll_c, scope: scope))
+              .to contain_exactly(have_attributes(id: another.id),
+                                  have_attributes(id: coll_e.id))
           end
         end
       end
@@ -130,81 +148,59 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   end
 
   describe '.available_parent_collections' do
-    describe 'given child is not nestable?' do
-      subject { described_class.available_parent_collections(child: child_double, scope: scope) }
+    describe 'when the proposed member is not nestable?' do
+      let(:member) { double(nestable?: false) }
 
-      let(:child_double) { double(nestable?: false) }
-
-      it { is_expected.to eq([]) }
+      it 'gives an empty list' do
+        expect(described_class.available_parent_collections(child: member, scope: scope))
+          .to be_empty
+      end
     end
 
     describe 'given child is nestable?' do
       describe 'and cannot read the child' do
-        subject { described_class.available_parent_collections(child: coll_c, scope: scope) }
+        before do
+          allow(scope)
+            .to receive(:can?)
+            .with(:read, coll_c)
+            .and_return(false)
+        end
 
-        it 'returns an empty array' do
-          expect(scope).to receive(:can?).with(:read, coll_c).and_return(false)
+        it 'gives an empty list of available collections' do
+          expect(described_class.available_parent_collections(child: coll_c, scope: scope))
+            .to be_empty
+        end
+
+        it 'does not query solr' do
           expect(described_class).not_to receive(:query_solr)
-          expect(subject).to eq([])
+          described_class.available_parent_collections(child: coll_c, scope: scope)
         end
       end
 
       describe 'and can read the child', with_nested_reindexing: true do
-        subject { described_class.available_parent_collections(child: coll_c, scope: scope) }
-
-        # using create option here because permission template is required for testing :deposit access
         let(:coll_a) do
-          build(:public_collection_lw,
-                id: 'Collection_A',
-                collection_type: collection_type,
-                user: user,
-                with_permission_template: true)
+          FactoryBot.build(:public_collection_lw,
+                           id: 'Collection_A',
+                           collection_type: collection_type,
+                           user: user,
+                           with_permission_template: true)
         end
-        let(:coll_b) do
-          build(:public_collection_lw,
-                id: 'Collection_B',
-                collection_type: collection_type,
-                user: user,
-                with_permission_template: true,
-                member_of_collections: [coll_a])
-        end
-        let(:coll_c) do
-          build(:public_collection_lw,
-                id: 'Collection_C',
-                collection_type: collection_type,
-                user: user,
-                with_permission_template: true,
-                member_of_collections: [coll_b])
-        end
-        let(:coll_d) do
-          build(:public_collection_lw,
-                id: 'Collection_D',
-                collection_type: collection_type,
-                user: user,
-                with_permission_template: true,
-                member_of_collections: [coll_c])
-        end
+
         let(:coll_e) do
-          create(:public_collection_lw,
-                 id: 'Collection_E',
-                 collection_type: collection_type,
-                 user: user,
-                 with_permission_template: true,
-                 member_of_collections: [coll_d])
+          FactoryBot.create(:public_collection_lw,
+                            id: 'Collection_E',
+                            collection_type: collection_type,
+                            user: user,
+                            with_permission_template: true,
+                            member_of_collections: [coll_d])
         end
+
         let(:another) do
-          create(:public_collection_lw,
-                 id: 'Another_One',
-                 collection_type: collection_type,
-                 user: user,
-                 with_permission_template: true)
-        end
-        let(:wrong) do
-          build(:public_collection_lw,
-                id: 'Wrong_Type',
-                collection_type: another_collection_type,
-                user: user,
-                with_permission_template: true)
+          FactoryBot.create(:public_collection_lw,
+                            id: 'Another_One',
+                            collection_type: collection_type,
+                            user: user,
+                            with_permission_template: true)
         end
 
         before do
@@ -214,10 +210,14 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
         end
 
         describe 'it prevents circular nesting' do
+          before do
+            allow(scope).to receive(:can?).with(:read, coll_c).and_return(true)
+          end
+
           it 'returns an array of collections of the same collection type excluding the given collection' do
-            expect(scope).to receive(:can?).with(:read, coll_c).and_return(true)
-            expect(described_class).to receive(:query_solr).with(collection: coll_c, access: :deposit, scope: scope, limit_to_id: nil, nest_direction: :as_parent).and_call_original
-            expect(subject.map(&:id)).to contain_exactly(coll_a.id, another.id)
+            expect(described_class.available_parent_collections(child: coll_c, scope: scope))
+              .to contain_exactly(have_attributes(id: coll_a.id),
+                                  have_attributes(id: another.id))
           end
         end
       end
@@ -225,131 +225,154 @@ RSpec.describe Hyrax::Collections::NestedCollectionQueryService, clean_repo: tru
   end
 
   describe '.parent_and_child_can_nest?' do
-    let(:parent) { coll_c }
-    let(:child) { another }
-
-    subject { described_class.parent_and_child_can_nest?(parent: parent, child: child, scope: scope) }
-
     before do
       coll_e
       another
       wrong
     end
 
-    describe 'given parent and child are nestable' do
+    describe 'when parent and child are nestable' do
       describe 'and are the same object' do
-        let(:child) { parent }
-
-        it { is_expected.to eq(false) }
+        it 'is false' do
+          expect(described_class.parent_and_child_can_nest?(parent: coll_c, child: coll_c, scope: scope))
+            .to eq false
+        end
       end
 
       describe 'and are of the same collection type', with_nested_reindexing: true do
-        # using create option here because permission template is required for testing :deposit access
-        let!(:parent) do
-          create(:public_collection_lw,
-                 id: 'Parent_Collecton',
-                 collection_type: collection_type,
-                 user: user,
-                 with_permission_template: true)
-        end
-        let!(:child) do
-          create(:public_collection_lw,
-                 id: 'Child_Collection',
-                 collection_type: collection_type,
-                 user: user,
-                 with_permission_template: true)
+        before { allow(scope).to receive(:can?).and_return(true) }
+
+        let(:collection) do
+          FactoryBot.create(:public_collection_lw,
+                            id: 'Parent_Collecton',
+                            collection_type: collection_type,
+                            user: user,
+                            with_permission_template: true)
         end
 
-        it { is_expected.to eq(true) }
+        let(:member) do
+          FactoryBot.create(:public_collection_lw,
+                            id: 'Child_Collection',
+                            collection_type: collection_type,
+                            user: user,
+                            with_permission_template: true)
+        end
+
+
+        it 'is true' do
+          expect(described_class.parent_and_child_can_nest?(parent: collection, child: member, scope: scope))
+            .to eq true
+        end
       end
+
       describe 'and the ability does not permit the actions' do
-        before do
-          expect(scope).to receive(:can?).and_return(false)
+        before { allow(scope).to receive(:can?).and_return(false) }
+
+        it 'is false' do
+          expect(described_class.parent_and_child_can_nest?(parent: coll_c, child: another, scope: scope))
+            .to eq false
         end
-
-        it { is_expected.to eq(false) }
       end
+
       describe 'and are of different collection types' do
-        let(:parent) { double(nestable?: true, collection_type_gid: 'another', id: 'parent_collection') }
+        let(:collection) { double(nestable?: true, collection_type_gid: 'another', id: 'parent_collection') }
 
-        it { is_expected.to eq(false) }
+        it 'is false' do
+          expect(described_class.parent_and_child_can_nest?(parent: collection, child: another, scope: scope))
+            .to eq false
+        end
       end
     end
 
-    describe 'given parent is not nestable?' do
-      let(:parent) { double(nestable?: false, collection_type_gid: 'same', id: 'parent_collection') }
+    describe 'when the proposed parent is not nestable?' do
+      let(:collection) { double(nestable?: false, collection_type_gid: 'same', id: 'parent_collection') }
 
-      it { is_expected.to eq(false) }
+      it 'is false' do
+        expect(described_class.parent_and_child_can_nest?(parent: collection, child: another, scope: scope))
+          .to eq false
+      end
     end
-    describe 'given child is not nestable?' do
-      let(:child) { double(nestable?: false, collection_type_gid: 'same', id: 'child_collection') }
 
-      it { is_expected.to eq(false) }
+    describe 'when the proposed child is not nestable?' do
+      let(:member) { double(nestable?: false, collection_type_gid: 'same', id: 'child_collection') }
+
+      it 'is false' do
+        expect(described_class.parent_and_child_can_nest?(parent: coll_c, child: member, scope: scope))
+          .to eq false
+      end
     end
+
     describe 'not in available parent collections' do
       before do
-        allow(described_class).to receive(:available_parent_collections).with(child: child, scope: scope, limit_to_id: parent.id).and_return([])
+        allow(described_class)
+          .to receive(:available_parent_collections)
+          .with(child: another, scope: scope, limit_to_id: coll_c.id)
+          .and_return([])
       end
 
-      it { is_expected.to eq(false) }
+      it 'is false' do
+        expect(described_class.parent_and_child_can_nest?(parent: coll_c, child: another, scope: scope))
+          .to eq false
+      end
     end
+
     describe 'not in available child collections' do
       before do
-        allow(described_class).to receive(:available_child_collections).with(parent: parent, scope: scope, limit_to_id: child.id).and_return([])
+        allow(described_class)
+          .to receive(:available_child_collections)
+          .with(parent: coll_c, scope: scope, limit_to_id: another.id)
+          .and_return([])
       end
 
-      it { is_expected.to eq(false) }
+      it 'is false' do
+        expect(described_class.parent_and_child_can_nest?(parent: coll_c, child: another, scope: scope))
+          .to eq false
+      end
     end
   end
 
   describe '.valid_combined_nesting_depth?' do
-    subject { described_class.valid_combined_nesting_depth?(parent: parent, child: child, scope: scope) }
-
     context 'when total depth > limit' do
-      let(:parent) { coll_e }
-      let(:child) { another }
-
       it 'returns false' do
-        expect(subject).to eq false
+        expect(described_class.valid_combined_nesting_depth?(parent: coll_e, child: another, scope: scope))
+          .to eq false
       end
     end
 
     context 'when valid combined depth' do
-      let(:parent) { coll_c }
-      let(:child) { coll_e }
-
       it 'returns true' do
-        expect(subject).to eq true
+        expect(described_class.valid_combined_nesting_depth?(parent: coll_c, child: coll_e, scope: scope))
+          .to eq true
       end
     end
   end
 
   describe 'nesting attributes object', with_nested_reindexing: true do
-    let(:user) { create(:user) }
-    let(:parent) { FactoryBot.create(:collection_lw, id: 'Parent_Coll', collection_type: collection_type, user: user) }
-    let(:child) { FactoryBot.create(:collection_lw, id: 'Child_Coll', collection_type: collection_type, user: user) }
-    let(:nesting_attributes) { Hyrax::Collections::NestedCollectionQueryService::NestingAttributes.new(id: child.id, scope: scope) }
+    let(:collection) do
+      FactoryBot.create(:collection_lw, collection_type: collection_type, user: user)
+    end
+
+    let(:member) do
+      FactoryBot.create(:collection_lw, collection_type: collection_type, user: user)
+    end
+
+    let(:nesting_attributes) do
+      Hyrax::Collections::NestedCollectionQueryService::NestingAttributes
+        .new(id: member.id, scope: scope)
+    end
 
     before do
       Hyrax::Collections::NestedCollectionPersistenceService
-        .persist_nested_collection_for(parent: parent, child: child)
-    end
-
-    it 'will respond to expected methods' do
-      expect(nesting_attributes).to respond_to(:id)
-      expect(nesting_attributes).to respond_to(:parents)
-      expect(nesting_attributes).to respond_to(:pathnames)
-      expect(nesting_attributes).to respond_to(:ancestors)
-      expect(nesting_attributes).to respond_to(:depth)
+        .persist_nested_collection_for(parent: collection, child: member)
     end
 
     it 'will encapsulate the nesting attributes in an object' do
-      expect(nesting_attributes).to be_a(Hyrax::Collections::NestedCollectionQueryService::NestingAttributes)
-      expect(nesting_attributes.id).to eq('Child_Coll')
-      expect(nesting_attributes.parents).to eq(['Parent_Coll'])
-      expect(nesting_attributes.pathnames).to eq(['Parent_Coll/Child_Coll'])
-      expect(nesting_attributes.ancestors).to eq(['Parent_Coll'])
-      expect(nesting_attributes.depth).to eq(2)
+      expect(nesting_attributes)
+        .to have_attributes(id: member.id,
+                            parents: contain_exactly(collection.id),
+                            pathnames: ["#{collection.id}/#{member.id}"],
+                            ancestors: contain_exactly(collection.id),
+                            depth: 2)
     end
   end
 end

--- a/spec/support/fakes/fake_search_builder_scope.rb
+++ b/spec/support/fakes/fake_search_builder_scope.rb
@@ -37,4 +37,8 @@ class FakeSearchBuilderScope
     @params = params
     @repository = Blacklight::Solr::Repository.new(blacklight_config)
   end
+
+  def can?(*args)
+    current_ability.can?(*args)
+  end
 end


### PR DESCRIPTION
reduces indirection and repeated setup in tests for NestedCollectionQueryService.

some of the more complicated setup for search builders (as used here) has been
extracted to `FakeSearchBuilderScope` since this was originally written.


@samvera/hyrax-code-reviewers
