### PR TITLE
Address log4j CVE-2021-44228 in Helm Chart for Solr

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: 3.1.0
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -261,6 +261,10 @@ solr:
     enabled: true
     persistence:
       enabled: true
+  extraEnvVars:
+    - name: SOLR_OPTS
+      value: "-Dlog4j2.formatMsgNoLookups=true"
+
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
This should be able to be removed once `8.11.1` is released, hopefully
in the next day or so.

see: https://solr.apache.org/security.html#apache-solr-affected-by-apache-log4j-cve-2021-44228

@samvera/hyrax-code-reviewers
