### PR TITLE
don't try to use rpsec mocks on $CHILD_STATUS!!!

### DIFF
--- a/spec/lib/hyrax/controlled_vocabulary/importer/language_spec.rb
+++ b/spec/lib/hyrax/controlled_vocabulary/importer/language_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe Hyrax::ControlledVocabulary::Importer::Language do
   before do
     allow(Hyrax.logger).to receive(:extend)
     allow(Hyrax::ControlledVocabulary::Importer::Downloader).to receive(:fetch)
-    allow(instance).to receive(:system) do
-      allow($CHILD_STATUS).to receive(:success?).and_return(true)
-    end
+    allow(instance).to receive(:extract)
   end
 
   let(:instance) { described_class.new }


### PR DESCRIPTION
RSpec gets mad about this under Ruby 3, and probably should have got mad a long
time ago. What!?

@samvera/hyrax-code-reviewers
