### PR TITLE
remove deprecated code from FileMetadata

### DIFF
--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -127,15 +127,6 @@ module Hyrax
     # attributes set by fits for video
     attribute :aspect_ratio, ::Valkyrie::Types::Set
 
-    # @param [ActionDispatch::Http::UploadedFile] file
-    # @deprecated Use #new instead; for removal in 4.0.0
-    def self.for(file:)
-      Deprecation.warn "#{self.class}##{__method__} is deprecated; use #new instead."
-      new(label: file.original_filename,
-          original_filename: file.original_filename,
-          mime_type: file.content_type)
-    end
-
     ##
     # @return [Boolean]
     def original_file?

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Hyrax::FileMetadata do
   end
 
   subject(:file_metadata) do
-    described_class.for(file: file).new(id: 'test_id', format_label: 'test_format_label')
+    described_class.new(id: 'test_id', format_label: 'test_format_label')
   end
 
   let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/world.png', 'image/png') }

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Hyrax::FileMetadata do
   end
 
   subject(:file_metadata) do
-    described_class.new(id: 'test_id', format_label: 'test_format_label')
+    described_class.new(id: 'test_id', format_label: 'test_format_label', label: 'world.png')
   end
 
   let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/world.png', 'image/png') }
@@ -52,19 +52,17 @@ RSpec.describe Hyrax::FileMetadata do
       .to have_attributes(id: 'test_id',
                           format_label: contain_exactly('test_format_label'),
                           label: contain_exactly('world.png'),
-                          mime_type: 'image/png',
-                          original_filename: 'world.png',
                           type: contain_exactly(described_class::Use::ORIGINAL_FILE))
   end
 
   context 'when saved with a file' do
-    subject(:file_metadata) { Hyrax.custom_queries.find_file_metadata_by(id: file.id) }
+    subject(:file_metadata) { Hyrax.custom_queries.find_file_metadata_by(id: stored_file.id) }
     let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
 
-    let(:file) do
+    let(:stored_file) do
       Hyrax.storage_adapter.upload(resource: file_set,
-                                   file: Tempfile.new('blah'),
-                                   original_filename: 'blah.txt')
+                                   file: file,
+                                   original_filename: 'world.png')
     end
 
     it 'can be changed and saved' do
@@ -72,6 +70,12 @@ RSpec.describe Hyrax::FileMetadata do
 
       expect(Hyrax.persister.save(resource: file_metadata).creator)
         .to contain_exactly('Tove')
+    end
+
+    it 'contains file metadata' do
+      expect(file_metadata)
+        .to have_attributes(mime_type: 'image/png',
+                            original_filename: 'world.png')
     end
   end
 

--- a/spec/services/hyrax/characterization/file_set_description_spec.rb
+++ b/spec/services/hyrax/characterization/file_set_description_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Hyrax::Characterization::FileSetDescription, valkyrie_adapter: :t
       let(:other_file) { Rack::Test::UploadedFile.new('spec/fixtures/1.5mb-avatar.jpg', other_ctype) }
 
       let(:custom_file) do
-        resource = Hyrax::FileMetadata.for(file: other_file).new(type: custom_type)
+        resource = Hyrax::FileMetadata(other_file)
+        resource.type = custom_type
         Hyrax.persister.save(resource: resource)
       end
 

--- a/spec/services/hyrax/characterization/file_set_description_spec.rb
+++ b/spec/services/hyrax/characterization/file_set_description_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe Hyrax::Characterization::FileSetDescription, valkyrie_adapter: :t
   let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/world.png', ctype) }
   let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set, file_ids: file_ids) }
   let(:file_ids) { [] }
-  let(:original_file) { Hyrax.persister.save(resource: Hyrax::FileMetadata.new(label: file.original_filename, original_filename: file.original_filename, mime_type: file.content_type)) }
+  let(:original_file) do
+    Hyrax.persister.save(resource: Hyrax::FileMetadata.new(label: file.original_filename,
+                                                           original_filename: file.original_filename,
+                                                           mime_type: file.content_type))
+  end
 
   describe '#mime_type' do
     context 'before the file set is saved' do
@@ -42,7 +46,9 @@ RSpec.describe Hyrax::Characterization::FileSetDescription, valkyrie_adapter: :t
       let(:other_file) { Rack::Test::UploadedFile.new('spec/fixtures/1.5mb-avatar.jpg', other_ctype) }
 
       let(:custom_file) do
-        resource = Hyrax::FileMetadata(other_file)
+        resource = Hyrax::FileMetadata.new(label: other_file.original_filename,
+                                           original_filename: other_file.original_filename,
+                                           mime_type: other_file.content_type)
         resource.type = custom_type
         Hyrax.persister.save(resource: resource)
       end


### PR DESCRIPTION
a lingering call from a private method is replaced to accomplish this, we probably want to backport that replacement.

@samvera/hyrax-code-reviewers
