### PR TITLE
Find permission templates via their admin set relation

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -456,7 +456,7 @@ module Hyrax
     def available_admin_sets
       admin_set_results = Hyrax::AdminSetService.new(self).search_results(:deposit)
       # get all the templates at once, reducing query load
-      templates = PermissionTemplate.where(id: admin_set_results.map(&:id)).to_a
+      templates = PermissionTemplate.where(source_id: admin_set_results.map(&:id)).to_a
 
       admin_sets = admin_set_results.map do |admin_set_doc|
         template = templates.find { |temp| temp.source_id == admin_set_doc.id.to_s }

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         get :new
 
         expect(assigns['admin_set_options'].select_options)
-          .to contain_exactly(["Default Admin Set", admin_set_id, { "data-release-no-delay" => true, "data-sharing" => false }])
+          .to contain_exactly(["Default Admin Set", admin_set_id, { "data-sharing" => true }])
       end
     end
   end

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -134,4 +134,18 @@ RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
       expect(page).to have_css('ul li#required-files.incomplete', text: 'Add files')
     end
   end
+
+  context "with valkyrie resources", metadata_adapter: :postgres_adapter do
+    before do
+      sign_in user
+      click_link 'Works'
+      click_link "Add new work"
+      choose "payload_concern", option: "GenericWork"
+      click_button 'Create work'
+    end
+
+    it "allows user to set an embargo" do
+      expect(page).to have_field("generic_work_visibility_embargo", disabled: false)
+    end
+  end
 end


### PR DESCRIPTION
Without this fix the form just always uses the default permission template behavior

closes #5460
