### PR TITLE
update collection membership for works during edit

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -99,6 +99,8 @@ module Hyrax
       property :in_works_ids, virtual: true, prepopulator: InWorksPrepopulator
       property :member_ids, default: [], type: Valkyrie::Types::Array
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
+      property :member_of_collections_attributes, virtual: true
+      validates_with CollectionMembershipValidator
 
       property :representative_id, type: Valkyrie::Types::String
       property :thumbnail_id, type: Valkyrie::Types::String

--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -13,6 +13,26 @@ module Hyrax
 
     # @api public
     #
+    # Validate member_of_collection_ids does not have any membership conflicts
+    # based on the collection types of the members.
+    #
+    # Collections that have a collection type declaring
+    # `allow_multiple_membership` as `false` require that its members do not
+    # also belong to other collections of the same type.
+    #
+    # @return [True, String] true if no conflicts; otherwise, an error message string
+    def validate
+      return true if item.member_of_collection_ids.empty? || item.member_of_collection_ids.count <= 1
+      return true unless single_membership_collection_types_exist?
+
+      collections_to_check = filter_to_single_membership_collections(item.member_of_collection_ids)
+      problematic_collections = check_collections(collections_to_check)
+      errs = build_error_message(problematic_collections)
+      errs.presence || true
+    end
+
+    # @api public
+    #
     # Scan a list of collection_ids for multiple single-membership collections.
     #
     # Collections that have a collection type declaring
@@ -42,15 +62,18 @@ module Hyrax
 
     private
 
+    # @return [Boolean] true if there a any collection types that restrict membership
     def single_membership_collection_types_exist?
       single_membership_collection_types_gids.present?
     end
 
+    # @return [Array<String] global ids of collection types that restrict membership
     def single_membership_collection_types_gids
       @single_membership_collection_types_gids ||=
         Hyrax::CollectionType.gids_that_do_not_allow_multiple_membership&.map(&:to_s)
     end
 
+    # @return [Array<Hyrax::PcdmCollection>] list of collection instances for single membership collections
     def filter_to_single_membership_collections(collection_ids)
       return [] if collection_ids.blank?
       field_pairs = {
@@ -58,11 +81,14 @@ module Hyrax
       }
       Hyrax::SolrQueryService.new
                              .with_generic_type(generic_type: "Collection")
-                             .with_ids(ids: Array[collection_ids])
+                             .with_ids(ids: Array(collection_ids).map(&:to_s))
                              .with_field_pairs(field_pairs: field_pairs, join_with: ' OR ')
                              .get_objects(use_valkyrie: true).to_a
     end
 
+    # @param proposed [Array<Hyrax::PcdmCollection>] collections with restricted membership that are being added
+    # @param include_current_members [Boolean] true if current collections for item should also be checked
+    # @return [Array<Hyrax::PcdmCollection>] collections with restricted membership
     def collections_to_check(proposed, include_current_members)
       # ActorStack does a wholesale collection membership replacement, such that
       # proposed collections include existing and new collections.  Parameter
@@ -72,6 +98,19 @@ module Hyrax
       proposed | filter_to_single_membership_collections(item.member_of_collection_ids)
     end
 
+    # @param collections_to_check [Array<Hyrax::PcdmCollection>] collections with restricted membership
+    # @return [Array<Array>] collections groups by collection type
+    # @example example return result
+    #   [
+    #     [
+    #       <Collection(id: 1, collection_type_gid: 1, ...)>,
+    #       <Collection(id: 4, collection_type_gid: 1, ...)>
+    #     ],
+    #     [
+    #       <Collection(id: 13, collection_type_gid: 8, ...)>,
+    #       <Collection(id: 26, collection_type_gid: 8, ...)>
+    #     ]
+    #   ]
     def check_collections(collections_to_check)
       # uniq insures we include a collection only once when it is in the list multiple
       # group_by groups collections of the same collection type together
@@ -82,6 +121,7 @@ module Hyrax
                           .select { |_gid, list| list.count > 1 }
     end
 
+    # @return [nil, String] nil if no errors; otherwise, errors appended into a single human readable message
     def build_error_message(problematic_collections)
       return if problematic_collections.blank?
       error_message_clauses = problematic_collections.map do |gid, list|
@@ -93,10 +133,13 @@ module Hyrax
         "#{error_message_clauses.join('; ')}"
     end
 
+    # @return [String] title of the collection type
     def collection_type_title_from_gid(gid)
       Hyrax::CollectionType.find_by_gid(gid).title
     end
 
