### PR TITLE
make nesting collections work with Hyrax::PcdmCollections

### DIFF
--- a/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/nested_collections_search_builder.rb
@@ -37,7 +37,7 @@ module Hyrax
 
       def limit_ids
         # exclude current collection from returned list
-        limit_ids = [@collection.id]
+        limit_ids = [@collection.id.to_s]
         # cannot add a parent that is already a parent
         limit_ids += @nesting_attributes.parents if @nesting_attributes.parents && @nest_direction == :as_parent
         limit_ids
@@ -91,7 +91,7 @@ module Hyrax
 
       def exclude_if_already_parent
         # 2) Exclude any of Collection F's direct children
-        "-" + ActiveFedora::SolrQueryBuilder.construct_query(Samvera::NestingIndexer.configuration.solr_field_name_for_storing_parent_ids => @collection.id)
+        "-" + ActiveFedora::SolrQueryBuilder.construct_query(Samvera::NestingIndexer.configuration.solr_field_name_for_storing_parent_ids => @collection.id.to_s)
       end
     end
   end

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -1,18 +1,8 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
-  subject(:form) do
-    described_class.new(parent: parent,
-                        child: child,
-                        context: context,
-                        query_service: query_service,
-                        persistence_service: persistence_service)
-  end
-
-  let(:child)                { FactoryBot.create(:collection) }
-  let(:context)              { double('Context', current_user: user) }
   let(:nesting_depth_result) { true }
-  let(:parent)               { FactoryBot.create(:collection) }
-  let(:user)                 { create(:user) }
+  let(:context) { double('Context', current_user: user) }
+  let(:user)    { create(:user) }
 
   let(:persistence_service) do
     double(Hyrax::Collections::NestedCollectionPersistenceService,
@@ -23,9 +13,6 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     double(Hyrax::Collections::NestedCollectionQueryService,
            valid_combined_nesting_depth?: nesting_depth_result)
   end
-
-  it { is_expected.to validate_presence_of(:parent) }
-  it { is_expected.to validate_presence_of(:child) }
 
   describe '.default_query_service' do
     subject { described_class.default_query_service }
@@ -42,144 +29,335 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
     it { is_expected.to respond_to(:persist_nested_collection_for) }
   end
 
-  context 'parent and child nesting' do
-    let(:nesting_depth_result) { false }
-
-    it 'is invalid if child cannot be nested within the parent' do
-      expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child, scope: context).and_return(false)
-
-      expect { form.valid? }
-        .to change { form.errors.to_hash }
-        .to include parent: ["cannot have child nested within it"],
-                    child: ["cannot nest within parent"],
-                    collection: ["nesting exceeds the allowed maximum nesting depth."]
+  context "when parent/child are ActiveFedora object" do
+    subject(:form) do
+      described_class.new(parent: parent,
+                          child: child,
+                          context: context,
+                          query_service: query_service,
+                          persistence_service: persistence_service)
     end
-  end
 
-  describe 'parent is not nestable' do
-    let(:parent) { double(nestable?: false) }
+    let(:child)                { FactoryBot.create(:collection) }
+    let(:parent)               { FactoryBot.create(:collection) }
 
-    it 'is not valid' do
-      expect { form.valid? }
-        .to change { form.errors.to_hash }
-        .to include parent: ["is not nestable"]
-    end
-  end
+    it { is_expected.to validate_presence_of(:parent) }
+    it { is_expected.to validate_presence_of(:child) }
 
-  describe 'child is not nestable' do
-    let(:child) { double(nestable?: false) }
+    context 'parent and child nesting' do
+      let(:nesting_depth_result) { false }
 
-    it 'is not valid' do
-      expect { form.valid? }
-        .to change { form.errors.to_hash }
-        .to include child: ["is not nestable"]
-    end
-  end
+      it 'is invalid if child cannot be nested within the parent' do
+        expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child, scope: context).and_return(false)
 
-  describe '#save' do
-    describe 'when not valid' do
-      it 'does not even attempt to persist the relationship' do
-        expect(form).to receive(:valid?).and_return(false) # rubocop:disable RSpec/SubjectStub
-        expect(persistence_service).not_to receive(:persist_nested_collection_for)
-
-        expect(form.save).to be_falsey
+        expect { form.valid? }
+          .to change { form.errors.to_hash }
+          .to include parent: ["cannot have child nested within it"],
+                      child: ["cannot nest within parent"],
+                      collection: ["nesting exceeds the allowed maximum nesting depth."]
       end
     end
 
