### PR TITLE
Fixes the missing sort call in add_sorting_to_solr (#5905).

### DIFF
--- a/app/search_builders/hyrax/collection_search_builder.rb
+++ b/app/search_builders/hyrax/collection_search_builder.rb
@@ -37,7 +37,7 @@ module Hyrax
     # This overrides the default 'relevance' sort.
     def add_sorting_to_solr(solr_parameters)
       return if solr_parameters[:q]
-      solr_parameters[:sort] ||= "#{sort_field} asc"
+      solr_parameters[:sort] = sort || "#{sort_field} asc"
     end
 
     # If :deposit access is requested, check to see which collections the user has

--- a/app/search_builders/hyrax/collection_search_builder.rb
+++ b/app/search_builders/hyrax/collection_search_builder.rb
@@ -37,7 +37,8 @@ module Hyrax
     # This overrides the default 'relevance' sort.
     def add_sorting_to_solr(solr_parameters)
       return if solr_parameters[:q]
-      solr_parameters[:sort] = sort || "#{sort_field} asc"
+      solr_parameters[:sort] ||= sort
+      solr_parameters[:sort] ||= "#{sort_field} asc"
     end
 
     # If :deposit access is requested, check to see which collections the user has

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -70,4 +70,18 @@ RSpec.describe Hyrax::CollectionSearchBuilder do
       end
     end
   end
+
+  describe '#add_sorting_to_solr' do
+    let(:builder_2) { described_class.new(scope).with(blacklight_params) }
+    let(:blacklight_params) do
+      { "sort" => "system_create_dtsi desc", "per_page" => "50", "locale" => "en" }
+    end
+    let(:solr_parameters) { {} }
+
+    before { builder_2.add_sorting_to_solr(solr_parameters) }
+
+    it 'sets the solr paramters for sorting correctly' do
+      expect(solr_parameters[:sort]).to eq('system_create_dtsi desc')
+    end
+  end
 end


### PR DESCRIPTION
Fixes #5905  ; refs #5905 

Because our override method never calls `Blacklight::SearchBuilder#sort`, it will always default to `title_si asc`, making the sort options useless on this show page.

Changes proposed in this pull request:
* Adds the missing sort command to the method that overrides one from Blacklight::Solr::SearchBuilderBehavior.
* Inserts a test to confirm that a sort option passed into the blacklight_params actually gets utilized.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Login and visit Dashboard
* Choose Collections and select one with multiple works to navigate to the show page
* Choose any sort option from the pull down menu
* After page load, the order of the works should be different

@samvera/hyrax-code-reviewers
