### PR TITLE
Update versioning service to support Valkyrie

### DIFF
--- a/app/presenters/hyrax/version_list_presenter.rb
+++ b/app/presenters/hyrax/version_list_presenter.rb
@@ -24,7 +24,7 @@ module Hyrax
                       else
                         Hyrax::FileSetFileService.new(file_set: file_set).original_file
                       end
-      new(original_file ? Hyrax::VersioningService.new(resource: original_file).versions : [])
+      new(Hyrax::VersioningService.new(resource: original_file).versions)
     rescue NoMethodError
       raise ArgumentError
     end

--- a/app/presenters/hyrax/version_list_presenter.rb
+++ b/app/presenters/hyrax/version_list_presenter.rb
@@ -24,7 +24,7 @@ module Hyrax
                       else
                         Hyrax::FileSetFileService.new(file_set: file_set).original_file
                       end
-      new(original_file&.versions&.all.to_a)
+      new(original_file ? Hyrax::VersioningService.new(resource: original_file).versions : [])
     rescue NoMethodError
       raise ArgumentError
     end

--- a/app/services/hyrax/versioning_service.rb
+++ b/app/services/hyrax/versioning_service.rb
@@ -1,7 +1,72 @@
 # frozen_string_literal: true
 
 module Hyrax
+  ##
+  # Provides methods for dealing with versions of files across both ActiveFedora
+  # and Valkyrie.
+  #
+  # Note that many of the methods pertaining to version creation are currently
+  # implemented as static methods.
   class VersioningService
+    ##
+    # @!attribute [rw] resource
+    #   @return [ActiveFedora::File | Hyrax::FileMetadata]
+    attr_accessor :resource
+
+    ##
+    # @!attribute [r] storage_adapter
+    #   @return [#supports?]
+    attr_reader :storage_adapter
+
+    ##
+    # @param resource [ActiveFedora::File | Hyrax::FileMetadata]
+    def initialize(resource:, storage_adapter: Hyrax.storage_adapter)
+      @storage_adapter = storage_adapter
+      self.resource = resource
+    end
+
+    ##
+    # Returns an array of versions for the file associated with this
+    # Hyrax::VersioningService.
+    #
+    # If the file is a Hyrax::FileMetadata and versioning is not supported in
+    # the storage adapter, an empty array will be returned.
+    def versions
+      if resource.is_a? Hyrax::FileMetadata
+        if storage_adapter.try(:"supports?", :versions)
+          storage_adapter.find_versions(id: resource.file_identifier).to_a
+        else
+          []
+        end
+      else
+        resource.versions.all.to_a
+      end
+    end
+
+    ##
+    # Returns the latest version of the file associated with this
+    # Hyrax::VersioningService.
+    def latest_version
+      versions.last
+    end
+
+    ##
+    # Returns the file ID of the latest version of the file associated with this
+    # Hyrax::VersioningService, or the ID of the file resource itself if no
+    # latest version is defined.
+    def versioned_file_id
+      latest = latest_version
+      if latest
+        if latest.respond_to?(:id)
+          latest.id
+        else
+          Hyrax.config.translate_uri_to_id.call(latest.uri)
+        end
+      else
+        resource.is_a?(Hyrax::FileMetadata) ? resource.file_identifier : resource.id
+      end
+    end
+
     class << self
       # Make a version and record the version committer
       # @param [ActiveFedora::File | Hyrax::FileMetadata] content
@@ -11,19 +76,14 @@ module Hyrax
         perform_create(content, user, use_valkyrie)
       end
 
-      # @param [ActiveFedora::File | Hyrax::FileMetadata] content
+      # @param [ActiveFedora::File | Hyrax::FileMetadata] file
       def latest_version_of(file)
-        file.versions.last
+        Hyrax::VersioningService.new(resource: file).latest_version
       end
 
-      # @param [ActiveFedora::File | Hyrax::FileMetadata] content
+      # @param [ActiveFedora::File | Hyrax::FileMetadata] file
       def versioned_file_id(file)
-        versions = file.versions.all
-        if versions.present?
-          Hyrax.config.translate_uri_to_id.call(versions.last.uri)
-        else
-          file.id
-        end
+        Hyrax::VersioningService.new(resource: file).versioned_file_id
       end
 
       # Record the version committer of the last version

--- a/lib/wings/valkyrie/storage.rb
+++ b/lib/wings/valkyrie/storage.rb
@@ -73,7 +73,7 @@ module Wings
             version_graph.query([uri, RDF::Vocab::Fcrepo4.created, :created])
                          .first_object
                          .object
