### PR TITLE
Expanding method interface

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter.rb
@@ -48,6 +48,12 @@ module Hyrax
     end
 
     ##
+    # @return [String]
+    def hostname
+      @hostname || 'localhost'
+    end
+
+    ##
     # @return [Boolean]
     def file_set?
       model.try(:file_set?) || Array(model[:has_model_ssim]).include?('FileSet')
@@ -209,6 +215,14 @@ module Hyrax
                iiif_endpoint: iiif_endpoint(latest_file_id, base_url: hostname))
       end
 
+      ##
+      # @return [#can?]
+      def ability
+        @ability ||= NullAbility.new
+      end
+
+      ##
+      # @return [String]
       def hostname
         @hostname || 'localhost'
       end
@@ -221,10 +235,6 @@ module Hyrax
     end
 
     private
-
-    def hostname
-      @hostname || 'localhost'
-    end
 
     def metadata_fields
       Hyrax.config.iiif_metadata_fields

--- a/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Hyrax::IiifManifestPresenter do
   subject(:presenter) { described_class.new(work) }
   let(:work) { build(:monograph) }
 
+  it { is_expected.to respond_to :hostname }
+  it { is_expected.to respond_to :ability }
+
   describe 'manifest generation' do
     let(:builder_service) { Hyrax::ManifestBuilderService.new }
 
@@ -48,6 +51,9 @@ RSpec.describe Hyrax::IiifManifestPresenter do
     subject(:presenter) { described_class.new(solr_doc) }
     let(:solr_doc) { SolrDocument.new(file_set.to_solr) }
     let(:file_set) { create(:file_set, :image) }
+
+    it { is_expected.to respond_to :hostname }
+    it { is_expected.to respond_to :ability }
 
     describe '#display_image' do
       it 'gives a IIIFManifest::DisplayImage' do


### PR DESCRIPTION
Prior to this commit, we had inconsistent method interfaces for the two IIIF presenters.  Further, we also had the case where the `hostname` and `ability` were not "public", even though we had public writer methods.

With this commit, we normalize that.
