### PR TITLE
wings: support non-AF FileMetadata nodes

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -2,6 +2,7 @@
 
 require 'wings/converter_value_mapper'
 require 'wings/active_fedora_converter/default_work'
+require 'wings/active_fedora_converter/file_metadata_node'
 require 'wings/active_fedora_converter/nested_resource'
 
 module Wings
@@ -100,6 +101,21 @@ module Wings
     private
 
     def instance
+      if resource.try(:file_identifier).present?
+        adapter_for_file =
+          begin
+            ::Valkyrie::StorageAdapter.adapter_for(id: resource.file_identifier)
+          rescue ::Valkyrie::StorageAdapter::AdapterNotFoundError => err
+            Hyrax.logger.warn "Processing a FileMetadata (id: #{id}) referencing " \
+                              "a file #{resource.file_identifier}; could not find a " \
+                              "storage adapter to handle that file.\n\t#{err.message}"
+            nil
+          end
+
+        return Wings::ActiveFedoraConverter::FileMetadataNode(resource.class).new(file_identifier: Array(resource.file_identifier).map(&:to_s)) unless
+          adapter_for_file.is_a?(::Valkyrie::Storage::Fedora)
+      end
+
       id.present? ? active_fedora_class.find(id) : active_fedora_class.new
     rescue ActiveFedora::ObjectNotFoundError
       active_fedora_class.new

--- a/lib/wings/active_fedora_converter/file_metadata_node.rb
+++ b/lib/wings/active_fedora_converter/file_metadata_node.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Wings
+  class ActiveFedoraConverter
+    def self.FileMetadataNode(resource_class) # rubocop:disable Naming/MethodName
+      class_cache[resource_class] ||= Class.new(FileMetadataNode) do
+        self.valkyrie_class = resource_class
+
+        # skip reserved attributes, we assume we don't need to translate valkyrie internals
+        schema = resource_class.schema.reject do |key|
+          resource_class.reserved_attributes.include?(key.name) ||
+            key.name == :size
+        end
+
+        Wings::ActiveFedoraConverter.apply_properties(self, schema)
+      end
+    end
+  end
+
+  class FileMetadataNode < ActiveFedora::Base
+    property :file_set_id, predicate: ::RDF::URI.intern("http://hyrax.samvera.org/ns/wings#file_set_id")
+    property :file_identifier, predicate: ::RDF::URI.intern("http://hyrax.samvera.org/ns/wings#file_identifier")
+
+    class_attribute :valkyrie_class
+
+    def model_name(*)
+      Hyrax::Name.new(valkyrie_class)
+    end
+  end
+end

--- a/lib/wings/active_fedora_converter/instance_builder.rb
+++ b/lib/wings/active_fedora_converter/instance_builder.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Wings
+  class ActiveFedoraConverter
+    ##
+    # Constructs an instance for the given converter. +converter+ must provide
+    # an +id+, +resource+, and +active_fedora_class+.
+    #
+    # This interface allows handling for special cases based on the target
+    # class, instance data for +resource+, or the id format. This originated as
+    # an extraction of some such special handling from the converter code.
+    class InstanceBuilder
+      ##
+      # @!attribute [r] converter
+      #   @return [#active_fedora_class, #id, #resource]
+      # @!attribute [r] resource
+      #   @return [Valkyrie::Resource]
+      attr_reader :converter, :resource
+
+      ##
+      # @param [#active_fedora_class, #id, #resource]
+      def initialize(converter)
+        @converter = converter
+        @resource = converter.resource
+      end
+
+      ##
+      # @return [ActiveFedora::Common]
+      def build
+        if builds_file_metadata? && !builds_metadata_for_active_fedora_file?
+          # convert to a generic/generated FileMetadataNode class with
+          # properties matching the source class
+          Wings::ActiveFedoraConverter::FileMetadataNode(resource.class)
+                                      .new(file_identifier: Array(resource.file_identifier)
+            .map(&:to_s))
+        elsif converter.id.present?
+          converter.active_fedora_class.find(converter.id)
+        else
+          converter.active_fedora_class.new
+        end
+      rescue ActiveFedora::ObjectNotFoundError
+        converter.active_fedora_class.new
+      end
+
+      ##
+      # @return [Boolean]
+      def builds_file_metadata?
+        resource.try(:file_identifier).present?
+      end
+
+      ##
+      # @return [Boolean]
+      def builds_metadata_for_active_fedora_file?
+        return false unless builds_file_metadata?
+
+        adapter_for_file = begin
+                             ::Valkyrie::StorageAdapter.adapter_for(id: resource.file_identifier)
+                           rescue ::Valkyrie::StorageAdapter::AdapterNotFoundError => err
+                             Hyrax.logger.warn "Processing a FileMetadata (id: #{converter.id}) referencing " \
+                                               "a file #{resource.file_identifier}; could not find a " \
+                                               "storage adapter to handle that file.\n\t#{err.message}"
+                           end
+
+        adapter_for_file.is_a?(::Valkyrie::Storage::Fedora)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,10 @@ Valkyrie::MetadataAdapter
   .register(Valkyrie::Persistence::Memory::MetadataAdapter.new, :test_adapter)
 Valkyrie::MetadataAdapter
   .register(Valkyrie::Persistence::Postgres::MetadataAdapter.new, :postgres_adapter)
