### PR TITLE
ValkyrieIngestJob: don't publish stale metadata

### DIFF
--- a/app/jobs/valkyrie_ingest_job.rb
+++ b/app/jobs/valkyrie_ingest_job.rb
@@ -69,7 +69,7 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
     file_metadata.size = uploaded.size
 
     saved_metadata = Hyrax.persister.save(resource: file_metadata)
-    Hyrax.publisher.publish("object.file.uploaded", metadata: file_metadata)
+    Hyrax.publisher.publish("object.file.uploaded", metadata: saved_metadata)
 
     saved_metadata
   end


### PR DESCRIPTION
Publishing the un-persisted version of the FileMetadata meant failing to preserve characterization information.

@samvera/hyrax-code-reviewers
