### PR TITLE
Factory method for finding collection type from collection

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -108,7 +108,7 @@ module Hyrax
 
         # Do not apply permissions to work if collection type is configured not to
         collection = Hyrax.config.collection_class.find(collection_id)
-        return unless collection.share_applies_to_new_works?
+        return unless Hyrax::CollectionType.for(collection: collection).share_applies_to_new_works?
 
         # Save the collection id in env for use in apply_permission_template_actor
         env.attributes[:collection_id] = collection_id

--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -76,11 +76,15 @@ module Hyrax
       @_prefixes ||= super + ['catalog', 'hyrax/base']
     end
 
+    # rubocop:disable Style/GuardClause
     def query_collection_members
       load_member_works
-      load_member_subcollections if collection.collection_type.nestable?
-      load_parent_collections if collection.collection_type.nestable? && action_name == 'show'
+      if Hyrax::CollectionType.for(collection: collection).nestable?
+        load_member_subcollections
+        load_parent_collections if action_name == 'show'
+      end
     end
+    # rubocop:enable Style/GuardClause
 
     # Instantiate the membership query service
     def collection_member_service

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -190,7 +190,7 @@ module Hyrax
         @collection.collection_type_gid = params[:collection_type_gid].presence || default_collection_type.to_global_id
         @collection.attributes = collection_params.except(:members, :parent_id, :collection_type_gid)
         @collection.apply_depositor_metadata(current_user.user_key)
-        @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE unless @collection.discoverable?
+        @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE unless Hyrax::CollectionType.for(collection: @collection).discoverable?
         if @collection.save
           after_create_response
         else
@@ -218,7 +218,7 @@ module Hyrax
         process_member_changes
         process_branding
 
-        @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE unless @collection.discoverable?
+        @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE unless Hyrax::CollectionType.for(collection: @collection).discoverable?
         # we don't have to reindex the full graph when updating collection
         @collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
         if @collection.update(collection_params.except(:members))

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -137,8 +137,7 @@ module Hyrax
         def nestable?(collection)
           return false if collection.blank?
           return collection.nestable? if collection.respond_to? :nestable?
-          collection_type = Hyrax::CollectionType.find_by_gid!(collection.collection_type_gid)
-          collection_type.nestable?
+          Hyrax::CollectionType.for(collection: collection).nestable?
         end
       end
     end

--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -123,14 +123,7 @@ module Hyrax
     ##
     # @param collection [Object]
     def collection_type_label_for(collection:)
-      case collection
-      when Valkyrie::Resource
-        CollectionType
-          .find_by_gid!(collection.collection_type_gid)
-          .title
-      else
-        collection.collection_type.title
-      end
+      CollectionType.for(collection: collection).title
     end
 
     ##
@@ -138,14 +131,7 @@ module Hyrax
     #
     # @return [Boolean]
     def collection_brandable?(collection:)
-      case collection
-      when Valkyrie::Resource
-        CollectionType
-          .find_by_gid!(collection.collection_type_gid)
-          .brandable?
-      else
-        collection.try(:brandable?)
-      end
+      CollectionType.for(collection: collection).brandable?
     end
 
     ##
@@ -153,14 +139,7 @@ module Hyrax
     #
     # @return [Boolean]
     def collection_discoverable?(collection:)
-      case collection
-      when Valkyrie::Resource
-        CollectionType
-          .find_by_gid!(collection.collection_type_gid)
-          .discoverable?
-      else
-        collection.try(:discoverable?)
-      end
+      CollectionType.for(collection: collection).discoverable?
     end
 
     ##
@@ -168,14 +147,7 @@ module Hyrax
     #
     # @return [Boolean]
     def collection_sharable?(collection:)
-      case collection
-      when Valkyrie::Resource
-        CollectionType
-          .find_by_gid!(collection.collection_type_gid)
-          .sharable?
-      else
-        collection.try(:sharable?)
-      end
+      CollectionType.for(collection: collection).sharable?
     end
 
     ##

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -43,6 +43,8 @@ module Hyrax
 
     # Get the collection_type when accessed
     def collection_type
+      Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
+                         "Instead, use Hyrax::CollectionType.for(collection: collection).")
       @collection_type ||= Hyrax::CollectionType.find_by_gid!(collection_type_gid)
     end
 

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -40,6 +40,7 @@ module Hyrax
     end
 
     delegate(*Hyrax::CollectionType.settings_attributes, to: :collection_type)
