### PR TITLE
Additional changes for graph indexer backport

### DIFF
--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -109,7 +109,9 @@ module Hyrax
         # needed to make the determination are too expensive to do for every possible
         # collection, so we only test for this situation prior to saving the new
         # relationship.
+        # note: the graph indexer does not care about nesting depth
         def nesting_within_maximum_depth
+          return true if Hyrax.config.use_solr_graph_for_collection_nesting
           return true if query_service.valid_combined_nesting_depth?(parent: parent, child: child, scope: context)
           errors.add(:collection, :exceeds_maximum_nesting_depth)
           false

--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -86,7 +86,10 @@ module Hyrax
       #   id is in the response. Useful for validation.
       # @param nest_direction [Symbol] :as_child or :as_parent
       def self.query_solr(collection:, access:, scope:, limit_to_id:, nest_direction:)
-        nesting_attributes = NestingAttributes.new(id: collection.id.to_s, scope: scope)
+
+        nesting_attributes = begin
+          Hyrax.config.use_solr_graph_for_collection_nesting ? nil : NestingAttributes.new(id: collection.id.to_s, scope: scope)
+        end
         query_builder = Hyrax::Dashboard::NestedCollectionsSearchBuilder.new(
           access: access,
           collection: collection,

--- a/app/services/hyrax/collections/nested_collection_query_service.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service.rb
@@ -86,10 +86,7 @@ module Hyrax
       #   id is in the response. Useful for validation.
       # @param nest_direction [Symbol] :as_child or :as_parent
       def self.query_solr(collection:, access:, scope:, limit_to_id:, nest_direction:)
-
-        nesting_attributes = begin
-          Hyrax.config.use_solr_graph_for_collection_nesting ? nil : NestingAttributes.new(id: collection.id.to_s, scope: scope)
-        end
+        nesting_attributes = (Hyrax.config.use_solr_graph_for_collection_nesting ? nil : NestingAttributes.new(id: collection.id.to_s, scope: scope))
         query_builder = Hyrax::Dashboard::NestedCollectionsSearchBuilder.new(
           access: access,
           collection: collection,

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -55,11 +55,18 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
         it 'is invalid if child cannot be nested within the parent' do
           expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child, scope: context).and_return(false)
 
-          expect { form.valid? }
+          if graph_status == "Solr graph is on"
+            expect { form.valid? }
+            .to change { form.errors.to_hash }
+            .to include parent: ["cannot have child nested within it"],
+                        child: ["cannot nest within parent"]
+          else
+            expect { form.valid? }
             .to change { form.errors.to_hash }
             .to include parent: ["cannot have child nested within it"],
                         child: ["cannot nest within parent"],
                         collection: ["nesting exceeds the allowed maximum nesting depth."]
+          end
         end
       end
 

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -153,9 +153,14 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
             let(:nesting_depth_result) { false }
 
             it 'validates the parent cannot have additional files nested' do
-              expect { form.validate_add }
-                .to change { form.errors.to_hash }
-                .to include collection: ["nesting exceeds the allowed maximum nesting depth."]
+              if graph_status == "Solr graph is on"
+                expect { form.validate_add }
+                .not_to change { form.errors.to_hash }
+              else
+                expect { form.validate_add }
+                  .to change { form.errors.to_hash }
+                  .to include collection: ["nesting exceeds the allowed maximum nesting depth."]
+              end
             end
           end
 
@@ -327,14 +332,9 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
           let(:parent_nestable) { false }
 
           it 'validates the parent cannnot contain nested subcollections' do
-            if graph_status == "Solr graph is on"
-              expect { form.validate_add }
-                .not_to change { form.errors.to_hash }
-            else
-              expect { form.validate_add }
-                .to change { form.errors.to_hash }
-                .to include parent: ["cannot have child nested within it"]
-            end
+            expect { form.validate_add }
+              .to change { form.errors.to_hash }
+              .to include parent: ["cannot have child nested within it"]
           end
         end
 

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -243,9 +243,9 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
 
           if graph_status == "Solr graph is on"
             expect { form.valid? }
-            .to change { form.errors.to_hash }
-            .to include parent: ["cannot have child nested within it"],
-                        child: ["cannot nest within parent"]
+              .to change { form.errors.to_hash }
+              .to include parent: ["cannot have child nested within it"],
+                          child: ["cannot nest within parent"]
           else
             expect { form.valid? }
               .to change { form.errors.to_hash }

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
             it 'validates the parent cannot have additional files nested' do
               if graph_status == "Solr graph is on"
                 expect { form.validate_add }
-                .not_to change { form.errors.to_hash }
+                  .not_to change { form.errors.to_hash }
               else
                 expect { form.validate_add }
                   .to change { form.errors.to_hash }

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -57,15 +57,15 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
 
           if graph_status == "Solr graph is on"
             expect { form.valid? }
-            .to change { form.errors.to_hash }
-            .to include parent: ["cannot have child nested within it"],
-                        child: ["cannot nest within parent"]
+              .to change { form.errors.to_hash }
+              .to include parent: ["cannot have child nested within it"],
+                          child: ["cannot nest within parent"]
           else
             expect { form.valid? }
-            .to change { form.errors.to_hash }
-            .to include parent: ["cannot have child nested within it"],
-                        child: ["cannot nest within parent"],
-                        collection: ["nesting exceeds the allowed maximum nesting depth."]
+              .to change { form.errors.to_hash }
+              .to include parent: ["cannot have child nested within it"],
+                          child: ["cannot nest within parent"],
+                          collection: ["nesting exceeds the allowed maximum nesting depth."]
           end
         end
       end

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -241,11 +241,18 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
         it 'is invalid if child cannot be nested within the parent' do
           expect(query_service).to receive(:parent_and_child_can_nest?).with(parent: parent, child: child, scope: context).and_return(false)
 
-          expect { form.valid? }
+          if graph_status == "Solr graph is on"
+            expect { form.valid? }
             .to change { form.errors.to_hash }
             .to include parent: ["cannot have child nested within it"],
-                        child: ["cannot nest within parent"],
-                        collection: ["nesting exceeds the allowed maximum nesting depth."]
+                        child: ["cannot nest within parent"]
+          else
+            expect { form.valid? }
+              .to change { form.errors.to_hash }
+              .to include parent: ["cannot have child nested within it"],
+                          child: ["cannot nest within parent"],
+                          collection: ["nesting exceeds the allowed maximum nesting depth."]
+          end
         end
       end
 
@@ -320,9 +327,14 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
           let(:parent_nestable) { false }
 
           it 'validates the parent cannnot contain nested subcollections' do
-            expect { form.validate_add }
-              .to change { form.errors.to_hash }
-              .to include parent: ["cannot have child nested within it"]
+            if graph_status == "Solr graph is on"
+              expect { form.validate_add }
+                .not_to change { form.errors.to_hash }
+            else
+              expect { form.validate_add }
+                .to change { form.errors.to_hash }
+                .to include parent: ["cannot have child nested within it"]
+            end
           end
         end
 
@@ -332,9 +344,14 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
             let(:nesting_depth_result) { false }
 
             it 'validates the parent cannot have additional files nested' do
-              expect { form.validate_add }
-                .to change { form.errors.to_hash }
-                .to include collection: ["nesting exceeds the allowed maximum nesting depth."]
+              if graph_status == "Solr graph is on"
+                expect { form.validate_add }
+                  .not_to change { form.errors.to_hash }
+              else
+                expect { form.validate_add }
+                  .to change { form.errors.to_hash }
+                  .to include collection: ["nesting exceeds the allowed maximum nesting depth."]
+              end
             end
           end
 


### PR DESCRIPTION
Additional fixes to https://github.com/samvera/hyrax/pull/5858

With the prior backport, collection nesting does not work with the graph indexer. This fixes remaining pieces.

Changes proposed in this pull request:
* Remove nesting depth check when using graph indexer
* NestingAttributes subclass is not applicable to graph indexer

@samvera/hyrax-code-reviewers
