### PR TITLE
WorkUploadsHandler: don't pre-publish events that depend on bg jobs

### DIFF
--- a/app/services/hyrax/work_uploads_handler.rb
+++ b/app/services/hyrax/work_uploads_handler.rb
@@ -116,9 +116,6 @@ module Hyrax
 
       ValkyrieIngestJob.perform_later(file)
 
-      # this triggers the re-index
-      Hyrax.publisher.publish('object.metadata.updated', object: file_set, user: file.user)
-
       { file_set: file_set, user: file.user }
     end
 

--- a/spec/services/hyrax/work_uploads_handler_spec.rb
+++ b/spec/services/hyrax/work_uploads_handler_spec.rb
@@ -74,10 +74,7 @@ RSpec.describe Hyrax::WorkUploadsHandler, valkyrie_adapter: :test_adapter do
       it 'publishes object.metadata.updated event for work' do
         expect { service.attach }
           .to change { listener.object_metadata_updated }
-          .to contain_exactly(have_attributes(payload: include(object: be_work)),
-                              have_attributes(payload: include(object: be_file_set)),
-                              have_attributes(payload: include(object: be_file_set)),
-                              have_attributes(payload: include(object: be_file_set)))
+          .to contain_exactly(have_attributes(payload: include(object: be_work)))
       end
 
       # we can't use the memory based test_adapter to test asynch,


### PR DESCRIPTION


@samvera/hyrax-code-reviewers
