### PR TITLE
add documentation for the Work and File Set relationship

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -432,7 +432,7 @@ module Hyrax
       when ActiveFedora::Common
         curation_concern.file_sets.present?
       else
-        Hyrax.custom_queries.find_child_fileset_ids(resource: curation_concern).any?
+        Hyrax.custom_queries.find_child_file_set_ids(resource: curation_concern).any?
       end
     end
 

--- a/app/jobs/concerns/hyrax/members_permission_job_behavior.rb
+++ b/app/jobs/concerns/hyrax/members_permission_job_behavior.rb
@@ -17,7 +17,7 @@ module Hyrax
       when ActiveFedora::Base
         ::FileSet.search_with_conditions(id: work.member_ids).map(&:id)
       when Valkyrie::Resource
-        Hyrax.custom_queries.find_child_fileset_ids(resource: work)
+        Hyrax.custom_queries.find_child_file_set_ids(resource: work)
       end
     end
 

--- a/app/jobs/inherit_permissions_job.rb
+++ b/app/jobs/inherit_permissions_job.rb
@@ -24,7 +24,7 @@ class InheritPermissionsJob < Hyrax::ApplicationJob
   # @param work [Resource]
   # @return [Array<Hyrax::File_Set>]
   def file_sets_for(work)
-    Hyrax.custom_queries.find_child_filesets(resource: work)
+    Hyrax.custom_queries.find_child_file_sets(resource: work)
   end
 
   # Perform the copy from the work to the contained filesets

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -4,6 +4,30 @@ module Hyrax
   ##
   # Valkyrie model for `FileSet` domain objects in the Hydra Works model.
   #
+  # ## Relationships
+  #
+  # ### File Set and Work
+  #
+  # * Defined: The relationship is defined by the inverse relationship stored in the
+  #   work's `:member_ids` attribute.
+  # * Tested: The work tests the relationship.
+  # * File Set to Work: (1..1)  A file set must be in one and only one work.
+  #
+  # @example Get work for a file set:
+  #       work = Hyrax.custom_queries.find_parent_work(resource: file_set)
+  #
+  # * Work to File Set: (0..m)  A work can have many file sets.
+  #   * See Hyrax::Work for code to get and set file sets for the work.
+  #
+  # ### File Set and File (TBD)
+  #
+  # @see Hyrax::Work
+  # @see Hyrax::CustomQueries::Navigators::ParentWorkNavigator#find_parent_work
+  #
+  # @todo The description in Hydra::Works Shared Modeling is out of date and uses
+  #   terminology to describe the relationships that is no longer used in code.
+  #   Update the model and link to it.  This can be a simple relationship diagram
+  #   with a link to the original Works Shared Modeling for historical perspective.
   # @see https://wiki.duraspace.org/display/samvera/Hydra%3A%3AWorks+Shared+Modeling
   class FileSet < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -67,7 +67,7 @@ module Hyrax
   #
   # @see Valkyrie query adapter's #find_by
   # @see Hyrax::CustomQueries::Navigators::CollectionMembers#find_collections_for
-  # @see Hyrax::CustomQueries::Navigators::CollectionMembers#find_parent_work
+  # @see Hyrax::CustomQueries::Navigators::ParentWorkNavigator#find_parent_work
   #
   # @see /lib/hyrax/specs/shared_specs/hydra_works.rb
   #

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -56,7 +56,24 @@ module Hyrax
   #
   # @note `:member_ids` holds ids of child works and file sets.
   #
-  # ### Work and File Set (TBD)
+  # ### Work and File Set
+  #
+  # * Defined: The relationship is defined in the parent work's `:member_ids` attribute.
+  # * Tested: The relationship is tested in shared spec `'a Hyrax::Work'` by testing
+  #   `it_behaves_like 'has_members'`.  Shared specs are defined in /lib/hyrax/specs/shared_specs/hydra_works.rb.
+  # * Work to File Set: (0..m)  A work can have many file sets.
+  #   * Add a file set to a work -- This is a multi-step process.  A good place to
+  #     start exploring the code is the calling of the transaction that creates
+  #     a work in Hyrax::WorksControllerBehavior #create_work.  Transaction step
+  #     Hyrax::Transactions::Steps::AddFileSets calls a file handler service that
+  #     creates a fileset for each uploaded file and attaches the fileset to the work.
+  #     Several steps happen before the transaction is called to upload the files.
+  #
+  # @example Get file sets:
+  #       file_sets = Hyrax.custom_queries.find_child_file_sets(resource: work)
+  #
+  # * File Set to Work: (1..1)  A file set must be in one and only one work.
+  #   * See Hyrax::FileSet for code to get the work a file set is in.
   #
   # @see Hyrax::AdministrativeSet
   # @see Hyrax::PcdmCollection
