### PR TITLE
Resource permission persisting

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -189,7 +189,8 @@ module Hyrax
           'work_resource.add_to_parent' => { parent_id: params[:parent_id], user: current_user },
           'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
           'change_set.set_user_as_depositor' => { user: current_user },
-          'work_resource.change_depositor' => { user: ::User.find_by_user_key(form.on_behalf_of) }
+          'work_resource.change_depositor' => { user: ::User.find_by_user_key(form.on_behalf_of) },
+          'work_resource.save_acl' => { permissions_params: form.input_params["permissions"] }
         )
         .call(form)
       @curation_concern = result.value_or { return after_create_error(transaction_err_msg(result)) }
@@ -202,7 +203,8 @@ module Hyrax
       result =
         transactions['change_set.update_work']
         .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
-                        'work_resource.update_work_members' => { work_members_attributes: work_members_attributes })
+                        'work_resource.update_work_members' => { work_members_attributes: work_members_attributes },
+                        'work_resource.save_acl' => { permissions_params: form.input_params["permissions"] })
         .call(form)
       @curation_concern = result.value_or { return after_update_error(transaction_err_msg(result)) }
       after_update_response

--- a/lib/hyrax/transactions/steps/save_access_control.rb
+++ b/lib/hyrax/transactions/steps/save_access_control.rb
@@ -22,7 +22,8 @@ module Hyrax
           acl = obj.permission_manager&.acl
           # Translate step args into Hyrax::Permission objects before saving
           Array(permissions_params).each do |param|
-            acl << param_to_permission(obj, param)
+            permission = param_to_permission(obj, param)
+            acl << permission if permission
           end
 
           acl&.save || (return Failure[:failed_to_save_acl, acl])
@@ -33,6 +34,7 @@ module Hyrax
         private
 
         def param_to_permission(obj, param)
+          return nil unless param["access"] && param["type"] && param["name"]
           mode = param["access"].to_sym
           agent = param["type"] == "group" ? "group/#{param['name']}" : param["name"]
           Hyrax::Permission.new(access_to: obj.id, mode: mode, agent: agent)

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -123,6 +123,17 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         end
       end
 
+      context 'when granting additional permissions' do
+        let(:create_params) { { title: 'comet in moominland', permissions_attributes: { "0" => { type: 'person', access: 'read', name: 'foo@bar.com' } } } }
+
+        it 'saves the visibility' do
+          post :create, params: { test_simple_work: create_params }
+
+          expect(Hyrax::AccessControlList(assigns[:curation_concern]).permissions)
+            .to include(have_attributes(mode: :read, agent: 'foo@bar.com'))
+        end
+      end
+
       context 'when adding a collection' do
         let(:collection) { FactoryBot.valkyrie_create(:pcdm_collection) }
 
@@ -563,6 +574,17 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
           expect(Hyrax::AccessControlList(assigns[:curation_concern]).permissions)
             .to include(have_attributes(mode: :read, agent: 'group/public'))
+        end
+      end
+
+      context 'and granting additional permissions' do
+        let(:update_params) { { title: 'comet in moominland', permissions_attributes: { "0" => { type: 'person', access: 'read', name: 'foo@bar.com' } } } }
+
+        it 'saves the visibility' do
+          post :update, params: { id: id, test_simple_work: update_params }
+
+          expect(Hyrax::AccessControlList(assigns[:curation_concern]).permissions)
+            .to include(have_attributes(mode: :read, agent: 'foo@bar.com'))
         end
       end
 

--- a/spec/hyrax/transactions/steps/save_access_control_spec.rb
+++ b/spec/hyrax/transactions/steps/save_access_control_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe Hyrax::Transactions::Steps::SaveAccessControl, valkyrie_adapter: 
         expect(result.failure).to contain_exactly(Symbol, Hyrax::AccessControlList)
       end
     end
+
+    context 'when permissions params are passed' do
+      let(:params) { [{ "access" => "read", "type" => "group", "name" => "admin" }, { "access" => "edit", "type" => "person", "name" => user.user_key }] }
+
+      it 'transforms and persists the params' do
+        expect { step.call(work, permissions_params: params) }
+          .to change { Hyrax::AccessControlList.new(resource: work).permissions }
+          .to contain_exactly(have_attributes(mode: :read, agent: user.user_key),
+                                    have_attributes(mode: :edit, agent: user.user_key),
+                                    have_attributes(mode: :read, agent: 'group/admin'))
+      end
+    end
   end
 
   context 'when the resource has no permission_manager' do

--- a/spec/hyrax/transactions/steps/save_access_control_spec.rb
+++ b/spec/hyrax/transactions/steps/save_access_control_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe Hyrax::Transactions::Steps::SaveAccessControl, valkyrie_adapter: 
                                     have_attributes(mode: :edit, agent: user.user_key),
                                     have_attributes(mode: :read, agent: 'group/admin'))
       end
+
+      context 'with invalid params' do
+        let(:params) { [{ "access" => "read", "type" => "group" }, { "type" => "person", "name" => "foo@bar.com" }, { "access" => "edit", "name" => "foo@bar.com" }] }
+
+        it 'does not persist the params' do
+          step.call(work, permissions_params: params)
+          expect(Hyrax::AccessControlList.new(resource: work).permissions).to contain_exactly(have_attributes(mode: :read, agent: user.user_key))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Introduces handling of `permissions_attributes` params that come from the controller in the `SaveAccessControl` transaction step.  The step converts the params into `Hyrax::Permission` objects and adds them to the ACL of the object being saved.

Also in the PR is change to the works controller to pass the step arg to make use of this new functionality.

In support of #5797 

Steps for testing:
1. Go to dashboard
2. Go to works
3. Click Add new work button
4. Fill in required metadata
5. Go to Sharing tab
6. Choose group 'admin' with 'Edit' access and click Add
7. Click deposit agreement
8. Click Save button
9. Click Edit button
10. Go to Sharing tab
11. Look for group 'admin' in 'Currently Shared With' table
