### PR TITLE
Remove .row class from announcements

### DIFF
--- a/app/views/hyrax/homepage/_announcement.html.erb
+++ b/app/views/hyrax/homepage/_announcement.html.erb
@@ -1,5 +1,5 @@
 <% if display_content_block? @announcement_text %>
-  <div id="announcement_text" class="row">
-    <%= displayable_content_block @announcement_text, class: 'row', id: 'announcement', role: 'complementary', 'aria-label': 'announcement-text' %>
+  <div id="announcement_text">
+    <%= displayable_content_block @announcement_text, id: 'announcement', role: 'complementary', 'aria-label': 'announcement-text' %>
   </div>
 <% end %>


### PR DESCRIPTION
In Bootstrap 4, this class generates a flex container. But
announcements display fine as ordinary blocks.

Fixes #5636.

<img width="983" alt="image" src="https://user-images.githubusercontent.com/3212430/169139610-f50366a7-c15a-478a-bc90-9bab751e8ddc.png">