### PR TITLE
add pool based redis connections #6056 

### DIFF
--- a/.dassie/config/initializers/redis_config.rb
+++ b/.dassie/config/initializers/redis_config.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 require 'redis'
+require 'connection_pool'
 config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
-Redis.current = Redis.new(config.merge(thread_safe: true))
+config[:thread_safe] = true
+
+size = ENV.fetch("HYRAX_REDIS_POOL_SIZE", 5)
+timeout = ENV.fetch("HYRAX_REDIS_TIMEOUT", 5)
+
+Hyrax.config.redis_connection =
+  ConnectionPool::Wrapper.new(size: size, timeout: timeout) { Redis.new(config) }

--- a/.koppie/config/initializers/redis_config.rb
+++ b/.koppie/config/initializers/redis_config.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 require 'redis'
+require 'connection_pool'
 config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
-Redis.current = Redis.new(config.merge(thread_safe: true))
+config[:thread_safe] = true
+
+size = ENV.fetch("HYRAX_REDIS_POOL_SIZE", 5)
+timeout = ENV.fetch("HYRAX_REDIS_TIMEOUT", 5)
+
+Hyrax.config.redis_connection =
+  ConnectionPool::Wrapper.new(size: size, timeout: timeout) { Redis.new(config) }

--- a/.regen
+++ b/.regen
@@ -1,2 +1,2 @@
 # When updating CI regen seed, set to current date.
-2023-04-11T16:25:55
+2023-05-15T10:04:07

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Hyrax offers the ability to:
 
 More detailed documentation about Hyrax is available on the [Hyrax Github Wiki](https://github.com/samvera/hyrax/wiki) but if you have questions or need help, please email the [Samvera community tech list](https://samvera.atlassian.net/wiki/spaces/samvera/pages/1171226735/Samvera+Community+Email+Lists#Samvera-Tech-(15-20-messages-per-week-on-average)) or stop by the #dev channel in the [Samvera community Slack team](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211682/Getting+Started+in+the+Samvera+Community#Join-the-Samvera-Slack-workspace). You can also get in touch with the [Hyrax Maintenance Working Group](https://samvera.atlassian.net/wiki/spaces/samvera/pages/496632295/Hyrax+Maintenance+Working+Group), including the Hyrax Product Owner and Hyrax Tech Lead.
 
-[Reporting Issues](./.github/SUPPORT.md) 
+[Reporting Issues](./.github/SUPPORT.md)
 
 ## How to Run the Code
 

--- a/app/services/hyrax/lock_manager.rb
+++ b/app/services/hyrax/lock_manager.rb
@@ -11,7 +11,7 @@ module Hyrax
     # @param [Fixnum] retry_delay Maximum wait time in milliseconds before retrying. Wait time is a random value between 0 and retry_delay.
     def initialize(time_to_live, retry_count, retry_delay)
       @ttl = time_to_live
-      @client = Redlock::Client.new([Redis.current], retry_count: retry_count, retry_delay: retry_delay)
+      @client = Redlock::Client.new([(Hyrax.config.redis_connection || Redis.current)], retry_count: retry_count, retry_delay: retry_delay)
     end
 
     # Blocks until lock is acquired or timeout.

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -41,6 +41,7 @@ SUMMARY
   spec.add_dependency 'browse-everything', '>= 0.16', '< 2.0'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
+  spec.add_dependency 'connection_pool', '~> 2.4'
   spec.add_dependency 'draper', '~> 4.0'
   spec.add_dependency 'dry-events', '~> 0.2.0'
   spec.add_dependency 'dry-equalizer', '~> 0.2'

--- a/lib/generators/hyrax/templates/config/initializers/redis_config.rb
+++ b/lib/generators/hyrax/templates/config/initializers/redis_config.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 require 'redis'
+require 'connection_pool'
 config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
-Redis.current = Redis.new(config.merge(thread_safe: true))
+config[:thread_safe] = true
+
+size = ENV.fetch("HYRAX_REDIS_POOL_SIZE", 5)
+timeout = ENV.fetch("HYRAX_REDIS_TIMEOUT", 5)
+
+Hyrax.config.redis_connection =
+  ConnectionPool::Wrapper.new(size: size, timeout: timeout) { Redis.new(config) }

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -618,7 +618,7 @@ module Hyrax
 
     attr_writer :redis_namespace
     def redis_namespace
-      @redis_namespace ||= "hyrax"
+      @redis_namespace ||= ENV.fetch("HYRAX_REDIS_NAMESPACE", "hyrax")
     end
 
     attr_writer :libreoffice_path

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -616,6 +616,7 @@ module Hyrax
       @persistent_hostpath ||= "http://localhost/files/"
     end
 
+    attr_accessor :redis_connection
     attr_writer :redis_namespace
     def redis_namespace
       @redis_namespace ||= ENV.fetch("HYRAX_REDIS_NAMESPACE", "hyrax")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -141,7 +141,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before :suite do
-    Hyrax::RedisEventStore.instance.redis.flushdb
+    Hyrax::RedisEventStore.instance.then(&:flushdb)
     DatabaseCleaner.clean_with(:truncation)
     # Noid minting causes extra LDP requests which slow the test suite.
     Hyrax.config.enable_noids = false
@@ -258,8 +258,7 @@ RSpec.configure do |config|
 
   config.before(:example, :clean_repo) do
     clean_active_fedora_repository unless Hyrax.config.disable_wings
-
-    Hyrax::RedisEventStore.instance.redis.flushdb
+    Hyrax::RedisEventStore.instance.then(&:flushdb)
     # Not needed to clean the Solr core used by ActiveFedora since
     # clean_active_fedora_repository will wipe that core
     Hyrax::SolrService.wipe! if Hyrax.config.query_index_from_valkyrie


### PR DESCRIPTION
moves new applications away from `Redis.current` per https://github.com/samvera/hyrax/issues/6056.

the proposed solution here is to use a global $hyrax_redis variable to capture a
`ConnectionPool::Wrapper`. the wrapper construction provides compatibility with
the existing connections, allowing us to migrate code stepwise. when the global
is not set, we continue to use `Redis.current`.

the new approach isn't setup to support Redis::Namespace in the way the older
setup is. we used to set `Redis::Namespace` everytime `RedisEventStore.instance`
was called(!). rather than repeating this pattern, we can recommend that
existing apps use `Redis::Namespace` in their pool setup:

```ruby
$redis = ConnectionPool::Wrapper.new(size: size , timeout: timeout) do
  Redis::Namespace.new(Hyrax.config.redis_namespace, config)
end
```

new apps that wish to continue to use `Redis::Namespace` can do so (e.g. Hyku
will want this). it's advisable for new apps to avoid this (we looked at
removing `redis-namespace` well over 5 years ago:
https://github.com/samvera/hyrax/issues/1671). http://www.mikeperham.com/2015/09/24/storing-data-with-redis/
is relevant.

Hyrax doesn't actually seem to use multiple namespaces, so it should be fine for
apps to just configure their Redis to use one of the numbered databases. folks
who have a problem with this will certainly know it and be able to setup
Redis::Namespace on their own.

@samvera/hyrax-code-reviewers
