### PR TITLE
Only trigger nurax deploy for main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: Trigger Nurax build
 on:
   workflow_dispatch:
   push:
+    branches:
+      - 'main'
 
 jobs:
   trigger:


### PR DESCRIPTION
Nurax dev/pg should only be redeployed when main is pushed to, not other branches.