### PR TITLE
Gen collection resource

### DIFF
--- a/.dassie/app/forms/collection_resource_form.rb
+++ b/.dassie/app/forms/collection_resource_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:collection_resource CollectionResource`
+class CollectionResourceForm < Hyrax::Forms::PcdmCollectionForm
+  include Hyrax::FormFields(:basic_metadata)
+  include Hyrax::FormFields(:collection_resource)
+end

--- a/.dassie/app/indexers/collection_resource_indexer.rb
+++ b/.dassie/app/indexers/collection_resource_indexer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:collection_resource CollectionResource`
+class CollectionResourceIndexer < Hyrax::PcdmCollectionIndexer
+  include Hyrax::Indexer(:basic_metadata)
+  include Hyrax::Indexer(:collection_resource)
+end

--- a/.dassie/app/models/collection_resource.rb
+++ b/.dassie/app/models/collection_resource.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:collection_resource CollectionResource`
+class CollectionResource < Hyrax::PcdmCollection
+  # @note Do not directly update `basic_metadata.yaml`.  It is also used by works.
+  #
+  # To change metadata for collections
+  # * extend by adding fields to `/config/metadata/CollectionResource_metadata.yaml`
+  # * remove all or some basic metadata fields
+  #   * comment out or delete the schema include statement for `:basic_metadata`
+  #   * modify the contents of `/config/metadata/CollectionResource_metadata.yaml`
+  #       to define the desired metadata characteristics, optionally copying some
+  #       definitions from Hyrax `/config/metadata/basic_metadata.yaml`
+  #   * update form and indexer classes to also remove the `:basic_metadata` schema includes
+  #
+  # Alternative:
+  # * comment out or delete both schema include statements
+  # * add Valkyrie attributes to this class
+  # * update form and indexer to process the attributes
+  #
+  include Hyrax::Schema(:basic_metadata)
+  include Hyrax::Schema(:collection_resource)
+end

--- a/.dassie/config/initializers/hyrax.rb
+++ b/.dassie/config/initializers/hyrax.rb
@@ -54,7 +54,7 @@ Hyrax.config do |config|
   ##
   # NOTE: To Valkyrie works, use Monograph which is_a Hyrax::Work is_a Valkyrie::Resource
   # To use Valkyrie models, uncomment the following lines.
-  # config.collection_model = 'Hyrax::PcdmCollection'
+  # config.collection_model = 'CollectionResource'
   # config.admin_set_model = 'Hyrax::AdministrativeSet'
 end
 

--- a/.dassie/config/metadata/collection_resource.yaml
+++ b/.dassie/config/metadata/collection_resource.yaml
@@ -1,0 +1,22 @@
+# Simple yaml config-driven schema which is used to define model attributes,
+# index key names, and form properties.
+#
+# Attributes must have a type but all other configuration options are optional.
+#
+# attributes:
+#   attribute_name:
+#     type: string
+#     multiple: false
+#     index_keys:
+#       - "attribute_name_sim"
+#     form:
+#       required: true
+#       primary: true
+#       multiple: false
+#
+# @see config/metadata/basic_metadata.yaml for an example configuration
+#
+# Generated via
+#  `rails generate hyrax:collection_resource CollectionResource`
+
+attributes: {}

--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -6,7 +6,7 @@ module Hyrax
     # @api public
     # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
     class PcdmCollectionForm < Valkyrie::ChangeSet # rubocop:disable Metrics/ClassLength
-      property :title, required: true, primary: true
+      include Hyrax::FormFields(:core_metadata)
 
       property :human_readable_type, writable: false
       property :date_modified, readable: false
@@ -18,7 +18,6 @@ module Hyrax
 
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 
-      validates :title, presence: true
       validates :collection_type_gid, presence: true
 
       class << self

--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -9,7 +9,6 @@ module Hyrax
     include Hyrax::VisibilityIndexer
     include Hyrax::ThumbnailIndexer
     include Hyrax::Indexer(:core_metadata)
-    include Hyrax::Indexer(:basic_metadata)
 
     self.thumbnail_path_service = CollectionThumbnailPathService
 

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -41,7 +41,6 @@ module Hyrax
   #
   class PcdmCollection < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
-    include Hyrax::Schema(:basic_metadata)
 
     attribute :collection_type_gid, Valkyrie::Types::String
     attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)

--- a/lib/generators/hyrax/collection_resource/USAGE
+++ b/lib/generators/hyrax/collection_resource/USAGE
@@ -1,0 +1,17 @@
+Description:
+  This generator creates the necessary files for a Hyrax::PcdmCollection.
+
+Example:
+  rails generate hyrax:collection_resource MyCollection
+
+  This will create:
+    app/models/my_collection.rb
+    app/forms/my_collection_form.rb
+    app/indexers/my_collection_indexer.rb
+    config/metadata/my_collection.yaml
+    spec/models/my_collection_spec.rb
+    spec/forms/my_collection_form_spec.rb
+    spec/indexers/my_collection_indexer_spec.rb
+
+  This will also:
+    set Hyrax.config.collection_model = "MyCollection"

--- a/lib/generators/hyrax/collection_resource/collection_resource_generator.rb
+++ b/lib/generators/hyrax/collection_resource/collection_resource_generator.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+require 'rails/generators'
+require 'rails/generators/model_helpers'
+
+class Hyrax::CollectionResourceGenerator < Rails::Generators::NamedBase
+  # ActiveSupport can interpret models as plural which causes
+  # counter-intuitive route paths. Pull in ModelHelpers from
+  # Rails which warns users about pluralization when generating
+  # new models or scaffolds.
+  include Rails::Generators::ModelHelpers
+
+  source_root File.expand_path('../templates', __FILE__)
+
+  desc 'This generator makes the following changes to your application:
+   1. Creates a collection model and spec.
+   2. Creates a collection form and spec.
+   3. Creates a collection indexer and spec.
+   4. Creates a collection metadata config.
+   5. Sets this to be the collection class.
+'
+
+  def self.exit_on_failure?
+    true
+  end
+
+  def validate_name
+    return unless name.strip.casecmp("collection").zero?
+    raise Thor::MalformattedArgumentError,
+          set_color("Error: A collection resource with the name '#{name}' would cause name-space clashes. "\
+                    "Please use a different name.", :red)
+  end
+
+  def banner
+    if revoking?
+      say_status("info", "DESTROYING VALKYRIE COLLECTION MODEL: #{class_name}", :blue)
+    else
+      say_status("info", "GENERATING VALKYRIE COLLECTION MODEL: #{class_name}", :blue)
+    end
+  end
+
+  def create_metadata_config
+    template('collection_metadata.yaml', File.join('config/metadata/', "#{file_name}.yaml"))
+  end
+
+  def create_model
+    template('collection.rb.erb', File.join('app/models/', "#{file_name}.rb"))
+    return unless rspec_installed?
+    template('collection_spec.rb.erb', File.join('spec/models/', "#{file_name}_spec.rb"))
+  end
+
+  def create_form
+    template('collection_form.rb.erb', File.join('app/forms/', "#{file_name}_form.rb"))
+    return unless rspec_installed?
+    template('collection_form_spec.rb.erb', File.join('spec/forms/', "#{file_name}_form_spec.rb"))
+  end
+
+  def create_indexer
+    template('collection_indexer.rb.erb', File.join('app/indexers/', class_path, "#{file_name}_indexer.rb"))
+    return unless rspec_installed?
+    template('collection_indexer_spec.rb.erb', File.join('spec/indexers/', "#{file_name}_indexer_spec.rb"))
+  end
+
+  # Inserts after the last registered work, or at the top of the config block
+  def set_as_the_collection_class
+    config = 'config/initializers/hyrax.rb'
+    lastmatch = nil
+    in_root do
+      File.open(config).each_line do |line|
+        lastmatch = line if line.match?(/config.collection_model = /)
+      end
+      content = "  # Injected via `rails g hyrax:collection_resource #{class_name}`\n" \
+                "  config.collection_model = '#{class_name}'\n"
+
+      anchor = lastmatch || "Hyrax.config do |config|\n"
+      inject_into_file config, after: anchor do
+        content
+      end
+    end
+  end
+
+  private
+
+  def rspec_installed?
+    defined?(RSpec) && defined?(RSpec::Rails)
+  end
+
+  def revoking?
+    behavior == :revoke
+  end
+end

