### PR TITLE
allow rights_statement to show up in the work show page.

### DIFF
--- a/config/metadata/basic_metadata.yaml
+++ b/config/metadata/basic_metadata.yaml
@@ -113,6 +113,8 @@ attributes:
     multiple: true
     form:
       primary: true
+    index_keys:
+      - "rights_statement_tesim"
   source:
     type: string
     multiple: true


### PR DESCRIPTION
Fixes #5860

After user deposits a work with a license the license should show up on the work show page.
The valkyrie indexer was not storing the rights_statement so that it was not available for display in the work show page.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* On nurax-pg or koppie, create a new Work
* On Descriptions tab, select a Rights Statement
* Add required information and save the work
* Review the public view of the Work and see that Rights Statement does show


@samvera/hyrax-code-reviewers
