### PR TITLE
Fix missing work id in file-set-in-work-download events

### DIFF
--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -8,7 +8,7 @@
       </audio>
       <%= link_to t('hyrax.file_set.show.downloadable_content.audio_link'),
                   hyrax.download_path(file_set),
-                  data: { label: file_set.id },
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
                   target: :_blank,
                   id: "file_download" %>
     </div>

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -4,7 +4,7 @@
     <p /><%= link_to t('hyrax.file_set.show.download'),
       hyrax.download_path(file_set),
       id: "file_download",
-      data: { label: file_set.id },
+      data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
       target: "_new" %>
   <% end %>
 </div>

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -7,7 +7,7 @@
                     role: "presentation") %>
       <%= link_to t('hyrax.file_set.show.downloadable_content.image_link'),
                   hyrax.download_path(file_set),
-                  data: { label: file_set.id },
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
                   target: :_blank,
                   id: "file_download" %>
     </div>

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -9,7 +9,7 @@
                   hyrax.download_path(file_set),
                   target: :_blank,
                   id: "file_download",
-                  data: { label: file_set.id } %>
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
     </div>
 <% else %>
     <div>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -9,7 +9,7 @@
                   hyrax.download_path(file_set),
                   target: :_blank,
                   id: "file_download",
-                  data: { label: file_set.id } %>
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
     </div>
 <% else %>
     <div>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -8,7 +8,7 @@
       </video>
       <%= link_to t('hyrax.file_set.show.downloadable_content.video_link'),
                   hyrax.download_path(file_set),
-                  data: { label: file_set.id },
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
                   target: :_blank,
                   id: "file_download" %>
     </div>

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -2,6 +2,10 @@
 RSpec.describe "work show view" do
   include Selectors::Dashboard
 
+  before do
+    allow(Hyrax::Analytics.config).to receive(:analytics_id).and_return('UA-XXXXXXXX')
+  end
+
   let(:work_path) { "/concern/generic_works/#{work.id}" }
   let(:app_host) { Capybara.app_host || 'http://www.example.com' }
 

--- a/spec/views/hyrax/file_sets/media_display/_audio.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_audio.html.erb_spec.rb
@@ -4,12 +4,17 @@ RSpec.describe 'hyrax/file_sets/media_display/_audio.html.erb', type: :view do
   let(:file_set) { stub_model(FileSet, parent: parent) }
   let(:parent) { double }
   let(:link) { true }
+  let(:work_solr_document) do
+    SolrDocument.new(id: '900', title_tesim: ['My Title'])
+  end
+  let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
 
   before do
     allow(controller).to receive(:current_ability).and_return(ability)
     allow(ability).to receive(:can?).with(:download, file_set).and_return(true)
     allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
+    assign(:presenter, parent_presenter)
     render 'hyrax/file_sets/media_display/audio', file_set: file_set
   end
 

--- a/spec/views/hyrax/file_sets/media_display/_default.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_default.html.erb_spec.rb
@@ -4,12 +4,17 @@ RSpec.describe 'hyrax/file_sets/media_display/_default.html.erb', type: :view do
   let(:file_set) { stub_model(FileSet, parent: parent) }
   let(:parent) { double }
   let(:link) { true }
+  let(:work_solr_document) do
+    SolrDocument.new(id: '900', title_tesim: ['My Title'])
+  end
+  let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
 
   before do
     allow(controller).to receive(:current_ability).and_return(ability)
     allow(ability).to receive(:can?).with(:download, file_set).and_return(true)
     allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
+    assign(:presenter, parent_presenter)
     render 'hyrax/file_sets/media_display/default', file_set: file_set
   end
 

--- a/spec/views/hyrax/file_sets/media_display/_video.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_video.html.erb_spec.rb
@@ -4,12 +4,17 @@ RSpec.describe 'hyrax/file_sets/media_display/_video.html.erb', type: :view do
   let(:file_set) { stub_model(FileSet, parent: parent) }
   let(:parent) { double }
   let(:link) { true }
+  let(:work_solr_document) do
+    SolrDocument.new(id: '900', title_tesim: ['My Video'])
+  end
+  let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
 
   before do
     allow(controller).to receive(:current_ability).and_return(ability)
     allow(ability).to receive(:can?).with(:download, file_set).and_return(true)
     allow(Hyrax.config).to receive(:display_media_download_link?).and_return(link)
     allow(view).to receive(:workflow_restriction?).with(parent).and_return(false)
+    assign(:presenter, parent_presenter)
     render 'hyrax/file_sets/media_display/video', file_set: file_set
   end
 


### PR DESCRIPTION
Add all the same data to media display download links as is present on the fileset list download link, to resolve file-set-in-work-download events not having work ids

Fixes #5956

@samvera/hyrax-code-reviewers
