### PR TITLE
valkyrie: extract upload methods into ValkyrieUpload service

### DIFF
--- a/app/jobs/valkyrie_ingest_job.rb
+++ b/app/jobs/valkyrie_ingest_job.rb
@@ -21,36 +21,19 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
   #
   # @param [Hyrax::UploadedFile] file
   # @param [RDF::URI] pcdm_use
-
   # @return [void]
   def ingest(file:, pcdm_use:)
     file_set_uri = Valkyrie::ID.new(file.file_set_uri)
     file_set = Hyrax.query_service.find_by(id: file_set_uri)
 
-    updated_metadata = upload_file(file: file, file_set: file_set, pcdm_use: pcdm_use)
-
-    add_file_to_file_set(file_set: file_set,
-                         file_metadata: updated_metadata,
-                         user: file.user)
+    updated_metadata = upload_file(
+      file: file,
+      file_set: file_set,
+      pcdm_use: pcdm_use,
+      user: file.user
+    )
 
     ValkyrieCreateDerivativesJob.perform_later(file_set.id.to_s, updated_metadata.id.to_s)
-  end
-
-  ##
-  # @api private
-  #
-  # @param [Hyrax::FileSet] file_set the file set to add to
-  # @param [Hyrax::FileMetadata] file_metadata the metadata object representing
-  #   the file to add
-  # @param [::User] user  the user performing the add
-  #
-  # @return [Hyrax::FileSet] updated file set
-  def add_file_to_file_set(file_set:, file_metadata:, user:)
-    file_set.file_ids << file_metadata.id
-    set_file_use_ids(file_set, file_metadata)
-
-    Hyrax.persister.save(resource: file_set)
-    Hyrax.publisher.publish('object.membership.updated', object: file_set, user: user)
   end
 
   ##
@@ -59,66 +42,21 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
   # @param [Hyrax::UploadedFile] file
   # @param [Hyrax::FileSet] file_set
   # @param [RDF::URI] pcdm_use  the use/type to apply to the created FileMetadata
+  # @param [User] user
   #
   # @return [Hyrax::FileMetadata] the metadata representing the uploaded file
-  def upload_file(file:, file_set:, pcdm_use:) # rubocop:disable Metrics/MethodLength
+  def upload_file(file:, file_set:, pcdm_use:, user: nil)
     carrier_wave_sanitized_file = file.uploader.file
     # Pull file, since carrierwave files don't respond to a proper IO #read. See
     # https://github.com/carrierwaveuploader/carrierwave/issues/1959
     file_io = carrier_wave_sanitized_file.to_file
-    uploaded = Hyrax.storage_adapter
-                    .upload(resource: file_set,
-                            file: file_io,
-                            original_filename: carrier_wave_sanitized_file.original_filename)
 
-    file_metadata = find_or_create_metadata(id: uploaded.id, file: carrier_wave_sanitized_file)
-
-    file_metadata.type << pcdm_use
-    file_metadata.file_set_id = file.file_set_uri
-    file_metadata.file_identifier = uploaded.id
-    file_metadata.size = uploaded.size
-
-    saved_metadata = Hyrax.persister.save(resource: file_metadata)
-    Hyrax.publisher.publish("object.file.uploaded", metadata: saved_metadata)
-    file_io.close
-
-    if pcdm_use == Hyrax::FileMetadata::Use::ORIGINAL_FILE
-      # Set file set label.
-      reset_title = file_set.title.first == file_set.label
-      # set title to label if that's how it was before this characterization
-      file_set.title = file_metadata.original_filename if reset_title
-      # always set the label to the original_name
-      file_set.label = file_metadata.original_filename
-    end
-
-    saved_metadata
-  end
-
-  ##
-  # @api private
-  def find_or_create_metadata(id:, file:)
-    Hyrax.custom_queries.find_file_metadata_by(id: id)
-  rescue Valkyrie::Persistence::ObjectNotFoundError => e
-    Hyrax.logger.warn "Failed to find existing metadata for #{id}:"
-    Hyrax.logger.warn e.message
-    Hyrax.logger.warn "Creating Hyrax::FileMetadata now"
-    Hyrax::FileMetadata.for(file: file)
-  end
-
-  ##
-  # @api private
-  def set_file_use_ids(file_set, file_metadata)
-    file_metadata.type.each do |type|
-      case type
-      when Hyrax::FileMetadata::Use::ORIGINAL_FILE
-        file_set.original_file_id = file_metadata.id
-      when Hyrax::FileMetadata::Use::THUMBNAIL
-        file_set.thumbnail_id = file_metadata.id
-      when Hyrax::FileMetadata::Use::EXTRACTED_TEXT
-        file_set.extracted_text_id = file_metadata.id
-      else
-        Rails.logger.warn "Unknown file use #{file_metadata.type} specified for #{file_metadata.file_identifier}"
-      end
-    end
+    ::Hyrax::ValkyrieUpload.file(
+      io: file_io,
+      filename: carrier_wave_sanitized_file.original_filename,
+      file_set: file_set,
+      use: pcdm_use,
+      user: user
+    )
   end
 end

