### PR TITLE
Geonames labels

### DIFF
--- a/.dassie/config/initializers/hyrax.rb
+++ b/.dassie/config/initializers/hyrax.rb
@@ -40,6 +40,8 @@ Hyrax.config do |config|
     config.browse_everything = nil
   end
 
+  # config.geonames_username = ''
+
   ##
   # Set the system-wide virus scanner
   config.virus_scanner = Hyrax::VirusScanner

--- a/app/assets/javascripts/hyrax/autocomplete/linked_data.es6
+++ b/app/assets/javascripts/hyrax/autocomplete/linked_data.es6
@@ -40,11 +40,9 @@ export default class LinkedData {
         // Called when Select2 is created to allow the user to initialize the
         // selection based on the value of the element select2 is attached to.
         // Essentially this is an id->object mapping function.
-
-        // TODO: Presently we're just showing a URI, but we should show the label.
         var data = {
           id: element.val(),
-          label: element.val()
+          label: element[0].dataset.label || element.val()
         };
         callback(data);
       },

--- a/app/inputs/controlled_vocabulary_input.rb
+++ b/app/inputs/controlled_vocabulary_input.rb
@@ -62,10 +62,12 @@ class ControlledVocabularyInput < MultiValueInput
 
   def build_options_for_new_row(_attribute_name, _index, options)
     options[:value] = ''
+    options[:data][:label] = ''
   end
 
   def build_options_for_existing_row(_attribute_name, _index, value, options)
     options[:value] = value.rdf_label.first || "Unable to fetch label for #{value.rdf_subject}"
+    options[:data][:label] = value.full_label || value.rdf_label
     options[:readonly] = true
   end
 

--- a/app/services/hyrax/location_service.rb
+++ b/app/services/hyrax/location_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+module Hyrax
+  class LocationService < ::Qa::Authorities::Geonames
+    CACHE_KEY_PREFIX = 'hyrax_geonames_label-v1-'
+    CACHE_EXPIRATION = 1.week
+
+    def full_label(uri)
+      return if uri.blank?
+      id = extract_id uri
+      Rails.cache.fetch(cache_key(id), expires_in: CACHE_EXPIRATION) do
+        label.call(find(id))
+      end
+    end
+
+    private
+
+    def extract_id(obj)
+      uri = case obj
+            when String
+              URI(obj)
+            when URI
+              obj
+            else
+              raise ArgumentError, "#{obj} is not a valid type"
+            end
+      uri.path.split('/').last
+    end
+
+    def cache_key(id)
+      "#{CACHE_KEY_PREFIX}#{id}"
+    end
+  end
+end

--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -8,8 +8,13 @@ module Hyrax
 
       # Return a tuple of url & label
       def solrize
-        return [rdf_subject.to_s] if rdf_label.first.to_s.blank? || rdf_label.first.to_s == rdf_subject.to_s
-        [rdf_subject.to_s, { label: "#{rdf_label.first}$#{rdf_subject}" }]
+        label = full_label || rdf_label.first.to_s
+        return [rdf_subject.to_s] if label.blank? || label == rdf_subject.to_s
+        [rdf_subject.to_s, { label: "#{label}$#{rdf_subject}" }]
+      end
+
+      def full_label
+        Hyrax::LocationService.new.full_label(rdf_subject.to_s)
       end
     end
   end