--- a/lib/generators/hyrax/collection_resource/templates/collection.rb.erb
+++ b/lib/generators/hyrax/collection_resource/templates/collection.rb.erb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:collection_resource <%= class_name %>`
+class <%= class_name %> < Hyrax::PcdmCollection
+  # @note Do not directly update `basic_metadata.yaml`.  It is also used by works.
+  #
+  # To change metadata for collections
+  # * extend by adding fields to `/config/metadata/<%= class_name %>_metadata.yaml`
+  # * remove all or some basic metadata fields
+  #   * comment out or delete the schema include statement for `:basic_metadata`
+  #   * modify the contents of `/config/metadata/<%= class_name %>_metadata.yaml`
+  #       to define the desired metadata characteristics, optionally copying some
+  #       definitions from Hyrax `/config/metadata/basic_metadata.yaml`
+  #   * update form and indexer classes to also remove the `:basic_metadata` schema includes
+  #
+  # Alternative:
+  # * comment out or delete both schema include statements
+  # * add Valkyrie attributes to this class
+  # * update form and indexer to process the attributes
+  #
+  include Hyrax::Schema(:basic_metadata)
+  include Hyrax::Schema(:<%= file_name %>)
+end

--- a/lib/generators/hyrax/collection_resource/templates/collection_form.rb.erb
+++ b/lib/generators/hyrax/collection_resource/templates/collection_form.rb.erb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:collection_resource <%= class_name %>`
+class <%= class_name %>Form < Hyrax::Forms::PcdmCollectionForm
+  include Hyrax::FormFields(:basic_metadata)
+  include Hyrax::FormFields(:<%= file_name %>)
+end

