### PR TITLE
Index create/modified date with same field as in ActiveFedora-based models

### DIFF
--- a/app/indexers/hyrax/valkyrie_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_indexer.rb
@@ -70,6 +70,8 @@ module Hyrax
         "id": resource.id.to_s,
         "date_uploaded_dtsi": resource.created_at,
         "date_modified_dtsi": resource.updated_at,
+        "system_create_dtsi": resource.created_at,
+        "system_modified_dtsi": resource.updated_at,
         "has_model_ssim": resource.internal_resource
       }.with_indifferent_access
     end

--- a/spec/indexers/hyrax/valkyrie_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_indexer_spec.rb
@@ -67,7 +67,9 @@ RSpec.describe Hyrax::ValkyrieIndexer do
       expect(indexer.to_solr).to match a_hash_including(
         id: resource.id.to_s,
         date_uploaded_dtsi: resource.created_at,
-        date_modified_dtsi: resource.updated_at
+        date_modified_dtsi: resource.updated_at,
+        system_create_dtsi: resource.created_at,
+        system_modified_dtsi: resource.updated_at
       )
     end
   end


### PR DESCRIPTION
These fields are used and expected throughout the code base.
Some examples:
- https://github.com/samvera/hyrax/blob/main/app/models/concerns/hyrax/solr_document/metadata.rb#L87-L88
- https://github.com/samvera/hyrax/blob/b034218b89dde7df534e32d1e5ade9161e129a1d/app/services/hyrax/statistics/query_service.rb#L36
- https://github.com/samvera/hyrax/blob/main/lib/generators/hyrax/templates/catalog_controller.rb#L11-L17
- https://github.com/samvera/hyrax/blob/main/lib/hyrax/resource_sync/change_list_writer.rb#L11
- https://github.com/samvera/hyrax/blob/main/lib/wings/setup.rb#L47