### PR TITLE
set and index permissions for admin sets

### DIFF
--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -148,7 +148,8 @@ module Hyrax
       form.validate(admin_set_params) &&
         @admin_set = transactions['change_set.create_admin_set']
                      .with_step_args(
-                       'change_set.set_user_as_creator' => { user: current_user }
+                       'change_set.set_user_as_creator' => { user: current_user },
+                       'admin_set_resource.apply_collection_type_permissions' => { user: current_user }
                      )
                      .call(form).value_or do |_failure|
                        setup_form # probably should do some real error handling here

--- a/app/indexers/hyrax/administrative_set_indexer.rb
+++ b/app/indexers/hyrax/administrative_set_indexer.rb
@@ -4,14 +4,19 @@ module Hyrax
   ##
   # Indexes Hyrax::AdministrativeSet objects
   class AdministrativeSetIndexer < Hyrax::ValkyrieIndexer
+    include Hyrax::ResourceIndexer
+    include Hyrax::PermissionIndexer
+    include Hyrax::VisibilityIndexer
     include Hyrax::Indexer(:core_metadata)
 
     def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
       super.tap do |solr_doc|
-        solr_doc[:generic_type_si]         = 'Admin Set'
         solr_doc[:alternative_title_tesim] = resource.alternative_title
-        solr_doc[:creator_ssim]            = resource.creator
+        solr_doc[:creator_ssim]            = [resource.creator]
+        solr_doc[:creator_tesim]           = [resource.creator]
         solr_doc[:description_tesim]       = resource.description
+        solr_doc[:generic_type_sim]        = ['Admin Set']
+        solr_doc[:thumbnail_path_ss]       = Hyrax::CollectionThumbnailPathService.call(resource)
       end
     end
   end

--- a/app/search_builders/hyrax/dashboard/collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/collections_search_builder.rb
@@ -9,7 +9,7 @@ module Hyrax
 
       # This overrides the models in FilterByType
       def models
-        [::AdminSet, ::Collection, Hyrax.config.collection_class].uniq.compact
+        [::AdminSet, Hyrax::AdministrativeSet, ::Collection, Hyrax.config.collection_class].uniq.compact
       end
 
       # adds a filter to exclude collections and admin sets created by the

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -196,3 +196,35 @@ RSpec.shared_examples 'a Collection indexer' do
     end
   end
 end
+
+RSpec.shared_examples 'an Administrative Set indexer' do
+  before do
+    raise 'indexer_class must be set with `let(:indexer_class)`' unless defined? indexer_class
+    # NOTE: resource must be persisted for permission tests to pass
+    raise 'resource must be set with `let(:resource)` and is expected to be a kind of Hyrax::AdministrativeSet' unless defined?(resource) && resource.kind_of?(Hyrax::AdministrativeSet)
+  end
+  subject(:indexer) { indexer_class.new(resource: resource) }
+
+  it_behaves_like 'a Hyrax::Resource indexer'
+  it_behaves_like 'a Core metadata indexer'
+  it_behaves_like 'a permission indexer'
+  it_behaves_like 'a visibility indexer'
+
+  describe '#to_solr' do
+    it 'indexes generic type' do
+      expect(indexer.to_solr)
+        .to include(generic_type_sim: a_collection_containing_exactly('Admin Set'))
+    end
+
+    it 'indexes thumbnail' do
+      expect(indexer.to_solr)
+        .to include(thumbnail_path_ss: include('assets/collection', '.png'))
+    end
+
+    it 'indexes creator' do
+      expect(indexer.to_solr)
+        .to include(creator_ssim: [resource.creator],
+                    creator_tesim: [resource.creator])
+    end
+  end
+end

--- a/spec/indexers/hyrax/administrative_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/administrative_set_indexer_spec.rb
@@ -3,19 +3,17 @@
 require 'hyrax/specs/shared_specs'
 
 RSpec.describe Hyrax::AdministrativeSetIndexer do
+  let(:resource) { FactoryBot.valkyrie_create(:hyrax_admin_set) }
+  let(:indexer_class) { described_class }
+
+  it_behaves_like 'an Administrative Set indexer'
+
   subject(:service) { described_class.new(resource: admin_set) }
   let(:admin_set) { FactoryBot.valkyrie_create(:hyrax_admin_set, title: [admin_set_title]) }
   let(:admin_set_title) { 'An Admin Set' }
 
   it 'is resolved from an admin set' do
