### PR TITLE
Refreeze FileMetadata type with note to not <<

### DIFF
--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -67,7 +67,7 @@ module Hyrax
     attribute :label, ::Valkyrie::Types::Set
     attribute :original_filename, ::Valkyrie::Types::String
     attribute :mime_type, ::Valkyrie::Types::String.default(GENERIC_MIME_TYPE)
-    attribute :type, ::Valkyrie::Types::Set.default([Use::ORIGINAL_FILE])
+    attribute :type, ::Valkyrie::Types::Set.default([Use::ORIGINAL_FILE].freeze) # Use += to add types, not <<
 
     # attributes set by fits
     attribute :format_label, ::Valkyrie::Types::Set

--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -38,7 +38,7 @@ class Hyrax::ValkyrieUpload
     streamfile = storage_adapter.upload(file: io, original_filename: filename, resource: file_set)
     file_metadata = Hyrax::FileMetadata(streamfile)
     file_metadata.file_set_id = file_set.id
-    file_metadata.type << use
+    file_metadata.type += [use]
 
     if use == Hyrax::FileMetadata::Use::ORIGINAL_FILE
       # Set file set label.


### PR DESCRIPTION
Fixes #5943 

Defaults for valkyrie resource attributes should be frozen to prevent unintended changes to other objects. This issue was revealed by this spec and fixed by freezing the default object and using a method that creates a new object instead of one the modifies the existing object.