### PR TITLE
Bundle before db:migrating to catch gem mismatches

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,8 +74,7 @@ services:
     user: root
     env_file:
       - .env
-    entrypoint: ["sh", "-c"]
-    command: db-migrate-seed.sh
+    command: sh -l -c 'bundle && db-migrate-seed.sh'
     depends_on:
       - postgres
     volumes:


### PR DESCRIPTION
Changes proposed in this pull request:
* Changes the dassie db-migrate service command style to match the other services. 
* Runs `bundle` before the migration script to catch any gem mismatches.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* When the dassie image's gems installed during `docker-compose build` do not match the current Gemfile.lock, the db-migrate service does not fail due to missing gems. 
*
*

@samvera/hyrax-code-reviewers
