### PR TITLE
Hyrax-5471 - Works in mediated workflow not listed as managed works f…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ coverage
 rdoc
 /.bundle
 tmp
+/.idea
+
 
 *.log
 *~

--- a/app/search_builders/hyrax/dashboard/managed_search_filters.rb
+++ b/app/search_builders/hyrax/dashboard/managed_search_filters.rb
@@ -25,6 +25,12 @@ module Hyrax
         search_terms
       end
 
+      # Look for a user's managing role and add filters for all admin sets that have permission
+      # templates that include managing roles.
+      #
+      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity
       def add_managing_role_search_filter(ability:, search_terms: [])
         search_terms ||= []
         # Look for managing role assignement
@@ -51,6 +57,9 @@ module Hyrax
         end
         search_terms
       end
+      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
     end
   end
 end

--- a/app/search_builders/hyrax/dashboard/managed_search_filters.rb
+++ b/app/search_builders/hyrax/dashboard/managed_search_filters.rb
@@ -11,15 +11,48 @@ module Hyrax
 
       # Override to exclude 'public' and 'registered' groups from read access.
       def apply_group_permissions(permission_types, ability = current_ability)
+        search_terms = add_managing_role_search_filter(ability: ability)
         groups = ability.user_groups
-        return [] if groups.empty?
-        permission_types.map do |type|
+        return search_terms if groups.empty?
+        permission_types.each do |type|
           field = solr_field_for(type, 'group')
-          user_groups = type == 'read' ? groups - [::Ability.public_group_name, ::Ability.registered_group_name] : groups
+          user_groups = type == 'read' ? groups - [::Ability.public_group_name,
+                                                   ::Ability.registered_group_name] : groups
           next if user_groups.empty?
-          "({!terms f=#{field}}#{user_groups.join(',')})" # parens required to properly OR the clauses together.
+          # parens required to properly OR the clauses together:
+          search_terms << "({!terms f=#{field}}#{user_groups.join(',')})"
         end
+        return search_terms
       end
+
+      def add_managing_role_search_filter( ability:, search_terms: [] )
+        search_terms ||= []
+        # Look for managing role assignement
+        managing_role = Sipity::Role.find_by(name: Hyrax::RoleRegistry::MANAGING)
+        return search_terms unless managing_role.present?
+        agent = ability.current_user.to_sipity_agent
+        return search_terms unless agent.workflow_responsibilities.present?
+        managing_workflow_roles = []
+        agent.workflow_responsibilities.each do |workflow_responsibility|
+          wfr = Sipity::WorkflowRole.find_by(id: workflow_responsibility.workflow_role_id)
+          managing_workflow_roles << wfr if wfr.role_id == managing_role.id
+        end
+        return search_terms if managing_workflow_roles.empty?
+        # if the user has managing responsibilties, then look up the associated admin set ids
+        admin_set_ids = managing_workflow_roles.map do |wfr|
+          wf = Sipity::Workflow.find_by(id: wfr.workflow_id)
+          pt = Hyrax::PermissionTemplate.find_by(id: wf.permission_template_id)
+          pt.source_id
+        end
+        admin_set_ids.uniq!
+        # create search terms for works that are in managed admin sets
+        admin_set_ids.each do |id|
+          search_terms << "isPartOf_ssim:#{id}"
+        end
+        return search_terms
+      end
+
     end
+
   end
 end

--- a/spec/search_builders/hyrax/dashboard/collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/collections_search_builder_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe Hyrax::Dashboard::CollectionsSearchBuilder do
 
     subject { builder.gated_discovery_filters }
 
+    before do
+      user.save!
+      user2.save!
+    end
+
     context "user has manage access" do
       let(:permissions) { { manage_users: [user] } }
 

--- a/spec/search_builders/hyrax/dashboard/collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/collections_search_builder_spec.rb
@@ -55,11 +55,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsSearchBuilder do
 
     subject { builder.gated_discovery_filters }
 
-    before do
-      user.save!
-      user2.save!
-    end
-
     context "user has manage access" do
       let(:permissions) { { manage_users: [user] } }
 

--- a/spec/search_builders/hyrax/dashboard/works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/works_search_builder_spec.rb
@@ -86,74 +86,7 @@ RSpec.describe Hyrax::Dashboard::WorksSearchBuilder do
                     }
                   ],
                   transition_to: "deposited",
