### PR TITLE
Use FileSetsController to access the presenter and deprecate FileSetBehavior#to_presenter

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -13,6 +13,7 @@ module Hyrax
     before_action do
       blacklight_config.track_search_session = false
     end
+    before_action :presenter
 
     # provides the help_text view method
     helper PermissionsHelper

--- a/app/models/concerns/hyrax/file_set_behavior.rb
+++ b/app/models/concerns/hyrax/file_set_behavior.rb
@@ -35,6 +35,7 @@ module Hyrax
 
     # Cast to a SolrDocument by querying from Solr
     def to_presenter
+      Deprecation.warn "Method #to_presenter will be removed in Hyrax 5.0. Use Hyrax::FileSetsController#presenter.solr_document or `@presenter.solr_document` from a view instead."
       Blacklight::SearchService.new(config: CatalogController.blacklight_config).fetch(id).last
     end
   end

--- a/app/views/hyrax/file_sets/edit.html.erb
+++ b/app/views/hyrax/file_sets/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="row">
   <div class="col-12 col-sm-4">
-    <%= render media_display_partial(curation_concern.to_presenter), file_set: curation_concern.to_presenter %>
+    <%= render media_display_partial(@presenter.solr_document), file_set: @presenter.solr_document %>
   </div>
   <div class="col-12 col-sm-8">
     <div class="card tabs">


### PR DESCRIPTION
Alternative to #5890

Ensures `@presenter` is available to views in the `Hyrax::FileSetsController` and uses it to access the solr doc instead of the poorly named FileSet model method `to_presenter` that was actually returning a solr doc.