### PR TITLE
Make hyrax_collection title be a sequence matching the collection factory

### DIFF
--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -4,7 +4,7 @@
 # Use this factory for generic Hyrax/HydraWorks Collections in valkyrie.
 FactoryBot.define do
   factory :hyrax_collection, class: 'Hyrax::PcdmCollection' do
-    title               { ['The Tove Jansson Collection'] }
+    sequence(:title) { |n| ["The Tove Jansson Collection #{n}"] }
     collection_type_gid { Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id }
 
     transient do

--- a/spec/helpers/hyrax/membership_helper_spec.rb
+++ b/spec/helpers/hyrax/membership_helper_spec.rb
@@ -16,11 +16,12 @@ RSpec.describe Hyrax::MembershipHelper do
 
       context 'when it is a member of a collection' do
         let(:work) { build(:monograph, :as_collection_member) }
+        let(:collection) { Hyrax.custom_queries.find_parent_collections(resource: work).first }
 
         it 'gives collection details' do
           expect(JSON.parse(helper.member_of_collections_json(resource)))
             .to contain_exactly(include('id' => an_instance_of(String),
-                                        'label' => 'The Tove Jansson Collection',
+                                        'label' => collection.title.first,
                                         'path' => an_instance_of(String)))
         end
       end
@@ -37,11 +38,12 @@ RSpec.describe Hyrax::MembershipHelper do
 
       context 'when it is a member of a collection' do
         let(:resource) { build(:hyrax_work, :as_collection_member) }
+        let(:collection) { Hyrax.custom_queries.find_parent_collections(resource: resource).first }
 
         it 'gives collection details' do
           expect(JSON.parse(helper.member_of_collections_json(resource)))
             .to contain_exactly(include('id' => an_instance_of(String),
-                                        'label' => 'The Tove Jansson Collection',
+                                        'label' => collection.title.first,
                                         'path' => an_instance_of(String)))
         end
       end


### PR DESCRIPTION
Some tests expect collection titles to be unique so matching the collection factory enables the tests to be more analogous between ActiveFedora and Valkyrie tests.  One test had to be updated since it hard-coded the title used in the factory.