### PR TITLE
Update Collection dashboard edit screens

### DIFF
--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -1,5 +1,5 @@
 legend small {
-  margin-left:.5em;
+  margin-left: 0.5em;
   color: #999999;
   font-size: 15px;
 }
@@ -7,16 +7,15 @@ legend small {
 .label-large {
   font-size: 110%;
   line-height: 1.2;
-  padding: .3em .6em;
+  padding: 0.3em 0.6em;
   white-space: normal;
   position: relative;
 
-
-  input[type="checkbox"]{
-    margin:-2px 0 0;
+  input[type="checkbox"] {
+    margin: -2px 0 0;
     position: absolute;
-    left:.5em;
-    top:38%;
+    left: 0.5em;
+    top: 38%;
   }
 }
 
@@ -25,14 +24,14 @@ legend small {
 }
 
 .label-checkbox .label-text {
-  display:block;
-  padding-left:1.2em;
+  display: block;
+  padding-left: 1.2em;
 }
 
 .form-group:invalid input,
 .form-group:invalid option,
 .form-group:invalid textarea {
-  color:$gray-dark;
+  color: $gray-dark;
 }
 
 .form-actions {
@@ -44,9 +43,6 @@ form {
     align-items: center;
 
     > div {
-      width: 100%;
-      padding: 0 15px;
-
       > .row {
         margin: 0;
 
@@ -81,7 +77,9 @@ form {
 }
 
 .set-access-controls {
-  label { font-weight: normal; }
+  label {
+    font-weight: normal;
+  }
   & .form-group {
     padding: 0 1.75em;
 
@@ -117,24 +115,24 @@ form {
   }
 
   .form-inline {
-    .col-form-label, label {
+    .col-form-label,
+    label {
       padding-left: 0;
       display: inline;
       &:after {
-        content: ' ';
+        content: " ";
       }
     }
     .form-text {
       display: inline;
       &:before {
-        content: ' ';
+        content: " ";
       }
     }
   }
 }
 
 .collection-types-settings {
-
   .form-inline {
     display: block;
     label {
@@ -151,7 +149,7 @@ form {
       padding-left: 0;
 
       &::after {
-        content: ' ';
+        content: " ";
       }
     }
 
@@ -159,7 +157,7 @@ form {
       display: inline;
 
       &::before {
-        content: ' ';
+        content: " ";
       }
     }
 
@@ -177,7 +175,7 @@ form {
 }
 
 form.button-to {
-  margin:0 .3em;
+  margin: 0 0.3em;
 }
 
 .required-tag {
@@ -200,7 +198,6 @@ form.button-to {
 }
 
 .search-form {
-
   .form-group {
     margin: 0;
   }

--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -45,27 +45,6 @@ body.dashboard {
     font-size: 1.1em;
   }
 
-  .tabs {
-    margin-top: $tab-margin;
-    position: relative;
-  }
-
-  .nav-tabs {
-    border-bottom: 0;
-    margin-bottom: 0;
-    margin-top: -$tab-margin;
-    padding: 0 5px;
-  }
-
-  .nav-tabs > li > a {
-    border-top: 2px solid transparent;
-  }
-
-  .nav-tabs > li.nav-item > a.active,
-  .nav-tabs > li.nav-item > a:hover {
-    border-top: 2px solid $tab-active-accent-color;
-  }
-
   /* This is needed in Chrome for the admin/admin_sets edit view AND the collection
    * sharing edit view to render the participants tab
    * Without this the contents of that tab flow off the right-hand side of the screen
@@ -208,20 +187,6 @@ body.dashboard {
   .spacer {
     margin-bottom: 5px;
   }
-}
-
-#discovery .panel .panel-body {
-  > .set-access-controls .form-group label {
-    display: block;
-    text-align: left !important;
-
-    > input {
-      position: absolute;
-      margin-left: -1.25rem;
-      margin-top: 0.25rem;
-    }
-  }
-  padding: 1rem;
 }
 
 .dropdown-item {

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/nav_safety_modal" %>
-<div class="card tabs" id="collection-edit-controls">
-  <ul class="nav nav-tabs" role="tablist">
+<div class="tabs mt-4" id="collection-edit-controls">
+  <ul class="nav nav-tabs" id="dashboard-collection-tab" role="tablist">
     <li class="nav-item">
       <a href="#description" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm">
         <%= t('.tabs.description') %>
@@ -32,7 +32,7 @@
   </ul>
 
   <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor nav-safety', data: { behavior: 'collection-form', 'param-key' => @form.model_name.param_key } } do |f| %>
-    <div class="tab-content">
+    <div class="tab-content" id="dashboard-collection-tab-content">
       <div id="description" class="tab-pane show active">
         <div class="card labels">
           <div class="card-body">
@@ -82,8 +82,8 @@
       <% if @form.persisted? %>
         <% if collection_brandable?(collection: @collection) %>
           <div id="branding" class="tab-pane">
-            <div class="panel panel-default labels">
-              <div class="panel-body">
+            <div class="card labels">
+              <div class="card-body">
                 <%= render 'form_branding', f: f %>
               </div>
             </div>
@@ -92,8 +92,8 @@
 
         <% if collection_discoverable?(collection: @collection) %>
           <div id="discovery" class="tab-pane">
-            <div class="panel panel-default labels">
-              <div class="panel-body">
+            <div class="card labels">
+              <div class="card-body">
                 <%= render 'form_discovery', f: f %>
               </div>
             </div>
@@ -102,8 +102,8 @@
 
         <% if collection_sharable?(collection: @collection) %>
           <div id="sharing" class="tab-pane">
-            <div class="panel panel-default labels" id="collection_permissions" data-param-key="<%= f.object.model_name.param_key %>">
-              <div class="panel-body">
+            <div class="card labels" id="collection_permissions" data-param-key="<%= f.object.model_name.param_key %>">
+              <div class="card-body">
                 <%= render 'form_share', f: f %>
               </div>
             </div>

--- a/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
@@ -3,16 +3,20 @@
   <p><%= t('.para1') %></p>
   <p><%= t('.para2') %></p>
 
-  <div class="form-group">
-    <label class="radio">
+  <div class="form-check">
+    <label class="form-check-label">
       <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>
       <strong><%= t('hyrax.visibility.open.text') %></strong> - <%= t('hyrax.visibility.open.note_html') %>
     </label>
-    <label class="radio">
+  </div>
+  <div class="form-check">
+    <label class="form-check-label">
       <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
       <strong><%= t('hyrax.visibility.authenticated.text', institution: institution_name) %></strong> - <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
     </label>
-    <label class="radio">
+  </div>
+  <div class="form-check">
+    <label class="form-check-label">
       <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
       <strong><%= t('hyrax.visibility.restricted.text') %></strong>- <%= t('hyrax.visibility.restricted.note_html') %>
     </label>

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -17,22 +17,22 @@
                               f.object.access_grants.build(agent_type: 'group'),
                               index: 0 do |builder| %>
 
-              <div class="form-group">
-                <label><%= t('.add_group') %>:</label>
+              <div class="form-group mr-2">
+                <label class="mr-2"><%= t('.add_group') %>:</label>
                 <%= builder.hidden_field :agent_type %>
                 <%= builder.text_field :agent_id,
                                         placeholder: t('.search_for_a_group'),
                                         class: 'form-control search-input' %>
               </div>
               <div class="form-group">
-                <label>as</label>
+                <label class="mr-2">as</label>
                 <%= builder.select :access,
                                       access_options,
                                       { prompt: t('.select_a_role') },
                                       class: 'form-control' %>
               </div>
             <% end %>
-            <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button', :disabled => true %>
+            <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button ml-2', :disabled => true %>
 
           </div><!-- /.form-inline -->
         <% end %>
@@ -50,13 +50,13 @@
                               index: 0 do |builder| %>
 
               <div class="form-group">
-                <label><%= t('.add_user') %>:</label>
+                <label class="mr-2"><%= t('.add_user') %>:</label>
                 <%= builder.hidden_field :agent_type %>
                 <%= builder.text_field :agent_id,
                                         placeholder: t('.search_for_a_user') %>
               </div>
               <div class="form-group">
-                <label>as</label>
+                <label class="mx-2">as</label>
                 <%= builder.select :access,
                                     access_options,
                                     { prompt: t('.select_a_role') },
@@ -64,17 +64,18 @@
               </div>
             <% end %>
 
-            <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button', :disabled => true %>
+            <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info edit-collection-add-sharing-button ml-2', :disabled => true %>
 
           </div> <!-- /.form-inline -->
         <% end %>
       </div>
 
-      <p class="form-text"><%= t('hyrax.admin.admin_sets.form.note') %></p>
+      <p class="form-text mt-2"><em><%= t('hyrax.admin.admin_sets.form.note') %></em></p>
     </section>
 
     <section class="section-collection-sharing">
-      <legend><%= t(".current_shared") %></legend>
+      <hr />
+      <p class="lead"><%= t(".current_shared") %></p>
       <%= render 'form_share_table', access: 'managers', filter: :manage? %>
       <%= render 'form_share_table', access: 'depositors', filter: :deposit? %>
       <%= render 'form_share_table', access: 'viewers', filter: :view? %>


### PR DESCRIPTION
Fixes #5687 
Updates the layout in Dashboard Edit Collections pages.

Changes proposed in this pull request:
* Remove references to previous Bootstrap components (ie. panels)
* Clean up non-bootstrap custom styling on touched pages

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to Dashboard > Edit Collection > Sharing tab
* Notice the UI

![image](https://user-images.githubusercontent.com/3020266/173898619-af82e522-4712-46f0-ac7a-52f17ede4f54.png)

![image](https://user-images.githubusercontent.com/3020266/173898704-a461df9d-9e6c-4cde-8958-d01944f6af58.png)


@samvera/hyrax-code-reviewers
