### PR TITLE
Update Collection view type icon buttons background

### DIFF
--- a/app/assets/stylesheets/hyrax/_catalog.scss
+++ b/app/assets/stylesheets/hyrax/_catalog.scss
@@ -77,8 +77,6 @@
 }
 
 .view-type-group a {
-  background-color: #fff;
-
   > span.caption {
     display: none;
   }

--- a/app/views/hyrax/collections/_view_type_group.html.erb
+++ b/app/views/hyrax/collections/_view_type_group.html.erb
@@ -3,7 +3,7 @@
   <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
   <div class="view-type-group btn-group">
     <% document_index_views.each do |view, config| %>
-      <%= link_to collection_path(params[:id], view: view), title: t("blacklight.search.view_title.#{view}", default: t("blacklight.search.view.#{view}", default: blacklight_config.view[view].title)), class: "btn btn-secondary view-type-#{view.to_s.parameterize } #{"active" if document_index_view_type == view}" do %>
+      <%= link_to collection_path(params[:id], view: view), title: t("blacklight.search.view_title.#{view}", default: t("blacklight.search.view.#{view}", default: blacklight_config.view[view].title)), class: "btn btn-light view-type-#{view.to_s.parameterize } #{"active" if document_index_view_type == view}" do %>
         <%= render_view_type_group_icon view %>
         <span class="caption"><%= t("blacklight.search.view.#{view}") %></span>
       <% end %>


### PR DESCRIPTION
Fixes #5630 

Update the colors on the Collection view type icon buttons.

<img width="326" alt="image" src="https://user-images.githubusercontent.com/3020266/174358511-b20b3561-9264-43f9-9cc2-8932872e35e4.png">


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to any Collection page (outside of Dashboard) and look for the icons in above screenshot

@samvera/hyrax-code-reviewers
