### PR TITLE
deprecate MultipleMembershipChecker#validate in favor of #check.

### DIFF
--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -21,7 +21,9 @@ module Hyrax
     # also belong to other collections of the same type.
     #
     # @return [True, String] true if no conflicts; otherwise, an error message string
+    # @deprecated Use #check instead; for removal in 4.0.0
     def validate
+      Deprecation.warn "#{self.class}##{__method__} is deprecated; use #check instead."
       return true if item.member_of_collection_ids.empty? || item.member_of_collection_ids.count <= 1
       return true unless single_membership_collection_types_exist?
 


### PR DESCRIPTION
this public method is only used by the unit tests. it's relatively complex and
reaches into various ActiveModel/`CollectionBehavior` implementation details, so
deprecating it seems like it will save us a substantial maintenance burden going
forward.

see #5619.
@samvera/hyrax-code-reviewers
