### PR TITLE
display admin set new form when configured for AdministrativeSet

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -131,6 +131,8 @@ module Hyrax
           "#{resource.class.name}Form".constantize.new(resource)
         rescue NameError => _err
           case resource
+          when Hyrax::AdministrativeSet
+            Hyrax::Forms::AdministrativeSetForm.new(resource)
           when Hyrax::FileSet
             Hyrax::Forms::FileSetForm.new(resource)
           when Hyrax::PcdmCollection

--- a/app/helpers/hyrax/url_helper.rb
+++ b/app/helpers/hyrax/url_helper.rb
@@ -3,7 +3,7 @@ module Hyrax
   module UrlHelper
     # generated models get registered as curation concerns and need a
     # track_model_path to render Blacklight-related views
-    (['FileSet', 'Collection'] + Hyrax.config.registered_curation_concern_types).each do |concern|
+    (['FileSet', 'Collection', 'Hyrax::AdministrativeSet'] + Hyrax.config.registered_curation_concern_types).each do |concern|
       model = concern.safe_constantize
       model_name = model.respond_to?(:model_name) && model.model_name
       next unless model_name

--- a/app/models/hyrax/administrative_set.rb
+++ b/app/models/hyrax/administrative_set.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency 'hyrax/administrative_set_name'
+
 module Hyrax
   ##
   # Valkyrie model for Admin Set domain objects.
@@ -13,6 +15,14 @@ module Hyrax
     def collection_type_gid
       # allow AdministrativeSet to behave more like a regular PcdmCollection
       Hyrax::CollectionType.find_or_create_admin_set_type.to_global_id
+    end
+
+    ##
+    # @api private
+    #
+    # @return [Class] an ActiveModel::Name compatible class
+    def self._hyrax_default_name_class
+      Hyrax::AdministrativeSetName
     end
   end
 end

--- a/lib/hyrax/administrative_set_name.rb
+++ b/lib/hyrax/administrative_set_name.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # A custom name for Valkyrie AdministrativeSet objects. Route keys are mapped to `admin_set`
+  # not be the same as the model name.
+  class AdministrativeSetName < Name
+    def initialize(klass, namespace = nil, name = nil)
+      super
+      @human              = 'AdminSet'
+      @i18n_key           = :admin_set
+      @param_key          = 'admin_set'
+      @plural             = 'admin_sets'
+      @route_key          = 'admin_sets'
+      @singular_route_key = 'admin_set'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #5380 

Changes in controller to support configured model:
* updates admin set controller to load the resource using the configured `admin_set_model`
* bases the form to use on the loaded resource

The remainder of changes sets up the ability to get the right form for new and edit by configuring the naming structure for `Hyrax::AdminstrativeSet`.

This follows the pattern established by `Hyrax::PcdmCollection` support.

_NOTE: There are errors when this configuration is used with the valkyrie admin set model.  Those will be addressed individually in other PRs.  This does not change the behavior when configured to use `AdminSet`.

@samvera/hyrax-code-reviewers
