### PR TITLE
Applies same styling from #87409ad to Content Blocks.

### DIFF
--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -27,9 +27,9 @@
                 <%= f.text_area :announcement, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
             </div>
           </div>
-          <div class="card-footer">
-            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
-            <%= f.button :submit, class: 'btn btn-primary float-right' %>
+          <div class="card-footer d-flex justify-content-end">
+            <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
           </div>
         <% end %>
       </div>
@@ -43,9 +43,9 @@
                 <%= f.text_area :marketing, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
             </div>
           </div>
-          <div class="card-footer">
-            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
-            <%= f.button :submit, class: 'btn btn-primary float-right' %>
+          <div class="card-footer d-flex justify-content-end">
+            <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
           </div>
         <% end %>
       </div>
@@ -59,9 +59,9 @@
                 <%= f.text_area :researcher, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
             </div>
           </div>
-          <div class="card-footer">
-            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary float-right' %>
-            <%= f.button :submit, class: 'btn btn-primary float-right' %>
+          <div class="card-footer d-flex justify-content-end">
+            <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
Fixes #5724

Changes proposed in this pull request:
* app/views/hyrax/content_blocks/_form.html.erb: updates the form to mirror changes made in commit #87409ad.
![Screen Shot 2022-06-23 at 2 57 00 PM](https://user-images.githubusercontent.com/18330149/175376613-d36a2b33-1661-4bed-b905-82b8c3f9c4a3.png)

@samvera/hyrax-code-reviewers
