### PR TITLE
add comments that make #available_admin_sets easier to understand

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -454,12 +454,16 @@ module Hyrax
     end
 
     def available_admin_sets
+      # only returns admin sets in which the user can deposit
       admin_set_results = Hyrax::AdminSetService.new(self).search_results(:deposit)
+
       # get all the templates at once, reducing query load
       templates = PermissionTemplate.where(source_id: admin_set_results.map(&:id)).to_a
 
       admin_sets = admin_set_results.map do |admin_set_doc|
         template = templates.find { |temp| temp.source_id == admin_set_doc.id.to_s }
+
+        # determine if sharing tab should be visible
         sharing = can?(:manage, template) || !!template&.active_workflow&.allows_access_grant?
 
         AdminSetSelectionPresenter::OptionsEntry


### PR DESCRIPTION
It is not clear what `WorkControllerBehavior #available_admin_sets` was doing to set the list of admin sets.  The comments make it clearer what each step is doing.

@samvera/hyrax-code-reviewers
