### PR TITLE
Starts work on the view type functionality issues.

### DIFF
--- a/.dassie/app/assets/javascripts/application.js
+++ b/.dassie/app/assets/javascripts/application.js
@@ -23,6 +23,7 @@
 //= require jquery.dataTables
 //= require dataTables.bootstrap4
 //= require blacklight/blacklight
+//= require blacklight_gallery
 
 //= require_tree .
 //= require hyrax

--- a/.dassie/app/assets/stylesheets/hyrax.scss
+++ b/.dassie/app/assets/stylesheets/hyrax.scss
@@ -11,5 +11,6 @@
 @import "blacklight_gallery/masonry";
 @import "blacklight_gallery/slideshow";
 @import "blacklight_gallery/osd_viewer";
+@import "hyrax/blacklight_gallery";
 @import 'hyrax/hyrax';
 @import 'hyrax/login_signup';

--- a/.dassie/app/controllers/catalog_controller.rb
+++ b/.dassie/app/controllers/catalog_controller.rb
@@ -15,18 +15,13 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
-    config.view.gallery!.partials = [:index_header, :index]
-    config.view.masonry!.partials = [:index]
-    config.view.slideshow!.partials = [:index]
-
+    config.view.gallery(document_component: Blacklight::Gallery::DocumentComponent)
+    config.view.masonry(document_component: Blacklight::Gallery::DocumentComponent)
+    config.view.slideshow(document_component: Blacklight::Gallery::SlideshowComponent)
 
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
     config.show.partials.insert(1, :openseadragon)
     config.search_builder_class = Hyrax::CatalogSearchBuilder
-
-    # Show gallery view
-    config.view.gallery.partials = [:index_header, :index]
-    config.view.slideshow.partials = [:index]
 
     # Because too many times on Samvera tech people raise a problem regarding a failed query to SOLR.
     # Often, it's because they inadvertently exceeded the character limit of a GET request.

--- a/app/assets/stylesheets/hyrax/blacklight_gallery.scss
+++ b/app/assets/stylesheets/hyrax/blacklight_gallery.scss
@@ -1,12 +1,12 @@
 /* These styles are very specific to override the thumbnails from blacklight gallery */
 
-.slideshow-documents {
+.documents-slideshow {
   .grid {
     .document {
       .thumbnail {
         padding: 0;
 
-        a > img {
+        > img {
           left: 0;
           max-width: 100%;
           top: 0;
@@ -14,4 +14,26 @@
       }
     }
   }
+}
+
+.documents-gallery li div.search-result-wrapper {
+    margin: 0.25rem;
+    padding: 0.5rem;
+    border: 1px solid #ddd;
+    border-radius: 0.25rem;
+
+    > .document-thumbnail {
+      margin: 0 auto 0.5rem auto;
+    }
+
+    > header {
+      margin: 0.5rem auto;
+      text-align: center;
+      width: 100%;
+      height: fit-content;
+    }
+
+    > .document-metadata {
+      margin: unset;
+    }
 }

--- a/lib/generators/hyrax/assets_generator.rb
+++ b/lib/generators/hyrax/assets_generator.rb
@@ -20,7 +20,6 @@ class Hyrax::AssetsGenerator < Rails::Generators::Base
     return if hyrax_javascript_installed?
     insert_into_file 'app/assets/javascripts/application.js', after: "//= require blacklight/blacklight\n" do
       "//= require hyrax\n" \
-      "//= require blacklight_gallery\n" \
     end
   end
 

--- a/lib/generators/hyrax/assets_generator.rb
+++ b/lib/generators/hyrax/assets_generator.rb
@@ -20,6 +20,7 @@ class Hyrax::AssetsGenerator < Rails::Generators::Base
     return if hyrax_javascript_installed?
     insert_into_file 'app/assets/javascripts/application.js', after: "//= require blacklight/blacklight\n" do
       "//= require hyrax\n" \
+      "//= require blacklight_gallery\n" \
     end
   end
 

--- a/lib/generators/hyrax/templates/catalog_controller.rb
+++ b/lib/generators/hyrax/templates/catalog_controller.rb
@@ -17,11 +17,13 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
-    config.search_builder_class = Hyrax::CatalogSearchBuilder
+    config.view.gallery(document_component: Blacklight::Gallery::DocumentComponent)
+    config.view.masonry(document_component: Blacklight::Gallery::DocumentComponent)
+    config.view.slideshow(document_component: Blacklight::Gallery::SlideshowComponent)
 
-    # Show gallery view
-    config.view.gallery!.partials = [:index_header, :index]
-    config.view.slideshow!.partials = [:index]
+    config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
+    config.show.partials.insert(1, :openseadragon)
+    config.search_builder_class = Hyrax::CatalogSearchBuilder
 
     # Because too many times on Samvera tech people raise a problem regarding a failed query to SOLR.
     # Often, it's because they inadvertently exceeded the character limit of a GET request.

--- a/lib/generators/hyrax/templates/hyrax.scss
+++ b/lib/generators/hyrax/templates/hyrax.scss
@@ -11,5 +11,6 @@
 @import "blacklight_gallery/masonry";
 @import "blacklight_gallery/slideshow";
 @import "blacklight_gallery/osd_viewer";
+@import "hyrax/blacklight_gallery";
 @import 'hyrax/hyrax';
 @import 'hyrax/login_signup';


### PR DESCRIPTION
Fixes #5721 

Note: This doesn't address Slideshow's functionality or Masonry's appearance issues.

Changes proposed in this pull request:
* .dassie/app/assets/javascripts/application.js: based upon the changes outlined in Blacklight Gallery's [update history](https://github.com/projectblacklight/blacklight-gallery/compare/v0.7.0...v4.0.1), adding this line is required in Blacklight applications.
* .dassie/app/assets/stylesheets/hyrax.scss: this actually activates the changes detailed in the already existing file.
* .dassie/app/controllers/catalog_controller.rb: swaps out to Component calls for the views stubbing.
* app/assets/stylesheets/hyrax/blacklight_gallery.scss: updates the classes for existing styling, and creates new CSS for Gallery.
* lib/generators/hyrax/*: stubs the new requirements for dassie changes listed above.

![Screen Shot 2022-06-23 at 12 51 18 PM](https://user-images.githubusercontent.com/18330149/175356346-20ededdc-37a0-4477-bdcb-606d74ea1c13.png)

@samvera/hyrax-code-reviewers
