### PR TITLE
Proxy deposit requests use valkyrie-specific query service when use_valkyrie? is true

### DIFF
--- a/app/controllers/hyrax/transfers_controller.rb
+++ b/app/controllers/hyrax/transfers_controller.rb
@@ -23,7 +23,6 @@ module Hyrax
       add_breadcrumb t(:'hyrax.controls.home'), root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb t(:'hyrax.transfers.new.header'), hyrax.new_work_transfer_path
-      @work = Hyrax::WorkRelation.new.find(params[:id])
     end
 
     def create
@@ -31,7 +30,6 @@ module Hyrax
       if @proxy_deposit_request.save
         redirect_to hyrax.transfers_path, notice: "Transfer request created"
       else
-        @work = Hyrax::WorkRelation.new.find(params[:id])
         render :new
       end
     end

--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -7,7 +7,7 @@ class ProxyDepositRequest < ActiveRecord::Base
   include ActionView::Helpers::UrlHelper
 
   class_attribute :work_query_service_class
-  self.work_query_service_class = Hyrax::WorkQueryService
+  self.work_query_service_class = Hyrax.config.use_valkyrie? ? Hyrax::WorkResourceQueryService : Hyrax::WorkQueryService
 
   delegate :deleted_work?, :work, :to_s, to: :work_query_service
 

--- a/app/services/hyrax/work_resource_query_service.rb
+++ b/app/services/hyrax/work_resource_query_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+module Hyrax
+  # Responsible for retrieving information based on the given work.
+  #
+  # @see ProxyDepositRequest
+  # @see SolrDocument
+  # @see Hyrax::SolrService
+  # @note This was extracted from the ProxyDepositRequest, which was coordinating lots of effort. It was also an ActiveRecord object that required lots of Fedora/Solr interactions.
+  class WorkResourceQueryService
+    # @param [String] id - The id of the work
+    def initialize(id:)
+      @id = id
+    end
+    attr_reader :id
+
+    # @return [Boolean] if the work has been deleted
+    def deleted_work?
+      Hyrax.query_service.find_by(id: id)
+      false
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      true
+    end
+
+    def work
+      # Need to ensure it is a work?
+      resource = Hyrax.query_service.find_by(id: id)
+      unless Hyrax.config.curation_concerns.include?(resource.class) ||
+             Hyrax.config.curation_concerns.map(&:to_s).include?(resource.class.to_s) || # Wings-wrapped models
+             Hyrax.config.curation_concerns.map(&:to_s).include?(resource.class.name) # Wings-wrapped models
+        raise ModelMismatchError, "Expected allowed work type but got #{resource.class}"
+      end
+      resource
+    end
+
+    def to_s
+      if deleted_work?
+        'work not found'
+      else
+        solr_doc.to_s
+      end
+    end
+
+    private
+
+    def solr_doc
+      @solr_doc ||= ::SolrDocument.new(Hyrax::SolrService.search_by_id(id))
+    end
+  end
+end

--- a/app/services/hyrax/work_resource_query_service.rb
+++ b/app/services/hyrax/work_resource_query_service.rb
@@ -24,11 +24,7 @@ module Hyrax
     def work
       # Need to ensure it is a work?
       resource = Hyrax.query_service.find_by(id: id)
-      unless Hyrax.config.curation_concerns.include?(resource.class) ||
-             Hyrax.config.curation_concerns.map(&:to_s).include?(resource.class.to_s) || # Wings-wrapped models
-             Hyrax.config.curation_concerns.map(&:to_s).include?(resource.class.name) # Wings-wrapped models
-        raise ModelMismatchError, "Expected allowed work type but got #{resource.class}"
-      end
+      raise ModelMismatchError, "Expected work but got #{resource.class}" unless resource.work?
       resource
     end
 

--- a/app/views/hyrax/transfers/new.html.erb
+++ b/app/views/hyrax/transfers/new.html.erb
@@ -5,7 +5,7 @@
 <span class="sr-only"><%= t(:'.sr_only_description', work_title: @proxy_deposit_request.to_s) %></span>
 
 <%= simple_form_for @proxy_deposit_request,
-             url: hyrax.work_transfers_path(@work) do |f| %>
+             url: hyrax.work_transfers_path(params[:id]) do |f| %>
   <%= f.input :transfer_to,
         placeholder: t(:'.placeholder') %>
   <%= f.input :sender_comment %>

--- a/lib/hyrax/errors.rb
+++ b/lib/hyrax/errors.rb
@@ -15,4 +15,6 @@ module Hyrax
   class SingleMembershipError < HyraxError; end
 
   class ObjectNotFoundError < ActiveFedora::ObjectNotFoundError; end
+
+  class ModelMismatchError < HyraxError; end
 end

