### PR TITLE
update Samvera copyright date to 2022

### DIFF
--- a/lib/generators/hyrax/templates/config/locales/hyrax.de.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.de.yml
@@ -50,7 +50,7 @@ de:
     directory:
       suffix: "@ Example.org"
     footer:
-      copyright_html: "<strong>Copyright © 2018 Samvera lizenziert</strong> unter der Apache Lizenz, Version 2.0"
+      copyright_html: "<strong>Copyright © 2022 Samvera lizenziert</strong> unter der Apache Lizenz, Version 2.0"
       service_html: Ein Dienst von <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
     institution_name: Institution
     institution_name_full: Name des Instituts

--- a/lib/generators/hyrax/templates/config/locales/hyrax.en.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.en.yml
@@ -50,7 +50,7 @@ en:
     directory:
       suffix: "@example.org"
     footer:
-      copyright_html: "<strong>Copyright &copy; 2018 Samvera</strong> Licensed under the Apache License, Version 2.0"
+      copyright_html: "<strong>Copyright &copy; 2022 Samvera</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
     institution_name: Institution
     institution_name_full: The Institution Name

--- a/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
@@ -50,7 +50,7 @@ es:
     directory:
       suffix: "@example.org"
     footer:
-      copyright_html: "<strong>Copyright &copy; 2018 Samvera</strong> bajo licencia de Apache, Version 2.0"
+      copyright_html: "<strong>Copyright &copy; 2022 Samvera</strong> bajo licencia de Apache, Version 2.0"
       service_html: Un servicio de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
     institution_name: institución
     institution_name_full: El nombre de la institución

--- a/lib/generators/hyrax/templates/config/locales/hyrax.fr.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.fr.yml
@@ -50,7 +50,7 @@ fr:
     directory:
       suffix: "@ Example.org"
     footer:
-      copyright_html: "<strong>Copyright © 2018 Samvera</strong> Licence sous Licence Apache, Version 2.0"
+      copyright_html: "<strong>Copyright © 2022 Samvera</strong> Licence sous Licence Apache, Version 2.0"
       service_html: Un service de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
     institution_name: Institution
     institution_name_full: Nom de l'établissement

--- a/lib/generators/hyrax/templates/config/locales/hyrax.it.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.it.yml
@@ -50,7 +50,7 @@ it:
     directory:
       suffix: "@ example.org"
     footer:
-      copyright_html: "<strong>Copyright © 2018 Samvera</strong> Licenza sotto la licenza Apache, versione 2.0"
+      copyright_html: "<strong>Copyright © 2022 Samvera</strong> Licenza sotto la licenza Apache, versione 2.0"
       service_html: Un servizio di <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
     institution_name: Istituzione
     institution_name_full: Nome dell'Istituzione

--- a/lib/generators/hyrax/templates/config/locales/hyrax.pt-BR.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.pt-BR.yml
@@ -50,7 +50,7 @@ pt-BR:
     directory:
       suffix: "@ Example.org"
     footer:
-      copyright_html: "<strong>Copyright © 2018 Samvera </strong> Licenciado sob a Licença Apache, Versão 2.0"
+      copyright_html: "<strong>Copyright © 2022 Samvera </strong> Licenciado sob a Licença Apache, Versão 2.0"
       service_html: Um serviço de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
     institution_name: Instituição
     institution_name_full: O Nome da Instituição

--- a/lib/generators/hyrax/templates/config/locales/hyrax.zh.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.zh.yml
@@ -50,7 +50,7 @@ zh:
     directory:
       suffix: "@example.org"
     footer:
-      copyright_html: "<strong>版权所有 &copy; 2018 Samvera</strong> 根据Apache许可证2.0版许可"
+      copyright_html: "<strong>版权所有 &copy; 2022 Samvera</strong> 根据Apache许可证2.0版许可"
       service_html: 的服务<a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
     institution_name: 机构
     institution_name_full: 机构名称


### PR DESCRIPTION
Changes proposed in this pull request:
* update Samvera copyright date to 2022. The date is displayed in footer of hyrax 

@samvera/hyrax-code-reviewers