-    describe 'when valid' do
-      before { expect(form).to receive(:valid?).and_return(true) } # rubocop:disable RSpec/SubjectStub
-
-      it "returns the result of the given persistence_service's call to persist_nested_collection_for" do
-        expect(persistence_service)
-          .to receive(:persist_nested_collection_for)
-          .with(parent: parent, child: child, user: user)
-          .and_return(:persisted)
-
-        expect(form.save).to eq :persisted
-      end
-    end
-  end
-
-  describe '#available_child_collections' do
-    it 'delegates to the underlying query_service' do
-      expect(query_service)
-        .to receive(:available_child_collections)
-        .with(parent: parent, scope: context)
-        .and_return(:results)
-
-      expect(form.available_child_collections).to eq(:results)
-    end
-  end
-
-  describe '#available_parent_collections' do
-    it 'delegates to the underlying query_service' do
-      expect(query_service)
-        .to receive(:available_parent_collections)
-        .with(child: child, scope: context)
-        .and_return(:results)
-
-      expect(form.available_parent_collections).to eq(:results)
-    end
-  end
-
-  describe '#validate_add' do
-    context 'when not nestable' do
+    describe 'parent is not nestable' do
       let(:parent) { double(nestable?: false) }
 
-      it 'validates the parent cannnot contain nested subcollections' do
-        expect { form.validate_add }
+      it 'is not valid' do
+        expect { form.valid? }
           .to change { form.errors.to_hash }
-          .to include parent: ["cannot have child nested within it"]
+          .to include parent: ["is not nestable"]
       end
     end
 
-    context 'when nestable' do
-      context 'when at maximum nesting level' do
-        let(:parent) { double(nestable?: true) }
-        let(:nesting_depth_result) { false }
+    describe 'child is not nestable' do
+      let(:child) { double(nestable?: false) }
 
-        it 'validates the parent cannot have additional files nested' do
-          expect { form.validate_add }
-            .to change { form.errors.to_hash }
-            .to include collection: ["nesting exceeds the allowed maximum nesting depth."]
+      it 'is not valid' do
+        expect { form.valid? }
+          .to change { form.errors.to_hash }
+          .to include child: ["is not nestable"]
+      end
+    end
+
+    describe '#save' do
+      describe 'when not valid' do
+        it 'does not even attempt to persist the relationship' do
+          expect(form).to receive(:valid?).and_return(false) # rubocop:disable RSpec/SubjectStub
+          expect(persistence_service).not_to receive(:persist_nested_collection_for)
+
+          expect(form.save).to be_falsey
         end
       end
 
-      context 'when valid' do
-        let(:parent) { double(nestable?: true) }
+      describe 'when valid' do
+        before { expect(form).to receive(:valid?).and_return(true) } # rubocop:disable RSpec/SubjectStub
 
