### PR TITLE
Update WorksSearchBuilder specs for Blacklight 7

### DIFF
--- a/spec/search_builders/hyrax/my/works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/works_search_builder_spec.rb
@@ -18,24 +18,6 @@ RSpec.describe Hyrax::My::WorksSearchBuilder do
   end
 
   describe ".default_processor_chain" do
-    subject { described_class.default_processor_chain }
-
-    let(:expected_filters) do
-      [
-        :default_solr_parameters,
-        :add_query_to_solr,
-        :add_facet_fq_to_solr,
-        :add_facetting_to_solr,
-        :add_solr_fields_to_query,
-        :add_paging_to_solr,
-        :add_sorting_to_solr,
-        :add_group_config_to_solr,
-        :add_facet_paging_to_solr,
-        :filter_models,
-        :show_only_resources_deposited_by_current_user
-      ]
-    end
-
-    it { is_expected.to eq expected_filters }
+    it { expect(described_class.default_processor_chain).to end_with(:filter_models, :show_only_resources_deposited_by_current_user) }
   end
 end

--- a/spec/search_builders/hyrax/works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/works_search_builder_spec.rb
@@ -1,24 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::WorksSearchBuilder do
   describe "::default_processor_chain" do
-    subject { described_class.default_processor_chain }
-
-    let(:blacklight_filters) do
-      # These filters are in Blacklight::Solr::SearchBuilderBehavior
-      [
-        :default_solr_parameters,
-        :add_query_to_solr,
-        :add_facet_fq_to_solr,
-        :add_facetting_to_solr,
-        :add_solr_fields_to_query,
-        :add_paging_to_solr,
-        :add_sorting_to_solr,
-        :add_group_config_to_solr,
-        :add_facet_paging_to_solr,
-        :add_access_controls_to_solr_params
-      ]
-    end
-
-    it { is_expected.to eq blacklight_filters + [:filter_models] }
+    it { expect(described_class.default_processor_chain).to end_with :filter_models }
   end
 end


### PR DESCRIPTION
See #5075; part of #5280.

Previously, these tests hardcoded the default blacklight filters, which will change in Blacklight 7. There is no need to check for all of these; it only makes the test more fragile. This commit revises the spec to instead only verify that our own filters have been added to the end.

Changes proposed in this pull request:
* Update the two `works_search_builder_spec`s to not hardcode filters from Blacklight, and instead just check for ours.