### PR TITLE
Fix Selenium::WebDriver::Error::UnknownError

### DIFF
--- a/lib/hyrax/specs/capybara.rb
+++ b/lib/hyrax/specs/capybara.rb
@@ -21,7 +21,7 @@ if ENV['IN_DOCKER'].present? || ENV['HUB_URL'].present?
   args = %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400]
   args.push('headless') if ActiveModel::Type::Boolean.new.cast(ENV['CHROME_HEADLESS_MODE'])
 
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: args })
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome("goog:chromeOptions" => { args: args })
 
   Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
     driver = Capybara::Selenium::Driver.new(app,


### PR DESCRIPTION
Running the test suite with the docker setup resulted in errors like

```
     1.2) Failure/Error:                                                                                                                                                              
            driver.browser.file_detector = lambda do |args|                                                                                                                           
              str = args.first.to_s                                                                                                                                                   
              str if File.exist?(str)                                                                                                                                                 
            end                                                                                                                                                                       
                                                                                                                                                                                      
          Selenium::WebDriver::Error::UnknownError:                                                                                                                                   
            Illegal key values seen in w3c capabilities: [chromeOptions]      
```

This fixes those.