### PR TITLE
chart: update CronJob api version

### DIFF
--- a/chart/hyrax/templates/cron-embargo.yaml
+++ b/chart/hyrax/templates/cron-embargo.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.embargoRelease.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
 metadata:

--- a/chart/hyrax/templates/cron-lease.yaml
+++ b/chart/hyrax/templates/cron-lease.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.leaseRelease.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
 metadata:


### PR DESCRIPTION
v1 has been available since 1.21, which is already EOL'd in some places.

@samvera/hyrax-code-reviewers
