### PR TITLE
Fix flaky test caused by querying solr for admin set with a nil id

### DIFF
--- a/spec/presenters/hyrax/admin_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::AdminSetPresenter do
   describe "total_items" do
     subject { presenter.total_items }
 
-    let(:admin_set) { build(:admin_set) }
+    let(:admin_set) { create(:admin_set) }
 
     context "empty admin set" do
       it { is_expected.to eq 0 }


### PR DESCRIPTION
`presenter.total_items` queries solr using the admin set id, but a built (not created) admin set has a nil id. This leads to flaky spec failures depending on the random order specs are run. Using create should avoid this.
