### PR TITLE
Use the ResourceForm for FileSets

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -195,7 +195,14 @@ module Hyrax
     def initialize_edit_form
       guard_for_workflow_restriction_on!(parent: parent)
 
-      @version_list = Hyrax::VersionListPresenter.for(file_set: @file_set)
+      case file_set
+      when Hyrax::Resource
+        @form = Hyrax::Forms::ResourceForm.for(file_set)
+        @form.prepopulate!
+      else
+        @form = form_class.new(file_set)
+      end
+      @version_list = Hyrax::VersionListPresenter.for(file_set: file_set)
       @groups = current_user.groups
     end
 

--- a/app/forms/hyrax/forms/file_set_edit_form.rb
+++ b/app/forms/hyrax/forms/file_set_edit_form.rb
@@ -4,7 +4,7 @@ module Hyrax::Forms
     include HydraEditor::Form
     include HydraEditor::Form::Permissions
 
-    delegate :depositor, :permissions, to: :model
+    delegate :depositor, :permissions, :human_readable_type, to: :model
 
     self.required_fields = [:title, :creator, :license]
 

--- a/app/forms/hyrax/forms/file_set_form.rb
+++ b/app/forms/hyrax/forms/file_set_form.rb
@@ -7,6 +7,11 @@ module Hyrax
     class FileSetForm < Hyrax::ChangeSet
       include Hyrax::FormFields(:core_metadata)
 
+      # The fields in +:file_set_metadata+ were hardcoded into this form in a
+      # previous version of Hyrax, but ideally in the future this metadata will
+      # be configurable.
+      include Hyrax::FormFields(:file_set_metadata)
+
       class << self
         ##
         # @return [Array<Symbol>] list of required field names as symbols
@@ -16,20 +21,6 @@ module Hyrax
             .keys.map(&:to_sym)
         end
       end
-
-      property :creator, required: true
-      property :license, required: true
-
-      property :based_near
-      property :contributor
-      property :date_created
-      property :description
-      property :identifier
-      property :keyword
-      property :language
-      property :publisher
-      property :related_url
-      property :subject
 
       property :permissions, virtual: true
       property :visibility, default: VisibilityIntention::PRIVATE

--- a/app/forms/hyrax/forms/file_set_form.rb
+++ b/app/forms/hyrax/forms/file_set_form.rb
@@ -3,8 +3,8 @@
 module Hyrax
   module Forms
     ##
-    # @api public
-    class FileSetForm < Hyrax::ChangeSet
+    # A form for +Hyrax::FileSet+s.
+    class FileSetForm < Hyrax::Forms::ResourceForm
       include Hyrax::FormFields(:core_metadata)
 
       # The fields in +:file_set_metadata+ were hardcoded into this form in a
@@ -12,26 +12,8 @@ module Hyrax
       # be configurable.
       include Hyrax::FormFields(:file_set_metadata)
 
-      class << self
-        ##
-        # @return [Array<Symbol>] list of required field names as symbols
-        def required_fields
-          definitions
-            .select { |_, definition| definition[:required] }
-            .keys.map(&:to_sym)
-        end
-      end
-
-      property :permissions, virtual: true
-      property :visibility, default: VisibilityIntention::PRIVATE
-
-      # virtual properties for embargo/lease;
-      property :embargo_release_date, virtual: true
-      property :visibility_after_embargo, virtual: true
-      property :visibility_during_embargo, virtual: true
-      property :lease_expiration_date, virtual: true
-      property :visibility_after_lease, virtual: true
-      property :visibility_during_lease, virtual: true
+      property :representative_id, type: Valkyrie::Types::String
+      property :thumbnail_id, type: Valkyrie::Types::String
     end
   end
 end

