### PR TITLE
wings: ensure FileMetadata pulled from `ActiveFedora` has a file id

### DIFF
--- a/lib/wings/attribute_transformer.rb
+++ b/lib/wings/attribute_transformer.rb
@@ -58,7 +58,11 @@ module Wings
       end
 
       attributes[:original_filename] = obj.original_name
-      attributes[:file_identifier] = obj.id if obj.id.present?
+
+      if obj.id.present?
+        uri = Hyrax.config.translate_id_to_uri.call(obj.id)
+        attributes[:file_identifier] = Wings::Valkyrie::Storage.cast_to_valkyrie_id(uri)
+      end
       attributes[:type] = obj.metadata_node.type.to_a
       attributes[:size] = obj.size
       attributes

--- a/lib/wings/valkyrie/storage.rb
+++ b/lib/wings/valkyrie/storage.rb
@@ -29,6 +29,12 @@ module Wings
       end
 
       ##
+      # @api private
+      def self.cast_to_valkyrie_id(id)
+        ::Valkyrie::ID.new(id.to_s.sub(/^.+\/\//, PROTOCOL))
+      end
+
+      ##
       # @param key [Symbol] the key for plugin behavior to check support for
       #
       # @return [Boolean] whether
@@ -140,7 +146,7 @@ module Wings
       end
 
       def cast_to_valkyrie_id(id)
-        ::Valkyrie::ID.new(id.to_s.sub(/^.+\/\//, PROTOCOL))
+        self.class.cast_to_valkyrie_id(id)
       end
     end
   end

--- a/spec/wings/services/file_converter_service_spec.rb
+++ b/spec/wings/services/file_converter_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Wings::FileConverterService, :clean_repo do
     it 'copies attributes to resource' do
       expect(subject.id.to_s).to eq af_file_id
       expect(subject.alternate_ids).to match_valkyrie_ids_with_active_fedora_ids [af_file_id]
-      expect(subject.file_identifier).to eq af_file_id
+      expect(subject.file_identifier.to_s).to end_with af_file_id
       expect(subject.created_at).to eq af_file.create_date
       expect(subject.updated_at).to eq af_file.modified_date
       expect(subject.type).to match_array af_file.metadata_node.type
@@ -73,6 +73,7 @@ RSpec.describe Wings::FileConverterService, :clean_repo do
     it 'copies attributes to af_file' do
       file_metadata = described_class.af_file_to_resource(af_file: af_file)
       subject = described_class.resource_to_af_file(metadata_resource: file_metadata)
+
       expect(subject.id.to_s).to eq af_file_id
       expect(subject.create_date).to eq af_file.create_date
       expect(subject.modified_date).not_to eq af_file.modified_date

--- a/spec/wings/valkyrie/storage_spec.rb
+++ b/spec/wings/valkyrie/storage_spec.rb
@@ -59,8 +59,18 @@ RSpec.describe Wings::Valkyrie::Storage, :clean_repo do
       expect(Hyrax.custom_queries.find_file_metadata_by(id: upload.id))
         .to have_attributes original_filename: file.original_filename,
                             mime_type: 'image/png',
-                            file_identifier: Hyrax::Base.uri_to_id(upload.id),
+                            file_identifier: upload.id,
                             size: [file.size]
+    end
+
+    it 'can find content from its metadata node ' do
+      upload = storage_adapter.upload(resource: file_set,
+                                      file: file,
+                                      original_filename: file.original_filename)
+      metadata = Hyrax.custom_queries.find_file_metadata_by(id: upload.id)
+
+      expect(storage_adapter.find_by(id: metadata.file_identifier).id)
+        .to eq upload.id
     end
 
     it 'adds the file to the /files (LDP) container for the file set' do


### PR DESCRIPTION
the approach where we use the exact same id for `FileMetadata` and the Storage
Adapter's file object doesn't work. it's necessary to include the protocol to
lookup the file.

add a test for round tripping content from the `FileMetadata` and make it
pass. transforming the id is a bit more complicated than i was hoping, but the
approach here should work even if custom id mappings are being used by
downstream apps.

@samvera/hyrax-code-reviewers
