### PR TITLE
Only call render if tabs should be shown

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -72,29 +72,35 @@
       </div> <!-- end description -->
 
       <% if @form.persisted? %>
-        <div id="branding" class="tab-pane">
-          <div class="panel panel-default labels">
-            <div class="panel-body">
-              <%= render 'form_branding', f: f %>
+        <% if collection_brandable?(collection: @collection) %>
+          <div id="branding" class="tab-pane">
+            <div class="panel panel-default labels">
+              <div class="panel-body">
+                <%= render 'form_branding', f: f %>
+              </div>
             </div>
           </div>
-        </div>
+        <% end %>
 
-        <div id="discovery" class="tab-pane">
-          <div class="panel panel-default labels">
-            <div class="panel-body">
-              <%= render 'form_discovery', f: f %>
+        <% if collection_discoverable?(collection: @collection) %>
+          <div id="discovery" class="tab-pane">
+            <div class="panel panel-default labels">
+              <div class="panel-body">
+                <%= render 'form_discovery', f: f %>
+              </div>
             </div>
           </div>
-        </div>
+        <% end %>
 
-        <div id="sharing" class="tab-pane">
-          <div class="panel panel-default labels" id="collection_permissions" data-param-key="<%= f.object.model_name.param_key %>">
-            <div class="panel-body">
-              <%= render 'form_share', f: f %>
+        <% if collection_sharable?(collection: @collection) %>
+          <div id="sharing" class="tab-pane">
+            <div class="panel panel-default labels" id="collection_permissions" data-param-key="<%= f.object.model_name.param_key %>">
+              <div class="panel-body">
+                <%= render 'form_share', f: f %>
+              </div>
             </div>
           </div>
-        </div>
+        <% end %>
       <% end %>
 
       <div class="panel-footer">


### PR DESCRIPTION
When working on https://github.com/samvera/hyrax/issues/5329 and following the steps to reproduce I found that even if a collection is of a collection type that doesn't allow branding the branding partial was still being rendered.  These changes now mirror the logic at the top of the partial for displaying the tab headers.

@samvera/hyrax-code-reviewers
