### PR TITLE
fix dashboard -> collection not showing collections created as valkyrie resources

### DIFF
--- a/app/search_builders/hyrax/dashboard/collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/collections_search_builder.rb
@@ -9,7 +9,7 @@ module Hyrax
 
       # This overrides the models in FilterByType
       def models
-        [::AdminSet, ::Collection, Hyrax.config.collection_model.safe_constantize].uniq.compact
+        [::AdminSet, ::Collection, Hyrax.config.collection_class].uniq.compact
       end
 
       # adds a filter to exclude collections and admin sets created by the

--- a/app/search_builders/hyrax/my/collections_search_builder.rb
+++ b/app/search_builders/hyrax/my/collections_search_builder.rb
@@ -21,6 +21,6 @@ class Hyrax::My::CollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
   # This overrides the models in FilterByType
   # @return [Array<Class>] a list of classes to include
   def models
-    [::AdminSet, Hyrax::AdministrativeSet, Hyrax.config.collection_model.safe_constantize].compact
+    [::AdminSet, Hyrax::AdministrativeSet, ::Collection, Hyrax.config.collection_class].uniq.compact
   end
 end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -707,7 +707,7 @@ module Hyrax
     ##
     # @return [Class] the configured collection model class
     def collection_class
-      collection_model.constantize
+      collection_model.safe_constantize
     end
 
     attr_writer :admin_set_model

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe Hyrax::CollectionSearchBuilder do
       is_expected
         .to contain_exactly(*[::Collection, Hyrax.config.collection_class].uniq)
     end
+
+    context 'when collection class is not ::Collection' do
+      before { allow(Hyrax.config).to receive(:collection_model).and_return('Hyrax::PcdmCollection') }
+      its(:models) do
+        is_expected
+          .to contain_exactly(*[::Collection, Hyrax::PcdmCollection].uniq)
+      end
+    end
   end
 
   describe '#discovery_permissions' do

--- a/spec/search_builders/hyrax/my/collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/collections_search_builder_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe Hyrax::My::CollectionsSearchBuilder do
                                      Hyrax::AdministrativeSet,
                                      Hyrax.config.collection_class)
     end
+
+    context 'when collection class is something other than ::Collection' do
+      before { allow(Hyrax.config).to receive(:collection_model).and_return('Hyrax::PcdmCollection') }
+      it do
+        is_expected.to contain_exactly(AdminSet,
+                                       Hyrax::AdministrativeSet,
+                                       ::Collection,
+                                       Hyrax::PcdmCollection)
+      end
+    end
   end
 
   describe ".default_processor_chain" do


### PR DESCRIPTION
Fixes #5281

Always includes `::Collection` when creating model filters for collections.  Otherwise, collections created with `Hyrax::PcdmCollection` will not be found by the search.  So all searches for collections should include `[::Collection, Hyrax.config.collection_class].uniq`, which will include `Hyrax::PcdmCollection` when it is the configured class.

@samvera/hyrax-code-reviewers
