### PR TITLE
Add a generic interface for ACL keys to Group and User

### DIFF
--- a/app/models/concerns/hyrax/user.rb
+++ b/app/models/concerns/hyrax/user.rb
@@ -53,6 +53,13 @@ module Hyrax::User
     public_send(self.class.user_key_field)
   end
 
+  ##
+  # @return [String] a local identifier for this user; for use (e.g.) in ACL
+  #   data
+  def agent_key
+    user_key
+  end
+
   # Look for, in order:
   #   A cached version of the agent
   #   A non-cached version (direct read of the database)
@@ -175,6 +182,10 @@ module Hyrax::User
 
     def find_or_create_system_user(user_key)
       User.find_by_user_key(user_key) || User.create!(user_key_field => user_key, password: Devise.friendly_token[0, 20])
+    end
+
+    def from_agent_key(key)
+      User.find_by_user_key(key)
     end
 
     def from_url_component(component)

--- a/app/models/hyrax/group.rb
+++ b/app/models/hyrax/group.rb
@@ -7,11 +7,25 @@ module Hyrax
       DEFAULT_NAME_PREFIX
     end
 
+    ##
+    # @return [Hyrax::Group]
+    def self.from_key(key)
+      new(key.slice!(name_prefix))
+    end
+
     def initialize(name)
       @name = name
     end
 
     attr_reader :name
+
+    ##
+    # @return [String] a local identifier for this group; for use (e.g.) in ACL
+    #   data
+    def group_key
+      self.class.name_prefix + name
+    end
+    alias user_key group_key
 
     def to_sipity_agent
       sipity_agent || create_sipity_agent!

--- a/app/models/hyrax/group.rb
+++ b/app/models/hyrax/group.rb
@@ -20,6 +20,13 @@ module Hyrax
     attr_reader :name
 
     ##
+    # @return [Boolean]
+    def ==(other)
+      other.class == self.class &&
+        other.name == self.name
+    end
+
+    ##
     # @return [String] a local identifier for this group; for use (e.g.) in ACL
     #   data
     def group_key

--- a/app/models/hyrax/group.rb
+++ b/app/models/hyrax/group.rb
@@ -10,7 +10,7 @@ module Hyrax
     ##
     # @return [Hyrax::Group]
     def self.from_key(key)
-      new(key.slice!(name_prefix))
+      new(key.delete_prefix(name_prefix))
     end
 
     def initialize(name)

--- a/app/models/hyrax/group.rb
+++ b/app/models/hyrax/group.rb
@@ -9,7 +9,7 @@ module Hyrax
 
     ##
     # @return [Hyrax::Group]
-    def self.from_key(key)
+    def self.from_agent_key(key)
       new(key.delete_prefix(name_prefix))
     end
 
@@ -22,17 +22,15 @@ module Hyrax
     ##
     # @return [Boolean]
     def ==(other)
-      other.class == self.class &&
-        other.name == self.name
+      other.class == self.class && other.name == name
     end
 
     ##
     # @return [String] a local identifier for this group; for use (e.g.) in ACL
     #   data
-    def group_key
+    def agent_key
       self.class.name_prefix + name
     end
-    alias user_key group_key
 
     def to_sipity_agent
       sipity_agent || create_sipity_agent!

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -201,12 +201,7 @@ module Hyrax
       private
 
       def id_for(agent:)
-        case agent
-        when Hyrax::Group
-          "#{Hyrax::Group.name_prefix}#{agent.name}"
-        else
-          agent.user_key.to_s
-        end
+        agent.user_key.to_s
       end
     end
 

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -200,8 +200,14 @@ module Hyrax
 
       private
 
+      ##
+      # Returns the identifier used by ACLs to identify agents.
+      #
+      # This defaults to the `:agent_key`, but if that method doesn’t exist,
+      # `:user_key` will be used as a fallback.
       def id_for(agent:)
