### PR TITLE
don't load_and_authorize a model when indexing Embargoes

### DIFF
--- a/app/controllers/concerns/hyrax/manages_embargoes.rb
+++ b/app/controllers/concerns/hyrax/manages_embargoes.rb
@@ -6,7 +6,7 @@ module Hyrax
     included do
       attr_accessor :curation_concern
       helper_method :curation_concern
-      load_and_authorize_resource class: ActiveFedora::Base, instance_name: :curation_concern
+      load_and_authorize_resource class: ActiveFedora::Base, instance_name: :curation_concern, except: [:index]
     end
 
     # This is an override of Hyrax::ApplicationController


### PR DESCRIPTION
this code doesn't need to execute for `index`, and only works by
co-incidence (since anyone whon can :index `Hydra::AccessControls::Embargo`, can
also index `ActiveFedora::Base`). this might not be true for other models, or
when apps have customized their Ability code, so it's strictly incorrect.

@samvera/hyrax-code-reviewers
