### PR TITLE
temporarily skip thumbnail for PcdmCollection

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -34,7 +34,8 @@
                 <%= render_edit_field_partial(term, f: f) %>
               <% end %>
 
-              <% if f.object.persisted? %>
+              <% # TODO: Remove check for PcdmCollection when Issue #5286 is resolved. %>
+              <% if f.object.persisted? && Hyrax.config.collection_class != Hyrax::PcdmCollection %>
                 <%# we're loading these values dynamically to speed page load %>
                 <%= f.input :thumbnail_id,
                     input_html: { data: { text: thumbnail_label_for(object: f.object) } } %>


### PR DESCRIPTION
See Issue #5286

This does not address the issue described in Issue #5286.  It is a temporary patch to allow the collection edit process to move forward.

This does not impact wings processing of `ActiveFedora::Base` collections.  They will continue to support thumbnails as they have.

This does not degrade functioning of `Hyrax::PcdmCollection` as the thumbnail code has not yet been implemented for `Hyrax::PcdmCollection`.

This is a temporary skip of the thumbnail code until the thumbnail implementation can be addressed.

@samvera/hyrax-code-reviewers
