### PR TITLE
Update depositors (proxies, transfers) synchronously

### DIFF
--- a/app/actors/hyrax/actors/transfer_request_actor.rb
+++ b/app/actors/hyrax/actors/transfer_request_actor.rb
@@ -18,7 +18,6 @@ module Hyrax
         work = env.curation_concern
         user = ::User.find_by_user_key(proxy)
         Hyrax::ChangeContentDepositorService.call(work, user, false)
-        ContentDepositorChangeEventJob.perform_later(work)
         true
       end
     end

--- a/app/actors/hyrax/actors/transfer_request_actor.rb
+++ b/app/actors/hyrax/actors/transfer_request_actor.rb
@@ -15,8 +15,10 @@ module Hyrax
       def create_proxy_deposit_request(env)
         proxy = env.curation_concern.on_behalf_of
         return true if proxy.blank?
-        ContentDepositorChangeEventJob.perform_later(env.curation_concern,
-                                                     ::User.find_by_user_key(proxy))
+        work = env.curation_concern
+        user = ::User.find_by_user_key(proxy)
+        Hyrax::ChangeContentDepositorService.call(work, user)
+        ContentDepositorChangeEventJob.perform_later(work, user)
         true
       end
     end

--- a/app/actors/hyrax/actors/transfer_request_actor.rb
+++ b/app/actors/hyrax/actors/transfer_request_actor.rb
@@ -17,8 +17,8 @@ module Hyrax
         return true if proxy.blank?
         work = env.curation_concern
         user = ::User.find_by_user_key(proxy)
-        Hyrax::ChangeContentDepositorService.call(work, user)
-        ContentDepositorChangeEventJob.perform_later(work, user)
+        Hyrax::ChangeContentDepositorService.call(work, user, false)
+        ContentDepositorChangeEventJob.perform_later(work)
         true
       end
     end

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -181,9 +181,12 @@ module Hyrax
 
       result =
         transactions['change_set.create_work']
-        .with_step_args('work_resource.add_to_parent' => { parent_id: params[:parent_id], user: current_user },
-                        'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
-                        'change_set.set_user_as_depositor' => { user: current_user })
+        .with_step_args(
+          'work_resource.add_to_parent' => { parent_id: params[:parent_id], user: current_user },
+          'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
+          'change_set.set_user_as_depositor' => { user: current_user },
+          'work_resource.change_content_depositor' => { user: form.on_behalf_of }
+        )
         .call(form)
       @curation_concern = result.value_or { return after_create_error(transaction_err_msg(result)) }
       after_create_response

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -185,7 +185,7 @@ module Hyrax
           'work_resource.add_to_parent' => { parent_id: params[:parent_id], user: current_user },
           'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
           'change_set.set_user_as_depositor' => { user: current_user },
-          'work_resource.change_content_depositor' => { user: form.on_behalf_of }
+          'work_resource.change_content_depositor' => { user: ::User.find_by_user_key(form.on_behalf_of) }
         )
         .call(form)
       @curation_concern = result.value_or { return after_create_error(transaction_err_msg(result)) }

--- a/app/jobs/content_depositor_change_event_job.rb
+++ b/app/jobs/content_depositor_change_event_job.rb
@@ -31,7 +31,7 @@ class ContentDepositorChangeEventJob < ContentEventJob
   alias log_file_set_event log_work_event
 
   def work
-    @work ||= Hyrax::ChangeContentDepositorService.call(repo_object, depositor, reset)
+    @work ||= repo_object
   end
 
   # overriding default to log the event to the depositor instead of their profile

--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -130,7 +130,7 @@ class ProxyDepositRequest < ActiveRecord::Base
   # @param [TrueClass,FalseClass] reset (false)  if true, reset the access controls. This revokes edit access from the depositor
   def transfer!(reset = false)
     Hyrax::ChangeContentDepositorService.call(work, receiving_user, reset)
-    ContentDepositorChangeEventJob.perform_later(work, receiving_user, reset)
+    ContentDepositorChangeEventJob.perform_later(work)
     fulfill!(status: ACCEPTED)
   end
 

