### PR TITLE
characterize valkyrie file uploads

### DIFF
--- a/app/indexers/hyrax/valkyrie_file_set_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_file_set_indexer.rb
@@ -23,7 +23,6 @@ module Hyrax
         solr_doc['extracted_text_id_ssi'] = resource.extracted_text_id.to_s
 
         # Add in metadata from the original file.
-        file_metadata = original_file
         return solr_doc unless file_metadata
 
         # Label is the actual file name. It's not editable by the user.
@@ -98,6 +97,16 @@ module Hyrax
     end
 
     private
+
+    def file_metadata
+      return @meta if @meta.present?
+
+      @meta = Hyrax.query_service.find_all_of_model(model: Hyrax::FileMetadata).select do |fm|
+        fm.file_set_id.to_s == resource.id
+      end
+
+      @meta
+    end
 
     def original_file
       Hyrax.custom_queries.find_original_file(file_set: resource)

--- a/app/services/hyrax/characterization/valkyrie_characterization_service.rb
+++ b/app/services/hyrax/characterization/valkyrie_characterization_service.rb
@@ -1,0 +1,106 @@
+require 'hydra-file_characterization'
+require 'nokogiri'
+
+class Hyrax::Characterization::ValkyrieCharacterizationService
+  # @param [Hyrax::FileMetadata] object which has properties to recieve characterization values.
+  # @param [Valkyrie::StorageAdapter::StreamFile] source for characterization to
+  # be run on.  File object or path on disk.  If none is provided, it will
+  # assume the binary content already present on the object.
+  # @param [Hash] options to be passed to characterization.  parser_mapping:, parser_class:, tools:
+  def self.run(object, source = nil, options = {})
+    new(object, source, options).characterize
+  end
+
+  attr_accessor :object, :source, :mapping, :parser_class, :tools
+
+  def initialize(object, source, options)
+    @object       = object
+    @source       = source
+    @mapping      = options.fetch(:parser_mapping, Hydra::Works::Characterization.mapper)
+    @parser_class = options.fetch(:parser_class, Hydra::Works::Characterization::FitsDocument)
+    @tools        = options.fetch(:ch12n_tool, :fits)
+  end
+
+  # Get given source into form that can be passed to Hydra::FileCharacterization
+  # Use Hydra::FileCharacterization to extract metadata (an OM XML document)
+  # Get the terms (and their values) from the extracted metadata
+  # Assign the values of the terms to the properties of the object
+  def characterize
+    content = source_to_content
+    extracted_md = extract_metadata(content)
+    terms = parse_metadata(extracted_md)
+    store_metadata(terms)
+  end
+
+  protected
+
+  # @return content of object if source is nil; otherwise, return a File or the source
+  def source_to_content
+    return object.file if source.nil?
+    # do not read the file into memory It could be huge...
+    return File.open(source) if source.is_a? String
+    source.rewind
+    source.read
+  end
+
+  def extract_metadata(content)
+    Hydra::FileCharacterization.characterize(content, file_name, tools) do |cfg|
+      cfg[:fits] = Hydra::Derivatives.fits_path
+    end
+  end
+
+  def file_name
+    object.original_filename
+  end
+
+  # Use OM to parse metadata
+  def parse_metadata(metadata)
+    omdoc = parser_class.new
+    omdoc.ng_xml = Nokogiri::XML(metadata) if metadata.present?
+    omdoc.__cleanup__ if omdoc.respond_to? :__cleanup__
+    characterization_terms(omdoc)
+  end
+
+  # Get proxy terms and values from the parser
+  def characterization_terms(omdoc)
+    h = {}
+    omdoc.class.terminology.terms.each_pair do |key, target|
+      # a key is a proxy if its target responds to proxied_term
+      next unless target.respond_to? :proxied_term
+      begin
+        h[key] = omdoc.send(key)
+      rescue NoMethodError
+        next
+      end
+    end
+    h.delete_if { |_k, v| v.empty? }
+  end
+
+  # Assign values of the instance properties from the metadata mapping :prop => val
+  def store_metadata(terms)
+    terms.each_pair do |term, value|
+      property = property_for(term)
+      next if property.nil?
+      # Array-ify the value to avoid a conditional here
+      Array(value).each { |v| append_property_value(property, v) }
+    end
+  end
+
+  # Check parser_config then self for matching term.
+  # Return property symbol or nil
+  def property_for(term)
+    if mapping.key?(term) && object.respond_to?(mapping[term])
+      mapping[term]
+    elsif object.respond_to?(term)
+      term
+    end
+  end
+
+  def append_property_value(property, value)
+    # We don't want multiple mime_types; this overwrites each time to accept last value
+    value = object.send(property) + [value] unless property == :mime_type
+    # We don't want multiple heights / widths, pick the max
+    value = value.map(&:to_i).max.to_s if property == :height || property == :width
+    object.send("#{property}=", value)
+  end
+end

--- a/app/services/hyrax/listeners.rb
+++ b/app/services/hyrax/listeners.rb
@@ -19,6 +19,7 @@ module Hyrax
 
     autoload :AclIndexListener
     autoload :BatchNotificationListener
