### PR TITLE
5681 search results page

### DIFF
--- a/app/assets/stylesheets/hyrax/_catalog.scss
+++ b/app/assets/stylesheets/hyrax/_catalog.scss
@@ -10,60 +10,16 @@
   }
 }
 
-.document {
-  .list-thumbnail {
-    width: 30%;
-    float: left;
-  }
-
-  .metadata {
-    width: 70%;
-    display: inline-block;
-  }
-}
-
-// Styles added to help with newly implemented
-// Bootstrap row / column setup for search results
 .search-result-wrapper {
-  border-bottom: 1px dashed #ccc;
-  margin-bottom: 30px;
-  padding-bottom: 0;
-
-  .search-results-title-row {
-    align-items: center;
-    display: flex;
-    padding: 0 0 15px;
-
-    .search-result-title {
-      display: inline-block;
-      margin: 0 15px;
-      font-size: 18px;
-    }
-
-    @media (max-width: 768px) {
-      display: block;
-
-      > .search-result-title {
-        display: block;
-        padding-bottom: 5px;
-      }
-
-      .badge {
-        margin-left: 15px;
-      }
-    }
-  }
-
   .list-thumbnail {
-    float: none;
+    display: flex;
+    justify-content: center;
     padding-bottom: 20px;
-    width: 100%;
 
     @media (max-width: 768px) {
       img {
         max-height: 200px;
       }
-
     }
   }
 
@@ -76,10 +32,12 @@
   }
 
   .collection-counts-wrapper {
-    text-align: right;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
 
     @media (max-width: 992px) {
-      text-align: left;
+      justify-content: flex-start;
     }
 
     .collection-counts-item {
@@ -120,8 +78,14 @@
 
 .view-type-group a {
   background-color: #fff;
-  
+
   > span.caption {
     display: none;
+  }
+}
+
+.search-widgets {
+  .view-type {
+    display: inline-block;
   }
 }

--- a/app/assets/stylesheets/hyrax/_header.scss
+++ b/app/assets/stylesheets/hyrax/_header.scss
@@ -1,7 +1,3 @@
-#search-form-header {
-  margin-top: $search-bar-margin-top;
-}
-
 .searchbar-right {
   margin-right: 0;
 }

--- a/app/assets/stylesheets/hyrax/_home-page.scss
+++ b/app/assets/stylesheets/hyrax/_home-page.scss
@@ -24,60 +24,17 @@
 
   .background-container-gradient {
     @include masthead-background-containers();
-    background:
-      linear-gradient(
-        rgba(0, 0, 0, 0.0),
-        rgba(0, 0, 0, 0.4),
-        rgba(0, 0, 0, 0.5)
-      );
+    background: linear-gradient(
+      rgba(0, 0, 0, 0),
+      rgba(0, 0, 0, 0.4),
+      rgba(0, 0, 0, 0.5)
+    );
   }
 
   .site-title {
     min-height: $title-height;
     padding-bottom: 6px;
     position: relative;
-  }
-
-  .navbar {
-    background-color: $navbar-transparent-bg;
-    color: #fff;
-    margin-bottom: 0;
-
-    .navbar-nav {
-      align-self: stretch;
-
-      a {
-        display: flex;
-        align-items: center;
-        height: 100%;
-        color: $navbar-transparent-link-color;
-        text-transform: uppercase;
-
-        &:hover,
-        &:focus {
-          background-color: $navbar-transparent-link-hover-bg;
-          color: $navbar-transparent-link-hover-color;
-        }
-      }
-      li {
-        background-color: #286090;
-      }
-    }
-
-    @media only screen and (max-width: 767px) {
-      .navbar-nav {
-        margin-left: 10px;
-      }
-    }
-
-    .active > a {
-      &,
-      &:hover,
-      &:focus {
-        background-color: $navbar-transparent-link-active-bg;
-        color: $navbar-transparent-link-active-color;
-      }
-    }
   }
 }
 

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,15 +1,15 @@
-<nav class="navbar navbar-dark navbar-expand-sm justify-content-between p-0" role="navigation" aria-label="Root Menu">
-  <ul class="nav navbar-nav col-sm-5">
-    <li class="nav-item <%= 'active' if current_page?(hyrax.root_path) %>">
-      <%= link_to t(:'hyrax.controls.home'), hyrax.root_path, class: "nav-link", aria: current_page?(hyrax.root_path) ? {current: 'page'} : nil %></li>
-    <li class="nav-item <%= 'active' if current_page?(hyrax.about_path) %>">
-      <%= link_to t(:'hyrax.controls.about'), hyrax.about_path, class: "nav-link", aria: current_page?(hyrax.about_path) ? {current: 'page'} : nil %></li>
-    <li class="nav-item <%= 'active' if current_page?(hyrax.help_path) %>">
-      <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, class: "nav-link", aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
-    <li class="nav-item <%= 'active' if current_page?(hyrax.contact_path) %>">
-      <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, class: "nav-link", aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
-  </ul><!-- /.nav -->
-  <div class="col-sm-7">
-    <%= render partial: 'catalog/search_form' %>
-  </div>
-</nav><!-- /.navbar -->
+<nav class="navbar navbar-light bg-light navbar-expand-sm justify-content-between align-items-center px-2 py-3 border-bottom" role="navigation" aria-label="Root Menu">
+    <ul class="nav navbar-nav col-sm-5">
+      <li class="nav-item <%= 'active' if current_page?(hyrax.root_path) %>">
+        <%= link_to t(:'hyrax.controls.home'), hyrax.root_path, class: "nav-link", aria: current_page?(hyrax.root_path) ? {current: 'page'} : nil %></li>
+      <li class="nav-item <%= 'active' if current_page?(hyrax.about_path) %>">
+        <%= link_to t(:'hyrax.controls.about'), hyrax.about_path, class: "nav-link", aria: current_page?(hyrax.about_path) ? {current: 'page'} : nil %></li>
+      <li class="nav-item <%= 'active' if current_page?(hyrax.help_path) %>">
+        <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, class: "nav-link", aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
+      <li class="nav-item <%= 'active' if current_page?(hyrax.contact_path) %>">
+        <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, class: "nav-link", aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
+    </ul><!-- /.nav -->
+    <div class="col-sm-7">
+      <%= render partial: 'catalog/search_form' %>
+    </div>
+  </nav><!-- /.navbar -->

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,5 +1,5 @@
-<li id="document_<%= document.to_param %>" class="document <%= render_document_class document %>" itemscope itemtype="<%= document.itemtype %>">
-  <div class="row search-result-wrapper">
+<li id="document_<%= document.to_param %>" class="pb-3 document <%= render_document_class document %>" itemscope itemtype="<%= document.itemtype %>">
+  <div class="search-result-wrapper row">
     <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, document_counter: document_counter %>
   </div>
 </li>

