### PR TITLE
Add `blacklight_config` to `RestrictionService`

### DIFF
--- a/app/services/hyrax/restriction_service.rb
+++ b/app/services/hyrax/restriction_service.rb
@@ -2,6 +2,10 @@
 module Hyrax
   class RestrictionService
     class << self
+      ##
+      # @note needed to construct SearchBuilders using self in Blacklight 7+
+      delegate :blacklight_config, to: :config
+
       private
 
       def presenter_class


### PR DESCRIPTION
See #5075; part of #5280.

Blacklight 7+ `SearchBuilder`s expect this to be present, and there’s nothing preventing us from adding this now. It will reduce the amount of failing tests when we make the migration.

Changes proposed in this pull request:
* Delegate `blacklight_config` to `config` on `RestrictionService`