### PR TITLE
comet: decouple Derivatives from Characterization

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -32,7 +32,11 @@ class CharacterizeJob < Hyrax::ApplicationJob
     # Ensure a fresh copy of the repo file's latest version is being worked on, if no filepath is directly provided
     filepath = Hyrax::WorkingDirectory.copy_repository_resource_to_working_directory(Hydra::PCDM::File.find(file_id), file_set.id) unless filepath && File.exist?(filepath)
     characterize(file_set, file_id, filepath)
-    CreateDerivativesJob.perform_later(file_set, file_id, filepath)
+
+    Hyrax.publisher.publish('file.characterized',
+                            file_set: file_set,
+                            file_id: file_id,
+                            path_hint: filepath)
   end
 
   private

--- a/app/services/hyrax/listeners/file_metadata_listener.rb
+++ b/app/services/hyrax/listeners/file_metadata_listener.rb
@@ -6,6 +6,17 @@ module Hyrax
     # Listens for events related to {Hyrax::FileMetadata}
     class FileMetadataListener
       ##
+      # Called when 'file.characterized' event is published;
+      # allows post-characterization handling, like derivatives generation.
+      #
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_file_characterized(event)
+        CreateDerivativesJob
+          .perform_later(event[:file_set], event[:file_id], event[:path_hint])
+      end
+
+      ##
       # Called when 'file.metadata.updated' event is published; reindexes a
       # {Hyrax::FileSet} when a file claiming to be its `pcdm_use:OriginalFile`
       #

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -119,6 +119,10 @@ module Hyrax
     #     unique id), AND a `:user` (the ::User responsible for the update).
     register_event('collection.membership.updated')
 
+    # @since 3.5.0
+    # @macro a_registered_event
+    register_event('file.characterized')
+
     # @since 3.3.0
     # @macro a_registered_event
     register_event('file.downloaded')


### PR DESCRIPTION
the tight coupling of Derivative generation to the Characterization background
job makes it hard to customize derivatives processing without changing
characterization behavior.

this takes a hack at decoupling the two by routing derivatives through an event
handler. instead of enqueing the derivatives job directly, the CharacterizeJob
now simply reports that it has characterized the given file_id within the
file_set. it also provides its path hint, in case a listener wants to log or
reuse that hint.

we then add a listener to do the work of actually characterizing. this is a bit
of indirection, but has a lot of benefits in flexibility: you no longer need to
rewrite characterization behavior to customize derivatives handling.


@samvera/hyrax-code-reviewers
