### PR TITLE
Fix counts of works and collections on a user's show page - #5568

### DIFF
--- a/app/helpers/hyrax/dashboard_helper_behavior.rb
+++ b/app/helpers/hyrax/dashboard_helper_behavior.rb
@@ -6,13 +6,13 @@ module Hyrax
     end
 
     # @param user [User]
-    # @param where [Hash] applied as the where clause when querying the Hyrax::WorkRelation
-    # @return [Integer] number of works matching the where that the user deposited
-    # @see Hyrax::WorkRelation
-    def number_of_works(user = current_user, where: { generic_type_sim: "Work" })
-      field_pairs = field_pairs(user)
-      field_pairs.merge!(where)
-      Hyrax::SolrQueryService.new.with_field_pairs(field_pairs: field_pairs).count
+    # @return [Integer] number of works that the user deposited
+    def number_of_works(user = current_user)
+      Hyrax::SolrQueryService
+        .new
+        .with_field_pairs(field_pairs: field_pairs(user))
+        .with_generic_type(generic_type: 'Work')
+        .count
     rescue RSolr::Error::ConnectionRefused
       'n/a'
     end
@@ -20,7 +20,11 @@ module Hyrax
     # @param user [User]
     # @return [Integer] number of FileSets the user deposited
     def number_of_files(user = current_user)
-      Hyrax::SolrQueryService.new.with_field_pairs(field_pairs: field_pairs(user)).count
+      Hyrax::SolrQueryService
+        .new
+        .with_field_pairs(field_pairs: field_pairs(user))
+        .with_generic_type(generic_type: 'FileSet')
+        .count
     rescue RSolr::Error::ConnectionRefused
       'n/a'
     end
@@ -28,7 +32,11 @@ module Hyrax
     # @param user [User]
     # @return [Integer] number of Collections the user created
     def number_of_collections(user = current_user)
-      Hyrax::SolrQueryService.new.with_field_pairs(field_pairs: field_pairs(user)).count
+      Hyrax::SolrQueryService
+        .new
+        .with_field_pairs(field_pairs: field_pairs(user))
+        .with_generic_type(generic_type: 'Collection')
+        .count
     rescue RSolr::Error::ConnectionRefused
       'n/a'
     end

--- a/app/services/hyrax/solr_query_service.rb
+++ b/app/services/hyrax/solr_query_service.rb
@@ -107,6 +107,7 @@ module Hyrax
     def with_generic_type(generic_type: 'Work')
       # TODO: Generic type was originally stored as `sim`.  Since it is never multi-valued, it is moving to being stored
       #       as `si`.  Until a migration is created to correct existing solr docs, this query searches in both fields.
+      #       @see https://github.com/samvera/hyrax/issues/6086
       field_pairs = { generic_type_si: generic_type, generic_type_sim: generic_type }
       type_query = construct_query_for_pairs(field_pairs, ' OR ', 'field')
       @query += [type_query]

--- a/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
+++ b/spec/helpers/hyrax/dashboard_helper_behavior_spec.rb
@@ -26,18 +26,8 @@ RSpec.describe Hyrax::DashboardHelperBehavior, type: :helper do
       create_models("GenericWork", user1, user2)
     end
 
-    it "finds 2 works" do
-      expect(helper.number_of_works(user1)).to eq(2)
-    end
-
-    context "with an over-riddent :where clause" do
-      it "finds 3 works when passed an empty where" do
-        expect(helper.number_of_works(user1, where: {})).to eq(3)
-      end
-
-      it "limits to those matching the where clause" do
-        expect(helper.number_of_works(user1, where: { "generic_type_sim" => "Big Work" })).to eq(1)
-      end
+    it 'finds 3 works' do
+      expect(helper.number_of_works(user1)).to eq(3)
     end
   end
 
@@ -69,18 +59,22 @@ RSpec.describe Hyrax::DashboardHelperBehavior, type: :helper do
 
   def create_models(model, user1, user2)
     solr_service = Hyrax::SolrService
+    generic_types_mapping = {
+      'GenericWork' => 'Work',
+      'Collection' => 'Collection',
+      'FileSet' => 'FileSet',
+    }
 
     # deposited by the first user
-    2.times do |t|
+    3.times do |t|
       solr_service.add({ id: "199#{t}", "depositor_tesim" => user1.user_key, "has_model_ssim" => [model],
-                         "depositor_ssim" => user1.user_key, "generic_type_sim" => "Work" })
+                         "depositor_ssim" => user1.user_key, "generic_type_si" => generic_types_mapping[model] })
     end
-
-    solr_service.add({ id: "1993", "depositor_tesim" => user1.user_key, "generic_type_sim" => "Big Work", "has_model_ssim" => [model], "depositor_ssim" => user1.user_key })
 
     # deposited by the second user, but editable by the first
     solr_service.add({ id: "1994", "depositor_tesim" => user2.user_key, "has_model_ssim" => [model],
-                       "depositor_ssim" => user2.user_key, "edit_access_person_ssim" => user1.user_key })
+                       "depositor_ssim" => user2.user_key, "generic_type_si" => generic_types_mapping[model],
+                       "edit_access_person_ssim" => user1.user_key })
     solr_service.commit
   end
 end


### PR DESCRIPTION
### Fixes

Ref 

- #5568

### Summary

Fix counts of works and collections on a user's show page

### Guidance for testing, such as acceptance criteria or new user interface behaviors:

1. Login as an admin who has not created any Works or Collections 
2. Navigate to Dashboard > Works 
3. Create two works 
4. Navigate to Dashboard > Collections 
5. Create one new Collection  
6. Navigate to the homepage (`/`) 
7. Under the Recently Uploaded tab, click your user's email next to Depositor 
8. Observe the numbers In the lefthand sidebar. The number of Collections created should be 1. The number of Works created should be 2. 

### Type of change (for release notes)

- [ ] Major Changes (Potentially breaking changes)
- [ ] New Features
- [ ] Deprecations
- [x] Bug Fixes
- [x] Valkyrie Progress
- [ ] Documentation
- [ ] Containerization

### Detailed Description

Use the `#with_generic_type` method instead of hard-coding the Generic Type Solr field until this issue is resolved:

- https://github.com/samvera/hyrax/issues/6086

See that ticket for more details on why this bug was happening.

### Changes proposed in this pull request:
* Remove `where` param from `#number_of_works` in favor of `#with_generic_type` 
* Add `#with_generic_type` filters to `#number_of_collections` and `#number_of_files` 
* Update specs accordingly 

@samvera/hyrax-code-reviewers
