### PR TITLE
add adminset title to work solrdoc

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -176,13 +176,7 @@ module Hyrax
     end
 
     def admin_set_id_for_new
-      # admin_set_id is required on the client, otherwise simple_form renders a blank option.
-      # however it isn't a required field for someone to submit via json.
-      # Set the default admin set if it exists; otherwise, set to first admin_set they have access to.
-      admin_sets = Hyrax::AdminSetService.new(self).search_results(:deposit)
-      return nil if admin_sets.blank? # shouldn't happen
-      return AdminSet::DEFAULT_ID if admin_sets.map(&:id).include?(AdminSet::DEFAULT_ID)
-      admin_sets.first.id
+      Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
     end
 
     def build_form

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -33,7 +33,7 @@ module Hyrax
     class ResourceForm < Hyrax::ChangeSet # rubocop:disable Metrics/ClassLength
       ##
       # @api private
-      InWorksPopulator = lambda do |_options|
+      InWorksPrepopulator = lambda do |_options|
         self.in_works_ids =
           if persisted?
             Hyrax.query_service
@@ -52,7 +52,7 @@ module Hyrax
       #   with `etag`-driven, application-side lock checks. for non-wings adapters
       #   we want to move away from application side lock validation and rely
       #   on the adapter/database features instead.
-      LockKeyPopulator = lambda do |_options|
+      LockKeyPrepopulator = lambda do |_options|
         if Hyrax.config.disable_wings || !Hyrax.metadata_adapter.is_a?(Wings::Valkyrie::MetadataAdapter)
           Hyrax.logger.info "trying to prepopulate a lock token for " \
                             "#{self.class.inspect}, but optimistic locking isn't " \
@@ -96,7 +96,7 @@ module Hyrax
 
       # pcdm relationships
       property :admin_set_id, prepopulator: ->(_opts) { self.admin_set_id = Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s }
-      property :in_works_ids, virtual: true, prepopulator: InWorksPopulator
+      property :in_works_ids, virtual: true, prepopulator: InWorksPrepopulator
       property :member_ids, default: [], type: Valkyrie::Types::Array
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 
@@ -112,7 +112,7 @@ module Hyrax
       # the model is disabled
       #
       # @see https://github.com/samvera/valkyrie/wiki/Optimistic-Locking
-      property :version, virtual: true, prepopulator: LockKeyPopulator
+      property :version, virtual: true, prepopulator: LockKeyPrepopulator
 
       # backs the child work search element;
       # @todo: look for a way for the view template not to depend on this

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -95,7 +95,7 @@ module Hyrax
       property :visibility_during_lease, virtual: true, prepopulator: ->(_opts) { self.visibility_during_lease = model.lease&.visibility_during_lease }
 
       # pcdm relationships
-      property :admin_set_id, prepopulator: ->(_opts) { self.admin_set_id = AdminSet::DEFAULT_ID }
+      property :admin_set_id, prepopulator: ->(_opts) { self.admin_set_id = Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s }
       property :in_works_ids, virtual: true, prepopulator: InWorksPopulator
       property :member_ids, default: [], type: Valkyrie::Types::Array
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -14,6 +14,9 @@ module Hyrax
         solr_doc['generic_type_si'] = 'Work'
         solr_doc['suppressed_bsi'] = suppressed?(resource)
         solr_doc['admin_set_id_ssim'] = [resource.admin_set_id.to_s]
+        admin_set_label = admin_set_label(resource)
+        solr_doc['admin_set_sim']   = admin_set_label
+        solr_doc['admin_set_tesim'] = admin_set_label
         solr_doc['member_of_collection_ids_ssim'] = resource.member_of_collection_ids.map(&:to_s)
         solr_doc['member_ids_ssim'] = resource.member_ids.map(&:to_s)
         solr_doc['depositor_ssim'] = [resource.depositor]
@@ -25,6 +28,12 @@ module Hyrax
 
     def suppressed?(resource)
       Hyrax::ResourceStatus.new(resource: resource).inactive?
+    end
+
+    def admin_set_label(resource)
+      return "" if resource.admin_set_id.blank?
+      admin_set = Hyrax.query_service.find_by(id: resource.admin_set_id)
+      admin_set.title
     end
   end
 end

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -31,7 +31,7 @@ module Hyrax
     end
 
     def admin_set_label(resource)
