### PR TITLE
Update navbar UI for Bootstrap 4

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -69,7 +69,7 @@ module Hyrax
       unread_notifications = mailbox.unread_count
       link_to(hyrax.notifications_path,
               'aria-label' => mailbox.label(params[:locale]),
-              class: 'notify-number') do
+              class: 'notify-number nav-link') do
         capture do
           concat tag.span('', class: 'fa fa-bell')
           concat "\n"

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,4 +1,3 @@
 <a id="logo" class="navbar-brand" href="<%= hyrax.root_path %>" data-no-turbolink="true">
-  <span class="glyphicon glyphicon-globe" role="img" aria-label="<%= application_name %>" aria-hidden="true"></span>
   <span class="institution_name"><%= application_name %></span>
 </a>

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -2,14 +2,10 @@
   <nav id="masthead" class="navbar navbar-expand-lg navbar-dark bg-dark" role="navigation" aria-label="masthead">
     <h1 class="sr-only"><%= application_name %></h1>
     <%= render '/logo' %>
-    <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
-      <span class="sr-only">Toggle navigation</span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
+    <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
     </button>
-
-    <div class="collapse navbar-collapse" id="top-navbar-collapse">
+    <div class="collapse navbar-collapse justify-content-end" id="top-navbar-collapse">
       <%= render '/user_util_links' %>
     </div>
   </nav>

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -5,23 +5,22 @@
       <%= render_notifications(user: current_user) %>
     </li>
     <li class="nav-item dropdown">
-      <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', class: 'nav-link dropdown-toggle', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false, controls: 'user-util-links' } do %>
+      <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
-        <span class="d-none d-md-block">&nbsp;<%= current_user.name %></span>
+        <span><%= current_user.name %></span>
         <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
-        <span class="fa fa-user" aria-hidden="true"></span>
-      <% end %>
-      <ul id="user-util-links" class="dropdown-menu" role="menu">
-        <li class="dropdown-item"><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
-
-        <li class="dropdown-divider"></li>
-        <li class="dropdown-item"><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
-      </ul>
-    </li><!-- /.btn-group -->
+      </a>
+      <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+        <%= link_to "My Profile", hyrax.dashboard_profile_path(current_user), class: 'dropdown-item' %>
+        <%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path, class: "dropdown-item" %>
+        <div class="dropdown-divider"></div>
+        <%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path, class: "dropdown-item" %>
+      </div>
+    </li>
   <% else %>
     <li class="nav-item">
       <%= link_to main_app.new_user_session_path, class: 'nav-link' do %>
-        <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> <%= t("hyrax.toolbar.profile.login") %>
+        <span class="fa fa-sign-in" aria-hidden="true"></span> <%= t("hyrax.toolbar.profile.login") %>
       <% end %>
     </li>
   <% end %>


### PR DESCRIPTION
Fixes #5335 

Updates nav bar styling and layout.  Now looks like this:

![image](https://user-images.githubusercontent.com/3020266/151023300-9c014d36-3858-4ed8-847b-bf06f7ffb73a.png)


Changes proposed in this pull request:
* Update to Bootstrap 4 convention and some cleanup


@samvera/hyrax-code-reviewers
