### PR TITLE
Remove SingularSubresourceController concern from CitationsController to enable citations for Valkyrie resources

### DIFF
--- a/.dassie/config/initializers/hyrax.rb
+++ b/.dassie/config/initializers/hyrax.rb
@@ -16,6 +16,7 @@ Hyrax.config do |config|
 
   config.iiif_image_server = true
   config.work_requires_files = false
+  config.citations = true
 
   # Returns a URL that resolves to an image provided by a IIIF image server
   config.iiif_image_url_builder = lambda do |file_id, base_url, size, format|

--- a/app/controllers/hyrax/citations_controller.rb
+++ b/app/controllers/hyrax/citations_controller.rb
@@ -3,7 +3,6 @@ module Hyrax
   class CitationsController < ApplicationController
     include WorksControllerBehavior
     include Breadcrumbs
-    include SingularSubresourceController
 
     # Overrides decide_layout from WorksControllerBehavior
     with_themed_layout '1_column'

--- a/app/controllers/hyrax/citations_controller.rb
+++ b/app/controllers/hyrax/citations_controller.rb
@@ -2,6 +2,7 @@
 module Hyrax
   class CitationsController < ApplicationController
     include WorksControllerBehavior
+    include DenyAccessOverrideBehavior
     include Breadcrumbs
 
     # Overrides decide_layout from WorksControllerBehavior

--- a/spec/controllers/hyrax/citations_controller_spec.rb
+++ b/spec/controllers/hyrax/citations_controller_spec.rb
@@ -29,6 +29,22 @@ RSpec.describe Hyrax::CitationsController do
         expect(session['user_return_to']).to eq request.url
       end
     end
+
+    context "with a Valkyrie resource" do
+      let(:work) { FactoryBot.valkyrie_create(:monograph, edit_users: [user]) }
+      before do
+        sign_in user
+      end
+
+      it "is successful" do
+        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        get :work, params: { id: work }
+        expect(response).to be_successful
+        expect(response).to render_template('layouts/hyrax/1_column')
+        expect(assigns(:presenter)).to be_kind_of Hyrax::WorkShowPresenter
+      end
+    end
   end
   describe "#file" do
     let(:user) { create(:user) }

--- a/spec/controllers/hyrax/citations_controller_spec.rb
+++ b/spec/controllers/hyrax/citations_controller_spec.rb
@@ -22,7 +22,21 @@ RSpec.describe Hyrax::CitationsController do
     end
 
     context "with an unauthenticated user" do
-      it "is not successful" do
+      let(:second_user) { FactoryBot.create(:user) }
+
+      before do
+        sign_in second_user
+      end
+
+      it "redirects to the home page" do
+        get :work, params: { id: work }
+        expect(response).to redirect_to main_app.root_path(locale: 'en')
+        expect(flash[:alert]).to eq "You are not authorized to access this page."
+      end
+    end
+
+    context "when a user is not logged in" do
+      it "redirects to the user login page" do
         get :work, params: { id: work }
         expect(response).to redirect_to main_app.new_user_session_path(locale: 'en')
         expect(flash[:alert]).to eq "You are not authorized to access this page."


### PR DESCRIPTION
Closes #5452 

- Enables citations button in dassie test app so it can be tested
- Remove SingularSubresourceController concern from CitationsController to enable citations for Valkyrie resources

SingularSubresourceController is bound tightly to ActiveFedorda and removing the controller mix-in enables citations for Valkyrie and non-Valkyrie works.
