### PR TITLE
stop using separate JS uploader configuration in development

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -827,12 +827,7 @@ module Hyrax
 
     attr_writer :uploader
     def uploader
-      @uploader ||= if Rails.env.development?
-                      # use sequential uploads in development to avoid database locking problems with sqlite3.
-                      default_uploader_config.merge(limitConcurrentUploads: 1, sequentialUploads: true)
-                    else
-                      default_uploader_config
-                    end
+      @uploader ||= default_uploader_config
     end
 
     attr_accessor :nested_relationship_reindexer


### PR DESCRIPTION
the reason for the uploader configuration being set this way was to avoid `sqlite3` locks. since we use postgresql in development now, this isn't necessary or helpful.

@samvera/hyrax-code-reviewers
