### PR TITLE
Fix failure of new Valkyrie shared specs for storage adapters

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -82,7 +82,7 @@ SUMMARY
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails'
-  spec.add_dependency 'valkyrie', '>= 2.1.1', '< 3.0.0.a'
+  spec.add_dependency 'valkyrie', '~> 2', '>= 2.1.1'
 
   spec.add_development_dependency "capybara", '~> 3.29'
   spec.add_development_dependency 'capybara-screenshot', '~> 1.0'


### PR DESCRIPTION
Circle CI is installing Valkyrie 3.0.0.beta1.  This version of Valkyrie adds to shared specs.  The new tests require `lsof` and `libpq-dev` which are not installed on Circle CI.

Valkyrie installs the missing commands for their own testing on Circle CI using...
```
      - run: sudo apt update -y && sudo apt-get install -y libpq-dev lsof
```

It is not clear why Circle CI is using Valkyrie 3.0.0.beta1.  Hyrax is configured for `< 3.0`.  The PR updates the cache key, but Circle CI reports using the previous cache key.

Options:
* continue to debug the incorrect install of Valkyrie 3.0.0.beta1 (needed but not necessarily required in this PR to allow main tests to begin passing again) 
* add the install of the missing commands (required if the cache won't update)

@samvera/hyrax-code-reviewers