--- a/spec/controllers/hyrax/transfers_controller_spec.rb
+++ b/spec/controllers/hyrax/transfers_controller_spec.rb
@@ -36,7 +36,19 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
           sign_in user
           get :new, params: { id: work.id }
           expect(response).to be_successful
-          expect(assigns[:work]).to eq(work)
+          expect(assigns[:proxy_deposit_request]).to be_kind_of ProxyDepositRequest
+          expect(assigns[:proxy_deposit_request].work_id).to eq(work.id)
+        end
+      end
+
+      context 'with work resource' do
+        let(:work) { FactoryBot.valkyrie_create(:hyrax_work, depositor: user.user_key, edit_users: [user]) }
+
+        it "is successful" do
+          expect(controller).to receive(:add_breadcrumb).exactly(3).times
+          sign_in user
+          get :new, params: { id: work.id }
+          expect(response).to be_successful
           expect(assigns[:proxy_deposit_request]).to be_kind_of ProxyDepositRequest
           expect(assigns[:proxy_deposit_request].work_id).to eq(work.id)
         end
@@ -74,8 +86,42 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
           post :create, params: { id: work.id, proxy_deposit_request: { transfer_to: 'foo' } }
         end.not_to change(ProxyDepositRequest, :count)
         expect(assigns[:proxy_deposit_request].errors[:transfer_to]).to eq(['Must be an existing user'])
-        expect(assigns[:work]).to be_instance_of GenericWork
         expect(response).to be_successful
+      end
+
+      context 'with work resource' do
+        let(:work) { FactoryBot.valkyrie_create(:hyrax_work, depositor: user.user_key, edit_users: [user]) }
+
+        it "is successful" do
+          expect do
+            post :create, params: {
+              id: work.id,
+              proxy_deposit_request: {
+                transfer_to: another_user.user_key,
+                sender_comment: 'Hi mom!'
+              }
+            }
+          end.to change(ProxyDepositRequest, :count).by(1)
+          expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+          expect(flash[:notice]).to eq('Transfer request created')
+          proxy_request = another_user.proxy_deposit_requests.first
+          expect(proxy_request.work_id).to eq(work.id)
+          expect(proxy_request.sending_user).to eq(user)
+          expect(proxy_request.sender_comment).to eq 'Hi mom!'
+          # AND A NOTIFICATION SHOULD HAVE BEEN CREATED
+          notification = another_user.reload.mailbox.inbox[0].messages[0]
+          expect(notification.subject).to eq("Ownership Change Request")
+          expect(notification.body).to eq("<a href=\"#{routes.url_helpers.user_path(user)}\">#{user.name}</a> " \
+                  "wants to transfer a work to you. Review all " \
+                  "<a href=\"#{routes.url_helpers.transfers_path}\">transfer requests</a>")
+        end
+        it "gives an error if the user is not found" do
+          expect do
+            post :create, params: { id: work.id, proxy_deposit_request: { transfer_to: 'foo' } }
+          end.not_to change(ProxyDepositRequest, :count)
+          expect(assigns[:proxy_deposit_request].errors[:transfer_to]).to eq(['Must be an existing user'])
+          expect(response).to be_successful
+        end
       end
     end
 
@@ -127,6 +173,53 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
           expect(flash[:alert]).to eq("You are not authorized to access this page.")
         end
       end
+
+      context 'with work resource' do
+        around do |example|
+          @query_class = ProxyDepositRequest.work_query_service_class
+          ProxyDepositRequest.work_query_service_class = Hyrax::WorkResourceQueryService
+          example.run
+          ProxyDepositRequest.work_query_service_class = @query_class
+        end
+
+        context "when I am the receiver" do
+          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: another_user.user_key, edit_users: [another_user]) }
+          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: user, sending_user: another_user) }
+
+          it "is successful when retaining access rights" do
+            put :accept, params: { id: user.proxy_deposit_requests.first }
+            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+            expect(flash[:notice]).to eq("Transfer complete")
+            expect(assigns[:proxy_deposit_request].status).to eq('accepted')
+            expect(Hyrax.query_service.find_by(id: work.id).edit_users).to match_array [another_user.user_key, user.user_key]
+          end
+          it "is successful when resetting access rights" do
+            put :accept, params: { id: user.proxy_deposit_requests.first, reset: true }
+            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+            expect(flash[:notice]).to eq("Transfer complete")
+            expect(assigns[:proxy_deposit_request].status).to eq('accepted')
+            expect(Hyrax.query_service.find_by(id: work.id).edit_users).to match_array [user.user_key]
+          end
+          it "handles sticky requests" do
+            put :accept, params: { id: user.proxy_deposit_requests.first, sticky: true }
+            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+            expect(flash[:notice]).to eq("Transfer complete")
+            expect(assigns[:proxy_deposit_request].status).to eq('accepted')
+            expect(user.can_receive_deposits_from).to include(another_user)
+          end
+        end
+
+        context "accepting one that isn't mine" do
+          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: user.user_key, edit_users: [user]) }
+          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: another_user, sending_user: user) }
+
+          it "does not allow me" do
+            put :accept, params: { id: another_user.proxy_deposit_requests.first }
+            expect(response).to redirect_to root_path
+            expect(flash[:alert]).to eq("You are not authorized to access this page.")
+          end
+        end
+      end
     end
 
     describe "#reject" do
