### PR TITLE
add back in the check before using the storage adapter to save

### DIFF
--- a/app/models/collection_branding_info.rb
+++ b/app/models/collection_branding_info.rb
@@ -14,16 +14,19 @@ class CollectionBrandingInfo < ApplicationRecord
     self.local_path = File.join(role, filename)
   end
 
-  def save(file_location, copy_file = true)
+  def save(file_location, upload_file = true)
     filename = File.split(local_path).last
     role_and_filename = File.join(role, filename)
 
-    storage.upload(resource: Hyrax::PcdmCollection.new(id: collection_id),
-                   file: File.open(file_location),
-                   original_filename: role_and_filename)
+    if upload_file
+      storage.upload(resource: Hyrax::PcdmCollection.new(id: collection_id),
+                     file: File.open(file_location),
+                     original_filename: role_and_filename)
+    end
+
     self.local_path = find_local_filename(collection_id, role, filename)
 
-    FileUtils.remove_file(file_location) if File.exist?(file_location) && copy_file
+    FileUtils.remove_file(file_location) if File.exist?(file_location) && upload_file
     super()
   end
 
@@ -35,7 +38,6 @@ class CollectionBrandingInfo < ApplicationRecord
          else
            local_path
          end
-
     storage.delete(id: id)
   end
 

--- a/spec/models/collection_branding_info_spec.rb
+++ b/spec/models/collection_branding_info_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe CollectionBrandingInfo, type: :model do
     end
 
     it "saves the logo info, but don't upload the log file" do
-      logo_info.save(file.path, false)
-
       expect(storage_adapter).not_to receive(:upload)
+
+      logo_info.save(file.path, false)
       expect(logo_info.local_path).to eq(logo_info.find_local_dir_name('123', 'logo') + "/logo.gif")
       expect(logo_info.alt_text).to eq("This is the logo")
       expect(logo_info.target_url).to eq("http://logo.com")

--- a/spec/models/collection_branding_info_spec.rb
+++ b/spec/models/collection_branding_info_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe CollectionBrandingInfo, type: :model do
       expect(logo_info.alt_text).to eq("This is the logo")
       expect(logo_info.target_url).to eq("http://logo.com")
     end
+
+    it "saves the logo info, but don't upload the log file" do
+      logo_info.save(file.path, false)
+
+      expect(storage_adapter).not_to receive(:upload)
+      expect(logo_info.local_path).to eq(logo_info.find_local_dir_name('123', 'logo') + "/logo.gif")
+      expect(logo_info.alt_text).to eq("This is the logo")
+      expect(logo_info.target_url).to eq("http://logo.com")
+    end
   end
 
   describe '#delete' do


### PR DESCRIPTION
Fixes #5483

When updating branding files: banner or logo, the system would error out.  This was because inadvertently a check was removed from the code.  This check insures that the the files are stored when needed.  The check has been placed back in.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
*  Create a collection.
*  Add a banner and logo to the collection.
*  Save the changes.
*  Then save the changes again.  You should not see any errors.

@samvera/hyrax-code-reviewers
