### PR TITLE
Don't setup event tracking or attempt any tracking if analytics provider is not on page

### DIFF
--- a/app/assets/javascripts/hyrax/analytics_events.js
+++ b/app/assets/javascripts/hyrax/analytics_events.js
@@ -8,7 +8,7 @@ class TrackingTags {
       return _paq;
     }
     else {
-      return _gaq
+      return _gaq;
     }
   }
 
@@ -42,6 +42,9 @@ function trackAnalyticsEvents() {
 
 function setupTracking() {
     var provider = $('meta[name="analytics-provider"]').prop('content')
+    if (provider === undefined) {
+      return;
+    }
     window.trackingTags = new TrackingTags(provider)
     trackPageView()
     trackAnalyticsEvents()
@@ -59,6 +62,9 @@ if (typeof Turbolinks !== 'undefined') {
 
 $(document).on('click', '#file_download', function(e) {
   var provider = $('meta[name="analytics-provider"]').prop('content')
+  if (provider === undefined) {
+    return;
+  }
   window.trackingTags = new TrackingTags(provider)
   window.trackingTags.analytics().push([trackingTags.trackEvent(), 'file-set', 'file-set-download', $(this).data('label')]);
   window.trackingTags.analytics().push([trackingTags.trackEvent(), 'file-set-in-work', 'file-set-in-work-download', $(this).data('work-id')]);


### PR DESCRIPTION
This change fixes a bug when the page does not have an analytics provider setup.  In
this scenario TrackingTags.analytics() assumes Google analytics and then errors because
_gaq is undefined.  This error keeps all subsequent JS from executing.  This causes the
[refreshing of CSRF tokens on turbolinks:load](https://github.com/samvera/hyrax/blob/2fef3dbb15f01c1d1a2d57ec1626e44555ae77b2/app/assets/javascripts/hyrax/turbolinks_events.js#L4) not to run and many forms to raise
InvalidAuthenticityToken.

Fixes #5464 and #5470

@samvera/hyrax-code-reviewers
