### PR TITLE
Hyrax 5795 works view item action file set delete throws error

### DIFF
--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -106,8 +106,8 @@ module Hyrax
     attribute :proxy_depositor,          Valkyrie::Types::String
     attribute :state,                    Valkyrie::Types::URI.default(Hyrax::ResourceStatus::ACTIVE)
     attribute :rendering_ids,            Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)
-    attribute :representative_id,        Valkyrie::Types::ID
-    attribute :thumbnail_id,             Valkyrie::Types::ID
+    attribute :representative_id,        Valkyrie::Types::ID.optional
+    attribute :thumbnail_id,             Valkyrie::Types::ID.optional
 
     ##
     # @return [Boolean] true

--- a/app/presenters/hyrax/pcdm_member_presenter_factory.rb
+++ b/app/presenters/hyrax/pcdm_member_presenter_factory.rb
@@ -48,9 +48,11 @@ module Hyrax
     #
     # @overload member_presenters
     #   @return [Enumerator<FileSetPresenter, WorkShowPresenter>]
+    #   @raise [ArgumentError] if an unindexed id is passed
     # @overload member_presenters
     #   @param [Array<#to_s>] ids
     #   @return [Enumerator<FileSetPresenter, WorkShowPresenter>]
+    #   @raise [ArgumentError] if an unindexed id is passed
     def member_presenters(ids = object.member_ids)
       return enum_for(:member_presenters, ids) unless block_given?
 
@@ -59,12 +61,8 @@ module Hyrax
       ids.each do |id|
         id = id.to_s
         indx = results.index { |doc| id == doc['id'] }
-        if indx.blank?
-          # raise(ArgumentError, "Could not find an indexed document for id: #{id}") if indx.nil?
-          # log an error if indx is not found and skip
-          Rails.logger.error "While building presenters, could not find an indexed document for id: #{id}"
-          next
-        end
+        raise(ArgumentError, "Could not find an indexed document for id: #{id}") if
+          indx.nil?
         hash = results.delete_at(indx)
         yield presenter_for(document: ::SolrDocument.new(hash), ability: ability)
       end

--- a/app/presenters/hyrax/pcdm_member_presenter_factory.rb
+++ b/app/presenters/hyrax/pcdm_member_presenter_factory.rb
@@ -61,7 +61,7 @@ module Hyrax
       ids.each do |id|
         id = id.to_s
         indx = results.index { |doc| id == doc['id'] }
-        raise(ArgumentError, "Could not find an indexed document for id: #{id}") if
+        raise(Hyrax::ObjectNotFoundError, "Could not find an indexed document for id: #{id}") if
           indx.nil?
         hash = results.delete_at(indx)
         yield presenter_for(document: ::SolrDocument.new(hash), ability: ability)

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -98,6 +98,9 @@ module Hyrax
           result = member_presenters([representative_id]).first
           return nil if result.try(:id) == id
           result.try(:representative_presenter) || result
+        rescue ArgumentError # Raised by valkyrie if representative_id object is not indexed
+          Rails.logger.warn "Unable to find representative_id #{representative_id} for work #{id}"
+          return nil
         end
     end
 

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -98,7 +98,7 @@ module Hyrax
           result = member_presenters([representative_id]).first
           return nil if result.try(:id) == id
           result.try(:representative_presenter) || result
-        rescue ArgumentError # Raised by valkyrie if representative_id object is not indexed
+        rescue Hyrax::ObjectNotFoundError
           Rails.logger.warn "Unable to find representative_id #{representative_id} for work #{id}"
           return nil
         end

--- a/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
+++ b/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
@@ -41,24 +41,33 @@ module Hyrax
           Success(file_set)
         end
 
+        private
+
         def find_parents(resource:)
           @query_service.find_parents(resource: resource)
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
         def unlink_file_set(parent:, file_set:)
           fid = file_set.id
-          return unless parent.thumbnail_id == fid || parent.representative_id == fid ||
-                        (parent.respond_to?(:rendering_ids) && parent.rendering_ids.present? && parent.rendering_ids.include?(fid))
+          unlink_thumbnail_id(fid: fid, parent: parent)
+          unlink_representative_id(fid: fid, parent: parent)
+          unlink_rendering_ids(fid: fid, parent: parent)
+        end
+
+        def unlink_rendering_ids(fid:, parent:)
+          parent.rendering_ids -= [fid] if parent.respond_to?(:rendering_ids) && parent.rendering_ids.present?
+        end
+
+        def unlink_representative_id(fid:, parent:)
+          parent.representative_id = nil if parent.representative_id == fid
+        end
+
+        def unlink_thumbnail_id(fid:, parent:)
           if parent.thumbnail_id == fid
             parent.thumbnail = nil if parent.respond_to? :thumbnail
             parent.thumbnail_id = nil
           end
