### PR TITLE
add new event topic for object membership changes; publish in ingest

### DIFF
--- a/app/jobs/valkyrie_ingest_job.rb
+++ b/app/jobs/valkyrie_ingest_job.rb
@@ -22,7 +22,7 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
 
     add_file_to_file_set(file_set: file_set,
                          file_metadata: updated_metadata,
-                         user:file.user)
+                         user: file.user)
   end
 
   ##

--- a/app/jobs/valkyrie_ingest_job.rb
+++ b/app/jobs/valkyrie_ingest_job.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
+
+##
+# Ingests a {Hyrax::UploadedFile} as file member of a {Hyrax::FileSet}.
+#
+# The {Hyrax::UploadedFile} is passed into {#perform}, and should have a
+# {Hyrax::UploadedFile#file_set_uri} identifying an existing {Hyrax::FileSet}.
 class ValkyrieIngestJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
@@ -28,8 +34,6 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
   ##
   # @api private
   #
-  # @todo this should publish something to allow the fileset
-  #   to reindex its membership
   # @param [Hyrax::FileSet] file_set the file set to add to
   # @param [Hyrax::FileMetadata] file_metadata the metadata object representing
   #   the file to add

--- a/app/jobs/valkyrie_ingest_job.rb
+++ b/app/jobs/valkyrie_ingest_job.rb
@@ -20,7 +20,9 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
 
     updated_metadata = upload_file(file: file, file_set: file_set)
 
-    add_file_to_file_set(file_set: file_set, file_metadata: updated_metadata)
+    add_file_to_file_set(file_set: file_set,
+                         file_metadata: updated_metadata,
+                         user:file.user)
   end
 
   ##
@@ -31,11 +33,13 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
   # @param [Hyrax::FileSet] file_set the file set to add to
   # @param [Hyrax::FileMetadata] file_metadata the metadata object representing
   #   the file to add
+  # @param [::User] user  the user performing the add
   #
   # @return [Hyrax::FileSet] updated file set
-  def add_file_to_file_set(file_set:, file_metadata:)
+  def add_file_to_file_set(file_set:, file_metadata:, user:)
     file_set.file_ids << file_metadata.id
     Hyrax.persister.save(resource: file_set)
+    Hyrax.publisher.publish('object.membership.updated', object: file_set, user: user)
   end
 
   ##

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -106,6 +106,13 @@ module Hyrax
 
     # @since 3.0.0
     # @macro a_registered_event
+    #   @note this event SHOULD be published whevener the membership is changed
+    #     for a PCDM Collection. this includes changes to the Collection's
+    #     `#member_ids` attribute, as well as inverse membership changes via
+    #     another Collection/Object's `#member_of_ids` or
+    #     `#member_of_collection_ids` attribute. the event payload MUST include
+    #     either a `:collection` OR a `:collection_id` (the Collection OR its
+    #     unique id), AND a `:user` (the ::User responsible for the update).
     register_event('collection.membership.updated')
 
     # @since 3.3.0
@@ -143,6 +150,17 @@ module Hyrax
     # @since 3.0.0
     # @macro a_registered_event
     register_event('object.acl.updated')
+
+    # @since 3.4.0
+    # @macro a_registered_event
+    #   @note this event SHOULD be published whevener the membership is changed
+    #     for a PCDM Object (including a Hydra Works FileSet). this includes
+    #     changes to the Object's `#member_ids` attribute, as well as inverse
+    #     membership changes via another Object's `#member_of_ids` attribute.
+    #     the event payload MUST include either an `:object` OR an `:object_id`
+    #     (the Object OR its unique id), AND a `:user` (the ::User responsible
+    #     for the update).
+    register_event('object.membership.updated')
 
     # @since 3.0.0
     # @macro a_registered_event

--- a/spec/jobs/valkyrie_ingest_job_spec.rb
+++ b/spec/jobs/valkyrie_ingest_job_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe ValkyrieIngestJob do
                                                             original_filename: upload.file.filename)))
     end
 
+    it 'publishes object.membership.updated for the changed file set' do
+      expect { described_class.perform_now(upload) }
+        .to change { listener.object_membership_updated.map(&:payload) }
+        .from(be_empty)
+        .to contain_exactly(match(object: have_attributes(id: file_set.id),
+                                  user: upload.user))
+    end
+
     context 'with no file_set_uri' do
       let(:upload) { FactoryBot.create(:uploaded_file) }
 


### PR DESCRIPTION
adds `object.membership.updated` to track membership updates on pcdm:Object
resources. publish this event when Hyrax ingests objects via
`Hyrax::ValkyrieIngestJob`.

this provides a hook we can subscribe to to reindex file sets when new files are
added to their membership.

followup work should review existing places where Objects and FileSets change
membership and publish accordingly.


@samvera/hyrax-code-reviewers
