### PR TITLE
contribute back: missing user graph

### DIFF
--- a/app/services/hyrax/statistics/users/over_time.rb
+++ b/app/services/hyrax/statistics/users/over_time.rb
@@ -26,7 +26,9 @@ module Hyrax
         end
 
         def point(date_string)
-          relation.where(query(date_string)).count
+          # convert the User::ActiveRecord_Relation to an array so that ".size" returns a number,
+          # instead of a hash of { user_id: size }
+          relation.where(query(date_string)).to_a.size
         end
       end
     end


### PR DESCRIPTION
update `Hyrax::Statistics::Users::OverTime#point` so user graph does not break.

the previous version of this method returned a hash that the Morris.Bar graph cannot map. this change returns an integer instead. which I believe was the initial intent.

contributing from:
- https://github.com/scientist-softserv/palni-palci/pull/473

@samvera/hyrax-code-reviewers