-          parent.representative_id = nil if parent.representative_id == fid
-          return unless parent.respond_to?(:rendering_ids) && parent.rendering_ids.present?
-          parent.rendering_ids = parent.rendering_ids - [fid]
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
       end
     end
   end

--- a/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
+++ b/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
@@ -45,19 +45,20 @@ module Hyrax
           @query_service.find_parents(resource: resource)
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def unlink_file_set(parent:, file_set:)
           fid = file_set.id
-          return unless (parent.thumbnail_id == fid || parent.representative_id == fid ||
-            (parent.respond_to?(:rendering_ids) && parent.rendering_ids.present? && parent.rendering_ids.include?(fid)) )
+          return unless parent.thumbnail_id == fid || parent.representative_id == fid ||
+                        (parent.respond_to?(:rendering_ids) && parent.rendering_ids.present? && parent.rendering_ids.include?(fid))
           if parent.thumbnail_id == fid
             parent.thumbnail = nil if parent.respond_to? :thumbnail
             parent.thumbnail_id = nil
           end
           parent.representative_id = nil if parent.representative_id == fid
-          if parent.respond_to?(:rendering_ids) && parent.rendering_ids.present?
-            parent.rendering_ids = parent.rendering_ids - [fid]
-          end
+          return unless parent.respond_to?(:rendering_ids) && parent.rendering_ids.present?
+          parent.rendering_ids = parent.rendering_ids - [fid]
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
       end
     end
   end

--- a/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
+++ b/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
@@ -32,75 +32,31 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(file_set, user: nil)
           return Failure('No user provided.') if user.nil?
-          @query_service.find_parents(resource: file_set).each do |parent|
-            # do_it(parent, file_set, user)
-            # byebug
-            puts "remove_file_set_form_work.call for each parent"
-            puts "file_set.id=#{file_set.id}"
-            puts "parent.member_ids=#{parent.member_ids}"
-            puts "parent.thumbnail_id=#{parent.thumbnail_id}"
-            puts "parent.representative_id=#{parent.representative_id}"
+          find_parents(resource: file_set).each do |parent|
             parent.member_ids -= [file_set.id]
-            # parent&.unlink_file_set(file_set: file_set)
             unlink_file_set(parent: parent, file_set: file_set)
-            puts "remove_file_set_form_work.call for each parent after unlink"
-            puts "file_set.id=#{file_set.id}"
-            puts "parent.member_ids=#{parent.member_ids}"
-            puts "parent.thumbnail_id=#{parent.thumbnail_id}"
-            puts "parent.representative_id=#{parent.representative_id}"
-            # byebug
             saved = @persister.save(resource: parent)
-            puts "remove_file_set_form_work.call for each parent after persister.save parent"
-            puts "file_set.id=#{file_set.id}"
-            puts "parent.member_ids=#{parent.member_ids}"
-            puts "parent.thumbnail_id=#{parent.thumbnail_id}"
-            puts "parent.representative_id=#{parent.representative_id}"
             Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
           end
-
           Success(file_set)
         end
 
+        def find_parents(resource:)
+          @query_service.find_parents(resource: resource)
+        end
+
         def unlink_file_set(parent:, file_set:)
-          puts "unlink_file_set -- begin"
           fid = file_set.id
