### PR TITLE
add Work-to-Work relationship documentation

### DIFF
--- a/app/models/hyrax/administrative_set.rb
+++ b/app/models/hyrax/administrative_set.rb
@@ -9,19 +9,18 @@ module Hyrax
   # *Relationships:*
   #
   # Administrative Set and Work
-  # * Administrative Set to Work (1..m): An admin set can have many works.  This relationship
-  #   is defined by the inverse relationship stored in the work.
-  #   * See Hyrax::Work for code to set the relationship.
-  #   * Get works using: <code>works = Hyrax.query_service.find_inverse_references_by(id: admin_set.id, property: :admin_set_id)</code>
-  #   * See 'a Hyrax::Work #admin_set_id' in /lib/hyrax/specs/shared_specs/hydra_works.rb
-  #     for tests of this relationship.
-  # * Work to Administrative Set (1..1):  A work must be in one and only one admin set.  The
-  #   relationship to the admin set is defined in the work.
+  #
+  # * <b>Defined:</b> The relationship is defined by the inverse relationship stored in the
+  #   work's `:admin_set_id` attribute.
+  # * <b>Tested:</b> The work tests the relationship.
+  # * <b>Administrative Set to Work:</b> (1..m)  An admin set can have many works.
+  #   * Get works in an admin set using:
+  #       works = Hyrax.query_service.find_inverse_references_by(id: admin_set.id, property: :admin_set_id)
+  # * <b>Work to Administrative Set:</b> (1..1)  A work must be in one and only one admin set.
   #   * See Hyrax::Work for code to get and set the admin set for the work.
   #
   # @see Hyrax::Work
   # @see Valkyrie query adapter's #find_inverse_references_by
-  # @see /lib/hyrax/specs/shared_specs/hydra_works.rb
   #
   class AdministrativeSet < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)

--- a/app/models/hyrax/administrative_set.rb
+++ b/app/models/hyrax/administrative_set.rb
@@ -6,17 +6,19 @@ module Hyrax
   ##
   # Valkyrie model for Admin Set domain objects.
   #
-  # *Relationships:*
+  # ## Relationships
   #
-  # Administrative Set and Work
+  # ### Administrative Set and Work
   #
-  # * <b>Defined:</b> The relationship is defined by the inverse relationship stored in the
+  # * Defined: The relationship is defined by the inverse relationship stored in the
   #   work's `:admin_set_id` attribute.
-  # * <b>Tested:</b> The work tests the relationship.
-  # * <b>Administrative Set to Work:</b> (1..m)  An admin set can have many works.
-  #   * Get works in an admin set using:
+  # * Tested: The work tests the relationship.
+  # * Administrative Set to Work: (1..m)  An admin set can have many works.
+  #
+  # @example Get works in an admin set:
   #       works = Hyrax.query_service.find_inverse_references_by(id: admin_set.id, property: :admin_set_id)
-  # * <b>Work to Administrative Set:</b> (1..1)  A work must be in one and only one admin set.
+  #
+  # * Work to Administrative Set: (1..1)  A work must be in one and only one admin set.
   #   * See Hyrax::Work for code to get and set the admin set for the work.
   #
   # @see Hyrax::Work

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -11,20 +11,29 @@ module Hyrax
   # Collection and Collection (TBA)
   #
   # Collection and Work
-  # * Collection to Work (0..m):  A collection can have many works.  This relationship
-  #   is defined by the inverse relationship stored in the work.
-  #   * See Hyrax::Work for code to set the relationship.
-  #   * Get works using: <code>works = Hyrax.custom_queries.find_members_of(collection: collection)</code>
-  #   * See 'a Hyrax::Work' behaves_like 'belongs to collections' in
-  #     /lib/hyrax/specs/shared_specs/hydra_works.rb for tests of this relationship.
-  # * Work to Collection (0..m):  A work can be in many collections.  The
-  #   relationship to the collection is defined in the work.
+  #
+  # * <b>Defined:</b> The relationship is defined by the inverse relationship stored in the
+  #   work's `:member_of_collection_ids` attribute.
+  # * <b>Tested:</b> The work tests the relationship.
+  # * <b>Collection to Work:</b> (0..m)  A collection can have many works.
+  #   * Get works in a collection using:
+  #       works = Hyrax.custom_queries.find_child_works(resource: collection)
+  # * <b>Work to Collection:</b> (0..m)  A work can be in many collections.
   #   * See Hyrax::Work for code to get and set collections for the work.
   # @note Some collection types limit a work to belong to one and only one collection of that type.
   #
