### PR TITLE
Allow batch form to load valkyrie objects

### DIFF
--- a/app/forms/hyrax/forms/batch_edit_form.rb
+++ b/app/forms/hyrax/forms/batch_edit_form.rb
@@ -65,7 +65,7 @@ module Hyrax
       def initialize_combined_fields
         # For each of the files in the batch, set the attributes to be the concatenation of all the attributes
         batch_document_ids.each_with_object({}) do |doc_id, combined_attributes|
-          work = ActiveFedora::Base.find(doc_id)
+          work = Hyrax.query_service.find_by(id: doc_id)
           terms.each do |field|
             combined_attributes[field] ||= []
             combined_attributes[field] = (combined_attributes[field] + work[field].to_a).uniq

--- a/spec/views/hyrax/batch_edits/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/batch_edits/edit.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'hyrax/batch_edits/edit.html.erb', type: :view do
   let(:form) { Hyrax::Forms::BatchEditForm.new(generic_work, nil, batch) }
 
   before do
-    allow(ActiveFedora::Base).to receive(:find).and_return(generic_work)
+    allow(Hyrax.query_service).to receive(:find_by).and_return(generic_work)
     # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
     allow(generic_work).to receive(:new_record?).and_return(false)
     # this prevents AF from hitting Fedora (permissions is a related object)


### PR DESCRIPTION
I think we'll still need a form object here even with valkyrie.

refs #5461