### PR TITLE
handle the case when table for saving default admin set doesn’t exist

### DIFF
--- a/app/models/hyrax/default_administrative_set.rb
+++ b/app/models/hyrax/default_administrative_set.rb
@@ -25,6 +25,10 @@ module Hyrax
         existing.save
       end
 
+      def save_supported?
+        ActiveRecord::Base.connection.table_exists? table_name
+      end
+
       private
 
       def validate_id(id)

--- a/spec/models/hyrax/default_administrative_set_spec.rb
+++ b/spec/models/hyrax/default_administrative_set_spec.rb
@@ -20,4 +20,30 @@ RSpec.describe Hyrax::DefaultAdministrativeSet, type: :model do
       end
     end
   end
+
+  describe 'save_supported?' do
+    context 'when table exists' do
+      before do
+        allow(ActiveRecord::Base.connection)
+          .to receive(:table_exists?)
+          .with(described_class.table_name)
+          .and_return(true)
+      end
+      it 'returns true' do
+        expect(described_class.save_supported?).to eq true
+      end
+    end
+
+    context 'when table does not exist' do
+      before do
+        allow(ActiveRecord::Base.connection)
+          .to receive(:table_exists?)
+          .with(described_class.table_name)
+          .and_return(false)
+      end
+      it 'returns false' do
+        expect(described_class.save_supported?).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
This removes the requirement to install the migration CreateDefaultAdministrativeSet.  This allows a release at the minor level.

@samvera/hyrax-code-reviewers
