### PR TITLE
Allow work form to display when wings is disabled

### DIFF
--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -384,7 +384,13 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
 
     context 'when using a generic valkyrie adapter', valkyrie_adapter: :test_adapter do
+      before do
+        allow(Hyrax).to receive_message_chain(:config, :disable_wings).and_return(true) # rubocop:disable RSpec/MessageChain
+        hide_const("Wings") # disable_wings=true removes the Wings constant
+      end
       it 'prepopulates as empty before save' do
+        expect(Hyrax.logger).to receive(:info)
+          .with(starting_with("trying to prepopulate a lock token for"))
         form.prepopulate!
         expect(form.version).to eq ''
       end
@@ -393,8 +399,9 @@ RSpec.describe Hyrax::Forms::ResourceForm do
         let(:work) { FactoryBot.valkyrie_create(:hyrax_work) }
 
         it 'prepopulates empty' do
+          expect(Hyrax.logger).to receive(:info)
+            .with(starting_with("trying to prepopulate a lock token for"))
           form.prepopulate!
-
           expect(form.version).to eq ''
         end
       end


### PR DESCRIPTION
### Description

When `Hyrax.config.disable_wings # true` the `Wings` constant is not defined.  This is the correct behavior, but means that any reference to `Wings` in `app` needs to check if `disable_wings #true` before using the `Wings` constant.

This PR addresses a specific instance in `Hyrax::ResourceForm` where there was a check to see if the metadata adapter is wings.

This PR includes
* update existing non-wings test to remove the `Wings` constant so that it provides a failing test for the scenario described in this PR
* code fix to prevent the exception

### Expected

Dashboard -> Works -> Add new work -> displays the work form

### Actual

Dashboard -> Works -> Add new work -> raises an exception

![image](https://user-images.githubusercontent.com/6855473/140191064-56ac95d2-3366-407b-ae4a-d48739991df0.png)

### Related Work

There are other places where `Wings` is used without checking `disable_wings #true`.  A cursory review indicates that these locations are places not expected to be encountered when using a non-wings adapter for Valkyrie (e.g. actor stack code, AF forms).  It is possible that other locations may be uncovered later that would need a similar approach as applied in this PR.

@samvera/hyrax-code-reviewers
