### PR TITLE
Remove the setting of values twice and method already present in FilterType.

### DIFF
--- a/app/search_builders/hyrax/collection_member_search_builder.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder.rb
@@ -30,7 +30,7 @@ module Hyrax
     # include filters into the query to only include the collection memebers
     def member_of_collection(solr_parameters)
       solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << "#{collection_membership_field}:#{collection.id}"
+      solr_parameters[:fq] << "#{collection_membership_field}:#{@collection.id}"
     end
 
     private

--- a/app/search_builders/hyrax/collection_member_search_builder.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder.rb
@@ -3,7 +3,7 @@ module Hyrax
   # This search builder requires that a accessor named "collection" exists in the scope
   class CollectionMemberSearchBuilder < ::Hyrax::CollectionSearchBuilder
     include Hyrax::FilterByType
-    attr_writer :collection, :search_includes_models
+    attr_accessor :collection, :search_includes_models
 
     class_attribute :collection_membership_field
     self.collection_membership_field = 'member_of_collection_ids_ssim'

--- a/app/search_builders/hyrax/collection_member_search_builder.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder.rb
@@ -36,11 +36,11 @@ module Hyrax
     private
 
     def only_works?
-      search_includes_models == :works
+      @search_includes_models == :works
     end
 
     def only_collections?
-      search_includes_models == :collections
+      @search_includes_models == :collections
     end
   end
 end

--- a/app/search_builders/hyrax/collection_member_search_builder.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder.rb
@@ -17,8 +17,8 @@ module Hyrax
                    scope: nil,
                    collection: nil,
                    search_includes_models: nil)
-      @collection = collection
-      @search_includes_models = search_includes_models
+      @collection = collection || (scope.context[:collection] if scope&.respond_to?(:context))
+      @search_includes_models = search_includes_models || :works
 
       if args.any?
         super(*args)
@@ -27,23 +27,10 @@ module Hyrax
       end
     end
 
-    def collection
-      @collection || (scope.context[:collection] if scope&.respond_to?(:context))
-    end
-
-    def search_includes_models
-      @search_includes_models || :works
-    end
-
     # include filters into the query to only include the collection memebers
     def member_of_collection(solr_parameters)
       solr_parameters[:fq] ||= []
       solr_parameters[:fq] << "#{collection_membership_field}:#{collection.id}"
-    end
-
-    # This overrides the models in FilterByType
-    def models
-      work_classes + collection_classes
     end
 
     private


### PR DESCRIPTION
Changes proposed in this pull request:
* Allows the class initializer to set alternate values if both come in as nil, which allows `collection` and `search_includes_models` definition methods to go away.
* Removes the `models` method, since it is now identical in FilterByType (which is included in this class).

@samvera/hyrax-code-reviewers
