### PR TITLE
Use FacetItemPresenter not render_facet_item

### DIFF
--- a/app/views/hyrax/my/_facet_pivot.html.erb
+++ b/app/views/hyrax/my/_facet_pivot.html.erb
@@ -9,7 +9,8 @@
         <% item.fq= {} if subfacet %>
 
         <% # The unless prevents Collection from being included in the select list for the Collection Type filter. %>
-        <%= render_facet_item(item.field, item) unless subfacet != true && item.value == "Collection" %>
+        <% facet_config= facet_configuration_for_field(item.field) %>
+        <%= (facet_config.item_presenter || Blacklight::FacetItemPresenter).new(item, facet_config, self, item.field).label unless subfacet != true && item.value == "Collection" %>
       </span>
 
       <% unless item.items.blank? %>


### PR DESCRIPTION
Fixes #5369.

`render_facet_item` is deprecated in Blacklight 7 and seems to be broken. Poking through the code, it looks like `Blacklight::FacetItemPresenter` is the new way of doing this, so I’ve taken an initial stab at that here.

I don’t love how messy this solution is, but without a deeper understanding of all the involved parts this is the simplest way I could get this page to work.