### PR TITLE
Update .github/CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to Contribute
 
-We want your help to make Samvera great. There are a few guidelines
+We want your help to make the Samvera community great. There are a few guidelines
 that we need contributors to follow so that we can have a chance of
 keeping on top of things.
 
@@ -11,16 +11,27 @@ experience for all its members, whether they are at a formal gathering, in
 a social setting, or taking part in activities online. Please see our
 [Code of Conduct](CODE_OF_CONDUCT.md) for more information.
 
-## Samvera Community Intellectual Property Licensing and Ownership
+## Language
 
-All code contributors must have an Individual Contributor License Agreement
-(iCLA) on file with the Samvera Steering Group. If the contributor works for
-an institution, the institution must have a Corporate Contributor License
-Agreement (cCLA) on file.
+The language we use matters.  Today, tomorrow, and for years to come
+people will read the code we write.  They will judge us for our
+design, logic, and the words we use to describe the system.
 
-https://wiki.lyrasis.org/display/samvera/Samvera+Community+Intellectual+Property+Licensing+and+Ownership
+Our words should be accessible.  Favor descriptive words that give
+meaning while avoiding reinforcing systemic inequities.  For example,
+in the Samvera community, we should favor using allowed\_list instead
+of whitelist, denied\_list instead of blacklist, or source/copy
+instead of master/slave.
 
-You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
+We're going to get it wrong, but this is a call to keep working to
+make it right.  View our code and the words we choose as a chance to
+have a conversation. A chance to grow an understanding of the systems
+we develop as well as the systems in which we live.
+
+See [“Blacklists” and “whitelists”: a salutary warning concerning the
+prevalence of racist language in discussions of predatory
+publishing](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6148600/) for
+further details.
 
 ## Contribution Tasks
 
