### PR TITLE
Citations menu buttons

### DIFF
--- a/app/views/hyrax/base/_citations.html.erb
+++ b/app/views/hyrax/base/_citations.html.erb
@@ -1,9 +1,9 @@
 <div class="citations">
     <% if Hyrax.config.citations? %>
-      <%= link_to t(".citations"), hyrax.citations_work_path(presenter), id: 'citations', class: 'btn btn-secondary' %>
+      <%= link_to t(".citations"), hyrax.citations_work_path(presenter), id: 'citations', class: 'btn btn-secondary btn-sm mr-2' %>
     <% end %>
     <div class="btn-group">
-      <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <%= t('.header') %>
       </button>
       <ul class="dropdown-menu">

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -1,4 +1,4 @@
-<dl class="work-show <%= dom_class(presenter) %>" <%= presenter.microdata_type_to_html %>>
+<dl class="work-show pt-3 <%= dom_class(presenter) %>" <%= presenter.microdata_type_to_html %>>
     <%= render 'attribute_rows', presenter: presenter %>
     <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date, html_dl: true) %>
     <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date, html_dl: true) %>


### PR DESCRIPTION
Fixes #5709 

Update UI for Work Citations buttons

Changes proposed in this pull request:
* Make the buttons BS4 "small" variant (so they fit), and add some margin between the buttons.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* View a work and notice the Citations buttons below the Universal Viewer

<img width="566" alt="image" src="https://user-images.githubusercontent.com/3020266/174321721-840e2ce6-221d-4186-a14a-dd9e49b5d685.png">


@samvera/hyrax-code-reviewers
