### PR TITLE
Hyrax::PcdmCollection delete

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -168,10 +168,10 @@ module Hyrax
         # leaving id to avoid changing the method's parameters prior to release
         respond_to do |format|
           format.html do
-            redirect_to my_collections_path,
+            redirect_to hyrax.my_collections_path,
                         notice: t('hyrax.dashboard.my.action.collection_delete_success')
           end
-          format.json { head :no_content, location: my_collections_path }
+          format.json { head :no_content, location: hyrax.my_collections_path }
         end
       end
 

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -188,8 +188,7 @@ module Hyrax
       def destroy
         case @collection
         when Valkyrie::Resource
-          Hyrax.persister.delete(resource: @collection)
-          after_destroy(params[:id])
+          valkyrie_destroy
         else
           if @collection.destroy
             after_destroy(params[:id])
@@ -239,6 +238,14 @@ module Hyrax
                         .call(form)
                         .value_or { return after_update_error }
         after_update
+      end
+
+      def valkyrie_destroy
+        if transactions['collection_resource.destroy'].call(@collection).success?
+          after_destroy(params[:id])
+        else
+          after_destroy_error(params[:id])
+        end
       end
 
       def default_collection_type

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -181,8 +181,10 @@ module Hyrax
     #
     # @return [Boolean]
     def destroy
-      persister.delete(resource: change_set.resource)
-      Hyrax.publisher.publish('object.acl.updated', acl: self, result: :success)
+      if change_set.resource.persisted?
+        persister.delete(resource: change_set.resource)
+        Hyrax.publisher.publish('object.acl.deleted', acl: self)
+      end
       @change_set = nil
 
       true

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -174,6 +174,20 @@ module Hyrax
       true
     end
 
+    ##
+    # @api public
+    #
+    # Deletes the ACL for the resource
+    #
+    # @return [Boolean]
+    def destroy
+      persister.delete(resource: change_set.resource)
+      Hyrax.publisher.publish('object.acl.updated', acl: self, result: :success)
+      @change_set = nil
+
+      true
+    end
+
     private
 
     ##

--- a/app/services/hyrax/listeners/acl_index_listener.rb
+++ b/app/services/hyrax/listeners/acl_index_listener.rb
@@ -18,6 +18,16 @@ module Hyrax
         return unless event[:result] == :success # do nothing on failure
         Hyrax.index_adapter.save(resource: event[:acl].resource)
       end
+
+      ##
+      # Deletes the resource for the ACL from the index.
+      #
+      # Called when 'object.acl.deleted' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_object_acl_deleted(event)
+        Hyrax.index_adapter.delete(resource: event[:acl].resource)
+      end
     end
   end
 end

--- a/app/services/hyrax/listeners/member_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/member_cleanup_listener.rb
@@ -16,7 +16,7 @@ module Hyrax
           begin
             Hyrax.persister.delete(resource: file_set)
             Hyrax.publisher
-                 .publish('object.deleted', object: file_set, id: file_set.id, user: user)
+                 .publish('object.deleted', object: file_set, id: file_set.id, user: event[:user])
           rescue StandardError # we don't uncaught errors looping filesets
             Hyrax.logger.warn "Failed to delete #{file_set.class}:#{file_set.id} " \
                               "during cleanup for resource: #{event[:object]}. " \

--- a/app/services/hyrax/listeners/metadata_index_listener.rb
+++ b/app/services/hyrax/listeners/metadata_index_listener.rb
@@ -61,6 +61,17 @@ module Hyrax
         Hyrax.index_adapter.delete(resource: event[:object])
       end
 
+      ##
+      # Remove the resource from the index.
+      #
+      # Called when 'collection.deleted' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_collection_deleted(event)
+        return unless resource?(event.payload[:collection])
+        Hyrax.index_adapter.delete(resource: event[:collection])
+      end
+
       private
 
       def resource?(resource)

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -157,6 +157,10 @@ module Hyrax
 
     # @since 3.4.0
     # @macro a_registered_event
+    register_event('object.acl.deleted')
+
+    # @since 3.4.0
+    # @macro a_registered_event
     #   @note this event SHOULD be published whevener the membership is changed
     #     for a PCDM Object (including a Hydra Works FileSet). this includes
     #     changes to the Object's `#member_ids` attribute, as well as inverse

