### PR TITLE
add extension behavior for FileSet show view partials

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -105,6 +105,12 @@ module Hyrax
       current_ability.can?(:edit, id) || current_ability.can?(:destroy, id) || current_ability.can?(:download, id)
     end
 
+    ##
+    # @return [Array<String>]
+    def show_partials
+      ['show_details']
+    end
+
     private
 
     def link_presenter_class

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -11,7 +11,7 @@
         <%= render 'file_set_title', presenter: @presenter %>
       </header>
 
-      <%# TODO: render 'show_descriptions' See https://github.com/samvera/hyrax/issues/1481 %>
+      <%# TODO: render 'show_descriptions' See https://github.com/samvera-deprecated/sufia/issues/1481 %>
       <%= render 'show_details' %>
       <%= render 'hyrax/users/activity_log', events: @presenter.events %>
     </div><!-- /columns second -->

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -11,8 +11,10 @@
         <%= render 'file_set_title', presenter: @presenter %>
       </header>
 
-      <%# TODO: render 'show_descriptions' See https://github.com/samvera-deprecated/sufia/issues/1481 %>
-      <%= render 'show_details' %>
+      <% @presenter.show_partials.each do |partial_path| %>
+      <%= render partial_path %>
+      <% end %>
+
       <%= render 'hyrax/users/activity_log', events: @presenter.events %>
     </div><!-- /columns second -->
   </div> <!-- /.row -->


### PR DESCRIPTION
if a user wants to extend the FileSet show view to, e.g. show file specific
details or relationships to other objects, they should be able to inject that
behavior via the presenter

extensions were vaguely waved at around Sufia 7:
https://github.com/samvera-deprecated/sufia/issues/1481

we have some in mind in Surfliner:
https://gitlab.com/surfliner/surfliner/-/issues/1282

Changes proposed in this pull request:
* adds `FileSetPresenter#show_partials` to list partial paths to render in the guts of the FileSet show page.


Guidance for testing, such as acceptance criteria or new user interface behaviors:
* no functional changes.

@samvera/hyrax-code-reviewers
