### PR TITLE
Add a note containing the configured file upload limits

### DIFF
--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -4,9 +4,14 @@
         <!-- The table listing the files available for upload/download -->
         <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
         <% if Hyrax.config.browse_everything? %>
-          <%= t('hyrax.base.form_files.local_upload_browse_everything_html', contact_href: link_to(t("hyrax.upload.alert.contact_href_text"), hyrax.contact_form_index_path)) %>
+          <%= t('hyrax.base.form_files.local_upload_browse_everything_html',
+                contact_href: link_to(t("hyrax.upload.alert.contact_href_text"), hyrax.contact_form_index_path),
+                upload_file_limit: Hyrax.config.uploader[:maxNumberOfFiles],
+                upload_size_limit: Hyrax.config.uploader[:maxFileSize] / 1.megabytes) %>
         <% else %>
-          <%= t('hyrax.base.form_files.local_upload_html') %>
+          <%= t('hyrax.base.form_files.local_upload_html',
+                upload_file_limit: Hyrax.config.uploader[:maxNumberOfFiles],
+                upload_size_limit: Hyrax.config.uploader[:maxFileSize] / 1.megabytes) %>
         <% end %>
         <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
         <div class="fileupload-buttonbar">

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -542,8 +542,16 @@ de:
         add_folder: Ordner hinzufügen
         cancel_upload: Upload abbrechen
         dropzone: Dateien hier hinziehen.
-        local_upload_browse_everything_html: "<p>Sie können eine oder mehre Dateien von Ihrem lokalen System oder einem Cloudanbieter hinzufügen, welche mit dieser Arbeit\nverknüpft werden sollen.</p>\n<p>Bitte beachten Sie, dass der Cloud-Anbieter möglicherweise nicht in der Lage ist Ihrer Anfrage nachzukommen, wenn Sie eine große Anzahl von Dateien\ninnerhalb einer kurzen Zeitspanne hochladen. \nWenn Sie\nirgendwelche Fehler beim Hochladen aus der Cloud erhalten, teilen Sie uns dies \nbitte über %{contact_href} mit.</p>\n"
-        local_upload_html: "<p> Sie können eine oder mehrere Dateien hinzufügen, die dieser Arbeit zugeordnet werden sollen. </p>"
+        local_upload_browse_everything_html: |
+          <p>Sie können eine oder mehre Dateien von Ihrem lokalen System oder einem Cloudanbieter hinzufügen, welche mit
+          dieser Arbeit verknüpft werden sollen.</p>
+          <p>Bitte beachten Sie, dass der Cloud-Anbieter möglicherweise nicht in der Lage ist Ihrer Anfrage 
+          nachzukommen, wenn Sie eine große Anzahl von Dateien innerhalb einer kurzen Zeitspanne hochladen. 
+          Wenn Sie irgendwelche Fehler beim Hochladen aus der Cloud erhalten, teilen Sie uns dies bitte über %{contact_href} mit.</p>
+          <p>Das Hochladen ist auf %{upload_file_limit} Dateien mit jeweils %{upload_size_limit} MB begrenzt.</p>
+        local_upload_html: |
+          <p>Sie können eine oder mehrere Dateien hinzufügen, die dieser Arbeit zugeordnet werden sollen.</p>
+          <p>Das Hochladen ist auf %{upload_file_limit} Dateien mit jeweils %{upload_size_limit} MB begrenzt.</p>
       form_member_of_collections:
         actions:
           remove: Aus der Sammlung entfernen

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -535,7 +535,10 @@ en:
           files within a short period of time, the provider may not be able to
           accommodate your request. If you experience errors uploading from the
           cloud, let us know via the %{contact_href}.</p>
-        local_upload_html: "<p>You can add one or more files to associate with this work.</p>"
+          <p>Uploads are limited to %{upload_file_limit} files, %{upload_size_limit} MB each.</p>
+        local_upload_html: |
+          <p>You can add one or more files to associate with this work.</p>
+          <p>Uploads are limited to %{upload_file_limit} files, %{upload_size_limit} MB each.</p>
       form_member_of_collections:
         actions:
           remove: Remove from collection

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -548,7 +548,10 @@ es:
           de tiempo, el proveedor en la nube podría no ser capaz de resolver la
           petición. Si se experimentan errores durante la carga, por favor,
           comuníquese con nosotros a través de %{contact_href}.</p>
