### PR TITLE
Deploy stable nurax only on latest published release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,9 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     steps:
-    - uses: peter-evans/repository-dispatch@v1
+    - uses: peter-evans/repository-dispatch@v2.1.1
       with:
          token: ${{ secrets.NURAX_ACCESS_TOKEN }}
          event-type: push
          repository: samvera-labs/nurax
          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
-
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,16 +2,22 @@ name: Trigger Nurax build
 on:
   workflow_dispatch:
   release:
+    types: [released]
 
 jobs:
   trigger:
     runs-on: ubuntu-latest
     steps:
-    - uses: peter-evans/repository-dispatch@v1
+    - id: latest-release
+      uses: pozetroninc/github-action-get-latest-release@v0.7.0
+      with:
+        repository: ${{ github.repository }}
+        token: ${{ github.token }}
+        excludes: prerelease, draft
+    - uses: peter-evans/repository-dispatch@v2.1.1
+      if: ${{ steps.latest-release.outputs.release == github.ref_name }}
       with:
          token: ${{ secrets.NURAX_ACCESS_TOKEN }}
          event-type: release
          repository: samvera-labs/nurax
          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
-
-


### PR DESCRIPTION
Unpublished and draft releases should not trigger this workflow. It should also only trigger for the latest release.

The repository-dispatch action needed updating due to the old NodeJS it used.