### PR TITLE
Fix build for Rails 6

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -83,6 +83,7 @@ SUMMARY
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 5.10'
   spec.add_dependency 'valkyrie', '~> 2', '>= 2.1.1'
+  spec.add_dependency 'sprockets', '~> 3.7'
 
   spec.add_development_dependency "capybara", '~> 3.29'
   spec.add_development_dependency 'capybara-screenshot', '~> 1.0'


### PR DESCRIPTION
- Set dependency `sprockets` version to  '~> 3.7'` to prevent this error:

```
# NoMethodError:
#   undefined method `start_with?' for /fontawesome-webfont\.(?:svg|ttf|woff)$/:Regexp
#   ./vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.3/lib/sprockets/uri_utils.rb:78:in `valid_asset_uri?'
```

I decided to set the version below `4.x` based on this thread https://github.com/rails/sprockets/issues/632.

- Add custom `engine_cart:generate` task to resolve this error:

```
PG::ObjectInUse: ERROR:  database "circle_test" is being accessed by other users
DETAIL:  There is 1 other session using the database.
```

the `engine_cart:generate` task runs `db:migrate` and `db:test:prepare` in one command which seems to trigger that issue. The custom task I added is the same as the original from `engine_cart`, except `db:migrate` and `db:test:prepare` are split into two commands.