--- a/app/forms/hyrax/forms/pcdm_object_form.rb
+++ b/app/forms/hyrax/forms/pcdm_object_form.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Forms
+    ##
+    # A form for PCDM objects: resources which have collection relationships and
+    # generally resemble +Hyrax::Work+.
+    class PcdmObjectForm < Hyrax::Forms::ResourceForm
+      include Hyrax::FormFields(:core_metadata)
+
+      property :on_behalf_of
+      property :proxy_depositor
+
+      # pcdm relationships
+      property :admin_set_id, prepopulator: ->(_opts) { self.admin_set_id = Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s }
+      property :member_ids, default: [], type: Valkyrie::Types::Array
+      property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
+      property :member_of_collections_attributes, virtual: true, populator: :in_collections_populator
+      validates_with CollectionMembershipValidator
+
+      property :representative_id, type: Valkyrie::Types::String
+      property :thumbnail_id, type: Valkyrie::Types::String
+      property :rendering_ids, default: [], type: Valkyrie::Types::Array
+
+      # backs the child work search element;
+      # @todo: look for a way for the view template not to depend on this
+      property :find_child_work, default: nil, virtual: true
+
+      private
+
+      def in_collections_populator(fragment:, **_options)
+        adds = []
+        deletes = []
+        fragment.each do |_, h|
+          if h["_destroy"] == "true"
+            deletes << Valkyrie::ID.new(h["id"])
+          else
+            adds << Valkyrie::ID.new(h["id"])
+          end
+        end
+
+        self.member_of_collection_ids = ((member_of_collection_ids + adds) - deletes).uniq
+      end
+    end
+  end
+end

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -11,11 +11,15 @@ module Hyrax
     #     # other WorkForm-like configuration here
     #   end
     #
+    # @note The returned class will extend +Hyrax::Forms::PcdmObjectForm+, not
+    #   only +Hyrax::Forms::ResourceForm+. This is for backwards‐compatibility
+    #   with existing Hyrax instances and satisfies the expected general use
+    #   case (building forms for various PCDM object classes), but is *not*
+    #   necessarily suitable for other kinds of Hyrax resource, like
+    #   +Hyrax::FileSet+s.
     def self.ResourceForm(work_class)
-      Class.new(Hyrax::Forms::ResourceForm) do
+      Class.new(Hyrax::Forms::PcdmObjectForm) do
         self.model_class = work_class
-
-        include Hyrax::FormFields(:core_metadata)
 
         ##
         # @return [String]
@@ -29,7 +33,7 @@ module Hyrax
     ##
     # @api public
     #
-    # This form wraps `Hyrax::ChangeSet` in the `HydraEditor::Form` interface.
+    # This form wraps +Hyrax::ChangeSet+ in the +HydraEditor::Form+ interface.
     class ResourceForm < Hyrax::ChangeSet # rubocop:disable Metrics/ClassLength
       ##
       # @api private
@@ -69,8 +73,6 @@ module Hyrax
       property :human_readable_type, writable: false
 
       property :depositor
-      property :on_behalf_of
-      property :proxy_depositor
 
       property :visibility, default: VisibilityIntention::PRIVATE, populator: :visibility_populator
 
@@ -97,17 +99,7 @@ module Hyrax
       property :visibility_after_lease, virtual: true, prepopulator: ->(_opts) { self.visibility_after_lease = model.lease&.visibility_after_lease }
       property :visibility_during_lease, virtual: true, prepopulator: ->(_opts) { self.visibility_during_lease = model.lease&.visibility_during_lease }
 
-      # pcdm relationships
-      property :admin_set_id, prepopulator: ->(_opts) { self.admin_set_id = Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s }
       property :in_works_ids, virtual: true, prepopulator: InWorksPrepopulator
-      property :member_ids, default: [], type: Valkyrie::Types::Array
-      property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
-      property :member_of_collections_attributes, virtual: true, populator: :in_collections_populator
-      validates_with CollectionMembershipValidator
-
-      property :representative_id, type: Valkyrie::Types::String
-      property :thumbnail_id, type: Valkyrie::Types::String
-      property :rendering_ids, default: [], type: Valkyrie::Types::Array
 
       # provide a lock token for optimistic locking; we name this `version` for
       # backwards compatibility
