### PR TITLE
backport: don't load_and_authorize a model when indexing Embargoes

### DIFF
--- a/app/controllers/concerns/hyrax/manages_embargoes.rb
+++ b/app/controllers/concerns/hyrax/manages_embargoes.rb
@@ -6,7 +6,7 @@ module Hyrax
     included do
       attr_accessor :curation_concern
       helper_method :curation_concern
-      load_and_authorize_resource class: ActiveFedora::Base, instance_name: :curation_concern
+      load_and_authorize_resource class: ActiveFedora::Base, instance_name: :curation_concern, except: [:index]
     end
 
     # This is an override of Hyrax::ApplicationController


### PR DESCRIPTION
backport #5809 to 3.x

@samvera/hyrax-code-reviewers
