### PR TITLE
add member ids for AdministrativeSets

### DIFF
--- a/app/forms/hyrax/forms/administrative_set_form.rb
+++ b/app/forms/hyrax/forms/administrative_set_form.rb
@@ -9,6 +9,8 @@ module Hyrax
       property :title, required: true, primary: true
       property :description, primary: true
 
+      property :member_ids, default: [], type: Valkyrie::Types::Array
+
       property :human_readable_type, writable: false
       property :date_modified, readable: false
       property :date_uploaded, readable: false

--- a/app/models/hyrax/administrative_set.rb
+++ b/app/models/hyrax/administrative_set.rb
@@ -8,6 +8,8 @@ module Hyrax
   class AdministrativeSet < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
 
+    attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)
+
     attribute :alternative_title, Valkyrie::Types::Set.of(Valkyrie::Types::String)
     attribute :creator,           Valkyrie::Types::Set.of(Valkyrie::Types::String)
     attribute :description,       Valkyrie::Types::Set.of(Valkyrie::Types::String)

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -153,6 +153,7 @@ RSpec.shared_examples 'a Hyrax::AdministrativeSet' do
   subject(:admin_set) { described_class.new }
 
   it_behaves_like 'a model with core metadata'
+  it_behaves_like 'has members'
 
   it 'has an #alternative_title' do
     expect { admin_set.alternative_title = ['Moomin'] }

--- a/spec/factories/administrative_sets.rb
+++ b/spec/factories/administrative_sets.rb
@@ -5,8 +5,9 @@ FactoryBot.define do
 
     transient do
       with_permission_template { false }
-      user { create(:user) }
+      user          { create(:user) }
       access_grants { [] }
+      members       { nil }
     end
 
     after(:build) do |adminset, evaluator|
@@ -27,6 +28,14 @@ FactoryBot.define do
                                                           agent_id: evaluator.user.user_key,
                                                           access: Hyrax::PermissionTemplateAccess::MANAGE)
         template.reset_access_controls_for(collection: admin_set)
+      end
+    end
+
+    trait :with_member_works do
+      transient do
+        members do
+          [valkyrie_create(:hyrax_work), valkyrie_create(:hyrax_work)]
+        end
       end
     end
   end

--- a/spec/forms/hyrax/forms/administrative_set_form_spec.rb
+++ b/spec/forms/hyrax/forms/administrative_set_form_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Hyrax::Forms::AdministrativeSetForm do
-  subject(:form)   { described_class.new(collection) }
-  let(:collection) { Hyrax::PcdmCollection.new }
+  subject(:form)   { described_class.new(adminset) }
+  let(:adminset) { FactoryBot.build(:hyrax_admin_set) }
 
   describe '.required_fields' do
     it 'lists required fields' do
@@ -14,6 +14,26 @@ RSpec.describe Hyrax::Forms::AdministrativeSetForm do
   describe '#primary_terms' do
     it 'gives "title" as a primary term' do
       expect(form.primary_terms).to contain_exactly(:title, :description)
+    end
+  end
+
+  describe '#member_ids' do
+    it 'for a new object has empty membership' do
+      expect(form.member_ids).to be_empty
+    end
+
+    it 'casts to an array' do
+      expect { form.validate(member_ids: '123') }
+        .to change { form.member_ids }
+        .to contain_exactly('123')
+    end
+
+    context 'when the object has members' do
+      let(:adminset) { FactoryBot.build(:hyrax_admin_set, :with_member_works) }
+
+      it 'gives member work ids' do
+        expect(form.member_ids).to contain_exactly(*adminset.member_ids.map(&:id))
+      end
     end
   end
 end


### PR DESCRIPTION
Adds members to AdministrativeSets allowing for works to be added to an admin set.  Uses the shared testing to confirm that the admin set behaves like it has members.

@samvera/hyrax-code-reviewers
