### PR TITLE
test AdminAdminSetMemberSearchBuilder for collection search

### DIFF
--- a/spec/search_builders/hyrax/admin_admin_set_member_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/admin_admin_set_member_search_builder_spec.rb
@@ -13,7 +13,17 @@ RSpec.describe Hyrax::AdminAdminSetMemberSearchBuilder do
 
     it 'searches for valid work types' do
       expect(builder.filter_models(solr_params))
-        .to contain_exactly("{!terms f=has_model_ssim}Monograph,#{Hyrax.config.collection_class}")
+        .to contain_exactly(include("{!terms f=has_model_ssim}Monograph"))
+    end
+
+    it 'searches for collections indexed as ActiveFedora' do
+      expect(builder.filter_models(solr_params))
+        .to contain_exactly(include("Collection"))
+    end
+
+    it 'searches for collections indexed as valkyrie' do
+      expect(builder.filter_models(solr_params))
+        .to contain_exactly(include(Hyrax.config.collection_class.to_s))
     end
 
     it 'does not limit to active only' do


### PR DESCRIPTION
update specs to ensure the correct models are included in the search:

  - always include `Collection`,
  - include configured collection model name,
  - include registered curationconcerns

should the implementation be updated to search using the indexed generic type?

@samvera/hyrax-code-reviewers
