### PR TITLE
wings: fix string interpolation in persister errors

### DIFF
--- a/lib/wings/valkyrie/persister.rb
+++ b/lib/wings/valkyrie/persister.rb
@@ -74,7 +74,8 @@ module Wings
 
         def initialize(msg = nil, obj:)
           self.obj = obj
-          msg = "Failed to save object {obj}.\n" + msg
+
+          msg = "Failed to save object #{obj}.\n" + msg
           super(msg)
         end
       end


### PR DESCRIPTION
include the object instead of a literal `{obj}`.

@samvera/hyrax-code-reviewers
