### PR TITLE
bump to ruby 2.7.5 and alpine 3.15 for base image

### DIFF
--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -8,7 +8,7 @@ else
 end
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.4'
+ruby '2.7.5'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.4', '>= 5.2.4.4'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG RUBY_VERSION=2.7.4
-FROM ruby:$RUBY_VERSION-alpine3.14 as hyrax-base
+ARG RUBY_VERSION=2.7.5
+FROM ruby:$RUBY_VERSION-alpine3.15 as hyrax-base
 
 ARG DATABASE_APK_PACKAGE="postgresql-dev"
 ARG EXTRA_APK_PACKAGES="git"


### PR DESCRIPTION
Update Ruby and Alpine version for the Docker images

There is a change in Ruby 2.7.5 that makes the very obsolete `require 'enumerator'` call fail. This require hasn't been necessary since ruby 1.8.7 was released, but was common practice for some time. Ruby gems like `oai` and `edtf` have not been updated to support Ruby 2.7.5 yet, so that may be a factor in merging this code.  We use the following patch to make those libraries work:

```
sed -i '/require .enumerator./d' /usr/local/bundle/gems/oai-1.1.0/lib/oai/provider/resumption_token.rb && \
sed -i '/require .enumerator./d' /usr/local/bundle/gems/edtf-3.0.5/lib/edtf.rb
```

Advantages to this change are current versions of Alpine and Ruby that are fully patched.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Build the dassie app and see that Hyrax still functions properly

@samvera/hyrax-code-reviewers
