### PR TITLE
add `file.metadata.updated` event type

### DIFF
--- a/app/services/hyrax/characterization/valkyrie_characterization_service.rb
+++ b/app/services/hyrax/characterization/valkyrie_characterization_service.rb
@@ -14,7 +14,7 @@ class Hyrax::Characterization::ValkyrieCharacterizationService
   def self.run(metadata:, file:, user: ::User.system_user, **options)
     new(metadata: metadata, file: file, **options).characterize
     saved = Hyrax.persister.save(resource: metadata)
-    Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
+    Hyrax.publisher.publish('file.metadata.updated', metadata: saved, user: user)
   end
 
   ##

--- a/app/services/hyrax/listeners/metadata_index_listener.rb
+++ b/app/services/hyrax/listeners/metadata_index_listener.rb
@@ -25,6 +25,17 @@ module Hyrax
       ##
       # Re-index the resource.
       #
+      # Called when 'file.metadata.updated' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_file_metadata_updated(event)
+        return unless resource? event[:metadata]
+        Hyrax.index_adapter.save(resource: event[:metadata])
+      end
+
+      ##
+      # Re-index the resource.
+      #
       # Called when 'object.membership.updated' event is published
       # @param [Dry::Events::Event] event
       # @return [void]

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -123,6 +123,12 @@ module Hyrax
     # @macro a_registered_event
     register_event('file.downloaded')
 
+    # @since 3.4.0
+    # @macro a_registered_event
+    #   @note this event SHOULD be published when the metadata is changed for a
+    #     file via its `FileMetadata` model. the event payload MUST include a
+    register_event('file.metadata.updated')
+
     # @since 3.0.0
     # @macro a_registered_event
     register_event('file.set.audited')

--- a/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
+++ b/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Hyrax::Characterization::ValkyrieCharacterizationService do
         described_class
           .run(metadata: metadata, file: file, characterizer: characterizer)
 
-        expect(listener.object_metadata_updated&.payload)
+        expect(listener.file_metadata_updated&.payload)
           .to include(user: ::User.system_user,
-                      object: metadata)
+                      metadata: metadata)
       end
     end
   end


### PR DESCRIPTION
publishing events related to `FileMetadata` and storage adapter activity on the
`object` namespace has been causing some errors. mainly: it enqueues
`ContentUpdateEventJob` on the `FileMetadata`, but that job is scoped to
objects.

i looked at a variety of approaches, but ultimately the issue here seems to be
that (in PCDM) Files are not Objects. subscribers should be able to trust that
the `object` namespaced event types will pertain to activity on an Object, and
that that Object will be in the payload. creating a new topic and subscribing an
indexer resolves the issue cleanly.

we should update the wiki page: https://github.com/samvera/hyrax/wiki/Hyrax's-Event-Bus-(Hyrax::Publisher)

it seems already to have fallen behind.

@samvera/hyrax-code-reviewers
