### PR TITLE
Add thumbnail and representative ids and paths to valkyrie solr indexers

### DIFF
--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -7,14 +7,16 @@ module Hyrax
     include Hyrax::ResourceIndexer
     include Hyrax::PermissionIndexer
     include Hyrax::VisibilityIndexer
+    include Hyrax::ThumbnailIndexer
     include Hyrax::Indexer(:core_metadata)
     include Hyrax::Indexer(:basic_metadata)
+
+    self.thumbnail_path_service = CollectionThumbnailPathService
 
     def to_solr
       super.tap do |index_document|
         index_document[Hyrax.config.collection_type_index_field.to_sym] = Array(resource.try(:collection_type_gid)&.to_s)
         index_document[:generic_type_sim] = ['Collection']
-        index_document[:thumbnail_path_ss] = Hyrax::CollectionThumbnailPathService.call(resource)
         index_document[:depositor_ssim] = [resource.depositor]
         index_document[:depositor_tesim] = [resource.depositor]
       end

--- a/app/indexers/hyrax/thumbnail_indexer.rb
+++ b/app/indexers/hyrax/thumbnail_indexer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+module Hyrax
+  module ThumbnailIndexer
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :thumbnail_path_service
+      self.thumbnail_path_service = ThumbnailPathService
+      class_attribute :thumbnail_field
+      self.thumbnail_field = :thumbnail_path_ss
+    end
+
+    # Adds thumbnail indexing to the solr document of a valkyrie resource
+    def to_solr
+      super.tap do |solr_doc|
+        index_thumbnails(solr_doc)
+      end
+    end
+
+    # Write the thumbnail paths into the solr_document
+    # @param [Hash] solr_document the solr document to add the field to
+    def index_thumbnails(solr_document)
+      solr_document[thumbnail_field] = thumbnail_path.to_s
+    end
+
+    # Returns the value for the thumbnail path to put into the solr document
+    def thumbnail_path
+      self.class.thumbnail_path_service.call(resource)
+    end
+  end
+end

--- a/app/indexers/hyrax/valkyrie_file_set_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_file_set_indexer.rb
@@ -7,20 +7,20 @@ module Hyrax
     include Hyrax::ResourceIndexer
     include Hyrax::PermissionIndexer
     include Hyrax::VisibilityIndexer
+    include Hyrax::ThumbnailIndexer
     include Hyrax::Indexer(:core_metadata)
     include Hyrax::Indexer(:basic_metadata)
-
-    # include Hyrax::IndexesThumbnails # TODO: Is there a Valkyrie version of a thumbnail indexer?
 
     def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       super.tap do |solr_doc| # rubocop:disable Metrics/BlockLength
         solr_doc['generic_type_si'] = 'FileSet'
 
         # Metadata from the FileSet
-        solr_doc['file_ids_ssim']         = resource.file_ids&.map(&:to_s)
-        solr_doc['original_file_id_ssi']  = resource.original_file_id.to_s
-        solr_doc['thumbnail_id_ssi']      = resource.thumbnail_id.to_s
-        solr_doc['extracted_text_id_ssi'] = resource.extracted_text_id.to_s
+        solr_doc['file_ids_ssim']                = resource.file_ids&.map(&:to_s)
+        solr_doc['original_file_id_ssi']         = resource.original_file_id.to_s
+        solr_doc['extracted_text_id_ssi']        = resource.extracted_text_id.to_s
+        solr_doc[:hasRelatedMediaFragment_ssim] = resource.representative_id.to_s
+        solr_doc[:hasRelatedImage_ssim]         = resource.thumbnail_id.to_s
 
         # Add in metadata from the original file.
         file_metadata = original_file

--- a/app/indexers/hyrax/valkyrie_file_set_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_file_set_indexer.rb
@@ -19,8 +19,8 @@ module Hyrax
         solr_doc['file_ids_ssim']                = resource.file_ids&.map(&:to_s)
         solr_doc['original_file_id_ssi']         = resource.original_file_id.to_s
         solr_doc['extracted_text_id_ssi']        = resource.extracted_text_id.to_s
-        solr_doc[:hasRelatedMediaFragment_ssim] = resource.representative_id.to_s
-        solr_doc[:hasRelatedImage_ssim]         = resource.thumbnail_id.to_s
+        solr_doc['hasRelatedMediaFragment_ssim'] = resource.representative_id.to_s
+        solr_doc['hasRelatedImage_ssim']         = resource.thumbnail_id.to_s
 
         # Add in metadata from the original file.
         file_metadata = original_file

--- a/app/indexers/hyrax/valkyrie_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_indexer.rb
@@ -64,14 +64,14 @@ module Hyrax
 
     ##
     # @api public
