### PR TITLE
remove deprecated `use_valkyrie` argument from InheritPermissionsJob

### DIFF
--- a/app/controllers/hyrax/batch_edits_controller.rb
+++ b/app/controllers/hyrax/batch_edits_controller.rb
@@ -54,7 +54,7 @@ module Hyrax
       obj.attributes = work_params(admin_set_id: obj.admin_set_id).except(*visibility_params)
       obj.date_modified = Time.current.ctime
 
-      InheritPermissionsJob.perform_now(obj, use_valkyrie: false)
+      InheritPermissionsJob.perform_now(obj)
       VisibilityCopyJob.perform_now(obj)
 
       obj.save

--- a/app/jobs/inherit_permissions_job.rb
+++ b/app/jobs/inherit_permissions_job.rb
@@ -5,11 +5,7 @@ class InheritPermissionsJob < Hyrax::ApplicationJob
   # Perform the copy from the work to the contained filesets
   #
   # @param work containing access level and filesets
-  # @param use_valkyrie [Boolean] whether to use valkyrie support (deprecated)
-  def perform(work, use_valkyrie: :DEFAULT)
-    Deprecation.warn("use_valkyrie argument is deprecated, behavior depends on deserialized resource") unless
-      use_valkyrie == :DEFAULT
-
+  def perform(work)
     case work
     when ActiveFedora::Base
       af_perform(work)


### PR DESCRIPTION
this argument was deprecated and a no-op. remove it for 4.0.0

@samvera/hyrax-code-reviewers
