### PR TITLE
Valkyrie: populate correct collection when depositing new works through collection

### DIFF
--- a/app/helpers/hyrax/membership_helper.rb
+++ b/app/helpers/hyrax/membership_helper.rb
@@ -14,16 +14,26 @@ module Hyrax
     #
     # @see app/assets/javascripts/hyrax/relationships.js
     def member_of_collections_json(resource)
+      # this is where we return for dassie
       return resource.member_of_collections_json if
-        resource.respond_to?(:member_of_collections_json)
+      resource.respond_to?(:member_of_collections_json)
 
       resource = resource.model if resource.respond_to?(:model)
 
-      Hyrax.custom_queries.find_collections_for(resource: resource).map do |collection|
-        { id: collection.id.to_s,
-          label: collection.title.first,
-          path: url_for(collection) }
+      existing_collections_array = Hyrax.custom_queries.find_collections_for(resource: resource) + add_collection_from_params
+      existing_collections_array.map do |collection| {
+        id: collection.id.to_s,
+        label: collection.title.first,
+        path: url_for(collection)
+      }
       end.to_json
+    end
+
+    def add_collection_from_params
+      # new valkyrie works need the collection from params when depositing directly into an existing collection
+      return [Hyrax.metadata_adapter.query_service.find_by(id: Valkyrie::ID.new(controller.params[:add_works_to_collection]))] if Valkyrie
+
+      [::Collection.find(@controller.params[:add_works_to_collection])]
     end
 
     ##


### PR DESCRIPTION
### Fixes

Fixes #5586

### Summary

Depositing a work through a collection should automate the correct collection relationship being assigned. Users should not have to go to the Relationships tab to manually add the collection.

### Testing Instructions:

1. Log in as a user with at least deposit-level access to a shared Collection
2. Go to Dashboard > Collections > Managed Collections and select a collection listed there
3. Scroll down and click the Deposit new work through this collection button
4. In the Create Work form, click the Relationships tab
5. Observe that the correct Collection is populated
6. Make sure that this works for both koppie & dassie

### Type of change (for release notes)

- [ ] Major Changes (Potentially breaking changes)
- [ ] New Features
- [ ] Deprecations
- [x] Bug Fixes
- [x] Valkyrie Progress
- [ ] Documentation
- [ ] Containerization

### screenshots
<details><summary>working in koppie</summary>
<img width="1183" alt="image" src="https://github.com/samvera/hyrax/assets/73361970/040b43b5-6dc9-4b8b-b836-d2040fb0add9">

</details>

<details><summary>working in dassie</summary>
<img width="1015" alt="image" src="https://github.com/samvera/hyrax/assets/73361970/5f0bf053-167d-4004-8d02-244cd30acf26">

</details>


### Changes proposed in this pull request:
* the correct collection will now automatically populate when creating a new work with the "deposit a new work in this collection" option

@samvera/hyrax-code-reviewers
