### PR TITLE
Add tab key highlighting to Dashboard side nav

### DIFF
--- a/app/assets/stylesheets/hyrax/sidebar.scss
+++ b/app/assets/stylesheets/hyrax/sidebar.scss
@@ -105,7 +105,6 @@ $gutter-width: $grid-gutter-width/2;
     margin-left: 0;
     margin-right: 0;
     li {
-      overflow: hidden;
       white-space: nowrap;
     }
     li .fa {
@@ -115,11 +114,6 @@ $gutter-width: $grid-gutter-width/2;
 
   .nav-pills > li > a {
     border-radius: 0;
-
-    &:focus {
-      background-color: transparent;
-      color: $admin-sidebar-link-color;
-    }
   }
 
   .nav-pills > li.active > a,

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -28,7 +28,7 @@
   </li>
 
   <% if can? :read, :admin_dashboard %>
-    <%= menu.nav_link(hyrax.admin_stats_path) do %>
+    <%= menu.nav_link(hyrax.admin_stats_path, class: "nav-link") do %>
       <span class="fa fa-bar-chart" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.statistics') %></span>
     <% end %>
   <% end %>
@@ -46,7 +46,7 @@
         <% end %>
 
         <%= menu.nav_link(hyrax.admin_analytics_work_reports_path,
-                          onclick: "dontChangeAccordion(event);") do %>
+                          onclick: "dontChangeAccordion(event);", class: "nav-link") do %>
           <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works_report') %></span>
         <% end %>
 


### PR DESCRIPTION
Fixes #5637 

This updates the Dashboard side nav to support keyboard tabbing throughout all navigation items (parent and children).  Visually the `focus:visible` pseudo class default browser behavior is restored.

Changes proposed in this pull request:
* Support keyboard tab nav in Dashboard

![image](https://user-images.githubusercontent.com/3020266/173627106-319311af-d2b0-4975-b425-47a2d86c9adf.png)


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to the Dashboard
* Refresh the page, and immediately start tabbing via the keyboard.  Notice focus states for expected elements

@samvera/hyrax-code-reviewers
