### PR TITLE
5575 item actions download

### DIFF
--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -37,6 +37,10 @@ module Hyrax
 
     protected
 
+    def get_mime_type(use_valkyrie:, file:)
+      use_valkyrie ? mime_type_for(file.id) : file.mime_type
+    end
+
     # OVERRIDE
     def asset
       @asset ||= if Hyrax.config.use_valkyrie?
@@ -49,17 +53,17 @@ module Hyrax
     # OVERRIDE mime_type_for
     def content_head
       response.headers['Content-Length'] = file.size
-      head :ok, content_type: mime_type_for(file.id)
+      head :ok, content_type: get_mime_type(use_valkyrie: Hyrax.config.use_valkyrie?, file: file)
     end
 
     # OVERRIDE mime_type_for
     def prepare_file_headers
       send_file_headers! content_options
-      response.headers['Content-Type'] = mime_type_for(file.id)
+      response.headers['Content-Type'] = get_mime_type(use_valkyrie: Hyrax.config.use_valkyrie?, file: file)
       response.headers['Content-Length'] ||= file.size.to_s
       # Prevent Rack::ETag from calculating a digest over body
       response.headers['Last-Modified'] = asset.modified_date.utc.strftime("%a, %d %b %Y %T GMT")
-      self.content_type = mime_type_for(file.id)
+      self.content_type = get_mime_type(use_valkyrie: Hyrax.config.use_valkyrie?, file: file)
     end
 
     # OVERRIDE remove original_file reference
@@ -75,7 +79,7 @@ module Hyrax
     # we have an attachement rather than 'inline'
     # OVERRIDE mime_type_for
     def content_options
-      { disposition: 'attachment', type: mime_type_for(file.id), filename: file_name }
+      { disposition: 'attachment', type: get_mime_type(use_valkyrie: Hyrax.config.use_valkyrie?, file: file), filename: file_name }
     end
 
     # Override this method if you want to change the options sent when downloading

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -39,7 +39,7 @@ module Hyrax
     end
 
     def file_set_parent(file_set_id)
-      file_set = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set_id, use_valkyrie: Hyrax.config.use_valkyrie?)
+      file_set = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set_id)
       @parent ||=
         case file_set
         when Hyrax::Resource

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -39,7 +39,8 @@ module Hyrax
     end
 
     def file_set_parent(file_set_id)
-      file_set = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set_id)
+      file_set = Hyrax.query_service.find_by(id: Valkyrie::ID.new(file_set_id))
+      file_set ||= Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set_id)
       @parent ||=
         case file_set
         when Hyrax::Resource

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -68,7 +68,10 @@ module Hyrax
 
     # OVERRIDE remove original_file reference
     def file_name
-      fname = params[:filename] || (asset.respond_to?(:label) && asset.label) || file.id
+      fname = params[:filename] ||
+              (file.respond_to?(:original_name) && file.original_name) ||
+              (asset.respond_to?(:label) && asset.label) ||
+              file.id
       fname = CGI.unescape(fname) if Rails.version >= '6.0'
       fname
     end

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -2,6 +2,7 @@
 
 # TODO: update all of the override comments to have details
 # OVERRIDE:
+
 module Hyrax
   class DownloadsController < ApplicationController
     include Hydra::Controller::DownloadBehavior
@@ -62,7 +63,8 @@ module Hyrax
       response.headers['Content-Type'] = get_mime_type(use_valkyrie: Hyrax.config.use_valkyrie?, file: file)
       response.headers['Content-Length'] ||= file.size.to_s
       # Prevent Rack::ETag from calculating a digest over body
-      response.headers['Last-Modified'] = asset.modified_date.utc.strftime("%a, %d %b %Y %T GMT")
+      # OVERRIDE: use "date_modified" which is defined on the asset, instead of "modified_date" which is defined in active-triples by way of active fedora
+      response.headers['Last-Modified'] = asset.date_modified.utc.strftime("%a, %d %b %Y %T GMT")
       self.content_type = get_mime_type(use_valkyrie: Hyrax.config.use_valkyrie?, file: file)
     end
 

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -101,10 +101,11 @@ module Wings
       #
       # @return [Valkyrie::Resource]
       # @raise [Valkyrie::Persistence::ObjectNotFoundError]
-      def find_by_alternate_identifier(alternate_identifier:, use_valkyrie: true)
+      def find_by_alternate_identifier(alternate_identifier:)
         raise(ArgumentError, 'id must be a Valkyrie::ID') unless
           alternate_identifier.respond_to?(:to_str)
 
+        use_valkyrie = Hyrax.config.use_valkyrie?
         af_object = ActiveFedora::Base.find(alternate_identifier.to_s)
 
         use_valkyrie ? resource_factory.to_resource(object: af_object) : af_object


### PR DESCRIPTION
### refs
- #5575 

### Summary
co-authored-by: @sephirothkod 

several of the hydra-head methods used to download an image needed to be overridden in order for the valkyrized files to also be able to download.

**>>>>>>>>do we want to fix these in hydra-head, or leave them as overrides?<<<<<<<<**

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* create or find a work with a file attached
* on the work show page, click actions >> download next to the item at the bottom of the page
* confirm the file was downloaded

### Type of change (for release notes)
- [X] New Features
- [X] Valkyrie Progress

### Demo
<details>
<summary>koppie</summary

https://github.com/samvera/hyrax/assets/29032869/6de1fecc-c1a5-4904-bce0-53432791965f
</details>

<details>
<summary>hyrax</summary

https://github.com/samvera/hyrax/assets/29032869/ff95c90d-a373-47fb-8b31-08a327c1842d
</details>

@samvera/hyrax-code-reviewers