+    autoload :FileMetadataListener
     autoload :FileSetLifecycleListener
     autoload :FileSetLifecycleNotificationListener
     autoload :MemberCleanupListener

--- a/app/services/hyrax/listeners/file_metadata_listener.rb
+++ b/app/services/hyrax/listeners/file_metadata_listener.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Listens for events related to Hyrax::FileMetadata
+    class FileMetadataListener
+      ##
+      # Called when 'object.file.uploaded' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_object_file_uploaded(event)
+        md = event[:metadata]
+
+        Hydra::Works::CharacterizationService.run(md, md.file)
+        Hyrax.persister.save(resource: md)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/listeners/file_metadata_listener.rb
+++ b/app/services/hyrax/listeners/file_metadata_listener.rb
@@ -14,6 +14,7 @@ module Hyrax
 
         Hyrax::Characterization::ValkyrieCharacterizationService.run(md, md.file)
         Hyrax.persister.save(resource: md)
+        Hyrax.index_adapter.save(resource: event[:file_set])
       end
     end
   end

--- a/app/services/hyrax/listeners/file_metadata_listener.rb
+++ b/app/services/hyrax/listeners/file_metadata_listener.rb
@@ -12,7 +12,7 @@ module Hyrax
       def on_object_file_uploaded(event)
         md = event[:metadata]
 
-        Hydra::Works::CharacterizationService.run(md, md.file)
+        Hyrax::Characterization::ValkyrieCharacterizationService.run(md, md.file)
         Hyrax.persister.save(resource: md)
       end
     end

--- a/app/services/hyrax/valkyrie_uploads_handler.rb
+++ b/app/services/hyrax/valkyrie_uploads_handler.rb
@@ -84,8 +84,15 @@ class Hyrax::ValkyrieUploadsHandler < Hyrax::WorkUploadsHandler
                             original_filename: file_metadata.original_filename)
     file_metadata.file_identifier = uploaded.id
     file_metadata.size = uploaded.size
-    Hyrax.persister.save(resource: file_metadata)
-    Hyrax.publisher.publish("object.file.uploaded", metadata: file_metadata)
+
+    # characterization is run on the Hyrax::FileMetadata, but re-indexing is
+    # only triggered when the FileSet is persisted, so we need to pass that
+    # through as well
+    Hyrax.publisher.publish(
+      "object.file.uploaded",
+      file_set: file_set,
+      metadata: file_metadata
+    )
 
     file_metadata
   end

--- a/app/services/hyrax/valkyrie_uploads_handler.rb
+++ b/app/services/hyrax/valkyrie_uploads_handler.rb
@@ -57,7 +57,7 @@ class Hyrax::ValkyrieUploadsHandler < Hyrax::WorkUploadsHandler
     files.map do |file|
       file_set = Hyrax.query_service.find_by(id: file.file_set_uri)
       file_metadata = upload_file(file: file, file_metadata: file_metadata, file_set: file_set)
-      add_file_to_file_set(file_metadata: file_metadata)
+      add_file_to_file_set(file_set: file_set, file_metadata: file_metadata)
     end
   end
 
@@ -65,7 +65,7 @@ class Hyrax::ValkyrieUploadsHandler < Hyrax::WorkUploadsHandler
   # @api private
   #
   # @return FileSet updated file set
-  def add_file_to_file_set(file_metadata:)
+  def add_file_to_file_set(file_set:, file_metadata:)
     file_set.file_ids << file_metadata.id
     Hyrax.persister.save(resource: file_set)
   end
@@ -86,5 +86,7 @@ class Hyrax::ValkyrieUploadsHandler < Hyrax::WorkUploadsHandler
     file_metadata.size = uploaded.size
     Hyrax.persister.save(resource: file_metadata)
     Hyrax.publisher.publish("object.file.uploaded", metadata: file_metadata)
+
+    file_metadata
   end
 end

