### PR TITLE
Specify Ruby Version In Only One Place

### DIFF
--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -8,8 +8,6 @@ else
 end
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.2.1'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0'
 # Use postgresql as the database for Active Record

--- a/.koppie/Gemfile
+++ b/.koppie/Gemfile
@@ -6,8 +6,6 @@ else
 end
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.7'
-
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap', '~> 4.0'
 gem 'coffee-rails', '~> 4.2'


### PR DESCRIPTION
Since koppie and dassie are only supported via Docker and Dockerfile specifies Ruby version, we should not also specify in the Gemfile. Only listing it once makes it easier to update correctly and also means changing the Dockerfile ARG can actually build the app successfully.

@samvera/hyrax-code-reviewers
