### PR TITLE
WorkShowPresenter#member_presenter_factory: pick based on solr model

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -305,9 +305,13 @@ module Hyrax
 
     def member_presenter_factory
       @member_presenter_factory ||=
-        self.class
-            .presenter_factory_class
-            .new(solr_document, current_ability, request)
+        if solr_document.hydra_model < Valkyrie::Resource
+          PcdmMemberPresenterFactory.new(solr_document, current_ability)
+        else
+          self.class
+              .presenter_factory_class
+              .new(solr_document, current_ability, request)
+        end
     end
 
     def graph

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,4 +1,4 @@
-<% if (can?(:download, file_set.id) || can?(:destroy, file_set.id) || can?(:edit, file_set.id)) && !workflow_restriction?(file_set.parent) %>
+<% if (can?(:download, file_set.id) || can?(:destroy, file_set.id) || can?(:edit, file_set.id)) && !workflow_restriction?(@parent) %>
   <% if can?(:download, file_set.id) && !(can?(:edit, file_set.id) || can?(:destroy, file_set.id)) %>
   <%= link_to t('.download'),
               hyrax.download_path(file_set),


### PR DESCRIPTION
Valkyrized applications can't use the legacy MemberPresenterFactory, which
depends on the AF `list_source`


@samvera/hyrax-code-reviewers
