### PR TITLE
use transactions for batch delete

### DIFF
--- a/app/controllers/hyrax/batch_edits_controller.rb
+++ b/app/controllers/hyrax/batch_edits_controller.rb
@@ -40,8 +40,8 @@ module Hyrax
     def destroy_collection
       batch.each do |doc_id|
         resource = Hyrax.query_service.find_by(id: Valkyrie::ID.new(doc_id))
-        transactions['work_resource.destroy']
-          .with_step_args('work_resource.delete' => { user: current_user })
+        transactions['collection_resource.destroy']
+          .with_step_args('collection_resource.delete' => { user: current_user })
           .call(resource)
           .value!
       end

--- a/app/controllers/hyrax/batch_edits_controller.rb
+++ b/app/controllers/hyrax/batch_edits_controller.rb
@@ -39,8 +39,11 @@ module Hyrax
 
     def destroy_collection
       batch.each do |doc_id|
-        obj = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: doc_id, use_valkyrie: false)
-        obj.destroy
+        resource = Hyrax.query_service.find_by(id: Valkyrie::ID.new(doc_id))
+        transactions['work_resource.destroy']
+          .with_step_args('work_resource.delete' => { user: current_user })
+          .call(resource)
+          .value!
       end
       flash[:notice] = "Batch delete complete"
       after_destroy_collection
@@ -83,7 +86,13 @@ module Hyrax
     end
 
     def destroy_batch
-      batch.each { |id| Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false).destroy }
+      batch.each do |id|
+        resource = Hyrax.query_service.find_by(id: Valkyrie::ID.new(id))
+        transactions['work_resource.destroy']
+          .with_step_args('work_resource.delete' => { user: current_user })
+          .call(resource)
+          .value!
+      end
       after_update
     end
 


### PR DESCRIPTION
Fixes #5512

Batch delete was using ActiveFedora to find and delete works and collections.  This PR switches to using Hyrax.persister to find works and collections and then calling the destroy transaction.

The transaction correctly deletes the resource from ActiveFedora or postgres, as well as deleting from Solr.

@samvera/hyrax-code-reviewers