-    # @return [Hash<Symbol, Object>]
+    # @return [HashWithIndifferentAccess<Symbol, Object>]
     def to_solr
       {
         "id": resource.id.to_s,
         "date_uploaded_dtsi": resource.created_at,
         "date_modified_dtsi": resource.updated_at,
         "has_model_ssim": resource.internal_resource
-      }
+      }.with_indifferent_access
     end
 
     ##

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -7,6 +7,7 @@ module Hyrax
     include Hyrax::ResourceIndexer
     include Hyrax::PermissionIndexer
     include Hyrax::VisibilityIndexer
+    include Hyrax::ThumbnailIndexer
     include Hyrax::Indexer(:core_metadata)
 
     def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
@@ -21,6 +22,8 @@ module Hyrax
         solr_doc['member_ids_ssim'] = resource.member_ids.map(&:to_s)
         solr_doc['depositor_ssim'] = [resource.depositor]
         solr_doc['depositor_tesim'] = [resource.depositor]
+        solr_doc[:hasRelatedMediaFragment_ssim] = [resource.representative_id.to_s]
+        solr_doc[:hasRelatedImage_ssim] = [resource.thumbnail_id.to_s]
       end
     end
 

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -22,8 +22,8 @@ module Hyrax
         solr_doc['member_ids_ssim'] = resource.member_ids.map(&:to_s)
         solr_doc['depositor_ssim'] = [resource.depositor]
         solr_doc['depositor_tesim'] = [resource.depositor]
-        solr_doc[:hasRelatedMediaFragment_ssim] = [resource.representative_id.to_s]
-        solr_doc[:hasRelatedImage_ssim] = [resource.thumbnail_id.to_s]
+        solr_doc['hasRelatedMediaFragment_ssim'] = [resource.representative_id.to_s]
+        solr_doc['hasRelatedImage_ssim'] = [resource.thumbnail_id.to_s]
       end
     end
 

--- a/app/jobs/valkyrie_ingest_job.rb
+++ b/app/jobs/valkyrie_ingest_job.rb
@@ -10,21 +10,24 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
 
   ##
   # @param [Hyrax::UploadedFile] file
-  def perform(file)
-    ingest(file: file)
+  # @param [RDF::URI] pcdm_use is the use/type to apply to the created FileMetadata
+  # @see Hyrax::FileMetadata::Use
+  def perform(file, pcdm_use: Hyrax::FileMetadata::Use::ORIGINAL_FILE)
+    ingest(file: file, pcdm_use: pcdm_use)
   end
 
   ##
   # @api private
   #
   # @param [Hyrax::UploadedFile] file
-  #
+  # @param [RDF::URI] pcdm_use
+
   # @return [void]
-  def ingest(file:)
+  def ingest(file:, pcdm_use:)
     file_set_uri = Valkyrie::ID.new(file.file_set_uri)
     file_set = Hyrax.query_service.find_by(id: file_set_uri)
 
-    updated_metadata = upload_file(file: file, file_set: file_set)
+    updated_metadata = upload_file(file: file, file_set: file_set, pcdm_use: pcdm_use)
 
     add_file_to_file_set(file_set: file_set,
                          file_metadata: updated_metadata,
@@ -42,6 +45,8 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
   # @return [Hyrax::FileSet] updated file set
   def add_file_to_file_set(file_set:, file_metadata:, user:)
     file_set.file_ids << file_metadata.id
+    set_file_use_ids(file_set, file_metadata)
+
     Hyrax.persister.save(resource: file_set)
     Hyrax.publisher.publish('object.membership.updated', object: file_set, user: user)
   end
@@ -54,7 +59,7 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
   # @param [RDF::URI] pcdm_use  the use/type to apply to the created FileMetadata
   #
   # @return [Hyrax::FileMetadata] the metadata representing the uploaded file
-  def upload_file(file:, file_set:, pcdm_use: Hyrax::FileMetadata::Use::ORIGINAL_FILE) # rubocop:disable Metrics/MethodLength
+  def upload_file(file:, file_set:, pcdm_use:) # rubocop:disable Metrics/MethodLength
     carrier_wave_sanitized_file = file.uploader.file
     # Pull file, since carrierwave files don't respond to a proper IO #read. See
     # https://github.com/carrierwaveuploader/carrierwave/issues/1959
@@ -75,12 +80,14 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
     Hyrax.publisher.publish("object.file.uploaded", metadata: saved_metadata)
     file_io.close
 
-    # Set file set label.
-    reset_title = file_set.title.first == file_set.label
-    # set title to label if that's how it was before this characterization
-    file_set.title = file_metadata.original_filename if reset_title
-    # always set the label to the original_name
-    file_set.label = file_metadata.original_filename
+    if pcdm_use == Hyrax::FileMetadata::Use::ORIGINAL_FILE
+      # Set file set label.
+      reset_title = file_set.title.first == file_set.label
+      # set title to label if that's how it was before this characterization
+      file_set.title = file_metadata.original_filename if reset_title
+      # always set the label to the original_name
+      file_set.label = file_metadata.original_filename
+    end
 
     saved_metadata
   end
@@ -94,5 +101,22 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
     Hyrax.logger.warn e.message
     Hyrax.logger.warn "Creating Hyrax::FileMetadata now"
     Hyrax::FileMetadata.for(file: file)
+  end
+
+  ##
+  # @api private
+  def set_file_use_ids(file_set, file_metadata)
+    file_metadata.type.each do |type|
+      case type
+      when Hyrax::FileMetadata::Use::ORIGINAL_FILE
+        file_set.original_file_id = file_metadata.id
+      when Hyrax::FileMetadata::Use::THUMBNAIL
+        file_set.thumbnail_id = file_metadata.id
+      when Hyrax::FileMetadata::Use::EXTRACTED_TEXT
+        file_set.extracted_text_id = file_metadata.id
+      else
+        Rails.logger.warn "Unknown file use #{file_metadata.type} specified for #{file_metadata.file_identifier}"
+      end
+    end
   end
 end

--- a/app/models/concerns/hyrax/file_set/characterization.rb
+++ b/app/models/concerns/hyrax/file_set/characterization.rb
@@ -29,7 +29,7 @@ module Hyrax
           :page_count, :file_title, :last_modified, :original_checksum,
           :duration, :sample_rate, :alpha_channels
         ]
