### PR TITLE
reinstate breadcrumb styling

### DIFF
--- a/app/builders/hyrax/bootstrap_breadcrumbs_builder.rb
+++ b/app/builders/hyrax/bootstrap_breadcrumbs_builder.rb
@@ -12,7 +12,7 @@ class Hyrax::BootstrapBreadcrumbsBuilder < BreadcrumbsOnRails::Breadcrumbs::Buil
   def render
     return "" if @elements.blank?
 
-    @context.tag.nav(breadcrumbs_options) do
+    @context.tag.nav(**breadcrumbs_options) do
       @context.tag.ol do
         safe_join(@elements.uniq.collect { |e| render_element(e) })
       end

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -15,7 +15,7 @@
     <div id="content-wrapper" class="container" role="main">
       <%= content_for(:container_header) %>
       <%= render '/flash_msg' %>
-      <%= render_breadcrumbs builder: Hyrax::BootstrapBreadcrumbsBuilder %>
+      <%= render_breadcrumbs builder: Hyrax.config.breadcrumb_builder %>
       <% if content_for?(:page_header) %>
         <div class="row">
           <div class="col-12 main-header">

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -16,7 +16,7 @@
         <%= render 'hyrax/dashboard/sidebar' %>
       </div>
       <div class="main-content maximized<%= " admin-stats" if request.fullpath.include? '/admin/stats' %>">
-        <%= render_breadcrumbs builder: Hyrax::BootstrapBreadcrumbsBuilder %>
+        <%= render_breadcrumbs builder: Hyrax.config.breadcrumb_builder %>
         <%= render '/flash_msg' %>
         <% if content_for?(:page_header) %>
           <div class="row">

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -393,6 +393,11 @@ module Hyrax
       @banner_image ||= 'https://user-images.githubusercontent.com/101482/29949206-ffa60d2c-8e67-11e7-988d-4910b8787d56.jpg'
     end
 
+    attr_writer :breadcrumb_builder
+    def breadcrumb_builder
+      @breadcrumb_builder ||= Hyrax::BootstrapBreadcrumbsBuilder
+    end
+
     ##
     # @return [Boolean]
     def disable_wings

--- a/spec/features/dashboard/display_dashboard_spec.rb
+++ b/spec/features/dashboard/display_dashboard_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe "The dashboard as viewed by a regular user", type: :feature do
       expect(page).to have_content "User Activity"
       expect(page).to have_content "User Notifications"
 
+      # displays the breadcrumbs
+      expect(page).to have_css '.breadcrumb'
+
       within '.sidebar' do
         expect(page).to have_link "Works"
         expect(page).to have_link "Collections"


### PR DESCRIPTION
fixes unstyled breadcrumbs in Ruby 3.

in the meanwhile, don't hardcode the breadcrumb builder implementation in the
views. make the builder configurable so new behavior can be injected downstream.

@samvera/hyrax-code-reviewers
