### PR TITLE
Use *_sim not *_tesim for catalog facet tests

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CatalogController, type: :controller do
       let(:objects) { [rocks, clouds] }
 
       before do
-        get :index, params: { 'f' => { 'contributor_tesim' => ['frodo'] } }
+        get :index, params: { 'f' => { 'contributor_sim' => ['frodo'] } }
       end
 
       it 'finds faceted works' do


### PR DESCRIPTION
The `*_tesim` facet search will fail in Blacklight 7, because only `*_sim` facets are declared in the catalog blacklight configuration. This was likely an error in writing the original spec. See projectblacklight/blacklight#2401.

Changes proposed in this pull request:
* Use `contributor_sim`, not `contributor_tesim`, in the `CatalogController` spec, since that is what we actually use.