### PR TITLE
don't show analytics in the sidebar if it is turned off

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -33,7 +33,7 @@
     <% end %>
   <% end %>
 
-  <% if current_ability.can_create_any_work? %>
+  <% if current_ability.can_create_any_work? && Hyrax.config.analytics? %>
     <li class="nav-item">
       <%= menu.collapsable_section t('hyrax.admin.sidebar.analytics'),
                                         icon_class: "fa fa-pie-chart",


### PR DESCRIPTION
prior to this, we showed the analytics link in the sidebar nav for the dashboard
even if Analytics is turned off on the repository.

@samvera/hyrax-code-reviewers
