### PR TITLE
build amd64 and arm64 images on release and push to ghcr.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+name: Build and push docker image
+on:
+  workflow_dispatch:
+  release:
+  push:
+    branches:
+      - build_images_on_release
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set env
+        run: echo "TAG=${GITHUB_SHA::8}" >> $GITHUB_ENV
+      - name: Downcase repo
+        run: echo "REPO_LOWER=${REPO,,}" >> $GITHUB_ENV
+        env:
+          REPO: '${{ github.repository }}'
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Github Container Login
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          target: hyrax-base
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/hyrax-base:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/hyrax-base:${{ github.ref_name }}
+      - name: Build and push worker
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          target: hyrax-worker-base
+          cache-from: |
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}:${TAG}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/hyrax-worker-base:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/hyrax-worker-base:${{ github.ref_name }}
+      - name: Build and push dassie
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          target: hyrax-engine-dev
+          cache-from: |
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}:${TAG}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/dassie:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/dassie:${{ github.ref_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,3 +65,15 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/dassie:${{ env.TAG }}
             ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/dassie:${{ github.ref_name }}
+      - name: Build and push dassie worker
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          target: hyrax-engine-dev-worker
+          cache-from: |
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/dassie:${TAG}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/dassie-worker:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/dassie-worker:${{ github.ref_name }}


### PR DESCRIPTION
Refs #4854 

Build ARM and Intel Docker images automatically based on the current recommendation from CONTAINERS.md.

Using Github Actions, we can build the docker images and push them to the Github Registry. This currently only builds hyrax-base, hyrax-base-worker and hyrax-engine-dev. There are more items described in #4854, but only those are listed in the current CONTAINERS.md. I'm not sure which list is right. It also currently does nothing about Docker Hub. I'm not super clear if we should or not at this point.

@samvera/hyrax-code-reviewers
