### PR TITLE
CharacterizeJob non-ASCII filename bug

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -62,7 +62,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
     file_set.date_modified = Hyrax::TimeService.time_in_utc if file_set.characterization_proxy.original_checksum.first != previous_checksum
 
     # set title to label if that's how it was before this characterization
-    file_set.title = [file_set.characterization_proxy.original_name] if reset_title
+    file_set.title = [file_set.characterization_proxy.original_name.force_encoding("UTF-8")] if reset_title
     # always set the label to the original_name
     file_set.label = file_set.characterization_proxy.original_name
 


### PR DESCRIPTION
Fixes #5671

It would be better to solve #5670 more generally but I'm [PR'ing this simple force_encoding solution in heliotrope](https://github.com/mlibrary/heliotrope/pull/3294) anyway to make sure filenames with non-ASCII characters can be ingested as before.

I'll just leave this here until I have more time to look at it and/or some feedback accrues.
It wouldn't hurt anything to merge it even it #5670 is solved later, I guess.

@samvera/hyrax-code-reviewers
