### PR TITLE
display on work page bibliographic_citation

### DIFF
--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -69,6 +69,7 @@ module Hyrax
         attribute :date_created, Solr::Array, "date_created_tesim"
         attribute :rights_statement, Solr::Array, "rights_statement_tesim"
         attribute :rights_notes, Solr::Array, "rights_notes_tesim"
+        attribute :bibliographic_citation, Solr::Array, "bibliographic_citation_tesim"
         attribute :access_right, Solr::Array, "access_right_tesim"
         attribute :mime_type, Solr::String, "mime_type_ssi"
         attribute :workflow_state, Solr::String, "workflow_state_name_ssim"

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -45,7 +45,7 @@ module Hyrax
     delegate :title, :date_created, :description,
              :creator, :contributor, :subject, :publisher, :language, :embargo_release_date,
              :lease_expiration_date, :license, :source, :rights_statement, :thumbnail_id, :representative_id,
-             :rendering_ids, :member_of_collection_ids, :alternative_title, to: :solr_document
+             :rendering_ids, :member_of_collection_ids, :alternative_title, :bibliographic_citation, to: :solr_document
 
     def workflow
       @workflow ||= WorkflowPresenter.new(solr_document, current_ability)

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -4,6 +4,7 @@
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:bibliographic_citation, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim', html_dl: true) %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted, html_dl: true) %>


### PR DESCRIPTION
Fixes #5887

The field bibliographic_citation was not showing up on the work page.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Edit or create a work with a  bibliographic citation in the metadata
* Save the work
* You should see the  bibliographic_citation field on the work page

@samvera/hyrax-code-reviewers