-          return false unless (parent.thumbnail_id == fid || parent.representative_id == fid ||
+          return unless (parent.thumbnail_id == fid || parent.representative_id == fid ||
             (parent.respond_to?(:rendering_ids) && parent.rendering_ids.present? && parent.rendering_ids.include?(fid)) )
-          # byebug
-          puts "unlink_file_set -- something to unlink"
-          puts "fid=#{fid}"
-          puts "parent.thumbnail_id=#{parent.thumbnail_id}"
           if parent.thumbnail_id == fid
-            puts "unlinking thumbnail"
             parent.thumbnail = nil if parent.respond_to? :thumbnail
             parent.thumbnail_id = nil
           end
-          puts "fid=#{fid}"
-          puts "parent.thumbnail_id=#{parent.thumbnail_id}"
-          puts "parent.representative_id=#{parent.representative_id}"
-          puts "unlinking representative_id"
           parent.representative_id = nil if parent.representative_id == fid
-          puts "fid=#{fid}"
-          puts "parent.thumbnail_id=#{parent.thumbnail_id}"
-          puts "parent.representative_id=#{parent.representative_id}"
           if parent.respond_to?(:rendering_ids) && parent.rendering_ids.present?
-            puts "unlinking rendering_ids"
-            puts "fid=#{fid}"
-            puts "parent.rendering_ids=#{parent.rendering_ids}"
             parent.rendering_ids = parent.rendering_ids - [fid]
-            puts "fid=#{fid}"
-            puts "parent.rendering_ids=#{parent.rendering_ids}"
           end
-          # save
-          true
-        end
-
-        def do_it(parent, file_set, user)
-          parent.member_ids -= [file_set.id]
-          parent&.unlink_file_set(file_set: file_set)
-          # byebug
-          saved = @persister.save(resource: parent)
-          Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
         end
       end
     end

--- a/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
+++ b/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
@@ -32,14 +32,75 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(file_set, user: nil)
           return Failure('No user provided.') if user.nil?
-
           @query_service.find_parents(resource: file_set).each do |parent|
+            # do_it(parent, file_set, user)
+            # byebug
+            puts "remove_file_set_form_work.call for each parent"
+            puts "file_set.id=#{file_set.id}"
+            puts "parent.member_ids=#{parent.member_ids}"
+            puts "parent.thumbnail_id=#{parent.thumbnail_id}"
+            puts "parent.representative_id=#{parent.representative_id}"
             parent.member_ids -= [file_set.id]
+            # parent&.unlink_file_set(file_set: file_set)
+            unlink_file_set(parent: parent, file_set: file_set)
+            puts "remove_file_set_form_work.call for each parent after unlink"
+            puts "file_set.id=#{file_set.id}"
+            puts "parent.member_ids=#{parent.member_ids}"
+            puts "parent.thumbnail_id=#{parent.thumbnail_id}"
+            puts "parent.representative_id=#{parent.representative_id}"
+            # byebug
             saved = @persister.save(resource: parent)
+            puts "remove_file_set_form_work.call for each parent after persister.save parent"
+            puts "file_set.id=#{file_set.id}"
+            puts "parent.member_ids=#{parent.member_ids}"
+            puts "parent.thumbnail_id=#{parent.thumbnail_id}"
+            puts "parent.representative_id=#{parent.representative_id}"
             Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
           end
 
           Success(file_set)
+        end
+
+        def unlink_file_set(parent:, file_set:)
+          puts "unlink_file_set -- begin"
+          fid = file_set.id
+          return false unless (parent.thumbnail_id == fid || parent.representative_id == fid ||
+            (parent.respond_to?(:rendering_ids) && parent.rendering_ids.present? && parent.rendering_ids.include?(fid)) )
+          # byebug
+          puts "unlink_file_set -- something to unlink"
+          puts "fid=#{fid}"
+          puts "parent.thumbnail_id=#{parent.thumbnail_id}"
+          if parent.thumbnail_id == fid
+            puts "unlinking thumbnail"
+            parent.thumbnail = nil if parent.respond_to? :thumbnail
+            parent.thumbnail_id = nil
+          end
+          puts "fid=#{fid}"
+          puts "parent.thumbnail_id=#{parent.thumbnail_id}"
+          puts "parent.representative_id=#{parent.representative_id}"
+          puts "unlinking representative_id"
+          parent.representative_id = nil if parent.representative_id == fid
+          puts "fid=#{fid}"
+          puts "parent.thumbnail_id=#{parent.thumbnail_id}"
+          puts "parent.representative_id=#{parent.representative_id}"
+          if parent.respond_to?(:rendering_ids) && parent.rendering_ids.present?
+            puts "unlinking rendering_ids"
+            puts "fid=#{fid}"
+            puts "parent.rendering_ids=#{parent.rendering_ids}"
+            parent.rendering_ids = parent.rendering_ids - [fid]
+            puts "fid=#{fid}"
+            puts "parent.rendering_ids=#{parent.rendering_ids}"
+          end
+          # save
+          true
+        end
+
+        def do_it(parent, file_set, user)
+          parent.member_ids -= [file_set.id]
+          parent&.unlink_file_set(file_set: file_set)
+          # byebug
+          saved = @persister.save(resource: parent)
+          Hyrax.publisher.publish('object.metadata.updated', object: saved, user: user)
         end
       end
     end

--- a/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
+++ b/lib/hyrax/transactions/steps/remove_file_set_from_work.rb
@@ -63,10 +63,9 @@ module Hyrax
         end
 
         def unlink_thumbnail_id(fid:, parent:)
-          if parent.thumbnail_id == fid
-            parent.thumbnail = nil if parent.respond_to? :thumbnail
-            parent.thumbnail_id = nil
-          end
+          return unless parent.thumbnail_id == fid
+          parent.thumbnail = nil if parent.respond_to? :thumbnail
+          parent.thumbnail_id = nil
         end
       end
     end

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -109,6 +109,14 @@ FactoryBot.define do
       end
     end
 
+    trait :with_renderings do
+      rendering_ids do
+        file_set = members.find(&:file_set?) ||
+          valkyrie_create(:hyrax_file_set)
+        file_set.id
+      end
+    end
+
     trait :as_collection_member do
       member_of_collection_ids { [valkyrie_create(:hyrax_collection).id] }
     end

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -112,7 +112,7 @@ FactoryBot.define do
     trait :with_renderings do
       rendering_ids do
         file_set = members.find(&:file_set?) ||
-          valkyrie_create(:hyrax_file_set)
+                   valkyrie_create(:hyrax_file_set)
         file_set.id
       end
     end

--- a/spec/hyrax/transactions/steps/remove_file_set_from_work_spec.rb
+++ b/spec/hyrax/transactions/steps/remove_file_set_from_work_spec.rb
@@ -20,7 +20,16 @@ RSpec.describe Hyrax::Transactions::Steps::RemoveFileSetFromWork do
       end
 
       context 'and with a parent' do
-        let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set, :in_work) }
+        let(:work) do
+          FactoryBot.valkyrie_create(:hyrax_work,
+                                     :with_member_file_sets,
+                                     :with_representative,
+                                     :with_thumbnail)
+        end
+        let(:file_sets) { Hyrax.query_service.custom_queries.find_child_file_sets(resource: work) }
+        let(:file_set) { file_sets.first }
+        # let(:file_set) { work.file_sets.to_a.first }
+        # let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set, :in_work) }
         let(:listener) { Hyrax::Specs::SpyListener.new }
 
         before { Hyrax.publisher.subscribe(listener) }
