### PR TITLE
deprecate #source_model in permission template; use #source instead

### DIFF
--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -87,12 +87,12 @@ class AdminSet < ActiveFedora::Base
   end
 
   ##
-  # @deprecated use PermissionTemplate#reset_access_controls instead
+  # @deprecated use PermissionTemplate#reset_access_controls_for instead
   #
   # Calculate and update who should have edit access based on who
   # has "manage" access in the PermissionTemplateAccess
   def reset_access_controls!
-    Deprecation.warn("reset_access_controls! is deprecated; use PermissionTemplate#reset_access_controls instead.")
+    Deprecation.warn("reset_access_controls! is deprecated; use PermissionTemplate#reset_access_controls_for instead.")
 
     permission_template.reset_access_controls_for(collection: self)
   end

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -121,12 +121,12 @@ module Hyrax
     end
 
     ##
-    # @deprecated use PermissionTemplate#reset_access_controls instead
+    # @deprecated use PermissionTemplate#reset_access_controls_for instead
     #
     # Calculate and update who should have read/edit access to the collections based on who
     # has access in PermissionTemplateAccess
     def reset_access_controls!
-      Deprecation.warn("reset_access_controls! is deprecated; use PermissionTemplate#reset_access_controls instead.")
+      Deprecation.warn("reset_access_controls! is deprecated; use PermissionTemplate#reset_access_controls_for instead.")
 
       permission_template
         .reset_access_controls_for(collection: self, interpret_visibility: true)

--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -4,7 +4,7 @@ module Hyrax
   # Holds policy data about the workflow and permissions applied objects when
   # they are deposited through an Administrative Set or a Collection. Each
   # template record has a {#source} (through {#source_id}); the template's
-  # rules inform the behavior of objects deposited through that {#source_model}.
+  # rules inform the behavior of objects deposited through that {#source}.
   #
   # The {PermissionTemplate} specifies:
   #
@@ -81,6 +81,10 @@ module Hyrax
     # A bit of an analogue for a `belongs_to :source_model` as it crosses from Fedora to the DB
     # @return [AdminSet, ::Collection]
     # @raise [Hyrax::ObjectNotFoundError] when neither an AdminSet or Collection is found
+    # @note This method will eventually be replaced by #source which returns a Hyrax::Resource
+    #   object.  Many methods are equally able to process both Hyrax::Resource and
+    #   ActiveFedora::Base.  Only call this method if you need the ActiveFedora::Base object.
+    # @see #source
     def source_model
       ActiveFedora::Base.find(source_id)
     rescue ActiveFedora::ObjectNotFoundError
@@ -88,11 +92,11 @@ module Hyrax
     end
 
     # A bit of an analogue for a `belongs_to :admin_set` as it crosses from Fedora to the DB
-    # @deprecated Use #source_model instead
+    # @deprecated Use #source instead
     # @return [AdminSet]
     # @raise [Hyrax::ObjectNotFoundError] when the we cannot find the AdminSet
     def admin_set
-      Deprecation.warn('Use #source_model instead')
+      Deprecation.warn("#admin_set is deprecated; use #source instead.")
       return AdminSet.find(source_id) if AdminSet.exists?(source_id)
       raise Hyrax::ObjectNotFoundError
     rescue ActiveFedora::ActiveFedoraError # TODO: remove the rescue when active_fedora issue #1276 is fixed
@@ -100,11 +104,11 @@ module Hyrax
     end
 
     # A bit of an analogue for a `belongs_to :collection` as it crosses from Fedora to the DB
-    # @deprecated Use #source_model instead
+    # @deprecated Use #source instead
     # @return [Collection]
     # @raise [Hyrax::ObjectNotFoundError] when the we cannot find the Collection
     def collection
-      Deprecation.warn('Use #source_model instead')
+      Deprecation.warn("#collection is deprecated; use #source instead.")
       return ::Collection.find(source_id) if ::Collection.exists?(source_id)
       raise Hyrax::ObjectNotFoundError
     rescue ActiveFedora::ActiveFedoraError # TODO: remove the rescue when active_fedora issue #1276 is fixed
@@ -216,10 +220,12 @@ module Hyrax
     end
 
     ##
+    # @deprecated Use #reset_access_controls_for instead
     # @param interpret_visibility [Boolean] whether to retain the existing
     #   visibility when applying permission template ACLs
     # @return [Boolean]
     def reset_access_controls(interpret_visibility: false)
+      Deprecation.warn("#reset_access_controls is deprecated; use #reset_access_controls_for instead.")
       reset_access_controls_for(collection: source_model,
                                 interpret_visibility: interpret_visibility)
     end

--- a/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
   let(:hyrax) { Hyrax::Engine.routes.url_helpers }
   let(:permission_template_access) { FactoryBot.create(:permission_template_access) }
   let(:source_id) { permission_template_access.permission_template.source_id }
