### PR TITLE
listeners: add further comments about Dry::Events behavior

### DIFF
--- a/app/services/hyrax/listeners.rb
+++ b/app/services/hyrax/listeners.rb
@@ -7,6 +7,13 @@ module Hyrax
   #
   #    You may need to register a listener as autoload.  See
   #    ./app/services/hyrax/listeners.rb
+  #
+  # When an instance of a listener class is registered with
+  # Dry::Events::Publisher#subscribe, its method(s) will be called when a event
+  # is published that maps to the method name using the pattern:
+  #   on_event_fired => 'event.fired'
+  #
+  # @see https://dry-rb.org/gems/dry-events/0.2/#event-listeners
   module Listeners
     extend ActiveSupport::Autoload
 

--- a/app/services/hyrax/listeners/acl_index_listener.rb
+++ b/app/services/hyrax/listeners/acl_index_listener.rb
@@ -11,7 +11,9 @@ module Hyrax
       ##
       # Re-index the resource for the updated ACL.
       #
-      # @param event [Dry::Event]
+      # Called when 'object.acl.updated' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_object_acl_updated(event)
         return unless event[:result] == :success # do nothing on failure
         Hyrax.index_adapter.save(resource: event[:acl].resource)

--- a/app/services/hyrax/listeners/active_fedora_acl_index_listener.rb
+++ b/app/services/hyrax/listeners/active_fedora_acl_index_listener.rb
@@ -11,7 +11,9 @@ module Hyrax
       ##
       # Re-index the resource for the updated ACL.
       #
-      # @param event [Dry::Event]
+      # Called when 'object.acl.updated' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_object_acl_updated(event)
         return if Hyrax.config.disable_wings
         return unless event[:result] == :success # do nothing on failure

--- a/app/services/hyrax/listeners/batch_notification_listener.rb
+++ b/app/services/hyrax/listeners/batch_notification_listener.rb
@@ -8,7 +8,9 @@ module Hyrax
       ##
       # Notify requesting users of batch success/failure
       #
-      # @param event [Dry::Event]
+      # Called when 'batch.created' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_batch_created(event)
         case event[:result]
         when :success

--- a/app/services/hyrax/listeners/file_set_lifecycle_listener.rb
+++ b/app/services/hyrax/listeners/file_set_lifecycle_listener.rb
@@ -6,13 +6,17 @@ module Hyrax
     # Listens for events related to Hydra Works FileSets
     class FileSetLifecycleListener
       ##
-      # @param event [Dry::Event]
+      # Called when 'file.set.attached' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_file_set_attached(event)
         FileSetAttachedEventJob.perform_later(event[:file_set], event[:user])
       end
 
       ##
-      # @param event [Dry::Event]
+      # Called when 'file.set.restored' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_file_set_restored(event)
         ContentRestoredVersionEventJob
           .perform_later(event[:file_set], event[:user], event[:revision])

--- a/app/services/hyrax/listeners/file_set_lifecycle_notification_listener.rb
+++ b/app/services/hyrax/listeners/file_set_lifecycle_notification_listener.rb
@@ -9,7 +9,9 @@ module Hyrax
       ##
       # Send a notification to the depositor for failed checksum audits.
       #
-      # @param event [Dry::Event]
+      # Called when 'file.set.audited' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_file_set_audited(event)
         return unless event[:result] == :failure # do nothing on success
 
@@ -24,7 +26,9 @@ module Hyrax
       # Send a notification to the depositing user for FileSet url import
       # failures.
       #
-      # @param event [Dry::Event]
+      # Called when 'file.set.url.imported' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_file_set_url_imported(event)
         Hyrax::ImportUrlFailureService.new(event[:file_set], event[:user]).call if
           event[:result] == :failure

--- a/app/services/hyrax/listeners/member_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/member_cleanup_listener.rb
@@ -5,6 +5,9 @@ module Hyrax
     ##
     # Listens for object deleted events and cleans up associated members
     class MemberCleanupListener
