### PR TITLE
remove dependency on dry-transaction

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -44,8 +44,8 @@ SUMMARY
   spec.add_dependency 'draper', '~> 4.0'
   spec.add_dependency 'dry-events', '~> 0.2.0'
   spec.add_dependency 'dry-equalizer', '~> 0.2'
+  spec.add_dependency 'dry-monads', '~> 1.5'
   spec.add_dependency 'dry-struct', '~> 1.0'
-  spec.add_dependency 'dry-transaction', '~> 0.11'
   spec.add_dependency 'dry-validation', '~> 1.3'
   spec.add_dependency 'flipflop', '~> 2.3'
   # Pin more tightly because 0.x gems are potentially unstable

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require "dry/transaction"
-require "dry/transaction/operation"
 
 module Hyrax
   module Transactions

--- a/lib/hyrax/transactions/steps/save_collection_banner.rb
+++ b/lib/hyrax/transactions/steps/save_collection_banner.rb
@@ -9,7 +9,7 @@ module Hyrax
       # to be used as a the banner for the collection.
       #
       class SaveCollectionBanner
-        include Dry::Transaction::Operation
+        include Dry::Monads[:result]
 
         ##
         # @param [Hyrax::ChangeSet] change_set

--- a/lib/hyrax/transactions/steps/save_collection_logo.rb
+++ b/lib/hyrax/transactions/steps/save_collection_logo.rb
@@ -9,7 +9,7 @@ module Hyrax
       # to be used as logo(s) for the collection.
       #
       class SaveCollectionLogo
-        include Dry::Transaction::Operation
+        include Dry::Monads[:result]
 
         ##
         # @param [Hyrax::ChangeSet] change_set

--- a/lib/valkyrie/indexing/solr/indexing_adapter.rb
+++ b/lib/valkyrie/indexing/solr/indexing_adapter.rb
@@ -62,7 +62,7 @@ module Valkyrie
             # generator now (if not, the application has bigger problems
             # than this missing configuration)
             bl_index = Blacklight.default_index.connection.uri
-          rescue RuntimeError
+          rescue StandardError
             return {}
           end
 


### PR DESCRIPTION
we don't really use any of the `Dry::Transaction` code. the dependency should have been removed when the legacy transactions got removed for 4.x.

@samvera/hyrax-code-reviewers
