### PR TITLE
Hyrax-2259 - Admins should allow delete of permission_template_access…

### DIFF
--- a/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
+++ b/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
@@ -5,30 +5,15 @@ module Hyrax
       load_and_authorize_resource class: 'Hyrax::PermissionTemplateAccess'
 
       def destroy
+        authorize! :destroy, @permission_template_access
         ActiveRecord::Base.transaction do
-          @permission_template_access.destroy if valid_delete?
+          @permission_template_access.destroy
           remove_access!
         end
-
-        if @permission_template_access.destroyed?
-          after_destroy_success
-        else
-          after_destroy_error
-        end
+        after_destroy_success if @permission_template_access.destroyed?
       end
 
       private
-
-      # This is a controller validation rather than a model validation
-      # because we don't want to prevent the ability to remove the whole
-      # PermissionTemplate and all of its associated PermissionTemplateAccesses
-      # @return [Boolean] true if it's valid
-      def valid_delete?
-        return true unless @permission_template_access.admin_group?
-        @permission_template_access.errors[:base] <<
-          t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group')
-        false
-      end
 
       def after_destroy_success
         if source.admin_set?
@@ -39,18 +24,6 @@ module Hyrax
           redirect_to hyrax.edit_dashboard_collection_path(source_id,
                                                            anchor: 'sharing'),
                       notice: translate('sharing', scope: 'hyrax.dashboard.collections.form.permission_update_notices')
-        end
-      end
-
-      def after_destroy_error
-        if source.admin_set?
-          redirect_to hyrax.edit_admin_admin_set_path(source_id,
-                                                      anchor: 'participants'),
-                      alert: @permission_template_access.errors.full_messages.to_sentence
-        else
-          redirect_to hyrax.edit_dashboard_collection_path(source_id,
-                                                           anchor: 'sharing'),
-                      alert: @permission_template_access.errors.full_messages.to_sentence
         end
       end
 

--- a/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
+++ b/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
@@ -10,10 +10,30 @@ module Hyrax
           @permission_template_access.destroy
           remove_access!
         end
-        after_destroy_success if @permission_template_access.destroyed?
+        if @permission_template_access.destroyed?
+          after_destroy_success
+        else
+          after_destroy_error
+        end
       end
 
       private
+
+      def after_destroy_error
+        if source.admin_set?
+          @permission_template_access.errors[:base] <<
+            t('hyrax.admin.admin_sets.form.permission_destroy_errors.participants')
+          redirect_to hyrax.edit_admin_admin_set_path(source_id,
+                                                      anchor: 'participants'),
+                      alert: @permission_template_access.errors.full_messages.to_sentence
+        else
+          @permission_template_access.errors[:base] <<
+            t('hyrax.dashboard.collections.form.permission_update_errors.sharing')
+          redirect_to hyrax.edit_dashboard_collection_path(source_id,
+                                                           anchor: 'sharing'),
+                      alert: @permission_template_access.errors.full_messages.to_sentence
+        end
+      end
 
       def after_destroy_success
         if source.admin_set?

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -91,6 +91,7 @@ en:
           note: Users granted a new role will only gain the role on works that are deposited after that role has been granted.
           permission_destroy_errors:
             admin_group: The repository administrators group cannot be removed
+            participants: The administrative set's participant rights failed to delete.
           permission_update_errors:
             error: Invalid update option for permission template.
             no_date: A date is required for the selected release option.
@@ -833,7 +834,6 @@ en:
         select_type_of_collection: Select type of collection
       collections:
         collection_title: Collection Title
-        title: Collections
         last_updated: Last updated
         works: Works
         files: Files
@@ -842,6 +842,7 @@ en:
         form:
           permission_update_errors:
             error: Invalid update option for permission template.
+            sharing: The collection's sharing options failed to update.
           permission_update_notices:
             participants: The collection's sharing options have been updated.
             sharing: The collection's sharing options have been updated.

