### PR TITLE
backport: provide default PermissionBadge presenter behavior when `nil`

### DIFF
--- a/app/presenters/hyrax/permission_badge.rb
+++ b/app/presenters/hyrax/permission_badge.rb
@@ -24,14 +24,15 @@ module Hyrax
     private
 
     def dom_label_class
-      VISIBILITY_LABEL_CLASS.fetch(@visibility.to_sym, 'label-info')
+      VISIBILITY_LABEL_CLASS.fetch(@visibility&.to_sym, 'label-info')
     end
 
     def text
       if registered?
         Institution.name
       else
-        I18n.t("hyrax.visibility.#{@visibility}.text")
+        visibility_key = @visibility || 'unknown'
+        I18n.t("hyrax.visibility.#{visibility_key}.text")
       end
     end
 

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1687,6 +1687,8 @@ en:
         note_html: Keep to myself with option to share.
         text: Private
       restricted_title_attr: Change the visibility of this resource
+      unknown:
+        text: Unknown
     work_button_row:
       attach_child: Attach Child
     workflow:

--- a/spec/presenters/hyrax/permission_badge_spec.rb
+++ b/spec/presenters/hyrax/permission_badge_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe Hyrax::PermissionBadge do
       context "when private" do
         it { is_expected.to eq "<span class=\"label label-danger\">Private</span>" }
       end
+
+      # solr document can have no visibility indexed
+      it "does not fail when nil is passed" do
+        badge = described_class.new(nil)
+
+        expect(badge.render).to eq "<span class=\"label label-info\">Unknown</span>"
+      end
     end
   end
 


### PR DESCRIPTION
if visibility wasn't indexed for any item, the `PermissionBadge` presenter will
cause any relevant page not to render.

this fixes that issue by providing a reasonable default display badge in the
case that we can't identify the visibility from the indexed data.

@samvera/hyrax-code-reviewers