--- a/lib/generators/hyrax/collection_resource/templates/collection_form_spec.rb.erb
+++ b/lib/generators/hyrax/collection_resource/templates/collection_form_spec.rb.erb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:work_resource <%= class_name %>`
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe <%= class_name %>Form do
+  let(:change_set) { described_class.new(resource) }
+  let(:resource)   { <%= class_name %>.new }
+
+  it_behaves_like 'a Valkyrie::ChangeSet'
+end

--- a/lib/generators/hyrax/collection_resource/templates/collection_indexer.rb.erb
+++ b/lib/generators/hyrax/collection_resource/templates/collection_indexer.rb.erb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:collection_resource <%= class_name %>`
+class <%= class_name %>Indexer < Hyrax::PcdmCollectionIndexer
+  include Hyrax::Indexer(:basic_metadata)
+  include Hyrax::Indexer(:<%= file_name %>)
+end

--- a/lib/generators/hyrax/collection_resource/templates/collection_indexer_spec.rb.erb
+++ b/lib/generators/hyrax/collection_resource/templates/collection_indexer_spec.rb.erb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:work_resource <%= class_name %>`
+require 'rails_helper'
+require 'hyrax/specs/shared_specs/indexers'
+
+RSpec.describe <%= class_name %>Indexer do
+  let(:indexer_class) { described_class }
+  let(:resource)      { <%= class_name %>.new }
+
+  it_behaves_like 'a Hyrax::Resource indexer'
+end

--- a/lib/generators/hyrax/collection_resource/templates/collection_metadata.yaml
+++ b/lib/generators/hyrax/collection_resource/templates/collection_metadata.yaml
@@ -1,0 +1,22 @@
+# Simple yaml config-driven schema which is used to define model attributes,
+# index key names, and form properties.
+#
+# Attributes must have a type but all other configuration options are optional.
+#
+# attributes:
+#   attribute_name:
+#     type: string
+#     multiple: false
+#     index_keys:
+#       - "attribute_name_sim"
+#     form:
+#       required: true
+#       primary: true
+#       multiple: false
+#
+# @see config/metadata/basic_metadata.yaml for an example configuration
+#
+# Generated via
+#  `rails generate hyrax:collection_resource <%= class_name %>`
+
+attributes: {}

--- a/lib/generators/hyrax/collection_resource/templates/collection_spec.rb.erb
+++ b/lib/generators/hyrax/collection_resource/templates/collection_spec.rb.erb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:collection_resource <%= class_name %>`
+require 'rails_helper'
+require 'hyrax/specs/shared_specs/hydra_works'
+
+RSpec.describe <%= class_name %> do
+  subject(:collection) { described_class.new }
+
+  it_behaves_like 'a Hyrax::PcdmCollection'
+  it_behaves_like 'a model with basic metadata'
+end

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -135,7 +135,6 @@ RSpec.shared_examples 'a Hyrax::PcdmCollection' do
 
   it_behaves_like 'a Hyrax::Resource'
   it_behaves_like 'a model with core metadata'
-  it_behaves_like 'a model with basic metadata'
   it_behaves_like 'has members'
 
   describe '#collection_type_gid' do

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -5,7 +5,7 @@
 FactoryBot.define do
   factory :hyrax_collection, class: 'Hyrax::PcdmCollection' do
     sequence(:title) { |n| ["The Tove Jansson Collection #{n}"] }
