### PR TITLE
Ensuring Hyrax::UserStatImporter returns false on exception

### DIFF
--- a/app/services/hyrax/user_stat_importer.rb
+++ b/app/services/hyrax/user_stat_importer.rb
@@ -84,6 +84,8 @@ module Hyrax
     rescue StandardError => exception
       log_message fail_message
       log_message "Last exception #{exception}"
+      # Without returning false, we return the results of log_message; which is true.
+      false
     end
 
     def date_since_last_cache(user)


### PR DESCRIPTION
Backport of #5874 

Prior to this commit, in the retriable block, if we hit an exception, we'd return `true` and upstream we'd raise an exception.

In the below code, the `extract_stats_for` is returning true, because calls to `Rails.logger.info` return true.

```ruby
view_stats = extract_stats_for(object: file, from: FileViewStat, start_date: start_date, user: user)
stats = tally_results(view_stats, :views, stats) if view_stats.present?
```

This resulted in attempting to call `.each` on the `view_stats`; which was true.

This builds on a [reported issue in Slack][1].

@samvera/hyrax-code-reviewers
