### PR TITLE
allow sub-collections to be created from collection page

### DIFF
--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -171,7 +171,7 @@ module Hyrax
       # @return [Fixnum] the largest number of collections in a path nested
       #   under this collection (including this collection)
       def self.child_nesting_depth(child:, scope:)
-        return 1 if child.nil?
+        return 1 unless child
         # The nesting depth of a child collection is found by finding the largest nesting depth
         # among all collections and works which have the child collection in the paths, and
         # subtracting the nesting depth of the child collection itself.


### PR DESCRIPTION
Fixes #5492

When it a collection page, the user should be able to create a sub-collection.

The reason this was not working was because the code was checking for a `nil` value for child, but if there is no child the value to check for is `false`.  The false value is set here in the code:

https://github.com/samvera/hyrax/blob/main/app/forms/hyrax/forms/dashboard/nest_collection_form.rb#L33

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to collection editing page.
* Clicking "Create new collection as subcollection"
* You should be able to create the new sub-collection.
* Go back to the collection page and you should see the newly created sub-collection displayed on this page.

@samvera/hyrax-code-reviewers
