### PR TITLE
dassie: ensure docker-compose seeds the application

### DIFF
--- a/.dassie/db/seeds.rb
+++ b/.dassie/db/seeds.rb
@@ -68,6 +68,8 @@ if wipe_data
 end
 
 if seed_dassie
+  puts 'Seeding Dassie ...'
+
   Hyrax::RequiredDataSeeder.new.generate_seed_data
   Hyrax::TestDataSeeders::UserSeeder.generate_seeds
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
     user: root
     env_file:
       - .env
+      - .dassie/.env
     command: sh -l -c 'bundle && db-migrate-seed.sh'
     depends_on:
       - postgres


### PR DESCRIPTION
the db migrate container was not including the dassie `.env` file, which is where `SEED_DASSIE` is set.

@samvera/hyrax-code-reviewers