-      return "" if resource.admin_set_id.blank?
+      return if resource.admin_set_id.blank?
       admin_set = Hyrax.query_service.find_by(id: resource.admin_set_id)
       admin_set.title
     end

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -52,6 +52,7 @@ module Hyrax
         attribute :read_groups, Solr::Array, ::Ability.read_group_field
         attribute :collection_ids, Solr::Array, 'collection_ids_tesim'
         attribute :admin_set, Solr::Array, "admin_set_tesim"
+        attribute :admin_set_id, Solr::Array, "admin_set_id_ssim"
         attribute :member_ids, Solr::Array, "member_ids_ssim"
         attribute :member_of_collection_ids, Solr::Array, "member_of_collection_ids_ssim"
         attribute :member_of_collections, Solr::Array, "member_of_collections_ssim"

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe Hyrax::Forms::ResourceForm do
   subject(:form) { described_class.for(work) }
   let(:work)     { Hyrax::Work.new }
 
+  let(:default_admin_set) { instance_double(Hyrax::AdministrativeSet, title: "DEFAULT_ADMINSET", id: "DEFAULT_ADMINSET_ID") }
+  before { allow(Hyrax::AdminSetCreateService).to receive(:find_or_create_default_admin_set).and_return(default_admin_set) }
+
   describe '.required_fields=' do
     subject(:form) { form_class.new(work) }
 
@@ -52,9 +55,6 @@ RSpec.describe Hyrax::Forms::ResourceForm do
   end
 
   describe '#admin_set_id' do
-    let(:default_admin_set) { instance_double(Hyrax::AdministrativeSet, title: "DEFAULT_ADMINSET", id: "DEFAULT_ADMINSET_ID") }
-    before { allow(Hyrax::AdminSetCreateService).to receive(:find_or_create_default_admin_set).and_return(default_admin_set) }
-
     it 'is nil' do
       expect(form.admin_set_id).to be_nil
     end

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -52,6 +52,9 @@ RSpec.describe Hyrax::Forms::ResourceForm do
   end
 
   describe '#admin_set_id' do
+    let(:default_admin_set) { instance_double(Hyrax::AdministrativeSet, title: "DEFAULT_ADMINSET", id: "DEFAULT_ADMINSET_ID") }
+    before { allow(Hyrax::AdminSetCreateService).to receive(:find_or_create_default_admin_set).and_return(default_admin_set) }
+
     it 'is nil' do
       expect(form.admin_set_id).to be_nil
     end
@@ -59,7 +62,7 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     it 'prepopulates to the default admin set' do
       expect { form.prepopulate! }
         .to change { form.admin_set_id }
-        .to AdminSet::DEFAULT_ID
+        .to Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
     end
   end
 

--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -60,13 +60,15 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
 
     let(:user) { create(:user) }
     let(:admin_set_title) { 'An Admin Set' }
-    let(:admin_set) { create(:admin_set, title: [admin_set_title]) }
+    let(:admin_set) { FactoryBot.valkyrie_create(:hyrax_admin_set, title: [admin_set_title]) }
     let(:collection_title) { 'A Collection' }
-    let(:col1) { valkyrie_create(:hyrax_collection, title: [collection_title]) }
-    let(:work) { valkyrie_create(:hyrax_work, :with_member_works, member_of_collection_ids: [col1.id], admin_set_id: admin_set.id, depositor: user.email) }
+    let(:col1) { FactoryBot.valkyrie_create(:hyrax_collection, title: [collection_title]) }
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :with_member_works, member_of_collection_ids: [col1.id], admin_set_id: admin_set.id, depositor: user.email) }
 
     it 'includes attributes defined outside Hyrax::Schema include' do
       expect(solr_document.fetch('generic_type_si')).to eq 'Work'
+      expect(solr_document.fetch('admin_set_sim')).to match_array [admin_set_title]
+      expect(solr_document.fetch('admin_set_tesim')).to match_array [admin_set_title]
       expect(solr_document.fetch('admin_set_id_ssim')).to match_array [admin_set.id]
       expect(solr_document.fetch('member_ids_ssim')).to match_array work.member_ids
       expect(solr_document.fetch('member_of_collection_ids_ssim')).to match_array [col1.id]


### PR DESCRIPTION
Fixes #5450 

Two changes:
* adding adminset title to work’s solrdoc is required for the relationship to appear on the work’s show page
* resource form’s prepopulator for `admin_set_id` was switched to use the `AdminSetCreateService` which is the preferred way to get the default admin set and is required for non-Wings implementations which cannot use `AdminSet::DEFAULT_ID` as the default admin set id.  This is required for the default admin set to be the default for new works.


@samvera/hyrax-code-reviewers
