### PR TITLE
Allow CronJob's to use podAnnotations

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 1.3.0
+version: 1.4.0
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/cron-embargo.yaml
+++ b/chart/hyrax/templates/cron-embargo.yaml
@@ -11,6 +11,11 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+        {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
         spec:
           containers:
           - name: embargo-release

--- a/chart/hyrax/templates/cron-lease.yaml
+++ b/chart/hyrax/templates/cron-lease.yaml
@@ -11,6 +11,11 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+        {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
         spec:
           containers:
           - name: lease-release


### PR DESCRIPTION
This is helpful for scenarios like using Hashicorp Vault secrets using the [Agent injection solution](https://www.vaultproject.io/docs/platform/k8s/injector), which leverages annotations.

I'm planning on following up with a PR to propose supporting the Vault secret use case explicitly, but I think allowing `podAnnotations` to be used in `CronJob` (and `Job`) templates is beneficial more broadly.

Changes proposed in this pull request:
* Allow existing `CronJob` templates to use `.Values.podAnnotations` if specified
* Bump chart version to `1.4.0`

@samvera/hyrax-code-reviewers