@@ -118,10 +110,6 @@ module Hyrax
       #
       # @see https://github.com/samvera/valkyrie/wiki/Optimistic-Locking
       property :version, virtual: true, prepopulator: LockKeyPrepopulator
-
-      # backs the child work search element;
-      # @todo: look for a way for the view template not to depend on this
-      property :find_child_work, default: nil, virtual: true
 
       class << self
         ##
@@ -143,6 +131,7 @@ module Hyrax
           when Hyrax::PcdmCollection
             Hyrax::Forms::PcdmCollectionForm.new(resource)
           else
+            # NOTE: This will create a +Hyrax::Forms::PcdmObjectForm+.
             Hyrax::Forms::ResourceForm(resource.class).new(resource)
           end
         end
@@ -217,20 +206,6 @@ module Hyrax
 
       def lease_populator(**)
         self.lease = Hyrax::LeaseManager.lease_for(resource: model)
-      end
-
-      def in_collections_populator(fragment:, **_options)
-        adds = []
-        deletes = []
-        fragment.each do |_, h|
-          if h["_destroy"] == "true"
-            deletes << Valkyrie::ID.new(h["id"])
-          else
-            adds << Valkyrie::ID.new(h["id"])
-          end
-        end
-
-        self.member_of_collection_ids = ((member_of_collection_ids + adds) - deletes).uniq
       end
 
       # https://trailblazer.to/2.1/docs/reform.html#reform-populators-populator-collections

--- a/app/indexers/hyrax/valkyrie_file_set_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_file_set_indexer.rb
@@ -9,7 +9,7 @@ module Hyrax
     include Hyrax::VisibilityIndexer
     include Hyrax::ThumbnailIndexer
     include Hyrax::Indexer(:core_metadata)
-    include Hyrax::Indexer(:basic_metadata)
+    include Hyrax::Indexer(:file_set_metadata)
 
     def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       super.tap do |solr_doc| # rubocop:disable Metrics/BlockLength

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -31,7 +31,7 @@ module Hyrax
   # @see https://wiki.duraspace.org/display/samvera/Hydra%3A%3AWorks+Shared+Modeling
   class FileSet < Hyrax::Resource
     include Hyrax::Schema(:core_metadata)
-    include Hyrax::Schema(:basic_metadata)
+    include Hyrax::Schema(:file_set_metadata)
 
     def self.model_name(name_class: Hyrax::Name)
       @_model_name ||= name_class.new(self, nil, 'FileSet')

--- a/app/services/hyrax/edit_permissions_service.rb
+++ b/app/services/hyrax/edit_permissions_service.rb
@@ -20,17 +20,35 @@ module Hyrax
     # @note
     #   +form object.class = SimpleForm::FormBuilder+
     #    For works (i.e. GenericWork):
-    #    * form object.object = Hyrax::GenericWorkForm
-    #    * form object.object.model = GenericWork
+    #    * form_object.object = Hyrax::GenericWorkForm
+    #    * form_object.object.model = GenericWork
     #    * use the work itself
     #    For file_sets:
-    #    * form object.object.class = FileSet
+    #    * form_object.object.class = FileSet
+    #    * use work the file_set is in
+    #    For file set forms:
+    #    * form_object.object.class = Hyrax::Forms::FileSetForm OR
+    #      Hyrax::Forms::FileSetEditForm
+    #    * form_object.object.model = FileSet
     #    * use work the file_set is in
     #    No other object types are supported by this view.
     def self.build_service_object_from(form:, ability:)
       if form.object.respond_to?(:model) && form.object.model.work?
+        # The provided form object is a work form.
         new(object: form.object, ability: ability)
