### PR TITLE
Destroy PcdmCollection using a transaction

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -168,10 +168,10 @@ module Hyrax
         # leaving id to avoid changing the method's parameters prior to release
         respond_to do |format|
           format.html do
-            redirect_to my_collections_path,
+            redirect_to hyrax.my_collections_path,
                         notice: t('hyrax.dashboard.my.action.collection_delete_success')
           end
-          format.json { head :no_content, location: my_collections_path }
+          format.json { head :no_content, location: hyrax.my_collections_path }
         end
       end
 
@@ -188,8 +188,7 @@ module Hyrax
       def destroy
         case @collection
         when Valkyrie::Resource
-          Hyrax.persister.delete(resource: @collection)
-          after_destroy(params[:id])
+          valkyrie_destroy
         else
           if @collection.destroy
             after_destroy(params[:id])
@@ -239,6 +238,14 @@ module Hyrax
                         .call(form)
                         .value_or { return after_update_error }
         after_update
+      end
+
+      def valkyrie_destroy
+        if transactions['collection_resource.destroy'].call(@collection).success?
+          after_destroy(params[:id])
+        else
+          after_destroy_error(params[:id])
+        end
       end
 
       def default_collection_type

--- a/lib/hyrax/transactions/collection_destroy.rb
+++ b/lib/hyrax/transactions/collection_destroy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/transaction'
+
+module Hyrax
+  module Transactions
+    ##
+    # Destroys a {Hyrax::PcdmCollection}
+    #
+    # @since 3.4.0
+    class CollectionDestroy < Transaction
+      # TODO: Add step that checks if collection is empty for collections of types that require it
+      DEFAULT_STEPS = ['collection_resource.delete',
+                       'collection_resource.delete_acl'].freeze
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -23,6 +23,7 @@ module Hyrax
       require 'hyrax/transactions/admin_set_update'
       require 'hyrax/transactions/apply_change_set'
       require 'hyrax/transactions/collection_create'
+      require 'hyrax/transactions/collection_destroy'
       require 'hyrax/transactions/collection_update'
       require 'hyrax/transactions/create_work'
       require 'hyrax/transactions/destroy_work'
@@ -172,6 +173,14 @@ module Hyrax
       namespace 'collection_resource' do |ops| # valkyrie collection
         ops.register 'apply_collection_type_permissions' do
           Steps::ApplyCollectionTypePermissions.new
+        end
+
+        ops.register 'delete' do
+          Steps::DeleteResource.new
+        end
+
+        ops.register 'destroy' do
+          CollectionDestroy.new
         end
 
         ops.register 'delete_acl' do

--- a/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
@@ -570,7 +570,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
 
     context "when it succeeds" do
       it "redirects to My Collections" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         delete :destroy, params: { id: collection }
 
         expect(response).to have_http_status(:found)
@@ -581,6 +580,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       it "returns json" do
         delete :destroy, params: { format: :json, id: collection }
         expect(response).to have_http_status(:no_content)
+        expect(response.location).to eq Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en')
       end
     end
 

--- a/spec/hyrax/transactions/collection_destroy_spec.rb
+++ b/spec/hyrax/transactions/collection_destroy_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::CollectionDestroy, valkyrie_adapter: :test_adapter do
+  subject(:tx)   { described_class.new }
+  let(:resource) { FactoryBot.valkyrie_create(:hyrax_collection) }
+
+  describe '#call' do
+    it 'is a success' do
+      expect(tx.call(resource)).to be_success
+    end
+  end
+end


### PR DESCRIPTION
Split out part of #5418

Proposed changes in this PR:
- Destroy collection by using new transaction collection_resource.destroy

This builds on top of #5427 so will need to be rebased once that gets merged.

@samvera/hyrax-code-reviewers
