### PR TITLE
check json, not string equality for JSON-LD output

### DIFF
--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -508,7 +508,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
     describe "#export_as_jsonld" do
       it do
         json = '{"@context": {"dc": "http://purl.org/dc/terms/"},"@id": "http://example.com/1","dc:title": "Test title"}'
-b
+
         expect(JSON.parse(presenter.export_as_jsonld)).to eq JSON.parse(json)
       end
     end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -508,7 +508,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
     describe "#export_as_jsonld" do
       it do
         json = '{"@context": {"dc": "http://purl.org/dc/terms/"},"@id": "http://example.com/1","dc:title": "Test title"}'
-
+b
         expect(JSON.parse(presenter.export_as_jsonld)).to eq JSON.parse(json)
       end
     end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -506,10 +506,10 @@ RSpec.describe Hyrax::WorkShowPresenter do
     end
 
     describe "#export_as_jsonld" do
-      subject { presenter.export_as_jsonld }
-
       it do
-        is_expected.to eq '{"@context":{"dc":"http://purl.org/dc/terms/"},"@id":"http://example.com/1","dc:title":"Test title"}'
+        json = '{"@context": {"dc": "http://purl.org/dc/terms/"},"@id": "http://example.com/1","dc:title": "Test title"}'
+
+        expect(JSON.parse(presenter.export_as_jsonld)).to eq JSON.parse(json)
       end
     end
   end


### PR DESCRIPTION
we care about the equality of the JSON structure, not the specific string output. the latter depends on the serialization code, which can change independently of our codebase

@samvera/hyrax-code-reviewers
