### PR TITLE
get a minimal passing EmbargoController for Valkyrie

### DIFF
--- a/app/actors/hyrax/actors/embargo_actor.rb
+++ b/app/actors/hyrax/actors/embargo_actor.rb
@@ -12,10 +12,17 @@ module Hyrax
       # Update the visibility of the work to match the correct state of the embargo, then clear the embargo date, etc.
       # Saves the embargo and the work
       def destroy
-        work.embargo_visibility! # If the embargo has lapsed, update the current visibility.
-        work.deactivate_embargo!
-        work.embargo.save!
-        work.save!
+        case work
+        when Valkyrie::Resource
+          embargo_manager = Hyrax::EmbargoManager.new(resource: work)
+          embargo_manager.release
+          Hyrax::AccessControlList(work).save
+        else
+          work.embargo_visibility! # If the embargo has lapsed, update the current visibility.
+          work.deactivate_embargo!
+          work.embargo.save!
+          work.save!
+        end
       end
     end
   end

--- a/app/actors/hyrax/actors/embargo_actor.rb
+++ b/app/actors/hyrax/actors/embargo_actor.rb
@@ -15,8 +15,8 @@ module Hyrax
         case work
         when Valkyrie::Resource
           embargo_manager = Hyrax::EmbargoManager.new(resource: work)
-          embargo_manager.release
-          Hyrax::AccessControlList(work).save
+          embargo_manager.release && Hyrax::AccessControlList(work).save
+          embargo_manager.nullify
         else
           work.embargo_visibility! # If the embargo has lapsed, update the current visibility.
           work.deactivate_embargo!

--- a/app/actors/hyrax/actors/lease_actor.rb
+++ b/app/actors/hyrax/actors/lease_actor.rb
@@ -12,10 +12,17 @@ module Hyrax
       # Update the visibility of the work to match the correct state of the lease, then clear the lease date, etc.
       # Saves the lease and the work
       def destroy
-        work.lease_visibility! # If the lease has lapsed, update the current visibility.
-        work.deactivate_lease!
-        work.lease.save!
-        work.save!
+        case work
+        when Valkyrie::Resource
+          lease_manager = Hyrax::LeaseManager.new(resource: work)
+          lease_manager.release && Hyrax::AccessControlList(work).save
+          lease_manager.nullify
+        else
+          work.lease_visibility! # If the lease has lapsed, update the current visibility.
+          work.deactivate_lease!
+          work.lease.save!
+          work.save!
+        end
       end
     end
   end

--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -74,14 +74,5 @@ module Hyrax
       concern.try(:embargo_history) ||
         concern.try(:embargo)&.embargo_history
     end
-
-    def work_has_file_set_members?(work)
-      case work
-      when Valkyrie::Resource
-        Hyrax.custom_queries.find_child_file_set_ids(resource: work).any?
-      else
-        work.file_sets.present?
-      end
-    end
   end
 end

--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -15,7 +15,7 @@ module Hyrax
     # Removes a single embargo
     def destroy
       Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
-      flash[:notice] = curation_concern.try(:embargo_history)&.last
+      flash[:notice] = embargo_history(curation_concern)
       if curation_concern.work? && work_has_file_set_members?(curation_concern)
         redirect_to confirm_permission_path
       else
@@ -67,6 +67,11 @@ module Hyrax
     end
 
     private
+
+    def embargo_history(concern)
+      concern.try(:embargo_history) ||
+        concern.try(:embargo)&.embargo_history
+    end
 
     def work_has_file_set_members?(work)
       case work

--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -15,8 +15,8 @@ module Hyrax
     # Removes a single embargo
     def destroy
       Hyrax::Actors::EmbargoActor.new(curation_concern).destroy
-      flash[:notice] = curation_concern.embargo_history.last
-      if curation_concern.work? && curation_concern.file_sets.present?
+      flash[:notice] = curation_concern.try(:embargo_history)&.last
+      if curation_concern.work? && work_has_file_set_members?(curation_concern)
         redirect_to confirm_permission_path
       else
         redirect_to edit_embargo_path
@@ -64,6 +64,17 @@ module Hyrax
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb t(:'hyrax.embargoes.index.manage_embargoes'), hyrax.embargoes_path
       add_breadcrumb t(:'hyrax.embargoes.edit.embargo_update'), '#'
+    end
+
+    private
+
+    def work_has_file_set_members?(work)
+      case work
+      when Valkyrie::Resource
+        Hyrax.custom_queries.find_child_file_set_ids(resource: work).any?
+      else
+        work.file_sets.present?
+      end
     end
   end
 end

