### PR TITLE
Enable editing Valkyrie resources with children

### DIFF
--- a/app/helpers/hyrax/membership_helper.rb
+++ b/app/helpers/hyrax/membership_helper.rb
@@ -41,7 +41,7 @@ module Hyrax
       Hyrax.custom_queries.find_child_works(resource: resource).map do |member|
         { id: member.id.to_s,
           label: member.title.first,
-          path: url_for(member) }
+          path: main_app.url_for([member, { only_path: true }]) }
       end.to_json
     end
   end

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -30,6 +30,7 @@ module Hyrax
         solr_doc['original_checksum_tesim'] = object.original_checksum
         solr_doc['alpha_channels_ssi']      = object.alpha_channels
         solr_doc['original_file_id_ssi']    = original_file_id
+        solr_doc['generic_type_si'] = 'FileSet'
       end
     end
 

--- a/app/presenters/hyrax/pcdm_member_presenter_factory.rb
+++ b/app/presenters/hyrax/pcdm_member_presenter_factory.rb
@@ -99,6 +99,8 @@ module Hyrax
       case document['has_model_ssim'].first
       when Hyrax::FileSet.name
         Hyrax::FileSetPresenter.new(document, ability)
+      when ::FileSet.name
+        Hyrax::FileSetPresenter.new(document, ability)
       else
         Hyrax::WorkShowPresenter.new(document, ability)
       end
@@ -111,7 +113,7 @@ module Hyrax
       query += "{!term f=generic_type_si}#{generic_type}" if generic_type
 
       Hyrax::SolrService
-        .post(query, rows: 10_000)
+        .post(q: query, rows: 10_000)
         .fetch('response')
         .fetch('docs')
     end

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -78,4 +78,17 @@ RSpec.describe 'Editing a work', type: :feature do
       expect(page).to have_selector('#new_group_name_skel', text: 'librarians admin donor')
     end
   end
+
+  context 'with a parent Valkyrie resource' do
+    let(:monograph) { FactoryBot.valkyrie_create(:monograph, :with_member_works) }
+
+    before do
+      sign_in user_admin
+    end
+
+    it 'displays an edit page with a relationships tab' do
+      visit edit_hyrax_monograph_path(monograph)
+      expect(page).to have_link("Relationships")
+    end
+  end
 end

--- a/spec/presenters/hyrax/pcdm_member_presenter_factory_spec.rb
+++ b/spec/presenters/hyrax/pcdm_member_presenter_factory_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hyrax::PcdmMemberPresenterFactory, index_adapter: :solr_index, valkyrie_adapter: :test_adapter do
+RSpec.describe Hyrax::PcdmMemberPresenterFactory do
   subject(:factory) { described_class.new(solr_doc, ability) }
   let(:ability)     { :FAKE_ABILITY }
   let(:ids)         { [] }
@@ -9,8 +9,7 @@ RSpec.describe Hyrax::PcdmMemberPresenterFactory, index_adapter: :solr_index, va
   RSpec::Matchers.define :be_presenter_for do |expected|
     match do |actual|
       actual.id == expected.id &&
-        (actual.solr_document['has_model_ssim'].first ==
-         expected.class.name)
+        actual.model_name.name == expected.model_name.name
     end
   end
 
@@ -33,92 +32,186 @@ RSpec.describe Hyrax::PcdmMemberPresenterFactory, index_adapter: :solr_index, va
     end
   end
 
-  describe '#file_set_presenters' do
-    it 'is empty' do
-      expect(factory.file_set_presenters.to_a).to be_empty
-    end
-
-    context 'with members' do
-      include_context 'with members'
-
-      it 'builds only file_set presenters' do
-        expect(factory.file_set_presenters)
-          .to contain_exactly(*file_sets.map { |fs| be_presenter_for(fs) })
+  context 'with ActiveFedora index adapter' do
+    describe '#file_set_presenters' do
+      it 'is empty' do
+        expect(factory.file_set_presenters.to_a).to be_empty
       end
 
