### PR TITLE
handle valkyrie collection models in search results

### DIFF
--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,3 +1,10 @@
+<% model = document["has_model_ssim"].first.safe_constantize %>
 <div class="search-results-title-row">
-  <h3 class="search-result-title"><%= link_to document.title_or_label, document %></h3>
+  <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
+    <h3 class="search-result-title"><%= link_to document.title_or_label, [hyrax, document] %></h3>
+    <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
+  <% else %>
+    <h3 class="search-result-title"><%= link_to document.title_or_label, document %></h3>
+  <% end %>
 </div>
+

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,4 +1,4 @@
-<% model = document["has_model_ssim"].first.safe_constantize %>
+<% model = document.hydra_model %>
 <div class="search-results-title-row">
   <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
     <h3 class="search-result-title"><%= link_to document.title_or_label, [hyrax, document] %></h3>

--- a/app/views/catalog/_index_header_list_hyrax_pcdm_collection.html.erb
+++ b/app/views/catalog/_index_header_list_hyrax_pcdm_collection.html.erb
@@ -1,4 +1,0 @@
-<div class="search-results-title-row">
-  <h3 class="search-result-title"><%= link_to document.title_or_label, [hyrax, document] %></h3>
-  <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
-</div>

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,4 +1,4 @@
-<% model = document["has_model_ssim"].first.safe_constantize %>
+<% model = document.hydra_model %>
 <div class="col-md-2">
   <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
     <%= render_thumbnail_tag document, {}, suppress_link: true %>

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,5 +1,10 @@
+<% model = document["has_model_ssim"].first.safe_constantize %>
 <div class="col-md-2">
-  <div class="list-thumbnail">
-    <%= render_thumbnail_tag document %>
-  </div>
+  <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
+    <%= render_thumbnail_tag document, {}, suppress_link: true %>
+  <% else %>
+    <div class="list-thumbnail">
+      <%= render_thumbnail_tag document %>
+    </div>
+  <% end %>
 </div>

--- a/spec/features/valkyrie_search_spec.rb
+++ b/spec/features/valkyrie_search_spec.rb
@@ -9,15 +9,18 @@ RSpec.describe 'searching', index_adapter: :solr_index, valkyrie_adapter: :test_
   end
 
   let!(:collection) do
-    FactoryBot.valkyrie_create(:hyrax_collection, :public, title: ['collection title abc'], description: [subject_value], members: [work])
+    FactoryBot.valkyrie_create(:collection_resource,
+                               :public,
+                               title: ['collection title abc'],
+                               creator: user.email,
+                               description: [subject_value],
+                               members: [work])
   end
 
-  before { allow(Hyrax.config).to receive(:collection_model).and_return('Hyrax::PcdmCollection') }
+  before { allow(Hyrax.config).to receive(:collection_model).and_return('CollectionResource') }
 
   context "as a public user", :clean_repo do
-    xit "using the gallery view" do
-      pending 'addition of a valkyrie collection with basic metadata defined'
-
+    it "using the gallery view" do
       visit '/'
       fill_in "search-field-header", with: "Toothbrush"
       click_button "search-submit-header"
@@ -33,9 +36,7 @@ RSpec.describe 'searching', index_adapter: :solr_index, valkyrie_adapter: :test_
       end
     end
 
-    xit "only searches all and does not display search options for dashboard files" do
-      pending 'addition of a valkyrie collection with basic metadata defined'
-
+    it "only searches all and does not display search options for dashboard files" do
       visit '/'
 
       # it "does not display search options for dashboard files" do


### PR DESCRIPTION
Fixes #5567 

This refactor handles all valkyrie collection models regardless of the model name.

This is required because blacklight generates partials based on the model name.  This is controlled in the catalog controller by setting the `display_type_field`.  For Hyrax, this is configured to…

```
    config.index.display_type_field = "has_model_ssim"
```
Then partials are created for each model that will be handled.

Pre-valkyrie, there was one and only one collection.  Everything else was a work.  So there were two partials, one to handle collections, and the default which handles all works regardless of model name.

Now there are at least two collection models, the AF `::Collection` and the Valkyrie `Hyrax::PcdmCollection`.  This was initiallly addressed by adding another partial to support hyrax_pcdmcollection.

With the ability to generate a collection using any name, added in PR https://github.com/samvera/hyrax/pull/5613, the name of the collection is not known in advance and a partial cannot be created specific to that collection model.  To address this, the PR adds processing to the default to check the model.  If it is a collection model, then it is processed as a collection.  Otherwise, it is processed as a work.

@samvera/hyrax-code-reviewers
