### PR TITLE
add navigator to find parent work for child works and filesets

### DIFF
--- a/app/services/hyrax/custom_queries/navigators/parent_work_navigator.rb
+++ b/app/services/hyrax/custom_queries/navigators/parent_work_navigator.rb
@@ -7,7 +7,7 @@ module Hyrax
       # Navigate from a resource to it's parent work.
       #
       # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
-      # @since 3.0.0
+      # @since 3.4.0
       class ParentWorkNavigator
         # Define the queries that can be fulfilled by this navigator.
         def self.queries

--- a/app/services/hyrax/custom_queries/navigators/parent_work_navigator.rb
+++ b/app/services/hyrax/custom_queries/navigators/parent_work_navigator.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module CustomQueries
+    module Navigators
+      ##
+      # Navigate from a resource to it's parent work.
+      #
+      # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
+      # @since 3.0.0
+      class ParentWorkNavigator
+        # Define the queries that can be fulfilled by this navigator.
+        def self.queries
+          [:find_parent_work, :find_parent_work_id]
+        end
+
+        attr_reader :query_service
+
+        def initialize(query_service:)
+          @query_service = query_service
+        end
+
+        ##
+        # Find parent work of a given resource, and map to Valkyrie Resources
+        # @note There should be only one parent resource.  A warning is logged if
+        #   more than one resource is found and the first of the resources is returned.
+        # @param [Valkyrie::Resource] resource
+        #
+        # @return [Array<Valkyrie::Resource>]
+        def find_parent_work(resource:)
+          results = Hyrax.query_service.find_inverse_references_by(resource: resource,
+                                                                   property: :member_ids).select(&:work?)
+          if results.count > 1
+            Hyrax.logger.warn("#{resource.work? ? 'Work' : 'File set'} " \
+                              "#{resource.id} is in #{results.count} works when it " \
+                              "should be in no more than one.")
+          end
+          results.first
+        end
+
+        ##
+        # Find the id of the parent work of a given resource, and map to Valkyrie Resources IDs
+        # @note There should be only one parent resource.  A warning is logged if
+        #   more than one resource is found and the first of the resources is returned.
+        # @param [Valkyrie::Resource] resource
+        #
+        # @return [Array<Valkyrie::ID>]
+        def find_parent_work_id(resource:)
+          find_parent_work(resource: resource)&.id
+        end
+      end
+    end
+  end
+end

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -95,6 +95,7 @@ custom_queries = [Hyrax::CustomQueries::Navigators::CollectionMembers,
                   Hyrax::CustomQueries::Navigators::ParentCollectionsNavigator,
                   Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator,
                   Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
+                  Hyrax::CustomQueries::Navigators::ParentWorkNavigator,
                   Hyrax::CustomQueries::Navigators::FindFiles,
                   Wings::CustomQueries::FindAccessControl, # override Hyrax::CustomQueries::FindAccessControl
                   Wings::CustomQueries::FindCollectionsByType,

--- a/spec/services/hyrax/custom_queries/navigators/parent_work_navigator_spec.rb
+++ b/spec/services/hyrax/custom_queries/navigators/parent_work_navigator_spec.rb
@@ -76,5 +76,13 @@ RSpec.describe Hyrax::CustomQueries::Navigators::ParentWorkNavigator, valkyrie_a
         expect(custom_query_service.find_parent_work_id(resource: fileset1)).to eq parent_work.id
       end
     end
+
+    context 'when no parents' do
+      let(:member_ids) { [] }
+      it 'returns nil' do
+        expect(custom_query_service.find_parent_work_id(resource: child_work1)).to be_nil
+        expect(custom_query_service.find_parent_work_id(resource: fileset1)).to be_nil
+      end
+    end
   end
 end

--- a/spec/services/hyrax/custom_queries/navigators/parent_work_navigator_spec.rb
+++ b/spec/services/hyrax/custom_queries/navigators/parent_work_navigator_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::CustomQueries::Navigators::ParentWorkNavigator, valkyrie_adapter: :test_adapter, clean_repo: true do
+  let!(:parent_work) { FactoryBot.valkyrie_create(:hyrax_work, id: 'pw1', title: ['Parent Work 1'], member_ids: member_ids) }
+
+  let(:child_work1) { FactoryBot.valkyrie_create(:hyrax_work, id: 'cw1', title: ['Child Work 1']) }
+  let(:child_work2) { FactoryBot.valkyrie_create(:hyrax_work, id: 'cw2', title: ['Child Work 2']) }
+  let(:fileset1)    { FactoryBot.valkyrie_create(:hyrax_file_set, id: 'fs1', title: ['Child File Set 1']) }
+  let(:fileset2)    { FactoryBot.valkyrie_create(:hyrax_file_set, id: 'fs2', title: ['Child File Set 2']) }
+
+  let(:member_ids) do
+    [
+      child_work1.id,
+      child_work2.id,
+      fileset1.id,
+      fileset2.id
+    ]
+  end
+
+  let(:custom_query_service) { Hyrax.custom_queries }
+
+  describe '#find_parent_work' do
+    context 'on a work' do
+      it 'returns one parent work as Valkyrie resources' do
+        expect(custom_query_service.find_parent_work(resource: child_work1).id).to eq parent_work.id
+      end
+
+      context 'when more than one parent' do
+        let!(:work) { FactoryBot.valkyrie_create(:hyrax_work, id: 'pw2', title: ['Parent Work 2'], member_ids: member_ids) }
+        let(:child_work3) { FactoryBot.valkyrie_create(:hyrax_work, id: 'cw3', title: ['Child Work 3']) }
+        let(:member_ids) { [child_work3.id] }
+        it 'logs warning about more than one parent and returns the first parent work as Valkyrie resources' do
+          expect(Hyrax.logger).to receive(:warn).with("Work cw3 is in 2 works when it should be in no more than one.")
+          parent = custom_query_service.find_parent_work(resource: child_work3)
+          # There is no guarantee which of the parents will be returned.
+          expect([work.id, parent_work.id]).to include parent.id
+        end
+      end
+    end
+
+    context 'on a fileset' do
+      it 'returns one parent work as Valkyrie resources' do
+        expect(custom_query_service.find_parent_work(resource: fileset1).id).to eq parent_work.id
+      end
+
+      context 'when more than one parent' do
+        let!(:work) { FactoryBot.valkyrie_create(:hyrax_work, id: 'pw2', title: ['Parent Work 2'], member_ids: member_ids) }
+        let(:fileset3) { FactoryBot.valkyrie_create(:hyrax_file_set, id: 'fs3', title: ['Child File Set 3']) }
+        let(:member_ids) { [fileset3.id] }
+        it 'logs warning about more than one parent and returns the first parent work as Valkyrie resources' do
+          expect(Hyrax.logger).to receive(:warn).with("File set fs3 is in 2 works when it should be in no more than one.")
+          parent = custom_query_service.find_parent_work(resource: fileset3)
+          # There is no guarantee which of the parents will be returned.
+          expect([work.id, parent_work.id]).to include parent.id
+        end
+      end
+    end
+
+    context 'when no parents' do
+      let(:member_ids) { [] }
+      it 'returns nil' do
+        expect(custom_query_service.find_parent_work(resource: child_work1)).to be_nil
+        expect(custom_query_service.find_parent_work(resource: fileset1)).to be_nil
+      end
+    end
+  end
+
+  describe '#find_parent_work_id' do
+    context 'on a work' do
+      it 'returns the id of one parent work as Valkyrie resources' do
+        expect(custom_query_service.find_parent_work_id(resource: child_work1)).to eq parent_work.id
+      end
+    end
+
+    context 'on a fileset' do
+      it 'returns the id of one parent work as Valkyrie resources' do
+        expect(custom_query_service.find_parent_work_id(resource: fileset1)).to eq parent_work.id
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,6 +97,7 @@ query_registration_target =
 [Hyrax::CustomQueries::Navigators::CollectionMembers,
  Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator,
  Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
+ Hyrax::CustomQueries::Navigators::ParentWorkNavigator,
  Hyrax::CustomQueries::FindAccessControl,
  Hyrax::CustomQueries::FindCollectionsByType,
  Hyrax::CustomQueries::FindManyByAlternateIds,


### PR DESCRIPTION
This provides a consistent API for navigating from a child work or fileset to the parent work without the caller needing to know the attribute storing the relationship or the directionality of the relationship.

This is consistent with other navigator custom queries found in [app/services/hyrax/custom_queries/navigators](https://github.com/samvera/hyrax/tree/main/app/services/hyrax/custom_queries/navigators).

@samvera/hyrax-code-reviewers