--- a/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
   let(:hyrax) { Hyrax::Engine.routes.url_helpers }
   let(:permission_template_access) { FactoryBot.create(:permission_template_access) }
   let(:source_id) { permission_template_access.permission_template.source_id }
-  let(:user_liz) { FactoryBot.create(:user, email: 'liz@example.com') }
+  let(:admin_set_update_notice) { 'The administrative set\'s participant rights have been updated' }
+  let(:collection_update_notice) { 'The collection\'s sharing options have been updated.' }
+  let(:rep_admin_cannot_remove_notice) { 'The repository administrators group cannot be removed' }
 
   before { sign_in FactoryBot.create(:user) }
 
   describe "destroy" do
-    context "without admin privleges" do
+    context "without admin privileges" do
+      let(:user_liz) { FactoryBot.create(:user, email: 'liz@example.com') }
       before do
         allow(controller.current_ability)
           .to receive(:test_edit)
@@ -25,6 +28,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
     end
 
     context "when signed in as an admin" do
+      let(:user_liz) { FactoryBot.create(:admin, email: 'liz@example.com') }
       let(:permission_template_access) do
         create(:permission_template_access,
                :manage,
@@ -32,12 +36,14 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
                agent_type: agent_type,
                agent_id: agent_id)
       end
+      let(:access_destroy) { true }
 
       it 'can remove admin group from depositors'
       it 'can remove admin group from viewers'
 
       context 'when source is an admin set' do
         let(:admin_set) { FactoryBot.create(:admin_set, edit_users: [user_liz.user_key]) }
+        # let(:admin_set) { FactoryBot.create(:admin_set) }
 
         let(:permission_template) do
           FactoryBot.create(:permission_template, source_id: admin_set.id)
@@ -48,17 +54,18 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
           let(:agent_id) { 'admin' }
 
           before do
-            allow(controller)
+            expect(controller)
               .to receive(:authorize!)
-              .with(:destroy, permission_template_access)
+              .with(:destroy, permission_template_access).at_least(:once).and_return access_destroy
           end
 
-          it "does not delete the permission template access" do
+          it "deletes the permission template access" do
             expect { delete :destroy, params: { id: permission_template_access } }
-              .not_to change { Hyrax::PermissionTemplateAccess.count }
+              .to change { Hyrax::PermissionTemplateAccess.count }
+              .by(-1)
           end
 
-          it "does something" do
+          it "redirects to the admin dashboard's admin set edit path" do
             delete :destroy, params: { id: permission_template_access }
 
             expect(response)
@@ -67,16 +74,16 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
                                                               anchor: 'participants'))
           end
 
-          it "does not flash a notice" do
+          it "flashes a notice" do
             delete :destroy, params: { id: permission_template_access }
 
-            expect(flash[:notice]).not_to be_present
+            expect(flash[:notice]).to eq admin_set_update_notice
           end
 
-          it "flashes an alert for failure" do
-            delete :destroy, params: { id: permission_template_access }
-
-            expect(flash[:alert]).to eq 'The repository administrators group cannot be removed'
+          it "empties the admin set's edit users" do
+            expect { delete :destroy, params: { id: permission_template_access } }
+              .to change { Hyrax.query_service.find_by(id: admin_set.id).permission_manager.edit_users.to_a }
+              .to be_empty
           end
         end
 
@@ -85,9 +92,9 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
           let(:agent_id) { user_liz.user_key }
 
           before do
-            allow(controller)
+            expect(controller)
               .to receive(:authorize!)
-              .with(:destroy, permission_template_access)
+              .with(:destroy, permission_template_access).at_least(:once).and_return access_destroy
           end
 
           it "deletes the permission template access" do
@@ -108,8 +115,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
           it "flashes a notice" do
             delete :destroy, params: { id: permission_template_access }
 
-            expect(flash[:notice])
-              .to eq "The administrative set's participant rights have been updated"
+            expect(flash[:notice]).to eq admin_set_update_notice
           end
 
           it "empties the admin set's edit users" do