--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -129,6 +129,7 @@ class ProxyDepositRequest < ActiveRecord::Base
 
   # @param [TrueClass,FalseClass] reset (false)  if true, reset the access controls. This revokes edit access from the depositor
   def transfer!(reset = false)
+    Hyrax::ChangeContentDepositorService.call(work, receiving_user, reset)
     ContentDepositorChangeEventJob.perform_later(work, receiving_user, reset)
     fulfill!(status: ACCEPTED)
   end

--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -130,7 +130,6 @@ class ProxyDepositRequest < ActiveRecord::Base
   # @param [TrueClass,FalseClass] reset (false)  if true, reset the access controls. This revokes edit access from the depositor
   def transfer!(reset = false)
     Hyrax::ChangeContentDepositorService.call(work, receiving_user, reset)
-    ContentDepositorChangeEventJob.perform_later(work)
     fulfill!(status: ACCEPTED)
   end
 

--- a/app/services/hyrax/change_content_depositor_service.rb
+++ b/app/services/hyrax/change_content_depositor_service.rb
@@ -18,6 +18,7 @@ module Hyrax
       # Use case: transfer a work that was deposited on_behalf_of
       # return work if work.try(:on_behalf_of).blank? || (work.on_behalf_of == work.depositor)
       return work if work.on_behalf_of == work.depositor
+      return work unless user&.user_key
       case work
       when ActiveFedora::Base
         call_af(work, user, reset)

--- a/app/services/hyrax/change_content_depositor_service.rb
+++ b/app/services/hyrax/change_content_depositor_service.rb
@@ -4,6 +4,10 @@ module Hyrax
     # Set the given `user` as the depositor of the given `work`; If
     # `reset` is true, first remove all previous permissions.
     #
+    # Used to transfer a an existing work, and to set
+    # depositor / proxy_depositor on a work newly deposited
+    # on_behalf_of another user
+    #
     # @param work [ActiveFedora::Base, Valkyrie::Resource] the work
     #             that is receiving a change of depositor
     # @param user [User] the user that will "become" the depositor of
@@ -14,11 +18,11 @@ module Hyrax
     #              the depositor of the given work
     # @return work, updated if necessary
     def self.call(work, user, reset)
-      # Use case: transfer a work that wasn't deposited on_behalf_of
-      # Use case: transfer a work that was deposited on_behalf_of
-      # return work if work.try(:on_behalf_of).blank? || (work.on_behalf_of == work.depositor)
-      return work if work.on_behalf_of == work.depositor
+      # user_key is nil when there was no `on_behalf_of` in the form
       return work unless user&.user_key
+      # Don't transfer to self
+      return work if user.user_key == work.depositor
+
       case work
       when ActiveFedora::Base
         call_af(work, user, reset)

--- a/app/services/hyrax/change_content_depositor_service.rb
+++ b/app/services/hyrax/change_content_depositor_service.rb
@@ -12,7 +12,9 @@ module Hyrax
     #              permissions for the given work and contained file
     #              sets; regardless of true/false make the given user
     #              the depositor of the given work
+    # @return work, updated if necessary
     def self.call(work, user, reset)
+      return work if work.try(:on_behalf_of).blank? || (work.on_behalf_of == work.depositor)
       case work
       when ActiveFedora::Base
         call_af(work, user, reset)

--- a/app/services/hyrax/change_content_depositor_service.rb
+++ b/app/services/hyrax/change_content_depositor_service.rb
@@ -14,7 +14,10 @@ module Hyrax
     #              the depositor of the given work
     # @return work, updated if necessary
     def self.call(work, user, reset)
-      return work if work.try(:on_behalf_of).blank? || (work.on_behalf_of == work.depositor)
+      # Use case: transfer a work that wasn't deposited on_behalf_of
+      # Use case: transfer a work that was deposited on_behalf_of
+      # return work if work.try(:on_behalf_of).blank? || (work.on_behalf_of == work.depositor)
+      return work if work.on_behalf_of == work.depositor
       case work
       when ActiveFedora::Base
         call_af(work, user, reset)

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -33,6 +33,7 @@ module Hyrax
       require 'hyrax/transactions/steps/add_to_collections'
       require 'hyrax/transactions/steps/add_to_parent'
       require 'hyrax/transactions/steps/apply_collection_type_permissions'