+  # All children
+  #
+  # * There are additional methods for finding all children without respect to
+  #   the child's type.
+  #   * Get works and child collections in a collection using:
+  #       members = Hyrax.custom_queries.find_members_of(resource: collection)
+  #
   # @see Hyrax::Work
+  #
+  # @see Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator#find_child_collections
+  # @see Hyrax::CustomQueries::Navigators::ChildWorksNavigator#find_child_works
   # @see Hyrax::CustomQueries::Navigators::CollectionMembers#find_members_of
-  # @see /lib/hyrax/specs/shared_specs/hydra_works.rb
   #
   class PcdmCollection < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -6,27 +6,31 @@ module Hyrax
   ##
   # Valkyrie model for Collection domain objects in the Hydra Works model.
   #
-  # *Relationships:*
+  # ## Relationships
   #
-  # Collection and Collection (TBA)
+  # ### Collection and Collection (TBA)
   #
-  # Collection and Work
+  # ### Collection and Work
   #
-  # * <b>Defined:</b> The relationship is defined by the inverse relationship stored in the
+  # * Defined: The relationship is defined by the inverse relationship stored in the
   #   work's `:member_of_collection_ids` attribute.
-  # * <b>Tested:</b> The work tests the relationship.
-  # * <b>Collection to Work:</b> (0..m)  A collection can have many works.
-  #   * Get works in a collection using:
+  # * Tested: The work tests the relationship.
+  # * Collection to Work: (0..m)  A collection can have many works.
+  #
+  # @example Get works in a collection:
   #       works = Hyrax.custom_queries.find_child_works(resource: collection)
-  # * <b>Work to Collection:</b> (0..m)  A work can be in many collections.
+  #
+  # * Work to Collection: (0..m)  A work can be in many collections.
   #   * See Hyrax::Work for code to get and set collections for the work.
+  #
   # @note Some collection types limit a work to belong to one and only one collection of that type.
   #
-  # All children
+  # ### All children
   #
   # * There are additional methods for finding all children without respect to
   #   the child's type.
-  #   * Get works and child collections in a collection using:
+  #
+  # @example Get works and child collections in a collection using:
   #       members = Hyrax.custom_queries.find_members_of(resource: collection)
   #
   # @see Hyrax::Work

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -4,52 +4,59 @@ module Hyrax
   ##
   # Valkyrie model for `Work` domain objects in the Hydra Works model.
   #
-  # *Relationships:*
+  # ## Relationships
   #
-  # Administrative Set and Work
+  # ### Administrative Set and Work
   #
-  # * <b>Defined:</b> The relationship is defined by the work's `:admin_set_id` attribute.
-  # * <b>Tested:</b> The relationship is tested in shared spec 'a Hyrax::Work' by testing
+  # * Defined: The relationship is defined by the work's `:admin_set_id` attribute.
+  # * Tested: The relationship is tested in shared spec `'a Hyrax::Work'` by testing
   #   `#admin_set_id`.  Shared specs are defined in /lib/hyrax/specs/shared_specs/hydra_works.rb.
-  # * <b>Administrative Set to Work:</b> (1..m) An admin set can have many works.
+  # * Administrative Set to Work: (1..m) An admin set can have many works.
   #   * See Hyrax::AdministrativeSet for code to get works in an admin set.
-  # * <b>Work to Administrative Set:</b> (1..1)  A work must be in one and only one admin set.
-  #   * Set admin set for a work using:
+  # * Work to Administrative Set: (1..1)  A work must be in one and only one admin set.
+  #
+  # @example Set admin set for a work:
   #       work.admin_set_id = admin_set.id
-  #   * Get admin set a work is in using:
+  # @example Get admin set a work is in:
   #       admin_set = Hyrax.query_service.find_by(id: work.admin_set_id)
   #
-  # Collection and Work
+  # ### Collection and Work
   #
-  # * <b>Defined:</b> The relationship is defined by the work's `:member_of_collection_ids` attribute.
-  # * <b>Tested:</b> The relationship is tested in shared spec 'a Hyrax::Work' by testing
+  # * Defined: The relationship is defined by the work's `:member_of_collection_ids` attribute.
+  # * Tested: The relationship is tested in shared spec `'a Hyrax::Work'` by testing
   #   `it_behaves_like 'belongs to collections'`.  Shared specs are defined in /lib/hyrax/specs/shared_specs/hydra_works.rb.
