### PR TITLE
docker-compose-v2

### DIFF
--- a/.koppie/README.md
+++ b/.koppie/README.md
@@ -1,18 +1,18 @@
 # Koppie
 
-> Isolated granite outcrops in Southern Africa that are a favored habitat for hyraxes. 
+> Isolated granite outcrops in Southern Africa that are a favored habitat for hyraxes.
 
 Koppie is an application used for testing the state of [Hyrax](https://github.com/samvera/hyrax)
-using Postgres as the metadata store for objects.  This is similar to the Dassie test application 
+using Postgres as the metadata store for objects.  This is similar to the Dassie test application
 that lives in `.dassie`, however in this application Fedora is
-not used for storing object metadata or files. The Hyrax gem is sourced from the local hyrax 
+not used for storing object metadata or files. The Hyrax gem is sourced from the local hyrax
 directory one level up from `.koppie` for development purposes.
 
 ## Known Issues
 
 Collection model
 * `/app/models/collection.rb` - is_a `ActiveFedora::Base`
-* if `Collection` is changed to `Valkyrie::Resource`, there is an infinite loop while loading 
+* if `Collection` is changed to `Valkyrie::Resource`, there is an infinite loop while loading
   due to reference to ::Collection in `lib/hyrax/collection_name.rb` in the hyrax engine
 
 Default Admin Set
@@ -21,14 +21,14 @@ Default Admin Set
 
 ## Questions
 
-Please direct questions about this code or the servers where it runs to the `#hyrax-valkyrie` 
+Please direct questions about this code or the servers where it runs to the `#hyrax-valkyrie`
 channel on Samvera slack.
 
 ## Contributing
 
 If you're working on a PR for this project, create a feature branch off of `main`.
 
-This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct) 
+This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct)
 and [language recommendations](https://github.com/samvera/maintenance/blob/master/templates/CONTRIBUTING.md#language).
 Please ***do not*** create a branch called `master` for this repository or as part of your pull request; the branch will
 either need to be removed or renamed before it can be considered for inclusion in the code base and history of this repository.
@@ -46,10 +46,10 @@ git clone https://github.com/samvera/hyrax.git
 Execute the following commands from the hyrax root to start the app using Docker.
 
 ```
-docker-compose -f docker-compose-koppie.yml build
-docker-compose -f docker-compose-koppie.yml up
+docker compose -f docker-compose-koppie.yml build
+docker compose -f docker-compose-koppie.yml up
 ```
 
-You can find help with additional commands in Hyrax' [FAQ-for-Dassie-Docker-Test-App](https://github.com/samvera/hyrax/wiki/FAQ-for-Dassie-Docker-Test-App).  
-Most commands can be used directly as described in the FAQ.  A few might require 
-a slight adjustment to work with koppie as a Docker app. 
+You can find help with additional commands in Hyrax' [FAQ-for-Dassie-Docker-Test-App](https://github.com/samvera/hyrax/wiki/FAQ-for-Dassie-Docker-Test-App).
+Most commands can be used directly as described in the FAQ.  A few might require
+a slight adjustment to work with koppie as a Docker app.

--- a/CONTAINERS.md
+++ b/CONTAINERS.md
@@ -13,7 +13,7 @@ There are two options for development environments to run:
 <!-- NOTE: This title is referenced in the top-level README.md. Keep that in mind if you change it. -->
 ## Hyrax Engine Development
 
-We support a `docker-compose`-based development environment for folks working on
+We support a `docker compose`-based development environment for folks working on
 the Hyrax engine. This environment is substantially more like a Hyrax production
 setup than the older `fedora_wrapper`/`solr_wrapper` approach.
 
@@ -24,8 +24,8 @@ First, make sure you have installed [Docker](https://www.docker.com/).  Then clo
 Within your cloned repository, tell Docker to get started installing your development environment:
 
 ```sh
-docker-compose build
-docker-compose up
+docker compose build
+docker compose up
 ```
 
 This starts containers for:
@@ -40,24 +40,24 @@ This starts containers for:
 
 It also runs database migrations. This will also bring up a development application on `http://localhost:3000`.
 
-To stop the containers for the Hyrax-based application, type <kbd>Ctrl</kbd>+<kbd>c</kbd>. To restart the containers you need only run `docker-compose up`.
+To stop the containers for the Hyrax-based application, type <kbd>Ctrl</kbd>+<kbd>c</kbd>. To restart the containers you need only run `docker compose up`.
 
 _**Note:** Starting and stopping Docker in this way will preserve your data between restarts._
 
 #### Code Changes and Testing
 
-With `docker-compose up` running, any changes you make to your cloned Hyrax code-base should show up in `http://localhost:3000`; There may be cases where you need to restart your test application (e.g. stop the containers and start them up again).
+With `docker compose up` running, any changes you make to your cloned Hyrax code-base should show up in `http://localhost:3000`; There may be cases where you need to restart your test application (e.g. stop the containers and start them up again).
 
 Any changes you make to Hyrax should be tested. You can run the full test suite using the following command:
 
 ```sh
-docker-compose exec -w /app/samvera/hyrax-engine app sh -c "bundle exec rspec"
+docker compose exec -w /app/samvera/hyrax-engine app sh -c "bundle exec rspec"
 ```
 
 Let's break down the above command:
 
 <dl>
-<dt><code>docker-compose exec</code></dt>
+<dt><code>docker compose exec</code></dt>
 <dd>Tell docker to run the following:</dd>
 <dt><code>-w /app/samvera/hyrax-engine</code></dt>
 <dd>In the working directory "/app/samvera/hyrax-engine" (e.g. your cloned Hyrax repository)</dd>
@@ -86,13 +86,13 @@ bind mount to `/app/samvera/hyrax-webapp`, and your local development copy of Hy
 What does this structure mean? Let's look at an example. The following command will list the rake tasks for the Hyrax-based application running in Docker:
 
 ```sh
-docker-compose exec -w /app/samvera/hyrax-webapp app sh -c "bundle exec rake -T"
+docker compose exec -w /app/samvera/hyrax-webapp app sh -c "bundle exec rake -T"
 ```
 
 And this command lists the rake tasks for the Hyrax engine that is in Docker:
 
 ```sh
-docker-compose exec -w /app/samvera/hyrax-engine app sh -c "bundle exec rake -T"
+docker compose exec -w /app/samvera/hyrax-engine app sh -c "bundle exec rake -T"
 ```
 
 In the two examples, note the difference in the `-w` switch. In the first case, it's referencing the Hyrax-based application. In the latter case, it's referencing the Hyrax engine.
@@ -101,7 +101,7 @@ In the two examples, note the difference in the `-w` switch. In the first case, 
 
 If you are interested in running Hyrax in debug mode, this requires a somewhat different approach than running Hyrax bare-metal.  You need to use `docker attach` to debug the running docker instance.
 
-1. With `docker-compose up` running open a new Terminal session.
+1. With `docker compose up` running open a new Terminal session.
 2. In that new Terminal session, using `docker container ls` find the "CONTAINER ID" for the `hyrax-engine-dev`.
 3. With the "CONTAINER ID", run `docker attach <CONTAINER ID>`.
 
@@ -111,7 +111,7 @@ This advice comes from [Debugging Rails App With Docker Compose: How to use Byeb
 
 ##### Bad Address SOLR
 
-With `docker-compose up` running, if you see the following, then there may be issues with file permissions:
+With `docker compose up` running, if you see the following, then there may be issues with file permissions:
 
 ```
 db_migrate_1  | waiting for solr:8983
@@ -125,15 +125,15 @@ Executing /opt/docker-solr/scripts/precreate-core hyrax_test /opt/solr/server/co
 cp: cannot create directory '/var/solr/data/hyrax_test': Permission denied
 ```
 
-The solution that appears to work is to `docker-compose down --volumes`; This will tear down the docker instance, and remove the volumes.  You can then run `docker-compose up` to get back to work.  _**Note:** the `--volumes` switch will remove all custom data._
+The solution that appears to work is to `docker compose down --volumes`; This will tear down the docker instance, and remove the volumes.  You can then run `docker compose up` to get back to work.  _**Note:** the `--volumes` switch will remove all custom data._
 
 ##### Errors building the Docker image
 
-If you encounter errors running `docker-compose build`, try running `bundle update` in `./hyrax` as well as within `./hyrax/.dassie`. That can help clear up the problem of a failure to build a particular gem.
+If you encounter errors running `docker compose build`, try running `bundle update` in `./hyrax` as well as within `./hyrax/.dassie`. That can help clear up the problem of a failure to build a particular gem.
 
 ##### Containers do not all start
 
-If any of the services fail to start on `docker-compose up`, try clearing out any `Gemfile.lock` files that might exist in `./hyrax` or `./hyrax/.dassie` and run `docker-compose build` again, then `docker-compose up` again.
+If any of the services fail to start on `docker compose up`, try clearing out any `Gemfile.lock` files that might exist in `./hyrax` or `./hyrax/.dassie` and run `docker compose build` again, then `docker compose up` again.
 
 ### Koppie Internal Test App with Valkyrie Connector to Postgres
 


### PR DESCRIPTION
Present tense short summary (50 characters or less)
v1 docker-compose has been deprecated and will be removed in a future version

Changes proposed in this pull request:
* update all references of v1 "docker-compose" to v2 "docker compose"
* remove trailing spaces in the same files where v2 changes were made

@samvera/hyrax-code-reviewers