+      require 'hyrax/transactions/steps/change_content_depositor'
       require 'hyrax/transactions/steps/check_for_empty_admin_set'
       require 'hyrax/transactions/steps/delete_access_control'
       require 'hyrax/transactions/steps/delete_resource'
@@ -202,6 +203,10 @@ module Hyrax
 
         ops.register 'add_to_parent' do
           Steps::AddToParent.new
+        end
+
+        ops.register 'change_content_depositor' do
+          Steps::ChangeContentDepositor.new
         end
 
         ops.register 'delete' do

--- a/lib/hyrax/transactions/steps/change_content_depositor.rb
+++ b/lib/hyrax/transactions/steps/change_content_depositor.rb
@@ -23,10 +23,6 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(obj, user: NullUser.new, reset: false)
           obj = Hyrax::ChangeContentDepositorService.call(obj, user, reset)
-          # TODO: The service should kick off the job. For example if the
-          # service hits a guard condition and returns without doing anything,
-          # the job should not run.
-          ContentDepositorChangeEventJob.perform_later(obj)
 
           Success(obj)
         rescue StandardError => err

--- a/lib/hyrax/transactions/steps/change_content_depositor.rb
+++ b/lib/hyrax/transactions/steps/change_content_depositor.rb
@@ -28,7 +28,7 @@ module Hyrax
 
           Success(obj)
         rescue NoMethodError => err
-          Failure([err.message, change_set])
+          Failure([err.message, obj])
         end
 
         ##

--- a/lib/hyrax/transactions/steps/change_content_depositor.rb
+++ b/lib/hyrax/transactions/steps/change_content_depositor.rb
@@ -21,13 +21,15 @@ module Hyrax
         #             the given work
         #
         # @return [Dry::Monads::Result]
-        def call(obj, user: NullUser.new)
-          reset = false
+        def call(obj, user: NullUser.new, reset: false)
           obj = Hyrax::ChangeContentDepositorService.call(obj, user, reset)
+          # TODO: The service should kick off the job. For example if the
+          # service hits a guard condition and returns without doing anything,
+          # the job should not run.
           ContentDepositorChangeEventJob.perform_later(obj)
 
           Success(obj)
-        rescue NoMethodError => err
+        rescue StandardError => err
           Failure([err.message, obj])
         end
 

--- a/lib/hyrax/transactions/steps/change_content_depositor.rb
+++ b/lib/hyrax/transactions/steps/change_content_depositor.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Add a given `::User` as the `#depositor`
+      # Move the previous value of that property to `#proxy_depositor`
+      #
+      #
+      # If no user is given, simply passes as a `Success`.
+      #
+      # @since 3.4.0
+      class ChangeContentDepositor
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Hyrax::Work] obj
+        # @param user [User] the user that will "become" the depositor of
+        #             the given work
+        #
+        # @return [Dry::Monads::Result]
+        def call(obj, user: NullUser.new)
+          reset = false
+          obj = Hyrax::ChangeContentDepositorService.call(obj, user, reset)
+          ContentDepositorChangeEventJob.perform_later(obj, user, reset)
+
+          Success(obj)
+        rescue NoMethodError => err
+          Failure([err.message, change_set])
+        end
+
+        ##
+        # @api private
+        class NullUser
+          ##
+          # @return [nil]
+          def user_key
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/change_content_depositor.rb
+++ b/lib/hyrax/transactions/steps/change_content_depositor.rb
@@ -24,7 +24,7 @@ module Hyrax
         def call(obj, user: NullUser.new)
           reset = false
           obj = Hyrax::ChangeContentDepositorService.call(obj, user, reset)
-          ContentDepositorChangeEventJob.perform_later(obj, user, reset)
+          ContentDepositorChangeEventJob.perform_later(obj)
 
           Success(obj)
         rescue NoMethodError => err

--- a/lib/hyrax/transactions/work_create.rb
+++ b/lib/hyrax/transactions/work_create.rb
@@ -13,6 +13,7 @@ module Hyrax
                        'change_set.set_user_as_depositor',
                        'change_set.apply',
                        'work_resource.save_acl',
