### PR TITLE
[Helm] separate the worker and web selectors 

### DIFF
--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -52,6 +52,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Worker Selector labels
+*/}}
+{{- define "hyrax.workerSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "hyrax.name" . }}-worker
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "hyrax.serviceAccountName" -}}

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -9,7 +9,7 @@ spec:
   replicas: {{ .Values.worker.replicaCount }}
   selector:
     matchLabels:
-      {{- include "hyrax.selectorLabels" . | nindent 6 }}
+      {{- include "hyrax.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
     {{- with .Values.podAnnotations }}
@@ -17,7 +17,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
-        {{- include "hyrax.selectorLabels" . | nindent 8 }}
+        {{- include "hyrax.workerSelectorLabels" . | nindent 8 }}
     spec:
       initContainers:
         - name: db-wait


### PR DESCRIPTION
Currently the selector labels for both web deployment and worker deployment are the same. This leads to the service seeing both web and worker pods. It should just see the web pods. Also it causes some UIs to be confused about how many pods there are (looking at you Rancher UI). This isolates the two deployments.

I'd like to see a chart release pushed once this is merged. I don't see any charts in the registry since 1.0.0 and we're on 1.6.0 in the code base. I can do the push if that's ok with reviewer.

@samvera/hyrax-code-reviewers
