### PR TITLE
Koppie fixes

### DIFF
--- a/.koppie/config/initializers/1_valkyrie.rb
+++ b/.koppie/config/initializers/1_valkyrie.rb
@@ -47,7 +47,8 @@ Valkyrie.config.metadata_adapter = :nurax_pg_metadata_adapter
 #
 # Valkyrie.config.storage_adapter = :repository_s3
 Valkyrie::StorageAdapter.register(
-  Valkyrie::Storage::Disk.new(base_path: Rails.root.join("public", "files")),
+  Valkyrie::Storage::Disk.new(base_path: Rails.root.join("storage", "files"),
+                              file_mover: FileUtils.method(:cp)),
   :disk
 )
 Valkyrie.config.storage_adapter  = :disk

--- a/.koppie/config/initializers/hyrax.rb
+++ b/.koppie/config/initializers/hyrax.rb
@@ -181,12 +181,12 @@ Hyrax.config do |config|
 
   # Temporary paths to hold uploads before they are ingested into FCrepo
   # These must be lambdas that return a Pathname. Can be configured separately
-  config.upload_path = ->() { ENV.fetch('UPLOADS_PATH', Rails.root + 'tmp' + 'uploads') }
-  config.cache_path = ->() { ENV.fetch('CACHE_PATH', Rails.root + 'tmp' + 'uploads' + 'cache') }
+  # config.upload_path = ->() { ENV.fetch('UPLOADS_PATH', Rails.root + 'tmp' + 'uploads') }
+  # config.cache_path = ->() { ENV.fetch('CACHE_PATH', Rails.root + 'tmp' + 'uploads' + 'cache') }
 
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
-  config.derivatives_path = ENV.fetch('DERIVATIVES_PATH', Rails.root.join('tmp', 'derivatives'))
+  # config.derivatives_path = ENV.fetch('DERIVATIVES_PATH', Rails.root.join('tmp', 'derivatives'))
 
   # Should schema.org microdata be displayed?
   # config.display_microdata = true
@@ -198,7 +198,7 @@ Hyrax.config do |config|
   # Location on local file system where uploaded files will be staged
   # prior to being ingested into the repository or having derivatives generated.
   # If you use a multi-server architecture, this MUST be a shared volume.
-  config.working_path = ENV.fetch('UPLOADS_PATH', Rails.root.join('tmp', 'uploads'))
+  # config.working_path = ENV.fetch('UPLOADS_PATH', Rails.root.join('tmp', 'uploads'))
 
   # Should the media display partial render a download link?
   # config.display_media_download_link = true

--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -9,7 +9,7 @@ services:
         - EXTRA_APK_PACKAGES=git less chromium
         - APP_PATH=.koppie
     image: ghcr.io/samvera/koppie
-    command: sh -l -c 'bundle && bundle exec puma -v -b tcp://0.0.0.0:3000'
+    command: sh -l -c 'bundle && yarn && bundle exec puma -v -b tcp://0.0.0.0:3000'
     stdin_open: true
     tty: true
     user: root

--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -31,6 +31,7 @@ services:
     volumes:
       - .koppie:/app/samvera/hyrax-webapp
       - .:/app/samvera/hyrax-engine
+      - hyrax-storage:/app/samvera/hyrax-webapp/storage
       - hyrax-derivatives:/app/samvera/hyrax-webapp/derivatives
       - hyrax-uploads:/app/samvera/hyrax-webapp/uploads
       - rails-public:/app/samvera/hyrax-webapp/public
@@ -58,6 +59,7 @@ services:
     volumes:
       - .koppie:/app/samvera/hyrax-webapp
       - .:/app/samvera/hyrax-engine
+      - hyrax-storage:/app/samvera/hyrax-webapp/storage
       - hyrax-derivatives:/app/samvera/hyrax-webapp/derivatives
       - hyrax-uploads:/app/samvera/hyrax-webapp/uploads
       - sidekiq-public:/app/samvera/hyrax-webapp/public
@@ -144,6 +146,7 @@ services:
 
 volumes:
   db:
+  hyrax-storage:
   hyrax-derivatives:
   hyrax-uploads:
   rails-public:


### PR DESCRIPTION
* Fixes koppie's storage paths so that the app and sidekiq containers can see the same files.
* Sets koppie to use cp when persisting files. If a ValkyrieIngestJob fails then the upload files will still exist when the job is retried.
* Runs `yarn` during startup to ensure UniversalViewer is installed.