--- a/app/views/catalog/_document_list.html.erb
+++ b/app/views/catalog/_document_list.html.erb
@@ -1,6 +1,6 @@
 <%# container for all documents in index view -%>
 <div id="search-results">
-  <ul class="list-unstyled catalog" start="<%= document_counter_with_offset(0) %>">
+  <ul class="list-unstyled catalog mt-4" start="<%= document_counter_with_offset(0) %>">
     <%= render documents, as: :document %>
   </ul>
 </div>

--- a/app/views/catalog/_index_header_list_collection.html.erb
+++ b/app/views/catalog/_index_header_list_collection.html.erb
@@ -1,4 +1,4 @@
-<div class="search-results-title-row">
-  <h3 class="search-result-title"><%= link_to document.title_or_label, [hyrax, document] %></h3>
+<div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2">
+  <h3 class="search-result-title mb-0 pr-3"><%= link_to document.title_or_label, [hyrax, document] %></h3>
   <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
 </div>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,5 +1,5 @@
 <% model = document.hydra_model %>
-<div class="search-results-title-row">
+<div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2">
   <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
     <h3 class="search-result-title"><%= link_to document.title_or_label, [hyrax, document] %></h3>
     <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,4 +1,4 @@
-<div class="col-md-6">
+<div class="col-md-9 col-lg-6">
   <div class="metadata">
     <dl>
     <% doc_presenter = index_presenter(document) %>
@@ -15,7 +15,7 @@
 </div>
 <% if document.collection? %>
 <% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
-<div class="col-md-4">
+<div class="col-md-12 col-lg-3">
   <div class="collection-counts-wrapper">
     <div class="collection-counts-item">
       <span><%= collection_presenter.total_viewable_collections %></span>Collections

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,13 +1,13 @@
 <%= form_tag search_form_action, method: :get, class: "search-form", id: "search-form-header", role: "search" do %>
   <%= render Blacklight::HiddenSearchStateComponent.new(params: search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <%= hidden_field_tag :search_field, 'all_fields' %>
-  <div class="form-group row pt-4">
+  <div class="form-group row">
 
-    <label class="col-sm-3" for="search-field-header">
+    <label class="col-sm-3 mb-0" for="search-field-header">
       <%= t("hyrax.search.form.q.label", application_name: application_name) %>
     </label>
 
-    <div class="input-group mb-2 col-sm-9">
+    <div class="input-group col-sm-9">
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
       <div class="input-group-append">

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag search_form_action, method: :get, class: "search-form", id: "search-form-header", role: "search" do %>
   <%= render Blacklight::HiddenSearchStateComponent.new(params: search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <%= hidden_field_tag :search_field, 'all_fields' %>
-  <div class="form-group row">
+  <div class="form-group row pt-4">
 
     <label class="col-sm-3" for="search-field-header">
       <%= t("hyrax.search.form.q.label", application_name: application_name) %>

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,4 +1,4 @@
-<div class="col-md-2">
+<div class="col-md-3">
   <%= document_presenter(document)&.thumbnail&.thumbnail_tag({}, { suppress_link: true }) %>
 </div> 
 

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,5 +1,5 @@
 <% model = document.hydra_model %>
-<div class="col-md-2">
+<div class="col-md-3">
   <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
     <%= document_presenter(document)&.thumbnail&.thumbnail_tag({}, suppress_link: true) %>
   <% else %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row mt-4">
   <div id="content" class="order-sm-1 order-md-2 col-md-9 col-sm-12">
     <%= render 'search_results' %>
   </div>


### PR DESCRIPTION
Fixes #5681 #5691 

Cleans up the display on Search page, in addition to fixing primary navigation (on home page and for mobile) on all non-Dashboard pages.

Changes proposed in this pull request:
* Search page layout cleaned up
* Non-Dashboard navbar color changed to Bootstrap's `bg-light` for readability
* Homepage masthead custom navigation removed in favor of default Bootstrap styling.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to Search page, search for anything
* View results, then across multiple viewports (mobile, tablet, desktop)
* Notice navigation on Search page across viewports.
* Go to Homepage, notice navigation across viewports

![image](https://user-images.githubusercontent.com/3020266/173688735-db946f0d-48e7-4344-a5b0-f3dde4c8aa9a.png)

![image](https://user-images.githubusercontent.com/3020266/173688891-a0365649-2894-4b82-995c-2a91df6998cf.png)

![image](https://user-images.githubusercontent.com/3020266/173689001-72a71b83-56fe-4475-8987-c14e1f7ba7a4.png)


@samvera/hyrax-code-reviewers
