### PR TITLE
Improve error handling for updating valkyrie collections

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -227,12 +227,13 @@ module Hyrax
       end
 
       def update_valkyrie_collection
+        return after_update_errors(form_err_msg(form)) unless form.validate(collection_params)
+
         process_member_changes
-        form.validate(collection_params) &&
-          @collection = transactions['change_set.update_collection']
-                        .call(form)
-                        .value_or { return after_update_error }
-        after_update
+        result = transactions['change_set.update_collection']
+                 .call(form)
+        @collection = result.value_or { return after_update_errors(result.failure.first) }
+        after_update_response
       end
 
       def valkyrie_destroy

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -229,10 +229,17 @@ module Hyrax
       def update_valkyrie_collection
         return after_update_errors(form_err_msg(form)) unless form.validate(collection_params)
 
-        process_member_changes
         result = transactions['change_set.update_collection']
                  .call(form)
         @collection = result.value_or { return after_update_errors(result.failure.first) }
+
+        process_member_changes
+
+        unless params[:update_collection].nil?
+          process_banner_input
+          process_logo_input
+        end
+
         after_update_response
       end
 

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -109,18 +109,13 @@ module Hyrax
       end
 
       def after_update
-        respond_to do |format|
-          format.html { redirect_to update_referer, notice: t('hyrax.dashboard.my.action.collection_update_success') }
-          format.json { render json: @collection, status: :updated, location: dashboard_collection_path(@collection) }
-        end
+        Deprecation.warn("Method `#after_update` will be removed in Hyrax 4.0.")
+        after_update_response # call private method for processing
       end
 
       def after_update_error
-        form
-        respond_to do |format|
-          format.html { render action: 'edit' }
-          format.json { render json: @collection.errors, status: :unprocessable_entity }
-        end
+        Deprecation.warn("Method `#after_update_error` will be removed in Hyrax 4.0.")
+        after_update_errors(@collection.errors) # call private method for processing
       end
 
       def update
@@ -579,6 +574,23 @@ module Hyrax
           wants.html do
             flash[:error] = errors.to_s
             render 'new', status: :unprocessable_entity
+          end
+          wants.json { render_json_response(response_type: :unprocessable_entity, options: { errors: errors }) }
+        end
+      end
+
+      def after_update_response
+        respond_to do |format|
+          format.html { redirect_to update_referer, notice: t('hyrax.dashboard.my.action.collection_update_success') }
+          format.json { render json: @collection, status: :updated, location: dashboard_collection_path(@collection) }
+        end
+      end
+
+      def after_update_errors(errors)
+        respond_to do |wants|
+          wants.html do
+            flash[:error] = errors.to_s
+            render 'edit', status: :unprocessable_entity
           end
           wants.json { render_json_response(response_type: :unprocessable_entity, options: { errors: errors }) }
         end

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -585,13 +585,27 @@ module Hyrax
         add_members_to_collection unless batch.empty?
       end
 
-      def after_create_errors(errors)
+      def after_create_errors_for_active_fedora(errors)
+        form
+        respond_to do |format|
+          format.html do
+            flash[:error] = errors.to_s
+            render action: 'new'
+          end
+          format.json { render json: @collection.errors, status: :unprocessable_entity }
+        end
+      end
+
+      def after_create_errors(errors) # for valkyrie
+        return after_create_errors_for_active_fedora(errors) if @collection.is_a? ActiveFedora::Base
         respond_to do |wants|
           wants.html do
             flash[:error] = errors.to_s
             render 'new', status: :unprocessable_entity
           end
-          wants.json { render_json_response(response_type: :unprocessable_entity, options: { errors: errors }) }
+          wants.json do
+            render_json_response(response_type: :unprocessable_entity, options: { errors: errors })
+          end
         end
       end
 
@@ -602,7 +616,19 @@ module Hyrax
         end
       end
 
-      def after_update_errors(errors)
+      def after_update_errors_for_active_fedora(errors)
+        form
+        respond_to do |format|
+          format.html do
+            flash[:error] = errors.to_s
+            render action: 'edit'
+          end
+          format.json { render json: @collection.errors, status: :unprocessable_entity }
+        end
+      end
+
+      def after_update_errors(errors) # for valkyrie
+        return after_update_errors_for_active_fedora(errors) if @collection.is_a? ActiveFedora::Base
         respond_to do |wants|
           wants.html do
             flash[:error] = errors.to_s

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
           id: collection,
           collection: collection_attrs
         }
