### PR TITLE
Move code propagating proxy depositor to file sets to new job

### DIFF
--- a/app/jobs/hyrax/propagate_change_depositor_job.rb
+++ b/app/jobs/hyrax/propagate_change_depositor_job.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+module Hyrax
+  # updates depositor on file sets and resets permissions if flagged. Used by
+  # ChangeDepositorService to background changes to lots of file sets
+  class PropagateChangeDepositorJob < ApplicationJob
+    # @param work [ActiveFedora::Base, Valkyrie::Resource] the work
+    #             that is receiving a change of depositor
+    # @param user [User] the user that will "become" the depositor of
+    #             the given work
+    # @param reset [TrueClass, FalseClass] when true, first clear
+    #              permissions for the given work and contained file
+    #              sets; regardless of true/false make the given user
+    #              the depositor of the given work
+    def perform(work, user, reset)
+      case work
+      when ActiveFedora::Base
+        call_af(work, user, reset)
+      when Valkyrie::Resource
+        call_valkyrie(work, user, reset)
+      end
+    end
+
+    private
+
+    def call_af(work, user, reset)
+      work.file_sets.each do |f|
+        f.permissions = [] if reset
+        f.apply_depositor_metadata(user)
+        f.save!
+      end
+    end
+
+    def call_valkyrie(work, user, reset)
+      Hyrax.custom_queries.find_child_file_sets(resource: work).each do |f|
+        if reset
+          f.permission_manager.acl.permissions = []
+          f.permission_manager.acl.save
+        end
+        apply_depositor_metadata(f, user)
+        Hyrax.persister.save(resource: f)
+      end
+    end
+
+    def apply_depositor_metadata(resource, depositor)
+      depositor_id = depositor.respond_to?(:user_key) ? depositor.user_key : depositor
+      resource.depositor = depositor_id if resource.respond_to? :depositor=
+      Hyrax::AccessControlList.new(resource: resource).grant(:edit).to(::User.find_by_user_key(depositor_id)).save
+    end
+  end
+end

--- a/app/services/hyrax/change_depositor_service.rb
+++ b/app/services/hyrax/change_depositor_service.rb
@@ -37,12 +37,12 @@ module Hyrax
       work.proxy_depositor = work.depositor
       work.permissions = [] if reset
       work.apply_depositor_metadata(user)
+      work.save!
       work.file_sets.each do |f|
         f.permissions = [] if reset
         f.apply_depositor_metadata(user)
         f.save!
       end
-      work.save!
       work
     end
     private_class_method :call_af
@@ -58,9 +58,9 @@ module Hyrax
       work.proxy_depositor = work.depositor
       apply_depositor_metadata(work, user)
 
+      work = Hyrax.persister.save(resource: work)
       apply_valkyrie_changes_to_file_sets(work: work, user: user, reset: reset)
-
-      Hyrax.persister.save(resource: work)
+      work
     end
     private_class_method :call_valkyrie
 

