### PR TITLE
make CollectionsSearchBuilder less strict

### DIFF
--- a/spec/search_builders/hyrax/my/collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/collections_search_builder_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Hyrax::My::CollectionsSearchBuilder do
     subject { builder.models }
 
     it do
-      is_expected.to contain_exactly(AdminSet,
-                                     Hyrax::AdministrativeSet,
-                                     Hyrax.config.collection_class)
+      is_expected.to include(AdminSet,
+                             Hyrax::AdministrativeSet,
+                             Hyrax.config.collection_class)
     end
 
     context 'when collection class is something other than ::Collection' do


### PR DESCRIPTION
the original version of the test is flatly contradicted by the test below it for
an important relevant case. instead of testing this strict membership, we want
to ensure these three objects are always in the resulting array.

@samvera/hyrax-code-reviewers
