### PR TITLE
Always use the custom query and remove a deprecated call

### DIFF
--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -109,10 +109,9 @@ module Hyrax
 
     ##
     # @return [Enumerable<Collection, PcdmCollection>]
-    def collections(use_valkyrie: false)
+    def collections
       return [] unless id
-      return Hyrax.custom_queries.find_collections_by_type(global_id: to_global_id) if use_valkyrie
-      ActiveFedora::Base.where(Hyrax.config.collection_type_index_field.to_sym => to_global_id.to_s)
+      Hyrax.custom_queries.find_collections_by_type(global_id: to_global_id)
     end
 
     ##

--- a/app/views/hyrax/admin/collection_types/index.html.erb
+++ b/app/views/hyrax/admin/collection_types/index.html.erb
@@ -41,7 +41,7 @@
                   <button class="btn btn-danger btn-sm delete-collection-type"
                           data-collection-type="<%= collection_type.to_json %>"
                           data-collection-type-index="<%= hyrax.dashboard_collections_path({ 'f[collection_type_gid_ssim][]' => collection_type.to_global_id.to_s, 'f[has_model_ssim][]' => 'Collection' }) %>"
-                          data-has-collections="<%= collection_type.collections? %>">
+                          data-has-collections="<%= collection_type.collections.any? %>">
                     <%= t('helpers.action.delete') %>
                   </button>
                   <% end %>


### PR DESCRIPTION
I came across this when working on nurax_pg.  After having created a custom collection type and a collection of that type I was blocked from going to the Collection Types index page because it was attempting to call out to ActiveFedora.  The custom query should work so the `use_valkyrie` flag shouldn't be necessary and the `ActiveFedora::Base#where` call can be removed.

Also I changed the call in the index partial to use the non-deprecated approach of `collections.any?` as advised by the deprecation warning on `collections?`

@samvera/hyrax-code-reviewers
