### PR TITLE
update admin set create process to convert to valkyrie resource when receiving AF adminset

### DIFF
--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -106,7 +106,8 @@ module Hyrax
       updated_admin_set = admin_set_create_service.call!(admin_set: admin_set_resource, creating_user: current_user)
       update_admin_set(updated_admin_set)
       true
-    rescue RuntimeError
+    rescue RuntimeError => err
+      Rails.logger.error("Failed to create admin set through valkyrie: #{err.message}")
       false
     end
 

--- a/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
@@ -202,6 +202,7 @@ RSpec.describe Hyrax::Admin::AdminSetsController do
           end
 
           it 'shows the new form' do
+            expect(Rails.logger).to receive(:error).with(/Failed to create admin set through valkyrie:/)
             post :create, params: { admin_set: { title: 'Test title',
                                                  description: 'test description' } }
             expect(response).to render_template 'new'

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'hyrax/specs/spy_listener'
+
 RSpec.describe Hyrax::AdminSetCreateService do
   let(:user) { FactoryBot.create(:user) }
   let(:persister) { Hyrax.persister }
@@ -203,12 +205,16 @@ RSpec.describe Hyrax::AdminSetCreateService do
       let(:admin_set) { FactoryBot.build(:hyrax_admin_set) }
 
       context "when the admin_set is valid" do
+        let(:listener) { Hyrax::Specs::SpyListener.new }
         let(:permission_template) { Hyrax::PermissionTemplate.find_by(source_id: admin_set.id) }
         let(:grants) { permission_template.access_grants }
         let(:available_workflows) { [create(:workflow), create(:workflow)] }
 
         # rubocop:disable RSpec/AnyInstance
         before do
+          Hyrax.publisher.subscribe(listener)
+          allow_any_instance_of(Hyrax::Listeners::MetadataIndexListener)
+            .to receive(:on_collection_metadata_updated).and_return(available_workflows)
           allow_any_instance_of(Hyrax::PermissionTemplate)
             .to receive(:available_workflows).and_return(available_workflows)
           allow(Sipity::Workflow)
@@ -220,10 +226,17 @@ RSpec.describe Hyrax::AdminSetCreateService do
         end
         # rubocop:enable RSpec/AnyInstance
 
+        after { Hyrax.publisher.unsubscribe(listener) }
+
         it 'creates the admin set' do
           updated_admin_set = service.create!
           expect(updated_admin_set).to be_kind_of Hyrax::AdministrativeSet
           expect(updated_admin_set.persisted?).to be true
+        end
+
+        it 'publishes a change to collection metadata' do
+          expect { service.create! }
+            .to change { listener.collection_metadata_updated&.payload }
         end
 
         it 'sets creator' do

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -213,8 +213,6 @@ RSpec.describe Hyrax::AdminSetCreateService do
         # rubocop:disable RSpec/AnyInstance
         before do
           Hyrax.publisher.subscribe(listener)
-          allow_any_instance_of(Hyrax::Listeners::MetadataIndexListener)
-            .to receive(:on_collection_metadata_updated).and_return(available_workflows)
           allow_any_instance_of(Hyrax::PermissionTemplate)
             .to receive(:available_workflows).and_return(available_workflows)
           allow(Sipity::Workflow)


### PR DESCRIPTION
Fixes #5334

To move closer to full Valkyrization, this refactors the AdminSetControllerto always convert `@admin_set` to a `Hyrax::AdministrativeSet` which is a `Valkyrie::Resource` before performing actions or calling other classes (e.g. `Hyrax::AdminSetCreateService`).

The create service was refactored to internally perform a conversion to `Hyrax::AdministrativeSet` if it received an ActiveFedora `AdminSet`.  This allowed removal of special processing depending on the type.  It already only returned a `Hyrax::AdministrativeSet`.  And the deprecated method `.call` still continues to allow `AdminSet` as a parameter.  These allow for backward compatibility.

@samvera/hyrax-code-reviewers