+    ActiveSupport::Deprecation.deprecate_methods(self, *Hyrax::CollectionType.settings_attributes)
 
     # Get the collection_type when accessed
     def collection_type

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -52,6 +52,14 @@ module Hyrax
     alias_attribute :visibility, :assigns_visibility
     alias_attribute :branding, :brandable
 
+    # Find the collection type associated with the collection
+    # @param [::Collection, Hyrax::PcdmCollection] collection
+    # @return [Hyrax::PcdmCollection | ::Collection] an instance of Hyrax::CollectionType with id = the model_id portion of the gid (e.g. 3)
+    # @raise [ActiveRecord::RecordNotFound] if record matching gid is not found
+    def self.for(collection:)
+      find_by_gid!(collection.collection_type_gid)
+    end
+
     # Find the collection type associated with the Global Identifier (gid)
     # @param [String] gid - Global Identifier for this collection_type (e.g. gid://internal/hyrax-collectiontype/3)
     # @return [Hyrax::CollectionType] if record matching gid is found, an instance of Hyrax::CollectionType with id = the model_id portion of the gid (e.g. 3)

--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -34,6 +34,11 @@ module Hyrax
       @collection_type ||= Hyrax::CollectionType.find_or_create_admin_set_type
     end
 
+    # Overrides delegate because admin sets do not index collection type gid
+    def collection_type_gid
+      collection_type.to_global_id
+    end
+
     def show_path
       Hyrax::Engine.routes.url_helpers.admin_admin_set_path(id, locale: I18n.locale)
     end

--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -218,8 +218,7 @@ module Hyrax
       def self.nestable?(collection:)
         return false if collection.blank?
         return collection.nestable? if collection.respond_to? :nestable?
-        collection_type = Hyrax::CollectionType.find_by_gid!(collection.collection_type_gid)
-        collection_type.nestable?
+        Hyrax::CollectionType.for(collection: collection).nestable?
       end
       private_class_method :nestable?
     end

--- a/app/services/hyrax/edit_permissions_service.rb
+++ b/app/services/hyrax/edit_permissions_service.rb
@@ -202,20 +202,7 @@ module Hyrax
         # Hyrax::AdministrativeSet, we need to test both cases.
         true
       else
