### PR TITLE
Use docker postgres to match dassie's environment

### DIFF
--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -104,7 +104,7 @@ services:
       - hyrax
 
   postgres:
-    image: bitnami/postgresql:14
+    image: postgres:latest
     restart: always
     env_file:
       - .env
@@ -112,7 +112,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - db:/bitnami/postgresql
+      - db:/var/lib/postgresql/data
     networks:
       - hyrax
 


### PR DESCRIPTION
This also resolves some issues with permissions to install postgres extensions when running tests within the app container.