-        it 'validates the parent can contain nested subcollections' do
-          expect(form.validate_add).to eq true
+        it "returns the result of the given persistence_service's call to persist_nested_collection_for" do
+          expect(persistence_service)
+            .to receive(:persist_nested_collection_for)
+            .with(parent: parent, child: child, user: user)
+            .and_return(:persisted)
+
+          expect(form.save).to eq :persisted
+        end
+      end
+    end
+
+    describe '#available_child_collections' do
+      it 'delegates to the underlying query_service' do
+        expect(query_service)
+          .to receive(:available_child_collections)
+          .with(parent: parent, scope: context)
+          .and_return(:results)
+
+        expect(form.available_child_collections).to eq(:results)
+      end
+    end
+
+    describe '#available_parent_collections' do
+      it 'delegates to the underlying query_service' do
+        expect(query_service)
+          .to receive(:available_parent_collections)
+          .with(child: child, scope: context)
+          .and_return(:results)
+
+        expect(form.available_parent_collections).to eq(:results)
+      end
+    end
+
+    describe '#validate_add' do
+      context 'when not nestable' do
+        let(:parent) { double(nestable?: false) }
+
+        it 'validates the parent cannnot contain nested subcollections' do
+          expect { form.validate_add }
+            .to change { form.errors.to_hash }
+            .to include parent: ["cannot have child nested within it"]
+        end
+      end
+
+      context 'when nestable' do
+        context 'when at maximum nesting level' do
+          let(:parent) { double(nestable?: true) }
+          let(:nesting_depth_result) { false }
+
+          it 'validates the parent cannot have additional files nested' do
+            expect { form.validate_add }
+              .to change { form.errors.to_hash }
+              .to include collection: ["nesting exceeds the allowed maximum nesting depth."]
+          end
+        end
+
+        context 'when valid' do
+          let(:parent) { double(nestable?: true) }
+
+          it 'validates the parent can contain nested subcollections' do
+            expect(form.validate_add).to eq true
+          end
+        end
+      end
+    end
+
+    describe '#remove' do
+      describe 'when not authorized' do
+        before do
+          expect(context).to receive(:can?).with(:edit, parent).and_return(false)
+        end
+
+        it 'does not even attempt to persist the relationship' do
+          expect(persistence_service).not_to receive(:remove_nested_relationship_for)
+          form.remove
+          expect(form.errors[:parent]).to eq(["permission is inadequate for removal of nesting relationship"])
+        end
+      end
+
+      describe 'when authorized' do
+        before do
+          expect(context).to receive(:can?).with(:edit, parent).and_return(true)
+        end
+
+        it "returns the result of the given persistence_service's call to remove_nested_relationship_for" do
+          expect(persistence_service)
+            .to receive(:remove_nested_relationship_for)
+            .with(parent: parent, child: child, user: user)
+            .and_return(:persisted)
+
+          expect(form.remove).to eq :persisted
         end
       end
     end
   end
 
-  describe '#remove' do
-    describe 'when not authorized' do
-      before do
-        expect(context).to receive(:can?).with(:edit, parent).and_return(false)
-      end
+  context "when receiving parent/child Valkyrie IDs" do
+    subject(:form) do
+      described_class.new(parent_id: parent_id,
+                          child_id: child_id,
+                          context: context,
+                          query_service: query_service,
+                          persistence_service: persistence_service)
+    end
 
-      it 'does not even attempt to persist the relationship' do
-        expect(persistence_service).not_to receive(:remove_nested_relationship_for)
-        form.remove
-        expect(form.errors[:parent]).to eq(["permission is inadequate for removal of nesting relationship"])
+    let(:child_nestable) { true }
+    let(:child_collection_type_gid) do
+      FactoryBot.create(:collection_type, nestable: child_nestable).to_global_id
+    end
+    let(:child) do
+      FactoryBot.valkyrie_create(:hyrax_collection,
+                                 collection_type_gid: child_collection_type_gid)
+    end
+    let(:child_id) { child.id }
+
+    let(:parent_nestable) { true }
+    let(:parent_collection_type_gid) do
+      FactoryBot.create(:collection_type, nestable: parent_nestable).to_global_id
+    end
+    let(:parent) do
+      FactoryBot.valkyrie_create(:hyrax_collection,
+                                 collection_type_gid: parent_collection_type_gid)
+    end
+    let(:parent_id) { parent.id }
+
+    it { is_expected.to validate_presence_of(:parent) }
+    it { is_expected.to validate_presence_of(:child) }
+
+    context 'parent and child nesting' do
+      let(:nesting_depth_result) { false }
+
+      it 'is invalid if child cannot be nested within the parent' do
+        expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child, scope: context).and_return(false)
+
+        expect { form.valid? }
+          .to change { form.errors.to_hash }
+          .to include parent: ["cannot have child nested within it"],
+                      child: ["cannot nest within parent"],
+                      collection: ["nesting exceeds the allowed maximum nesting depth."]
       end
     end
 
-    describe 'when authorized' do
-      before do
-        expect(context).to receive(:can?).with(:edit, parent).and_return(true)
+    describe 'parent is not nestable' do
+      let(:parent_nestable) { false }
+
+      it 'is not valid' do
+        expect { form.valid? }
+          .to change { form.errors.to_hash }
+          .to include parent: ["is not nestable"]
+      end
+    end
+
+    describe 'child is not nestable' do
+      let(:child_nestable) { false }
+
+      it 'is not valid' do
+        expect { form.valid? }
+          .to change { form.errors.to_hash }
+          .to include child: ["is not nestable"]
+      end
+    end
+
+    describe '#save' do
+      describe 'when not valid' do
+        it 'does not even attempt to persist the relationship' do
+          expect(form).to receive(:valid?).and_return(false) # rubocop:disable RSpec/SubjectStub
+          expect(persistence_service).not_to receive(:persist_nested_collection_for)
+
+          expect(form.save).to be_falsey
+        end
       end
 
