### PR TITLE
fix #original_file? status for FileMetadata created by ValkyrieIngestJob

### DIFF
--- a/app/jobs/valkyrie_ingest_job.rb
+++ b/app/jobs/valkyrie_ingest_job.rb
@@ -3,13 +3,15 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
   ##
-  # @param [Valkyrie::StorageAdapter::StreamFile] file
+  # @param [Hyrax::UploadedFile] file
   def perform(file)
     ingest(file: file)
   end
 
   ##
-  # @param [Valkyrie::StorageAdapter::StreamFile] file
+  # @api private
+  #
+  # @param [Hyrax::UploadedFile] file
   #
   # @return [void]
   def ingest(file:)
@@ -20,6 +22,8 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
   end
 
   ##
+  # @api private
+  #
   # @todo this should publish something to allow the fileset
   #   to reindex its membership
   # @param [Hyrax::FileSet] file_set the file set to add to
@@ -33,6 +37,8 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
   end
 
   ##
+  # @api private
+  #
   # @param [Hyrax::UploadedFile] file
   # @param [Hyrax::FileSet] file_set
   #
@@ -54,6 +60,8 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
     file_metadata
   end
 
+  ##
+  # @api private
   def find_or_create_metadata(id:, file:)
     Hyrax.custom_queries.find_file_metadata_by(id: id)
   rescue Valkyrie::Persistence::ObjectNotFoundError => e

--- a/app/services/hyrax/work_uploads_handler.rb
+++ b/app/services/hyrax/work_uploads_handler.rb
@@ -165,13 +165,6 @@ module Hyrax
 
     ##
     # @api private
-    # @return [JobIoWrapper]
-    def wrap_file(file, file_set)
-      JobIoWrapper.create_with_varied_file_handling!(user: file.user, file: file, relation: :original_file, file_set: file_set)
-    end
-
-    ##
-    # @api private
     #
     # @note ported from AttachFilesToWorkJob. do we need this? maybe we should
     #   validate something other than type?

--- a/spec/jobs/valkyrie_ingest_job_spec.rb
+++ b/spec/jobs/valkyrie_ingest_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+RSpec.describe ValkyrieIngestJob do
+  let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+  let(:upload) { FactoryBot.create(:uploaded_file, file_set_uri: file_set.id) }
+
+  before do
+    # stub out characterization to avoid system calls
+    characterize = double(run: true)
+    allow(Hyrax.config)
+      .to receive(:characterization_service)
+      .and_return(characterize)
+  end
+
+  describe '.perform_now' do
+    it 'adds an original_file file to the file_set' do
+      described_class.perform_now(upload)
+
+      expect(Hyrax.query_service.find_by(id: file_set.id))
+        .to have_attached_files(be_original_file)
+    end
+
+    context 'with no file_set_uri' do
+      let(:upload) { FactoryBot.create(:uploaded_file) }
+
+      it 'raises an error indicating a missing object' do
+        expect { described_class.perform_now(upload) }
+          .to raise_error Valkyrie::Persistence::ObjectNotFoundError
+      end
+    end
+  end
+end

--- a/spec/support/matchers/pcdm_matchers.rb
+++ b/spec/support/matchers/pcdm_matchers.rb
@@ -12,7 +12,7 @@ RSpec::Matchers.define :have_attached_files do |*expected_files|
     @actual_files = Hyrax.custom_queries.find_files(file_set: actual_file_set)
 
     (expected_files.empty? && @actual_files.any?) ||
-      @actual_files == expected_files
+      values_match?(expected_files, @actual_files)
   end
 
   failure_message_for_should do |actual_file_set|


### PR DESCRIPTION
after the ingest job runs:

  - the metadata should be saved, even if the characterizer didn't save it.
  - the uploaded file should be set as an `#original_file? # => true`

since the file set is created specifically for this uploaded file, we always
want a file uploaded through this process to be THE `#original_file` for the
FileSet.

it's possible we'll want to reuse this ingest job to attach files for other
"uses"/of other types. in this case, we should consider parameterizing the use.

@samvera/hyrax-code-reviewers
