### PR TITLE
Fix build errors caused by search_state_class

### DIFF
--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -83,7 +83,7 @@ module Hyrax
 
       # Force CatalogController to use our SearchState class, which has an important
       # work-around for some highly suspect SPARQL-gem monkeypatching.
-      CatalogController.search_state_class = Hyrax::SearchState if CatalogController.search_state_class == Blacklight::SearchState
+      CatalogController.search_state_class = Hyrax::SearchState if CatalogController.try(:search_state_class) == Blacklight::SearchState
     end
 
     initializer 'requires' do


### PR DESCRIPTION
Cherry-picks this commit from the Rails 6.1 PR (#5786)

search_state_class isn't defined on CatalogController until after blacklight generator has run



@samvera/hyrax-code-reviewers
