### PR TITLE
include module for PermissionTemplate

### DIFF
--- a/app/services/hyrax/collections/permissions_create_service.rb
+++ b/app/services/hyrax/collections/permissions_create_service.rb
@@ -14,8 +14,8 @@ module Hyrax
         def create_default(collection:, creating_user:, grants: [])
           collection_type = Hyrax::CollectionType.find_by_gid!(collection.collection_type_gid)
           access_grants = access_grants_attributes(collection_type: collection_type, creating_user: creating_user, grants: grants)
-          template = PermissionTemplate.create!(source_id: collection.id.to_s,
-                                                access_grants_attributes: access_grants.uniq)
+          template = Hyrax::PermissionTemplate.create!(source_id: collection.id.to_s,
+                                                       access_grants_attributes: access_grants.uniq)
 
           template.reset_access_controls_for(collection: collection, interpret_visibility: true)
           template


### PR DESCRIPTION
When using the postgres adapter, the following error happens when creating collection permissions.

```
NameError: uninitialized constant PermissionTemplate
/Users/elr37/Documents/__DEVELOPMENT__/Samvera/TEST/nurax-pg/vendor/bundle/ruby/2.7.0/bundler/gems/hyrax-8c6b1d32e8a1/app/services/hyrax/collections/permissions_create_service.rb:17:in `create_default'
```

This happened because the permission template was referenced without the module…
```
PermissionTemplate.create!
```

The fix is to reference permission template with the module…
```
Hyrax::PermissionTemplate.create!
```

@samvera/hyrax-code-reviewers
