### PR TITLE
Use file_set.id instead of file_set in can?

### DIFF
--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -9,7 +9,7 @@ module Hyrax::FileSetHelper
   #   set
   def display_media_download_link?(file_set:)
     Hyrax.config.display_media_download_link? &&
-      can?(:download, file_set) &&
+      can?(:download, file_set.id) &&
       !workflow_restriction?(file_set.try(:parent))
   end
 


### PR DESCRIPTION
Fixes #5241;

I think the call to `can?` in `display_media_download_link?` should use `file_set.id`, not `file_set`. This PR makes that change.

@samvera/hyrax-code-reviewers
