### PR TITLE
add ACL key handling for Hyrax::Group

### DIFF
--- a/app/models/hyrax/group.rb
+++ b/app/models/hyrax/group.rb
@@ -7,11 +7,25 @@ module Hyrax
       DEFAULT_NAME_PREFIX
     end
 
+    ##
+    # @return [Hyrax::Group]
+    def self.from_key(key)
+      new(key.slice!(name_prefix))
+    end
+
     def initialize(name)
       @name = name
     end
 
     attr_reader :name
+
+    ##
+    # @return [String] a local identifier for this group; for use (e.g.) in ACL
+    #   data
+    def group_key
+      self.class.name_prefix + name
+    end
+    alias user_key group_key
 
     def to_sipity_agent
       sipity_agent || create_sipity_agent!

--- a/app/models/hyrax/group.rb
+++ b/app/models/hyrax/group.rb
@@ -20,6 +20,13 @@ module Hyrax
     attr_reader :name
 
     ##
+    # @return [Boolean]
+    def ==(other)
+      other.class == self.class &&
+        other.name == self.name
+    end
+
+    ##
     # @return [String] a local identifier for this group; for use (e.g.) in ACL
     #   data
     def group_key

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -201,12 +201,7 @@ module Hyrax
       private
 
       def id_for(agent:)
-        case agent
-        when Hyrax::Group
-          "#{Hyrax::Group.name_prefix}#{agent.name}"
-        else
-          agent.user_key.to_s
-        end
+        agent.user_key.to_s
       end
     end
 


### PR DESCRIPTION
knowledge about how the ACL keys are handled for Groups is spread throughout the
codebase. treating this information as an attribute on the group seems cleaner.

`Hyrax::Group#user_key` is provided for easy compatibility with `::User`.

@samvera/hyrax-code-reviewers