--- a/spec/jobs/hyrax/propagate_change_depositor_job_spec.rb
+++ b/spec/jobs/hyrax/propagate_change_depositor_job_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::PropagateChangeDepositorJob do
+  let(:depositor) { create(:user) }
+  let!(:receiver) { create(:user) }
+
+  context "for AF objects" do
+    let(:file_set) { create(:file_set) }
+    let!(:file) do
+      create(:file_set, user: depositor)
+    end
+    let!(:work) do
+      create(:work, title: ['Test work'], user: depositor).tap do |w|
+        w.members << file
+      end
+    end
+
+    it "changes the depositor of the child file sets" do
+      described_class.perform_now(work, receiver, false)
+      file.reload
+      expect(file.depositor).to eq receiver.user_key
+      expect(file.edit_users).to include(receiver.user_key, depositor.user_key)
+    end
+
+    context "when permissions are reset" do
+      it "changes the depositor of the child file sets and clears edit users" do
+        described_class.perform_now(work, receiver, true)
+        file.reload
+        expect(file.depositor).to eq receiver.user_key
+        expect(file.edit_users).to contain_exactly(receiver.user_key)
+      end
+    end
+  end
+
+  context "for valkyrie objects" do
+    let!(:work) { valkyrie_create(:hyrax_work, :with_member_file_sets, title: ['SoonToBeSomeoneElses'], depositor: depositor.user_key, edit_users: [depositor]) }
+
+    before do
+      work_acl = Hyrax::AccessControlList.new(resource: work)
+      Hyrax.custom_queries.find_child_file_sets(resource: work).each do |file_set|
+        Hyrax::AccessControlList.copy_permissions(source: work_acl, target: file_set)
+      end
+    end
+
+    it "changes the depositor of the child file sets" do
+      described_class.perform_now(work, receiver, false)
+      file_sets = Hyrax.custom_queries.find_child_file_sets(resource: work)
+      expect(file_sets.size).not_to eq 0 # A quick check to make sure our each block works
+
+      file_sets.each do |file_set|
+        expect(file_set.depositor).to eq receiver.user_key
+        expect(file_set.edit_users.to_a).to include(receiver.user_key, depositor.user_key)
+      end
+    end
+
+    context "when permissions are reset" do
+      it "changes the depositor of the child file sets and clears edit users" do
+        described_class.perform_now(work, receiver, true)
+        file_sets = Hyrax.custom_queries.find_child_file_sets(resource: work)
+        expect(file_sets.size).not_to eq 0 # A quick check to make sure our each block works
+
+        file_sets.each do |file_set|
+          expect(file_set.depositor).to eq receiver.user_key
+          expect(file_set.edit_users.to_a).to contain_exactly(receiver.user_key)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/change_depositor_service_spec.rb
+++ b/spec/services/hyrax/change_depositor_service_spec.rb
@@ -4,32 +4,19 @@ RSpec.describe Hyrax::ChangeDepositorService do
   let!(:receiver) { create(:user) }
 
   context "for Active Fedora objects" do
-    let!(:file) do
-      create(:file_set, user: depositor)
-    end
     let!(:work) do
       create(:work, title: ['Test work'], user: depositor)
     end
-
-    before do
-      work.members << file
-      described_class.call(work, receiver, reset)
-    end
+    let(:reset) { false }
 
     context "by default, when permissions are not reset" do
-      let(:reset) { false }
-
       it "changes the depositor and records an original depositor" do
+        described_class.call(work, receiver, reset)
         work.reload
         expect(work.depositor).to eq receiver.user_key
         expect(work.proxy_depositor).to eq depositor.user_key
         expect(work.edit_users).to include(receiver.user_key, depositor.user_key)
-      end
-
-      it "changes the depositor of the child file sets" do
-        file.reload
-        expect(file.depositor).to eq receiver.user_key
-        expect(file.edit_users).to include(receiver.user_key, depositor.user_key)
+        expect(Hyrax::PropagateChangeDepositorJob).not_to have_been_enqueued
       end
     end
 
@@ -37,70 +24,71 @@ RSpec.describe Hyrax::ChangeDepositorService do
       let(:reset) { true }
 
       it "excludes the depositor from the edit users" do
+        described_class.call(work, receiver, reset)
         work.reload
         expect(work.depositor).to eq receiver.user_key
         expect(work.proxy_depositor).to eq depositor.user_key
         expect(work.edit_users).to contain_exactly(receiver.user_key)
+        expect(Hyrax::PropagateChangeDepositorJob).not_to have_been_enqueued
+      end
+    end
+
+    context "when there are filesets" do
+      let!(:file) do
+        create(:file_set, user: depositor)
+      end
+      let!(:work) do
+        create(:work, title: ['Test work'], user: depositor).tap do |w|
+          w.members << file
+        end
       end
 
       it "changes the depositor of the child file sets" do
-        file.reload
-        expect(file.depositor).to eq receiver.user_key
-        expect(file.edit_users).to contain_exactly(receiver.user_key)
+        described_class.call(work, receiver, reset)
+        expect(Hyrax::PropagateChangeDepositorJob).to have_been_enqueued
       end
     end
   end
 
   context "for Valkyrie objects" do
