### PR TITLE
5844-deactivated-leases

### DIFF
--- a/app/forms/hyrax/forms/work_lease_form.rb
+++ b/app/forms/hyrax/forms/work_lease_form.rb
@@ -11,6 +11,7 @@ module Hyrax
     #   +LeasesControllerBehavior+.
     class WorkLeaseForm < Hyrax::ChangeSet
       property :lease, form: Hyrax::Forms::Lease, populator: :lease_populator, prepopulator: :lease_populator
+      property :lease_history, virtual: true, prepopulator: proc { |_opts| self.lease_history = model.lease&.lease_history }
       property :lease_expiration_date, virtual: true, prepopulator: proc { |_opts| self.lease_expiration_date = model.lease&.lease_expiration_date }
       property :visibility_after_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_after_lease = model.lease&.visibility_after_lease }
       property :visibility_during_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_during_lease = model.lease&.visibility_during_lease }

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -60,6 +60,8 @@ module Hyrax
         doc['lease_expiration_date_dtsi'] = resource.lease.lease_expiration_date&.to_datetime
         doc['visibility_after_lease_ssim'] = resource.lease.visibility_after_lease
         doc['visibility_during_lease_ssim'] = resource.lease.visibility_during_lease
+      else
+        doc['lease_history_ssim'] = resource&.lease&.lease_history
       end
 
       doc

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -53,7 +53,7 @@ module Hyrax
     end
 
     def index_lease(doc)
-      if Hyrax::LeaseManager.new(resource: resource).under_lease?
+      if resource.lease&.active?
         doc['lease_expiration_date_dtsi'] = resource.lease.lease_expiration_date&.to_datetime
         doc['visibility_after_lease_ssim'] = resource.lease.visibility_after_lease
         doc['visibility_during_lease_ssim'] = resource.lease.visibility_during_lease

--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -36,7 +36,7 @@ module Hyrax
 
     attribute :alternate_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID)
     attribute :embargo,       Hyrax::Embargo.optional
-    attribute :lease,         Hyrax::Lease.optional
+    attribute :lease_id, Valkyrie::Types::ID
 
     delegate :edit_groups, :edit_groups=,
              :edit_users,  :edit_users=,
@@ -101,6 +101,17 @@ module Hyrax
 
     def visibility
       visibility_reader.read
+    end
+
+    def lease=(value)
+      raise TypeError "can't convert #{value.class} into Hyrax::Lease" unless value.is_a? Hyrax::Lease
+
+      @lease = value
+      self.lease_id = @lease.id
+    end
+
+    def lease
+      @lease ||= (Hyrax.query_service.find_by(id: lease_id) if lease_id.present?)
     end
 
     protected

--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -123,7 +123,8 @@ module Hyrax
     end
 
     def lease
-      @lease ||= (Hyrax.query_service.find_by(id: lease_id) if lease_id.present?)
+      return @lease if @lease
+      @lease = Hyrax.query_service.find_by(id: lease_id) if lease_id.present?
     end
 
     protected

--- a/app/services/hyrax/embargo_manager.rb
+++ b/app/services/hyrax/embargo_manager.rb
@@ -126,13 +126,13 @@ module Hyrax
       embargo_record = embargo_history_message(
         embargo_state,
         Time.zone.today,
-        DateTime.parse(embargo.embargo_release_date),
+        embargo.embargo_release_date,
         embargo.visibility_during_embargo,
         embargo.visibility_after_embargo
       )
 
-      nullify(force: true)
       release(force: true)
+      nullify(force: true)
       embargo.embargo_history += [embargo_record]
     end
 
@@ -180,14 +180,17 @@ module Hyrax
     end
 
     ##
-    # Drop the embargo by setting its release date to `nil`.
+    # Drop the embargo by setting its release date and visibility settings to `nil`.
     #
     # @param force [boolean] force the nullify even when the embargo period is current
     #
     # @return [void]
     def nullify(force: false)
       return false if !force && under_embargo?
+
       embargo.embargo_release_date = nil
+      embargo.visibility_during_embargo = nil
+      embargo.visibility_after_embargo = nil
     end
 
     ##

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -86,7 +86,11 @@ module Hyrax
     ##
     # @return [Hyrax::Lease]
     def lease
-      resource.lease || Lease.new
+      if resource[:lease_id].present?
+        Hyrax.query_service.find_by(id: resource[:lease_id])
+      else
+        Hyrax.persister.save(resource: Lease.new)
+      end
     end
 
     ##

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -119,11 +119,7 @@ module Hyrax
     ##
     # @return [Hyrax::Lease]
     def lease
