### PR TITLE
Pass through some properties for Blacklight 7 compatibility

### DIFF
--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -31,6 +31,17 @@ module Hyrax::Controller
 
   ##
   # @deprecated provides short-term compatibility with Blacklight 6
+  # @return [Class<Blacklight::SearchBuilder>]
+  def search_builder_class
+    return super if defined?(super)
+    Deprecation.warn("Avoid direct calls to `#search_builder_class`; this" \
+                     " method provides short-term compatibility to" \
+                     " Blacklight 6 clients.")
+    blacklight_config.search_builder_class
+  end
+
+  ##
+  # @deprecated provides short-term compatibility with Blacklight 6
   # @return [Blacklight::AbstractRepository]
   def repository
     return super if defined?(super)

--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -29,6 +29,17 @@ module Hyrax::Controller
     super.merge(locale: I18n.locale)
   end
 
+  ##
+  # @deprecated provides short-term compatibility with Blacklight 6
+  # @return [Blacklight::AbstractRepository]
+  def repository
+    return super if defined?(super)
+    Deprecation.warn("Avoid direct calls to `#repository`; this method" \
+                     " provides short-term compatibility to Blacklight 6 " \
+                     " clients.")
+    blacklight_config.repository
+  end
+
   private
 
   ##


### PR DESCRIPTION
See #5075; part of #5280.

`#repository` and `#search_builder_class` will be moved off of controllers and into their `blacklight_config` in Blacklight 7. The methods in this PR keep them available on `ApplicationController` to reduce code breakage during the upgrade.

Probably, we will eventually want to eliminate any dependency on these methods, but the Blacklight 7 migration is a large enough project as it is. Also, it’s worth noting that upstream `Blacklight::SearchService` [has no problem making this sort of delegation](https://github.com/projectblacklight/blacklight/blob/064302f73eee4baae4d2abf863c68317d3efb5b7/app/services/blacklight/search_service.rb#L93).

Changes proposed in this pull request:
* 497eeec670ed329dba0585d85a2b659d5f3bd77b: Pass through `#repository`
* 923bb1a1155178cd3fe14a33f9d98c4561d07993: Pass through `#search_builder_class`
