### PR TITLE
make the VisibilityMap configurable

### DIFF
--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -204,7 +204,7 @@ module Hyrax
       interpreted_read_groups = read_groups
 
       if interpret_visibility
-        visibilities = Hyrax::VisibilityMap.instance
+        visibilities = Hyrax.config.visibility_map
         interpreted_read_groups -= visibilities.deletions_for(visibility: collection.visibility)
         interpreted_read_groups += visibilities.additions_for(visibility: collection.visibility)
       end

--- a/app/services/hyrax/visibility_reader.rb
+++ b/app/services/hyrax/visibility_reader.rb
@@ -41,7 +41,7 @@ module Hyrax
     end
 
     def visibility_map
-      Hyrax::VisibilityMap.instance
+      Hyrax.config.visibility_map
     end
   end
 end

--- a/app/services/hyrax/visibility_writer.rb
+++ b/app/services/hyrax/visibility_writer.rb
@@ -44,7 +44,7 @@ module Hyrax
     end
 
     def visibility_map
-      Hyrax::VisibilityMap.instance
+      Hyrax.config.visibility_map
     end
   end
 end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -880,6 +880,17 @@ module Hyrax
       @derivative_services ||= [Hyrax::FileSetDerivativesService]
     end
 
+    attr_writer :visibility_map
+    # A mapping from visibility string values to permissions; the default and
+    # reference implementation is provided by {Hyrax::VisibilityMap}.
+    #
+    # @return [Hyrax::VisibilityMap]
+    # @see Hyrax::VisibilityReader
+    # @see Hyrax::VisibilityWriter
+    def visibility_map
+      @visibility_map ||= Hyrax::VisibilityMap.instance
+    end
+
     private
 
     # @param [Symbol, #to_s] model_name - symbol representing the model


### PR DESCRIPTION
it's a common use case to extend or otherwise change the visibilities supported in a Hyrax install. making the map instance used throughout Hyrax configurable should make this easier.

@samvera/hyrax-code-reviewers
