### PR TITLE
Update Bootstrap nav-tabs class structure

### DIFF
--- a/app/views/hyrax/admin/admin_sets/_form.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form.html.erb
@@ -1,8 +1,8 @@
     <%= render 'shared/nav_safety_modal' %>
     <div class="card tabs" id="admin-set-controls">
       <ul class="nav nav-tabs" role="tablist">
-        <li class="nav-item active">
-          <a href="#description" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t('.tabs.description') %></a>
+        <li class="nav-item">
+          <a href="#description" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm"><%= t('.tabs.description') %></a>
         </li>
         <% if @form.persisted? %>
           <li class="nav-item">
@@ -17,7 +17,7 @@
         <% end %>
       </ul>
       <div class="tab-content">
-        <div id="description" class="tab-pane active">
+        <div id="description" class="tab-pane show active">
           <div class="card labels">
             <%= simple_form_for @form, url: [hyrax, :admin, @form], html: { class: 'nav-safety' } do |f| %>
               <div class="card-body">

--- a/app/views/hyrax/admin/collection_types/_form.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form.html.erb
@@ -1,8 +1,8 @@
 <%= render "shared/nav_safety_modal" %>
 <div class="card tabs" id="collection-types-controls">
   <ul class="nav nav-tabs" role="tablist">
-    <li class="active nav-item">
-      <a href="#metadata" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t('hyrax.admin.collection_types.form.tab.metadata') %></a>
+    <li class="nav-item">
+      <a href="#metadata" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm"><%= t('hyrax.admin.collection_types.form.tab.metadata') %></a>
     </li>
     <% if @form.persisted? %>
       <li class="nav-item">
@@ -20,7 +20,7 @@
   <%= simple_form_for @form, url: form_url, as: :collection_type, html: {class: 'nav-safety'} do |f| %>
     <div class="tab-content">
       <% if @collection_type.admin_set? %>
-        <div id="metadata" class="tab-pane active">
+        <div id="metadata" class="tab-pane show active">
           <div class="card labels">
             <div class="card-body">
               <%= render 'form_metadata_admin_set', f: f %>
@@ -28,7 +28,7 @@
           </div>
         </div>
       <% else %>
-        <div id="metadata" class="tab-pane active">
+        <div id="metadata" class="tab-pane show active">
           <div class="card labels">
             <div class="card-body">
               <%= render 'form_metadata', f: f %>

--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -6,15 +6,15 @@
   <div class="col-md-12">
     <div class="card tabs">
       <ul class="nav nav-tabs" role="tablist">
-        <li class="nav-item active">
-          <a class="nav-link" href="#under-review" role="tab" data-toggle="tab"><%= t('.tabs.under_review') %></a>
+        <li class="nav-item">
+          <a class="nav-link active" href="#under-review" role="tab" data-toggle="tab"><%= t('.tabs.under_review') %></a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="#published" role="tab" data-toggle="tab"><%= t('.tabs.published') %></a>
         </li>
       </ul>
       <div class="tab-content">
-        <div id="under-review" class="tab-pane active">
+        <div id="under-review" class="tab-pane show active">
           <div class="card labels">
             <div class="card-body">
               <div class="table-responsive">

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -5,15 +5,11 @@
       <!-- Nav tabs -->
       <ul class="nav nav-tabs" role="tablist">
         <% (tabs - ['share']).each_with_index do | tab, i | %>
-          <% if i == 0 %>
-            <li role="presentation" class="nav-item active">
-          <% else %>
-            <li role="presentation" class="nav-item">
-          <% end %>
-              <a class="nav-link" href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
-                <%= form_tab_label_for(form: f.object, tab: tab) %>
-              </a>
-            </li>
+          <li role="presentation" class="nav-item">
+            <a class="nav-link <% if i == 0 %>active<% end %>" href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
+              <%= form_tab_label_for(form: f.object, tab: tab) %>
+            </a>
+          </li>
         <% end %>
 
         <li role="presentation" id="tab-share" class="nav-item" hidden="">
@@ -26,11 +22,7 @@
       <!-- Tab panes -->
       <div class="tab-content">
         <% (tabs - ['share']).each_with_index do | tab, i | %>