+                       'work_resource.change_content_depositor',
                        'work_resource.add_file_sets',
                        'work_resource.add_to_parent'].freeze
 

--- a/spec/actors/hyrax/actors/transfer_request_actor_spec.rb
+++ b/spec/actors/hyrax/actors/transfer_request_actor_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Hyrax::Actors::TransferRequestActor do
       end
 
       it "adds the template users to the work" do
-        expect(ContentDepositorChangeEventJob).to receive(:perform_later).with(work, User)
+        expect(ContentDepositorChangeEventJob).to receive(:perform_later).with(work)
         expect(middleware.create(env)).to be true
       end
     end

--- a/spec/hyrax/transactions/steps/change_content_depositor_spec.rb
+++ b/spec/hyrax/transactions/steps/change_content_depositor_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::ChangeContentDepositor, valkyrie_adapter: :test_adapter do
+  subject(:step) { described_class.new }
+  let(:work)     { FactoryBot.valkyrie_create(:hyrax_work) }
+
+  it 'gives Success(obj) in basic case' do
+    expect(step.call(work).value!).to eql(work)
+  end
+
+  context "when the depositor update is successful" do
+    it "calls the service" do
+      allow(Hyrax::ChangeContentDepositorService).to receive(:call)
+      step.call(work)
+
+      expect(Hyrax::ChangeContentDepositorService).to have_received(:call)
+    end
+  end
+
+  context "when there's an error" do
+    it 'returns a Failure' do
+      allow(Hyrax::ChangeContentDepositorService).to receive(:call).and_raise
+      result = step.call(work)
+
+      expect(result).to be_failure
+    end
+  end
+end

--- a/spec/jobs/content_depositor_change_event_job_spec.rb
+++ b/spec/jobs/content_depositor_change_event_job_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 RSpec.describe ContentDepositorChangeEventJob do
-  let(:user) { create(:user) }
-  let(:another_user) { create(:user) }
+  let(:previous_user) { create(:user) }
+  let(:new_user) { create(:user) }
   let(:mock_time) { Time.zone.at(1) }
   let(:event) do
