### PR TITLE
Fix admin dashboard filters

### DIFF
--- a/app/helpers/hyrax/facets_helper.rb
+++ b/app/helpers/hyrax/facets_helper.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module FacetsHelper
+    # Methods in this module are from Blacklight::FacetsHelperBehavior, blacklight v6.24.0
+    # This module is used to ensure Hyrax facet views that rely on deprecated Blacklight helper methods are still functional
+
+    include Blacklight::Facet
+
+    ##
+    # Renders the list of values
+    # removes any elements where render_facet_item returns a nil value. This enables an application
+    # to filter undesireable facet items so they don't appear in the UI
+    def render_facet_limit_list(paginator, facet_field, wrapping_element = :li)
+      safe_join(paginator.items.map { |item| render_facet_item(facet_field, item) }.compact.map { |item| content_tag(wrapping_element, item) })
+    end
+
+    ##
+    # Renders a single facet item
+    def render_facet_item(facet_field, item)
+      if facet_in_params?(facet_field, item.value)
+        render_selected_facet_value(facet_field, item)
+      else
+        render_facet_value(facet_field, item)
+      end
+    end
+
+    ##
+    # Standard display of a facet value in a list. Used in both _facets sidebar
+    # partial and catalog/facet expanded list. Will output facet value name as
+    # a link to add that to your restrictions, with count in parens.
+    #
+    # @param [Blacklight::Solr::Response::Facets::FacetField] facet_field
+    # @param [Blacklight::Solr::Response::Facets::FacetItem] item
+    # @param [Hash] options
+    # @option options [Boolean] :suppress_link display the facet, but don't link to it
+    # @return [String]
+    def render_facet_value(facet_field, item, options = {})
+      path = path_for_facet(facet_field, item)
+      content_tag(:span, class: "facet-label") do
+        link_to_unless(options[:suppress_link], facet_display_value(facet_field, item), path, class: "facet_select")
+      end + render_facet_count(item.hits)
+    end
+
+    ##
+    # Where should this facet link to?
+    # @param [Blacklight::Solr::Response::Facets::FacetField] facet_field
+    # @param [String] item
+    # @return [String]
+    def path_for_facet(facet_field, item)
+      facet_config = facet_configuration_for_field(facet_field)
+      if facet_config.url_method
+        send(facet_config.url_method, facet_field, item)
+      else
+        search_action_path(search_state.add_facet_params_and_redirect(facet_field, item))
+      end
+    end
+
+    ##
+    # Standard display of a SELECTED facet value (e.g. without a link and with a remove button)
+    # @see #render_facet_value
+    # @param [Blacklight::Solr::Response::Facets::FacetField] facet_field
+    # @param [String] item
+    def render_selected_facet_value(facet_field, item)
+      remove_href = search_action_path(search_state.remove_facet_params(facet_field, item))
+      content_tag(:span, class: "facet-label") do
+        content_tag(:span, facet_display_value(facet_field, item), class: "selected") +
+          # remove link
+          link_to(remove_href, class: "remove") do
+            content_tag(:span, '', class: "glyphicon glyphicon-remove") +
+              content_tag(:span, '[remove]', class: 'sr-only')
+          end
+      end + render_facet_count(item.hits, classes: ["selected"])
+    end
+
+    ##
+    # Renders a count value for facet limits. Can be over-ridden locally
+    # to change style. And can be called by plugins to get consistent display.
+    #
+    # @param [Integer] num number of facet results
+    # @param [Hash] options
+    # @option options [Array<String>]  an array of classes to add to count span.
+    # @return [String]
+    def render_facet_count(num, options = {})
+      classes = (options[:classes] || []) << "facet-count"
+      content_tag("span", t('blacklight.search.facets.count', number: number_with_delimiter(num)), class: classes)
+    end
+
+    ##
+    # Check if the query parameters have the given facet field with the
+    # given value.
+    #
+    # @param [Object] field
+    # @param [Object] item facet value
+    # @return [Boolean]
+    def facet_in_params?(field, item)
+      value = facet_value_for_facet_item(item)
+
+      (facet_params(field) || []).include? value
+    end
+
+    ##
+    # Get the values of the facet set in the blacklight query string
+    def facet_params(field)
+      config = facet_configuration_for_field(field)
+
+      params[:f][config.key] if params[:f]
+    end
+
+    ##
+    # Get the displayable version of a facet's value
+    #
+    # @param [Object] field
+    # @param [String] item value
+    # @return [String]
+    # rubocop:disable Metrics/MethodLength
+    def facet_display_value(field, item)
+      facet_config = facet_configuration_for_field(field)
+
+      value = if item.respond_to? :label
+                item.label
+              else
+                facet_value_for_facet_item(item)
+              end
+
+      if facet_config.helper_method
+        send facet_config.helper_method, value
+      elsif facet_config.query && facet_config.query[value]
+        facet_config.query[value][:label]
+      elsif facet_config.date
+        localization_options = facet_config.date == true ? {} : facet_config.date
+
+        l(value.to_datetime, localization_options)
+      else
+        value
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    private
+
+    def facet_value_for_facet_item(item)
+      if item.respond_to? :value
+        item.value
+      else
+        item
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -18,6 +18,7 @@ module Hyrax
     include Hyrax::PermissionLevelsHelper
     include Hyrax::WorkFormHelper
     include Hyrax::WorkflowsHelper
