### PR TITLE
Ensure excluded work id is a String

### DIFF
--- a/app/views/hyrax/base/_form_child_work_relationships.html.erb
+++ b/app/views/hyrax/base/_form_child_work_relationships.html.erb
@@ -18,7 +18,7 @@ HTML Properties:
                         data: {
                           autocomplete: 'work',
                           'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/find_works',
-                          'exclude-work': f.object.model.id # exclude this item from the result set.
+                          'exclude-work': f.object.model.id.to_s # exclude this item from the result set.
                         } %>
       <a href="#" onclick="return false;" class="btn btn-primary" data-behavior="add-relationship"><%= t('.add') %></a>
   </div>

--- a/spec/views/hyrax/base/_form_child_work_relationships.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_child_work_relationships.html.erb_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe "hyrax/base/_form_child_work_relationships.html.erb", type: :view
 
         # input with add button
         expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/find_works"]')
+        expect(rendered).to have_selector("[data-exclude-work='#{work.id}']")
         expect(rendered).to have_selector("[data-behavior='add-relationship']")
       end
     end
@@ -44,6 +45,7 @@ RSpec.describe "hyrax/base/_form_child_work_relationships.html.erb", type: :view
       it "draws the page" do
         # input with add button
         expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/find_works"]')
+        expect(rendered).to have_selector("[data-exclude-work='#{work.id}']")
         expect(rendered).to have_selector("[data-behavior='add-relationship']")
 
         # generate the json to drive the script


### PR DESCRIPTION
Closes #5551

Ensures that the excluded work id passed in the child relationships partial is a string. Important for Valkyrie resources as ids are objects.

@samvera/hyrax-code-reviewers