-          <% if i == 0 %>
-            <div role="tabpanel" class="tab-pane active" id="<%= tab %>">
-          <% else %>
-            <div role="tabpanel" class="tab-pane" id="<%= tab %>">
-          <% end %>
+          <div role="tabpanel" class="tab-pane <% if i == 0 %>show active<% end %>" id="<%= tab %>">
             <div class="form-tab-content">
               <% # metadata_tab is sometimes provided %>
               <%= yield "#{tab}_tab".to_sym if content_for? "#{tab}_tab".to_sym %>

--- a/app/views/hyrax/batch_edits/edit.html.erb
+++ b/app/views/hyrax/batch_edits/edit.html.erb
@@ -9,12 +9,20 @@
   <h3><%= t('.descriptions_title') %></h3>
   <div class="card tabs">
     <ul class="nav nav-tabs">
-      <li id="edit_descriptions_link" class="nav-item active"><a class="nav-link" href="#descriptions_display" data-toggle="tab"><span class="glyphicon glyphicon-tags"></span> <%= t('.descriptions') %></a></li>
-      <li id="edit_permissions_link" class="nav-item"><a class="nav-link" href="#permissions_display" data-toggle="tab"><span class="glyphicon glyphicon-lock"></span> <%= t('.permissions') %></a></li>
+      <li id="edit_descriptions_link" class="nav-item">
+        <a class="nav-link active" href="#descriptions_display" data-toggle="tab">
+          <span class="glyphicon glyphicon-tags"></span> <%= t('.descriptions') %>
+        </a>
+      </li>
+      <li id="edit_permissions_link" class="nav-item">
+        <a class="nav-link" href="#permissions_display" data-toggle="tab">
+          <span class="glyphicon glyphicon-lock"></span> <%= t('.permissions') %>
+        </a>
+      </li>
     </ul>
     <div class="card-body">
       <div class="tab-content">
-        <div class="tab-pane active" id="descriptions_display">
+        <div class="tab-pane show active" id="descriptions_display">
           <% @form.terms.each do |term| %>
             <div class="row">
               <%= simple_form_for @form,

--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -1,18 +1,24 @@
 <%= render "shared/nav_safety_modal" %>
 <div class="card tabs">
   <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item active">
-      <a href="#announcement_text" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.announcement_text') %></a>
+    <li class="nav-item">
+      <a href="#announcement_text" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm">
+        <%= t(:'hyrax.content_blocks.tabs.announcement_text') %>
+      </a>
     </li>
     <li class="nav-item">
-      <a href="#marketing" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.marketing_text') %></a>
+      <a href="#marketing" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+        <%= t(:'hyrax.content_blocks.tabs.marketing_text') %>
+      </a>
     </li>
     <li class="nav-item">
-      <a href="#researcher" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.featured_researcher') %></a>
+      <a href="#researcher" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+        <%= t(:'hyrax.content_blocks.tabs.featured_researcher') %>
+      </a>
     </li>
   </ul>
   <div class="tab-content">
-    <div id="announcement_text" class="tab-pane active">
+    <div id="announcement_text" class="tab-pane show active">
       <div class="card labels">
         <%= simple_form_for ContentBlock.for(:announcement), url: hyrax.content_block_path(ContentBlock.for(:announcement)), html: {class: 'nav-safety'} do |f| %>
           <div class="card-body">

--- a/app/views/hyrax/dashboard/_tabs.html.erb
+++ b/app/views/hyrax/dashboard/_tabs.html.erb
@@ -1,11 +1,15 @@
 <!-- Nav tabs -->
 <ul class="nav nav-tabs" role="tablist">
-  <li role="presentation" class="active nav-item"><a class="nav-link" href="#admin_sets" aria-selected="true" role="tab" data-toggle="tab"><%= t('.admin_sets') %></a></li>
+  <li role="presentation" class="nav-item">
+    <a class="nav-link active" href="#admin_sets" aria-selected="true" role="tab" data-toggle="tab">
+      <%= t('.admin_sets') %>
+      </a>
+    </li>
 </ul>
 
 <!-- Tab panes -->
 <div class="tab-content">
-  <div role="tabpanel" class="tab-pane active" id="admin_sets">
+  <div role="tabpanel" class="tab-pane show active" id="admin_sets">
     <%= render 'admin_sets' %>
   </div>
 </div>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -1,23 +1,31 @@
 <%= render "shared/nav_safety_modal" %>
 <div class="card tabs" id="collection-edit-controls">
   <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item active">
