### PR TITLE
Avoid depending on delegatation of collection_type through @collection

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -83,6 +83,7 @@ module Hyrax
 
       def edit
         form
+        collection_type
       end
 
       def after_create

--- a/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
@@ -1,6 +1,6 @@
                   <h3><%= t(".#{access}.title") %></h3>
                   <p><%= t(".#{access}.help") %></p>
-                  <p><%= t(".#{access}.help_with_works", type_title: @collection.collection_type.title) if @collection.share_applies_to_new_works? && access != 'depositors' %></p>
+                  <p><%= t(".#{access}.help_with_works", type_title: @collection_type.title) if @collection_type.share_applies_to_new_works? && access != 'depositors' %></p>
                   <% if collection_permission_template_form_for(form: @form).access_grants.select(&filter).any? %>
                     <table class="table table-striped share-status">
                       <thead>

--- a/spec/views/hyrax/dashboard/collections/_form_share.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_share.erb_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe 'hyrax/dashboard/collections/_form_share.html.erb', type: :view d
                     to_key: template.to_key,
                     access_grants: template.access_grants)
   end
-  let(:collection) { stub_model(Collection, share_applies_to_new_works?: false) }
+  let(:collection) { stub_model(Collection) }
+  let(:collection_type) { stub_model(Hyrax::CollectionType, share_applies_to_new_works?: false) }
 
   before do
     assign(:collection, collection)
+    assign(:collection_type, collection_type)
     @form = instance_double(Hyrax::Forms::CollectionForm,
                             to_model: collection,
                             permission_template: pt_form,

--- a/spec/views/hyrax/dashboard/collections/_form_share_table.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_share_table.html.erb_spec.rb
@@ -3,7 +3,8 @@ RSpec.describe 'hyrax/dashboard/collections/_form_share_table.html.erb', type: :
   let(:template) { stub_model(Hyrax::PermissionTemplate) }
   let(:user) { create(:user) }
   let(:access_grant) { stub_model(Hyrax::PermissionTemplateAccess) }
-  let(:collection) { stub_model(Collection, share_applies_to_new_works?: false) }
+  let(:collection) { stub_model(Collection) }
+  let(:collection_type) { stub_model(Hyrax::CollectionType, share_applies_to_new_works?: false) }
   let(:pt_form) do
     instance_double(Hyrax::Forms::PermissionTemplateForm,
                     model_name: template.model_name,
@@ -13,6 +14,7 @@ RSpec.describe 'hyrax/dashboard/collections/_form_share_table.html.erb', type: :
 
   before do
     assign(:collection, collection)
+    assign(:collection_type, collection_type)
     @form = instance_double(Hyrax::Forms::CollectionForm,
                             to_model: stub_model(Collection),
                             permission_template: pt_form)


### PR DESCRIPTION
Fixes #5409 

There is a controller method to load the collection type into an instance variable.  Ensuring that this gets run during the edit action allows us to avoid having to use the delegation declared in `::Collection` (and not declared in `Hyrax::PcdmCollection`).

@samvera/hyrax-code-reviewers
