### PR TITLE
Update Hyrax chart

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 3.1.0
+version: 3.2.0
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -6,7 +6,7 @@ version: 3.1.0
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo
-    version: 0.8.0
+    version: 1.0.0
     repository: oci://ghcr.io/samvera
     condition: fcrepo.enabled
   - name: memcached

--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -193,7 +193,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "hyrax.solr.port" -}}
-{{- .Values.externalSolrPort | default "8983" }}
+{{- if .Values.solr.enabled }}
+{{- .Values.solr.containerPorts.http | default 8983 }}
+{{- else }}
+{{- .Values.externalSolrPort }}
+{{- end }}
 {{- end -}}
 
 {{- define "hyrax.solr.url" -}}

--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -147,6 +147,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end }}
 {{- end -}}
 
+{{- define "hyrax.postgresql.url" -}}
+{{- printf "postgresql://%s:%s@%s/%s?pool=5" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) -}}
+{{- end -}}
+
 {{- define "hyrax.redis.fullname" -}}
 {{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -14,7 +14,7 @@ data:
   CH12N_TOOL: "fits"
   {{- end }}
   DB_HOST: {{ template "hyrax.postgresql.host" . }}
-  DB_PORT: "5432"
+  DB_PORT: {{ .Values.postgresql.containerPorts.postgresql | default 5432 | quote }}
   DB_USERNAME: {{ template "hyrax.postgresql.database" . }}
   {{- if .Values.memcached.enabled }}
   MEMCACHED_HOST: {{ template "hyrax.memcached.fullname" . }}

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -48,5 +48,5 @@ data:
   SOLR_COLLECTION_NAME: {{ template "hyrax.solr.collectionName" . }}
   SOLR_CONFIGSET_NAME: {{ template "hyrax.fullname" . }}
   SOLR_HOST: {{ template "hyrax.solr.host" . }}
-  SOLR_PORT: {{ (include "hyrax.solr.port" .) | quote }}
+  SOLR_PORT: {{ include "hyrax.solr.port" . | quote}}
   SOLR_URL: {{ template "hyrax.solr.url" . }}

--- a/chart/hyrax/templates/secrets.yaml
+++ b/chart/hyrax/templates/secrets.yaml
@@ -8,7 +8,7 @@ type: Opaque
 data:
   SECRET_KEY_BASE: {{ randAlphaNum 20 | b64enc | quote }}
   DB_PASSWORD: {{ include "hyrax.postgresql.password" . | b64enc }}
-  DATABASE_URL: {{ printf "postgresql://%s:%s@%s/%s?pool=5" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) | b64enc }}
+  DATABASE_URL: {{ include "hyrax.postgresql.url" . | b64enc }}
   {{- if .Values.minio.enabled }}
   MINIO_ACCESS_KEY: {{ .Values.minio.auth.rootUser | b64enc}}
   MINIO_SECRET_KEY: {{ .Values.minio.auth.rootPassword | b64enc}}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -279,12 +279,11 @@ postgresql:
 ## and to act as an auth proxy for Cantelope
 nginx:
   enabled: false
+  image:
+    repository: bitnami/nginx
+    tag: 1.23.0-debian-11-r1
   # The set up below does malicious bot / ip blocking and mounts
-  # vaolumes to allow nginx to server assets and other public directory items
-  # image:
-  #   registry: registry.gitlab.com
-  #   repository: notch8/scripts/bitnami-nginx
-  #   tag: 1.21.5-debian-10-r4
+  # volumes to allow nginx to server assets and other public directory items
   # extraVolumes:
   #   - name: "uploads"
   #     persistentVolumeClaim:

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -226,7 +226,7 @@ fcrepo:
     enabled: false
     image:
       repository: bitnami/postgresql
-      tag: 12.3.0
+      tag: 14.4.0-debian-11-r6
 
 # configuration for an external/existing fits service;
 #   ignored if `fits.enabled` is true

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/samvera/dassie
+  repository: ghcr.io/samvera/hyrax/dassie
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -193,7 +193,7 @@ worker:
   enabled: true
   replicaCount: 3
   image:
-    repository: samveralabs/dassie-worker
+    repository: ghcr.io/samvera/hyrax/dassie-worker
     pullPolicy: IfNotPresent
     tag: ""
   extraInitContainers: []

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -247,6 +247,9 @@ memcached:
 
 minio:
   enabled: false
+  image:
+    repository: bitnami/minio
+    tag: 2022.7.4-debian-11-r0
   auth:
     rootUser: hyrax-access-key
     rootPassword: hyrax-secret-key

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -413,6 +413,9 @@ nginx:
 
 redis:
   enabled: true
+  image:
+    repository: bitnami/redis
+    tag: 7.0.2-debian-11-r7
   auth:
     password: mysecret
 

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -423,12 +423,14 @@ solr:
   enabled: true
   image:
     repository: bitnami/solr
-    tag: 8.11.1
+    tag: 8.11.2-debian-11-r4
+  containerPorts:
+    http: 8983
   auth:
     enabled: true
     adminUsername: admin
     adminPassword: admin
-  coreName: hyrax
+  coreNames: hyrax
   collection: hyrax
   cloudBootstrap: true
   cloudEnabled: true

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -241,6 +241,9 @@ fits:
 
 memcached:
   enabled: false
+  image:
+    repository: bitnami/memcached
+    tag: 1.6.15-debian-11-r12
 
 minio:
   enabled: false

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -261,7 +261,7 @@ postgresql:
   enabled: true
   image:
     repository: bitnami/postgresql
-    tag: 12.3.0
+    tag: 12.11.0-debian-11-r12
   auth:
     database: hyrax
     password: hyrax_pass
@@ -446,8 +446,9 @@ autoscaling:
 
 global:
   postgresql:
-    postgresqlUsername: hyrax
-    postgresqlPassword: hyrax_pass
+    auth:
+      username: hyrax
+      password: hyrax_pass
   # This is th name of the running rails server pod
   hyraxHostName: hyrax
 

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: samveralabs/dassie
+  repository: ghcr.io/samvera/dassie
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -220,13 +220,12 @@ worker:
 
 fcrepo:
   enabled: true
-  externalDatabaseUsername: "hyrax"
   servicePort: 8080
   postgresql:
     enabled: false
     image:
       repository: bitnami/postgresql
-      tag: 14.4.0-debian-11-r6
+      tag: 12.11.0-debian-11-r12
 
 # configuration for an external/existing fits service;
 #   ignored if `fits.enabled` is true
@@ -449,6 +448,7 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 
 global:
+  # These global postgresql values are used by the fcrepo chart
   postgresql:
     auth:
       username: hyrax

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,10 +100,10 @@ services:
       - hyrax
 
   postgres:
-    image: postgres:latest
+    image: bitnami/postgresql:14.4.0
+    restart: always
     environment:
-      - POSTGRES_USER=hyrax_user
-      - POSTGRES_PASSWORD=hyrax_password
+      - POSTGRESQL_PASSWORD=hyrax_super
       - POSTGRES_DB=hyrax
       - POSTGRES_HOST_AUTH_METHOD=trust
     ports:


### PR DESCRIPTION
refs #5357

Depends on: 
- https://github.com/samvera-labs/fcrepo-charts/pull/13
- An updated `dassie` image for `3.4.1` to use as the chart default image/tag
- A `dassie-worker` image for `3.4.1` to use as the chart `worker` default image/tag (currently no image exists at all in `ghcr.io/samvera` as far as I can tell)

Upgrade Hyrax Helm chart to 2.0.0

Changes proposed in this pull request:
* Create a new release of the Hyrax helm chart at version 2.0 (major version bump)
* Bump all chart dependencies to their latest versions
* Bump and set chart `image.tag` for each dependency, with the idea that #5357 will be done soon and automate keeping these up to date
* Update chart configuration as needed for each dependency upgrade
