### PR TITLE
Adjust size of collection input

### DIFF
--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -38,6 +38,10 @@ legend small {
   margin-top: 1em;
 }
 
+.select2-container .select2-choice > .select2-chosen {
+  max-width: 26em;
+}
+
 form {
   .form-group {
     align-items: center;

--- a/app/assets/stylesheets/hyrax/_modal.scss
+++ b/app/assets/stylesheets/hyrax/_modal.scss
@@ -6,3 +6,7 @@ div.collection-list legend {
 .modal-body select {
   max-width: 100%;
 }
+
+.modal-body input {
+  width: 100%;
+}

--- a/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
@@ -14,7 +14,7 @@
                 <p><%= t("hyrax.collection.select_form.select_heading") %></p>
               
                 <% if @add_works_to_collection.present? %>
-                  <%= text_field_tag 'member_of_collection_label', @add_works_to_collection_label, size: '90', disabled: true %>
+                  <%= text_field_tag 'member_of_collection_label', @add_works_to_collection_label, disabled: true %>
                   <%= hidden_field_tag 'member_of_collection_ids', @add_works_to_collection %>
                 <% else %>
                   <%= text_field_tag 'member_of_collection_ids', nil,


### PR DESCRIPTION
Fixes #5688

This prevents the input used for selecting the collection when adding a work to a collection from overflowing the modal dialog.

@samvera/hyrax-code-reviewers