--- a/spec/fixtures/geonames.json
+++ b/spec/fixtures/geonames.json
@@ -1,0 +1,577 @@
+{
+  "__license__": "https://creativecommons.org/licenses/by/4.0/ https://www.geonames.org/",
+  "timezone": {
+    "gmtOffset": -6,
+    "timeZoneId": "America/Chicago",
+    "dstOffset": -5
+  },
+  "bbox": {
+    "east": -93.19402300000002,
+    "south": 44.889787,
+    "north": 45.051249999999996,
+    "west": -93.329163,
+    "accuracyLevel": 0
+  },
+  "asciiName": "Minneapolis",
+  "astergdem": 275,
+  "countryId": "6252001",
+  "fcl": "P",
+  "srtm3": 262,
+  "adminId2": "5029877",
+  "adminId3": "5037657",
+  "countryCode": "US",
+  "adminCodes1": {
+    "ISO3166_2": "MN"
+  },
+  "adminId1": "5037779",
+  "lat": "44.97997",
+  "fcode": "PPLA2",
+  "continentCode": "NA",
+  "elevation": 253,
+  "adminCode2": "053",
+  "adminCode3": "43000",
+  "adminCode1": "MN",
+  "lng": "-93.26384",
+  "geonameId": 5037649,
+  "toponymName": "Minneapolis",
+  "population": 410939,
+  "wikipediaURL": "en.wikipedia.org/wiki/Minneapolis",
+  "adminName5": "",
+  "adminName4": "",
+  "adminName3": "City of Minneapolis",
+  "alternateNames": [
+    {
+      "name": "미니애폴리스",
+      "lang": "ko"
+    },
+    {
+      "name": "55401",
+      "lang": "post"
+    },
+    {
+      "name": "55402",
+      "lang": "post"
+    },
+    {
+      "name": "55403",
+      "lang": "post"
+    },
+    {
+      "name": "55404",
+      "lang": "post"
+    },
+    {
+      "name": "55405",
+      "lang": "post"
+    },
+    {
+      "name": "55406",
+      "lang": "post"
+    },
+    {
+      "name": "55407",
+      "lang": "post"
+    },
+    {
+      "name": "55408",
+      "lang": "post"
+    },
+    {
+      "name": "55409",
+      "lang": "post"
+    },
+    {
+      "name": "55410",
+      "lang": "post"
+    },
+    {
+      "name": "55411",
+      "lang": "post"
+    },
+    {
+      "name": "55412",
+      "lang": "post"
+    },
+    {
+      "name": "55413",
+      "lang": "post"
+    },
+    {
+      "name": "55414",
+      "lang": "post"
+    },
+    {
+      "name": "55415",
+      "lang": "post"
+    },
+    {
+      "name": "55416",
+      "lang": "post"
+    },
+    {
+      "name": "55417",
+      "lang": "post"
+    },
+    {
+      "name": "55418",
+      "lang": "post"
+    },
+    {
+      "name": "55419",
+      "lang": "post"
+    },
+    {
+      "name": "55420",
+      "lang": "post"
+    },
+    {
+      "name": "55422",
+      "lang": "post"
+    },
+    {
+      "name": "55423",
+      "lang": "post"
+    },
+    {
+      "name": "55424",
+      "lang": "post"
+    },
+    {
+      "name": "55425",
+      "lang": "post"
+    },
+    {
+      "name": "55426",
+      "lang": "post"
+    },
+    {
+      "name": "55427",
+      "lang": "post"
+    },
+    {
+      "name": "55428",
+      "lang": "post"
+    },
+    {
+      "name": "55429",
+      "lang": "post"
+    },
+    {
+      "name": "55430",
+      "lang": "post"
+    },
+    {
+      "name": "55431",
+      "lang": "post"
+    },
+    {
+      "name": "55435",
+      "lang": "post"
+    },
+    {
+      "name": "55436",
+      "lang": "post"
+    },
+    {
+      "name": "55437",
+      "lang": "post"
+    },
+    {
+      "name": "55438",
+      "lang": "post"
+    },
+    {
+      "name": "55439",
+      "lang": "post"
+    },
+    {
+      "name": "55440",
+      "lang": "post"
+    },
+    {
+      "name": "55441",
+      "lang": "post"
+    },
+    {
+      "name": "55442",
+      "lang": "post"
+    },
+    {
+      "name": "55443",
+      "lang": "post"
+    },
+    {
+      "name": "55444",
+      "lang": "post"
+    },
+    {
+      "name": "55445",
+      "lang": "post"
+    },
+    {
+      "name": "55446",
+      "lang": "post"
+    },
+    {
+      "name": "55447",
+      "lang": "post"
+    },
+    {
+      "name": "55450",
+      "lang": "post"
+    },
+    {
+      "name": "55454",
+      "lang": "post"
+    },
+    {
+      "name": "55455",
+      "lang": "post"
+    },
+    {
+      "name": "55458",
+      "lang": "post"
+    },
+    {
+      "name": "55459",
+      "lang": "post"
+    },
+    {
+      "name": "55460",
+      "lang": "post"
+    },
+    {
+      "name": "55467",
+      "lang": "post"
+    },
+    {
+      "name": "55470",
+      "lang": "post"
+    },
+    {
+      "name": "55472",
+      "lang": "post"
+    },
+    {
+      "name": "55474",
+      "lang": "post"
+    },
+    {
+      "name": "55478",
+      "lang": "post"
+    },
+    {
+      "name": "55479",
+      "lang": "post"
+    },
+    {
+      "name": "55480",
+      "lang": "post"
+    },
+    {
+      "name": "55483",
+      "lang": "post"
+    },
+    {
+      "name": "55484",
+      "lang": "post"
+    },
+    {
+      "name": "55485",
+      "lang": "post"
+    },
+    {
+      "name": "55486",
+      "lang": "post"
+    },
+    {
+      "name": "55487",
+      "lang": "post"
+    },
+    {
+      "name": "55488",
+      "lang": "post"
+    },
+    {
+      "name": "City of Minneapolis"
+    },
+    {
+      "name": "Gakaabikaang"
+    },
+    {
+      "name": "https://en.wikipedia.org/wiki/Minneapolis",
+      "lang": "link"
+    },
+    {
+      "name": "https://ru.wikipedia.org/wiki/%D0%9C%D0%B8%D0%BD%D0%BD%D0%B5%D0%B0%D0%BF%D0%BE%D0%BB%D0%B8%D1%81",
+      "lang": "link"
+    },
+    {
+      "name": "Mineapoli",
+      "lang": "haw"
+    },
+    {
+      "name": "Mineapolis",
+      "lang": "lt"
+    },
+    {
+      "name": "Mineápolis",
+      "lang": "es"
+    },
+    {
+      "name": "Mineapolisa",
+      "lang": "lv"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "ca"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "da"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "de"
+    },
+    {
+      "isPreferredName": true,
+      "name": "Minneapolis",
+      "lang": "en"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "eo"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "fi"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "fr"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "ga"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "gl"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "hu"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "id"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "io"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "it"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "la"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "nl"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "nn"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "no"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "pl"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "pt"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "sk"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "sv"
+    },
+    {
+      "name": "Minneapolis",
+      "lang": "tr"
+    },
+    {
+      "name": "Minneapòlis",
+      "lang": "oc"
+    },
+    {
+      "name": "Minnéapolis",
+      "lang": "ug"
+    },
+    {
+      "name": "Mìn-nì-â-pô-li-sṳ̂",
+      "lang": "hak"
+    },
+    {
+      "name": "Minyapolis",
+      "lang": "tl"
+    },
+    {
+      "name": "MSP",
+      "lang": "iata"
+    },
+    {
+      "name": "Q36091",
+      "lang": "wkdt"
+    },
+    {
+      "name": "USMES",
+      "lang": "unlc"
+    },
+    {
+      "name": "Μινεάπολη",
+      "lang": "el"
+    },
+    {
+      "name": "Минеаполис",
+      "lang": "bg"
+    },
+    {
+      "name": "Минеаполис",
+      "lang": "mk"
+    },
+    {
+      "name": "Минеаполис",
+      "lang": "sr"
+    },
+    {
+      "name": "Миннеаполис",
+      "lang": "kk"
+    },
+    {
+      "name": "Миннеаполис",
+      "lang": "ky"
+    },
+    {
+      "name": "Миннеаполис",
+      "lang": "mrj"
+    },
+    {
+      "name": "Миннеаполис",
+      "lang": "os"
+    },
+    {
+      "name": "Миннеаполис",
+      "lang": "ru"
+    },
+    {
+      "name": "Миннеаполис",
+      "lang": "sah"
+    },
+    {
+      "name": "Миннеаполис",
+      "lang": "tg"
+    },
+    {
+      "name": "Мінеапаліс",
+      "lang": "be"
+    },
+    {
+      "name": "Міннеаполіс",
+      "lang": "uk"
+    },
+    {
+      "name": "მინეაპოლისი",
+      "lang": "ka"
+    },
+    {
+      "name": "Մինեապոլիս",
+      "lang": "hy"
+    },
+    {
+      "name": "מיניאפוליס",
+      "lang": "he"
+    },
+    {
+      "name": "منیاپولس",
+      "lang": "ur"
+    },
+    {
+      "name": "مينيابولس",
+      "lang": "ar"
+    },
+    {
+      "name": "مینیاپولیس",
+      "lang": "fa"
+    },
+    {
+      "name": "मिनियापोलिस",
+      "lang": "hi"
+    },
+    {
+      "name": "मिनीयापोलिस",
+      "lang": "mr"
+    },
+    {
+      "name": "মিনিয়াপোলিস",
+      "lang": "bn"
+    },
+    {
+      "name": "મિનેપોલિસ",
+      "lang": "gu"
+    },
+    {
+      "name": "மினியாப்பொலிஸ்",
+      "lang": "ta"
+    },
+    {
+      "name": "మిన్నియాపోలిస్",
+      "lang": "te"
+    },
+    {
+      "name": "ಮಿನ್ನಿಯಾಪೋಲಿಸ್",
+      "lang": "kn"
+    },
+    {
+      "name": "มินนีแอโพลิส",
+      "lang": "th"
+    },
+    {
+      "name": "ミネアポリス",
+      "lang": "ja"
+    },
+    {
+      "name": "明尼亞波利斯",
+      "lang": "yue"
+    },
+    {
+      "name": "明尼阿波利斯",
+      "lang": "lzh"
+    },
+    {
+      "name": "明尼阿波利斯",
+      "lang": "wuu"
+    },
+    {
+      "name": "明尼阿波利斯",
+      "lang": "zh"
+    }
+  ],
+  "adminName2": "Hennepin",
+  "name": "Minneapolis",
+  "fclName": "city, village,...",
+  "countryName": "United States",
+  "fcodeName": "seat of a second-order administrative division",
+  "adminName1": "Minnesota"
+}