--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -60,6 +60,8 @@ module Hyrax
     end
 
     def edit
+      @curation_concern = Hyrax::Forms::WorkEmbargoForm.new(curation_concern).prepopulate! if
+        Hyrax.config.use_valkyrie?
       add_breadcrumb t(:'hyrax.controls.home'), root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb t(:'hyrax.embargoes.index.manage_embargoes'), hyrax.embargoes_path

--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -51,6 +51,8 @@ module Hyrax
     end
 
     def edit
+      @curation_concern = Hyrax::Forms::WorkLeaseForm.new(curation_concern).prepopulate! if
+        Hyrax.config.use_valkyrie?
       add_breadcrumb t(:'hyrax.controls.home'), root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb t(:'hyrax.leases.index.manage_leases'), hyrax.leases_path

--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -16,7 +16,7 @@ module Hyrax
     def destroy
       Hyrax::Actors::LeaseActor.new(curation_concern).destroy
       flash[:notice] = lease_history(curation_concern)&.last
-      if curation_concern.work? && curation_concern.file_sets.present?
+      if curation_concern.work? && work_has_file_set_members?(curation_concern)
         redirect_to confirm_permission_path
       else
         redirect_to edit_lease_path

--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -15,7 +15,7 @@ module Hyrax
     # Removes a single lease
     def destroy
       Hyrax::Actors::LeaseActor.new(curation_concern).destroy
-      flash[:notice] = curation_concern.lease_history.last
+      flash[:notice] = lease_history(curation_concern)&.last
       if curation_concern.work? && curation_concern.file_sets.present?
         redirect_to confirm_permission_path
       else
@@ -55,6 +55,13 @@ module Hyrax
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb t(:'hyrax.leases.index.manage_leases'), hyrax.leases_path
       add_breadcrumb t(:'hyrax.leases.edit.lease_update'), '#'
+    end
+
+    private
+
+    def lease_history(concern)
+      concern.try(:lease_history) ||
+        concern.try(:lease)&.lease_history
     end
   end
 end

--- a/app/controllers/concerns/hyrax/manages_embargoes.rb
+++ b/app/controllers/concerns/hyrax/manages_embargoes.rb
@@ -6,7 +6,8 @@ module Hyrax
     included do
       attr_accessor :curation_concern
       helper_method :curation_concern
-      load_and_authorize_resource class: ActiveFedora::Base, instance_name: :curation_concern, except: [:index]
+      base_class = Hyrax.config.use_valkyrie? ? Hyrax::Resource : ActiveFedora::Base
+      load_and_authorize_resource class: base_class, instance_name: :curation_concern, except: [:index]
     end
 
     # This is an override of Hyrax::ApplicationController

--- a/app/controllers/concerns/hyrax/manages_embargoes.rb
+++ b/app/controllers/concerns/hyrax/manages_embargoes.rb
@@ -16,5 +16,16 @@ module Hyrax
     end
 
     def edit; end
+
+    private
+
+    def work_has_file_set_members?(work)
+      case work
+      when Valkyrie::Resource
+        Hyrax.custom_queries.find_child_file_set_ids(resource: work).any?
+      else
+        work.file_sets.present?
+      end
+    end
   end
 end

--- a/app/forms/hyrax/forms/work_embargo_form.rb
+++ b/app/forms/hyrax/forms/work_embargo_form.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Forms
+    ##
+    # Represents an embargo for edit through a work. That is, this form can
+    # be used to wrap a Work in order to capture state changes related only to
+    # its embargo, ignoring the work's other fields.
+    #
+    # @note this supports the edit functionality of
+    #   +EmbargoesControllerBehavior+.
+    class WorkEmbargoForm < Hyrax::ChangeSet
+      property :embargo, form: Hyrax::Forms::Embargo, populator: :embargo_populator, prepopulator: :embargo_populator
+      property :embargo_release_date, virtual: true, prepopulator: ->(_opts) { self.embargo_release_date = model.embargo&.embargo_release_date }
+      property :visibility_after_embargo, virtual: true, prepopulator: ->(_opts) { self.visibility_after_embargo = model.embargo&.visibility_after_embargo }
+      property :visibility_during_embargo, virtual: true, prepopulator: ->(_opts) { self.visibility_during_embargo = model.embargo&.visibility_during_embargo }
+
+      def embargo_populator(**)
+        self.embargo = Hyrax::EmbargoManager.embargo_for(resource: model)
+      end
+
+      ##
+      # @return [String]
+      def human_readable_type
+        model.to_model.human_readable_type
+      end
+
+      ##
+      # @return [ActiveModel::Name]
+      def model_name
+        model.to_model.model_name
+      end
+    end
+  end
+end

