### PR TITLE
Fix admin set valkyrie create

### DIFF
--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -141,7 +141,7 @@ module Hyrax
       updated_admin_set = Hyrax.persister.save(resource: admin_set).tap do |result|
         if result
           ActiveRecord::Base.transaction do
-            permission_template = permissions_create_service.create_default(collection: admin_set,
+            permission_template = permissions_create_service.create_default(collection: result,
                                                                             creating_user: creating_user)
             workflow = create_workflows_for(permission_template: permission_template)
             create_default_access_for(permission_template: permission_template, workflow: workflow) if default_admin_set?(id: admin_set.id)

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Hyrax::AdminSetCreateService do
     end
 
     describe "#create!" do
-      let(:admin_set) { AdminSet.new(title: ['test']) }
+      let(:admin_set) { FactoryBot.build(:hyrax_admin_set) }
 
       context "when the admin_set is valid" do
         let(:permission_template) { Hyrax::PermissionTemplate.find_by(source_id: admin_set.id) }
@@ -147,7 +147,8 @@ RSpec.describe Hyrax::AdminSetCreateService do
             .to receive(:available_workflows).and_return(available_workflows)
           allow(Sipity::Workflow)
             .to receive(:activate!)
-            .with(permission_template: kind_of(Hyrax::PermissionTemplate), workflow_name: Hyrax.config.default_active_workflow_name)
+            .with(permission_template: kind_of(Hyrax::PermissionTemplate),
+                  workflow_name: Hyrax.config.default_active_workflow_name)
           # Load expected Sipity roles, which were likely cleaned by DatabaseCleaner
           Hyrax.config.persist_registered_roles!
         end


### PR DESCRIPTION
The valkyrie_create! method was passing the original admin_set to`Hyrax::Collections::PermissionsCreateService.create_default`.  This works for ActiveFedora because it updates the original admin_set during save.  For valkyrie, the original admin_set does not have a value for id after it is persisted.  It needs to pass the results of `Hyrax.persister.save` which is the updated admin_set that does have a value for id.

### Expected

Create the new admin set and associated permission template without errors.

### Actual

Creates the new admin set, but gets an error when creating the permission template.

```
     RSolr::Error::Http:
       RSolr::Error::Http - 400 Bad Request
       Error: {
         "responseHeader":{
           "status":400,
           "QTime":1},
         "error":{
           "metadata":[
             "error-class","org.apache.solr.common.SolrException",
             "root-error-class","org.apache.solr.common.SolrException"],
           "msg":"Document is missing mandatory uniqueKey field: id",
           "code":400}}
 ```

### To reproduce:

Run the following test with the first commit that adds the test, but not the fix.

```
bundle exec rspec spec/services/hyrax/admin_set_create_service_spec.rb:157
```

@samvera/hyrax-code-reviewers