+Valkyrie::StorageAdapter.register(
+  Valkyrie::Storage::Disk.new(base_path: Rails.root / 'tmp' / 'test_adapter_uploads'),
+  :test_disk
+)
 
 # Require supporting ruby files from spec/support/ and subdirectories.  Note: engine, not Rails.root context.
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -63,6 +63,32 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       end
     end
 
+    context 'when given a FileMetadata node' do
+      let(:resource) { Hyrax::FileMetadata.new(file_identifier: file.id) }
+      let(:file) do
+        io = fixture_file_upload('/world.png', 'image/png')
+        file_set = FactoryBot.valkyrie_create(:hyrax_file_set)
+        storage_adapter.upload(file: io, resource: file_set, original_filename: 'test-world.png')
+      end
+
+      context 'when it describes an ActiveFedora File' do
+        it 'converts to a Hydra::Pcdm::File'
+      end
+
+      context 'when it describes a file for an arbitrary storage adapter' do
+        let(:storage_adapter) { Valkyrie::StorageAdapter.find(:test_disk) }
+
+        it 'converts to a generic FileMetadataNode' do
+          expect(converter.convert).to be_a Wings::FileMetadataNode
+        end
+
+        it 'refers to the correct file id' do
+          expect(converter.convert)
+            .to have_attributes(file_identifier: contain_exactly(file.id))
+        end
+      end
+    end
+
     context 'when given a valkyrie native model' do
       let(:resource) { klass.new(title: ['comet in moominland'], distant_relation: ['Snufkin']) }
       let(:klass) { Hyrax::Test::Converter::Resource }

--- a/spec/wings/services/file_converter_service_spec.rb
+++ b/spec/wings/services/file_converter_service_spec.rb
@@ -56,16 +56,14 @@ RSpec.describe Wings::FileConverterService, :clean_repo do
 
     it 'copies attributes to af_file' do
       expect(subject.id.to_s).to eq id
-      expect(subject.original_name).to eq plain_text_valkyrie_attrs[:original_filename]
 
       expected_attrs = plain_text_valkyrie_attrs
 
-      expect(subject.metadata_node.type).to match_array expected_attrs[:type]
-      expect(subject.mime_type).to eq expected_attrs[:mime_type]
-      expect(subject.format_label).to eq Array(expected_attrs[:format_label])
-      expect(subject.language).to eq Array(expected_attrs[:language])
-      expect(subject.word_count).to eq Array(expected_attrs[:content].split(' ').count)
-      expect(subject.character_count).to eq Array(expected_attrs[:content].size)
+      expect(subject.mime_type).to contain_exactly(expected_attrs[:mime_type])
+      expect(subject.format_label).to contain_exactly(expected_attrs[:format_label])
+      expect(subject.language).to contain_exactly(expected_attrs[:language])
+      expect(subject.word_count).to contain_exactly(expected_attrs[:content].split(' ').count)
+      expect(subject.character_count).to contain_exactly(expected_attrs[:content].size)
     end
   end
 
@@ -79,11 +77,11 @@ RSpec.describe Wings::FileConverterService, :clean_repo do
       expect(subject.modified_date).not_to eq af_file.modified_date
       expect(subject.original_name).to eq plain_text_af_attrs[:original_name]
 
-      expect(subject.mime_type).to eq plain_text_af_attrs[:mime_type]
-      expect(subject.format_label).to eq Array(plain_text_af_attrs[:format_label])
-      expect(subject.language).to eq Array(plain_text_af_attrs[:language])
-      expect(subject.word_count).to eq Array(plain_text_af_attrs[:content].split(' ').count)
-      expect(subject.character_count).to eq Array(plain_text_af_attrs[:content].size)
+      expect(subject.mime_type).to eq 'text/plain'
+      expect(subject.format_label).to contain_exactly(plain_text_af_attrs[:format_label])
+      expect(subject.language).to contain_exactly(plain_text_af_attrs[:language])
+      expect(subject.word_count).to contain_exactly(plain_text_af_attrs[:content].split(' ').count)
+      expect(subject.character_count).to contain_exactly(plain_text_af_attrs[:content].size)
     end
   end
 

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -147,8 +147,8 @@ RSpec.describe Wings::Valkyrie::Persister do
         .to raise_error described_class::FailedSaveError
     end
 