-      if resource[:lease_id].present?
-        Hyrax.query_service.find_by(id: resource[:lease_id])
-      else
-        Hyrax.persister.save(resource: Lease.new)
-      end
+      resource.lease || Lease.new
     end
 
     ##

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -7,14 +7,14 @@ module Hyrax
   #
   # The lease terminology used here is as follows:
   #
-  #    - "Release Date" is the day an lease is scheduled to be released.
-  #    - "Under Lease" means the lease is "active"; i.e. that its release
+  #    - "Expiration Date" is the day a lease is scheduled to expire.
+  #    - "Under Lease" means the lease is "active"; i.e. that its expiration
   #       date is today or later.
-  #    - "Applied" means the lease's pre-release visibility has been set on
+  #    - "Applied" means the lease's pre-expiration visibility has been set on
   #      the resource.
-  #    - "Released" means the lease's post-release visibility has been set on
+  #    - "Released" means the lease's post-expiration visibility has been set on
   #      the resource.
-  #    - "Enforced" means the object's visibility matches the pre-release
+  #    - "Enforced" means the object's visibility matches the pre-expiration
   #      visibility of the lease; i.e. the lease has been applied,
   #      but not released.
   #    - "Deactivate" means that the existing lease will be removed

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -90,7 +90,7 @@ module Hyrax
     def copy_lease_to(target:)
       return false unless under_lease?
 
-      target.lease = Hyrax.persister.save(resource:Lease.new(clone_attributes))
+      target.lease = Hyrax.persister.save(resource: Lease.new(clone_attributes))
       self.class.apply_lease_for(resource: target)
     end
 

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -33,6 +33,7 @@ module Hyrax
           begin
             new_collections = changed_collection_membership(change_set)
             unsaved = change_set.sync
+            unsaved.lease = @persister.save(resource: unsaved.lease) if unsaved.lease.present?
             saved = @persister.save(resource: unsaved)
           rescue StandardError => err
             return Failure(["Failed save on #{change_set}\n\t#{err.message}", change_set.resource])

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -39,7 +39,7 @@ module Hyrax
               unsaved.embargo = @persister.save(resource: unsaved.embargo)
             end
             if unsaved.lease.present?
-              unsaved.lease.lease_release_date = unsaved.lease.lease_release_date&.to_datetime
+              unsaved.lease.lease_expiration_date = unsaved.lease.lease_expiration_date&.to_datetime
               unsaved.lease = @persister.save(resource: unsaved.lease)
             end
             saved = @persister.save(resource: unsaved)

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -34,10 +34,13 @@ module Hyrax
           begin
             new_collections = changed_collection_membership(change_set)
             unsaved = change_set.sync
-            unsaved.lease = @persister.save(resource: unsaved.lease) if unsaved.lease.present?
             if unsaved.embargo.present?
               unsaved.embargo.embargo_release_date = unsaved.embargo.embargo_release_date&.to_datetime
               unsaved.embargo = @persister.save(resource: unsaved.embargo)
+            end
+            if unsaved.lease.present?
+              unsaved.lease.lease_release_date = unsaved.lease.lease_release_date&.to_datetime
+              unsaved.lease = @persister.save(resource: unsaved.lease)
             end
             saved = @persister.save(resource: unsaved)
           rescue StandardError => err

--- a/spec/actors/hyrax/actors/lease_actor_spec.rb
+++ b/spec/actors/hyrax/actors/lease_actor_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Hyrax::Actors::LeaseActor do
 
   describe "#destroy" do
     let(:work) do
-      FactoryBot.valkyrie_create(:hyrax_resource, :under_lease)
+      FactoryBot.valkyrie_create(:hyrax_resource, :lease: lease)
     end
+    let(:lease) { FactoryBot.create(:hyrax_lease) }
 
     before do
       work.visibility = public_vis
@@ -33,12 +34,12 @@ RSpec.describe Hyrax::Actors::LeaseActor do
         FactoryBot.valkyrie_create(:hyrax_resource, lease: lease)
       end
 
-      let(:lease) { FactoryBot.build(:hyrax_lease) }
+      let(:lease) { FactoryBot.create(:hyrax_lease) }
 
       before do
         allow(Hyrax::TimeService)
           .to receive(:time_in_utc)
-          .and_return(work.lease.lease_expiration_date + 1)
+          .and_return(work.lease.lease_expiration_date.to_datetime + 1)
       end
 
       it "leaves the lease in place" do

--- a/spec/factories/hyrax_lease.rb
+++ b/spec/factories/hyrax_lease.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :hyrax_lease, class: "Hyrax::Lease" do
-    lease_expiration_date   { Time.zone.today + 10 }
+    lease_expiration_date   { (Time.zone.today + 10).to_s }
     visibility_after_lease  { 'authenticated' }
     visibility_during_lease { 'open' }
 
     to_create do |instance|
