### PR TITLE
Resolve failures for `create_admin_set_spec.rb`

### DIFF
--- a/app/views/hyrax/admin/admin_sets/show.html.erb
+++ b/app/views/hyrax/admin/admin_sets/show.html.erb
@@ -11,7 +11,7 @@
         <div class="col-md-2">
           <% if has_thumbnail? @presenter.solr_document %>
             <div class="document-thumbnail">
-              <%= @presenter&.thumbnail&.thumbnail_tag({}, { suppress_link: true }) %>
+              <%= render_thumbnail_tag(@presenter.solr_document, {}, { suppress_link: true }) %>
             </div>
           <% else %>
             <span class="fa fa-sitemap collection-icon-search" aria-hidden="true"></span>


### PR DESCRIPTION
#### `spec/features/dashboard/collection_spec.rb`
This [PR](https://github.com/samvera/hyrax/commit/58ec0451a1dbe7fae9ff5c90226d0e27b6923b45) introduced a change that broke those specs, specifically in file `/Users/abeleml/Desktop/hyrax/app/views/hyrax/admin/admin_sets/show.html.erb`, and I reverted the change. `AdminSetPresenter` does not extend `DocumentPresenter`, thus it has no attribute `thumbnail` (the error triggered). The original implementation refers to the `document_presenter` and renders the thumbnail tag correctly.