### PR TITLE
Fix method not found error for File analytics page

### DIFF
--- a/app/models/file_download_stat.rb
+++ b/app/models/file_download_stat.rb
@@ -12,10 +12,10 @@ class FileDownloadStat < Hyrax::Statistic
         Hyrax.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
         return []
       end
-      profile.hyrax__analytics__google__download(sort: 'date',
-                                                 start_date: start_date,
-                                                 end_date: Date.yesterday,
-                                                 limit: 10_000)
+      profile.hyrax__download(sort: 'date',
+                              start_date: start_date,
+                              end_date: Date.yesterday,
+                              limit: 10_000)
              .for_file(file.id)
     end
 

--- a/app/models/hyrax/statistic.rb
+++ b/app/models/hyrax/statistic.rb
@@ -34,10 +34,10 @@ module Hyrax
           Hyrax.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
           return []
         end
-        profile.hyrax__analytics__google__pageviews(sort: 'date',
-                                                    start_date: start_date,
-                                                    end_date: Date.yesterday,
-                                                    limit: 10_000)
+        profile.hyrax__pageview(sort: 'date',
+                                start_date: start_date,
+                                end_date: Date.yesterday,
+                                limit: 10_000)
                .for_path(path)
       end
 

--- a/spec/models/file_download_stat_spec.rb
+++ b/spec/models/file_download_stat_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe FileDownloadStat, type: :model do
     end
     context "when a profile is available" do
       let(:views) { double }
-      let(:profile) { double(hyrax__analytics__google__download: views) }
+      let(:profile) { double(hyrax__download: views) }
 
       it "calls the Legato method with the correct path" do
         expect(views).to receive(:for_file).with(99)

--- a/spec/models/work_view_stat_spec.rb
+++ b/spec/models/work_view_stat_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe WorkViewStat, type: :model do
     end
     context "when a profile is available" do
       let(:views) { double }
-      let(:profile) { double(hyrax__analytics__google__pageviews: views) }
+      let(:profile) { double(hyrax__pageview: views) }
 
       it "calls the Legato method with the correct path" do
         expect(views).to receive(:for_path).with(expected_path)


### PR DESCRIPTION
Fix method not found error for File analytics page by using hyrax_pageview and hyrax_download methods

Fixes #5955

As described in the ticket, the File analytics page is throwing an error in hyrax 3 and 4. It can be verified on nurax. The change in this PR resolves the problem in my local repository.

It looks like file_download_stat.rb and statistic.rb used these methods at one point, so I do not know if there is a good reason not to use them.

https://github.com/samvera/hyrax/pull/5089/files#diff-5b2a56b95bdff9c7fa8cc57e7444e3b10f7dc22f45aa739805e49cb19ae93d0fL15

@samvera/hyrax-code-reviewers @orangewolf @alishaevn @sara-g @no-reply