-      it "returns the result of the given persistence_service's call to remove_nested_relationship_for" do
-        expect(persistence_service)
-          .to receive(:remove_nested_relationship_for)
-          .with(parent: parent, child: child, user: user)
-          .and_return(:persisted)
+      describe 'when valid' do
+        before { expect(form).to receive(:valid?).and_return(true) } # rubocop:disable RSpec/SubjectStub
 
-        expect(form.remove).to eq :persisted
+        it "returns the result of the given persistence_service's call to persist_nested_collection_for" do
+          expect(persistence_service)
+            .to receive(:persist_nested_collection_for)
+            .with(parent: parent, child: child, user: user)
+            .and_return(:persisted)
+
+          expect(form.save).to eq :persisted
+        end
+      end
+    end
+
+    describe '#available_child_collections' do
+      it 'delegates to the underlying query_service' do
+        expect(query_service)
+          .to receive(:available_child_collections)
+          .with(parent: parent, scope: context)
+          .and_return(:results)
+
+        expect(form.available_child_collections).to eq(:results)
+      end
+    end
+
+    describe '#available_parent_collections' do
+      it 'delegates to the underlying query_service' do
+        expect(query_service)
+          .to receive(:available_parent_collections)
+          .with(child: child, scope: context)
+          .and_return(:results)
+
+        expect(form.available_parent_collections).to eq(:results)
+      end
+    end
+
+    describe '#validate_add' do
+      context 'when not nestable' do
+        let(:parent_nestable) { false }
+
+        it 'validates the parent cannnot contain nested subcollections' do
+          expect { form.validate_add }
+            .to change { form.errors.to_hash }
+            .to include parent: ["cannot have child nested within it"]
+        end
+      end
+
+      context 'when nestable' do
+        context 'when at maximum nesting level' do
+          let(:parent_nestable) { true }
+          let(:nesting_depth_result) { false }
+
+          it 'validates the parent cannot have additional files nested' do
+            expect { form.validate_add }
+              .to change { form.errors.to_hash }
+              .to include collection: ["nesting exceeds the allowed maximum nesting depth."]
+          end
+        end
+
+        context 'when valid' do
+          let(:parent_nestable) { true }
+
+          it 'validates the parent can contain nested subcollections' do
+            expect(form.validate_add).to eq true
+          end
+        end
+      end
+    end
+
+    describe '#remove' do
+      describe 'when not authorized' do
+        before do
+          expect(context).to receive(:can?).with(:edit, parent).and_return(false)
+        end
+
+        it 'does not even attempt to persist the relationship' do
+          expect(persistence_service).not_to receive(:remove_nested_relationship_for)
+          form.remove
+          expect(form.errors[:parent]).to eq(["permission is inadequate for removal of nesting relationship"])
+        end
+      end
+
+      describe 'when authorized' do
+        before do
+          expect(context).to receive(:can?).with(:edit, parent).and_return(true)
+        end
+
+        it "returns the result of the given persistence_service's call to remove_nested_relationship_for" do
+          expect(persistence_service)
+            .to receive(:remove_nested_relationship_for)
+            .with(parent: parent, child: child, user: user)
+            .and_return(:persisted)
+
+          expect(form.remove).to eq :persisted
+        end
       end
     end
   end

--- a/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
@@ -1,85 +1,143 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Dashboard::NestedCollectionsSearchBuilder do
-  let(:collection) { double(id: 'Collection_123', collection_type_gid: 'gid/abc') }
   let(:scope) { double(current_ability: ability, blacklight_config: CatalogController.blacklight_config) }
   let(:access) { :read }
   let(:user) { create(:user) }
   let(:ability) { ::Ability.new(user) }
-  let(:nesting_attributes) { double(parents: ['Parent_1', 'Parent_2'], pathnames: ['Parent_1/Collection_123', 'Parent_2/Collection_123'], ancestors: ['Parent_1', 'Parent_2'], depth: 2) }
   let(:test_nest_direction) { :as_parent }
