### PR TITLE
Favoring `Hyrax.logger` over `Rails.logger`

### DIFF
--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -40,7 +40,7 @@ module Hyrax
         expected_user_id = env.user.id
         files.each do |file|
           if file.user_id != expected_user_id
-            Rails.logger.error "User #{env.user.user_key} attempted to ingest uploaded_file #{file.id}, but it belongs to a different user"
+            Hyrax.logger.error "User #{env.user.user_key} attempted to ingest uploaded_file #{file.id}, but it belongs to a different user"
             return false
           end
         end

--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -62,7 +62,7 @@ module Hyrax
             # Escape any space characters, so that this is a legal URI
             uri = URI.parse(Addressable::URI.escape(file_info[:url]))
             unless self.class.validate_remote_url(uri)
-              Rails.logger.error "User #{user.user_key} attempted to ingest file from url #{file_info[:url]}, which doesn't pass validation"
+              Hyrax.logger.error "User #{user.user_key} attempted to ingest file from url #{file_info[:url]}, which doesn't pass validation"
               return false
             end
             auth_header = file_info.fetch(:auth_header, {})
@@ -84,7 +84,7 @@ module Hyrax
               path.start_with?(dir) && path.length > dir.length
             end
           else
-            Rails.logger.debug "Assuming #{uri.scheme} uri is valid without a serious attempt to validate: #{uri}"
+            Hyrax.logger.debug "Assuming #{uri.scheme} uri is valid without a serious attempt to validate: #{uri}"
             true
           end
         end

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -165,7 +165,7 @@ module Hyrax
           end
         end
       rescue StandardError => err
-        Rails.logger.error(err)
+        Hyrax.logger.error(err)
         after_destroy_error(params[:id])
       end
 
@@ -484,7 +484,7 @@ module Hyrax
           params[:destination_collection_id]
         flash[:notice] = "Successfully moved #{batch.count} files to #{destination_title} Collection."
       rescue StandardError => err
-        Rails.logger.error(err)
+        Hyrax.logger.error(err)
         destination_title =
           Hyrax.query_service.find_by(id: params[:destination_collection_id]).title.first ||
           destination_id

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -120,7 +120,7 @@ module Hyrax
         primary = (required_fields & terms)
 
         (required_fields - primary).each do |missing|
