### PR TITLE
5342 search label alignment

### DIFF
--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -1,5 +1,5 @@
 legend small {
-  margin-left:.5em;
+  margin-left: 0.5em;
   color: #999999;
   font-size: 15px;
 }
@@ -7,16 +7,15 @@ legend small {
 .label-large {
   font-size: 110%;
   line-height: 1.2;
-  padding: .3em .6em;
+  padding: 0.3em 0.6em;
   white-space: normal;
   position: relative;
 
-
-  input[type="checkbox"]{
-    margin:-2px 0 0;
+  input[type="checkbox"] {
+    margin: -2px 0 0;
     position: absolute;
-    left:.5em;
-    top:38%;
+    left: 0.5em;
+    top: 38%;
   }
 }
 
@@ -25,14 +24,14 @@ legend small {
 }
 
 .label-checkbox .label-text {
-  display:block;
-  padding-left:1.2em;
+  display: block;
+  padding-left: 1.2em;
 }
 
 .form-group:invalid input,
 .form-group:invalid option,
 .form-group:invalid textarea {
-  color:$gray-dark;
+  color: $gray-dark;
 }
 
 .form-actions {
@@ -40,7 +39,17 @@ legend small {
 }
 
 form {
-  label { margin-bottom: 7px; }
+  .form-group {
+    align-items: center;
+
+    > label {
+      text-align: left;
+
+      @media only screen and (min-width: 640px) {
+        text-align: right;
+      }
+    }
+  }
 
   .form-text {
     margin-top: 0;
@@ -49,7 +58,9 @@ form {
 }
 
 .set-access-controls {
-  label { font-weight: normal; }
+  label {
+    font-weight: normal;
+  }
   & .form-group {
     padding: 0 1.75em;
 
@@ -85,24 +96,24 @@ form {
   }
 
   .form-inline {
-    .col-form-label, label {
+    .col-form-label,
+    label {
       padding-left: 0;
       display: inline;
       &:after {
-        content: ' ';
+        content: " ";
       }
     }
     .form-text {
       display: inline;
       &:before {
-        content: ' ';
+        content: " ";
       }
     }
   }
 }
 
 .collection-types-settings {
-
   .form-inline {
     label {
       font-weight: bold;
@@ -118,7 +129,7 @@ form {
       padding-left: 0;
 
       &::after {
-        content: ' ';
+        content: " ";
       }
     }
 
@@ -126,7 +137,7 @@ form {
       display: inline;
 
       &::before {
-        content: ' ';
+        content: " ";
       }
     }
   }
@@ -139,7 +150,7 @@ form {
 }
 
 form.button-to {
-  margin:0 .3em;
+  margin: 0 0.3em;
 }
 
 .required-tag {
@@ -162,7 +173,6 @@ form.button-to {
 }
 
 .search-form {
-
   .form-group {
     margin: 0;
   }

--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -1,5 +1,5 @@
 legend small {
-  margin-left: 0.5em;
+  margin-left:.5em;
   color: #999999;
   font-size: 15px;
 }
@@ -7,15 +7,16 @@ legend small {
 .label-large {
   font-size: 110%;
   line-height: 1.2;
-  padding: 0.3em 0.6em;
+  padding: .3em .6em;
   white-space: normal;
   position: relative;
 
-  input[type="checkbox"] {
-    margin: -2px 0 0;
+
+  input[type="checkbox"]{
+    margin:-2px 0 0;
     position: absolute;
-    left: 0.5em;
-    top: 38%;
+    left:.5em;
+    top:38%;
   }
 }
 
@@ -24,14 +25,14 @@ legend small {
 }
 
 .label-checkbox .label-text {
-  display: block;
-  padding-left: 1.2em;
+  display:block;
+  padding-left:1.2em;
 }
 
 .form-group:invalid input,
 .form-group:invalid option,
 .form-group:invalid textarea {
-  color: $gray-dark;
+  color:$gray-dark;
 }
 
 .form-actions {
@@ -58,9 +59,7 @@ form {
 }
 
 .set-access-controls {
-  label {
-    font-weight: normal;
-  }
+  label { font-weight: normal; }
   & .form-group {
     padding: 0 1.75em;
 
@@ -96,24 +95,24 @@ form {
   }
 
   .form-inline {
-    .col-form-label,
-    label {
+    .col-form-label, label {
       padding-left: 0;
       display: inline;
       &:after {
-        content: " ";
+        content: ' ';
       }
     }
     .form-text {
       display: inline;
       &:before {
-        content: " ";
+        content: ' ';
       }
     }
   }
 }
 
 .collection-types-settings {
+
   .form-inline {
     label {
       font-weight: bold;
@@ -129,7 +128,7 @@ form {
       padding-left: 0;
 
       &::after {
-        content: " ";
+        content: ' ';
       }
     }
 
@@ -137,7 +136,7 @@ form {
       display: inline;
 
       &::before {
-        content: " ";
+        content: ' ';
       }
     }
   }
@@ -150,7 +149,7 @@ form {
 }
 
 form.button-to {
-  margin: 0 0.3em;
+  margin:0 .3em;
 }
 
 .required-tag {
@@ -173,6 +172,7 @@ form.button-to {
 }
 
 .search-form {
+
   .form-group {
     margin: 0;
   }


### PR DESCRIPTION
Fixes #5342 ; refs #5276

## Summary

This remove the pixel based decision for alignment of the search label and leans on the flexbox CSS property `align-items` to center vertically. I attempt to be as specific as possible on label and use the `>` to target the label that is the immediate child of the `form-group`. A media query is also included to accommodate differing viewport sizes.

![image](https://user-images.githubusercontent.com/7376450/151248894-4af2733b-0eec-4a77-841a-5c28c00c535e.png)

## Notes

While completing this work I noted that the wrapping CSS classes of the search-form are adding extra padding in smaller view-ports (below 640px). A new issue will be created for this.
