### PR TITLE
Switch to parameters required by selenium 4

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -102,7 +102,7 @@ SUMMARY
   spec.add_development_dependency 'rspec-its', '~> 1.1'
   spec.add_development_dependency 'rspec-rails', '~> 5.0'
   spec.add_development_dependency 'rspec_junit_formatter'
-  spec.add_development_dependency "selenium-webdriver"
+  spec.add_development_dependency "selenium-webdriver", '~> 4.4'
   spec.add_development_dependency 'i18n-debug'
   spec.add_development_dependency 'i18n_yaml_sorter'
   spec.add_development_dependency 'rails-controller-testing', '~> 1'

--- a/lib/hyrax/specs/capybara.rb
+++ b/lib/hyrax/specs/capybara.rb
@@ -23,12 +23,12 @@ if ENV['IN_DOCKER'].present? || ENV['HUB_URL'].present?
   args = %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400]
   args.push('headless') if ActiveModel::Type::Boolean.new.cast(ENV['CHROME_HEADLESS_MODE'])
 
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome("goog:chromeOptions" => { args: args })
+  options = Selenium::WebDriver::Options.chrome("goog:chromeOptions" => { args: args })
 
   Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
     driver = Capybara::Selenium::Driver.new(app,
                                        browser: :remote,
-                                       desired_capabilities: capabilities,
+                                       capabilities: options,
                                        url: ENV['HUB_URL'])
 
     # Fix for capybara vs remote files. Selenium handles this for us


### PR DESCRIPTION
I needed to make these changes in order to run feature tests locally in dassie and koppie.  I see that CircleCI builds have the latest `selenium-webdriver` and still pass so the requirement for 4.4+ may not be necessary.

Based upon https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/