### PR TITLE
Expanding IIIF Manifest gem version

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -52,7 +52,7 @@ SUMMARY
   spec.add_dependency 'hydra-editor', '>= 3.3', '< 6.0'
   spec.add_dependency 'hydra-head', '>= 10.6.1', '< 12'
   spec.add_dependency 'hydra-works', '>= 0.16', '< 2.0'
-  spec.add_dependency 'iiif_manifest', '>= 0.3', '< 0.6'
+  spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4'
   spec.add_dependency 'jquery-ui-rails', '~> 6.0'
   spec.add_dependency 'json-schema' # for Arkivo


### PR DESCRIPTION
This commit will allow IIIF Manifest gem versions under 2.0.
