### PR TITLE
Support embargo & lease in valkyrie forms

### DIFF
--- a/app/forms/hyrax/forms/embargo.rb
+++ b/app/forms/hyrax/forms/embargo.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Hyrax
+  module Forms
+    ##
+    # Nested form for embargos.
+    class Embargo < Hyrax::ChangeSet
+      property :visibility_after_embargo
+      property :visibility_during_embargo
+      property :embargo_release_date
+      property :embargo_history, default: []
+    end
+  end
+end

--- a/app/forms/hyrax/forms/lease.rb
+++ b/app/forms/hyrax/forms/lease.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Hyrax
+  module Forms
+    ##
+    # Nested form for leases.
+    class Lease < Hyrax::ChangeSet
+      property :visibility_after_lease
+      property :visibility_during_lease
+      property :lease_expiration_date
+      property :lease_history, default: []
+    end
+  end
+end

--- a/app/services/hyrax/visibility_map.rb
+++ b/app/services/hyrax/visibility_map.rb
@@ -51,15 +51,23 @@ module Hyrax
     end
 
     def additions_for(visibility:)
-      self[visibility][:additions]
+      fetch(visibility)&.fetch(:additions)
     end
 
     def deletions_for(visibility:)
-      self[visibility][:deletions]
+      fetch(visibility)&.fetch(:deletions)
+    end
+
+    def fetch(key, &block)
+      @map.fetch(key, &block)
+    rescue KeyError => e
+      raise(UnknownVisibility, e.message)
     end
 
     def visibilities
       @map.keys
     end
+
+    class UnknownVisibility < KeyError; end
   end
 end

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -427,6 +427,58 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
   end
 
+  describe '#sync' do
+    context 'when setting an embargo' do
+      let(:params) do
+        { title: ["Object Under Embargo"],
+          embargo_release_date: Date.tomorrow.to_s,
+          visibility: "embargo",
+          visibility_after_embargo: "open",
+          visibility_during_embargo: "restricted" }
+      end
+
+      it 'builds an embargo' do
+        form.validate(params)
+
+        expect { form.sync }
+          .to change { work.embargo }
+          .to have_attributes(embargo_release_date: Date.tomorrow.to_s,
+                              visibility_after_embargo: "open",
+                              visibility_during_embargo: "restricted")
+      end
+
+      it 'sets visibility to "during" value' do
+        form.validate(params)
+
+        expect(form.visibility).to eq "restricted"
+      end
+    end
+
+    context 'when setting a lease' do
+      let(:params) do
+        { title: ["Object Under Lease"],
+          lease_expiration_date: Date.tomorrow.to_s,
+          visibility: "lease",
+          visibility_after_lease: "restricted",
+          visibility_during_lease: "open" }
+      end
+
+      it 'builds an embargo' do
+        form.validate(params)
+
+        expect { form.sync }
+          .to change { work.lease }
+          .to have_attributes(lease_expiration_date: Date.tomorrow.to_s)
+      end
+
+      it 'sets visibility to "during" value' do
+        form.validate(params)
+
+        expect(form.visibility).to eq "open"
+      end
+    end
+  end
+
   describe '#version' do
     context 'when using wings', valkyrie_adapter: :wings_adapter do
       it 'prepopulates as empty before save' do

--- a/spec/models/hyrax/resource_spec.rb
+++ b/spec/models/hyrax/resource_spec.rb
@@ -51,5 +51,11 @@ RSpec.describe Hyrax::Resource do
           .to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
       end
     end
+
+    context 'when setting to unknown visibility' do
+      it 'raises a useful error' do
+        expect { resource.visibility = "oops" }.to raise_error KeyError
+      end
+    end
   end
 end


### PR DESCRIPTION
prior work allows management of Embargo and Lease in Valkyrie using
`Hyrax::Embargo`/`Hyrax::EmbargoManager` and
`Hyrax::Lease`/`Hyrax::LeaseManager`. application of this data through the form
hasn't been implemented until now.

this is a first pass that transforms existing (non-nested) form parameters into
nested attributes that result in the correct data objects. Follow-up work should
test and refine the functionality through WorksControllerBehavior.

related to https://github.com/samvera/hyrax/issues/5572.

@samvera/hyrax-code-reviewers
