### PR TITLE
Add transaction to add and remove work members

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -192,13 +192,17 @@ module Hyrax
     def update_valkyrie_work
       form = build_form
       return after_update_error(form_err_msg(form)) unless form.validate(params[hash_key_for_curation_concern])
-
       result =
         transactions['change_set.update_work']
-        .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] })
+        .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
+                        'work_resource.update_work_members' => { work_members_attributes: work_members_attributes })
         .call(form)
       @curation_concern = result.value_or { return after_update_error(transaction_err_msg(result)) }
       after_update_response
+    end
+
+    def work_members_attributes
+      params[hash_key_for_curation_concern][:work_members_attributes]&.permit!&.to_h
     end
 
     def form_err_msg(form)

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -46,6 +46,7 @@ module Hyrax
       require 'hyrax/transactions/steps/set_uploaded_date_unless_present'
       require 'hyrax/transactions/steps/set_user_as_creator'
       require 'hyrax/transactions/steps/set_user_as_depositor'
+      require 'hyrax/transactions/steps/update_work_members'
       require 'hyrax/transactions/steps/validate'
 
       # The following transactions and steps are deprecated.
@@ -218,6 +219,10 @@ module Hyrax
 
         ops.register 'save_acl' do
           Steps::SaveAccessControl.new
+        end
+
+        ops.register 'update_work_members' do
+          Steps::UpdateWorkMembers.new
         end
       end
 

--- a/lib/hyrax/transactions/steps/update_work_members.rb
+++ b/lib/hyrax/transactions/steps/update_work_members.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Adds and removes work members
+      class UpdateWorkMembers
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Hyrax::Work] obj
+        # @param [Hash] work_members_attributes
+        #
+        # @return [Dry::Monads::Result]
+        def call(obj, work_members_attributes: nil, user: nil)
+          return Success(obj) if work_members_attributes.blank?
+
+          attributes = extract_attributes(work_members_attributes)
+          current_member_ids = obj.member_ids.map(&:id)
+          destroys = attributes.select do |v|
+            ActiveModel::Type::Boolean.new.cast(v['_destroy'])
+          end
+
+          inserts  = (attributes - destroys).map { |h| h['id'] }.compact - current_member_ids
+          destroys = destroys.map { |h| h['id'] }.compact & current_member_ids
+          obj.member_ids += inserts.map  { |id| Valkyrie::ID.new(id) }
+          obj.member_ids -= destroys.map { |id| Valkyrie::ID.new(id) }
+
+          save_resource(obj, user)
+          Success(obj)
+        end
+
+        private
+
+        def extract_attributes(attribute_hash)
+          attribute_hash
+            .sort_by { |i, _| i.to_i }
+            .map { |_, attributes| attributes }
+        end
+
+        def save_resource(obj, user)
+          saved = Hyrax.persister.save(resource: obj)
+          user ||= ::User.find_by_user_key(obj.depositor)
+          Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/work_update.rb
+++ b/lib/hyrax/transactions/work_update.rb
@@ -6,7 +6,8 @@ module Hyrax
     class WorkUpdate < Transaction
       DEFAULT_STEPS = ['change_set.apply',
                        'work_resource.save_acl',
-                       'work_resource.add_file_sets'].freeze
+                       'work_resource.add_file_sets',
+                       'work_resource.update_work_members'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/spec/controllers/hyrax/monographs_controller_spec.rb
+++ b/spec/controllers/hyrax/monographs_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# This tests the Hyrax::WorksControllerBehavior module with a Valkyrie resource.
+# Included into .internal_test_app/app/controllers/hyrax/monographs_controller.rb
+RSpec.describe Hyrax::MonographsController do
+  routes { Rails.application.routes }
+  let(:main_app) { Rails.application.routes.url_helpers }
+  let(:hyrax) { Hyrax::Engine.routes.url_helpers }
+  let(:user) { FactoryBot.create(:user, groups: 'admin') }
+
+  before { sign_in user }
+
+  describe "#update" do
+    context "when updating work members" do
+      let(:work) { FactoryBot.valkyrie_create(:comet_in_moominland, :with_member_works) }
+      let(:children) { Hyrax.query_service.custom_queries.find_child_works(resource: work) }
+      let(:child1) { children.first }
+      let(:child2) { children.last }
+      let(:child3) { FactoryBot.valkyrie_create(:monograph) }
+      let(:attributes) do
+        { '0' => { id: child1.id, _destroy: 'true' },
+          '1' => { id: child3.id } }
+      end
+
+      it "can add and remove children" do
+        patch :update, params: { id: work, monograph: { work_members_attributes: attributes } }
+        reloaded = Hyrax.query_service.find_by(id: work.id)
+        expect(reloaded.member_ids).to contain_exactly(child2.id, child3.id)
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/steps/update_work_members_spec.rb
+++ b/spec/hyrax/transactions/steps/update_work_members_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+require 'hyrax/specs/spy_listener'
+
+RSpec.describe Hyrax::Transactions::Steps::UpdateWorkMembers, valkyrie_adapter: :test_adapter do
+  subject(:step) { described_class.new }
+  let(:listener) { Hyrax::Specs::SpyListener.new }
+  let(:work)     { FactoryBot.valkyrie_create(:hyrax_work) }
+
+  before { Hyrax.publisher.subscribe(listener) }
+  after  { Hyrax.publisher.unsubscribe(listener) }
+
+  context 'with a blank work_members_attributes param' do
+    it 'returns success' do
+      expect(step.call(work)).to be_success
+    end
+  end
+
+  context 'when adding a work member' do
+    let(:child) { FactoryBot.valkyrie_create(:hyrax_work) }
+    let(:attributes) { HashWithIndifferentAccess.new({ '0' => { id: child.id } }) }
+
+    it 'adds member work' do
+      expect { step.call(work, work_members_attributes: attributes) }
+        .to change { Hyrax.query_service.custom_queries.find_child_works(resource: work) }
+        .from(be_empty)
+        .to contain_exactly(child)
+    end
+
+    it 'publishes a metadata change event for the work' do
+      expect { step.call(work, work_members_attributes: attributes) }
+        .to change { listener.object_metadata_updated&.payload }
+        .to match object: be_a(Hyrax::Resource), user: nil
+    end
+  end
+
+  context 'when removing a work member' do
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :with_member_works) }
+    let(:children) { Hyrax.query_service.custom_queries.find_child_works(resource: work) }
+    let(:child1) { children.first }
+    let(:child2) { children.last }
+    let(:attributes) { HashWithIndifferentAccess.new({ '0' => { id: child1.id, _destroy: 'true' } }) }
+
+    it 'removes a member work' do
+      expect { step.call(work, work_members_attributes: attributes) }
+        .to change { Hyrax.query_service.custom_queries.find_child_works(resource: work) }
+        .from([child1, child2])
+        .to contain_exactly(child2)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #5545

Adds UpdateWorkMembers transaction step to enable users to add and remove child works for Valkyrie resources in the edit form.

@samvera/hyrax-code-reviewers
