### PR TITLE
test model sensitive collection behavior for relationships views

### DIFF
--- a/spec/views/hyrax/base/_relationships.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_relationships.html.erb_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'hyrax/base/relationships', type: :view do
     Hyrax::CollectionPresenter.new(
       SolrDocument.new(
         id: '345',
-        has_model_ssim: ['Collection'],
+        has_model_ssim: [Hyrax.config.collection_model],
         title_tesim: ['Containing collection']
       ),
       ability


### PR DESCRIPTION
relationship specs shouldn't try to check behavior for "Collection" when that
model is disabled in favor of `Hyrax::PcdmCollection`.

@samvera/hyrax-code-reviewers