-        if resource.respond_to?(:share_applies_to_new_works?)
-          # The Collection model has traditionally delegated #share_applies_to_new_works? to
-          # the underlying collection_type
-          # (see https://github.com/samvera/hyrax/blob/696da5db/spec/models/collection_spec.rb#L189)
-          resource.share_applies_to_new_works?
-        elsif resource.respond_to?(:collection_type_gid)
-          # This is likely a Hyrax::PcdmCollection object, which means we don't have the delegation
-          # behavior.  Instead we'll query the collection type directly.
-          collection_type = CollectionType.find_by_gid(resource.collection_type_gid)
-          collection_type&.share_applies_to_new_works?
-        else
-          # How might we get here?
-          false
-        end
+        Hyrax::CollectionType.for(collection: resource).share_applies_to_new_works?
       end
     end
 

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -132,6 +132,11 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor, skip: !(Hyrax.config.c
       let!(:collection_type) { create(:collection_type) }
       let!(:collection) { FactoryBot.create(:collection_lw, collection_type: collection_type, with_permission_template: true) }
 
+      before do
+        # Return the collection type instance which has stubs
+        allow(Hyrax::CollectionType).to receive(:for).with(collection: collection).and_return(collection_type)
+      end
+
       subject(:middleware) do
         stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
           middleware.use described_class
@@ -141,7 +146,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor, skip: !(Hyrax.config.c
 
       context "when share applies to works" do
         before do
-          allow(collection.collection_type).to receive(:share_applies_to_works).and_return(true)
+          allow(collection_type).to receive(:share_applies_to_works).and_return(true)
         end
 
         context "and only one collection" do
@@ -186,7 +191,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor, skip: !(Hyrax.config.c
 
       context "when share does NOT apply to works" do
         before do
-          allow(collection.collection_type).to receive(:share_applies_to_new_works?).and_return(false)
+          allow(collection_type).to receive(:share_applies_to_new_works?).and_return(false)
           allow(Collection).to receive(:find).with(collection.id).and_return(collection)
           allow(Collection).to receive(:find).with([collection.id]).and_return([collection])
         end

--- a/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/nest_collections_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
   end
 
   let(:parent) do
-    FactoryBot.create(:collection_lw, collection_type_settings: :nestable, user: user)
+    FactoryBot.valkyrie_create(:hyrax_collection, :public, user: user)
   end
 
   before { sign_in(user) }
@@ -21,8 +21,8 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
     Class.new do
       attr_reader :child, :parent
       def initialize(parent: nil, parent_id: nil, child: nil, child_id: nil, context:)
-        @parent = parent || (parent_id.present? && Hyrax.config.collection_class.find(parent_id))
-        @child = child || (child_id.present? && Hyrax.config.collection_class.find(child_id))
+        @parent = parent || (parent_id.present? && Hyrax.query_service.find_by(id: parent_id))
+        @child = child || (child_id.present? && Hyrax.query_service.find_by(id: child_id))
         @context = context
       end
     end
@@ -139,7 +139,7 @@ RSpec.describe Hyrax::Dashboard::NestCollectionsController do
         get 'create_collection_under', params: parameters
 
         expect(response)
-          .to redirect_to new_dashboard_collection_path(collection_type_id: parent.collection_type.id,
+          .to redirect_to new_dashboard_collection_path(collection_type_id: Hyrax::CollectionType.for(collection: parent).id,
                                                         parent_id: parent.id)
       end
     end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -286,7 +286,7 @@ FactoryBot.define do
     # @param [Collection] collection object being built/created by the factory
     # @param [Class] evaluator holding the transient properties for the current build/creation process
     def self.process_with_nesting_attributes(collection, evaluator)
-      return unless evaluator.with_nesting_attributes.present? && collection.nestable?
+      return unless evaluator.with_nesting_attributes.present? && Hyrax::CollectionType.for(collection: collection).nestable?
       Hyrax::Adapters::NestingIndexAdapter.add_nesting_attributes(
         solr_doc: solr_document_with_permissions(collection, evaluator),
         ancestors: evaluator.with_nesting_attributes[:ancestors],
@@ -303,7 +303,7 @@ FactoryBot.define do
     # @param [Class] evaluator holding the transient properties for the current build/creation process
     def self.process_with_solr_document(collection, evaluator)
       return unless evaluator.with_solr_document
-      return if evaluator.with_nesting_attributes.present? && collection.nestable? # will create the solr document there instead
+      return if evaluator.with_nesting_attributes.present? && Hyrax::CollectionType.for(collection: collection).nestable? # will create the solr document there instead
       Hyrax::SolrService.add(solr_document_with_permissions(collection, evaluator), commit: true)
     end
 

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
       # if requested, create a solr document and add the nesting fields into it
       # when a nestable collection is built. This reduces the need to use
       # create and :with_nested_indexing for nested collection testing
-      if evaluator.with_nesting_attributes.present? && collection.nestable?
+      if evaluator.with_nesting_attributes.present? && Hyrax::CollectionType.for(collection: collection).nestable?
         Hyrax::Adapters::NestingIndexAdapter.add_nesting_attributes(
           solr_doc: evaluator.to_solr,
           ancestors: evaluator.with_nesting_attributes[:ancestors],

--- a/spec/factory_tests/collections_factory_spec.rb
+++ b/spec/factory_tests/collections_factory_spec.rb
@@ -31,10 +31,11 @@ RSpec.describe 'Collections Factory' do # rubocop:disable RSpec/DescribeClass
 
       it 'will create a collection type with specified settings when collection_type_settings is set to attributes identifying settings' do
         col = build(:collection_lw, collection_type_settings: [:not_discoverable, :not_sharable, :not_brandable, :nestable])
-        expect(col.collection_type.discoverable?).to be false
-        expect(col.collection_type.sharable?).to be false
-        expect(col.collection_type.brandable?).to be false
-        expect(col.collection_type.nestable?).to be true
+        collection_type = Hyrax::CollectionType.for(collection: col)
+        expect(collection_type.discoverable?).to be false
+        expect(collection_type.sharable?).to be false
+        expect(collection_type.brandable?).to be false
+        expect(collection_type.nestable?).to be true
       end
     end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -163,9 +163,9 @@ RSpec.describe ::Collection, type: :model do
       expect { collection.collection_type_gid = nil }.to raise_error(URI::InvalidURIError)
     end
 
-    it 'updates the collection_type instance variable' do
+    it 'updates the collection_type' do
       expect { collection.collection_type_gid = collection_type.to_global_id }
-        .to change { collection.collection_type }
+        .to change { Hyrax::CollectionType.for(collection: collection) }
         .from(create(:user_collection_type)).to(collection_type)
     end
 

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
 
   shared_context 'with a collection' do
     let(:collection_type) { FactoryBot.create(:collection_type) }
-    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id) }
+    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id.to_s) }
   end
 
   describe '.collection_type_settings_methods' do
@@ -125,6 +125,14 @@ RSpec.describe Hyrax::CollectionType, type: :model do
     it "ensures uniqueness" do
       is_expected.to validate_uniqueness_of(:title)
       is_expected.to validate_uniqueness_of(:machine_id)
+    end
+  end
+
+  describe '.for' do
+    include_context 'with a collection'
+
+    it 'returns the collection type for the collection' do
+      expect(described_class.for(collection: collection)).to eq collection_type
     end
   end
 

--- a/spec/validators/hyrax/collection_membership_validator_spec.rb
+++ b/spec/validators/hyrax/collection_membership_validator_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Hyrax::CollectionMembershipValidator do
           context 'and work is in another collection NOT posing a conflict' do
             let(:work) { FactoryBot.build(:hyrax_work, :as_collection_member) }
             let(:col_id) { work.member_of_collection_ids.first.id }
-            let(:sm_col) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
+            let(:sm_col) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id.to_s) }
             let(:mem_of_cols_attrs) do
               { "0" => { "id" => col_id.to_s, "_destroy" => "false" },
                 "1" => { "id" => sm_col.id.to_s, "_destroy" => "false" } }
