### PR TITLE
Fix Hyrax 3.x build errors caused by linkeddata and json-ld gem updates

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -70,6 +70,7 @@ SUMMARY
   spec.add_dependency 'oauth2', '~> 1.2'
   spec.add_dependency 'posix-spawn'
   spec.add_dependency 'power_converter', '~> 0.1', '>= 0.1.2'
+  spec.add_dependency 'psych', '~> 3.3'
   spec.add_dependency 'qa', '~> 5.5', '>= 5.5.1' # questioning_authority
   spec.add_dependency 'rails_autolink', '~> 1.1'
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -58,6 +58,7 @@ SUMMARY
   spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4'
   spec.add_dependency 'jquery-ui-rails', '~> 6.0'
+  spec.add_dependency 'json-ld', '< 3.2'
   spec.add_dependency 'json-schema' # for Arkivo
   # Pin more tightly because 0.x gems are potentially unstable
   spec.add_dependency 'kaminari_route_prefix', '~> 0.1.1'


### PR DESCRIPTION
Fix Hyrax 3.x build errors caused by linkeddata and json-ld gem updates

The linked data gem added dependencies that in turn added a dependency on psych. This causes bundle to want to update psych to version 4, which changes the method signature of safe_load. ActiveFedora is not yet compatible with the new format.

Additionally, the json-ld gem added support for using multi_json to load the json writer. The default output is no longer prettified, breaking a hyrax spec. This PR limits the version to prevent breakage and maintain Ruby 2.5 support.

@samvera/hyrax-code-reviewers
