### PR TITLE
Fix missing metadata in IIIF manifest

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter.rb
@@ -77,7 +77,7 @@ module Hyrax
       metadata_fields.map do |field_name|
         {
           'label' => I18n.t("simple_form.labels.defaults.#{field_name}"),
-          'value' => Array(self[field_name]).map { |value| scrub(value.to_s) }
+          'value' => Array(send(field_name)).map { |value| scrub(value.to_s) }
         }
       end
     end


### PR DESCRIPTION
Fixes #6008 

The default list of manifest metadata fields is sourced from the WorkForm and does not contain the solr field suffix. The delegation in IiifManifestPresenter makes those fields available by method call.

@samvera/hyrax-code-reviewers
