### PR TITLE
passing and failing test for acl.save when resource is not saved

### DIFF
--- a/spec/services/hyrax/access_control_list_spec.rb
+++ b/spec/services/hyrax/access_control_list_spec.rb
@@ -142,6 +142,25 @@ RSpec.describe Hyrax::AccessControlList do
           .to change { listener.object_acl_updated&.payload }
           .to include(result: :success)
       end
+
+      context 'when resource is not saved' do
+        context 'and resource is :hyrax_resource' do
+          let(:resource) { FactoryBot.build(:hyrax_resource) }
+          it 'does not save the permission policies' do
+            expect { acl.save }
+              .not_to change { Hyrax::AccessControl.for(resource: resource, query_service: acl.query_service).permissions }
+          end
+        end
+
+        context 'and resource is any other model' do
+          let(:resource) { FactoryBot.build(:hyrax_admin_set) } # same error for :hyrax_collection
+          it 'does not save the permission policies' do
+            pending 'error occurs when the resource is a :hyrax_work, :hyrax_collection, or :hyrax_admin_set'
+            expect { acl.save }
+              .not_to change { Hyrax::AccessControl.for(resource: resource, query_service: acl.query_service).permissions }
+          end
+        end
+      end
     end
 
     context 'with deletions' do


### PR DESCRIPTION
When the resource is a `Hyrax::Resource` and it isn't saved, it appears to behave as expected.

When the resource is a `Hyrax::Work`, `Hyrax::Collection`, or `Hyrax::AdministrativeSet`, an error is raised when it tries to write to solr...

```
     Failure/Error: Wings::ActiveFedoraConverter.convert(resource: acl(event)).update_index
     
     RSolr::Error::Http:
       RSolr::Error::Http - 400 Bad Request
       Error: {
         "responseHeader":{
           "status":400,
           "QTime":0},
         "error":{
           "metadata":[
             "error-class","org.apache.solr.common.SolrException",
             "root-error-class","org.apache.solr.common.SolrException"],
           "msg":"Document is missing mandatory uniqueKey field: id",
           "code":400}}
     
       URI: http://127.0.0.1:8985/solr/hydra-test/update?wt=json&softCommit=true
       Request Headers: {"Content-Type"=>"application/json"}
       Request Data: "[{\"system_create_dtsi\":\"2021-10-30T07:31:33Z\",\"system_modified_dtsi\":\"2021-10-30T07:31:33Z\",\"has_model_ssim\":\"AdminSet\",\"id\":null,\"thumbnail_path_ss\":\"/assets/collection-a38b932554788aa578debf2319e8c4ba8a7db06b3ba57ecda1391a548a4b6e0a.png\",\"generic_type_sim\":\"Admin Set\",\"creator_ssim\":\"user2@example.com\",\"title_tesim\":\"My Admin Set\",\"title_sim\":\"My Admin Set\",\"human_readable_type_sim\":\"Admin Set\",\"human_readable_type_tesim\":\"Admin Set\"}]"
     
       Backtrace: /Users/elr37/Documents/__DEVELOPMENT__/Samvera/sprint/hyrax/vendor/bundle/ruby/2.5.0/gems/rsolr-2.3.0/lib/rsolr/client.rb:206:in `rescue in execute'
       /Users/elr37/Documents/__DEVELOPMENT__/Samvera/sprint/hyrax/vendor/bundle/ruby/2.5.0/gems/rsolr-2.3.0/lib/rsolr/client.rb:196:in `execute'
       /Users/elr37/Documents/__DEVELOPMENT__/Samvera/sprint/hyrax/vendor/bundle/ruby/2.5.0/gems/rsolr-2.3.0/lib/rsolr/client.rb:191:in `send_and_receive'
       (eval):2:in `post'
       /Users/elr37/Documents/__DEVELOPMENT__/Samvera/sprint/hyrax/vendor/bundle/ruby/2.5.0/gems/rsolr-2.3.0/lib/rsolr/client.rb:94:in `update'
       /Users/elr37/Documents/__DEVELOPMENT__/Samvera/sprint/hyrax/vendor/bundle/ruby/2.5.0/gems/rsolr-2.3.0/lib/rsolr/client.rb:113:in `add'
       /Users/elr37/Documents/__DEVELOPMENT__/Samvera/sprint/hyrax/vendor/bundle/ruby/2.5.0/gems/active-fedora-13.2.4/lib/active_fedora/solr_service.rb:87:in `add'
       /Users/elr37/Documents/__DEVELOPMENT__/Samvera/sprint/hyrax/vendor/bundle/ruby/2.5.0/gems/active-fedora-13.2.4/lib/active_fedora/indexing.rb:51:in `update_index'
       /Users/elr37/Documents/__DEVELOPMENT__/Samvera/sprint/hyrax/vendor/bundle/ruby/2.5.0/gems/active-fedora-13.2.4/lib/active_fedora/callbacks.rb:235:in `block in update_index'
       /Users/elr37/Documents/__DEVELOPMENT__/Samvera/sprint/hyrax/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:98:in `run_callbacks'
       /Users/elr37/Documents/__DEVELOPMENT__/Samvera/sprint/hyrax/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:816:in `_run_update_index_callbacks'
     # (eval):2:in `post'
     # ./app/services/hyrax/listeners/active_fedora_acl_index_listener.rb:22:in `on_object_acl_updated'
     # ./app/services/hyrax/access_control_list.rb:171:in `save'
     # ./app/models/hyrax/permission_template.rb:247:in `reset_access_controls_for'
     # ./app/services/hyrax/collections/permissions_create_service.rb:20:in `create_default'
     # ./app/services/hyrax/admin_set_create_service.rb:144:in `block (2 levels) in valkyrie_create!'
     # ./app/services/hyrax/admin_set_create_service.rb:143:in `block in valkyrie_create!'
     # ./app/services/hyrax/admin_set_create_service.rb:141:in `tap'
     # ./app/services/hyrax/admin_set_create_service.rb:141:in `valkyrie_create!'
     # ./app/services/hyrax/admin_set_create_service.rb:123:in `create!'
     # ./spec/services/hyrax/admin_set_create_service_spec.rb:160:in `block (6 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Faraday::ClientError:
     #   the server responded with status 400
     #   (eval):2:in `post'
```

There is no solution proposed in this PR.  It only includes the failing test and what appears to be a passing test for `Hyrax::Resource`.

@samvera/hyrax-code-reviewers
