### PR TITLE
generated indexer test requires resource variable

### DIFF
--- a/lib/generators/hyrax/work_resource/templates/indexer_spec.rb.erb
+++ b/lib/generators/hyrax/work_resource/templates/indexer_spec.rb.erb
@@ -7,6 +7,7 @@ require 'hyrax/specs/shared_specs/indexers'
 
 RSpec.describe <%= class_name %>Indexer do
   let(:indexer_class) { described_class }
+  let(:resource) { <%= class_name %>.new }
 
   it_behaves_like 'a Hyrax::Resource indexer'
 end


### PR DESCRIPTION
`it_behaves_like 'a Hyrax::Resource indexer'` requires `:indexer_class` and `:resource` to be defined for tests to run without error.  The work_resource generator did not set `:resource`.  This PR adds the definition so that generates work resource tests pass out of the box.

@samvera/hyrax-code-reviewers
