### PR TITLE
Stop testing middle ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,13 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.7.7
+        default: 2.7.8
       bundler_version:
         type: string
-        default: 2.4.8
+        default: 2.4.15
       rails_version:
         type: string
-        default: 6.1.7.2
+        default: 6.1.7.4
     executor:
       name: 'samvera/ruby'
       ruby_version: << parameters.ruby_version >>
@@ -71,13 +71,13 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.7.7
+        default: 2.7.8
       bundler_version:
         type: string
-        default: 2.4.8
+        default: 2.4.15
       rails_version:
         type: string
-        default: 6.1.7.2
+        default: 6.1.7.4
     executor:
       name: 'samvera/ruby_fcrepo_solr_redis_postgres'
       ruby_version: << parameters.ruby_version >>
@@ -114,10 +114,10 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.7.7
+        default: 2.7.8
       bundler_version:
         type: string
-        default: 2.4.8
+        default: 2.4.15
       hyrax_valkyrie:
         type: string
         default: "false"
@@ -191,85 +191,49 @@ workflows:
     jobs:
       - bundle:
           ruby_version: "3.2.2"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
+          rails_version: "6.1.7.4"
+          bundler_version: "2.4.15"
       - build:
           ruby_version: "3.2.2"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
+          rails_version: "6.1.7.4"
+          bundler_version: "2.4.15"
           requires:
             - bundle
       - test:
           name: "ruby3-2"
           ruby_version: "3.2.2"
-          bundler_version: "2.4.8"
+          bundler_version: "2.4.15"
           requires:
             - build
       - test:
           name: "ruby3-2-valkyrie"
           ruby_version: "3.2.2"
-          bundler_version: "2.4.8"
+          bundler_version: "2.4.15"
           hyrax_valkyrie: "true"
-          requires:
-            - build
-  ruby3-1:
-    jobs:
-      - bundle:
-          ruby_version: "3.1.4"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
-      - build:
-          ruby_version: "3.1.4"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
-          requires:
-            - bundle
-      - test:
-          name: "ruby3-1"
-          ruby_version: "3.1.4"
-          bundler_version: "2.4.8"
-          requires:
-            - build
-  ruby3-0:
-    jobs:
-      - bundle:
-          ruby_version: "3.0.6"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
-      - build:
-          ruby_version: "3.0.6"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
-          requires:
-            - bundle
-      - test:
-          name: "ruby3-0"
-          ruby_version: "3.0.6"
-          bundler_version: "2.4.8"
           requires:
             - build
   ruby2-7:
     jobs:
       - bundle:
-          ruby_version: "2.7.7"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
+          ruby_version: "2.7.8"
+          rails_version: "6.1.7.4"
+          bundler_version: "2.4.15"
       - build:
-          ruby_version: "2.7.7"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
+          ruby_version: "2.7.8"
+          rails_version: "6.1.7.4"
+          bundler_version: "2.4.15"
           requires:
             - bundle
       - test:
           name: "ruby2-7"
-          ruby_version: "2.7.7"
-          bundler_version: "2.4.8"
+          ruby_version: "2.7.8"
+          bundler_version: "2.4.15"
           requires:
             - build
       - test:
           name: "ruby2-7-valkyrie"
-          ruby_version: "2.7.7"
-          bundler_version: "2.4.8"
+          ruby_version: "2.7.8"
+          bundler_version: "2.4.15"
           hyrax_valkyrie: "true"
           requires:
             - build


### PR DESCRIPTION
Only perform tests on our min/max ruby versions. These are not required checks already.
Also updates some versions in circle.

@samvera/hyrax-code-reviewers