-      Valkyrie.config.metadata_adapter.persister.save(resource: instance)
+      saved_instance = Valkyrie.config.metadata_adapter.persister.save(resource: instance)
+      instance.id = saved_instance.id
+      saved_instance
     end
 
     trait :expired do

--- a/spec/factories/hyrax_lease.rb
+++ b/spec/factories/hyrax_lease.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :hyrax_lease, class: "Hyrax::Lease" do
-    lease_expiration_date   { Time.zone.today + 10 }
+    lease_expiration_date   { (Time.zone.today + 10).to_datetime }
     visibility_after_lease  { 'authenticated' }
     visibility_during_lease { 'open' }
 
@@ -12,7 +12,7 @@ FactoryBot.define do
     end
 
     trait :expired do
-      lease_expiration_date { Time.zone.today - 1 }
+      lease_expiration_date { (Time.zone.today - 1).to_datetime }
     end
   end
 end

--- a/spec/factories/hyrax_lease.rb
+++ b/spec/factories/hyrax_lease.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :hyrax_lease, class: "Hyrax::Lease" do
-    lease_expiration_date   { (Time.zone.today + 10).to_s }
+    lease_expiration_date   { Time.zone.today + 10 }
     visibility_after_lease  { 'authenticated' }
     visibility_during_lease { 'open' }
 

--- a/spec/factories/hyrax_resource.rb
+++ b/spec/factories/hyrax_resource.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     end
 
     trait :under_lease do
-      association :lease, factory: :hyrax_lease
+      lease_id { FactoryBot.create(:hyrax_lease).id }
     end
   end
 end

--- a/spec/models/hyrax/resource_spec.rb
+++ b/spec/models/hyrax/resource_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe Hyrax::Resource do
     subject(:resource) { described_class.new(lease: lease) }
     let(:lease)        { FactoryBot.build(:hyrax_lease) }
 
-    it 'saves the lease' do
+    it 'saves the lease id' do
+      resource.lease = Hyrax.persister.save(resource: lease)
+
       expect(Hyrax.persister.save(resource: resource).lease)
         .to have_attributes(lease_expiration_date: lease.lease_expiration_date)
     end

--- a/spec/services/hyrax/lease_manager_spec.rb
+++ b/spec/services/hyrax/lease_manager_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Hyrax::LeaseManager do
         expect(manager.lease)
           .to have_attributes visibility_after_lease: 'authenticated',
                               visibility_during_lease: 'open',
-                              lease_expiration_date: an_instance_of(String),
+                              lease_expiration_date: an_instance_of(DateTime),
                               lease_history: be_empty
       end
     end

--- a/spec/services/hyrax/lease_manager_spec.rb
+++ b/spec/services/hyrax/lease_manager_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::LeaseManager do
 
   shared_context 'with expired lease' do
     let(:resource) { FactoryBot.build(:hyrax_resource, lease: lease) }
-    let(:lease)    { FactoryBot.build(:hyrax_lease, :expired) }
+    let(:lease)    { FactoryBot.create(:hyrax_lease, :expired) }
   end
 
   describe '#apply' do
@@ -90,7 +90,7 @@ RSpec.describe Hyrax::LeaseManager do
         expect(manager.lease)
           .to have_attributes visibility_after_lease: 'authenticated',
                               visibility_during_lease: 'open',
-                              lease_expiration_date: an_instance_of(Date),
+                              lease_expiration_date: an_instance_of(String),
                               lease_history: be_empty
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -149,6 +149,8 @@ RSpec.configure do |config|
     User.group_service = TestHydraGroupService.new
     # Set a geonames username; doesn't need to be real.
     Hyrax.config.geonames_username = 'hyrax-test'
+    # Initialize query_service class attribute by calling to avoid it sometimes being set to test_adapter
+    Hyrax::SolrQueryService.query_service
     # disable analytics except for specs which will have proper api mocks
   end
 


### PR DESCRIPTION
co-authored-by: braydon <braydon.justice@1268456bcltd.ca>

### Related
- #6098 

### Summary
decouple the deactivated lease work from the deactivated embargo work.



### Guidance for testing, such as acceptance criteria or new user interface behaviors:
*
*
*

### Detailed Description
while working on #6098, braydon and I began updating some of the lease code to follow the pattern of the embargo code we were implementing. however, actually fixing the ability to deactivate leases was out of scope for #5844, so the work was moved here. I do not see a ticket for it, but wanted to capture the work somewhere so that we have somewhere to start from when fixing this feature is added to a sprint. 

#### TODO
in my current testing, we cannot deactivate a lease yet. it will probably need something similar to `#deactivate` in the embargo pr, but I haven't debugged the issue at all.

### Changes proposed in this pull request:
*
*
*

@samvera/hyrax-code-reviewers