-      <a href="#description" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t('.tabs.description') %></a>
+    <li class="nav-item">
+      <a href="#description" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm">
+        <%= t('.tabs.description') %>
+      </a>
     </li>
     <% if @form.persisted? %>
       <% if collection_brandable?(collection: @collection) %>
       <li class="nav-item">
-        <a href="#branding" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t('.tabs.branding') %></a>
+        <a href="#branding" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+          <%= t('.tabs.branding') %>
+        </a>
       </li>
       <% end %>
       <% if collection_discoverable?(collection: @collection) %>
       <li class="nav-item">
-        <a href="#discovery" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t('.tabs.discovery') %></a>
+        <a href="#discovery" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+          <%= t('.tabs.discovery') %>
+        </a>
       </li>
       <% end %>
       <% if collection_sharable?(collection: @collection) %>
       <li class="nav-item">
-        <a href="#sharing" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t('.tabs.sharing') %></a>
+        <a href="#sharing" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+          <%= t('.tabs.sharing') %>
+        </a>
       </li>
       <% end %>
     <% end %>
@@ -25,7 +33,7 @@
 
   <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor nav-safety' } do |f| %>
     <div class="tab-content">
-      <div id="description" class="tab-pane active">
+      <div id="description" class="tab-pane show active">
         <div class="card labels">
           <div class="card-body">
 

--- a/app/views/hyrax/embargoes/index.html.erb
+++ b/app/views/hyrax/embargoes/index.html.erb
@@ -4,13 +4,25 @@
 
 <div class="card tabs">
   <ul class="nav nav-tabs">
-    <li class="nav-item active"><a class="nav-link" href="#active" data-toggle="tab"><%= t('.active') %></a></li>
-    <li class="nav-item"><a class="nav-link" href="#expired" data-toggle="tab"><%= t('.expired') %></a></li>
-    <li class="nav-item"><a class="nav-link" href="#deactivated" data-toggle="tab"><%= t('.deactivated') %></a></li>
+    <li class="nav-item">
+      <a class="nav-link active" href="#active" data-toggle="tab">
+        <%= t('.active') %>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#expired" data-toggle="tab">
+        <%= t('.expired') %>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#deactivated" data-toggle="tab">
+        <%= t('.deactivated') %>
+      </a>
+    </li>
   </ul>
   <div class="card-body">
     <div class="tab-content">
-      <div class="tab-pane active" id="active">
+      <div class="tab-pane show active" id="active">
         <%= render "list_active_embargoes" %>
       </div>
       <div class="tab-pane" id="expired">

--- a/app/views/hyrax/file_sets/edit.html.erb
+++ b/app/views/hyrax/file_sets/edit.html.erb
@@ -11,19 +11,25 @@
   <div class="col-12 col-sm-8">
     <div class="card tabs">
       <ul class="nav nav-tabs" role="tablist">
-        <li id="edit_descriptions_link" class="nav-item active">
-          <a href="#descriptions_display" data-toggle="tab" class="nav-link nav-safety-confirm"><i class="fa fa-tags" aria-hidden="true"></i></span> <%= t('.descriptions') %></a>
+        <li id="edit_descriptions_link" class="nav-item">
+          <a href="#descriptions_display" data-toggle="tab" class="nav-link active nav-safety-confirm">
+            <i class="fa fa-tags" aria-hidden="true"></i> <%= t('.descriptions') %>
+          </a>
         </li>
         <li id="edit_versioning_link" class="nav-item">
-          <a href="#versioning_display" data-toggle="tab" class="nav-link nav-safety-confirm"><i class="fa fa-sitemap" aria-hidden="true"></i> <%= t('.versions') %></a>
+          <a href="#versioning_display" data-toggle="tab" class="nav-link nav-safety-confirm">
+            <i class="fa fa-sitemap" aria-hidden="true"></i> <%= t('.versions') %>
+          </a>
         </li>
         <li id="edit_permissions_link" class="nav-item">
-          <a href="#permissions_display" data-toggle="tab" class="nav-link nav-safety-confirm"><i class="fa fa-key" aria-hidden="true"></i> <%= t('.permissions') %></a>
+          <a href="#permissions_display" data-toggle="tab" class="nav-link nav-safety-confirm">
+            <i class="fa fa-key" aria-hidden="true"></i> <%= t('.permissions') %>
+          </a>
         </li>
       </ul>
       <div class="card-body">
         <div class="tab-content">
