### PR TITLE
backport: add an explicit dependency on `Redis`

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -76,6 +76,7 @@ SUMMARY
   spec.add_dependency 'rails_autolink', '~> 1.1'
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
   spec.add_dependency 'rdf-vocab', '~> 3.0'
+  spec.add_dependency 'redis', '~> 4.0'
   spec.add_dependency 'redis-namespace', '~> 1.5'
   spec.add_dependency 'redlock', '>= 0.1.2'
   spec.add_dependency 'reform', '~> 2.3'


### PR DESCRIPTION
`hyrax` has a direct dependency on the `redis` gem; add it to the gemspec.

backports  #5838

@samvera/hyrax-code-reviewers
