### PR TITLE
use configured admin_set_class to test admin_set? in solr doc

### DIFF
--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -65,7 +65,7 @@ module Hyrax
     ##
     # @return [Boolean]
     def admin_set?
-      hydra_model == ::AdminSet
+      hydra_model == Hyrax.config.admin_set_class
     end
 
     ##


### PR DESCRIPTION
refs #5408

PR #5421, PR #5422, PR #5423, PR #5424 were all related to producing and querying a solr doc so that admin sets appeared in the list of collections on Dashboard -> Collections.

Once they were in the list, their links were not correct.  The links were created using the collection routes instead of admin set routes.  This was happening because the `SolrDocument` for admin sets was always return `false` for `#admin_set?`.  And this was happening because the method `#admin_set?` was checking for class `::AdminSet`.  This PR updates the method to check for class `Hyrax.config.admin_set_class`.  This config defaults to `AdminSet` allowing for backward compatibility.  And allows for valkyrie apps (e.g. nurax-pg) which are configured to `Hyrax::AdministrativeSets` to correctly identify admin sets.

@samvera/hyrax-code-reviewers