-    context 'and it corresponds to a File' do
-      let(:resource) { Hyrax::FileMetadata.new(id: file.id, file_identifier: file.id) }
+    context 'and it corresponds to a ActiveFedora File' do
+      let(:resource) { Hyrax::FileMetadata.new(id: file.id) }
       let(:file) do
         Hydra::PCDM::File.new.tap do |f|
           f.content = "moomin\n"
@@ -172,6 +172,44 @@ RSpec.describe Wings::Valkyrie::Persister do
         persister.save(resource: resource)
         file.reload
         expect(file.content).to eq("moomin\n")
+      end
+    end
+
+    context "and it is metadata about a non-AF file" do
+      let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+      let(:io) { Tempfile.new('moomin-deriviative') }
+      let(:resource) { Hyrax::FileMetadata.new(file_identifier: file.id) }
+      let(:storage_adapter) { Valkyrie::StorageAdapter.find(:derivatives_disk) }
+
+      let(:file) do
+        storage_adapter.upload(file: io, original_filename: 'moomin.txt', resource: file_set)
+      end
+
+      it "can save a resource" do
+        expect(persister.save(resource: resource)).to be_persisted
+      end
+
+      it "recalls the file id" do
+        expect(persister.save(resource: resource))
+          .to have_attributes(file_identifier: file.id)
+      end
+
+      it "uses OriginalFile as type by default" do
+        expect(persister.save(resource: resource))
+          .to have_attributes(type: contain_exactly(RDF::URI("http://pcdm.org/use#OriginalFile")))
+      end
+
+      it "saves file metadata attributes" do
+        resource.file_set_id = file_set.id
+        resource.label = 'Comet in Moominland'
+        resource.mime_type = 'application/moomin'
+        resource.width = 7
+
+        expect(persister.save(resource: resource))
+          .to have_attributes(file_set_id: file_set.id,
+                              label: contain_exactly('Comet in Moominland'),
+                              mime_type: 'application/moomin',
+                              width: contain_exactly(7))
       end
     end
   end

--- a/spec/wings/valkyrie/resource_factory_spec.rb
+++ b/spec/wings/valkyrie/resource_factory_spec.rb
@@ -28,5 +28,43 @@ RSpec.describe Wings::Valkyrie::ResourceFactory do
         expect(factory.from_resource(resource: resource)).to be_a FileSet
       end
     end
+
+    context 'with a FileMetadata' do
+      let(:resource) { Hyrax::FileMetadata.new }
+
+      it 'is a Hydra::PCDM::File' do
+        expect(factory.from_resource(resource: resource)).to be_a Hydra::PCDM::File
+      end
+
+      context 'when it has a file identifier' do
+        let(:resource) { Hyrax::FileMetadata.new(file_identifier: file.id) }
+        let(:storage_adapter) { Valkyrie::StorageAdapter.find(:test_disk) }
+
+        let(:file) do
+          io = fixture_file_upload('/world.png', 'image/png')
+          file_set = FactoryBot.valkyrie_create(:hyrax_file_set)
+          storage_adapter.upload(file: io, resource: file_set, original_filename: 'test-world.png')
+        end
+
+        it 'returns an ActiveFedora::Base with the existing file' do
+          expect(factory.from_resource(resource: resource))
+            .to have_attributes(file_identifier: contain_exactly(file.id))
+        end
+
+        it 'still resolves for a missing identifier' do
+          resource = Hyrax::FileMetadata.new(file_identifier: 'disk://made-up.png')
+
+          expect(factory.from_resource(resource: resource))
+            .to have_attributes(file_identifier: contain_exactly('disk://made-up.png'))
+        end
+
+        it 'still resolves for a missing adapter' do
+          resource = Hyrax::FileMetadata.new(file_identifier: 'unknown://uh-oh.png')
+
+          expect(factory.from_resource(resource: resource))
+            .to have_attributes(file_identifier: contain_exactly('unknown://uh-oh.png'))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
when converting to/from Hyrax::FileMetadata, we have a need to handle two
separate cases.

in the first case, we want to follow ActiveFedora's pattern for ldp:describes
links. Fedora generates a node to describe a file when the file is uploaded, and
ActiveFedora reuses AF::Base but bends it to this use case. we already have some
specialized handling throughout Wings to address the unusual save patterns for
these nodes, and most of the Hyrax codebase conforms to some off-spec
requirements for handling valkyrie representations for these nodes.

this adds handling for the second case: when the file is a non-AF file, but the
app is using Wings for metadata (e.g. for derivatives stored via a disk
adapter), we need Wings to be able to save the FileMetadata resource instance
normally. i.e. it should handle it like any other resource, without the special
handling or requirements imposed by ActiveFedora.

we test this handling from three key Wings interfaces.
@dunn 