### PR TITLE
always pull repo file if filepath param is missing

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -29,7 +29,8 @@ class CharacterizeJob < Hyrax::ApplicationJob
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
   def perform(file_set, file_id, filepath = nil)
     raise "#{file_set.class.characterization_proxy} was not found for FileSet #{file_set.id}" unless file_set.characterization_proxy?
-    filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id) unless filepath && File.exist?(filepath)
+    # Ensure a fresh copy of the repo file's latest version is being worked on, if no filepath is directly provided
+    filepath = Hyrax::WorkingDirectory.copy_repository_resource_to_working_directory(Hydra::PCDM::File.find(file_id), file_set.id) unless filepath && File.exist?(filepath)
     characterize(file_set, file_id, filepath)
     CreateDerivativesJob.perform_later(file_set, file_id, filepath)
   end

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -7,9 +7,11 @@ class CreateDerivativesJob < Hyrax::ApplicationJob
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
   def perform(file_set, file_id, filepath = nil)
     return if file_set.video? && !Hyrax.config.enable_ffmpeg
-    filename = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
 
-    file_set.create_derivatives(filename)
+    # Ensure a fresh copy of the repo file's latest version is being worked on, if no filepath is directly provided
+    filepath = Hyrax::WorkingDirectory.copy_repository_resource_to_working_directory(Hydra::PCDM::File.find(file_id), file_set.id) unless filepath && File.exist?(filepath)
+
+    file_set.create_derivatives(filepath)
 
     # Reload from Fedora and reindex for thumbnail and extracted text
     file_set.reload

--- a/app/services/hyrax/working_directory.rb
+++ b/app/services/hyrax/working_directory.rb
@@ -3,6 +3,7 @@ module Hyrax
   # @deprecated Use JobIoWrapper instead
   class WorkingDirectory
     class << self
+      # @deprecated No longer used anywhere in Hyrax code, naively assumes filenames of versions/revisions are distinct
       # Returns the file passed as filepath if that file exists. Otherwise it grabs the file from repository,
       # puts it on the disk and returns that path.
       # @param [String] repository_file_id identifier for Hydra::PCDM::File
@@ -10,6 +11,7 @@ module Hyrax
       # @param [String, NilClass] filepath path to existing cached copy of the file
       # @return [String] path of the working file
       def find_or_retrieve(repository_file_id, id, filepath = nil)
+        Deprecation.warn("Hyrax::WorkingDirectory.find_or_retrieve() is deprecated and no longer used in Hyrax")
         return filepath if filepath && File.exist?(filepath)
         repository_file = Hydra::PCDM::File.find(repository_file_id)
         working_path = full_filename(id, repository_file.original_name)

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -33,8 +33,18 @@ RSpec.describe CharacterizeJob, :clean_repo do
   context 'with valid filepath param' do
     let(:filename) { File.join(fixture_path, 'world.png') }
 
-    it 'skips Hyrax::WorkingDirectory' do
-      expect(Hyrax::WorkingDirectory).not_to receive(:find_or_retrieve)
+    it 'skips Hyrax::WorkingDirectory.copy_repository_resource_to_working_directory' do
+      expect(Hyrax::WorkingDirectory).not_to receive(:copy_repository_resource_to_working_directory)
+      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      described_class.perform_now(file_set, file.id, filename)
+    end
+  end
+
+  context 'with no filepath param' do
+    let(:filename) { nil }
+
+    it 'uses Hyrax::WorkingDirectory.copy_repository_resource_to_working_directory to pull the repo file' do
+      expect(Hyrax::WorkingDirectory).to receive(:copy_repository_resource_to_working_directory)
       expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
       described_class.perform_now(file_set, file.id, filename)
     end


### PR DESCRIPTION
Fixes #5676

Remove Hyrax::WorkingDirectory.find_or_retrieve() as it cannot handle FileSet file versions using the same filename.
This module is marked as deprecated anyway, and its removal a suggested (future) TODO on [this PR](https://github.com/samvera/hyrax/pull/1301).

@samvera/hyrax-code-reviewers
