### PR TITLE
fix bug in Hyrax::Ability#download_permissions SolrDocument handling

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -103,7 +103,7 @@ module Hyrax
         test_download(id)
       end
 
-      can :download, SolrDocument do |obj|
+      can :download, ::SolrDocument do |obj|
         cache.put(obj.id, obj)
         test_download(obj.id)
       end

--- a/spec/helpers/hyrax/file_set_helper_spec.rb
+++ b/spec/helpers/hyrax/file_set_helper_spec.rb
@@ -19,6 +19,19 @@ RSpec.describe Hyrax::FileSetHelper do
 
       expect(helper.display_media_download_link?(file_set: file_set)).to eq true
     end
+
+    context 'with a FileSetPresenter' do
+      let(:ability) { Ability.new(user) }
+      let(:file_set) { FactoryBot.create(:file_set, user: user) }
+      let(:presenter) { Hyrax::FileSetPresenter.new(solr_document, ability) }
+      let(:solr_document) { SolrDocument.new(file_set.to_solr) }
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'resolves permissions based on the solr document' do
+        expect(helper.display_media_download_link?(file_set: presenter))
+          .to eq true
+      end
+    end
   end
 
   describe '#media_display' do

--- a/spec/models/concerns/hyrax/ability_spec.rb
+++ b/spec/models/concerns/hyrax/ability_spec.rb
@@ -66,6 +66,27 @@ RSpec.describe Hyrax::Ability do
     end
   end
 
+  context 'with a FileSetPresenter' do
+    # we want to stub the object under test here, because we want to ensure it
+    # is calling another method on itself to resolve these authorizations
+    # rubocop:disable RSpec/SubjectStub
+    let(:attributes)    { { id: 'my_solr_doc_id' } }
+    let(:presenter)     { Hyrax::FileSetPresenter.new(solr_document, ability, :NULL_REQUEST) }
+    let(:solr_document) { SolrDocument.new(attributes) }
+
+    describe 'can?(:download)' do
+      it 'defers strictly to the presenter solr_document ' do
+        expect(ability)
+          .to receive(:test_download)
+          .with('my_solr_doc_id')
+          .and_return(true)
+
+        ability.can?(:download, presenter)
+      end
+    end
+    # rubocop:enable RSpec/SubjectStub
+  end
+
   context 'with a WorkShowPresenter' do
     # we want to stub the object under test here, because we want to ensure it
     # is calling another method on itself to resolve these authorizations


### PR DESCRIPTION
the mistaken namespacing of `::SolrDocument` led to mistakenly restricted
authentication on SolrDocument download. where `can?(:download, id)` had the
expected behavior `can?(:download, solr_document)` gave `false` in all cases.

this bug in `Ability` had been present for some time. beginning in Hyrax 3.1.0,
we rely on this permission to be correct, so the bug is visible in that release.

this issue was reported as #5241.

@samvera/hyrax-code-reviewers
