### PR TITLE
make the member presenter factory for WorkShowPresenter configurable

### DIFF
--- a/app/presenters/hyrax/pcdm_member_presenter_factory.rb
+++ b/app/presenters/hyrax/pcdm_member_presenter_factory.rb
@@ -19,7 +19,7 @@ module Hyrax
     ##
     # @param [#member_ids] object
     # @param [::Ability] ability
-    def initialize(object, ability)
+    def initialize(object, ability, _request = nil)
       @object = object
       @ability = ability
     end

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -10,10 +10,11 @@ module Hyrax
     attr_writer :member_presenter_factory
     attr_accessor :solr_document, :current_ability, :request
 
-    class_attribute :collection_presenter_class
+    class_attribute :collection_presenter_class, :presenter_factory_class
 
     # modify this attribute to use an alternate presenter class for the collections
     self.collection_presenter_class = CollectionPresenter
+    self.presenter_factory_class = MemberPresenterFactory
 
     # Methods used by blacklight helpers
     delegate :has?, :first, :fetch, :export_formats, :export_as, to: :solr_document
@@ -304,7 +305,9 @@ module Hyrax
 
     def member_presenter_factory
       @member_presenter_factory ||=
-        MemberPresenterFactory.new(solr_document, current_ability, request)
+        self.class
+            .presenter_factory_class
+            .new(solr_document, current_ability, request)
     end
 
     def graph


### PR DESCRIPTION
the default implementation of `WorkShowPresenter#member_presenter_factory` had a
hard coded dependency on `MemberPresenterFactory`, which depended on
`AF::Base#list_source`. an alteranative implementation at
`PcdmMemberPresenterFactory` already exists and is in use in the
`form_file_set_select_for` view helper, as well as a drop-in replacement for
`WorkShowPresenter#member_presenter_factory` in Surfliner's `comet`. this
override can now be set by doing `WorkShowPresenter.presenter_factory_class =
PcdmMemberPresenterFactory` (e.g.) in an initializer.

the factory for member presenters was already settable on the instance level,
but the more common configuration need is to have a site-wide override.

@samvera/hyrax-code-reviewers
