### PR TITLE
Remove collection from index when deleted event published

### DIFF
--- a/app/services/hyrax/listeners/metadata_index_listener.rb
+++ b/app/services/hyrax/listeners/metadata_index_listener.rb
@@ -72,6 +72,17 @@ module Hyrax
         Hyrax.index_adapter.delete(resource: event[:object])
       end
 
+      ##
+      # Remove the resource from the index.
+      #
+      # Called when 'collection.deleted' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_collection_deleted(event)
+        return unless resource?(event.payload[:collection])
+        Hyrax.index_adapter.delete(resource: event[:collection])
+      end
+
       private
 
       def resource?(resource)

--- a/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
+++ b/spec/services/hyrax/listeners/metadata_index_listener_spec.rb
@@ -92,6 +92,29 @@ RSpec.describe Hyrax::Listeners::MetadataIndexListener do
     end
   end
 
+  describe '#on_collection_deleted' do
+    let(:event_type) { :on_collection_deleted }
+    let(:resource)   { FactoryBot.valkyrie_create(:hyrax_collection) }
+    let(:data)       { { collection: resource } }
+
+    it 'reindexes the collection on the configured adapter' do
+      expect(Hyrax.logger).not_to receive(:info).with(skipping_message)
+      expect { listener.on_collection_deleted(event) }
+        .to change { fake_adapter.deleted_resources }
+        .to contain_exactly(resource)
+    end
+
+    context 'when it gets a non-resource as payload' do
+      let(:resource) { ActiveFedora::Base.new }
+
+      it 'returns as a no-op' do
+        expect(Hyrax.logger).to receive(:info).with(skipping_message)
+        expect { listener.on_collection_deleted(event) }
+          .not_to change { fake_adapter.deleted_resources }
+      end
+    end
+  end
+
   describe '#on_collection_metadata_updated' do
     let(:event_type) { :on_collection_metadata_updated }
     let(:data)       { { collection: resource } }


### PR DESCRIPTION
Part of break out of #5418 

This PR addresses removing the collection resource from the index when a collection.deleted event is published.

@samvera/hyrax-code-reviewers