-          <div id="descriptions_display" class="tab-pane active">
+          <div id="descriptions_display" class="tab-pane show active">
             <h2><%= t('.descriptions') %></h2>
             <%= render "form" %>
           </div>

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -1,27 +1,41 @@
 <div class="col-sm-6">
   <ul id="homeTabs" class="nav nav-tabs" role="list">
-    <li class="nav-itemactive"><a class="nav-link" href="#featured_container" data-toggle="tab" id="featureTab"><%= t('hyrax.homepage.featured_works.tab_label') %></a></li>
-    <li class="nav-item"><a class="nav-link" href="#recently_uploaded" data-toggle="tab" id="recentTab"><%= t('hyrax.homepage.recently_uploaded.tab_label') %></a></li>
+    <li class="nav-item">
+      <a class="nav-link active" href="#featured_container" data-toggle="tab" id="featureTab">
+        <%= t('hyrax.homepage.featured_works.tab_label') %>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#recently_uploaded" data-toggle="tab" id="recentTab">
+        <%= t('hyrax.homepage.recently_uploaded.tab_label') %>
+      </a>
+    </li>
   </ul>
   <div class="tab-content">
-    <div class="tab-pane fade in active" id="featured_container" role="tabpanel" aria-labelledby="featureTab">
+    <div class="tab-pane show active" id="featured_container" role="tabpanel" aria-labelledby="featureTab">
       <%= render 'featured_works' %>
     </div>
-    <div class="tab-pane fade" id="recently_uploaded" role="tabpanel" aria-labelledby="recentTab">
+    <div class="tab-pane" id="recently_uploaded" role="tabpanel" aria-labelledby="recentTab">
       <%= render 'recently_uploaded', recent_documents: @recent_documents %>
     </div>
   </div>
-</div><!-- /.col-sm-6 -->
+</div>
 
 <div class="col-sm-6">
-
   <ul class="nav nav-tabs" role="list">
-    <li class="nav-item active"><a class="nav-item" aria-expanded="true" href="#tab-col2-first" data-toggle="tab"><%= t('hyrax.homepage.admin_sets.title') %></a></li>
-    <li class="nav-item"><a class="nav-item" aria-expanded="false" href="#tab-col2-second" data-toggle="tab"><%= t('hyrax.homepage.featured_researcher.tab_label') %></a></li>
+    <li class="nav-item">
+      <a class="nav-link active" aria-expanded="true" href="#tab-col2-first" data-toggle="tab">
+        <%= t('hyrax.homepage.admin_sets.title') %>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" aria-expanded="false" href="#tab-col2-second" data-toggle="tab">
+        <%= t('hyrax.homepage.featured_researcher.tab_label') %>
+      </a>
+    </li>
   </ul>
-
   <div class="tab-content">
-    <div class="tab-pane active" id="tab-col2-first">
+    <div class="tab-pane show active" id="tab-col2-first">
       <h2 class="sr-only"><%= t('hyrax.homepage.admin_sets.title') %></h2>
       <%= render 'explore_collections', collections: @presenter.collections %>
     </div>

--- a/app/views/hyrax/leases/index.html.erb
+++ b/app/views/hyrax/leases/index.html.erb
@@ -4,13 +4,25 @@
 
 <div class="card tabs">
   <ul class="nav nav-tabs">
-    <li class="active nav-item"><a class="nav-link" href="#active" data-toggle="tab"><%= t('.active') %></a></li>
-    <li class="nav-item"><a class="nav-link" href="#expired" data-toggle="tab"><%= t('.expired') %></a></li>
-    <li class="nav-item"><a class="nav-link" href="#deactivated" data-toggle="tab"><%= t('.deactivated') %></a></li>
+    <li class="nav-item">
+      <a class="nav-link active" href="#active" data-toggle="tab">
+        <%= t('.active') %>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#expired" data-toggle="tab">
+        <%= t('.expired') %>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#deactivated" data-toggle="tab">
+        <%= t('.deactivated') %>
+      </a>
+    </li>
   </ul>
   <div class="card-body">
     <div class="tab-content">
