### PR TITLE
use core metadata in forms for pcdm collections

### DIFF
--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -6,7 +6,7 @@ module Hyrax
     # @api public
     # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
     class PcdmCollectionForm < Valkyrie::ChangeSet # rubocop:disable Metrics/ClassLength
-      property :title, required: true, primary: true
+      include Hyrax::FormFields(:core_metadata)
 
       property :human_readable_type, writable: false
       property :date_modified, readable: false
@@ -18,7 +18,6 @@ module Hyrax
 
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
 
-      validates :title, presence: true
       validates :collection_type_gid, presence: true
 
       class << self


### PR DESCRIPTION
### Description

This is a simple change to make the pcdm collection form use the schema loader to load core metadata which generates the property and validation for the title field instead of defining the property directly in the the form.  The model and indexer already include core metadata.  This doesn't change any behaviors of Hyrax.

@samvera/hyrax-code-reviewers
