### PR TITLE
Addresss Settings > Features page layout (Bootstrap 4) 

### DIFF
--- a/app/assets/stylesheets/hyrax/_badge.scss
+++ b/app/assets/stylesheets/hyrax/_badge.scss
@@ -1,0 +1,7 @@
+.badge-enabled {
+  @extend .badge-success;
+}
+
+.badge-disabled {
+  @extend .badge-secondary;
+}

--- a/app/assets/stylesheets/hyrax/_buttons.scss
+++ b/app/assets/stylesheets/hyrax/_buttons.scss
@@ -60,3 +60,7 @@ span.appliedFilter .remove {
   background-color: #e6e6e6;
   border-color: #adadad;
 }
+
+td.toggle input[type="submit"]:not(.active) {
+  @extend .btn-default;
+}

--- a/app/assets/stylesheets/hyrax/_hyrax.scss
+++ b/app/assets/stylesheets/hyrax/_hyrax.scss
@@ -9,7 +9,8 @@
   "hyrax/file_upload", "hyrax/representative-media", "hyrax/footer",
   "hyrax/select_work_type", "hyrax/users", "hyrax/dashboard", "hyrax/sidebar",
   "hyrax/controlled_vocabulary", "hyrax/accessibility", "hyrax/recent",
-  "hyrax/viewer", "hyrax/breadcrumbs", "hyrax/facets", "hyrax/card";
+  "hyrax/viewer", "hyrax/breadcrumbs", "hyrax/facets", "hyrax/card",
+  "hyrax/badge";
 @import "hydra-editor/multi_value_fields";
 @import "typeahead";
 @import "sharing_buttons";

--- a/app/views/hyrax/admin/features/index.html.erb
+++ b/app/views/hyrax/admin/features/index.html.erb
@@ -30,7 +30,7 @@
               <% features.each do |feature| %>
               <tr data-feature="<%= feature.name.dasherize.parameterize %>">
                 <td class="status">
-                  <span class="<%= @feature_set.status(feature) -%>"><%= @feature_set.status(feature) -%></span>
+                  <span class="badge badge-<%= @feature_set.status(feature) -%>"><%= @feature_set.status(feature) -%></span>
                 </td>
                 <td class="name"><%= feature.name.humanize -%></td>
                 <td class="description"><%= feature.description -%></td>


### PR DESCRIPTION
## What does this do?
This address visual styling issues on the Settings > Features page.

![image](https://user-images.githubusercontent.com/7376450/173658958-429d3885-2f14-4683-bc25-95dfc5feea56.png)

- Toggle button group now has an inactive state matching previous Hyrax versions
- The Enabled/Disabled badges are now legible by extending bootstrap 4 classes
- Enabled badge state extends `btn-success` to display green background-color and differentiate it from disabled visually