@@ -64,10 +81,13 @@ module Hyrax
   #
   # @see Hyrax::CollectionMemberService
   # @see Hyrax::Transactions::Steps::AddToParent
+  # @see Hyrax::Transactions::Steps::AddFileSets
+  # @see Hyrax::WorksControllerBehavior
   #
   # @see Valkyrie query adapter's #find_by
   # @see Hyrax::CustomQueries::Navigators::CollectionMembers#find_collections_for
   # @see Hyrax::CustomQueries::Navigators::ParentWorkNavigator#find_parent_work
+  # @see Hyrax::CustomQueries::Navigators::ChildFileSetsNavigator#find_child_file_sets
   #
   # @see /lib/hyrax/specs/shared_specs/hydra_works.rb
   #

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -62,13 +62,12 @@ module Hyrax
   # * Tested: The relationship is tested in shared spec `'a Hyrax::Work'` by testing
   #   `it_behaves_like 'has_members'`.  Shared specs are defined in /lib/hyrax/specs/shared_specs/hydra_works.rb.
   # * Work to File Set: (0..m)  A work can have many file sets.
-  #   * Add a file set to a work -- This is a multi-step process.  A good place to
-  #     start exploring the code is the calling of the transaction that creates
-  #     a work in Hyrax::WorksControllerBehavior #create_work.  Transaction step
-  #     Hyrax::Transactions::Steps::AddFileSets calls a file handler service that
-  #     creates a fileset for each uploaded file and attaches the fileset to the work.
-  #     Several steps happen before the transaction is called to upload the files.
-  #
+  # @example Add a file set to a work (code from Hyrax::WorkUploadsHandler#append_to_work)
+  #       work.member_ids << file_set.id
+  #       work.representative_id = file_set.id if work.respond_to?(:representative_id) && work.representative_id.blank?
+  #       work.thumbnail_id = file_set.id if work.respond_to?(:thumbnail_id) && work.thumbnail_id.blank?
+  #       Hyrax.persister.save(resource: work)
+  #       Hyrax.publisher.publish('object.metadata.updated', object: work, user: files.first.user)
   # @example Get file sets:
   #       file_sets = Hyrax.custom_queries.find_child_file_sets(resource: work)
   #
@@ -83,6 +82,7 @@ module Hyrax
   # @see Hyrax::Transactions::Steps::AddToParent
   # @see Hyrax::Transactions::Steps::AddFileSets
   # @see Hyrax::WorksControllerBehavior
+  # @see Hyrax::WorkUploadsHandler#append_to_work
   #
   # @see Valkyrie query adapter's #find_by
   # @see Hyrax::CustomQueries::Navigators::CollectionMembers#find_collections_for

--- a/app/services/hyrax/change_content_depositor_service.rb
+++ b/app/services/hyrax/change_content_depositor_service.rb
@@ -61,7 +61,7 @@ module Hyrax
     private_class_method :apply_depositor_metadata
 
     def self.apply_valkyrie_changes_to_file_sets(work:, user:, reset:)
-      Hyrax.custom_queries.find_child_filesets(resource: work).each do |f|
+      Hyrax.custom_queries.find_child_file_sets(resource: work).each do |f|
         if reset
           f.permission_manager.acl.permissions = []
           f.permission_manager.acl.save

--- a/app/services/hyrax/custom_queries/navigators/child_file_sets_navigator.rb
+++ b/app/services/hyrax/custom_queries/navigators/child_file_sets_navigator.rb
@@ -6,13 +6,12 @@ module Hyrax
       ##
       # Navigate from a resource to the child filesets in the resource.
       #
-      # @deprecated use Hyrax::CustomQueries::Navigators::ChildFileSetsNavigator instead
       # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
-      # @since 3.0.0
-      class ChildFilesetsNavigator
+      # @since 3.4.0
+      class ChildFileSetsNavigator
         # Define the queries that can be fulfilled by this navigator.
         def self.queries
-          [:find_child_filesets, :find_child_fileset_ids]
+          [:find_child_file_sets, :find_child_file_set_ids]
         end
 
         attr_reader :query_service
