### PR TITLE
Don't always restart docker pg service

### DIFF
--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -104,7 +104,6 @@ services:
 
   postgres:
     image: postgres:latest
-    restart: always
     env_file:
       - .koppie/.env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,6 @@ services:
 
   postgres:
     image: postgres:latest
-    restart: always
     environment:
       - POSTGRES_USER=hyrax_user
       - POSTGRES_PASSWORD=hyrax_password


### PR DESCRIPTION
Having this on for non-production instances leads to the service hanging around after hours.