### PR TITLE
add checked option to radio button

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
@@ -5,19 +5,19 @@
 
   <div class="form-check">
     <label class="form-check-label">
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, checked: @collection.open_access? %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, checked: @collection&.open_access? %>
       <strong><%= t('hyrax.visibility.open.text') %></strong> - <%= t('hyrax.visibility.open.note_html') %>
     </label>
   </div>
   <div class="form-check">
     <label class="form-check-label">
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, checked: @collection.authenticated_only_access? %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, checked: @collection&.authenticated_only_access? %>
       <strong><%= t('hyrax.visibility.authenticated.text', institution: institution_name) %></strong> - <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
     </label>
   </div>
   <div class="form-check">
     <label class="form-check-label">
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, checked: @collection.private_access? %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, checked: @collection&.private_access? %>
       <strong><%= t('hyrax.visibility.restricted.text') %></strong>- <%= t('hyrax.visibility.restricted.note_html') %>
     </label>
   </div>

--- a/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
@@ -5,19 +5,19 @@
 
   <div class="form-check">
     <label class="form-check-label">
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, checked: @collection.open_access? %>
       <strong><%= t('hyrax.visibility.open.text') %></strong> - <%= t('hyrax.visibility.open.note_html') %>
     </label>
   </div>
   <div class="form-check">
     <label class="form-check-label">
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, checked: @collection.authenticated_only_access? %>
       <strong><%= t('hyrax.visibility.authenticated.text', institution: institution_name) %></strong> - <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
     </label>
   </div>
   <div class="form-check">
     <label class="form-check-label">
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, checked: @collection.private_access? %>
       <strong><%= t('hyrax.visibility.restricted.text') %></strong>- <%= t('hyrax.visibility.restricted.note_html') %>
     </label>
   </div>


### PR DESCRIPTION
## Summary
Through radio buttons, give indicator what visibility the collection is currently set to. Tested change on Hyku.

Changes proposed in this pull request:
* add checked option to radio button

### Screenshot
![hyrax-radio-button](https://user-images.githubusercontent.com/19597776/181368339-e1acc6bf-e276-4c5a-bf97-91729652aa69.gif)

