### PR TITLE
Persist visibility changes during PcdmCollection updates

### DIFF
--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -14,6 +14,7 @@ module Hyrax
 
       property :depositor, required: true
       property :collection_type_gid, required: true
+      property :visibility, default: VisibilityIntention::PRIVATE
 
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -32,5 +32,27 @@ module Hyrax
     def pcdm_object?
       true
     end
+
+    def permission_manager
+      @permission_manager ||= Hyrax::PermissionManager.new(resource: self)
+    end
+
+    def visibility=(value)
+      visibility_writer.assign_access_for(visibility: value)
+    end
+
+    def visibility
+      visibility_reader.read
+    end
+
+    protected
+
+    def visibility_writer
+      Hyrax::VisibilityWriter.new(resource: self)
+    end
+
+    def visibility_reader
+      Hyrax::VisibilityReader.new(resource: self)
+    end
   end
 end

--- a/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
@@ -5,13 +5,16 @@
 
   <div class="form-group">
     <label class="radio">
-      <input type="radio" id="visibility_open" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>" <% if @collection.open_access? %> checked="true"<% end %> /><strong><%= t('hyrax.visibility.open.text') %></strong> - <%= t('hyrax.visibility.open.note_html') %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>
+      <strong><%= t('hyrax.visibility.open.text') %></strong> - <%= t('hyrax.visibility.open.note_html') %>
     </label>
     <label class="radio">
-      <input type="radio" id="visibility_registered" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if @collection.authenticated_only_access? %> checked="true"<% end %> /><strong><%= t('hyrax.visibility.authenticated.text', institution: institution_name) %></strong> - <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+      <strong><%= t('hyrax.visibility.authenticated.text', institution: institution_name) %></strong> - <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
     </label>
     <label class="radio">
-      <input type="radio" id="visibility_restricted" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>" <% if @collection.private_access? %> checked="true"<% end %> /><strong><%= t('hyrax.visibility.restricted.text') %></strong>- <%= t('hyrax.visibility.restricted.note_html') %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+      <strong><%= t('hyrax.visibility.restricted.text') %></strong>- <%= t('hyrax.visibility.restricted.note_html') %>
     </label>
   </div>
 

--- a/lib/hyrax/transactions/collection_update.rb
+++ b/lib/hyrax/transactions/collection_update.rb
@@ -4,11 +4,12 @@ require 'hyrax/transactions/transaction'
 module Hyrax
   module Transactions
     ##
-    # Creates a Collection from a ChangeSet
+    # Updates a Collection from a ChangeSet
     #
     # @since 3.2.0
     class CollectionUpdate < Transaction
-      DEFAULT_STEPS = ['change_set.apply'].freeze
+      DEFAULT_STEPS = ['change_set.apply',
+                       'collection_resource.save_acl'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
@@ -13,15 +13,10 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
   routes { Hyrax::Engine.routes }
 
   controller described_class do
-    before_action :find_collection
     load_and_authorize_resource except: [:index],
                                 instance_name: :collection,
-                                prepend: :find_collection,
+                                prepend: true,
                                 class: Hyrax::PcdmCollection
-
-    def find_collection
-      @collection = Hyrax::PcdmCollection.new(collection_params)
-    end
   end
 
   before { allow(Hyrax.config).to receive(:collection_model).and_return('Hyrax::PcdmCollection') }
@@ -53,7 +48,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
     before { sign_in user }
 
     it 'assigns @collection' do
-      pending 'update of test to work with Hyrax::PcdmCollection'
       get :new
 
       expect(assigns(:collection)).to be_kind_of(Hyrax.config.collection_class)
@@ -253,7 +247,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
 
       it "removes members from the collection" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         parameters = { id: collection,
                        collection: { members: 'remove' },
                        batch_document_ids: [asset2] }
@@ -264,7 +257,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
 
       it "publishes object.metadata.updated for removed objects" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         parameters = { id: collection,
                        collection: { members: 'remove' },
                        batch_document_ids: [asset2] }
@@ -301,7 +293,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
 
       it 'moves the members' do # rubocop:disable RSpec/ExampleLength
-        pending 'update of test to work with Hyrax::PcdmCollection'
         parameters = { id: collection,
                        collection: { members: 'move' },
                        destination_collection_id: collection2,
@@ -319,7 +310,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
 
     context "updating a collections metadata" do
       it "saves the metadata" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         expect { put :update, params: { id: collection, collection: { title: ['New Collection Title'] } } }
           .to change { Hyrax.query_service.find_by(id: collection.id).title }
           .to contain_exactly('New Collection Title')
@@ -341,16 +331,20 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
     end
 
-    context "when update fails" do
-      let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection) }
-      let(:repository) { instance_double(Blacklight::Solr::Repository, search: result) }
-      let(:result) { double(documents: [], total: 0) }
+    context "updating a collection's visibility" do
+      it "saves the visibility" do
+        expect { put :update, params: { id: collection, collection: { title: ['Moomin in Space'], visibility: 'restricted' } } }
+          .to change { Hyrax.query_service.find_by(id: collection.id).visibility }
+          .from('open')
+          .to('restricted')
 
