### PR TITLE
Update GA4 param name

### DIFF
--- a/app/assets/javascripts/hyrax/analytics_events.js
+++ b/app/assets/javascripts/hyrax/analytics_events.js
@@ -55,7 +55,7 @@ class GA4TagTracker {
   trackEvent(category, action, name) {
     gtag('event', action, {
       'category': category,
-      'name': name
+      'label': name
     });
   }
 


### PR DESCRIPTION
### Summary
Change GA4 event parameter name from "name" to "label". While the field name is mostly anything we want, it was named "label" in UA and "name" is confusing when paired with "eventName" which is a required all events have.

@samvera/hyrax-code-reviewers