-    let!(:base_work) { valkyrie_create(:hyrax_work, :with_member_file_sets, title: ['SoonToBeSomeoneElses'], depositor: depositor.user_key, edit_users: [depositor]) }
-    before do
-      work_acl = Hyrax::AccessControlList.new(resource: base_work)
-      Hyrax.custom_queries.find_child_file_sets(resource: base_work).each do |file_set|
-        Hyrax::AccessControlList.copy_permissions(source: work_acl, target: file_set)
-      end
-    end
+    let!(:base_work) { valkyrie_create(:hyrax_work, title: ['SoonToBeSomeoneElses'], depositor: depositor.user_key, edit_users: [depositor]) }
+    let!(:work_acl) { Hyrax::AccessControlList.new(resource: base_work) }
 
     context "by default, when permissions are not reset" do
       it "changes the depositor and records an original depositor" do
-        expect(ChangeDepositorEventJob).to receive(:perform_later)
         described_class.call(base_work, receiver, false)
         work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: base_work.id, use_valkyrie: true)
         expect(work.depositor).to eq receiver.user_key
         expect(work.proxy_depositor).to eq depositor.user_key
         expect(work.edit_users.to_a).to include(receiver.user_key, depositor.user_key)
-      end
-
-      it "changes the depositor of the child file sets" do
-        described_class.call(base_work, receiver, false)
-        file_sets = Hyrax.custom_queries.find_child_file_sets(resource: base_work)
-        expect(file_sets.size).not_to eq 0 # A quick check to make sure our each block works
-
-        file_sets.each do |file_set|
-          expect(file_set.depositor).to eq receiver.user_key
-          expect(file_set.edit_users.to_a).to include(receiver.user_key, depositor.user_key)
-        end
+        expect(Hyrax::PropagateChangeDepositorJob).not_to have_been_enqueued
+        expect(ChangeDepositorEventJob).to have_been_enqueued
       end
     end
 
     context "when permissions are reset" do
       it "changes the depositor and records an original depositor" do
-        expect(ChangeDepositorEventJob).to receive(:perform_later)
         described_class.call(base_work, receiver, true)
         work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: base_work.id, use_valkyrie: true)
         expect(work.depositor).to eq receiver.user_key
         expect(work.proxy_depositor).to eq depositor.user_key
         expect(work.edit_users.to_a).to contain_exactly(receiver.user_key)
+        expect(Hyrax::PropagateChangeDepositorJob).not_to have_been_enqueued
+        expect(ChangeDepositorEventJob).to have_been_enqueued
+      end
+    end
+
+    context "when there are filesets" do
+      let!(:base_work) { valkyrie_create(:hyrax_work, :with_member_file_sets, title: ['SoonToBeSomeoneElses'], depositor: depositor.user_key, edit_users: [depositor]) }
+      before do
+        Hyrax.custom_queries.find_child_file_sets(resource: base_work).each do |file_set|
+          Hyrax::AccessControlList.copy_permissions(source: work_acl, target: file_set)
+        end
       end
 
       it "changes the depositor of the child file sets" do
-        described_class.call(base_work, receiver, true)
-        file_sets = Hyrax.custom_queries.find_child_file_sets(resource: base_work)
-        expect(file_sets.size).not_to eq 0 # A quick check to make sure our each block works
-
-        file_sets.each do |file_set|
-          expect(file_set.depositor).to eq receiver.user_key
-          expect(file_set.edit_users.to_a).to contain_exactly(receiver.user_key)
-        end
+        described_class.call(base_work, receiver, false)
+        expect(Hyrax::PropagateChangeDepositorJob).to have_been_enqueued
       end
     end
 


### PR DESCRIPTION
It would probably be better to have this job spin off one job per file set.

it would also be good to stop checking for active fedora. But there were time constraints and this should at least ensure that nothing runs too long inline.

closes https://github.com/samvera/hyrax/issues/5557