### PR TITLE
Backport to 3.x - AdminSets need an id to save their associations

### DIFF
--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -97,6 +97,14 @@ class AdminSet < ActiveFedora::Base
     permission_template.reset_access_controls_for(collection: self)
   end
 
+  # @api public
+  #
+  # return an id for the AdminSet.
+  # defaults to calling Hyrax::Noid, but needs a fall back if noid is off
+  def assign_id
+    super || SecureRandom.uuid
+  end
+
   private
 
   def destroy_permission_template

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -206,6 +206,12 @@ RSpec.describe AdminSet, type: :model do
 
   describe '#assign_id' do
     context 'with noid true' do
+      around(:each) do |example|
+        Hyrax.config.enable_noids = true
+        example.run
+        Hyrax.config.enable_noids = false
+      end
+
       it 'should assign a NOID' do
         new_id = subject.assign_id
         expect(new_id).to be
@@ -215,7 +221,6 @@ RSpec.describe AdminSet, type: :model do
 
     context 'with noid false' do
       it 'should assign a UUID if no other id is minted' do
-        expect(Hyrax.config).should_receive(:enable_noids?).and_return false
         new_id = subject.assign_id
         expect(new_id).to be
         expect(new_id.size).to eq(36)

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe AdminSet, type: :model do
 
     context 'with noid false' do
       it 'should assign a UUID if no other id is minted' do
-        expect(Hyrax.config).to_receive(:enable_noids?).and_return false
+        expect(Hyrax.config).should_receive(:enable_noids?).and_return false
         new_id = subject.assign_id
         expect(new_id).to be
         expect(new_id.size).to eq(36)

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -211,7 +211,6 @@ RSpec.describe AdminSet, type: :model do
         expect(new_id).to be
         expect(new_id.size).to eq(9)
       end
-
     end
 
     context 'with noid false' do

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -204,6 +204,26 @@ RSpec.describe AdminSet, type: :model do
     end
   end
 
+  describe '#assign_id' do
+    context 'with noid true' do
+      it 'should assign a NOID' do
+        new_id = subject.assign_id
+        expect(new_id).to be
+        expect(new_id.size).to eq(9)
+      end
+
+    end
+
+    context 'with noid false' do
+      it 'should assign a UUID if no other id is minted' do
+        expect(Hyrax.config).to_receive(:enable_noids?).and_return false
+        new_id = subject.assign_id
+        expect(new_id).to be
+        expect(new_id.size).to eq(36)
+      end
+    end
+  end
+
   describe '#reset_access_controls!' do
     let!(:user) { build(:user) }
     let!(:admin_set) { create(:admin_set, creator: [user.user_key], edit_users: [user.user_key], edit_groups: [::Ability.admin_group_name], read_users: [], read_groups: ['public']) }


### PR DESCRIPTION
Set up a fallback for the case where NOID is false.

Fixes https://github.com/samvera/hyrax/issues/5788

@samvera/hyrax-code-reviewers
