### PR TITLE
select_options is undefined for an array

### DIFF
--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -6,7 +6,7 @@ module Hyrax
     #   from views. refactor to avoid
     # @return  [Array<Array<String, String, Hash>] options for the admin set drop down.
     def admin_set_options
-      return @admin_set_options.select_options if @admin_set_options
+      return @admin_set_options if @admin_set_options
 
       service = Hyrax::AdminSetService.new(controller)
       Hyrax::AdminSetOptionsPresenter.new(service).select_options


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10081604/180254345-516424fd-3107-4ec7-929f-60f4d3cba8b7.png)

When creating a new work, a 500 error is returned: undefined method select_options for array.
This was tested within the latest version of Hyku(4.0 - which upgraded to hyrax 3.4.0).

@admin_set_options => [["Default Admin Set", "admin_set/default"]]
I think we don't need to call #select_options here ^^

because [line 12](https://github.com/samvera/hyrax/blob/v3.4.0/app/helpers/hyrax/work_form_helper.rb#L12) returns similar results if they aren't @admin_set_options is not already present:

Hyrax::AdminSetOptionsPresenter.new(service).select_options => [["Default Admin Set",
"admin_set/default",
{"data-sharing"=>true}]]