### PR TITLE
401 if an unauthorized user attempts to download a workflow restricted file

### DIFF
--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -39,9 +39,7 @@ module Hyrax
     end
 
     def file_set_parent(file_set_id)
-      file_set = Hyrax.query_service.find_by_alternate_identifier(
-                      alternate_identifier: file_set_id,
-                      use_valkyrie: Hyrax.config.use_valkyrie?)
+      file_set = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set_id, use_valkyrie: Hyrax.config.use_valkyrie?)
       @parent ||=
         case file_set
         when Hyrax::Resource
@@ -57,8 +55,7 @@ module Hyrax
     def authorize_download!
       authorize! :download, params[asset_param_key]
       # Deny access if the work containing this file is restricted by a workflow
-      return unless workflow_restriction?(file_set_parent(params[asset_param_key]),
-                                          ability: current_ability)
+      return unless workflow_restriction?(file_set_parent(params[asset_param_key]), ability: current_ability)
       raise Hyrax::WorkflowAuthorizationException
     rescue CanCan::AccessDenied, Hyrax::WorkflowAuthorizationException
       unauthorized_image = Rails.root.join("app", "assets", "images", "unauthorized.png")

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -38,6 +38,16 @@ module Hyrax
       { type: mime_type_for(file), disposition: 'inline' }
     end
 
+    def parent(file_set: curation_concern)
+      @parent ||=
+        case file_set
+        when Hyrax::Resource
+          Hyrax.query_service.find_parents(resource: file_set).first
+        else
+          file_set.parent
+        end
+    end
+
     # Customize the :read ability in your Ability class, or override this method.
     # Hydra::Ability#download_permissions can't be used in this case because it assumes
     # that files are in a LDP basic container, and thus, included in the asset's uri.
@@ -45,7 +55,8 @@ module Hyrax
       authorize! :download, params[asset_param_key]
       # Deny access if the work containing this file is restricted by a workflow
       file_set = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[asset_param_key], use_valkyrie: Hyrax.config.use_valkyrie?)
-      return unless workflow_restriction?(file_set.parent, ability: current_ability)
+      file_set_parent = parent(file_set: file_set)
+      return unless workflow_restriction?(file_set_parent, ability: current_ability)
       raise Hyrax::WorkflowAuthorizationException
     rescue CanCan::AccessDenied, Hyrax::WorkflowAuthorizationException
       unauthorized_image = Rails.root.join("app", "assets", "images", "unauthorized.png")

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -39,8 +39,16 @@ module Hyrax
     end
 
     def file_set_parent(file_set_id)
-      file_set = ActiveFedora::Base.where(id: file_set_id).first
-      file_set.parent
+      file_set = Hyrax.query_service.find_by_alternate_identifier(
+                      alternate_identifier: file_set_id,
+                      use_valkyrie: Hyrax.config.use_valkyrie?)
+      @parent ||=
+        case file_set
+        when Hyrax::Resource
+          Hyrax.query_service.find_parents(resource: file_set).first
+        else
+          file_set.parent
+        end
     end
 
     # Customize the :read ability in your Ability class, or override this method.

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -82,6 +82,11 @@ RSpec.describe Hyrax::DownloadsController do
             expect(response.headers['Accept-Ranges']).to eq "bytes"
           end
 
+          it 'retrieves the thumbnail without contacting Fedora' do
+            expect(ActiveFedora::Base).not_to receive(:find).with(file_set.id)
+            get :show, params: { id: file_set, file: 'thumbnail' }
+          end
+
           it 'sends 304 response when client has valid cached data' do
             get :show, params: { id: file_set, file: 'thumbnail' }
             expect(response).to have_http_status :success

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -82,11 +82,6 @@ RSpec.describe Hyrax::DownloadsController do
             expect(response.headers['Accept-Ranges']).to eq "bytes"
           end
 
-          it 'retrieves the thumbnail without contacting Fedora' do
-            expect(ActiveFedora::Base).not_to receive(:find).with(file_set.id)
-            get :show, params: { id: file_set, file: 'thumbnail' }
-          end
-
           it 'sends 304 response when client has valid cached data' do
             get :show, params: { id: file_set, file: 'thumbnail' }
             expect(response).to have_http_status :success

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -26,18 +26,6 @@ RSpec.describe Hyrax::DownloadsController do
       end
     end
 
-    context 'when restricted by workflow' do
-      before do
-        allow(subject).to receive(:workflow_restriction?).and_return(true)
-      end
-
-      it 'returns :unauthorized status with image content' do
-        get :show, params: { id: file_set.to_param }
-        expect(response).to have_http_status(:unauthorized)
-        expect(response.content_type).to eq 'image/png'
-      end
-    end
-
     context "when user isn't logged in" do
       context "and the unauthorized image exists" do
         before do
@@ -65,6 +53,18 @@ RSpec.describe Hyrax::DownloadsController do
         expect(response.body).to eq file_set.original_file.content
       end
 
+      context 'when restricted by workflow' do
+        before do
+          allow(subject).to receive(:workflow_restriction?).and_return(true)
+        end
+
+        it 'returns :unauthorized status with image content' do
+          get :show, params: { id: file_set.to_param }
+          expect(response).to have_http_status(:unauthorized)
+          expect(response.content_type).to eq 'image/png'
+        end
+      end
+
       context "with an alternative file" do
         context "that is persisted" do
           let(:file) { File.open(fixture_path + '/world.png', 'rb') }
@@ -80,11 +80,6 @@ RSpec.describe Hyrax::DownloadsController do
             expect(response.body).to eq content
             expect(response.headers['Content-Length']).to eq "4218"
             expect(response.headers['Accept-Ranges']).to eq "bytes"
-          end
-
-          it 'retrieves the thumbnail without contacting Fedora' do
-            expect(ActiveFedora::Base).not_to receive(:find).with(file_set.id)
-            get :show, params: { id: file_set, file: 'thumbnail' }
           end
 
           it 'sends 304 response when client has valid cached data' do

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Hyrax::DownloadsController do
       end
     end
 
+    context 'when restricted by workflow' do
+      before do
+        allow(subject).to receive(:workflow_restriction?).and_return(true)
+      end
+
+      it 'returns :unauthorized status with image content' do
+        get :show, params: { id: file_set.to_param }
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.content_type).to eq 'image/png'
+      end
+    end
+
     context "when user isn't logged in" do
       context "and the unauthorized image exists" do
         before do


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/5913
I've confirmed this bug in 3.x and 2.x, and it was confirmed in nurax.

Files are currently downloadable by unauthorized users if they are restricted by a workflow and the user knows the download URL. See the issue for more details.

Changes proposed in this pull request:
* Adds a `workflow_restriction?` check of the FileSets parent to the `authorize_download!` method in DownloadsController

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Direct download links to workflow restricted files (such as in the case of a mediated deposit that has not been approved) should respond with a not authorized response, just like with regular access restrictions
* Other requests to download should behave as before.

@samvera/hyrax-code-reviewers
