### PR TITLE
Pcdm collection search results

### DIFF
--- a/app/views/catalog/_index_header_list_hyrax_pcdm_collection.html.erb
+++ b/app/views/catalog/_index_header_list_hyrax_pcdm_collection.html.erb
@@ -1,0 +1,4 @@
+<div class="search-results-title-row">
+  <h3 class="search-result-title"><%= link_to document.title_or_label, [hyrax, document] %></h3>
+  <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
+</div>

--- a/config/metadata/basic_metadata.yaml
+++ b/config/metadata/basic_metadata.yaml
@@ -50,6 +50,8 @@ attributes:
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "description_tesim"
   identifier:
     type: string
     multiple: true

--- a/lib/hyrax/collection_name.rb
+++ b/lib/hyrax/collection_name.rb
@@ -14,6 +14,8 @@ module Hyrax
       @plural             = 'collections'
       @route_key          = 'collections'
       @singular_route_key = 'collection'
+      @collection         = 'collections'
+      @element            = 'collection'
     end
   end
 end

--- a/spec/features/search_spec_valkyrie.rb
+++ b/spec/features/search_spec_valkyrie.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+RSpec.describe 'searching', index_adapter: :solr_index do
+  let(:user) { create :user }
+  let(:subject_value) { 'mustache' }
+  let!(:work) do
+    FactoryBot.valkyrie_create(:monograph, :public,
+           title: ["Toothbrush"],
+           keyword: [subject_value, 'taco'])
+  end
+
+  let!(:collection) do
+    FactoryBot.valkyrie_create(:hyrax_collection, :public, title: ['collection title abc'], description: [subject_value], members: [work])
+  end
+
+  before { allow(Hyrax.config).to receive(:collection_model).and_return('Hyrax::PcdmCollection') }
+
+  context "as a public user", :clean_repo do
+    it "using the gallery view" do
+      visit '/'
+      fill_in "search-field-header", with: "Toothbrush"
+      click_button "search-submit-header"
+      expect(page).to have_content "1 entry found"
+      within "#search-results" do
+        expect(page).to have_content "Toothbrush"
+      end
+
+      click_link "Gallery"
+      expect(page).to have_content "Filtering by: Toothbrush"
+      within "#documents" do
+        expect(page).to have_content "Toothbrush"
+      end
+    end
+
+    it "only searches all and does not display search options for dashboard files" do
+      visit '/'
+
+      # it "does not display search options for dashboard files" do
+      # This section was tested on its own, and required a full setup.
+      within(".input-group-btn") do
+        expect(page).not_to have_content("All")
+        expect(page).not_to have_content("My Works")
+        expect(page).not_to have_content("My Collections")
+        expect(page).not_to have_content("My Shares")
+      end
+
+      expect(page).not_to have_css("a[data-search-label*=All]", visible: false)
+      expect(page).not_to have_css("a[data-search-label*='My Works']", visible: false)
+      expect(page).not_to have_css("a[data-search-label*='My Collections']", visible: false)
+      expect(page).not_to have_css("a[data-search-label*='My Highlights']", visible: false)
+      expect(page).not_to have_css("a[data-search-label*='My Shares']", visible: false)
+
+      fill_in "search-field-header", with: subject_value
+      click_button("Go")
+      expect(page).to have_content('Search Results')
+      expect(page).to have_content "Toothbrush"
+      expect(page).to have_content('collection title abc')
+      expect(page).to have_selector("//img")
+
+      expect(page.body).to include "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=taco&amp;locale=en\">taco</a></span>"
+      expect(page.body).to include "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=mustache&amp;locale=en\">mustache</a></span>"
+    end
+  end
+end

--- a/spec/models/concerns/hyrax/solr_document_behavior_spec.rb
+++ b/spec/models/concerns/hyrax/solr_document_behavior_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe Hyrax::SolrDocumentBehavior do
         expect(solr_document.to_model.to_partial_path).to eq 'hyrax/monographs/monograph'
       end
     end
+
+    context 'with Hyrax::PcdmCollection' do
+      let(:solr_hash) { { 'has_model_ssim' => 'Hyrax::PcdmCollection' } }
+
+      it 'resolves to collection path' do
+        expect(solr_document.to_model.to_partial_path).to eq 'hyrax/collections/collection'
+      end
+    end
   end
 
   describe '#hydra_model' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -303,6 +303,14 @@ RSpec.configure do |config|
     Valkyrie::IndexingAdapter.find(adapter_name).wipe!
   end
 
+  # Configure blacklight to use the valkyrie solr index
+  config.around(:example, index_adapter: :solr_index) do |example|
+    blacklight_connection_url = CatalogController.blacklight_config.connection_config[:url]
+    CatalogController.blacklight_config.connection_config[:url] = Valkyrie::IndexingAdapter.find(:solr_index).connection.options[:url]
+    example.run
+    CatalogController.blacklight_config.connection_config[:url] = blacklight_connection_url
+  end
+
   config.before(:example, :valkyrie_adapter) do |example|
     adapter_name = example.metadata[:valkyrie_adapter]
 


### PR DESCRIPTION
Fixes #5463

Journey to getting Hyrax::PcdmCollection resources to show in search results:
- Added additional values to `Hyrax::CollectionName` to force Rails to resolve view partials to `hyrax/collections/collection`.  Without this change Rails was looking in `hyrax/hyrax/pcdm_collections/pcdm_collection` when attempting to render a SolrDocument with `has_model_ssim: Hyrax::PcdmCollection` (See https://github.com/samvera/hyrax/blob/main/lib/hyrax/active_fedora_dummy_model.rb#L53)
- Copied `catalog/_index_headers_list_collection.html.erb` to `catalog/_index_headers_list_hyrax_pcdm_collection.html.erb` so Blacklight could find it.  This seemed simpler than overriding Blacklight's helper which looks for partials to render (See https://github.com/projectblacklight/blacklight/blob/v6.24.0/app/helpers/blacklight/render_partials_helper.rb#L128-L146)
- Cloned a simple feature test that shows work and collection search results to reconfigure it to work with valkyrie resources and the valkyrie solr index.  
- To get the tests to pass I added an around hook which changes the blacklight config for the CatalogController to point to the valkyrie solr core instead of the normal `hyrax-test` core. 
- I also had to modify the `basic_metadata.yaml` to have the description field be indexed like it is in ActiveFedora work and collection models.

@samvera/hyrax-code-reviewers
