### PR TITLE
add depositor to pcdm collection indexer

### DIFF
--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -15,6 +15,8 @@ module Hyrax
         index_document[Hyrax.config.collection_type_index_field.to_sym] = Array(resource.try(:collection_type_gid)&.to_s)
         index_document[:generic_type_sim] = ['Collection']
         index_document[:thumbnail_path_ss] = Hyrax::CollectionThumbnailPathService.call(resource)
+        index_document[:depositor_ssim] = [resource.depositor]
+        index_document[:depositor_tesim] = [resource.depositor]
       end
     end
   end

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -188,5 +188,11 @@ RSpec.shared_examples 'a Collection indexer' do
       expect(indexer.to_solr)
         .to include(thumbnail_path_ss: include('assets/collection', '.png'))
     end
+
+    it 'indexes depositor' do
+      expect(indexer.to_solr)
+        .to include(depositor_ssim: [resource.depositor],
+                    depositor_tesim: [resource.depositor])
+    end
   end
 end


### PR DESCRIPTION
Dashboard -> Collections lists collections for a user.  The search builder determines the collections a user created by searching for collections where the user is the depositor.  Hyrax::PcdmCollectionIndexer was not indexing the depositor.  This leads to a new `Hyrax::PcdmCollection` being created with the current user as depositor.  But when it is indexed, there is no depositor information.  This leads to the Dashboard -> Collections list to not include the collections created by the user.

### Expected

{
        "id":"be749208-d286-427b-abd8-f02174e4c7e7",
        "date_uploaded_dtsi":"2021-11-02T10:54:35Z",
        "date_modified_dtsi":"2021-11-02T10:54:35Z",
        "has_model_ssim":["Hyrax::PcdmCollection"],
        "human_readable_type_tesim":["Collection"],
        "edit_access_group_ssim":["admin"],
        "edit_access_person_ssim":["elrayle@hotmail.com"],
        "visibility_ssi":"restricted",
        "title_tesim":["uc-02-01"],
        "collection_type_gid_ssim":["gid://nurax-pg/Hyrax::CollectionType/1"],
        "thumbnail_path_ss":"/assets/collection-a38b932554788aa578debf2319e8c4ba8a7db06b3ba57ecda1391a548a4b6e0a.png",
        "depositor_ssim": ["me@example.com"],
        "depositor_tesim": ["me@example.com"],
        "_version_":1715313548903579648,
        "timestamp":"2021-11-02T10:54:36.173Z",
        "score":1.0
}
### Actual

{
        "id":"be749208-d286-427b-abd8-f02174e4c7e7",
        "date_uploaded_dtsi":"2021-11-02T10:54:35Z",
        "date_modified_dtsi":"2021-11-02T10:54:35Z",
        "has_model_ssim":["Hyrax::PcdmCollection"],
        "human_readable_type_tesim":["Collection"],
        "edit_access_group_ssim":["admin"],
        "edit_access_person_ssim":["elrayle@hotmail.com"],
        "visibility_ssi":"restricted",
        "title_tesim":["uc-02-01"],
        "collection_type_gid_ssim":["gid://nurax-pg/Hyrax::CollectionType/1"],
        "thumbnail_path_ss":"/assets/collection-a38b932554788aa578debf2319e8c4ba8a7db06b3ba57ecda1391a548a4b6e0a.png",
        "_version_":1715313548903579648,
        "timestamp":"2021-11-02T10:54:36.173Z",
        "score":1.0
}

### To reproduce:

Prereq: Turn on valkyrie indexing.

With the test change, but not the fix to `app/indexers/hyrax/pcdm_collection_indexer.rb`, the following test will fail.

```
bundle exec rspec spec/indexers/hyrax/pcdm_collection_indexer.rb
```

Alternate, create a pcdm collection in rails console and index it.  The resulting solr document in the valkyrie solr core will not include the depositor.

@samvera/hyrax-code-reviewers
