### PR TITLE
Allow some specs to run with Wings undefined

### DIFF
--- a/spec/support/book_resource.rb
+++ b/spec/support/book_resource.rb
@@ -33,4 +33,4 @@ module Hyrax
   end
 end
 
-Wings::ModelRegistry.register(Hyrax::Test::BookResource, Hyrax::Test::Book)
+Wings::ModelRegistry.register(Hyrax::Test::BookResource, Hyrax::Test::Book) if defined?(Wings)

--- a/spec/support/simple_work.rb
+++ b/spec/support/simple_work.rb
@@ -25,4 +25,4 @@ module Hyrax
   end
 end
 
-Wings::ModelRegistry.register(Hyrax::Test::SimpleWork, Hyrax::Test::SimpleWorkLegacy)
+Wings::ModelRegistry.register(Hyrax::Test::SimpleWork, Hyrax::Test::SimpleWorkLegacy) if defined?(Wings)


### PR DESCRIPTION
Only attempt to register models with Wings if Wings is defined.  This allows running tests that use these resource models in Koppie.