### PR TITLE
add test for published events in ValkyrieIngestJob specs

### DIFF
--- a/spec/jobs/valkyrie_ingest_job_spec.rb
+++ b/spec/jobs/valkyrie_ingest_job_spec.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
+
+require 'hyrax/specs/spy_listener'
+
 RSpec.describe ValkyrieIngestJob do
   let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
   let(:upload) { FactoryBot.create(:uploaded_file, file_set_uri: file_set.id) }
 
+  let(:listener) { Hyrax::Specs::AppendingSpyListener.new }
+
   before do
+    Hyrax.publisher.subscribe(listener)
+
     # stub out characterization to avoid system calls
     characterize = double(run: true)
     allow(Hyrax.config)
@@ -11,12 +18,22 @@ RSpec.describe ValkyrieIngestJob do
       .and_return(characterize)
   end
 
+  after { Hyrax.publisher.unsubscribe(listener) }
+
   describe '.perform_now' do
     it 'adds an original_file file to the file_set' do
       described_class.perform_now(upload)
 
       expect(Hyrax.query_service.find_by(id: file_set.id))
         .to have_attached_files(be_original_file)
+    end
+
+    it 'publishes object.file.uploaded with a FileMetadata' do
+      expect { described_class.perform_now(upload) }
+        .to change { listener.object_file_uploaded.map(&:payload) }
+        .from(be_empty)
+        .to contain_exactly(match(metadata: have_attributes(id: an_instance_of(Valkyrie::ID),
+                                                            original_filename: upload.file.filename)))
     end
 
     context 'with no file_set_uri' do


### PR DESCRIPTION
it's important that this job publish the right events. for now, test that it
publishes for the ingest. this event should have a payload containing the
`FileMetadata` for the new ingest.

it looks like some publishes are missing (e.g. there's a note saying to publish
an update for the FileSet membership change), or incorrectly scoped (the
characterizer publishes a `object.metadata.updated` when it's changing a File's
metadata; in PCDM, Files are not Objects).


@samvera/hyrax-code-reviewers
