### PR TITLE
add `Hyrax::FileMetadata(file)` caster

### DIFF
--- a/lib/wings/active_fedora_converter/file_metadata_node.rb
+++ b/lib/wings/active_fedora_converter/file_metadata_node.rb
@@ -23,8 +23,26 @@ module Wings
 
     class_attribute :valkyrie_class
 
-    def model_name(*)
-      Hyrax::Name.new(valkyrie_class)
+    class << self
+      def model_name(*)
+        Hyrax::Name.new(valkyrie_class)
+      end
+
+      def to_rdf_representation
+        "Wings(#{valkyrie_class})"
+      end
+      alias inspect to_rdf_representation
+      alias to_s inspect
+    end
+
+    def indexing_service
+      Hyrax::ValkyrieIndexer.for(resource: valkyrie_resource)
+    end
+
+    def to_solr
+      super.tap do |doc|
+        doc[:file_identifier_ssim] = file_identifier
+      end
     end
   end
 end

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -2,6 +2,39 @@
 
 require 'valkyrie/specs/shared_specs'
 
+RSpec.describe Hyrax do
+  describe ".FileMetadata()" do
+    let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+
+    context 'when trying to cast a resource class' do
+      it 'raises an argument error' do
+        expect { described_class::FileMetadata(file_set) }
+          .to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when uploaded from a generic storage adapter' do
+      let(:storage_adapter) { Valkyrie::StorageAdapter.find(:derivatives_disk) }
+
+      let(:file) do
+        storage_adapter.upload(resource: file_set,
+                               file: Tempfile.new('moomin'),
+                               original_filename: 'test_for_filemetadata')
+      end
+
+      it 'builds a new FileMetadata' do
+        expect(described_class::FileMetadata(file))
+          .to have_attributes(file_identifier: file.id)
+      end
+
+      it 'can recover the metadata after saving' do
+        file_meta = Hyrax.persister.save(resource: described_class::FileMetadata(file))
+        expect(described_class::FileMetadata(file)).to eq file_meta
+      end
+    end
+  end
+end
+
 RSpec.describe Hyrax::FileMetadata do
   it_behaves_like 'a Valkyrie::Resource' do
     let(:resource_klass) { described_class }

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -86,6 +86,13 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
           expect(converter.convert)
             .to have_attributes(file_identifier: contain_exactly(file.id))
         end
+
+        it 'round trips' do
+          af = converter.convert
+          af.save
+
+          expect(ActiveFedora::Base.find(af.id)).to be_a(Wings::FileMetadataNode)
+        end
       end
     end
 


### PR DESCRIPTION
this new method follows the `Array(arg)` style type casting pattern to give an
appropriate FileMetadata for a given file within the storage adapter.

this uses the custom query `find_file_metadata_by` to handle casting, but has an
"ensure" style feature to give a new file identifier with appropriate references
if none already exists. this isn't intended to populate metadata, unlike the
to-be-deprecated `FileMetadata#for`.

an implementation for the custom query that works for `Wings` is given. we
populate `alternative_ids` in the `new` branch of the type cast method to make
query easier for other adapters, but don't yet provide a generic solution. some
more exploration may be needed to decide the best approach for the non-Wings
case. some adapters may benefit from a custom query of `file_identifier`, but
Hyrax is committed to a base Valkyrie implementation of the custom query.


@samvera/hyrax-code-reviewers
