### PR TITLE
search for legacy collections in statistics OverTime

### DIFF
--- a/app/services/hyrax/statistics/collections/over_time.rb
+++ b/app/services/hyrax/statistics/collections/over_time.rb
@@ -7,7 +7,7 @@ module Hyrax
 
         def relation
           AbstractTypeRelation
-            .new(allowable_types: [Hyrax.config.collection_class])
+            .new(allowable_types: [::Collection, Hyrax.config.collection_class].uniq)
         end
       end
     end


### PR DESCRIPTION
even if a different collection class is used, search for legacy models in
`Collections::OverTime`. Valkyrie collections indexed via ActiveFedora by
`Wings` will still be indexed as `Collection`.


@samvera/hyrax-code-reviewers
