### PR TITLE
Disable analytics dashboard for GA4 until support is done

### DIFF
--- a/app/controllers/hyrax/admin/analytics/collection_reports_controller.rb
+++ b/app/controllers/hyrax/admin/analytics/collection_reports_controller.rb
@@ -5,7 +5,7 @@ module Hyrax
       class CollectionReportsController < AnalyticsController
         include Hyrax::BreadcrumbsForCollectionAnalytics
         def index
-          return unless Hyrax.config.analytics?
+          return unless Hyrax.config.analytics? && Hyrax.config.analytics_provider != 'ga4'
 
           @pageviews = Hyrax::Analytics.daily_events('collection-page-view')
           @work_page_views = Hyrax::Analytics.daily_events('work-in-collection-view')
@@ -21,7 +21,7 @@ module Hyrax
         end
 
         def show
-          return unless Hyrax.config.analytics?
+          return unless Hyrax.config.analytics? && Hyrax.config.analytics_provider != 'ga4'
           @document = ::SolrDocument.find(params[:id])
           @pageviews = Hyrax::Analytics.daily_events_for_id(@document.id, 'collection-page-view')
           @work_page_views = Hyrax::Analytics.daily_events_for_id(@document.id, 'work-in-collection-view')

--- a/app/controllers/hyrax/admin/analytics/work_reports_controller.rb
+++ b/app/controllers/hyrax/admin/analytics/work_reports_controller.rb
@@ -6,7 +6,7 @@ module Hyrax
         include Hyrax::BreadcrumbsForWorksAnalytics
 
         def index
-          return unless Hyrax.config.analytics?
+          return unless Hyrax.config.analytics? && Hyrax.config.analytics_provider != 'ga4'
 
           @accessible_works ||= accessible_works
           @accessible_file_sets ||= accessible_file_sets

--- a/app/views/hyrax/admin/analytics/collection_reports/index.html.erb
+++ b/app/views/hyrax/admin/analytics/collection_reports/index.html.erb
@@ -8,7 +8,7 @@
   <div class="col-sm-12">
     <div class="collection-reports">
 
-<% if Hyrax.config.analytics? %>
+<% if Hyrax.config.analytics? && Hyrax.config.analytics_provider != 'ga4' %>
       <div class="panel panel-default">
         <div class="panel-heading"><%= t('.repo_summary') %> <b><%= pluralize(Collection.count, "collection") %></b>, <%= t('.repo_summary_2') %> <b><%= @pageviews.all %> <%= t('.views') %></b> <%= t('.and') %> <b><%= @downloads.all %> <%= t('.downloads') %></b>.</div>
         <div class="panel-body">

--- a/app/views/hyrax/admin/analytics/work_reports/index.html.erb
+++ b/app/views/hyrax/admin/analytics/work_reports/index.html.erb
@@ -9,7 +9,7 @@
     <div class="work-reports">
 
     <div class="panel panel-default">
-    <% if Hyrax.config.analytics? %>
+    <% if Hyrax.config.analytics? && Hyrax.config.analytics_provider != 'ga4' %>
       <% if current_user.ability.admin? %>
         <div class="panel-heading"><b><%= @works_count %> <%= t('.works') %></b> <%= t('.repo_summary') %> <b><%= @pageviews.all if @pageviews %> <%= t('.views') %></b> <%= t('.and') %> <b><%= @downloads.all if @downloads %> <%= t('.downloads') %></b>.</div>
       <% else %>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -17,7 +17,7 @@
             class: presenter.display_unfeature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
       <% end %>
     <% end %>
-    <% if Hyrax.config.analytics? %>
+    <% if Hyrax.config.analytics? && Hyrax.config.analytics_provider != 'ga4' %>
       <% # turbolinks needs to be turned off or the page will use the cache and the %>
       <% # analytics graph will not show unless the page is refreshed. %>
       <%= link_to t('.analytics'), presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>

--- a/app/views/hyrax/base/_work_button_row.html.erb
+++ b/app/views/hyrax/base/_work_button_row.html.erb
@@ -37,7 +37,7 @@
           data: { behavior: 'unfeature' },
           class: presenter.display_feature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
     <% end %>
-    <% if Hyrax.config.analytics? %>
+    <% if Hyrax.config.analytics? && Hyrax.config.analytics_provider != 'ga4' %>
       <%= link_to t(".analytics"), presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
     <% end %>
   </div>

--- a/app/views/hyrax/dashboard/_user_activity.html.erb
+++ b/app/views/hyrax/dashboard/_user_activity.html.erb
@@ -2,7 +2,7 @@
   <h3 class="panel-title"><%= t('.title') %></h3>
 </div>
 <div class="panel-body text-center">
-  <% if Hyrax.config.analytics? %>
+  <% if Hyrax.config.analytics? && Hyrax.config.analytics_provider != 'ga4' %>
     <%= render 'user_activity_graph' %>
 
     <div class="col-md-3">

--- a/app/views/hyrax/dashboard/show_admin.html.erb
+++ b/app/views/hyrax/dashboard/show_admin.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t("hyrax.dashboard.title") %></h1>
 <% end %>
 
-<% if Hyrax.config.analytics? %>
+<% if Hyrax.config.analytics? && Hyrax.config.analytics_provider != 'ga4' %>
 <div class="row">
   <div class="col-md-12">
     <div class="panel panel-default">

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -32,7 +32,7 @@
     <% end %>
   <% end %>
 
-  <% if current_ability.can_create_any_work? && Hyrax.config.analytics? %>
+  <% if current_ability.can_create_any_work? && Hyrax.config.analytics? && Hyrax.config.analytics_provider != 'ga4' %>
     <li>
       <%= menu.collapsable_section t('hyrax.admin.sidebar.analytics'),
                                         icon_class: "fa fa-pie-chart",

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -1,5 +1,5 @@
 <div class="form-actions">
-  <% if Hyrax.config.analytics? %>
+  <% if Hyrax.config.analytics? && Hyrax.config.analytics_provider != 'ga4' %>
     <% # turbolinks needs to be turned off or the page will use the cache and the %>
     <% # analytics graph will not show unless the page is refreshed. %>
     <%= link_to t('.analytics'), @presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>


### PR DESCRIPTION
### Summary

Disables the analytics displays in the admin dashboard when GA4 is the analytics provider

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* No errors on the dashboard when GA4 is selected

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

Once support for GA4 is done, either by updating legato or by using another library, these dashboards will be restored.

