### PR TITLE
chart: bump the solr version for current kubernetes support

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 2.0.0
+version: 2.1.0
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo
@@ -26,7 +26,7 @@ dependencies:
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: redis.enabled
   - name: solr
-    version: 1.0.1
+    version: 6.1.4
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: solr.enabled
   - name: nginx


### PR DESCRIPTION
Kubernetes 1.25 drops support for apis used by the solr/zk charts in the versions referenced here. use the latest chart version for compatibility.

@samvera/hyrax-code-reviewers
