### PR TITLE
move default admin set id to Hyrax module

### DIFF
--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -140,4 +140,17 @@ module Hyrax
   def self.custom_queries
     query_service.custom_queries
   end
+
+  ##
+  # The default admin set
+  def self.default_admin_set
+    @default_admin_set ||= Hyrax::AdminSetCreateService.find_or_create_default_admin_set
+  end
+
+  ##
+  # @param admin_set [#to_s] the id of the admin set to test
+  # @return [Boolean] true if it is the default admin set; otherwise, false
+  def self.default_admin_set_id?(id:)
+    id.to_s == default_admin_set.id.to_s
+  end
 end

--- a/spec/lib/hyrax_spec.rb
+++ b/spec/lib/hyrax_spec.rb
@@ -7,4 +7,28 @@ RSpec.describe Hyrax do
       expect(described_class.logger).to respond_to :log
     end
   end
+
+  describe 'default_admin_set' do
+    it 'returns true' do
+      default_admin_set = described_class.default_admin_set
+      expect(default_admin_set).to be_kind_of Hyrax::AdministrativeSet
+      expect(default_admin_set.alternate_ids).to eq [Hyrax::AdminSetCreateService::DEFAULT_ID]
+    end
+  end
+
+  describe 'default_admin_set_id?' do
+    context 'when id is for the default admin set' do
+      let(:admin_set) { FactoryBot.valkyrie_create(:default_hyrax_admin_set) }
+      it 'returns true' do
+        expect(described_class.default_admin_set_id?(id: admin_set.id)).to eq true
+      end
+    end
+
+    context 'when id is NOT for the default admin set' do
+      let(:admin_set) { FactoryBot.valkyrie_create(:hyrax_admin_set) }
+      it 'returns true' do
+        expect(described_class.default_admin_set_id?(id: admin_set.id)).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is the first step in moving the default admin set id to a place where it won't have to be regenerated every time we want to check it.

@samvera/hyrax-code-reviewers
