### PR TITLE
Hyrax-5856 - Collection and Work count numbers not displaying correct…

### DIFF
--- a/app/assets/stylesheets/hyrax/_catalog.scss
+++ b/app/assets/stylesheets/hyrax/_catalog.scss
@@ -76,6 +76,10 @@
   color: #fff;
 }
 
+.dark-text {
+  color: #000
+}
+
 .view-type-group a {
   > span.caption {
     display: none;

--- a/app/views/hyrax/users/_vitals.html.erb
+++ b/app/views/hyrax/users/_vitals.html.erb
@@ -3,16 +3,16 @@
 </div>
 
 <div class="list-group-item">
-  <span class="badge"><%= number_of_collections(user) %></span>
+  <span class="badge dark-text"><%= number_of_collections(user) %></span>
   <span class="fa fa-folder-open" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.collections"), {generic_type: "Collection", depositor: user.to_s}) %>
 </div>
 
 <div class="list-group-item">
-  <span class="badge"><%= number_of_works(user) %></span>
+  <span class="badge dark-text"><%= number_of_works(user) %></span>
   <span class="fa fa-upload" aria-hidden="true"></span> <%= link_to_field('', '', t("hyrax.dashboard.stats.works"), {generic_type: "Work", depositor: user.to_s}) %>
 
   <ul class="views-downloads-dashboard list-unstyled">
-      <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>
-      <li><span class="badge badge-optional"><%= user.total_file_downloads %></span> <%= t("hyrax.dashboard.stats.file_downloads").pluralize(user.total_file_downloads) %></li>
+      <li><span class="badge badge-optional dark-text"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>
+      <li><span class="badge badge-optional dark-text"><%= user.total_file_downloads %></span> <%= t("hyrax.dashboard.stats.file_downloads").pluralize(user.total_file_downloads) %></li>
   </ul>
 </div>


### PR DESCRIPTION
…ly on user profile

Fixes #5856

Present tense short summary (50 characters or less)

Add a ```dark-text``` CSS class to override white text in ```app/views/hyrax/users/_vitals.html.erb```

Adding CSS:

``` css
.dark-text {
  color: #000
}
```

Changes proposed in this pull request:
* Update CSS file and view.

Guidance for testing, such as acceptance criteria or new user interface behaviors:

1. Log in to nurax-dev (or nurax-pg)
2. Go to Dashboard > Your Activity > Profile
3. The integer counts for Collections and Works should be visible.
4. Go to Home page for public view, click on Recently Uploaded tab, and click on Depositor's name
5. Repeat steps 3 and 4 to see that numbers are there for Works and Collections but they are not visible.

@samvera/hyrax-code-reviewers

