### PR TITLE
call canonicalize instead of canonicalize! for URIs

### DIFF
--- a/lib/hyrax/controlled_vocabularies/resource_label_caching.rb
+++ b/lib/hyrax/controlled_vocabularies/resource_label_caching.rb
@@ -35,7 +35,7 @@ module Hyrax
       private
 
       def cache_key
-        "#{CACHE_KEY_PREFIX}#{to_uri.canonicalize!.pname}"
+        "#{CACHE_KEY_PREFIX}#{to_uri.canonicalize.pname}"
       end
     end
   end


### PR DESCRIPTION
Calling `canonicalize!` updates the URI object.  When the URI is frozen, this results in error `<FrozenError: can’t modify frozen RDF::URI…>`

The `canonicalize`, defined in `RDF::URI`, makes a copy of the URI object first and then calls `canonicalize!`

refs #5254; refs #5493

This issue was introduced in PR #5254.  And it is a blocker for follow-on work in PR #5493.

@samvera/hyrax-code-reviewers