@@ -27,10 +26,8 @@ module Hyrax
         # @param [Valkyrie::Resource] resource
         #
         # @return [Array<Valkyrie::Resource>]
-        # @deprecated
-        def find_child_filesets(resource:)
-          Deprecation.warn("Custom query find_child_filesets is deprecated; use find_child_file_sets instead.")
-          Hyrax.custom_queries.find_child_file_sets(resource: resource)
+        def find_child_file_sets(resource:)
+          query_service.find_members(resource: resource).select(&:file_set?)
         end
 
         ##
@@ -39,10 +36,8 @@ module Hyrax
         # @param [Valkyrie::Resource] resource
         #
         # @return [Array<Valkyrie::ID>]
-        # @deprecated
-        def find_child_fileset_ids(resource:)
-          Deprecation.warn("Custom query find_child_fileset_ids is deprecated; use find_child_file_set_ids instead.")
-          Hyrax.custom_queries.find_child_file_set_ids(resource: resource)
+        def find_child_file_set_ids(resource:)
+          find_child_file_sets(resource: resource).map(&:id)
         end
       end
     end

--- a/app/services/hyrax/custom_queries/navigators/child_filesets_navigator.rb
+++ b/app/services/hyrax/custom_queries/navigators/child_filesets_navigator.rb
@@ -11,7 +11,8 @@ module Hyrax
       class ChildFilesetsNavigator
         # Define the queries that can be fulfilled by this navigator.
         def self.queries
-          [:find_child_filesets, :find_child_fileset_ids]
+          [:find_child_file_sets, :find_child_file_set_ids,
+           :find_child_filesets, :find_child_fileset_ids]
         end
 
         attr_reader :query_service
@@ -26,9 +27,11 @@ module Hyrax
         # @param [Valkyrie::Resource] resource
         #
         # @return [Array<Valkyrie::Resource>]
-        def find_child_filesets(resource:)
+        def find_child_file_sets(resource:)
           query_service.find_members(resource: resource).select(&:file_set?)
         end
+        alias find_child_filesets find_child_file_sets
+        deprecation_deprecate find_child_filesets: "use find_child_file_sets instead"
 
         ##
         # Find the ids of child filesets of a given resource, and map to Valkyrie Resources IDs
@@ -36,9 +39,11 @@ module Hyrax
         # @param [Valkyrie::Resource] resource
         #
         # @return [Array<Valkyrie::ID>]
-        def find_child_fileset_ids(resource:)
-          find_child_filesets(resource: resource).map(&:id)
+        def find_child_file_set_ids(resource:)
+          find_child_file_sets(resource: resource).map(&:id)
         end
+        alias find_child_fileset_ids find_child_file_set_ids
+        deprecation_deprecate find_child_fileset_ids: "use find_child_file_set_ids instead"
       end
     end
   end

--- a/app/services/hyrax/listeners/member_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/member_cleanup_listener.rb
@@ -12,7 +12,7 @@ module Hyrax
         return unless event.payload.key?(:object) # legacy callback
         return if event[:object].is_a?(ActiveFedora::Base) # handled by legacy code
 
-        Hyrax.custom_queries.find_child_filesets(resource: event[:object]).each do |file_set|
+        Hyrax.custom_queries.find_child_file_sets(resource: event[:object]).each do |file_set|
           begin
             Hyrax.persister.delete(resource: file_set)
             Hyrax.publisher

--- a/app/services/hyrax/resource_visibility_propagator.rb
+++ b/app/services/hyrax/resource_visibility_propagator.rb
@@ -39,7 +39,7 @@ module Hyrax
     #
     # @raise [RuntimeError] if visibility propagation fails
     def propagate
