### PR TITLE
Remove hard dependency on ActiveFedora/Wings from SolrDocument

### DIFF
--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -75,9 +75,9 @@ module Hyrax
     end
 
     # Method to return the model
-    def hydra_model(classifier: ActiveFedora.model_mapper)
+    def hydra_model(classifier: nil)
       first('has_model_ssim')&.safe_constantize ||
-        classifier.classifier(self).best_model
+        model_classifier(classifier).classifier(self).best_model
     end
 
     def depositor(default = '')
@@ -106,6 +106,12 @@ module Hyrax
 
     def collection_type_gid
       first(Hyrax.config.collection_type_index_field)
+    end
+
+    private
+
+    def model_classifier(classifier)
+      classifier || ActiveFedora.model_mapper
     end
   end
 end

--- a/spec/models/concerns/hyrax/solr_document_behavior_spec.rb
+++ b/spec/models/concerns/hyrax/solr_document_behavior_spec.rb
@@ -64,6 +64,17 @@ RSpec.describe Hyrax::SolrDocumentBehavior do
       it 'resolves the correct model name' do
         expect(solr_document.hydra_model).to eq Monograph
       end
+
+      context 'using non-wings adapter', valkyrie_adapter: :test_adapter do
+        before do
+          allow(Hyrax.config).to receive(:disable_wings).and_return(true)
+          hide_const("Wings")
+        end
+
+        it 'does not call Wings' do
+          expect(solr_document.hydra_model).to eq Monograph
+        end
+      end
     end
 
     context 'with a Wings model name' do


### PR DESCRIPTION
None of the calls to #hydra_model pass the classifier kwarg so Wings/ActiveFedora is invoked as the default value for the kwarg even though it is not used.  This refactor changes the kwarg default value to nil and passes it the kwarg to a private method to dynamically determine if the default Wings implementation should be used.  In most cases this method should never be called and thus the hard dependency on Wings has been removed.
