### PR TITLE
test deposit of files via WorkUploadsHandser 

### DIFF
--- a/app/jobs/valkyrie_ingest_job.rb
+++ b/app/jobs/valkyrie_ingest_job.rb
@@ -14,9 +14,8 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
   # @return [void]
   def ingest(file:)
     file_set = Hyrax.query_service.find_by(id: file.file_set_uri)
-    file_metadata = Hyrax::FileMetadata.for(file: file.uploader.file)
+    updated_metadata = upload_file(file: file, file_set: file_set)
 
-    updated_metadata = upload_file(file: file, file_metadata: file_metadata, file_set: file_set)
     add_file_to_file_set(file_set: file_set, file_metadata: updated_metadata)
   end
 
@@ -33,24 +32,24 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
     Hyrax.persister.save(resource: file_set)
   end
 
+  ##
   # @param [Hyrax::UploadedFile] file
-  # @param [Hyrax::FileMetadata] file_metadata
   # @param [Hyrax::FileSet] file_set
-  # @return Hyrax::FileMetadata uploaded file
-  def upload_file(file:, file_metadata:, file_set:)
-    uploader = file.uploader
-    file_metadata.file_set_id = file.file_set_uri
+  #
+  # @return [Hyrax::FileMetadata] the metadata representing the uploaded file
+  def upload_file(file:, file_set:)
+    carrier_wave_sanitized_file = file.uploader.file
     uploaded = Hyrax.storage_adapter
                     .upload(resource: file_set,
-                            file: File.open(uploader.file.file),
-                            original_filename: file_metadata.original_filename)
+                            file: carrier_wave_sanitized_file,
+                            original_filename: carrier_wave_sanitized_file.original_filename)
+
+    file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: uploaded.id)
+    file_metadata.file_set_id = file.file_set_uri
     file_metadata.file_identifier = uploaded.id
     file_metadata.size = uploaded.size
 
-    Hyrax.publisher.publish(
-      "object.file.uploaded",
-      metadata: file_metadata
-    )
+    Hyrax.publisher.publish("object.file.uploaded", metadata: file_metadata)
 
     file_metadata
   end

--- a/app/services/hyrax/listeners/file_metadata_listener.rb
+++ b/app/services/hyrax/listeners/file_metadata_listener.rb
@@ -10,8 +10,9 @@ module Hyrax
       # @param [Dry::Events::Event] event
       # @return [void]
       def on_object_file_uploaded(event)
-        Hyrax::Characterization::ValkyrieCharacterizationService
-          .run(metadata: event[:metadata], file: event[:metadata])
+        Hyrax.config
+             .characterization_service
+             .run(metadata: event[:metadata], file: event[:metadata].file)
       end
     end
   end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -484,6 +484,17 @@ module Hyrax
     # Override characterization runner
     attr_accessor :characterization_runner
 
+    ##
+    # @!attribute [rw] characterization_service
+    #   @return [#run] the service to use for charactaerization for Valkyrie
+    #     objects
+    #   @ see Hyrax::Characterization::ValkyrieCharacterizationService
+    attr_writer :characterization_service
+    def characterization_service
+      @characterization_service ||=
+        Hyrax::Characterization::ValkyrieCharacterizationService
+    end
+
     # Attributes for the lock manager which ensures a single process/thread is mutating a ore:Aggregation at once.
     # @!attribute [w] lock_retry_count
     #   How many times to retry to acquire the lock before raising UnableToAcquireLockError

--- a/spec/support/matchers/pcdm_matchers.rb
+++ b/spec/support/matchers/pcdm_matchers.rb
@@ -7,6 +7,25 @@ RSpec::Matchers.define :have_file_set_members do |*expected_file_sets|
   end
 end
 
+RSpec::Matchers.define :have_attached_files do |*expected_files|
+  match do |actual_file_set|
+    @actual_files = Hyrax.custom_queries.find_files(file_set: actual_file_set)
+
+    (expected_files.empty? && @actual_files.any?) ||
+      @actual_files == expected_files
+  end
+
+  failure_message_for_should do |actual_file_set|
+    if expected_files.empty?
+      "Expected #{actual_file_set} to have at least one file.\n" \
+      "Found #{@actual_files}."
+    else
+      "Expected #{actual_file_set} to have files: #{expected_files}\n" \
+      "Found #{@actual_files}."
+    end
+  end
+end
+
 RSpec::Matchers.define :be_a_resource_with_permissions do |*expected_permissions|
   match do |actual_resource|
     expect(Hyrax::AccessControlList.new(resource: actual_resource).permissions)


### PR DESCRIPTION
`Hyrax::WorkUploadsHandler` should always ingest files matching its
uploads. prior to this, its tests skipped running the background job that
handles ingest. that job has (still) no unit tests of its own.

this makes inroads toward comprehensive ingest tests by wireing in one spec from
`WorkUploadsHandler` down. we stub out the characterizer since that behavior has
strong tests of its own, and we don't want to include the system call to
`fits.sh` here---the background job is run by the ActiveJob test adapter
directly in the app container, so the fits dependency isn't expected to be
installed.

@samvera/hyrax-code-reviewers