-      it 'gives members in order' do
-        expect(factory.file_set_presenters.map(&:id)).to eq file_sets.map(&:id)
+      context 'with members' do
+        include_context 'with members'
+
+        it 'builds only file_set presenters' do
+          expect(factory.file_set_presenters)
+            .to contain_exactly(*file_sets.map { |fs| be_presenter_for(fs) })
+        end
+
+        it 'gives members in order' do
+          expect(factory.file_set_presenters.map(&:id)).to eq file_sets.map(&:id)
+        end
       end
     end
-  end
 
-  describe '#member_presenters' do
-    it 'is empty' do
-      expect(factory.member_presenters.to_a).to be_empty
-    end
-
-    it 'accepts bespoke member ids' do
-      fs = FactoryBot.valkyrie_create(:hyrax_file_set)
-      Hyrax.index_adapter.save(resource: fs)
-
-      expect(factory.member_presenters([fs.id]).to_a)
-        .to contain_exactly(be_presenter_for(fs))
-    end
-
-    it 'raises an error if given an unindexed id' do
-      expect { factory.member_presenters(['FAKE_ID']).to_a }
-        .to raise_error ArgumentError
-    end
-
-    context 'with members' do
-      include_context 'with members'
-
-      it 'builds all member presenters' do
-        members = file_sets + works
-
-        expect(factory.member_presenters)
-          .to contain_exactly(*members.map { |fs| be_presenter_for(fs) })
+    describe '#member_presenters' do
+      it 'is empty' do
+        expect(factory.member_presenters.to_a).to be_empty
       end
 
-      it 'builds member presenters with appropriate classes' do
-        expect(factory.member_presenters)
-          .to contain_exactly(an_instance_of(Hyrax::WorkShowPresenter),
-                              an_instance_of(Hyrax::WorkShowPresenter),
-                              an_instance_of(Hyrax::FileSetPresenter),
-                              an_instance_of(Hyrax::FileSetPresenter))
+      it 'accepts bespoke member ids' do
+        fs = FactoryBot.valkyrie_create(:hyrax_file_set)
+        Hyrax.index_adapter.save(resource: fs)
+
+        expect(factory.member_presenters([fs.id]).to_a)
+          .to contain_exactly(be_presenter_for(fs))
       end
 
-      it 'gives members in order' do
-        expect(factory.member_presenters.map(&:id)).to eq ids
+      it 'raises an error if given an unindexed id' do
+        expect { factory.member_presenters(['FAKE_ID']).to_a }
+          .to raise_error ArgumentError
+      end
+
+      context 'with members' do
+        include_context 'with members'
+
+        it 'builds all member presenters' do
+          members = file_sets + works
+
+          expect(factory.member_presenters)
+            .to contain_exactly(*members.map { |fs| be_presenter_for(fs) })
+        end
+
+        it 'builds member presenters with appropriate classes' do
+          expect(factory.member_presenters)
+            .to contain_exactly(an_instance_of(Hyrax::WorkShowPresenter),
+                                an_instance_of(Hyrax::WorkShowPresenter),
+                                an_instance_of(Hyrax::FileSetPresenter),
+                                an_instance_of(Hyrax::FileSetPresenter))
+        end
+
+        it 'gives members in order' do
+          expect(factory.member_presenters.map(&:id)).to eq ids
+        end
       end
     end
-  end
 
-  describe '#ordered_ids' do
-    its(:ordered_ids) { is_expected.to eq ids }
-
-    context 'with members' do
-      include_context 'with members'
-
+    describe '#ordered_ids' do
       its(:ordered_ids) { is_expected.to eq ids }
+
+      context 'with members' do
+        include_context 'with members'
+
+        its(:ordered_ids) { is_expected.to eq ids }
+      end
+    end
+
+    describe '#work_presenters' do
+      it 'is empty' do
+        expect(factory.work_presenters.to_a).to be_empty
+      end
+
+      context 'with members' do
+        include_context 'with members'
+
+        it 'builds only work presenters' do
+          expect(factory.work_presenters)
+            .to contain_exactly(*works.map { |fs| be_presenter_for(fs) })
+        end
+
+        it 'gives members in order' do
+          expect(factory.work_presenters.map(&:id)).to eq works.map(&:id)
+        end
+      end
     end
   end
 
