### PR TITLE
Bootstrap 4 masthead navbar menu responsiveness

### DIFF
--- a/app/assets/stylesheets/hyrax/_header.scss
+++ b/app/assets/stylesheets/hyrax/_header.scss
@@ -2,15 +2,6 @@
   margin-top: $search-bar-margin-top;
 }
 
-.top-header,
-.top-header > .navbar {
-  min-height: 4rem;
-}
-
-header > .navbar {
-  margin-bottom: 0;
-}
-
 .searchbar-right {
   margin-right: 0;
 }

--- a/app/assets/stylesheets/hyrax/_styles.scss
+++ b/app/assets/stylesheets/hyrax/_styles.scss
@@ -63,16 +63,6 @@ label.disabled {
   display: flex;
 }
 
-.navbar {
-  .navbar-nav {
-    li {
-      a {
-        color: #666;
-      }
-    }
-  }
-}
-
 .read-only {
   font-size: 1.2em;
   margin: 0 0 10px;

--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -37,11 +37,7 @@ $admin-panel-border-color: #dedede !default;
 
 body.dashboard {
   background-color: $body-background-color;
-  //padding-top: $navbar-brand-height + 2 * $navbar-padding-y;
-
-  @media only screen and (max-width: 767px) {
-    padding-top: 0;
-  }
+  padding-top: 3.5rem;
 }
 
 .dashboard {
@@ -68,21 +64,6 @@ body.dashboard {
   .nav-tabs > li.active > a,
   .nav-tabs > li.active > a:hover {
     border-top: 2px solid $tab-active-accent-color;
-  }
-
-  /* The #masthead selector below could (and ideally, should) be removed if we can
-   * replace the "navbar-static-top" class with "navbar-fixed-top" for the Admin UI only
-   */
-  #masthead {
-    border: 0;
-    left: 0;
-    position: fixed;
-    right: 0;
-    top: 0;
-
-    @media only screen and (max-width: 767px) {
-      position: initial;
-    }
   }
 
   /* This is needed in Chrome for the admin/admin_sets edit view AND the collection

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,8 +1,8 @@
 <header aria-label="header" class="top-header">
-  <nav id="masthead" class="navbar navbar-expand-lg navbar-dark bg-dark flex-column flex-md-row fixed-top" role="navigation" aria-label="masthead">
+  <nav id="masthead" class="navbar navbar-expand-lg navbar-dark bg-dark justify-content-between <%= placement_class %>" role="navigation" aria-label="masthead">
     <h1 class="sr-only"><%= application_name %></h1>
     <%= render '/logo' %>
-    <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse justify-content-end" id="top-navbar-collapse">
@@ -10,4 +10,3 @@
     </div>
   </nav>
 </header>
-

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,4 +1,4 @@
-<ul id="user_utility_links" class="navbar-nav">
+<ul id="user_utility_links" class="navbar-nav navbar-dark">
   <%= render 'shared/locale_picker' if available_translations.size > 1 %>
   <% if user_signed_in? %>
     <li class="nav-item">

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -9,7 +9,7 @@
     <div class="skip-to-content">
       <%= link_to "Skip to Content", "#skip-to-content" %>
     </div>
-    <%= render '/masthead' %>
+    <%= render '/masthead', placement_class: nil %>
     <%= content_for(:navbar) %>
     <%= content_for(:precontainer_content) %>
     <div id="content-wrapper" class="container" role="main">

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -9,7 +9,7 @@
     <div class="skip-to-content">
       <%= link_to "Skip to Content", "#skip-to-content" %>
     </div>
-    <%= render '/masthead' %>
+    <%= render '/masthead', placement_class: 'fixed-top' %>
     <%= content_for(:navbar) %>
     <div id="content-wrapper" role="main">
       <div class="sidebar maximized">

--- a/app/views/shared/_locale_picker.html.erb
+++ b/app/views/shared/_locale_picker.html.erb
@@ -3,13 +3,11 @@
         <span class="sr-only"><%= t('hyrax.toolbar.language_switch') %></span>
         <span title="<%= t('hyrax.toolbar.language_switch') %>"><%= available_translations[I18n.locale.to_s] %></span>
     </a>
-    <ul id="language-dropdown-menu" class="dropdown-menu" role="menu">
-        <li role="presentation" class="dropdown-header"><%= t('hyrax.toolbar.language_switch') %></li>
-        <li role="presentation" class="dropdown-divider"></li>
+    <div id="language-dropdown-menu" class="dropdown-menu" role="menu">
+        <div role="presentation" class="dropdown-header"><%= t('hyrax.toolbar.language_switch') %></div>
+        <div role="presentation" class="dropdown-divider"></div>
         <% available_translations.each do |language, label| %>
-            <li class="dropdown-item" role="presentation" lang="<%= language %>">
-                <%= link_to label, "?locale=#{language}", class: 'dropdown-item', role: 'menuitem', tabindex: '-1', data: { locale: language } %>
-            </li>
+            <%= link_to label, "?locale=#{language}", class: 'dropdown-item', role: 'menuitem', lang: language, tabindex: '-1', data: { locale: language } %>
         <% end %>
-    </ul>
+    </div>
 </li>


### PR DESCRIPTION
Fixes #5393  ; refs #5276 

## Summary

This resolves some issues introduced in the upgrade to Bootstrap 4 and utilizes new flexbox utility classes to improve alignment behaviors.

## Changes proposed in this pull request:
- Refines flexbox behavior for responsiveness
- Add `placement_class` (is this an argument?) on masthead render and removes CSS overrides
- Updates locale picker dropdown structure and converts unordered list to div/anchors


