### PR TITLE
Set actions dropdown to default, add interior classes.

### DIFF
--- a/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="btn-group">
-  <button class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown"><%= t('.select') %> <span class="caret"></span>
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown"><%= t('.select') %> <span class="caret"></span>
   </button>
   <ul class="dropdown-menu dropdown-menu-right">
     <% if can?( :edit, document ) && !workflow_restriction?(@presenter) %>

--- a/app/views/hyrax/my/_admin_set_action_menu.html.erb
+++ b/app/views/hyrax/my/_admin_set_action_menu.html.erb
@@ -2,7 +2,7 @@
 <% ul_id = 'admin-set-action-dropdown-ul-' + id %>
 
 <div class="btn-group">
-  <button class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
     <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
     <%= t("hyrax.dashboard.my.action.select") %>
   </button>

--- a/app/views/hyrax/my/_collection_action_menu.html.erb
+++ b/app/views/hyrax/my/_collection_action_menu.html.erb
@@ -2,7 +2,7 @@
 <% ul_id = 'collection-action-dropdown-ul-' + id %>
 
 <div class="btn-group">
-  <button class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
     <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
     <%= t("hyrax.dashboard.my.action.select") %>
   </button>

--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -2,7 +2,7 @@
 
 <div class="btn-group">
 
-  <button class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= document.id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= document.id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
     <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
     <%= t("hyrax.dashboard.my.action.select") %>
   </button>
@@ -10,7 +10,7 @@
   <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
 
     <% if can? :edit, document.id %>
-      <li role="menuitem" tabindex="-1">
+      <li class="dropdown-item" role="menuitem" tabindex="-1">
         <%= link_to [main_app, :edit, document],
                     id: 'action-edit-work' do %>
           <%= t("hyrax.dashboard.my.action.edit_work") %>
@@ -35,7 +35,7 @@
     </li>
 
     <% if can? :transfer, document.id %>
-      <li role="menuitem" tabindex="-1">
+      <li class="dropdown-item" role="menuitem" tabindex="-1">
         <%= link_to(hyrax.new_work_transfer_path(document.id), id: 'action-transfer-work', class: 'itemicon itemtransfer', title: t("hyrax.dashboard.my.action.transfer")) do %>
           <%= t("hyrax.dashboard.my.action.transfer") %>
         <% end %>


### PR DESCRIPTION
## What does this do?

This updates Actions dropdowns to use the `btn-default` styling with a light background color and dark foreground. It also adds omitted `dropdown-item` classes to items within the dropdown menu. The blue link color is inherited from the global `a` styling and thus not overridden. 

![image](https://user-images.githubusercontent.com/7376450/173916499-b9adebd8-0b24-422b-b120-db7031b51538.png)
