### PR TITLE
Index admin set relationship using the same field as ActiveFedora-based works

### DIFF
--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -18,7 +18,7 @@ module Hyrax
         admin_set_label = admin_set_label(resource)
         solr_doc['admin_set_sim']   = admin_set_label
         solr_doc['admin_set_tesim'] = admin_set_label
-        solr_doc['isPartOf_ssim'] = [resource.admin_set_id.to_s]
+        solr_doc["#{Hyrax.config.admin_set_predicate.qname.last}_ssim"] = [resource.admin_set_id.to_s]
         solr_doc['member_of_collection_ids_ssim'] = resource.member_of_collection_ids.map(&:to_s)
         solr_doc['member_ids_ssim'] = resource.member_ids.map(&:to_s)
         solr_doc['depositor_ssim'] = [resource.depositor]

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -18,6 +18,7 @@ module Hyrax
         admin_set_label = admin_set_label(resource)
         solr_doc['admin_set_sim']   = admin_set_label
         solr_doc['admin_set_tesim'] = admin_set_label
+        solr_doc['isPartOf_ssim'] = [resource.admin_set_id.to_s]
         solr_doc['member_of_collection_ids_ssim'] = resource.member_of_collection_ids.map(&:to_s)
         solr_doc['member_ids_ssim'] = resource.member_ids.map(&:to_s)
         solr_doc['depositor_ssim'] = [resource.depositor]

--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -8,11 +8,11 @@ module Hyrax
     end
 
     def total_items
-      Hyrax::SolrService.count("{!field f=isPartOf_ssim}#{id}")
+      Hyrax::SolrService.count("{!field f=#{Hyrax.config.admin_set_predicate.qname.last}_ssim}#{id}")
     end
 
     def total_viewable_items
-      field_pairs = { "isPartOf_ssim" => id.to_s }
+      field_pairs = { "#{Hyrax.config.admin_set_predicate.qname.last}_ssim" => id.to_s }
       SolrQueryService.new
                       .with_field_pairs(field_pairs: field_pairs)
                       .accessible_by(ability: current_ability)

--- a/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_work_indexer_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Hyrax::ValkyrieWorkIndexer do
       expect(solr_document.fetch('admin_set_sim')).to match_array [admin_set_title]
       expect(solr_document.fetch('admin_set_tesim')).to match_array [admin_set_title]
       expect(solr_document.fetch('admin_set_id_ssim')).to match_array [admin_set.id]
+      expect(solr_document.fetch('isPartOf_ssim')).to match_array [admin_set.id]
       expect(solr_document.fetch('member_ids_ssim')).to match_array work.member_ids
       expect(solr_document.fetch('member_of_collection_ids_ssim')).to match_array [col1.id]
       expect(solr_document.fetch('depositor_ssim')).to match_array [user.email]


### PR DESCRIPTION
Fixes #5497 

The `isPartOf_ssim` field is used when searching for works belonging to an admin set. 
https://github.com/samvera/hyrax/blob/d628b58ca15fe0614547c3ad3fd7e6d900070660/app/presenters/hyrax/admin_set_presenter.rb#L11

Future work:
- write a feature test
- change the hardcoded `isPartOf_ssim` in the line referenced above and the other occurrence in that presenter to use the configuration `Hyrax.config.admin_set_predicate.qname.last` which is used in the search builder
https://github.com/samvera/hyrax/blob/b034218b89dde7df534e32d1e5ade9161e129a1d/app/search_builders/hyrax/admin_admin_set_member_search_builder.rb#L27