### PR TITLE
place save work section on right side of page regardless of language

### DIFF
--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -589,7 +589,7 @@ de:
         depositor: Deponent
         directions: Unabhängig von den Sichtbarkeitseinstellungen für diese Arbeit können Sie sie auch für andere Benutzer und Gruppen freigeben.
         group: Gruppe
-        permissions_save_note_html: Berechtigungen werden <strong> nicht </ strong> gespeichert, bis die Option & quot; Speichern & quot; Die Taste wird unten auf der Seite gedrückt.
+        permissions_save_note_html: Berechtigungen werden <strong> nicht </strong> gespeichert, bis die Option & quot; Speichern & quot; Die Taste wird unten auf der Seite gedrückt.
         use_add_button: Verwenden Sie die Schaltfläche "Hinzufügen", um Zugriff auf jeweils eine %{account_label} zu gewähren (diese wird der folgenden Liste hinzugefügt). Wählen Sie den Benutzer nach Name oder %{account_label} \ aus. Wählen Sie dann die Zugriffsebene aus, die Sie gewähren möchten, und klicken Sie auf Add this %{account_label}, um das Hinzufügen der Berechtigung abzuschließen.
       form_thumbnail:
         help_html: Wählen Sie die Datei aus, die als Miniaturansicht für diese Arbeit verwendet werden soll.
@@ -1405,14 +1405,14 @@ de:
       count:
         collections:
           collections_listing: Auflistung der Sammlungen
-          in_repo: "<strong> %{total_count} Sammlungen </ strong> im Repository"
-          you_manage: "<strong> %{total_count} Sammlungen </ strong>, die Sie im Repository verwalten können"
-          you_own: "<strong> %{total_count} Sammlungen </ strong>, die Sie im Repository besitzen"
+          in_repo: "<strong> %{total_count} Sammlungen </strong> im Repository"
+          you_manage: "<strong> %{total_count} Sammlungen </strong>, die Sie im Repository verwalten können"
+          you_own: "<strong> %{total_count} Sammlungen </strong>, die Sie im Repository besitzen"
         works:
-          in_repo: "<strong> %{total_count} Arbeiten </ strong> im Repository"
+          in_repo: "<strong> %{total_count} Arbeiten </strong> im Repository"
           works_listing: Auflistung der Arbeiten
-          you_manage: "<strong> %{total_count} Arbeiten </ strong>, das Sie im Repository verwalten können"
-          you_own: "<strong> %{total_count} Arbeiten </ strong>, das Sie im Repository besitzen"
+          you_manage: "<strong> %{total_count} Arbeiten </strong>, das Sie im Repository verwalten können"
+          you_own: "<strong> %{total_count} Arbeiten </strong>, das Sie im Repository besitzen"
       sort_and_per_page:
         number_of_results_to_display_per_page: Anzahl der anzuzeigenden Ergebnisse pro Seite
     nav_safety:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1412,14 +1412,14 @@ es:
       count:
         collections:
           collections_listing: Listado de colecciones
-          in_repo: "<strong> colecciones %{total_count} </ strong> en el repositorio"
-          you_manage: "<strong> colecciones %{total_count} </ strong> puede administrar en el repositorio"
-          you_own: "<strong> colecciones %{total_count} </ strong> que posee en el repositorio"
+          in_repo: "<strong> colecciones %{total_count} </strong> en el repositorio"
+          you_manage: "<strong> colecciones %{total_count} </strong> puede administrar en el repositorio"
+          you_own: "<strong> colecciones %{total_count} </strong> que posee en el repositorio"
         works:
-          in_repo: "<strong> %{total_count} funciona </ strong> en el repositorio"
+          in_repo: "<strong> %{total_count} funciona </strong> en el repositorio"
           works_listing: Listado de obras