+        expect(flash[:notice]).to eq "Collection was successfully updated."
+      end
+    end
+
+    context "when update fails" do
       before do
-        allow(controller).to receive(:authorize!)
-        allow(Collection).to receive(:find).and_return(collection)
-        allow(collection).to receive(:update).and_return(false)
-        allow(controller).to receive(:repository).and_return(repository)
+        collection # ensure the collection is loaded before we stub the persister save
         allow(Hyrax.persister)
           .to receive(:save)
           .with(any_args)
@@ -371,7 +365,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       let(:uploaded) { FactoryBot.create(:uploaded_file) }
 
       it "saves banner metadata" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         put :update, params: { id: collection,
                                banner_files: [uploaded.id],
                                collection: { creator: ['Emily'] },
@@ -395,7 +388,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
 
       it "saves logo metadata" do # rubocop:disable RSpec/ExampleLength
-        pending 'update of test to work with Hyrax::PcdmCollection'
         put :update, params: { id: collection,
                                logo_files: [uploaded.id],
                                alttext: ["Logo alt Text"],
@@ -416,7 +408,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
         let(:uploaded) { FactoryBot.create(:uploaded_file) }
 
         it "does not save linkurl containing html; target_url is empty" do # rubocop:disable RSpec/ExampleLength
-          pending 'update of test to work with Hyrax::PcdmCollection'
           put :update, params: { id: collection,
                                  logo_files: [uploaded.id],
                                  alttext: ["Logo alt Text"], linkurl: ["<script>remove_me</script>"],
@@ -432,7 +423,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
         end
 
         it "does not save linkurl containing dodgy protocol; target_url is empty" do # rubocop:disable RSpec/ExampleLength
-          pending 'update of test to work with Hyrax::PcdmCollection'
           put :update, params: { id: collection,
                                  logo_files: [uploaded.id],
                                  alttext: ["Logo alt Text"],
@@ -470,7 +460,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
 
       it "returns the collection and its members" do # rubocop:disable RSpec/ExampleLength
-        pending 'update of test to work with Hyrax::PcdmCollection'
         expect(controller)
           .to receive(:add_breadcrumb)
           .with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
@@ -497,7 +486,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
 
       context "and searching" do
         it "returns some works and collections" do
-          pending 'update of test to work with Hyrax::PcdmCollection'
           # "/dashboard/collections/4m90dv529?utf8=%E2%9C%93&cq=King+Louie&sort="
           get :show, params: { id: collection, cq: "Second" }
           expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
@@ -510,7 +498,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
 
       context 'when the page parameter is passed' do
         it 'loads the collection (paying no attention to the page param)' do
-          pending 'update of test to work with Hyrax::PcdmCollection'
           get :show, params: { id: collection, page: '2' }
           expect(response).to be_successful
           expect(assigns[:presenter]).to be_kind_of Hyrax::CollectionPresenter
@@ -520,7 +507,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
 
       context "without a referer" do
         it "sets breadcrumbs" do
-          pending 'update of test to work with Hyrax::PcdmCollection'
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
@@ -536,7 +522,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
         end
 
         it "sets breadcrumbs" do
-          pending 'update of test to work with Hyrax::PcdmCollection'
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
@@ -565,7 +550,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
 
       it "returns successfully" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         get :show, params: { id: collection }
 
         expect(response).to be_successful
@@ -595,7 +579,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
 
       it "returns json" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         delete :destroy, params: { format: :json, id: collection }
         expect(response).to have_http_status(:no_content)
       end
@@ -603,17 +586,13 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
 
     context "when an error occurs" do
       before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Collection).to receive(:destroy).and_return(nil)
         allow(Hyrax.persister)
           .to receive(:delete)
           .with(any_args)
           .and_raise(StandardError, "Failed to delete collection.")
-        # rubocop:enable RSpec/AnyInstance
       end
 
       it "renders the edit view" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         delete :destroy, params: { id: collection }
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(:edit)
@@ -621,7 +600,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
 
       it "returns json" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         delete :destroy, params: { format: :json, id: collection }
         expect(response).to have_http_status(:unprocessable_entity)
       end
@@ -632,7 +610,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
     before { sign_in user }
 
     it "is successful" do
-      pending 'update of test to work with Hyrax::PcdmCollection'
       get :edit, params: { id: collection }
 
       expect(response).to be_successful
@@ -641,7 +618,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
 
     context "without a referer" do
       it "sets breadcrumbs" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
@@ -655,7 +631,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       before { request.env['HTTP_REFERER'] = 'http://test.host/foo' }
 
       it "sets breadcrumbs" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))

--- a/spec/views/hyrax/dashboard/collections/_form_discovery.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_discovery.erb_spec.rb
@@ -1,68 +1,69 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/dashboard/collections/_form_discovery.html.erb', type: :view do
   let(:collection) { Collection.new }
-  let(:collection_form) { Hyrax::Forms::CollectionForm.new(collection, double, double) }
-
-  let(:form) do
-    view.simple_form_for(collection, url: '/update') do |fs_form|
+  let(:form) { Hyrax::Forms::CollectionForm.new(collection, double, double) }
+  let(:f) do
+    view.simple_form_for(form, url: '/update') do |fs_form|
       return fs_form
     end
   end
 
+  before do
+    allow(form).to receive(:visibility).and_return(visibility)
+    allow(view).to receive(:f).and_return(f)
+    render
+  end
+
   context "collection has open access" do
-    before do
-      allow(collection).to receive(:open_access?).and_return(true)
-      allow(collection).to receive(:authenticated_only_access?).and_return(false)
-      allow(collection).to receive(:private_access?).and_return(false)
-      controller.request.path_parameters[:id] = 'j12345'
-      assign(:form, collection_form)
-      assign(:collection, collection)
-      allow(view).to receive(:f).and_return(form)
-      render
-    end
+    let(:visibility) { 'open' }
 
     it "check open access is set" do
-      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=open][checked=true]')
-      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=authenticated]')
-      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=restricted]')
+      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=open][checked]')
     end
   end
 
   context "collection has authenticated access" do
