### PR TITLE
do not get all collections for dashboard

### DIFF
--- a/app/controllers/hyrax/dashboard_controller.rb
+++ b/app/controllers/hyrax/dashboard_controller.rb
@@ -21,7 +21,6 @@ module Hyrax
       if can? :read, :admin_dashboard
         @presenter = Hyrax::Admin::DashboardPresenter.new
         @admin_set_rows = Hyrax::AdminSetService.new(self).search_results_with_work_count(:read)
-        @collections = Collection.order(date_modified: :desc)
         render 'show_admin'
       else
         @presenter = Dashboard::UserPresenter.new(current_user, view_context, params[:since])


### PR DESCRIPTION
`@collections` cannot be set with `Collection.order` when `Collection` is `Hyrax::PcdmCollection`.  The `order` method is not defined.  Use of `all` was suggested, but it is also not defined for `Hyrax::PcdmCollection`.

There is an alternative approach to get all collections, but it is not clear that this is necessary.
* `@collections` does not appear to be used anywhere (added in PR #5089) This PR added the new Analytics
* `@collections` does not appear to have been used prior to this PR in any `views` or `presenters`
* getting all collections is very expensive and should be avoided unless really necessary
* if collections are required, it is better to get them from solr instead of the persistent store.  This should be more performant and also enforce permissions if search builders are used.

For all these reasons, setting `@collections` is being removed.

@samvera/hyrax-code-reviewers
