### PR TITLE
Use a fake instead of doubles for scopes in SearchBuilder specs

### DIFF
--- a/spec/search_builders/hyrax/catalog_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/catalog_search_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::CatalogSearchBuilder do
-  let(:context) { double }
+  let(:context) { FakeSearchBuilderScope.new }
   let(:builder) { described_class.new(context).with(blacklight_params) }
   let(:solr_params) { Blacklight::Solr::Request.new }
   let(:blacklight_params) { { q: user_query, search_field: 'all_fields' } }
@@ -53,7 +53,7 @@ RSpec.describe Hyrax::CatalogSearchBuilder do
   describe "#filter_collection_facet_for_access" do
     let(:user) { build(:user) }
     let(:ability) { Ability.new(user) }
-    let(:context) { double(current_ability: ability) }
+    let(:context) { FakeSearchBuilderScope.new(current_ability: ability) }
 
     subject { builder.filter_collection_facet_for_access(solr_params) }
 

--- a/spec/search_builders/hyrax/embargo_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/embargo_search_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::EmbargoSearchBuilder do
-  let(:context) { double }
+  let(:context) { FakeSearchBuilderScope.new }
   let(:search_builder) { described_class.new(context) }
 
   describe "#processor_chain" do

--- a/spec/search_builders/hyrax/file_set_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/file_set_search_builder_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Hyrax::FileSetSearchBuilder do
   let(:processor_chain) { [:filter_models] }
   let(:ability) { double('ability') }
-  let(:context) { double('context') }
+  let(:context) { FakeSearchBuilderScope.new }
   let(:user) { double('user') }
   let(:solr_params) { { fq: [] } }
 

--- a/spec/search_builders/hyrax/lease_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/lease_search_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::LeaseSearchBuilder do
-  let(:context) { double }
+  let(:context) { FakeSearchBuilderScope.new }
   let(:search_builder) { described_class.new(context) }
 
   describe "#processor_chain" do

--- a/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
   let(:params) { ActionController::Parameters.new(q: q, id: work.id, user: user.email, controller: "qa/terms", action: "search", vocab: "find_works") }
 
   let(:context) do
-    double(current_ability: ability,
-           current_user: user,
-           params: params)
+    FakeSearchBuilderScope.new(current_ability: ability,
+                               current_user: user,
+                               params: params)
   end
   let!(:work) { create(:generic_work, :public, title: ['foo'], user: user) }
 

--- a/spec/support/fakes/fake_search_builder_scope.rb
+++ b/spec/support/fakes/fake_search_builder_scope.rb
@@ -30,11 +30,11 @@ class FakeSearchBuilderScope
   # @param [Blacklight::Configuration] blacklight_config
   # @param [::Ability, nil] current_ability
   # @param [::User, nil] current_user
-  def initialize(blacklight_config: CatalogController.blacklight_config, current_ability: nil, current_user: nil)
+  def initialize(blacklight_config: CatalogController.blacklight_config, current_ability: nil, current_user: nil, params: {})
     @blacklight_config = blacklight_config
     @current_user = current_user
     @current_ability = current_ability || ::Ability.new(current_user)
-    @params = {} # all existing tests explitly pass in an empty hash, real controller params are used in practice?
+    @params = params
     @repository = Blacklight::Solr::Repository.new(blacklight_config)
   end
 end


### PR DESCRIPTION
See #5075; part of #5280.

A fake has been implemented for search builder scopes; it should be used in these tests.

Although these tests pass under Blacklight 6, they are fragile and will break when the Blacklight 7 upgrade occurs. Best to fix them now.

Changes proposed in this pull request:
* Update various specs to use the existing `FakeSearchBuilderScope` class