### PR TITLE
Support readinessProbe in Sidekiq Deployment

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 1.4.1
+version: 1.5.0
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -64,6 +64,17 @@ spec:
             {{- end }}
           env:
             {{- toYaml .Values.worker.extraEnvVars | nindent 12 }}
+          {{- if .Values.worker.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                {{- toYaml .Values.worker.readinessProbe.command | nindent 16 }}
+            failureThreshold: {{ .Values.worker.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.worker.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.worker.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.worker.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.worker.readinessProbe.timeoutSeconds }}
+          {{- end }}
           volumeMounts:
             - name: derivatives
               mountPath: /app/samvera/derivatives

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -201,6 +201,18 @@ worker:
   affinity: {}
   resources: {}
 
+  # see: https://github.com/mperham/sidekiq/wiki/Kubernetes#health-checks
+  readinessProbe:
+    enabled: false
+    # command:
+    #  - cat
+    #  - /app/samvera/hyrax-webapp/tmp/sidekiq_process_has_started_and_will_begin_processing_jobs
+    # initialDelaySeconds: 10
+    # periodSeconds: 2
+    # timeoutSeconds: 1
+    # failureThreshold: 10
+    # successThreshold: 2
+
 fcrepo:
   enabled: true
   externalDatabaseUsername: "hyrax"


### PR DESCRIPTION
Following the recommendations from the Sidekiq wiki [1], this updates
the chart to support defining a `readinessProbe` for the sidekiq worker
`Deployment`.

An example is given in the values.yaml, and would look something like:

```yaml
worker:
  readinessProbe:
    enabled: true
    command:
     - cat
     - /app/samvera/hyrax-webapp/tmp/sidekiq_process_has_started_and_will_begin_processing_jobs
    initialDelaySeconds: 10
    periodSeconds: 2
    timeoutSeconds: 1
    failureThreshold: 10
    successThreshold: 2
```

The downstream developer will also need to setup, or modify, a sidekiq
initializer to create/delete the file used for the health checks.

Example from the wiki:

```ruby
SIDEKIQ_WILL_PROCESSES_JOBS_FILE = Rails.root.join('tmp/sidekiq_process_has_started_and_will_begin_processing_jobs').freeze

Sidekiq.configure_server do |config|
  # We touch and destroy files in the Sidekiq lifecycle to provide a
  # signal to Kubernetes that we are ready to process jobs or not.
  #
  # Doing this gives us a better sense of when a process is actually
  # alive and healthy, rather than just beginning the boot process.
  config.on(:startup) do
    FileUtils.touch(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
  end

  config.on(:shutdown) do
    FileUtils.rm_f(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
  end
end
```

1. https://github.com/mperham/sidekiq/wiki/Kubernetes#health-checks

@samvera/hyrax-code-reviewers
