### PR TITLE
raise a useful error when setting an unknown visibility

### DIFF
--- a/app/services/hyrax/visibility_map.rb
+++ b/app/services/hyrax/visibility_map.rb
@@ -51,15 +51,23 @@ module Hyrax
     end
 
     def additions_for(visibility:)
-      self[visibility][:additions]
+      fetch(visibility)&.fetch(:additions)
     end
 
     def deletions_for(visibility:)
-      self[visibility][:deletions]
+      fetch(visibility)&.fetch(:deletions)
+    end
+
+    def fetch(key, &block)
+      @map.fetch(key, &block)
+    rescue KeyError => e
+      raise(UnknownVisibility, e.message)
     end
 
     def visibilities
       @map.keys
     end
+
+    class UnknownVisibility < KeyError; end
   end
 end

--- a/spec/models/hyrax/resource_spec.rb
+++ b/spec/models/hyrax/resource_spec.rb
@@ -51,5 +51,11 @@ RSpec.describe Hyrax::Resource do
           .to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
       end
     end
+
+    context 'when setting to unknown visibility' do
+      it 'raises a useful error' do
+        expect { resource.visibility = "oops" }.to raise_error KeyError
+      end
+    end
   end
 end


### PR DESCRIPTION
when a user tries to set a visilibity we don't know about, don't respond with
`NoMethodError` on `nil`, but give a useful error message that hints at what has
gone wrong.


@samvera/hyrax-code-reviewers