--- a/app/services/hyrax/valkyrie_uploads_handler.rb
+++ b/app/services/hyrax/valkyrie_uploads_handler.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+##
+# Accepts uploaded files via `#add` and attaches them to a Work with `#attach`,
+# avoiding the AF assumptions of the default implementation.
+#
+# @todo replace `Lockable` Redis locks with database transactions?
+class Hyrax::ValkyrieUploadsHandler < Hyrax::WorkUploadsHandler
+  ##
+  # @api public
+  #
+  # Create filesets for each added file, then push the uploads to the storage
+  # backend.
+  #
+  # @return [Boolean]
+  def attach
+    return true if Array.wrap(files).empty?
+
+    event_payloads = []
+
+    acquire_lock_for(work.id) do
+      event_payloads = files.map { |file| attach_member(file: file) }.to_a
+
+      @persister.save(resource: work) &&
+        Hyrax.publisher.publish("object.metadata.updated", object: work, user: files.first.user)
+    end
+
+    event_payloads.each { |payload| Hyrax.publisher.publish("file.set.attached", payload) }
+
+    ingest(files: files)
+  end
+
+  private
+
+  ##
+  # @api private
+  #
+  # @return [void]
+  def ingest(files:)
+    files.map do |file|
+      uploader = file.uploader
+      file_metadata = Hyrax::FileMetadata.for(file: uploader.file)
+      file_metadata.file_set_id = file.file_set_uri
+      file_metadata = Hyrax.persister.save(resource: file_metadata)
+
+      file_set = Hyrax.query_service.find_by(id: file.file_set_uri)
+      file_set.file_ids << file_metadata.id
+      Hyrax.persister.save(resource: file_set)
+
+      uploaded = Hyrax.storage_adapter
+        .upload(resource: file_metadata,
+          file: File.open(uploader.file.file),
+          original_filename: file_metadata.original_filename)
+      file_metadata.file_identifier = uploaded.id
+      file_metadata.size = uploaded.size
+      Hyrax.persister.save(resource: file_metadata)
+
+      Hyrax.publisher.publish("object.file.uploaded", metadata: file_metadata)
+    end
+  end
+
+  ##
+  # @api private
+  # @return [Hash{Symbol => Object}] event payloads for `file.set.attached`
+  #   events. we want to publish these after updating the work metadata
+  def attach_member(file:)
+    file_set = @persister.save(resource: Hyrax::FileSet.new(file_set_args(file)))
+    file.add_file_set!(file_set) # update carrierwave db record
+
+    Hyrax::AccessControlList.copy_permissions(source: target_permissions, target: file_set)
+
+    append_to_work(file_set)
+    Hyrax.publisher.publish("object.metadata.updated", object: file_set, user: file.user)
+
+    {file_set: file_set, user: file.user}
+  end
+end

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 Hyrax.publisher.subscribe(Hyrax::Listeners::AclIndexListener.new)
-Hyrax.publisher.subscribe(Hyrax::Listeners::ActiveFedoraAclIndexListener.new) unless
-  Hyrax.config.disable_wings
-Hyrax.publisher.subscribe(Hyrax::Listeners::MemberCleanupListener.new)
-Hyrax.publisher.subscribe(Hyrax::Listeners::MetadataIndexListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::ActiveFedoraAclIndexListener.new) unless Hyrax.config.disable_wings
 Hyrax.publisher.subscribe(Hyrax::Listeners::BatchNotificationListener.new)
-Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::FileMetadataListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleNotificationListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::MemberCleanupListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::MetadataIndexListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ProxyDepositListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::TrophyCleanupListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::WorkflowListener.new)

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -52,6 +52,7 @@ SUMMARY
   spec.add_dependency 'font-awesome-rails', '~> 4.2'
   spec.add_dependency 'hydra-derivatives', '~> 3.3'
   spec.add_dependency 'hydra-editor', '~> 5.0', ">= 5.0.4"
+  spec.add_dependency 'hydra-file_characterization', '~> 1.1.2'
   spec.add_dependency 'hydra-head', '~> 11.0', ">= 11.0.1"
   spec.add_dependency 'hydra-works', '>= 0.16'
   spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -53,7 +53,7 @@ SUMMARY
   spec.add_dependency 'hydra-derivatives', '~> 3.3'
   spec.add_dependency 'hydra-editor', '~> 5.0', ">= 5.0.4"
   spec.add_dependency 'hydra-head', '~> 11.0', ">= 11.0.1"
-  spec.add_dependency 'hydra-works', '>= 0.16', '< 2.0'
+  spec.add_dependency 'hydra-works', '>= 0.16'
   spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4'
   spec.add_dependency 'jquery-ui-rails', '~> 6.0'

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -141,5 +141,9 @@ module Hyrax
     # @since 3.0.0
     # @macro a_registered_event
     register_event('object.metadata.updated')
+
+    # @since 3.2.0
+    # @macro a_registered_event
+    register_event('object.file.uploaded')
   end
 end

--- a/lib/hyrax/transactions/steps/add_file_sets.rb
+++ b/lib/hyrax/transactions/steps/add_file_sets.rb
@@ -13,7 +13,7 @@ module Hyrax
 
         ##
         # @param [Class] handler
-        def initialize(handler: Hyrax::WorkUploadsHandler)
+        def initialize(handler: Hyrax::ValkyrieUploadsHandler)
           @handler = handler
         end
 

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -160,6 +160,7 @@ module Wings
       new_type = (resource.type - af_object.metadata_node.type.to_a).first
       af_object.metadata_node.type = new_type if new_type
       af_object.mime_type = resource.mime_type
+      af_object.content = resource.content unless resource.content.nil?
     end
   end
 end


### PR DESCRIPTION
this adds characterization metadata to `Hyrax::FileMetadata` for whatever setters it has defined that match the terms extracted by fits.

this is accomplished by
- adding a new `ValkyrieUploadsHandler` to circumvent the current pipeline that makes many AF assumptions (this means that the Valkyrie logic in `JobIOWrapper` is dead code now)
- adding a new event `object.file.uploaded` (distinct from `object.metadata.updated` because characterization should not run every time metadata is chaged)
- adding a new listener that runs  a new `ValkyrieCharacterizationService` to execute fits and attach the metadata (currently runs synchronously, but making it run as a job may be added as acceptance criteria)

this does not yet teach Hyrax how to display characterization information in the UI.

@samvera/hyrax-code-reviewers
