### PR TITLE
allow branding info to be processed with Hyrax::PcdmCollectionForm

### DIFF
--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -8,6 +8,31 @@ module Hyrax
     class PcdmCollectionForm < Valkyrie::ChangeSet # rubocop:disable Metrics/ClassLength
       include Hyrax::FormFields(:core_metadata)
 
+      BannerInfoPrepopulator = lambda do |_options|
+        self.banner_info ||= begin
+          banner_info = CollectionBrandingInfo.where(collection_id: id.to_s, role: "banner")
+          banner_file = File.split(banner_info.first.local_path).last unless banner_info.empty?
+          alttext = banner_info.first.alt_text unless banner_info.empty?
+          file_location = banner_info.first.local_path unless banner_info.empty?
+          relative_path = "/" + banner_info.first.local_path.split("/")[-4..-1].join("/") unless banner_info.empty?
+          { file: banner_file, full_path: file_location, relative_path: relative_path, alttext: alttext }
+        end
+      end
+
+      LogoInfoPrepopulator = lambda do |_options|
+        self.logo_info ||= begin
+          logos_info = CollectionBrandingInfo.where(collection_id: id.to_s, role: "logo")
+
+          logos_info.map do |logo_info|
+            logo_file = File.split(logo_info.local_path).last
+            relative_path = "/" + logo_info.local_path.split("/")[-4..-1].join("/")
+            alttext = logo_info.alt_text
+            linkurl = logo_info.target_url
+            { file: logo_file, full_path: logo_info.local_path, relative_path: relative_path, alttext: alttext, linkurl: linkurl }
+          end
+        end
+      end
+
       property :human_readable_type, writable: false
       property :date_modified, readable: false
       property :date_uploaded, readable: false
@@ -19,6 +44,9 @@ module Hyrax
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 
       validates :collection_type_gid, presence: true
+
+      property :banner_info, virtual: true, prepopulator: BannerInfoPrepopulator
+      property :logo_info, virtual: true, prepopulator: LogoInfoPrepopulator
 
       class << self
         def model_class

--- a/app/views/hyrax/dashboard/collections/_form_branding.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_branding.html.erb
@@ -34,6 +34,7 @@
     <div class="row branding-banner-list">
       <div class="col-xs-12">
         <div class="container">
+        <%# Where the request to display the branding comes from. %>
         <% if f.object.banner_info[:file] %>
           <div id="banner">
             <div class="row branding-banner-row">

--- a/lib/hyrax/transactions/collection_update.rb
+++ b/lib/hyrax/transactions/collection_update.rb
@@ -9,6 +9,8 @@ module Hyrax
     # @since 3.2.0
     class CollectionUpdate < Transaction
       DEFAULT_STEPS = ['change_set.apply',
+                       'collection_resource.save_collection_banner',
+                       'collection_resource.save_collection_logo',
                        'collection_resource.save_acl'].freeze
 
       ##

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -42,6 +42,8 @@ module Hyrax
       require 'hyrax/transactions/steps/remove_file_set_from_work'
       require 'hyrax/transactions/steps/save'
       require 'hyrax/transactions/steps/save_access_control'
+      require 'hyrax/transactions/steps/save_collection_banner'
+      require 'hyrax/transactions/steps/save_collection_logo'
       require 'hyrax/transactions/steps/set_default_admin_set'
       require 'hyrax/transactions/steps/set_modified_date'
       require 'hyrax/transactions/steps/set_uploaded_date_unless_present'
@@ -194,6 +196,14 @@ module Hyrax
 
         ops.register 'save_acl' do
           Steps::SaveAccessControl.new
+        end
+
+        ops.register 'save_collection_banner' do
+          Steps::SaveCollectionBanner.new
+        end
+
+        ops.register 'save_collection_logo' do
+          Steps::SaveCollectionLogo.new
         end
       end
 

