### PR TITLE
make change set forms allow multiple values for title

### DIFF
--- a/config/metadata/core_metadata.yaml
+++ b/config/metadata/core_metadata.yaml
@@ -8,7 +8,7 @@ attributes:
     form:
       required: true
       primary: true
-      multiple: false
+      multiple: true
   date_modified:
     type: date_time
   date_uploaded:

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         get :edit, params: { id: work.id }
 
         expect(assigns[:form])
-          .to have_attributes(title: work.title.first, version: an_instance_of(String))
+          .to have_attributes(title: work.title, version: an_instance_of(String))
       end
 
       context 'and the work has member FileSets' do

--- a/spec/services/hyrax/simple_schema_loader_spec.rb
+++ b/spec/services/hyrax/simple_schema_loader_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::SimpleSchemaLoader do
   describe '#form_definitions_for' do
     it 'provides form configuration' do
       expect(schema_loader.form_definitions_for(schema: :core_metadata))
-        .to eq(title: { required: true, primary: true, multiple: false })
+        .to eq(title: { required: true, primary: true, multiple: true })
     end
   end
 end


### PR DESCRIPTION
Per conversation with @jlhardes, work forms should allow for multiple titles to maintain backward compatibility with metadata that already has multiple fields.  Otherwise, this presents problems for migrated data.

Prior to this PR
* work titles could have multiple values
  * this allows multi-valued titles to migrate as multi-valued
* work form only displays a single field for titles
  * this restricts new works to a single title
  * for existing works with multi-valued title, only one title would be selected for display and there isn't a way for the multiple values to be edited

With this PR
* work titles can have multiple values (no change)
* work form also allows for multiple values

@samvera/hyrax-code-reviewers
