### PR TITLE
check solr directly for depositor instead of going through ActiveFedora

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -413,10 +413,8 @@ module Hyrax
     # Returns true if the current user is the depositor of the specified work
     # @param document_id [String] the id of the document.
     def user_is_depositor?(document_id)
-      Hyrax::WorkRelation.new.search_with_conditions(
-        id: document_id,
-        DepositSearchBuilder.depositor_field => current_user.user_key
-      ).any?
+      doc = Hyrax::SolrService.search_by_id(document_id, fl: 'depositor_ssim')
+      current_user.user_key == doc.fetch('depositor_ssim').first
     end
 
     def curation_concerns_models


### PR DESCRIPTION
Fixes #5247

The goal of this code is to determine if the user is the depositor of a specific work.

The code being replaced uses `ActiveFedora::Relation::FinderMethods #search_with_conditions` which calls `#default_sort_params` on the work.  This method is not defined for Valkyrie based works.  The sort param isn't needed to determine if the user is the depositor.

The replacement code checks solr directly to determine if the user is the depositor of the work.  The check is simpler and doesn't have side effects like looking for the default sort parameter when it isn't needed.

@samvera/hyrax-code-reviewers
