### PR TITLE
add collection_type_gid attribute to Hyrax::AdministrativeSets

### DIFF
--- a/app/indexers/hyrax/administrative_set_indexer.rb
+++ b/app/indexers/hyrax/administrative_set_indexer.rb
@@ -11,6 +11,7 @@ module Hyrax
 
     def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
       super.tap do |solr_doc|
+        solr_doc[Hyrax.config.collection_type_index_field.to_sym] = Array(resource.try(:collection_type_gid)&.to_s)
         solr_doc[:alternative_title_tesim] = resource.alternative_title
         solr_doc[:creator_ssim]            = [resource.creator]
         solr_doc[:creator_tesim]           = [resource.creator]

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -172,10 +172,12 @@ RSpec.shared_examples 'a Hyrax::AdministrativeSet' do
       .to contain_exactly('lorem ipsum')
   end
 
-  it 'has an #title' do
-    expect { admin_set.title = ['Moomin'] }
-      .to change { admin_set.title }
-      .to contain_exactly('Moomin')
+  describe '#collection_type_gid' do
+    let(:gid) { Hyrax::CollectionType.find_or_create_admin_set_type.to_global_id }
+
+    it 'has a GlobalID for a collection type' do
+      expect(admin_set.collection_type_gid).to eq gid
+    end
   end
 end
 

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -211,6 +211,11 @@ RSpec.shared_examples 'an Administrative Set indexer' do
   it_behaves_like 'a visibility indexer'
 
   describe '#to_solr' do
+    it 'indexes collection type gid' do
+      expect(indexer.to_solr)
+        .to include(collection_type_gid_ssim: a_collection_containing_exactly(an_instance_of(String)))
+    end
+
     it 'indexes generic type' do
       expect(indexer.to_solr)
         .to include(generic_type_sim: a_collection_containing_exactly('Admin Set'))


### PR DESCRIPTION
Partially Addresses #5408

Collection type gid is required for listing admin sets at Dashboard -> Collections.  This is what identifies this as an admin set.

@samvera/hyrax-code-reviewers
