### PR TITLE
Present error to user if trying to add a work to 2 single membership collections.

### DIFF
--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -97,5 +97,112 @@ module Hyrax
         hash[presenter.title_or_label] = presenter.id
       end
     end
+
+    ##
+    # This helper retrieves errors based on form type.
+    #
+    # @param form [Hyrax::Forms::WorkForm] or Hyrax::ChangeSet
+    # @return [String] specific error message
+    def in_works_ids_errors_for(form:)
+      case form
+      when Hyrax::ChangeSet
+        form.errors[:in_works_ids]
+      else
+        form.model.errors[:in_works_ids]
+      end
+    end
+
+    ##
+    # This helper retrieves errors based on form type.
+    #
+    # @param form [Hyrax::Forms::WorkForm] or Hyrax::ChangeSet
+    # @return [String] specific error message
+    def ordered_member_ids_errors_for(form:)
+      case form
+      when Hyrax::ChangeSet
+        form.errors[:ordered_member_ids]
+      else
+        form.model.errors[:ordered_member_ids]
+      end
+    end
+
+    ##
+    # This helper retrieves errors based on form type.
+    #
+    # @param form [Hyrax::Forms::WorkForm] or Hyrax::ChangeSet
+    # @return [String] specific error message
+    def visibility_errors_for(form:)
+      case form
+      when Hyrax::ChangeSet
+        form.errors[:visibility]
+      else
+        form.model.errors[:visibility]
+      end
+    end
+
+    ##
+    # This helper retrieves errors based on form type.
+    #
+    # @param form [Hyrax::Forms::WorkForm] or Hyrax::ChangeSet
+    # @return [String] specific error message
+    def embargo_release_date_errors_for(form:)
+      case form
+      when Hyrax::ChangeSet
+        form.errors[:embargo_release_date]
+      else
+        form.model.errors[:embargo_release_date]
+      end
+    end
+
+    ##
+    # This helper retrieves errors based on form type.
+    #
+    # @param form [Hyrax::Forms::WorkForm] or Hyrax::ChangeSet
+    # @return [String] specific error message
+    def visibility_after_embargo_errors_for(form:)
+      case form
+      when Hyrax::ChangeSet
+        form.errors[:visibility_after_embargo]
+      else
+        form.model.errors[:visibility_after_embargo]
+      end
+    end
+
+    ##
+    # This helper retrieves errors based on form type.
+    #
+    # @param form [Hyrax::Forms::WorkForm] or Hyrax::ChangeSet
+    # @return [String] specific error message
+    def lease_expiration_date_errors_for(form:)
+      case form
+      when Hyrax::ChangeSet
+        form.errors[:lease_expiration_date_errors]
+      else
+        form.model.errors[:lease_expiration_date_errors]
+      end
+    end
+
+    ##
+    # This helper retrieves errors based on form type.
+    #
+    # @param form [Hyrax::Forms::WorkForm] or Hyrax::ChangeSet
+    # @return [String] specific error message
+    def visibility_after_lease_errors_for(form:)
+      case form
+      when Hyrax::ChangeSet
+        form.errors[:visibility_after_lease]
+      else
+        form.model.errors[:visibility_after_lease]
+      end
+    end
+
+    ##
+    # This helper retrieves errors based on form type.
+    #
+    # @param form [Hyrax::Forms::WorkForm] or Hyrax::ChangeSet
+    # @return [String] specific error message
+    def full_collections_errors(form:)
+      form.full_error(:collections) || form.full_error(:member_of_collection_ids)
+    end
   end
 end

--- a/app/views/hyrax/base/_form_collections_error.html.erb
+++ b/app/views/hyrax/base/_form_collections_error.html.erb
@@ -1,1 +1,1 @@
-<%= f.full_error(:collections) %>
+<%= full_collections_errors(form: f) %>

--- a/app/views/hyrax/base/_form_in_works_error.html.erb
+++ b/app/views/hyrax/base/_form_in_works_error.html.erb
@@ -1,3 +1,3 @@
-<% unless f.object.model.errors[:in_works_ids].empty? %>
+<% unless in_works_ids_errors_for(form: f.object).empty? %>
   <%= f.full_error(:in_works_ids) %>
 <% end %>

--- a/app/views/hyrax/base/_form_ordered_members_error.html.erb
+++ b/app/views/hyrax/base/_form_ordered_members_error.html.erb
@@ -1,3 +1,3 @@
-<% unless f.object.model.errors[:ordered_member_ids].empty? %>
+<% unless ordered_member_ids_errors_for(form: f.object).empty? %>
   <%= f.full_error(:ordered_member_ids) %>
 <% end %>

--- a/app/views/hyrax/base/_form_visibility_error.html.erb
+++ b/app/views/hyrax/base/_form_visibility_error.html.erb
@@ -1,5 +1,19 @@
-<%= f.full_error(:visibility) %>
-<%= f.full_error(:embargo_release_date) %>
-<%= f.full_error(:visibility_after_embargo) %>
-<%= f.full_error(:lease_expiration_date) %>
-<%= f.full_error(:visibility_after_lease) %>
+<% unless visibility_errors_for(form: f.object).empty? %>
+  <%= f.full_error(:visibility) %>
+<% end %>
+
+<% unless embargo_release_date_errors_for(form: f.object).empty? %>
+  <%= f.full_error(:embargo_release_date) %>
+<% end %>
+
+<% unless visibility_after_embargo_errors_for(form: f.object).empty? %>
+  <%= f.full_error(:visibility_after_embargo) %>
+<% end %>
+
+<% unless lease_expiration_date_errors_for(form: f.object).empty? %>
+  <%= f.full_error(:lease_expiration_date) %>
+<% end %>
+
+<% unless visibility_after_lease_errors_for(form: f.object).empty? %>
+  <%= f.full_error(:visibility_after_lease) %>
+<% end %>


### PR DESCRIPTION
Fixes #5594

Adding a work to two collections of the same single membership type raises NoMethodError - undefined method 'errors' for <GenericWork>.  With the code change presented in this PR, this is resolved.

Now with Valkyrie in place, the view needs to know where to grab the error messages.  When the form is of Hyrax::ChangeSet type (this is the case for valkyrie items) the errors are stored in the form, otherwise it is stored in the model.  In order to make this process clean, new methods were added to the helper that the view now calls to grab the errors.

Prerequisite:

* Create a collection type that is single membership
* Create two collections of that type

To Test:

* Dashboard -> Works -> Add new work -> select any work type
* Fill in required metadata
* Select tab: Relationships
* In Add to collection selection, type name of first single membership collection and click button: Add
* In Add to collection selection, type name of second single membership collection and click button: Add
* Click button: Save changes
* User should see an error message indicating that the item can't be added to two collections that are restricted to single membership.

@samvera/hyrax-code-reviewers