-        local_upload_html: "<p>Puede agregar uno o más archivos para asociar con esta obra.</p>"
+          <p>Las cargas están limitadas a %{upload_file_limit} archivos, %{upload_size_limit} MB cada uno.</p>
+        local_upload_html: |
+          <p>Puede agregar uno o más archivos para asociar con esta obra.</p>
+          <p>Las cargas están limitadas a %{upload_file_limit} archivos, %{upload_size_limit} MB cada uno.</p>
       form_member_of_collections:
         actions:
           remove: Eliminar de la colección

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -549,7 +549,10 @@ fr:
           répondre à votre demande. Si vous rencontrez des erreurs de
           téléchargement depuis le nuage, faites-nous savoir via le
           %{contact_href}.</p>
-        local_upload_html: "<p>Vous pouvez ajouter un ou plusieurs fichiers à associer à ce travail.</p>"
+          <p>Les téléchargements sont limités à %{upload_file_limit} fichiers de %{upload_size_limit} Mo chacun.</p>
+        local_upload_html: |
+          <p>Vous pouvez ajouter un ou plusieurs fichiers à associer à ce travail.</p>
+          <p>Les téléchargements sont limités à %{upload_file_limit} fichiers de %{upload_size_limit} Mo chacun.</p>
       form_member_of_collections:
         actions:
           remove: Supprimer de la collection

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -548,7 +548,10 @@ it:
           periodo di tempo, il provider di cloud potrebbe non essere in grado di
           accogliere la tua richiesta. Se si verificano errori di caricamento
           dalla nube, fateci sapere tramite %{contact_href}.</p>
-        local_upload_html: "<p>È possibile aggiungere uno o più file da associare a questo lavoro.</p>"
+          <p>I caricamenti sono limitati a %{upload_file_limit} file, %{upload_size_limit} MB ciascuno.</p>
+        local_upload_html: |
+          <p>È possibile aggiungere uno o più file da associare a questo lavoro.</p>
+          <p>I caricamenti sono limitati a %{upload_file_limit} file, %{upload_size_limit} MB ciascuno.</p>
       form_member_of_collections:
         actions:
           remove: Rimuovi dalla raccolta

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -542,8 +542,15 @@ pt-BR:
         add_folder: Adicionar pasta
         cancel_upload: Cancelar upload
         dropzone: Largue os arquivos aqui.
-        local_upload_browse_everything_html: "<p>Você pode associar um ou mais arquivos a esta obra. Associe arquivos de seu sistema local ou um provedor de nuvem.</p> <p>Note que se você carregar uma grande quantidade de arquivos dentro de um curto período de tempo, o fornecedor de nuvem pode não ser capaz de acomodar a sua solicitação. Se você tiver algum erro ao carregar da nuvem, avise-nos através do %{contact_href}.<p>"
-        local_upload_html: "<p>Você pode acrescentar um ou mais arquivos para associar a esta obra.</p>"
+        local_upload_browse_everything_html: |
+          <p>Você pode associar um ou mais arquivos a esta obra. Associe arquivos de seu sistema local ou um provedor de nuvem.</p>
+          <p>Note que se você carregar uma grande quantidade de arquivos dentro de um curto período de tempo, 
+          o fornecedor de nuvem pode não ser capaz de acomodar a sua solicitação. Se você tiver algum erro ao carregar 
+          da nuvem, avise-nos através do %{contact_href}.<p>
+          <p>Os uploads são limitados a %{upload_file_limit} arquivos, %{upload_size_limit} MB cada.</p>
+        local_upload_html: |
+          <p>Você pode acrescentar um ou mais arquivos para associar a esta obra.</p>
+          <p>Os uploads são limitados a %{upload_file_limit} arquivos, %{upload_size_limit} MB cada.</p>
       form_member_of_collections:
         actions:
           remove: Remover da coleção

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -546,7 +546,10 @@ zh:
           <p>您可以添加一个或多个文件与该工作相关联。</p>
           <p>请注意如果您在短时间内上传了大量文件, 云提供商可能不能满足您的请求。
            如果您上传中遇到问题，请用%{contact_href}报告。</p>
-        local_upload_html: "<p>您可以添加一个或多个文件与该工作相关联。</p>"
+          <p>上传限制为 %{upload_file_limit} 个文件，每个文件 %{upload_size_limit} MB。</p>
+        local_upload_html: |
+          <p>您可以添加一个或多个文件与该工作相关联。</p>
+          <p>上传限制为 %{upload_file_limit} 个文件，每个文件 %{upload_size_limit} MB。</p>
       form_member_of_collections:
         actions:
           remove: 从收藏中删除


### PR DESCRIPTION
refs #6068 #6069

This provides upfront notice of the limits applied to file uploads. The error message mentioned in the above issues still needs to be fixed.

Changes proposed in this pull request:
* Add a note containing the configured file upload limits to the file upload form.
* Reformat the text in some locales to be multiline.

Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Updated message appears on the file upload form in all languages.

@samvera/hyrax-code-reviewers
