### PR TITLE
Index resources created from test factries by default

### DIFF
--- a/spec/factories/administrative_sets.rb
+++ b/spec/factories/administrative_sets.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
       with_permission_template { false }
       user { create(:user) }
       access_grants { [] }
+      with_index { true }
     end
 
     after(:build) do |adminset, evaluator|
@@ -28,6 +29,7 @@ FactoryBot.define do
                                                           access: Hyrax::PermissionTemplateAccess::MANAGE)
         template.reset_access_controls_for(collection: admin_set)
       end
+      Hyrax.index_adapter.save(resource: admin_set) if evaluator.with_index
     end
   end
 

--- a/spec/factories/hyrax_file_set.rb
+++ b/spec/factories/hyrax_file_set.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
       edit_groups        { [] }
       read_users         { [] }
       read_groups        { [] }
+      with_index         { true }
     end
 
     after(:build) do |file_set, evaluator|
@@ -46,6 +47,8 @@ FactoryBot.define do
       file_set.permission_manager.read_users  = evaluator.read_groups
 
       file_set.permission_manager.acl.save
+
+      Hyrax.index_adapter.save(resource: file_set) if evaluator.with_index
     end
 
     trait :public do

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
       read_users         { [] }
       members            { nil }
       visibility_setting { nil }
+      with_index         { true }
     end
 
     after(:build) do |work, evaluator|
@@ -46,6 +47,8 @@ FactoryBot.define do
       work.permission_manager.read_users  = evaluator.read_users
 
       work.permission_manager.acl.save
+
+      Hyrax.index_adapter.save(resource: work) if evaluator.with_index
     end
 
     trait :public do

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe Hyrax::Forms::ResourceForm do
 
     context 'when using a generic valkyrie adapter', valkyrie_adapter: :test_adapter do
       before do
-        allow(Hyrax).to receive_message_chain(:config, :disable_wings).and_return(true) # rubocop:disable RSpec/MessageChain
+        allow(Hyrax.config).to receive(:disable_wings).and_return(true)
         hide_const("Wings") # disable_wings=true removes the Wings constant
       end
       it 'prepopulates as empty before save' do

--- a/spec/services/hyrax/listeners/file_metadata_listener_spec.rb
+++ b/spec/services/hyrax/listeners/file_metadata_listener_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hyrax::Listeners::FileMetadataListener, valkyrie_adapter: :test_a
   let(:data)         { { metadata: metadata, user: user } }
   let(:event)        { Dry::Events::Event.new(event_type, data) }
   let(:fake_adapter) { FakeIndexingAdapter.new }
-  let(:file_set)     { FactoryBot.valkyrie_create(:hyrax_file_set) }
+  let(:file_set)     { FactoryBot.valkyrie_create(:hyrax_file_set, with_index: false) }
   let(:metadata)     { FactoryBot.valkyrie_create(:hyrax_file_metadata, file_set_id: file_set.id) }
   let(:user)         { FactoryBot.create(:user) }
 


### PR DESCRIPTION
This follows the pattern already set in the `hyrax_collection` factory.
https://github.com/samvera/hyrax/blob/d628b58ca15fe0614547c3ad3fd7e6d900070660/spec/factories/hyrax_collection.rb#L44

A couple tests needed slight changes as a result of this change in indexing behavior.