### PR TITLE
Fix flaky file ordering in spec for ValkyrieIngestJob

### DIFF
--- a/spec/jobs/valkyrie_ingest_job_spec.rb
+++ b/spec/jobs/valkyrie_ingest_job_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe ValkyrieIngestJob do
 
         reloaded_file_set = Hyrax.query_service.find_by(id: file_set.id)
         files = Hyrax.custom_queries.find_files(file_set: reloaded_file_set)
-        expect(files).to match(a_collection_containing_exactly(be_original_file, be_thumbnail_file))
+        expect(files).to contain_exactly(be_original_file, be_thumbnail_file)
         expect(reloaded_file_set.title).to eq ["image.png"]
         expect(reloaded_file_set.label).to eq "image.png"
         expect(reloaded_file_set.file_ids)

--- a/spec/jobs/valkyrie_ingest_job_spec.rb
+++ b/spec/jobs/valkyrie_ingest_job_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe ValkyrieIngestJob do
         described_class.perform_now(thumbnail_upload, pcdm_use: Hyrax::FileMetadata::Use::THUMBNAIL)
 
         reloaded_file_set = Hyrax.query_service.find_by(id: file_set.id)
-        expect(reloaded_file_set)
-          .to have_attached_files(be_original_file, be_thumbnail_file)
+        files = Hyrax.custom_queries.find_files(file_set: reloaded_file_set)
+        expect(files).to match(a_collection_containing_exactly(be_original_file, be_thumbnail_file))
         expect(reloaded_file_set.title).to eq ["image.png"]
         expect(reloaded_file_set.label).to eq "image.png"
         expect(reloaded_file_set.file_ids)


### PR DESCRIPTION
The order that files are returned can vary causing the test to fail sometimes. This makes the spec not care about the ordering.

@samvera/hyrax-code-reviewers
