### PR TITLE
Use cancan override in tests that uses Hyrax.config to find resources

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -43,12 +43,9 @@ module Hyrax
       # The search builder to find the collections' members
       self.membership_service_class = Collections::CollectionMemberSearchService
 
-      load_and_authorize_resource except: [:index],
+      load_and_authorize_resource except: [:index, :create],
                                   instance_name: :collection,
                                   class: Hyrax.config.collection_model
-
-      skip_load_resource only: :create if
-        Hyrax.config.collection_class < ActiveFedora::Base
 
       def deny_collection_access(exception)
         if exception.action == :edit
@@ -110,12 +107,13 @@ module Hyrax
       end
 
       def create
-        return valkyrie_create if @collection.is_a?(Valkyrie::Resource)
         # Manual load and authorize necessary because Cancan will pass in all
         # form attributes. When `permissions_attributes` are present the
         # collection is saved without a value for `has_model.`
         @collection = Hyrax.config.collection_class.new
         authorize! :create, @collection
+        return valkyrie_create if @collection.is_a?(Valkyrie::Resource)
+
         # Coming from the UI, a collection type gid should always be present.  Coming from the API, if a collection type gid is not specified,
         # use the default collection type (provides backward compatibility with versions < Hyrax 2.1.0)
         @collection.collection_type_gid = params[:collection_type_gid].presence || default_collection_type.to_global_id

--- a/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
@@ -12,13 +12,6 @@ require 'hyrax/specs/spy_listener'
 RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean_repo: true do
   routes { Hyrax::Engine.routes }
 
-  controller described_class do
-    load_and_authorize_resource except: [:index],
-                                instance_name: :collection,
-                                prepend: true,
-                                class: Hyrax::PcdmCollection
-  end
-
   before { allow(Hyrax.config).to receive(:collection_model).and_return('Hyrax::PcdmCollection') }
   let(:collection_type_gid) { FactoryBot.create(:user_collection_type).to_global_id.to_s }
   let(:queries) { Hyrax.custom_queries }
@@ -221,7 +214,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
 
       it "adds members to the collection from edit form" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         parameters = { id: collection,
                        collection: { members: 'add' },
                        batch_document_ids: [asset3.id],
@@ -235,7 +227,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
 
       it "adds members to the collection from other than the edit form" do
-        pending 'update of test to work with Hyrax::PcdmCollection'
         parameters = { id: collection,
                        collection: { members: 'add' },
                        batch_document_ids: [asset3.id] }

--- a/spec/support/can_can_overrides.rb
+++ b/spec/support/can_can_overrides.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+##
+# This monkey-patch shim is for both active_fedora and valkyrie resources for tests
+# This shim handles the case where controllers are loaded with an ActiveFedora collection class
+# different than a test mocks Hyrax.config.collection_class.
+# This override checks the value in Hyrax.config and uses it when it is a known collection or admin set class.
+# This override also memoizes the resource_class to avoid multiple lookups.
+CanCan::ControllerResource.class_eval do
+  def resource_class
+    return @resource_class if @resource_class.present?
+    @resource_class = case @options[:class]
+                      when false then
+                        name.to_sym
+                      when nil then
+                        namespaced_name.to_s.camelize.constantize
+                      when String then
+                        @options[:class].constantize
+                      else
+                        @options[:class]
+                      end
+    @resource_class = dynamically_resolve_class(@resource_class)
+  end
+
+  private
+
+  def dynamically_resolve_class(resource_class)
+    if collection_class?(resource_class)
+      Hyrax.config.collection_class
+    elsif admin_set_class?(resource_class)
+      Hyrax.config.admin_set_class
+    else
+      resource_class
+    end
+  end
+
+  def collection_class?(model_class)
+    model_class == Hyrax::PcdmCollection || model_class < Hyrax::PcdmCollection || model_class == ::Collection || model_class < ::Collection
+  end
+
+  def admin_set_class?(model_class)
+    model_class == Hyrax::AdministrativeSet || model_class < Hyrax::AdministrativeSet || model_class == AdminSet || model_class < AdminSet
+  end
+end


### PR DESCRIPTION
Remove anonymous controller to test that adapter works

This resolves the issue where the before action set on the controller by `load_and_authorize_resource` does not dynamically evaluate the class used so looks for the wrong model when mocking Hyrax.config.collection_model in specific tests.