### PR TITLE
Address View Work > Items List layout (Bootstrap 4)

### DIFF
--- a/app/assets/stylesheets/hyrax/_buttons.scss
+++ b/app/assets/stylesheets/hyrax/_buttons.scss
@@ -4,7 +4,7 @@
 }
 
 .multi_value .listing .input-group {
-  margin-bottom: .35em;
+  margin-bottom: 0.35em;
 }
 
 .input-group-btn:last-child > .btn {
@@ -33,4 +33,30 @@ span.appliedFilter .remove {
 
 .additional-fields {
   margin-bottom: 1.5em;
+}
+
+/* add bootstrap 3.x style .btn-default */
+
+.btn-default {
+  color: #333;
+  background-color: #fff;
+  border-color: #ccc;
+}
+
+.btn-default:focus {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #8c8c8c;
+}
+
+.btn-default:hover {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
+}
+
+.btn-default:active {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
 }

--- a/app/assets/stylesheets/hyrax/_card.scss
+++ b/app/assets/stylesheets/hyrax/_card.scss
@@ -1,0 +1,10 @@
+.card {
+  margin-bottom: 20px;
+}
+
+.card-title {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  color: inherit;
+}

--- a/app/assets/stylesheets/hyrax/_hyrax.scss
+++ b/app/assets/stylesheets/hyrax/_hyrax.scss
@@ -9,7 +9,7 @@
   "hyrax/file_upload", "hyrax/representative-media", "hyrax/footer",
   "hyrax/select_work_type", "hyrax/users", "hyrax/dashboard", "hyrax/sidebar",
   "hyrax/controlled_vocabulary", "hyrax/accessibility", "hyrax/recent",
-  "hyrax/viewer", "hyrax/breadcrumbs", "hyrax/facets";
+  "hyrax/viewer", "hyrax/breadcrumbs", "hyrax/facets", "hyrax/card";
 @import "hydra-editor/multi_value_fields";
 @import "typeahead";
 @import "sharing_buttons";

--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -1,6 +1,14 @@
 .related-files {
   .thumbnail {
     width: $related-files-thumbnail-width;
+
+    img {
+      display: block;
+      max-width: 100%;
+      height: auto;
+      margin-right: auto;
+      margin-left: auto;
+    }
   }
 }
 

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -33,7 +33,7 @@
 
     <div class="card">
       <div class="card-header">
-        <h1 class="card-title"><%= t('hyrax.base.show.relationships') %></h1>
+        <h2 class="card-title"><%= t('hyrax.base.show.relationships') %></h2>
       </div>
       <div class="card-body">
         <%= render 'relationships', presenter: @presenter %>
@@ -42,7 +42,7 @@
 
     <div class="card">
       <div class="card-header">
-        <h1 class="card-title"><%= t('.items') %></h1>
+        <h2 class="card-title"><%= t('.items') %></h2>
       </div>
       <div class="card-body">
         <%= render 'items', presenter: @presenter %>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -9,7 +9,7 @@
               data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
   <% else %>
   <div class="btn-group">
-    <button class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
+    <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
       <span class="sr-only"><%= t('.press_to') %> </span>
       <%= t('.header') %>
     </button>


### PR DESCRIPTION
## What does this do?

This address https://github.com/samvera/hyrax/issues/5677 and cleans up the Items styling.

![image](https://user-images.githubusercontent.com/7376450/173638622-9eb7da0a-ceb1-4120-99e0-8a709bcb5575.png)

- The element for `card-title` is now and `<h2>`, formally was `<h1>`
- `font-size` for card title is now 16px
- `max-width` has been set for images that child selectors of `.thumbnail` classes
-  The items action button now matches more closely to existing styling
- `btn-default` classes (a bootstrap 3.x convention) have been added to mimic an outlined btn with a gray border.