### PR TITLE
Limit redlock to versions < 2.0, as these cause sidekiq jobs to fail

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -76,7 +76,7 @@ SUMMARY
   spec.add_dependency 'rdf-vocab', '~> 3.0'
   spec.add_dependency 'redis', '~> 4.0'
   spec.add_dependency 'redis-namespace', '~> 1.5'
-  spec.add_dependency 'redlock', '>= 0.1.2'
+  spec.add_dependency 'redlock', '>= 0.1.2', '< 2.0'
   spec.add_dependency 'reform', '~> 2.3'
   spec.add_dependency 'reform-rails', '~> 0.2.0'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'


### PR DESCRIPTION
After bringing up my dassie vm today, post ingest jobs to add files to works no longer succeeded. I ran into the same problem with main and hyrax 3.5.0. @dlpierce suggested it might be related to the just released version of redlock, which appears to have been the case. So this PR locks the version at < 2.0.0

```
ERROR -- : [ActiveJob] [AttachFilesToWorkJob] [79e40862-dc38-4f32-b816-3a2dc7450523] Error performing AttachFilesToWorkJob (Job ID: 79e40862-dc38-4f32-b816-3a2dc7450523) from Sidekiq(default) in 72483.02ms: Redis::CommandError (NOSCRIPT No matching script. Please use EVAL.):

hyrax-sidekiq-1     | /usr/local/bundle/gems/redis-4.8.0/lib/redis/client.rb:162:in `call'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redis-4.8.0/lib/redis.rb:270:in `block in send_command'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redis-4.8.0/lib/redis.rb:269:in `synchronize'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redis-4.8.0/lib/redis.rb:269:in `send_command'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redis-4.8.0/lib/redis/commands.rb:206:in `call'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redis-namespace-1.10.0/lib/redis/namespace.rb:558:in `wrapped_send'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redis-namespace-1.10.0/lib/redis/namespace.rb:410:in `method_missing'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:171:in `block in lock'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:210:in `recover_from_script_flush'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:170:in `lock'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:260:in `block (2 levels) in lock_instances'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:260:in `select'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:260:in `block in lock_instances'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:313:in `timed'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:259:in `lock_instances'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:234:in `block in try_lock_instances'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:230:in `times'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:230:in `try_lock_instances'
hyrax-sidekiq-1     | /usr/local/bundle/gems/redlock-2.0.0/lib/redlock/client.rb:69:in `lock'
hyrax-sidekiq-1     | /app/samvera/hyrax-engine/app/services/hyrax/lock_manager.rb:20:in `lock'
hyrax-sidekiq-1     | /app/samvera/hyrax-engine/app/services/hyrax/lockable.rb:7:in `acquire_lock_for'
hyrax-sidekiq-1     | /app/samvera/hyrax-engine/app/actors/hyrax/actors/file_set_actor.rb:71:in `attach_to_work'
hyrax-sidekiq-1     | /app/samvera/hyrax-engine/app/jobs/attach_files_to_work_job.rb:40:in `attach_work'
hyrax-sidekiq-1     | /app/samvera/hyrax-engine/app/jobs/attach_files_to_work_job.rb:28:in `block in perform_af'
hyrax-sidekiq-1     | /app/samvera/hyrax-engine/app/jobs/attach_files_to_work_job.rb:26:in `each'
hyrax-sidekiq-1     | /app/samvera/hyrax-engine/app/jobs/attach_files_to_work_job.rb:26:in `perform_af'
hyrax-sidekiq-1     | /app/samvera/hyrax-engine/app/jobs/attach_files_to_work_job.rb:11:in `perform'
```

@samvera/hyrax-code-reviewers