-          Version.new(cast_to_valkyrie_id(uri.to_s), timestamp, self)
+          Version.new(id: cast_to_valkyrie_id(uri.to_s), created: timestamp, adapter: self)
         end.sort
       end
 
@@ -86,13 +86,17 @@ module Wings
       # this implementation uses an orderable {#version_token}. in practice
       # the token is the fcrepo created date for the version, as extracted from
       # the versions graph.
-      Version = Struct.new(:id, :version_token, :adapter) do
+      Version = Struct.new("Version", :id, :created, :adapter, keyword_init: true) do
         include Comparable
 
         ##
         # @return [#read]
         def io
           adapter.find_by(id: id)
+        end
+
+        def version_token
+          created
         end
 
         def <=>(other)

--- a/spec/services/hyrax/versioning_service_spec.rb
+++ b/spec/services/hyrax/versioning_service_spec.rb
@@ -9,7 +9,38 @@ RSpec.describe Hyrax::VersioningService do
       Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :original_file, versioning: true)
     end
 
-    describe '#versioned_file_id' do
+    describe '#versions' do
+      subject do
+        described_class.new(resource: file.original_file).versions.map do |v|
+          Hyrax.config.translate_uri_to_id.call(v.uri)
+        end
+      end
+
+      context 'without version data' do
+        before do
+          allow(file.original_file).to receive(:has_versions?).and_return(false)
+        end
+        it { is_expected.to eq [] }
+      end
+
+      context 'with one version' do
+        it { is_expected.to eq ["#{file.original_file.id}/fcr:versions/version1"] }
+      end
+
+      context 'with two versions' do
+        before do
+          file.original_file.create_version
+        end
+        it {
+          is_expected.to eq [
+            "#{file.original_file.id}/fcr:versions/version1",
+            "#{file.original_file.id}/fcr:versions/version2"
+          ]
+        }
+      end
+    end
+
+    describe '.versioned_file_id' do
       subject { described_class.versioned_file_id file.original_file }
 
       context 'without version data' do
@@ -31,7 +62,7 @@ RSpec.describe Hyrax::VersioningService do
       end
     end
 
-    describe '#latest_version_of' do
+    describe '.latest_version_of' do
       subject { described_class.latest_version_of(file.original_file).label }
 
       context 'with one version' do
@@ -57,7 +88,43 @@ RSpec.describe Hyrax::VersioningService do
     end
     let(:file_metadata) { query_service.custom_queries.find_file_metadata_by(id: uploaded.id) }
 
-    describe '#versioned_file_id' do
+    describe '#versions' do
+      subject { described_class.new(resource: file_metadata).versions.map(&:id) }
+
+      context 'when versions are unsupported' do
+        before do
+          allow(storage_adapter).to receive(:supports?).and_return(false)
+        end
+        it { is_expected.to eq [] }
+      end
+
+      context 'without version data' do
+        before do
+          allow(storage_adapter).to receive(:supports?).and_return(true)
+          allow(storage_adapter).to receive(:find_versions).and_return([])
+        end
+        it { is_expected.to eq [] }
+      end
+
+      context 'with one version' do
+        it { is_expected.to eq ["#{uploaded.id}/fcr:versions/version1"] }
+      end
+
+      context 'with two versions' do
+        let(:another_file) { fixture_file_upload('/hyrax_generic_stub.txt') }
+        before do
+          storage_adapter.upload(resource: file_set, file: another_file, original_filename: 'filenew.txt')
+        end
+        it {
+          is_expected.to eq [
+            "#{uploaded.id}/fcr:versions/version1",
+            "#{uploaded.id}/fcr:versions/version2"
+          ]
+        }
+      end
+    end
+
+    describe '.versioned_file_id' do
       subject { described_class.versioned_file_id file_metadata }
 
       context 'when versions are unsupported' do
@@ -88,7 +155,7 @@ RSpec.describe Hyrax::VersioningService do
       end
     end
 
-    describe '#latest_version_of' do
+    describe '.latest_version_of' do
       subject { described_class.latest_version_of(file_metadata).id.to_s.split('/').last }
 
       context 'with one version' do

--- a/spec/services/hyrax/versioning_service_spec.rb
+++ b/spec/services/hyrax/versioning_service_spec.rb
@@ -3,45 +3,105 @@ RSpec.describe Hyrax::VersioningService do
   let(:user) { build(:user) }
   let(:file) { create(:file_set) }
 
