### PR TITLE
Pin view_component pending updated blacklight

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -84,6 +84,7 @@ SUMMARY
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 5.10'
   spec.add_dependency 'valkyrie', '~> 2', '>= 2.1.1'
+  spec.add_dependency 'view_component', '~> 2.74.1' # Pin until blacklight is updated with workaround for https://github.com/ViewComponent/view_component/issues/1565
   spec.add_dependency 'sprockets', '~> 3.7'
   spec.add_dependency 'sass-rails', '~> 6.0'
   spec.add_dependency 'select2-rails', '~> 3.5'


### PR DESCRIPTION
Fixes CI build failing with `/home/circleci/.rubygems/gems/blacklight-7.31.0/lib/blacklight/component.rb:30:in 'index': type mismatch: NilClass given (TypeError)`

Should be able to remove once blacklight is updated with support for this view_component version.

@samvera/hyrax-code-reviewers
