### PR TITLE
Featured Works MIA After Reindex

### DIFF
--- a/app/models/featured_work_list.rb
+++ b/app/models/featured_work_list.rb
@@ -18,7 +18,6 @@ class FeaturedWorkList
     @works = FeaturedWork.all
     add_solr_document_to_works
     @works = @works.reject do |work|
-      work.destroy if work.presenter.blank?
       work.presenter.blank?
     end
   end


### PR DESCRIPTION
Stop removing featured records if the item is missing from the index. If an app is being reindexed OR solr is having a bad day, we shouldn't destroy database records, just skip them.


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a work
* Feature that work
* Clear or drop your solr index
* Load the home page
* Reindex
* Previously the work would no longer be featured, with this code change the featuring comes back

@samvera/hyrax-code-reviewers
