### PR TITLE
always force original_name to UTF-8 encoding

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -65,8 +65,9 @@ class CharacterizeJob < Hyrax::ApplicationJob
     # mod time. This is done in the versioning code.
     file_set.date_modified = Hyrax::TimeService.time_in_utc if file_set.characterization_proxy.original_checksum.first != previous_checksum
 
-    # set title to label if that's how it was before this characterization
-    file_set.title = [file_set.characterization_proxy.original_name.force_encoding("UTF-8")] if reset_title
+    file_set.characterization_proxy.original_name.force_encoding("UTF-8")
+    # set title to label (i.e. file name, `original_name`) if that's how it was before this characterization
+    file_set.title = [file_set.characterization_proxy.original_name] if reset_title
     # always set the label to the original_name
     file_set.label = file_set.characterization_proxy.original_name
 


### PR DESCRIPTION
Fixes #5671... cause I missed a corner case for which a spec is also added here.

@samvera/hyrax-code-reviewers