+    include Hyrax::FacetsHelper
 
     ##
     # @return [Array<String>] the list of all user groups

--- a/app/views/hyrax/my/_facet_limit.html.erb
+++ b/app/views/hyrax/my/_facet_limit.html.erb
@@ -3,7 +3,7 @@
       class in only necessary for the former and causes display issues in the latter. -%>
   <ul id="<%= facet_field.field.parameterize + '-dropdown-options' %>" class="<%= 'dropdown-menu ' if action_name == 'index' %>facet-values" aria-labelledby="<%= facet_field.field.parameterize %>">
     <% paginator = facet_paginator(facet_field, display_facet) %>
-    <%= render_facet_limit_list paginator, facet_field.key %>
+    <%= render_facet_limit_list(paginator, facet_field.key) %>
 
     <% unless paginator.last_page? || params[:action] == "facet" %>
       <li role="separator" class="dropdown-divider"></li>

--- a/app/views/hyrax/my/_facet_pivot.html.erb
+++ b/app/views/hyrax/my/_facet_pivot.html.erb
@@ -9,8 +9,7 @@
         <% item.fq= {} if subfacet %>
 
         <% # The unless prevents Collection from being included in the select list for the Collection Type filter. %>
-        <% facet_config= facet_configuration_for_field(item.field) %>
-        <%= (facet_config.item_presenter || Blacklight::FacetItemPresenter).new(item, facet_config, self, item.field).label unless subfacet != true && item.value == "Collection" %>
+        <%= render_facet_item(item.field, item) unless subfacet != true && item.value == "Collection" %>
       </span>
 
       <% unless item.items.blank? %>


### PR DESCRIPTION
The Collection filters in the admin dashboard are broken. Essentially, with the update to Blacklight 7, all the code we used to render those filters is deprecated, and most of the logic was moved from `facets_helper_behavior.rb` to components.

My initial approach to solve this issue was attempting to migrate some of the views we use to render facets to view components from Blacklight 7. After I managed to use components and render them successfully, I realized that the components are hard to customize for some of the use cases in Hyrax, like rendering `Admin Set` under `Collection Type` in the collections admin dashboard. Any further attempts to override components for some of the customization we need led to complex logic that is hard to read and will make it much harder for future developers to track any bugs.

The approach in this PR requires minimal edits compared to overriding Blacklight components. Instead of migrating to components to adapt to Blacklight 7, I created a helper class `Hyrax::FacetsHelper` that has the same methods as the `Blacklight::FacetsHelperBehavior` in Blacklight `6.24.0`. The helper methods in Blacklight 6 are different from those deprecated in Blacklight 7 because they do not rely on components to render the facets. The facets helper I added simply ensures the deprecated method we use to render custom facet views in Hyrax can still be used in the codebase, and no components are needed.

The PR accomplishes the following:
- Restore filtering by `Collection Type` under Dashboard > Collections
- Resolve all the specs that were failing because of the broken filtering functionality for collections