@@ -34,7 +45,7 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 ### Reporting Issues
 
 * Make sure you have a [GitHub account](https://github.com/signup/free)
-* Submit a [Github issue](./issues) by:
+* Submit a [Github issue](https://github.com/samvera/hyrax/issues/) by:
   * Clearly describing the issue
     * Provide a descriptive summary
     * Explain the expected behavior
@@ -45,14 +56,21 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 
 * Fork the repository on GitHub
 * Create a topic branch from where you want to base your work.
-  * This is usually the master branch.
-  * To quickly create a topic branch based on master; `git branch fix/master/my_contribution master`
-  * Then checkout the new branch with `git checkout fix/master/my_contribution`.
-  * Please avoid working directly on the `master` branch.
+  * This is usually the `main` branch.
+  * To quickly create a topic branch based on `main`; `git branch fix/main/my_contribution main`
+  * Then checkout the new branch with `git checkout fix/main/my_contribution`.
+  * Please avoid working directly on the `main` branch.
+  * Please do not create a branch called `master`. (See note below.)
   * You may find the [hub suite of commands](https://github.com/defunkt/hub) helpful
 * Make sure you have added sufficient tests and documentation for your changes.
   * Test functionality with RSpec; Test features / UI with Capybara.
 * Run _all_ the tests to assure nothing else was accidentally broken.
+
+NOTE: This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct) 
+and [language recommendations](#language).  
+Please ***do not*** create a branch called `master` for this repository or as part of 
+your pull request; the branch will either need to be removed or renamed before it can 
+be considered for inclusion in the code base and history of this repository.
 
 ### Documenting Code
 
@@ -63,15 +81,11 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
   * If you don't know exactly what a bit of code does, it is extra likely that it needs to be documented. Take a stab at it and ask for feedback in your pull request. You can use the 'blame' button on GitHub to identify the original developer of the code and @mention them in your comment.
   * This work greatly increases the usability of the code base and supports the on-ramping of new committers.
   * We will all be understanding of one another's time constraints in this area.
-* YARD examples:
-  * [Hyrax::AdminSet](https://github.com/samvera/hyrax/blob/master/app/models/admin_set.rb)
-  * [ActiveTriples::LocalName::Minter](https://github.com/ActiveTriples/active_triples-local_name/blob/master/lib/active_triples/local_name/minter.rb)
 * [Getting started with YARD](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 
 ### Committing changes
 
 * Make commits of logical units.
-  * Your commit should include a high level description of your work in HISTORY.textile
 * Check for unnecessary whitespace with `git diff --check` before committing.
 * Make sure your commit messages are [well formed](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 * If you created an issue, you can close it by including "Closes #issue" in your commit message. See [Github's blog post for more details](https://github.com/blog/1386-closing-issues-via-commit-messages)
@@ -112,18 +126,16 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 
 ### Submitting Changes
 
-[Detailed Walkthrough of One Pull Request per Commit](http://ndlib.github.io/practices/one-commit-per-pull-request/)
-
 * Read the article ["Using Pull Requests"](https://help.github.com/articles/using-pull-requests) on GitHub.
-* Make sure your branch is up to date with its parent branch (i.e. master)
-  * `git checkout master`
+* Make sure your branch is up to date with its parent branch (i.e. main)
+  * `git checkout main`
   * `git pull --rebase`
   * `git checkout <your-branch>`
-  * `git rebase master`
+  * `git rebase main`
   * It is a good idea to run your tests again.
 * If you've made more than one commit take a moment to consider whether squashing commits together would help improve their logical grouping.
   * [Detailed Walkthrough of One Pull Request per Commit](http://ndlib.github.io/practices/one-commit-per-pull-request/)
-  * `git rebase --interactive master` ([See Github help](https://help.github.com/articles/interactive-rebase))
+  * `git rebase --interactive main` ([See Github help](https://help.github.com/articles/interactive-rebase))
   * Squashing your branch's changes into one commit is "good form" and helps the person merging your request to see everything that is going on.
 * Push your changes to a topic branch in your fork of the repository.
 * Submit a pull request from your fork to the project.
@@ -133,14 +145,14 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 We adopted [Github's Pull Request Review](https://help.github.com/articles/about-pull-request-reviews/) for our repositories.
 Common checks that may occur in our repositories:
 
-1. Travis CI - where our automated tests are running
-2. Hound CI - where we check for style violations
+1. [CircleCI](https://circleci.com/gh/samvera) - where our automated tests are running
+2. RuboCop/Bixby - where we check for style violations
 3. Approval Required - Github enforces at least one person approve a pull request. Also, all reviewers that have chimed in must approve.
 4. CodeClimate - is our code remaining healthy (at least according to static code analysis)
 
 If one or more of the required checks failed (or are incomplete), the code should not be merged (and the UI will not allow it). If all of the checks have passed, then anyone on the project (including the pull request submitter) may merge the code.
 
-*Example: Carolyn submits a pull request, Justin reviews the pull request and approves. However, Justin is still waiting on other checks (Travis CI is usually the culprit), so he does not merge the pull request. Eventually, all of the checks pass. At this point, Carolyn or anyone else may merge the pull request.*
+*Example: Carolyn submits a pull request, Justin reviews the pull request and approves. However, Justin is still waiting on other checks (CI tests are usually the culprit), so he does not merge the pull request. Eventually, all of the checks pass. At this point, Carolyn or anyone else may merge the pull request.*
 
 #### Things to Consider When Reviewing
 
@@ -157,7 +169,7 @@ This is your chance for a mentoring moment of another developer. Take time to gi
   * Do new or changed methods, modules, and classes have documentation?
   * Does the commit contain more than it should? Are two separate concerns being addressed in one commit?
   * Does the description of the new/changed specs match your understanding of what the spec is doing?
-  * Did the Travis tests complete successfully?
+  * Did the Continuous Integration tests complete successfully?
 
 If you are uncertain, bring other contributors into the conversation by assigning them as a reviewer.
 


### PR DESCRIPTION
Contributing text updated at .github path to match updated contributing text at root path.

Contributing text linked in README is using .github/CONTRIBUTING.md but that text was outdated and didn't match ./CONTRIBUTING.md. This updates the text at .github/CONTRIBUTING.md to match ./CONTRIBUTING.md. It might be worth considering if we need this info in two places or not.

@samvera/hyrax-code-reviewers
