### PR TITLE
Update _tabs.html.erb

### DIFF
--- a/app/views/hyrax/my/works/_tabs.html.erb
+++ b/app/views/hyrax/my/works/_tabs.html.erb
@@ -1,6 +1,11 @@
 <ul class="nav nav-tabs" id="my_nav" role="list">
   <li<%= ' class="active"'.html_safe if current_page?(hyrax.dashboard_works_path(locale: nil)) %>>
-    <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.works"), hyrax.dashboard_works_path %>
+    <% if params[:add_works_to_collection].present? && params[:add_works_to_collection_label].present? %>
+      <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.works"), hyrax.dashboard_works_path(add_works_to_collection: params[:add_works_to_collection], add_works_to_collection_label: params[:add_works_to_collection_label]) %>
+    <% else %>
+      <%= link_to t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.works"), hyrax.dashboard_works_path %>
+    <% end %>
+    
   </li>
   <li<%= ' class="active"'.html_safe if current_page?(hyrax.my_works_path(locale: nil)) %>>
     <%= link_to t('hyrax.dashboard.my.your_works'), hyrax.my_works_path %>


### PR DESCRIPTION
Fixes #4513

When adding managed works to an existing collection via the collection’s edit page, the pre-selected collection name is cleared after the user clicks the “managed works” tab. This PR ensures a pre-selected collection is still saved when moving from `Your Works` to either `Managed Works` or `All Works`.

Changes proposed in this pull request:
* When rendering `Your Works` page, if parameters `add_works_to_collection` and `add_works_to_collection_label` are present, add them to the link of either tab `Managed Works` or `All Works`. This ensures the pre-selected collection is saved and rendered correctly when a user attempts to add a work from either `Managed Works` or `All Works`.


Guidance for testing, such as acceptance criteria or new user interface behaviors:
1. Ensure testing user has manager access to a collection, and edit access to at least one work
2. Access the collection the user has a manager access to
3. Click `Add existing works to this Collection`
4. On the Works page, switch from tab `Your Works` to tab `Managed Works`
5. Select a work from `Managed Works` and click `Add to collection`
6. Verify that under the `Add to collection` modal, the collection selected is the collection the user initially wanted to add an existing work to

@samvera/hyrax-code-reviewers