--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Hyrax::ValkyrieUpload
+  # @param [IO] io
+  # @param [String] filename
+  # @param [Hyrax::FileSet] file_set
+  # @param [RDF::URI] use
+  # @param [User] user
+  #
+  # @see Hyrax::FileMetadata::Use
+  # @return [Hyrax::FileMetadata] the metadata representing the uploaded file
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/ParameterLists
+  def self.file(
+    filename:,
+    file_set:,
+    io:,
+    storage_adapter: Hyrax.storage_adapter,
+    use: Hyrax::FileMetadata::Use::ORIGINAL_FILE,
+    user: nil
+  )
+
+    streamfile = storage_adapter.upload(
+      file: io,
+      original_filename: filename,
+      resource: file_set,
+      use: use
+    )
+    io.close
+
+    file_metadata = find_or_create_metadata(id: streamfile.id, file: streamfile)
+    file_metadata.file_set_id = file_set.id
+
+    case use
+    when Hyrax::FileMetadata::Use::ORIGINAL_FILE
+      # Set file set label.
+      reset_title = file_set.title.first == file_set.label
+      # set title to label if that's how it was before this characterization
+      file_set.title = file_metadata.original_filename if reset_title
+      # always set the label to the original_name
+      file_set.label = file_metadata.original_filename
+    when Hyrax::FileMetadata::Use::THUMBNAIL
+      # TODO: the parent work's thumbnail_id remains incorrect (it's set to the
+      # FileSet ID, rather than the ID of this thumbnail FileMetadata; but
+      # trying to update the parent attributes here doesn't seem to stick
+      file_set.thumbnail_id = file_metadata.id
+    end
+
+    saved_metadata = Hyrax.persister.save(resource: file_metadata)
+    Hyrax.publisher.publish("object.file.uploaded", metadata: saved_metadata)
+
+    add_file_to_file_set(file_set: file_set,
+                         file_metadata: saved_metadata,
+                         user: user)
+
+    Hyrax.publisher.publish('file.metadata.updated', metadata: saved_metadata, user: user)
+
+    saved_metadata
+  end
+
+  # @param [Hyrax::FileSet] file_set the file set to add to
+  # @param [Hyrax::FileMetadata] file_metadata the metadata object representing
+  #   the file to add
+  # @param [::User] user  the user performing the add
+  #
+  # @return [Hyrax::FileSet] updated file set
+  def self.add_file_to_file_set(file_set:, file_metadata:, user:)
+    file_set.file_ids << file_metadata.id
+    set_file_use_ids(file_set, file_metadata)
+
+    Hyrax.persister.save(resource: file_set)
+    Hyrax.publisher.publish('object.membership.updated', object: file_set, user: user)
+  end
+
+  # @api private
+  # @param [Hyrax::FileSet] file_set the file set to add to
+  # @param [Hyrax::FileMetadata] file_metadata the metadata object representing
+  #   the file to add
+  # @return [void]
+  def self.set_file_use_ids(file_set, file_metadata)
+    file_metadata.type.each do |type|
+      case type
+      when Hyrax::FileMetadata::Use::ORIGINAL_FILE
+        file_set.original_file_id = file_metadata.id
+      when Hyrax::FileMetadata::Use::THUMBNAIL
+        file_set.thumbnail_id = file_metadata.id
+      when Hyrax::FileMetadata::Use::EXTRACTED_TEXT
+        file_set.extracted_text_id = file_metadata.id
+      else
+        Rails.logger.warn "Unknown file use #{file_metadata.type} specified for #{file_metadata.file_identifier}"
+      end
+    end
+  end
+
+  # @api private
+  # @param [#to_s] id
+  # @param [Valkyrie::StorageAdapter::StreamFile] file
+  def self.find_or_create_metadata(id:, file:)
+    Hyrax.custom_queries.find_file_metadata_by(id: id)
+  rescue Valkyrie::Persistence::ObjectNotFoundError => e
+    Hyrax.logger.warn "Failed to find existing metadata for #{id}:"
+    Hyrax.logger.warn e.message
+    Hyrax.logger.warn "Creating Hyrax::FileMetadata now"
+    Hyrax::FileMetadata.for(file: file)
+  end
+end

