### PR TITLE
Add placeholder stylesheet for adjusting font-size globally

### DIFF
--- a/app/assets/stylesheets/hyrax/_html.scss
+++ b/app/assets/stylesheets/hyrax/_html.scss
@@ -1,0 +1,11 @@
+/*
+ * Bootstrap 4 has increased global font-size from 14px to 1rem, computed 
+ * by modern browsers as 16px. This can be reset by overriding the html
+ * selector and adding the property/value of `font-size: 14px;`.
+ *
+ * See https://getbootstrap.com/docs/4.0/migration/ for more information.
+ */
+
+html {
+  font-size: inherit;
+}

--- a/app/assets/stylesheets/hyrax/_hyrax.scss
+++ b/app/assets/stylesheets/hyrax/_hyrax.scss
@@ -1,17 +1,18 @@
-@import 'hyrax/variables', 'hyrax/file_sets', 'hyrax/settings', 'hyrax/header',
-  'hyrax/styles', 'hyrax/file-listing', 'hyrax/browse_everything_overrides',
-  'hyrax/nestable', 'hyrax/collections', 'hyrax/collection_types',
-  'hyrax/batch-edit', 'hyrax/home-page', 'hyrax/featured', 'hyrax/usage-stats',
-  'hyrax/catalog', 'hyrax/buttons', 'hyrax/tinymce', 'hyrax/proxy-rights',
-  'hyrax/file-show', 'hyrax/work-show', 'hyrax/modal', 'hyrax/forms',
-  'hyrax/form', 'hyrax/file_manager', 'hyrax/form-progress', 'hyrax/positioning',
-  'hyrax/fixedsticky', 'hyrax/file_upload', 'hyrax/representative-media',
-  'hyrax/footer', 'hyrax/select_work_type', 'hyrax/users', 'hyrax/dashboard',
-  'hyrax/sidebar', 'hyrax/controlled_vocabulary', 'hyrax/accessibility',
-  'hyrax/recent', 'hyrax/viewer', 'hyrax/breadcrumbs';
-@import 'hydra-editor/multi_value_fields';
-@import 'typeahead';
-@import 'sharing_buttons';
+@import "hyrax/variables", "hyrax/file_sets", "hyrax/settings", "hyrax/html",
+  "hyrax/header", "hyrax/styles", "hyrax/file-listing",
+  "hyrax/browse_everything_overrides", "hyrax/nestable", "hyrax/collections",
+  "hyrax/collection_types", "hyrax/batch-edit", "hyrax/home-page",
+  "hyrax/featured", "hyrax/usage-stats", "hyrax/catalog", "hyrax/buttons",
+  "hyrax/tinymce", "hyrax/proxy-rights", "hyrax/file-show", "hyrax/work-show",
+  "hyrax/modal", "hyrax/forms", "hyrax/form", "hyrax/file_manager",
+  "hyrax/form-progress", "hyrax/positioning", "hyrax/fixedsticky",
+  "hyrax/file_upload", "hyrax/representative-media", "hyrax/footer",
+  "hyrax/select_work_type", "hyrax/users", "hyrax/dashboard", "hyrax/sidebar",
+  "hyrax/controlled_vocabulary", "hyrax/accessibility", "hyrax/recent",
+  "hyrax/viewer", "hyrax/breadcrumbs";
+@import "hydra-editor/multi_value_fields";
+@import "typeahead";
+@import "sharing_buttons";
 
 /* This class is to workaround an issue in which Bootstrap requires a div to display a tooltip
  * on a disabled button. Using a span instead of a div would be ideal but unfortunately it does


### PR DESCRIPTION
Fixes #5340  ; refs #5276 

## Summary

Bootstrap 4 has increased global font-size from 14px to 1rem, computed  by modern browsers as 16px. This pull request provides minimal guidance to Hyrax developers on how to reset font-size. 

See https://getbootstrap.com/docs/4.0/migration/ for more information.