-  describe '#work_presenters' do
-    it 'is empty' do
-      expect(factory.work_presenters.to_a).to be_empty
-    end
-
-    context 'with members' do
-      include_context 'with members'
-
-      it 'builds only work presenters' do
-        expect(factory.work_presenters)
-          .to contain_exactly(*works.map { |fs| be_presenter_for(fs) })
+  context 'with Valkyrie index adapter', index_adapter: :solr_index, valkyrie_adapter: :test_adapter do
+    describe '#file_set_presenters' do
+      it 'is empty' do
+        expect(factory.file_set_presenters.to_a).to be_empty
       end
 
-      it 'gives members in order' do
-        expect(factory.work_presenters.map(&:id)).to eq works.map(&:id)
+      context 'with members' do
+        include_context 'with members'
+
+        it 'builds only file_set presenters' do
+          expect(factory.file_set_presenters)
+            .to contain_exactly(*file_sets.map { |fs| be_presenter_for(fs) })
+        end
+
+        it 'gives members in order' do
+          expect(factory.file_set_presenters.map(&:id)).to eq file_sets.map(&:id)
+        end
+      end
+    end
+
+    describe '#member_presenters' do
+      it 'is empty' do
+        expect(factory.member_presenters.to_a).to be_empty
+      end
+
+      it 'accepts bespoke member ids' do
+        fs = FactoryBot.valkyrie_create(:hyrax_file_set)
+        Hyrax.index_adapter.save(resource: fs)
+
+        expect(factory.member_presenters([fs.id]).to_a)
+          .to contain_exactly(be_presenter_for(fs))
+      end
+
+      it 'raises an error if given an unindexed id' do
+        expect { factory.member_presenters(['FAKE_ID']).to_a }
+          .to raise_error ArgumentError
+      end
+
+      context 'with members' do
+        include_context 'with members'
+
+        it 'builds all member presenters' do
+          members = file_sets + works
+
+          expect(factory.member_presenters)
+            .to contain_exactly(*members.map { |fs| be_presenter_for(fs) })
+        end
+
+        it 'builds member presenters with appropriate classes' do
+          expect(factory.member_presenters)
+            .to contain_exactly(an_instance_of(Hyrax::WorkShowPresenter),
+                                an_instance_of(Hyrax::WorkShowPresenter),
+                                an_instance_of(Hyrax::FileSetPresenter),
+                                an_instance_of(Hyrax::FileSetPresenter))
+        end
+
+        it 'gives members in order' do
+          expect(factory.member_presenters.map(&:id)).to eq ids
+        end
+      end
+    end
+
+    describe '#ordered_ids' do
+      its(:ordered_ids) { is_expected.to eq ids }
+
+      context 'with members' do
+        include_context 'with members'
+
+        its(:ordered_ids) { is_expected.to eq ids }
+      end
+    end
+
+    describe '#work_presenters' do
+      it 'is empty' do
+        expect(factory.work_presenters.to_a).to be_empty
+      end
+
+      context 'with members' do
+        include_context 'with members'
+
+        it 'builds only work presenters' do
+          expect(factory.work_presenters)
+            .to contain_exactly(*works.map { |fs| be_presenter_for(fs) })
+        end
+
+        it 'gives members in order' do
+          expect(factory.work_presenters.map(&:id)).to eq works.map(&:id)
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #5462
Closes #5447

Adds work-around for two issues:

1. **Named routes for url_for are not available for Valkyrie resources.**

- Solution is to use the `main_app` helper.

2. **PcdmMemberPresenterFactory does not work with ActiveFedora adapter**

- Solr queries against the Valkyrie and ActiveFedora cores are subtly different, and we have to bypass the [qt: standard ](https://github.com/samvera/hyrax/blob/29887d7d98e8ec28f672d328f0d5c436446e4e3f/app/services/hyrax/solr_service.rb#L71)param.
- Another complication is that FileSets are indexed with `has_model_ssim: FileSet` in ActiveFedora and with `has_model_ssim: Hyrax::FileSet` with the Valkyrie solr adapter.