--- a/spec/services/hyrax/valkyrie_upload_spec.rb
+++ b/spec/services/hyrax/valkyrie_upload_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'hyrax/specs/spy_listener'
+
+RSpec.describe Hyrax::ValkyrieUpload do
+  let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+  let(:upload) { FactoryBot.create(:uploaded_file, file_set_uri: file_set.id, file: File.open('spec/fixtures/image.png')) }
+
+  let(:listener) { Hyrax::Specs::AppendingSpyListener.new }
+  let(:characterizer) { double(characterize: fits_response) }
+  let(:fits_response) { IO.read('spec/fixtures/png_fits.xml') }
+
+  before do
+    Hyrax.publisher.subscribe(listener)
+
+    # stub out characterization to avoid system calls. It's important some
+    # amount of characterization happens so listeners fire.
+    allow(Hydra::FileCharacterization).to receive(:characterize).and_return(fits_response)
+  end
+
+  after { Hyrax.publisher.unsubscribe(listener) }
+
+  describe '.file' do
+    it 'adds an original_file file to the file_set' do
+      described_class.file(
+        filename: Rails.root.join('spec', 'fixtures', 'image.png'),
+        file_set: file_set,
+        io: upload.uploader.file.to_file
+      )
+
+      reloaded_file_set = Hyrax.query_service.find_by(id: file_set.id)
+      expect(reloaded_file_set)
+        .to have_attached_files(be_original_file)
+      expect(reloaded_file_set.title).to eq ["image.png"]
+      expect(reloaded_file_set.label).to eq "image.png"
+      expect(reloaded_file_set.file_ids)
+        .to contain_exactly(reloaded_file_set.original_file_id)
+    end
+
+    it 'makes original_file queryable by use' do
+      described_class.file(
+        filename: Rails.root.join('spec', 'fixtures', 'image.png'),
+        file_set: file_set,
+        io: upload.uploader.file.to_file,
+        user: upload.user
+      )
+
+      resource = Hyrax.query_service.find_by(id: file_set.id)
+
+      expect(Hyrax.custom_queries.find_original_file(file_set: resource))
+        .to be_a Hyrax::FileMetadata
+    end
+
+    it 'publishes events' do
+      described_class.file(
+        filename: Rails.root.join('spec', 'fixtures', 'image.png'),
+        file_set: file_set,
+        io: upload.uploader.file.to_file,
+        user: upload.user
+      )
+      expect(listener.object_file_uploaded.map(&:payload))
+        .to contain_exactly(match(metadata: have_attributes(id: an_instance_of(Valkyrie::ID),
+                                                            original_filename: upload.file.filename)))
+
+      expect(listener.file_metadata_updated.map(&:payload))
+        .to include(match(metadata: have_attributes(id: an_instance_of(Valkyrie::ID),
+                                                    original_filename: upload.file.filename),
+                          user: upload.user))
+
+      expect(listener.object_membership_updated.map(&:payload))
+        .to contain_exactly(match(object: file_set,
+                                  user: upload.user))
+    end
+  end
+end


### PR DESCRIPTION
This will let us use the same tooling for uploading in other contexts (like derivatives).

Extracted from #5626