### PR TITLE
display banner and logo file and info at file selection.

### DIFF
--- a/app/views/hyrax/uploads/_js_templates_branding.html.erb
+++ b/app/views/hyrax/uploads/_js_templates_branding.html.erb
@@ -37,7 +37,7 @@
 <!-- The template to display the banner once upload is complete -->
 <script id="template-download" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
-        <span class="template-download fade">
+        <span class="template-download fade show">
           <div id="banner">
             <div class="row branding-banner-row">
               <div class="col-sm-3">
@@ -69,7 +69,7 @@
 <!-- The template to display logo in the table once upload is complete -->
 <script id="logo-template-download" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
-            <span class="template-download fade">
+            <span class="template-download fade show">
             <div class="row branding-logo-row">
               <div class="col-sm-3">
                 <span class="preview">


### PR DESCRIPTION
Fixes #5930

When selecting a banner and log file for a collection, display the file selected and the alt and link text.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Edit a collection
* Click Branding tab
* Click Choose File button in Logo section and select one of your logo images, you should see the file and the input boxes to enter the Link URL and Alt Text show up.
* Click Choose File button in Banner section and select one of your banner images, you should see the file show up.

@samvera/hyrax-code-reviewers
