### PR TITLE
Address 5680 file manager layout

### DIFF
--- a/app/views/hyrax/base/_file_manager_actions.html.erb
+++ b/app/views/hyrax/base/_file_manager_actions.html.erb
@@ -1,5 +1,7 @@
-  <div class="actions form-group row card">
-    <%= button_tag t('.save'), class: "btn btn-primary disabled", data: { action: "save-actions" } %>
-    <%= button_tag t('.sort_alphabetically'), class: "btn btn-primary", data: { action: "alpha-sort-action" } %>
+  <div class="actions card">
+    <div class="d-flex">
+      <%= button_tag t('.save'), class: "btn btn-primary disabled mr-2", data: { action: "save-actions" } %>
+      <%= button_tag t('.sort_alphabetically'), class: "btn btn-primary ", data: { action: "alpha-sort-action" } %>
+    </div>
   </div>
   <%= render "file_manager_resource_form" %>

--- a/app/views/hyrax/base/_file_manager_members.html.erb
+++ b/app/views/hyrax/base/_file_manager_members.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :ul,
                 id: "sortable",
-                class: "list-unstyled grid clearfix",
+                class: "list-unstyled grid d-flex flex-wrap clearfix",
                 data: {
                   id: @form.id,
                   "class-name" => @form.model_name.plural,

--- a/app/views/hyrax/base/_file_manager_thumbnail.html.erb
+++ b/app/views/hyrax/base/_file_manager_thumbnail.html.erb
@@ -1,1 +1,1 @@
-<%= document_presenter(node)&.thumbnail&.thumbnail_tag({ class: 'thumbnail-inner' }, {}) %>
+<%= document_presenter(node)&.thumbnail&.thumbnail_tag({ class: 'thumbnail-inner mw-100' }, {}) %>

--- a/app/views/hyrax/base/file_manager.html.erb
+++ b/app/views/hyrax/base/file_manager.html.erb
@@ -6,12 +6,11 @@
 </ul>
 
 <% if !@form.member_presenters.empty? %>
-  <div data-action="file-manager">
+  <div class="row" data-action="file-manager">
     <div class="col-md-3" id="file-manager-tools">
       <h2><%= t('.toolbar') %></h2>
       <%= render "file_manager_actions" %>
     </div>
-    <div class="col-md-3" id="label-tools-spacer" class="fixed"></div>
     <div class="col-md-9" id="order-grid">
       <%= render "file_manager_members" %>
     </div>

--- a/app/views/hyrax/base/file_manager.html.erb
+++ b/app/views/hyrax/base/file_manager.html.erb
@@ -7,11 +7,11 @@
 
 <% if !@form.member_presenters.empty? %>
   <div class="row" data-action="file-manager">
-    <div class="col-md-3" id="file-manager-tools">
+    <div class="col-lg-3" id="file-manager-tools">
       <h2><%= t('.toolbar') %></h2>
       <%= render "file_manager_actions" %>
     </div>
-    <div class="col-md-9" id="order-grid">
+    <div class="col-lg-9" id="order-grid">
       <%= render "file_manager_members" %>
     </div>
   </div>


### PR DESCRIPTION
## What does this do?

This cleans up the File Manager view for Bootstrap 4.

![image](https://user-images.githubusercontent.com/7376450/173890410-01134ab5-0032-4900-ba99-dccfd86adb2a.png)

- A spacing div on the main viewer no longer needed has been removed.
- A wrapping `.row` class has been added.
- Sortable grid now renders in a 3 column layout
- The `.grid` layout for the sortable list items now uses the BS4 utility classes of `d-flex` and `flex-wrap`
- Thumbnail images have a max-width of 100% to not overflow their cards