### PR TITLE
publish updates for collection membership in transactional save

### DIFF
--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -96,6 +96,12 @@ module Hyrax
 
     # @since 3.0.0
     # @macro a_registered_event
+    #   @note this event SHOULD be published whevener the metadata is saved
+    #     for a PCDM Collection. the payload for each published event MUST
+    #     include an `:collection` (the updated Collection) AND a `:user` (the
+    #     {::User} responsible for the update). the event SHOULD NOT be
+    #     published for changes that only impact membership properties
+    #     (`#member_of_ids`, `#member_of_collection_ids`, and `#member_ids`)
     register_event('collection.metadata.updated')
 
     # @since 3.0.0
@@ -140,6 +146,13 @@ module Hyrax
 
     # @since 3.0.0
     # @macro a_registered_event
+    #   @note this event SHOULD be published whevener the metadata is saved
+    #     for a PCDM Object (including a Hydra Works FileSet). the payload for
+    #     each published event MUST include an `:object` (the updated Object),
+    #     AND a `:user` (the ::User responsible for the update). the event
+    #     SHOULD NOT be published for changes that only impact membership
+    #     properties (`#member_of_ids`, `#member_of_collection_ids`, and
+    #     `#member_ids`)
     register_event('object.metadata.updated')
 
     # @since 3.2.0


### PR DESCRIPTION
some time ago we introduced `collection.membership.updated` as an event
topic. this introduces publishing of those events to the save step of
transactions.

this tx step should:
  - continue to function without change for change sets that do not have
  `#member_of_collection_ids` as a field;
  - likewise when no collection changes are included in the change set;
  - publish only for added collections.

opting here to publish only the collection id for the changed collections, since
a lot of care is taken to ensure Hyrax doesn't need to fetch a collection in
whole to change its membership. the tradeoff is that listeners will need to pull
the collection themselves if they need more data about it than just the
id. doing this across multiple listeners could be expensive.

@samvera/hyrax-code-reviewers
