### PR TITLE
thumbnails and other derivatives were not stored in the path we expected them to be

### DIFF
--- a/app/services/hyrax/derivative_bucketed_storage.rb
+++ b/app/services/hyrax/derivative_bucketed_storage.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# this class overrides the Valkyrie::Storage::Disk::BucketStorage class so that file paths match
+module Hyrax
+  class DerivativeBucketedStorage
+    attr_reader :base_path
+
+    def initialize(base_path:)
+      @base_path = base_path
+    end
+
+    # rubocop:disable Lint/UnusedMethodArgument
+    def generate(resource:, file:, original_filename:)
+      raise ArgumentError, "original_filename must be provided" unless original_filename
+      Pathname.new(base_path).join(*bucketed_path(resource.id)).join(original_filename)
+    end
+    # rubocop:enable Lint/UnusedMethodArgument
+
+    def bucketed_path(id)
+      # We want to use the same code the derivative process uses so that items end up
+      # stored in the place we expect them.
+      Hyrax::DerivativePath.new(id.to_s).pair_directory
+    end
+  end
+end

--- a/app/services/hyrax/derivative_path.rb
+++ b/app/services/hyrax/derivative_path.rb
@@ -35,6 +35,14 @@ module Hyrax
       end
     end
 
+    def pair_directory
+      id.split('').each_slice(2).map(&:join)[0..-2]
+    end
+
+    def pair_path
+      (pair_directory + [id[-2..-1]]).join('/')
+    end
+
     private
 
     # @return [String] Returns the root path where derivatives will be generated into.
@@ -45,10 +53,6 @@ module Hyrax
     # @return <Pathname> Full prefix of the path for object.
     def path_prefix
       Pathname.new(Hyrax.config.derivatives_path).join(pair_path)
-    end
-
-    def pair_path
-      id.split('').each_slice(2).map(&:join).join('/')
     end
 
     def file_name

--- a/app/services/hyrax/derivative_path.rb
+++ b/app/services/hyrax/derivative_path.rb
@@ -35,12 +35,16 @@ module Hyrax
       end
     end
 
+    def pairs
+      @pairs ||= id.split('').each_slice(2).map(&:join)
+    end
+
     def pair_directory
-      id.split('').each_slice(2).map(&:join)[0..-2]
+      pairs[0..-2]
     end
 
     def pair_path
-      (pair_directory + [id[-2..-1]]).join('/')
+      (pair_directory + pairs[-1..-1]).join('/')
     end
 
     private

--- a/app/services/hyrax/valkyrie_persist_derivatives.rb
+++ b/app/services/hyrax/valkyrie_persist_derivatives.rb
@@ -25,11 +25,13 @@ module Hyrax
       # responds to #path -- here we only have a StringIO, so some
       # transformation is in order
       tmpfile = Tempfile.new(file_set.id, encoding: 'ascii-8bit')
-      tmpfile.write stream.read
+      stream.rewind
+      output = tmpfile.write(stream.read)
+      tmpfile.flush
+      raise 'blank file detected' if output.zero?
 
       filename = filename(directives)
       Hyrax.logger.debug "Uploading thumbnail for FileSet #{file_set.id} as #{filename}"
-
       uploader.upload(
         io: tmpfile,
         filename: filename,

--- a/config/initializers/storage_adapter_initializer.rb
+++ b/config/initializers/storage_adapter_initializer.rb
@@ -7,6 +7,6 @@ Valkyrie::StorageAdapter.register(
 )
 
 Valkyrie::StorageAdapter.register(
-  Valkyrie::Storage::Disk.new(base_path: Hyrax.config.derivatives_path),
+  Valkyrie::Storage::Disk.new(base_path: Hyrax.config.derivatives_path, path_generator: Hyrax::DerivativeBucketedStorage),
   :derivatives_disk
 )


### PR DESCRIPTION
### Fixes
- #5504

### Summary

Derivatives were stored in a pairtree using the first 5 non-dash items. But Hyrax expects them to be stored in a pairtree of the full id. This mismatch meant no derivatives could be found properly. 

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* This is a Valkyrie only change. 
* Create a work with an attached file. After a minute or two the thumbnail should show

### Type of change (for release notes)

- [ ] Major Changes (Potentially breaking changes)
- [ ] New Features
- [ ] Deprecations
- [ ] Bug Fixes
- [x] Valkyrie Progress
- [ ] Documentation
- [ ] Containerization

@samvera/hyrax-code-reviewers