+  let(:user_liz) { FactoryBot.create(:user, email: 'liz@example.com') }
 
   before { sign_in FactoryBot.create(:user) }
 
@@ -36,7 +37,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
       it 'can remove admin group from viewers'
 
       context 'when source is an admin set' do
-        let(:admin_set) { FactoryBot.create(:admin_set, edit_users: ['Liz']) }
+        let(:admin_set) { FactoryBot.create(:admin_set, edit_users: [user_liz.user_key]) }
 
         let(:permission_template) do
           FactoryBot.create(:permission_template, source_id: admin_set.id)
@@ -81,7 +82,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
 
         context 'with deleting any agent other than the admin users group' do
           let(:agent_type) { 'user' }
-          let(:agent_id) { 'Liz' }
+          let(:agent_id) { user_liz.user_key }
 
           before do
             allow(controller)
@@ -113,7 +114,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
 
           it "empties the admin set's edit users" do
             expect { delete :destroy, params: { id: permission_template_access } }
-              .to change { admin_set.reload.edit_users.to_a }
+              .to change { Hyrax.query_service.find_by(id: admin_set.id).permission_manager.edit_users.to_a }
               .to be_empty
           end
         end
@@ -121,7 +122,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
 
       context 'when source is a collection' do
         let(:permission_template) { create(:permission_template, source_id: collection.id) }
-        let(:collection) { create(:collection, edit_users: ['Liz']) }
+        let(:collection) { create(:collection, edit_users: [user_liz.user_key]) }
 
         context 'when deleting the admin users group' do
           let(:agent_type) { 'group' }
@@ -163,7 +164,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
 
         context 'as an agent not in the admin users group' do
           let(:agent_type) { 'user' }
-          let(:agent_id) { 'Liz' }
+          let(:agent_id) { user_liz.user_key }
 
           before do
             allow(controller)

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -10,9 +10,10 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
 
   it { is_expected.to delegate_method(:available_workflows).to(:model) }
   it { is_expected.to delegate_method(:active_workflow).to(:model) }
+  it { is_expected.to delegate_method(:source).to(:model) }
   it { is_expected.to delegate_method(:source_model).to(:model) }
+  it { is_expected.to delegate_method(:source_id).to(:model) }
   it { is_expected.to delegate_method(:visibility).to(:model) }
-  it { is_expected.to delegate_method(:id).to(:source_model).with_prefix(:source) }
   it { is_expected.to delegate_method(:reset_access_controls!).to(:source_model) }
 
   it 'is expected to delegate method #active_workflow_id to #active_workflow#id' do
@@ -201,9 +202,10 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     end
 
     context "without a manager" do
+      let(:user_bob) { FactoryBot.create(:user, email: "bob@example.com") }
       let(:grant_attributes) do
         [ActionController::Parameters.new(agent_type: "user",
-                                          agent_id: "bob",
+                                          agent_id: user_bob.user_key,
                                           access: "view").permit!]
       end
 


### PR DESCRIPTION
Fixes #5406

The issue is addressed by changes in `PermissionTemplateForm`
* changing to use `PermissionTemplate#source` instead of `PermissionTemplate#source_method`
* calling `PermissionTemplate#reset_access_controls_for(collection: source)` instead of `source_model.reset_access_controls!` in `#update_access`.

### Add note suggesting to use `PermissionTemplate#source` instead of `PermissionTemplate#source_method`

`PermissionTemplate#source_method` uses `ActiveFedora::Base.find` to get an instance based on `source_id`.  It always returns an `ActiveFedora::Base`.

`PermissionTemplate#source` uses `Hyrax.query_service.find_by` to get an instance based on `source_id`.  It always returns a `Valkyrie::Resource`.

The only place `#source_method` is called within Hyrax code is `Hyrax::Forms::PermissionTemplateForm`.  Usages include:
* #source_model - makes this method available from PermissionTemplateForm through delegation.  This was moved to a method to allow for note recommending use of #source
* #reset_access_controls! - This method calls `source_model.reset_access_controls!` which requires an ActiveFedora::Base object.  This is a deprecated method.  It was not changed other than to update the delegation warning to recommend use of `PermissionTemplate#reset_access_controls_for` instead of `PermissionTempate#reset_access_controls.
* #update_access - This called `source_model.reset_access_controls!` which requires an ActiveFedora::Base object provided by `source_model`.  It was updated to call `PermissionTemplate #reset_access_controls_for` which can receive both ActiveFedora::Base or Valkyrie::Resource objects.  So it can be (and is) passed `source`.

### Deprecate `PermissionTemplate#reset_access_controls`, use `PermissionTemplate#reset_access_controls_for` instead

Similarly, `Hyrax::PermissionTemplate#reset_access_controls` was only called from `Hyrax::Forms::PermissionTemplateForm`.  It is worth noting that the replacement `PermissionTemplate#reset_access_controls_for` is already in use in all other classes that want to reset access.

@samvera/hyrax-code-reviewers
