### PR TITLE
Update ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,20 +1,25 @@
 ### Descriptive summary
 
-Include what version of Hyrax relates to this issue (7.x, 6.x, HEAD, etc.) if appropriate, and any relevant tracebacks if you're reporting a bug.
+Present tense short summary (30 words or less)
 
-### Rationale
-
-Provide the rationale or user story that describes "why" this issue should be addressed. Especially if this is a new feature or significant change to the existing implementation.
-
-### Expected behavior
-
-### Actual behavior
-
-### Steps to reproduce the behavior
+### Steps to reproduce the behavior in User Interface (UI)
 
 1. Do this
 2. Then do this...
+3. Include note here if not testable in UI
+
+### Actual behavior (include screenshots if available)
+
+Include what version of Hyrax relates to this issue (3.x, 4.x, main branch, etc.) if appropriate, and any relevant error messages/tracebacks if you're reporting a bug.
+
+### Acceptance Criteria/Expected Behavior
+
+- [ ] Create checkbox list of what done looks like...
+
+### Rationale (for feature request only)
+
+Provide the rationale or user story that describes "why" this issue should be addressed. Especially if this is a new feature or significant change to the existing implementation.
 
 ### Related work
 
-Link to related tickets or prior related work here.
+Link to related issues or prior related work here.


### PR DESCRIPTION
Reorganize and improve template prompts

Redoing MD for better prompts and organizing info to be more easily readable for issues. Could also take this into new Github issue template model using yml file and form model.

@samvera/hyrax-code-reviewers
