### PR TITLE
Index member_of_collection_ids for PcdmCollection

### DIFF
--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -16,6 +16,7 @@ module Hyrax
       super.tap do |index_document|
         index_document[Hyrax.config.collection_type_index_field.to_sym] = Array(resource.try(:collection_type_gid)&.to_s)
         index_document[:generic_type_sim] = ['Collection']
+        index_document[:member_of_collection_ids_ssim] = resource.member_of_collection_ids.map(&:to_s)
         index_document[:depositor_ssim] = [resource.depositor]
         index_document[:depositor_tesim] = [resource.depositor]
       end

--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -266,6 +266,11 @@ RSpec.shared_examples 'a Collection indexer' do
         .to include(generic_type_sim: a_collection_containing_exactly('Collection'))
     end
 
+    it 'indexes member_of_collection_ids' do
+      expect(indexer.to_solr)
+        .to include(member_of_collection_ids_ssim: resource.member_of_collection_ids)
+    end
+
     it 'indexes depositor' do
       expect(indexer.to_solr)
         .to include(depositor_ssim: [resource.depositor],

--- a/spec/indexers/hyrax/pcdm_collection_indexer_spec.rb
+++ b/spec/indexers/hyrax/pcdm_collection_indexer_spec.rb
@@ -3,7 +3,7 @@
 require 'hyrax/specs/shared_specs'
 
 RSpec.describe Hyrax::PcdmCollectionIndexer do
-  let(:resource) { FactoryBot.valkyrie_create(:hyrax_collection) }
+  let(:resource) { FactoryBot.valkyrie_create(:hyrax_collection, :as_collection_member) }
   let(:indexer_class) { described_class }
 
   it_behaves_like 'a Collection indexer'


### PR DESCRIPTION
This field wasn't being indexed but is expected by the nested indexing (which might get removed by #5850) and probably elsewhere in the codebase.