### PR TITLE
Fix SerializationError in Regenerate Derivatives task

### DIFF
--- a/lib/tasks/regenerate_derivatives.rake
+++ b/lib/tasks/regenerate_derivatives.rake
@@ -5,7 +5,7 @@ namespace :hyrax do
     desc 'Regenerate derivatives for all FileSets in the repository'
     task regenerate_derivatives: :environment do
       FileSet.all.each do |fs|
-        fs.files.each { |fi| CreateDerivativesJob.perform_later(fs, fi) }
+        fs.files.each { |fi| CreateDerivativesJob.perform_later(fs, fi.id) }
       end
     end
   end


### PR DESCRIPTION
Fixes ActiveJob::SerializationError in hyrax:file_sets:regenerate_derivatives task.

CreateDerivativesJob expects a FileID of type String instead of a Hydra::PCDM::File object.  
see https://github.com/samvera/hyrax/blob/main/app/jobs/create_derivatives_job.rb#L6

Running the task as-is gives me the following error:
```
 RAILS_ENV=production bundle exec rails hyrax:file_sets:regenerate_derivatives 
[DEPRECATION] PCDM is deprecating 'Class#PreservationMasterFile'. Use Class#PreservationFile instead.
rails aborted!
ActiveJob::SerializationError: Unsupported argument type: Hydra::PCDM::File
```

This was the simplest change I could make to get the task to run successfully.

Changes proposed in this pull request:
* Send the CreateDerivatives job the expected argument type

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* The task had no test that I could see

@samvera/hyrax-code-reviewers
