### PR TITLE
add Hyrax::FileSet to FileSetSearchBuilder model search filter

### DIFF
--- a/app/search_builders/hyrax/file_set_search_builder.rb
+++ b/app/search_builders/hyrax/file_set_search_builder.rb
@@ -5,7 +5,7 @@ module Hyrax
 
     # This overrides the models in FilterByType
     def models
-      [::FileSet]
+      [::FileSet, ::Hyrax::FileSet]
     end
   end
 end

--- a/spec/search_builders/hyrax/file_set_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/file_set_search_builder_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hyrax::FileSetSearchBuilder do
     before { subject.filter_models(solr_params) }
 
     it 'adds FileSet to query' do
-      expect(solr_params[:fq].first).to include('{!terms f=has_model_ssim}FileSet')
+      expect(solr_params[:fq].first).to include('{!terms f=has_model_ssim}FileSet,Hyrax::FileSet')
     end
   end
 


### PR DESCRIPTION
Refs 

- #5796 

### Fixes

Fixes #5796 

### Summary

Adds `Hyrax::FileSet` to the `FileSet` search builder model filter so that `FileSet`-related searches work in both ActiveFedora and Valkyrie Hyrax apps.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
1. Spin up the `.koppie` app locally 
2. Login as an admin 
3. Navigate to Dashboard > Works 
4. Click the "Add New Work" button. Select GenericWork. Click "Create work" 
5. Fill out the required metadata fields 
6. Under the Files tab, upload a file 
7. Click "Public" under the Visibility sidebar 
8. Check the deposit agreement and click "Save" 
9. On the newly-created Work's details page, click the title of the uploaded file under the Items section 
10. Verify that you can see the File's details page (i.e. you do not get redirected to the homepage with an "unauthorized access" message) 
11. Repeat steps 2-10 locally with the `.dassie` app 

### Type of change (for release notes)

- [ ] Major Changes (Potentially breaking changes)
- [ ] New Features
- [ ] Deprecations
- [x] Bug Fixes
- [x] Valkyrie Progress
- [ ] Documentation
- [ ] Containerization

### Detailed Description

When running a Valkyrie-based Hyrax app, the model is indexed in Solr as "Hyrax::FileSet" (`has_model_ssim:"Hyrax::FileSet"`). In an ActiveFedora-based Hyrax app, by contrast, the model is indexed as just "FileSet" (`has_model_ssim:FileSet`).

Before this change, we were only handling the latter in FileSet-related searches. This was breaking the FileSet show page in Valkyrie-based Hyrax apps since the FileSet being searched for was being filtered out.

<details><summary>Change working in .koppie</summary>

![File Set large jpg ID 1950ae52-41c2-4222-abdb-7b034d89aee5 Koppie 2023-05-31 at 5 45 21 PM](https://github.com/samvera/hyrax/assets/32469930/38412644-9e4a-4d65-87fe-e4615bf135c5)

</details>

<details><summary>Change working in .dassie</summary>

![File cat_scan jpg ID s1784k724 Hyrax 2023-05-31 at 5 46 05 PM](https://github.com/samvera/hyrax/assets/32469930/01b62c6a-e72d-44c9-bbc7-7189d99fc21f)

</details>

### Changes proposed in this pull request:

* Add `Hyrax::FileSet` to the `Hyrax::FileSetSearchBuilder` models query filter 

@samvera/hyrax-code-reviewers
