### PR TITLE
Remove style font-weight for form > label

### DIFF
--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -40,8 +40,6 @@ legend small {
 }
 
 form {
-  label { font-weight: bold; }
-
   label { margin-bottom: 7px; }
 
   .form-text {


### PR DESCRIPTION
Fixes #5347

Changes proposed in this pull request:
* Remove style `font-weight: bold` in `/hyrax/_forms.scss`

In the code the only other place this would affect is in https://github.com/samvera/hyrax/blob/main/app/views/shared/_select_work_type_modal.html.erb#L21.
This is the modal for creating new work, which doesn't work right now in the branch to test. Once that's fixed this needs to be checked.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to `Collections` page from the dashboard sidebar
* Click on `New Collection`
![collection-modal](https://user-images.githubusercontent.com/1331659/151236749-14648191-4b8a-4971-9cbd-33de7955c4a7.png)

Once the font-size [issue](https://github.com/samvera/hyrax/issues/5340) is fixed the radio buttons should align with the text.

@samvera/hyrax-code-reviewers