+      # Called when 'object.deleted' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_object_deleted(event)
         return unless event.payload.key?(:object) # legacy callback
         return if event[:object].is_a?(ActiveFedora::Base) # handled by legacy code

--- a/app/services/hyrax/listeners/metadata_index_listener.rb
+++ b/app/services/hyrax/listeners/metadata_index_listener.rb
@@ -14,7 +14,9 @@ module Hyrax
       ##
       # Re-index the resource.
       #
-      # @param event [Dry::Event]
+      # Called when 'collection.metadata.updated' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_collection_metadata_updated(event)
         return unless resource? event[:collection]
         Hyrax.index_adapter.save(resource: event[:collection])
@@ -23,7 +25,9 @@ module Hyrax
       ##
       # Re-index the resource.
       #
-      # @param event [Dry::Event]
+      # Called when 'object.metadata.updated' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_object_metadata_updated(event)
         return unless resource? event[:object]
         Hyrax.index_adapter.save(resource: event[:object])
@@ -32,7 +36,9 @@ module Hyrax
       ##
       # Remove the resource from the index.
       #
-      # @param event [Dry::Event]
+      # Called when 'object.deleted' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_object_deleted(event)
         return unless resource?(event.payload[:object])
         Hyrax.index_adapter.delete(resource: event[:object])

--- a/app/services/hyrax/listeners/object_lifecycle_listener.rb
+++ b/app/services/hyrax/listeners/object_lifecycle_listener.rb
@@ -6,19 +6,25 @@ module Hyrax
     # Listens for events related to the PCDM Object lifecycles.
     class ObjectLifecycleListener
       ##
-      # @param event [Dry::Event]
+      # Called when 'object.deleted' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_object_deleted(event)
         ContentDeleteEventJob.perform_later(event[:id].to_s, event[:user])
       end
 
       ##
-      # @param event [Dry::Event]
+      # Called when 'object.deposited' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_object_deposited(event)
         ContentDepositEventJob.perform_later(event[:object], event[:user])
       end
 
       ##
-      # @param event [Dry::Event]
+      # Called when 'object.metadata.updated' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_object_metadata_updated(event)
         ContentUpdateEventJob.perform_later(event[:object], event[:user])
       end

--- a/app/services/hyrax/listeners/proxy_deposit_listener.rb
+++ b/app/services/hyrax/listeners/proxy_deposit_listener.rb
@@ -7,7 +7,9 @@ module Hyrax
     # deposits an item `on_behalf_of` another, ensures transfer is handled.
     class ProxyDepositListener
       ##
-      # @param event [Dry::Event]
+      # Called when 'object.deposited' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_object_deposited(event)
         return if event[:object].try(:on_behalf_of).blank? ||
                   (event[:object].on_behalf_of == event[:object].depositor)

--- a/app/services/hyrax/listeners/trophy_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/trophy_cleanup_listener.rb
@@ -5,6 +5,9 @@ module Hyrax
     ##
     # Listens for object deleted events and cleans up associated members
     class TrophyCleanupListener
+      # Called when 'object.deleted' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_object_deleted(event)
         Trophy.where(work_id: event[:id]).destroy_all
       rescue StandardError => err

--- a/app/services/hyrax/listeners/workflow_listener.rb
+++ b/app/services/hyrax/listeners/workflow_listener.rb
@@ -21,7 +21,9 @@ module Hyrax
       end
 
       ##
-      # @param event [Dry::Event]
+      # Called when 'object.deposited' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
       def on_object_deposited(event)
         return Rails.logger.warn("Skipping workflow initialization for #{event[:object]}; no user is given\n\t#{event}") if
           event[:user].blank?


### PR DESCRIPTION
dry-events is somewhat unintuitive, especially in how event names are extracted from listener method names.  This might provide some clarity for future developers working on events.

@samvera/hyrax-code-reviewers
