### PR TITLE
Add descriptions to migration tasks

### DIFF
--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 namespace :hyrax do
   namespace :migrate do
+    desc 'Move all works to default AdminSet'
     task move_all_works_to_admin_set: :environment do
       require 'hyrax/move_all_works_to_admin_set'
       MoveAllWorksToAdminSet.run(AdminSet.find(AdminSet::DEFAULT_ID))
     end
 
+    desc 'Add the MANAGING role to legacy works'
     task add_admin_group_to_admin_sets: :environment do
       # Force creation of registered MANAGING role if it doesn't exist
       # This code must be invoked before calling `Sipity::Role.all` or the managing role won't be there
@@ -28,6 +30,7 @@ namespace :hyrax do
       end
     end
 
+    desc 'Set collection type and permissions for legacy (<2.1.0) Hyrax collections'
     task add_collection_type_and_permissions_to_collections: :environment do
       # Run collection migration which sets the collection_type of legacy collections to User Collection and adds
       # a permission template assigning users/groups with edit_access to the Manager role and users/groups with
@@ -37,7 +40,8 @@ namespace :hyrax do
     end
 
     # Migrate any orphan fedora data from the first to the second predicate
-    task migrate_keyword_predicate: :environment do
+    desc 'Migrate keywords and license predicates for Hyrax 2.x --> 3.x'
+    task migrate_keyword_and_license_predicate: :environment do
       Hyrax::Works::MigrationService.migrate_predicate(::RDF::Vocab::DC11.relation, ::RDF::Vocab::SCHEMA.keywords)
       Hyrax::Works::MigrationService.migrate_predicate(::RDF::Vocab::DC.rights, ::RDF::Vocab::DC.license)
     end


### PR DESCRIPTION
Add descriptions so these tasks show up when running `rake -T`.

Update the predicate migration task name to clarify what changes will be made

@samvera/hyrax-code-reviewers