-    expect(Hyrax::ValkyrieIndexer.for(resource: admin_set))
+    expect(Hyrax::ValkyrieIndexer.for(resource: resource))
       .to be_a described_class
-  end
-
-  describe '#to_solr' do
-    it 'includes default attributes ' do
-      expect(subject.to_solr)
-        .to include generic_type_si: 'Admin Set', title_tesim: [admin_set_title]
-    end
   end
 end

--- a/spec/search_builders/hyrax/dashboard/collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/collections_search_builder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsSearchBuilder do
   describe '#models' do
     subject { builder.models }
 
-    it { is_expected.to eq([AdminSet, ::Collection, Hyrax.config.collection_class].uniq) }
+    it { is_expected.to eq([AdminSet, Hyrax::AdministrativeSet, ::Collection, Hyrax.config.collection_class].uniq) }
   end
 
   describe ".default_processor_chain" do


### PR DESCRIPTION
Partially Addresses #5408

There are several issue preventing admin sets from being listed on Dashboard -> Collections.  
* the `valkyrie_create` method in the controller did not pass the user to the transaction creating permissions
* the indexer didn't index permissions
* the search builder didn't include Hyrax::AdministrativeSet in the list of models (selects all of the model set)
* the search builder didn't include Hyrax::AdministrativeSet in the permissions limiter (filters out all without valid permissions)

The first 3 are fixed in this PR.  The last part of the search build issue is not complete.  See Remaining Work below.

----
### Remaining Work

There is still an outstanding issue with the query to retrieve collections and admin sets.

#### Old Query:
```
{"qt"=>"search", "facet.field"=>["visibility_ssi", "suppressed_bsi", "resource_type_sim", "has_model_ssim"], "facet.query"=>[], "facet.pivot"=>["has_model_ssim,collection_type_gid_ssim"], "fq"=>["", "{!terms f=has_model_ssim}AdminSet,Hyrax::AdministrativeSet,Hyrax::PcdmCollection", "-suppressed_bsi:true", "(_query_:\"{!raw f=depositor_ssim}****@hotmail.com\" OR (_query_:\"{!raw f=has_model_ssim}AdminSet\" AND _query_:\"{!raw f=creator_ssim}****@hotmail.com\"))"], "hl.fl"=>[], "rows"=>10, "qf"=>"title_tesim description_tesim creator_tesim keyword_tesim", "facet"=>true, "f.visibility_ssi.facet.limit"=>6, "f.resource_type_sim.facet.limit"=>6, "f.collection_type_gid_ssim.facet.limit"=>6, "f.has_model_ssim.facet.limit"=>6, "sort"=>"title_si asc"}
```

This includes adding the `Hyrax::AdministrativeSet` to the set of models `"{!terms f=has_model_ssim}AdminSet,Hyrax::AdministrativeSet,Hyrax::PcdmCollection"`, but the part that limits admin sets to the current user being the creator does not include `Hyrax::AdministrativeSet`.  I wasn't able to come to a syntax for the query that would allow the model for this part of the query to be `AdminSet` OR `Hyrax::AdministrativeSet`.  `(_query_:\"{!raw f=has_model_ssim}AdminSet\" AND _query_:\"{!raw f=creator_ssim}****@hotmail.com\")`

#### Attempt at a New Query (doesn't work):
```
{"qt"=>"search", "facet.field"=>["visibility_ssi", "suppressed_bsi", "resource_type_sim", "has_model_ssim"], "facet.query"=>[], "facet.pivot"=>["has_model_ssim,collection_type_gid_ssim"], "fq"=>["", "{!terms f=has_model_ssim}AdminSet,Hyrax::AdministrativeSet,Hyrax::PcdmCollection", "-suppressed_bsi:true", "(_query_:\"{!raw f=depositor_ssim}****@hotmail.com\" OR (_query_:\"{!terms f=has_model_ssim}AdminSet,Hyrax::AdministrativeSet\" AND _query_:\"{!raw f=creator_ssim}****@hotmail.com\"))"], "hl.fl"=>[], "rows"=>10, "qf"=>"title_tesim description_tesim creator_tesim keyword_tesim", "facet"=>true, "f.visibility_ssi.facet.limit"=>6, "f.resource_type_sim.facet.limit"=>6, "f.collection_type_gid_ssim.facet.limit"=>6, "f.has_model_ssim.facet.limit"=>6, "sort"=>"title_si asc"}
```

@samvera/hyrax-code-reviewers