-        self.characterization_proxy = :original_file
+        self.characterization_proxy = Hyrax.config.characterization_proxy
 
         delegate(*characterization_terms, to: :characterization_proxy)
 

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -39,6 +39,9 @@ module Hyrax
       end
     end
 
+    class_attribute :characterization_proxy
+    self.characterization_proxy = Hyrax.config.characterization_proxy
+
     attribute :file_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID) # id for FileMetadata resources
     attribute :original_file_id, Valkyrie::Types::ID # id for FileMetadata resource
     attribute :thumbnail_id, Valkyrie::Types::ID # id for FileMetadata resource

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -55,5 +55,11 @@ module Hyrax
     def file_set?
       true
     end
+
+    ##
+    # @return [Valkyrie::Types::ID]
+    def representative_id
+      id
+    end
   end
 end

--- a/app/presenters/hyrax/pcdm_member_presenter_factory.rb
+++ b/app/presenters/hyrax/pcdm_member_presenter_factory.rb
@@ -97,7 +97,7 @@ module Hyrax
     # @return
     def presenter_for(document:, ability:)
       case document['has_model_ssim'].first
-      when Hyrax::FileSet.name
+      when Hyrax::FileSet.name, ::FileSet.name # ActiveFedora FileSet within a Valkyrie Resource
         Hyrax::FileSetPresenter.new(document, ability)
       else
         Hyrax::WorkShowPresenter.new(document, ability)

--- a/app/services/hyrax/file_set_type_service.rb
+++ b/app/services/hyrax/file_set_type_service.rb
@@ -17,13 +17,10 @@ module Hyrax
     attr_reader :file_set
 
     ##
-    # @todo make `file_set_characterization_proxy` (or something better?)
-    #   application-level configuration.
-    #
     # @param [Hyrax::FileSet] file_set
     # @param [Symbol] characterization_proxy defaults to the setting provided by
     #   the application's ActiveFedora `FileSet` class.
-    def initialize(file_set:, characterization_proxy: ::FileSet.characterization_proxy, query_service: Hyrax.custom_queries)
+    def initialize(file_set:, characterization_proxy: Hyrax.config.characterization_proxy, query_service: Hyrax.custom_queries)
       @file_set = file_set
       @proxy_use = Hyrax::FileMetadata::Use.uri_for(use: characterization_proxy)
       @queries = query_service

--- a/app/services/hyrax/file_set_type_service.rb
+++ b/app/services/hyrax/file_set_type_service.rb
@@ -45,7 +45,7 @@ module Hyrax
     private
 
     def audio_types
-      return ::FileSet.audio_mime_types if defined?(::FileSet)
+      return ::FileSet.audio_mime_types if defined?(::FileSet) && ::FileSet.respond_to?(:audio_mime_types)
       DEFAULT_AUDIO_TYPES
     end
   end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -496,6 +496,15 @@ module Hyrax
         Hyrax::Characterization::ValkyrieCharacterizationService
     end
 
+    ##
+    # @!attribute [w] characterization_proxy
+    #   Which FileSet file to use for mime type resolution
+    #   @ see Hyrax::FileSetTypeService
+    attr_writer :characterization_proxy
+    def characterization_proxy
+      @characterization_proxy ||= :original_file
+    end
+
     # Attributes for the lock manager which ensures a single process/thread is mutating a ore:Aggregation at once.
     # @!attribute [w] lock_retry_count
     #   How many times to retry to acquire the lock before raising UnableToAcquireLockError

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -258,6 +258,7 @@ RSpec.shared_examples 'a Hyrax::FileSet' do
 
   it_behaves_like 'a Hyrax::Resource'
   it_behaves_like 'a model with core metadata'
