### PR TITLE
Hyrax-151 - I can add a proxy that already exists when I accept a tra…

### DIFF
--- a/app/controllers/hyrax/transfers_controller.rb
+++ b/app/controllers/hyrax/transfers_controller.rb
@@ -45,7 +45,11 @@ module Hyrax
     # any existing edit permissions on the work.
     def accept
       @proxy_deposit_request.transfer!(params[:reset])
-      current_user.can_receive_deposits_from << @proxy_deposit_request.sending_user if params[:sticky]
+      if params[:sticky]
+        unless current_user.can_receive_deposits_from.include? @proxy_deposit_request.sending_user
+          current_user.can_receive_deposits_from << @proxy_deposit_request.sending_user
+        end
+      end
       redirect_to hyrax.transfers_path, notice: "Transfer complete"
     end
 

--- a/app/controllers/hyrax/transfers_controller.rb
+++ b/app/controllers/hyrax/transfers_controller.rb
@@ -46,9 +46,8 @@ module Hyrax
     def accept
       @proxy_deposit_request.transfer!(params[:reset])
       if params[:sticky]
-        unless current_user.can_receive_deposits_from.include? @proxy_deposit_request.sending_user
-          current_user.can_receive_deposits_from << @proxy_deposit_request.sending_user
-        end
+        current_user.can_receive_deposits_from << @proxy_deposit_request.sending_user unless
+                current_user.can_receive_deposits_from.include? @proxy_deposit_request.sending_user
       end
       redirect_to hyrax.transfers_path, notice: "Transfer complete"
     end

--- a/spec/controllers/hyrax/transfers_controller_spec.rb
+++ b/spec/controllers/hyrax/transfers_controller_spec.rb
@@ -156,6 +156,18 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
           expect(assigns[:proxy_deposit_request].status).to eq('accepted')
           expect(user.can_receive_deposits_from).to include(another_user)
         end
+        context "already received sticky proxy" do
+          before do
+            user.can_receive_deposits_from << another_user
+          end
+          it "handles sticky requests and does not add another user" do
+            put :accept, params: { id: user.proxy_deposit_requests.first, sticky: true }
+            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+            expect(flash[:notice]).to eq("Transfer complete")
+            expect(assigns[:proxy_deposit_request].status).to eq('accepted')
+            expect(user.can_receive_deposits_from.to_a.count(another_user)).to eq 1
+          end
+        end
       end
 
       context "accepting one that isn't mine" do


### PR DESCRIPTION
…nsfer

Fixes #151 ; refs #2454

Transferring a work can cause multiple duplicate proxies

When transferring a work from one user to another, the user transferring the work
can end up entered multiple times as proxies for the receiving user. Each
time a receiving user accepts a transferred work with an "Authorize depositor as proxy" action,
they transferring user will be added as a proxy for the receiving user.

Changes proposed in this pull request:
* Don't add transferring user to ```current_user.can_receive_deposits_from array``` if it already contains that user

Guidance for testing, such as acceptance criteria or new user interface behaviors:
1. As user 1, create or find a work
2. -- from dashboard works, select action on work found in prior step and select action "Transfer ownership of work"
3. -- find user 2 and select transfer
4. As user 2, go to Dashboard
5. -- under "Current Proxies" select "Manage Proxies" and verify that user 1 does not appear in the "Current Proxies" list or appears only once
6. -- Navigate back to Dashboard
7. -- Under "Transfers Received" choose "Accept" --> "Authorize depositor as proxy"
8. -- Navigate to Dashboard: under "Current Proxies" select "Manage Proxies"
9. -- User 1 should be listed once under "Current Proxies"
10. Repeat steps 1-4 and steps 7 to transfer a second work from user 1 to user 2 if user 1 did not appear in "Current Proxies" in step 5.
11. -- User 1  only once under "Current Proxies"


@samvera/hyrax-code-reviewers

