### PR TITLE
Fix catalog modals

### DIFF
--- a/app/views/catalog/_facet_limit.html.erb
+++ b/app/views/catalog/_facet_limit.html.erb
@@ -5,7 +5,7 @@
   <% unless paginator.last_page? || params[:action] == "facet" %>
     <li class="more_facets_link">
       <%= link_to t("more_#{field_name}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: facet_field_label(facet_field.field).pluralize),
-          search_facet_path(id: facet_field.key), class: "more_facets_link" %>
+          search_facet_path(id: facet_field.key), class: "more_facets_link", data: { blacklight_modal: 'trigger' } %>
     </li>
   <% end %>
 </ul>

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -1,0 +1,18 @@
+<%# Blacklight 7.24.0 %>
+<%# Override app/views/catalog/facet.html.erb %>
+
+<%= render Blacklight::System::ModalComponent.new do |component| %>
+  <% component.title { facet_field_label(@facet.key) } %>
+
+  <%= render partial: 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
+
+  <div class="facet-extended-list">
+    <%= render_facet_limit(@display_facet, layout: false) %>
+  </div>
+
+  <div class="container">
+    <div class="facet-pagination bottom row justify-content-between">
+      <%= render :partial=>'facet_pagination' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -2,6 +2,8 @@
 <%# Override app/views/catalog/facet.html.erb %>
 
 <%= render Blacklight::System::ModalComponent.new do |component| %>
+  <%# Removed component prefix that duplicates the facet pagination view %>
+
   <% component.title { facet_field_label(@facet.key) } %>
 
   <%= render partial: 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
@@ -10,6 +12,7 @@
     <%= render_facet_limit(@display_facet, layout: false) %>
   </div>
 
+  <%# Removed component footer and placed the facet pagination partial within a `container` div %>
   <div class="container">
     <div class="facet-pagination bottom row justify-content-between">
       <%= render :partial=>'facet_pagination' %>


### PR DESCRIPTION
Fixes #5714 

This PR does the following:

- Ensure the modal appears correctly in the same page
- Ensure the modal header does not include a duplicate of the pagination view, by overriding the facet view from `Blacklight`

Please refer to the following screenshots:

<img width="831" alt="Screen Shot 2022-06-22 at 6 08 13 PM" src="https://user-images.githubusercontent.com/13107510/175160764-3ef40c7a-ae32-4c8b-9bec-20ac17713943.png">

<img width="837" alt="Screen Shot 2022-06-22 at 6 07 33 PM" src="https://user-images.githubusercontent.com/13107510/175160622-b62eaf8a-8bfb-48fe-8dc8-1a7cbd1c0329.png">