--- a/lib/hyrax/transactions/admin_set_destroy.rb
+++ b/lib/hyrax/transactions/admin_set_destroy.rb
@@ -9,7 +9,8 @@ module Hyrax
     # @since 3.4.0
     class AdminSetDestroy < Transaction
       DEFAULT_STEPS = ['admin_set_resource.check_empty',
-                       'admin_set_resource.delete'].freeze
+                       'admin_set_resource.delete',
+                       'admin_set_resource.delete_acl'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/collection_destroy.rb
+++ b/lib/hyrax/transactions/collection_destroy.rb
@@ -9,7 +9,8 @@ module Hyrax
     # @since 3.4.0
     class CollectionDestroy < Transaction
       # TODO: Add step that checks if collection is empty for collections of types that require it
-      DEFAULT_STEPS = ['collection_resource.delete'].freeze
+      DEFAULT_STEPS = ['collection_resource.delete',
+                       'collection_resource.delete_acl'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/collection_destroy.rb
+++ b/lib/hyrax/transactions/collection_destroy.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/transaction'
+
+module Hyrax
+  module Transactions
+    ##
+    # Destroys a {Hyrax::PcdmCollection}
+    #
+    # @since 3.4.0
+    class CollectionDestroy < Transaction
+      # TODO: Add step that checks if collection is empty for collections of types that require it
+      DEFAULT_STEPS = ['collection_resource.delete'].freeze
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -39,6 +39,7 @@ module Hyrax
       require 'hyrax/transactions/steps/apply_permission_template'
       require 'hyrax/transactions/steps/apply_visibility'
       require 'hyrax/transactions/steps/check_for_empty_admin_set'
+      require 'hyrax/transactions/steps/delete_access_control'
       require 'hyrax/transactions/steps/delete_resource'
       require 'hyrax/transactions/steps/destroy_work'
       require 'hyrax/transactions/steps/ensure_admin_set'
@@ -160,6 +161,10 @@ module Hyrax
           Steps::ApplyCollectionTypePermissions.new
         end
 
+        ops.register 'delete_acl' do
+          Steps::DeleteAccessControl.new
+        end
+
         ops.register 'save_acl' do
           Steps::SaveAccessControl.new
         end
@@ -176,6 +181,10 @@ module Hyrax
 
         ops.register 'destroy' do
           CollectionDestroy.new
+        end
+
+        ops.register 'delete_acl' do
+          Steps::DeleteAccessControl.new
         end
 
         ops.register 'save_acl' do
@@ -198,6 +207,10 @@ module Hyrax
 
         ops.register 'destroy' do
           WorkDestroy.new
+        end
+
+        ops.register 'delete_acl' do
+          Steps::DeleteAccessControl.new
         end
 
         ops.register 'save_acl' do

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -23,6 +23,7 @@ module Hyrax
       require 'hyrax/transactions/admin_set_update'
       require 'hyrax/transactions/apply_change_set'
       require 'hyrax/transactions/collection_create'
+      require 'hyrax/transactions/collection_destroy'
       require 'hyrax/transactions/collection_update'
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/destroy_work'
@@ -167,6 +168,14 @@ module Hyrax
       namespace 'collection_resource' do |ops| # valkyrie collection
         ops.register 'apply_collection_type_permissions' do
           Steps::ApplyCollectionTypePermissions.new
+        end
+
+        ops.register 'delete' do
+          Steps::DeleteResource.new
+        end
+
+        ops.register 'destroy' do
+          CollectionDestroy.new
         end
 
         ops.register 'save_acl' do

--- a/lib/hyrax/transactions/steps/delete_access_control.rb
+++ b/lib/hyrax/transactions/steps/delete_access_control.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Deletes the Hyrax::AccessControlList for any resource with a `#permission_manager`.
+      # If `#permission_manager` is undefined, succeeds.
+      #
+      # @see https://dry-rb.org/gems/dry-monads/1.0/result/
+      class DeleteAccessControl
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Valkyrie::Resource] obj
+        #
+        # @return [Dry::Monads::Result]
+        def call(obj)
+          return Success(obj) unless obj.respond_to?(:permission_manager)
+          obj.permission_manager&.acl&.destroy ||
+            (return Failure[:failed_to_delete_acl, acl])
+
+          Success(obj)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/delete_access_control.rb
+++ b/lib/hyrax/transactions/steps/delete_access_control.rb
@@ -18,8 +18,11 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(obj)
           return Success(obj) unless obj.respond_to?(:permission_manager)