--- a/spec/hyrax/controlled_vocabularies/location_spec.rb
+++ b/spec/hyrax/controlled_vocabularies/location_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::ControlledVocabularies::Location do
+  let(:rdf_subject) { 'https://sws.geonames.org/5037649/' }
+  let(:location) { described_class.new(rdf_subject) }
+
+  before do
+    stub_request(:get, 'http://www.geonames.org/getJSON')
+      .with(query: hash_including({ 'geonameId': '5037649' }))
+      .to_return(status: 200, body: File.open(File.join(fixture_path, 'geonames.json')))
+  end
+
+  context 'when indexed' do
+    it 'retrieves the full label' do
+      expect(location.solrize).to eq [rdf_subject, { label: "Minneapolis, Minnesota, United States$#{rdf_subject}" }]
+    end
+  end
+end

--- a/spec/indexers/hyrax/deep_indexing_service_spec.rb
+++ b/spec/indexers/hyrax/deep_indexing_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hyrax::DeepIndexingService do
           <rdf:RDF xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gn="http://www.geonames.org/ontology#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
           <gn:Feature rdf:about="http://sws.geonames.org/5037649/">
           <rdfs:label>an RDFS Label</gn:name>
-          <gn:name>Newberg</gn:name>
+          <gn:name>Minneapolis</gn:name>
           </gn:Feature>
           </rdf:RDF>
 RDFXML
