### PR TITLE
5844-set-embargo-date-as-datetime

### DIFF
--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -106,7 +106,6 @@ module Hyrax
     def embargo=(value)
       raise TypeError "can't convert #{value.class} into Hyrax::Embargo" unless value.is_a? Hyrax::Embargo
 
-      value.embargo_release_date = value.embargo_release_date.to_datetime if value.embargo_release_date.class == String
       @embargo = value
       self.embargo_id = @embargo.id
     end

--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -106,6 +106,7 @@ module Hyrax
     def embargo=(value)
       raise TypeError "can't convert #{value.class} into Hyrax::Embargo" unless value.is_a? Hyrax::Embargo
 
+      value.embargo_release_date = value.embargo_release_date.to_datetime if value.embargo_release_date.class == String
       @embargo = value
       self.embargo_id = @embargo.id
     end

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -36,7 +36,7 @@ module Hyrax
             unsaved = change_set.sync
             if unsaved.embargo.present?
               unsaved.embargo.embargo_release_date = unsaved.embargo.embargo_release_date.to_datetime
-              unsaved.embargo = @persister.save(resource: unsaved.embargo) if unsaved.embargo.present?
+              unsaved.embargo = @persister.save(resource: unsaved.embargo)
             end
             saved = @persister.save(resource: unsaved)
           rescue StandardError => err

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -33,7 +33,10 @@ module Hyrax
           begin
             new_collections = changed_collection_membership(change_set)
             unsaved = change_set.sync
-            unsaved.embargo = @persister.save(resource: unsaved.embargo) if unsaved.embargo.present?
+            if unsaved.embargo.present?
+              unsaved.embargo.embargo_release_date = unsaved.embargo.embargo_release_date.to_datetime
+              unsaved.embargo = @persister.save(resource: unsaved.embargo) if unsaved.embargo.present?
+            end
             saved = @persister.save(resource: unsaved)
           rescue StandardError => err
             return Failure(["Failed save on #{change_set}\n\t#{err.message}", change_set.resource])

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -35,7 +35,7 @@ module Hyrax
             new_collections = changed_collection_membership(change_set)
             unsaved = change_set.sync
             if unsaved.embargo.present?
-              unsaved.embargo.embargo_release_date = unsaved.embargo.embargo_release_date.to_datetime
+              unsaved.embargo.embargo_release_date = unsaved.embargo.embargo_release_date&.to_datetime
               unsaved.embargo = @persister.save(resource: unsaved.embargo)
             end
             saved = @persister.save(resource: unsaved)

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -29,6 +29,7 @@ module Hyrax
         # @return [Dry::Monads::Result] `Success(work)` if the change_set is
         #   applied and the resource is saved;
         #   `Failure([#to_s, change_set.resource])`, otherwise.
+        # rubocop:disable Metrics/MethodLength
         def call(change_set, user: nil)
           begin
             new_collections = changed_collection_membership(change_set)
@@ -52,6 +53,7 @@ module Hyrax
           publish_changes(resource: saved, user: user, new: unsaved.new_record, new_collections: new_collections)
           Success(saved)
         end
+        # rubocop:enable Metrics/MethodLength
 
         private
 


### PR DESCRIPTION
### Fixes

- #5844 

### Summary

save the `embargo_release_date` property as a DateTime instead of String. this way it will match the data type of the same value on dassie embargoes.

# demo
<img width="1436" alt="image" src="https://github.com/samvera/hyrax/assets/29032869/0cd066f9-70c6-484e-b3f1-4ea7a8130786">


### Detailed Description

when creating a new work with an embargo, `params['<work-type>']['embargo_release_date']` is a `YYYY-MM-DD` string in both dassie and koppie. so somewhere down the line we must be converting it to a DateTime in dassie.
I started going deep into the stack trace then decided to come back and just see if I could update the attribute from a string to date time before we save the embargo

@samvera/hyrax-code-reviewers