-        agent.user_key.to_s
+        key = agent.try(:agent_key) || agent.user_key
+        key.to_s
       end
     end
 

--- a/spec/models/hyrax/group_spec.rb
+++ b/spec/models/hyrax/group_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Group, type: :model do
+  let(:name) { 'etaoin' }
+  let(:group) { described_class.new(name) }
+
+  describe '.from_key' do
+    it 'returns an equivalent group' do
+      expect(Hyrax::Group.from_key(Hyrax::Group.name_prefix + group.name)).to eq group
+    end
+  end
+
+  describe '#==' do
+    let (:other_group) { described_class.new(group.name) }
+
+    it 'correctly determines equality for equivalent groups' do
+      expect(other_group).to eq group
+    end
+  end
+
+  describe '#name' do
+    it 'returns the name' do
+      expect(group.name).to eq name
+    end
+  end
+
+  describe '#to_sipity_agent' do
+    subject { group.to_sipity_agent }
+
+    it 'will find or create a Sipity::Agent' do
+      expect { subject }.to change { Sipity::Agent.count }.by(1)
+    end
+
+    context "when another process makes the agent" do
+      before do
+        group.to_sipity_agent # create the agent ahead of time
+      end
+
+      it "returns the existing agent" do
+        expect { subject }.not_to change { Sipity::Agent.count }
+      end
+    end
+  end
+end

--- a/spec/models/hyrax/group_spec.rb
+++ b/spec/models/hyrax/group_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Hyrax::Group, type: :model do
   let(:name) { 'etaoin' }
   let(:group) { described_class.new(name) }
 
-  describe '.from_key' do
+  describe '.from_agent_key' do
     it 'returns an equivalent group' do
-      expect(Hyrax::Group.from_key(Hyrax::Group.name_prefix + group.name)).to eq group
+      expect(described_class.from_agent_key(group.agent_key)).to eq group
     end
   end
 
   describe '#==' do
-    let (:other_group) { described_class.new(group.name) }
+    let(:other_group) { described_class.new(group.name) }
 
     it 'correctly determines equality for equivalent groups' do
       expect(other_group).to eq group
@@ -21,6 +21,12 @@ RSpec.describe Hyrax::Group, type: :model do
   describe '#name' do
     it 'returns the name' do
       expect(group.name).to eq name
+    end
+  end
+
+  describe '#agent_key' do
+    it 'returns the name prefixed with the name prefix' do
+      expect(group.agent_key).to eq described_class.name_prefix + group.name
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,6 +61,20 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#agent_key' do
+    let(:key) { user.agent_key }
+
+    it 'is the same as the user key' do
+      expect(key).to eq user.user_key
+    end
+
+    it 'is findable by agent_key' do
+      user.save!
+
+      expect(described_class.from_agent_key(key)).to eq user
+    end
+  end
+
   it "has an email" do
     expect(user.email).to be_kind_of String
   end


### PR DESCRIPTION
Resumes work on #5439.

Adds a full set of tests for `Hyrax::Group`, and adds `#agent_key` and `.from_agent_key` as new methods on `Hyrax::Group` and `[Hyrax::]User`. In the latter case, these just fall back to `#user_key` and `User.find_by_user_key`.

The `#to_sipity_agent` tests on `Hyrax::Group` were mostly copied from the ones on `Hyrax::User`, and may warrant a closer look by someone more familiar with what they should be testing.

(If adding methods on `User` is undesirable, we could either ⓐ fallback to the existing `#user_key` and `User.find_by_user_key` if `#agent_key` and `.from_agent_key` are not defined, or ⓑ just implement `#user_key` and `.find_by_user_key` on `Hyrax::Group` directly. I’d probably prefer the first option, but neither of these solutions felt ideal to me.)

I’ll open a PR to backport this to `3.x-stable` if this gets merged, as we would like it for our current experimental work on a `hyrax-acl` gem.

@samvera/hyrax-code-reviewers
