### PR TITLE
Partial PR - Clean up of Admin Sets UI

### DIFF
--- a/app/views/hyrax/admin/admin_sets/_form.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form.html.erb
@@ -1,5 +1,5 @@
     <%= render 'shared/nav_safety_modal' %>
-    <div class="card tabs" id="admin-set-controls">
+    <div class="tabs mt-4" id="admin-set-controls">
       <ul class="nav nav-tabs" role="tablist">
         <li class="nav-item">
           <a href="#description" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm"><%= t('.tabs.description') %></a>
@@ -16,9 +16,9 @@
           </li>
         <% end %>
       </ul>
-      <div class="tab-content">
+      <div class="tab-content card">
         <div id="description" class="tab-pane show active">
-          <div class="card labels">
+          <div class="labels">
             <%= simple_form_for @form, url: [hyrax, :admin, @form], html: { class: 'nav-safety' } do |f| %>
               <div class="card-body">
                 <%= render 'form_metadata', f: f %>
@@ -31,10 +31,10 @@
 
               </div>
 
-              <div class="card-footer">
+              <div class="card-footer d-flex justify-content-end">
                 <% cancel_path = f.object.persisted? ? hyrax.admin_admin_set_path(f.object) : hyrax.dashboard_collections_path %>
-                <%= link_to t('.cancel'), cancel_path, class: 'btn btn-secondary float-right' %>
-                <%= f.button :submit, class: 'btn btn-primary float-right' %>
+                <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
+                <%= link_to t('.cancel'), cancel_path, class: 'btn btn-light' %>
               </div>
             <% end %>
           </div>

--- a/app/views/hyrax/admin/admin_sets/_form_participant_table.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_participant_table.html.erb
@@ -1,33 +1,35 @@
-                  <h3><%= t(".#{access}.title") %></h3>
-                  <p><%= t(".#{access}.help") %></p>
-                  <% if collection_permission_template_form_for(form: @form).access_grants.select(&filter).any? %>
-                    <table class="table table-striped share-status">
-                      <thead>
-                        <tr>
-                          <th><%= t(".#{access}.agent_name") %></th>
-                          <th><%= t(".#{access}.type") %></th>
-                          <th><%= t(".#{access}.action") %></th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                      <% collection_permission_template_form_for(form: @form).access_grants.select(&filter).each do |g| %>
-                        <tr>
-                          <td data-agent="<%= g.agent_id %>"><%= g.label %></td>
-                          <td><%= g.agent_type.titleize %></td>
-                          <td>
-                            <% if g.admin_group? && g.access == Hyrax::PermissionTemplateAccess::MANAGE %>
-                              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
-                            <% else %>
-                              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger' %>
-                            <% end %>
-                          </td>
-                        </tr>
-                      <% end %>
-                      </tbody>
-                    </table>
-                  <% else %>
-                    <p><em><%= t(".#{access}.empty") %></em></p>
-                  <% end %>
-                  <%= button_tag t('.allow_all_registered'),
-                                 class: 'btn btn-info',
-                                 data: { behavior: 'add-registered-users' } if access == 'depositors' %>
+<div class="mb-4">
+  <h3 class="h4"><%= t(".#{access}.title") %></h3>
+  <p><%= t(".#{access}.help") %></p>
+  <% if collection_permission_template_form_for(form: @form).access_grants.select(&filter).any? %>
+    <table class="table table-striped share-status">
+      <thead>
+        <tr>
+          <th><%= t(".#{access}.agent_name") %></th>
+          <th><%= t(".#{access}.type") %></th>
+          <th><%= t(".#{access}.action") %></th>
+        </tr>
+      </thead>
+      <tbody>
+      <% collection_permission_template_form_for(form: @form).access_grants.select(&filter).each do |g| %>
+        <tr>
+          <td data-agent="<%= g.agent_id %>"><%= g.label %></td>
+          <td><%= g.agent_type.titleize %></td>
+          <td>
+            <% if g.admin_group? && g.access == Hyrax::PermissionTemplateAccess::MANAGE %>
+              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
+            <% else %>
+              <%= button_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger' %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p><em><%= t(".#{access}.empty") %></em></p>
+  <% end %>
+  <%= button_tag t('.allow_all_registered'),
+                  class: 'btn btn-primary ',
+                  data: { behavior: 'add-registered-users' } if access == 'depositors' %>
+</div>

