### PR TITLE
Test returning of pcdm_collections

### DIFF
--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -109,9 +109,9 @@ module Hyrax
 
     ##
     # @return [Enumerable<Collection, PcdmCollection>]
-    def collections(use_valkyrie: false)
+    def collections(use_valkyrie: Hyrax.config.use_valkyrie?)
       return [] unless id
-      return Hyrax.custom_queries.find_collections_by_type(global_id: to_global_id) if use_valkyrie
+      return Hyrax.custom_queries.find_collections_by_type(global_id: to_global_id.to_s) if use_valkyrie
       ActiveFedora::Base.where(Hyrax.config.collection_type_index_field.to_sym => to_global_id.to_s)
     end
 

--- a/app/views/hyrax/admin/collection_types/index.html.erb
+++ b/app/views/hyrax/admin/collection_types/index.html.erb
@@ -41,7 +41,7 @@
                   <button class="btn btn-danger btn-sm delete-collection-type"
                           data-collection-type="<%= collection_type.to_json %>"
                           data-collection-type-index="<%= hyrax.dashboard_collections_path({ 'f[collection_type_gid_ssim][]' => collection_type.to_global_id.to_s, 'f[has_model_ssim][]' => 'Collection' }) %>"
-                          data-has-collections="<%= collection_type.collections? %>">
+                          data-has-collections="<%= collection_type.collections.any? %>">
                     <%= t('helpers.action.delete') %>
                   </button>
                   <% end %>

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -170,16 +170,28 @@ RSpec.describe Hyrax::CollectionType, type: :model do
   end
 
   describe "collections" do
-    let!(:collection) { FactoryBot.create(:collection_lw, collection_type_gid: collection_type.gid.to_s) }
     let(:collection_type) { FactoryBot.create(:collection_type) }
 
-    it 'returns collections of this collection type' do
-      expect(collection_type.collections.to_a).to include collection
-    end
-
     it 'returns empty array if gid is nil' do
+      valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id.to_s)
       expect(Collection.count).not_to be_zero
       expect(build(:collection_type).collections).to eq []
+    end
+
+    context 'when use_valkyrie is true' do
+      let!(:pcdm_collection) { valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id.to_s) }
+
+      it 'returns pcdm collections of this collection type' do
+        expect(collection_type.collections(use_valkyrie: true).to_a).to include pcdm_collection
+      end
+    end
+
+    context 'when use_valkyrie is false' do
+      let!(:collection) { FactoryBot.create(:collection_lw, collection_type_gid: collection_type.to_global_id.to_s) }
+
+      it 'returns collections of this collection type' do
+        expect(collection_type.collections(use_valkyrie: false).to_a).to include collection
+      end
     end
   end
 


### PR DESCRIPTION
Changes proposed in this PR:
- Default use_valkyrie to Hyrax.config.use_valkyrie? to avoid having to explicitly pass in a value
- Use non-deprecated form of collections? in collection_type index view
- Add test for returning of PcdmCollections from #collections
- Force globalid to string when passing to custom query

I came across this when working on nurax_pg.

@samvera/hyrax-code-reviewers
