### PR TITLE
use configured adminset model in search builders

### DIFF
--- a/app/search_builders/hyrax/dashboard/collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/collections_search_builder.rb
@@ -19,7 +19,7 @@ module Hyrax
         return if current_ability.admin?
         clauses = [
           '-' + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key),
-          '-' + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::AdminSet.to_s, creator: current_user_key)
+          '-' + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: Hyrax.config.admin_set_model, creator: current_user_key)
         ]
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += ["(#{clauses.join(' OR ')})"]

--- a/app/search_builders/hyrax/my/collections_search_builder.rb
+++ b/app/search_builders/hyrax/my/collections_search_builder.rb
@@ -12,7 +12,7 @@ class Hyrax::My::CollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
   def show_only_collections_deposited_by_current_user(solr_parameters)
     clauses = [
       ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key),
-      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::AdminSet.to_s, creator: current_user_key)
+      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: Hyrax.config.admin_set_model, creator: current_user_key)
     ]
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] += ["(#{clauses.join(' OR ')})"]


### PR DESCRIPTION
Fixes #5408

Instead of hardcoding the admin set class, use the configured `Hyrax.config.admin_set_model`.

----

FEEDBACK REQUESTED:

@no-reply @cjcolvar 

This works for pure Valkyrie and pure ActiveFedora apps.  It will not work for any apps that may have some solr docs with model `AdminSet` and some with model `Hyrax::AdministrativeSet`.  

OPTIONS:
* OPTION 1:  Use the change in this PR.  If this is the long term solution, then once apps start to migrate to Valkyrie, this would lead to a need to add a data migration for solr docs to update all docs with model `AdminSet` to have model `Hyrax::AdministrativeSet` instead.
* OPTION 2: Update solr query to allow either model.  Not a simple query.  See notes below.  Seems like the best to prevent the need to migrate solr docs once Valkyrie migrations start in the community.  (Maybe migrations would be expected anyway?)
* OPTION 3: Accept the PR as it is now and create an issue addressing OPTION 2's OR query or creating a migration script for solr docs.  Fixes the functionality required for the MVP while acknowledging the need for a long term plan for how to deal with or prevent the need for solr doc migrations.
* Other options?
 
Seems like there should be a way to include an OR that allows for either model.  I have not been able to determine the way to write that query.  See Issue #5408 for more information on the current query and attempts to make the query work with both models.

I confirmed that with this fix, the admin sets are in the list of collections on Dashboard -> My (and All) Collections for nurax-pg.


@samvera/hyrax-code-reviewers
