### PR TITLE
Update Solr version to 8.11.1 in Chart

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: 3.1.0
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -246,7 +246,7 @@ solr:
   enabled: true
   image:
     repository: bitnami/solr
-    tag: 8.8.1
+    tag: 8.11.1
   authentication:
     enabled: true
     adminUsername: admin
@@ -261,10 +261,6 @@ solr:
     enabled: true
     persistence:
       enabled: true
-  extraEnvVars:
-    - name: SOLR_OPTS
-      value: "-Dlog4j2.formatMsgNoLookups=true"
-
 
 autoscaling:
   enabled: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       - hyrax
 
   solr:
-    image: solr:8.7
+    image: solr:8.11.1
     ports:
       - 8983:8983
     command:


### PR DESCRIPTION
To more permanently address the log4j CVE

Changes proposed in this pull request:
* Bump Solr to 8.11.1 as the default for the Helm chart
* Match Solr version as 8.11.1 for docker-compose dev environment
* Bump Hyrax Helm chart version to 1.0.2

@samvera/hyrax-code-reviewers
