### PR TITLE
Preventing duplicate Sipity::Entity.create attempts

### DIFF
--- a/app/services/hyrax/workflow/workflow_factory.rb
+++ b/app/services/hyrax/workflow/workflow_factory.rb
@@ -19,6 +19,7 @@ module Hyrax
       # @param user [User]
       # @return [TrueClass]
       def self.create(work, attributes, user)
+        return true if Sipity::Entity.find_by(proxy_for_global_id: work.to_global_id.to_s)
         new(work, attributes, user).create
       end
 

--- a/spec/services/hyrax/workflow/workflow_factory_spec.rb
+++ b/spec/services/hyrax/workflow/workflow_factory_spec.rb
@@ -19,8 +19,19 @@ RSpec.describe Hyrax::Workflow::WorkflowFactory do
         expect do
           subject
         end.to change { Sipity::Entity.count }.by(1)
-                                              .and change { Sipity::EntitySpecificResponsibility.count }.by(1)
+          .and change { Sipity::EntitySpecificResponsibility.count }.by(1)
       end.not_to change { Sipity::WorkflowResponsibility.count }
+    end
+
+    it 'skips creating a Sipity::Entity if one already exists' do
+      # Yes, this is cheating by setting the workflow_id instead of a valid previously created workflow.
+      # However, for this moment, we don't care about the whole AdminSet/PermissionTemplate/Workflow ecosystem.
+      Sipity::Entity.create!(proxy_for_global_id: work.to_global_id.to_s, workflow_id: 1)
+      expect do
+        expect do
+          subject
+        end.not_to change { Sipity::Entity.count }
+      end.not_to change { Sipity::EntitySpecificResponsibility.count }
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, if we created a Sipity::Entity for a work but failed to fully complete the ingest of that work, we might enter a state where we'd see the following exception:

```
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR: duplicate key
value violates unique constraint "sipity_entities_proxy_for_global_id"
```

This echoes behavior introduced in Hyrax v3.0.0.  See https://github.com/samvera/hyrax/blob/v3.0.0/app/actors/hyrax/actors/initialize_workflow_actor.rb#L25-L32 for prior art.

In merging this, we should consider a v2.9.7 release.

@samvera/hyrax-code-reviewers
