### PR TITLE
correctly derive paths for UploadedFileUploader

### DIFF
--- a/app/uploaders/hyrax/uploaded_file_uploader.rb
+++ b/app/uploaders/hyrax/uploaded_file_uploader.rb
@@ -4,21 +4,21 @@ module Hyrax
     # Override the directory where uploaded files will be stored.
     # This is a sensible default for uploaders that are meant to be mounted:
     def store_dir
-      configured_upload_path + "#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      (configured_upload_path / model.class.to_s.underscore / mounted_as.to_s / model.id.to_s).to_s
     end
 
     def cache_dir
-      configured_cache_path + "#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      (configured_cache_path / model.class.to_s.underscore / mounted_as.to_s / model.id.to_s).to_s
     end
 
     private
 
     def configured_upload_path
-      Hyrax.config.upload_path.call
+      Pathname.new(Hyrax.config.upload_path.call)
     end
 
     def configured_cache_path
-      Hyrax.config.cache_path.call
+      Pathname.new(Hyrax.config.cache_path.call)
     end
   end
 end


### PR DESCRIPTION
`UploadedFileUploader`'s path generation was extremely fragile. for instance, it
would generate an incorrect path if the configuration option didn't end with
'/'.

to generate a vaild in a system independent way, use `Pathname#/` and then cast
back to a string.

@samvera/hyrax-code-reviewers