--- a/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
@@ -2,7 +2,7 @@
             <div class="card labels edit-sharing-tab">
               <div class="card-body">
                 <section class="section-add-sharing clearfix">
-                  <h3><%= t('.add_participants') %></h3>
+                  <h2 class="h3"><%= t('.add_participants') %></h2>
                   <% access_options = options_for_select([['Manager', 'manage'], ['Depositor', 'deposit'], ['Viewer', 'view']]) %>
                   <div class="sharing-row-form">
                     <%= simple_form_for collection_permission_template_form_for(form: @form),
@@ -27,7 +27,7 @@
                                 class: 'form-control' %>
                           </div>
                         <% end %>
-                        <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
+                        <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-secondary ml-2' %>
 
                     <% end %>
                   </div>
@@ -54,15 +54,16 @@
                                       class: 'form-control' %>
                         </div>
                       <% end %>
-                      <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-info' %>
+                      <%= f.submit t('helpers.submit.hyrax_permission_template_access.create'), class: 'btn btn-secondary ml-2' %>
                     <% end %>
                   </div>
 
                   <p class="form-text"><%= t('hyrax.admin.admin_sets.form.note') %></p>
                 </section>
 
+                <h2 class="h3"><%= t(".current_participants") %></h2>
                 <fieldset class="admin-set-participants section-collection-sharing">
-                  <legend><%= t(".current_participants") %></legend>
+                  
                   <%= render 'form_participant_table', access: 'managers', filter: :manage? %>
                   <%= render 'form_participant_table', access: 'depositors', filter: :deposit? %>
                   <%= render 'form_participant_table', access: 'viewers', filter: :view? %>

--- a/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
@@ -41,7 +41,7 @@
                       </li>
                     </ul>
                   </div>
-                  <div id="release-fixed" class="form-check form-check-inline">
+                  <div id="release-fixed" class="form-check form-check-inline mb-4">
                     <label class="form-check-label">
                       <%= f.radio_button :release_period, Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED, class: 'form-check-input' %>
                       <%= t('.release.fixed') %>
@@ -56,9 +56,9 @@
                     <% b.label(class: 'form-check-label') { b.radio_button(class: 'form-check-input') + b.text } %>
                   <% end %>
                 </div>
