### PR TITLE
Update Dashboard Work page to match styles of Collection page

### DIFF
--- a/app/views/hyrax/my/_document_list.html.erb
+++ b/app/views/hyrax/my/_document_list.html.erb
@@ -1,4 +1,4 @@
 <% # container for all documents in index view -%>
-<div class="table-responsive" id="documents">
+<div class="table-responsive mt-4" id="documents">
   <%= render 'default_group', docs: @response.docs %>
 </div>

--- a/app/views/hyrax/my/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/my/_sort_and_per_page.html.erb
@@ -1,16 +1,14 @@
 <% if show_sort_and_per_page? %>
-  <div class="sort-toggle">
+  <div class="sort-toggle mt-2">
       <%= form_tag search_action_for_dashboard, method: :get, class: 'per_page' do %>
-        <div class="form-group">
-          <fieldset class="col-12">
-            <legend class="sr-only"><%= t('hyrax.dashboard.my.sr.results_per_page') %></legend>
-            <%= label_tag :per_page do %>
-                Show <%= select_tag :per_page, options_for_select(Hyrax.config.range_for_number_of_results_to_display_per_page.map(&:to_s), h(params[:per_page])),
-                                    title: t(".number_of_results_to_display_per_page") %> per page
-            <% end %>
-            <%= render Blacklight::HiddenSearchStateComponent.new(params: search_state.params_for_search.except(:per_page, :sort, :utf8)) %>
-          </fieldset>
-        </div>
+        <fieldset class="col-12">
+          <legend class="sr-only"><%= t('hyrax.dashboard.my.sr.results_per_page') %></legend>
+          <%= label_tag :per_page do %>
+              Show <%= select_tag :per_page, options_for_select(Hyrax.config.range_for_number_of_results_to_display_per_page.map(&:to_s), h(params[:per_page])),
+                                  title: t(".number_of_results_to_display_per_page") %> per page
+          <% end %>
+          <%= render Blacklight::HiddenSearchStateComponent.new(params: search_state.params_for_search.except(:per_page, :sort, :utf8)) %>
+        </fieldset>
       <% end %>
   </div>
 <% end %>

--- a/app/views/hyrax/my/works/index.html.erb
+++ b/app/views/hyrax/my/works/index.html.erb
@@ -54,23 +54,25 @@
 
 <div class="row">
   <div class="col-md-12">
-    <div class="card <%= 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>">
+    <div class="<%= 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>">
       <%= render 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>
-      <div class="card-header">
-        <% if current_page?(hyrax.my_works_path(locale: nil)) %>
-          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_own', total_count: @response.total_count).html_safe %></span>
-        <% elsif current_page?(hyrax.dashboard_works_path(locale: nil)) && !current_ability.admin? %>
-          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_manage', total_count: @response.total_count).html_safe %></span>
-        <% else %>
-          <span class="count-display"><%= I18n.t('hyrax.my.count.works.in_repo', total_count: @response.total_count).html_safe %></span>
-        <% end %>
-      </div>
-      <div class="panel-body">
-        <%= render 'search_header' %>
-        <h2 class="sr-only"><%= t('hyrax.my.count.works.works_listing') %></h2>
-        <%= render 'document_list' %>
+      <div class="card">
+        <div class="card-header">
+          <% if current_page?(hyrax.my_works_path(locale: nil)) %>
+            <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_own', total_count: @response.total_count).html_safe %></span>
+          <% elsif current_page?(hyrax.dashboard_works_path(locale: nil)) && !current_ability.admin? %>
+            <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_manage', total_count: @response.total_count).html_safe %></span>
+          <% else %>
+            <span class="count-display"><%= I18n.t('hyrax.my.count.works.in_repo', total_count: @response.total_count).html_safe %></span>
+          <% end %>
+        </div>
+        <div class="card-body">
+          <%= render 'search_header' %>
+          <h2 class="sr-only"><%= t('hyrax.my.count.works.works_listing') %></h2>
+          <%= render 'document_list' %>
 
-        <%= render 'results_pagination' %>
+          <%= render 'results_pagination' %>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #5708 

Fixes the UI in the Dashboard Works page to match styles and layout more closely with the Dashboard Collections page

<img width="1395" alt="image" src="https://user-images.githubusercontent.com/3020266/174334234-0893cded-5507-4fc2-854a-8173e60dae22.png">

<img width="1398" alt="image" src="https://user-images.githubusercontent.com/3020266/174334307-1cc69dbd-109b-47ed-badb-e4311294dc4a.png">


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to Dashboard, then Work and Collections pages and compare



@samvera/hyrax-code-reviewers
