### PR TITLE
add basic characterization of Valkyrie file uploads

### DIFF
--- a/app/jobs/valkyrie_ingest_job.rb
+++ b/app/jobs/valkyrie_ingest_job.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+class ValkyrieIngestJob < Hyrax::ApplicationJob
+  queue_as Hyrax.config.ingest_queue_name
+
+  # after_perform do |job|
+  #   # We want the lastmost Hash, if any.
+  #   opts = job.arguments.reverse.detect { |x| x.is_a? Hash } || {}
+  #   wrapper = job.arguments.first
+  #   ContentNewVersionEventJob.perform_later(wrapper.file_set, wrapper.user) if opts[:notification]
+  # end
+
+  # @param [Valkyrie::StorageAdapter::StreamFile] file
+  # @param [Boolean] notification send the user a notification, used in after_perform callback
+  # @see 'config/initializers/hyrax_callbacks.rb'
+  def perform(file, _notification: false)
+    ingest(file: file)
+  end
+
+  # @param [Valkyrie::StorageAdapter::StreamFile] file
+  # @return [void]
+  def ingest(file:)
+    file_set = Hyrax.query_service.find_by(id: file.file_set_uri)
+    file_metadata = Hyrax::FileMetadata.for(file: file.uploader.file)
+
+    updated_metadata = upload_file(file: file, file_metadata: file_metadata, file_set: file_set)
+    add_file_to_file_set(file_set: file_set, file_metadata: updated_metadata)
+  end
+
+  # @return FileSet updated file set
+  def add_file_to_file_set(file_set:, file_metadata:)
+    file_set.file_ids << file_metadata.id
+    Hyrax.persister.save(resource: file_set)
+  end
+
+  # @param [Hyrax::UploadedFile] file
+  # @param [Hyrax::FileMetadata] file_metadata
+  # @param [Hyrax::FileSet] file_set
+  # @return Hyrax::FileMetadata uploaded file
+  def upload_file(file:, file_metadata:, file_set:)
+    uploader = file.uploader
+    file_metadata.file_set_id = file.file_set_uri
+    uploaded = Hyrax.storage_adapter
+                    .upload(resource: file_set,
+                            file: File.open(uploader.file.file),
+                            original_filename: file_metadata.original_filename)
+    file_metadata.file_identifier = uploaded.id
+    file_metadata.size = uploaded.size
+
+    Hyrax.publisher.publish(
+      "object.file.uploaded",
+      metadata: file_metadata
+    )
+
+    file_metadata
+  end
+end

--- a/app/services/hyrax/characterization/valkyrie_characterization_service.rb
+++ b/app/services/hyrax/characterization/valkyrie_characterization_service.rb
@@ -3,10 +3,9 @@ require 'hydra-file_characterization'
 require 'nokogiri'
 
 class Hyrax::Characterization::ValkyrieCharacterizationService
-  # @param [Hyrax::FileMetadata] object which has properties to recieve characterization values.
+  # @param [Hyrax::FileMetadata] object which has properties to recieve characterization values
   # @param [Valkyrie::StorageAdapter::StreamFile] source for characterization to
-  # be run on.  File object or path on disk.  If none is provided, it will
-  # assume the binary content already present on the object.
+  # be run on
   # @param [Hash] options to be passed to characterization.  parser_mapping:, parser_class:, tools:
   #
   # @return [Hash]
@@ -40,11 +39,7 @@ class Hyrax::Characterization::ValkyrieCharacterizationService
 
   protected
 
-  # @return content of object if source is nil; otherwise, return a File or the source
   def source_to_content
-    return object.file if source.nil?
-    # do not read the file into memory It could be huge...
-    return File.open(source) if source.is_a? String
     source.rewind
     source.read
   end

