### PR TITLE
Replace Glyphicons with Font Awesome icons

### DIFF
--- a/app/assets/javascripts/hyrax/batch_select_all.js
+++ b/app/assets/javascripts/hyrax/batch_select_all.js
@@ -26,10 +26,10 @@
   function toggleStateBool (obj, state) {
     if (state){
       obj.attr("data-state", 'on');
-      obj.find('a i').addClass('glyphicon glyphicon-ok');
+      obj.find('a i').addClass('fa fa-check');
     }else {
       obj.attr("data-state", 'off');
-      obj.find('a i').removeClass('glyphicon glyphicon-ok');
+      obj.find('a i').removeClass('fa fa-check');
     }
 
   }

--- a/app/assets/javascripts/hyrax/dashboard_actions.js
+++ b/app/assets/javascripts/hyrax/dashboard_actions.js
@@ -14,21 +14,21 @@ Blacklight.onLoad(function() {
     if (array.length > 1) {
       var docId = array[1];
       $("#detail_" + docId + " .expanded-details").slideToggle();
-      $(item).toggleClass('glyphicon-chevron-right glyphicon-chevron-down');
+      $(item).toggleClass('fa-chevron-right fa-chevron-down');
     }
   }
 
   // show/hide more information on the dashboard when clicking
   // plus/minus
-  $('.glyphicon-chevron-right').on('click', function() {
+  $('.fa-chevron-right').on('click', function() {
     show_details(this);
     return false;
   });
 
   $('a').filter( function() {
-      return $(this).find('.glyphicon-chevron-right').length === 1;
+      return $(this).find('.fa-chevron-right').length === 1;
    }).on('click', function() {
-    show_details($(this).find(".glyphicon-chevron-right")[0]);
+    show_details($(this).find(".fa-chevron-right")[0]);
     return false;
   });
 

--- a/app/assets/javascripts/hyrax/editor/controlled_vocabulary.es6
+++ b/app/assets/javascripts/hyrax/editor/controlled_vocabulary.es6
@@ -19,10 +19,10 @@ export default class ControlledVocabulary extends FieldManager {
         listClass:         '.listing',
         inputTypeClass:    '.controlled_vocabulary',
 
-        addHtml:           '<button type=\"button\" class=\"btn btn-link add\"><span class=\"glyphicon glyphicon-plus\"></span><span class="controls-add-text"></span></button>',
+        addHtml:           '<button type=\"button\" class=\"btn btn-link add\"><span class=\"fa fa-plus\"></span><span class="controls-add-text"></span></button>',
         addText:           'Add another',
 
-        removeHtml:        '<button type=\"button\" class=\"btn btn-link remove\"><span class=\"glyphicon glyphicon-remove\"></span><span class="controls-remove-text"></span> <span class=\"sr-only\"> previous <span class="controls-field-name-text">field</span></span></button>',
+        removeHtml:        '<button type=\"button\" class=\"btn btn-link remove\"><span class=\"fa fa-minus\"></span><span class="controls-remove-text"></span> <span class=\"sr-only\"> previous <span class="controls-field-name-text">field</span></span></button>',
         removeText:         'Remove',
 
         labelControls:      true,

--- a/app/assets/javascripts/hyrax/facets.js
+++ b/app/assets/javascripts/hyrax/facets.js
@@ -4,11 +4,11 @@ Blacklight.onLoad(function() {
    */
   $("li.expandable").click(function(){
     $(this).next("ul").slideToggle();
-    $(this).find('i').toggleClass("glyphicon-chevron-right glyphicon-chevron-down");
+    $(this).find('i').toggleClass("fa-chevron-right fa-chevron-down");
   });
 
   $("li.expandable_new").click(function(){
-    $(this).find('i').toggleClass("glyphicon-chevron-right glyphicon-chevron-down");
+    $(this).find('i').toggleClass("fa-chevron-right fa-chevron-down");
   });
 
 }); //end of Blacklight.onload

--- a/app/assets/stylesheets/hyrax/_batch-edit.scss
+++ b/app/assets/stylesheets/hyrax/_batch-edit.scss
@@ -1,6 +1,6 @@
 .help-icon {
-  @extend .glyphicon !optional; // FIXME: not supported in bootstrap 4
-  @extend .glyphicon-question-sign !optional; // FIXME: not supported in bootstrap 4
+  @extend .fa !optional;
+  @extend .fa-question !optional;
   @extend .large-icon;
   top: 5px;
 }
@@ -17,10 +17,10 @@
   margin-bottom: $input-btn-padding-y-lg;
 }
 
-.glyphicon-chevron-right-helper.collapsed .chevron {
-  @extend .glyphicon-chevron-right !optional; // FIXME: not supported in bootstrap 4
+.fa-chevron-right-helper.collapsed .chevron {
+  @extend .fa-chevron-right !optional;
 }
-.glyphicon-chevron-right-helper .chevron {
-  @extend .glyphicon !optional; // FIXME: not supported in bootstrap 4
-  @extend .glyphicon-chevron-down !optional; // FIXME: not supported in bootstrap 4
+.fa-chevron-right-helper .chevron {
+  @extend .fa !optional;
+  @extend .fa-chevron-down !optional;
 }

--- a/app/assets/stylesheets/hyrax/_collections.scss
+++ b/app/assets/stylesheets/hyrax/_collections.scss
@@ -219,7 +219,7 @@ button.branding-banner-remove:hover {
       }
     }
 
-    .glyphicon {
+    .fa {
       margin: 4px 0 0 4px;
     }
   }

--- a/app/assets/stylesheets/hyrax/_form-progress.scss
+++ b/app/assets/stylesheets/hyrax/_form-progress.scss
@@ -29,6 +29,7 @@
   padding-left: 8px;
 }
 
+// FIXME: There should be a better way to implement these with FontAwesome direct in the markup?
 aside.form-progress {
   .incomplete::before {
     content: "\e101";

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -195,7 +195,7 @@ module Hyrax
       # this block is only executed when a link is inserted;
       # if we pass text containing no links, it just returns text.
       auto_link(html_escape(text)) do |value|
-        "<span class='glyphicon glyphicon-new-window'></span>#{('&nbsp;' + value) if show_link}"
+        "<span class='fa fa-external-link'></span>#{('&nbsp;' + value) if show_link}"
       end
     end
 

--- a/app/renderers/hyrax/renderers/external_link_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/external_link_attribute_renderer.rb
@@ -6,7 +6,7 @@ module Hyrax
 
       def li_value(value)
         auto_link(value) do |link|
-          "<span class='glyphicon glyphicon-new-window'></span>&nbsp;#{link}"
+          "<span class='fa fa-external-link'></span>&nbsp;#{link}"
         end
       end
     end

--- a/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
@@ -3,7 +3,7 @@
 <tr id="document_<%= id %>">
   <td>&nbsp;
     <% if current_user and document.depositor != current_user.user_key %>
-      <i class="glyphicon glyphicon-share-alt" />
+      <i class="fa fa-share" />
     <% end %>
   </td>
   <td>
@@ -14,7 +14,7 @@
       <div class="media-body">
         <p class="media-heading">
           <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
-          <a href="#" class="small" title="Click for more details"><span id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></span></a>
+          <a href="#" class="small" title="Click for more details"><span id="expand_<%= id %>" class="fa fa-chevron-right"></span></a>
         </p>
         <%= render_collection_links(document) %>
       </div>

--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -1,5 +1,5 @@
 <% provide :page_header do %>
-  <h1><span class="glyphicon glyphicon-ok-circle"></span> <%= t('.header') %></h1>
+  <h1><span class="fa fa-check-circle"></span> <%= t('.header') %></h1>
 <% end %>
 
 <div class="row">

--- a/app/views/hyrax/base/_file_manager_member.html.erb
+++ b/app/views/hyrax/base/_file_manager_member.html.erb
@@ -7,7 +7,7 @@
           </div>
           <div class="file-set-link float-right">
             <%= link_to contextual_path(node, @presenter), title: "Edit file" do %>
-              <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+              <span class="fa fa-pencil" aria-hidden="true"></span>
             <% end %>
           </div>
           <% if node.respond_to?(:label) %>

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -15,14 +15,14 @@
                 <div class="fileinput-button" id="add-files">
                   <input id="addfiles" type="file" style="display:none;"  name="files[]" multiple />
                   <button type="button" class="btn btn-success" onclick="document.getElementById('addfiles').click();">
-                    <span class="glyphicon glyphicon-plus"></span>
+                    <span class="fa fa-plus"></span>
                     <span><%=  t(".add_files") %></span>
                   </button>
                 </div>
                 <div class="fileinput-button">
                   <input id="addfolder" type="file" style="display:none;"  name="files[]" multiple directory webkitdirectory />
                   <button type="button" class="btn btn-success" onclick="document.getElementById('addfolder').click();">
-                    <span class="glyphicon glyphicon-plus"></span>
+                    <span class="fa fa-plus"></span>
                     <span><%=  t(".add_folder") %></span>
                   </button>
                 </div>
@@ -30,12 +30,12 @@
                   <%= button_tag(type: 'button', class: 'btn btn-success', id: "browse-btn",
                     'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,
                     'data-target' => "#{f.object.persisted? ? "#edit_#{f.object.model.model_name.param_key}_#{f.object.model.id}" : "#new_#{f.object.model.model_name.param_key}"}" ) do %>
-                    <span class="glyphicon glyphicon-plus"></span>
+                    <span class="fa fa-plus"></span>
                     <%= t('hyrax.upload.browse_everything.browse_files_button') %>
                   <% end %>
                 <% end %>
                 <button type="reset" id="file-upload-cancel-btn" class="btn btn-warning cancel" hidden="">
-                    <span class="glyphicon glyphicon-ban-circle"></span>
+                    <span class="fa fa-ban"></span>
                     <span><%= t('.cancel_upload') %></span>
                 </button>
                 <!-- The global file processing state -->

--- a/app/views/hyrax/batch_edits/edit.html.erb
+++ b/app/views/hyrax/batch_edits/edit.html.erb
@@ -11,12 +11,12 @@
     <ul class="nav nav-tabs">
       <li id="edit_descriptions_link" class="nav-item">
         <a class="nav-link active" href="#descriptions_display" data-toggle="tab">
-          <span class="glyphicon glyphicon-tags"></span> <%= t('.descriptions') %>
+          <span class="fa fa-tags"></span> <%= t('.descriptions') %>
         </a>
       </li>
       <li id="edit_permissions_link" class="nav-item">
         <a class="nav-link" href="#permissions_display" data-toggle="tab">
-          <span class="glyphicon glyphicon-lock"></span> <%= t('.permissions') %>
+          <span class="fa fa-lock"></span> <%= t('.permissions') %>
         </a>
       </li>
     </ul>
@@ -34,7 +34,7 @@
                                           class: "ajax-form" },
                                   data: { model: @form.model_name.param_key } do |f| %>
                 <div class="col-12 col-sm-4">
-                  <a class="accordion-toggle grey glyphicon-chevron-right-helper collapsed" data-toggle="collapse" href="#collapse_<%= term %>" id="expand_link_<%=term.to_s%>">
+                  <a class="accordion-toggle grey fa-chevron-right-helper collapsed" data-toggle="collapse" href="#collapse_<%= term %>" id="expand_link_<%=term.to_s%>">
                     <%= f.input_label term %> <span class="chevron"></span>
                   </a>
                 </div>
@@ -67,7 +67,7 @@
                                 html: { id: "form_permissions_visibility", class: "ajax-form"},
                                 data: { 'param-key' => @form.model_name.param_key } do |f| %>
               <div class="col-12 col-sm-4">
-                <a class="accordion-toggle grey glyphicon-chevron-right-helper collapsed" data-toggle="collapse" href="#collapse_permissions_visibility" id="expand_link_permissions_visibility">
+                <a class="accordion-toggle grey fa-chevron-right-helper collapsed" data-toggle="collapse" href="#collapse_permissions_visibility" id="expand_link_permissions_visibility">
                   <%= f.input_label t(".visibility") %> <span class="chevron"></span>
                 </a>
               </div>
@@ -97,7 +97,7 @@
                                 html: { id: "form_permissions", class: "ajax-form"},
                                 data: { 'param-key' => @form.model_name.param_key } do |f| %>
               <div class="col-12 col-sm-4">
-                <a class="accordion-toggle grey glyphicon-chevron-right-helper collapsed" data-toggle="collapse" href="#collapse_permissions_sharing" id="expand_link_permissions_sharing">
+                <a class="accordion-toggle grey fa-chevron-right-helper collapsed" data-toggle="collapse" href="#collapse_permissions_sharing" id="expand_link_permissions_sharing">
                   <%= f.input_label t(".sharing") %> <span class="chevron"></span>
                 </a>
               </div>

--- a/app/views/hyrax/collections/_list_collections.html.erb
+++ b/app/views/hyrax/collections/_list_collections.html.erb
@@ -11,7 +11,7 @@
               <%= collection_presenter.title_or_label %>
           <% end %>
           <a href="#" class="small" title="Click for more details">
-            <span id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+            <span id="expand_<%= id %>" class="fa fa-chevron-right" aria-hidden="true"></span>
             <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{collection_presenter.title_or_label}" %></span>
           </a>
         </div>

--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -3,7 +3,7 @@
       <div class="input-group">
         <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('hyrax.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
         <div class="input-group-btn">
-          <button type="submit" class="btn btn-primary" id="collection_submit"><span class="glyphicon glyphicon-search"></span> <%= t('hyrax.collections.search_form.button_label') %></button>
+          <button type="submit" class="btn btn-primary" id="collection_submit"><span class="fa fa-search"></span> <%= t('hyrax.collections.search_form.button_label') %></button>
         </div>
       </div>
       <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -2,7 +2,7 @@
 <tr id="document_<%= id %>">
   <td>&nbsp;
     <% if current_user and document.depositor != current_user.user_key %>
-      <i class="glyphicon glyphicon-share-alt" />
+      <i class="fa fa-share" />
     <% end %>
   </td>
   <td>

--- a/app/views/hyrax/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/collections/_sort_and_per_page.html.erb
@@ -10,7 +10,7 @@
         <%= select_tag(:per_page, options_for_select(Hyrax.config.range_for_number_of_results_to_display_per_page, h(params[:per_page])), title: t('.number_of_results_to_display_per_page')) %>
       <% end %>
       <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:per_page, :sort)) %>
-      &nbsp;<button class="btn btn-sm btn-secondary tiny-nudge"><span class="glyphicon glyphicon-refresh"></span> <%= t('helpers.action.refresh') %></button>
+      &nbsp;<button class="btn btn-sm btn-secondary tiny-nudge"><span class="fa fa-refresh"></span> <%= t('helpers.action.refresh') %></button>
     </fieldset>
   <% end %>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/_batch_edits_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_batch_edits_actions.html.erb
@@ -1,3 +1,3 @@
-<li data-behavior="batch-edit-select-none" data-state="on"><a href="#"><i class="glyphicon glyphicon-ok"></i> Select None</a></li>
+<li data-behavior="batch-edit-select-none" data-state="on"><a href="#"><i class="fa fa-check"></i> Select None</a></li>
 <li data-behavior="batch-edit-select-page" data-state="off"><a href="#"><i class=""></i> Select Current Page</a></li>
 <li><%= button_for_remove_selected_from_collection @collection %></li>

--- a/app/views/hyrax/dashboard/collections/_form_branding.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_branding.html.erb
@@ -14,7 +14,7 @@
       <div class="col-4">
         <!-- The fileinput-button span is used to style the file input field as button -->
         <span class="btn btn-success fileinput-button">
-          <span class="glyphicon glyphicon-plus"></span>
+          <span class="fa fa-plus"></span>
           <span><%= t('.choose_file') %></span>
           <input type="file" name="files[]" single />
         </span>
@@ -46,7 +46,7 @@
 
               <div class="col-sm-2">
                 <button class="btn btn-danger delete branding-banner-remove" data-type="DELETE" data-url="/" onclick=$("#banner").remove();>
-                  <span class="glyphicon glyphicon-remove"></span>
+                  <span class="fa fa-times"></span>
                   <span class="controls-remove-text"><%= t('.remove') %></span>
                   <span class="sr-only">
                     <%= t('.previous') %>
@@ -91,7 +91,7 @@
       <div class="col-4">
         <!-- The fileinput-button span is used to style the file input field as button -->
         <span class="btn btn-success fileinput-button">
-          <span class="glyphicon glyphicon-plus"></span>
+          <span class="fa fa-plus"></span>
           <span><%= t('.choose_file') %></span>
           <input type="file" name="files[]" single />
         </span>
@@ -132,7 +132,7 @@
 
               <div class="col-sm-2">
                 <button class="btn btn-danger delete branding-logo-remove" data-type="DELETE" data-url="/" onclick=$("#logorow_<%= i %>").remove();>
-                  <span class="glyphicon glyphicon-remove"></span>
+                  <span class="fa fa-times"></span>
                   <span class="controls-remove-text"><%= t('.remove') %></span>
                    <span class="sr-only">
                     <%= t('.previous') %>

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -31,7 +31,7 @@
 
       <%# Expand arrow %>
       <a href="#" class="small show-more" title="Click for more details">
-        <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i>
+        <i id="expand_<%= id %>" class="fa fa-chevron-right" aria-hidden="true"></i>
         <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{collection_presenter.title_or_label}" %></span>
       </a>
     </div>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
@@ -8,13 +8,13 @@
                     class: "itemicon itemedit",
                     title: t('hyrax.collection.document_list.edit'),
                     id: "edit_work_link_#{document.id}" do %>
-          <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i> <%= t('hyrax.collection.document_list.edit') %>
+          <i class="fa fa-pencil" aria-hidden="true"></i> <%= t('hyrax.collection.document_list.edit') %>
         <% end %>
       </li>
     <% end %>
     <li class="dropdown-item">
       <%= display_trophy_link(current_user, document.id) do |text| %>
-        <i class="glyphicon glyphicon-star" aria-hidden="true"></i> <%= text %>
+        <i class="fa fa-star" aria-hidden="true"></i> <%= text %>
       <% end %>
     </li>
   </ul>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -2,7 +2,7 @@
 <tr id="document_<%= id %>">
   <td>&nbsp;
     <% if current_user and document.depositor != current_user.user_key %>
-      <i class="glyphicon glyphicon-share-alt" />
+      <i class="fa fa-share" />
     <% end %>
   </td>
   <td>
@@ -13,7 +13,7 @@
       <div class="media-body">
         <p class="media-heading">
           <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
-          <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></i></a>
+          <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="fa fa-chevron-right"></i></a>
         </p>
         <%= render_other_collection_links(document, @presenter.id) %>
       </div>

--- a/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
@@ -20,7 +20,7 @@
                <%= t(".show_par_page_html", select: select_tag(:per_page, options_for_select(Hyrax.config.range_for_number_of_results_to_display_per_page, params[:per_page]), title: t('hyrax.dashboard.my.sr.results_per_page'))) %>
              <% end %>
              <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:per_page, :sort)) %>
-             <button class="btn btn-info"><span class="glyphicon glyphicon-refresh"></span> <%= t('helpers.action.refresh') %></button>
+             <button class="btn btn-info"><span class="fa fa-refresh"></span> <%= t('helpers.action.refresh') %></button>
            </fieldset>
            <div class="col-sm-3">
              <%= render 'hyrax/collections/view_type_group' %>

--- a/app/views/hyrax/dashboard/collections/_work_action_menu.html.erb
+++ b/app/views/hyrax/dashboard/collections/_work_action_menu.html.erb
@@ -13,27 +13,27 @@
 
     <li class="dropdown-item" role="menuitem" tabindex="-1">
       <%= link_to [main_app, :edit, document] do %>
-        <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
+        <i class="fa fa-pencil" aria-hidden="true"></i>
         <span> <%= t('.edit_work') %> </span>
       <% end %>
     </li>
 
     <li class="dropdown-item" role="menuitem" tabindex="-1">
       <%= link_to [main_app, document], method: :delete, data: { confirm: t(".deleting_from_work", application_name: application_name) } do %>
-        <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
+        <i class="fa fa-trash" aria-hidden="true"></i>
         <span><%= t('.delete_work') %></span>
       <% end %>
     </li>
 
     <li class="dropdown-item" role="menuitem" tabindex="-1">
       <%= display_trophy_link @user, document.id do |text| %>
-        <i class="glyphicon glyphicon-star" aria-hidden="true"></i> <%= text %>
+        <i class="fa fa-star" aria-hidden="true"></i> <%= text %>
       <% end %>
     </li>
 
     <li class="dropdown-item" role="menuitem" tabindex="-1">
       <%= link_to(hyrax.new_work_transfer_path(document.id), class: 'itemicon itemtransfer', title: t('.transfer_ownership_of_work')) do %>
-        <i aria-hidden="true" class="glyphicon glyphicon-transfer"></i>
+        <i aria-hidden="true" class="fa fa-exchange"></i>
         <span> <%=t('.transfer_ownership_of_work') %> </span>
       <% end %>
     </li>

--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -13,7 +13,7 @@
         <%= f.label :remove_avatar, class: 'form-check-label' do %>
           <%= f.check_box :remove_avatar, class: 'form-check-input' %>
           <%= t(".delete_picture") %>
-          <a href="#" id="delete_picture_help" data-toggle="popover" data-content="<%= t('.delete_picture_data_content') %>" data-original-title="<%= t('.delete_picture_data_original_title') %>"><i class="glyphicon glyphicon-question-sign"></i></a>
+          <a href="#" id="delete_picture_help" data-toggle="popover" data-content="<%= t('.delete_picture_data_content') %>" data-original-title="<%= t('.delete_picture_data_original_title') %>"><i class="fa fa-question"></i></a>
         <% end %>
       </div>
     </div>

--- a/app/views/hyrax/dashboard/profiles/_trophy_edit.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_trophy_edit.html.erb
@@ -1,8 +1,8 @@
 <% if trophies.any? %>
   <div class="form-group">
     <span>
-      <i class="glyphicon glyphicon-star trophy-on"></i> Remove Highlight Designation
-      <a href="#" id="remove_trophy_help" data-toggle="popover" data-content="If you would like to remove a highlight designation, check the box and save your profile." data-original-title="Remove Highlight Designation"><i class="glyphicon glyphicon-question-sign"></i></a>
+      <i class="fa fa-star trophy-on"></i> Remove Highlight Designation
+      <a href="#" id="remove_trophy_help" data-toggle="popover" data-content="If you would like to remove a highlight designation, check the box and save your profile." data-original-title="Remove Highlight Designation"><i class="fa fa-question"></i></a>
     </span>
     <% trophies.each do |t| %>
       <div class="form-check">

--- a/app/views/hyrax/file_sets/_descriptions.html.erb
+++ b/app/views/hyrax/file_sets/_descriptions.html.erb
@@ -7,7 +7,7 @@
       <% end %>
     <div>
       <%= button_tag class: 'btn btn-primary btn-lg', id: "upload_submit", name: "update_descriptions" do %>
-        <i class="glyphicon glyphicon-floppy-disk"></i> <%= t('.save') %>
+        <i class="fa fa-floppy-o"></i> <%= t('.save') %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/hyrax/file_sets/_extra_fields_modal.html.erb
+++ b/app/views/hyrax/file_sets/_extra_fields_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="modal-div extra_tag">
 <% label = name.to_s.titleize %>
 <!-- Button to trigger modal -->
-<a href="#extraFieldsModal_<%= name %>" role="button" class="btn btn-warning fright vmiddle" data-toggle="modal"><%= t('.additional') %> <%= label %> <i class="glyphicon glyphicon-plus large-icon"></i></a>
+<a href="#extraFieldsModal_<%= name %>" role="button" class="btn btn-warning fright vmiddle" data-toggle="modal"><%= t('.additional') %> <%= label %> <i class="fa fa-plus large-icon"></i></a>
 <!-- Modal -->
 <div class="modal fade" id="extraFieldsModal_<%= name %>" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
   <div class="modal-dialog">

--- a/app/views/hyrax/file_sets/_permission_form.html.erb
+++ b/app/views/hyrax/file_sets/_permission_form.html.erb
@@ -39,7 +39,7 @@
     <div class="col-sm-3">
       <button class="btn btn-secondary" id="add_new_user_skel">
         <span class="sr-only"><%= t('.add_new_user_skel', account_label: t('hyrax.account_label')) %></span>
-        <span aria-hidden="true"><i class="glyphicon glyphicon-plus"></i></span>
+        <span aria-hidden="true"><i class="fa fa-plus"></i></span>
       </button>
       <br /> <span id="directory_user_result"></span>
     </div>
@@ -59,7 +59,7 @@
     </div>
     <div class="col-sm-3">
       <span class="sr-only"><%= t('.add_new_group_skel') %></span>
-      <button class="btn btn-secondary" id="add_new_group_skel"><i class="glyphicon glyphicon-plus"></i></button>
+      <button class="btn btn-secondary" id="add_new_group_skel"><i class="fa fa-plus"></i></button>
       <br /><span id="directory_group_result"></span>
     </div>
   </div>

--- a/app/views/hyrax/homepage/_sortable_featured.html.erb
+++ b/app/views/hyrax/homepage/_sortable_featured.html.erb
@@ -11,7 +11,7 @@
             <%= link_to hyrax.featured_work_path(presenter, format: :json),
               title: "Remove work from feature section",
               data: {behavior: 'unfeature'} do %>
-              <i class='glyphicon glyphicon-remove'></i>
+              <i class='fa fa-times'></i>
             <% end %>
             <p class="sr-only"><%= t 'helpers.action.remove' %></p>
           </h3>

--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -7,18 +7,18 @@
       <%= link_to '#',
         class: "btn btn-primary btn-lg",
         data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
-        <i class="glyphicon glyphicon-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
+        <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
       <% end %>
     <% else # simple link to the first work type %>
       <%= link_to new_polymorphic_path([main_app, @presenter.first_work_type]),
             class: 'btn btn-primary btn-lg' do %>
-        <i class="glyphicon glyphicon-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
+        <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
       <% end %>
     <% end %>
   <% else %>
     <%= link_to hyrax.my_works_path,
       class: "btn btn-primary btn-lg" do %>
-      <i class="glyphicon glyphicon-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
+      <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
     <% end %>
   <% end %>
   <p class="terms-of-use"><%= link_to t(:'hyrax.pages.tabs.terms_page'), hyrax.terms_path %></p>

--- a/app/views/hyrax/my/_constraints.html.erb
+++ b/app/views/hyrax/my/_constraints.html.erb
@@ -3,7 +3,7 @@
     <div class="float-right">
       <%= link_to start_over_path,
           class: "catalog_startOverLink btn btn-sm btn-text", id: "startOverLink" do %>
-          <span class="btn btn-sm btn-danger start-over"><span class="glyphicon glyphicon-remove"></span></span>
+          <span class="btn btn-sm btn-danger start-over"><span class="fa fa-times"></span></span>
           <%= t('blacklight.search.start_over') %>
       <% end %>
     </div>

--- a/app/views/hyrax/my/_facet_selected.html.erb
+++ b/app/views/hyrax/my/_facet_selected.html.erb
@@ -5,7 +5,7 @@
       <% link_options = remove_facet_params(k, selected_facet, params).merge(action: :index) %>
       <div class="alert alert-warning">
         <%= link_to "X", hyrax.url_for(link_options), { class: "close", data: { dismiss: "alert" } } %>
-        <i class="glyphicon glyphicon-ok"></i> <strong><%= selected_facet %></strong>
+        <i class="fa fa-check"></i> <strong><%= selected_facet %></strong>
       </div>
     <% end %>
   <% end %>

--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -12,7 +12,7 @@
     <% if can? :edit, document.id %>
       <li class="dropdown-item" role="menuitem" tabindex="-1">
         <%= link_to [main_app, :edit, document] do %>
-          <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
+          <i class="fa fa-pencil" aria-hidden="true"></i>
           <span> <%= t("hyrax.dashboard.my.action.edit_work") %> </span>
         <% end %>
       </li>
@@ -22,7 +22,7 @@
                     method: :delete,
                     data: {
                       confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
-          <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
+          <i class="fa fa-trash" aria-hidden="true"></i>
           <span> <%= t("hyrax.dashboard.my.action.delete_work") %> </span>
         <% end %>
       </li>
@@ -30,14 +30,14 @@
 
     <li class="dropdown-item" role="menuitem" tabindex="-1">
       <%= display_trophy_link(current_user, document.id) do |text| %>
-        <i class="glyphicon glyphicon-star" aria-hidden="true"></i> <%= text %>
+        <i class="fa fa-star" aria-hidden="true"></i> <%= text %>
       <% end %>
     </li>
 
     <% if can? :transfer, document.id %>
       <li class="dropdown-item" role="menuitem" tabindex="-1">
         <%= link_to(hyrax.new_work_transfer_path(document.id), class: 'itemicon itemtransfer', title: t("hyrax.dashboard.my.action.transfer")) do %>
-          <i class="glyphicon glyphicon-transfer" aria-hidden="true"></i>
+          <i class="fa fa-exchange" aria-hidden="true"></i>
           <span> <%= t("hyrax.dashboard.my.action.transfer") %> </span>
         <% end %>
       </li>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -33,7 +33,7 @@
 
       <%# Expand arrow %>
       <a href="#" class="small show-more" title="Click for more details">
-        <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i>
+        <i id="expand_<%= id %>" class="fa fa-chevron-right" aria-hidden="true"></i>
         <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{collection_presenter.title_or_label}" %></span>
       </a>
     </div>

--- a/app/views/hyrax/notifications/_notifications.html.erb
+++ b/app/views/hyrax/notifications/_notifications.html.erb
@@ -25,7 +25,7 @@
                       title: t('hyrax.mailbox.delete'),
                       method: :delete do %>
                   <span class="sr-only"><%= I18n.t('hyrax.dashboard.delete_notification') %></span>
-                <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
+                <i class="fa fa-trash" aria-hidden="true"></i>
                 <% end %>
             </td>
           </tr>

--- a/app/views/hyrax/notifications/index.html.erb
+++ b/app/views/hyrax/notifications/index.html.erb
@@ -4,7 +4,7 @@
               method: :delete,
               class: 'btn btn-danger float-right',
               title: 'Delete all user notifications' do %>
-    <i class="glyphicon glyphicon-trash"></i> <%= t('hyrax.admin.sidebar.delete_all') %>
+    <i class="fa fa-trash"></i> <%= t('hyrax.admin.sidebar.delete_all') %>
   <% end %>
 <% end %>
 

--- a/app/views/hyrax/stats/file.html.erb
+++ b/app/views/hyrax/stats/file.html.erb
@@ -13,7 +13,7 @@
   <div class="col-sm-12">
     <%= content_tag :h2, "File Analytics" %>
     <div class="alert alert-info">
-      <span class="glyphicon glyphicon-signal large-icon"></span>
+      <span class="fa fa-signal large-icon"></span>
       <%= content_tag :strong, @stats.total_pageviews %> views and <%= content_tag :strong, @stats.total_downloads %> downloads since <%= @stats.created.strftime("%B %-d, %Y") %>
     </div>
     <div class="stats-container">

--- a/app/views/hyrax/stats/work.html.erb
+++ b/app/views/hyrax/stats/work.html.erb
@@ -11,7 +11,7 @@
   <div class="col-sm-12">
     <%= content_tag :h2, "#{t('.header')}" %>
     <div class="alert alert-info">
-      <span class="glyphicon glyphicon-signal large-icon"></span>
+      <span class="fa fa-signal large-icon"></span>
         <%= t('total_view', count: @pageviews.range(Hyrax.config.analytics_start_date.to_date, Time.zone.today)) %>
         <%= t('download', count: @downloads.range(Hyrax.config.analytics_start_date.to_date, Time.zone.today)) %>
     </div>

--- a/app/views/hyrax/uploads/_js_templates.html.erb
+++ b/app/views/hyrax/uploads/_js_templates.html.erb
@@ -17,13 +17,13 @@
         <td class="text-right">
             {% if (!i && !o.options.autoUpload) { %}
                 <button class="btn btn-primary start" disabled>
-                    <span class="glyphicon glyphicon-upload"></span>
+                    <span class="fa fa-upload"></span>
                     <span><%= t('.start') %></span>
                 </button>
             {% } %}
             {% if (!i) { %}
                 <button class="btn btn-sm btn-warning cancel">
-                    <span class="glyphicon glyphicon-ban-circle"></span>
+                    <span class="fa fa-ban"></span>
                     <span><%= t('helpers.action.cancel') %></span>
                 </button>
             {% } %}
@@ -67,7 +67,7 @@
               {% } %}
               <span class="size">{%=o.formatFileSize(file.size)%}</span>
               <button class="btn btn-sm btn-danger delete float-right" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
-                  <span class="glyphicon glyphicon-trash"></span>
+                  <span class="fa fa-trash"></span>
                   <span><%= t('helpers.action.delete') %></span>
               </button>
             </div>
@@ -124,7 +124,7 @@
         </td>
         <td class="text-right">
             <button class="btn btn-sm btn-danger delete" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
-                <span class="glyphicon glyphicon-trash"></span>
+                <span class="fa fa-trash"></span>
                 <%= t('helpers.action.delete') %>
             </button>
         </td>

--- a/app/views/hyrax/uploads/_js_templates_branding.html.erb
+++ b/app/views/hyrax/uploads/_js_templates_branding.html.erb
@@ -52,7 +52,7 @@
 
               <div class="col-sm-2">
                 <button class="btn btn-link remove branding-banner-remove" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}" onclick=$("#banner").remove(); {% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
-                  <span class="glyphicon glyphicon-remove"></span>
+                  <span class="fa fa-times"></span>
                   <span class="controls-remove-text"><%= t('.remove') %></span>
                   <span class="sr-only">
                     <%= t('.previous') %>
@@ -104,7 +104,7 @@
               <div class="col-sm-2 text-right">
                 <span class="input-group-btn field-controls">
             <button class="btn btn-sm btn-danger delete branding-logo-remove" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
-                    <span class="glyphicon glyphicon-remove"></span>
+                    <span class="fa fa-times"></span>
                     <span class="controls-remove-text">Remove</span>
                     <span class="sr-only">
                       <%= t('.previous') %>

--- a/app/views/hyrax/uploads/_js_templates_versioning.html.erb
+++ b/app/views/hyrax/uploads/_js_templates_versioning.html.erb
@@ -23,13 +23,13 @@
         <td class="text-right">
             {% if (!i && !o.options.autoUpload) { %}
                 <button class="btn btn-primary start" disabled>
-                    <span class="glyphicon glyphicon-upload"></span>
+                    <span class="fa fa-upload"></span>
                     <span><%= t('.start') %></span>
                 </button>
             {% } %}
             {% if (!i) { %}
                 <button class="btn btn-sm btn-warning cancel">
-                    <span class="glyphicon glyphicon-ban-circle"></span>
+                    <span class="fa fa-ban"></span>
                     <span><%= t('helpers.action.cancel') %></span>
                 </button>
             {% } %}
@@ -76,7 +76,7 @@
                       data-type="{%=file.deleteType%}"
                       data-url="{%=file.deleteUrl%}"
                       {% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
-                  <span class="glyphicon glyphicon-trash"></span>
+                  <span class="fa fa-trash"></span>
                   <span><%= t('helpers.action.delete') %></span>
               </button>
             </div>
@@ -134,7 +134,7 @@
                         data-type="{%=file.deleteType%}"
                         data-url="{%=file.deleteUrl%}"
                         onclick=$("#files").remove(); {% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
-                  <span class="glyphicon glyphicon-remove"></span>
+                  <span class="fa fa-times"></span>
                   <span class="controls-remove-text"><%= t('.remove') %></span>
                   <span class="sr-only">
                     <%= t('.previous') %>

--- a/app/views/hyrax/users/_contributions.html.erb
+++ b/app/views/hyrax/users/_contributions.html.erb
@@ -11,8 +11,8 @@
           <td>
             <%= link_to t.to_s, [main_app, t] %>
             <% if presenter.current_user? %>
-              <%= display_trophy_link current_user, t.id, class: 'glyphicon glyphicon-star', data: { removerow: true } do %>
-                <span class='trophy-on glyphicon glyphicon-remove'></span>
+              <%= display_trophy_link current_user, t.id, class: 'fa fa-star', data: { removerow: true } do %>
+                <span class='trophy-on fa fa-times'></span>
               <% end %>
             <% end %>
           </td>

--- a/app/views/hyrax/users/_left_sidebar.html.erb
+++ b/app/views/hyrax/users/_left_sidebar.html.erb
@@ -1,4 +1,4 @@
 <%= render 'hyrax/users/user', user: @user %>
 
 <br />
-<a class="btn btn-primary" href="<%= hyrax.users_path %>"><i class="glyphicon glyphicon-globe" aria-hidden="true"></i><%= t('.view_users') %></a>
+<a class="btn btn-primary" href="<%= hyrax.users_path %>"><i class="fa fa-globe" aria-hidden="true"></i><%= t('.view_users') %></a>

--- a/app/views/hyrax/users/_profile_tabs.html.erb
+++ b/app/views/hyrax/users/_profile_tabs.html.erb
@@ -1,12 +1,12 @@
 <ul class="nav nav-tabs" id="myTab">
   <li class="nav-item">
     <a class="nav-link active" href="#contributions">
-      <span class="glyphicon glyphicon-star"></span> <%= I18n.t('hyrax.user_profile.tab_highlighted') %>
+      <span class="fa fa-star"></span> <%= I18n.t('hyrax.user_profile.tab_highlighted') %>
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link" href="#activity_log">
-      <span class="glyphicon glyphicon-calendar"></span> <%= I18n.t('hyrax.user_profile.tab_activity') %>
+      <span class="fa fa-calendar"></span> <%= I18n.t('hyrax.user_profile.tab_activity') %>
     </a>
   </li>
 </ul>

--- a/app/views/hyrax/users/_search_form.html.erb
+++ b/app/views/hyrax/users/_search_form.html.erb
@@ -6,7 +6,7 @@
     <%= hidden_field_tag :sort, params[:sort], id: 'user_sort' %>
     <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:uq, :sort, :qt, :page, :utf8)) %>
     <button type="submit" class="btn btn-primary" id="user_submit">
-      <span class="glyphicon glyphicon-search"></span><%= t('.go') %>
+      <span class="fa fa-search"></span><%= t('.go') %>
     </button>
   <% end %>
 </div>

--- a/app/views/hyrax/users/_user.html.erb
+++ b/app/views/hyrax/users/_user.html.erb
@@ -17,7 +17,7 @@
   <div class="card-footer clearfix">
     <% if can? :edit, user %>
       <%= link_to hyrax.edit_dashboard_profile_path(user), class: "btn btn-secondary float-right" do %>
-        <span class="glyphicon glyphicon-edit"></span> <%= t("hyrax.edit_profile") %>
+        <span class="fa fa-edit"></span> <%= t("hyrax.edit_profile") %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -34,12 +34,12 @@
   <dd><%= mail_to user.email %></dd>
 
   <% if user.chat_id %>
-    <dt><span class="glyphicon glyphicon-bullhorn" aria-hidden="true"></span> Chat ID</dt>
+    <dt><span class="fa fa-bullhorn" aria-hidden="true"></span> Chat ID</dt>
     <dd><%= user.chat_id %></dd>
   <% end %>
 
   <% if user.website %>
-    <dt><span class="glyphicon glyphicon-globe" aria-hidden="true"></span> Website(s)</dt>
+    <dt><span class="fa fa-globe" aria-hidden="true"></span> Website(s)</dt>
     <dd><%= iconify_auto_link(user.website) %></dd>
   <% end %>
 
@@ -64,7 +64,7 @@
   <% end %>
 
   <% if user.address %>
-    <dt><span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span> Address</dt>
+    <dt><span class="fa fa-map-marker" aria-hidden="true"></span> Address</dt>
     <dd><%= user.address %></dd>
   <% end %>
 
@@ -74,7 +74,7 @@
   <% end %>
 
   <% if user.telephone %>
-    <dt><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> Telephone</dt>
+    <dt><span class="fa fa-phone" aria-hidden="true"></span> Telephone</dt>
     <dd><%= link_to_telephone(user) %></dd>
   <% end %>
 

--- a/app/views/hyrax/users/_vitals.html.erb
+++ b/app/views/hyrax/users/_vitals.html.erb
@@ -1,15 +1,15 @@
 <div class="list-group-item">
-  <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= t("hyrax.dashboard.stats.joined_on") %> <%= user.created_at.to_date.strftime("%b %d, %Y") %>
+  <span class="fa fa-clock-o" aria-hidden="true"></span> <%= t("hyrax.dashboard.stats.joined_on") %> <%= user.created_at.to_date.strftime("%b %d, %Y") %>
 </div>
 
 <div class="list-group-item">
   <span class="badge"><%= number_of_collections(user) %></span>
-  <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.collections"), {generic_type: "Collection", depositor: user.to_s}) %>
+  <span class="fa fa-folder-open" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.collections"), {generic_type: "Collection", depositor: user.to_s}) %>
 </div>
 
 <div class="list-group-item">
   <span class="badge"><%= number_of_works(user) %></span>
-  <span class="glyphicon glyphicon-upload" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.works"), {generic_type: "Work", depositor: user.to_s}) %>
+  <span class="fa fa-upload" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.works"), {generic_type: "Work", depositor: user.to_s}) %>
 
   <ul class="views-downloads-dashboard list-unstyled">
       <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -1085,14 +1085,14 @@ de:
       no_transfers: Sie haben keine Arbeit übertragen
       profiles:
         edit_primary:
-          change_picture: <i class = "glyphicon glyphicon-camera"> </ i> Bild ändern
+          change_picture: <i class = "fa fa-camera"> </ i> Bild ändern
           delete_picture: Bild löschen
           delete_picture_data_content: Wenn Sie Ihr Bild vollständig entfernen möchten, aktivieren Sie das Kontrollkästchen und speichern Sie Ihr Profil.
           delete_picture_data_original_title: Bild löschen
           facebook_handle: <i class = "fa fa-facebook" aria-hidden = "true"> </ i> Facebook-Handle
           google_handle: <i class = "fa-fa-google-plus"> </ i> Google+ Handle
           help_change_picture_type: JPG, GIF oder PNG (weniger als 2 MB)
-          save_profile: <i class = "glyphicon glyphicon-save"> </ i> Profil speichern
+          save_profile: <i class = "fa fa-floppy-o"> </ i> Profil speichern
           twitter_handle: <i class = "fa fa-twitter" aria-hidden = "true"> </ i> Twitter-Handle
       proxy_activity: Vertreter-Aktivität
       proxy_add_deny: Sie können sich nicht selbst zum Stellvertreter machen
@@ -1482,7 +1482,7 @@ de:
       read: Lesen/Download
     search:
       button:
-        html: <span class="glyphicon glyphicon-search"></span> Suchen
+        html: <span class="fa fa-search"></span> Suchen
         text: Suche
       form:
         option:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1075,14 +1075,14 @@ en:
       no_transfers: You haven't transferred any work
       profiles:
         edit_primary:
-          change_picture: <i class="glyphicon glyphicon-camera"></i> Change picture
+          change_picture: <i class="fa fa-camera"></i> Change picture
           delete_picture: Delete picture
           delete_picture_data_content: If you would like to remove your picture entirely, check the box and save your profile.
           delete_picture_data_original_title: Delete Picture
           facebook_handle: <i class="fa fa-facebook" aria-hidden="true"></i> Facebook Handle
           google_handle: <i class="fa fa-google-plus"></i> Google+ Handle
           help_change_picture_type: JPG, GIF, or PNG (less than 2MB)
-          save_profile: <i class="glyphicon glyphicon-save"></i> Save Profile
+          save_profile: <i class="fa fa-floppy-o"></i> Save Profile
           twitter_handle: <i class="fa fa-twitter" aria-hidden="true"></i> Twitter Handle
       proxy_activity: Proxy Activity
       proxy_add_deny: You cannot make yourself a proxy
@@ -1471,7 +1471,7 @@ en:
     read_only: The repository is in read-only mode for maintenance. No submissions or edits can be made at this time.
     search:
       button:
-        html: <span class="glyphicon glyphicon-search" aria-hidden="true"></span> Go
+        html: <span class="fa fa-search" aria-hidden="true"></span> Go
         text: Search
       form:
         option:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1090,14 +1090,14 @@ es:
       no_transfers: No ha transferido ningún trabajo
       profiles:
         edit_primary:
-          change_picture: <i class = "glyphicon glyphicon-camera"> </i> Cambiar imagen
+          change_picture: <i class = "fa fa-camera"> </i> Cambiar imagen
           delete_picture: Eliminar foto
           delete_picture_data_content: Si desea eliminar su imagen por completo, marque la casilla y guarde su perfil.
           delete_picture_data_original_title: Eliminar imagen
           facebook_handle: <i class = "fa fa-facebook" aria-hidden = "true"> </i> Asa de Facebook
           google_handle: <i class = "fa fa-google-plus"> </i> Manija de Google+
           help_change_picture_type: JPG, GIF o PNG (menos de 2 MB)
-          save_profile: <i class = "glyphicon glyphicon-save"> </i> Guardar perfil
+          save_profile: <i class = "fa fa-floppy-o"> </i> Guardar perfil
           twitter_handle: <i class = "fa fa-twitter" aria-hidden = "true"> </i> Twitter Handle
       proxy_activity: Actividad de Proxy
       proxy_add_deny: No puedes hacerte un proxy
@@ -1455,7 +1455,7 @@ es:
         changes_required:
           message: |-
             %{title} (%{link}) requiere cambios adicionales antes de la aprobación.
-             '%{comment}'
+             '%{comment}'
           subject: Su depósito requiere cambios
         deposited:
           message: "%{title} (%{link}) fue aprobado por %{user}. %{comment}"
@@ -1489,7 +1489,7 @@ es:
       read: Ver descarga
     search:
       button:
-        html: <span class="glyphicon glyphicon-search"></span> Ir
+        html: <span class="fa fa-search"></span> Ir
         text: Buscar
       form:
         option:

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -440,7 +440,7 @@ fr:
           end_label: Terminer [par défaut pour le moment]
           headers:
             main: Statistiques de travail
-            total: 'Total des travaux :'
+            total: 'Total des travaux :'
             visibility: Totaux par visibilité
           heading: Afficher les fichiers déposés par les utilisateurs
           start_label: Départ
@@ -1091,14 +1091,14 @@ fr:
       no_transfers: Vous n'avez transféré aucun travail
       profiles:
         edit_primary:
-          change_picture: <i class = "glyphicon glyphicon-camera"> </ i> Changer photo
+          change_picture: <i class = "fa fa-camera"> </ i> Changer photo
           delete_picture: Supprimer la photo
           delete_picture_data_content: Si vous souhaitez supprimer entièrement votre image, cochez la case et enregistrez votre profil.
           delete_picture_data_original_title: Supprimer l'image
           facebook_handle: <i class = "fa fa-facebook" aria-hidden = "true"> </ i> Poignée Facebook
           google_handle: <i class = "fa fa-google-plus"> </ i> Poignée Google+
           help_change_picture_type: JPG, GIF ou PNG (moins de 2 Mo)
-          save_profile: <i class = "glyphicon glyphicon-save"> </ i> Enregistrer le profil
+          save_profile: <i class = "fa fa-floppy-o"> </ i> Enregistrer le profil
           twitter_handle: <i class = "fa fa-twitter" aria-hidden = "true"> </ i> Poignée Twitter
       proxy_activity: Activité de procuration
       proxy_add_deny: Vous ne pouvez pas vous faire un proxy
@@ -1454,7 +1454,7 @@ fr:
         changes_required:
           message: |-
             %{title} (%{link}) nécessite des modifications supplémentaires avant d'être approuvé.
-             '%{comment}'
+             '%{comment}'
           subject: Votre dépôt nécessite des modifications
         deposited:
           message: "%{title} (%{link}) a été approuvé par %{user}. %{comment}"
@@ -1488,7 +1488,7 @@ fr:
       read: Voir le téléchargement
     search:
       button:
-        html: <span class="glyphicon glyphicon-search"></span> Aller
+        html: <span class="fa fa-search"></span> Aller
         text: Chercher
       form:
         option:

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -1090,14 +1090,14 @@ it:
       no_transfers: Non hai trasferito alcun lavoro
       profiles:
         edit_primary:
-          change_picture: <i class = "glyphicon glyphicon-camera"> </i> Cambia immagine
+          change_picture: <i class = "fa fa-camera"> </i> Cambia immagine
           delete_picture: Elimina foto
           delete_picture_data_content: Se desideri rimuovere completamente la tua foto, seleziona la casella e salva il tuo profilo.
           delete_picture_data_original_title: Elimina immagine
           facebook_handle: <i class = "fa fa-facebook" aria-hidden = "true"> </i> Handle di Facebook
           google_handle: <i class = "fa fa-google-plus"> </i> Handle di Google+
           help_change_picture_type: JPG, GIF o PNG (meno di 2 MB)
-          save_profile: <i class = "glyphicon glyphicon-save"> </i> Salva profilo
+          save_profile: <i class = "fa fa-floppy-o"> </i> Salva profilo
           twitter_handle: <i class = "fa fa-twitter" aria-hidden = "true"> </i> Handle di Twitter
       proxy_activity: Attività proxy
       proxy_add_deny: Non puoi renderti un proxy
@@ -1453,7 +1453,7 @@ it:
         changes_required:
           message: |-
             %{title} (%{link}) richiede ulteriori modifiche prima dell'approvazione.
-             '%{comment}'
+             '%{comment}'
           subject: Il tuo deposito richiede modifiche
         deposited:
           message: "%{title} (%{link}) è stato approvato da %{user}. %{comment}"
@@ -1487,7 +1487,7 @@ it:
       read: Visualizza / Scarica
     search:
       button:
-        html: <span class="glyphicon glyphicon-search"></span> Partire
+        html: <span class="fa fa-search"></span> Partire
         text: Ricerca
       form:
         option:

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -1085,14 +1085,14 @@ pt-BR:
       no_transfers: Você não transferiu nenhuma obra
       profiles:
         edit_primary:
-          change_picture: <i class = "glyphicon glyphicon-camera"> </i> Alterar imagem
+          change_picture: <i class = "fa fa-camera"> </i> Alterar imagem
           delete_picture: Excluir foto
           delete_picture_data_content: Se você deseja remover sua foto completamente, marque a caixa e salve seu perfil.
           delete_picture_data_original_title: Excluir imagem
           facebook_handle: <i class = "fa-facebook" aria-hidden = "true"> </i> Manipulação do Facebook
           google_handle: <i class = "fa fa-google-plus"> </i> Manipulação do Google+
           help_change_picture_type: JPG, GIF ou PNG (menos de 2 MB)
-          save_profile: <i class = "glyphicon glyphicon-save"> </i> Salvar perfil
+          save_profile: <i class = "fa fa-floppy-o"> </i> Salvar perfil
           twitter_handle: <i class = "fa-twitter" aria-hidden = "true"> </i> Manipulação do Twitter
       proxy_activity: Atividade de suplente
       proxy_add_deny: Você não pode se tornar um proxy
@@ -1448,7 +1448,7 @@ pt-BR:
         changes_required:
           message: |-
             %{title} (%{link}) requer alterações adicionais antes da aprovação.
-             '%{comment}'
+             '%{comment}'
           subject: Seu depósito requer alterações
         deposited:
           message: "%{title} (%{link}) foi aprovado por %{user}. %{comment}"
@@ -1482,7 +1482,7 @@ pt-BR:
       read: Visualizar download
     search:
       button:
-        html: <span class="glyphicon glyphicon-search"></span> Ir
+        html: <span class="fa fa-search"></span> Ir
         text: Pesquisar
       form:
         option:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -1088,14 +1088,14 @@ zh:
       no_transfers: 您没有转让任何作品
       profiles:
         edit_primary:
-          change_picture: "<i class =“glyphicon glyphicon-camera”> </ i>更改图片"
+          change_picture: "<i class =“fa fa-camera”> </ i>更改图片"
           delete_picture: 删除图片
           delete_picture_data_content: 如果您想完全删除图片，请选中相应复选框并保存您的个人资料。
           delete_picture_data_original_title: 删除图片
           facebook_handle: "<i class =“fa fa-facebook”aria-hidden =“true”> </ i> Facebook句柄"
           google_handle: "<i class =“fa fa-google-plus”> </ i> Google+处理"
           help_change_picture_type: JPG，GIF或PNG（小于2MB）
-          save_profile: "<i class =“glyphicon glyphicon-save”> </ i>保存个人资料"
+          save_profile: "<i class =“fa fa-floppy-o”> </ i>保存个人资料"
           twitter_handle: "<i class =“fa fa-twitter”aria-hidden =“true”> </ i> Twitter句柄"
       proxy_activity: 代理活动
       proxy_add_deny: 你不能让自己成为代理人
@@ -1451,7 +1451,7 @@ zh:
         changes_required:
           message: |-
             %{title}（%{link}）在批准之前需要进行其他更改。
-             '%{comment}'
+             '%{comment}'
           subject: 您的存款需要更改
         deposited:
           message: zxzxzxx（%{link}）被%{user}批准。 %{comment}
@@ -1485,7 +1485,7 @@ zh:
       read: 查看/下载
     search:
       button:
-        html: <span class="glyphicon glyphicon-search"></span> 转到
+        html: <span class="fa fa-search"></span> 转到
         text: 搜索
       form:
         option:

--- a/spec/features/browse_dashboard_works_spec.rb
+++ b/spec/features/browse_dashboard_works_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Browse Dashboard", type: :feature do
     expect(page).to have_content("Fake PDF Title")
     within(".constraints-container") do
       expect(page).to have_content("Filtering by:")
-      expect(page).to have_css("span.glyphicon-remove")
+      expect(page).to have_css("span.fa-times")
       find(".dropdown-toggle").click
     end
     expect(page).to have_content("Fake Wav File")

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe BlacklightHelper, type: :helper do
 
       it do
         is_expected.to eq 'This links to ' \
-                          '<a href="http://example.com/"><span class="glyphicon glyphicon-new-window"></span>' \
+                          '<a href="http://example.com/"><span class="fa fa-external-link"></span>' \
                           ' http://example.com/</a> What about that?'
       end
     end

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe HyraxHelper, type: :helper do
 
   describe "#iconify_auto_link" do
     let(:text)              { 'Foo < http://www.example.com. & More text' }
-    let(:linked_text)       { 'Foo &lt; <a href="http://www.example.com"><span class="glyphicon glyphicon-new-window"></span> http://www.example.com</a>. &amp; More text' }
+    let(:linked_text)       { 'Foo &lt; <a href="http://www.example.com"><span class="fa fa-external-link"></span> http://www.example.com</a>. &amp; More text' }
     let(:document)          { SolrDocument.new(has_model_ssim: ['GenericWork'], id: 512, title_tesim: text, description_tesim: text) }
     let(:blacklight_config) { CatalogController.blacklight_config }
 
@@ -300,7 +300,7 @@ RSpec.describe HyraxHelper, type: :helper do
         expect(subject).to include('<a href="http://www.example.com">')
       end
       it "adds icons" do
-        expect(subject).to include('class="glyphicon glyphicon-new-window"')
+        expect(subject).to include('class="fa fa-external-link"')
       end
     end
 

--- a/spec/javascripts/fixtures/file_manager_member.html
+++ b/spec/javascripts/fixtures/file_manager_member.html
@@ -1,25 +1,39 @@
 <li data-reorder-id="j38606956">
-  <form accept-charset="UTF-8" action="/concern/file_sets/j38606956" class=
-  "simple_form edit_file_set" data-remote="true" id="edit_file_set_j38606956"
-  method="post" name="edit_file_set_j38606956">
-    <input name="utf8" type="hidden" value="✓"><input name="_method" type=
-    "hidden" value="patch">
+  <form
+    accept-charset="UTF-8"
+    action="/concern/file_sets/j38606956"
+    class="simple_form edit_file_set"
+    data-remote="true"
+    id="edit_file_set_j38606956"
+    method="post"
+    name="edit_file_set_j38606956"
+  >
+    <input name="utf8" type="hidden" value="✓" /><input
+      name="_method"
+      type="hidden"
+      value="patch"
+    />
     <div class="panel panel-default">
       <div class="panel-heading ui-sortable-handle">
         <div class="order-title">
           <div class="form-group string required file_set_title">
             <div>
-              <input aria-required="true" class=
-              "string required title form-control" id="file_set_title" name=
-              "file_set[title][]" required="required" type="text" value=
-              "01.tif">
+              <input
+                aria-required="true"
+                class="string required title form-control"
+                id="file_set_title"
+                name="file_set[title][]"
+                required="required"
+                type="text"
+                value="01.tif"
+              />
             </div>
           </div>
         </div>
         <div class="file-set-link pull-right">
-          <a href="/concern/file_sets/j38606956" title=
-          "Edit file"><span aria-hidden="true" class=
-          "glyphicon glyphicon-edit"></span></a>
+          <a href="/concern/file_sets/j38606956" title="Edit file"
+            ><span aria-hidden="true" class="fa fa-pencil"></span
+          ></a>
         </div>
         <div class="order-filename">
           <em title="01.tif">(01.tif)</em>
@@ -27,10 +41,14 @@
       </div>
       <div class="panel-body">
         <div class="text-center thumbnail">
-          <a data-context-href="/catalog/j38606956/track?search_id=1" href=
-          "/concern/file_sets/j38606956"><img alt="J38606956?file=thumbnail"
-          class="thumbnail-inner" src=
-          "/downloads/j38606956?file=thumbnail"></a>
+          <a
+            data-context-href="/catalog/j38606956/track?search_id=1"
+            href="/concern/file_sets/j38606956"
+            ><img
+              alt="J38606956?file=thumbnail"
+              class="thumbnail-inner"
+              src="/downloads/j38606956?file=thumbnail"
+          /></a>
         </div>
         <div class="attributes"></div>
         <div class="spacer"></div>

--- a/spec/javascripts/fixtures/sortable.html
+++ b/spec/javascripts/fixtures/sortable.html
@@ -1,182 +1,363 @@
-<ul id="sortable" data-id="st74cq794" data-class-name="generic_works" data-singular-class-name="generic_work" class="list-unstyled grid clearfix ui-sortable">
-   <li data-reorder-id="m326m2125">
+<ul
+  id="sortable"
+  data-id="st74cq794"
+  data-class-name="generic_works"
+  data-singular-class-name="generic_work"
+  class="list-unstyled grid clearfix ui-sortable"
+>
+  <li data-reorder-id="m326m2125">
     <div class="panel panel-default">
-      <form data-type="json" novalidate="novalidate" class="simple_form edit_file_set" id="edit_file_set_m326m2125" action="/concern/file_sets/m326m2125" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="patch">
+      <form
+        data-type="json"
+        novalidate="novalidate"
+        class="simple_form edit_file_set"
+        id="edit_file_set_m326m2125"
+        action="/concern/file_sets/m326m2125"
+        accept-charset="UTF-8"
+        data-remote="true"
+        method="post"
+      >
+        <input name="utf8" type="hidden" value="✓" /><input
+          type="hidden"
+          name="_method"
+          value="patch"
+        />
         <div class="panel-heading ui-sortable-handle">
           <div class="order-title">
-            <div class="form-group string required file_set_title"><input class="form-control string required title" name="file_set[title][]" type="text" value="CIMG1815.JPG" id="file_set_title"></div>
+            <div class="form-group string required file_set_title">
+              <input
+                class="form-control string required title"
+                name="file_set[title][]"
+                type="text"
+                value="CIMG1815.JPG"
+                id="file_set_title"
+              />
+            </div>
           </div>
           <div class="file-set-link pull-right">
-            <a title="Edit file" href="/concern/parent/st74cq794/file_sets/m326m2125">
-              <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
-</a>          </div>
-            <div class="order-filename">
-              <em title="CIMG1815.JPG">(CIMG1815.JPG)</em>
-            </div>
+            <a
+              title="Edit file"
+              href="/concern/parent/st74cq794/file_sets/m326m2125"
+            >
+              <span class="fa fa-pencil" aria-hidden="true"></span>
+            </a>
+          </div>
+          <div class="order-filename">
+            <em title="CIMG1815.JPG">(CIMG1815.JPG)</em>
+          </div>
         </div>
         <div class="panel-body">
           <div class="text-center thumbnail">
-            <a data-context-href="/catalog/m326m2125/track" href="/concern/file_sets/m326m2125"><img class="thumbnail-inner" src="/downloads/m326m2125?file=thumbnail" alt="M326m2125?file=thumbnail"></a>
-
+            <a
+              data-context-href="/catalog/m326m2125/track"
+              href="/concern/file_sets/m326m2125"
+              ><img
+                class="thumbnail-inner"
+                src="/downloads/m326m2125?file=thumbnail"
+                alt="M326m2125?file=thumbnail"
+            /></a>
           </div>
-          <div class="attributes">
-            
-          </div>
-          <div class="spacer">
-          </div>
+          <div class="attributes"></div>
+          <div class="spacer"></div>
         </div>
-</form>            <div class="form-group radio_buttons member_resource_options">
+      </form>
+      <div class="form-group radio_buttons member_resource_options">
         <span class="radio">
-          <input type="radio" name="thumbnail_id" id="thumbnail_id_m326m2125" value="m326m2125" class="radio_buttons" checked="checked">
+          <input
+            type="radio"
+            name="thumbnail_id"
+            id="thumbnail_id_m326m2125"
+            value="m326m2125"
+            class="radio_buttons"
+            checked="checked"
+          />
           <label for="thumbnail_id_m326m2125">Thumbnail</label>
         </span>
       </div>
-
     </div>
-</li>
+  </li>
 
-   <li data-reorder-id="pr76f369j">
+  <li data-reorder-id="pr76f369j">
     <div class="panel panel-default">
-      <form data-type="json" novalidate="novalidate" class="simple_form edit_file_set" id="edit_file_set_pr76f369j" action="/concern/file_sets/pr76f369j" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="patch">
+      <form
+        data-type="json"
+        novalidate="novalidate"
+        class="simple_form edit_file_set"
+        id="edit_file_set_pr76f369j"
+        action="/concern/file_sets/pr76f369j"
+        accept-charset="UTF-8"
+        data-remote="true"
+        method="post"
+      >
+        <input name="utf8" type="hidden" value="✓" /><input
+          type="hidden"
+          name="_method"
+          value="patch"
+        />
         <div class="panel-heading ui-sortable-handle">
           <div class="order-title">
-            <div class="form-group string required file_set_title"><input class="form-control string required title" name="file_set[title][]" type="text" value="zeldogbeach2.jpg" id="file_set_title"></div>
+            <div class="form-group string required file_set_title">
+              <input
+                class="form-control string required title"
+                name="file_set[title][]"
+                type="text"
+                value="zeldogbeach2.jpg"
+                id="file_set_title"
+              />
+            </div>
           </div>
           <div class="file-set-link pull-right">
-            <a title="Edit file" href="/concern/parent/st74cq794/file_sets/pr76f369j">
-              <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
-</a>          </div>
-            <div class="order-filename">
-              <em title="zeldogbeach2.jpg">(zeldogbeach2.jpg)</em>
-            </div>
+            <a
+              title="Edit file"
+              href="/concern/parent/st74cq794/file_sets/pr76f369j"
+            >
+              <span class="fa fa-pencil" aria-hidden="true"></span>
+            </a>
+          </div>
+          <div class="order-filename">
+            <em title="zeldogbeach2.jpg">(zeldogbeach2.jpg)</em>
+          </div>
         </div>
         <div class="panel-body">
           <div class="text-center thumbnail">
-            <a data-context-href="/catalog/pr76f369j/track" href="/concern/file_sets/pr76f369j"><img class="thumbnail-inner" src="/downloads/pr76f369j?file=thumbnail" alt="Pr76f369j?file=thumbnail"></a>
-
+            <a
+              data-context-href="/catalog/pr76f369j/track"
+              href="/concern/file_sets/pr76f369j"
+              ><img
+                class="thumbnail-inner"
+                src="/downloads/pr76f369j?file=thumbnail"
+                alt="Pr76f369j?file=thumbnail"
+            /></a>
           </div>
-          <div class="attributes">
-            
-          </div>
-          <div class="spacer">
-          </div>
+          <div class="attributes"></div>
+          <div class="spacer"></div>
         </div>
-</form>            <div class="form-group radio_buttons member_resource_options">
+      </form>
+      <div class="form-group radio_buttons member_resource_options">
         <span class="radio">
-          <input type="radio" name="thumbnail_id" id="thumbnail_id_pr76f369j" value="pr76f369j" class="radio_buttons">
+          <input
+            type="radio"
+            name="thumbnail_id"
+            id="thumbnail_id_pr76f369j"
+            value="pr76f369j"
+            class="radio_buttons"
+          />
           <label for="thumbnail_id_pr76f369j">Thumbnail</label>
         </span>
       </div>
-
     </div>
-</li>
+  </li>
 
-   <li data-reorder-id="3484zh205">
+  <li data-reorder-id="3484zh205">
     <div class="panel panel-default">
-      <form data-type="json" novalidate="novalidate" class="simple_form edit_file_set" id="edit_file_set_3484zh205" action="/concern/file_sets/3484zh205" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="patch">
+      <form
+        data-type="json"
+        novalidate="novalidate"
+        class="simple_form edit_file_set"
+        id="edit_file_set_3484zh205"
+        action="/concern/file_sets/3484zh205"
+        accept-charset="UTF-8"
+        data-remote="true"
+        method="post"
+      >
+        <input name="utf8" type="hidden" value="✓" /><input
+          type="hidden"
+          name="_method"
+          value="patch"
+        />
         <div class="panel-heading ui-sortable-handle">
           <div class="order-title">
-            <div class="form-group string required file_set_title"><input class="form-control string required title" name="file_set[title][]" type="text" value="CIMG1816 copy.JPG" id="file_set_title"></div>
+            <div class="form-group string required file_set_title">
+              <input
+                class="form-control string required title"
+                name="file_set[title][]"
+                type="text"
+                value="CIMG1816 copy.JPG"
+                id="file_set_title"
+              />
+            </div>
           </div>
           <div class="file-set-link pull-right">
-            <a title="Edit file" href="/concern/parent/st74cq794/file_sets/3484zh205">
-              <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
-</a>          </div>
-            <div class="order-filename">
-              <em title="CIMG1816 copy.JPG">(CIMG1816 copy.JPG)</em>
-            </div>
+            <a
+              title="Edit file"
+              href="/concern/parent/st74cq794/file_sets/3484zh205"
+            >
+              <span class="fa fa-pencil" aria-hidden="true"></span>
+            </a>
+          </div>
+          <div class="order-filename">
+            <em title="CIMG1816 copy.JPG">(CIMG1816 copy.JPG)</em>
+          </div>
         </div>
         <div class="panel-body">
           <div class="text-center thumbnail">
-            <a data-context-href="/catalog/3484zh205/track" href="/concern/file_sets/3484zh205"><img class="thumbnail-inner" src="/downloads/3484zh205?file=thumbnail" alt="3484zh205?file=thumbnail"></a>
-
+            <a
+              data-context-href="/catalog/3484zh205/track"
+              href="/concern/file_sets/3484zh205"
+              ><img
+                class="thumbnail-inner"
+                src="/downloads/3484zh205?file=thumbnail"
+                alt="3484zh205?file=thumbnail"
+            /></a>
           </div>
-          <div class="attributes">
-            
-          </div>
-          <div class="spacer">
-          </div>
+          <div class="attributes"></div>
+          <div class="spacer"></div>
         </div>
-</form>            <div class="form-group radio_buttons member_resource_options">
+      </form>
+      <div class="form-group radio_buttons member_resource_options">
         <span class="radio">
-          <input type="radio" name="thumbnail_id" id="thumbnail_id_3484zh205" value="3484zh205" class="radio_buttons">
+          <input
+            type="radio"
+            name="thumbnail_id"
+            id="thumbnail_id_3484zh205"
+            value="3484zh205"
+            class="radio_buttons"
+          />
           <label for="thumbnail_id_3484zh205">Thumbnail</label>
         </span>
       </div>
-
     </div>
-</li>
+  </li>
 
-   <li data-reorder-id="sb397864f">
+  <li data-reorder-id="sb397864f">
     <div class="panel panel-default">
-      <form data-type="json" novalidate="novalidate" class="simple_form edit_generic_work" id="edit_generic_work_sb397864f" action="/concern/generic_works/sb397864f" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="patch">
+      <form
+        data-type="json"
+        novalidate="novalidate"
+        class="simple_form edit_generic_work"
+        id="edit_generic_work_sb397864f"
+        action="/concern/generic_works/sb397864f"
+        accept-charset="UTF-8"
+        data-remote="true"
+        method="post"
+      >
+        <input name="utf8" type="hidden" value="✓" /><input
+          type="hidden"
+          name="_method"
+          value="patch"
+        />
         <div class="panel-heading ui-sortable-handle">
           <div class="order-title">
-            <div class="form-group string required generic_work_title"><input class="form-control string required title" name="generic_work[title][]" type="text" value="child1" id="generic_work_title"></div>
+            <div class="form-group string required generic_work_title">
+              <input
+                class="form-control string required title"
+                name="generic_work[title][]"
+                type="text"
+                value="child1"
+                id="generic_work_title"
+              />
+            </div>
           </div>
           <div class="file-set-link pull-right">
-            <a title="Edit file" href="/concern/parent/st74cq794/generic_works/sb397864f">
-              <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
-</a>          </div>
-            <div class="order-filename">
-              <em title="child1">(child1)</em>
-            </div>
+            <a
+              title="Edit file"
+              href="/concern/parent/st74cq794/generic_works/sb397864f"
+            >
+              <span class="fa fa-pencil" aria-hidden="true"></span>
+            </a>
+          </div>
+          <div class="order-filename">
+            <em title="child1">(child1)</em>
+          </div>
         </div>
         <div class="panel-body">
           <div class="text-center thumbnail">
-            <a data-context-href="/catalog/sb397864f/track" href="/concern/generic_works/sb397864f"><img class="thumbnail-inner" src="/assets/default-c6018ff301250c55bcc663293e1816c7daece4159cbc93fc03d9b35dbc3db30d.png" alt="Default"></a>
-
+            <a
+              data-context-href="/catalog/sb397864f/track"
+              href="/concern/generic_works/sb397864f"
+              ><img
+                class="thumbnail-inner"
+                src="/assets/default-c6018ff301250c55bcc663293e1816c7daece4159cbc93fc03d9b35dbc3db30d.png"
+                alt="Default"
+            /></a>
           </div>
-          <div class="attributes">
-            
-          </div>
-          <div class="spacer">
-          </div>
+          <div class="attributes"></div>
+          <div class="spacer"></div>
         </div>
-</form>            <div class="form-group radio_buttons member_resource_options">
+      </form>
+      <div class="form-group radio_buttons member_resource_options">
         <span class="radio">
-          <input type="radio" name="thumbnail_id" id="thumbnail_id_sb397864f" value="sb397864f" class="radio_buttons">
+          <input
+            type="radio"
+            name="thumbnail_id"
+            id="thumbnail_id_sb397864f"
+            value="sb397864f"
+            class="radio_buttons"
+          />
           <label for="thumbnail_id_sb397864f">Thumbnail</label>
         </span>
       </div>
-
     </div>
-</li>
+  </li>
 
-   <li data-reorder-id="bc386j55f">
+  <li data-reorder-id="bc386j55f">
     <div class="panel panel-default">
-      <form data-type="json" novalidate="novalidate" class="simple_form edit_generic_work" id="edit_generic_work_bc386j55f" action="/concern/generic_works/bc386j55f" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="patch">
+      <form
+        data-type="json"
+        novalidate="novalidate"
+        class="simple_form edit_generic_work"
+        id="edit_generic_work_bc386j55f"
+        action="/concern/generic_works/bc386j55f"
+        accept-charset="UTF-8"
+        data-remote="true"
+        method="post"
+      >
+        <input name="utf8" type="hidden" value="✓" /><input
+          type="hidden"
+          name="_method"
+          value="patch"
+        />
         <div class="panel-heading ui-sortable-handle">
           <div class="order-title">
-            <div class="form-group string required generic_work_title"><input class="form-control string required title" name="generic_work[title][]" type="text" value="child2" id="generic_work_title"></div>
+            <div class="form-group string required generic_work_title">
+              <input
+                class="form-control string required title"
+                name="generic_work[title][]"
+                type="text"
+                value="child2"
+                id="generic_work_title"
+              />
+            </div>
           </div>
           <div class="file-set-link pull-right">
-            <a title="Edit file" href="/concern/parent/st74cq794/generic_works/bc386j55f">
-              <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
-</a>          </div>
-            <div class="order-filename">
-              <em title="child2">(child2)</em>
-            </div>
+            <a
+              title="Edit file"
+              href="/concern/parent/st74cq794/generic_works/bc386j55f"
+            >
+              <span class="fa fa-pencil" aria-hidden="true"></span>
+            </a>
+          </div>
+          <div class="order-filename">
+            <em title="child2">(child2)</em>
+          </div>
         </div>
         <div class="panel-body">
           <div class="text-center thumbnail">
-            <a data-context-href="/catalog/bc386j55f/track" href="/concern/generic_works/bc386j55f"><img class="thumbnail-inner" src="/assets/default-c6018ff301250c55bcc663293e1816c7daece4159cbc93fc03d9b35dbc3db30d.png" alt="Default"></a>
-
+            <a
+              data-context-href="/catalog/bc386j55f/track"
+              href="/concern/generic_works/bc386j55f"
+              ><img
+                class="thumbnail-inner"
+                src="/assets/default-c6018ff301250c55bcc663293e1816c7daece4159cbc93fc03d9b35dbc3db30d.png"
+                alt="Default"
+            /></a>
           </div>
-          <div class="attributes">
-            
-          </div>
-          <div class="spacer">
-          </div>
+          <div class="attributes"></div>
+          <div class="spacer"></div>
         </div>
-</form>            <div class="form-group radio_buttons member_resource_options">
+      </form>
+      <div class="form-group radio_buttons member_resource_options">
         <span class="radio">
-          <input type="radio" name="thumbnail_id" id="thumbnail_id_bc386j55f" value="bc386j55f" class="radio_buttons">
+          <input
+            type="radio"
+            name="thumbnail_id"
+            id="thumbnail_id_bc386j55f"
+            value="bc386j55f"
+            class="radio_buttons"
+          />
           <label for="thumbnail_id_bc386j55f">Thumbnail</label>
         </span>
       </div>
-
     </div>
-</li>
-
+  </li>
 </ul>

--- a/spec/renderers/hyrax/renderers/external_link_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/external_link_attribute_renderer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyrax::Renderers::ExternalLinkAttributeRenderer do
        "<td><ul class='tabular'>" \
        "<li class=\"attribute attribute-name\">"\
        "<a href=\"http://example.com\">"\
-       "<span class='glyphicon glyphicon-new-window'></span>&nbsp;"\
+       "<span class='fa fa-external-link'></span>&nbsp;"\
        "http://example.com</a></li>\n" \
        "</ul></td></tr>"
     end

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'hyrax/base/_attribute_rows.html.erb', type: :view do
   end
 
   it 'shows external link with icon for related url field' do
-    expect(page).to have_selector '.glyphicon-new-window'
+    expect(page).to have_selector '.fa-external-link'
     expect(page).to have_link(url)
   end
 


### PR DESCRIPTION
Fixes #5292 

This PR will replace references to Bootstrap 3 Glyphicons with Font Awesome for icon usage in the app.

Validating the PR basically would be just cruising through the app and noticing icons show up.   If any obvious icons have shifted or are not present, feel free to make note.

@samvera/hyrax-code-reviewers