+      elsif form.object.respond_to?(:model) && form.object.model.file_set?
+        # The provided form object is a FileSet form. For Valkyrie forms
+        # (+Hyrax::Forms::FileSetForm+), +:in_works_ids+ is prepopulated onto
+        # the form object itself. For +Hyrax::Forms::FileSetEditForm+, the
+        # +:in_works+ method is present on the wrapped +:model+.
+        if form.object.is_a?(Hyrax::Forms::FileSetForm)
+          object_id = form.object.in_works_ids.first
+          new(object: Hyrax.query_service.find_by(id: object_id), ability: ability)
+        else
+          new(object: form.object.model.in_works.first, ability: ability)
+        end
       elsif form.object.file_set?
+        # The provided form object is a FileSet.
         new(object: form.object.in_works.first, ability: ability)
       end
     end

--- a/app/views/hyrax/file_sets/_permission.html.erb
+++ b/app/views/hyrax/file_sets/_permission.html.erb
@@ -1,5 +1,5 @@
   <div id="permissions_display" class="tab-pane">
-    <%= simple_form_for [main_app, file_set],
+    <%= simple_form_for [main_app, form_object],
                         html: { multipart: true,
                                 id: 'permission',
                                 data: { param_key: file_set.model_name.param_key },

--- a/app/views/hyrax/file_sets/edit.html.erb
+++ b/app/views/hyrax/file_sets/edit.html.erb
@@ -33,7 +33,7 @@
             <h2><%= t('.descriptions') %></h2>
             <%= render "form" %>
           </div>
-          <%= render "permission", file_set: curation_concern %>
+          <%= render "permission", file_set: curation_concern, form_object: @form %>
           <%= render "versioning", file_set: curation_concern %>
         </div>
       </div>

--- a/config/metadata/file_set_metadata.yaml
+++ b/config/metadata/file_set_metadata.yaml
@@ -1,0 +1,130 @@
+# This is the metadata used for `Hyrax::FileSet`s.` It is similar to
+# `basic_metadata.yaml`, but not exactly the same.
+#
+# Terms which are already present in `core_metadata.yaml` are not repeated here.
+attributes:
+  # Required attributes:
+  creator:
+    type: string
+    multiple: true
+    form:
+      required: true
+      primary: true
+    index_keys:
+      - "creator_tesim"
+  license:
+    type: string
+    multiple: true
+    form:
+      required: true
+      primary: true
+
+  # Other attributes:
+  abstract:
+    type: string
+    multiple: true
+  # form:
+  #   primary: false
+  # missing: access_right
+  # missing: alternative_title
+  based_near:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "based_near_sim"
+      - "based_near_tesim"
+  # missing: bibliograpic_citation
+  contributor:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  # required: creator
+  date_created:
+    type: date_time
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "date_created_tesim"
+  description:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "description_tesim"
+  identifier:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  # missing: import_url
+  keyword:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "keyword_sim"
+      - "keyword_tesim"
+  # missing: publisher
+  label:
+    type: string
+  # form:
+  #   primary: false
+  language:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  # required: license
+  publisher:
+    type: string
+    multiple: true
+    form:
+      primary: false
+  related_url:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "related_url_tesim"
+  relative_path:
+    type: string
+  resource_type:
+    type: string
+    multiple: true
+  # form:
+  #   primary: false
+    index_keys:
+      - "resource_type_sim"
+      - "resource_type_tesim"
+  rights_notes:
+    type: string
+    multiple: true
+  # form:
+  #   primary: false
+  rights_statement:
+    type: string
+    multiple: true
+  # form:
+  #   primary: true
+    index_keys:
+      - "rights_statement_tesim"
+  source:
+    type: string
+    multiple: true
+  # form:
+  #   primary: false
+  subject:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "subject_sim"
+      - "subject_tesim"

--- a/spec/validators/hyrax/collection_membership_validator_spec.rb
+++ b/spec/validators/hyrax/collection_membership_validator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::CollectionMembershipValidator do
     end
 
     context 'when record is a work form changeset' do
-      let(:form) { Hyrax::Forms::ResourceForm.new(work) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(work) }
       let(:work) { FactoryBot.build(:hyrax_work) }
       let(:mem_of_cols_attrs) { {} }
 

--- a/spec/views/hyrax/file_sets/_permission.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_permission.html.erb_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/file_sets/_permission.html.erb', type: :view do
   let(:file_set) { stub_model(FileSet) }
+  let(:form_object) { Hyrax::Forms::FileSetEditForm.new(file_set) }
 
   before do
     stub_template "hyrax/file_sets/_permission_form.html.erb" => 'a form'
-    render 'hyrax/file_sets/permission', file_set: file_set
+    render 'hyrax/file_sets/permission', file_set: file_set, form_object: form_object
   end
 
   context "without additional users" do


### PR DESCRIPTION
This PR makes the following changes (in the interest of resolving the remaining issues with #5575) :—

- It refactors work‐specific form behaviours into a new class, `Hyrax::Forms::PcdmObjectForm`, to enable `Hyrax::Forms::ResourceForm` to be used with resource types other than PCDM objects @ 5c48b30e130bb62d00040de1141b92456d037cc4. *[Note №1]*
- It moves FileSet metadata into a new YAML‐based configuration, `file_set_metadata`, and updates the model and form to both use the same metadata (previously the model used `basic_metadata`, and the form had hardcoded fields) @ f70045238739c4e918ee02df57309a944641d1e1. *[Note №2]*
- It modifies `Hyrax::Forms::FileSetForm` to inherit from `Hyrax::Forms::ResourceForm`, with the intention of inheriting the lease and embargo handling behaviours provided there @ f63ca9cdad50d443d952012a5834f4d1a6b09ba8.
- It uses the form, instead of the model object directly, in the FileSet edit view, to allow embargo information to be populated in a Valkyrie context @ d0b785eb925bf5520a9024780d9018d1589677cb.

**Notes:**

1. `Hyrax::Forms::ResourceForm(…)` now returns a class subclassing `Hyrax::Forms::PcdmObjectForm`, not `Hyrax::Forms::ResourceForm` directly. This is a bit awkward and confusing, but it preserves backwards‐compatibility with existing Hyrax applications which defined their models using the recommended `class MyObjectForm < Hyrax::Forms::ResourceForm(MyObjectForm)` syntax.

    FileSet forms (and other future forms which want to use the ResourceForm embargo/lease implementations but do not have PCDM object properties) consequently cannot use the function‐call syntax and should just subclass `Hyrax::Forms::ResourceForm` directly.

    See commit 5c48b30e130bb62d00040de1141b92456d037cc4.

2. `Hyrax::FileSet` formerly included `Hyrax::Schema(:basic_metadata)` in the model, but had a more limited set of metadata actually exposed through the `Hyrax::FileSetForm`. The two furthermore did not agree on `license`, in that it is optional in `basic_metadata` but was required in `Hyrax::FileSetForm`.

    I’ve resolved this by creating a new metadata YAML, `file_set_metadata`, with just the attributes listed in the form or required by tests, and `license` set to `required`. But another solution might be to keep the full `basic_metadata` schema and allow `license` to be optional. See https://github.com/samvera/hyrax/blob/bd2bcffc33e183904be2c175367648815f25bc2b/lib/hyrax/specs/shared_specs/hydra_works.rb#L252-L260 which implies general `basic_metadata` support, but not all attributes are tested and compare also 792ccfdb0c4cddb542d8915a7317b9d83eeba5f0 which removed that requirement for collections considering that those attributes were never exposed in forms.

    (The attributes required by `it_behaves_like 'a model with basic metadata'` but not previously exposed on the form are: `abstract`, `label`, `relative_path`, `resource_type`, `rights_notes`, `rights_statement`, and `source`. If we’re comfortable revising this test, we could probably drop those from `file_set_metadata.yaml`.)

   > By “form” I mean in a Reform/`Hyrax::ChangeSet` sense; the actual Edit page only has a field for title. That leaves open the question of which, if any, of these attributes actually need to be defined on the FileSet model?

    In the long term, I would like for the FileSet metadata to be configurable, but it’s hardcoded to whatever is in the YAML file for now.

    See commit f70045238739c4e918ee02df57309a944641d1e1.