### PR TITLE
add deprecation notices for transactions that are no longer supported

### DIFF
--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -10,9 +10,9 @@ module Hyrax
     #
     # In advanced use, the container could provide runtime dependency injection
     # for particular step code. For the basic case, users can consider it as
-    # providing namespaceing and resolution for steps (as used in
-    # `Hyrax::Transaction::CreateWork`; e.g.
-    # `step :save_work, with: 'work.save_work'`).
+    # providing namespacing and resolution for steps (as used in
+    # `Hyrax::Transaction::WorkCreate`; e.g.
+    # `step :save, with: 'work_resource.save'`).
     #
     # @since 2.4.0
     #
@@ -25,29 +25,21 @@ module Hyrax
       require 'hyrax/transactions/collection_create'
       require 'hyrax/transactions/collection_destroy'
       require 'hyrax/transactions/collection_update'
-      require 'hyrax/transactions/create_work'
-      require 'hyrax/transactions/destroy_work'
       require 'hyrax/transactions/file_set_destroy'
       require 'hyrax/transactions/work_create'
       require 'hyrax/transactions/work_destroy'
-      require 'hyrax/transactions/update_work'
+      require 'hyrax/transactions/work_update'
       require 'hyrax/transactions/steps/add_file_sets'
       require 'hyrax/transactions/steps/add_to_collections'
       require 'hyrax/transactions/steps/add_to_parent'
-      require 'hyrax/transactions/steps/apply_collection_permission_template'
       require 'hyrax/transactions/steps/apply_collection_type_permissions'
-      require 'hyrax/transactions/steps/apply_permission_template'
-      require 'hyrax/transactions/steps/apply_visibility'
       require 'hyrax/transactions/steps/check_for_empty_admin_set'
       require 'hyrax/transactions/steps/delete_access_control'
       require 'hyrax/transactions/steps/delete_resource'
-      require 'hyrax/transactions/steps/destroy_work'
       require 'hyrax/transactions/steps/ensure_admin_set'
       require 'hyrax/transactions/steps/set_collection_type_gid'
-      require 'hyrax/transactions/steps/ensure_permission_template'
       require 'hyrax/transactions/steps/remove_file_set_from_work'
       require 'hyrax/transactions/steps/save'
-      require 'hyrax/transactions/steps/save_work'
       require 'hyrax/transactions/steps/save_access_control'
       require 'hyrax/transactions/steps/set_default_admin_set'
       require 'hyrax/transactions/steps/set_modified_date'
@@ -56,11 +48,22 @@ module Hyrax
       require 'hyrax/transactions/steps/set_user_as_depositor'
       require 'hyrax/transactions/steps/validate'
 
+      # The following transactions and steps are deprecated.
+      require 'hyrax/transactions/create_work'
+      require 'hyrax/transactions/destroy_work'
+      require 'hyrax/transactions/update_work'
+      require 'hyrax/transactions/steps/apply_collection_permission_template'
+      require 'hyrax/transactions/steps/apply_permission_template'
+      require 'hyrax/transactions/steps/apply_visibility'
+      require 'hyrax/transactions/steps/destroy_work'
+      require 'hyrax/transactions/steps/ensure_permission_template'
+      require 'hyrax/transactions/steps/save_work'
+
       extend Dry::Container::Mixin
 
       # Disable BlockLength rule for DSL code
       # rubocop:disable Metrics/BlockLength
-      namespace 'change_set' do |ops|
+      namespace 'change_set' do |ops| # Hyrax::ChangeSet
         ops.register 'add_to_collections' do
           Steps::AddToCollections.new
         end
@@ -75,10 +78,6 @@ module Hyrax
 
         ops.register 'create_collection' do
           CollectionCreate.new
-        end
-
-        ops.register 'update_collection' do
-          CollectionUpdate.new
         end
 
         ops.register 'create_work' do
@@ -117,8 +116,12 @@ module Hyrax
           Steps::SetUserAsDepositor.new
         end
 
+        ops.register 'update_collection' do
+          CollectionUpdate.new
+        end
+
         ops.register 'update_work' do
-          UpdateWork.new
+          WorkUpdate.new
         end
 
         ops.register 'validate' do
