### PR TITLE
Increase Z-Index of .skip-to-content

### DIFF
--- a/app/assets/stylesheets/hyrax/_accessibility.scss
+++ b/app/assets/stylesheets/hyrax/_accessibility.scss
@@ -33,5 +33,5 @@
   position: absolute;
   top: 0.5rem;
   width: auto;
-  z-index: 1005;
+  z-index: 99999; // always display on top
 }


### PR DESCRIPTION
Fixes #5639

For some reason the header Z‐Index was increased. The “skip to content” link should always appear on top of everything, so I gave it a suitably large number to avoid these sorts of issues.

<img width="316" alt="image" src="https://user-images.githubusercontent.com/3212430/169136120-5787fb92-7e44-40fe-b9a1-2cd2a06d3c96.png">