@@ -129,47 +135,9 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
           let(:agent_id) { 'admin' }
 
           before do
-            allow(controller)
+            expect(controller)
               .to receive(:authorize!)
-              .with(:destroy, permission_template_access)
-          end
-
-          it "does not delete the permission template access" do
-            expect { delete :destroy, params: { id: permission_template_access } }
-              .not_to change { Hyrax::PermissionTemplateAccess.count }
-          end
-
-          it "redirects to the dashboard collection edit path" do
-            delete :destroy, params: { id: permission_template_access }
-
-            expect(response)
-              .to redirect_to(hyrax.edit_dashboard_collection_path(source_id,
-                                                                   locale: 'en',
-                                                                   anchor: 'sharing'))
-          end
-
-          it "does not flash a notice" do
-            delete :destroy, params: { id: permission_template_access }
-
-            expect(flash[:notice]).not_to be_present
-          end
-
-          it "flashes an alert showing failure status" do
-            delete :destroy, params: { id: permission_template_access }
-
-            expect(flash[:alert])
-              .to eq 'The repository administrators group cannot be removed'
-          end
-        end
-
-        context 'as an agent not in the admin users group' do
-          let(:agent_type) { 'user' }
-          let(:agent_id) { user_liz.user_key }
-
-          before do
-            allow(controller)
-              .to receive(:authorize!)
-              .with(:destroy, permission_template_access)
+              .with(:destroy, permission_template_access).at_least(:once).and_return access_destroy
           end
 
           it "deletes the permission template access" do
@@ -190,8 +158,39 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
           it "flashes a notice" do
             delete :destroy, params: { id: permission_template_access }
 
-            expect(flash[:notice])
-              .to eq "The collection's sharing options have been updated."
+            expect(flash[:notice]).to eq collection_update_notice
+          end
+        end
+
+        context 'as an agent not in the admin users group' do
+          let(:agent_type) { 'user' }
+          let(:agent_id) { user_liz.user_key }
+
+          before do
+            expect(controller)
+              .to receive(:authorize!)
+              .with(:destroy, permission_template_access).at_least(:once).and_return access_destroy
+          end
+
+          it "deletes the permission template access" do
+            expect { delete :destroy, params: { id: permission_template_access } }
+              .to change { Hyrax::PermissionTemplateAccess.count }
+              .by(-1)
+          end
+
+          it "redirects to the dashboard collection edit path" do
+            delete :destroy, params: { id: permission_template_access }
+
+            expect(response)
+              .to redirect_to(hyrax.edit_dashboard_collection_path(source_id,
+                                                                   locale: 'en',
+                                                                   anchor: 'sharing'))
+          end
+
+          it "flashes a notice" do
+            delete :destroy, params: { id: permission_template_access }
+
+            expect(flash[:notice]).to eq collection_update_notice
           end
         end
       end


### PR DESCRIPTION
Works in mediated workflow not listed as managed works for user with managing role

Fixes #2259

Change permission template access controller to use can? :destroy

Update [app/controllers/hyrax/admin/permission_template_accesses_controller.rb]:
* add authorize! :destroy, @permission_template_access to destroy method
* remove valid_delete? test from destroy method
* remove after_destroy_error from destroy method

Guidance for testing:
* (1) Login as admin
* (2) Create or find an admin set
* (3) Edit: Dashboard -> Administrative Sets -> click title of an admin set -> Edit -> Participants tab
* (4) Add group: 'admin' as: 'Depositor' --> Click Add
* (5) Under the Depositors section there should be a row for "Repository Administrators"
* (6) Click the "Remove" button at end of row in step 5.
* (7) Verify a flash message is display: 'The administrative set's participant rights have been updated'
* (8) Verify the "Repository Administrators" row under Depositors has been removed
* (9) Repeat steps 4 through 8 with 'Viewer' role replacing 'Depositor'

@samvera/hyrax-code-reviewers
