### PR TITLE
Configure Github automatic release notes feature

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  categories:
+    - title: Major Changes (Potentially breaking changes)
+      labels:
+        - notes-major
+    - title: New Features
+      labels:
+        - notes-minor
+    - title: Deprecations
+      labels:
+        - notes-deprecation
+    - title: Bug Fixes
+      labels:
+        - notes-bugfix
+    - title: Valkyrie Progress
+      labels:
+        - notes-valkyrie
+    - title: Documentation
+      labels:
+        - notes-docs
+    - title: Containerization
+      labels:
+        - notes-container
+    - title: Other
+      labels:
+        - "*"


### PR DESCRIPTION
Makes Github automatic release notes feature recognize notes-* PR tags.