### PR TITLE
sprockets4 fix

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -83,7 +83,6 @@ SUMMARY
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 5.10'
   spec.add_dependency 'valkyrie', '~> 2', '>= 2.1.1'
-  spec.add_dependency 'sprockets', '~> 3.7'
 
   spec.add_development_dependency "capybara", '~> 3.29'
   spec.add_development_dependency 'capybara-screenshot', '~> 1.0'

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -118,7 +118,7 @@ module Hyrax
       app.config.assets.paths << config.root.join('app', 'assets', 'images', 'hydra')
       app.config.assets.paths << config.root.join('app', 'assets', 'images', 'site_images')
 
-      app.config.assets.precompile << /fontawesome-webfont\.(?:svg|ttf|woff)$/
+      app.config.assets.precompile += %w[fontawesome-webfont.svg fontawesome-webfont.ttf fontawesome-webfont.woff]
       app.config.assets.precompile += %w[*.png *.jpg *.ico *.gif *.svg]
 
       Sprockets::ES6.configuration = { 'modules' => 'amd', 'moduleIds' => true }


### PR DESCRIPTION
The issue with sprockets 4 originated from use of a regexp to define assets to precompile.