### PR TITLE
use persisted? instead of new_record?

### DIFF
--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -14,7 +14,7 @@
       <%= render 'form_visibility_error', f: f %>
     </div>
   <% end %>
-  <% if Flipflop.batch_upload? && f.object.new_record? %>
+  <% if Flipflop.batch_upload? && !f.object.persisted? %>
     <% provide :metadata_tab do %>
       <p class="switch-upload-type"><%= t('.batch_upload_hint') %> <%= link_to t('.batch_link'), hyrax.new_batch_upload_path(payload_concern: @form.model.class) %></p>
     <% end %>


### PR DESCRIPTION
Both valkyrie resources and active fedora base objects respond to `#persisted?`, but only active fedora objects respond to `#new_record?`.  Switch to using `#persisted?` to support both approaches.

Fixes #5447

@samvera/hyrax-code-reviewers
