### PR TITLE
avoid repeated lookups of labels for URIs using low-level caching

### DIFF
--- a/app/indexers/hyrax/deep_indexing_service.rb
+++ b/app/indexers/hyrax/deep_indexing_service.rb
@@ -41,7 +41,7 @@ module Hyrax
 
     def fetch_with_persistence(resource)
       old_label = resource.rdf_label.first
-      return unless old_label == resource.rdf_subject.to_s || old_label.nil?
+      return unless old_label == resource.rdf_subject.to_s
       fetch_value(resource)
       return if old_label == resource.rdf_label.first || resource.rdf_label.first == resource.rdf_subject.to_s
       resource.persist! # Stores the fetched values into our marmotta triplestore

--- a/lib/hyrax/controlled_vocabularies.rb
+++ b/lib/hyrax/controlled_vocabularies.rb
@@ -5,6 +5,7 @@ module Hyrax
 
     eager_autoload do
       autoload :Location
+      autoload :ResourceLabelCaching
     end
   end
 end

--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -4,6 +4,8 @@ module Hyrax
     class Location < ActiveTriples::Resource
       configure rdf_label: ::RDF::Vocab::GEONAMES.name
 
+      include ResourceLabelCaching
+
       # Return a tuple of url & label
       def solrize
         return [rdf_subject.to_s] if rdf_label.first.to_s.blank? || rdf_label.first.to_s == rdf_subject.to_s

--- a/lib/hyrax/controlled_vocabularies/resource_label_caching.rb
+++ b/lib/hyrax/controlled_vocabularies/resource_label_caching.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+module Hyrax
+  module ControlledVocabularies
+    ##
+    # adds caching to the {#rdf_label} method.
+    #
+    # for systems that check the {#rdf_label}and use {#fetch} to get upstream
+    # data if it is not present, this can be used to avoid making round trips
+    # to an authoritative web source.
+    #
+    # @see Hyrax::DeepIndexingService
+    module ResourceLabelCaching
+      CACHE_KEY_PREFIX = "hy_label-v1-"
+
+      ##
+      # @note uses the Rails cache to avoid repeated lookups.
+      # @see ActiveTriples::Resource#rdf_label
+      def rdf_label
+        # only cache if this rdf source is represented by a URI;
+        # i.e. don't cache for blank nodes
+        return super unless uri?
+
+        Rails.cache.fetch(cache_key) { super }
+      end
+
+      ##
+      # @note adds behavior to clear the cache whenever a manual fetch of data
+      #   is performed.
+      # @see ActiveTriples::Resource#fetch
+      def fetch(*)
+        Rails.cache.delete(cache_key)
+        super
+      end
+
+      private
+
+      def cache_key
+        "#{CACHE_KEY_PREFIX}#{to_uri.canonicalize!.pname}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
lean on the rails cache to avoid repeated lookups of labels for the same URI.

a mixin module is provided to overlay the caching behavior. this commit proposes
including that mixin immediately in the `Location` model class, but if we wanted
to be more conservative we could include it on condition of some configuration
option. i couldn't think of any reason rolling this out immediately wouldn't be
attractive, so i opted not to work that up.

@samvera/hyrax-code-reviewers
