### PR TITLE
add documentation of the relationship between admin sets and works

### DIFF
--- a/app/models/hyrax/administrative_set.rb
+++ b/app/models/hyrax/administrative_set.rb
@@ -5,6 +5,23 @@ require_dependency 'hyrax/administrative_set_name'
 module Hyrax
   ##
   # Valkyrie model for Admin Set domain objects.
+  #
+  # *Relationships:*
+  # * Administrative Set and Work
+  #   * Administrative Set to Work (1..m): An admin set can have many works.  This relationship
+  #     is defined by the inverse relationship stored in the work.
+  #     * See Hyrax::Work for code to set the relationship.
+  #     * Get works using: <code>works = Hyrax.query_service.find_inverse_references_by(id: admin_set.id, property: :admin_set_id)</code>
+  #     * See 'a Hyrax::Work #admin_set_id' in /lib/hyrax/specs/shared_specs/hydra_works.rb
+  #       for tests of this relationship.
+  #   * Work to Administrative Set (1..1):  A work must be in one and only one admin set.  The
+  #     relationship to the admin set is defined in the work.
+  #     * See Hyrax::Work for code to get and set the admin set for the work.
+  #
+  # @see Hyrax::Work
+  # @see Valkyrie query adapter's #find_inverse_references_by
+  # @see /lib/hyrax/specs/shared_specs/hydra_works.rb
+  #
   class AdministrativeSet < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
 

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -4,6 +4,29 @@ module Hyrax
   ##
   # Valkyrie model for `Work` domain objects in the Hydra Works model.
   #
+  # *Relationships:*
+  # * Administrative Set and Work
+  #   * Administrative Set to Work (1..m): An admin set can have many works.  This relationship
+  #     is defined by the inverse relationship stored in the work's attribute `:admin_set_id`.
+  #     * See Hyrax::AdministrativeSet for code to get works in an admin set.
+  #   * Work to Administrative Set (1..1):  A work must be in one and only one admin set.  The
+  #     relationship to the admin set is defined in the work's attribute `:admin_set_id`.
+  #     * Set admin set for work using: <code>work.admin_set_id = admin_set.id</code>
+  #     * Get admin set resource using: <code>admin_set = Hyrax.query_service.find_by(id: work.admin_set_id)</code>
+  #     * See 'a Hyrax::Work #admin_set_id' in /lib/hyrax/specs/shared_specs/hydra_works.rb
+  #       for tests of this relationship.
+  # * Collection and Work (TBD)
+  # * Work and Work (TBD)
+  # * Work and File Set (TBD)
+  #
+  # @see Hyrax::AdministrativeSet
+  # @see Valkyrie query adapter's #find_by
+  # @see /lib/hyrax/specs/shared_specs/hydra_works.rb
+  #
+  # TODO: The description in Hydra::Works Shared Modeling is out of date and uses
+  # terminology to describe the relationships that is no longer used in code.
+  # Update the model and link to it.  This can be a simple relationship diagram
+  # with a link to the original Works Shared Modeling for historical perspective.
   # @see https://wiki.lyrasis.org/display/samvera/Hydra::Works+Shared+Modeling
   class Work < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)


### PR DESCRIPTION
Adds documentation of the relationship between admin sets and works.  Also establishes a pattern for documenting other relationships in the model.

Basic guidelines:
* define the relationship both directions in both classes involved in the relationship
* include cardinality of each direction of the relationship (e.g. (1..m): An admin set can have many works.)
* if a class includes an attribute storing the relationship
  * include code for how to set in an instance of this class
  * include code for how to find the related resource(s) given an instance of this class
* if a class does not include an attribute storing the relationship
  * include a note to see the other class for how to set the relationship
  * include code for how to find the related resource(s) given an instance of this class
* include information on where the relationship is tested
* include @see for 
  * related class 
  * query service method(s) used to find related resource(s)
  * path to tests of the relationship

@samvera/hyrax-code-reviewers