-      queries.find_child_filesets(resource: source).each do |file_set|
+      queries.find_child_file_sets(resource: source).each do |file_set|
         file_set.visibility = source.visibility
         embargo_manager.copy_embargo_to(target: file_set)
         lease_manager.copy_lease_to(target: file_set)

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -93,7 +93,8 @@ Valkyrie.config.storage_adapter = :active_fedora
 custom_queries = [Hyrax::CustomQueries::Navigators::CollectionMembers,
                   Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator,
                   Hyrax::CustomQueries::Navigators::ParentCollectionsNavigator,
-                  Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator,
+                  Hyrax::CustomQueries::Navigators::ChildFileSetsNavigator,
+                  Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator, # deprecated; use ChildFileSetsNavigator
                   Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
                   Hyrax::CustomQueries::Navigators::ParentWorkNavigator,
                   Hyrax::CustomQueries::Navigators::FindFiles,

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe AttachFilesToWorkJob, perform_enqueued: [AttachFilesToWorkJob] do
         expect(ValkyrieIngestJob).to receive(:perform_later).twice
         described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
         generic_work = Hyrax.query_service.find_by(id: id)
-        file_sets = Hyrax.custom_queries.find_child_filesets(resource: generic_work)
+        file_sets = Hyrax.custom_queries.find_child_file_sets(resource: generic_work)
         expect(file_sets.count).to eq 2
         expect(file_sets.map(&:visibility)).to all(eq 'open')
         expect(uploaded_file1.reload.file_set_uri).not_to be_nil
@@ -127,7 +127,7 @@ RSpec.describe AttachFilesToWorkJob, perform_enqueued: [AttachFilesToWorkJob] do
       end
       it_behaves_like 'a file attacher' do
         it 'records the depositor(s) in edit_users' do
-          file_sets = Hyrax.custom_queries.find_child_filesets(resource: generic_work)
+          file_sets = Hyrax.custom_queries.find_child_file_sets(resource: generic_work)
           expect(file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor, 'userz@bbb.ddd']))
         end
 
@@ -137,10 +137,10 @@ RSpec.describe AttachFilesToWorkJob, perform_enqueued: [AttachFilesToWorkJob] do
 
           it 'skips files that already have a FileSet' do
             id = generic_work.id
-            expect(Hyrax.custom_queries.find_child_filesets(resource: generic_work).count).to eq 0
+            expect(Hyrax.custom_queries.find_child_file_sets(resource: generic_work).count).to eq 0
             described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
             generic_work = Hyrax.query_service.find_by(id: id)
-            expect(Hyrax.custom_queries.find_child_filesets(resource: generic_work).count).to eq 1
+            expect(Hyrax.custom_queries.find_child_file_sets(resource: generic_work).count).to eq 1
           end
         end
       end
@@ -168,7 +168,7 @@ RSpec.describe AttachFilesToWorkJob, perform_enqueued: [AttachFilesToWorkJob] do
 
       it_behaves_like 'a file attacher' do
         it 'records the depositor(s) in edit_users' do
-          file_sets = Hyrax.custom_queries.find_child_filesets(resource: generic_work)
+          file_sets = Hyrax.custom_queries.find_child_file_sets(resource: generic_work)
 
           expect(file_sets.map(&:edit_users)).to all(match_array([user.user_key]))
         end
@@ -183,7 +183,7 @@ RSpec.describe AttachFilesToWorkJob, perform_enqueued: [AttachFilesToWorkJob] do
 
       it_behaves_like 'a file attacher' do
         it 'records the depositor(s) in edit_users' do
-          file_sets = Hyrax.custom_queries.find_child_filesets(resource: generic_work)
+          file_sets = Hyrax.custom_queries.find_child_file_sets(resource: generic_work)
 
           expect(file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor]))
         end

--- a/spec/jobs/inherit_permissions_job_spec.rb
+++ b/spec/jobs/inherit_permissions_job_spec.rb
@@ -116,14 +116,14 @@ RSpec.describe InheritPermissionsJob do
         expect(resource.edit_users).to match_array [user.to_s, user2.to_s]
 
         # files have the depositor as the edit user to begin with
-        file_sets = Hyrax.query_service.custom_queries.find_child_filesets(resource: resource)
+        file_sets = Hyrax.query_service.custom_queries.find_child_file_sets(resource: resource)
         expect(file_sets.count).to eq 1
         expect(file_sets[0].edit_users).to match_array [user.to_s]
 
         described_class.perform_now(resource)
 
         # files have both edit users from parent resource
-        file_sets = Hyrax.query_service.custom_queries.find_child_filesets(resource: resource)
+        file_sets = Hyrax.query_service.custom_queries.find_child_file_sets(resource: resource)
         expect(file_sets.count).to eq 1
         expect(file_sets[0].edit_users).to match_array [user.to_s, user2.to_s]
       end
@@ -136,14 +136,14 @@ RSpec.describe InheritPermissionsJob do
         expect(resource.edit_users).to match_array [user.to_s]
 
         # files have the depositor and extra user as the edit users to begin with