@@ -30,6 +39,46 @@ RSpec.describe Hyrax::Transactions::Steps::RemoveFileSetFromWork do
           expect { step.call(file_set, user: user) }
             .to change { Hyrax.query_service.find_parents(resource: file_set).to_a }
             .to be_empty
+        end
+
+        describe 'it unlinks the file set from the parent' do
+          # before do
+          #   expect(step).to receive(:do_it) do |args|
+          #     expect(args[0].id).to eq work.id
+          #     expect(args[1].id).to eq file_set.id
+          #   end.and_call_original
+          #   #puts work.class.name
+          #   #puts work.methods.sort.join "\n"
+          # end
+
+          it 'unlinks' do
+            # byebug
+            puts "file_set.id=#{file_set.id}"
+            puts "work.member_ids=#{work.member_ids}"
+            puts "work.thumbnail_id=#{work.thumbnail_id}"
+            puts "work.representative_id=#{work.representative_id}"
+            expect(work.member_ids.include? file_set.id).to eq true
+            expect(work.representative_id).to eq file_set.id
+            expect(Hyrax.query_service.find_parents(resource: file_set).is_a? Array).to eq true
+            expect(Hyrax.query_service.find_parents(resource: file_set).first).to eq work
+            step.call(file_set, user: user)
+            reloaded = Hyrax.query_service.find_by(id: work.id)
+            expect(work.id).to eq reloaded.id
+            puts "file_set.id=#{file_set.id}"
+            puts "reloaded.member_ids=#{reloaded.member_ids}"
+            puts "reloaded.thumbnail_id=#{reloaded.thumbnail_id}"
+            puts "reloaded.representative_id=#{reloaded.representative_id}"
+            expect(reloaded.member_ids.include? file_set.id).to eq false
+            expect(reloaded.thumbnail_id).not_to eq file_set.id
+            expect(reloaded.representative_id).not_to eq file_set.id
+            # byebug
+            # puts "file_set.id=#{file_set.id}"
+            # puts "work.member_ids=#{work.member_ids}"
+            # puts "work.thumbnail_id=#{work.thumbnail_id}"
+            # puts "work.representative_id=#{work.representative_id}"
+            # expect(work.member_ids.include? file_set.id).to eq false
+            # expect(work.representative_id).not_to eq file_set.id
+          end
         end
 
         it 'publishes an update of the parent' do