-    before do
-      allow(collection).to receive(:open_access?).and_return(false)
-      allow(collection).to receive(:authenticated_only_access?).and_return(true)
-      allow(collection).to receive(:private_access?).and_return(false)
-      controller.request.path_parameters[:id] = 'j12345'
-      assign(:form, collection_form)
-      assign(:collection, collection)
-      allow(view).to receive(:f).and_return(form)
-      render
-    end
+    let(:visibility) { 'authenticated' }
 
     it "check authenticated access is set" do
-      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=open]')
-      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=authenticated][checked=true]')
-      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=restricted]')
+      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=authenticated][checked]')
     end
   end
 
   context "collection has restricted access" do
-    before do
-      allow(collection).to receive(:open_access?).and_return(false)
-      allow(collection).to receive(:authenticated_only_access?).and_return(false)
-      allow(collection).to receive(:private_access?).and_return(true)
-      controller.request.path_parameters[:id] = 'j12345'
-      assign(:form, collection_form)
-      assign(:collection, collection)
-      allow(view).to receive(:f).and_return(form)
-      render
+    let(:visibility) { 'restricted' }
+
+    it "restricted access is set" do
+      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=restricted][checked]')
+    end
+  end
+
+  context "with PcdmCollection" do
+    let(:collection) { Hyrax::PcdmCollection.new }
+    let(:form) { Hyrax::Forms::PcdmCollectionForm.new(collection) }
+
+    context "collection has open access" do
+      let(:visibility) { 'open' }
+
+      it "check open access is set" do
+        expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=open][checked]')
+      end
     end
 
-    it "check restricted access is set" do
-      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=open]')
-      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=authenticated]')
-      expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=restricted][checked=true]')
+    context "collection has authenticated access" do
+      let(:visibility) { 'authenticated' }
+
+      it "check authenticated access is set" do
+        expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=authenticated][checked]')
+      end
+    end
+
+    context "collection has restricted access" do
+      let(:visibility) { 'restricted' }
+
+      it "restricted access is set" do
+        expect(rendered).to have_selector('input[type=radio][name="collection[visibility]"][value=restricted][checked]')
+      end
     end
   end
 end


### PR DESCRIPTION
While working on https://github.com/samvera/hyrax/issues/5329, I was blocked by the discovery tab not rendering on the collection edit form.  This PR resolves that issue and the persisting of changes to the visibility of a PcdmCollection.

Proposed changes:
- Add visibility property to PcdmCollectionForm
- Add permission_manager, visibility, and visibility= methods to PcdmCollection
- Update discovery form partial to use form helpers and to follow the approach in `app/views/hyrax/base/_form_visibility_component.html.erb`
- Refactors the tests for this partial and adds tests for PcdmCollectionForm
- Add the save_acl step to the collection update transaction
- Add a test for updating visibility and refactor the tests along the way (this fixed many pending tests!) 

@samvera/hyrax-code-reviewers
