### PR TITLE
Require rails/generators explicitly

### DIFF
--- a/app/services/hyrax/database_migrator.rb
+++ b/app/services/hyrax/database_migrator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rails/generators/actions'
+require 'rails/generators'
 require 'rails/generators/active_record'
 
 module Hyrax


### PR DESCRIPTION
This resolves an issue where Rails::Generators::Base is not autoloaded leading to an error: NoMethodError:  undefined method `subclasses' for Rails::Generators:Module The require for rails/generators/actions isn't needed because rails/generators autoloads it.

After this is merged open PRs with failing builds due to this issue will need to be rebased.