### PR TITLE
DownloadsController Valkyrie support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
           name: Install system dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install imagemagick librsvg2-bin
+            sudo apt-get install imagemagick librsvg2-bin lsof
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.7.6
+        default: 2.7.7
       bundler_version:
         type: string
         default: 2.3.13
@@ -68,7 +68,7 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.7.6
+        default: 2.7.7
       bundler_version:
         type: string
         default: 2.3.13
@@ -102,7 +102,7 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.7.6
+        default: 2.7.7
       bundler_version:
         type: string
         default: 2.3.13
@@ -168,27 +168,27 @@ jobs:
             --header 'Content-Type: application/json'
 workflows:
   version: 2
-  ruby2-7-6:
+  ruby2-7-7:
     jobs:
       - bundle:
-          ruby_version: "2.7.6"
+          ruby_version: "2.7.7"
           rails_version: "6.1.6.1"
           bundler_version: "2.3.13"
       - build:
-          ruby_version: "2.7.6"
+          ruby_version: "2.7.7"
           rails_version: "6.1.6.1"
           bundler_version: "2.3.13"
           requires:
             - bundle
       - test:
-          name: "ruby2-7-6"
-          ruby_version: "2.7.6"
+          name: "ruby2-7-7"
+          ruby_version: "2.7.7"
           bundler_version: "2.3.13"
           requires:
             - build
       - test:
-          name: "ruby2-7-6-valkyrie"
-          ruby_version: "2.7.6"
+          name: "ruby2-7-7-valkyrie"
+          ruby_version: "2.7.7"
           bundler_version: "2.3.13"
           hyrax_valkyrie: "true"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,9 @@ version: 2.1
 orbs:
   samvera: samvera/circleci-orb@1
   browser-tools: circleci/browser-tools@1.3
+  ruby: circleci/ruby@2
+  node: circleci/node@5
+
 jobs:
   bundle:
     parameters:
@@ -10,14 +13,14 @@ jobs:
         default: 2.7.7
       bundler_version:
         type: string
-        default: 2.3.13
+        default: 2.4.8
       rails_version:
         type: string
-        default: 6.1.6.1
+        default: 6.1.7.2
     executor:
       name: 'samvera/ruby'
       ruby_version: << parameters.ruby_version >>
-    resource_class: medium+
+    resource_class: medium
     environment:
       RAILS_VERSION: << parameters.rails_version >>
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
@@ -44,8 +47,8 @@ jobs:
       - restore_cache:
           name: Restore rubocop cache
           keys:
-            - v1-ruby<< parameters.ruby_version >>-bundle{{ checksum "Gemfile.lock" }}
-            - v1-ruby<< parameters.ruby_version >>
+            - v1-rubocop-ruby<< parameters.ruby_version >>-bundle{{ checksum "Gemfile.lock" }}
+            - v1-rubocop-ruby<< parameters.ruby_version >>
             - v1
 
       - run:
@@ -54,9 +57,9 @@ jobs:
 
       - save_cache:
           name: Save rubocop cache
-          key: v1-ruby<< parameters.ruby_version >>-bundle{{ checksum "Gemfile.lock" }}
+          key: v1-rubocop-ruby<< parameters.ruby_version >>-bundle{{ checksum "Gemfile.lock" }}
           paths:
-            - ~/.cache
+            - ~/.cache/rubocop_cache
 
       - persist_to_workspace:
           root: ~/
@@ -71,14 +74,14 @@ jobs:
         default: 2.7.7
       bundler_version:
         type: string
-        default: 2.3.13
+        default: 2.4.8
       rails_version:
         type: string
-        default: 6.1.6.1
+        default: 6.1.7.2
     executor:
       name: 'samvera/ruby_fcrepo_solr_redis_postgres'
       ruby_version: << parameters.ruby_version >>
-    resource_class: medium+
+    resource_class: medium
     environment:
       RAILS_VERSION: << parameters.rails_version >>
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
@@ -92,6 +95,15 @@ jobs:
       - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
+      - run:
+          name: Generate .internal_test_app/Gemfile.lock
+          command: bundle lock
+          working_directory: .internal_test_app
+      - ruby/install-deps:
+          app-dir: .internal_test_app
+      - node/install-packages:
+          pkg-manager: yarn
+          app-dir: .internal_test_app
       - persist_to_workspace:
           root: ~/
           paths:
@@ -105,7 +117,7 @@ jobs:
         default: 2.7.7
       bundler_version:
         type: string
-        default: 2.3.13
+        default: 2.4.8
       hyrax_valkyrie:
         type: string
         default: "false"
@@ -120,6 +132,7 @@ jobs:
       DATABASE_URL: postgresql://postgres@127.0.0.1/circle_test # Hard-coded with data from CircleCI orb, related to https://github.com/samvera-labs/samvera-circleci-orb/issues/42
       KARMA_BROWSER: ChromeHeadlessCustom
       RAILS_ROOT: .internal_test_app
+      SPEC_OPTS: "" # Clear output conflicts between samvera orb executor and ruby orb rspec command
     steps:
       - attach_workspace:
           at: ~/
@@ -131,13 +144,21 @@ jobs:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:
+          name: Check Chrome install
           command: |
             google-chrome --version
             chromedriver --version
-          name: Check Chrome install
+      - restore_cache:
+          keys:
+            - engine-node-v1-{{ checksum "package.json" }}
+      # Call yarn directly for hyrax engine; node orb demands a lockfile to use caching
       - run:
-          name: Yarn install
+          name: Yarn Install (engine)
           command: yarn install
+      - save_cache:
+          key: engine-node-v1-{{ checksum "package.json" }}
+          paths:
+            - node_modules
       - samvera/install_solr_core:
           solr_config_path: .internal_test_app/solr/conf
       - samvera/install_solr_core:
@@ -147,56 +168,47 @@ jobs:
       - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
+      # Ensure gems needed by the test app are installed
+      - ruby/install-deps:
+          app-dir: .internal_test_app
+      - node/install-packages:
+          pkg-manager: yarn
+          app-dir: .internal_test_app
       - run:
-          command: bundle exec rake app:db:migrate
-      - samvera/parallel_rspec
+          command: bundle exec rake db:migrate
+          working_directory: .internal_test_app
+      - ruby/rspec-test
+      - store_artifacts:
+          path: Gemfile.lock
+          destination: engine-gemfile-lock
+      - store_artifacts:
+          path: .internal_test_app/Gemfile.lock
+          destination: webapp-gemfile-lock
 
-# Trigger a workflow on the nurax repository that will deploy the most recent hyrax gem code to https://nurax-dev.curationexperts.com/
-  deploy:
-    docker:
-      - image: ubuntu
-    steps:
-      - run:
-          name: Install curl
-          command: apt-get update && apt-get install -y curl
-      - run:
-          name: "Trigger Nurax deploy"
-          command: |
-            curl -X POST https://circleci.com/api/v2/project/gh/curationexperts/nurax/pipeline \
-            --header "Circle-Token: $NURAX_CIRCLECI_TOKEN" \
-            --header 'Accept: text/plain'    \
-            --header 'Content-Type: application/json'
 workflows:
   version: 2
-  ruby2-7-7:
+  ruby2-7:
     jobs:
       - bundle:
           ruby_version: "2.7.7"
-          rails_version: "6.1.6.1"
-          bundler_version: "2.3.13"
+          rails_version: "6.1.7.2"
+          bundler_version: "2.4.8"
       - build:
           ruby_version: "2.7.7"
-          rails_version: "6.1.6.1"
-          bundler_version: "2.3.13"
+          rails_version: "6.1.7.2"
+          bundler_version: "2.4.8"
           requires:
             - bundle
       - test:
-          name: "ruby2-7-7"
+          name: "ruby2-7"
           ruby_version: "2.7.7"
-          bundler_version: "2.3.13"
+          bundler_version: "2.4.8"
           requires:
             - build
       - test:
-          name: "ruby2-7-7-valkyrie"
+          name: "ruby2-7-valkyrie"
           ruby_version: "2.7.7"
