### PR TITLE
Corrects the styling and javascript for fileset permissions.

### DIFF
--- a/app/assets/javascripts/hyrax/permissions/user_controls.es6
+++ b/app/assets/javascripts/hyrax/permissions/user_controls.es6
@@ -51,7 +51,9 @@ export class UserControls {
   }
 
   userName() {
-    return this.userField.val()
+    if (this.userField.select2('data')) {
+      return this.userField.select2('data').text
+    }
   }
 
   addError(message) {

--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -43,6 +43,28 @@ form {
   .form-group {
     align-items: center;
 
+    > div {
+      width: 100%;
+      padding: 0 15px;
+
+      > .row {
+        margin: 0;
+
+        > div > .select2-container {
+          width: 100%;
+
+          > .select2-choice {
+            height: 100%;
+            > .select2-chosen {
+              height: 100%;
+              padding-top: 0.5rem;
+              padding-left: 0.5rem;
+            }
+          }
+        }
+      }
+    }
+
     > label {
       text-align: left;
 

--- a/app/views/hyrax/file_sets/_permission_form.html.erb
+++ b/app/views/hyrax/file_sets/_permission_form.html.erb
@@ -28,20 +28,22 @@
   <div id="new-user">
     <p class="col-sm-12"><%= t('.enter', account_label: t('hyrax.account_label')) %></p>
     <p class="sr-only"><%= t('.new_user_help_text', account_label: t('hyrax.account_label')) %></p>
-    <div class="col-sm-5">
-      <label for="new_user_name_skel" class="sr-only"><%= t('.new_user_name_skel', account_label: t('hyrax.account_label'), suffix: t('hyrax.directory.suffix')) %></label>
-      <%= text_field_tag 'new_user_name_skel', nil %>
-    </div>
-    <div class="col-sm-4">
-      <label for="new_user_permission_skel" class="sr-only"><%= t('.new_user_permission_skel') %></label>
-      <%= select_tag 'new_user_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
-    </div>
-    <div class="col-sm-3">
-      <button class="btn btn-secondary" id="add_new_user_skel">
-        <span class="sr-only"><%= t('.add_new_user_skel', account_label: t('hyrax.account_label')) %></span>
-        <span aria-hidden="true"><i class="fa fa-plus"></i></span>
-      </button>
-      <br /> <span id="directory_user_result"></span>
+    <div class="row">
+      <div class="col-sm-5">
+        <label for="new_user_name_skel" class="sr-only"><%= t('.new_user_name_skel', account_label: t('hyrax.account_label'), suffix: t('hyrax.directory.suffix')) %></label>
+        <%= text_field_tag 'new_user_name_skel', nil %>
+      </div>
+      <div class="col-sm-4">
+        <label for="new_user_permission_skel" class="sr-only"><%= t('.new_user_permission_skel') %></label>
+        <%= select_tag 'new_user_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
+      </div>
+      <div class="col-sm-3">
+        <button class="btn btn-secondary" id="add_new_user_skel">
+          <span class="sr-only"><%= t('.add_new_user_skel', account_label: t('hyrax.account_label')) %></span>
+          <span aria-hidden="true"><i class="fa fa-plus"></i></span>
+        </button>
+        <br /> <span id="directory_user_result"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -49,18 +51,20 @@
 <div class="form-group row">
   <div id="new-group">
     <p class="sr-only"><%= t('.new_group_help_text') %></p>
-    <div class="col-sm-5">
-      <label for="new_group_name_skel" class="sr-only"><%= t('.new_group_name_skel') %></label>
-      <%= select_tag 'new_group_name_skel', options_for_select([t('.select_group')] + current_user.groups), class: 'form-control' %>
-    </div>
-    <div class="col-sm-4">
-      <label for="new_group_permission_skel" class="sr-only"><%= t('.new_group_permission_skel') %></label>
-      <%= select_tag 'new_group_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
-    </div>
-    <div class="col-sm-3">
-      <span class="sr-only"><%= t('.add_new_group_skel') %></span>
-      <button class="btn btn-secondary" id="add_new_group_skel"><i class="fa fa-plus"></i></button>
-      <br /><span id="directory_group_result"></span>
+    <div class="row">
+      <div class="col-sm-5">
+        <label for="new_group_name_skel" class="sr-only"><%= t('.new_group_name_skel') %></label>
+        <%= select_tag 'new_group_name_skel', options_for_select([t('.select_group')] + current_user.groups), class: 'form-control' %>
+      </div>
+      <div class="col-sm-4">
+        <label for="new_group_permission_skel" class="sr-only"><%= t('.new_group_permission_skel') %></label>
+        <%= select_tag 'new_group_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
+      </div>
+      <div class="col-sm-3">
+        <span class="sr-only"><%= t('.add_new_group_skel') %></span>
+        <button class="btn btn-secondary" id="add_new_group_skel"><i class="fa fa-plus"></i></button>
+        <br /><span id="directory_group_result"></span>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #5641

Changes

- app/assets/javascripts/hyrax/permissions/user_controls.es6: updates the call to pull the input data for the select2 field.
- app/assets/stylesheets/hyrax/_forms.scss: styles the fields so that they display correctly.
- app/views/hyrax/file_sets/_permission_form.html.erb: wraps the columns in `row`s to force them to display side-by-side.

![Screen Shot 2022-05-25 at 11 50 55 AM](https://user-images.githubusercontent.com/18330149/170304585-55289399-cbe6-489b-b69b-f2cfc60e18eb.png)


@samvera/hyrax-code-reviewers
