### PR TITLE
fix dashboard/my/collections when default admin set table doesn’t exist

### DIFF
--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -118,7 +118,12 @@ module Hyrax
         return if id.blank?
         Hyrax.query_service.find_by(id: id)
       rescue Valkyrie::Persistence::ObjectNotFoundError
-        # id is saved but doesn't exist
+        # The default ID is DEFAULT_ID when saving is not supported.  It is ok
+        # for this default id to be known but not found.  The admin set will be
+        # created with DEFAULT_ID by find_or_create_default_admin_set.
+        return unless save_default?
+
+        # id is saved in the default_admin_set_persister's table but doesn't exist
         # NOTE: This is a corrupt state and shouldn't happen.  Manual intervention
         #       is required to determine the correct value for the default admin
         #       set id.  The saved id either needs to be updated to the correct
@@ -142,7 +147,7 @@ module Hyrax
       # @return [String | nil] the default admin set id; returns nil if not set
       # @note For general use, it is better to use `Hyrax.config.default_admin_set_id`.
       def default_admin_set_id
-        DEFAULT_ID unless save_default?
+        return DEFAULT_ID unless save_default?
         id = default_admin_set_persister.first&.default_admin_set_id
         id = find_unsaved_default_admin_set&.id&.to_s if id.blank?
         id

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe Hyrax::AdminSetCreateService do
       end
     end
 
+    context "and Hyrax::DefaultAdministrativeSet table does not exist" do
+      before { allow(Hyrax::DefaultAdministrativeSet).to receive(:save_supported?).and_return(false) }
+      it "creates a default admin set with the DEFAULT_ID" do
+        expect(Hyrax::DefaultAdministrativeSet).not_to receive(:first)
+        expect(described_class.find_or_create_default_admin_set.id).to eq described_class::DEFAULT_ID
+      end
+    end
+
     context "when default admin set id is NOT saved in the database" do
       before { allow(Hyrax::DefaultAdministrativeSet).to receive(:count).and_return(0) }
       context "but default admin set does exist" do


### PR DESCRIPTION
### Description

A bug caused the missing table to be checked even after determining that saving the default admin set id wasn’t supported.  It is supposed to be ok for the table to be missing for backward compatibility.

![image](https://user-images.githubusercontent.com/6855473/150391456-8b413f8a-a1a2-4824-969e-b9aaa3cad245.png)

### Solution

The primary cause of the bug was that a return was missing in the method that determines the default admin set id.  It was supposed to return the `DEFAULT_ID` after determining that saving the id was not supported because the table was missing.  

Adding the return of the `DEFAULT_ID` when saving is not supported fixed the first problem and revealed a second problem where after not finding an admin set with the `DEFAULT_ID`, it was throwing an exception.  It is not ok for an admin set not to exist with the saved admin set id, but it is ok for an admin set with the `DEFAULT_ID` not to exist.  When this happens, the default admin set will be created with `id=DEFAULT_ID`.  This missing object exception is now ignored when the `id==DEFAULT_ID`.

@samvera/hyrax-code-reviewers
