### PR TITLE
Clean collection page css

### DIFF
--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -175,5 +175,14 @@ form.button-to {
 
   .form-group {
     margin: 0;
+    flex-wrap: nowrap;
+
+    @media (max-width: 768px) {
+      flex-wrap: wrap;
+    }
+  }
+
+  label {
+    word-wrap: initial;
   }
 }

--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -175,19 +175,5 @@ form.button-to {
 
   .form-group {
     margin: 0;
-    flex-wrap: nowrap;
-
-    @media (max-width: 768px) {
-      flex-wrap: wrap;
-    }
-  }
-
-  button {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-
-  label {
-    word-wrap: initial;
   }
 }

--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -182,6 +182,11 @@ form.button-to {
     }
   }
 
+  button {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
   label {
     word-wrap: initial;
   }

--- a/app/assets/stylesheets/hyrax/_styles.scss
+++ b/app/assets/stylesheets/hyrax/_styles.scss
@@ -1,7 +1,3 @@
-.input-group {
-  margin-bottom: $input-padding-y-lg;
-}
-
 .breadcrumbs {
   padding: 1em 0;
 }

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -7,10 +7,10 @@
       <%= t("hyrax.search.form.q.label", application_name: application_name) %>
     </label>
 
-    <div class="input-group col-sm-9">
+    <div class="input-group mb-2 col-sm-9">
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
-      <div class="input-group-btn">
+      <div class="input-group-append">
         <button type="submit" class="btn btn-primary" id="search-submit-header">
           <%= t('hyrax.search.button.html') %>
         </button>
@@ -21,7 +21,7 @@
             <span aria-hidden="true"><%= t("hyrax.search.form.option.all.label_short") %></span>
           </button>
 
-          <ul class="dropdown-menu float-right">
+          <ul class="dropdown-menu dropdown-menu-right">
             <li class="dropdown-item">
               <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
                   data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
@@ -34,9 +34,8 @@
               <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
                   data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
             </li>
-          <% end %>
-
-        </ul>
+          </ul>
+        <% end %>
       </div><!-- /.input-group-btn -->
     </div><!-- /.input-group -->
     

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -10,7 +10,7 @@
     <div class="input-group col-sm-9">
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
-      <div class="input-group-append">
+      <div class="input-group-btn">
         <button type="submit" class="btn btn-primary" id="search-submit-header">
           <%= t('hyrax.search.button.html') %>
         </button>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -10,7 +10,7 @@
     <div class="input-group col-sm-9">
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
-      <div class="input-group-btn">
+      <div class="input-group-append">
         <button type="submit" class="btn btn-primary" id="search-submit-header">
           <%= t('hyrax.search.button.html') %>
         </button>

--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -1,8 +1,8 @@
   <%= form_for presenter, url: url, method: :get, class: "well form-search" do |f| %>
       <label for="collection_search" class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
-      <div class="input-group">
+      <div class="input-group mb-sm-auto">
         <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('hyrax.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
-        <div class="input-group-btn">
+        <div class="input-group-append">
           <button type="submit" class="btn btn-primary" id="collection_submit"><span class="fa fa-search"></span> <%= t('hyrax.collections.search_form.button_label') %></button>
         </div>
       </div>

--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -2,7 +2,7 @@
       <label for="collection_search" class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
       <div class="input-group">
         <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('hyrax.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
-        <div class="input-group-btn">
+        <div class="input-group-append">
           <button type="submit" class="btn btn-primary" id="collection_submit"><span class="fa fa-search"></span> <%= t('hyrax.collections.search_form.button_label') %></button>
         </div>
       </div>

--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -2,7 +2,7 @@
       <label for="collection_search" class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
       <div class="input-group">
         <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('hyrax.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
-        <div class="input-group-append">
+        <div class="input-group-btn">
           <button type="submit" class="btn btn-primary" id="collection_submit"><span class="fa fa-search"></span> <%= t('hyrax.collections.search_form.button_label') %></button>
         </div>
       </div>

--- a/app/views/hyrax/my/_search_form.html.erb
+++ b/app/views/hyrax/my/_search_form.html.erb
@@ -2,18 +2,17 @@
 
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <div class="form-group row">
-    <label class="col-form-label col-sm-3" for="search-field-header">
+    <label class="col-form-label col-sm-3 text-right" for="search-field-header">
       <%= t("hyrax.search.form.q.label", application_name: application_name) %>
     </label>
 
-    <div class="input-group">
+    <div class="input-group mb-sm-auto col-sm-9">
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
-
-      <div class="input-group-btn">
+      <div class="input-group-append">
         <button type="submit" class="btn btn-primary" id="search-submit-header">
           <%= t('hyrax.search.button.html') %>
         </button>
       </div>
     </div><!-- /.input-group -->
-  </div><!-- /.form-group -->
+  </div><!-- /.form-row -->
 <% end %>

--- a/app/views/hyrax/my/_search_form.html.erb
+++ b/app/views/hyrax/my/_search_form.html.erb
@@ -9,7 +9,7 @@
     <div class="input-group">
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
-      <div class="input-group-append">
+      <div class="input-group-btn">
         <button type="submit" class="btn btn-primary" id="search-submit-header">
           <%= t('hyrax.search.button.html') %>
         </button>

--- a/app/views/hyrax/my/_search_form.html.erb
+++ b/app/views/hyrax/my/_search_form.html.erb
@@ -9,7 +9,7 @@
     <div class="input-group">
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
-      <div class="input-group-btn">
+      <div class="input-group-append">
         <button type="submit" class="btn btn-primary" id="search-submit-header">
           <%= t('hyrax.search.button.html') %>
         </button>

--- a/app/views/hyrax/my/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/my/_sort_and_per_page.html.erb
@@ -1,6 +1,6 @@
 <% if show_sort_and_per_page? %>
   <div class="sort-toggle">
-      <%= form_tag search_action_for_dashboard, method: :get, class: 'per_page form-inline' do %>
+      <%= form_tag search_action_for_dashboard, method: :get, class: 'per_page' do %>
         <div class="form-group">
           <fieldset class="col-12">
             <legend class="sr-only"><%= t('hyrax.dashboard.my.sr.results_per_page') %></legend>


### PR DESCRIPTION
Fixes #5348

Changes proposed in this pull request:
* Override default `flex-wrap: wrap` injected from `.row` for the horizontal layout of the `.search-form` when screen width > 768px (there might be a better way to achieve this)
* Override `word-wrap: break-word` leaking from `div.card.collections-panel-wrapper` in `.search-form`

  Before: 
  ![wordbreak-bl7](https://user-images.githubusercontent.com/1331659/151614525-eba84c03-8e73-478c-b358-fe6270ea4843.png)
  After:
  ![wordbreak-fix](https://user-images.githubusercontent.com/1331659/151614542-243bde5e-8cff-4821-8a17-8dfe0faf60f0.png)

* Replace `input-group-btn` class with `input-group-append`

  Before: 
  ![searchform-bl7](https://user-images.githubusercontent.com/1331659/151614331-454d51f8-5269-48f4-8d3e-5c468c91f3e0.png)
  After:
  ![searchform-fix](https://user-images.githubusercontent.com/1331659/151614346-f28c0d58-5947-4ccc-94d4-e86c49e677d7.png)


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Mainly look at collections and works page
* Check other pages where `search_form` is being used

@samvera/hyrax-code-reviewers
