### PR TITLE
stop-testing-middle-ruby-versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,42 +214,6 @@ workflows:
           hyrax_valkyrie: "true"
           requires:
             - build
-  ruby3-1:
-    jobs:
-      - bundle:
-          ruby_version: "3.1.4"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
-      - build:
-          ruby_version: "3.1.4"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
-          requires:
-            - bundle
-      - test:
-          name: "ruby3-1"
-          ruby_version: "3.1.4"
-          bundler_version: "2.4.8"
-          requires:
-            - build
-  ruby3-0:
-    jobs:
-      - bundle:
-          ruby_version: "3.0.6"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
-      - build:
-          ruby_version: "3.0.6"
-          rails_version: "6.1.7.2"
-          bundler_version: "2.4.8"
-          requires:
-            - bundle
-      - test:
-          name: "ruby3-0"
-          ruby_version: "3.0.6"
-          bundler_version: "2.4.8"
-          requires:
-            - build
   ruby2-7:
     jobs:
       - bundle:


### PR DESCRIPTION
### Summary
stop testing against ruby3-0 and ruby3-1. these were already not required.

this work was originally done by @dlpierce in #6105. that pr however also updates the circle ci versions and is failing. I expect those are legitimate failures, but do not want to hold up removing these testing versions in the meantime. removing these versions will allow our spec suite to move faster and provide a shorter pathway to a green spec suite.

@samvera/hyrax-code-reviewers
