### PR TITLE
support flipflop 2.7.1

### DIFF
--- a/.regen
+++ b/.regen
@@ -1,2 +1,2 @@
 # When updating CI regen seed, set to current date.
-2022-07-01T00
+2023-04-11T16:25:55

--- a/app/controllers/hyrax/admin/strategies_controller.rb
+++ b/app/controllers/hyrax/admin/strategies_controller.rb
@@ -7,8 +7,8 @@ module Hyrax
       end
 
       # TODO: we could remove this if we used an isolated engine
-      def features_url
-        hyrax.admin_features_path
+      def features_url(*args)
+        hyrax.admin_features_path(*args)
       end
     end
   end


### PR DESCRIPTION
2.7.1 passes arguments to `features_url`, which breaks our override. the
override should have always accepted arguments, since the upstream
implementation does.

@samvera/hyrax-code-reviewers