-          obj.permission_manager&.acl&.destroy ||
-            (return Failure[:failed_to_delete_acl, acl])
+
+          acl = obj.permission_manager&.acl
+          return Success(obj) if acl.nil?
+
+          acl.destroy || (return Failure[:failed_to_delete_acl, acl])
 
           Success(obj)
         end

--- a/lib/hyrax/transactions/steps/save_access_control.rb
+++ b/lib/hyrax/transactions/steps/save_access_control.rb
@@ -18,8 +18,8 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(obj)
           return Success(obj) unless obj.respond_to?(:permission_manager)
-          obj.permission_manager&.acl&.save ||
-            (return Failure[:failed_to_save_acl, acl])
+          acl = obj.permission_manager&.acl
+          acl&.save || (return Failure[:failed_to_save_acl, acl])
 
           Success(obj)
         end

--- a/lib/hyrax/transactions/work_destroy.rb
+++ b/lib/hyrax/transactions/work_destroy.rb
@@ -8,7 +8,8 @@ module Hyrax
     #
     # @since 3.0.0
     class WorkDestroy < Transaction
-      DEFAULT_STEPS = ['work_resource.delete'].freeze
+      DEFAULT_STEPS = ['work_resource.delete',
+                       'work_resource.delete_acl'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
@@ -570,7 +570,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
 
     context "when it succeeds" do
       it "redirects to My Collections" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         delete :destroy, params: { id: collection }
 
         expect(response).to have_http_status(:found)

--- a/spec/hyrax/transactions/collection_destroy_spec.rb
+++ b/spec/hyrax/transactions/collection_destroy_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::CollectionDestroy, valkyrie_adapter: :test_adapter do
+  subject(:tx)   { described_class.new }
+  let(:resource) { FactoryBot.valkyrie_create(:hyrax_collection) }
+
+  describe '#call' do
+    it 'is a success' do
+      expect(tx.call(resource)).to be_success
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/delete_access_control_spec.rb
+++ b/spec/hyrax/transactions/steps/delete_access_control_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::DeleteAccessControl, valkyrie_adapter: :test_adapter do
+  subject(:step) { described_class.new }
+  let(:work)     { FactoryBot.valkyrie_create(:hyrax_work) }
+
+  context 'when acl has not been persisted' do
+    it 'gives Success(obj) in basic case' do
+      expect(step.call(work).value!).to eql(work)
+    end
+  end
+
+  context 'when existing permissions exist' do
+    let(:user) { FactoryBot.create(:user) }
+
+    before do
+      work.permission_manager.read_users = [user.user_key]
+      work.permission_manager.acl.save
+    end
+
+    it 'deletes the access control resource' do
+      expect { step.call(work) }
+        .to change { Hyrax::AccessControl.for(resource: work).persisted? }
+        .from(true)
+        .to(false)
+    end
+  end
+
+  context 'when the resource has no permission_manager' do
+    before do
+      module Hyrax
+        module Test
+          module DeleteAccessControlStep
+            class SimpleResource < Valkyrie::Resource
+            end
+          end
+        end
+      end
+    end
+
+    after { Hyrax::Test.send(:remove_const, :DeleteAccessControlStep) }
+
+    let(:resource) { Hyrax.persister.save(resource: Hyrax::Test::DeleteAccessControlStep::SimpleResource.new) }
+
+    it 'succeeds happily' do
+      expect(step.call(work).value!).to eql(work)
+    end
+  end
+end

--- a/spec/services/hyrax/access_control_list_spec.rb
+++ b/spec/services/hyrax/access_control_list_spec.rb
@@ -164,4 +164,31 @@ RSpec.describe Hyrax::AccessControlList do
       end
     end
   end
+
+  describe "#destroy" do
+    let(:listener) { Hyrax::Specs::SpyListener.new }
+
+    before do
+      acl << permission
+      acl.save
+
+      # Subscribe to events after acl has been persisted
+      Hyrax.publisher.subscribe(listener)
+    end
+
+    after { Hyrax.publisher.unsubscribe(listener) }
+
+    it 'deletes the acl resource' do
+      expect { acl.destroy }
+        .to change { Hyrax::AccessControl.for(resource: resource, query_service: acl.query_service).persisted? }
+        .from(true)
+        .to(false)
+    end
+
+    it 'publishes an event' do
+      expect { acl.destroy }
+        .to change { listener.object_acl_deleted&.payload }
+        .to include(acl: acl)
+    end
+  end
 end

--- a/spec/services/hyrax/listeners/member_cleanup_listener_spec.rb
+++ b/spec/services/hyrax/listeners/member_cleanup_listener_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'hyrax/specs/spy_listener'
+
+RSpec.describe Hyrax::Listeners::MemberCleanupListener do
+  subject(:listener) { described_class.new }
+  let(:data)         { { collection: collection, user: user } }
+  let(:event)        { Dry::Events::Event.new(event_type, data) }
+  let(:user)         { FactoryBot.create(:user) }
+  let(:spy_listener) { Hyrax::Specs::SpyListener.new }
+
+  before { Hyrax.publisher.subscribe(spy_listener) }
+  after  { Hyrax.publisher.unsubscribe(spy_listener) }
+
+  describe '#on_object_deleted' do
+    let(:data)         { { object: work, user: user } }
+    let(:event_type)   { :on_object_deleted }
+    let(:work)         { FactoryBot.valkyrie_create(:hyrax_work, member_ids: [file_set.id]) }
+    let(:file_set)     { FactoryBot.valkyrie_create(:hyrax_file_set) }
+
+    it 'removes child file set objects' do
+      expect { listener.on_object_deleted(event) }
+        .to change { Hyrax.custom_queries.find_child_filesets(resource: event[:object]).size }
+        .from(1)
+        .to(0)
+    end
+
+    it 'publishes events' do
+      listener.on_object_deleted(event)
+      expect(spy_listener.object_deleted&.payload)
+        .to include(id: file_set.id, object: file_set, user: user)
+    end
+  end
+
+  describe '#on_collection_deleted' do
+    let(:collection)   { FactoryBot.valkyrie_create(:hyrax_collection) }
+    let(:data)         { { collection: collection, user: user } }
+    let(:event_type)   { :on_collection_deleted }
+    let(:work)         { FactoryBot.valkyrie_create(:monograph, member_of_collection_ids: [collection.id]) }
+
+    before do
+      work
+    end
+
+    it 'removes collection references from member objects' do
+      expect { listener.on_collection_deleted(event) }
+        .to change { Hyrax.custom_queries.find_members_of(collection: event[:collection]).size }
+        .from(1)
+        .to(0)
+    end
+
+    it 'publishes events' do
+      listener.on_collection_deleted(event)
+      expect(spy_listener.collection_membership_updated&.payload)
+        .to include(collection: collection, user: user)
+    end
+  end
+end

--- a/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
@@ -35,6 +35,29 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
     end
   end
 
+  describe '#on_collection_deleted' do
+    let(:event_type) { :on_collection_deleted }
+    let(:resource)   { FactoryBot.valkyrie_create(:hyrax_collection) }
+    let(:data)       { { collection: resource } }
+
+    it 'reindexes the collection on the configured adapter' do
+      expect(Hyrax.logger).not_to receive(:info).with(skipping_message)
+      expect { listener.on_collection_deleted(event) }
+        .to change { fake_adapter.deleted_resources }
+        .to contain_exactly(resource)
+    end
+
+    context 'when it gets a non-resource as payload' do
+      let(:resource) { ActiveFedora::Base.new }
+
+      it 'returns as a no-op' do
+        expect(Hyrax.logger).to receive(:info).with(skipping_message)
+        expect { listener.on_collection_deleted(event) }
+          .not_to change { fake_adapter.deleted_resources }
+      end
+    end
+  end
+
   describe '#on_object_membership_updated' do
     let(:event_type) { :on_object_membership_updated }
 


### PR DESCRIPTION
Fixes #5407 and #5331

This PR got rather large and the pieces intertwined.  I can split this apart into smaller PRs if necessary.

Proposed changes in this PR:
- Destroy collection by using new transaction `collection_resource.destroy`
- Add listener for `collection.deleted` event which removes references to the collection from member resources
- Add listener for `collection.deleted` event which removes collection resource from the index
- Destroy access control resource in new `DeleteAccessControl` transaction step
- Add new `DeleteAccessControl` transaction step to `AdminSetDestroy`, `CollectionDestroy`, and `WorkDestroy` transactions
- Add `#destroy` method to AccessControlList which deletes the acl resource and publishes a `object.acl.deleted` event
- Add listener for new `object.acl.deleted` event which removes the acl resource from the index
