### PR TITLE
Dispatch workflow events to samvera-labs/nurax instead of curationexperts/nurax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       with:
          token: ${{ secrets.NURAX_ACCESS_TOKEN }}
          event-type: push
-         repository: curationexperts/nurax
+         repository: samvera-labs/nurax
          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       with:
          token: ${{ secrets.NURAX_ACCESS_TOKEN }}
          event-type: release
-         repository: curationexperts/nurax
+         repository: samvera-labs/nurax
          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
 
 


### PR DESCRIPTION
Update GitHub Actions workflows to dispatch deploy events to the new repo at [`samvera-labs/nurax`](https://github.com/samvera-labs/nurax)

@samvera/hyrax-code-reviewers