-          you_manage: "<strong> %{total_count} funciona </ strong> puedes administrar en el repositorio"
-          you_own: "<strong> %{total_count} funciona </ strong> en el repositorio"
+          you_manage: "<strong> %{total_count} funciona </strong> puedes administrar en el repositorio"
+          you_own: "<strong> %{total_count} funciona </strong> en el repositorio"
       sort_and_per_page:
         number_of_results_to_display_per_page: Número de resultados a mostrar por página
     nav_safety:

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -595,7 +595,7 @@ fr:
         depositor: Déposant
         directions: Indépendamment des paramètres de visibilité pour ce travail, vous pouvez également le partager avec d'autres utilisateurs et groupes.
         group: Groupe
-        permissions_save_note_html: Les autorisations ne sont <strong> pas </ strong> enregistrées tant que le & quot; Enregistrer & quot; bouton est enfoncé en bas de la page.
+        permissions_save_note_html: Les autorisations ne sont <strong> pas </strong> enregistrées tant que le & quot; Enregistrer & quot; bouton est enfoncé en bas de la page.
         use_add_button: Utilisez le bouton Ajouter pour donner accès à un %{account_label} à la fois (il sera ajouté à la liste ci-dessous). Sélectionnez l'utilisateur, par son nom ou par %{account_label} \. Ensuite, sélectionnez le niveau d'accès que vous souhaitez accorder et cliquez sur Ajouter ce %{account_label} pour terminer l'ajout de l'autorisation.
       form_thumbnail:
         help_html: Sélectionnez le fichier à utiliser comme vignette pour ce travail.
@@ -1411,14 +1411,14 @@ fr:
       count:
         collections:
           collections_listing: Liste des collections
-          in_repo: "<strong> Collections %{total_count} </ strong> dans le référentiel"
-          you_manage: "<strong> collections %{total_count} </ strong> que vous pouvez gérer dans le référentiel"
-          you_own: "<strong> collections %{total_count} </ strong> que vous possédez dans le référentiel"
+          in_repo: "<strong> Collections %{total_count} </strong> dans le référentiel"
+          you_manage: "<strong> collections %{total_count} </strong> que vous pouvez gérer dans le référentiel"
+          you_own: "<strong> collections %{total_count} </strong> que vous possédez dans le référentiel"
         works:
-          in_repo: "<strong> %{total_count} fonctionne </ strong> dans le référentiel"
+          in_repo: "<strong> %{total_count} fonctionne </strong> dans le référentiel"
           works_listing: Liste des travaux
-          you_manage: "<strong> %{total_count} fonctionne </ strong> vous pouvez gérer dans le référentiel"
-          you_own: "<strong> %{total_count} fonctionne </ strong> que vous possédez dans le référentiel"
+          you_manage: "<strong> %{total_count} fonctionne </strong> vous pouvez gérer dans le référentiel"
+          you_own: "<strong> %{total_count} fonctionne </strong> que vous possédez dans le référentiel"
       sort_and_per_page:
         number_of_results_to_display_per_page: Nombre de résultats à afficher par page
     nav_safety:

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -1410,14 +1410,14 @@ it:
       count:
         collections:
           collections_listing: Elenco delle collezioni
-          in_repo: "<strong> collezioni %{total_count} </ strong> nel repository"
-          you_manage: "<strong> collezioni %{total_count} </ strong> che puoi gestire nel repository"
-          you_own: "<strong> collezioni %{total_count} </ strong> che possiedi nel repository"
+          in_repo: "<strong> collezioni %{total_count} </strong> nel repository"
+          you_manage: "<strong> collezioni %{total_count} </strong> che puoi gestire nel repository"
+          you_own: "<strong> collezioni %{total_count} </strong> che possiedi nel repository"
         works:
-          in_repo: "<strong> %{total_count} funziona </ strong> nel repository"
+          in_repo: "<strong> %{total_count} funziona </strong> nel repository"
           works_listing: Elenco delle opere
-          you_manage: "<strong> %{total_count} funziona </ strong> che puoi gestire nel repository"
-          you_own: "<strong> %{total_count} funziona </ strong> nel repository"
+          you_manage: "<strong> %{total_count} funziona </strong> che puoi gestire nel repository"
+          you_own: "<strong> %{total_count} funziona </strong> nel repository"
       sort_and_per_page:
         number_of_results_to_display_per_page: Numero di risultati da visualizzare per pagina
     nav_safety:

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -1405,14 +1405,14 @@ pt-BR:
       count:
         collections:
           collections_listing: Listagem de coleções
