### PR TITLE
add a list of actions that Hyrax::Ability defines rules for

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -1,7 +1,30 @@
 # frozen_string_literal: true
 module Hyrax
   ##
-  # Provides Hyrax's engine level user/group permissions.
+  # Provides Hyrax's engine level user/group authorizations.
+  #
+  # Authorization (allow or deny) of the following actions is managed by the
+  # rules defined here:
+  #
+  #   - read:
+  #   - show:
+  #   - edit:
+  #   - update:
+  #   - create:
+  #   - discover:
+  #   - manage:
+  #   - download:
+  #   - destroy:
+  #   - collect:
+  #   - toggle_trophy:
+  #   - transfer:
+  #   - accept:
+  #   - reject:
+  #   - manage_any:
+  #   - create_any:
+  #   - view_admin_show_any:
+  #   - review:
+  #   - create_collection_type:
   #
   # @note This is intended as a mixin layered over
   #   +Blacklight::AccessControls::Ability+ and +Hydra::AccessControls+. Its


### PR DESCRIPTION
generated this programatically by inspecting cancan internals. this is the full
list of ability actions we handle authorization on via Hyrax's `Hyrax::Ability` mixin.

@samvera/hyrax-code-reviewers
