### PR TITLE
remove funny display when batch loading files.

### DIFF
--- a/app/views/hyrax/uploads/_js_templates.html.erb
+++ b/app/views/hyrax/uploads/_js_templates.html.erb
@@ -3,18 +3,18 @@
 <script id="template-upload" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
     <tr class="template-upload <%= fade_class_if_not_test %>">
-        <td>
+        <span>
             <span class="preview"></span>
-        </td>
-        <td>
+        </span>
+        <span>
             <p class="name">{%=file.name%}</p>
             <strong class="error text-danger"></strong>
-        </td>
-        <td>
+        </span>
+        <span>
             <p class="size">Processing...</p>
             <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="progress-bar progress-bar-striped progress-bar-animated bg-success" style="width:0%;"></div></div>
-        </td>
-        <td class="text-right">
+        </span>
+        <span class="text-right">
             {% if (!i && !o.options.autoUpload) { %}
                 <button class="btn btn-primary start" disabled>
                     <span class="fa fa-upload"></span>
@@ -27,7 +27,7 @@
                     <span><%= t('helpers.action.cancel') %></span>
                 </button>
             {% } %}
-        </td>
+        </span>
     </tr>
 {% } %}
 </script>


### PR DESCRIPTION
Fixes #1267

I changed the <td> tag to <span> and that seems to have fixed the issue.  I tested it on Chrome and Safari.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Make sure that batch upload is enabled
* Navigate to Dashboard -> Works
* Click the "Create batch of works" button and select Generic Work
* Click and drag several files into the "Drop files here" section of the screen. The  size of the file metadata section should not contract.  Refer to the image in the issue (https://github.com/samvera/hyrax/issues/1267) to see how the display behaved before this fix.

@samvera/hyrax-code-reviewers