-  let(:builder) { described_class.new(scope: scope, access: access, collection: collection, nesting_attributes: nesting_attributes, nest_direction: test_nest_direction) }
 
-  describe '#query' do
-    subject { builder.query }
-
-    it { is_expected.to be_a(Hash) }
-  end
-
-  describe '#default_processor_chain' do
-    subject { builder.default_processor_chain }
-
-    it { is_expected.to include(:with_pagination) }
-    it { is_expected.to include(:show_only_other_collections_of_the_same_collection_type) }
-  end
-
-  describe '#show_only_other_collections_of_the_same_collection_type' do
-    let(:solr_params) { {} }
-
-    subject { builder.show_only_other_collections_of_the_same_collection_type(solr_params) }
-
-    context 'when nesting :as_parent' do
-      let(:test_nest_direction) { :as_parent }
-
-      it 'will exclude the given collection and its parents' do
-        subject
-        expect(solr_params.fetch(:fq)).to contain_exactly(
-          "-{!terms f=id}#{collection.id},#{nesting_attributes.parents.first},#{nesting_attributes.parents.last}",
-          "_query_:\"{!field f=collection_type_gid_ssim}#{collection.collection_type_gid}\"",
-          "-_query_:\"{!lucene df=nesting_collection__pathnames_ssim}*#{collection.id}*\""
-        )
+  [false, true].each do |test_valkyrie|
+    context "when test_valkyrie is #{test_valkyrie}" do
+      let(:builder) do
+        described_class.new(scope: scope, access: access, collection: collection,
+                            nesting_attributes: nesting_attributes, nest_direction: test_nest_direction)
       end
-    end
-
-    context 'when nesting :as_child' do
-      let(:test_nest_direction) { :as_child }
-
-      it 'will build the search for valid children' do
-        subject
-        # rubocop:disable Layout/LineLength
-        expect(solr_params.fetch(:fq)).to contain_exactly(
-          "-{!terms f=id}#{collection.id}",
-          "_query_:\"{!field f=collection_type_gid_ssim}#{collection.collection_type_gid}\"",
-          "-_query_:\"{!lucene q.op=OR df=nesting_collection__pathnames_ssim}#{nesting_attributes.pathnames.first} #{nesting_attributes.pathnames.last} #{nesting_attributes.ancestors.first} #{nesting_attributes.ancestors.last}\"",
-          "-_query_:\"{!field f=nesting_collection__parent_ids_ssim}#{collection.id}\""
-        )
-        # rubocop:enable Layout/LineLength
+      let(:nesting_attributes) do
+        double(parents: ['Parent_1', 'Parent_2'],
+               pathnames: ["Parent_1/#{collection_id}", "Parent_2/#{collection_id}"],
+               ancestors: ['Parent_1', 'Parent_2'],
+               depth: 2)
       end
-    end
-  end
+      let(:collection_id) { collection.id.to_s }
 
-  describe '#gated_discovery_filters' do
-    subject { builder.gated_discovery_filters(access, ability) }
+      let(:af_collection) do
+        FactoryBot.create(:collection_lw,
+                          id: af_collection_id,
+                          collection_type_gid: 'gid/abc')
+      end
+      let(:af_collection_id) { 'Collection_123' }
 
-    context 'when access is :deposit' do
-      let(:access) { "deposit" }
-      let!(:collection) { create(:collection_lw, with_permission_template: attributes) }
-
-      context 'and user has access' do
-        let(:attributes) { { deposit_users: [user.user_key] } }
-
-        it { is_expected.to eq ["{!terms f=id}#{collection.id}"] }
+      let(:val_collection) do
+        FactoryBot.valkyrie_create(:hyrax_collection,
+                                   collection_type_gid: 'gid/abc')
       end
 
-      context 'and group has access' do
-        let(:attributes) { { deposit_groups: ['registered'] } }
+      let(:collection) { test_valkyrie ? val_collection : af_collection }
 
-        it { is_expected.to eq ["{!terms f=id}#{collection.id}"] }
+      describe '#query' do
+        subject { builder.query }
+
+        it { is_expected.to be_a(Hash) }
       end
 
