### PR TITLE
[3.x] Delegate collection visibility to model

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -9,7 +9,7 @@ module Hyrax
       attr_reader :scope
 
       delegate :id, :depositor, :permissions, :human_readable_type, :member_ids, :nestable?,
-               :alternative_title, to: :model
+               :alternative_title, :visibility, to: :model
 
       class_attribute :membership_service_class
 

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -117,6 +117,12 @@ RSpec.describe Hyrax::Forms::CollectionForm, skip: !(Hyrax.config.collection_cla
     it { is_expected.to eq 'Collection' }
   end
 
+  describe "#visibility" do
+    subject { form.visibility }
+
+    it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+  end
+
   describe "#member_ids" do
     before do
       allow(collection).to receive(:member_ids).and_return(['9999'])


### PR DESCRIPTION
Fixes the collection form object not containing any visibility data. 

This caused the collection edit form to not have the current visibility checked.

This fix is not needed with hydra-head 12 & hyrax 4 thanks to this commit:
https://github.com/samvera/hydra-head/commit/57405cce591e3a6525907825c835093ffd43e29f