### PR TITLE
Address User/Dashboard/Login menu styling (Bootstrap 4)

### DIFF
--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -225,7 +225,6 @@ body.dashboard {
 }
 
 .dropdown-item {
-  padding: 0 0;
   display: list-item;
 
   > .facet-values {


### PR DESCRIPTION
## What does this do?

This reverts the `padding: 0 0` override on the dropdown-item and allows for the default bootstrap padding on `bootstrap/_dropdown.scss` to render.

![image](https://user-images.githubusercontent.com/7376450/173683645-9cd566fe-9092-4b87-8f27-f8dbda0c5111.png)