### PR TITLE
Enable Geonames for `Collection` location input autocomplete

### DIFF
--- a/app/assets/javascripts/hyrax/collections_v2.es6
+++ b/app/assets/javascripts/hyrax/collections_v2.es6
@@ -1,10 +1,12 @@
 import CollectionUtilities from 'hyrax/collections_utils';
+import Editor from 'hyrax/editor';
 
 export default class CollectionsV2 {
   constructor() {
     this.collectionUtilities = new CollectionUtilities();
     this.setupAddSharingHandler();
     this.sharingAddButtonDisabler();
+    this.setupEditor();
   }
 
   /**
@@ -54,4 +56,15 @@ export default class CollectionsV2 {
         )
       );
   }
+
+  /**
+   * Set up editor to enable Geonames autocomplete for Location data
+   * @return {void}
+   */
+   setupEditor() {
+    var element = $("[data-behavior='collection-form']");
+    if (element.length > 0) {
+      new Editor(element).init();
+    }
+   }
 }

--- a/app/views/collections/edit_fields/_based_near.html.erb
+++ b/app/views/collections/edit_fields/_based_near.html.erb
@@ -1,8 +1,8 @@
 <%= f.input key,
-            as: :multi_value,
-            input_html: {
-              class: 'form-control',
-              data: { 'autocomplete-url' => "/authorities/search/geonames",
-                      'autocomplete' => key }
-            },
-            required: f.object.required?(key) %>
+  as: :multi_value,
+  input_html: {
+    class: 'form-control',
+    data: { 'autocomplete-url' => "/authorities/search/geonames",
+            'autocomplete' => key }
+  },
+  required: f.object.required?(key) %>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -23,7 +23,7 @@
     <% end %>
   </ul>
 
-  <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor nav-safety' } do |f| %>
+  <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor nav-safety', data: { behavior: 'collection-form', 'param-key' => @form.model_name.param_key } } do |f| %>
     <div class="tab-content">
       <div id="description" class="tab-pane active">
         <div class="panel panel-default labels">
@@ -116,3 +116,4 @@
   <% end # simple_form_for %>
 
 </div> <!-- end collection-controls -->
+

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -265,14 +265,16 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
     end
 
     context 'when user can create collections of one type' do
+      let(:location) { 'Minneapolis, Minnesota, United States' }
+      let(:geonames_data) { [{ "id": "https://sws.geonames.org/5037649/", "label": "Minneapolis, Minnesota, United States" }] }
+
       before do
         user_collection_type
-
         sign_in user
         visit '/dashboard/my/collections'
       end
 
-      it 'makes a new collection' do
+      it 'makes a new collection', js: true do
         find('#add-new-collection-button').click
         expect(page).to have_selector('h1', text: 'New User Collection')
         expect(page).to have_selector "input.collection_title.multi_value"
@@ -284,9 +286,15 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         fill_in('Description', with: description)
         fill_in('Related URL', with: 'http://example.com/')
 
+        find('#s2id_collection_based_near').click
+        expect_any_instance_of(Qa::Authorities::Geonames).to receive(:search).and_return(geonames_data)
+        find('input.select2-input').send_keys("minneapolis", :enter)
+        first('.select2-result').click
+
         click_button("Save")
         expect(page).to have_content title
         expect(page).to have_content description
+        expect(page.body).to have_content location
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -144,6 +144,8 @@ RSpec.configure do |config|
     Hyrax.config.nested_relationship_reindexer = ->(id:, extent:) {}
     # setup a test group service
     User.group_service = TestHydraGroupService.new
+    # Set a geonames username; doesn't need to be real.
+    Hyrax.config.geonames_username = 'hyrax-test'
     # disable analytics except for specs which will have proper api mocks
   end
 

--- a/spec/views/collections/edit_fields/_based_near.html.erb_spec.rb
+++ b/spec/views/collections/edit_fields/_based_near.html.erb_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+RSpec.describe 'collections/edit_fields/_based_near.html.erb', type: :view do
+  let(:collection) { Collection.new }
+  let(:form) { Hyrax::Forms::CollectionForm.new(collection, nil, controller) }
+  let(:form_template) do
+    %(
+      <%= simple_form_for @form, url: [hyrax, :dashboard, @form] do |f| %>
+        <%= render "collections/edit_fields/based_near", f: f, key: 'based_near' %>
+      <% end %>
+    )
+  end
+
+  before do
+    assign(:form, form)
+    render inline: form_template
+  end
+
+  it 'has url for autocomplete service' do
+    expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/geonames"][data-autocomplete="based_near"]')
+  end
+end


### PR DESCRIPTION
Fixes #3725

Adds Geonames autocomplete to Location data input in the `Collection` form.

On one hand, the `Collection` model has a `based_near` attribute which is a `String` instance, and stores location related data in field `based_near_tesim` in Solr. On the other hand, the `GenericWork` model has a `based_near` attribute which is a `Hyrax::ControlledVocabularies::Location` instance, and stores location related data in fields `based_near_tesim` (Geonames URL) and `based_near_label_tesim` (Location label) in Solr.

Issue #3725 addresses the differences in location data input for Collections and Works, highlighting that the `Work` form require the selection of a Geonames record while the `Collection` form allows the user to input any string value. The ticket suggests adding the Geonames functionality such that the user must select a Geonames location record when inputting location data for Collections.

For the purposes of a feature release that is backwards compatible, I opted out of adding field `based_near_label_tesim` to Collections in Solr and changing a `Collection`'s `based_near` value from being a `String` instance to a `Hyrax::ControlledVocabularies::Location`. In this PR, I focused on delivering the immediate need for ensuring a user selects a record on Geonames to input location data for a `Collection`, and a user is unable to enter any random data. More importantly, I also ensure that any previously entered data still remains valid, even if it does not match a Geonames record. This ensures older records can be displayed and edited without any errors.

In a future major release, we should add the `based_near_label_tesim` to Collections in Solr, and ensure `Location` is stored and faceted the same way for Works and Collections.

Changes proposed in this pull request:
* Enable Geonames autocomplete for `Collection` location data input in a `Collection` form
* Ensure a user can only select a location based on a Geonames record, and can no longer enter any random string

Please refer to the screenshot below for changes in the `Collection` form UI:

![Screen Shot 2022-04-26 at 4 38 23 AM](https://user-images.githubusercontent.com/13107510/165258978-2de2f25e-b2db-45b0-ba81-bec1159850b4.png)

Guidance for testing, such as acceptance criteria or new user interface behaviors:

#### New Collection
* Go to Dashboard > Collections
* Click "Add New Collection"
* Fill in Collection name
* Scroll down to Location
* Search and select a location from the Geonames dropdown
* Save Collection
* Ensure saved collection is saved and displayed correctly

#### Existing Collection

* Go to Dashboard > Collections
* Click on existing Collection
* Click "Edit Collection"
* Scroll down to "Location"
* Ensure any previously stored location data is displayed correctly
* Search and select a location from the Geonames dropdown
* Save Collection
* Ensure saved collection is saved and displayed correctly

@samvera/hyrax-code-reviewers