-  # * <b>Collection to Work:</b> (0..m)  A collection can have many works.
+  # * Collection to Work: (0..m)  A collection can have many works.
   #   * See Hyrax::PcdmCollection for code to get works in a collection.
-  # * <b>Work to Collection:</b> (0..m)  A work can be in many collections.
-  #   * Add a work to a collection using Hyrax::CollectionMemberService (multiple method options)
+  # * Work to Collection: (0..m)  A work can be in many collections.
+  #
+  # @example Add a work to a collection using Hyrax::CollectionMemberService (multiple method options)
   #       Hyrax::CollectionMemberService.add_members(collection_id: col.id, members: works, user: current_user)
-  #   * Get collections a work is in using:
+  # @example Get collections a work is in:
   #       collections = Hyrax.custom_queries.find_collections_for(resource: work)
+  #
   # @note Some collection types limit a work to belong to one and only one collection of that type.
   #
-  # Work and Work
+  # ### Work and Work
   #
-  # * <b>Defined:</b> The relationship is defined in the parent work's `:member_ids` attribute.
-  # * <b>Tested:</b> The relationship is tested in shared spec 'a Hyrax::Work' by testing
+  # * Defined: The relationship is defined in the parent work's `:member_ids` attribute.
+  # * Tested: The relationship is tested in shared spec `'a Hyrax::Work'` by testing
   #   `it_behaves_like 'has_members'`.  Shared specs are defined in /lib/hyrax/specs/shared_specs/hydra_works.rb.
-  # * <b>Work to child Work:</b> (0..m)  A work can have many child works.
-  #   * Add a child work to a work using:
+  # * Work to child Work: (0..m)  A work can have many child works.
+  #
+  # @example Add a child work to a work:
   #       Hyrax::Transactions::Container['work_resource.add_to_parent']
   #         .call(child_work, parent_id: parent_work.id, user: current_user)
-  #   * Get child works using:
+  # @example Get child works:
   #       works = Hyrax.custom_queries.find_child_works(resource: parent_work)
-  # * <b>Work to parent Work:</b> (0..1)  A work can be in at most one parent work.
-  #   * Get parent work using:
+  #
+  # * Work to parent Work: (0..1)  A work can be in at most one parent work.
+  #
+  # @example Get parent work:
   #       parent_work = Hyrax.custom_queries.find_parent_work(resource: child_work)
+  #
   # @note `:member_ids` holds ids of child works and file sets.
   #
-  # Work and File Set (TBD)
+  # ### Work and File Set (TBD)
   #
   # @see Hyrax::AdministrativeSet
   # @see Hyrax::PcdmCollection

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -7,38 +7,61 @@ module Hyrax
   # *Relationships:*
   #
   # Administrative Set and Work
-  # * Administrative Set to Work (1..m): An admin set can have many works.  This relationship
-  #   is defined by the inverse relationship stored in the work's attribute `:admin_set_id`.
+  #
+  # * <b>Defined:</b> The relationship is defined by the work's `:admin_set_id` attribute.
+  # * <b>Tested:</b> The relationship is tested in shared spec 'a Hyrax::Work' by testing
+  #   `#admin_set_id`.  Shared specs are defined in /lib/hyrax/specs/shared_specs/hydra_works.rb.
+  # * <b>Administrative Set to Work:</b> (1..m) An admin set can have many works.
   #   * See Hyrax::AdministrativeSet for code to get works in an admin set.
-  # * Work to Administrative Set (1..1):  A work must be in one and only one admin set.  The
-  #   relationship to the admin set is defined in the work's attribute `:admin_set_id`.
-  #   * Set admin set for work using: <code>work.admin_set_id = admin_set.id</code>
-  #   * Get admin set resource using: <code>admin_set = Hyrax.query_service.find_by(id: work.admin_set_id)</code>
-  #   * See 'a Hyrax::Work #admin_set_id' in /lib/hyrax/specs/shared_specs/hydra_works.rb
-  #     for tests of this relationship.
+  # * <b>Work to Administrative Set:</b> (1..1)  A work must be in one and only one admin set.
+  #   * Set admin set for a work using:
+  #       work.admin_set_id = admin_set.id
+  #   * Get admin set a work is in using:
+  #       admin_set = Hyrax.query_service.find_by(id: work.admin_set_id)
   #
   # Collection and Work
