### PR TITLE
do not include basic metadata in pcdm collections

### DIFF
--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -9,7 +9,6 @@ module Hyrax
     include Hyrax::VisibilityIndexer
     include Hyrax::ThumbnailIndexer
     include Hyrax::Indexer(:core_metadata)
-    include Hyrax::Indexer(:basic_metadata)
 
     self.thumbnail_path_service = CollectionThumbnailPathService
 

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -41,7 +41,6 @@ module Hyrax
   #
   class PcdmCollection < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
-    include Hyrax::Schema(:basic_metadata)
 
     attribute :collection_type_gid, Valkyrie::Types::String
     attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -135,7 +135,6 @@ RSpec.shared_examples 'a Hyrax::PcdmCollection' do
 
   it_behaves_like 'a Hyrax::Resource'
   it_behaves_like 'a model with core metadata'
-  it_behaves_like 'a model with basic metadata'
   it_behaves_like 'has members'
 
   describe '#collection_type_gid' do

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
     FactoryBot.valkyrie_create(:hyrax_collection,
                                :public,
                                title: ["My collection"],
-                               description: ["My incredibly detailed description of the collection"],
                                edit_users: [user.user_key], read_users: [user.user_key])
   end
 
@@ -20,7 +19,7 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
   let(:unowned_asset) { FactoryBot.valkyrie_create(:work, user: other) }
 
   let(:collection_attrs) do
-    { title: ['My First Collection'], description: ["The Description\r\n\r\nand more"] }
+    { title: ['My First Collection'] }
   end
 
   describe "#show" do # public landing page

--- a/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
     before { sign_in user }
 
     it "removes blank strings from params before creating Collection" do
+      pending 'creation of a collection resource that includes basic metadata'
       expect { post :create, params: { collection: collection_attrs.merge(creator: ['']) } }
         .to change { Hyrax.query_service.count_all_of_model(model: Hyrax::PcdmCollection) }
         .by(1)
@@ -309,6 +310,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
       end
 
       it "removes blank strings from params before updating Collection metadata" do # rubocop:disable RSpec/ExampleLength
+        pending 'creation of a collection resource that includes basic metadata'
         put :update, params: {
           id: collection,
           collection: {

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -4,14 +4,24 @@ RSpec.describe Hyrax::CollectionPresenter do
   let(:collection) do
     build(:hyrax_collection,
           id: 'adc12v',
+          title: ['A clever title'])
+  end
+  let(:active_fedora_collection) do
+    build(:collection_lw,
+          id: 'adc12v',
           description: ['a nice collection'],
           based_near: ['Over there'],
           title: ['A clever title'],
           keyword: ['neologism'],
           resource_type: ['Collection'],
           related_url: ['http://example.com/'],
-          date_created: ['some date'])
+          date_created: ['some date'],
+          with_solr_document: true)
   end
+  let(:active_fedora_solr_hash) do
+    active_fedora_collection.to_solr
+  end
+
   let(:ability) { double(::Ability) }
   let(:solr_doc) { SolrDocument.new(solr_hash) }
   let(:solr_hash) { Hyrax::ValkyrieIndexer.for(resource: collection).to_solr }
@@ -68,10 +78,16 @@ RSpec.describe Hyrax::CollectionPresenter do
   end
 
   describe "#resource_type" do
-    it { is_expected.to have_attributes resource_type: collection.resource_type }
+    let(:collection) { active_fedora_collection }
+    let(:solr_hash) { active_fedora_solr_hash }
+    it 'has resource_type' do
+      expect(presenter).to have_attributes resource_type: collection.resource_type
+    end
   end
 
   describe "#terms_with_values" do
+    let(:collection) { active_fedora_collection }
+    let(:solr_hash) { active_fedora_solr_hash }
     it 'gives the list of terms that have values' do
       expect(presenter.terms_with_values)
         .to contain_exactly(:total_items, :size, :resource_type, :keyword,
@@ -88,22 +104,32 @@ RSpec.describe Hyrax::CollectionPresenter do
   end
 
   describe '#keyword' do
+    let(:collection) { active_fedora_collection }
+    let(:solr_hash) { active_fedora_solr_hash }
     it { is_expected.to have_attributes keyword: collection.keyword }
   end
 
   describe "#based_near" do
+    let(:collection) { active_fedora_collection }
+    let(:solr_hash) { active_fedora_solr_hash }
     it { is_expected.to have_attributes based_near: collection.based_near }
   end
 
   describe "#related_url" do
+    let(:collection) { active_fedora_collection }
+    let(:solr_hash) { active_fedora_solr_hash }
     it { is_expected.to have_attributes related_url: collection.related_url }
   end
 
   describe '#to_key' do
+    let(:collection) { active_fedora_collection }
+    let(:solr_hash) { active_fedora_solr_hash }
     it { expect(presenter.to_key).to eq ['adc12v'] }
   end
 
   describe '#size' do
+    let(:collection) { active_fedora_collection }
+    let(:solr_hash) { active_fedora_solr_hash }
     it 'returns a hard-coded string and issues a deprecation warning' do
       expect(Deprecation).to receive(:warn).once
       expect(presenter.size).to eq('unknown')


### PR DESCRIPTION
### Description

The change in this PR is being made to make the processing of PcdmCollection's consistent across the components (i.e., model, indexer, form).

### Expected

Model, indexer, and form will all handle core and basic metadata, if included, through the schema loader consistently across all components.  All will be tested.

### Actual

Model, indexer, and form do not handle core and basic metadata consistently through the schema loader across all components.  Some are tested.

* model included core and basic metadata loaded through the schema, and tested both
* indexer included core and basic metadata loaded through the schema, but only tested core
* form didn't include either.  There don't appear to be tests specific to parts of the form loaded through the schema loader.  For resource form, title is tested directly in specs.  The same is done in the PcdmCollectionForm tests.

### Confirm form is the same

#### Prerequisites:
Configure to collection model:
1. Edit /config/initializers/hyrax.rb and set:
```
  config.collection_model = "Hyrax::PcdmCollection"
```
2. Restart rails server.

#### Test form in browser

Before and after this change, the following steps take you to a form that has only one field, the Title field.

1. navigate to Dashboard -> Collections
2. click button: New Collection
3. select type: any type
4. click button: Create Collection

NOTE: Title is the only available metadata field before and after the change in this PR.

### Related Work

Working toward resolution of Issue #5494.

@samvera/hyrax-code-reviewers
