### PR TITLE
listen for membership changes on objects; index in response

### DIFF
--- a/app/services/hyrax/listeners/metadata_index_listener.rb
+++ b/app/services/hyrax/listeners/metadata_index_listener.rb
@@ -25,6 +25,23 @@ module Hyrax
       ##
       # Re-index the resource.
       #
+      # Called when 'object.membership.updated' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_object_membership_updated(event)
+        resource = event.to_h.fetch(:object) { Hyrax.query_service.find_by(id: event[:object_id]) }
+        return unless resource?(resource)
+
+        Hyrax.index_adapter.save(resource: resource)
+      rescue Valkyrie::Persistence::ObjectNotFoundError => err
+        Hyrax.logger.error("Tried to index for an #{event.id} event with " \
+                           "payload #{event.payload}, but failed due to error:\n"\
+                           "\t#{err.message}")
+      end
+
+      ##
+      # Re-index the resource.
+      #
       # Called when 'object.metadata.updated' event is published
       # @param [Dry::Events::Event] event
       # @return [void]

--- a/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
@@ -35,6 +35,42 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
     end
   end
 
+  describe '#on_object_membership_updated' do
+    let(:event_type) { :on_object_membership_updated }
+
+    it 'reindexes the object on the configured adapter' do
+      expect { listener.on_object_membership_updated(event) }
+        .to change { fake_adapter.saved_resources }
+        .to contain_exactly(resource)
+    end
+
+    it 'reindexes the object from ID on the configured adapter' do
+      data  = { object_id: resource.id }
+      event = Dry::Events::Event.new(event_type, data)
+
+      expect { listener.on_object_membership_updated(event) }
+        .to change { fake_adapter.saved_resources }
+        .to contain_exactly(resource)
+    end
+
+    context 'when the resource does not exist' do
+      let(:data) { { object_id: 'MISSING_ID_FOR_METADATA_INDEX_LISTENER_SPEC' } }
+
+      it 'does not raise' do
+        expect { listener.on_object_membership_updated(event) }
+          .not_to raise_error
+      end
+
+      it 'logs failure' do
+        expect(Hyrax.logger)
+          .to receive(:error)
+          .with(/MISSING_ID_FOR_METADATA_INDEX_LISTENER_SPEC/)
+
+        listener.on_object_membership_updated(event)
+      end
+    end
+  end
+
   describe '#on_object_metadata_updated' do
     let(:event_type) { :on_object_metadata_updated }
 


### PR DESCRIPTION
when membership changes take place, index the relevant objects.

this is a pretty naive implementation of this requirement. refinements with
fewer hard/manual solr commits are possible and should be considered as
development continues.

@samvera/hyrax-code-reviewers
