### PR TITLE
Switches JS compressor to Terser to evade ES6 errors.

### DIFF
--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -18,8 +18,8 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.3.8'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
-# Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+# Use Terser as compressor for JavaScript assets
+gem 'terser'
 
 gem 'dalli' # mem_cache_store support
 

--- a/.dassie/config/environments/production.rb
+++ b/.dassie/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Updates the JS Compressor used to Terser, rather than Uglifier. `docker-compose build` is currently producing the following error:
```
#15 172.9 rake aborted!
#15 172.9 Uglifier::Error:
#15 172.9 /usr/local/bundle/gems/uglifier-4.2.0/lib/uglifier.rb:291:in `parse_result'
#15 172.9 /usr/local/bundle/gems/uglifier-4.2.0/lib/uglifier.rb:221:in `run_uglifyjs'
#15 172.9 /usr/local/bundle/gems/uglifier-4.2.0/lib/uglifier.rb:166:in `compile'
#15 172.9 /usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/compressing.rb:65:in `block in js_compressor='
#15 172.9 /usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/legacy_proc_processor.rb:31:in `call'
#15 172.9 /usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:75:in `call_processor'
#15 172.9 /usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:57:in `block in call_processors'
#15 172.9 /usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:56:in `reverse_each'
#15 172.9 /usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:56:in `call_processors'
#15 172.9 /usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/loader.rb:134:in `load_from_unloaded'
#15 172.9 /usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/loader.rb:60:in `block in load'
```
That error mentions no code we touch inside Hyrax, and my research suggests that one of the javascript libraries we precompile may be using ES6, which breaks Uglifier. Terser is the recommended replacement, and has shown to produce no errors during another build.

Changes proposed in this pull request:
* Add Terser to Gemfile.
* Point to Terser as desired compressor in Rails production configuration.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* `docker-compose build` should run without the error displayed above.

@samvera/hyrax-code-reviewers
