### PR TITLE
bump support for hydra-file_characterization to 1.x

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -53,7 +53,7 @@ SUMMARY
   spec.add_dependency 'font-awesome-rails', '~> 4.2'
   spec.add_dependency 'hydra-derivatives', '~> 3.3'
   spec.add_dependency 'hydra-editor', '~> 6.0'
-  spec.add_dependency 'hydra-file_characterization', '~> 1.1.2'
+  spec.add_dependency 'hydra-file_characterization', '~> 1.1'
   spec.add_dependency 'hydra-head', '~> 12.0'
   spec.add_dependency 'hydra-works', '>= 0.16'
   spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'


### PR DESCRIPTION
don't limit support for file characterization gem to 1.1.x.

@samvera/hyrax-code-reviewers
