### PR TITLE
use the `ActiveModel::Name#human` instead of `#to_s` for human names

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -154,7 +154,7 @@ module Hyrax
     def grouped_presenters(filtered_by: nil, except: nil)
       # TODO: we probably need to retain collection_presenters (as parent_presenters)
       #       and join this with member_of_collection_presenters
-      grouped = member_of_collection_presenters.group_by(&:model_name).transform_keys { |key| key.to_s.underscore }
+      grouped = member_of_collection_presenters.group_by(&:model_name).transform_keys(&:human)
       grouped.select! { |obj| obj.downcase == filtered_by } unless filtered_by.nil?
       grouped.except!(*except) unless except.nil?
       grouped

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -566,6 +566,23 @@ RSpec.describe Hyrax::WorkShowPresenter do
     end
   end
 
+  describe "#grouped_presenters" do
+    let(:collections) do
+      [FactoryBot.valkyrie_create(:hyrax_collection),
+       FactoryBot.valkyrie_create(:hyrax_collection)]
+    end
+
+    before do
+      allow(presenter)
+        .to receive(:member_of_authorized_parent_collections)
+        .and_return collections.map(&:id).map(&:to_s)
+    end
+
+    it "groups the presenters with the human version of the model name" do
+      expect(presenter.grouped_presenters.keys).to contain_exactly("Collection")
+    end
+  end
+
   describe "#show_deposit_for?" do
     context "when user has depositable collections" do
       let(:user_collections) { double }


### PR DESCRIPTION
when grouping relationship presenters for display in the show view, calling
`#to_s` results in a Ruby style model name. we want to display the human name,
which `ActiveModel` supports via `#human`.

the view also calls `String#humanize` which should be a no-op in most cases
after this, but still seems appropriate.

fixes #5587.

@samvera/hyrax-code-reviewers
