### PR TITLE
Initialize query_service before tests 

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -149,6 +149,8 @@ RSpec.configure do |config|
     User.group_service = TestHydraGroupService.new
     # Set a geonames username; doesn't need to be real.
     Hyrax.config.geonames_username = 'hyrax-test'
+    # Initialize query_service class attribute by calling to avoid it sometimes being set to test_adapter
+    Hyrax::SolrQueryService.query_service
     # disable analytics except for specs which will have proper api mocks
   end
 


### PR DESCRIPTION
### Fixes

refs #6075 

### Summary

Initialize query_service before tests to avoid flaky test_adapter assignment

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Specs pass, hopefully with less falky failures
*
*

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

This is an attempt to address the root cause of some flaky tests as described in #6075. 
It calls `Hyrax::SolrQueryService.query_service` before the test suite start in order to seed the value with the correct standard adapter. This avoids it being set during a test that alters the query service to be test_adapter, thereby storing it for all other subsequent tests as well.

### Changes proposed in this pull request:
* Initialize the `Hyrax::SolrQueryService.query_service` class attribute before the test suite
*
*

@samvera/hyrax-code-reviewers
