### PR TITLE
mark failing valkyrie search feature tests pending the addition of a valkyrie collection with basic metadata

### DIFF
--- a/spec/features/valkyrie_search_spec.rb
+++ b/spec/features/valkyrie_search_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe 'searching', index_adapter: :solr_index, valkyrie_adapter: :test_
 
   context "as a public user", :clean_repo do
     it "using the gallery view" do
+      pending 'addition of a valkyrie collection with basic metadata defined'
+
       visit '/'
       fill_in "search-field-header", with: "Toothbrush"
       click_button "search-submit-header"
@@ -32,6 +34,8 @@ RSpec.describe 'searching', index_adapter: :solr_index, valkyrie_adapter: :test_
     end
 
     it "only searches all and does not display search options for dashboard files" do
+      pending 'addition of a valkyrie collection with basic metadata defined'
+
       visit '/'
 
       # it "does not display search options for dashboard files" do

--- a/spec/features/valkyrie_search_spec.rb
+++ b/spec/features/valkyrie_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'searching', index_adapter: :solr_index, valkyrie_adapter: :test_
   before { allow(Hyrax.config).to receive(:collection_model).and_return('Hyrax::PcdmCollection') }
 
   context "as a public user", :clean_repo do
-    it "using the gallery view" do
+    xit "using the gallery view" do
       pending 'addition of a valkyrie collection with basic metadata defined'
 
       visit '/'
@@ -33,7 +33,7 @@ RSpec.describe 'searching', index_adapter: :solr_index, valkyrie_adapter: :test_
       end
     end
 
-    it "only searches all and does not display search options for dashboard files" do
+    xit "only searches all and does not display search options for dashboard files" do
       pending 'addition of a valkyrie collection with basic metadata defined'
 
       visit '/'


### PR DESCRIPTION
Fixes failing tests on main branch.

### First commit

The valkyrie search feature test depends on there being a description field for the collection that is searchable.  PR #5604 removed basic metadata from Hyrax::PcdmCollections.  It is unclear why the failing tests didn't fail during the PR process as those tests pre-date that PR.

There are several refactors in progress for Valkyrie collections.  When they are merged, there will be a description field available for this test.  Instead of rewriting the tests to pass with the Hyrax::PcdmCollection class as it is today, they are marked `pending`.  The other work will be merged soon and these tests will start passing allowing the `pending` command to be removed.

_NOTE: Using just `pending`, failures were still recorded.`

### Second commit

A second commit was made to use xit to stop running the tests altogether.

Using the `pending` command by itself, the tests still runs and failures are reported due to the execution of `let!` before the test begins.  Apparently since `let!` runs outside the test, that part isn't considered the test failing.  Pending wants the test to fail, not something outside the test.  Using `xit` prevents rspec from even trying to run the tests.  This seems to also prevent the running of `let!`.

I left the `pending` message in the tests, as it explains why the tests are being skipped.

@samvera/hyrax-code-reviewers
