### PR TITLE
set alternate_identifier instead of id during default adminset creation

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -95,7 +95,7 @@ module Hyrax
       property :visibility_during_lease, virtual: true, prepopulator: ->(_opts) { self.visibility_during_lease = model.lease&.visibility_during_lease }
 
       # pcdm relationships
-      property :admin_set_id, prepopulator: ->(_opts) { self.admin_set_id = AdminSet::DEFAULT_ID }
+      property :admin_set_id, prepopulator: ->(_opts) { self.admin_set_id = Hyrax::AdminSetCreateService.default_admin_set_id }
       property :in_works_ids, virtual: true, prepopulator: InWorksPopulator
       property :member_ids, default: [], type: Valkyrie::Types::Array
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array

--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -44,21 +44,23 @@ class AdminSet < ActiveFedora::Base
 
   def self.default_set?(id)
     Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
-                     "Instead, use 'Hyrax::AdminSetCreateService.default_admin_set?(id:)'.")
-    Hyrax::AdminSetCreateService.default_admin_set?(id: id)
+                     "Instead, use 'Hyrax::AdminSetCreateService.default_admin_set_id?(id:)' or " \
+                     "'Hyrax::AdminSetCreateService.default_admin_set?(admin_set:)'")
+    Hyrax::AdminSetCreateService.default_admin_set_id?(id: id)
   end
 
   def default_set?
     Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
-                     "Instead, use 'Hyrax::AdminSetCreateService.default_admin_set?(id:)'.")
+                     "Instead, use 'Hyrax::AdminSetCreateService.default_admin_set_id?(id:)' or " \
+                     "'Hyrax::AdminSetCreateService.default_admin_set?(admin_set:)'")
     self.class.default_set?(id)
   end
 
   # Creates the default AdminSet and an associated PermissionTemplate with workflow
   def self.find_or_create_default_admin_set_id
     Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
-                     "Instead, use 'Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id'.")
-    Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
+                     "Instead, use 'Hyrax::AdminSetCreateService.default_admin_set_id'.")
+    Hyrax::AdminSetCreateService.default_admin_set_id
   end
 
   def collection_type_gid

--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -66,7 +66,7 @@ module Hyrax
     private
 
     def default_set?
-      Hyrax::AdminSetCreateService.default_admin_set?(id: id)
+      Hyrax::AdminSetCreateService.default_admin_set_id?(id: id)
     end
   end
 end

--- a/app/services/hyrax/ensure_well_formed_admin_set_service.rb
+++ b/app/services/hyrax/ensure_well_formed_admin_set_service.rb
@@ -19,7 +19,7 @@ module Hyrax
     #
     # @see Hyrax::AdminSetCreateService.find_or_create_default_admin_set
     def self.call(admin_set_id: nil)
-      admin_set_id = admin_set_id.presence&.to_s || Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
+      admin_set_id = admin_set_id.presence&.to_s || Hyrax::AdminSetCreateService.default_admin_set_id.to_s
       Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id)
       admin_set_id
     end

--- a/spec/factories/administrative_sets.rb
+++ b/spec/factories/administrative_sets.rb
@@ -37,6 +37,7 @@ FactoryBot.define do
 
   factory :default_hyrax_admin_set, class: 'Hyrax::AdministrativeSet' do
     id { Hyrax::AdminSetCreateService::DEFAULT_ID }
+    alternate_ids { [Hyrax::AdminSetCreateService::DEFAULT_ID] }
     title { Hyrax::AdminSetCreateService::DEFAULT_TITLE }
   end
 end

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -385,9 +385,11 @@ RSpec.describe Hyrax::Forms::ResourceForm do
 
     context 'when using a generic valkyrie adapter', valkyrie_adapter: :test_adapter do
       before do
+        allow(Hyrax).to receive(:config).and_call_original
         allow(Hyrax).to receive_message_chain(:config, :disable_wings).and_return(true) # rubocop:disable RSpec/MessageChain
         hide_const("Wings") # disable_wings=true removes the Wings constant
       end
+
       it 'prepopulates as empty before save' do
         expect(Hyrax.logger).to receive(:info)
           .with(starting_with("trying to prepopulate a lock token for"))

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe Hyrax::AdminSetCreateService do
 
     context "when new admin set fails to persist" do
       before do
-        allow(persister).to receive(:save).with(resource: instance_of(Hyrax::AdministrativeSet))
-                                          .and_raise(RuntimeError)
+        allow(persister).to receive(:save)
+          .with(resource: instance_of(Hyrax::AdministrativeSet))
+          .and_raise(RuntimeError)
       end
 
       it "returns false" do