--- a/lib/hyrax/transactions/steps/save_collection_banner.rb
+++ b/lib/hyrax/transactions/steps/save_collection_banner.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Adds banner info via `ChangeSet`.
+      #
+      # During the update collection process this step is called to update the file
+      # to be used as a the banner for the collection.
+      #
+      class SaveCollectionBanner
+        include Dry::Transaction::Operation
+
+        ##
+        # @param [Hyrax::ChangeSet] change_set
+        # @param [Array<Integer>] update_banner_file_ids
+        # @param [Boolean] banner_unchanged_indicator
+        #
+        # @return [Dry::Monads::Result] `Failure` if the banner info fails to save;
+        #   `Success(input)`, otherwise.
+        def call(collection_resource, update_banner_file_ids: nil, banner_unchanged_indicator: true)
+          return Success(collection_resource) if ActiveModel::Type::Boolean.new.cast(banner_unchanged_indicator)
+          collection_id = collection_resource.id.to_s
+          process_banner_input(collection_id: collection_id, update_banner_file_ids: update_banner_file_ids)
+          Success(collection_resource)
+        end
+
+        private
+
+        def process_banner_input(collection_id:, update_banner_file_ids:)
+          remove_banner(collection_id: collection_id)
+          add_new_banner(collection_id: collection_id, uploaded_file_ids: update_banner_file_ids) if update_banner_file_ids
+        end
+
+        def remove_banner(collection_id:)
+          banner_info = CollectionBrandingInfo.where(collection_id: collection_id).where(role: "banner")
+          banner_info&.delete_all
+        end
+
+        def add_new_banner(collection_id:, uploaded_file_ids:)
+          f = uploaded_files(uploaded_file_ids).first
+          banner_info = CollectionBrandingInfo.new(
+            collection_id: collection_id,
+            filename: File.split(f.file_url).last,
+            role: "banner",
+            alt_txt: "",
+            target_url: ""
+          )
+          banner_info.save f.file_url
+        end
+
+        def uploaded_files(uploaded_file_ids)
+          return [] if uploaded_file_ids.empty?
+          UploadedFile.find(uploaded_file_ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/save_collection_logo.rb
+++ b/lib/hyrax/transactions/steps/save_collection_logo.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Adds logo info via `ChangeSet`.
+      #
+      # During the update collection process this step is called to update the file(s)
+      # to be used as logo(s) for the collection.
+      #
+      class SaveCollectionLogo
+        include Dry::Transaction::Operation
+
+        ##
+        # @param [Hyrax::ChangeSet] change_set
+        # @param [Array<#Integer>] update_logo_file_ids
+        # @param [Array<String>] alttext_values
+        # @param [Array<String>] linkurl_values
+        #
+        # @return [Dry::Monads::Result] `Failure` if the work fails to save;
+        #   `Success(input)`, otherwise.
+        def call(collection_resource, update_logo_file_ids: nil, alttext_values: nil, linkurl_values: nil)
+          collection_id = collection_resource.id.to_s
+          process_logo_input(collection_id: collection_id, update_logo_file_ids: update_logo_file_ids, alttext_values: alttext_values, linkurl_values: linkurl_values)
+          Success(collection_resource)
+        end
+
+        private
+
+        def process_logo_input(collection_id:, update_logo_file_ids:, alttext_values:, linkurl_values:)
+          uploaded_file_ids = update_logo_file_ids
+          public_files = []
+
+          if uploaded_file_ids.nil?
+            # all logo files were removed, so delete all files previously uploaded
+            remove_redundant_files(collection_id: collection_id, public_files: public_files)
+            return
+          end
+
+          public_files = process_logo_records(collection_id: collection_id, uploaded_file_ids: uploaded_file_ids, alttext_values: alttext_values, linkurl_values: linkurl_values)
+          remove_redundant_files(collection_id: collection_id, public_files: public_files)
+        end
+
+        def process_logo_records(collection_id:, uploaded_file_ids:, alttext_values:, linkurl_values:)
+          public_files = []
+          uploaded_file_ids.each_with_index do |ufi, i|
+            # If the user has chosen a new logo, the ufi will be an integer
+            # If the logo was previously chosen, the ufi will be a path
+            # If it is a path, update the rec, else create a new rec
+            if !ufi.match(/\D/).nil?
+              update_logo_info(collection_id: collection_id, uploaded_file_id: ufi, alttext: alttext_values[i], linkurl: verify_linkurl(linkurl_values[i]))
+              public_files << ufi
+            else # brand new one, insert in the database
+              logo_info = create_logo_info(collection_id: collection_id, uploaded_file_id: ufi, alttext: alttext_values[i], linkurl: verify_linkurl(linkurl_values[i]))
+              public_files << logo_info.local_path
+            end
+          end
+          public_files
+        end
+
+        def update_logo_info(collection_id:, uploaded_file_id:, alttext:, linkurl:)
+          logo_info = CollectionBrandingInfo.where(collection_id: collection_id).where(role: "logo").where(local_path: uploaded_file_id.to_s).first
+          logo_info.alt_text = alttext
+          logo_info.target_url = linkurl
+          logo_info.local_path = uploaded_file_id
+          logo_info.save(uploaded_file_id, false)
+        end
+
+        def create_logo_info(collection_id:, uploaded_file_id:, alttext:, linkurl:)
+          file = uploaded_files(uploaded_file_id)
+          logo_info = CollectionBrandingInfo.new(
+            collection_id: collection_id,
+            filename: File.split(file.file_url).last,
+            role: "logo",
+            alt_txt: alttext,
+            target_url: linkurl
+          )
+          logo_info.save file.file_url
+          logo_info
+        end
+
+        def uploaded_files(uploaded_file_ids)
+          return [] if uploaded_file_ids.empty?
+          UploadedFile.find(uploaded_file_ids)
+        end
+
+        def remove_redundant_files(collection_id:, public_files:)
+          # remove any public ones that were not included in the selection.
+          logos_info = CollectionBrandingInfo.where(collection_id: collection_id).where(role: "logo")
+          logos_info.each do |logo_info|
+            logo_info.delete(logo_info.local_path) unless public_files.include? logo_info.local_path
+            logo_info.destroy unless public_files.include? logo_info.local_path
+          end
+        end
+
+        # Only accept HTTP|HTTPS urls;
+        # @return <String> the url
+        def verify_linkurl(linkurl)
+          url = Loofah.scrub_fragment(linkurl, :prune).to_s
+          url if valid_url?(url)
+        end
+
+        def valid_url?(url)
+          (url =~ URI.regexp(['http', 'https']))
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -344,6 +344,17 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       end
     end
 
+    context "updating a collection's visibility" do
+      it "saves the visibility" do
+        expect { put :update, params: { id: collection, collection: { title: ['Moomin in Space'], visibility: 'restricted' } } }
+          .to change { Hyrax.query_service.find_by(id: collection.id).visibility }
+          .from('open')
+          .to('restricted')
+
+        expect(flash[:notice]).to eq "Collection was successfully updated."
+      end
+    end
+
     context "when update fails" do
       let(:collection) { FactoryBot.create(:collection_lw) }
       let(:repository) { instance_double(Blacklight::Solr::Repository, search: result) }
@@ -386,8 +397,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       it "saves banner metadata" do
         put :update, params: { id: collection,
                                banner_files: [uploaded.id],
-                               collection: { creator: ['Emily'] },
-                               update_collection: true }
+                               collection: { creator: ['Emily'] } }
 
         expect(CollectionBrandingInfo
                  .where(collection_id: collection.id.to_s, role: "banner")
@@ -395,24 +405,12 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
           .to exist
       end
 
-      it "don't save banner metadata" do
-        put :update, params: { id: collection,
-                               banner_files: [uploaded.id],
-                               collection: { creator: ['Emily'] } }
-
-        expect(CollectionBrandingInfo
-                 .where(collection_id: collection.id.to_s, role: "banner")
-                 .where("local_path LIKE '%#{uploaded.file.filename}'"))
-          .not_to exist
-      end
-
       it "saves logo metadata" do
         put :update, params: { id: collection,
                                logo_files: [uploaded.id],
                                alttext: ["Logo alt Text"],
                                linkurl: ["http://abc.com"],
-                               collection: { creator: ['Emily'] },
-                               update_collection: true }
+                               collection: { creator: ['Emily'] } }
 
         expect(CollectionBrandingInfo
                  .where(collection_id: collection.id.to_s,
@@ -430,8 +428,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
           put :update, params: { id: collection,
                                  logo_files: [uploaded.id],
                                  alttext: ["Logo alt Text"], linkurl: ["<script>remove_me</script>"],
-                                 collection: { creator: ['Emily'] },
-                                 update_collection: true }
+                                 collection: { creator: ['Emily'] } }
 
           expect(
             CollectionBrandingInfo.where(
@@ -446,8 +443,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
                                  logo_files: [uploaded.id],
                                  alttext: ["Logo alt Text"],
                                  linkurl: ['javascript:alert("remove_me")'],
-                                 collection: { creator: ['Emily'] },
-                                 update_collection: true }
+                                 collection: { creator: ['Emily'] } }
 
           expect(
             CollectionBrandingInfo.where(

--- a/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
@@ -213,6 +213,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
           allow(controller).to receive(:authorize!)
           allow(Hyrax::Forms::ResourceForm).to receive(:for).with(collection).and_return(form)
           allow(form).to receive(:validate).with(any_args).and_return(false)
+          allow(form).to receive(:prepopulate!).with(any_args).and_return(true)
         end
 
         let(:collection) { Hyrax::PcdmCollection.new }
@@ -433,6 +434,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
         before do
           allow(Hyrax::Forms::ResourceForm).to receive(:for).with(collection).and_return(form)
           allow(form).to receive(:validate).with(any_args).and_return(false)
+          allow(form).to receive(:prepopulate!).with(any_args).and_return(true)
         end
 
         it "renders the form again" do
@@ -467,8 +469,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       it "saves banner metadata" do
         put :update, params: { id: collection,
                                banner_files: [uploaded.id],
-                               collection: { creator: ['Emily'] },
-                               update_collection: true }
+                               collection: { creator: ['Emily'] } }
 
         expect(CollectionBrandingInfo
                  .where(collection_id: collection.id.to_s, role: "banner")
@@ -476,24 +477,12 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
           .to exist
       end
 
-      it "don't save banner metadata when `update_collection` param is missing" do
-        put :update, params: { id: collection,
-                               banner_files: [uploaded.id],
-                               collection: { creator: ['Emily'] } }
-
-        expect(CollectionBrandingInfo
-                 .where(collection_id: collection.id.to_s, role: "banner")
-                 .where("local_path LIKE '%#{uploaded.file.filename}'"))
-          .not_to exist
-      end
-
       it "saves logo metadata" do # rubocop:disable RSpec/ExampleLength
         put :update, params: { id: collection,
                                logo_files: [uploaded.id],
                                alttext: ["Logo alt Text"],
                                linkurl: ["http://abc.com"],
-                               collection: { creator: ['Emily'] },
-                               update_collection: true }
+                               collection: { creator: ['Emily'] } }
 
         expect(CollectionBrandingInfo
                  .where(collection_id: collection.id.to_s,
@@ -511,8 +500,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
           put :update, params: { id: collection,
                                  logo_files: [uploaded.id],
                                  alttext: ["Logo alt Text"], linkurl: ["<script>remove_me</script>"],
-                                 collection: { creator: ['Emily'] },
-                                 update_collection: true }
+                                 collection: { creator: ['Emily'] } }
 
           expect(
             CollectionBrandingInfo.where(
@@ -527,8 +515,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
                                  logo_files: [uploaded.id],
                                  alttext: ["Logo alt Text"],
                                  linkurl: ['javascript:alert("remove_me")'],
-                                 collection: { creator: ['Emily'] },
-                                 update_collection: true }
+                                 collection: { creator: ['Emily'] } }
 
           expect(
             CollectionBrandingInfo.where(

--- a/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Hyrax::Forms::PcdmCollectionForm do
+  let(:collection) { Hyrax::PcdmCollection.new(id: "123") }
   subject(:form)   { described_class.new(collection) }
-  let(:collection) { Hyrax::PcdmCollection.new }
 
   describe '.required_fields' do
     it 'lists required fields' do
@@ -14,6 +14,41 @@ RSpec.describe Hyrax::Forms::PcdmCollectionForm do
   describe '#primary_terms' do
     it 'gives "title" as a primary term' do
       expect(form.primary_terms).to contain_exactly(:title)
+    end
+  end
+
+  describe '#banner_info' do
+    let(:banner_info) do
+      CollectionBrandingInfo.new(
+        collection_id: "123",
+        filename: "abc/123/banner.gif",
+        role: "banner",
+        target_url: ""
+      )
+    end
+
+    it 'gives the banner info' do
+      banner_info.save!
+      form.prepopulate!
+      expect(form.banner_info).to contain_exactly([:alttext, ""], [:file, "banner.gif"], [:full_path, "banner/abc/123/banner.gif"], [:relative_path, "/banner/abc/123/banner.gif"])
+    end
+  end
+
+  describe '#logo_info' do
+    let(:banner_info) do
+      CollectionBrandingInfo.new(
+        collection_id: "123",
+        filename: "abc/123/logo.gif",
+        role: "logo",
+        alt_txt: "Logo alt Text",
+        target_url: "http://abc.com"
+      )
+    end
+
+    it 'gives the logo info' do
+      banner_info.save!
+      form.prepopulate!
+      expect(form.logo_info).to contain_exactly({ alttext: "Logo alt Text", file: "logo.gif", full_path: "logo/abc/123/logo.gif", linkurl: "http://abc.com", relative_path: "/logo/abc/123/logo.gif" })
     end
   end
 

--- a/spec/hyrax/transactions/steps/save_collection_banner_spec.rb
+++ b/spec/hyrax/transactions/steps/save_collection_banner_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::SaveCollectionBanner do
+  subject(:step)   { described_class.new }
+  let(:collection) do
+    FactoryBot.valkyrie_create(:hyrax_collection,
+                               title: "My Resource")
+  end
+
+  context 'update the banner info' do
+    let(:uploaded) { FactoryBot.create(:uploaded_file) }
+
+    it 'successfully updates the banner info' do
+      expect(step.call(collection, update_banner_file_ids: [uploaded.id.to_s], banner_unchanged_indicator: false)).to be_success
+
+      expect(CollectionBrandingInfo
+             .where(collection_id: collection.id.to_s, role: "banner")
+              .where("local_path LIKE '%#{uploaded.file.filename}'"))
+        .to exist
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/save_collection_logo_spec.rb
+++ b/spec/hyrax/transactions/steps/save_collection_logo_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::SaveCollectionLogo do
+  subject(:step)   { described_class.new }
+  let(:collection) do
+    FactoryBot.valkyrie_create(:hyrax_collection,
+                               title: "My Resource")
+  end
+
+  context 'update collection logo metadta' do
+    let(:uploaded) { FactoryBot.create(:uploaded_file) }
+
+    it 'saves logo metadata' do
+      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ["http://abc.com"])).to be_success
+
+      expect(CollectionBrandingInfo
+               .where(collection_id: collection.id.to_s,
+                      role: "logo",
+                      alt_text: "Logo alt Text",
+                      target_url: "http://abc.com")
+               .where("local_path LIKE '%#{uploaded.file.filename}'"))
+        .to exist
+    end
+
+    it 'does not save linkurl containing html; target_url is empty' do
+      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ["<script>remove_me</script>"])).to be_success
+
+      expect(
+        CollectionBrandingInfo.where(
+          collection_id: collection.id.to_s,
+          target_url: "<script>remove_me</script>"
+        ).where("target_url LIKE '%remove_me%)'")
+      ).not_to exist
+    end
+
+    it 'does not save linkurl containing dodgy protocol; target_url is empty' do
+      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ['javascript:alert("remove_me")'])).to be_success
+
+      expect(
+        CollectionBrandingInfo.where(
+          collection_id: collection.id.to_s,
+          target_url: 'javascript:alert("remove_me")'
+        ).where("target_url LIKE '%remove_me%)'")
+      ).not_to exist
+    end
+  end
+end


