### PR TITLE
remove unneeded `config[:thread_safe] = true` from redis config

### DIFF
--- a/.dassie/config/initializers/redis_config.rb
+++ b/.dassie/config/initializers/redis_config.rb
@@ -2,7 +2,6 @@
 require 'redis'
 require 'connection_pool'
 config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
-config[:thread_safe] = true
 
 size = ENV.fetch("HYRAX_REDIS_POOL_SIZE", 5)
 timeout = ENV.fetch("HYRAX_REDIS_TIMEOUT", 5)

--- a/.koppie/config/initializers/redis_config.rb
+++ b/.koppie/config/initializers/redis_config.rb
@@ -2,7 +2,6 @@
 require 'redis'
 require 'connection_pool'
 config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
-config[:thread_safe] = true
 
 size = ENV.fetch("HYRAX_REDIS_POOL_SIZE", 5)
 timeout = ENV.fetch("HYRAX_REDIS_TIMEOUT", 5)

--- a/lib/generators/hyrax/templates/config/initializers/redis_config.rb
+++ b/lib/generators/hyrax/templates/config/initializers/redis_config.rb
@@ -2,7 +2,6 @@
 require 'redis'
 require 'connection_pool'
 config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
-config[:thread_safe] = true
 
 size = ENV.fetch("HYRAX_REDIS_POOL_SIZE", 5)
 timeout = ENV.fetch("HYRAX_REDIS_TIMEOUT", 5)


### PR DESCRIPTION
the `Redis` gem has set `:thread_safe` to `true` by default since 2.2.0. Hyrax depends on `> 3`, so does not need to set this value explicitly.

@samvera/hyrax-code-reviewers
