### PR TITLE
Support alternative solr ports

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 1.5.1
+version: 1.6.0
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -163,8 +163,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end }}
 {{- end -}}
 
+{{- define "hyrax.solr.port" -}}
+{{- .Values.externalSolrPort | default "8983" }}
+{{- end -}}
+
 {{- define "hyrax.solr.url" -}}
-{{- printf "http://%s:%s@%s:%s/solr/%s" (include "hyrax.solr.username" .) (include "hyrax.solr.password" .) (include "hyrax.solr.host" .) "8983" (include "hyrax.solr.collectionName" .)  -}}
+{{- printf "http://%s:%s@%s:%s/solr/%s" (include "hyrax.solr.username" .) (include "hyrax.solr.password" .) (include "hyrax.solr.host" .) (include "hyrax.solr.port" .) (include "hyrax.solr.collectionName" .)  -}}
 {{- end -}}
 
 {{- define "hyrax.zk.fullname" -}}

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -38,5 +38,5 @@ data:
   SOLR_COLLECTION_NAME: {{ template "hyrax.solr.collectionName" . }}
   SOLR_CONFIGSET_NAME: {{ template "hyrax.fullname" . }}
   SOLR_HOST: {{ template "hyrax.solr.host" . }}
-  SOLR_PORT: "8983"
+  SOLR_PORT: {{ (include "hyrax.solr.port" .) | quote }}
   SOLR_URL: {{ template "hyrax.solr.url" . }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -22,6 +22,7 @@ loadSolrConfigSet: true
 #   ignored if `solr.enabled` is true
 solrExistingSecret: ""
 externalSolrHost: ""
+externalSolrPort: ""
 externalSolrUser: ""
 externalSolrPassword: ""
 externalSolrCollection: "hyrax"


### PR DESCRIPTION
Folks managing their own external Solr deployments may not run Solr on
the default `8983` port, so we should have the Hyrax chart support that.

Changes proposed in this pull request:
* Add a new chart value `externalSolrPort`, which defaults to `8983`
* Use to populate the `SOLR_URL` env var
* Use to populate the `SOLR_PORT` env var

Guidance for testing, such as acceptance criteria or new user interface behaviors:

I setup a yaml file with the following content (toggling having `externalSolrPort` set, or not):

```yaml
# External Solr
solr:
  enabled: false
loadSolrConfigSet: false
externalSolrPassword: "the-password"
externalSolrHost: lib-solr-stage.ucsd.edu
externalSolrPort: "9030"
externalSolrUser: sadmin
externalSolrCollection: "hyrax"
```
and ran a couple dry-run's to verify the output:

```sh
helm upgrade --dry-run --debug --install --values /tmp/solr-test.yaml  --namespace comet-review extsolr hyrax
```

@samvera/hyrax-code-reviewers
