### PR TITLE
fix some inaccurate tests for Dashboard::CollectionsController 

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -209,6 +209,7 @@ module Hyrax
             'collection_resource.apply_collection_type_permissions' => { user: current_user }
           )
           .call(form)
+
         @collection = result.value_or { return after_create_errors(result.failure.first) }
         after_create_response
       end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -75,10 +75,11 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
 
     it "removes blank strings from params before creating Collection" do
       expect { post :create, params: { collection: collection_attrs.merge(creator: ['']) } }
-        .to change { Collection.count }.by(1)
+        .to change { Collection.count }
+        .by(1)
 
-      expect(assigns[:collection].title).to eq ["My First Collection"]
-      expect(assigns[:collection].creator).to eq []
+      expect(assigns[:collection].title).to contain_exactly("My First Collection")
+      expect(assigns[:collection].creator).to be_blank
     end
 
     it "sets current user as the depositor" do
@@ -198,7 +199,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
 
         expect(response).to have_http_status(:ok)
         expect(response).to render_template(:new)
-        expect(flash[:error]).to eq error
+        expect(flash[:error]).to include error
       end
 
       it "renders json" do
@@ -206,7 +207,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to eq "application/json"
-        expect(response.body).to eq error
+        expect(response.body).to include error
       end
     end
   end
@@ -334,13 +335,13 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         put :update, params: {
           id: collection,
           collection: {
-            title: ["My Next Collection "],
+            title: ["My Next Collection-"],
             creator: [""]
           }
         }
 
-        expect(assigns[:collection].title).to eq ["My Next Collection "]
-        expect(assigns[:collection].creator).to eq []
+        expect(assigns[:collection].title).to contain_exactly("My Next Collection-")
+        expect(assigns[:collection].creator).to be_blank
       end
     end
 
@@ -385,9 +386,10 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
           collection: collection_attrs,
           format: :json
         }
+
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to eq "application/json"
-        expect(response.body).to eq error
+        expect(response.body).to include error
       end
     end
 

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -197,7 +197,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
       it "renders the form again" do
         post :create, params: { collection: collection_attrs }
 
-        expect(response).to have_http_status(:ok)
         expect(response).to render_template(:new)
         expect(flash[:error]).to include error
       end
@@ -376,7 +375,6 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
           id: collection,
           collection: collection_attrs
         }
-        expect(response).to have_http_status(:ok)
         expect(response).to render_template(:edit)
       end
 


### PR DESCRIPTION
these tests are too specific:

checking for equality with `[]` is only right if the Dry::Types are setup to
guarantee an array. code shouldn't rely on this since end users have
control over metadata. check for `#blank?` instead.

the JSON body checks previously checked explicitly for invalid JSON. the
valkyrie implementation returns valid JSON; we should tolerate that.

the last set checks for 200 response codes when the status is actually an error. :|

@samvera/hyrax-code-reviewers
