### PR TITLE
Fix nokogiri on arm64 alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG EXTRA_APK_PACKAGES="git"
 RUN apk --no-cache upgrade && \
   apk --no-cache add build-base \
   curl \
+  gcompat \
   imagemagick \
   tzdata \
   nodejs \


### PR DESCRIPTION
The nokogori gem when used in alpine linux on the arm64 platform does not provide compatible precompiled binaries. The gcompat package allows the binaries compoiled for glibc to work.

Changes proposed in this pull request:
* Add gcompat package to the Dockerfile in the hyrax-base image

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* `docker-compose build` is successful on an arm64 computer such as an M1 Mac

@samvera/hyrax-code-reviewers