@@ -17,6 +17,10 @@ RDFXML
     stub_request(:get, "http://sws.geonames.org/5037649/")
       .to_return(status: 200, body: newberg,
                  headers: { 'Content-Type' => 'application/rdf+xml;charset=UTF-8' })
+
+    stub_request(:get, 'http://www.geonames.org/getJSON')
+      .with(query: hash_including({ 'geonameId': '5037649' }))
+      .to_return(status: 200, body: File.open(File.join(fixture_path, 'geonames.json')))
   end
 
   describe '#add_assertions' do
@@ -25,7 +29,7 @@ RDFXML
 
       expect { service.add_assertions(nil) }
         .to change { work.based_near.map(&:rdf_label).flatten }
-        .to contain_exactly(["Newberg"])
+        .to contain_exactly(["Minneapolis"])
     end
   end
 end

--- a/spec/indexers/hyrax/generic_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/generic_work_indexer_spec.rb
@@ -118,14 +118,19 @@ RDFXML
     before do
       allow(service).to receive(:rdf_service).and_return(Hyrax::DeepIndexingService)
       work.based_near_attributes = [{ id: 'http://sws.geonames.org/5037649/' }]
+
       stub_request(:get, "http://sws.geonames.org/5037649/")
         .to_return(status: 200, body: mpls,
                    headers: { 'Content-Type' => 'application/rdf+xml;charset=UTF-8' })
+
+      stub_request(:get, 'http://www.geonames.org/getJSON')
+        .with(query: hash_including({ 'geonameId': '5037649' }))
+        .to_return(status: 200, body: File.open(File.join(fixture_path, 'geonames.json')))
     end
 
     it "indexes id and label" do
       expect(solr_document.fetch('based_near_sim')).to eq ["http://sws.geonames.org/5037649/"]