-    collection_type_gid { Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id }
+    collection_type_gid { Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id.to_s }
 
     transient do
       with_permission_template { true }
@@ -70,6 +70,9 @@ FactoryBot.define do
          valkyrie_create(:hyrax_collection).id,
          valkyrie_create(:hyrax_collection).id]
       end
+    end
+
+    factory :collection_resource, class: 'CollectionResource' do
     end
   end
 end

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Hyrax::CollectionPresenter do
   subject(:presenter) { described_class.new(solr_doc, ability) }
   let(:collection) do
-    build(:hyrax_collection,
+    build(:collection_resource,
           id: 'adc12v',
           description: ['a nice collection'],
           based_near: ['Over there'],
@@ -114,7 +114,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     context "empty collection" do
       let(:ability) { double(::Ability, user_groups: ['public'], current_user: user) }
       let(:user) { create(:user) }
-      let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection) }
+      let(:collection) { FactoryBot.valkyrie_create(:collection_resource) }
 
       before { allow(ability).to receive(:admin?).and_return(false) }
 

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -17,6 +17,33 @@ class TestAppGenerator < Rails::Generators::Base
     rake 'valkyrie_engine:install:migrations'
   end
 
+  def create_collection_resource
+    generate 'hyrax:collection_resource CollectionResource'
+
+    gsub_file "config/metadata/collection_resource.yaml", "attributes: {}",
+              <<-YAML
+
+---
+attributes:
+  target_audience:
+    type: string
+    form:
+      primary: true
+      multiple: true
+  department:
+    type: string
+    form:
+      primary: true
+  course:
+    type: string
+    form:
+      primary: false
+YAML
+
+    # create the collection, but don't register is as 'the' collection
+    gsub_file "config/initializers/hyrax.rb", /[^#] config.collection_model/, "  # config.collection_model"
+  end
+
   def create_generic_work
     generate 'hyrax:work GenericWork'
   end
@@ -67,7 +94,7 @@ class TestAppGenerator < Rails::Generators::Base
     end
   end
 
-  def create_work
+  def create_work_resource
     generate 'hyrax:work_resource Monograph monograph_title:string'
 
     append_file 'config/metadata/monograph.yaml' do
@@ -176,5 +203,16 @@ YAML
 
   def create_sample_metadata_configuration
     copy_file 'sample_metadata.yaml', 'config/metadata/sample_metadata.yaml'
+  end
+
+  def add_valkyrie_test_adapter
+    append_file 'spec/spec_helper.rb' do
+      <<-CONFIG
+
+require 'valkyrie'
+Valkyrie::MetadataAdapter
+  .register(Valkyrie::Persistence::Memory::MetadataAdapter.new, :test_adapter)
+CONFIG
+    end
   end
 end


### PR DESCRIPTION
### Description

This PR...
* creates a generator for collection resources
* removes basic_metadata from `Hyrax::PcdmCollection`
* adds a resource collection to the test app

### Collection Resource Generator

Generates:
1. Creates a collection model and spec.
2. Creates a collection form and spec.
3. Creates a collection indexer and spec.
4. Creates a collection metadata config.
5. Sets this to be the collection class.

The generated collection resource classes include `basic_metadata`.

### Move basic metadata

The generated collection resource class includes `basic_metadata`.  For that reason, the inclusion of `basic_metadata` was removed from `Hyrax::PcdmCollection` and its indexer.

_NOTE: This follows the pattern used for works where `Hyrax::Work` includes `core_metadata`, but not `basic_metadata`, as it is included in generated work classes.

### Add CollectionResource in test app

The test generator was updated to create a collection resource class named "CollectionResource".  The config that is generated to set this as 'the' collection class is commented out in `/config/initializers/hyrax.rb` by the test generator.  

For now, this allows the ActiveFedora `::Collection` class to continue to be 'the' collection class.

_NOTE: At this time, Hyrax supports a single class that is 'the' collection class.  It is configured in `config/initializers/hyrax.rb` by setting `config.collection_model =`._

### Potential Future Work

This pattern allows for future work that would update Hyrax to allow multiple collection resource classes each with their own metadata.

### Related Work

This PR replaces the proposed work in PR #5157 that added a separate `collection_basic_metadata` file.


@samvera/hyrax-code-reviewers
