### PR TITLE
add transactions for creating an admin set

### DIFF
--- a/lib/hyrax/transactions/admin_set_create.rb
+++ b/lib/hyrax/transactions/admin_set_create.rb
@@ -4,7 +4,7 @@ require 'hyrax/transactions/transaction'
 module Hyrax
   module Transactions
     ##
-    # Creates a Collection from a ChangeSet
+    # Creates a Hyrax::AdministrativeSet from a ChangeSet
     #
     # @since 3.2.0
     class AdminSetCreate < Transaction

--- a/lib/hyrax/transactions/admin_set_create.rb
+++ b/lib/hyrax/transactions/admin_set_create.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/transaction'
+
+module Hyrax
+  module Transactions
+    ##
+    # Creates a Collection from a ChangeSet
+    #
+    # @since 3.2.0
+    class AdminSetCreate < Transaction
+      DEFAULT_STEPS = ['change_set.apply',
+                       'admin_set_resource.apply_collection_type_permissions',
+                       'admin_set_resource.save_acl'].freeze
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -18,6 +18,7 @@ module Hyrax
     #
     # @see https://dry-rb.org/gems/dry-container/
     class Container # rubocop:disable Metrics/ClassLength
+      require 'hyrax/transactions/admin_set_create'
       require 'hyrax/transactions/apply_change_set'
       require 'hyrax/transactions/collection_create'
       require 'hyrax/transactions/collection_update'
@@ -122,6 +123,16 @@ module Hyrax
 
         ops.register 'remove_from_work' do
           Steps::RemoveFileSetFromWork.new
+        end
+      end
+
+      namespace 'admin_set_resource' do |ops| # valkyrie administrative set
+        ops.register 'apply_collection_type_permissions' do
+          Steps::ApplyCollectionTypePermissions.new
+        end
+
+        ops.register 'save_acl' do
+          Steps::SaveAccessControl.new
         end
       end
 

--- a/spec/hyrax/transactions/admin_set_create_spec.rb
+++ b/spec/hyrax/transactions/admin_set_create_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+require 'dry/container/stub'
+
+RSpec.describe Hyrax::Transactions::AdminSetCreate, :clean_repo do
+  subject(:tx)     { described_class.new }
+  let(:change_set) { Hyrax::ChangeSet.for(resource) }
+  let(:resource)   { Hyrax::AdministrativeSet.new(title: "My Resource") }
+
+  describe '#call' do
+    it 'is a success' do
+      expect(tx.call(change_set)).to be_success
+    end
+
+    it 'wraps a saved collection' do
+      expect(tx.call(change_set).value!).to be_persisted
+    end
+
+    context 'when collection type has permissions' do
+      let(:manager)   { create(:user, email: 'manager@example.com') }
+      let(:creator)   { create(:user, email: 'creator@example.com') }
+      let(:depositor) { create(:user, email: 'depositor@example.com') }
+
+      let(:collection_type) do
+        create(:admin_set_collection_type,
+          creator_user: creator.user_key,
+          creator_group: 'creator_group',
+          manager_user: manager.user_key,
+          manager_group: 'manager_group')
+      end
+      let!(:collection_type_gid) { collection_type.to_global_id.to_s }
+
+      it 'sets permissions on admin set through Hyrax::Collections::PermissionsCreateService.create_default' do
+        tx.with_step_args('admin_set_resource.apply_collection_type_permissions' => { user: depositor })
+
+        expect(Hyrax::Collections::PermissionsCreateService)
+          .to receive(:create_default).with(any_args).and_call_original
+        updated_resource = tx.call(change_set).value!
+        expect(updated_resource.permission_manager.edit_users).to match_array [manager.user_key, depositor.user_key]
+        expect(updated_resource.permission_manager.edit_groups).to match_array ['admin', 'manager_group']
+        expect(updated_resource.permission_manager.read_users).to match_array []
+        expect(updated_resource.permission_manager.read_groups).to match_array []
+      end
+    end
+  end
+end


### PR DESCRIPTION
Partially addresses Issue #5130 - Val MVP: Create AdministrativeSet as a valkyrie resource through UI

----

This adds transactions used when creating a `Hyrax::AdministrativeSet` that is a valkyrie resource.  This will be used for the `#create` action in the `Hyrax::Admin::AdminSetsController`.

@samvera/hyrax-code-reviewers
