### PR TITLE
Add to_presenter method to Hyrax::FileSet

### DIFF
--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -70,5 +70,9 @@ module Hyrax
     def file_set?
       true
     end
+
+    def to_presenter
+      Hyrax::SearchService.new(config: CatalogController.blacklight_config).fetch(id).last
+    end
   end
 end


### PR DESCRIPTION
For parity with `Hyrax::FileSetBehaviour`, per 3a220bf88b2d4d54cf93e7a61000493a3e6aae1a.

(This is needed by the FileSet presenters, but is extending the model like this still the best approach?)