--- a/spec/hyrax/transactions/steps/remove_file_set_from_work_spec.rb
+++ b/spec/hyrax/transactions/steps/remove_file_set_from_work_spec.rb
@@ -42,42 +42,22 @@ RSpec.describe Hyrax::Transactions::Steps::RemoveFileSetFromWork do
         end
 
         describe 'it unlinks the file set from the parent' do
-          # before do
-          #   expect(step).to receive(:do_it) do |args|
-          #     expect(args[0].id).to eq work.id
-          #     expect(args[1].id).to eq file_set.id
-          #   end.and_call_original
-          #   #puts work.class.name
-          #   #puts work.methods.sort.join "\n"
-          # end
+          before do
+            expect(step).to receive(:find_parents).with(resource: file_set).and_return [work]
+          end
 
           it 'unlinks' do
-            # byebug
-            puts "file_set.id=#{file_set.id}"
-            puts "work.member_ids=#{work.member_ids}"
-            puts "work.thumbnail_id=#{work.thumbnail_id}"
-            puts "work.representative_id=#{work.representative_id}"
             expect(work.member_ids.include? file_set.id).to eq true
             expect(work.representative_id).to eq file_set.id
             expect(Hyrax.query_service.find_parents(resource: file_set).is_a? Array).to eq true
             expect(Hyrax.query_service.find_parents(resource: file_set).first).to eq work
             step.call(file_set, user: user)
-            reloaded = Hyrax.query_service.find_by(id: work.id)
-            expect(work.id).to eq reloaded.id
-            puts "file_set.id=#{file_set.id}"
-            puts "reloaded.member_ids=#{reloaded.member_ids}"
-            puts "reloaded.thumbnail_id=#{reloaded.thumbnail_id}"
-            puts "reloaded.representative_id=#{reloaded.representative_id}"
-            expect(reloaded.member_ids.include? file_set.id).to eq false
-            expect(reloaded.thumbnail_id).not_to eq file_set.id
-            expect(reloaded.representative_id).not_to eq file_set.id
-            # byebug
-            # puts "file_set.id=#{file_set.id}"
-            # puts "work.member_ids=#{work.member_ids}"
-            # puts "work.thumbnail_id=#{work.thumbnail_id}"
-            # puts "work.representative_id=#{work.representative_id}"
-            # expect(work.member_ids.include? file_set.id).to eq false
-            # expect(work.representative_id).not_to eq file_set.id
+            # reloaded = Hyrax.query_service.find_by(id: work.id)
+            # expect(reloaded.member_ids.include? file_set.id).to eq false
+            # expect(reloaded.thumbnail_id).not_to eq file_set.id
+            # expect(reloaded.representative_id).not_to eq file_set.id
+            expect(work.member_ids.include? file_set.id).to eq false
+            expect(work.representative_id).not_to eq file_set.id
           end
         end
 

--- a/spec/hyrax/transactions/steps/remove_file_set_from_work_spec.rb
+++ b/spec/hyrax/transactions/steps/remove_file_set_from_work_spec.rb
@@ -50,13 +50,13 @@ RSpec.describe Hyrax::Transactions::Steps::RemoveFileSetFromWork, valkyrie_adapt
           it 'by clearing thumbnail_id' do
             expect { step.call(file_set, user: user) }
               .to change { Hyrax.query_service.find_by(id: parent.id).thumbnail_id }
-                    .to be_nil
+              .to be_nil
           end
 
           it 'by deleting from rendering_ids' do
             expect { step.call(file_set, user: user) }
               .to change { Hyrax.query_service.find_by(id: parent.id).rendering_ids }
-                    .to be_empty
+              .to be_empty
           end
         end
 