+    # @return [String] comma separated (with and before final) list of titles
+    # @example "Title 1, Title 2, and Title 3"
     def collection_titles_from_list(collection_list)
       collection_list.map do |collection|
         collection.title.first

--- a/app/validators/hyrax/collection_membership_validator.rb
+++ b/app/validators/hyrax/collection_membership_validator.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+module Hyrax
+  # validates that the title has at least one title
+  class CollectionMembershipValidator < ActiveModel::Validator
+    def validate(record)
+      errs = update_collections(record)
+      return if errs.blank?
+      record.errors[:member_of_collection_ids] << errs
+    end
+
+    private
+
+    # @return errs if any occurred; otherwise, false
+    # @note Always ok to remove, so do that first.  Avoids add conflict when the
+    #    conflicting collection is one that was being removed.
+    def update_collections(record)
+      return if record.member_of_collections_attributes.blank?
+      remove_collections(record)
+      add_collections(record)
+    end
+
+    def remove_collections(record)
+      record.member_of_collection_ids -= collection_ids_to_remove(record)
+    end
+
+    # @return errs if any occurred; otherwise, false
+    def add_collections(record)
+      ids_to_add = collection_ids_to_add(record)
+      errs = check_multi_membership(record, ids_to_add)
+      return errs if errs.present?
+      record.member_of_collection_ids += ids_to_add
+      false
+    end
+
+    def check_multi_membership(record, collection_ids)
+      # collections in collections do not have multi-membership restrictions
+      return if record.is_a? Hyrax::Forms::PcdmCollectionForm
+
+      Hyrax::MultipleMembershipChecker
+        .new(item: record)
+        .check(collection_ids: collection_ids, include_current_members: true)
+    end
+
+    def collection_ids_to_add(record)
+      record.member_of_collections_attributes
+            .each_value
+            .select { |h| h["_destroy"] == "false" }
+            .map { |col_data| Valkyrie::ID.new(col_data["id"]) }
+    end
+
+    def collection_ids_to_remove(record)
+      record.member_of_collections_attributes
+            .each_value
+            .select { |h| h["_destroy"] == "true" }
+            .map { |col_data| Valkyrie::ID.new(col_data["id"]) }
+    end
+  end
+end

--- a/app/validators/hyrax/collection_membership_validator.rb
+++ b/app/validators/hyrax/collection_membership_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  # validates that the title has at least one title
+  # Validates that the record passes the multiple membership checker
   class CollectionMembershipValidator < ActiveModel::Validator
     def validate(record)
       update_collections(record)