--- a/app/forms/hyrax/forms/work_lease_form.rb
+++ b/app/forms/hyrax/forms/work_lease_form.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Forms
+    ##
+    # Represents a lease for edit through a work. That is, this form can
+    # be used to wrap a Work in order to capture state changes related only to
+    # its lease, ignoring the work's other fields.
+    #
+    # @note this supports the edit functionality of
+    #   +LeasesControllerBehavior+.
+    class WorkLeaseForm < Hyrax::ChangeSet
+      property :lease, form: Hyrax::Forms::Lease, populator: :lease_populator, prepopulator: :lease_populator
+      property :lease_expiration_date, virtual: true, prepopulator: ->(_opts) { self.lease_expiration_date = model.lease&.lease_expiration_date }
+      property :visibility_after_lease, virtual: true, prepopulator: ->(_opts) { self.visibility_after_lease = model.lease&.visibility_after_lease }
+      property :visibility_during_lease, virtual: true, prepopulator: ->(_opts) { self.visibility_during_lease = model.lease&.visibility_during_lease }
+
+      def lease_populator(**)
+        self.lease = Hyrax::LeaseManager.lease_for(resource: model)
+      end
+
+      ##
+      # @return [String]
+      def human_readable_type
+        model.to_model.human_readable_type
+      end
+
+      ##
+      # @return [ActiveModel::Name]
+      def model_name
+        model.to_model.model_name
+      end
+    end
+  end
+end

--- a/app/models/hyrax/embargo.rb
+++ b/app/models/hyrax/embargo.rb
@@ -15,7 +15,7 @@ module Hyrax
     attribute :embargo_history,           Valkyrie::Types::Array
 
     def active?
-      (embargo_release_date.present? && Time.zone.today < embargo_release_date)
+      (embargo_release_date.present? && Hyrax::TimeService.time_in_utc < embargo_release_date)
     end
   end
 end

--- a/app/models/hyrax/lease.rb
+++ b/app/models/hyrax/lease.rb
@@ -15,7 +15,7 @@ module Hyrax
     attribute :lease_history,           Valkyrie::Types::Array
 
     def active?
-      (lease_expiration_date.present? && Time.zone.today < lease_expiration_date)
+      (lease_expiration_date.present? && Hyrax::TimeService.time_in_utc < lease_expiration_date)
     end
   end
 end

--- a/app/services/hyrax/embargo_manager.rb
+++ b/app/services/hyrax/embargo_manager.rb
@@ -162,6 +162,15 @@ module Hyrax
     end
 
     ##
+    # Drop the embargo by setting its release date to `nil`.
+    #
+    # @return [void]
+    def nullify
+      return unless under_embargo?
+      embargo.embargo_release_date = nil
+    end
+
+    ##
     # Sets the visibility of the resource to the embargo's visibility condition.
     # no-op if the embargo period is current.
     #

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -90,6 +90,15 @@ module Hyrax
     end
 
     ##
+    # Drop the lease by setting its release date to `nil`.
+    #
+    # @return [void]
+    def nullify
+      return unless under_lease?
+      lease.lease_expiration_date = nil
+    end
+
+    ##
     # @return [Boolean]
     def release
       return false if under_lease?

--- a/app/views/hyrax/leases/edit.html.erb
+++ b/app/views/hyrax/leases/edit.html.erb
@@ -13,7 +13,7 @@
       <fieldset class="set-access-controls">
         <section class="form-text">
           <p>
-            <% if curation_concern.lease_expiration_date %>
+            <% if lease_enforced?(curation_concern) %>
               <%= t('.lease_true_html',  cc: cc_type) %>
             <% else %>
               <%= t('.lease_false_html', cc: cc_type) %>
@@ -29,7 +29,7 @@
 
       <div class="row">
         <div class="col-md-12 form-actions">
-          <% if curation_concern.lease_expiration_date %>
+          <% if lease_enforced?(curation_concern) %>
             <%= f.submit t('.lease_update'), class: 'btn btn-primary' %>
             <%= link_to t('.lease_deactivate'), lease_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
           <% else %>
