### PR TITLE
add .dir-locals.el for rspec-in-docker configuration

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+((nil . ((rspec-use-docker-when-possible . t)
+         (rspec-docker-wrapper-fn . (lambda (rspec-docker-command rspec-docker-container command) (format "%s -w /app/samvera/hyrax-engine %s sh -c \"%s\"" rspec-docker-command rspec-docker-container command)))
+         (rspec-docker-cwd . "/app/samvera/hyrax-engine/")
+         (rspec-docker-container . "app"))))


### PR DESCRIPTION
running Hyrax tests within docker requires some special handling, since we're running the specs for the engine rather than the app (dassie). this automatically sets the necessary variables when running tests from within emacs using `rspec-mode`

@samvera/hyrax-code-reviewers
