### PR TITLE
use helper to get permission template for collections and admin sets

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -191,6 +191,20 @@ module Hyrax
       CollectionType.find_or_create_default_collection_type.title
     end
 
+    ##
+    # @param collection [Object]
+    #
+    # @return [PermissionTemplateForm]
+    def collection_permission_template_form_for(form:)
+      case form
+      when Valkyrie::ChangeSet
+        template_model = Hyrax::PermissionTemplate.find_or_create_by(source_id: form.id.to_s)
+        Hyrax::Forms::PermissionTemplateForm.new(template_model)
+      else
+        form.permission_template
+      end
+    end
+
     private
 
     # add hidden fields to a form for performing an action on a single document on a collection

--- a/app/views/hyrax/admin/admin_sets/_form_participant_table.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_participant_table.html.erb
@@ -1,6 +1,6 @@
                   <h3><%= t(".#{access}.title") %></h3>
                   <p><%= t(".#{access}.help") %></p>
-                  <% if @form.permission_template.access_grants.select(&filter).any? %>
+                  <% if collection_permission_template_form_for(form: @form).access_grants.select(&filter).any? %>
                     <table class="table table-striped share-status">
                       <thead>
                         <tr>
@@ -10,7 +10,7 @@
                         </tr>
                       </thead>
                       <tbody>
-                      <% @form.permission_template.access_grants.select(&filter).each do |g| %>
+                      <% collection_permission_template_form_for(form: @form).access_grants.select(&filter).each do |g| %>
                         <tr>
                           <td data-agent="<%= g.agent_id %>"><%= g.label %></td>
                           <td><%= g.agent_type.titleize %></td>

--- a/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
@@ -5,7 +5,7 @@
                   <h3><%= t('.add_participants') %></h3>
                   <% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
                   <div class="sharing-row-form">
-                    <%= simple_form_for @form.permission_template,
+                    <%= simple_form_for collection_permission_template_form_for(form: @form),
                         url: [hyrax, :admin, @form, :permission_template],
                         html: { id: 'group-participants-form', class: 'form-inline' } do |f| %>
 
@@ -33,7 +33,7 @@
                   </div>
 
                   <div class="sharing-row-form">
-                    <%= simple_form_for @form.permission_template,
+                    <%= simple_form_for collection_permission_template_form_for(form: @form),
                         url: [hyrax, :admin, @form, :permission_template],
                         html: { id: 'user-participants-form', class: 'form-inline add-users' } do |f| %>
 

--- a/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
@@ -1,6 +1,6 @@
           <div id="visibility" class="tab-pane">
             <div class="panel panel-default labels">
-              <%= simple_form_for @form.permission_template,
+              <%= simple_form_for collection_permission_template_form_for(form: @form),
                                   url: [hyrax, :admin, @form, :permission_template],
                                   html: { class: 'nav-safety' } do |f| %>
                 <div class="panel-body">

--- a/app/views/hyrax/admin/admin_sets/_form_workflow.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_workflow.erb
@@ -1,6 +1,6 @@
                 <div id="workflow" class="tab-pane">
                   <div class="panel panel-default labels">
-                    <%= simple_form_for @form.permission_template,
+                    <%= simple_form_for collection_permission_template_form_for(form: @form),
                       url: [hyrax, :admin, @form, :permission_template],
                       html: { id: 'form_workflows', class: 'nav-safety' } do |f| %>
                       <% if f.object.available_workflows.any? %>

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -8,7 +8,7 @@
 
       <!-- Add group form -->
       <div class="form-add-sharing-wrapper" data-id="<%= @form.id %>">
-        <%= simple_form_for @form.permission_template,
+        <%= simple_form_for collection_permission_template_form_for(form: @form),
                             url: [hyrax, :dashboard, @form, :permission_template],
                             html: { id: 'group-participants-form' } do |f| %>
 
@@ -40,7 +40,7 @@
 
       <!-- Add user form -->
       <div class="form-add-sharing-wrapper" data-id="<%= @form.id %>">
