### PR TITLE
Handle object.acl.deleted event by deleting ACL from index

### DIFF
--- a/app/services/hyrax/listeners/acl_index_listener.rb
+++ b/app/services/hyrax/listeners/acl_index_listener.rb
@@ -18,6 +18,16 @@ module Hyrax
         return unless event[:result] == :success # do nothing on failure
         Hyrax.index_adapter.save(resource: event[:acl].resource)
       end
+
+      ##
+      # Deletes the resource for the ACL from the index.
+      #
+      # Called when 'object.acl.deleted' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_object_acl_deleted(event)
+        Hyrax.index_adapter.delete(resource: event[:acl])
+      end
     end
   end
 end

--- a/spec/services/hyrax/listeners/acl_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/acl_index_listener_spec.rb
@@ -31,4 +31,15 @@ RSpec.describe Hyrax::Listeners::AclIndexListener do
       end
     end
   end
+
+  describe '#on_object_acl_deleted' do
+    let(:data)       { { acl: acl } }
+    let(:event_type) { :on_object_acl_deleted }
+
+    it 'removes the acl from the configured adapter' do
+      expect { listener.on_object_acl_deleted(event) }
+        .to change { fake_adapter.deleted_resources }
+        .to contain_exactly(acl)
+    end
+  end
 end


### PR DESCRIPTION
Split out part of https://github.com/samvera/hyrax/pull/5418.

Changes proposed in this PR:
- Add listener for new object.acl.deleted event which removes the acl resource from the index

@samvera/hyrax-code-reviewers