-      <div class="tab-pane active" id="active">
+      <div class="tab-pane show active" id="active">
         <%= render "list_active_leases" %>
       </div>
       <div class="tab-pane" id="expired">

--- a/app/views/hyrax/my/collections/_tabs.html.erb
+++ b/app/views/hyrax/my/collections/_tabs.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-tabs" id="my_nav" role="navigation">
   <li<%= ' class="nav-item"'.html_safe if current_page?(hyrax.dashboard_collections_path(locale: nil)) %>>
-    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.collections"), hyrax.dashboard_collections_path, class: "nav-link active" %>
+    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.collections"), hyrax.dashboard_collections_path, class: "nav-link" %>
   </li>
   <li<%= ' class="nav-item"'.html_safe if current_page?(hyrax.my_collections_path(locale: nil)) %>>
     <%= link_to t('hyrax.dashboard.my.your_collections'), hyrax.my_collections_path, class: "nav-link active" %>

--- a/app/views/hyrax/my/collections/_tabs.html.erb
+++ b/app/views/hyrax/my/collections/_tabs.html.erb
@@ -1,8 +1,8 @@
 <ul class="nav nav-tabs" id="my_nav" role="navigation">
-  <li<%= ' class="nav-item active"'.html_safe if current_page?(hyrax.dashboard_collections_path(locale: nil)) %>>
-    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.collections"), hyrax.dashboard_collections_path, class: "nav-link" %>
+  <li<%= ' class="nav-item"'.html_safe if current_page?(hyrax.dashboard_collections_path(locale: nil)) %>>
+    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.collections"), hyrax.dashboard_collections_path, class: "nav-link active" %>
   </li>
-  <li<%= ' class="nav-item active"'.html_safe if current_page?(hyrax.my_collections_path(locale: nil)) %>>
-    <%= link_to t('hyrax.dashboard.my.your_collections'), hyrax.my_collections_path, class: "nav-link" %>
+  <li<%= ' class="nav-item"'.html_safe if current_page?(hyrax.my_collections_path(locale: nil)) %>>
+    <%= link_to t('hyrax.dashboard.my.your_collections'), hyrax.my_collections_path, class: "nav-link active" %>
   </li>
 </ul>

--- a/app/views/hyrax/my/works/_tabs.html.erb
+++ b/app/views/hyrax/my/works/_tabs.html.erb
@@ -1,8 +1,8 @@
 <ul class="nav nav-tabs" id="my_nav" role="list">
-  <li<%= ' class="nav-item active"'.html_safe if current_page?(hyrax.dashboard_works_path(locale: nil)) %>>
-    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.works"), hyrax.dashboard_works_path, class: "nav-link" %>
+  <li<%= ' class="nav-item"'.html_safe if current_page?(hyrax.dashboard_works_path(locale: nil)) %>>
+    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.works"), hyrax.dashboard_works_path, class: "nav-link active" %>
   </li>
-  <li<%= ' class="nav-item active"'.html_safe if current_page?(hyrax.my_works_path(locale: nil)) %>>
-    <%= link_to t('hyrax.dashboard.my.your_works'), hyrax.my_works_path, class: "nav-link" %>
+  <li<%= ' class="nav-item"'.html_safe if current_page?(hyrax.my_works_path(locale: nil)) %>>
+    <%= link_to t('hyrax.dashboard.my.your_works'), hyrax.my_works_path, class: "nav-link active" %>
   </li>
 </ul>

--- a/app/views/hyrax/my/works/_tabs.html.erb
+++ b/app/views/hyrax/my/works/_tabs.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-tabs" id="my_nav" role="list">
   <li<%= ' class="nav-item"'.html_safe if current_page?(hyrax.dashboard_works_path(locale: nil)) %>>
-    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.works"), hyrax.dashboard_works_path, class: "nav-link active" %>
+    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.works"), hyrax.dashboard_works_path, class: "nav-link" %>
   </li>
   <li<%= ' class="nav-item"'.html_safe if current_page?(hyrax.my_works_path(locale: nil)) %>>
     <%= link_to t('hyrax.dashboard.my.your_works'), hyrax.my_works_path, class: "nav-link active" %>

--- a/app/views/hyrax/pages/_form.html.erb
+++ b/app/views/hyrax/pages/_form.html.erb
@@ -1,83 +1,95 @@
 <%= render "shared/nav_safety_modal" %>
 <div class="card tabs">