-        <%= simple_form_for @form.permission_template,
+        <%= simple_form_for collection_permission_template_form_for(form: @form),
                             url: [hyrax, :dashboard, @form, :permission_template],
                             html: { id: 'user-participants-form' } do |f| %>
 

--- a/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
@@ -1,7 +1,7 @@
                   <h3><%= t(".#{access}.title") %></h3>
                   <p><%= t(".#{access}.help") %></p>
                   <p><%= t(".#{access}.help_with_works", type_title: @collection.collection_type.title) if @collection.share_applies_to_new_works? && access != 'depositors' %></p>
-                  <% if @form.permission_template.access_grants.select(&filter).any? %>
+                  <% if collection_permission_template_form_for(form: @form).access_grants.select(&filter).any? %>
                     <table class="table table-striped share-status">
                       <thead>
                         <tr>
@@ -11,7 +11,7 @@
                         </tr>
                       </thead>
                       <tbody>
-                      <% @form.permission_template.access_grants.select(&filter).each do |g| %>
+                      <% collection_permission_template_form_for(form: @form).access_grants.select(&filter).each do |g| %>
                         <tr>
                           <td data-agent="<%= g.agent_id %>"><%= g.label %></td>
                           <td><%= g.agent_type.titleize %></td>

--- a/spec/helpers/hyrax/collections_helper_spec.rb
+++ b/spec/helpers/hyrax/collections_helper_spec.rb
@@ -196,4 +196,51 @@ RSpec.describe Hyrax::CollectionsHelper do
       end
     end
   end
+
+  describe "#collection_permission_template_form" do
+    subject { helper.collection_permission_template_form_for(form: form) }
+    context "when receiving an admin_set_form" do
+      let(:ability)    { Ability.new(create(:user)) }
+      let(:repository) { double }
+      let(:model)      { build(:admin_set, description: ['one']) }
+      let(:form)       { Hyrax::Forms::AdminSetForm.new(model, ability, repository) }
+
+      it 'returns the permission_template_form' do
+        expect(subject).to be_instance_of Hyrax::Forms::PermissionTemplateForm
+        expect(subject.model).to be_instance_of Hyrax::PermissionTemplate
+      end
+    end
+
+    context "when receiving an administrative_set_form" do
+      let(:form)      { Hyrax::Forms::AdministrativeSetForm.new(admin_set) }
+      let(:admin_set) { Hyrax::AdministrativeSet.new }
+
+      it 'returns the permission_template_form' do
+        expect(subject).to be_instance_of Hyrax::Forms::PermissionTemplateForm
+        expect(subject.model).to be_instance_of Hyrax::PermissionTemplate
+      end
+    end
+
+    context "when receiving an collection_form" do
+      let(:ability)    { Ability.new(create(:user)) }
+      let(:repository) { double }
+      let(:model)      { build(:collection_lw) }
+      let(:form)       { Hyrax::Forms::CollectionForm.new(model, ability, repository) }
+
+      it 'returns the permission_template_form' do
+        expect(subject).to be_instance_of Hyrax::Forms::PermissionTemplateForm
+        expect(subject.model).to be_instance_of Hyrax::PermissionTemplate
+      end
+    end
+
+    context "when receiving an pcdm_collection_form" do
+      let(:form)      { Hyrax::Forms::PcdmCollectionForm.new(admin_set) }
+      let(:admin_set) { Hyrax::PcdmCollection.new }
+
+      it 'returns the permission_template_form' do
+        expect(subject).to be_instance_of Hyrax::Forms::PermissionTemplateForm
+        expect(subject.model).to be_instance_of Hyrax::PermissionTemplate
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #5329, #5400

Views currently get the permission_template for a model from the form, which then uses the model to get the permission_template.  This was moved to a collection helper.  It helper receives the model to avoid forcing a naming convention on the form (e.g. requiring @form.model for all forms).

This same code works for Collections and Admin Sets.

@samvera/hyrax-code-reviewers
