### PR TITLE
chart: add extraDeploy template variable for extensibility 

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 3.0.1
+version: 3.1.0
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/extra-list.yaml
+++ b/chart/hyrax/templates/extra-list.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraDeploy }}
+---
+{{- if typeIs "string" . }}
+{{- tpl . $ }}
+{{- else }}
+{{- tpl (. | toYaml) $ }}
+{{- end }}
+{{- end }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -66,6 +66,10 @@ extraEnvFrom: []
 # tty: true
 extraContainerConfiguration: []
 
+## @param extraDeploy Array of extra objects to deploy with the release (evaluated as a template)
+##
+extraDeploy: []
+
 # an existing volume containing a Hyrax-based application
 # must be a ReadWriteMany volume if worker is enabled
 applicationExistingClaim: ""


### PR DESCRIPTION
improve chart extensibility by allowing users to specify `extraDeploy`
information. YAML specs can be included for arbitrary resources and will be
deployed alongside other chart resources.

@samvera/hyrax-code-reviewers
