### PR TITLE
Changes the view type styling to eliminate text, change background color.

### DIFF
--- a/app/assets/stylesheets/hyrax/_catalog.scss
+++ b/app/assets/stylesheets/hyrax/_catalog.scss
@@ -117,3 +117,11 @@
 .badge {
   color: #fff;
 }
+
+.view-type-group a {
+  background-color: #fff;
+  
+  > span.caption {
+    display: none;
+  }
+}


### PR DESCRIPTION
Fixes #5630.

app/assets/stylesheets/hyrax/_catalog.scss: updates background color to white, blocks displaying of captions.
![Screen Shot 2022-05-26 at 9 50 07 AM](https://user-images.githubusercontent.com/18330149/170501296-9e101ed5-9e5b-4340-b1eb-9b59f7672895.png)
![Screen Shot 2022-05-26 at 9 50 31 AM](https://user-images.githubusercontent.com/18330149/170501299-189cbf7b-b4c4-49fc-8bca-2f72684703c8.png)