@@ -28,17 +29,21 @@ RSpec.describe Hyrax::AdminSetCreateService do
   describe '.find_or_create_default_admin_set', :clean_repo do
     context "when default admin set doesn't exist yet" do
       it "is a convenience method for .create_default_admin_set!" do
-        expect(query_service).to receive(:find_by).with(id: described_class::DEFAULT_ID)
-                                                  .and_raise(Valkyrie::Persistence::ObjectNotFoundError)
+        expect(query_service).to receive(:find_by_alternate_identifier)
+          .with(alternate_identifier: described_class::DEFAULT_ID)
+          .and_raise(Valkyrie::Persistence::ObjectNotFoundError)
         expect(described_class).to receive(:create_default_admin_set!).and_call_original
-        expect(query_service).to receive(:find_by).with(id: anything).and_call_original # permission template
+        expect(query_service).to receive(:find_by_alternate_identifier) # permission template
+          .with(alternate_identifier: anything)
+          .and_call_original
         admin_set = described_class.find_or_create_default_admin_set
         expect(admin_set.title).to eq described_class::DEFAULT_TITLE
+        expect(admin_set.alternate_ids).to match_array [described_class::DEFAULT_ID]
       end
 
       it 'sets up an active workflow' do
-        described_class.find_or_create_default_admin_set
-        expect(Sipity::Workflow.find_active_workflow_for(admin_set_id: AdminSet::DEFAULT_ID))
+        admin_set = described_class.find_or_create_default_admin_set
+        expect(Sipity::Workflow.find_active_workflow_for(admin_set_id: admin_set.id))
           .to be_persisted
       end
     end
@@ -47,23 +52,47 @@ RSpec.describe Hyrax::AdminSetCreateService do
       let(:default_admin_set) { FactoryBot.valkyrie_create(:default_hyrax_admin_set) }
 
       it "returns existing default admin set" do
-        expect(query_service).to receive(:find_by).with(id: described_class::DEFAULT_ID)
-                                                  .and_return(default_admin_set)
+        expect(query_service).to receive(:find_by_alternate_identifier)
+          .with(alternate_identifier: described_class::DEFAULT_ID)
+          .and_return(default_admin_set)
         expect(described_class).not_to receive(:create_default_admin_set!)
         admin_set = described_class.find_or_create_default_admin_set
         expect(admin_set.title).to eq described_class::DEFAULT_TITLE
+        expect(admin_set.alternate_ids).to match_array [described_class::DEFAULT_ID]
       end
     end
   end
 
   describe ".default_admin_set?" do
+    let(:default_admin_set) { FactoryBot.build(:hyrax_admin_set, alternate_ids: [described_class::DEFAULT_ID]) }
+    let(:admin_set) { FactoryBot.build(:hyrax_admin_set) }
+
     it "is true for the default admin set id" do
-      expect(described_class.default_admin_set?(id: described_class::DEFAULT_ID))
-        .to eq true
+      expect(described_class.default_admin_set?(admin_set: default_admin_set)).to eq true
     end
 
     it "is false for anything else" do
-      expect(described_class.default_admin_set?(id: 'anythingelse')).to eq false
+      expect(described_class.default_admin_set?(admin_set: admin_set)).to eq false
+    end
+  end
+
+  describe ".default_admin_set_id?" do
+    let(:default_admin_set) { FactoryBot.valkyrie_create(:default_hyrax_admin_set) }
+    let(:admin_set) { FactoryBot.valkyrie_create(:hyrax_admin_set) }
+
+    it "is true for the default admin set id" do
+      expect(described_class.default_admin_set_id?(id: default_admin_set.id)).to eq true
+    end
+
+    it "is false for anything else" do
+      expect(described_class.default_admin_set_id?(id: admin_set.id)).to eq false
+    end
+  end
+
+  describe ".default_admin_set_id" do
+    let(:default_admin_set) { FactoryBot.valkyrie_create(:default_hyrax_admin_set) }
+    it "is the default admin set id" do
+      expect(described_class.default_admin_set_id).to eq default_admin_set.id
     end
   end
 


### PR DESCRIPTION
For at least some non-wings adapters, you cannot set the id directly.  So need to set the alternate id instead.

Also, update methods checking default admin set to use create service methods.

This makes the same changes as PR #5236, but without the dependency of caching the default admin set in the Hyrax module.

@samvera/hyrax-code-reviewers