-          Rails.logger.warn("The form field #{missing} is configured as a " \
+          Hyrax.logger.warn("The form field #{missing} is configured as a " \
                             'required field, but not as a term. This can lead ' \
                             'to unexpected behavior. Did you forget to add it ' \
                             "to `#{self.class}#terms`?")

--- a/app/indexers/hyrax/deep_indexing_service.rb
+++ b/app/indexers/hyrax/deep_indexing_service.rb
@@ -48,12 +48,12 @@ module Hyrax
     end
 
     def fetch_value(value)
-      Rails.logger.info "Fetching #{value.rdf_subject} from the authorative source. (this is slow)"
+      Hyrax.logger.info "Fetching #{value.rdf_subject} from the authorative source. (this is slow)"
       value.fetch(headers: { 'Accept' => default_accept_header })
     rescue IOError, SocketError => e
       # IOError could result from a 500 error on the remote server
       # SocketError results if there is no server to connect to
-      Rails.logger.error "Unable to fetch #{value.rdf_subject} from the authorative source.\n#{e.message}"
+      Hyrax.logger.error "Unable to fetch #{value.rdf_subject} from the authorative source.\n#{e.message}"
     end
 
     # Stripping off the */* to work around https://github.com/rails/rails/issues/9940

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -52,7 +52,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
     reset_title = file_set.title.first == file_set.label
 
     characterization_service.run(file_set.characterization_proxy, filepath)
-    Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
+    Hyrax.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
     file_set.characterization_proxy.alpha_channels = channels(filepath) if file_set.image? && Hyrax.config.iiif_image_server?
     file_set.characterization_proxy.save!
 

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -77,7 +77,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
   def copy_remote_file(name)
     filename = File.basename(name)
     dir = Dir.mktmpdir
-    Rails.logger.debug("ImportUrlJob: Copying <#{uri}> to #{dir}")
+    Hyrax.logger.debug("ImportUrlJob: Copying <#{uri}> to #{dir}")
 
     File.open(File.join(dir, filename), 'wb') do |f|
       write_file(f)
@@ -85,7 +85,7 @@ class ImportUrlJob < Hyrax::ApplicationJob
     rescue StandardError => e
       send_error(e.message)
     end
-    Rails.logger.debug("ImportUrlJob: Closing #{File.join(dir, filename)}")
+    Hyrax.logger.debug("ImportUrlJob: Closing #{File.join(dir, filename)}")
   end
 
   ##

--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -86,7 +86,7 @@ module Hyrax
       doc = permissions_doc(id)
       return [] if doc.nil?
       groups = Array(doc[self.class.read_group_field]) + Array(doc[self.class.edit_group_field])
-      Rails.logger.debug("[CANCAN] download_groups: #{groups.inspect}")
+      Hyrax.logger.debug("[CANCAN] download_groups: #{groups.inspect}")
       groups
     end
 
@@ -95,7 +95,7 @@ module Hyrax
       doc = permissions_doc(id)
       return [] if doc.nil?
       users = Array(doc[self.class.read_user_field]) + Array(doc[self.class.edit_user_field])
-      Rails.logger.debug("[CANCAN] download_users: #{users.inspect}")
+      Hyrax.logger.debug("[CANCAN] download_users: #{users.inspect}")
       users
     end
 

--- a/app/models/file_download_stat.rb
+++ b/app/models/file_download_stat.rb
@@ -9,7 +9,7 @@ class FileDownloadStat < Hyrax::Statistic
     def ga_statistics(start_date, file)
       profile = Hyrax::Analytics.profile
       unless profile
-        Rails.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
+        Hyrax.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
         return []
       end
       profile.hyrax__analytics__google__download(sort: 'date',

--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -86,7 +86,7 @@ module Hyrax
       raise(URI::InvalidURIError) if gid.nil?
       GlobalID::Locator.locate(gid)
     rescue NameError
-      Rails.logger.warn "#{self.class}##{__method__} called with #{gid}, which is " \
+      Hyrax.logger.warn "#{self.class}##{__method__} called with #{gid}, which is " \
                         "a legacy collection type global id format. If this " \
                         "collection type gid is attached to a collection in " \
                         "your repository you'll want to run " \

--- a/app/models/hyrax/statistic.rb
+++ b/app/models/hyrax/statistic.rb
@@ -31,7 +31,7 @@ module Hyrax
         path = polymorphic_path(object)
         profile = Hyrax::Analytics.profile
         unless profile
-          Rails.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
+          Hyrax.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
           return []
         end
         profile.hyrax__analytics__google__pageviews(sort: 'date',

--- a/app/models/sipity.rb
+++ b/app/models/sipity.rb
@@ -57,32 +57,32 @@ module Sipity
   # @return [Sipity::Entity]
   # rubocop:disable Naming/MethodName, Metrics/CyclomaticComplexity, Metrics/MethodLength
   def Entity(input, &block) # rubocop:disable Metrics/AbcSize
-    Rails.logger.debug("Trying to make an Entity for #{input.inspect}")
+    Hyrax.logger.debug("Trying to make an Entity for #{input.inspect}")
 
     result = case input
              when Sipity::Entity
                input
              when URI::GID, GlobalID
-               Rails.logger.debug("Entity() got a GID, searching by proxy")
+               Hyrax.logger.debug("Entity() got a GID, searching by proxy")
                Entity.find_by(proxy_for_global_id: input.to_s)
              when SolrDocument
-               Rails.logger.debug("Entity() got a SolrDocument, retrying on #{input.to_model}")
+               Hyrax.logger.debug("Entity() got a SolrDocument, retrying on #{input.to_model}")
                Entity(input.to_model)
              when Draper::Decorator
-               Rails.logger.debug("Entity() got a Decorator, retrying on #{input.model}")
+               Hyrax.logger.debug("Entity() got a Decorator, retrying on #{input.model}")
                Entity(input.model)
              when Sipity::Comment
-               Rails.logger.debug("Entity() got a Comment, retrying on #{input.entity}")
+               Hyrax.logger.debug("Entity() got a Comment, retrying on #{input.entity}")
                Entity(input.entity)
              when Valkyrie::Resource
-               Rails.logger.debug("Entity() got a Resource, retrying on #{Hyrax::GlobalID(input)}")
+               Hyrax.logger.debug("Entity() got a Resource, retrying on #{Hyrax::GlobalID(input)}")
                Entity(Hyrax::GlobalID(input))
              else
-               Rails.logger.debug("Entity() got something else, testing #to_global_id")
+               Hyrax.logger.debug("Entity() got something else, testing #to_global_id")
                Entity(input.to_global_id) if input.respond_to?(:to_global_id)
              end
 
-    Rails.logger.debug("Entity(): attempting conversion on #{result}")
+    Hyrax.logger.debug("Entity(): attempting conversion on #{result}")
     handle_conversion(input, result, :to_sipity_entity, &block)
   rescue URI::GID::MissingModelIdError
     Entity(nil)

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -69,7 +69,7 @@ module Hyrax
           result = original_file_id
 
           if result.blank?
-            Rails.logger.warn "original_file_id for #{id} not found, falling back to Fedora."
+            Hyrax.logger.warn "original_file_id for #{id} not found, falling back to Fedora."
             result = Hyrax::VersioningService.versioned_file_id ::FileSet.find(id).original_file
           end
 

--- a/app/presenters/hyrax/presenter_renderer.rb
+++ b/app/presenters/hyrax/presenter_renderer.rb
@@ -39,7 +39,7 @@ module Hyrax
     def find_field_partial(field_name)
       ["#{collection_path}/show_fields/_#{field_name}", "records/show_fields/_#{field_name}",
        "#{collection_path}/show_fields/_default", "records/show_fields/_default"].find do |partial|
-        Rails.logger.debug "Looking for show field partial #{partial}"
+        Hyrax.logger.debug "Looking for show field partial #{partial}"
         return partial.sub(/\/_/, '/') if partial_exists?(partial)
       end
     end

--- a/app/presenters/hyrax/presents_attributes.rb
+++ b/app/presenters/hyrax/presents_attributes.rb
@@ -15,7 +15,7 @@ module Hyrax
     # @option options [String] :work_type name of work type class (e.g., "GenericWork")
     def attribute_to_html(field, options = {})
       unless respond_to?(field)
-        Rails.logger.warn("#{self.class} attempted to render #{field}, but no method exists with that name.")
+        Hyrax.logger.warn("#{self.class} attempted to render #{field}, but no method exists with that name.")
         return
       end
 

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -99,7 +99,7 @@ module Hyrax
           return nil if result.try(:id) == id
           result.try(:representative_presenter) || result
         rescue Hyrax::ObjectNotFoundError
-          Rails.logger.warn "Unable to find representative_id #{representative_id} for work #{id}"
+          Hyrax.logger.warn "Unable to find representative_id #{representative_id} for work #{id}"
           return nil
         end
     end

--- a/app/services/hyrax/adapters/nesting_index_adapter.rb
+++ b/app/services/hyrax/adapters/nesting_index_adapter.rb
@@ -65,7 +65,7 @@ module Hyrax
           if object.try(:use_nested_reindexing?)
             yield(id, parent_ids) if parent_ids.empty?
           else
-            Rails.logger.info "Re-indexing via to_solr ... #{id}"
+            Hyrax.logger.info "Re-indexing via to_solr ... #{id}"
             Hyrax::SolrService.add(object.to_solr, commit: true)
           end
         end

--- a/app/services/hyrax/analytics/google.rb
+++ b/app/services/hyrax/analytics/google.rb
@@ -27,7 +27,7 @@ module Hyrax
             filename = Rails.root.join('config', 'analytics.yml')
             yaml = YAML.safe_load(ERB.new(File.read(filename)).result)
             unless yaml
-              Rails.logger.error("Unable to fetch any keys from #{filename}.")
+              Hyrax.logger.error("Unable to fetch any keys from #{filename}.")
               return new({})
             end
             config = yaml.fetch('analytics')&.fetch('google', nil)

--- a/app/services/hyrax/analytics/matomo.rb
+++ b/app/services/hyrax/analytics/matomo.rb
@@ -24,7 +24,7 @@ module Hyrax
             filename = Rails.root.join('config', 'analytics.yml')
             yaml = YAML.safe_load(ERB.new(File.read(filename)).result)
             unless yaml
-              Rails.logger.error("Unable to fetch any keys from #{filename}.")
+              Hyrax.logger.error("Unable to fetch any keys from #{filename}.")
               return new({})
             end
             new yaml.fetch('analytics')&.fetch('matomo')

--- a/app/services/hyrax/collection_types/create_service.rb
+++ b/app/services/hyrax/collection_types/create_service.rb
@@ -147,7 +147,7 @@ module Hyrax
           Hyrax::CollectionTypeParticipant.create!(hyrax_collection_type_id: collection_type_id, agent_type: p.fetch(:agent_type), agent_id: p.fetch(:agent_id), access: p.fetch(:access))
         end
       rescue InvalidParticipantError => error
-        Rails.logger.error "Participants not created for collection type " \
+        Hyrax.logger.error "Participants not created for collection type " \
                            " #{collection_type_id}: #{error.message}"
         raise error
       end

--- a/app/services/hyrax/collections/migration_service.rb
+++ b/app/services/hyrax/collections/migration_service.rb
@@ -13,17 +13,17 @@ module Hyrax
       def self.migrate_all_collections
         Deprecation.warn('This migration tool will be removed in Hyrax 4.0.0.')
 
-        Rails.logger.info "*** Migrating #{::Collection.count} collections"
+        Hyrax.logger.info "*** Migrating #{::Collection.count} collections"
         ::Collection.all.each do |col|
           migrate_collection(col)
-          Rails.logger.info "  migrating collection - id: #{col.id}, title: #{col.title}"
+          Hyrax.logger.info "  migrating collection - id: #{col.id}, title: #{col.title}"
         end
 
         AdminSet.all.each do |adminset|
           migrate_adminset(adminset)
-          Rails.logger.info "  migrating adminset - id: #{adminset.id}, title: #{adminset.title}"
+          Hyrax.logger.info "  migrating adminset - id: #{adminset.id}, title: #{adminset.title}"
         end
-        Rails.logger.info "--- Migration Complete"
+        Hyrax.logger.info "--- Migration Complete"
       end
 
       # @api private
@@ -64,16 +64,16 @@ module Hyrax
       def self.repair_migrated_collections
         Deprecation.warn('This migration tool will be removed in Hyrax 4.0.0.')
 
-        Rails.logger.info "*** Repairing migrated collections"
+        Hyrax.logger.info "*** Repairing migrated collections"
         ::Collection.all.each do |col|
           repair_migrated_collection(col)
-          Rails.logger.info "  repairing collection - id: #{col.id}, title: #{col.title}"
+          Hyrax.logger.info "  repairing collection - id: #{col.id}, title: #{col.title}"
         end
         AdminSet.all.each do |adminset|
           migrate_adminset(adminset)
-          Rails.logger.info "  repairing adminset - id: #{adminset.id}, title: #{adminset.title}"
+          Hyrax.logger.info "  repairing adminset - id: #{adminset.id}, title: #{adminset.title}"
         end
-        Rails.logger.info "--- Repairing Complete"
+        Hyrax.logger.info "--- Repairing Complete"
       end
 
       # @api private

--- a/app/services/hyrax/listeners/workflow_listener.rb
+++ b/app/services/hyrax/listeners/workflow_listener.rb
@@ -25,13 +25,13 @@ module Hyrax
       # @param [Dry::Events::Event] event
       # @return [void]
       def on_object_deposited(event)
-        return Rails.logger.warn("Skipping workflow initialization for #{event[:object]}; no user is given\n\t#{event}") if
+        return Hyrax.logger.warn("Skipping workflow initialization for #{event[:object]}; no user is given\n\t#{event}") if
           event[:user].blank?
 
         factory.create(event[:object], {}, event[:user])
       rescue Sipity::StateError, Sipity::ConversionError => err
         # don't error on known sipity error types; log instead
-        Rails.logger.error(err)
+        Hyrax.logger.error(err)
       end
     end
   end

--- a/app/services/hyrax/solr_service.rb
+++ b/app/services/hyrax/solr_service.rb
@@ -75,7 +75,7 @@ module Hyrax
     # Wraps get by default
     # @return [Array<SolrHit>] the response docs wrapped in SolrHit objects
     def query(query, **args)
-      Rails.logger.warn rows_warning unless args.key?(:rows)
+      Hyrax.logger.warn rows_warning unless args.key?(:rows)
       method = args.delete(:method) || :get
 
       result = case method

--- a/app/services/hyrax/statistics/term_query.rb
+++ b/app/services/hyrax/statistics/term_query.rb
@@ -28,7 +28,7 @@ module Hyrax
                                       'json.nl': 'map',
                                       omitHeader: 'true')
         unless json
-          Rails.logger.error "Unable to reach TermsComponent via Solr connection. Is it enabled in your solr config?"
+          Hyrax.logger.error "Unable to reach TermsComponent via Solr connection. Is it enabled in your solr config?"
           return []
         end
 

--- a/app/services/hyrax/thumbnail_path_service.rb
+++ b/app/services/hyrax/thumbnail_path_service.rb
@@ -31,7 +31,7 @@ module Hyrax
         return object if object.thumbnail_id == object.id
         Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: object.thumbnail_id)
       rescue Valkyrie::Persistence::ObjectNotFoundError, Hyrax::ObjectNotFoundError
-        Rails.logger.error("Couldn't find thumbnail #{object.thumbnail_id} for #{object.id}")
+        Hyrax.logger.error("Couldn't find thumbnail #{object.thumbnail_id} for #{object.id}")
         nil
       end
 

--- a/app/services/hyrax/user_stat_importer.rb
+++ b/app/services/hyrax/user_stat_importer.rb
@@ -9,7 +9,7 @@ module Hyrax
       if options[:verbose]
         stdout_logger = Logger.new(STDOUT)
         stdout_logger.level = Logger::INFO
-        Rails.logger.extend(ActiveSupport::Logger.broadcast(stdout_logger))
+        Hyrax.logger.extend(ActiveSupport::Logger.broadcast(stdout_logger))
       end
       @logging = options[:logging]
       @delay_secs = options[:delay_secs].to_f
@@ -147,7 +147,7 @@ module Hyrax
     end
 
     def log_message(message)
-      Rails.logger.info "#{self.class}: #{message}" if @logging
+      Hyrax.logger.info "#{self.class}: #{message}" if @logging
     end
 
     def retry_options

--- a/app/services/hyrax/valkyrie_persist_derivatives.rb
+++ b/app/services/hyrax/valkyrie_persist_derivatives.rb
@@ -27,7 +27,7 @@ module Hyrax
       tmpfile = Tempfile.new(fileset_id, encoding: 'ascii-8bit')
       tmpfile.write stream.read
 
-      Rails.logger.debug "Uploading thumbnail for FileSet #{fileset_id} as #{filepath}"
+      Hyrax.logger.debug "Uploading thumbnail for FileSet #{fileset_id} as #{filepath}"
       Hyrax.config.derivatives_storage_adapter.upload(
         file: tmpfile,
         original_filename: filepath,

--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -87,7 +87,7 @@ module Hyrax::ValkyrieUpload
       when Hyrax::FileMetadata::Use::EXTRACTED_TEXT
         file_set.extracted_text_id = file_metadata.id
       else
-        Rails.logger.warn "Unknown file use #{file_metadata.type} specified for #{file_metadata.file_identifier}"
+        Hyrax.logger.warn "Unknown file use #{file_metadata.type} specified for #{file_metadata.file_identifier}"
       end
     end
   end

--- a/app/services/hyrax/versioning_service.rb
+++ b/app/services/hyrax/versioning_service.rb
@@ -42,7 +42,7 @@ module Hyrax
       def perform_create(content, user, use_valkyrie)
         use_valkyrie ? perform_create_through_valkyrie(content, user) : perform_create_through_active_fedora(content, user)
       rescue NotImplementedError
-        Rails.logger.warn "Declining to create a Version for #{content}; #{self} doesn't support versioning with use_valkyrie: #{use_valkyrie}"
+        Hyrax.logger.warn "Declining to create a Version for #{content}; #{self} doesn't support versioning with use_valkyrie: #{use_valkyrie}"
       end
 
       def perform_create_through_active_fedora(content, user)

--- a/app/services/hyrax/workflow/action_taken_service.rb
+++ b/app/services/hyrax/workflow/action_taken_service.rb
@@ -35,12 +35,12 @@ module Hyrax
         return unless action.triggered_methods.any?
         success = action.triggered_methods.order(:weight).all? do |method|
           status = process_action(method.service_name)
-          Rails.logger.debug("Result of #{method.service_name} is #{status}")
+          Hyrax.logger.debug("Result of #{method.service_name} is #{status}")
           status
         end
 
         return save_target if success
-        Rails.logger.error "Not all workflow methods were successful, so not saving (#{target.id})"
+        Hyrax.logger.error "Not all workflow methods were successful, so not saving (#{target.id})"
         false
       end
 
@@ -63,11 +63,11 @@ module Hyrax
         klass = begin
                   class_name.constantize
                 rescue NameError
-                  Rails.logger.error "Unable to find '#{class_name}', so not running workflow callback"
+                  Hyrax.logger.error "Unable to find '#{class_name}', so not running workflow callback"
                   return nil
                 end
         return klass if klass.respond_to?(:call)
-        Rails.logger.error "Expected '#{class_name}' to respond to 'call', but it didn't, so not running workflow callback"
+        Hyrax.logger.error "Expected '#{class_name}' to respond to 'call', but it didn't, so not running workflow callback"
         nil
       end
 

--- a/app/services/hyrax/workflow/notification_service.rb
+++ b/app/services/hyrax/workflow/notification_service.rb
@@ -60,11 +60,11 @@ module Hyrax
         klass = begin
                   class_name.constantize
                 rescue NameError
-                  Rails.logger.error "Unable to find '#{class_name}', so not sending notification"
+                  Hyrax.logger.error "Unable to find '#{class_name}', so not sending notification"
                   return nil
                 end
         return klass if klass.respond_to?(:send_notification)
-        Rails.logger.error "Expected '#{class_name}' to respond to 'send_notification', but it didn't, so not sending notification"
+        Hyrax.logger.error "Expected '#{class_name}' to respond to 'send_notification', but it didn't, so not sending notification"
         nil
       end
     end

--- a/app/services/hyrax/workflow/workflow_importer.rb
+++ b/app/services/hyrax/workflow/workflow_importer.rb
@@ -7,7 +7,7 @@ module Hyrax
     # @see .generate_from_json_file
     class WorkflowImporter
       class_attribute :default_logger
-      self.default_logger = Rails.logger
+      self.default_logger = Hyrax.logger
       class_attribute :path_to_workflow_files
       self.path_to_workflow_files = Rails.root.join('config', 'workflows', '*.json')
 
@@ -132,7 +132,7 @@ module Hyrax
         rescue InvalidStateRemovalException => e
           e.states.each do |state|
             error = I18n.t('hyrax.workflow.load.state_error', workflow_name: state.workflow.name, state_name: state.name, entity_count: state.entities.count)
-            Rails.logger.error(error)
+            Hyrax.logger.error(error)
             errors << error
           end
           Sipity::Workflow.find_by(name: configuration[:name])

--- a/app/services/hyrax/working_directory.rb
+++ b/app/services/hyrax/working_directory.rb
@@ -16,7 +16,7 @@ module Hyrax
         repository_file = Hydra::PCDM::File.find(repository_file_id)
         working_path = full_filename(id, repository_file.original_name)
         if File.exist?(working_path)
-          Rails.logger.debug "#{repository_file.original_name} already exists in the working directory at #{working_path}"
+          Hyrax.logger.debug "#{repository_file.original_name} already exists in the working directory at #{working_path}"
           return working_path
         end
         copy_repository_resource_to_working_directory(repository_file, id)
@@ -26,7 +26,7 @@ module Hyrax
       # @param [String] id the identifier of the FileSet
       # @return [String] path of the working file
       def copy_repository_resource_to_working_directory(file, id)
-        Rails.logger.debug "Loading #{file.original_name} (#{file.id}) from the repository to the working directory"
+        Hyrax.logger.debug "Loading #{file.original_name} (#{file.id}) from the repository to the working directory"
         copy_stream_to_working_directory(id, file.original_name, StringIO.new(file.content))
       end
 
@@ -38,7 +38,7 @@ module Hyrax
       # @return [String] path of the working file
       def copy_stream_to_working_directory(id, name, stream)
         working_path = full_filename(id, name)
-        Rails.logger.debug "Writing #{name} to the working directory at #{working_path}"
+        Hyrax.logger.debug "Writing #{name} to the working directory at #{working_path}"
         FileUtils.mkdir_p(File.dirname(working_path))
         IO.copy_stream(stream, working_path)
         working_path

--- a/app/services/hyrax/works/migration_service.rb
+++ b/app/services/hyrax/works/migration_service.rb
@@ -10,13 +10,13 @@ module Hyrax
       #   and the original data cleaned up.
       def self.migrate_predicate(predicate_from, predicate_to, works_to_update = ActiveFedora::Base.all)
         migrated = 0
-        Rails.logger.info "*** Migrating #{predicate_from} to #{predicate_to} in #{works_to_update.count} works"
+        Hyrax.logger.info "*** Migrating #{predicate_from} to #{predicate_to} in #{works_to_update.count} works"
         works_to_update.each do |work|
           next unless work.ldp_source.content.include?(predicate_from.to_s)
           migrate_data(predicate_from, predicate_to, work)
           migrated += 1
         end
-        Rails.logger.info "--- Migration Complete (#{migrated} migrated)"
+        Hyrax.logger.info "--- Migration Complete (#{migrated} migrated)"
       end
 
       # @api private
@@ -27,7 +27,7 @@ module Hyrax
         orm.value(predicate_from).each { |val| orm.graph.insert([orm.resource.subject_uri, predicate_to, val.to_s]) }
         orm.graph.delete([orm.resource.subject_uri, predicate_from, nil])
         orm.save
-        Rails.logger.info " Data migrated from #{predicate_from} to #{predicate_to} - id: #{work.id}"
+        Hyrax.logger.info " Data migrated from #{predicate_from} to #{predicate_to} - id: #{work.id}"
       end
     end
   end

--- a/app/views/hyrax/transfers/_received.html.erb
+++ b/app/views/hyrax/transfers/_received.html.erb
@@ -49,7 +49,7 @@
       <td><%= req.sender_comment %></td>
     </tr>
     <% else %>
-      <% Rails.logger.error "A proxy request has no sender: #{req.inspect}" %>
+      <% Hyrax.logger.error "A proxy request has no sender: #{req.inspect}" %>
     <% end %>
   <% end %>
   </tbody>

--- a/app/views/hyrax/transfers/_sent.html.erb
+++ b/app/views/hyrax/transfers/_sent.html.erb
@@ -32,7 +32,7 @@
           <td><%= req.sender_comment %></td>
         </tr>
       <% else %>
-          <% Rails.logger.error "A proxy request has no receiver: #{req.inspect}" %>
+          <% Hyrax.logger.error "A proxy request has no receiver: #{req.inspect}" %>
       <% end %>
     <% end %>
   </tbody>

--- a/config/features.rb
+++ b/config/features.rb
@@ -47,5 +47,5 @@ Flipflop.configure do
           default: false,
           description: "Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled."
 rescue Flipflop::StrategyError, Flipflop::FeatureError => err
-  Rails.logger.warn "Ignoring #{err}: #{err.message}"
+  Hyrax.logger.warn "Ignoring #{err}: #{err.message}"
 end

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -22,6 +22,9 @@ Hyrax.config do |config|
   # avoid clashes if you plan to use the default (dct:hasFormat) for other relations.
   # config.rendering_predicate = ::RDF::DC.hasFormat
 
+  # Configure the Logger for the Hyrax application; by default it is the Rails.logger.
+  # config.logger = Rails.logger
+
   # Email recipient of messages sent via the contact form
   # config.contact_email = "repo-admin@example.org"
 
@@ -256,7 +259,7 @@ Hyrax.config do |config|
     if defined? BrowseEverything
       config.browse_everything = BrowseEverything.config
     else
-      Rails.logger.warn "BrowseEverything is not installed"
+      Hyrax.logger.warn "BrowseEverything is not installed"
     end
   rescue Errno::ENOENT
     config.browse_everything = nil

--- a/lib/generators/hyrax/templates/config/initializers/riiif.rb
+++ b/lib/generators/hyrax/templates/config/initializers/riiif.rb
@@ -16,7 +16,7 @@ ActiveSupport::Reloader.to_prepare do
 
   Riiif::Image.file_resolver.id_to_uri = lambda do |id|
     Hyrax::Base.id_to_uri(CGI.unescape(id)).tap do |url|
-      Rails.logger.info "Riiif resolved #{id} to #{url}"
+      Hyrax.logger.info "Riiif resolved #{id} to #{url}"
     end
   end
 

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -80,7 +80,7 @@ module Hyrax
   ##
   # @return [Logger]
   def self.logger
-    @logger ||= Valkyrie.logger
+    config.logger
   end
 
   def self.primary_work_type

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -71,6 +71,19 @@ module Hyrax
     DEFAULT_ACTIVE_WORKFLOW_NAME = 'default'
     private_constant :DEFAULT_ACTIVE_WORKFLOW_NAME
 
+    # Set the default logger for Hyrax.
+    attr_writer :logger
+
+    ##
+    # @return [Logger]
+    def logger
+      @logger ||= if defined?(Rails)
+                    Rails.logger
+                  else
+                    Valkyrie.logger
+                  end
+    end
+
     # @api public
     # When an admin set is created, we need to activate a workflow.
     # The :default_active_workflow_name is the name of the workflow we will activate.
@@ -643,7 +656,7 @@ module Hyrax
       # overriding the value in0 their config unless it's already
       # flipped to false
       if ENV.fetch('SERVER_SOFTWARE', '').match(/Apache.*Phusion_Passenger/).present?
-        Rails.logger.warn('Cannot enable realtime notifications atop Passenger + Apache. Coercing `Hyrax.config.realtime_notifications` to `false`. Set this value to `false` in config/initializers/hyrax.rb to stop seeing this warning.') unless @realtime_notifications == false
+        Hyrax.logger.warn('Cannot enable realtime notifications atop Passenger + Apache. Coercing `Hyrax.config.realtime_notifications` to `false`. Set this value to `false` in config/initializers/hyrax.rb to stop seeing this warning.') unless @realtime_notifications == false
         @realtime_notifications = false
       end
       return @realtime_notifications unless @realtime_notifications.nil?

--- a/lib/hyrax/controlled_vocabulary/importer/language.rb
+++ b/lib/hyrax/controlled_vocabulary/importer/language.rb
@@ -13,7 +13,7 @@ module Hyrax
           stdout_logger.formatter = proc do |_severity, _datetime, _progname, msg|
             "#{msg}\n"
           end
-          Rails.logger.extend(ActiveSupport::Logger.broadcast(stdout_logger))
+          Hyrax.logger.extend(ActiveSupport::Logger.broadcast(stdout_logger))
         end
 
         def import

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -68,7 +68,7 @@ module Hyrax
 
       can_persist = can_connect && begin
         Hyrax.config.persist_registered_roles!
-        Rails.logger.info("Hyrax::Engine.after_initialize - persisting registered roles!")
+        Hyrax.logger.info("Hyrax::Engine.after_initialize - persisting registered roles!")
         true
                                    rescue ActiveRecord::StatementInvalid
                                      false
@@ -78,7 +78,7 @@ module Hyrax
         message = "Hyrax::Engine.after_initialize - unable to persist registered roles.\n"
         message += "It is expected during the application installation - during integration tests, rails install.\n"
         message += "It is UNEXPECTED if you are booting up a Hyrax powered application via `rails server'"
-        Rails.logger.info(message)
+        Hyrax.logger.info(message)
       end
 
       # Force CatalogController to use our SearchState class, which has an important

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe Hyrax::Forms::WorkForm do
       after  { form.class.required_fields -= [bad_term] }
 
       it 'logs a warning' do
-        expect(Rails.logger).to receive(:warn).with(/#{bad_term}/)
+        expect(Hyrax.logger).to receive(:warn).with(/#{bad_term}/)
         form.primary_terms
       end
 

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -83,12 +83,12 @@ RSpec.describe ImportUrlJob do
       context 'when the FileSet has an existing label' do
         let(:label) { "example.tif" }
         before do
-          allow(Rails.logger).to receive(:debug)
+          allow(Hyrax.logger).to receive(:debug)
         end
         it 'uses the FileSet label' do
           described_class.perform_now(file_set, operation)
           tmp_file_path = Rails.root.join(tmpdir, label)
-          expect(Rails.logger).to have_received(:debug).with("ImportUrlJob: Closing #{tmp_file_path}")
+          expect(Hyrax.logger).to have_received(:debug).with("ImportUrlJob: Closing #{tmp_file_path}")
           expect(File.exist?(tmp_file_path.to_s)).to be true
         end
       end

--- a/spec/lib/hyrax/analytics_spec.rb
+++ b/spec/lib/hyrax/analytics_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Hyrax::Analytics do
       end
 
       it "is not valid" do
-        expect(Rails.logger).to receive(:error)
+        expect(Hyrax.logger).to receive(:error)
           .with(starting_with("Unable to fetch any keys from"))
         expect(config).not_to be_valid
       end

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:libreoffice_path) }
   it { is_expected.to respond_to(:license_service_class) }
   it { is_expected.to respond_to(:license_service_class=) }
+  it { is_expected.to respond_to(:logger) }
+  it { is_expected.to respond_to(:logger=) }
   it { is_expected.to respond_to(:max_days_between_fixity_checks) }
   it { is_expected.to respond_to(:max_days_between_fixity_checks=) }
   it { is_expected.to respond_to(:max_notifications_for_dashboard) }

--- a/spec/lib/hyrax/controlled_vocabulary/importer/language_spec.rb
+++ b/spec/lib/hyrax/controlled_vocabulary/importer/language_spec.rb
@@ -3,7 +3,7 @@ require 'hyrax/controlled_vocabulary/importer/language'
 
 RSpec.describe Hyrax::ControlledVocabulary::Importer::Language do
   before do
-    allow(Rails.logger).to receive(:extend)
+    allow(Hyrax.logger).to receive(:extend)
     allow(Hyrax::ControlledVocabulary::Importer::Downloader).to receive(:fetch)
     allow(instance).to receive(:system) do
       allow($CHILD_STATUS).to receive(:success?).and_return(true)

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
 
     context "with a field that doesn't exist" do
       it "logs a warning" do
-        expect(Rails.logger).to receive(:warn).with('Hyrax::WorkShowPresenter attempted to render restrictions, but no method exists with that name.')
+        expect(Hyrax.logger).to receive(:warn).with('Hyrax::WorkShowPresenter attempted to render restrictions, but no method exists with that name.')
         presenter.attribute_to_html(:restrictions)
       end
     end

--- a/spec/services/hyrax/collection_types/create_service_spec.rb
+++ b/spec/services/hyrax/collection_types/create_service_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Hyrax::CollectionTypes::CreateService do
       end
 
       it 'logs and raises an error' do
-        expect(Rails.logger)
+        expect(Hyrax.logger)
           .to receive(:error)
           .with a_string_starting_with('Participants not created')
 

--- a/spec/services/hyrax/listeners/workflow_listener_spec.rb
+++ b/spec/services/hyrax/listeners/workflow_listener_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hyrax::Listeners::WorkflowListener do
     end
 
     it 'logs an error' do
-      expect(Rails.logger).to receive(:error)
+      expect(Hyrax.logger).to receive(:error)
 
       listener.on_object_deposited(event)
     end
@@ -42,7 +42,7 @@ RSpec.describe Hyrax::Listeners::WorkflowListener do
       let(:user) { nil }
 
       it 'logs a warning' do
-        expect(Rails.logger).to receive(:warn)
+        expect(Hyrax.logger).to receive(:warn)
 
         listener.on_object_deposited(event)
       end

--- a/spec/services/hyrax/solr_service_spec.rb
+++ b/spec/services/hyrax/solr_service_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Hyrax::SolrService do
 
     it "warns about not passing rows" do
       allow(mock_conn).to receive(:get).and_return(stub_result)
-      expect(Rails.logger).to receive(:warn).with(/^Calling Hyrax::SolrService\.get without passing an explicit value for ':rows' is not recommended/)
+      expect(Hyrax.logger).to receive(:warn).with(/^Calling Hyrax::SolrService\.get without passing an explicit value for ':rows' is not recommended/)
       described_class.query('querytext')
     end
 

--- a/spec/services/hyrax/workflow/action_taken_service_spec.rb
+++ b/spec/services/hyrax/workflow/action_taken_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Hyrax::Workflow::ActionTakenService do
         before { SpyAction.fail = true }
 
         it "calls the method and does not save the object" do
-          expect(Rails.logger)
+          expect(Hyrax.logger)
             .to receive(:error)
             .with("Not all workflow methods were successful, so not saving (#{work.id})")
 
@@ -97,10 +97,10 @@ RSpec.describe Hyrax::Workflow::ActionTakenService do
       end
 
       it "logs an error" do
-        expect(Rails.logger)
+        expect(Hyrax.logger)
           .to receive(:error)
           .with("Expected 'SpyAction' to respond to 'call', but it didn't, so not running workflow callback")
-        expect(Rails.logger)
+        expect(Hyrax.logger)
           .to receive(:error)
           .with("Not all workflow methods were successful, so not saving (#{work.id})")
 
@@ -110,10 +110,10 @@ RSpec.describe Hyrax::Workflow::ActionTakenService do
 
     context "when the notification doesn't exist" do
       it "logs an error" do
-        expect(Rails.logger)
+        expect(Hyrax.logger)
           .to receive(:error)
           .with("Unable to find 'SpyAction', so not running workflow callback")
-        expect(Rails.logger)
+        expect(Hyrax.logger)
           .to receive(:error)
           .with("Not all workflow methods were successful, so not saving (#{work.id})")
 

--- a/spec/services/hyrax/workflow/notification_service_spec.rb
+++ b/spec/services/hyrax/workflow/notification_service_spec.rb
@@ -73,14 +73,14 @@ RSpec.describe Hyrax::Workflow::NotificationService do
         Object.send(:remove_const, :ConfirmationOfSubmittedToUlraCommittee)
       end
       it "logs an error" do
-        expect(Rails.logger).to receive(:error).with("Expected 'ConfirmationOfSubmittedToUlraCommittee' to respond to 'send_notification', but it didn't, so not sending notification")
+        expect(Hyrax.logger).to receive(:error).with("Expected 'ConfirmationOfSubmittedToUlraCommittee' to respond to 'send_notification', but it didn't, so not sending notification")
         subject
       end
     end
 
     context "when the notification doesn't exist" do
       it "logs an error" do
-        expect(Rails.logger).to receive(:error).with("Unable to find 'ConfirmationOfSubmittedToUlraCommittee', so not sending notification")
+        expect(Hyrax.logger).to receive(:error).with("Unable to find 'ConfirmationOfSubmittedToUlraCommittee', so not sending notification")
         subject
       end
     end

--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -51,6 +51,6 @@ namespace :wings do
 
   def setup_logger
     $VERBOSE = nil unless ENV['RUBY_LOUD']
-    Rails.logger.level = ENV.fetch('BM_LOG_LEVEL', :error)
+    Hyrax.logger.level = ENV.fetch('BM_LOG_LEVEL', :error)
   end
 end


### PR DESCRIPTION
With this change, Hyrax will consistently use the same logger: first defaulting to `Rails.logger` and falling back to `Valkyrie.logger`.

This is a potentially breaking change as we're currently writing to two different loggers (which may be the same based on downstream configuration).

I have also exposed a means for the upstream application to configure the `Hyrax.logger`.

Closes #5879

@samvera/hyrax-code-reviewers