-          bundler_version: "2.3.13"
+          bundler_version: "2.4.8"
           hyrax_valkyrie: "true"
           requires:
             - build
-  nurax-dev_deploy:
-    jobs:
-      - deploy:
-          filters:
-            branches:
-              only:
-                - main

--- a/.dassie/app/controllers/catalog_controller.rb
+++ b/.dassie/app/controllers/catalog_controller.rb
@@ -25,7 +25,7 @@ class CatalogController < ApplicationController
 
     # Because too many times on Samvera tech people raise a problem regarding a failed query to SOLR.
     # Often, it's because they inadvertently exceeded the character limit of a GET request.
-    config.http_method = :post
+    config.http_method = Hyrax.config.solr_default_method
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {

--- a/.dassie/config/initializers/hyrax.rb
+++ b/.dassie/config/initializers/hyrax.rb
@@ -46,6 +46,10 @@ Hyrax.config do |config|
   # Set the system-wide virus scanner
   config.virus_scanner = Hyrax::VirusScanner
 
+  # The default method used for Solr queries. Values are :get or :post.
+  # Post is suggested to prevent issues with URL length.
+  config.solr_default_method = :post
+
   ##
   # To index to the Valkyrie core, uncomment the following lines.
   # config.query_index_from_valkyrie = true

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,10 +1,9 @@
 # Getting Help
 
-If you have questions or need help, please email [the Samvera community tech list](mailto:samvera-tech@googlegroups.com) or stop by the #dev channel in [the Samvera community Slack team](https://wiki.lyrasis.org/pages/viewpage.action?pageId=87460391#Getintouch!-Slack).
+If you have questions or need help, please email [the Samvera community tech list](mailto:samvera-tech@googlegroups.com) or stop by the #dev channel in [the Samvera Community Slack Workspace](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211682/Getting+Started+in+the+Samvera+Community#Join-the-Samvera-Slack-workspace).
 
 The [Hyrax wiki](https://github.com/samvera/hyrax/wiki) gathers documentation as the community tries things and learns what works. There is useful knowledge and history there but please keep in mind that this information can age quickly. Refer to the [README.md](./README.md) for the best updated guidance we have to offer.
 
-You can also look in the [Samvera Community Knowledge Base](https://samvera.github.io) for help with Hyrax or other Samvera Community questions.
 
 ## Reporting Issues
 
@@ -12,4 +11,4 @@ If you would like to report an issue with Hyrax, first do search [the list of is
 
 ## Reporting Security Issues
 
-To report a security vulnerability, email [samvera-steering@googlegroups.com](mailto:samvera-steering@googlegroups.com) and the Steering Group will coordinate the community response. In your message, please document to the best of your ability cases (relevant software versions, conditions, etc.) where the vulnerability is applicable, the potential negative effects, and any known workarounds or fixes to mitigate the risk. Steering will communicate this to the Partners and the rest of the community in a timely fashion.
+To report a security vulnerability, email [the Samvera Board](mailto:board@samvera.org) and the they will coordinate the community response. In your message, please document to the best of your ability cases (relevant software versions, conditions, etc.) where the vulnerability is applicable, the potential negative effects, and any known workarounds or fixes to mitigate the risk. The Board will communicate this to the Partners and the rest of the community in a timely fashion.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       with:
          token: ${{ secrets.NURAX_ACCESS_TOKEN }}
          event-type: push
-         repository: curationexperts/nurax
+         repository: samvera-labs/nurax
          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       with:
          token: ${{ secrets.NURAX_ACCESS_TOKEN }}
          event-type: release
-         repository: curationexperts/nurax
+         repository: samvera-labs/nurax
          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
 
 

--- a/.koppie/Gemfile
+++ b/.koppie/Gemfile
@@ -29,7 +29,6 @@ gem 'turbolinks', '~> 5'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier', '>= 1.3.0'
-gem 'valkyrie', '~> 2', '>= 2.1.1'
 
 group :development do
   gem 'better_errors' # add command line in browser when errors

--- a/.koppie/app/controllers/catalog_controller.rb
+++ b/.koppie/app/controllers/catalog_controller.rb
@@ -29,7 +29,7 @@ class CatalogController < ApplicationController
 
     # Because too many times on Samvera tech people raise a problem regarding a failed query to SOLR.
     # Often, it's because they inadvertently exceeded the character limit of a GET request.
-    config.http_method = :post
+    config.http_method = Hyrax.config.solr_default_method
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {

--- a/.koppie/db/schema.rb
+++ b/.koppie/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.

--- a/.koppie/yarn.lock
+++ b/.koppie/yarn.lock
@@ -1355,7 +1355,7 @@ unfetch@^4.2.0:
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
   integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
-universalviewer@^3.1.1:
+universalviewer@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/universalviewer/-/universalviewer-3.1.4.tgz#5355aa77e06a05d1252f473e7b437caa24ecd9ff"
   integrity sha512-1z/0iN0JcGlN3lNX3/hMts2WAaLdmvG+j50lgqdzKsGex6033XmE30otl0U2UvF21S5U7bVlW+KYlMeIQyTRww==

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ USER root
 RUN apk --no-cache add bash \
   ffmpeg \
   mediainfo \
-  openjdk11-jre \
+  openjdk17-jre \
   perl
 USER app
 

--- a/README.md
+++ b/README.md
@@ -16,19 +16,13 @@ Jump in: [![Samvera Community Slack](https://img.shields.io/badge/samvera-slack-
 ## Table of Contents
 
 * [What is Hyrax?](#what-is-hyrax)
-* [Feature Documentation](#feature-documentation)
-* [Support Policies](#support-policies)
-* [Help](#help)
-* [Working with Hyrax](#working-with-hyrax)
-  * [Developing the Hyrax Engine](#developing-the-hyrax-engine)
-    * [Contributing](#contributing)
-    * [Release process](#release-process)
-  * [Developing your Hyrax\-based Application](#developing-your-hyrax-based-application)
-  * [Deploying your Hyrax\-based Application to production](#deploying-your-hyrax-based-application-to-production)
+* [Getting Help and Asking Questions](#getting-help-and-asking-questions)
+* [How to Run the Code](#how-to-run-the-code)
+* [Contribute](#contribute)
+* [Release Process](#release-process)
+* [Deploy](#deploy)
 * [Acknowledgments](#acknowledgments)
 * [License](#license)
-
-<aside>Table of contents created by <a href="https://github.com/ekalinin/github-markdown-toc.go">gh-md-toc</a></aside>
 
 ## What is Hyrax?
 
@@ -44,104 +38,37 @@ Hyrax offers the ability to:
 * Enable/disable optional features via an administrative dashboard
 * And more (https://hyrax.samvera.org/about/)
 
-## Feature Documentation
+## Getting Help and Asking Questions
 
-* List of features: [Feature Matrix](https://github.com/samvera/hyrax/wiki/Feature-matrix)
-* Configuration and enabling features: [Hyrax Management Guide](https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide)
-* Walk-through on using features: [Hyrax Feature Guides](https://samvera.github.io/intro-to.html)
-* [Entity Relationship Diagram](./artifacts/entity-relationship-diagram.pdf)
-* For general information about Hyrax: [Hyrax Site](https://hyrax.samvera.org/)
-* A note about [versions of Hyrax](./documentation/note-about-versions.md)
+More detailed documentation about Hyrax is available on the [Hyrax Github Wiki](https://github.com/samvera/hyrax/wiki) but if you have questions or need help, please email the [Samvera community tech list](https://samvera.atlassian.net/wiki/spaces/samvera/pages/1171226735/Samvera+Community+Email+Lists#Samvera-Tech-(15-20-messages-per-week-on-average)) or stop by the #dev channel in the [Samvera community Slack team](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211682/Getting+Started+in+the+Samvera+Community#Join-the-Samvera-Slack-workspace). You can also get in touch with the [Hyrax Maintenance Working Group](https://samvera.atlassian.net/wiki/spaces/samvera/pages/496632295/Hyrax+Maintenance+Working+Group), including the Hyrax Product Owner and Hyrax Tech Lead.
 
-## Support Policies
+[Reporting Issues](./.github/SUPPORT.md) 
 
-* Hyrax 3.x supports the latest browser versions for Chrome, Firefox, Edge, and Safari.
+## How to Run the Code
 
-## Help
+[Run Hyrax Locally Using Docker](./CONTAINERS.md)
 
-The Samvera community is here to help. Please see our [support guide](./.github/SUPPORT.md).
+Hyrax can also work running prerequisite dependencies separately. The following describe ways to do this:
+* [Developing Your Hyrax-based Application](./documentation/developing-your-hyrax-based-app.md)
+* [Development setup using Engine Cart and Solr Fedora wrapper](https://github.com/samvera/hyrax/wiki/Development-setup-using-Engine-Cart-and-Solr---Fedora-wrapper)
 
-## Working with Hyrax
+## Contribute
 
-There are two primary Hyrax development concerns:
+We'd love to accept your contributions. Please see our [guide to contributing to Hyrax](./.github/CONTRIBUTING.md).
 
-1. Developing the Hyrax engine
-2. Developing your Hyrax-based Application
+[Installing Analytics](https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide#installing-analytics)
 
-### Developing the Hyrax Engine
-
-This is where you work on the code-base that will be used by yours and other Hyrax-based applications.  We recommend using [Docker and Hyrax's engine development containers](./CONTAINERS.md).
-
-<aside>
-    <p><em><strong>Note:</em></strong> This is not the only path for Hyrax-engine development.  In the past, <a href="./documentation/legacyREADME.md">we documented extensive steps</a> to install the various dependencies for Hyrax-engine development. There is also a <a href="https://github.com/samvera/hyrax/wiki/Hyrax-Development-Guide#quick-start-for-hyrax-development">Quick Start for Hyrax engine development</a> that outlines steps for working on the Hyrax engine.</p>
-    <p>By moving to Docker, we are encoding the documentation steps for standing up a Hyrax-engine development environment.</p>
-</aside>
-
-### Installing Analytics
-
-Hyrax supports your choice of either Google Analytics or Matomo.  To enable analytics tracking and reporting features, follow the directions below.
-
-Enable Analytics Features
-
-Analytics can be enabled and configured using environment variables. Set HYRAX_ANALYTICS to true, set either 'google' or 'matomo' for  HYRAX_ANALYTICS_PROVIDER, and set the date you would like reporting to start (ANALYTICS_START_DATE).
-
-```
-HYRAX_ANALYTICS=true
-HYRAX_ANALYTICS_PROVIDER=google
-ANALYTICS_START_DATE=2021-08-21
-```
-
-If using google, you'll also need the following ENV variables:
-
-```
-GOOGLE_ANALYTICS_ID=UA-111111-1  # Universal ID (Currently Hyrax Analytics only works with Univeral (UA) accounts)
-GOOGLE_OAUTH_APP_NAME=
-GOOGLE_OAUTHAPP_VERSION=
-GOOGLE_OAUTH_PRIVATE_KEY_PATH= # store the .p12 file in the root of your application
-GOOGLE_OAUTH_PRIVATE_KEY_SECRET=
-GOOGLE_OAUTH_CLIENT_EMAIL=
-```
-
-Add these ENV variables if using Matomo:
-
-```
-MATOMO_SITE_ID=
-MATOMO_BASE_URL=
-MATOMO_AUTH_TOKEN=
-```
-
-#### Analytics Features
-
-Once analytics is enabled, Hyrax will automatically install the JS tracking code.  Page views and downloads of a file set are recorded and sent to the selected analytics provider.  Admin users will have access to an expanded dashboard with details about how many vistors viewed a page, and how many visitors downloaded a file.  Easily find the top works by views, and most popular file downloads!
-
-#### Contributing
-
-We'd love to accept your contributions.  Please see our guide to [contributing to Hyrax](./.github/CONTRIBUTING.md).
-
-Here are possible ways to help:
-
-* The Hyrax user interface is translated into a number of languages, and many of these translations come from Google Translate. If you are a native or fluent speaker of a non-English language, your help improving these translations are most welcome. (Hyrax currently supports English, Spanish, Chinese, Italian, German, French, and Portuguese.)
-  * Do you see English in the application where you would expect to see one of the languages above? If so, [file an issue](https://github.com/samvera/hyrax/issues/new) and suggest a translation, please.
-* [Contribute a user story](https://github.com/samvera/hyrax/issues/new).
-* Help us improve [Hyrax's test coverage](https://coveralls.io/r/samvera/hyrax) or [documentation coverage](https://inch-ci.org/github/samvera/hyrax).
-* Refactor away [code smells](https://codeclimate.com/github/samvera/hyrax).
-
-#### Release process
+## Release Process
 
 See the [release management process](https://github.com/samvera/hyrax/wiki/Release-management-process).
 
-### Developing your Hyrax-based Application
+We also have a [Maintenance Policy](./documentation/MAINTENANCE.md).
 
-For those familiar with Rails, this is where you create your own application (via `rails new`) and add Hyrax as a gem to your `Gemfile`.  Your Hyrax-based application is the place for you to create features specific to your Hyrax-based application.
-
-For more information, see [our documentation on developing your Hyrax-based application](./documentation/developing-your-hyrax-based-app.md).
-
-### Deploying your Hyrax-based Application to production
+## Deploy
 
 Steps to deploy a Hyrax-based application to production will vary depending on your particular ecosystem but here are some methods and things to consider:
-
- * [Samvera Community Knowledge Base: Running in Production](https://samvera.github.io/service-stack.html)
- * [Helm Chart](./CONTAINERS.md#deploying-to-production) (for cloud-based Kubernetes-style deployments)
+* [Hyrax Management Guide](https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide) (provides guidance for things to keep in mind in production environments)
+* [Helm Chart to deploy Hyrax-based application](./CONTAINERS.md#deploying-to-production) (for cloud-based Kubernetes-style deployments)
 
 ## Acknowledgments
 

--- a/app/assets/stylesheets/hyrax/_catalog.scss
+++ b/app/assets/stylesheets/hyrax/_catalog.scss
@@ -76,6 +76,10 @@
   color: #fff;
 }
 
+.dark-text {
+  color: #000
+}
+
 .view-type-group a {
   > span.caption {
     display: none;

--- a/app/assets/stylesheets/hyrax/_modal.scss
+++ b/app/assets/stylesheets/hyrax/_modal.scss
@@ -6,7 +6,3 @@ div.collection-list legend {
 .modal-body select {
   max-width: 100%;
 }
-
-.modal-body input {
-  width: 100%;
-}

--- a/app/controllers/concerns/hyrax/valkyrie_downloads_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/valkyrie_downloads_controller_behavior.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+module Hyrax
+  module ValkyrieDownloadsControllerBehavior
+    # before_action :authorize_download!
+
+    def show_valkyrie
+      file_set_id = params.require(:id)
+      file_set = Hyrax.query_service.find_by(id: file_set_id)
+      send_file_contents(file_set)
+    end
+
+    private
+
+    def authorize_download!
+      authorize!(:download, params[:id])
+    rescue CanCan::AccessDenied, Blacklight::Exceptions::RecordNotFound
+      unauthorized_image = Rails.root.join("app", "assets", "images", "unauthorized.png")
+      send_file unauthorized_image, status: :unauthorized
+    end
+
+    def send_file_contents(file_set)
+      response.headers["Accept-Ranges"] = "bytes"
+      self.status = 200
+      use = params.fetch(:use, :original_file).to_sym
+      file_metadata = find_file_metadata(file_set: file_set, use: use)
+      file = Hyrax.storage_adapter.find_by(id: file_metadata.file_identifier)
+      prepare_file_headers(metadata: file_metadata, file: file)
+      file.rewind
+      self.response_body = file.read
+    end
+
+    def prepare_file_headers(metadata:, file:, inline: false)
+      inline_display = ActiveRecord::Type::Boolean.new.cast(params.fetch(:inline, inline))
+      response.headers["Content-Disposition"] = "#{inline_display ? 'inline' : 'attachment'}; filename=#{metadata.original_filename}"
+      response.headers["Content-Type"] = metadata.mime_type
+      response.headers["Content-Length"] ||= (file.try(:size) || metadata.size.first)
+      # Prevent Rack::ETag from calculating a digest over body
+      response.headers["Last-Modified"] = metadata.updated_at.utc.strftime("%a, %d %b %Y %T GMT")
+      self.content_type = metadata.mime_type
+    end
+
+    def content_options(file_metadata)
+      { disposition: "attachment", type: file_metadata.mime_type, filename: file_metadata.original_filename }
+    end
+
+    def find_file_metadata(file_set:, use: :original_file)
+      use = Hyrax::FileMetadata::Use.uri_for(use: use)
+
+      results = Hyrax.custom_queries.find_many_file_metadata_by_use(resource: file_set, use: use)
+
+      results.first || raise(Hyrax::ObjectNotFoundError)
+    end
+  end
+end

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -3,6 +3,7 @@ module Hyrax
   class DownloadsController < ApplicationController
     include Hydra::Controller::DownloadBehavior
     include Hyrax::LocalFileDownloadsControllerBehavior
+    include Hyrax::ValkyrieDownloadsControllerBehavior
     include Hyrax::WorkflowsHelper # Provides #workflow_restriction?
 
     def self.default_content_path
@@ -12,6 +13,8 @@ module Hyrax
     # Render the 404 page if the file doesn't exist.
     # Otherwise renders the file.
     def show
+      return show_valkyrie if Hyrax.config.use_valkyrie?
+
       case file
       when ActiveFedora::File
         # For original files that are stored in fedora

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -42,7 +42,11 @@ module Hyrax
     end
 
     def file_set_parent(file_set_id)
-      file_set = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set_id, use_valkyrie: Hyrax.config.use_valkyrie?)
+      file_set = if defined?(Wings) && Hyrax.metadata_adapter.is_a?(Wings::Valkyrie::MetadataAdapter)
+                   Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set_id, use_valkyrie: Hyrax.config.use_valkyrie?)
+                 else
+                   Hyrax.query_service.find_by(id: file_set_id)
+                 end
       @parent ||=
         case file_set
         when Hyrax::Resource

--- a/app/controllers/hyrax/my/works_controller.rb
+++ b/app/controllers/hyrax/my/works_controller.rb
@@ -30,7 +30,9 @@ module Hyrax
       private
 
       def collections_service
-        Hyrax::CollectionsService.new(self)
+        cloned = clone
+        cloned.params = {}
+        Hyrax::CollectionsService.new(cloned)
       end
 
       def search_action_url(*args)

--- a/app/controllers/hyrax/transfers_controller.rb
+++ b/app/controllers/hyrax/transfers_controller.rb
@@ -45,7 +45,10 @@ module Hyrax
     # any existing edit permissions on the work.
     def accept
       @proxy_deposit_request.transfer!(params[:reset])
-      current_user.can_receive_deposits_from << @proxy_deposit_request.sending_user if params[:sticky]
+      if params[:sticky]
+        current_user.can_receive_deposits_from << @proxy_deposit_request.sending_user unless
+                current_user.can_receive_deposits_from.include? @proxy_deposit_request.sending_user
+      end
       redirect_to hyrax.transfers_path, notice: "Transfer complete"
     end
 

--- a/app/controllers/hyrax/workflow_actions_controller.rb
+++ b/app/controllers/hyrax/workflow_actions_controller.rb
@@ -40,7 +40,7 @@ module Hyrax
 
     def after_update_response
       respond_to do |wants|
-        wants.html { redirect_to [main_app, curation_concern], notice: "The #{curation_concern.human_readable_type} has been updated." }
+        wants.html { redirect_to [main_app, curation_concern], notice: "The #{curation_concern.class.human_readable_type} has been updated." }
         wants.json { render 'hyrax/base/show', status: :ok, location: polymorphic_path([main_app, curation_concern]) }
       end
     end

--- a/app/controllers/hyrax/workflow_actions_controller.rb
+++ b/app/controllers/hyrax/workflow_actions_controller.rb
@@ -9,7 +9,8 @@ module Hyrax
     #   @return [Hyrax::Resource]
     attr_reader :curation_concern
 
-    load_resource class: Hyrax::Resource, instance_name: :curation_concern
+    resource_klass = Hyrax.config.use_valkyrie? ? Hyrax::Resource : ActiveFedora::Base
+    load_resource class: resource_klass, instance_name: :curation_concern
     before_action :authenticate_user!
 
     def update

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -65,8 +65,9 @@ class CharacterizeJob < Hyrax::ApplicationJob
     # mod time. This is done in the versioning code.
     file_set.date_modified = Hyrax::TimeService.time_in_utc if file_set.characterization_proxy.original_checksum.first != previous_checksum
 
-    # set title to label if that's how it was before this characterization
-    file_set.title = [file_set.characterization_proxy.original_name.force_encoding("UTF-8")] if reset_title
+    file_set.characterization_proxy.original_name.force_encoding("UTF-8")
+    # set title to label (i.e. file name, `original_name`) if that's how it was before this characterization
+    file_set.title = [file_set.characterization_proxy.original_name] if reset_title
     # always set the label to the original_name
     file_set.label = file_set.characterization_proxy.original_name
 

--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -414,7 +414,7 @@ module Hyrax
     # @param document_id [String] the id of the document.
     def user_is_depositor?(document_id)
       doc = Hyrax::SolrService.search_by_id(document_id, fl: 'depositor_ssim')
-      current_user.user_key == doc.fetch('depositor_ssim').first
+      current_user.user_key == doc['depositor_ssim']&.first
     end
 
     def curation_concerns_models

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -52,25 +52,6 @@ module Hyrax
       self.collection_type_gid = new_collection_type.to_global_id
     end
 
-    # Add members using the members association.
-    def add_members(new_member_ids)
-      Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
-                         "Instead, use Hyrax::Collections::CollectionMemberService.add_members_by_ids.")
-      Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection_id: id,
-                                                                     new_member_ids: new_member_ids,
-                                                                     user: nil)
-    end
-
-    # Add member objects by adding this collection to the objects' member_of_collection association.
-    # @param [Enumerable<String>] the ids of the new child collections and works collection ids
-    def add_member_objects(new_member_ids)
-      Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
-                         "Instead, use Hyrax::Collections::CollectionMemberService.add_members_by_ids.")
-      Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection_id: id,
-                                                                     new_member_ids: new_member_ids,
-                                                                     user: nil)
-    end
-
     # @return [Enumerable<ActiveFedora::Base>] an enumerable over the children of this collection
     def member_objects
       ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}")
@@ -96,22 +77,6 @@ module Hyrax
           "hyrax/#{collection}/#{element}"
         end
       end
-
-      def collection_type_gid_document_field_name
-        Deprecation.warn('use Hyrax.config.collection_type_index_field instead')
-        Hyrax.config.collection_type_index_field
-      end
-    end
-
-    # @deprecated to be removed in 4.0.0; this feature was replaced with a
-    #   hard-coded null implementation
-    # @return [Fixnum] 0
-    def bytes
-      Deprecation.warn('#bytes has been deprecated for removal in Hyrax 4.0.0; ' \
-                       'The implementation of the indexed Collection size ' \
-                       'feature is extremely inefficient, so it has been removed. ' \
-                       'This method now returns a hard-coded `0` for compatibility.')
-      0
     end
 
     # @api public
@@ -120,18 +85,6 @@ module Hyrax
     # @raise [ActiveRecord::RecordNotFound]
     def permission_template
       Hyrax::PermissionTemplate.find_by!(source_id: id)
-    end
-
-    ##
-    # @deprecated use PermissionTemplate#reset_access_controls_for instead
-    #
-    # Calculate and update who should have read/edit access to the collections based on who
-    # has access in PermissionTemplateAccess
-    def reset_access_controls!
-      Deprecation.warn("reset_access_controls! is deprecated; use PermissionTemplate#reset_access_controls_for instead.")
-
-      permission_template
-        .reset_access_controls_for(collection: self, interpret_visibility: true)
     end
 
     private

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -69,6 +69,7 @@ module Hyrax
         attribute :date_created, Solr::Array, "date_created_tesim"
         attribute :rights_statement, Solr::Array, "rights_statement_tesim"
         attribute :rights_notes, Solr::Array, "rights_notes_tesim"
+        attribute :bibliographic_citation, Solr::Array, "bibliographic_citation_tesim"
         attribute :access_right, Solr::Array, "access_right_tesim"
         attribute :mime_type, Solr::String, "mime_type_ssi"
         attribute :workflow_state, Solr::String, "workflow_state_name_ssim"

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -43,7 +43,7 @@ module Hyrax
     # Terms is the list of fields displayed by
     # app/views/collections/_show_descriptions.html.erb
     def self.terms
-      [:total_items, :size, :resource_type, :creator, :contributor, :keyword, :license, :publisher, :date_created, :subject,
+      [:total_items, :alternative_title, :size, :resource_type, :creator, :contributor, :keyword, :license, :publisher, :date_created, :subject,
        :language, :identifier, :based_near, :related_url]
     end
 

--- a/app/presenters/hyrax/iiif_manifest_presenter.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter.rb
@@ -48,6 +48,12 @@ module Hyrax
     end
 
     ##
+    # @return [String]
+    def hostname
+      @hostname || 'localhost'
+    end
+
+    ##
     # @return [Boolean]
     def file_set?
       model.try(:file_set?) || Array(model[:has_model_ssim]).include?('FileSet')
@@ -209,6 +215,14 @@ module Hyrax
                iiif_endpoint: iiif_endpoint(latest_file_id, base_url: hostname))
       end
 
+      ##
+      # @return [#can?]
+      def ability
+        @ability ||= NullAbility.new
+      end
+
+      ##
+      # @return [String]
       def hostname
         @hostname || 'localhost'
       end
@@ -221,10 +235,6 @@ module Hyrax
     end
 
     private
-
-    def hostname
-      @hostname || 'localhost'
-    end
 
     def metadata_fields
       Hyrax.config.iiif_metadata_fields

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -45,7 +45,7 @@ module Hyrax
     delegate :title, :date_created, :description,
              :creator, :contributor, :subject, :publisher, :language, :embargo_release_date,
              :lease_expiration_date, :license, :source, :rights_statement, :thumbnail_id, :representative_id,
-             :rendering_ids, :member_of_collection_ids, :alternative_title, to: :solr_document
+             :rendering_ids, :member_of_collection_ids, :alternative_title, :bibliographic_citation, to: :solr_document
 
     def workflow
       @workflow ||= WorkflowPresenter.new(solr_document, current_ability)

--- a/app/services/hyrax/database_migrator.rb
+++ b/app/services/hyrax/database_migrator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rails/generators/actions'
+require 'rails/generators'
 require 'rails/generators/active_record'
 
 module Hyrax

--- a/app/services/hyrax/solr_query_service.rb
+++ b/app/services/hyrax/solr_query_service.rb
@@ -26,21 +26,29 @@ module Hyrax
     end
 
     ##
+    # execute the query using a GET request
     # @return [Hash] the results returned from solr for the current query
     def get
       solr_service.get(build)
     end
 
     ##
+    # execute the solr query and return results
+    # @return [Hash] the results returned from solr for the current query
+    def query_result
+      solr_service.query_result(build)
+    end
+
+    ##
     # @return [Enumerable<SolrDocument>]
     def solr_documents
-      get['response']['docs'].map { |doc| self.class.document_model.new(doc) }
+      query_result['response']['docs'].map { |doc| self.class.document_model.new(doc) }
     end
 
     ##
     # @return [Array<String>] ids of documents matching the current query
     def get_ids # rubocop:disable Naming/AccessorMethodName
-      results = get
+      results = query_result
       results['response']['docs'].map { |doc| doc['id'] }
     end
 

--- a/app/services/hyrax/workflow/status_list_service.rb
+++ b/app/services/hyrax/workflow/status_list_service.rb
@@ -69,7 +69,7 @@ module Hyrax
         actionable_roles = roles_for_user
         Hyrax.logger.debug("Actionable roles for #{@user.user_key} are #{actionable_roles}")
         return [] if actionable_roles.empty?
-        WorkRelation.new.search_with_conditions(query(actionable_roles), method: :post)
+        WorkRelation.new.search_with_conditions(query(actionable_roles), method: Hyrax.config.solr_default_method)
       end
 
       def query(actionable_roles)

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -4,6 +4,7 @@
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:bibliographic_citation, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim', html_dl: true) %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted, html_dl: true) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,3 +1,4 @@
+<%= presenter.attribute_to_html(:alternative_title, html_dl: true) %>
 <%= presenter.attribute_to_html(:abstract, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_modified, label: t('hyrax.base.show.last_modified'), html_dl: true) %>
 <%= presenter.attribute_to_html(:creator, render_as: :faceted, html_dl: true) %>

--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -8,7 +8,7 @@
       </audio>
       <%= link_to t('hyrax.file_set.show.downloadable_content.audio_link'),
                   hyrax.download_path(file_set),
-                  data: { label: file_set.id },
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
                   target: :_blank,
                   id: "file_download" %>
     </div>

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -4,7 +4,7 @@
     <p /><%= link_to t('hyrax.file_set.show.download'),
       hyrax.download_path(file_set),
       id: "file_download",
-      data: { label: file_set.id },
+      data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
       target: "_new" %>
   <% end %>
 </div>

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -7,7 +7,7 @@
                     role: "presentation") %>
       <%= link_to t('hyrax.file_set.show.downloadable_content.image_link'),
                   hyrax.download_path(file_set),
-                  data: { label: file_set.id },
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
                   target: :_blank,
                   id: "file_download" %>
     </div>

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -9,7 +9,7 @@
                   hyrax.download_path(file_set),
                   target: :_blank,
                   id: "file_download",
-                  data: { label: file_set.id } %>
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
     </div>
 <% else %>
     <div>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -9,7 +9,7 @@
                   hyrax.download_path(file_set),
                   target: :_blank,
                   id: "file_download",
-                  data: { label: file_set.id } %>
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
     </div>
 <% else %>
     <div>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -8,7 +8,7 @@
       </video>
       <%= link_to t('hyrax.file_set.show.downloadable_content.video_link'),
                   hyrax.download_path(file_set),
-                  data: { label: file_set.id },
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
                   target: :_blank,
                   id: "file_download" %>
     </div>

--- a/app/views/hyrax/uploads/_js_templates.html.erb
+++ b/app/views/hyrax/uploads/_js_templates.html.erb
@@ -3,18 +3,18 @@
 <script id="template-upload" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
     <tr class="template-upload <%= fade_class_if_not_test %>">
-        <td>
+        <span>
             <span class="preview"></span>
-        </td>
-        <td>
+        </span>
+        <span>
             <p class="name">{%=file.name%}</p>
             <strong class="error text-danger"></strong>
-        </td>
-        <td>
+        </span>
+        <span>
             <p class="size">Processing...</p>
             <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="progress-bar progress-bar-striped progress-bar-animated bg-success" style="width:0%;"></div></div>
-        </td>
-        <td class="text-right">
+        </span>
+        <span class="text-right">
             {% if (!i && !o.options.autoUpload) { %}
                 <button class="btn btn-primary start" disabled>
                     <span class="fa fa-upload"></span>
@@ -27,7 +27,7 @@
                     <span><%= t('helpers.action.cancel') %></span>
                 </button>
             {% } %}
-        </td>
+        </span>
     </tr>
 {% } %}
 </script>

--- a/app/views/hyrax/uploads/_js_templates_branding.html.erb
+++ b/app/views/hyrax/uploads/_js_templates_branding.html.erb
@@ -37,7 +37,7 @@
 <!-- The template to display the banner once upload is complete -->
 <script id="template-download" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
-        <span class="template-download fade">
+        <span class="template-download fade show">
           <div id="banner">
             <div class="row branding-banner-row">
               <div class="col-sm-3">
@@ -69,7 +69,7 @@
 <!-- The template to display logo in the table once upload is complete -->
 <script id="logo-template-download" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
-            <span class="template-download fade">
+            <span class="template-download fade show">
             <div class="row branding-logo-row">
               <div class="col-sm-3">
                 <span class="preview">

--- a/app/views/hyrax/users/_vitals.html.erb
+++ b/app/views/hyrax/users/_vitals.html.erb
@@ -3,16 +3,16 @@
 </div>
 
 <div class="list-group-item">
-  <span class="badge"><%= number_of_collections(user) %></span>
+  <span class="badge dark-text"><%= number_of_collections(user) %></span>
   <span class="fa fa-folder-open" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.collections"), {generic_type: "Collection", depositor: user.to_s}) %>
 </div>
 
 <div class="list-group-item">
-  <span class="badge"><%= number_of_works(user) %></span>
+  <span class="badge dark-text"><%= number_of_works(user) %></span>
   <span class="fa fa-upload" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.works"), {generic_type: "Work", depositor: user.to_s}) %>
 
   <ul class="views-downloads-dashboard list-unstyled">
-      <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>
-      <li><span class="badge badge-optional"><%= user.total_file_downloads %></span> <%= t("hyrax.dashboard.stats.file_downloads").pluralize(user.total_file_downloads) %></li>
+      <li><span class="badge badge-optional dark-text"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>
+      <li><span class="badge badge-optional dark-text"><%= user.total_file_downloads %></span> <%= t("hyrax.dashboard.stats.file_downloads").pluralize(user.total_file_downloads) %></li>
   </ul>
 </div>

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 2.0.0
+version: 2.1.0
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo
@@ -26,7 +26,7 @@ dependencies:
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: redis.enabled
   - name: solr
-    version: 1.0.1
+    version: 6.1.4
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: solr.enabled
   - name: nginx

--- a/documentation/MAINTENANCE.md
+++ b/documentation/MAINTENANCE.md
@@ -1,0 +1,77 @@
+# Maintenance Policy for Hyrax
+January 25, 2023
+
+[Hyrax Maintenance Working Group](https://samvera.atlassian.net/wiki/spaces/samvera/pages/496632295/Hyrax+Maintenance+Working+Group)
+
+## Why do we need a policy? 
+A written policy prevents word-of-mouth policies which create confusion in the community. 
+A written policy also provides a transparent way to communicate our values to people who may 
+not work on the maintenance team consistently. It gives a basis to justify spending time on 
+something that isn’t in the product backlog.
+
+Updated versions of JavaScript libraries, Ruby, and Ruby gems are released all the time. 
+If we don’t keep our applications up-to-date with the latest released versions of their 
+dependencies, we may end up with applications that rely on dependencies with known 
+vulnerabilities, bugs, or deprecated features.
+
+Hyrax releases are managed in two groupings: 
+- Breaking changes which include new features with incompatible changes such as requiring 
+  data migration, bug fixes or security fixes with incompatible changes. 
+- Non-breaking changes which have new features that can be introduced with feature flipper, 
+  backwards compatibility, or that do not require data migration, bug fixes or security fixes
+  that do not require data migration. 
+
+## Semantic Versioning
+
+Hyrax follows [semver](https://semver.org/) for release versioning. All releases are handled in X.Y.Z format.
+
+Current releases are at https://github.com/samvera/hyrax/releases 
+
+### Major X
+New features with incompatible changes such as requiring data migration, bug fixes or security 
+fixes with incompatible changes. Breaking changes are paired with deprecation notices in the 
+previous minor or major release.
+
+### Minor Y
+New features that can be introduced with feature flipper, backwards compatibility, or that do not 
+require data migration. May also contain bug fixes or security fixes that do not require data migration.
+
+### Patch Z
+Bug fixes or security fixes that do not require data migration. No new features.
+
+## Supported Versions
+Supported versions are the highest currently released X version and then backwards to X-1. So when 
+Hyrax 4.0 is released, the latest Hyrax 3.y is supported but Hyrax 2.y is not. Extended support for 
+an otherwise unsupported version may be offered at the Product Owner or Technical Lead’s discretion. 
+See End-of-Life Versions below.
+
+## New features
+New features that are added to the current release may be backported to supported past versions on 
+a case-by-case basis. New features that are not relevant to the current release can be added to a 
+supported past version.
+
+## Bug fixes
+Bug fixes that are added to the current release may be backported to supported past versions on a 
+case-by-case basis. 
+
+## Security fixes
+The current major release will receive patches and new versions in case of a security fix. The last
+release in the previous major version will also receive security updates. So when Hyrax 4.y has a 
+security fix applied, this security fix would also be applied to the latest Hyrax 3.y, but not to 
+Hyrax 2.y.
+
+## Dependency Management
+Deprecated or end-of-life versions of dependencies used as part of building a Hyrax-based application 
+will be removed from the test suite to manage maintenance. If an outdated version of a dependency is 
+still supported that does not pose security issues, it may remain supported in the test suite.
+
+## End-of-Life  Versions
+End-of-life versions are X-1 versions behind the highest currently released X version. So when Hyrax 4.0 
+is released, Hyrax 2.y is end-of-life and no longer supported, but Hyrax 3.y is still supported and is 
+not end-of-life. Extended support for an otherwise unsupported version may be offered at the Product 
+Owner or Technical Lead’s discretion (e.g. many major releases in a short period of time). 
+See Supported Versions above.
+
+End-of-Life versions of Hyrax will not be supported. Applying fixes (security or otherwise) will be 
+up to the implementing entity. We encourage updating to supported versions of Hyrax to receive updates 
+and security fixes.

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -83,7 +83,7 @@ SUMMARY
   spec.add_dependency 'samvera-nesting_indexer', '~> 2.0'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 5.10'
-  spec.add_dependency 'valkyrie', '~> 2', '>= 2.1.1'
+  spec.add_dependency 'valkyrie', '~> 3.0.1'
   spec.add_dependency 'view_component', '~> 2.74.1' # Pin until blacklight is updated with workaround for https://github.com/ViewComponent/view_component/issues/1565
   spec.add_dependency 'sprockets', '~> 3.7'
   spec.add_dependency 'sass-rails', '~> 6.0'

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -76,7 +76,7 @@ SUMMARY
   spec.add_dependency 'rdf-vocab', '~> 3.0'
   spec.add_dependency 'redis', '~> 4.0'
   spec.add_dependency 'redis-namespace', '~> 1.5'
-  spec.add_dependency 'redlock', '>= 0.1.2'
+  spec.add_dependency 'redlock', '>= 0.1.2', '< 2.0'
   spec.add_dependency 'reform', '~> 2.3'
   spec.add_dependency 'reform-rails', '~> 0.2.0'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'

--- a/lib/generators/hyrax/templates/catalog_controller.rb
+++ b/lib/generators/hyrax/templates/catalog_controller.rb
@@ -19,7 +19,7 @@ class CatalogController < ApplicationController
 
     # Because too many times on Samvera tech people raise a problem regarding a failed query to SOLR.
     # Often, it's because they inadvertently exceeded the character limit of a GET request.
-    config.http_method = :post
+    config.http_method = Hyrax.config.solr_default_method
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -846,6 +846,11 @@ module Hyrax
       @solr_select_path ||= ActiveFedora.solr_config.fetch(:select_path, 'select')
     end
 
+    attr_writer :solr_default_method
+    def solr_default_method
+      @solr_default_method ||= :post
+    end
+
     attr_writer :identifier_registrars
     def identifier_registrars
       @identifier_registrars ||= {}

--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Hyrax::Ability, :clean_repo do
                           permission_template: collection.permission_template,
                           agent_type: 'user',
                           agent_id: manager.user_key)
-        collection.reset_access_controls!
+        collection.permission_template.reset_access_controls_for(collection: collection)
       end
 
       it 'can do everything for the collection they manage' do
@@ -280,7 +280,7 @@ RSpec.describe Hyrax::Ability, :clean_repo do
                           permission_template: collection.permission_template,
                           agent_type: 'user',
                           agent_id: viewer.user_key)
-        collection.reset_access_controls!
+        collection.permission_template.reset_access_controls_for(collection: collection)
       end
 
       it 'can view the collection where they are a viewer' do

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe Hyrax::DownloadsController do
   describe '#show' do
     let(:user) { create(:user) }
     let(:file_set) do
-      create(:file_with_work, user: user, content: File.open(fixture_path + '/image.png'))
+      if Hyrax.config.use_valkyrie?
+        FactoryBot.valkyrie_create()
+      else
+        create(:file_with_work, user: user, content: File.open(fixture_path + '/image.png'))
+      end
     end
 
     it 'raises an error if the object does not exist' do

--- a/spec/controllers/hyrax/transfers_controller_spec.rb
+++ b/spec/controllers/hyrax/transfers_controller_spec.rb
@@ -156,6 +156,18 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
           expect(assigns[:proxy_deposit_request].status).to eq('accepted')
           expect(user.can_receive_deposits_from).to include(another_user)
         end
+        context "already received sticky proxy" do
+          before do
+            user.can_receive_deposits_from << another_user
+          end
+          it "handles sticky requests and does not add another user" do
+            put :accept, params: { id: user.proxy_deposit_requests.first, sticky: true }
+            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+            expect(flash[:notice]).to eq("Transfer complete")
+            expect(assigns[:proxy_deposit_request].status).to eq('accepted')
+            expect(user.can_receive_deposits_from.to_a.count(another_user)).to eq 1
+          end
+        end
       end
 
       context "accepting one that isn't mine" do

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -99,7 +99,6 @@ FactoryBot.define do
 
     after(:create) do |collection, _evaluator|
       collection.permission_template.reset_access_controls_for(collection: collection, interpret_visibility: true)
-      # Hyrax::PermissionTemplate.reset_access_controls_for(collection: collection)
     end
 
     factory :public_collection_lw, traits: [:public_lw]

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -99,6 +99,7 @@ FactoryBot.define do
 
     after(:create) do |collection, _evaluator|
       collection.permission_template.reset_access_controls_for(collection: collection, interpret_visibility: true)
+      # Hyrax::PermissionTemplate.reset_access_controls_for(collection: collection)
     end
 
     factory :public_collection_lw, traits: [:public_lw]

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
         attributes[:manage_users] = CollectionFactoryHelper.user_managers(evaluator.with_permission_template, evaluator.user, evaluator.create_access)
         attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
         create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
-        collection.reset_access_controls!
+        collection.permission_template.reset_access_controls_for(collection: collection, interpret_visibility: true)
       end
     end
 

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -178,19 +178,19 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
              permission_template: collection1.permission_template,
              agent_type: 'user',
              agent_id: user2.user_key)
-      collection1.reset_access_controls!
+      collection1.permission_template.reset_access_controls_for(collection: collection1, interpret_visibility: true)
       create(:permission_template_access,
              :deposit,
              permission_template: collection2.permission_template,
              agent_type: 'user',
              agent_id: user2.user_key)
-      collection2.reset_access_controls!
+      collection2.permission_template.reset_access_controls_for(collection: collection2, interpret_visibility: true)
       create(:permission_template_access,
              :view,
              permission_template: collection4.permission_template,
              agent_type: 'user',
              agent_id: user2.user_key)
-      collection4.reset_access_controls!
+      collection4.permission_template.reset_access_controls_for(collection: collection4, interpret_visibility: true)
       sign_in user2
       visit '/dashboard/my/collections'
     end

--- a/spec/features/dashboard/my_works_spec.rb
+++ b/spec/features/dashboard/my_works_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+# https://github.com/samvera/hyrax/issues/5969
+RSpec.describe "As an regular user I should be able to filter works and add them to a preselected collection", :clean_repo do
+  let(:user) { create(:user) }
+  let!(:work1) { create(:work, title: ['Testing Work'], admin_set: adminset, user: user) }
+  let!(:work2) { create(:work, title: ['Samvera Document'], admin_set: adminset, user: user) }
+  let(:collection_type) { create(:collection_type, creator_user: user) }
+  let(:collection) { FactoryBot.create(:public_collection_lw, user: user, collection_type: collection_type, with_permission_template: true) }
+  let(:adminset) { create(:admin_set) }
+
+  before do
+    sign_in user
+  end
+  it do
+    visit "/dashboard/my/works?add_works_to_collection=#{collection.id}&add_works_to_collection_label[]=Special+Test+Collection"
+    expect(page).to have_content 'Works'
+    expect(page).to have_content 'Testing Work'
+    expect(page).to have_content 'Samvera Document'
+
+    # Verify add to collection button works without a filter
+    first('.batch_document_selector').click
+
+    click_button("Add to collection")
+
+    expect(find('#member_of_collection_label')['value']).to eq "Special Test Collection"
+    expect(page).to have_button 'Save changes'
+    find('#collection-list-container button.btn').click # click on the close button for the modal
+
+    # Verify add to collection button works with a filter
+    fill_in('search-field-header', with: "work")
+    click_button("Go")
+
+    expect(page).to have_content 'Testing Work'
+    expect(page).not_to have_content 'Samvera Document'
+
+    first('.batch_document_selector').click
+
+    click_button("Add to collection")
+
+    expect(find('#member_of_collection_label')['value']).to eq "Special Test Collection"
+    expect(page).to have_button 'Save changes'
+  end
+end

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -2,6 +2,10 @@
 RSpec.describe "work show view" do
   include Selectors::Dashboard
 
+  before do
+    allow(Hyrax::Analytics.config).to receive(:analytics_id).and_return('UA-XXXXXXXX')
+  end
+
   let(:work_path) { "/concern/generic_works/#{work.id}" }
   let(:app_host) { Capybara.app_host || 'http://www.example.com' }
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -6,13 +6,6 @@ RSpec.describe ::Collection, type: :model do
     expect(collection.read_groups).to eq ['public']
   end
 
-  describe '#bytes' do
-    it 'returns a hard-coded integer and issues a deprecation warning' do
-      expect(Deprecation).to receive(:warn).at_least(:once)
-      expect(collection.bytes).to eq(0)
-    end
-  end
-
   describe "#validates_with" do
     before { collection.title = nil }
     it "ensures the collection has a title" do
@@ -226,25 +219,25 @@ RSpec.describe ::Collection, type: :model do
 
     it 'resets user edit access' do
       expect(collection.edit_users).to match_array([user.user_key])
-      collection.reset_access_controls!
+      permission_template.reset_access_controls_for(collection: collection)
       expect(collection.edit_users).to match_array([user.user_key, 'mgr1@ex.com', 'mgr2@ex.com'])
     end
 
     it 'resets group edit access' do
       expect(collection.edit_groups).to match_array([])
-      collection.reset_access_controls!
+      permission_template.reset_access_controls_for(collection: collection)
       expect(collection.edit_groups).to match_array(['managers', ::Ability.admin_group_name])
     end
 
     it 'resets user read access' do
       expect(collection.read_users).to match_array([])
-      collection.reset_access_controls!
+      permission_template.reset_access_controls_for(collection: collection)
       expect(collection.read_users).to match_array(['vw1@ex.com', 'vw2@ex.com', 'dep1@ex.com', 'dep2@ex.com'])
     end
 
     it 'resets group read access' do
       expect(collection.read_groups).to match_array([])
-      collection.reset_access_controls!
+      permission_template.reset_access_controls_for(collection: collection)
       expect(collection.read_groups).to match_array(['viewers', 'depositors', ::Ability.admin_group_name])
     end
   end

--- a/spec/models/concerns/hyrax/ability_spec.rb
+++ b/spec/models/concerns/hyrax/ability_spec.rb
@@ -105,6 +105,26 @@ RSpec.describe Hyrax::Ability do
         expect(ability.can?(:edit, presenter)).to eq true
       end
     end
+
+    describe 'can?(:transfer)' do
+      before do
+        allow(Hyrax::SolrService).to receive(:search_by_id).and_return(solr_document)
+      end
+
+      context 'without a depositor field' do
+        it 'does not have transfer ability' do
+          expect(ability.can?(:transfer, 'my_solr_doc_id')).to eq false
+        end
+      end
+
+      context 'with a depositor field' do
+        let(:attributes) { { id: 'my_solr_doc_id', depositor_ssim: [user.email] } }
+
+        it 'has transfer ability ' do
+          expect(ability.can?(:transfer, 'my_solr_doc_id')).to eq true
+        end
+      end
+    end
     # rubocop:enable RSpec/SubjectStub
   end
 end

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hyrax::CollectionPresenter do
     subject { described_class.terms }
 
     it do
-      is_expected.to eq [:total_items, :size, :resource_type, :creator,
+      is_expected.to eq [:total_items, :alternative_title, :size, :resource_type, :creator,
                          :contributor, :keyword, :license, :publisher,
                          :date_created, :subject, :language, :identifier,
                          :based_near, :related_url]

--- a/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Hyrax::IiifManifestPresenter do
   subject(:presenter) { described_class.new(work) }
   let(:work) { build(:monograph) }
 
+  it { is_expected.to respond_to :hostname }
+  it { is_expected.to respond_to :ability }
+
   describe 'manifest generation' do
     let(:builder_service) { Hyrax::ManifestBuilderService.new }
 
@@ -48,6 +51,9 @@ RSpec.describe Hyrax::IiifManifestPresenter do
     subject(:presenter) { described_class.new(solr_doc) }
     let(:solr_doc) { SolrDocument.new(file_set.to_solr) }
     let(:file_set) { create(:file_set, :image) }
+
+    it { is_expected.to respond_to :hostname }
+    it { is_expected.to respond_to :ability }
 
     describe '#display_image' do
       it 'gives a IIIFManifest::DisplayImage' do

--- a/spec/services/hyrax/solr_service_spec.rb
+++ b/spec/services/hyrax/solr_service_spec.rb
@@ -91,9 +91,14 @@ RSpec.describe Hyrax::SolrService do
       allow(described_class).to receive(:instance).and_return(double("instance", conn: mock_conn))
     end
 
-    it "defaults to HTTP GET method" do
-      expect(mock_conn).to receive(:get).with('select', params: { rows: 2, q: 'querytext', qt: 'standard' }).and_return(stub_result)
+    it "defaults to HTTP POST method" do
+      expect(mock_conn).to receive(:post).with('select', data: { rows: 2, q: 'querytext', qt: 'standard' }).and_return(stub_result)
       described_class.query('querytext', rows: 2)
+    end
+
+    it "allows callers to specify HTTP GET method" do
+      expect(mock_conn).to receive(:get).with('select', params: { rows: 2, q: 'querytext', qt: 'standard' }).and_return(stub_result)
+      described_class.query('querytext', rows: 2, method: :get)
     end
 
     it "allows callers to specify HTTP POST method" do
@@ -109,14 +114,14 @@ RSpec.describe Hyrax::SolrService do
     end
 
     it "wraps the solr response documents in Solr hits" do
-      expect(mock_conn).to receive(:get).with('select', params: { rows: 2, q: 'querytext', qt: 'standard' }).and_return(stub_result)
+      expect(mock_conn).to receive(:post).with('select', data: { rows: 2, q: 'querytext', qt: 'standard' }).and_return(stub_result)
       result = described_class.query('querytext', rows: 2)
       expect(result.size).to eq 1
       expect(result.first.id).to eq 'x'
     end
 
     it "warns about not passing rows" do
-      allow(mock_conn).to receive(:get).and_return(stub_result)
+      allow(mock_conn).to receive(:post).and_return(stub_result)
       expect(Hyrax.logger).to receive(:warn).with(/^Calling Hyrax::SolrService\.get without passing an explicit value for ':rows' is not recommended/)
       described_class.query('querytext')
     end
@@ -127,7 +132,7 @@ RSpec.describe Hyrax::SolrService do
       let(:doc) { { 'id' => 'valkyrie-x' } }
 
       it "uses valkyrie solr based on config query_index_from_valkyrie" do
-        expect(mock_conn).to receive(:get).with('select', params: { q: 'querytext' }).and_return(stub_result)
+        expect(mock_conn).to receive(:post).with('select', data: { q: 'querytext' }).and_return(stub_result)
 
         result = service.query('querytext')
         expect(result.first.id).to eq 'valkyrie-x'
@@ -249,7 +254,7 @@ RSpec.describe Hyrax::SolrService do
     let(:stub_result) { { 'response' => { 'numFound' => '2' } } }
 
     it "calls solr" do
-      expect(mock_conn).to receive(:get).with('select', params: { rows: 0, q: 'querytext', qt: 'standard' }).and_return(stub_result)
+      expect(mock_conn).to receive(:post).with('select', data: { rows: 0, q: 'querytext', qt: 'standard' }).and_return(stub_result)
       allow(described_class).to receive(:instance).and_return(double("instance", conn: mock_conn))
       expect(described_class.count('querytext')).to eq 2
     end
@@ -258,7 +263,7 @@ RSpec.describe Hyrax::SolrService do
       subject(:service) { described_class.new(use_valkyrie: true) }
 
       it "uses valkyrie solr based on config query_index_from_valkyrie" do
-        expect(mock_conn).to receive(:get).with('select', params: { rows: 0, q: 'querytext' }).and_return(stub_result)
+        expect(mock_conn).to receive(:post).with('select', data: { rows: 0, q: 'querytext' }).and_return(stub_result)
         expect(service.count('querytext')).to eq 2
       end
     end

--- a/spec/views/hyrax/file_sets/media_display/_audio.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_audio.html.erb_spec.rb
@@ -4,12 +4,17 @@ RSpec.describe 'hyrax/file_sets/media_display/_audio.html.erb', type: :view do
   let(:file_set) { stub_model(FileSet, parent: parent) }
   let(:parent) { double }
   let(:link) { true }
+  let(:work_solr_document) do
+    SolrDocument.new(id: '900', title_tesim: ['My Title'])
+  end
+  let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
 
   before do
     allow(controller).to receive(:current_ability).and_return(ability)
     allow(ability).to receive(:can?).with(:download, file_set).and_return(true)
     allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
+    assign(:presenter, parent_presenter)
     render 'hyrax/file_sets/media_display/audio', file_set: file_set
   end
 

--- a/spec/views/hyrax/file_sets/media_display/_default.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_default.html.erb_spec.rb
@@ -4,12 +4,17 @@ RSpec.describe 'hyrax/file_sets/media_display/_default.html.erb', type: :view do
   let(:file_set) { stub_model(FileSet, parent: parent) }
   let(:parent) { double }
   let(:link) { true }
+  let(:work_solr_document) do
+    SolrDocument.new(id: '900', title_tesim: ['My Title'])
+  end
+  let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
 
   before do
     allow(controller).to receive(:current_ability).and_return(ability)
     allow(ability).to receive(:can?).with(:download, file_set).and_return(true)
     allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
+    assign(:presenter, parent_presenter)
     render 'hyrax/file_sets/media_display/default', file_set: file_set
   end
 

--- a/spec/views/hyrax/file_sets/media_display/_video.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_video.html.erb_spec.rb
@@ -4,12 +4,17 @@ RSpec.describe 'hyrax/file_sets/media_display/_video.html.erb', type: :view do
   let(:file_set) { stub_model(FileSet, parent: parent) }
   let(:parent) { double }
   let(:link) { true }
+  let(:work_solr_document) do
+    SolrDocument.new(id: '900', title_tesim: ['My Video'])
+  end
+  let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
 
   before do
     allow(controller).to receive(:current_ability).and_return(ability)
     allow(ability).to receive(:can?).with(:download, file_set).and_return(true)
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
     allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
+    assign(:presenter, parent_presenter)
     render 'hyrax/file_sets/media_display/video', file_set: file_set
   end
 


### PR DESCRIPTION
Fixes #5794 ; Depends on merge of #5626 

Adopts surfliner's DownloadsController and uses it when using valkyrie. Allows download of files stored in a valkyrie storage adapter.
