### PR TITLE
Fix repository access in CollectionMemberService

### DIFF
--- a/app/services/hyrax/collection_member_service.rb
+++ b/app/services/hyrax/collection_member_service.rb
@@ -24,7 +24,7 @@ module Hyrax
 
     def list_collections
       query = collection_search_builder.rows(1000)
-      resp = repository.search(query)
+      resp = blacklight_config.repository.search(query)
       resp.documents
     end
 


### PR DESCRIPTION
Fixes #5367

Blacklight 7 doesn’t provide `repository` anymore; it has to be pulled from `blacklight_config`. This change was made for controllers, but not for this service.

See #5306.