@@ -162,6 +255,31 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
           expect(flash[:alert]).to eq("You are not authorized to access this page.")
         end
       end
+
+      context 'with work resource' do
+        context "when I am the receiver" do
+          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: another_user.user_key, edit_users: [another_user]) }
+          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: user, sending_user: another_user) }
+
+          it "is successful" do
+            put :reject, params: { id: user.proxy_deposit_requests.first }
+            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+            expect(flash[:notice]).to eq("Transfer rejected")
+            expect(assigns[:proxy_deposit_request].status).to eq('rejected')
+          end
+        end
+
+        context "accepting one that isn't mine" do
+          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: user.user_key, edit_users: [user]) }
+          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: another_user, sending_user: user) }
+
+          it "does not allow me" do
+            put :reject, params: { id: another_user.proxy_deposit_requests.first }
+            expect(response).to redirect_to root_path
+            expect(flash[:alert]).to eq("You are not authorized to access this page.")
+          end
+        end
+      end
     end
 
     describe "#destroy" do
@@ -194,6 +312,30 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
           delete :destroy, params: { id: user.proxy_deposit_requests.first }
           expect(response).to redirect_to root_path
           expect(flash[:alert]).to eq("You are not authorized to access this page.")
+        end
+      end
+
+      context 'with work resource' do
+        context "when I am the sender" do
+          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: user.user_key, edit_users: [user]) }
+          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: another_user, sending_user: user) }
+
+          it "is successful" do
+            delete :destroy, params: { id: another_user.proxy_deposit_requests.first }
+            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+            expect(flash[:notice]).to eq("Transfer canceled")
+          end
+        end
+
+        context "accepting one that isn't mine" do
+          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: another_user.user_key, edit_users: [another_user]) }
+          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: user, sending_user: another_user) }
+
+          it "does not allow me" do
+            delete :destroy, params: { id: user.proxy_deposit_requests.first }
+            expect(response).to redirect_to root_path
+            expect(flash[:alert]).to eq("You are not authorized to access this page.")
+          end
         end
       end
     end

--- a/spec/services/hyrax/work_query_service_spec.rb
+++ b/spec/services/hyrax/work_query_service_spec.rb
@@ -30,7 +30,7 @@ module Hyrax
 
       subject { work_query_service.work }
 
-      context 'when not in SOLR' do
+      context 'when in SOLR' do
         before { allow(work_relation).to receive(:find).with(work_id).and_return(expected_work) }
         it { is_expected.to eq(expected_work) }
       end

--- a/spec/services/hyrax/work_resource_query_service_spec.rb
+++ b/spec/services/hyrax/work_resource_query_service_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module Hyrax
+  RSpec.describe WorkResourceQueryService do
+    let(:user) { create(:user) }
+    let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['Test work']) }
+    let(:work_query_service) { described_class.new(id: work.id) }
+
+    describe '#deleted_work?' do
+      subject { work_query_service.deleted_work? }
+
+      context 'when not in SOLR' do
+        let(:work_query_service) { described_class.new(id: 'deleted-id') }
+
+        it { is_expected.to be_truthy }
+      end
+      context 'when in SOLR' do
+        it { is_expected.to be_falsey }
+      end
+    end
+    describe '#work' do
+      subject { work_query_service.work }
+
+      context 'when in SOLR' do
+        it { expect(subject.id).to eq(work.id) }
+      end
+    end
+    describe '#to_s' do
+      subject { work_query_service.to_s }
+
+      context 'when the work is deleted' do
+        let(:work_query_service) { described_class.new(id: 'deleted-id') }
+
+        it { is_expected.to eq('work not found') }
+      end
+
+      context 'when the work is not deleted' do
+        it 'will retrieve the SOLR document and use the #to_s method of that' do
+          expect(subject).to eq(work.title.first)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I tried to replicate the behavior of WorkRelation where it should only retrieve objects of registered curation concerns (in `Hyrax::WorkResourceQueryService#work`), but I'm not sure if it is really necessary so I didn't write any tests for it yet.

I believe this should fix #5456