### PR TITLE
use Hyrax::SolrQueryService for My/Collections

### DIFF
--- a/app/search_builders/hyrax/my/collections_search_builder.rb
+++ b/app/search_builders/hyrax/my/collections_search_builder.rb
@@ -10,10 +10,7 @@ class Hyrax::My::CollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
   # the current user has deposited
   # @param [Hash] solr_parameters
   def show_only_collections_deposited_by_current_user(solr_parameters)
-    clauses = [
-      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user_key),
-      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: Hyrax.config.admin_set_model, creator: current_user_key)
-    ]
+    clauses = [query_for_my_collections]
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] += ["(#{clauses.join(' OR ')})"]
   end
@@ -22,5 +19,15 @@ class Hyrax::My::CollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
   # @return [Array<Class>] a list of classes to include
   def models
     [::AdminSet, Hyrax::AdministrativeSet, ::Collection, Hyrax.config.collection_class].uniq.compact
+  end
+
+  private
+
+  def query_for_my_collections
+    query_service = Hyrax::SolrQueryService.new
+    query_service.with_field_pairs(field_pairs: { depositor_ssim: current_user_key }, type: 'terms')
+    query_service.with_field_pairs(field_pairs: { has_model_ssim: Hyrax.config.admin_set_model,
+                                                  creator_ssim: current_user_key }, type: 'terms')
+    query_service.build(join_with: 'OR')
   end
 end

--- a/app/services/hyrax/solr_query_service.rb
+++ b/app/services/hyrax/solr_query_service.rb
@@ -59,10 +59,11 @@ module Hyrax
     end
 
     ##
+    # @param join_with [String] the connector (eg. 'AND', 'OR') used to join each clause (default: 'AND')
     # @return [String] the combined query that can be submitted to solr
-    def build
+    def build(join_with: 'AND')
       return 'id:NEVER_USE_THIS_ID' if @query.blank? # forces this method to always return a valid solr query
-      @query.join(' AND ')
+      @query.join(padded_join_with(join_with))
     end
 
     ##
@@ -106,8 +107,8 @@ module Hyrax
 
     ##
     # @param field_pairs [Hash] a list of pairs of property name and values (e.g. { field1: values, field2: values })
-    # @param join_with [String] the connector used to join the field pairs (default: ' AND ')
-    # @param type [String] type of query to run. Either 'raw' or 'field' (default: 'field')
+    # @param join_with [String] the connector (eg. 'AND', 'OR') used to join the field pairs (default: 'AND')
+    # @param type [String] type of query to run (e.g. 'raw', 'field', 'terms') (default: 'field')
     # @return [SolrQueryService] the existing service with field_pair query appended
     def with_field_pairs(field_pairs: {}, join_with: default_join_with, type: 'field')
       pairs_query = construct_query_for_pairs(field_pairs, join_with, type)
@@ -140,7 +141,7 @@ module Hyrax
 
     # Construct a solr query from a list of pairs (e.g. { field1: values, field2: values })
     # @param [Hash] field_pairs a list of pairs of property name and values
-    # @param [String] join_with the value we're joining the clauses with (default: ' AND ')
+    # @param [String] join_with the value (e.g. 'AND', 'OR') we're joining the clauses with (default: 'AND')
     # @param [String] type of query to run. Either 'raw' or 'field' (default: 'field')
     # @return [String] a solr query
     # @example
@@ -150,7 +151,7 @@ module Hyrax
       clauses = pairs_to_clauses(field_pairs, type)
       return "" if clauses.count.zero?
       return clauses.first if clauses.count == 1
-      "(#{clauses.join(join_with)})"
+      "(#{clauses.join(padded_join_with(join_with))})"
     end
 
     # Construct a solr query from the model (e.g. Collection, Monograph)
@@ -184,7 +185,11 @@ module Hyrax
     end
 
     def default_join_with
-      ' AND '
+      'AND'
+    end
+
+    def padded_join_with(join_with)
+      " #{join_with.strip} "
     end
 
     # @param [Array<Array>] pairs a list of (key, value) pairs. The value itself may

--- a/spec/search_builders/hyrax/my/collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/collections_search_builder_spec.rb
@@ -44,7 +44,9 @@ RSpec.describe Hyrax::My::CollectionsSearchBuilder do
 
     it "has filter that excludes depositor" do
       subject
-      expect(solr_params[:fq]).to eq ["(_query_:\"{!raw f=depositor_ssim}#{user.user_key}\" OR (_query_:\"{!raw f=has_model_ssim}AdminSet\" AND _query_:\"{!raw f=creator_ssim}#{user.user_key}\"))"]
+      expect(solr_params[:fq]).to eq ["(_query_:\"{!terms f=depositor_ssim}#{user.user_key}\" " \
+                                      "OR (_query_:\"{!terms f=has_model_ssim}AdminSet\" " \
+                                      "AND _query_:\"{!terms f=creator_ssim}#{user.user_key}\"))"]
     end
   end
 end


### PR DESCRIPTION
refs #5408

When deployed to nurax-pg, the query to  list my collections in Dashboard -> Collections still did not list admin sets I created.  This reworks the query to use `terms` instead of `raw`.

As an aside, it also removed references to `ActiveFedora::SolrQueryBuilder`.  The calls are replaced with calls to `Hyrax::SolrQueryService` which is a replacement for `ActiveFedora::SolrQueryBuilder`.

@samvera/hyrax-code-reviewers
