### PR TITLE
add @member_docs to assigns for dashboard/collections/show view spec

### DIFF
--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     assign(:presenter, presenter)
     assign(:parent_collection_count, 0)
     assign(:members_count, 0)
+    assign(:member_docs, [])
 
     allow(controller).to receive(:current_ability).and_return(ability)
 


### PR DESCRIPTION
blacklight newly *requires* a `documents` arg for `#render_document_index`.

our controller actually populates this, but this view spec didn't bother before and needs to now.

@samvera/hyrax-code-reviewers