-        file_sets = Hyrax.query_service.custom_queries.find_child_filesets(resource: resource)
+        file_sets = Hyrax.query_service.custom_queries.find_child_file_sets(resource: resource)
         expect(file_sets.count).to eq 1
         expect(file_sets[0].edit_users).to match_array [user.to_s, user2.to_s]
 
         described_class.perform_now(resource)
 
         # files have single edit user from parent resource
-        file_sets = Hyrax.query_service.custom_queries.find_child_filesets(resource: resource)
+        file_sets = Hyrax.query_service.custom_queries.find_child_file_sets(resource: resource)
         expect(file_sets.count).to eq 1
         expect(file_sets[0].edit_users).to match_array [user.to_s]
       end
@@ -155,14 +155,14 @@ RSpec.describe InheritPermissionsJob do
         expect(resource.read_users).to match_array [user2.to_s]
 
         # files have no read users to begin with
-        file_sets = Hyrax.query_service.custom_queries.find_child_filesets(resource: resource)
+        file_sets = Hyrax.query_service.custom_queries.find_child_file_sets(resource: resource)
         expect(file_sets.count).to eq 1
         expect(file_sets[0].read_users.to_a).to be_empty
 
         described_class.perform_now(resource)
 
         # files have the specified read user
-        file_sets = Hyrax.query_service.custom_queries.find_child_filesets(resource: resource)
+        file_sets = Hyrax.query_service.custom_queries.find_child_file_sets(resource: resource)
         expect(file_sets.count).to eq 1
         expect(file_sets[0].read_users.to_a).to match_array [user2.to_s]
       end
@@ -180,7 +180,7 @@ RSpec.describe InheritPermissionsJob do
         described_class.perform_now(resource)
 
         # files have the specified read group
-        file_sets = Hyrax.query_service.custom_queries.find_child_filesets(resource: resource)
+        file_sets = Hyrax.query_service.custom_queries.find_child_file_sets(resource: resource)
         expect(file_sets.count).to eq 1
         expect(file_sets[0].edit_users).to match_array [user.to_s]
         expect(file_sets[0].read_groups).to match_array ["my_read_group"]
@@ -199,7 +199,7 @@ RSpec.describe InheritPermissionsJob do
         described_class.perform_now(resource)
 
         # files have the specified edit group
-        file_sets = Hyrax.query_service.custom_queries.find_child_filesets(resource: resource)
+        file_sets = Hyrax.query_service.custom_queries.find_child_file_sets(resource: resource)
         expect(file_sets.count).to eq 1
         expect(file_sets[0].edit_users).to match_array [user.to_s]
         expect(file_sets[0].edit_groups).to match_array ["my_edit_group"]

--- a/spec/jobs/visibility_copy_job_spec.rb
+++ b/spec/jobs/visibility_copy_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe VisibilityCopyJob do
       resource.visibility = 'open'
 
       expect { described_class.perform_now(resource) }
-        .to change { queries.find_child_filesets(resource: resource).map(&:visibility) }
+        .to change { queries.find_child_file_sets(resource: resource).map(&:visibility) }
         .to ['open', 'open']
     end
 
@@ -27,7 +27,7 @@ RSpec.describe VisibilityCopyJob do
         release_date = resource.embargo.embargo_release_date
 
         expect { described_class.perform_now(resource) }
-          .to change { queries.find_child_filesets(resource: resource).map(&:embargo) }
+          .to change { queries.find_child_file_sets(resource: resource).map(&:embargo) }
           .to contain_exactly(have_attributes(embargo_release_date: release_date),
                               have_attributes(embargo_release_date: release_date))
       end
@@ -40,7 +40,7 @@ RSpec.describe VisibilityCopyJob do
         release_date = resource.lease.lease_expiration_date
 
         expect { described_class.perform_now(resource) }
-          .to change { queries.find_child_filesets(resource: resource).map(&:lease) }
+          .to change { queries.find_child_file_sets(resource: resource).map(&:lease) }
           .to contain_exactly(have_attributes(lease_expiration_date: release_date),
                               have_attributes(lease_expiration_date: release_date))
       end

--- a/spec/services/hyrax/change_content_depositor_service_spec.rb
+++ b/spec/services/hyrax/change_content_depositor_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
     let!(:base_work) { valkyrie_create(:hyrax_work, :with_member_file_sets, title: ['SoonToBeSomeoneElses'], depositor: depositor.user_key, edit_users: [depositor]) }
     before do
       work_acl = Hyrax::AccessControlList.new(resource: base_work)
