### PR TITLE
Improve error handling for creating valkyrie collections

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -84,12 +84,12 @@ module Hyrax
       end
 
       def after_create
-        Deprecation.warn("Method `#after_create` will be removed in the next major release.")
+        Deprecation.warn("Method `#after_create` will be removed in Hyrax 4.0.")
         after_create_response # call private method for processing
       end
 
       def after_create_error
-        Deprecation.warn("Method `#after_create_error` will be removed in the next major release.")
+        Deprecation.warn("Method `#after_create_error` will be removed in Hyrax 4.0.")
         after_create_errors("") # call private method for processing
       end
 

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       it "renders the form again" do
         post :create, params: { collection: collection_attrs }
 
-        expect(response).to be_successful
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(:new)
       end
     end


### PR DESCRIPTION
### Description

The new collection instance was being set to the results of the validation failure when it failed and to false when the transactions failed.

WAS:

```
@collection =
          form.validate(params[collection_params]) &&
          transactions['change_set.create_collection']
          ...
         .call(form).value_or { return after_create_error }
```

Now, the form validation is processed before setting @collection. If a failure occurs, the process is aborted and calls after_create_errors.  Likewise, if there is a failure during the transaction process, after_create_errors is called to process the error and redisplay the new form.

_NOTE: This PR also moves after and before methods for create to private, deprecating the public versions.  Again, this is consistent with the pattern used in works._

### Follow-on work

Need to do the same for updates.  This will be done in a separate PR to keep this one easier to review.

### Related work

The approach is based on the same change that was made for works in [PR #5448](https://github.com/samvera/hyrax/pull/5448/files#diff-843d5f344066ba9de62a999cf88a87b29479b10988676c0bc474f4853e2adaf4).

@samvera/hyrax-code-reviewers
