### PR TITLE
5844-save-embargoes-again

### DIFF
--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -106,7 +106,7 @@ module Hyrax
     def embargo=(value)
       raise TypeError "can't convert #{value.class} into Hyrax::Embargo" unless value.is_a? Hyrax::Embargo
 
-      @embargo = value
+      @embargo = Hyrax.persister.save(resource: value)
       self.embargo_id = @embargo.id
     end
 

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -33,7 +33,6 @@ module Hyrax
           begin
             new_collections = changed_collection_membership(change_set)
             unsaved = change_set.sync
-            unsaved.embargo = @persister.save(resource: unsaved.embargo) if unsaved.embargo.present?
             saved = @persister.save(resource: unsaved)
           rescue StandardError => err
             return Failure(["Failed save on #{change_set}\n\t#{err.message}", change_set.resource])


### PR DESCRIPTION
### Fixes
- #5844

### Summary
we are able to save embargoes again.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* create/edit a work
* add an embargo and save
* visit "/embargoes" and see that it's there

### Detailed Description

Idk why we were not able to. the work that was done on #6098 was to be able to deactivate embargoes, and we were able to save them as well. however, when that pr got merged to main, I was no longer able to set an embargo at all in koppie. saving the embargo in app/models/hyrax/resource.rb#embargo= is something we committed at https://github.com/samvera/hyrax/pull/6098/commits/efffe9b5b8d2e07ec73f60895649ce6f24992b39, but we then removed it and opted to save the embargo in lib/hyrax/transactions/steps/save.rb#call. however, the `value` argument that gets passed to #embargo= does not have a valid id. just an empty string. so we do not ever set or find the embargo. this change does at least work.

@samvera/hyrax-code-reviewers
