### PR TITLE
Add !important to custom navbar background

### DIFF
--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -4,7 +4,7 @@
 a { color: <%= appearance.link_color %>; }
 .navbar-dark.bg-dark .navbar-link { color: <%= appearance.footer_link_color %>; }
 
-.navbar-dark.bg-dark { background-color: <%= appearance.header_background_color %>; }
+.navbar-dark.bg-dark { background-color: <%= appearance.header_background_color %> !important; }
 
 .navbar-dark.bg-dark .navbar-nav > .open > a,
 .navbar-dark.bg-dark .navbar-nav > .open > a:hover,


### PR DESCRIPTION
The .bg-dark class uses `!important` so we need to apply an
`!important` here to override it.

<img width="711" alt="image" src="https://user-images.githubusercontent.com/3212430/169170634-8c48e8f3-ab7e-4e56-8dc2-7d9daf198279.png">

Fixes #5635