-  # * Collection to Work (0..m):  A collection can have many works.  This relationship
-  #   is defined by the inverse relationship stored in the work's attribute `:member_of_collection_ids`.
+  #
+  # * <b>Defined:</b> The relationship is defined by the work's `:member_of_collection_ids` attribute.
+  # * <b>Tested:</b> The relationship is tested in shared spec 'a Hyrax::Work' by testing
+  #   `it_behaves_like 'belongs to collections'`.  Shared specs are defined in /lib/hyrax/specs/shared_specs/hydra_works.rb.
+  # * <b>Collection to Work:</b> (0..m)  A collection can have many works.
   #   * See Hyrax::PcdmCollection for code to get works in a collection.
-  # * Work to Collection (0..m):  A work can be in many collections.  The
-  #   relationship to the collection is defined in the work's attribute `:member_of_collection_ids`.
+  # * <b>Work to Collection:</b> (0..m)  A work can be in many collections.
   #   * Add a work to a collection using Hyrax::CollectionMemberService (multiple method options)
-  #     * <code>Hyrax::CollectionMemberService.add_members(collection_id: col.id, members: works, user: current_user)</code>
-  #   * Get collection resources using: <code>collections = Hyrax.custom_queries.find_collections_for(resource: work)</code>
-  #   * See 'a Hyrax::Work' behaves_like 'belongs to collections' in
-  #     /lib/hyrax/specs/shared_specs/hydra_works.rb for tests of this relationship.
+  #       Hyrax::CollectionMemberService.add_members(collection_id: col.id, members: works, user: current_user)
+  #   * Get collections a work is in using:
+  #       collections = Hyrax.custom_queries.find_collections_for(resource: work)
   # @note Some collection types limit a work to belong to one and only one collection of that type.
   #
-  # Work and Work (TBD)
+  # Work and Work
+  #
+  # * <b>Defined:</b> The relationship is defined in the parent work's `:member_ids` attribute.
+  # * <b>Tested:</b> The relationship is tested in shared spec 'a Hyrax::Work' by testing
+  #   `it_behaves_like 'has_members'`.  Shared specs are defined in /lib/hyrax/specs/shared_specs/hydra_works.rb.
+  # * <b>Work to child Work:</b> (0..m)  A work can have many child works.
+  #   * Add a child work to a work using:
+  #       Hyrax::Transactions::Container['work_resource.add_to_parent']
+  #         .call(child_work, parent_id: parent_work.id, user: current_user)
+  #   * Get child works using:
+  #       works = Hyrax.custom_queries.find_child_works(resource: parent_work)
+  # * <b>Work to parent Work:</b> (0..1)  A work can be in at most one parent work.
+  #   * Get parent work using:
+  #       parent_work = Hyrax.custom_queries.find_parent_work(resource: child_work)
+  # @note `:member_ids` holds ids of child works and file sets.
   #
   # Work and File Set (TBD)
   #
   # @see Hyrax::AdministrativeSet
   # @see Hyrax::PcdmCollection
+  # @see Hyrax::FileSet
+  #
+  # @see Hyrax::CollectionMemberService
+  # @see Hyrax::Transactions::Steps::AddToParent
+  #
   # @see Valkyrie query adapter's #find_by
   # @see Hyrax::CustomQueries::Navigators::CollectionMembers#find_collections_for
-  # @see Hyrax::CollectionMemberService
+  # @see Hyrax::CustomQueries::Navigators::CollectionMembers#find_parent_work
+  #
   # @see /lib/hyrax/specs/shared_specs/hydra_works.rb
   #
   # @todo The description in Hydra::Works Shared Modeling is out of date and uses


### PR DESCRIPTION
Adds documentation for the Work-to-Work relationship.

Also refactors the layout of each relationship to avoid repeating statements and code and to make each characteristic (where defined, where tested, each direction of the relationship) easier to see at a glance.  Code is separated out into code blocks instead of being inline.

## Examples yard doc layout after refactor:

### In the work

![image](https://user-images.githubusercontent.com/6855473/153662413-76c13619-7535-443a-8ec5-66a7f984b097.png)

### In the admin set

![image](https://user-images.githubusercontent.com/6855473/153662488-a165cc6d-a4a2-4717-9f8c-af35c2bf020f.png)

