### PR TITLE
force collection for sharing to load before running the feature test

### DIFF
--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -762,10 +762,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   end
 
   describe 'edit collection' do
-    let(:collection) { build(:named_collection_lw, user: user, with_permission_template: true) }
-    let!(:work1) { create(:work, title: ["King Louie"], member_of_collections: [collection], user: user) }
-    let!(:work2) { create(:work, title: ["King Kong"], member_of_collections: [collection], user: user) }
-
     context 'from dashboard -> collections action menu' do
       before do
         create(:permission_template_access,
@@ -792,7 +788,14 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
     context 'from dashboard -> collections action menu' do
       context 'for a collection' do
+        let(:collection) { build(:named_collection_lw, user: user, with_permission_template: true) }
+        let(:work1) { create(:work, title: ["King Louie"], member_of_collections: [collection], user: user) }
+        let(:work2) { create(:work, title: ["King Kong"], member_of_collections: [collection], user: user) }
+
         before do
+          collection
+          work1
+          work2
           sign_in user
           visit '/dashboard/my/collections'
         end
@@ -936,15 +939,16 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         context "to true, limits available users", js: true do
           let(:user2) { create(:user) }
-          it "to system users filted by select2" do
+          it "to system users filtered by select2" do
             visit "/dashboard/collections/#{sharable_collection_id}/edit"
             expect(page).to have_link('Sharing', href: '#sharing')
             click_link('Sharing')
             expect(page).to have_selector(".form-inline.add-users .select2-container")
             select_user(user2, 'Depositor')
-            click_button('Save')
-            click_link('Sharing')
-            expect(page).to have_selector('td', text: user2.user_key)
+            expect(page).to have_content "The collection's sharing options have been updated."
+            within('section.section-collection-sharing') do
+              expect(page).to have_selector('td', text: user2.user_key)
+            end
           end
         end
 


### PR DESCRIPTION
Addresses 2 flaky feature tests for dashboard/collections.

@samvera/hyrax-code-reviewers