@@ -126,7 +129,7 @@ module Hyrax
         end
       end
 
-      namespace 'file_set' do |ops| # Hyrax::FileSet
+      namespace 'file_set' do |ops| # Hyrax::FileSet resource
         ops.register 'delete' do
           Steps::DeleteResource.new
         end
@@ -140,7 +143,7 @@ module Hyrax
         end
       end
 
-      namespace 'admin_set_resource' do |ops| # valkyrie administrative set
+      namespace 'admin_set_resource' do |ops| # Hyrax::AdministrativeSet resource
         ops.register 'check_empty' do
           Steps::CheckForEmptyAdminSet.new
         end
@@ -170,7 +173,7 @@ module Hyrax
         end
       end
 
-      namespace 'collection_resource' do |ops| # valkyrie collection
+      namespace 'collection_resource' do |ops| # Hyrax::PcdmCollection resource
         ops.register 'apply_collection_type_permissions' do
           Steps::ApplyCollectionTypePermissions.new
         end
@@ -192,7 +195,7 @@ module Hyrax
         end
       end
 
-      namespace 'work_resource' do |ops| # valkyrie works
+      namespace 'work_resource' do |ops| # Hyrax::Work resource
         ops.register 'add_file_sets' do
           Steps::AddFileSets.new
         end
@@ -218,7 +221,8 @@ module Hyrax
         end
       end
 
-      namespace 'work' do |ops| # legacy AF works
+      # legacy AF works processing by transactions is deprecated
+      namespace 'work' do |ops|
         ops.register 'apply_collection_permission_template' do
           Steps::ApplyCollectionPermissionTemplate.new
         end

--- a/lib/hyrax/transactions/create_work.rb
+++ b/lib/hyrax/transactions/create_work.rb
@@ -46,8 +46,11 @@ module Hyrax
     # @deprecated Development on Dry::Transaction has been discontinued, we're
     #   removing existing transactions and replacing them with Dry::Monad-based
     #   valkyrie versions.
+    # @see Hyrax::Transactions::WorkCreate
     class CreateWork
       include Dry::Transaction(container: Hyrax::Transactions::Container)
+
+      # DO NOT USE - This class is deprecated.  See Hyrax::Transactions::WorkCreate for resource works.
 
       step :set_default_admin_set,     with: 'work.set_default_admin_set'
       step :ensure_admin_set,          with: 'work.ensure_admin_set'

--- a/lib/hyrax/transactions/destroy_work.rb
+++ b/lib/hyrax/transactions/destroy_work.rb
@@ -16,8 +16,11 @@ module Hyrax
     # @deprecated Development on Dry::Transaction has been discontinued, we're
     #   removing existing transactions and replacing them with Dry::Monad-based
     #   valkyrie versions.
+    # @see Hyrax::Transactions::WorkDestroy
     class DestroyWork
       include Dry::Transaction(container: Hyrax::Transactions::Container)
+
+      # DO NOT USE - This class is deprecated.  See Hyrax::Transactions::WorkDestroy for resource works.
 
       step :destroy_work, with: 'work.destroy_work'
     end

--- a/lib/hyrax/transactions/steps/apply_collection_permission_template.rb
+++ b/lib/hyrax/transactions/steps/apply_collection_permission_template.rb
@@ -7,6 +7,8 @@ module Hyrax
       # collections on a given work.
       #
       # @since 3.0.0
+      # @deprecated This is part of the legacy AF set of transaction steps for works.
+      #   Transactions are not being used with AF works.  This will be removed in 4.0.
       class ApplyCollectionPermissionTemplate
         include Dry::Transaction::Operation
 

--- a/lib/hyrax/transactions/steps/apply_permission_template.rb
+++ b/lib/hyrax/transactions/steps/apply_permission_template.rb
@@ -7,6 +7,8 @@ module Hyrax
       # work's AdminSet.
       #
       # @since 2.4.0
+      # @deprecated This is part of the legacy AF set of transaction steps for works.
+      #   Transactions are not being used with AF works.  This will be removed in 4.0.
       class ApplyPermissionTemplate
         include Dry::Transaction::Operation
 

