### PR TITLE
Update bootstrap classes for required badges (multilingual).

### DIFF
--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -1828,7 +1828,7 @@ de:
         find_child_work: Suche nach einer Arbeit ...
         member_of_collection_ids: Wählen Sie eine Sammlung ...
     required:
-      html: <span class="label label-info required-tag">erforderlich</span>
+      html: <span class="badge badge-info required-tag">erforderlich</span>
   total_view:
     one: Diese Arbeit hat 1 Gesamtansicht
     other: Dieses Werk hat insgesamt %{count} Aufrufe

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1816,7 +1816,7 @@ en:
         find_child_work: Search for a work…
         member_of_collection_ids: Select a collection…
     required:
-      html: <span class="label label-info required-tag">required</span>
+      html: <span class="badge badge-info required-tag">required</span>
   total_view:
     one: This work has 1 total view
     other: This work has %{count} total views

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1835,7 +1835,7 @@ es:
         find_child_work: Busque un trabajo ...
         member_of_collection_ids: Seleccione una colección ...
     required:
-      html: <span class="label label-info required-tag">obligatorio</span>
+      html: <span class="badge badge-info required-tag">obligatorio</span>
   total_view:
     one: Este trabajo tiene 1 vista total
     other: Este trabajo tiene un total de %{count} visualizaciones

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -1834,7 +1834,7 @@ fr:
         find_child_work: Rechercher un travail ...
         member_of_collection_ids: Sélectionnez une collection ...
     required:
-      html: <span class="label label-info required-tag">Champs obligatoires</span>
+      html: <span class="badge badge-info required-tag">Champs obligatoires</span>
   total_view:
     one: Ce travail a 1 vue totale
     other: Ce travail a zxzxxx0 vues au total

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -1833,7 +1833,7 @@ it:
         find_child_work: Cerca un lavoro ...
         member_of_collection_ids: Seleziona una collezione ...
     required:
-      html: <span class="label label-info required-tag">necessario</span>
+      html: <span class="badge badge-info required-tag">necessario</span>
   total_view:
     one: Quest'opera ha 1 vista totale
     other: Questo lavoro ha %{count} visualizzazioni totali

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -1828,7 +1828,7 @@ pt-BR:
         find_child_work: Procure uma obra ...
         member_of_collection_ids: Selecione uma coleção ...
     required:
-      html: <span class="label label-info required-tag">obrigatórios</span>
+      html: <span class="badge badge-info required-tag">obrigatórios</span>
   total_view:
     one: Este trabalho tem 1 visualização total
     other: Este trabalho tem %{count} visualizações totais

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -1831,7 +1831,7 @@ zh:
         find_child_work: 搜索工作...
         member_of_collection_ids: 选择一个集合...
     required:
-      html: <span class="label label-info required-tag">需要的</span>
+      html: <span class="badge badge-info required-tag">需要的</span>
   total_view:
     one: 该作品共有 1 次浏览
     other: 此作品总浏览量为 %{count}


### PR DESCRIPTION
Fixes #5396 ; refs #5276

## Summary 
This update quickly adjusts the bootstrap classes that render Badge-like components for the required labels on form fields. 

See https://getbootstrap.com/docs/4.0/components/badge/

## Testing

The easiest view to review this on is the my collections page at  http://localhost:3000/dashboard/collections/new?locale=en&collection_type_id=1

As these _required_  labels includes multilanguage support, adjust the language in the masthead navbar, all languages should render the required badges correctly.

## Notes
No opinion is given here to the flavor of the badge, so `badge-info` is used which by default renders a tealish color. If red is the expected color we may want to consider `badge-danger` though I wonder if this should be reserved for more critical alerts.