@@ -48,7 +48,7 @@
     <h2 class="card-title"><%= t('.header.past') %></h2>
   </div>
   <div class="card-body">
-    <% if curation_concern.lease_history.empty? %>
+    <% if lease_history(curation_concern).empty? %>
       <%= t('.history_empty', cc: cc_type) %>
     <% else %>
       <%= render partial: 'lease_history', object: curation_concern.lease_history %>

--- a/lib/hyrax/active_fedora_dummy_model.rb
+++ b/lib/hyrax/active_fedora_dummy_model.rb
@@ -37,6 +37,12 @@ module Hyrax
 
     ##
     # @api public
+    def to_key
+      [@id]
+    end
+
+    ##
+    # @api public
     def model_name
       @model.model_name
     end

--- a/lib/hyrax/active_fedora_dummy_model.rb
+++ b/lib/hyrax/active_fedora_dummy_model.rb
@@ -49,6 +49,13 @@ module Hyrax
 
     ##
     # @api public
+    # @return [String]
+    def human_readable_type
+      @model.human_readable_type
+    end
+
+    ##
+    # @api public
     #
     # @note uses the @model's `._to_partial_path` if implemented, otherwise
     #   constructs a default

--- a/lib/hyrax/specs/shared_specs/factories/strategies/valkyrie_resource.rb
+++ b/lib/hyrax/specs/shared_specs/factories/strategies/valkyrie_resource.rb
@@ -3,6 +3,12 @@
 # @example
 #   let(:resource) { FactoryBot.valkyrie_create(:hyrax_work) }
 class ValkyrieCreateStrategy
+  def initialize
+    @strategy = FactoryBot.strategy_by_name(:create).new
+  end
+
+  delegate :association, to: :@strategy
+
   def result(evaluation)
     evaluation.notify(:after_build, evaluation.object)
     evaluation.notify(:before_create, evaluation.object)

--- a/spec/actors/hyrax/actors/embargo_actor_spec.rb
+++ b/spec/actors/hyrax/actors/embargo_actor_spec.rb
@@ -1,37 +1,96 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Actors::EmbargoActor do
   let(:actor) { described_class.new(work) }
-
-  let(:work) do
-    GenericWork.new do |work|
-      work.apply_depositor_metadata 'foo'
-      work.title = ["test"]
-      work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-      work.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-      work.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-      work.embargo_release_date = release_date.to_s
-      work.save(validate: false)
-    end
-  end
+  let(:authenticated_vis) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+  let(:public_vis) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
 
   describe "#destroy" do
-    context "with an active embargo" do
-      let(:release_date) { Time.zone.today + 2 }
+    let(:work) do
+      FactoryBot.valkyrie_create(:hyrax_resource, :under_embargo)
+    end
 
