### PR TITLE
Exposing `Hyrax.config.derivative_services`

### DIFF
--- a/app/services/hyrax/derivative_service.rb
+++ b/app/services/hyrax/derivative_service.rb
@@ -1,8 +1,24 @@
 # frozen_string_literal: true
 class Hyrax::DerivativeService
-  class_attribute :services
-  self.services = [Hyrax::FileSetDerivativesService]
-  def self.for(file_set)
+  # @deprecated favor Hyrax.config.derivative_services=
+  def self.services=(services)
+    Deprecation.warn("Hyrax::DerivativeService.services= is deprecated; favor Hyrax.config.derivative_servies=")
+    Hyrax.config.derivative_services = Array(services)
+  end
+
+  # @deprecated favor Hyrax.config.derivative_services
+  def self.services
+    Deprecation.warn("Hyrax::DerivativeService.services is deprecated; favor Hyrax.config.derivative_servies")
+    Hyrax.config.derivative_services
+  end
+
+  # @api public
+  #
+  # Get the first valid registered service for the given file_set.
+  #
+  # @param file_set [#uri, #file_set]
+  # @return [#cleanup_derivatives, #create_derivatives, #derivative_url]
+  def self.for(file_set, services: Hyrax.config.derivative_services)
     services.map { |service| service.new(file_set) }.find(&:valid?) ||
       new(file_set)
   end

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -165,6 +165,10 @@ Hyrax.config do |config|
   #  config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' }
   #  config.cache_path = ->() { Rails.root + 'tmp' + 'uploads' + 'cache' }
 
+  # The registered candidate derivative services.  In the array, the first `valid?` candidate will
+  # handle the derivative generation.
+  # config.derivative_services = [Hyrax::FileSetDerivativesService]
+
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
   # config.derivatives_path = Rails.root.join('tmp', 'derivatives')

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -860,6 +860,16 @@ module Hyrax
       @range_for_number_of_results_to_display_per_page ||= [10, 20, 50, 100]
     end
 
+    attr_writer :derivative_services
+    # The registered candidate derivative services.  In the array, the first `valid?` candidate will
+    # handle the derivative generation.
+    #
+    # @return [Array] of objects that conform to Hyrax::DerivativeService interface.
+    # @see Hyrax::DerivativeService
+    def derivative_services
+      @derivative_services ||= [Hyrax::FileSetDerivativesService]
+    end
+
     private
 
     # @param [Symbol, #to_s] model_name - symbol representing the model

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:contact_email) }
   it { is_expected.to respond_to(:default_admin_set_id) }
   it { is_expected.to respond_to(:default_nested_relationship_reindexer) }
+  it { is_expected.to respond_to(:derivative_services) }
+  it { is_expected.to respond_to(:derivative_services=) }
   it { is_expected.to respond_to(:display_media_download_link=) }
   it { is_expected.to respond_to(:display_media_download_link?) }
   it { is_expected.to respond_to(:display_microdata?) }

--- a/spec/services/hyrax/derivative_service_spec.rb
+++ b/spec/services/hyrax/derivative_service_spec.rb
@@ -7,26 +7,8 @@ RSpec.describe Hyrax::DerivativeService do
   subject { described_class.new(file_set) }
 
   it_behaves_like "a Hyrax::DerivativeService"
-  around do |example|
-    cached_services = described_class.services
-    example.run
-    described_class.services = cached_services
-  end
-
-  describe ".services=" do
-    it "allows you to set the available services" do
-      described_class.services = [Hyrax::FileSetDerivativesService, Hyrax::FileSetDerivativesService]
-      expect(described_class.services).to eq [Hyrax::FileSetDerivativesService, Hyrax::FileSetDerivativesService]
-    end
-    it "defaults to an array" do
-      expect(described_class.services).to eq [Hyrax::FileSetDerivativesService]
-    end
-  end
 
   describe ".for" do
-    before do
-      described_class.services = [Hyrax::FileSetDerivativesService]
-    end
     context "when a FileSet matches the requirements of a service" do
       let(:file_set) do
         FileSet.new.tap do |f|
@@ -35,14 +17,14 @@ RSpec.describe Hyrax::DerivativeService do
       end
 
       it "returns it" do
-        expect(described_class.for(file_set)).to be_instance_of Hyrax::FileSetDerivativesService
+        expect(described_class.for(file_set, services: [Hyrax::FileSetDerivativesService])).to be_instance_of Hyrax::FileSetDerivativesService
       end
     end
     context "when a FileSet matches no services" do
       let(:file_set) { FileSet.new }
 
       it "returns a base DerivativeService" do
-        expect(described_class.for(file_set)).to be_instance_of described_class
+        expect(described_class.for(file_set, services: [Hyrax::FileSetDerivativesService])).to be_instance_of described_class
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, we had a somewhat opaque mechanism for overriding the candidate Hyrax::DerivativeService services.  There is precedence on doing this (see [NewspaperWorks][1]) yet the configuration was not exposed during application generation nor as part of `Hyrax::Configuration`.

This change exposes the setting of the derivative services a primary concern of configuring a Hyrax application.

Related to #5866

[1]:https://github.com/samvera-labs/newspaper_works/blob/d0c0c0595ad318178896fb7f2abd93c5139fe5b7/lib/newspaper_works/engine.rb#L15-L35

@samvera/hyrax-code-reviewers