--- a/spec/hyrax/transactions/steps/remove_file_set_from_work_spec.rb
+++ b/spec/hyrax/transactions/steps/remove_file_set_from_work_spec.rb
@@ -47,16 +47,16 @@ RSpec.describe Hyrax::Transactions::Steps::RemoveFileSetFromWork do
           end
 
           it 'unlinks' do
-            expect(work.member_ids.include? file_set.id).to eq true
+            expect(work.member_ids.include?(file_set.id)).to eq true
             expect(work.representative_id).to eq file_set.id
-            expect(Hyrax.query_service.find_parents(resource: file_set).is_a? Array).to eq true
+            expect(Hyrax.query_service.find_parents(resource: file_set).is_a?(Array)).to eq true
             expect(Hyrax.query_service.find_parents(resource: file_set).first).to eq work
             step.call(file_set, user: user)
             # reloaded = Hyrax.query_service.find_by(id: work.id)
             # expect(reloaded.member_ids.include? file_set.id).to eq false
             # expect(reloaded.thumbnail_id).not_to eq file_set.id
             # expect(reloaded.representative_id).not_to eq file_set.id
-            expect(work.member_ids.include? file_set.id).to eq false
+            expect(work.member_ids.include?(file_set.id)).to eq false
             expect(work.representative_id).not_to eq file_set.id
           end
         end

--- a/spec/presenters/hyrax/pcdm_member_presenter_factory_spec.rb
+++ b/spec/presenters/hyrax/pcdm_member_presenter_factory_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Hyrax::PcdmMemberPresenterFactory do
 
       it 'raises an error if given an unindexed id' do
         expect { factory.member_presenters(['FAKE_ID']).to_a }
-          .to raise_error ArgumentError
+          .to raise_error Hyrax::ObjectNotFoundError
       end
 
       context 'with members' do
@@ -159,7 +159,7 @@ RSpec.describe Hyrax::PcdmMemberPresenterFactory do
 
       it 'raises an error if given an unindexed id' do
         expect { factory.member_presenters(['FAKE_ID']).to_a }
-          .to raise_error ArgumentError
+          .to raise_error Hyrax::ObjectNotFoundError
       end
 
       context 'with members' do

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
       it 'has a nil presenter' do
         expect(presenter).to receive(:member_presenters)
           .with([obj.members[0].id])
-          .and_raise ArgumentError
+          .and_raise Hyrax::ObjectNotFoundError
         expect(presenter.representative_presenter).to be_nil
       end
     end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -387,8 +387,8 @@ RSpec.describe Hyrax::WorkShowPresenter do
     context 'has an unindexed representative' do
       it 'has a nil presenter' do
         expect(presenter).to receive(:member_presenters)
-                               .with([obj.members[0].id])
-                               .and_raise ArgumentError
+          .with([obj.members[0].id])
+          .and_raise ArgumentError
         expect(presenter.representative_presenter).to be_nil
       end
     end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -384,6 +384,15 @@ RSpec.describe Hyrax::WorkShowPresenter do
       end
     end
 
+    context 'has an unindexed representative' do
+      it 'has a nil presenter' do
+        expect(presenter).to receive(:member_presenters)
+                               .with([obj.members[0].id])
+                               .and_raise ArgumentError
+        expect(presenter.representative_presenter).to be_nil
+      end
+    end
+
     context 'when it is its own representative' do
       let(:obj) { create(:work) }
 


### PR DESCRIPTION
Fixes #5795 ; refs #5136 #5794 #5575

Deleting a file set from a work does not entirely unlink file set.

The Delete option on the drop-down menu for Items on a work view page throws an error. Selecting Delete in drop-down menu raises ano ArgumentError in Hyrax::GenericWorks#show

![Screen Shot 2022-08-12 at 9 59 32 AM](https://user-images.githubusercontent.com/3440166/184372222-21a1b48d-cb8d-4f39-a2a9-48b85727f8ad.png)

Changes proposed in this pull request:
* Unlink representative_id and template_id from work in remove from file set transaction step.
* Catch argument error from missing representative id resource in work show presenter.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Log in to user dashboard, click work name to display work view page.
* In the section of "Items", find the dropdown menu "Select an action" and select Delete from the drop-down menu and click OK at prompt to confirm delete action.
* You will see an error like ArgumentError in Hyrax::GenericWorks#show

@samvera/hyrax-code-reviewers
