### PR TITLE
find file content using dynamic storage adapters in FileMetadata

### DIFF
--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -156,7 +156,14 @@ module Hyrax
     end
 
     def file
-      Hyrax.storage_adapter.find_by(id: file_identifier)
+      adapter =
+        begin
+          Valkyrie::StorageAdapter.adapter_for(id: file_identifier)
+        rescue Valkyrie::StorageAdapter::AdapterNotFoundError => _err
+          Hyrax.storage_adapter
+        end
+
+      adapter.find_by(id: file_identifier)
     end
   end
 end


### PR DESCRIPTION
`FileMetadata#file` should work for all storage adapters. it previously assumed
that the storage adapter would be the configured one, but if a `FileMetadata`
exists with a `file_identifier` in another URI scheme, it should resolve rather
than error.

rescue the AdapterNotFound case because the prior behavior was to always
return a file, even if `file_identifier` is `nil`. for compatibility reasons, i
don't want to change that at least until a sharper interface with error handling
can be dreamed up.

@samvera/hyrax-code-reviewers
