### PR TITLE
place radio button to right of collection type in modal.

### DIFF
--- a/app/assets/stylesheets/hyrax/_modal.scss
+++ b/app/assets/stylesheets/hyrax/_modal.scss
@@ -6,7 +6,3 @@ div.collection-list legend {
 .modal-body select {
   max-width: 100%;
 }
-
-.modal-body input {
-  width: 100%;
-}


### PR DESCRIPTION
Fixes #5932

When selecting to Add a collection from the dashboard, the modal that list the types of collections should place the radio buttons to the left of the collection type names.


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Make sure you have a few collection types to choose from
* Click on Collections in the sidebar of the Dashboard
* Click on Add New Collection on the right
* Dialogue box displays showing collection types
* Note the radio buttons for the different collection types are shown to the left of the collection type names.

@samvera/hyrax-code-reviewers
