### PR TITLE
fix Samvera Slack badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docs: [![Documentation Status](https://inch-ci.org/github/samvera/hyrax.svg?bran
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./.github/CONTRIBUTING.md)
 [![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE)
 
-Jump in: [![Slack Status](http://slack.samvera.org/badge.svg)](http://slack.samvera.org/)
+Jump in: [![Samvera Community Slack](https://img.shields.io/badge/samvera-slack-orange)](https://samvera.slack.com/)
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docs: [![Documentation Status](https://inch-ci.org/github/samvera/hyrax.svg?bran
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./.github/CONTRIBUTING.md)
 [![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE)
 
-Jump in: [![Samvera Community Slack](https://img.shields.io/badge/samvera-slack-orange)](https://samvera.slack.com/)
+Jump in: [![Samvera Community Slack](https://img.shields.io/badge/samvera-slack-blueviolet)](https://samvera.slack.com/)
 
 ## Table of Contents
 


### PR DESCRIPTION
Fix the Samvera Slack badge in the README.

There were two issues with the existing Slack badge: 

- The badge did not render correctly, showing a text link instead 
- The link did not link to the correct URL 

![samverahyrax at fix-slack-badge-in-readme 2022-12-12 at 8 59 22 AM](https://user-images.githubusercontent.com/32469930/207107182-674a8121-edb6-4c29-af4a-a9e1ac0a36cc.jpg)

@samvera/hyrax-code-reviewers