-    { action: "User <a href=\"/users/#{user.to_param}\">#{user.user_key}</a> " \
-                          "has transferred <a href=\"/concern/generic_works/#{generic_work.id}\">BethsMac</a> " \
-                          "to user <a href=\"/users/#{another_user.to_param}\">#{another_user.user_key}</a>",
+    { action:
+        "User <a href=\"/users/#{previous_user.to_param}\">#{previous_user.user_key}</a> " \
+        "has transferred <a href=\"/concern/generic_works/#{generic_work.id}\">BethsMac</a> " \
+        "to user <a href=\"/users/#{new_user.to_param}\">#{new_user.user_key}</a>",
       timestamp: '1' }
   end
 
@@ -15,42 +16,42 @@ RSpec.describe ContentDepositorChangeEventJob do
   end
 
   context "when passing an ActiveFedora work" do
-    let(:generic_work) { create(:generic_work, title: ['BethsMac'], user: user) }
+    let(:generic_work) { create(:generic_work, title: ['BethsMac'], user: new_user, proxy_depositor: previous_user.user_key) }
 
     it "logs the event to the proxy depositor's profile, the depositor's dashboard, and the FileSet" do
-      expect { described_class.perform_now(generic_work, another_user) }
-        .to change { user.profile_events.length }
+      expect { described_class.perform_now(generic_work) }
+        .to change { previous_user.profile_events.length }
         .by(1)
-        .and change { another_user.events.length }
+        .and change { new_user.events.length }
         .by(1)
         .and change { generic_work.events.length }
         .by(1)
-      expect(user.profile_events.first).to eq(event)
-      expect(another_user.events.first).to eq(event)
+      expect(previous_user.profile_events.first).to eq(event)
+      expect(new_user.events.first).to eq(event)
       expect(generic_work.events.first).to eq(event)
     end
   end
 
   context "when passing a valkyrie work" do
-    let(:monograph) { valkyrie_create(:monograph, title: ['BethsMac'], depositor: user.user_key) }
+    let(:monograph) { valkyrie_create(:monograph, title: ['BethsMac'], depositor: new_user.user_key, proxy_depositor: previous_user.user_key) }
 
     let(:event) do
-      { action: "User <a href=\"/users/#{user.to_param}\">#{user.user_key}</a> " \
+      { action: "User <a href=\"/users/#{previous_user.to_param}\">#{previous_user.user_key}</a> " \
                 "has transferred <a href=\"/concern/monographs/#{monograph.id}\">BethsMac</a> " \
-                "to user <a href=\"/users/#{another_user.to_param}\">#{another_user.user_key}</a>",
+                "to user <a href=\"/users/#{new_user.to_param}\">#{new_user.user_key}</a>",
         timestamp: '1' }
     end
 
     it "logs the event to the proxy depositor's profile, the depositor's dashboard, and the FileSet" do
-      expect { subject.perform(monograph, another_user) }
-        .to change { user.profile_events.length }
+      expect { subject.perform(monograph) }
+        .to change { previous_user.profile_events.length }
         .by(1)
-        .and change { another_user.events.length }
+        .and change { new_user.events.length }
         .by(1)
         .and change { monograph.events.length }
         .by(1)
-      expect(user.profile_events.first).to eq(event)
-      expect(another_user.events.first).to eq(event)
+      expect(previous_user.profile_events.first).to eq(event)
+      expect(new_user.events.first).to eq(event)
       expect(monograph.events.first).to eq(event)
     end
   end

--- a/spec/models/proxy_deposit_request_spec.rb
+++ b/spec/models/proxy_deposit_request_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe ProxyDepositRequest, type: :model do
   describe '#transfer!' do
     it 'will change the status, fulfillment_date, and perform later the ContentDepositorChangeEventJob' do
       allow(ContentDepositorChangeEventJob).to receive(:perform_later)
-      allow(Hyrax::ChangeContentDepositorService).to receive(:call).and_call_original
+      allow(Hyrax::ChangeContentDepositorService).to receive(:call)
       subject.transfer!
       expect(subject.status).to eq(described_class::ACCEPTED)
       expect(subject.fulfillment_date).to be_a(Time)

--- a/spec/models/proxy_deposit_request_spec.rb
+++ b/spec/models/proxy_deposit_request_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe ProxyDepositRequest, type: :model do
 
   describe '#transfer!' do
     it 'will change the status, fulfillment_date, and perform later the ContentDepositorChangeEventJob' do
-      allow(ContentDepositorChangeEventJob).to receive(:perform_later)
       allow(Hyrax::ChangeContentDepositorService).to receive(:call)
       subject.transfer!
       expect(subject.status).to eq(described_class::ACCEPTED)

--- a/spec/models/proxy_deposit_request_spec.rb
+++ b/spec/models/proxy_deposit_request_spec.rb
@@ -78,10 +78,12 @@ RSpec.describe ProxyDepositRequest, type: :model do
   describe '#transfer!' do
     it 'will change the status, fulfillment_date, and perform later the ContentDepositorChangeEventJob' do
       allow(ContentDepositorChangeEventJob).to receive(:perform_later)
+      allow(Hyrax::ChangeContentDepositorService).to receive(:call).and_call_original
       subject.transfer!
       expect(subject.status).to eq(described_class::ACCEPTED)
       expect(subject.fulfillment_date).to be_a(Time)
       expect(subject).to be_accepted
+      expect(Hyrax::ChangeContentDepositorService).to have_received(:call)
     end
   end
 

--- a/spec/services/hyrax/change_content_depositor_service_spec.rb
+++ b/spec/services/hyrax/change_content_depositor_service_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
 
     context "by default, when permissions are not reset" do
       it "changes the depositor and records an original depositor" do
+        expect(ContentDepositorChangeEventJob).to receive(:perform_later)
         described_class.call(base_work, receiver, false)
         work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: base_work.id, use_valkyrie: true)
         expect(work.depositor).to eq receiver.user_key
@@ -83,6 +84,7 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
 
     context "when permissions are reset" do
       it "changes the depositor and records an original depositor" do
+        expect(ContentDepositorChangeEventJob).to receive(:perform_later)
         described_class.call(base_work, receiver, true)
         work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: base_work.id, use_valkyrie: true)
         expect(work.depositor).to eq receiver.user_key
