### PR TITLE
bump support for `noid-rails` to 3.x

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -64,7 +64,7 @@ SUMMARY
   spec.add_dependency 'linkeddata' # Required for getting values from geonames
   spec.add_dependency 'mailboxer', '~> 0.12'
   spec.add_dependency 'nest', '~> 3.1'
-  spec.add_dependency 'noid-rails', '~> 3.0.0'
+  spec.add_dependency 'noid-rails', '~> 3.0'
   spec.add_dependency 'oauth'
   spec.add_dependency 'oauth2', '~> 1.2'
   spec.add_dependency 'openseadragon'


### PR DESCRIPTION
don't limit support for `noid-rails` to 3.0.x.

@samvera/hyrax-code-reviewers
