### PR TITLE
Don't default member_of_collection_ids in collection_params

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -422,7 +422,6 @@ module Hyrax
           params.permit(collection: {})[:collection]
                 .merge(params.permit(:collection_type_gid)
                              .with_defaults(collection_type_gid: default_collection_type_gid))
-                .merge(member_of_collection_ids: Array(params[:parent_id]))
         end
       end
 

--- a/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_with_resource_spec.rb
@@ -526,6 +526,25 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, type: :controller, clean
         end
       end
     end
+
+    context 'with nested collection' do
+      let(:parent_collection) { FactoryBot.valkyrie_create(:collection_resource) }
+      let(:collection) do
+        FactoryBot.valkyrie_create(:collection_resource,
+          :public,
+          title: ["My collection"],
+          creator: ["Mr. Smith"],
+          depositor: user.user_key,
+          edit_users: [user],
+          member_of_collection_ids: [parent_collection.id])
+      end
+
+      it 'retains parent collection relationship' do
+        put :update, params: { id: collection, collection: { description: ['Videos of importance'] } }
+        expect(assigns[:collection].description).to eq ['Videos of importance']
+        expect(assigns[:collection].member_of_collection_ids).to eq [parent_collection.id]
+      end
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
This default is not necessary and had the side effect of removing pre-existing member_of_collection_ids when updating collections