### PR TITLE
prepopulate `AdministrativeSetForm#member_ids` for display in UI

### DIFF
--- a/app/forms/hyrax/forms/administrative_set_form.rb
+++ b/app/forms/hyrax/forms/administrative_set_form.rb
@@ -6,6 +6,20 @@ module Hyrax
     # @api public
     # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
     class AdministrativeSetForm < Valkyrie::ChangeSet
+      ##
+      # @api private
+      AdminSetMembersPopulator = lambda do |_options|
+        self.member_ids =
+          if model.new_record
+            []
+          else
+            Hyrax
+              .query_service
+              .find_inverse_references_by(property: :admin_set_id, resource: model)
+              .map(&:id)
+          end
+      end
+
       property :title, required: true, primary: true
       property :description, primary: true
 
@@ -14,6 +28,8 @@ module Hyrax
       property :date_uploaded, readable: false
 
       property :depositor
+
+      property :member_ids, virtual: true, default: [], prepopulator: AdminSetMembersPopulator
 
       class << self
         def model_class

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -168,9 +168,10 @@ module Wings
         id ||= resource.id
         raise ArgumentError, "Resource has no id; is it persisted?" unless id
 
+        property = Hyrax.config.admin_set_predicate.qname.last if property.to_sym == :admin_set_id
         active_fedora_model = model ? model_class_for(model) : ActiveFedora::Base
-
         uri = active_fedora_model.id_to_uri(id.to_s)
+
         active_fedora_model.where("+(#{property}_ssim: \"#{uri}\" OR #{property}_ssim: \"#{id}\")").map do |obj|
           resource_factory.to_resource(object: obj)
         end

--- a/spec/forms/hyrax/forms/administrative_set_form_spec.rb
+++ b/spec/forms/hyrax/forms/administrative_set_form_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Hyrax::Forms::AdministrativeSetForm do
-  subject(:form)   { described_class.new(collection) }
-  let(:collection) { Hyrax::PcdmCollection.new }
+  subject(:form)  { described_class.new(admin_set) }
+  let(:admin_set) { Hyrax::AdministrativeSet.new }
 
   describe '.required_fields' do
     it 'lists required fields' do
@@ -14,6 +14,34 @@ RSpec.describe Hyrax::Forms::AdministrativeSetForm do
   describe '#primary_terms' do
     it 'gives "title" as a primary term' do
       expect(form.primary_terms).to contain_exactly(:title, :description)
+    end
+  end
+
+  describe '#member_ids' do
+    it 'populates as empty' do
+      expect { form.prepopulate! }
+        .not_to change { form.member_ids }
+        .from be_empty
+    end
+
+    context 'when the admin set is persisted' do
+      let(:admin_set) { FactoryBot.valkyrie_create(:hyrax_admin_set) }
+
+      it 'populates as empty' do
+        expect { form.prepopulate! }
+          .not_to change { form.member_ids }
+          .from be_empty
+      end
+
+      it 'populates with members' do
+        works = [FactoryBot.valkyrie_create(:hyrax_work, admin_set_id: admin_set.id),
+                 FactoryBot.valkyrie_create(:hyrax_work, admin_set_id: admin_set.id)]
+
+        expect { form.prepopulate! }
+          .to change { form.member_ids }
+          .from(be_empty)
+          .to contain_exactly(*works.map(&:id))
+      end
     end
   end
 end


### PR DESCRIPTION
when loading the admin set form, we want to populate the member ids.

these are tracked by an inverse reference property `admin_set_id` on the
members, so we define a prepopulator to run a query on that.

i found that wasn't quite enough, because `Wings` wasn't supporting inverse
lookup for admin sets. since the admin set RDF property is configurable, and the
index terms on ActiveFedora's side are derived from the configured property's
qname, we need to do the same on query. the solution for this problem is a
little hacky, but gets the job done; maybe it can be refactored later?


cc: @elrayle 
@samvera/hyrax-code-reviewers
