### PR TITLE
support enumerators in FindFiles "navigator" queries

### DIFF
--- a/app/services/hyrax/custom_queries/navigators/find_files.rb
+++ b/app/services/hyrax/custom_queries/navigators/find_files.rb
@@ -80,10 +80,7 @@ module Hyrax
           files =
             query_service.custom_queries.find_many_file_metadata_by_use(resource: file_set, use: use)
 
-          raise Valkyrie::Persistence::ObjectNotFoundError, "FileSet #{file_set.id}'s #{use.fragment} is missing." if
-            files.empty?
-
-          files.first
+          files.first || raise(Valkyrie::Persistence::ObjectNotFoundError, "FileSet #{file_set.id}'s #{use.fragment} is missing.")
         end
       end
     end


### PR DESCRIPTION
in addition to supporting enumerable values from
`find_many_file_metadata_by_use`, this avoids double peeking at the first element in an array. we can just give the element, and if it's `nil` fallback to error behavior.

@samvera/hyrax-code-reviewers
