### PR TITLE
Hyrax-5844 - Cannot remove embargo from work

### DIFF
--- a/app/controllers/hyrax/permissions_controller.rb
+++ b/app/controllers/hyrax/permissions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Hyrax
   class PermissionsController < ApplicationController
-    load_resource class: ActiveFedora::Base, instance_name: :curation_concern
+    load_resource class: Hyrax::Resource, instance_name: :curation_concern
 
     attr_reader :curation_concern
     helper_method :curation_concern

--- a/spec/controllers/hyrax/permissions_controller_spec.rb
+++ b/spec/controllers/hyrax/permissions_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::PermissionsController do
 
   context 'with legacy AF models' do
     describe '#confirm_access' do
-      let(:work) { FactoryBot.create(:generic_work, user: user) }
+      let(:work) { FactoryBot.valkyrie_create(:monograph, edit_users: [user]) }
 
       it 'draws the page' do
         get :confirm_access, params: { id: work }
@@ -15,27 +15,27 @@ RSpec.describe Hyrax::PermissionsController do
     end
 
     describe '#copy' do
-      let(:work) { FactoryBot.create(:generic_work, user: user) }
+      let(:work) { FactoryBot.valkyrie_create(:monograph, edit_users: [user]) }
 
       it 'adds a worker to the queue' do
         expect { post :copy, params: { id: work } }
           .to have_enqueued_job(VisibilityCopyJob)
           .with(work)
 
-        expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
+        expect(response).to redirect_to main_app.hyrax_monograph_path(work, locale: 'en')
         expect(flash[:notice]).to eq 'Updating file permissions. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file permissions.'
       end
     end
 
     describe '#copy_access' do
-      let(:work) { FactoryBot.create(:work_with_one_file, user: user) }
+      let(:work) { FactoryBot.valkyrie_create(:monograph, edit_users: [user]) }
 
       it 'adds VisibilityCopyJob to the queue' do
         expect { post :copy_access, params: { id: work } }
           .to have_enqueued_job(VisibilityCopyJob)
           .with(work)
 
-        expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
+        expect(response).to redirect_to main_app.hyrax_monograph_path(work, locale: 'en')
         expect(flash[:notice]).to eq 'Updating file access levels. This may take a few minutes. ' \
                                      'You may want to refresh your browser or return to this record ' \
                                      'later to see the updated file access levels.'


### PR DESCRIPTION
Fixes #5844 ; refs #5572

Unembargoing a work under valkyrie throws an error

When deactivating an embargo on a work under koppie image/valkyrie, a TCP error is thrown by Hyrax::PermissionsController because it attempts to load ActiveFedora resource.

![Screen Shot 2022-09-08 at 11 38 35 AM](https://user-images.githubusercontent.com/3440166/189167165-71d634be-6ec7-472b-953d-4966a5109e93.png)

Proposed change(s):
* Update Hyrax::PermissionsController to 

To test:
* In koppie/nurax-pg, navigate to a Work which contains an embargo
* Click the "Edit" button 
* In the "Save Work" box on the right side, click the "Embargo Management Page" link in the Visibility section
* Click the "Deactivate Embargo" button
* Error message appears (see screenshot above)

@samvera/hyrax-code-reviewers