### PR TITLE
soften dependendy on search_state_class for app generation

### DIFF
--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -71,10 +71,6 @@ module Hyrax
       end
     end
 
-    def catalog_controller
-      copy_file "catalog_controller.rb", "app/controllers/catalog_controller.rb"
-    end
-
     # Add behaviors to the SolrDocument model
     def inject_solr_document_behavior
       file_path = 'app/models/solr_document.rb'
@@ -124,6 +120,10 @@ module Hyrax
       else
         puts "     \e[31mFailure\e[0m  Could not find #{file_path}.  To add Hyrax behaviors to your Controllers, you must include the Hyrax::Controller module in the Controller class definition."
       end
+    end
+
+    def catalog_controller
+      copy_file "catalog_controller.rb", "app/controllers/catalog_controller.rb"
     end
 
     def copy_helper

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -83,7 +83,7 @@ module Hyrax
 
       # Force CatalogController to use our SearchState class, which has an important
       # work-around for some highly suspect SPARQL-gem monkeypatching.
-      CatalogController.search_state_class = Hyrax::SearchState if CatalogController.search_state_class == Blacklight::SearchState
+      CatalogController.search_state_class = Hyrax::SearchState if CatalogController.try(:search_state_class) == Blacklight::SearchState
     end
 
     initializer 'requires' do


### PR DESCRIPTION
search_state_class isn't defined on CatalogController until after blacklight
generator has run, but `Hyrax::Engine` needs to execute before that in
generation.

cc @cjcolvar

@samvera/hyrax-code-reviewers
