### PR TITLE
Ensure Failure doesn't fail to return

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -115,6 +115,7 @@ RSpec/AnyInstance:
     - 'spec/controllers/hyrax/stats_controller_spec.rb'
     - 'spec/controllers/hyrax/users_controller_spec.rb'
     - 'spec/hyrax/transactions/steps/delete_access_control_spec.rb'
+    - 'spec/hyrax/transactions/steps/save_access_control_spec.rb'
     - 'spec/jobs/content_restored_version_event_job_spec.rb'
     - 'spec/jobs/file_set_attached_event_job_spec.rb'
     - 'spec/jobs/hyrax/grant_edit_to_members_job_spec.rb'

--- a/lib/hyrax/transactions/steps/save_access_control.rb
+++ b/lib/hyrax/transactions/steps/save_access_control.rb
@@ -18,8 +18,8 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(obj)
           return Success(obj) unless obj.respond_to?(:permission_manager)
-          obj.permission_manager&.acl&.save ||
-            (return Failure[:failed_to_save_acl, acl])
+          acl = obj.permission_manager&.acl
+          acl&.save || (return Failure[:failed_to_save_acl, acl])
 
           Success(obj)
         end

--- a/spec/hyrax/transactions/steps/save_access_control_spec.rb
+++ b/spec/hyrax/transactions/steps/save_access_control_spec.rb
@@ -20,6 +20,17 @@ RSpec.describe Hyrax::Transactions::Steps::SaveAccessControl, valkyrie_adapter: 
         .to change { Hyrax::AccessControlList.new(resource: work).permissions }
         .to contain_exactly(have_attributes(mode: :read, agent: user.user_key))
     end
+
+    context 'when it fails to update' do
+      before { allow_any_instance_of(Hyrax::AccessControlList).to receive(:save).and_return(false) }
+
+      it 'returns a Failure' do
+        result = step.call(work)
+
+        expect(result).to be_failure
+        expect(result.failure).to contain_exactly(Symbol, Hyrax::AccessControlList)
+      end
+    end
   end
 
   context 'when the resource has no permission_manager' do


### PR DESCRIPTION
Part of break out of #5418 

Bugfix found when working on the delete access control transaction step.

@samvera/hyrax-code-reviewers
