### PR TITLE
Update show.json.jbuilder

### DIFF
--- a/app/views/hyrax/base/show.json.jbuilder
+++ b/app/views/hyrax/base/show.json.jbuilder
@@ -1,6 +1,3 @@
 # frozen_string_literal: true
-# @curation_concern = Wings::ActiveFedoraConverter.convert(resource: @curation_concern) if
-  @curation_concern.is_a? Hyrax::Resource
-
 json.extract! @curation_concern, *[:id] + @curation_concern.class.fields.reject { |f| [:has_model].include? f }
 json.version @curation_concern.try(:etag)


### PR DESCRIPTION
Test skipping converting Hyrax::Resource objects back to ActiveFedora::Base objects because both support class.fields.