-          in_repo: "<strong> coleções %{total_count} </ strong> no repositório"
-          you_manage: "<strong> %{total_count} coleções</ strong> que você pode curatelar no repositório"
-          you_own: "<strong> %{total_count} coleções </ strong> que você possui no repositório"
+          in_repo: "<strong> coleções %{total_count} </strong> no repositório"
+          you_manage: "<strong> %{total_count} coleções</strong> que você pode curatelar no repositório"
+          you_own: "<strong> %{total_count} coleções </strong> que você possui no repositório"
         works:
-          in_repo: "<strong> %{total_count} obras </ strong> no repositório"
+          in_repo: "<strong> %{total_count} obras </strong> no repositório"
           works_listing: Lista de obras
-          you_manage: "<strong> %{total_count} obras </ strong> que você pode curatelar no repositório"
-          you_own: "<strong> %{total_count} obras </ strong> que você possui no repositório"
+          you_manage: "<strong> %{total_count} obras </strong> que você pode curatelar no repositório"
+          you_own: "<strong> %{total_count} obras </strong> que você possui no repositório"
       sort_and_per_page:
         number_of_results_to_display_per_page: Número de resultados a serem exibidos por página
     nav_safety:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -592,7 +592,7 @@ zh:
         depositor: 储户
         directions: 无论此工作的可见性设置如何，您也可以与其他用户和组共享。
         group: 组
-        permissions_save_note_html: 权限<strong> </ strong>保存，直到“保存”为止。按钮在页面底部按下。
+        permissions_save_note_html: 权限<strong> </strong>保存，直到“保存”为止。按钮在页面底部按下。
         use_add_button: 使用添加按钮一次可以访问一个%{account_label}（它将被添加到下面的列表中）。按名称或%{account_label} \选择用户。然后选择您要授予的访问级别，并单击“添加此%{account_label}”以完成添加权限。
       form_thumbnail:
         help_html: 选择要用作此作品缩略图的文件。
@@ -1408,14 +1408,14 @@ zh:
       count:
         collections:
           collections_listing: 收藏清单
-          in_repo: 存储库中的<strong> %{total_count}集合</ strong>
-          you_manage: 您可以在存储库中管理<strong> %{total_count}集合</ strong>
-          you_own: 您在存储库中拥有<strong> %{total_count}集合</ strong>
+          in_repo: 存储库中的<strong> %{total_count}集合</strong>
+          you_manage: 您可以在存储库中管理<strong> %{total_count}集合</strong>
+          you_own: 您在存储库中拥有<strong> %{total_count}集合</strong>
         works:
-          in_repo: 存储库中的<strong> %{total_count}有效</ strong>
+          in_repo: 存储库中的<strong> %{total_count}有效</strong>
           works_listing: 作品清单
-          you_manage: 您可以在存储库中管理<strong> %{total_count}作品</ strong>
-          you_own: 您在存储库中拥有<strong> %{total_count}作品</ strong>
+          you_manage: 您可以在存储库中管理<strong> %{total_count}作品</strong>
+          you_own: 您在存储库中拥有<strong> %{total_count}作品</strong>
       sort_and_per_page:
         number_of_results_to_display_per_page: 每页显示的结果数
     nav_safety:


### PR DESCRIPTION
Fixes #5923

When depositing a work, and the user changes language, always show the "Save Work" section next to the area where the user enters the metadata. 

There was some invalid xml in the locale files which was causing the "Save Work" section to be shown below the metadata section in the deposit screen. After the locale files were corrected, the "Save Work" section shows up next to the metadata.


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Go deposit a work
* On the page where you enter the metadata, switch to all the languages one at a time
* The "Save Work" section should always be next to the metadata.

@samvera/hyrax-code-reviewers