-      Hyrax.custom_queries.find_child_filesets(resource: base_work).each do |file_set|
+      Hyrax.custom_queries.find_child_file_sets(resource: base_work).each do |file_set|
         Hyrax::AccessControlList.copy_permissions(source: work_acl, target: file_set)
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
 
       it "changes the depositor of the child file sets" do
         described_class.call(base_work, receiver, false)
-        file_sets = Hyrax.custom_queries.find_child_filesets(resource: base_work)
+        file_sets = Hyrax.custom_queries.find_child_file_sets(resource: base_work)
         expect(file_sets.size).not_to eq 0 # A quick check to make sure our each block works
 
         file_sets.each do |file_set|
@@ -92,7 +92,7 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
 
       it "changes the depositor of the child file sets" do
         described_class.call(base_work, receiver, true)
-        file_sets = Hyrax.custom_queries.find_child_filesets(resource: base_work)
+        file_sets = Hyrax.custom_queries.find_child_file_sets(resource: base_work)
         expect(file_sets.size).not_to eq 0 # A quick check to make sure our each block works
 
         file_sets.each do |file_set|

--- a/spec/services/hyrax/custom_queries/navigators/child_file_sets_navigator_spec.rb
+++ b/spec/services/hyrax/custom_queries/navigators/child_file_sets_navigator_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator, :clean_repo do
+RSpec.describe Hyrax::CustomQueries::Navigators::ChildFileSetsNavigator, :clean_repo do
   subject(:factory) { Wings::ModelTransformer.new(pcdm_object: pcdm_object) }
   let(:resource) { subject.build }
   let(:custom_query_service) { Hyrax.custom_queries }

--- a/spec/services/hyrax/custom_queries/navigators/child_filesets_navigator_spec.rb
+++ b/spec/services/hyrax/custom_queries/navigators/child_filesets_navigator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator, :clean_
   let(:fileset1) { build(:file_set, id: 'fs1', title: ['Child File Set 1']) }
   let(:fileset2) { build(:file_set, id: 'fs2', title: ['Child File Set 2']) }
 
-  describe '#find_child_filesets' do
+  describe '#find_child_file_sets' do
     let(:pcdm_object) { work1 }
     let(:work1_resource) { resource }
 
@@ -20,12 +20,12 @@ RSpec.describe Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator, :clean_
     end
 
     it 'returns only child filesets as Valkyrie resources' do
-      child_filesets = custom_query_service.find_child_filesets(resource: work1_resource)
+      child_filesets = custom_query_service.find_child_file_sets(resource: work1_resource)
       expect(child_filesets.map(&:id)).to match_valkyrie_ids_with_active_fedora_ids([fileset1.id, fileset2.id])
     end
   end
 
-  describe '#find_child_fileset_ids' do
+  describe '#find_child_file_set_ids' do
     let(:pcdm_object) { work1 }
     let(:work1_resource) { resource }
 
@@ -35,7 +35,7 @@ RSpec.describe Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator, :clean_
     end
 
     it 'returns Valkyrie ids for child filesets only' do
-      child_fileset_ids = custom_query_service.find_child_fileset_ids(resource: work1_resource)
+      child_fileset_ids = custom_query_service.find_child_file_set_ids(resource: work1_resource)
       expect(child_fileset_ids).to match_valkyrie_ids_with_active_fedora_ids([fileset1.id, fileset2.id])
     end
   end

--- a/spec/services/hyrax/listeners/member_cleanup_listener_spec.rb
+++ b/spec/services/hyrax/listeners/member_cleanup_listener_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Hyrax::Listeners::MemberCleanupListener do
 
     it 'removes child file set objects' do
       expect { listener.on_object_deleted(event) }
-        .to change { Hyrax.custom_queries.find_child_filesets(resource: event[:object]).size }
+        .to change { Hyrax.custom_queries.find_child_file_sets(resource: event[:object]).size }
         .from(1)
         .to(0)
     end

--- a/spec/services/hyrax/resource_visibility_propagator_spec.rb
+++ b/spec/services/hyrax/resource_visibility_propagator_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hyrax::ResourceVisibilityPropagator do
   subject(:propagator) { described_class.new(source: work) }
   let(:queries)        { Hyrax.custom_queries }
   let(:work)           { FactoryBot.create(:work_with_files).valkyrie_resource }