-                <div class="card-footer">
-                  <%= link_to t('.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
-                  <%= f.button :submit, class: 'btn btn-primary float-right' %>
+                <div class="card-footer d-flex justify-content-end">
+                  <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
+                  <%= link_to t('.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
                 </div>
               <% end %>
             </div>

--- a/app/views/hyrax/admin/admin_sets/_form_workflow.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_workflow.erb
@@ -11,9 +11,9 @@
                                 <p><%= b.object.description %></p>
                               <% end %>
                         </div>
-                        <div class="card-footer">
-                          <%= link_to t('.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right'%>
-                          <%= f.button :submit, class: 'btn btn-primary float-right'%>
+                        <div class="card-footer d-flex justify-content-end">
+                          <%= f.button :submit, class: 'btn btn-primary text-white mr-2'%>
+                          <%= link_to t('.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light'%>
                         </div>
                       <% else %>
                         <div class="card-body">

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -32,9 +32,9 @@
   </ul>
 
   <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor nav-safety', data: { behavior: 'collection-form', 'param-key' => @form.model_name.param_key } } do |f| %>
-    <div class="tab-content" id="dashboard-collection-tab-content">
+    <div class="tab-content card" id="dashboard-collection-tab-content">
       <div id="description" class="tab-pane show active">
-        <div class="card labels">
+        <div class="labels">
           <div class="card-body">
 
             <div id="base-terms">

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -73,9 +73,10 @@
       <p class="form-text mt-2"><em><%= t('hyrax.admin.admin_sets.form.note') %></em></p>
     </section>
 
+    <h2 class="h3"><%= t(".current_shared") %></h2>
     <section class="section-collection-sharing">
-      <hr />
-      <p class="lead"><%= t(".current_shared") %></p>
+     
+      
       <%= render 'form_share_table', access: 'managers', filter: :manage? %>
       <%= render 'form_share_table', access: 'depositors', filter: :deposit? %>
       <%= render 'form_share_table', access: 'viewers', filter: :view? %>

--- a/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
@@ -1,31 +1,34 @@
-                  <h3><%= t(".#{access}.title") %></h3>
-                  <p><%= t(".#{access}.help") %></p>
-                  <p><%= t(".#{access}.help_with_works", type_title: @collection_type.title) if @collection_type.share_applies_to_new_works? && access != 'depositors' %></p>
-                  <% if collection_permission_template_form_for(form: @form).access_grants.select(&filter).any? %>
-                    <table class="table table-striped share-status">
-                      <thead>
-                        <tr>
-                          <th><%= t(".#{access}.agent_name") %></th>
-                          <th><%= t(".#{access}.type") %></th>
-                          <th><%= t(".#{access}.action") %></th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                      <% collection_permission_template_form_for(form: @form).access_grants.select(&filter).each do |g| %>
-                        <tr>
-                          <td data-agent="<%= g.agent_id %>"><%= g.label %></td>
-                          <td><%= g.agent_type.titleize %></td>
-                          <td>
-                            <% if g.admin_group? %>
-                              <%= link_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
-                            <% else %>
-                              <%= link_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger' %>
-                            <% end %>
-                          </td>
-                        </tr>
-                      <% end %>
-                      </tbody>
-                    </table>
-                  <% else %>
-                    <p><em><%= t(".#{access}.empty") %></em></p>
-                  <% end %>
+<div class="mb-4">
+                  
+  <h3 class="h4"><%= t(".#{access}.title") %></h3>
+  <p><%= t(".#{access}.help") %></p>
+  <p><%= t(".#{access}.help_with_works", type_title: @collection_type.title) if @collection_type.share_applies_to_new_works? && access != 'depositors' %></p>
+  <% if collection_permission_template_form_for(form: @form).access_grants.select(&filter).any? %>
+    <table class="table table-striped share-status">
+      <thead>
+        <tr>
+          <th><%= t(".#{access}.agent_name") %></th>
+          <th><%= t(".#{access}.type") %></th>
+          <th><%= t(".#{access}.action") %></th>
+        </tr>
+      </thead>
+      <tbody>
+      <% collection_permission_template_form_for(form: @form).access_grants.select(&filter).each do |g| %>
+        <tr>
+          <td data-agent="<%= g.agent_id %>"><%= g.label %></td>
+          <td><%= g.agent_type.titleize %></td>
+          <td>
+            <% if g.admin_group? %>
+              <%= link_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger disabled', disabled: true, title: t('hyrax.admin.admin_sets.form.permission_destroy_errors.admin_group') %>
+            <% else %>
+              <%= link_to t(".#{access}.remove"), hyrax.admin_permission_template_access_path(g), method: :delete, class: 'btn btn-sm btn-danger' %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p><em><%= t(".#{access}.empty") %></em></p>
+  <% end %>
+</div>


### PR DESCRIPTION
Fixes #5713 

Partial PR to address some Admin Sets UI cleanup. 

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go to a Collection / Admin Set and choose to "Edit".  View screens

<img width="1147" alt="image" src="https://user-images.githubusercontent.com/3020266/174394638-0b14a724-a875-42c6-9601-017e04305c87.png">

<img width="1149" alt="image" src="https://user-images.githubusercontent.com/3020266/174395022-82fb3ef0-4f83-421b-96ae-226cbfa203d2.png">

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/3020266/174395094-34e1f84d-ad4d-4ba1-8611-a7576a853430.png">

<img width="1133" alt="image" src="https://user-images.githubusercontent.com/3020266/174395149-6b5cf58d-43b8-4898-a6fc-9263fff9f119.png">


@samvera/hyrax-code-reviewers