+  it_behaves_like 'a model with basic metadata'
 
   it { is_expected.not_to be_collection }
   it { is_expected.not_to be_file }
@@ -287,6 +288,10 @@ RSpec.shared_examples 'a Hyrax::FileSet' do
 
       it 'has file_ids' do
         expect(fileset.file_ids).to eq file_ids
+      end
+
+      it 'has a representative_id' do
+        expect(fileset.representative_id).to eq fileset.id
       end
 
       it 'can query files' do

--- a/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
@@ -141,8 +141,12 @@ RSpec.describe Hyrax::ValkyrieFileSetIndexer do
       # from FileSet metadata
       expect(subject['file_ids_ssim']).to match_array [mock_file.id.to_s, mock_text.id.to_s]
       expect(subject['original_file_id_ssi']).to eq mock_file.id.to_s
-      expect(subject['thumbnail_id_ssi']).to eq ""
       expect(subject['extracted_text_id_ssi']).to eq mock_text.id.to_s
+      expect(subject['hasRelatedMediaFragment_ssim']).to eq fileset_id
+      expect(subject['hasRelatedImage_ssim']).to eq fileset_id
+
+      # from ThumbnailIndexer
+      expect(subject['thumbnail_path_ss']).to eq '/downloads/foo12345?file=thumbnail'
 
       # from FileMetadata
       expect(subject['original_file_alternate_ids_tesim']).to eq mock_file['alternate_ids']

--- a/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hyrax::ValkyrieFileSetIndexer do
       id: fileset_id,
       file_ids: [mock_file.id, mock_text.id],
       original_file_id: mock_file.id,
+      thumbnail_id: mock_thumbnail.id,
       extracted_text_id: mock_text.id,
       contributor: ['Rogers, Jacqueline'],
       creator: ['Cleary, Beverly'],
@@ -109,6 +110,11 @@ RSpec.describe Hyrax::ValkyrieFileSetIndexer do
     mock_file_factory(content: "abcxyz")
   end
 
+  let(:mock_thumbnail) do
+    Hyrax::FileMetadata.new(file_set_id: fileset_id,
+                            type: [Hyrax::FileMetadata::Use::THUMBNAIL])
+  end
+
   let(:indexer) { described_class.new(resource: file_set) }
 
   describe '#to_solr' do
@@ -143,7 +149,7 @@ RSpec.describe Hyrax::ValkyrieFileSetIndexer do
       expect(subject['original_file_id_ssi']).to eq mock_file.id.to_s
       expect(subject['extracted_text_id_ssi']).to eq mock_text.id.to_s
       expect(subject['hasRelatedMediaFragment_ssim']).to eq fileset_id
-      expect(subject['hasRelatedImage_ssim']).to eq fileset_id
+      expect(subject['hasRelatedImage_ssim']).to eq mock_thumbnail.id.to_s
 
       # from ThumbnailIndexer
       expect(subject['thumbnail_path_ss']).to eq '/downloads/foo12345?file=thumbnail'

--- a/spec/indexers/hyrax/valkyrie_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_indexer_spec.rb
@@ -59,6 +59,10 @@ RSpec.describe Hyrax::ValkyrieIndexer do
   describe "#to_solr" do
     let(:resource) { FactoryBot.valkyrie_create(:hyrax_work) }
 
+    it "provides indifferent access" do
+      expect(indexer.to_solr).to be_a HashWithIndifferentAccess
+    end
+
     it "provides id, date_uploaded_dtsi, and date_modified_dtsi" do
       expect(indexer.to_solr).to match a_hash_including(
         id: resource.id.to_s,


### PR DESCRIPTION
Fixes #4788 (shows the default thumbnail until derivative creation is done)

Adds indexing for thumbnails and representative objects to valkyrie solr index. 

Other changes:
* Copies and adapts to valkyrie the old `services/indexes_thumbnails.rb` to `indexers/hyrax/thumbnail_indexer.rb`
* Aligns the existing collection thumbnail_path_ss indexing with that of works and filesets.
* Makes the output of ValkyrieIndexer#to_solr a HashWithIndifferentAccess. The existing output already has a mix of strings and symbols which complicates testing. This should affect all its subclasses.
* ValkyrieIngestJob now has an optional pcdm_use argument to allow thumbnails and other types of files to be ingested.
* Make FileSet.characterization_proxy configurable at the application level
* When determining which type of presenter to use, detect AF FileSets within Resources. This was needed to pass specs, but maybe can be removed later?

