### PR TITLE
update the cc license config file for koppie

### DIFF
--- a/.koppie/config/authorities/licenses.yml
+++ b/.koppie/config/authorities/licenses.yml
@@ -1,25 +1,25 @@
 terms:
     - id: http://creativecommons.org/licenses/by/3.0/us/
       term: Attribution 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-sa/3.0/us/
       term: Attribution-ShareAlike 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nc/3.0/us/
       term: Attribution-NonCommercial 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nd/3.0/us/
       term: Attribution-NoDerivs 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nc-nd/3.0/us/
       term: Attribution-NonCommercial-NoDerivs 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nc-sa/3.0/us/
       term: Attribution-NonCommercial-ShareAlike 3.0 United States
-      active: true
+      active: false
     - id: http://www.europeana.eu/portal/rights/rr-r.html
       term: All rights reserved
-      active: true
+      active: false
     - id: https://creativecommons.org/licenses/by/4.0/
       term: Creative Commons BY Attribution 4.0 International
       active: true


### PR DESCRIPTION
Fixes #810 (kind of)

I have updated the .koppie/config/authorities/licenses.yml to reflect the desired configuration expressed in issue #810 ( using cc 4.0, and not cc 3.0 when depositing a work).

These files already have the correct configuration:
(1) ./.dassie/config/authorities/licenses.yml
(2) ./lib/generators/hyrax/templates/config/authorities/licenses.yml

The reason that nurax-dev is not giving depositors the configured options is because nurax-dev is presently built from a different repository:

https://github.com/curationexperts/nurax

Very soon ( not sure when ) that will change and then these configurations will be the ones used.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* You can test this on your local machine, but not on nurax-dev until the build for nurax-dev changes.
* On your local machine, go deposit a generic work.
* On the metadata page, you should see the desired options for the License metadata.

@samvera/hyrax-code-reviewers
