### PR TITLE
Change class name for hidden input field

### DIFF
--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -17,7 +17,7 @@
 <% end %>
 
 <%= form_for @contact_form, url: hyrax.contact_form_index_path do |f| %>
-  <%= f.text_field :contact_method, class: 'hide' %>
+  <%= f.text_field :contact_method, class: 'd-none' %>
   <div class="form-group row">
     <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 col-form-label" %>
     <div class="col-sm-10">

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -17,7 +17,7 @@
 <% end %>
 
 <%= form_for @contact_form, url: hyrax.contact_form_index_path do |f| %>
-  <%= f.text_field :contact_method, class: 'd-none' %>
+  <%= f.hidden_field :contact_method %>
   <div class="form-group row">
     <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 col-form-label" %>
     <div class="col-sm-10">


### PR DESCRIPTION
Fixes #5346

Changes proposed in this pull request:
* Use new class name to hide elements in Bootstrap 4 (https://getbootstrap.com/docs/4.0/utilities/display/#hiding-elements) 

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Log into hyrax
* Visit `Contact` page

@samvera/hyrax-code-reviewers
