### PR TITLE
provide a NullAnalyticsParser if no analytics provider is given

### DIFF
--- a/app/services/hyrax/analytics.rb
+++ b/app/services/hyrax/analytics.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 module Hyrax
   module Analytics
+    ##
+    # a completely empty module to include if no parser is configured
+    module NullAnalyticsParser; end
+
     def self.provider_parser
-      "Hyrax::Analytics::#{Hyrax.config.analytics_provider.to_s.capitalize}"
+      "Hyrax::Analytics::#{Hyrax.config.analytics_provider.to_s.capitalize}".constantize
+    rescue NameError => err
+      Hyrax.logger.warn("Couldn't find an Analtics provider matching "\
+                        " #{Hyrax.config.analytics_provider}. Loading " \
+                        " NullAnalyticsProvider.\n#{err.message}")
+      NullAnalyticsParser
     end
-    include provider_parser.constantize
+
+    include provider_parser
   end
 end


### PR DESCRIPTION
this dynamic `include` strategy seems like it could be approved upon with a more
conventional dependency injection or Strategy pattern approach. in the meanwhile,
don't `NameError` on startup if no analytics provider is specified.

@samvera/hyrax-code-reviewers
