### PR TITLE
cleanly recharacterize new file versions

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -36,12 +36,48 @@ class CharacterizeJob < Hyrax::ApplicationJob
 
   private
 
-  def characterize(file_set, _file_id, filepath)
+  def characterize(file_set, _file_id, filepath) # rubocop:disable Metrics/AbcSize
+    # store this so we can tell if the original_file is actually changing
+    previous_checksum = file_set.characterization_proxy.original_checksum.first
+
+    clear_metadata(file_set)
+
+    # If the current FileSet title is the same as the label, it must be a filename as opposed to a user-entered...
+    # value. So later we'll ensure it's set to the new file's filename.
+    reset_title = file_set.title.first == file_set.label
+
     characterization_service.run(file_set.characterization_proxy, filepath)
     Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
     file_set.characterization_proxy.alpha_channels = channels(filepath) if file_set.image? && Hyrax.config.iiif_image_server?
     file_set.characterization_proxy.save!
-    file_set.update_index
+
+    # Ensure that if the actual file content has changed, the mod timestamp on the FileSet object changes.
+    # Otherwise this does not happen when rolling back to a previous version. Perhaps this should be set as part of...
+    # `FileActor.revert_to` (or its replacement Transaction?!), where the FileSet is saved. Not sure if the...
+    # before/after checksum is readily available there though. I like this checksum verification because it allows...
+    # all changes to the current FileSet version to be detected, which in our case triggers re-creation of a...
+    # "cold storage" archive of the parent Work. It's worth noting that adding a *new* version always touches this...
+    # mod time. This is done in the versioning code.
+    file_set.date_modified = Hyrax::TimeService.time_in_utc if file_set.characterization_proxy.original_checksum.first != previous_checksum
+
+    # set title to label if that's how it was before this characterization
+    file_set.title = [file_set.characterization_proxy.original_name] if reset_title
+    # always set the label to the original_name
+    file_set.label = file_set.characterization_proxy.original_name
+
+    file_set.save!
+  end
+
+  def clear_metadata(file_set)
+    # The characterization of additional file versions adds new height/width/size/checksum values to un-orderable...
+    # `ActiveTriples::Relation` fields on `original_file`. Values from those are then randomly pulled into Solr...
+    # fields which may have scalar or vector cardinality. So for height/width you get two scalar values pulled from...
+    # "randomized parallel arrays". Upshot is to reset all of these before (re)characterization to stop the mayhem.
+    file_set.characterization_proxy.height = []
+    file_set.characterization_proxy.width  = []
+    file_set.characterization_proxy.original_checksum = []
+    file_set.characterization_proxy.file_size = []
+    file_set.characterization_proxy.format_label = []
   end
 
   def channels(filepath)

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
-RSpec.describe CharacterizeJob do
+RSpec.describe CharacterizeJob, :clean_repo do
   let(:file_set_id) { 'abc12345' }
   let(:filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
+  let(:label) { 'picture.png' }
+  let(:title) { ['My User-Entered Title'] }
   let(:file_set) do
-    FileSet.new(id: file_set_id).tap do |fs|
+    FileSet.new(id: file_set_id, title: title, label: label, date_modified: 'old_mod_date').tap do |fs|
       allow(fs).to receive(:original_file).and_return(file)
       allow(fs).to receive(:update_index)
     end
@@ -13,8 +15,12 @@ RSpec.describe CharacterizeJob do
     Hydra::PCDM::File.new.tap do |f|
       f.content = 'foo'
       f.original_name = 'picture.png'
+      f.height = '111'
+      f.width = '222'
+      f.file_size = '123456'
+      f.format_label = ["Portable Network Graphics"]
+      f.original_checksum = ['checksum123']
       f.save!
-      allow(f).to receive(:save!)
     end
   end
 
@@ -48,6 +54,101 @@ RSpec.describe CharacterizeJob do
     before { allow(file_set).to receive(:characterization_proxy?).and_return(false) }
     it 'raises an error' do
       expect { described_class.perform_now(file_set, file.id) }.to raise_error(StandardError, /original_file was not found/)
+    end
+  end
+
+  context 'FileSet with preexisting characterization metadata getting a new version' do
+    before do
+      allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+    end
+
+    it 'resets height, width, checksum, file_size and format_label' do
+      expect(file).to receive(:save!)
+      expect(file_set).to receive(:update_index)
+      described_class.perform_now(file_set, file.id)
+
+      expect(file_set.characterization_proxy.height).to eq []
+      expect(file_set.original_file.width).to eq []
+      expect(file_set.original_file.original_checksum).to eq []
+      expect(file_set.original_file.file_size).to eq []
+      expect(file_set.original_file.format_label).to eq []
+      expect(file_set.label).to eq 'picture.png'
+    end
+
+    describe 'title and label' do
+      before do
+        allow(file_set).to receive(:characterization_proxy).and_call_original
+      end
+
+      context 'title and label were the previously the same' do
+        let(:title) { ['old_filename.jpg'] }
+        let(:label) { 'old_filename.jpg' }
+
+        before do
+          allow(file_set).to receive_message_chain(:characterization_proxy, :original_name).and_return('new_filename.jpg') # rubocop:disable RSpec/MessageChain
+        end
+
+        it 'sets title to label' do
+          expect(file).to receive(:save!)
+          expect(file_set).to receive(:update_index)
+          described_class.perform_now(file_set, file.id)
+          expect(file_set.title).to eq ['new_filename.jpg']
+          expect(file_set.label).to eq 'new_filename.jpg'
+        end
+      end
+
+      context 'title and label were not previously the same' do
+        let(:title) { ['My User-Entered Title'] }
+        let(:label) { 'old_filename.jpg' }
+
+        before do
+          allow(file_set).to receive_message_chain(:characterization_proxy, :original_name).and_return('new_filename.jpg') # rubocop:disable RSpec/MessageChain
+        end
+
+        it 'assumes a user-entered title value and leaves title as-is' do
+          expect(file).to receive(:save!)
+          expect(file_set).to receive(:update_index)
+          described_class.perform_now(file_set, file.id)
+          expect(file_set.title).to eq ['My User-Entered Title']
+          expect(file_set.label).to eq 'new_filename.jpg'
+        end
+      end
+    end
+
+    describe 'date_modified' do
+      before do
+        allow(file_set).to receive(:characterization_proxy).and_call_original
+        allow(Hyrax::TimeService).to receive(:time_in_utc).and_return('new_mod_date')
+      end
+
+      context 'the new checksum is the same as the previous one' do
+        before do
+          allow(file_set).to receive_message_chain(:characterization_proxy, :original_checksum).and_return(['old_checksum']) # rubocop:disable RSpec/MessageChain
+        end
+
+        it 'leaves it as-is' do
+          expect(file).to receive(:save!)
+          expect(file_set).to receive(:update_index)
+          expect(file_set.date_modified).to eq 'old_mod_date'
+          described_class.perform_now(file_set, file.id)
+          expect(file_set.date_modified).to eq 'old_mod_date'
+        end
+      end
+
+      context 'the new checksum is not the same as the previous one' do
+        before do
+          allow(file_set).to receive_message_chain(:characterization_proxy, :original_checksum).and_return(['old_checksum'], ['new_checksum']) # rubocop:disable RSpec/MessageChain
+        end
+
+        it 'sets it to now()' do
+          expect(file).to receive(:save!)
+          expect(file_set).to receive(:update_index)
+          expect(file_set.date_modified).to eq 'old_mod_date'
+          described_class.perform_now(file_set, file.id)
+          expect(file_set.date_modified).to eq 'new_mod_date'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Characterization of subsequent FileSet "versions" should result in metadata that looks similar to that present after the first version's characterization.

Fixes #1152 

When FileSets have a new version uploaded, weird things happen with metadata. Fields such as checksum, height and width (for audio/video), file size and file format label are aggregated in unordered multivalued fields in Fedora. This causes a seemingly-random value to display when indexed to a single-valued Solr field (e.g. height, width and file size) and multiple confusing values to display when indexed to a multi-valued field (e.g format label, checksum).

Knowing the correct current version's height/width and size can also be crucial when initiating certain tools like image viewers and functions like file download.

All of the previous metadata that causes issues should be deleted when a new version is characterized. In my experience, this is what editors expect.

Two other metadata fields have caused issues:
- when blank, title is set to label, which is just a filename. Versioning changes label but not title, because, while label is not user-settable, a title could have been set to any user-entered non-filename value. This PR sets a FileSet's title to a new version's label only if the title was previously the same as the previous version's label.
- date modified is not updated in all cases, such as when rolling back to a previous version. This PR ensures date modified is always updated if characterization shows a checksum that is different to the current version's checksum.

@samvera/hyrax-code-reviewers
