### PR TITLE
Prevent error on nil depositor

### DIFF
--- a/app/jobs/content_event_job.rb
+++ b/app/jobs/content_event_job.rb
@@ -18,6 +18,6 @@ class ContentEventJob < EventJob
 
   # log the event to the users profile stream
   def log_user_event(depositor)
-    depositor.log_profile_event(event)
+    depositor&.log_profile_event(event)
   end
 end


### PR DESCRIPTION
Do not call log_profile_event when depositor nil. 

ref https://github.com/scientist-softserv/utk-hyku/pull/248 This situation arose from the Bulkrax::CreateRelationships job, as works are connected to a collection.

The [deprecation of the add_members method in collection_behavior routes to Hyrax::Collections::CollectionMemberService.add_members_by_ids, which expects a user, and passes nil by default](https://github.com/samvera/hyrax/blob/main/app/models/concerns/hyrax/collection_behavior.rb#L59-L61). This means that the [ObjectLifecycleListener receives an event with a nil user as it creates the ContentUpdateEventJob](https://github.com/samvera/hyrax/blob/main/app/services/hyrax/listeners/object_lifecycle_listener.rb#L29) and throws a NoMethodError on the log_profile_event call for each collection member that is added.

I have verified that this is only a notifier and not an indication of a failure. Collection relationships were created appropriately in spite of this notification error.

@samvera/hyrax-code-reviewers