-  let(:file_sets)      { queries.find_child_filesets(resource: work) }
+  let(:file_sets)      { queries.find_child_file_sets(resource: work) }
 
   context 'a public work' do
     before { work.visibility = 'open' }
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::ResourceVisibilityPropagator do
       expect(file_sets.first.visibility).to eq 'restricted'
 
       expect { propagator.propagate }
-        .to change { queries.find_child_filesets(resource: work).map(&:visibility) }
+        .to change { queries.find_child_file_sets(resource: work).map(&:visibility) }
         .to contain_exactly(work.visibility, work.visibility)
     end
   end
@@ -30,7 +30,7 @@ RSpec.describe Hyrax::ResourceVisibilityPropagator do
 
     it 'copies visibility' do
       expect { propagator.propagate }
-        .to change { queries.find_child_filesets(resource: work).map(&:visibility) }
+        .to change { queries.find_child_file_sets(resource: work).map(&:visibility) }
         .to contain_exactly(work.visibility, work.visibility)
     end
 
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::ResourceVisibilityPropagator do
       release_date = work.embargo.embargo_release_date
 
       expect { propagator.propagate }
-        .to change { queries.find_child_filesets(resource: work).map(&:embargo) }
+        .to change { queries.find_child_file_sets(resource: work).map(&:embargo) }
         .to contain_exactly(have_attributes(embargo_release_date: release_date),
                             have_attributes(embargo_release_date: release_date))
     end
@@ -55,7 +55,7 @@ RSpec.describe Hyrax::ResourceVisibilityPropagator do
 
     it 'copies visibility' do
       expect { propagator.propagate }
-        .to change { queries.find_child_filesets(resource: work).map(&:visibility) }
+        .to change { queries.find_child_file_sets(resource: work).map(&:visibility) }
         .to contain_exactly(work.visibility, work.visibility)
     end
 
@@ -63,7 +63,7 @@ RSpec.describe Hyrax::ResourceVisibilityPropagator do
       release_date = work.lease.lease_expiration_date
 
       expect { propagator.propagate }
-        .to change { queries.find_child_filesets(resource: work).map(&:lease) }
+        .to change { queries.find_child_file_sets(resource: work).map(&:lease) }
         .to contain_exactly(have_attributes(lease_expiration_date: release_date),
                             have_attributes(lease_expiration_date: release_date))
     end

--- a/spec/services/hyrax/workflow/grant_read_to_depositor_spec.rb
+++ b/spec/services/hyrax/workflow/grant_read_to_depositor_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Hyrax::Workflow::GrantReadToDepositor do
 
       let(:file_set) do
         queries = Hyrax.query_service.custom_queries
-        queries.find_child_filesets(resource: work).first
+        queries.find_child_file_sets(resource: work).first
       end
 
       it "grants read access" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,7 +95,8 @@ end
 query_registration_target =
   Valkyrie::MetadataAdapter.find(:test_adapter).query_service.custom_queries
 [Hyrax::CustomQueries::Navigators::CollectionMembers,
- Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator,
+ Hyrax::CustomQueries::Navigators::ChildFileSetsNavigator,
+ Hyrax::CustomQueries::Navigators::ChildFilesetsNavigator, # deprecated, use ChildFileSetsNavigator
  Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
  Hyrax::CustomQueries::Navigators::ParentWorkNavigator,
  Hyrax::CustomQueries::FindAccessControl,

--- a/spec/support/matchers/pcdm_matchers.rb
+++ b/spec/support/matchers/pcdm_matchers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec::Matchers.define :have_file_set_members do |*expected_file_sets|
   match do |actual_work|
-    actual_file_sets = Hyrax.custom_queries.find_child_filesets(resource: actual_work)
+    actual_file_sets = Hyrax.custom_queries.find_child_file_sets(resource: actual_work)
 
     expect(actual_file_sets).to contain_exactly(*expected_file_sets)
   end


### PR DESCRIPTION
Adds documentation for the Work-to-FileSet relationship.

Also performs a refactor of the find child file sets navigator.

### Description of Refactor

`fileset` and `file_set` are used interchangably in the code.  It is better to be consistent, so as code is touched, references are being refactored to be `file_set` whenever possible.  This commit refactors the child file set navigator methods to use `file_set` in method names.

### Rationale

The model name is File Set.  Classes and methods that act on file sets should use camel case and snake case, respectively,  of File Set (i.e. FileSet for classes and modules, and file_set for methods).

@samvera/hyrax-code-reviewers
