### PR TITLE
add @member_docs to assigns for admin/admin_sets/show view spec

### DIFF
--- a/spec/views/hyrax/admin/admin_sets/show.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/show.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "hyrax/admin/admin_sets/show.html.erb", type: :view do
     stub_template '_document_list.html.erb' => 'document list'
     stub_template '_paginate.html.erb' => 'paginate'
 
+    assign(:member_docs, [])
     assign(:presenter, presenter)
     render
   end


### PR DESCRIPTION
blacklight newly *requires* a `documents` arg for `#render_document_index`.

our controller actually populates this, but this view spec didn't bother before must do so now.

@samvera/hyrax-code-reviewers