-        expect(response).to be_successful
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -184,23 +184,29 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
 
     context "when create fails" do
       let(:collection) { Collection.new }
+      let(:error) { "Failed to save collection" }
 
       before do
         allow(controller).to receive(:authorize!)
         allow(Collection).to receive(:new).and_return(collection)
         allow(collection).to receive(:save).and_return(false)
-
-        allow(Hyrax.persister)
-          .to receive(:save)
-          .with(any_args)
-          .and_raise(StandardError, 'Failed to save collection')
+        allow(collection).to receive(:errors).and_return(error)
       end
 
       it "renders the form again" do
         post :create, params: { collection: collection_attrs }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:ok)
         expect(response).to render_template(:new)
+        expect(flash[:error]).to eq error
+      end
+
+      it "renders json" do
+        post :create, params: { collection: collection_attrs, format: :json }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to eq "application/json"
+        expect(response.body).to eq error
       end
     end
   end
@@ -339,19 +345,18 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
     end
 
     context "when update fails" do
-      let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection) }
+      let(:collection) { FactoryBot.create(:collection_lw) }
       let(:repository) { instance_double(Blacklight::Solr::Repository, search: result) }
       let(:result) { double(documents: [], total: 0) }
+      let(:error) { "Failed to save collection" }
 
       before do
         allow(controller).to receive(:authorize!)
         allow(Collection).to receive(:find).and_return(collection)
         allow(collection).to receive(:update).and_return(false)
         allow(controller).to receive(:repository).and_return(repository)
-        allow(Hyrax.persister)
-          .to receive(:save)
-          .with(any_args)
-          .and_raise(StandardError, 'Failed to save collection')
+        allow_any_instance_of(::Collection).to receive(:save).and_return(false)
+        allow(collection).to receive(:errors).and_return(error)
       end
 
       it "renders the form again" do
@@ -359,8 +364,19 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
           id: collection,
           collection: collection_attrs
         }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:ok)
         expect(response).to render_template(:edit)
+      end
+
+      it "renders json" do
+        put :update, params: {
+          id: collection,
+          collection: collection_attrs,
+          format: :json
+        }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to eq "application/json"
+        expect(response.body).to eq error
       end
     end
 

--- a/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
@@ -360,20 +360,43 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
 
     context "when update fails" do
       before do
+        allow(controller).to receive(:authorize!)
         collection # ensure the collection is loaded before we stub the persister save
-        allow(Hyrax.persister)
-          .to receive(:save)
-          .with(any_args)
-          .and_raise(StandardError, 'Failed to save collection')
       end
 
-      it "renders the form again" do
-        put :update, params: {
-          id: collection,
-          collection: collection_attrs
-        }
-        expect(response).to be_successful
-        expect(response).to render_template(:edit)
+      context "in transaction processing" do
+        before do
+          allow(Hyrax.persister)
+            .to receive(:save)
+            .with(any_args)
+            .and_raise(StandardError, 'Failed to save collection')
+        end
+
+        it "renders the form again" do
+          put :update, params: { id: collection, collection: collection_attrs }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(flash[:error]).to match(/Failed to save collection/)
+          expect(response).to render_template(:edit)
+        end
+      end
+
+      context "in validations" do
+        let(:form) { instance_double(Hyrax::Forms::PcdmCollectionForm, errors: errors) }
+        let(:errors) { instance_double(Reform::Contract::CustomError, messages: messages) }
+        let(:messages) { { "error" => "Validation error" } }
+        before do
+          allow(Hyrax::Forms::ResourceForm).to receive(:for).with(collection).and_return(form)
+          allow(form).to receive(:validate).with(any_args).and_return(false)
+        end
+
+        it "renders the form again" do
+          put :update, params: { id: collection, collection: collection_attrs }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(flash[:error]).to eq "Validation error"
+          expect(response).to render_template(:edit)
+        end
       end
     end
 

--- a/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
@@ -189,12 +189,26 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
           expect(flash[:error]).to match(/Failed to save collection/)
           expect(response).to render_template(:new)
         end
+
+        it "renders json" do
+          post :create, params: { collection: collection_attrs, format: :json }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.content_type).to eq "application/json"
+
+          json_response = JSON.parse(response.body)
+          expect(json_response["code"]).to eq 422
+          expect(json_response["message"]).to eq "Unprocessable Entity"
+          expect(json_response["description"]).to eq "The resource you attempted to modify cannot be modified according to your request."
+          expect(json_response["errors"]).to match(/Failed to save collection/)
+        end
       end
 
       context "in validations" do
         let(:form) { instance_double(Hyrax::Forms::PcdmCollectionForm, errors: errors) }
         let(:errors) { instance_double(Reform::Contract::CustomError, messages: messages) }
