### PR TITLE
check if logo file id is a string, not just public.

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -340,7 +340,10 @@ module Hyrax
       def process_logo_records(uploaded_file_ids)
         public_files = []
         uploaded_file_ids.each_with_index do |ufi, i|
-          if ufi.include?('public')
+          # If the user has chosen a new logo, the ufi will be an integer
+          # If the logo was previously chosen, the ufi will be a path
+          # If it is a path, update the rec, else create a new rec
+          if !ufi.match(/\D/).nil?
             update_logo_info(ufi, params["alttext"][i], verify_linkurl(params["linkurl"][i]))
             public_files << ufi
           else # brand new one, insert in the database


### PR DESCRIPTION
This could potentially fix issue #3475

The code presently checks for the string "public" in the id list of logo files to determine if the file was previously uploaded.  Because configurations can change, it is better to check if the id is a string.  Basically:

If the user has chosen a new logo, the file id will be an integer
If the logo was previously chosen, the file id will be a path (string)
If it is a path, update the branding record, else create a new branding record.

I do not S3 configured on my local machine, but if someone does, perhaps they can check if this fixes issue #3475

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a collection.
* Upload a banner and logo, and save the changes.
* Save the changes again.
* Upload a new logo, and Save the changes.
* You should be able to do this without any errors occurring.

@samvera/hyrax-code-reviewers
