### PR TITLE
check if user can create based on configured collection model

### DIFF
--- a/app/views/hyrax/my/collections/index.html.erb
+++ b/app/views/hyrax/my/collections/index.html.erb
@@ -21,7 +21,7 @@
     <!-- Page tabs -->
     <nav><%= render 'tabs' if @managed_collection_count > 0 %></nav>
 
-    <% if can?(:create_any, Collection) && @collection_type_list_presenter.any? %>
+    <% if can?(:create_any, Hyrax.config.collection_class) && @collection_type_list_presenter.any? %>
       <% if @collection_type_list_presenter.many? %>
         <% # modal to select type %>
         <button type="button"

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -19,17 +19,36 @@ RSpec.describe 'Creating a new Admin Set', :js, :workflow, :clean_repo do
 
   context "when the user is not an admin" do
     context "and user does not have permissions to create managed collection type" do
-      before do
-        sign_in user
-        click_link('Collections', match: :first)
+      context "and collection model is an ActiveFedora::Base" do
+        before do
+          allow(Hyrax.config).to receive(:collection_model).and_return('::Collection')
+          sign_in user
+          click_link('Collections', match: :first)
+        end
+
+        it 'user is not offered the option to create that type of collection' do
+          # try and create the new admin set
+          click_button "New Collection"
+          expect(page).to have_xpath("//h4", text: "User Collection")
+          expect(page).to have_xpath("//h4", text: "Other")
+          expect(page).not_to have_xpath("//h4", text: "Managed Collection")
+        end
       end
 
-      it 'user is not offered the option to create that type of collection' do
-        # try and create the new admin set
-        click_button "New Collection"
-        expect(page).to have_xpath("//h4", text: "User Collection")
-        expect(page).to have_xpath("//h4", text: "Other")
-        expect(page).not_to have_xpath("//h4", text: "Managed Collection")
+      context "and collection model is a Valkyrie::Resource" do
+        before do
+          allow(Hyrax.config).to receive(:collection_model).and_return('Hyrax::PcdmCollection')
+          sign_in user
+          click_link('Collections', match: :first)
+        end
+
+        it 'user is not offered the option to create that type of collection' do
+          # try and create the new admin set
+          click_button "New Collection"
+          expect(page).to have_xpath("//h4", text: "User Collection")
+          expect(page).to have_xpath("//h4", text: "Other")
+          expect(page).not_to have_xpath("//h4", text: "Managed Collection")
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #5272

Dashboard -> Collections was checking hardcoded `Collection` instead of `Hyrax.config.collection_class` to determine if the user could create any collections.  This was preventing the `New Collection` button from displaying when configured to use `Hyrax::PcdmCollection` model.

@samvera/hyrax-code-reviewers