@@ -104,6 +106,7 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
 
     context "when no user is provided" do
       it "does not update the work" do
+        expect(ContentDepositorChangeEventJob).not_to receive(:perform_later)
         persister = double("Valkyrie Persister")
         allow(Hyrax).to receive(:persister).and_return(persister)
         allow(persister).to receive(:save)
@@ -117,6 +120,7 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
       let!(:base_work) { valkyrie_create(:hyrax_work, :with_member_file_sets, title: ['AlreadyMine'], depositor: depositor.user_key, edit_users: [depositor]) }
 
       it "does not update the work" do
+        expect(ContentDepositorChangeEventJob).not_to receive(:perform_later)
         persister = double("Valkyrie Persister")
         allow(Hyrax).to receive(:persister).and_return(persister)
         allow(persister).to receive(:save)

--- a/spec/services/hyrax/change_content_depositor_service_spec.rb
+++ b/spec/services/hyrax/change_content_depositor_service_spec.rb
@@ -101,5 +101,29 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
         end
       end
     end
+
+    context "when no user is provided" do
+      it "does not update the work" do
+        persister = double("Valkyrie Persister")
+        allow(Hyrax).to receive(:persister).and_return(persister)
+        allow(persister).to receive(:save)
+
+        described_class.call(base_work, nil, false)
+        expect(persister).not_to have_received(:save)
+      end
+    end
+
+    context "when transfer is requested to the existing owner" do
+      let!(:base_work) { valkyrie_create(:hyrax_work, :with_member_file_sets, title: ['AlreadyMine'], depositor: depositor.user_key, edit_users: [depositor]) }
+
+      it "does not update the work" do
+        persister = double("Valkyrie Persister")
+        allow(Hyrax).to receive(:persister).and_return(persister)
+        allow(persister).to receive(:save)
+
+        described_class.call(base_work, depositor, false)
+        expect(persister).not_to have_received(:save)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR is in draft since it depends on merge of #5529. It should be rebased on main once that happens.

Follow-up to #5529
closes #5457

The ChangeContentDepositorService is where the correct depositor and
proxy_depositor values are set. the ContentDepositorChangeEventJob emits events related to depositor changes. Before this PR the service was always called by the job, which ran the service before emitting the related events. After this PR, that's flipped and the service enqueues the job after it's finished making the updates. Where the job was previously invoked, now we invoke the service.

Previous to #5529, the job (and thus the service) was called by a
listener or a callback in response to object deposit events. The changes in
#5529, intended to resolve a race condition bug, also made it easier to decouple
the AF behavior from the Valkyrie behavior, making the change in synchronous code in both cases.

Previous code state and summary of changes:

```
ChangeContentDepositorService was called from
  ContentDepositorChangeEventJob which is called from:

    app/models/proxy_deposit_request#transfer! (used by transfers_controller)

      - Call the depositor service instead of the change event job


    app/actors/hyrax/actors/transfer_request_actor

      - Call the depositor service instead of the change event job


    app/services/hyrax/listeners/proxy_deposit_listener
      listened for object.deposited, which is published by:

        lib/hyrax/transactions/steps/save.rb

          - Create a new transaction step to call invoke the service


        app/services/hyrax/work_uploads_handler.rb

          - I don't think the work uploads handler has any implications for
            proxy depositors so I think it's fine to leave this alone -- it can
            still publish the object.deposited message but with the proxy depositor
            listener removed I don't think there's any impact to behavior for
            this workflow.

        the after_create_concern callback, which is invoked by base_actor.rb

           - With the transfer request actor back in use, there's no impact here
             either.

Update the ChangeContentDepositorService to enqueue the ContentDepositorChangeEventJob. Update the ContentDepositorChangeEventJob to expect an work that has already been transferred, and to simply emit the required events rather than changing the objects first.
```