### PR TITLE
never return `nil` from the thumbnail path service

### DIFF
--- a/app/services/hyrax/thumbnail_path_service.rb
+++ b/app/services/hyrax/thumbnail_path_service.rb
@@ -9,7 +9,7 @@ module Hyrax
 
         thumb = fetch_thumbnail(object)
 
-        return unless thumb
+        return default_image unless thumb
         return call(thumb) unless thumb.file_set?
         if audio?(thumb)
           audio_image

--- a/spec/services/hyrax/thumbnail_path_service_spec.rb
+++ b/spec/services/hyrax/thumbnail_path_service_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Hyrax::ThumbnailPathService do
     context 'when it has a missing thumbnail' do
       let(:object) { GenericWork.new(thumbnail_id: 'very_fake') }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to match %r{/assets/default-.+.png} }
     end
 
     context "that doesn't have a representative" do


### PR DESCRIPTION
the poor views count on this to be a real path they can resolve! if we return
nil, the views die. just give a default image if we can't find the thumbnail.

@samvera/hyrax-code-reviewers
