### PR TITLE
Pin tinymce-rails gem to 5.x

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -82,7 +82,7 @@ SUMMARY
   spec.add_dependency 'samvera-nesting_indexer', '~> 2.0'
   spec.add_dependency 'select2-rails', '~> 3.5'
   spec.add_dependency 'signet'
-  spec.add_dependency 'tinymce-rails'
+  spec.add_dependency 'tinymce-rails', '~> 5.10'
   spec.add_dependency 'valkyrie', '~> 2', '>= 2.1.1'
 
   spec.add_development_dependency "capybara", '~> 3.29'


### PR DESCRIPTION
Version 6 of tinymce-rails causes uglifier to error during assets:precompile

refs #5611

Once Uglifier is phased out (in favor of terser?) then this pin can likely be removed.