### PR TITLE
better handling for error cases in FileMetadata.find

### DIFF
--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -155,15 +155,17 @@ module Hyrax
       ''
     end
 
+    ##
+    # @return [Valkyrie::StorageAdapter::File]
+    #
+    # @raise [Valkyrie::StorageAdapter::AdapterNotFoundError] if no adapter
+    #   could be found matching the file_identifier's scheme
+    # @raise [Valkyrie::StorageAdapter::FileNotFound] when the file can't
+    #   be found in the registered adapter
     def file
-      adapter =
-        begin
-          Valkyrie::StorageAdapter.adapter_for(id: file_identifier)
-        rescue Valkyrie::StorageAdapter::AdapterNotFoundError => _err
-          Hyrax.storage_adapter
-        end
-
-      adapter.find_by(id: file_identifier)
+      Valkyrie::StorageAdapter
+        .adapter_for(id: file_identifier)
+        .find_by(id: file_identifier)
     end
   end
 end


### PR DESCRIPTION
the base case originally tested relied on a bug in
Valkyrie (https://github.com/samvera/valkyrie/issues/905).

this reimplements with a more serious error handling approach.

@samvera/hyrax-code-reviewers