### PR DESCRIPTION
Fixes #5330

This PR will allow the user to update the branding files: banner, and logo, for the Hyrax::PcdmCollectionForm.

In order to test this, you will need configure the collection model:

Edit /config/initializers/hyrax.rb and set:

  config.collection_model = "Hyrax::PcdmCollection"

I want to point out that in order to get the Prepopulators to work, I had to add this line of code in the `form` method in collection_controller.rb.  Perhaps there may be a better way to do this in the future.
            form.prepopulate!

Also, in the `update` method of the collection_controller.rb file, I added a call to `process_branding`, and in there I check what model is being used.   You don't want to do any processing in the method if the model is Pcdm, since that will be taken care by the ChangeSet and steps defined further down in that file.  Not sure this is the best way to do this. :

```     
def process_branding
  if Hyrax.config.collection_model.present? && Hyrax.config.collection_model == "Hyrax::PcdmCollection"
  elsif !params[:update_collection].nil?
    process_banner_input
    process_logo_input
  end
end
```

Guidance for testing, such as acceptance criteria or new user interface behaviors:
First
To isolate issues in other tabs, create a collection_type with all options off except Branding.

1. navigate to Dashboard -> Settings -> Collection Types
2. click button: Create new collection type
3. set Type name: Brandable only (or other meaningful name)
4. click button: Save
5. click tab: Settings
6. uncheck all but Branding (as seen below)
7. click button: Save changes

Then, you can test the uploading and creation of banner and logo:
1. navigate to Dashboard -> Collections
2. click button: New Collection
3. select type: Brandable only (or the name you used when creating the collection type)
4. click button: Create Collection
5. set Title: My Branded Collection (or other meaningful name)
6. Update a banner and logo.  You can do a couple of logos if you'd like.
7. click Save 



@samvera/hyrax-code-reviewers
