### PR TITLE
Reduce usage of `SearchBuilder#where`

### DIFF
--- a/app/authorities/qa/authorities/collections.rb
+++ b/app/authorities/qa/authorities/collections.rb
@@ -32,7 +32,7 @@ module Qa::Authorities
       access = controller.params[:access] || 'read'
 
       search_service(controller).search_results do |builder|
-        builder.where(controller.params[:q])
+        builder.with({ q: controller.params[:q] })
                .with_access(access)
                .rows(100)
       end

--- a/app/authorities/qa/authorities/find_works.rb
+++ b/app/authorities/qa/authorities/find_works.rb
@@ -33,7 +33,7 @@ module Qa::Authorities
       access = controller.params[:access] || 'read'
 
       search_service(controller).search_results do |builder|
-        builder.where(controller.params[:q])
+        builder.with({ q: controller.params[:q] })
                .with_access(access)
                .rows(100)
       end


### PR DESCRIPTION
See #5075; part of #5280.

The behaviour of `SearchBuilder#where` gets notably more complex in Blacklight 7, and in many cases, `SearchBuilder#with` suffices. This PR only makes the change where it is necessary to prevent failing tests post‐upgrade, but we should consider moving away from `#where` more broadly if it isn’t necessary.

Changes proposed in this pull request:
* Use `#with` instead of `#where` in `Qa::Authorities` specs 
* Use `#with` instead of `#where` when determining child nesting depth (and refactor a bit to more closely follow Blacklight 7 conventions)