### PR TITLE
Change the way we click content block tabs in testing

### DIFF
--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -1,17 +1,17 @@
 <%= render "shared/nav_safety_modal" %>
 <div class="card tabs">
   <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item">
+    <li id="announcement-nav-item" class="nav-item">
       <a href="#announcement_text" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm">
         <%= t(:'hyrax.content_blocks.tabs.announcement_text') %>
       </a>
     </li>
-    <li class="nav-item">
+    <li id="marketing-nav-item" class="nav-item">
       <a href="#marketing" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
         <%= t(:'hyrax.content_blocks.tabs.marketing_text') %>
       </a>
     </li>
-    <li class="nav-item">
+    <li id="researcher-nav-item" class="nav-item">
       <a href="#researcher" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
         <%= t(:'hyrax.content_blocks.tabs.featured_researcher') %>
       </a>

--- a/spec/features/edit_content_block_admin_spec.rb
+++ b/spec/features/edit_content_block_admin_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Editing content blocks as admin', :js do
     it "does not display a confirmation message when form data has not changed" do
       expect(page).to have_content('Content Blocks')
       expect(page).to have_content('Announcement')
-      click_link 'Marketing Text'
+      find('#marketing-nav-item').click
       expect(page).not_to have_content(confirm_modal_text)
     end
 
@@ -26,7 +26,7 @@ RSpec.describe 'Editing content blocks as admin', :js do
       within_frame('content_block_announcement_ifr') do
         find('body').set('Updated text.')
       end
-      click_link 'Marketing Text'
+      find('#marketing-nav-item').click
       within('#nav-safety-modal') do
         expect(page).to have_content(confirm_modal_text)
       end
@@ -38,7 +38,7 @@ RSpec.describe 'Editing content blocks as admin', :js do
       within_frame('content_block_announcement_ifr') do
         find('body').set('Updated text.')
       end
-      click_link 'Marketing Text'
+      find('#marketing-nav-item').click
       within('#nav-safety-modal') do
         click_button('OK')
       end
@@ -52,11 +52,11 @@ RSpec.describe 'Editing content blocks as admin', :js do
       within_frame('content_block_announcement_ifr') do
         find('body').set('Updated text.')
       end
-      click_link 'Marketing Text'
+      find('#marketing-nav-item').click
       within('#nav-safety-modal') do
         click_button('OK')
       end
-      click_link 'Marketing Text'
+      find('#marketing-nav-item').click
       expect(page).not_to have_content(confirm_modal_text)
     end
   end


### PR DESCRIPTION
The way we click tabs in the spec is causing issues for some of the specs where certain tabs cannot be found. In this PR, I select the tabs by id and click them in the specs, which solves the issue.