--- a/lib/hyrax/transactions/steps/apply_visibility.rb
+++ b/lib/hyrax/transactions/steps/apply_visibility.rb
@@ -7,6 +7,8 @@ module Hyrax
       # passed arguments.
       #
       # @since 3.0.0
+      # @deprecated This is part of the legacy AF set of transaction steps for works.
+      #   Transactions are not being used with AF works.  This will be removed in 4.0.
       class ApplyVisibility
         include Dry::Transaction::Operation
 

--- a/lib/hyrax/transactions/steps/destroy_work.rb
+++ b/lib/hyrax/transactions/steps/destroy_work.rb
@@ -6,7 +6,9 @@ module Hyrax
       # A `dry-transcation` step that destroys a Work.
       #
       # @since 3.0.0
-      # @deprecated
+      # @deprecated This is part of the legacy AF set of transaction steps for works.
+      #   Transactions are not being used with AF works.  This will be removed in 4.0.
+      # @see Hyrax::Transactions::Steps::DeleteResource
       class DestroyWork
         include Dry::Transaction::Operation
 

--- a/lib/hyrax/transactions/steps/ensure_permission_template.rb
+++ b/lib/hyrax/transactions/steps/ensure_permission_template.rb
@@ -7,6 +7,8 @@ module Hyrax
       # template.
       #
       # @since 2.4.0
+      # @deprecated This is part of the legacy AF set of transaction steps for works.
+      #   Transactions are not being used with AF works.  This will be removed in 4.0.
       class EnsurePermissionTemplate
         include Dry::Transaction::Operation
 

--- a/lib/hyrax/transactions/steps/save_work.rb
+++ b/lib/hyrax/transactions/steps/save_work.rb
@@ -18,6 +18,9 @@ module Hyrax
       #   step.call(work).or { |err| puts err.messages }
       #
       # @since 2.4.0
+      # @deprecated This is part of the legacy AF set of transaction steps for works.
+      #   Transactions are not being used with AF works.  This will be removed in 4.0.
+      # @see Hyrax::Transactions::Steps::Save
       class SaveWork
         include Dry::Transaction::Operation
 

--- a/lib/hyrax/transactions/update_work.rb
+++ b/lib/hyrax/transactions/update_work.rb
@@ -3,10 +3,11 @@ module Hyrax
   module Transactions
     ##
     # @since 3.0.0
+    # @deprecated Use Hyrax::Transactions::WorkUpdate instead.
     class UpdateWork < Transaction
-      DEFAULT_STEPS = ['change_set.apply',
-                       'work_resource.save_acl',
-                       'work_resource.add_file_sets'].freeze
+      DEFAULT_STEPS = Hyrax::Transactions::WorkUpdate::DEFAULT_STEPS
+
+      # DO NOT USE - This class is deprecated.  Use Hyrax::Transactions::WorkUpdate instead.
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/work_update.rb
+++ b/lib/hyrax/transactions/work_update.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    ##
+    # @since 3.4.0
+    class WorkUpdate < Transaction
+      DEFAULT_STEPS = ['change_set.apply',
+                       'work_resource.save_acl',
+                       'work_resource.add_file_sets'].freeze
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/work_update_spec.rb
+++ b/spec/hyrax/transactions/work_update_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'hyrax/transactions'
 require 'dry/container/stub'
 
-RSpec.describe Hyrax::Transactions::UpdateWork, valkyrie_adapter: :test_adapter do
+RSpec.describe Hyrax::Transactions::WorkUpdate, valkyrie_adapter: :test_adapter do
   subject(:tx)     { described_class.new }
   let(:change_set) { Hyrax::ChangeSet.for(resource) }
   let(:xmas)       { DateTime.parse('2018-12-25 11:30').iso8601 }


### PR DESCRIPTION
This does a bit of cleanup as well.  There should not be any impact on the function of code.
* rename update_work to work_update - All resources follow the pattern resourcetype_create, resourcetype_destroy, resourcetype_update.  The other work transactions followed this pattern already (e.g. work_create and work_destroy).
* moved requires for deprecated transactions and steps to a separate location to make them easier to remove later
* add more prominent DO NOT USE notice to deprecated legacy AF work transactions - This has been a source of confusion for several developers
* added deprecation notices to steps that are no longer supported


@samvera/hyrax-code-reviewers
