### PR TITLE
mark feature test for AF work types pending

### DIFF
--- a/lib/generators/hyrax/work/templates/feature_spec.rb.erb
+++ b/lib/generators/hyrax/work/templates/feature_spec.rb.erb
@@ -31,11 +31,13 @@ RSpec.feature 'Create a <%= class_name %>', js: false do
     end
 
     scenario do
+      pending 'Changes may be required for this test to pass.  See TODO in test.'
+
       visit '/dashboard'
       click_link "Works"
       click_link "Add new work"
 
-      # If you generate more than one work uncomment these lines
+      # TODO: If you generate more than one work uncomment these lines
       # choose "payload_concern", option: "<%= class_name %>"
       # click_button "Create work"
 


### PR DESCRIPTION
Issue #5248 recommended removal of the failing feature test generated for work types.  Further discussion recommended marking it pending.

Minimally, users need to uncomment some lines if they generate more than one work type.  To prevent this test from failing out-of-the-box, it is marked pending.

Fixes #5248

_NOTE: This PR and description originally were removing the tests.  Initial comments on this PR are related to the possibility of removing the tests.  As recommended in those comments, this PR was refactored to mark the tests pending instead._

@samvera/hyrax-code-reviewers