-      it "removes the embargo" do
-        actor.destroy
-        expect(work.reload.embargo_release_date).to be_nil
-        expect(work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    before do
+      work.visibility = authenticated_vis
+      Hyrax::AccessControlList(work).save
+    end
+
+    it "removes the embargo" do
+      expect { actor.destroy }
+        .to change { Hyrax::EmbargoManager.new(resource: work).under_embargo? }
+        .from(true)
+        .to false
+    end
+
+    it "does not change the visibility" do
+      expect { actor.destroy }
+        .not_to change { work.visibility }
+        .from authenticated_vis
+    end
+
+    context "with an expired embargo" do
+      let(:work) do
+        FactoryBot.valkyrie_create(:hyrax_resource, embargo: embargo)
+      end
+
+      let(:embargo) { FactoryBot.build(:hyrax_embargo) }
+
+      before do
+        allow(Hyrax::TimeService)
+          .to receive(:time_in_utc)
+          .and_return(work.embargo.embargo_release_date + 1)
+      end
+
+      it "leaves the embargo in place" do
+        expect { actor.destroy }
+          .not_to change { work.embargo.embargo_release_date }
+      end
+
+      it "releases the embargo" do
+        expect { actor.destroy }
+          .to change { Hyrax::EmbargoManager.new(resource: work).enforced? }
+          .from(true)
+          .to false
+      end
+
+      it "changes the visibility" do
+        expect { actor.destroy }
+          .to change { work.visibility }
+          .from(authenticated_vis)
+          .to public_vis
       end
     end
 
-    context 'with an expired embargo' do
-      let(:release_date) { Time.zone.today - 2 }
+    context "with a ActiveFedora model" do
+      let(:work) do
+        GenericWork.new do |work|
+          work.apply_depositor_metadata 'foo'
+          work.title = ["test"]
+          work.visibility =
+            work.visibility_during_embargo = authenticated_vis
+          work.visibility_after_embargo = public_vis
+          work.embargo_release_date = release_date.to_s
+          work.save(validate: false)
+        end
+      end
 
-      it "removes the embargo" do
-        actor.destroy
-        expect(work.reload.embargo_release_date).to be_nil
-        expect(work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      context "with an active embargo" do
+        let(:release_date) { Time.zone.today + 2 }
+
+        it "removes the embargo" do
+          actor.destroy
+          expect(work.reload.embargo_release_date).to be_nil
+          expect(work.visibility).to eq authenticated_vis
+        end
+      end
+
+      context 'with an expired embargo' do
+        let(:release_date) { Time.zone.today - 2 }
+
+        it "removes the embargo" do
+          actor.destroy
+          expect(work.reload.embargo_release_date).to be_nil
+          expect(work.visibility).to eq public_vis
+        end
       end
     end
   end

--- a/spec/actors/hyrax/actors/lease_actor_spec.rb
+++ b/spec/actors/hyrax/actors/lease_actor_spec.rb
@@ -1,55 +1,115 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Actors::LeaseActor do
   let(:actor) { described_class.new(work) }
-
-  let(:work) do
-    GenericWork.new do |work|
-      work.apply_depositor_metadata 'foo'
-      work.title = ["test"]
-      work.visibility_during_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-      work.visibility_after_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-      work.lease_expiration_date = release_date.to_s
-      work.save(validate: false)
-    end
-  end
+  let(:authenticated_vis) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+  let(:public_vis) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+  let(:private_vis) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
   describe "#destroy" do
+    let(:work) do
+      FactoryBot.valkyrie_create(:hyrax_resource, :under_lease)
+    end
+
     before do
-      actor.destroy
+      work.visibility = public_vis
+      Hyrax::AccessControlList(work).save
     end
 
-    context "with an active lease" do
-      let(:release_date) { Time.zone.today + 2 }
+    it "removes the lease" do
+      expect { actor.destroy }
+        .to change { Hyrax::LeaseManager.new(resource: work).under_lease? }
+        .from(true)
+        .to false
+    end
 
-      it "removes the lease" do
-        expect(work.reload.lease_expiration_date).to be_nil
-        expect(work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    it "does not change the visibility" do
+      expect { actor.destroy }
+        .not_to change { work.visibility }
+        .from public_vis
+    end
+
+    context "with an expired lease" do
+      let(:work) do
+        FactoryBot.valkyrie_create(:hyrax_resource, lease: lease)
+      end
+
+      let(:lease) { FactoryBot.build(:hyrax_lease) }
+
+      before do
+        allow(Hyrax::TimeService)
+          .to receive(:time_in_utc)
+          .and_return(work.lease.lease_expiration_date + 1)
+      end
+
+      it "leaves the lease in place" do
+        expect { actor.destroy }
+          .not_to change { work.lease.lease_expiration_date }
+      end
+
+      it "releases the lease" do
+        expect { actor.destroy }
+          .to change { Hyrax::LeaseManager.new(resource: work).enforced? }
+          .from(true)
+          .to false
+      end
+
+      it "changes the visibility" do
+        expect { actor.destroy }
+          .to change { work.visibility }
+          .from(public_vis)
+          .to authenticated_vis
       end
     end
 
-    context 'with an expired lease' do
-      let(:release_date) { Time.zone.today - 2 }
+    context "with a ActiveFedora model" do
+      let(:work) do
+        GenericWork.new do |work|
+          work.apply_depositor_metadata 'foo'
+          work.title = ["test"]
+          work.visibility_during_lease = public_vis
+          work.visibility_after_lease = private_vis
+          work.lease_expiration_date = release_date.to_s
+          work.save(validate: false)
+        end
+      end
 
-      it "removes the lease" do
-        expect(work.reload.lease_expiration_date).to be_nil
-        expect(work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      before do
+        actor.destroy
+      end
+
+      context "with an active lease" do
+        let(:release_date) { Time.zone.today + 2 }
+
+        it "removes the lease" do
+          expect(work.reload.lease_expiration_date).to be_nil
+          expect(work.visibility).to eq public_vis
+        end
+      end
+
+      context 'with an expired lease' do
+        let(:release_date) { Time.zone.today - 2 }
+
+        it "removes the lease" do
+          expect(work.reload.lease_expiration_date).to be_nil
+          expect(work.visibility).to eq private_vis
+        end
       end
     end
-  end
 
-  context 'deactivating an expired lease', clean_repo: true do
-    let(:lease_attributes) do
-      { lease_date: Date.tomorrow.to_s,
-        current_state: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
-        future_state: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
-    end
-    let(:leased_work) { create(:leased_work, with_lease_attributes: lease_attributes) }
-    let(:subject) { described_class.new(leased_work) }
+    context 'deactivating an expired lease', clean_repo: true do
+      let(:lease_attributes) do
+        { lease_date: Date.tomorrow.to_s,
+          current_state: public_vis,
+          future_state: authenticated_vis }
+      end
+      let(:leased_work) { create(:leased_work, with_lease_attributes: lease_attributes) }
+      let(:subject) { described_class.new(leased_work) }
 
-    it 'destroys and reindexes the new permission appropriately in solr', with_nested_reindexing: true do
-      allow(leased_work.lease).to receive(:active?).and_return false
-      subject.destroy
-      expect(::SolrDocument.find(leased_work.id)[:visibility_ssi]).to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
+      it 'destroys and reindexes the new permission appropriately in solr', with_nested_reindexing: true do
+        allow(leased_work.lease).to receive(:active?).and_return false
+        subject.destroy
+        expect(::SolrDocument.find(leased_work.id)[:visibility_ssi]).to eq(authenticated_vis)
+      end
     end
   end
 end

--- a/spec/controllers/hyrax/embargoes_controller_spec.rb
+++ b/spec/controllers/hyrax/embargoes_controller_spec.rb
@@ -56,15 +56,8 @@ RSpec.describe Hyrax::EmbargoesController do
     end
 
     context 'when I have permission to edit the object' do
-      before do
-        expect(Hyrax::Actors::EmbargoActor).to receive(:new).with(a_work).and_return(actor)
-      end
-
-      let(:actor) { double }
-
       context 'that has no files' do
         it 'deactivates embargo and redirects' do
-          expect(actor).to receive(:destroy)
           get :destroy, params: { id: a_work }
           expect(response).to redirect_to edit_embargo_path(a_work)
         end
@@ -77,7 +70,6 @@ RSpec.describe Hyrax::EmbargoesController do
         end
 
         it 'deactivates embargo and checks to see if we want to copy the visibility to files' do
-          expect(actor).to receive(:destroy)
           get :destroy, params: { id: a_work }
           expect(response).to redirect_to confirm_permission_path(a_work)
         end

--- a/spec/controllers/hyrax/leases_controller_spec.rb
+++ b/spec/controllers/hyrax/leases_controller_spec.rb
@@ -59,15 +59,8 @@ RSpec.describe Hyrax::LeasesController do
     end
 
     context 'when I have permission to edit the object' do
-      let(:actor) { double('lease actor') }
-
-      before do
-        allow(Hyrax::Actors::LeaseActor).to receive(:new).with(a_work).and_return(actor)
-      end
-
       context 'that has no files' do
         it 'deactivates the lease and redirects' do
-          expect(actor).to receive(:destroy)
           get :destroy, params: { id: a_work }
           expect(response).to redirect_to edit_lease_path(a_work)
         end
@@ -80,7 +73,6 @@ RSpec.describe Hyrax::LeasesController do
         end
 
         it 'deactivates the lease and redirects' do
-          expect(actor).to receive(:destroy)
           get :destroy, params: { id: a_work }
           expect(response).to redirect_to confirm_permission_path(a_work)
         end

--- a/spec/features/embargo_spec.rb
+++ b/spec/features/embargo_spec.rb
@@ -70,6 +70,8 @@ RSpec.describe 'embargo' do
     let(:work) do
       create(:work, title: ['embargoed work1'],
                     embargo_release_date: future_date.to_datetime.iso8601,
+                    visibility_after_embargo: 'open',
+                    visibility_during_embargo: 'restricted',
                     admin_set_id: my_admin_set.id,
                     edit_users: [user])
     end


### PR DESCRIPTION
take a first pass through the `EmbargoController` to make it pass the tests when ActiveFedora is not available. it's likely that this doesn't translate into a fully working Manage Embargoes dashboard page, but it's a start.

---

followed up by a second pass which fixes up some behavior on `EmbargoActor`. i think there's still more to do, but given that this behavior isn't very thoroughly tested, it's going to take some trial and error to get it right.

----

now a third pass to pass the feature tests related to embargo/lease.

@samvera/hyrax-code-reviewers
