### PR TITLE
Remove unneeded variables in FileSet permission_form

### DIFF
--- a/app/views/hyrax/file_sets/_permission_form.html.erb
+++ b/app/views/hyrax/file_sets/_permission_form.html.erb
@@ -1,8 +1,3 @@
-<% depositor = f.object.depositor %>
-<% public_perm = f.object.permissions.map { |perm| perm.access if perm.agent_name == "public"}.compact.first %>
-<% public_perm = true if params[:controller] == 'batch' %>
-<% registered_perm = f.object.permissions.map { |perm| perm.access if perm.agent_name == "registered"}.compact.first %>
-
 <h2 id="permissions_display"><% if params[:controller] == 'batch' %><%= t('.bulk') %> <% end %><%= t('.header') %> <% if params[:controller] == 'batch' %>
       <small><%= t('.applied_to') %></small><% end %>
 </h2>


### PR DESCRIPTION
These definitions date back to commit eb9d5cb203f545218d923f6d32140292be784150 in May 2015, before the adoption of `hyrax/base/form_permission` for actually rendering this form out (by a different name, in commit f77f4d4605772440e186925d4075391e411b14d7, Dec 2015). They don’t appear to do anything now and are incompatible with the newer Hyrax permission model.

The need for `depositor` was removed somewhat later, in commit 70ff2ee968c0b4fe3cb9ae7e1df511a4ae6a5c21 (Feb 2021).