-        let(:messages) { { "error" => "Validation error" } }
+        let(:messages) { { "error" => errmsg } }
+        let(:errmsg) { "Validation error" }
         before do
           allow(controller).to receive(:authorize!)
           allow(Hyrax::Forms::ResourceForm).to receive(:for).with(collection).and_return(form)
@@ -205,9 +219,23 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
 
         it "renders the form again" do
           post :create, params: { collection: collection_attrs }
+
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(flash[:error]).to eq "Validation error"
+          expect(flash[:error]).to eq errmsg
           expect(response).to render_template(:new)
+        end
+
+        it "renders json" do
+          post :create, params: { collection: collection_attrs, format: :json }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.content_type).to eq "application/json"
+
+          json_response = JSON.parse(response.body)
+          expect(json_response["code"]).to eq 422
+          expect(json_response["message"]).to eq "Unprocessable Entity"
+          expect(json_response["description"]).to eq "The resource you attempted to modify cannot be modified according to your request."
+          expect(json_response["errors"]).to eq errmsg
         end
       end
     end
@@ -379,12 +407,29 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
           expect(flash[:error]).to match(/Failed to save collection/)
           expect(response).to render_template(:edit)
         end
+
+        it "renders json" do
+          put :update, params: {
+            id: collection,
+            collection: collection_attrs,
+            format: :json
+          }
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.content_type).to eq "application/json"
+
+          json_response = JSON.parse(response.body)
+          expect(json_response["code"]).to eq 422
+          expect(json_response["message"]).to eq "Unprocessable Entity"
+          expect(json_response["description"]).to eq "The resource you attempted to modify cannot be modified according to your request."
+          expect(json_response["errors"]).to match(/Failed to save collection/)
+        end
       end
 
       context "in validations" do
         let(:form) { instance_double(Hyrax::Forms::PcdmCollectionForm, errors: errors) }
         let(:errors) { instance_double(Reform::Contract::CustomError, messages: messages) }
-        let(:messages) { { "error" => "Validation error" } }
+        let(:messages) { { "error" => errmsg } }
+        let(:errmsg) { "Validation error" }
         before do
           allow(Hyrax::Forms::ResourceForm).to receive(:for).with(collection).and_return(form)
           allow(form).to receive(:validate).with(any_args).and_return(false)
@@ -394,8 +439,24 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
           put :update, params: { id: collection, collection: collection_attrs }
 
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(flash[:error]).to eq "Validation error"
+          expect(flash[:error]).to eq errmsg
           expect(response).to render_template(:edit)
+        end
+
+        it "renders json" do
+          put :update, params: {
+            id: collection,
+            collection: collection_attrs,
+            format: :json
+          }
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.content_type).to eq "application/json"
+
+          json_response = JSON.parse(response.body)
+          expect(json_response["code"]).to eq 422
+          expect(json_response["message"]).to eq "Unprocessable Entity"
+          expect(json_response["description"]).to eq "The resource you attempted to modify cannot be modified according to your request."
+          expect(json_response["errors"]).to eq errmsg
         end
       end
     end


### PR DESCRIPTION
### Description

When processing an update for a valkyrie collection, the updated collection instance was not being handled correctly when failures occurred.

If the form validation failed, the updates were not processed and `after_update` was called instead of `after_update_error`.  

If the transactions failed, `@collection` was set to false by `.value_or` before it called `after_update_error.

Similar issues were happening with the create process that were fixed in PR #5604.

WAS:

```
form.validate(collection_params) &&
          @collection = transactions['change_set.update_collection']
                        .call(form)
                        .value_or { return after_update_error }
after_update
```

Now, the form validation is processed before setting @collection. If a failure occurs, the process is aborted and calls after_update_errors.  Likewise, if there is a failure during the transaction process, after_update_errors is called to process the error and redisplay the edit form.  `@collection` is only updated if there are no form or transaction failures.

_NOTE: This PR also moves after and before methods for update to private, deprecating the public versions.  This is consistent with the pattern used in works and for create collection._

### Related work

The approach is based on the same change that was made for works in [PR #5448](https://github.com/samvera/hyrax/pull/5448/files#diff-843d5f344066ba9de62a999cf88a87b29479b10988676c0bc474f4853e2adaf4).

This is follow-on work for the changes to the create collection process in PR #5604.

@samvera/hyrax-code-reviewers