-      context "and user has no access" do
-        let(:attributes) { true }
+      describe '#default_processor_chain' do
+        subject { builder.default_processor_chain }
 
-        it { is_expected.to eq ["{!terms f=id}"] }
+        it { is_expected.to include(:with_pagination) }
+        it { is_expected.to include(:show_only_other_collections_of_the_same_collection_type) }
+      end
+
+      describe '#show_only_other_collections_of_the_same_collection_type' do
+        let(:solr_params) { {} }
+
+        subject { builder.show_only_other_collections_of_the_same_collection_type(solr_params) }
+
+        context 'when nesting :as_parent' do
+          let(:test_nest_direction) { :as_parent }
+
+          it 'will exclude the given collection and its parents' do
+            subject
+            expect(solr_params.fetch(:fq)).to contain_exactly(
+              "-{!terms f=id}#{collection_id},#{nesting_attributes.parents.first},#{nesting_attributes.parents.last}",
+              "_query_:\"{!field f=collection_type_gid_ssim}#{collection.collection_type_gid}\"",
+              "-_query_:\"{!lucene df=nesting_collection__pathnames_ssim}*#{collection_id}*\""
+            )
+          end
+        end
+
+        context 'when nesting :as_child' do
+          let(:test_nest_direction) { :as_child }
+
+          it 'will build the search for valid children' do
+            subject
+            # rubocop:disable Layout/LineLength
+            expect(solr_params.fetch(:fq)).to contain_exactly(
+              "-{!terms f=id}#{collection_id}",
+              "_query_:\"{!field f=collection_type_gid_ssim}#{collection.collection_type_gid}\"",
+              "-_query_:\"{!lucene q.op=OR df=nesting_collection__pathnames_ssim}#{nesting_attributes.pathnames.first} #{nesting_attributes.pathnames.last} #{nesting_attributes.ancestors.first} #{nesting_attributes.ancestors.last}\"",
+              "-_query_:\"{!field f=nesting_collection__parent_ids_ssim}#{collection_id}\""
+            )
+            # rubocop:enable Layout/LineLength
+          end
+        end
+      end
+
+      describe '#gated_discovery_filters' do
+        subject { builder.gated_discovery_filters(access, ability) }
+
+        before { collection }
+
+        context 'when access is :deposit' do
+          let(:access) { "deposit" }
+
+          let(:af_collection) { create(:collection_lw, with_permission_template: af_attributes) }
+
+          let(:val_collection) do
+            FactoryBot.valkyrie_create(:hyrax_collection,
+                                       with_permission_template: true,
+                                       access_grants: val_grants)
+          end
+
+          context 'and user has access' do
+            let(:af_attributes) { { deposit_users: [user.user_key] } }
+            let(:val_grants) do
+              [
+                {
+                  agent_type: Hyrax::PermissionTemplateAccess::USER,
+                  agent_id: user.user_key,
+                  access: Hyrax::PermissionTemplateAccess::DEPOSIT
+                }
+              ]
+            end
+
+            it { is_expected.to eq ["{!terms f=id}#{collection.id}"] }
+          end
+
+          context 'and group has access' do
+            let(:af_attributes) { { deposit_groups: ['registered'] } }
+            let(:val_grants) do
+              [
+                {
+                  agent_type: Hyrax::PermissionTemplateAccess::GROUP,
+                  agent_id: 'registered',
+                  access: Hyrax::PermissionTemplateAccess::DEPOSIT
+                }
+              ]
+            end
+
+            it { is_expected.to eq ["{!terms f=id}#{collection.id}"] }
+          end
+
+          context "and user has no access" do
+            let(:af_attributes) { true }
+            let(:val_collection) do
+              FactoryBot.valkyrie_create(:hyrax_collection,
+                                         with_permission_template: true)
+            end
+
+            it { is_expected.to eq ["{!terms f=id}"] }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #5449

The problem boils down to 3 issues.  The issues and their solutions are:
* Hyrax::PcdmCollection doesn't respond to `:find`
  * find with Hyrax.query_service 
* Hyrax::PcdmCollection instances don't respond to `:nestable?`
  * get collection_type from the collection and call `:nestable?` on the collection type
* SearchBuilders and solr queries want a string for ID instead of a Valkyrie::ID
  * called `to_s` on IDs

@samvera/hyrax-code-reviewers