--- a/lib/hyrax/transactions/work_create.rb
+++ b/lib/hyrax/transactions/work_create.rb
@@ -11,7 +11,6 @@ module Hyrax
       DEFAULT_STEPS = ['change_set.set_default_admin_set',
                        'change_set.ensure_admin_set',
                        'change_set.set_user_as_depositor',
-                       'change_set.add_to_collections',
                        'change_set.apply',
                        'work_resource.save_acl',
                        'work_resource.add_file_sets',

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -210,16 +210,12 @@ RSpec.describe Hyrax::Forms::ResourceForm do
       end
 
       context 'from 3 down to 2' do
-        let(:work) { FactoryBot.valkyrie_create(:hyrax_work) }
+        let(:work) { FactoryBot.valkyrie_create(:hyrax_work, member_of_collection_ids: before_collection_ids) }
         let(:col1) { FactoryBot.valkyrie_create(:hyrax_collection) }
         let(:col2) { FactoryBot.valkyrie_create(:hyrax_collection) }
         let(:col3) { FactoryBot.valkyrie_create(:hyrax_collection) }
         let(:before_collection_ids) { [col1.id, col2.id, col3.id] }
         let(:after_collection_ids) { [col1.id.to_s, col2.id.to_s] }
-
-        before do
-          work.member_of_collection_ids = before_collection_ids
-        end
         let(:member_of_collections_attributes) do
           { "0" => { "id" => col3.id.to_s, "_destroy" => "true" } }
         end

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -217,7 +217,9 @@ RSpec.describe Hyrax::Forms::ResourceForm do
         let(:before_collection_ids) { [col1.id, col2.id, col3.id] }
         let(:after_collection_ids) { [col1.id.to_s, col2.id.to_s] }
         let(:member_of_collections_attributes) do
-          { "0" => { "id" => col3.id.to_s, "_destroy" => "true" } }
+          { "0" => { "id" => col1.id.to_s, "_destroy" => "false" },
+            "1" => { "id" => col2.id.to_s, "_destroy" => "false" },
+            "2" => { "id" => col3.id.to_s, "_destroy" => "true" } }
         end
 
         it 'is populated from member_of_collections_attributes' do

--- a/spec/hyrax/transactions/work_create_spec.rb
+++ b/spec/hyrax/transactions/work_create_spec.rb
@@ -43,22 +43,6 @@ RSpec.describe Hyrax::Transactions::WorkCreate, :clean_repo do
       end
     end
 
-    context 'when adding to collections' do
-      let(:collections) do
-        [FactoryBot.valkyrie_create(:hyrax_collection),
-         FactoryBot.valkyrie_create(:hyrax_collection)]
-      end
-
-      let(:collection_ids) { collections.map(&:id) }
-
-      it 'adds to the collections' do
-        tx.with_step_args('change_set.add_to_collections' => { collection_ids: collection_ids })
-
-        expect(tx.call(change_set).value!)
-          .to have_attributes member_of_collection_ids: contain_exactly(*collection_ids)
-      end
-    end
-
     context 'when attaching uploaded files' do
       let(:uploaded_files) { FactoryBot.create_list(:uploaded_file, 4) }
 

--- a/spec/validators/collection_membership_validator_spec.rb
+++ b/spec/validators/collection_membership_validator_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe Hyrax::CollectionMembershipValidator, :clean_repo do
             let(:mem_of_cols_attrs) do
               { "0" => { "id" => sm_col2.id.to_s, "_destroy" => "false" } }
             end
-            # before { work.member_of_collection_ids += [sm_col1.id] }
 
             it 'fails validating and sets errors' do
               validator.validate(form)

--- a/spec/validators/collection_membership_validator_spec.rb
+++ b/spec/validators/collection_membership_validator_spec.rb
@@ -8,27 +8,19 @@ RSpec.describe Hyrax::CollectionMembershipValidator, :clean_repo do
       let(:work) { FactoryBot.build(:hyrax_work) }
       let(:mem_of_cols_attrs) { {} }
 
+      # @note The form sets :member_of_collections_attributes to include
+      #   * all collections (already existing and newly added) that will be the set of collections
+      #   * any collections that were removed
+      # The validator is only checking collections that will be the set of collections.
       before { allow(form).to receive(:member_of_collections_attributes).and_return(mem_of_cols_attrs) }
 
-      context 'and there are no changes to collections' do
-        let(:mem_of_cols_attrs) { {} }
-        it 'validates and leaves member_of_collection_ids empty' do
+      context 'and there are no collections' do
+        let(:mem_of_cols_attrs) { nil }
+        it 'validates and sets member_of_collection_ids to empty' do
           validator.validate(form)
 
           expect(form.errors).to be_blank
           expect(form.member_of_collection_ids).to be_empty
-        end
-
-        context 'when it is already in a collection' do
-          let(:work) { FactoryBot.build(:hyrax_work, :as_collection_member) }
-          let(:col_id) { work.member_of_collection_ids.first.id }
-
-          it 'validates and leaves member_of_collection_ids unchanged' do
-            validator.validate(form)
-
-            expect(form.errors).to be_blank
-            expect(form.member_of_collection_ids).to contain_exactly(col_id)
-          end
         end
       end
 
@@ -51,23 +43,24 @@ RSpec.describe Hyrax::CollectionMembershipValidator, :clean_repo do
           let(:work) { FactoryBot.build(:hyrax_work, :as_collection_member) }
           let(:col_id) { work.member_of_collection_ids.first.id }
 
-          it 'validates and appends new collections to member_of_collection_ids' do
+          it 'validates and replaces member_of_collection_ids with new collection set' do
             validator.validate(form)
 
             expect(form.errors).to be_blank
-            expect(form.member_of_collection_ids).to contain_exactly(col_id, col1.id, col2.id)
+            expect(form.member_of_collection_ids).to contain_exactly(col1.id, col2.id)
           end
         end
 
         context 'and collection type does not allow multiple membership' do
           let(:single_mem_col_type) { FactoryBot.create(:collection_type, allow_multiple_membership: false) }
 
-          context 'and work is not in another collection posing a conflict' do
+          context 'and work is in another collection NOT posing a conflict' do
             let(:work) { FactoryBot.build(:hyrax_work, :as_collection_member) }
             let(:col_id) { work.member_of_collection_ids.first.id }
             let(:sm_col) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
             let(:mem_of_cols_attrs) do
-              { "0" => { "id" => sm_col.id.to_s, "_destroy" => "false" } }
+              { "0" => { "id" => col_id.to_s, "_destroy" => "false" },
+                "1" => { "id" => sm_col.id.to_s, "_destroy" => "false" } }
             end
 
             it 'validates and appends new collections to member_of_collection_ids' do
@@ -78,36 +71,38 @@ RSpec.describe Hyrax::CollectionMembershipValidator, :clean_repo do
             end
           end
 
-          context 'and work is in another collection posing a conflict' do
+          context 'and work is in another collection that IS posing a conflict' do
             let(:work) { FactoryBot.build(:hyrax_work, member_of_collection_ids: [sm_col1.id]) }
             let(:sm_col1) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
             let(:sm_col2) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
             let(:mem_of_cols_attrs) do
-              { "0" => { "id" => sm_col2.id.to_s, "_destroy" => "false" } }
+              { "0" => { "id" => sm_col1.id.to_s, "_destroy" => "false" },
+                "1" => { "id" => sm_col2.id.to_s, "_destroy" => "false" } }
             end
 
             it 'fails validating and sets errors' do
               validator.validate(form)
 
               expect(form.errors).not_to be_blank
-              expect(form.member_of_collection_ids).to contain_exactly(sm_col1.id)
             end
           end
         end
       end
 
-      context 'and work is removed from one collection' do
+      context 'and includes removing work from a collection' do
         let(:work) { FactoryBot.build(:hyrax_work, :as_collection_member) }
         let(:col_id) { work.member_of_collection_ids.first.id }
         let(:mem_of_cols_attrs) do
           { "0" => { "id" => col_id, "_destroy" => "true" } }
         end
 
-        it 'validates and leaves member_of_collection_ids empty' do
-          validator.validate(form)
+        context 'when only one collections' do
+          it 'validates and sets member_of_collection_ids to empty' do
+            validator.validate(form)
 
-          expect(form.errors).to be_blank
-          expect(form.member_of_collection_ids).to be_empty
+            expect(form.errors).to be_blank
+            expect(form.member_of_collection_ids).to be_empty
+          end
         end
 
         context 'when it was in multiple collections' do
@@ -116,10 +111,12 @@ RSpec.describe Hyrax::CollectionMembershipValidator, :clean_repo do
           let(:remove_col_id) { col_ids.first }
           let(:keep_col_ids) { col_ids - [remove_col_id] }
           let(:mem_of_cols_attrs) do
-            { "0" => { "id" => remove_col_id, "_destroy" => "true" } }
+            { "0" => { "id" => remove_col_id, "_destroy" => "true" },
+              "1" => { "id" => keep_col_ids.first, "_destroy" => "false" },
+              "2" => { "id" => keep_col_ids.second, "_destroy" => "false" } }
           end
 
-          it 'validates and leaves member_of_collection_ids unchanged' do
+          it 'validates, removing one collection, and leaving the rest' do
             validator.validate(form)
 
             expect(form.errors).to be_blank
@@ -130,7 +127,86 @@ RSpec.describe Hyrax::CollectionMembershipValidator, :clean_repo do
     end
 
     context 'when record is a collection form changeset' do
-      pending "add tests for validating adding collections-to-collections"
+      let(:form) { Hyrax::Forms::PcdmCollectionForm.new(col) }
+      let(:col) { FactoryBot.build(:hyrax_collection) }
+      let(:mem_of_cols_attrs) { {} }
+
+      # @note Collections do not restrict membership and always pass validation
+      before { allow(form).to receive(:member_of_collections_attributes).and_return(mem_of_cols_attrs) }
+
+      context 'and there are no collections' do
+        let(:mem_of_cols_attrs) { {} }
+        it 'validates and sets member_of_collection_ids to empty' do
+          validator.validate(form)
+
+          expect(form.errors).to be_blank
+          expect(form.member_of_collection_ids).to be_empty
+        end
+      end
+
+      context 'and collection is added to collections' do
+        let(:col1) { FactoryBot.valkyrie_create(:hyrax_collection) }
+        let(:col2) { FactoryBot.valkyrie_create(:hyrax_collection) }
+        let(:mem_of_cols_attrs) do
+          { "0" => { "id" => col1.id.to_s, "_destroy" => "false" },
+            "1" => { "id" => col2.id.to_s, "_destroy" => "false" } }
+        end
+
+        it 'validates and sets member_of_collection_ids to new collections' do
+          validator.validate(form)
+
+          expect(form.errors).to be_blank
+          expect(form.member_of_collection_ids).to contain_exactly(col1.id, col2.id)
+        end
+
+        context 'when it is already in a collection' do
+          let(:col) { FactoryBot.build(:hyrax_collection, :as_collection_member) }
+          let(:col_id) { col.member_of_collection_ids.first.id }
+
+          it 'validates and replaces member_of_collection_ids with new collection set' do
+            validator.validate(form)
+
+            expect(form.errors).to be_blank
+            expect(form.member_of_collection_ids).to contain_exactly(col1.id, col2.id)
+          end
+        end
+      end
+
+      context 'and includes removing collection from a collection' do
+        let(:col) { FactoryBot.build(:hyrax_collection, :as_collection_member) }
+        let(:col_id) { col.member_of_collection_ids.first.id }
+        let(:mem_of_cols_attrs) do
+          { "0" => { "id" => col_id, "_destroy" => "true" } }
+        end
+
+        context 'when only one collections' do
+          it 'validates and sets member_of_collection_ids to empty' do
+            validator.validate(form)
+
+            expect(form.errors).to be_blank
+            expect(form.member_of_collection_ids).to be_empty
+          end
+        end
+
+        context 'when it was in multiple collections' do
+          let(:col) { FactoryBot.build(:hyrax_collection, :as_member_of_multiple_collections) }
+          let(:col_ids) { col.member_of_collection_ids }
+          let(:remove_col_id) { col_ids.first }
+          let(:keep_col_ids) { col_ids - [remove_col_id] }
+          let(:mem_of_cols_attrs) do
+            { "0" => { "id" => remove_col_id, "_destroy" => "true" },
+              "1" => { "id" => keep_col_ids.first, "_destroy" => "false" },
+              "2" => { "id" => keep_col_ids.second, "_destroy" => "false" } }
+          end
+
+          it 'validates, removing one collection, and leaving the rest' do
+            validator.validate(form)
+
+            expect(form.errors).to be_blank
+            expect(form.member_of_collection_ids).to contain_exactly(*keep_col_ids)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/validators/collection_membership_validator_spec.rb
+++ b/spec/validators/collection_membership_validator_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::CollectionMembershipValidator, :clean_repo do
+  describe '#validate' do
+    subject(:validator) { described_class.new }
+
+    context 'when record is a work form changeset' do
+      let(:form) { Hyrax::Forms::ResourceForm.new(work) }
+      let(:work) { FactoryBot.build(:hyrax_work) }
+      let(:mem_of_cols_attrs) { {} }
+
+      before { allow(form).to receive(:member_of_collections_attributes).and_return(mem_of_cols_attrs) }
+
+      context 'and there are no changes to collections' do
+        let(:mem_of_cols_attrs) { {} }
+        it 'validates and leaves member_of_collection_ids empty' do
+          validator.validate(form)
+
+          expect(form.errors).to be_blank
+          expect(form.member_of_collection_ids).to be_empty
+        end
+
+        context 'when it is already in a collection' do
+          let(:work) { FactoryBot.build(:hyrax_work, :as_collection_member) }
+          let(:col_id) { work.member_of_collection_ids.first.id }
+
+          it 'validates and leaves member_of_collection_ids unchanged' do
+            validator.validate(form)
+
+            expect(form.errors).to be_blank
+            expect(form.member_of_collection_ids).to contain_exactly(col_id)
+          end
+        end
+      end
+
+      context 'and work is added to collections' do
+        let(:col1) { FactoryBot.valkyrie_create(:hyrax_collection) }
+        let(:col2) { FactoryBot.valkyrie_create(:hyrax_collection) }
+        let(:mem_of_cols_attrs) do
+          { "0" => { "id" => col1.id.to_s, "_destroy" => "false" },
+            "1" => { "id" => col2.id.to_s, "_destroy" => "false" } }
+        end
+
+        it 'validates and sets member_of_collection_ids to new collections' do
+          validator.validate(form)
+
+          expect(form.errors).to be_blank
+          expect(form.member_of_collection_ids).to contain_exactly(col1.id, col2.id)
+        end
+
+        context 'when it is already in a collection' do
+          let(:work) { FactoryBot.build(:hyrax_work, :as_collection_member) }
+          let(:col_id) { work.member_of_collection_ids.first.id }
+
+          it 'validates and appends new collections to member_of_collection_ids' do
+            validator.validate(form)
+
+            expect(form.errors).to be_blank
+            expect(form.member_of_collection_ids).to contain_exactly(col_id, col1.id, col2.id)
+          end
+        end
+
+        context 'and collection type does not allow multiple membership' do
+          let(:single_mem_col_type) { FactoryBot.create(:collection_type, allow_multiple_membership: false) }
+
+          context 'and work is not in another collection posing a conflict' do
+            let(:work) { FactoryBot.build(:hyrax_work, :as_collection_member) }
+            let(:col_id) { work.member_of_collection_ids.first.id }
+            let(:sm_col) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
+            let(:mem_of_cols_attrs) do
+              { "0" => { "id" => sm_col.id.to_s, "_destroy" => "false" } }
+            end
+
+            it 'validates and appends new collections to member_of_collection_ids' do
+              validator.validate(form)
+
+              expect(form.errors).to be_blank
+              expect(form.member_of_collection_ids).to contain_exactly(col_id, sm_col.id)
+            end
+          end
+
+          context 'and work is in another collection posing a conflict' do
+            let(:work) { FactoryBot.build(:hyrax_work, member_of_collection_ids: [sm_col1.id]) }
+            let(:sm_col1) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
+            let(:sm_col2) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
+            let(:mem_of_cols_attrs) do
+              { "0" => { "id" => sm_col2.id.to_s, "_destroy" => "false" } }
+            end
+            # before { work.member_of_collection_ids += [sm_col1.id] }
+
+            it 'fails validating and sets errors' do
+              validator.validate(form)
+
+              expect(form.errors).not_to be_blank
+              expect(form.member_of_collection_ids).to contain_exactly(sm_col1.id)
+            end
+          end
+        end
+      end
+
+      context 'and work is removed from one collection' do
+        let(:work) { FactoryBot.build(:hyrax_work, :as_collection_member) }
+        let(:col_id) { work.member_of_collection_ids.first.id }
+        let(:mem_of_cols_attrs) do
+          { "0" => { "id" => col_id, "_destroy" => "true" } }
+        end
+
+        it 'validates and leaves member_of_collection_ids empty' do
+          validator.validate(form)
+
+          expect(form.errors).to be_blank
+          expect(form.member_of_collection_ids).to be_empty
+        end
+
+        context 'when it was in multiple collections' do
+          let(:work) { FactoryBot.build(:hyrax_work, :as_member_of_multiple_collections) }
+          let(:col_ids) { work.member_of_collection_ids }
+          let(:remove_col_id) { col_ids.first }
+          let(:keep_col_ids) { col_ids - [remove_col_id] }
+          let(:mem_of_cols_attrs) do
+            { "0" => { "id" => remove_col_id, "_destroy" => "true" } }
+          end
+
+          it 'validates and leaves member_of_collection_ids unchanged' do
+            validator.validate(form)
+
+            expect(form.errors).to be_blank
+            expect(form.member_of_collection_ids).to contain_exactly(*keep_col_ids)
+          end
+        end
+      end
+    end
+
+    context 'when record is a collection form changeset' do
+      pending "add tests for validating adding collections-to-collections"
+    end
+  end
+end


### PR DESCRIPTION
Fixes #5446, #5465, #5466

### For 5446...

Collection membership is set by the form in the `member_of_collections_attributes` parameter.  It includes a hash structure that lists collections to add and to remove. 

```
      # member_of_collections_attributes"=>
        {"0"=>{"id"=>"r207tp33p", "_destroy"=>"false"},
         "1"=>{"id"=>"1234asef", "_destroy"=>"true"}}
```
 This PR adds a virtual property to the form changeset to provide access to the `member_of_collections_attributes` parameter and uses a validator to determine that the membership changes are allowed and updates the `member_of_collection_ids` property which syncs with the work resource attribute of the same name.

### For 5465...

The work instance was being set to the results of the validation failure when it failed and to the updated work when the validation passed...

WAS:
```
@curation_concern =
          form.validate(params[hash_key_for_curation_concern]) &&
          transactions['change_set.create_work']
```

Now, the form validation is processed before setting `@curation_concern`.  If a failure occurs, the process is aborted and calls `after_update_error` to process the error and redisplay the edit form.

### For 5466...

Assuming validation passed, but a transaction failure occurred, there was an attempt to call #value on the transaction Failure instance which does not respond to #value.  set the work instance was being set to 

```
.call(form).value!
```

The solution  is to use `.call(form).value_or { #err handling }` which will return the value if there isn't a failure and process the code block if there is.  Similar to the validations failure processing, the err handling block for transactions aborts the process and calls `after_update_error`.


@samvera/hyrax-code-reviewers