-  before do
-    # Add the original_file (this service  creates a version after saving when you call it with versioning: true)
-    Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :original_file, versioning: true)
+  describe 'using ActiveFedora' do
+    before do
+      # Add the original_file (this service creates a version after saving when you call it with versioning: true)
+      Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :original_file, versioning: true)
+    end
+
+    describe '#versioned_file_id' do
+      subject { described_class.versioned_file_id file.original_file }
+
+      context 'without version data' do
+        before do
+          allow(file.original_file).to receive(:has_versions?).and_return(false)
+        end
+        it { is_expected.to eq file.original_file.id }
+      end
+
+      context 'with one version' do
+        it { is_expected.to eq "#{file.original_file.id}/fcr:versions/version1" }
+      end
+
+      context 'with two versions' do
+        before do
+          file.original_file.create_version
+        end
+        it { is_expected.to eq "#{file.original_file.id}/fcr:versions/version2" }
+      end
+    end
+
+    describe '#latest_version_of' do
+      subject { described_class.latest_version_of(file.original_file).label }
+
+      context 'with one version' do
+        it { is_expected.to eq 'version1' }
+      end
+
+      context 'with two versions' do
+        before do
+          file.original_file.create_version
+        end
+        it { is_expected.to eq 'version2' }
+      end
+    end
   end
 
-  describe '#versioned_file_id' do
-    subject { described_class.versioned_file_id file.original_file }
+  describe 'using valkyrie' do
+    let(:file) { fixture_file_upload('/world.png', 'image/png') }
+    let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+    let(:query_service) { Hyrax.query_service }
+    let(:storage_adapter) { Hyrax.storage_adapter }
+    let(:uploaded) do
+      storage_adapter.upload(resource: file_set, file: file, original_filename: file.original_filename)
+    end
+    let(:file_metadata) { query_service.custom_queries.find_file_metadata_by(id: uploaded.id) }
 
-    context 'without version data' do
-      before do
-        allow(file.original_file).to receive(:has_versions?).and_return(false)
+    describe '#versioned_file_id' do
+      subject { described_class.versioned_file_id file_metadata }
+
+      context 'when versions are unsupported' do
+        before do
+          allow(storage_adapter).to receive(:supports?).and_return(false)
+        end
+        it { is_expected.to eq uploaded.id }
       end
-      it { is_expected.to eq file.original_file.id }
-    end
 
-    context 'with one version' do
-      it { is_expected.to eq "#{file.original_file.id}/fcr:versions/version1" }
-    end
-
-    context 'with two versions' do
-      before do
-        file.original_file.create_version
+      context 'without version data' do
+        before do
+          allow(storage_adapter).to receive(:supports?).and_return(true)
+          allow(storage_adapter).to receive(:find_versions).and_return([])
+        end
+        it { is_expected.to eq uploaded.id }
       end
-      it { is_expected.to eq "#{file.original_file.id}/fcr:versions/version2" }
-    end
-  end
 
-  describe '#latest_version_of' do
-    subject { described_class.latest_version_of(file.original_file).label }
-
-    context 'with one version' do
-      it { is_expected.to eq 'version1' }
-    end
-
-    context 'with two versions' do
-      before do
-        file.original_file.create_version
+      context 'with one version' do
+        it { is_expected.to eq "#{uploaded.id}/fcr:versions/version1" }
       end
-      it { is_expected.to eq 'version2' }
+
+      context 'with two versions' do
+        let(:another_file) { fixture_file_upload('/hyrax_generic_stub.txt') }
+        before do
+          storage_adapter.upload(resource: file_set, file: another_file, original_filename: 'filenew.txt')
+        end
+        it { is_expected.to eq "#{uploaded.id}/fcr:versions/version2" }
+      end
+    end
+
+    describe '#latest_version_of' do
+      subject { described_class.latest_version_of(file_metadata).id.to_s.split('/').last }
+
+      context 'with one version' do
+        it { is_expected.to eq 'version1' }
+      end
+
+      context 'with two versions' do
+        let(:another_file) { fixture_file_upload('/hyrax_generic_stub.txt') }
+        before do
+          storage_adapter.upload(resource: file_set, file: another_file, original_filename: 'filenew.txt')
+        end
+        it { is_expected.to eq 'version2' }
+      end
     end
   end
 end


### PR DESCRIPTION
- Allow instances of `VersioningService` to be created and used to access the versions of a resource
- Update the Wings `Version` struct to support some additional properties needed by the versioning presenter (namely `created`)
- Initial set of tests for Valkyrie versioning behaviour

See #5876.

Things I’m curious about:

- Is this appropriation of `VersioningService` acceptable?
- What additional tests are necessary here?