-                  methods: [  describe "#apply_group_permissions" do
-                    subject { builder.apply_group_permissions(permission_types,ability) }
-                    let(:permission_types) { ["edit", "read"] }
-
-                    context 'default user' do
-                      it "creates expected search term" do
-                        expect(subject).to eq ["({!terms f=edit_access_group_ssim}public,registered)"]
-                      end
-                    end
-
-                    context 'as admin' do
-                      let(:user) { create(:user, groups: 'admin') }
-                      it "creates expected search term" do
-                        expect(subject).to eq ["({!terms f=edit_access_group_ssim}public,admin,registered)",
-                                               "({!terms f=read_access_group_ssim}admin)"]
-                      end
-                    end
-
-                    context 'user with managing role' do
-                      let(:role) { Sipity::Role.find_or_create_by( name: Hyrax::RoleRegistry::MANAGING ) }
-                      let(:agent) { Sipity::Agent(user) }
-                      let(:one_step_workflow) do
-                        {
-                          workflows: [
-                            {
-                              name: "one_step",
-                              label: "One-step mediated deposit workflow",
-                              description: "A single-step workflow for mediated deposit",
-                              actions: [
-                                {
-                                  name: "deposit",
-                                  from_states: [],
-                                  transition_to: "pending_review"
-                                },
-                                {
-                                  name: "approve",
-                                  from_states: [
-                                    {
-                                      names: ["pending_review"],
-                                      roles: ["approving"]
-                                    }
-                                  ],
-                                  transition_to: "deposited",
-                                  methods: [
-                                    "Hyrax::Workflow::ActivateObject"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      end
-                      let(:permission_template) { create(:permission_template) }
-
-                      before do
-                        Hyrax::Workflow::WorkflowImporter.generate_from_hash(data: one_step_workflow.as_json,
-                                                                             permission_template: permission_template)
-                        Hyrax::Workflow::PermissionGenerator.call(roles: [role],
-                                                                  workflow: Sipity::Workflow.last,
-                                                                  agents: user)
-                      end
-
-                      it "creates expected search term" do
-                        expect(subject).to eq ["isPartOf_ssim:#{permission_template.source_id}",
-                                               "({!terms f=edit_access_group_ssim}public,registered)"]
-                      end
-                    end
-
+                  methods: [
                     "Hyrax::Workflow::ActivateObject"
                   ]
                 }
@@ -177,7 +110,5 @@ RSpec.describe Hyrax::Dashboard::WorksSearchBuilder do
                                "({!terms f=edit_access_group_ssim}public,registered)"]
       end
     end
-
-
   end
 end

--- a/spec/search_builders/hyrax/dashboard/works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/works_search_builder_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hyrax::Dashboard::WorksSearchBuilder do
   end
 
   describe "#apply_group_permissions" do
-    subject { builder.apply_group_permissions(permission_types,ability) }
+    subject { builder.apply_group_permissions(permission_types, ability) }
     let(:permission_types) { ["edit", "read"] }
 
     context 'default user' do
@@ -62,7 +62,7 @@ RSpec.describe Hyrax::Dashboard::WorksSearchBuilder do
     end
 
     context 'user with managing role' do
-      let(:role) { Sipity::Role.find_or_create_by( name: Hyrax::RoleRegistry::MANAGING ) }
+      let(:role) { Sipity::Role.find_or_create_by(name: Hyrax::RoleRegistry::MANAGING) }
       let(:agent) { Sipity::Agent(user) }
       let(:one_step_workflow) do
         {

--- a/spec/search_builders/hyrax/dashboard/works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/works_search_builder_spec.rb
@@ -42,4 +42,142 @@ RSpec.describe Hyrax::Dashboard::WorksSearchBuilder do
       end
     end
   end
+
+  describe "#apply_group_permissions" do
+    subject { builder.apply_group_permissions(permission_types,ability) }
+    let(:permission_types) { ["edit", "read"] }
+
+    context 'default user' do
+      it "creates expected search term" do
+        expect(subject).to eq ["({!terms f=edit_access_group_ssim}public,registered)"]
+      end
+    end
+
+    context 'as admin' do
+      let(:user) { create(:user, groups: 'admin') }
+      it "creates expected search term" do
+        expect(subject).to eq ["({!terms f=edit_access_group_ssim}public,admin,registered)",
+                               "({!terms f=read_access_group_ssim}admin)"]
+      end
+    end
+
+    context 'user with managing role' do
+      let(:role) { Sipity::Role.find_or_create_by( name: Hyrax::RoleRegistry::MANAGING ) }
+      let(:agent) { Sipity::Agent(user) }
+      let(:one_step_workflow) do
+        {
+          workflows: [
+            {
+              name: "one_step",
+              label: "One-step mediated deposit workflow",
+              description: "A single-step workflow for mediated deposit",
+              actions: [
+                {
+                  name: "deposit",
+                  from_states: [],
+                  transition_to: "pending_review"
+                },
+                {
+                  name: "approve",
+                  from_states: [
+                    {
+                      names: ["pending_review"],
+                      roles: ["approving"]
+                    }
+                  ],
+                  transition_to: "deposited",
+                  methods: [  describe "#apply_group_permissions" do
+                    subject { builder.apply_group_permissions(permission_types,ability) }
+                    let(:permission_types) { ["edit", "read"] }
+
+                    context 'default user' do
+                      it "creates expected search term" do
+                        expect(subject).to eq ["({!terms f=edit_access_group_ssim}public,registered)"]
+                      end
+                    end
+
+                    context 'as admin' do
+                      let(:user) { create(:user, groups: 'admin') }
+                      it "creates expected search term" do
+                        expect(subject).to eq ["({!terms f=edit_access_group_ssim}public,admin,registered)",
+                                               "({!terms f=read_access_group_ssim}admin)"]
+                      end
+                    end
+
+                    context 'user with managing role' do
+                      let(:role) { Sipity::Role.find_or_create_by( name: Hyrax::RoleRegistry::MANAGING ) }
+                      let(:agent) { Sipity::Agent(user) }
+                      let(:one_step_workflow) do
+                        {
+                          workflows: [
+                            {
+                              name: "one_step",
+                              label: "One-step mediated deposit workflow",
+                              description: "A single-step workflow for mediated deposit",
+                              actions: [
+                                {
+                                  name: "deposit",
+                                  from_states: [],
+                                  transition_to: "pending_review"
+                                },
+                                {
+                                  name: "approve",
+                                  from_states: [
+                                    {
+                                      names: ["pending_review"],
+                                      roles: ["approving"]
+                                    }
+                                  ],
+                                  transition_to: "deposited",
+                                  methods: [
+                                    "Hyrax::Workflow::ActivateObject"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      end
+                      let(:permission_template) { create(:permission_template) }
+
+                      before do
+                        Hyrax::Workflow::WorkflowImporter.generate_from_hash(data: one_step_workflow.as_json,
+                                                                             permission_template: permission_template)
+                        Hyrax::Workflow::PermissionGenerator.call(roles: [role],
+                                                                  workflow: Sipity::Workflow.last,
+                                                                  agents: user)
+                      end
+
+                      it "creates expected search term" do
+                        expect(subject).to eq ["isPartOf_ssim:#{permission_template.source_id}",
+                                               "({!terms f=edit_access_group_ssim}public,registered)"]
+                      end
+                    end
+
+                    "Hyrax::Workflow::ActivateObject"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:permission_template) { create(:permission_template) }
+
+      before do
+        Hyrax::Workflow::WorkflowImporter.generate_from_hash(data: one_step_workflow.as_json,
+                                                             permission_template: permission_template)
+        Hyrax::Workflow::PermissionGenerator.call(roles: [role],
+                                                  workflow: Sipity::Workflow.last,
+                                                  agents: user)
+      end
+
+      it "creates expected search term" do
+        expect(subject).to eq ["isPartOf_ssim:#{permission_template.source_id}",
+                               "({!terms f=edit_access_group_ssim}public,registered)"]
+      end
+    end
+
+
+  end
 end


### PR DESCRIPTION
Works in mediated workflow not listed as managed works for user with managing role

Fixes #5471

This issue stemmed from investigation into issue: #5436 

Add code to search builders to filter for admin sets with user's managing role.

Update [app/search_builders/hyrax/dashboard/managed_search_filters.rb] to add a method that performs the following steps:
* Find the managing sippity role
* convert the current user into a sippity agent
* from the agent's list of workflow responsibilities, find all responsibilities that are managing
* with this list of workflow responsibilities, find the corresponding admin set ids through the corresponding permission templates
* add a list of search filters that include "isPartOf" admin set ids identified in prior step

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* (1) Ensure that an admin set with a one-step mediated workflow exists.
* (2) As a normal user, create a work and add the admin set with a one-step mediated workflow identified or created in step 1.
* (3) Grant a non-admin user managing status to the admin set with the one-step mediated workflow used in step 2.
* (4) Go to the Dashboard, then Works page of a non-admin user with managing status from step 3.
* (5) The Managed User tab should be visible. Go to that tab.
* (6) The work created in step 2 should be listed in this tab. (It should also be listed in the Review Submissions tab.)

@samvera/hyrax-code-reviewers
