### PR TITLE
Existing valkyrie feature tests should work without Wings

### DIFF
--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
   let(:file2) { File.open(fixture_path + '/image.jp2') }
   let!(:uploaded_file1) { Hyrax::UploadedFile.create(file: file1, user: user) }
   let!(:uploaded_file2) { Hyrax::UploadedFile.create(file: file2, user: user) }
-  let(:permission_template) { create(:permission_template, source_id: 'admin_set/default', with_admin_set: true, with_active_workflow: true) }
+  let(:permission_template) { create(:permission_template, with_admin_set: true, with_active_workflow: true) }
 
   before do
     # Grant the user access to deposit into an admin set.
@@ -135,7 +135,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
     end
   end
 
-  context "with valkyrie resources", metadata_adapter: :postgres_adapter do
+  context "with valkyrie resources", valkyrie_adapter: :postgres_adapter do
     before do
       sign_in user
       click_link 'Works'

--- a/spec/features/default_workflow_spec.rb
+++ b/spec/features/default_workflow_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe 'The default Hyrax workflow', type: :feature do
+RSpec.describe 'The default Hyrax workflow', type: :feature, valkyrie_adapter: :test_adapter do
   let(:depositor) { FactoryBot.create(:user) }
 
   let(:work) do

--- a/spec/features/delete_resource_spec.rb
+++ b/spec/features/delete_resource_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'hyrax/specs/spy_listener'
 
-RSpec.describe 'Deleting a valkyrie work', type: :feature do
+RSpec.describe 'Deleting a valkyrie work', type: :feature, valkyrie_adapter: :test_adapter, index_adapter: :solr_index do
   let(:work) do
     FactoryBot.valkyrie_create(:monograph,
                                :as_member_of_multiple_collections,

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Editing a work', type: :feature do
     end
   end
 
-  context 'with a parent Valkyrie resource' do
+  context 'with a parent Valkyrie resource', valkyrie_adapter: :test_adapter, index_adapter: :solr_index do
     let(:monograph) { FactoryBot.valkyrie_create(:monograph, :with_member_works) }
 
     before do

--- a/spec/features/valkyrie_search_spec.rb
+++ b/spec/features/valkyrie_search_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe 'searching', index_adapter: :solr_index do
+RSpec.describe 'searching', index_adapter: :solr_index, valkyrie_adapter: :test_adapter do
   let(:user) { create :user }
   let(:subject_value) { 'mustache' }
   let!(:work) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -310,8 +310,10 @@ RSpec.configure do |config|
   config.around(:example, index_adapter: :solr_index) do |example|
     blacklight_connection_url = CatalogController.blacklight_config.connection_config[:url]
     CatalogController.blacklight_config.connection_config[:url] = Valkyrie::IndexingAdapter.find(:solr_index).connection.options[:url]
+    Blacklight.default_index.connection = nil # force reloading of rsolr connection
     example.run
     CatalogController.blacklight_config.connection_config[:url] = blacklight_connection_url
+    Blacklight.default_index.connection = nil # force reloading of rsolr connection
   end
 
   # Prepend this before block to ensure that it runs before other before blocks like clean_repo

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -314,7 +314,8 @@ RSpec.configure do |config|
     CatalogController.blacklight_config.connection_config[:url] = blacklight_connection_url
   end
 
-  config.before(:example, :valkyrie_adapter) do |example|
+  # Prepend this before block to ensure that it runs before other before blocks like clean_repo
+  config.prepend_before(:example, :valkyrie_adapter) do |example|
     adapter_name = example.metadata[:valkyrie_adapter]
 
     allow(Hyrax)


### PR DESCRIPTION
Adjusts the existing feature tests which use valkyrie to run cleanly on a non-wings adapter without making any calling fedora.

@samvera/hyrax-code-reviewers
