### PR TITLE
helperize Embargo edit view dependencies on ActiveFedora behavior

### DIFF
--- a/app/helpers/hyrax/embargo_helper.rb
+++ b/app/helpers/hyrax/embargo_helper.rb
@@ -40,5 +40,16 @@ module Hyrax
         Hyrax::EmbargoManager.new(resource: resource).enforced?
       end
     end
+
+    ##
+    # @since 3.5.0
+    #
+    # @param [#embargo_history, #embargo] resource
+    #
+    # @return [Array]
+    def embargo_history(resource)
+      resource.try(:embargo_history) ||
+        Array(resource.embargo&.embargo_history)
+    end
   end
 end

--- a/app/helpers/hyrax/lease_helper.rb
+++ b/app/helpers/hyrax/lease_helper.rb
@@ -40,5 +40,16 @@ module Hyrax
         Hyrax::LeaseManager.new(resource: resource).enforced?
       end
     end
+
+    ##
+    # @since 3.5.0
+    #
+    # @param [#lease_history, #lease] resource
+    #
+    # @return [Array]
+    def lease_history(resource)
+      resource.try(:lease_history) ||
+        Array(resource.lease&.lease_history)
+    end
   end
 end

--- a/app/views/hyrax/embargoes/edit.html.erb
+++ b/app/views/hyrax/embargoes/edit.html.erb
@@ -13,7 +13,7 @@
       <fieldset class="set-access-controls">
         <section class="form-text">
           <p>
-            <% if curation_concern.embargo_release_date %>
+            <% if embargo_enforced?(curation_concern) %>
               <%= t('.embargo_true_html',  cc: cc_type) %>
             <% else %>
               <%= t('.embargo_false_html', cc: cc_type) %>
@@ -29,7 +29,7 @@
 
       <div class="row">
         <div class="col-md-12 form-actions">
-          <% if curation_concern.embargo_release_date %>
+          <% if embargo_enforced?(curation_concern) %>
             <%= f.submit t('.embargo_update'), class: 'btn btn-primary' %>
             <%= link_to t('.embargo_deactivate'), embargo_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
           <% else %>
@@ -48,10 +48,10 @@
     <h2 class="card-title"><%= t('.header.past') %></h2>
   </div>
   <div class="card-body">
-    <% if curation_concern.embargo_history.empty? %>
+    <% if embargo_history(curation_concern).empty? %>
       <%= t('.history_empty', cc: cc_type) %>
     <% else %>
-      <%= render partial: "embargo_history", object: curation_concern.embargo_history %>
+      <%= render partial: "embargo_history", object: embargo_history(curation_concern) %>
     <% end %>
   </div>
 </div>

--- a/spec/helpers/hyrax/embargo_helper_spec.rb
+++ b/spec/helpers/hyrax/embargo_helper_spec.rb
@@ -152,4 +152,47 @@ RSpec.describe Hyrax::EmbargoHelper do
       end
     end
   end
+
+  describe '#embargo_history' do
+    context 'with an ActiveFedora resource' do
+      let(:resource) { FactoryBot.build(:work) }
+
+      it 'is empty' do
+        expect(embargo_history(resource)).to be_empty
+      end
+
+      context 'when the resource is under embargo' do
+        let(:resource) { FactoryBot.build(:embargoed_work) }
+
+        before do
+          resource.embargo.embargo_history << "updated the lease"
+        end
+
+        it 'has a history' do
+          expect(embargo_history(resource)).to contain_exactly("updated the lease")
+        end
+      end
+    end
+
+    context 'with a Hyrax::Work' do
+      let(:resource) { FactoryBot.build(:hyrax_work) }
+
+      it 'is empty' do
+        expect(embargo_history(resource)).to be_empty
+      end
+
+      context 'when the resource is under embargo' do
+        let(:resource) { FactoryBot.build(:hyrax_work, :under_embargo) }
+
+        before do
+          resource.embargo.embargo_history = ['Embargo in place!', 'Embargo expired!']
+        end
+
+        it 'contains the lease history' do
+          expect(embargo_history(resource))
+            .to contain_exactly 'Embargo in place!', 'Embargo expired!'
+        end
+      end
+    end
+  end
 end

--- a/spec/helpers/hyrax/lease_helper_spec.rb
+++ b/spec/helpers/hyrax/lease_helper_spec.rb
@@ -149,4 +149,47 @@ RSpec.describe Hyrax::LeaseHelper do
       end
     end
   end
+
+  describe '#lease_history' do
+    context 'with an ActiveFedora resource' do
+      let(:resource) { FactoryBot.build(:work) }
+
+      it 'is empty' do
+        expect(lease_history(resource)).to be_empty
+      end
+
+      context 'when the resource is under lease' do
+        let(:resource) { FactoryBot.build(:leased_work) }
+
+        before do
+          resource.lease.lease_history << "updated the lease"
+        end
+
+        it 'has a history' do
+          expect(lease_history(resource)).to contain_exactly("updated the lease")
+        end
+      end
+    end
+
+    context 'with a Hyrax::Work' do
+      let(:resource) { FactoryBot.build(:hyrax_work) }
+
+      it 'is empty' do
+        expect(lease_history(resource)).to be_empty
+      end
+
+      context 'when the resource is under lease' do
+        let(:resource) { FactoryBot.build(:hyrax_work, :under_lease) }
+
+        before do
+          resource.lease.lease_history = ['Lease in place!', 'Lease expired!']
+        end
+
+        it 'contains the lease history' do
+          expect(lease_history(resource))
+            .to contain_exactly 'Lease in place!', 'Lease expired!'
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
this view depended directly on ActiveFedora and `Hydra::AccessControls` specific
behavior. helperize those dependencies so the view can be extended to support
Valkyrie.

@samvera/hyrax-code-reviewers