+
   <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item active">
-      <a href="#about" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t(:'hyrax.pages.tabs.about_page') %></a>
+    <li class="nav-item">
+      <a href="#about" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm">
+        <%= t(:'hyrax.pages.tabs.about_page') %>
+      </a>
     </li>
     <li class="nav-item">
-      <a href="#help" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t(:'hyrax.pages.tabs.help_page') %></a>
+      <a href="#help" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+        <%= t(:'hyrax.pages.tabs.help_page') %>
+      </a>
     </li>
     <li class="nav-item">
-      <a href="#agreement" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t(:'hyrax.pages.tabs.agreement_page') %></a>
+      <a href="#agreement" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+        <%= t(:'hyrax.pages.tabs.agreement_page') %>
+      </a>
     </li>
     <li class="nav-item">
-      <a href="#terms" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t(:'hyrax.pages.tabs.terms_page') %></a>
+      <a href="#terms" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+        <%= t(:'hyrax.pages.tabs.terms_page') %>
+      </a>
     </li>
   </ul>
+
   <div class="tab-content">
-  <div id="about" class="tab-pane active">
-    <div class="card labels">
-      <%= simple_form_for ContentBlock.for(:about), url: hyrax.page_path(ContentBlock.for(:about)), html: { class: 'nav-safety' } do |f| %>
-        <div class="card-body">
-          <div class="field form-group">
-              <%= f.label :about %><br />
-              <%= f.text_area :about, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+    <div id="about" class="tab-pane show active">
+      <div class="card labels">
+        <%= simple_form_for ContentBlock.for(:about), url: hyrax.page_path(ContentBlock.for(:about)), html: { class: 'nav-safety' } do |f| %>
+          <div class="card-body">
+            <div class="field form-group">
+                <%= f.label :about %><br />
+                <%= f.text_area :about, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
           </div>
-        </div>
-        <div class="card-footer">
-          <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
-          <%= f.button :submit, class: 'btn btn-primary float-right' %>
-        </div>
-      <% end %>
+          <div class="card-footer">
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
+            <%= f.button :submit, class: 'btn btn-primary float-right' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="help" class="tab-pane">
+      <div class="card labels">
+        <%= simple_form_for ContentBlock.for(:help), url: hyrax.page_path(ContentBlock.for(:help)), html: { class: 'nav-safety' } do |f| %>
+          <div class="card-body">
+            <div class="field form-group">
+                <%= f.label :help %><br />
+                <%= f.text_area :help, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="card-footer">
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
+            <%= f.button :submit, class: 'btn btn-primary float-right' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="agreement" class="tab-pane">
+      <div class="card labels">
+        <%= simple_form_for ContentBlock.for(:agreement), url: hyrax.page_path(ContentBlock.for(:agreement)), html: { class: 'nav-safety' } do |f| %>
+          <div class="card-body">
+            <div class="field form-group">
+                <%= f.label :agreement %><br />
+                <%= f.text_area :agreement, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="card-footer">
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
+            <%= f.button :submit, class: 'btn btn-primary float-right' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="terms" class="tab-pane">
+      <div class="card labels">
+        <%= simple_form_for ContentBlock.for(:terms), url: hyrax.page_path(ContentBlock.for(:terms)), html: { class: 'nav-safety' } do |f| %>
+          <div class="card-body">
+            <div class="field form-group">
+                <%= f.label :terms %><br />
+                <%= f.text_area :terms, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="card-footer">
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
+            <%= f.button :submit, class: 'btn btn-primary float-right' %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
-  <div id="help" class="tab-pane">
-    <div class="card labels">
-      <%= simple_form_for ContentBlock.for(:help), url: hyrax.page_path(ContentBlock.for(:help)), html: { class: 'nav-safety' } do |f| %>
-        <div class="card-body">
-          <div class="field form-group">
-              <%= f.label :help %><br />
-              <%= f.text_area :help, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
-          </div>
-        </div>
-        <div class="card-footer">
-          <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
-          <%= f.button :submit, class: 'btn btn-primary float-right' %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-  <div id="agreement" class="tab-pane">
-    <div class="card labels">
-      <%= simple_form_for ContentBlock.for(:agreement), url: hyrax.page_path(ContentBlock.for(:agreement)), html: { class: 'nav-safety' } do |f| %>
-        <div class="card-body">
-          <div class="field form-group">
-              <%= f.label :agreement %><br />
-              <%= f.text_area :agreement, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
-          </div>
-        </div>
-        <div class="card-footer">
-          <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
-          <%= f.button :submit, class: 'btn btn-primary float-right' %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-  <div id="terms" class="tab-pane">
-    <div class="card labels">
-      <%= simple_form_for ContentBlock.for(:terms), url: hyrax.page_path(ContentBlock.for(:terms)), html: { class: 'nav-safety' } do |f| %>
-        <div class="card-body">
-          <div class="field form-group">
-              <%= f.label :terms %><br />
-              <%= f.text_area :terms, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
-          </div>
-        </div>
-        <div class="card-footer">
-          <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
-          <%= f.button :submit, class: 'btn btn-primary float-right' %>
-        </div>
-      <% end %>
-    </div>
-  </div>
+
 </div>
 <%= tinymce :content_block %>

