### PR TITLE
Don't throw an error if depositor field isn't present

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -414,7 +414,7 @@ module Hyrax
     # @param document_id [String] the id of the document.
     def user_is_depositor?(document_id)
       doc = Hyrax::SolrService.search_by_id(document_id, fl: 'depositor_ssim')
-      current_user.user_key == doc.fetch('depositor_ssim').first
+      current_user.user_key == doc['depositor_ssim']&.first
     end
 
     def curation_concerns_models

--- a/spec/models/concerns/hyrax/ability_spec.rb
+++ b/spec/models/concerns/hyrax/ability_spec.rb
@@ -105,6 +105,26 @@ RSpec.describe Hyrax::Ability do
         expect(ability.can?(:edit, presenter)).to eq true
       end
     end
+
+    describe 'can?(:transfer)' do
+      before do
+        allow(Hyrax::SolrService).to receive(:search_by_id).and_return(solr_document)
+      end
+
+      context 'without a depositor field' do
+        it 'does not have transfer ability' do
+          expect(ability.can?(:transfer, 'my_solr_doc_id')).to eq false
+        end
+      end
+
+      context 'with a depositor field' do
+        let(:attributes) { { id: 'my_solr_doc_id', depositor_ssim: [user.email] } }
+
+        it 'has transfer ability ' do
+          expect(ability.can?(:transfer, 'my_solr_doc_id')).to eq true
+        end
+      end
+    end
     # rubocop:enable RSpec/SubjectStub
   end
 end


### PR DESCRIPTION
Fixes https://github.com/samvera/hyrax/issues/5951

* `user_is_depositor?` will return false if there is no depositor field in solr rather than throwing a "Key not found" error.

@samvera/hyrax-code-reviewers
