### PR TITLE
docker-compose: cleanup rails containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,10 +28,59 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - .dassie:/app/samvera/hyrax-webapp:cached
-      - .:/app/samvera/hyrax-engine:cached
+      - .dassie:/app/samvera/hyrax-webapp
+      - .:/app/samvera/hyrax-engine
       - hyrax-derivatives:/app/samvera/hyrax-webapp/derivatives
       - hyrax-uploads:/app/samvera/hyrax-webapp/uploads
+      - rails-public:/app/samvera/hyrax-webapp/public
+      - rails-tmp:/app/samvera/hyrax-webapp/tmp
+    networks:
+      - hyrax
+
+  sidekiq:
+    build:
+      context: .
+      target: hyrax-engine-dev-worker
+    image: ghcr.io/samvera/dassie-worker
+    command: sh -l -c 'bundle && bundle exec sidekiq'
+    user: root
+    env_file:
+      - .env
+      - .dassie/.env
+    depends_on:
+      - db_migrate
+      - fcrepo
+      - memcached
+      - postgres
+      - redis
+      - solr
+    volumes:
+      - .dassie:/app/samvera/hyrax-webapp
+      - .:/app/samvera/hyrax-engine
+      - hyrax-derivatives:/app/samvera/hyrax-webapp/derivatives
+      - hyrax-uploads:/app/samvera/hyrax-webapp/uploads
+      - sidekiq-public:/app/samvera/hyrax-webapp/public
+      - sidekiq-tmp:/app/samvera/hyrax-webapp/tmp
+    networks:
+      - hyrax
+
+  db_migrate:
+    build:
+      context: .
+      target: hyrax-engine-dev
+      args:
+        - EXTRA_APK_PACKAGES=git less
+    image: ghcr.io/samvera/dassie
+    user: root
+    env_file:
+      - .env
+    entrypoint: ["sh", "-c"]
+    command: db-migrate-seed.sh
+    depends_on:
+      - postgres
+    volumes:
+      - .dassie:/app/samvera/hyrax-webapp
+      - .:/app/samvera/hyrax-engine
       - rails-public:/app/samvera/hyrax-webapp/public
       - rails-tmp:/app/samvera/hyrax-webapp/tmp
     networks:
@@ -47,23 +96,6 @@ services:
     ports:
       - "4444:4444"
       - "5959:5900"
-    networks:
-      - hyrax
-
-  db_migrate:
-    image: ghcr.io/samvera/dassie
-    user: root
-    env_file:
-      - .env
-    entrypoint: ["sh", "-c"]
-    command: db-migrate-seed.sh
-    depends_on:
-      - postgres
-    volumes:
-      - .dassie:/app/samvera/hyrax-webapp:cached
-      - .:/app/samvera/hyrax-engine:cached
-      - rails-public:/app/samvera/hyrax-webapp/public
-      - rails-tmp:/app/samvera/hyrax-webapp/tmp
     networks:
       - hyrax
 
@@ -102,33 +134,6 @@ services:
     image: redis:5-alpine
     volumes:
       - redis:/data
-    networks:
-      - hyrax
-
-  sidekiq:
-    build:
-      context: .
-      target: hyrax-engine-dev-worker
-    image: ghcr.io/samvera/dassie-worker
-    command: sh -l -c 'bundle && bundle exec sidekiq'
-    user: root
-    env_file:
-      - .env
-      - .dassie/.env
-    depends_on:
-      - db_migrate
-      - fcrepo
-      - memcached
-      - postgres
-      - redis
-      - solr
-    volumes:
-      - .dassie:/app/samvera/hyrax-webapp:cached
-      - .:/app/samvera/hyrax-engine:cached
-      - hyrax-derivatives:/app/samvera/hyrax-webapp/derivatives
-      - hyrax-uploads:/app/samvera/hyrax-webapp/uploads
-      - sidekiq-public:/app/samvera/hyrax-webapp/public
-      - sidekiq-tmp:/app/samvera/hyrax-webapp/tmp
     networks:
       - hyrax
 


### PR DESCRIPTION
- don't cache volume mounts
    this prevents bundler errors such as:
    ````
        hyrax-db_migrate-1  | bundler: failed to load command: rails (/usr/local/bundle/bin/rails)
        hyrax-db_migrate-1  | /usr/local/bundle/gems/bundler-2.3.6/lib/bundler/definition.rb:481:in `materialize': Could not find pg-1.2.3, bootsnap-1.9.3, capybara-screenshot-1.0.25, pry-doc-1.2.0, sidekiq-6.3.1, msgpack-1.4.2, nokogiri-1.12.5-x86_64-linux, i18n-1.8.11, autoprefixer-rails-10.4.0.0, redis-4.5.1, ffi-1.15.4, rdf-microdata-3.2.0, rdf-n3-3.2.0, shacl-0.2.0, shex-0.7.0, rainbow-3.0.0, aws-sdk-core-3.125.5, aws-partitions-1.550.0 in any of the sources (Bundler::GemNotFound)
    ````

- add a `build` block to the db_migrate service
    this lets us avoid using a potentially out-of-date published image, if we
    prefer to build our own from the current state of the repo



@samvera/hyrax-code-reviewers
