### PR TITLE
don't attempt to save AF::WithMetadata::MetadataNode#file_hash

### DIFF
--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -48,6 +48,17 @@ module ActiveFedora
     end
   end
 
+  module WithMetadata
+    class MetadataNode
+      ##
+      # @note fcrepo rejects `:file_hash` updates. the attribute is managed by
+      #   the data store. always drop it from changed attributes.
+      def changed_attributes
+        super.except(:file_hash)
+      end
+    end
+  end
+
   module Associations
     class ContainerProxy
       delegate :build_or_set, to: :@association

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe Hyrax::FileMetadata do
                           type: contain_exactly(described_class::Use::ORIGINAL_FILE))
   end
 
+  context 'when saved with a file' do
+    subject(:file_metadata) { Hyrax.custom_queries.find_file_metadata_by(id: file.id) }
+    let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+
+    let(:file) do
+      Hyrax.storage_adapter.upload(resource: file_set,
+                                   file: Tempfile.new('blah'),
+                                   original_filename: 'blah.txt')
+    end
+
+    it 'can be changed and saved' do
+      file_metadata.creator = 'Tove'
+
+      expect(Hyrax.persister.save(resource: file_metadata).creator)
+        .to contain_exactly('Tove')
+    end
+  end
+
   describe '#original_file?' do
     context 'when use says file is the original file' do
       before do

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -15,56 +15,66 @@ RSpec.describe Hyrax::FileMetadata do
   let(:pcdm_file_uri) { RDF::URI('http://pcdm.org/models#File') }
 
   it 'sets the proper attributes' do
-    expect(subject.id.to_s).to eq 'test_id'
-    expect(subject.label).to contain_exactly('world.png')
-    expect(subject.original_filename).to eq 'world.png'
-    expect(subject.mime_type).to eq('image/png')
-    expect(subject.format_label).to contain_exactly('test_format_label')
-    expect(subject.type).to contain_exactly(described_class::Use::ORIGINAL_FILE)
+    expect(file_metadata)
+      .to have_attributes(id: 'test_id',
+                          format_label: contain_exactly('test_format_label'),
+                          label: contain_exactly('world.png'),
+                          mime_type: 'image/png',
+                          original_filename: 'world.png',
+                          type: contain_exactly(described_class::Use::ORIGINAL_FILE))
   end
 
   describe '#original_file?' do
     context 'when use says file is the original file' do
-      before { subject.type = [described_class::Use::ORIGINAL_FILE, pcdm_file_uri] }
-      it 'returns true' do
-        expect(subject).to be_original_file
+      before do
+        file_metadata.type = [described_class::Use::ORIGINAL_FILE, pcdm_file_uri]
       end
+
+      it { is_expected.to be_original_file }
     end
+
     context 'when use does not say file is the original file' do
-      before { subject.type = [described_class::Use::THUMBNAIL, pcdm_file_uri] }
-      it 'returns false' do
-        expect(subject).not_to be_original_file
+      before do
+        file_metadata.type = [described_class::Use::THUMBNAIL, pcdm_file_uri]
       end
+
+      it { is_expected.not_to be_original_file }
     end
   end
 
   describe '#thumbnail_file?' do
     context 'when use says file is the thumbnail file' do
-      before { subject.type = [described_class::Use::THUMBNAIL, pcdm_file_uri] }
-      it 'returns true' do
-        expect(subject).to be_thumbnail_file
+      before do
+        file_metadata.type = [described_class::Use::THUMBNAIL, pcdm_file_uri]
       end
+
+      it { is_expected.to be_thumbnail_file }
     end
+
     context 'when use does not say file is the thumbnail file' do
-      before { subject.type = [described_class::Use::ORIGINAL_FILE, pcdm_file_uri] }
-      it 'returns false' do
-        expect(subject).not_to be_thumbnail_file
+      before do
+        file_metadata.type = [described_class::Use::ORIGINAL_FILE, pcdm_file_uri]
       end
+
+      it { is_expected.not_to be_thumbnail_file }
     end
   end
 
   describe '#extracted_file?' do
     context 'when use says file is the extracted file' do
-      before { subject.type = [described_class::Use::EXTRACTED_TEXT, pcdm_file_uri] }
-      it 'returns true' do
-        expect(subject).to be_extracted_file
+      before do
+        file_metadata.type = [described_class::Use::EXTRACTED_TEXT, pcdm_file_uri]
       end
+
+      it { is_expected.to be_extracted_file }
     end
+
     context 'when use does not say file is the extracted file' do
-      before { subject.type = [described_class::Use::ORIGINAL_FILE, pcdm_file_uri] }
-      it 'returns false' do
-        expect(subject).not_to be_extracted_file
+      before do
+        file_metadata.type = [described_class::Use::ORIGINAL_FILE, pcdm_file_uri]
       end
+
+      it { is_expected.not_to be_extracted_file }
     end
   end
 


### PR DESCRIPTION
`ActiveFedora::WithMetadata::MetadataNode` provides a `#file_hash` attribute,
but writing to it, even with the existing data, prevents all saves.

Wings needs to map data in and out of this class freely, and this attribute
functions as a honeypot. it baits Wings to preserve the data, and then fails
save when the converters try to do keep the existing data. since any attempt to
write this data will break save, ActiveFedora should treat it as read only.

never include `MetadataNode#file_hash` in changed attributes lists when Wings is
loaded.

i think this is the issue presently blocking #5278.