-      expect(solr_document.fetch('based_near_label_sim')).to eq ["Minneapolis"]
+      expect(solr_document.fetch('based_near_label_sim')).to eq ["Minneapolis, Minnesota, United States"]
     end
   end
 end

--- a/spec/inputs/controlled_vocabulary_input_spec.rb
+++ b/spec/inputs/controlled_vocabulary_input_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe 'ControlledVocabularyInput', type: :input do
 
   describe '#input' do
     before { allow(work).to receive(:[]).with(:based_near).and_return([item1, item2]) }
-    let(:item1) { double('value 1', rdf_label: ['Item 1'], rdf_subject: 'http://example.org/1', node?: false) }
-    let(:item2) { double('value 2', rdf_label: ['Item 2'], rdf_subject: 'http://example.org/2') }
+    let(:item1) { double('value 1', rdf_label: ['Item 1'], rdf_subject: 'http://example.org/1', full_label: 'Item One', node?: false) }
+    let(:item2) { double('value 2', rdf_label: ['Item 2'], rdf_subject: 'http://example.org/2', full_label: 'Item Two') }
 
     it 'renders multi-value' do
       expect(input).to receive(:build_field).with(item1, 0)
@@ -35,7 +35,7 @@ RSpec.describe 'ControlledVocabularyInput', type: :input do
     subject { input.send(:build_field, value, 0) }
 
     context 'for a resource' do
-      let(:value) { double('value 1', rdf_label: ['Item 1'], rdf_subject: 'http://example.org/1', node?: false) }
+      let(:value) { double('value 1', rdf_label: ['Item 1'], rdf_subject: 'http://example.org/1', full_label: 'Item One', node?: false) }
 
       it 'renders multi-value' do
         expect(subject).to have_selector('input.generic_work_based_near.multi_value')
@@ -58,7 +58,7 @@ RSpec.describe 'ControlledVocabularyInput', type: :input do
 
       it "preserves passed in data" do
         subject
-        expect(options).to include(data: { attribute: :based_near, 'search-url' => '/authorities/search' })
+        expect(options).to include(data: { attribute: :based_near, label: '', 'search-url' => '/authorities/search' })
       end
     end
   end

--- a/spec/services/hyrax/location_service_spec.rb
+++ b/spec/services/hyrax/location_service_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::LocationService do
+  let(:service) { described_class.new }
+
+  before do
+    stub_request(:get, 'http://www.geonames.org/getJSON')
+      .with(query: hash_including({ 'geonameId': '5037649' }))
+      .to_return(status: 200, body: File.open(File.join(fixture_path, 'geonames.json')))
+  end
+
+  context 'with Geonames uri string' do
+    let(:uri) { 'https://sws.geonames.org/5037649/' }
+
+    describe 'full_label' do
+      it 'returns a full label' do
+        expect(service.full_label(uri)).to eq 'Minneapolis, Minnesota, United States'
+      end
+    end
+  end
+
+  context 'with Geonames uri object' do
+    let(:uri) { URI('https://sws.geonames.org/5037649/') }
+
+    describe 'full_label' do
+      it 'returns a full label' do
+        expect(service.full_label(uri)).to eq 'Minneapolis, Minnesota, United States'
+      end
+    end
+  end
+
+  context 'with invalid type' do
+    let(:uri) { 5_037_649 }
+
+    describe 'full_label' do
+      it 'returns a full label' do
+        expect { service.full_label(uri) }.to raise_error
+      end
+    end
+  end
+
+  context 'with blank object' do
+    let(:uri) { nil }
+
+    describe 'full_label' do
+      it 'returns a full label' do
+        expect(service.full_label(uri)).to eq nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1065, #3269

Retrieves, indexes and displays the full location label

Previously when indexing the Based Near/Location field on works, only the city name was available as it was all that is available in the rdf data that was retrieved. This PR add a service that retrieves a full label from another Geonames endpoint via questioning authority, caching the results locally. That service is then used when creating the solr doc and rendering the edit form.

Geonames wants a username to use this service. This is defined in `config/initializers/hyrax.rb` as `config.geonames_username = Qa::Authorities::Geonames.username = '{username}'` to set the user in Qa at the same time.

Changes proposed in this pull request:
* Add service based on Qa::Authorities::Geonames to supply a full label
* Index that full label
* Display that full label on the work edit form

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Creating a work with a location
* Verify full label (e.g. City, State, Country) is shown on work details and edit form

@samvera/hyrax-code-reviewers
