### PR TITLE
Clean up Add to Collection modal UI when viewing Works

### DIFF
--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -166,19 +166,6 @@ body.dashboard {
     margin-bottom: 0;
   }
 
-  // The select collection modal for batch operations
-  .collection-list-modal {
-    .modal-content {
-      float: left;
-      .modal-header,
-      .modal-footer,
-      .modal-body {
-        float: left;
-        width: 100%;
-      }
-    }
-  }
-
   .card.labels {
     border-top: 1px solid $card-border-color;
     margin-bottom: 0;

--- a/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
@@ -2,17 +2,17 @@
   <div class="modal-dialog text-left">
       <div class="modal-content">
         <div class="modal-header">
+          <h5 class="modal-title" id="col_add_title"><%= t("hyrax.collection.select_form.title") %></h5>
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <span class="modal-title" id="col_add_title"><%= t("hyrax.collection.select_form.title") %></span>
         </div>
         <div class="modal-body">
           <% if user_collections.blank? %>
             <em> <%= t("hyrax.collection.select_form.no_collections") %></em><br /><br /><br /><br />
           <% else %>
             <div class="collection-list">
-              <fieldset>
-                <legend><%= t("hyrax.collection.select_form.select_heading") %></legend>
-              <ul>
+              <div class="form-group">
+                <p><%= t("hyrax.collection.select_form.select_heading") %></p>
+              
                 <% if @add_works_to_collection.present? %>
                   <%= text_field_tag 'member_of_collection_label', @add_works_to_collection_label, size: '90', disabled: true %>
                   <%= hidden_field_tag 'member_of_collection_ids', @add_works_to_collection %>
@@ -25,8 +25,8 @@
                                 'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/collections?access=deposit'
                               } %>
                 <% end %>
-              </ul>
-              </fieldset>
+            
+              </div>
             </div><!-- collection-list -->
           <% end %> <!-- else -->
         </div>


### PR DESCRIPTION
Fixes #5688 

Fixes header layout and general UI cleanup for Add Work to Collection modal

Changes proposed in this pull request:
* Conform to Bootstrap 4 modal markup
* Remove invalid markup in modal content

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* See issue #5688 for how to test

<img width="915" alt="image" src="https://user-images.githubusercontent.com/3020266/174149174-8b6795c7-7f4a-433f-aafd-be58515f51ba.png">


@samvera/hyrax-code-reviewers
