### PR TITLE
Use VisibilityComponent for FileSet permissions

### DIFF
--- a/app/assets/javascripts/hyrax/app.js.erb
+++ b/app/assets/javascripts/hyrax/app.js.erb
@@ -104,7 +104,7 @@ Hyrax = {
         // On the edit work page
         new PermissionsControl($("#share"), 'tmpl-work-grant');
         // On the edit fileset page
-        new PermissionsControl($("#permission"), 'tmpl-file-set-grant');
+        new PermissionsControl($("#permission"), 'tmpl-file-set-grant', { with_visibility_component: true });
         // On the batch edit page
         new PermissionsControl($("#form_permissions"), 'tmpl-work-grant');
         // On the edit collection page

--- a/app/assets/javascripts/hyrax/permissions/control.es6
+++ b/app/assets/javascripts/hyrax/permissions/control.es6
@@ -1,6 +1,7 @@
 import { Registry } from './registry'
 import { UserControls } from './user_controls'
 import { GroupControls } from './group_controls'
+import VisibilityComponent from '../save_work/visibility_component'
 
 export default class PermissionsControl {
   /**
@@ -8,7 +9,8 @@ export default class PermissionsControl {
    * @param {jQuery} element the jquery selector for the permissions container
    * @param {String} template_id the identifier of the template for the added elements
    */
-  constructor(element, template_id) {
+  constructor(element, template_id, options = {}) {
+    const { with_visibility_component } = options
     if (element.length === 0) {
       return
     }
@@ -17,6 +19,11 @@ export default class PermissionsControl {
     this.registry = new Registry(this.element, this.object_name(), template_id)
     this.user_controls = new UserControls(this.element, this.registry)
     this.group_controls = new GroupControls(this.element, this.registry)
+    if (with_visibility_component) {
+      this.visibility_component = new VisibilityComponent(this.element)
+    } else {
+      this.visibility_component = null
+    }
   }
 
   // retrieve object_name the name of the object to create

--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -19,7 +19,7 @@
     </div>
 
     <div class="set-access-controls list-group-item">
-      <%= render 'form_visibility_component', f: f %>
+      <%= render 'form_visibility_component', f: f, save_work: true %>
     </div>
     <% if Flipflop.proxy_deposit? && current_user.can_make_deposits_for.any? %>
         <div class="list-group-item">

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -4,7 +4,11 @@
   <%= render 'form_permission_under_lease', f: f %>
 <% else %>
     <fieldset>
-      <legend class="legend-save-work"><%= t('.visibility') %></legend>
+      <% if local_assigns[:save_work] %>
+        <legend class="legend-save-work"><%= t('.visibility') %></legend>
+      <% else %>
+        <legend><%= t('.visibility') %><%= raw(t('.subtitle_html')) %></legend>
+      <% end %>
       <ul class="visibility">
         <li class="form-check">
           <label class="form-check-label">

--- a/app/views/hyrax/file_sets/_permission_form.html.erb
+++ b/app/views/hyrax/file_sets/_permission_form.html.erb
@@ -13,7 +13,7 @@
   <span id="permissions_error_text"></span>
 </div>
 
-<%= render 'hyrax/base/form_permission', f: f %>
+<%= render 'hyrax/base/form_visibility_component', f: f %>
 
 <!-- Share With -->
 <div class="row">

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -557,7 +557,7 @@ de:
           actions: Aktion
           title: Sammlungstitel
       form_permission:
-        visibility: Sichtbarkeit <small> Wer sollte diesen Inhalt anzeigen oder herunterladen können? </ Small>
+        visibility: Sichtbarkeit <small> Wer sollte diesen Inhalt anzeigen oder herunterladen können? </small>
       form_permission_under_embargo:
         help_html: "<strong>Diese Arbeit ist unter Embargo.</strong> Hier können Sie die Einstellungen des Embargos ändern, oder Sie können den %{edit_link} besuchen, um ihn zu deaktivieren."
         legend_html: Sichtbarkeit <small>Wer sollte in der Lage sein, diesen Inhalt anzusehen oder herunterzuladen?</small>
@@ -596,6 +596,7 @@ de:
         legend_html: Miniaturansicht
       form_visibility_component:
         visibility: Sichtbarkeit
+        subtitle_html: <small>Wer sollte diesen Inhalt anzeigen oder herunterladen können?</small>
       inspect_work:
         back_to: Zurück zu
         entity_id: Mandanten-ID

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -588,6 +588,7 @@ en:
         legend_html: Thumbnail
       form_visibility_component:
         visibility: Visibility
+        subtitle_html: <small>Who should be able to view or download this content?</small>
       inspect_work:
         back_to: Back to
         entity_id: Entity ID

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -601,6 +601,7 @@ es:
         legend_html: Miniatura
       form_visibility_component:
         visibility: La visibilidad
+        subtitle_html: <small>¿Quién debería poder ver o descargar este contenido?</small>
       inspect_work:
         back_to: De regreso
         entity_id: ID de entidad

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -563,7 +563,7 @@ fr:
           actions: action
           title: Titre de la collection
       form_permission:
-        visibility: Visibilité <small> Qui devrait être en mesure d’afficher ou de télécharger ce contenu? </ Small>
+        visibility: Visibilité <small> Qui devrait être en mesure d’afficher ou de télécharger ce contenu? </small>
       form_permission_under_embargo:
         help_html: "<strong>Ce travail est sous embargo.</strong> Vous pouvez modifier les paramètres de l'embargo ici, ou vous pouvez visiter le %{edit_link} pour le désactiver."
         legend_html: Visibilité <small>Qui devrait pouvoir afficher ou télécharger ce contenu?</small>
@@ -602,6 +602,7 @@ fr:
         legend_html: La vignette
       form_visibility_component:
         visibility: Visibilité
+        subtitle_html: <small>Qui devrait être en mesure d’afficher ou de télécharger ce contenu?</small>
       inspect_work:
         back_to: Retour à
         entity_id: ID d'entité

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -601,6 +601,7 @@ it:
         legend_html: Thumbnail
       form_visibility_component:
         visibility: Visibilità
+        subtitle_html: <small>Chi dovrebbe essere in grado di visualizzare o scaricare questo contenuto?</small>
       inspect_work:
         back_to: Torna a
         entity_id: ID entità

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -596,6 +596,7 @@ pt-BR:
         legend_html: Miniatura
       form_visibility_component:
         visibility: Visibilidade
+        subtitle_html: <small>Quem deve conseguir visualizar ou baixar este conteúdo?</small>
       inspect_work:
         back_to: De volta a
         entity_id: ID da entidade

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -599,6 +599,7 @@ zh:
         legend_html: 缩略图
       form_visibility_component:
         visibility: 可见性
+        subtitle_html: <small>谁应该能够查看或下载此内容？</ small>
       inspect_work:
         back_to: 回到
         entity_id: 实体ID


### PR DESCRIPTION
The “visibility component” form used on the Edit Work page is much nicer and more robust than the “form permission” component used by the Edit File(Set) page. This commit substitutes the former for the latter to make keeping these components in sync easier.

Notes:

- The `hyrax/base/form_permission` component is still used for batch editing; I’m not as familiar with that part of the codebase but presumably a similar substitution could be made there.

- Not all permissions tabs include a “Visibility” section; the Edit Work page puts Visibility not in the tab but in the Save Work component. Consequently, in the Javascript it is an option when constructing a `PermissionControl` whether to include a `VisibilityComponent` or not.

- The “Edit Work” page displays the “Visibility” legend slightly differently from the FileSet Permissions tab; this behaviour is now toggleable in the partial by setting `save_work` when rendering.

Screenshot before:

<img width="812" alt="image" src="https://user-images.githubusercontent.com/3212430/194435411-9599ad54-e2e0-4bda-82eb-7a05a97fa233.png">

Screenshot after:

<img width="807" alt="image" src="https://user-images.githubusercontent.com/3212430/194435366-45a5c94e-c354-4101-8dea-b13efba39e80.png">