@@ -83,8 +83,8 @@ RSpec.describe Hyrax::CollectionMembershipValidator do
 
           context 'and work is already ni collections with membership restriction conflicts' do
             let(:work) { FactoryBot.build(:hyrax_work, member_of_collection_ids: [sm_col1.id]) }
-            let(:sm_col1) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
-            let(:sm_col2) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
+            let(:sm_col1) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id.to_s) }
+            let(:sm_col2) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id.to_s) }
 
             let(:mem_of_cols_attrs) do
               { "0" => { "id" => sm_col2.id.to_s, "_destroy" => "false" } }
@@ -104,8 +104,8 @@ RSpec.describe Hyrax::CollectionMembershipValidator do
 
           context 'and work is added to collections with membership restriction conflicts' do
             let(:work) { FactoryBot.build(:hyrax_work) }
-            let(:sm_col1) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
-            let(:sm_col2) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
+            let(:sm_col1) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id.to_s) }
+            let(:sm_col2) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id.to_s) }
             let(:mem_of_cols_attrs) do
               { "0" => { "id" => sm_col1.id.to_s, "_destroy" => "false" },
                 "1" => { "id" => sm_col2.id.to_s, "_destroy" => "false" } }
@@ -206,7 +206,7 @@ RSpec.describe Hyrax::CollectionMembershipValidator do
           context 'and collection is in another collection of a different collection type' do
             let(:col) { FactoryBot.build(:hyrax_collection, :as_collection_member) }
             let(:col_id) { col.member_of_collection_ids.first.id }
-            let(:sm_col) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
+            let(:sm_col) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id.to_s) }
             let(:mem_of_cols_attrs) do
               { "0" => { "id" => col_id.to_s, "_destroy" => "false" },
                 "1" => { "id" => sm_col.id.to_s, "_destroy" => "false" } }
@@ -221,8 +221,8 @@ RSpec.describe Hyrax::CollectionMembershipValidator do
 
           context 'and collection is in another collection of the same single membership type' do
             let(:col) { FactoryBot.build(:hyrax_collection, member_of_collection_ids: [sm_col1.id]) }
-            let(:sm_col1) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
-            let(:sm_col2) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id) }
+            let(:sm_col1) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id.to_s) }
+            let(:sm_col2) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: single_mem_col_type.to_global_id.to_s) }
             let(:mem_of_cols_attrs) do
               { "0" => { "id" => sm_col1.id.to_s, "_destroy" => "false" },
                 "1" => { "id" => sm_col2.id.to_s, "_destroy" => "false" } }

--- a/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'hyrax/dashboard/collections/edit.html.erb', type: :view do
   before do
     assign(:collection, collection)
     assign(:form, form)
-    allow(collection).to receive(:collection_type).and_return(collection_type)
+    allow(Hyrax::CollectionType).to receive(:for).with(collection: collection).and_return(collection_type)
     stub_template '_form.html.erb' => 'my-edit-form partial'
     stub_template '_flash_msg.html.erb' => 'flash_msg partial'
 

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       end
 
       it 'has the given collection type' do
-        expect(converter.convert.collection_type.to_global_id.to_s)
+        expect(Hyrax::CollectionType.for(collection: converter.convert).to_global_id.to_s)
           .to eq resource.collection_type_gid
       end
 


### PR DESCRIPTION
Hyrax::PcdmCollection does not have a `collection_type` getter method so switching to a factory allows for valkyrie exclusive tests to pass.

In support of #5596.