### PR TITLE
Rename InvalidSolrID to RecordNotFound

### DIFF
--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::DownloadsController do
     it 'raises an error if the object does not exist' do
       expect do
         get :show, params: { id: '8675309' }
-      end.to raise_error Blacklight::Exceptions::InvalidSolrID
+      end.to raise_error Blacklight::Exceptions::RecordNotFound
     end
 
     context "when user doesn't have access" do


### PR DESCRIPTION
The former has been deprecated in Blacklight since 2015 and will no longer be supported in Blacklight 7. See projectblacklight/blacklight@32832e77cddd9e4d91438cde0d548ea807a65a17 .
