### PR TITLE
Hyrax-5844 - Cannot remove embargo from work - 2

### DIFF
--- a/app/actors/hyrax/actors/embargo_actor.rb
+++ b/app/actors/hyrax/actors/embargo_actor.rb
@@ -15,8 +15,10 @@ module Hyrax
         case work
         when Valkyrie::Resource
           embargo_manager = Hyrax::EmbargoManager.new(resource: work)
-          embargo_manager.release && Hyrax::AccessControlList(work).save
-          embargo_manager.nullify
+          return if embargo_manager.embargo.embargo_release_date.blank?
+          embargo_manager.nullify(force: true)
+          embargo_manager.release(force: true)
+          Hyrax::AccessControlList(work).save
         else
           work.embargo_visibility! # If the embargo has lapsed, update the current visibility.
           work.deactivate_embargo!

--- a/app/services/hyrax/embargo_manager.rb
+++ b/app/services/hyrax/embargo_manager.rb
@@ -164,19 +164,23 @@ module Hyrax
     ##
     # Drop the embargo by setting its release date to `nil`.
     #
+    # @param force [boolean] force the nullify even when the embargo period is current
+    #
     # @return [void]
-    def nullify
-      return unless under_embargo?
+    def nullify(force: false)
+      return false if !force && under_embargo?
       embargo.embargo_release_date = nil
     end
 
     ##
-    # Sets the visibility of the resource to the embargo's visibility condition.
-    # no-op if the embargo period is current.
+    # Sets the visibility of the resource to the embargo's after embargo visibility.
+    # no-op if the embargo period is current and the force flag is false.
+    #
+    # @param force [boolean] force the release even when the embargo period is current
     #
     # @return [Boolean] truthy if the embargo has been applied
-    def release
-      return false if under_embargo?
+    def release(force: false)
+      return false if !force && under_embargo?
       return true if embargo.visibility_after_embargo.nil?
 
       resource.visibility = embargo.visibility_after_embargo


### PR DESCRIPTION
Fixes #5844 ; refs #5572

Unembargoing a work under valkyrie throws an error

When deactivating an embargo on a work under koppie image/valkyrie, a TCP error is thrown by Hyrax::PermissionsController because it attempts to load ActiveFedora resource.

![Screen Shot 2022-09-08 at 11 38 35 AM](https://user-images.githubusercontent.com/3440166/189167165-71d634be-6ec7-472b-953d-4966a5109e93.png)

Proposed change(s):
* Update Hyrax::PermissionsController to 

To test:
* In koppie/nurax-pg, navigate to a Work which contains an embargo
* Click the "Edit" button 
* In the "Save Work" box on the right side, click the "Embargo Management Page" link in the Visibility section
* Click the "Deactivate Embargo" button
* Error message appears (see screenshot above)

@samvera/hyrax-code-reviewers