### PR TITLE
Remove whitespace from jsonld spec

### DIFF
--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -509,13 +509,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
       subject { presenter.export_as_jsonld }
 
       it do
-        is_expected.to eq '{
-  "@context": {
-    "dc": "http://purl.org/dc/terms/"
-  },
-  "@id": "http://example.com/1",
-  "dc:title": "Test title"
-}'
+        is_expected.to eq '{"@context":{"dc":"http://purl.org/dc/terms/"},"@id":"http://example.com/1","dc:title":"Test title"}'
       end
     end
   end


### PR DESCRIPTION
Starting with json-ld 3.2.2 the jsonld output is no longer pretty formatted by default.

@samvera/hyrax-code-reviewers
