### PR TITLE
WIP Publish Docker Images From Circle CI and Include ARM64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   samvera: samvera/circleci-orb@0
+  docker: circleci/docker@1.4.0
   buildx: sensu/docker-buildx@1.1.1
 jobs:
   bundle:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,11 +167,11 @@ jobs:
       - run:
           name: Build Images
           command: |
-            docker buildx bake -f docker-compose.yml --set \*.platform=linux/arm64,linux/amd64%
+            docker buildx bake -f docker-compose.yml --set \*.platform=linux/arm64,linux/amd64
       - run:
           name: Push Images
           command: |
-            echo "$DOCKERHUB_PASS" | docker login ghcr.io -u "$DOCKERHUB_USERNAME" --password-stdin && \
+            echo "$GITHUB_PASS" | docker login ghcr.io -u "$GITHUB_USERNAME" --password-stdin && \
             export SHORT_SHA=`git rev-parse --short=8 HEAD` && \
             docker tag ghcr.io/samvera/dassie:latest ghcr.io/samvera/dassie:$SHORT_SHA
             docker push ghcr.io/samvera/dassie:$SHORT_SHA

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,15 +231,6 @@ workflows:
           bundler_version: "2.1.4"
           requires:
             - build
-  nurax-dev_deploy:
-    jobs:
-      - deploy:
-          filters:
-            branches:
-              only:
-                - main
-  publish_dassie_images:
-    jobs:
       - publish:
           requires:
             - build
@@ -248,3 +239,11 @@ workflows:
               only:
                 - main
                 - publish_or_parish
+
+  nurax-dev_deploy:
+    jobs:
+      - deploy:
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,8 @@ workflows:
   publish_dassie_images:
     jobs:
       - publish:
+          requires:
+            - build
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   samvera: samvera/circleci-orb@0
+  docker-buildx: sensu/docker-buildx@1.1.1
 jobs:
   bundle:
     parameters:
@@ -148,6 +149,27 @@ jobs:
             --header "Circle-Token: $NURAX_CIRCLECI_TOKEN" \
             --header 'Accept: text/plain'    \
             --header 'Content-Type: application/json'
+  publish:
+    steps:
+      - attach_workspace:
+          at: ~/
+      - docker-buildx/install
+      - run:
+          name: Enable additional Docker features
+          command: |
+            echo 'export DOCKER_BUILDKIT=1' >> $BASH_ENV && \
+            echo 'export COMPOSE_DOCKER_CLI_BUILD=1' >> $BASH_ENV
+      - run:
+          name: Build Images
+          command: |
+            docker buildx bake -f docker-compose.yml --set \*.platform=linux/arm64,linux/amd64%
+      - run:
+          name: Push Images
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login ghcr.io -u "$DOCKERHUB_USERNAME" --password-stdin && \
+            export SHORT_SHA=`git rev-parse --short=8 HEAD` && \
+            docker tag ghcr.io/samvera/dassie:latest ghcr.io/samvera/dassie:$SHORT_SHA
+            docker push ghcr.io/samvera/dassie:$SHORT_SHA
 workflows:
   version: 2
   ruby2-5-8:
@@ -211,3 +233,11 @@ workflows:
             branches:
               only:
                 - main
+  publish_dassie_images:
+    jobs:
+      - publish:
+          filters:
+            branches:
+              only:
+                - main
+                - publish_or_parish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   samvera: samvera/circleci-orb@0
-  docker-buildx: sensu/docker-buildx@1.1.1
+  buildx: sensu/docker-buildx@1.1.1
 jobs:
   bundle:
     parameters:
@@ -150,10 +150,14 @@ jobs:
             --header 'Accept: text/plain'    \
             --header 'Content-Type: application/json'
   publish:
+    executor:
+      name: docker/machine
+      image: "ubuntu-2004:202101-01"
+      dlc: true
     steps:
       - attach_workspace:
           at: ~/
-      - docker-buildx/install
+      - buildx/install
       - run:
           name: Enable additional Docker features
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: Push Images
           command: |
-            echo "$GITHUB_PASS" | docker login ghcr.io -u "$GITHUB_USERNAME" --password-stdin && \
+            echo "$GITHUB_PASS" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin && \
             export SHORT_SHA=`git rev-parse --short=8 HEAD` && \
             docker tag ghcr.io/samvera/dassie:latest ghcr.io/samvera/dassie:$SHORT_SHA
             docker push ghcr.io/samvera/dassie:$SHORT_SHA


### PR DESCRIPTION
We currently only push images to the Github registry manually. I instead propose that we build them via Circle CI and build both amd64 and arm64. This lays the groundwork for other architectures.

Changes proposed in this pull request:
* Add a new CircleCI job
* Run that job automatically on push to main (this should be discussed)

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* The CircleCi build passes
* The images are available for pulling

@samvera/hyrax-code-reviewers