--- a/app/views/hyrax/users/_activity.html.erb
+++ b/app/views/hyrax/users/_activity.html.erb
@@ -1,3 +1,3 @@
-        <div class="tab-pane" id="activity_log">
-          <%= render 'hyrax/users/activity_log', events: presenter.events %>
-        </div>
+<div class="tab-pane" id="activity_log">
+  <%= render 'hyrax/users/activity_log', events: presenter.events %>
+</div>

--- a/app/views/hyrax/users/_contributions.html.erb
+++ b/app/views/hyrax/users/_contributions.html.erb
@@ -1,4 +1,4 @@
-<div class="tab-pane active" id="contributions">
+<div class="tab-pane show active" id="contributions">
   <% if presenter.trophies.count > 0 %>
     <table>
       <% presenter.trophies.each do |t| %>

--- a/app/views/hyrax/users/_profile_tabs.html.erb
+++ b/app/views/hyrax/users/_profile_tabs.html.erb
@@ -1,9 +1,17 @@
-      <ul class="nav nav-tabs" id="myTab">
-        <li class="nav-item active"><a class="nav-link" href="#contributions"><span class="glyphicon glyphicon-star"></span> <%= I18n.t('hyrax.user_profile.tab_highlighted') %></a></li>
-        <li class="nav-item"><a class="nav-link" href="#activity_log"><span class="glyphicon glyphicon-calendar"></span> <%= I18n.t('hyrax.user_profile.tab_activity') %></a></li>
-      </ul>
+<ul class="nav nav-tabs" id="myTab">
+  <li class="nav-item">
+    <a class="nav-link active" href="#contributions">
+      <span class="glyphicon glyphicon-star"></span> <%= I18n.t('hyrax.user_profile.tab_highlighted') %>
+    </a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#activity_log">
+      <span class="glyphicon glyphicon-calendar"></span> <%= I18n.t('hyrax.user_profile.tab_activity') %>
+    </a>
+  </li>
+</ul>
 
-      <div class="tab-content card-body">
-        <%= render 'contributions', presenter: presenter %>
-        <%= render 'activity', presenter: presenter %>
-      </div> <!-- /tab-content -->
+<div class="tab-content card-body">
+  <%= render 'contributions', presenter: presenter %>
+  <%= render 'activity', presenter: presenter %>
+</div> <!-- /tab-content -->


### PR DESCRIPTION
Fixes #5336 ; refs #5276

## Summary

This PR reworks class structure throughout the codebase for Bootstrap `.nav-tabs` and the `.tab-panes` they control according to [Bootstrap 4 documentation](https://getbootstrap.com/docs/4.6/components/navs/#javascript-behavior).

Most changes across involve moving the `.active` class to the child anchor `.nav-link` and adding the `.show` class to the active `.tab-pane`. Some other minor adjustments were made to clean up `if` statements wrapping `.tabs`. 

![image](https://user-images.githubusercontent.com/7376450/151195571-d246ca8c-b192-4012-8909-c2abaffbb177.png)

## Changes proposed in this pull request:
* Adjust `.nav-tabs` and `.tab-panes` class structure throughout views.

## Guidance for testing, such as acceptance criteria or new user interface behaviors:
The best way to review this may be review these changes from the perspective of code review and not necessarily verify from the interface side.
