### PR TITLE
Improving file handle life cycle

### DIFF
--- a/app/services/hyrax/local_file_service.rb
+++ b/app/services/hyrax/local_file_service.rb
@@ -5,7 +5,9 @@ module Hyrax
     # @param [Hash] _options
     # @yield [File] opens the file and yields it to the block
     def self.call(file_name, _options)
-      yield File.open(file_name)
+      File.open(file_name) do |file|
+        yield(file)
+      end
     end
   end
 end


### PR DESCRIPTION
What follows is speculation, but informed by the [File.open documentation][1].

Prior to this commit, there was no guarantee that once we opened a file,
we would close it.  This means that as this process ran we could
accumulate open file handles on the system.

By switching to the `File.open { |file| ... }` approach the
aforementioned block will ensure that we close the file when the block
terminates.

Note: This came about in trying to debug the callstack for
[ruby2-6 (65220) - samvera/hyrax][2]

[1]:https://ruby-doc.org/core-2.7.2/File.html#method-c-open
[2]:https://app.circleci.com/pipelines/github/samvera/hyrax/8274/workflows/26246722-a8e8-43a0-a1fa-7b32db139856/jobs/65220

@samvera/hyrax-code-reviewers