--- a/app/services/hyrax/characterization/valkyrie_characterization_service.rb
+++ b/app/services/hyrax/characterization/valkyrie_characterization_service.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+require 'hydra-file_characterization'
+require 'nokogiri'
+
+class Hyrax::Characterization::ValkyrieCharacterizationService
+  # @param [Hyrax::FileMetadata] object which has properties to recieve characterization values.
+  # @param [Valkyrie::StorageAdapter::StreamFile] source for characterization to
+  # be run on.  File object or path on disk.  If none is provided, it will
+  # assume the binary content already present on the object.
+  # @param [Hash] options to be passed to characterization.  parser_mapping:, parser_class:, tools:
+  #
+  # @return [Hash]
+  def self.run(object, source = nil, options = {})
+    new(object, source, options).characterize
+    Hyrax.persister.save(resource: object)
+  end
+
+  attr_accessor :object, :source, :mapping, :parser_class, :tools
+
+  def initialize(object, source, options)
+    @object       = object
+    @source       = source
+    @mapping      = options.fetch(:parser_mapping, Hydra::Works::Characterization.mapper)
+    @parser_class = options.fetch(:parser_class, Hydra::Works::Characterization::FitsDocument)
+    @tools        = options.fetch(:ch12n_tool, :fits)
+  end
+
+  # Get given source into form that can be passed to Hydra::FileCharacterization
+  # Use Hydra::FileCharacterization to extract metadata (an OM XML document)
+  # Get the terms (and their values) from the extracted metadata
+  # Assign the values of the terms to the properties of the object
+  #
+  # @return [Hash]
+  def characterize
+    content = source_to_content
+    extracted_md = extract_metadata(content)
+    terms = parse_metadata(extracted_md)
+    store_metadata(terms)
+  end
+
+  protected
+
+  # @return content of object if source is nil; otherwise, return a File or the source
+  def source_to_content
+    return object.file if source.nil?
+    # do not read the file into memory It could be huge...
+    return File.open(source) if source.is_a? String
+    source.rewind
+    source.read
+  end
+
+  def extract_metadata(content)
+    Hydra::FileCharacterization.characterize(content, file_name, tools) do |cfg|
+      cfg[:fits] = Hydra::Derivatives.fits_path
+    end
+  end
+
+  def file_name
+    object.original_filename
+  end
+
+  # Use OM to parse metadata
+  def parse_metadata(metadata)
+    omdoc = parser_class.new
+    omdoc.ng_xml = Nokogiri::XML(metadata) if metadata.present?
+    omdoc.__cleanup__ if omdoc.respond_to? :__cleanup__
+    characterization_terms(omdoc)
+  end
+
+  # Get proxy terms and values from the parser
+  def characterization_terms(omdoc)
+    h = {}
+    omdoc.class.terminology.terms.each_pair do |key, target|
+      # a key is a proxy if its target responds to proxied_term
+      next unless target.respond_to? :proxied_term
+      begin
+        h[key] = omdoc.send(key)
+      rescue NoMethodError
+        next
+      end
+    end
+    h.delete_if { |_k, v| v.empty? }
+  end
+
+  # Assign values of the instance properties from the metadata mapping :prop => val
+  # @return [Hash]
+  def store_metadata(terms)
+    terms.each_pair do |term, value|
+      property = property_for(term)
+      next if property.nil?
+      # Array-ify the value to avoid a conditional here
+      Array(value).each { |v| append_property_value(property, v) }
+    end
+  end
+
+  # Check parser_config then self for matching term.
+  # Return property symbol or nil
+  def property_for(term)
+    if mapping.key?(term) && object.respond_to?(mapping[term])
+      mapping[term]
+    elsif object.respond_to?(term)
+      term
+    end
+  end
+
+  def append_property_value(property, value)
+    # We don't want multiple mime_types; this overwrites each time to accept last value
+    value = object.send(property) + [value] unless property == :mime_type
+    # We don't want multiple heights / widths, pick the max
+    value = value.map(&:to_i).max.to_s if property == :height || property == :width
+    object.send("#{property}=", value)
+  end
+end

--- a/app/services/hyrax/listeners.rb
+++ b/app/services/hyrax/listeners.rb
@@ -19,6 +19,7 @@ module Hyrax
 
     autoload :AclIndexListener
     autoload :BatchNotificationListener
+    autoload :FileMetadataListener
     autoload :FileSetLifecycleListener
     autoload :FileSetLifecycleNotificationListener
     autoload :MemberCleanupListener

--- a/app/services/hyrax/listeners/file_metadata_listener.rb
+++ b/app/services/hyrax/listeners/file_metadata_listener.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Listens for events related to Hyrax::FileMetadata
+    class FileMetadataListener
+      ##
+      # Called when 'object.file.uploaded' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_object_file_uploaded(event)
+        md = event[:metadata]
+        Hyrax::Characterization::ValkyrieCharacterizationService.run(md, md.file)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/work_uploads_handler.rb
+++ b/app/services/hyrax/work_uploads_handler.rb
@@ -114,8 +114,11 @@ module Hyrax
       file_set.permission_manager.acl.save if file_set.permission_manager.acl.pending_changes?
       append_to_work(file_set)
 
-      IngestJob.perform_later(wrap_file(file, file_set))
+      ValkyrieIngestJob.perform_later(file)
+
+      # this triggers the re-index
       Hyrax.publisher.publish('object.metadata.updated', object: file_set, user: file.user)
+
       { file_set: file_set, user: file.user }
     end
 

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 Hyrax.publisher.subscribe(Hyrax::Listeners::AclIndexListener.new)
-Hyrax.publisher.subscribe(Hyrax::Listeners::ActiveFedoraAclIndexListener.new) unless
-  Hyrax.config.disable_wings
-Hyrax.publisher.subscribe(Hyrax::Listeners::MemberCleanupListener.new)
-Hyrax.publisher.subscribe(Hyrax::Listeners::MetadataIndexListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::ActiveFedoraAclIndexListener.new) unless Hyrax.config.disable_wings
 Hyrax.publisher.subscribe(Hyrax::Listeners::BatchNotificationListener.new)
-Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::FileMetadataListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::FileSetLifecycleNotificationListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::MemberCleanupListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::MetadataIndexListener.new)
+Hyrax.publisher.subscribe(Hyrax::Listeners::ObjectLifecycleListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::ProxyDepositListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::TrophyCleanupListener.new)
 Hyrax.publisher.subscribe(Hyrax::Listeners::WorkflowListener.new)

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -52,8 +52,9 @@ SUMMARY
   spec.add_dependency 'font-awesome-rails', '~> 4.2'
   spec.add_dependency 'hydra-derivatives', '~> 3.3'
   spec.add_dependency 'hydra-editor', '~> 5.0', ">= 5.0.4"
+  spec.add_dependency 'hydra-file_characterization', '~> 1.1.2'
   spec.add_dependency 'hydra-head', '~> 11.0', ">= 11.0.1"
-  spec.add_dependency 'hydra-works', '>= 0.16', '< 2.0'
+  spec.add_dependency 'hydra-works', '>= 0.16'
   spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4'
   spec.add_dependency 'jquery-ui-rails', '~> 6.0'

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -141,5 +141,9 @@ module Hyrax
     # @since 3.0.0
     # @macro a_registered_event
     register_event('object.metadata.updated')
+
+    # @since 3.2.0
+    # @macro a_registered_event
+    register_event('object.file.uploaded')
   end
 end

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe AttachFilesToWorkJob, perform_enqueued: [AttachFilesToWorkJob] do
     shared_examples 'a file attacher', perform_enqueued: [described_class, IngestJob] do
       it 'attaches files, copies visibility and permissions and updates the uploaded files' do
         id = generic_work.id
-        expect(CharacterizeJob).to receive(:perform_later).twice
+        expect(ValkyrieIngestJob).to receive(:perform_later).twice
         described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
         generic_work = Hyrax.query_service.find_by(id: id)
         file_sets = Hyrax.custom_queries.find_child_filesets(resource: generic_work)

--- a/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
+++ b/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/AnyInstance
+RSpec.describe Hyrax::Characterization::ValkyrieCharacterizationService do
+  describe "run" do
+    let(:fits_response) { IO.read('spec/fixtures/png_fits.xml') }
+    let(:upload)        { Rack::Test::UploadedFile.new('spec/fixtures/world.png', 'image/png') }
+
+    let(:metadata) do
+      Hyrax::FileMetadata.for(file: upload).new(id: 'test_id')
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:extract_metadata).and_return(fits_response)
+      described_class.run(metadata, metadata.file)
+    end
+
+    it 'successfully sets the property values' do
+      expect(metadata.compression).to eq(["Deflate/Inflate"])
+      expect(metadata.format_label).to eq(["Portable Network Graphics"])
+      expect(metadata.height).to eq(["50"])
+      expect(metadata.width).to eq(["50"])
+    end
+  end
+end
+# rubocop:enable RSpec/AnyInstance


### PR DESCRIPTION
this adds `ValkyrieCharacterizationService`, based on the hydra-works service class, to allow characterizing file uploads of Valkyrie objects.

the attributes/setters haven't been modified, so currently this just assigns values for those which match the attributes in the fits response, like `height` and `width`:
```
[1] pry(Hyrax::Characterization::ValkyrieCharacterizationService)> object
=> #<Hyrax::FileMetadata id=#<Valkyrie::ID:0x00007f4683d82680 @id="test_id"> internal_resource="Hyrax::FileMetadata" created_at=nil updated_at=nil new_record=true file_identifier=nil alternate_ids=[] file_set_id=nil label=["world.png"] original_filename="world.png" mime_type="image/png" type=[#<RDF::Vocabulary::Term:0x4dff8 ID:http://pcdm.org/use#OriginalFile>] format_label=["test_format_label", "Portable Network Graphics"] size=[] well_formed=[] valid=[] date_created=[] fits_version=[] exif_version=[] checksum=[] frame_rate=[] bit_rate=[] duration=[] sample_rate=[] height=["50"] width=["50"] bit_depth=[] channels=[] data_format=[] offset=[] file_title=[] creator=[] page_count=[] language=[] word_count=[] character_count=[] line_count=[] character_set=[] markup_basis=[] markup_language=[] paragraph_count=[] table_count=[] graphics_count=[] byte_order=[] compression=["Deflate/Inflate"] color_space=[] profile_name=[] profile_version=[] orientation=[] color_map=[] image_producer=[] capture_device=[] scanning_software=[] gps_timestamp=[] latitude=[] longitude=[] aspect_ratio=[]>
```

the characterization status is also not yet reflected in the ui, since the valkyrie presenter does not use `Hyrax::CharacterizationBehavior`.

@samvera/hyrax-code-reviewers
