### PR TITLE
remove values that are blank from resources

### DIFF
--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -76,7 +76,11 @@ module Hyrax
       ##
       # @return [Dry::Types::Type]
       def type
-        collection_type = config['multiple'] ? Valkyrie::Types::Array : Identity
+        collection_type = if config['multiple']
+                            Valkyrie::Types::Array.constructor { |v| Array(v).select(&:present?) }
+                          else
+                            Identity
+                          end
         collection_type.of(type_for(config['type']))
       end
 

--- a/spec/models/hyrax/work_spec.rb
+++ b/spec/models/hyrax/work_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Hyrax::Work do
       .to be_empty
   end
 
+  context 'when fields generated from schema' do
+    let(:monograph) { FactoryBot.valkyrie_create(:monograph, title: 'A Monograph', creator: [""]) }
+    it "removes blank strings from params before updating work metadata" do
+      expect(monograph.title).to eq ["A Monograph"]
+      expect(monograph.creator).to eq []
+    end
+  end
+
   describe '#human_readable_type' do
     it 'has a human readable type' do
       expect(work.human_readable_type).to eq 'Work'


### PR DESCRIPTION
In other work under development, collections are including basic metadata.  There was already a test similar to the new work test in this PR that checked for blank values.  That test started failing with the addition of basic metadata.  

The work test in this PR was added as a failing test for the current code, and which is now passing with the change in the way type is generated through the schema loader.  Thanks to @tpendragon for the proper code to remove blank values.

Co-authored-by: @tpendragon 

@samvera/hyrax-code-reviewers
