### PR TITLE
6126 deactivated leases

### DIFF
--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -71,7 +71,8 @@ module Hyrax
       def save(env, use_valkyrie: false)
         return env.curation_concern.save unless use_valkyrie
 
-        resource = valkyrie_save(resource: env.curation_concern.valkyrie_resource)
+        # don't run validations again on the converted object if they've already passed
+        resource = valkyrie_save(resource: env.curation_concern.valkyrie_resource, valid: env.curation_concern.save)
 
         # we need to manually set the id and reload, because the actor stack requires
         # `env.curation_concern` to be the exact same instance throughout.
@@ -115,9 +116,9 @@ module Hyrax
         attributes.select { |_, v| v.respond_to?(:select) && !v.respond_to?(:read) }
       end
 
-      def valkyrie_save(resource:)
+      def valkyrie_save(resource:, valid:)
         permissions = resource.permission_manager.acl.permissions
-        resource    = Hyrax.persister.save(resource: resource)
+        resource    = Hyrax.persister.save(resource: resource, valid: valid)
 
         resource.permission_manager.acl.permissions = permissions
         resource.permission_manager.acl.save

--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -72,7 +72,7 @@ module Hyrax
         return env.curation_concern.save unless use_valkyrie
 
         # don't run validations again on the converted object if they've already passed
-        resource = valkyrie_save(resource: env.curation_concern.valkyrie_resource, perform_af_validation: !env.curation_concern.save)
+        resource = valkyrie_save(resource: env.curation_concern.valkyrie_resource, is_valid: env.curation_concern.save)
 
         # we need to manually set the id and reload, because the actor stack requires
         # `env.curation_concern` to be the exact same instance throughout.
@@ -116,9 +116,9 @@ module Hyrax
         attributes.select { |_, v| v.respond_to?(:select) && !v.respond_to?(:read) }
       end
 
-      def valkyrie_save(resource:, valid:)
+      def valkyrie_save(resource:, is_valid:)
         permissions = resource.permission_manager.acl.permissions
-        resource    = Hyrax.persister.save(resource: resource, valid: valid)
+        resource    = Hyrax.persister.save(resource: resource, perform_af_validation: !is_valid)
 
         resource.permission_manager.acl.permissions = permissions
         resource.permission_manager.acl.save

--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -72,7 +72,7 @@ module Hyrax
         return env.curation_concern.save unless use_valkyrie
 
         # don't run validations again on the converted object if they've already passed
-        resource = valkyrie_save(resource: env.curation_concern.valkyrie_resource, valid: env.curation_concern.save)
+        resource = valkyrie_save(resource: env.curation_concern.valkyrie_resource, perform_af_validation: !env.curation_concern.save)
 
         # we need to manually set the id and reload, because the actor stack requires
         # `env.curation_concern` to be the exact same instance throughout.

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -182,13 +182,15 @@ module Hyrax
     # @return [#errors]
     def create_valkyrie_work
       form = build_form
-      return after_create_error(form_err_msg(form)) unless form.validate(params[hash_key_for_curation_concern])
+      # fallback to an empty array to avoid: # NoMethodError: undefined method `has_key?' for nil:NilClass
+      original_input_params_for_form = params[hash_key_for_curation_concern] ? params[hash_key_for_curation_concern] : {}
+      return after_create_error(form_err_msg(form), original_input_params_for_form) unless form.validate(original_input_params_for_form)
 
       result =
         transactions['change_set.create_work']
         .with_step_args(
           'work_resource.add_to_parent' => { parent_id: params[:parent_id], user: current_user },
-          'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
+          'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: original_input_params_for_form[:file_set] },
           'change_set.set_user_as_depositor' => { user: current_user },
           'work_resource.change_depositor' => { user: ::User.find_by_user_key(form.on_behalf_of) },
           'work_resource.save_acl' => { permissions_params: form.input_params["permissions"] }

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -180,6 +180,7 @@ module Hyrax
 
     ##
     # @return [#errors]
+    # rubocop:disable Metrics/MethodLength
     def create_valkyrie_work
       form = build_form
       # fallback to an empty array to avoid: # NoMethodError: undefined method `has_key?' for nil:NilClass
@@ -199,6 +200,7 @@ module Hyrax
       @curation_concern = result.value_or { return after_create_error(transaction_err_msg(result)) }
       after_create_response
     end
+    # rubocop:enable Metrics/MethodLength
 
     def update_valkyrie_work
       form = build_form

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -183,7 +183,7 @@ module Hyrax
     # rubocop:disable Metrics/MethodLength
     def create_valkyrie_work
       form = build_form
-      # fallback to an empty array to avoid: # NoMethodError: undefined method `has_key?' for nil:NilClass
+      # fallback to an empty hash to avoid: # NoMethodError: undefined method `has_key?` for nil:NilClass
       original_input_params_for_form = params[hash_key_for_curation_concern] ? params[hash_key_for_curation_concern] : {}
       return after_create_error(form_err_msg(form), original_input_params_for_form) unless form.validate(original_input_params_for_form)
 

--- a/app/forms/hyrax/forms/work_lease_form.rb
+++ b/app/forms/hyrax/forms/work_lease_form.rb
@@ -11,6 +11,7 @@ module Hyrax
     #   +LeasesControllerBehavior+.
     class WorkLeaseForm < Hyrax::ChangeSet
       property :lease, form: Hyrax::Forms::Lease, populator: :lease_populator, prepopulator: :lease_populator
+      property :lease_history, virtual: true, prepopulator: proc { |_opts| self.lease_history = model.lease&.lease_history }
       property :lease_expiration_date, virtual: true, prepopulator: proc { |_opts| self.lease_expiration_date = model.lease&.lease_expiration_date }
       property :visibility_after_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_after_lease = model.lease&.visibility_after_lease }
       property :visibility_during_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_during_lease = model.lease&.visibility_during_lease }

--- a/app/indexers/hyrax/valkyrie_file_set_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_file_set_indexer.rb
@@ -22,6 +22,8 @@ module Hyrax
         solr_doc['hasRelatedMediaFragment_ssim'] = resource.representative_id.to_s
         solr_doc['hasRelatedImage_ssim']         = resource.thumbnail_id.to_s
 
+        index_lease(solr_doc)
+
         # Add in metadata from the original file.
         file_metadata = Hyrax::FileSetFileService.new(file_set: resource).original_file
         return solr_doc unless file_metadata
@@ -115,6 +117,18 @@ module Hyrax
       elsif file.format_label.present?
         file.format_label
       end
+    end
+
+    def index_lease(doc)
+      if resource.lease&.active?
+        doc['lease_expiration_date_dtsi'] = resource.lease.lease_expiration_date&.to_datetime
+        doc['visibility_after_lease_ssim'] = resource.lease.visibility_after_lease
+        doc['visibility_during_lease_ssim'] = resource.lease.visibility_during_lease
+      else
+        doc['lease_history_ssim'] = resource&.lease&.lease_history
+      end
+
+      doc
     end
   end
 end

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -60,6 +60,8 @@ module Hyrax
         doc['lease_expiration_date_dtsi'] = resource.lease.lease_expiration_date&.to_datetime
         doc['visibility_after_lease_ssim'] = resource.lease.visibility_after_lease
         doc['visibility_during_lease_ssim'] = resource.lease.visibility_during_lease
+      else
+        doc['lease_history_ssim'] = resource&.lease&.lease_history
       end
 
       doc

--- a/app/indexers/hyrax/valkyrie_work_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_work_indexer.rb
@@ -53,7 +53,7 @@ module Hyrax
     end
 
     def index_lease(doc)
-      if Hyrax::LeaseManager.new(resource: resource).under_lease?
+      if resource.lease&.active?
         doc['lease_expiration_date_dtsi'] = resource.lease.lease_expiration_date&.to_datetime
         doc['visibility_after_lease_ssim'] = resource.lease.visibility_after_lease
         doc['visibility_during_lease_ssim'] = resource.lease.visibility_during_lease

--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -36,7 +36,7 @@ module Hyrax
 
     attribute :alternate_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID)
     attribute :embargo,       Hyrax::Embargo.optional
-    attribute :lease,         Hyrax::Lease.optional
+    attribute :lease_id, Valkyrie::Types::ID
 
     delegate :edit_groups, :edit_groups=,
              :edit_users,  :edit_users=,
@@ -101,6 +101,17 @@ module Hyrax
 
     def visibility
       visibility_reader.read
+    end
+
+    def lease=(value)
+      raise TypeError "can't convert #{value.class} into Hyrax::Lease" unless value.is_a? Hyrax::Lease
+
+      @lease = value
+      self.lease_id = @lease.id
+    end
+
+    def lease
+      @lease ||= (Hyrax.query_service.find_by(id: lease_id) if lease_id.present?)
     end
 
     protected

--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -123,7 +123,8 @@ module Hyrax
     end
 
     def lease
-      @lease ||= (Hyrax.query_service.find_by(id: lease_id) if lease_id.present?)
+      return @lease if @lease
+      @lease = Hyrax.query_service.find_by(id: lease_id) if lease_id.present?
     end
 
     protected

--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -192,7 +192,7 @@ module Hyrax
     # @raise [RuntimeError] if admin set cannot be persisted
     def create!
       admin_set.creator = [creating_user.user_key] if creating_user
-      updated_admin_set = Hyrax.persister.save(resource: admin_set, perform_af_validation: true).tap do |result|
+      updated_admin_set = Hyrax.persister.save(resource: admin_set).tap do |result|
         if result
           ActiveRecord::Base.transaction do
             permission_template = PermissionTemplate.find_by(source_id: result.id.to_s) ||

--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -192,7 +192,7 @@ module Hyrax
     # @raise [RuntimeError] if admin set cannot be persisted
     def create!
       admin_set.creator = [creating_user.user_key] if creating_user
-      updated_admin_set = Hyrax.persister.save(resource: admin_set).tap do |result|
+      updated_admin_set = Hyrax.persister.save(resource: admin_set, perform_af_validation: true).tap do |result|
         if result
           ActiveRecord::Base.transaction do
             permission_template = PermissionTemplate.find_by(source_id: result.id.to_s) ||

--- a/app/services/hyrax/embargo_manager.rb
+++ b/app/services/hyrax/embargo_manager.rb
@@ -126,13 +126,13 @@ module Hyrax
       embargo_record = embargo_history_message(
         embargo_state,
         Time.zone.today,
-        DateTime.parse(embargo.embargo_release_date),
+        embargo.embargo_release_date,
         embargo.visibility_during_embargo,
         embargo.visibility_after_embargo
       )
 
-      nullify(force: true)
       release(force: true)
+      nullify(force: true)
       embargo.embargo_history += [embargo_record]
     end
 
@@ -180,14 +180,17 @@ module Hyrax
     end
 
     ##
-    # Drop the embargo by setting its release date to `nil`.
+    # Drop the embargo by setting its release date and visibility settings to `nil`.
     #
     # @param force [boolean] force the nullify even when the embargo period is current
     #
     # @return [void]
     def nullify(force: false)
       return false if !force && under_embargo?
+
       embargo.embargo_release_date = nil
+      embargo.visibility_during_embargo = nil
+      embargo.visibility_after_embargo = nil
     end
 
     ##

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -130,7 +130,6 @@ module Hyrax
     def nullify(force: false)
       return false if !force && under_lease?
 
-      # TODO(alishaevn): why isn't this working?
       lease.lease_expiration_date = nil
       lease.visibility_during_lease = nil
       lease.visibility_after_lease = nil

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -86,7 +86,11 @@ module Hyrax
     ##
     # @return [Hyrax::Lease]
     def lease
-      resource.lease || Lease.new
+      if resource[:lease_id].present?
+        Hyrax.query_service.find_by(id: resource[:lease_id])
+      else
+        Hyrax.persister.save(resource: Lease.new)
+      end
     end
 
     ##

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -119,11 +119,7 @@ module Hyrax
     ##
     # @return [Hyrax::Lease]
     def lease
-      if resource[:lease_id].present?
-        Hyrax.query_service.find_by(id: resource[:lease_id])
-      else
-        Hyrax.persister.save(resource: Lease.new)
-      end
+      resource.lease || Lease.new
     end
 
     ##

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -63,8 +63,11 @@ module Hyrax
           .release!
       end
 
+      # Creates or updates an existing lease on a member to match the lease on the parent work
+      # @param [Array<Valkyrie::Resource>] members
+      # @param [Hyrax::Work] work
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      def add_or_update_lease_on_members(members, work)
+      def create_or_update_lease_on_members(members, work)
         # TODO: account for all members and levels, not just file sets. ref: #6131
 
         members.each do |member|

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -77,7 +77,6 @@ module Hyrax
 
       release(force: true)
       nullify(force: true)
-      # TODO(alishaevn): why isn't this working?
       lease.lease_history += [lease_record]
     end
 

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -7,14 +7,14 @@ module Hyrax
   #
   # The lease terminology used here is as follows:
   #
-  #    - "Release Date" is the day an lease is scheduled to be released.
-  #    - "Under Lease" means the lease is "active"; i.e. that its release
+  #    - "Expiration Date" is the day a lease is scheduled to expire.
+  #    - "Under Lease" means the lease is "active"; i.e. that its expiration
   #       date is today or later.
-  #    - "Applied" means the lease's pre-release visibility has been set on
+  #    - "Applied" means the lease's pre-expiration visibility has been set on
   #      the resource.
-  #    - "Released" means the lease's post-release visibility has been set on
+  #    - "Released" means the lease's post-expiration visibility has been set on
   #      the resource.
-  #    - "Enforced" means the object's visibility matches the pre-release
+  #    - "Enforced" means the object's visibility matches the pre-expiration
   #      visibility of the lease; i.e. the lease has been applied,
   #      but not released.
   #    - "Deactivate" means that the existing lease will be removed

--- a/app/services/hyrax/lease_manager.rb
+++ b/app/services/hyrax/lease_manager.rb
@@ -90,7 +90,7 @@ module Hyrax
     def copy_lease_to(target:)
       return false unless under_lease?
 
-      target.lease = Hyrax.persister.save(resource:Lease.new(clone_attributes))
+      target.lease = Hyrax.persister.save(resource: Lease.new(clone_attributes))
       self.class.apply_lease_for(resource: target)
     end
 

--- a/app/views/hyrax/base/_form_permission_lease.html.erb
+++ b/app/views/hyrax/base/_form_permission_lease.html.erb
@@ -1,6 +1,6 @@
 <div class="form-inline">
   <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE) %>
   <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
-  <%= f.input :lease_expiration_date, wrapper: :inline, input_html: { value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker' } %>
+  <%= f.input :lease_expiration_date, wrapper: :inline, input_html: { value: f.object.lease_expiration_date&.to_date || Date.tomorrow, class: 'datepicker' } %>
   <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
 </div>

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -39,7 +39,7 @@
               <div class="form-inline">
                 <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
                 <%= t('hyrax.works.form.visibility_until') %>
-                <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date&.to_date || Date.tomorrow, class: 'datepicker form-control' %>
                 <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
               </div>
             </div>
@@ -55,7 +55,7 @@
               <div class="form-inline">
                 <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
                 <%= t('hyrax.works.form.visibility_until') %>
-                <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date&.to_date || Date.tomorrow, class: 'datepicker form-control' %>
                 <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
               </div>
             </div>

--- a/lib/hyrax/transactions/steps/add_file_sets.rb
+++ b/lib/hyrax/transactions/steps/add_file_sets.rb
@@ -30,7 +30,7 @@ module Hyrax
                 Hyrax.query_service.find_by(id: member) if Hyrax.query_service.find_by(id: member).is_a? Hyrax::FileSet
               end
 
-              Hyrax::LeaseManager.add_or_update_lease_on_members(file_sets, obj)
+              Hyrax::LeaseManager.create_or_update_lease_on_members(file_sets, obj)
             end
 
             Success(obj)

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -29,6 +29,7 @@ module Hyrax
         # @return [Dry::Monads::Result] `Success(work)` if the change_set is
         #   applied and the resource is saved;
         #   `Failure([#to_s, change_set.resource])`, otherwise.
+        # rubocop:disable Metrics/MethodLength
         def call(change_set, user: nil)
           begin
             valid_future_date?(change_set.lease, 'lease_expiration_date') if change_set.lease
@@ -51,13 +52,13 @@ module Hyrax
           publish_changes(resource: saved, user: user, new: unsaved.new_record, new_collections: new_collections)
           Success(saved)
         end
+        # rubocop:disable Metrics/MethodLength
 
         def valid_future_date?(item, attribute)
-          raise StandardError.new 'Must be a future date' if item.fields[attribute] < Time.zone.now
+          raise StandardError, "#{item.model} must use a future date" if item.fields[attribute] < Time.zone.now
         end
 
         def save_leases_and_embargoes(unsaved)
-          binding.pry
           if unsaved.embargo.present?
             unsaved.embargo.embargo_release_date = unsaved.embargo.embargo_release_date&.to_datetime
             unsaved.embargo = @persister.save(resource: unsaved.embargo)

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -33,6 +33,7 @@ module Hyrax
           begin
             new_collections = changed_collection_membership(change_set)
             unsaved = change_set.sync
+            unsaved.lease = @persister.save(resource: unsaved.lease) if unsaved.lease.present?
             saved = @persister.save(resource: unsaved)
           rescue StandardError => err
             return Failure(["Failed save on #{change_set}\n\t#{err.message}", change_set.resource])

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -39,7 +39,7 @@ module Hyrax
               unsaved.embargo = @persister.save(resource: unsaved.embargo)
             end
             if unsaved.lease.present?
-              unsaved.lease.lease_release_date = unsaved.lease.lease_release_date&.to_datetime
+              unsaved.lease.lease_expiration_date = unsaved.lease.lease_expiration_date&.to_datetime
               unsaved.lease = @persister.save(resource: unsaved.lease)
             end
             saved = @persister.save(resource: unsaved)

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -93,7 +93,6 @@ module Hyrax
             else
               work_lease_manager = Hyrax::LeaseManager.new(resource: change_set.model)
               work_lease_manager.copy_lease_to(target: item)
-              # confirm tomorrow if the assignment below is in fact useless
               item = Hyrax.persister.save(resource: item) # rubocop:disable Lint/UselessAssignment
             end
 

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -75,7 +75,7 @@ module Hyrax
           unsaved.lease = @persister.save(resource: unsaved.lease)
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         def add_lease_to_members(change_set)
           # TODO: account for all members and levels, ref: #6131
           # use recursion to ensure the change_set that applies to the member is getting saved and published/indexed
@@ -103,7 +103,7 @@ module Hyrax
             @publisher.publish('object.metadata.updated', object: item, user: user)
           end
         end
-        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
         ##
         # @param [Hyrax::ChangeSet] change_set

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -34,10 +34,13 @@ module Hyrax
           begin
             new_collections = changed_collection_membership(change_set)
             unsaved = change_set.sync
-            unsaved.lease = @persister.save(resource: unsaved.lease) if unsaved.lease.present?
             if unsaved.embargo.present?
               unsaved.embargo.embargo_release_date = unsaved.embargo.embargo_release_date&.to_datetime
               unsaved.embargo = @persister.save(resource: unsaved.embargo)
+            end
+            if unsaved.lease.present?
+              unsaved.lease.lease_release_date = unsaved.lease.lease_release_date&.to_datetime
+              unsaved.lease = @persister.save(resource: unsaved.lease)
             end
             saved = @persister.save(resource: unsaved)
           rescue StandardError => err

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -32,8 +32,8 @@ module Hyrax
         # rubocop:disable Metrics/MethodLength
         def call(change_set, user: nil)
           begin
-            valid_future_date?(change_set.lease, 'lease_expiration_date') if change_set.lease
-            valid_future_date?(change_set.embargo, 'embargo_release_date') if change_set.embargo
+            valid_future_date?(change_set.lease, 'lease_expiration_date') if change_set.respond_to?(:lease) && change_set.lease
+            valid_future_date?(change_set.embargo, 'embargo_release_date') if change_set.respond_to?(:embargo) && change_set.embargo
             new_collections = changed_collection_membership(change_set)
             unsaved = change_set.sync
             save_leases_and_embargoes(unsaved)

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -141,6 +141,11 @@ module Wings
         members = Array.wrap(converted_attrs.delete(:members))
         files = converted_attrs.delete(:files)
         af_object.attributes = converted_attrs
+        # af_object.lease.class has the same name as resource.lease.class; however, each class has a different object_id
+        # so a type mismatch happens. the code below coerces the one object into the other
+        # TODO(alishaevn): fix this!
+        resource_lease = af_object.reflections.fetch(:lease).klass.new(resource.lease.attributes.except(:internal_resource, :created_at, :updated_at, :new_record))
+        af_object.lease = resource_lease
         members.empty? ? af_object.try(:ordered_members)&.clear : af_object.try(:ordered_members=, members)
         af_object.try(:members)&.replace(members)
         af_object.files.build_or_set(files) if files

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -130,7 +130,6 @@ module Wings
 
     ##
     # apply attributes to the ActiveFedora model
-    # rubocop:disable Metrics/MethodLength
     def apply_attributes_to_model(af_object)
       case af_object
       when Hydra::AccessControl
@@ -147,7 +146,6 @@ module Wings
         af_object.files.build_or_set(files) if files
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     # Add attributes from resource which aren't AF properties into af_object
     def add_access_control_attributes(af_object)

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -146,8 +146,8 @@ module Wings
           # af_object.lease.class has the same name as resource.lease.class; however, each class has a different object_id
           # so a type mismatch happens. the code below coerces the one object into the other
           # TODO(alishaevn): fix this!
-          resource_lease = af_object.reflections.fetch(:lease).klass.new(resource.lease.attributes.except(:internal_resource, :created_at, :updated_at, :new_record))
-          af_object.lease = resource_lease
+          resource_lease_dup = af_object.reflections.fetch(:lease).klass.new(resource.lease.attributes.except(:id, :internal_resource, :created_at, :updated_at, :new_record))
+          af_object.lease = resource_lease_dup
         end
         members.empty? ? af_object.try(:ordered_members)&.clear : af_object.try(:ordered_members=, members)
         af_object.try(:members)&.replace(members)

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -141,11 +141,13 @@ module Wings
         members = Array.wrap(converted_attrs.delete(:members))
         files = converted_attrs.delete(:files)
         af_object.attributes = converted_attrs
-        # af_object.lease.class has the same name as resource.lease.class; however, each class has a different object_id
-        # so a type mismatch happens. the code below coerces the one object into the other
-        # TODO(alishaevn): fix this!
-        resource_lease = af_object.reflections.fetch(:lease).klass.new(resource.lease.attributes.except(:internal_resource, :created_at, :updated_at, :new_record))
-        af_object.lease = resource_lease
+        if af_object.reflections.respond_to?(:lease)
+          # af_object.lease.class has the same name as resource.lease.class; however, each class has a different object_id
+          # so a type mismatch happens. the code below coerces the one object into the other
+          # TODO(alishaevn): fix this!
+          resource_lease = af_object.reflections.fetch(:lease).klass.new(resource.lease.attributes.except(:internal_resource, :created_at, :updated_at, :new_record))
+          af_object.lease = resource_lease
+        end
         members.empty? ? af_object.try(:ordered_members)&.clear : af_object.try(:ordered_members=, members)
         af_object.try(:members)&.replace(members)
         af_object.files.build_or_set(files) if files

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -142,7 +142,7 @@ module Wings
         members = Array.wrap(converted_attrs.delete(:members))
         files = converted_attrs.delete(:files)
         af_object.attributes = converted_attrs
-        if af_object.reflections.include?(:lease) && resource.lease
+        if resource.try(:lease) && af_object.reflections.include?(:lease)
           # af_object.lease.class has the same name as resource.lease.class; however, each class has a different object_id
           # so a type mismatch happens. the code below coerces the one object into the other
           # TODO(alishaevn): fix this!

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -142,13 +142,6 @@ module Wings
         members = Array.wrap(converted_attrs.delete(:members))
         files = converted_attrs.delete(:files)
         af_object.attributes = converted_attrs
-        if resource.try(:lease) && af_object.reflections.include?(:lease)
-          # NOTE: af_object.lease.class has the same name as resource.lease.class; however, each class has a different object_id
-          # so a type mismatch happens. the code below coerces the one object into the other
-          # ref: #6134
-          resource_lease_dup = af_object.reflections.fetch(:lease).klass.new(resource.lease.attributes.except(:id, :internal_resource, :created_at, :updated_at, :new_record))
-          af_object.lease = resource_lease_dup
-        end
         members.empty? ? af_object.try(:ordered_members)&.clear : af_object.try(:ordered_members=, members)
         af_object.try(:members)&.replace(members)
         af_object.files.build_or_set(files) if files

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -142,7 +142,7 @@ module Wings
         members = Array.wrap(converted_attrs.delete(:members))
         files = converted_attrs.delete(:files)
         af_object.attributes = converted_attrs
-        if af_object.reflections.respond_to?(:lease)
+        if af_object.reflections.include?(:lease)
           # af_object.lease.class has the same name as resource.lease.class; however, each class has a different object_id
           # so a type mismatch happens. the code below coerces the one object into the other
           # TODO(alishaevn): fix this!

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -142,7 +142,7 @@ module Wings
         members = Array.wrap(converted_attrs.delete(:members))
         files = converted_attrs.delete(:files)
         af_object.attributes = converted_attrs
-        if af_object.reflections.include?(:lease)
+        if af_object.reflections.include?(:lease) && resource.lease
           # af_object.lease.class has the same name as resource.lease.class; however, each class has a different object_id
           # so a type mismatch happens. the code below coerces the one object into the other
           # TODO(alishaevn): fix this!

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -130,6 +130,7 @@ module Wings
 
     ##
     # apply attributes to the ActiveFedora model
+    # rubocop:disable Metrics/MethodLength
     def apply_attributes_to_model(af_object)
       case af_object
       when Hydra::AccessControl
@@ -153,6 +154,7 @@ module Wings
         af_object.files.build_or_set(files) if files
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     # Add attributes from resource which aren't AF properties into af_object
     def add_access_control_attributes(af_object)

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -143,9 +143,9 @@ module Wings
         files = converted_attrs.delete(:files)
         af_object.attributes = converted_attrs
         if resource.try(:lease) && af_object.reflections.include?(:lease)
-          # af_object.lease.class has the same name as resource.lease.class; however, each class has a different object_id
+          # NOTE: af_object.lease.class has the same name as resource.lease.class; however, each class has a different object_id
           # so a type mismatch happens. the code below coerces the one object into the other
-          # TODO(alishaevn): fix this!
+          # ref: #6134
           resource_lease_dup = af_object.reflections.fetch(:lease).klass.new(resource.lease.attributes.except(:id, :internal_resource, :created_at, :updated_at, :new_record))
           af_object.lease = resource_lease_dup
         end

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -160,7 +160,6 @@ module Wings
     def append_embargo(attrs)
       return unless pcdm_object.try(:embargo)
       embargo_attrs = pcdm_object.embargo.attributes.symbolize_keys
-      embargo_attrs[:embargo_history] = embargo_attrs[:embargo_history].to_a
       embargo_attrs[:id] = ::Valkyrie::ID.new(embargo_attrs[:id]) if embargo_attrs[:id]
 
       attrs[:embargo] = Hyrax::Embargo.new(**embargo_attrs)
@@ -169,7 +168,6 @@ module Wings
     def append_lease(attrs)
       return unless pcdm_object.try(:lease)
       lease_attrs = pcdm_object.lease.attributes.symbolize_keys
-      lease_attrs[:lease_history] = lease_attrs[:embargo_history].to_a
       lease_attrs[:id] = ::Valkyrie::ID.new(lease_attrs[:id]) if lease_attrs[:id]
 
       attrs[:lease] = Hyrax::Lease.new(**lease_attrs)

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -34,7 +34,7 @@ module Wings
     #
     # @param pcdm_object [ActiveFedora::Base]
     #
-    # @return [::Valkyrie::Resource] a resource mirroiring `pcdm_object`
+    # @return [::Valkyrie::Resource] a resource mirroring `pcdm_object`
     def self.for(pcdm_object)
       new(pcdm_object: pcdm_object).build
     end
@@ -53,7 +53,10 @@ module Wings
       attrs = attributes.tap { |hash| hash[:new_record] = pcdm_object.new_record? }
       attrs[:alternate_ids] = [::Valkyrie::ID.new(pcdm_object.id)] if pcdm_object.id
 
-      klass.new(**attrs).tap { |resource| ensure_current_permissions(resource) }
+      klass.new(**attrs).tap do |resource|
+        resource.lease = pcdm_object.lease&.valkyrie_resource if pcdm_object.respond_to?(:lease)
+        ensure_current_permissions(resource)
+      end
     end
 
     def ensure_current_permissions(resource)

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -43,6 +43,7 @@ module Wings
     # Builds a `Valkyrie::Resource` equivalent to the `pcdm_object`
     #
     # @return [::Valkyrie::Resource] a resource mirroring `pcdm_object`
+    # rubocop:disable Metrics/AbcSize
     def build
       klass = cache.fetch(pcdm_object.class) do
         OrmConverter.to_valkyrie_resource_class(klass: pcdm_object.class)
@@ -57,6 +58,7 @@ module Wings
         resource.lease = pcdm_object.lease&.valkyrie_resource if pcdm_object.respond_to?(:lease) && pcdm_object.lease
         ensure_current_permissions(resource)
       end
+      # rubocop:enable Metrics/AbcSize
     end
 
     def ensure_current_permissions(resource)

--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -54,7 +54,7 @@ module Wings
       attrs[:alternate_ids] = [::Valkyrie::ID.new(pcdm_object.id)] if pcdm_object.id
 
       klass.new(**attrs).tap do |resource|
-        resource.lease = pcdm_object.lease&.valkyrie_resource if pcdm_object.respond_to?(:lease)
+        resource.lease = pcdm_object.lease&.valkyrie_resource if pcdm_object.respond_to?(:lease) && pcdm_object.lease
         ensure_current_permissions(resource)
       end
     end

--- a/lib/wings/valkyrie/persister.rb
+++ b/lib/wings/valkyrie/persister.rb
@@ -22,8 +22,9 @@ module Wings
 
       # Persists a resource using ActiveFedora
       # @param [Valkyrie::Resource] resource
+      # @param [Boolean] perform_af_validation
       # @return [Valkyrie::Resource] the persisted/updated resource
-      def save(resource:, valid: true)
+      def save(resource:, perform_af_validation: false)
         af_object = resource_factory.from_resource(resource: resource)
 
         check_lock_tokens(af_object: af_object, resource: resource)
@@ -32,7 +33,7 @@ module Wings
         # if we get a falsey response, we expect we have a File that has failed to save due
         # to empty content
         # we disable validation on the Active Fedora object, only if validations have already been run and passed
-        af_object.save!(validate: !valid) ||
+        af_object.save!(validate: perform_af_validation) ||
           raise(FailedSaveError.new("#{af_object.class}#save! returned non-true. It might be missing required content.", obj: af_object))
 
         resource_factory.to_resource(object: af_object)

--- a/lib/wings/valkyrie/persister.rb
+++ b/lib/wings/valkyrie/persister.rb
@@ -31,7 +31,9 @@ module Wings
         # the #save! api differs between ActiveFedora::Base and ActiveFedora::File objects,
         # if we get a falsey response, we expect we have a File that has failed to save due
         # to empty content
-        af_object.save! ||
+        # we disable validation on the Active Fedora object
+        # because we've already done validation as a Valkyrie object
+        af_object.save!(validate: false) ||
           raise(FailedSaveError.new("#{af_object.class}#save! returned non-true. It might be missing required content.", obj: af_object))
 
         resource_factory.to_resource(object: af_object)

--- a/lib/wings/valkyrie/persister.rb
+++ b/lib/wings/valkyrie/persister.rb
@@ -23,7 +23,7 @@ module Wings
       # Persists a resource using ActiveFedora
       # @param [Valkyrie::Resource] resource
       # @return [Valkyrie::Resource] the persisted/updated resource
-      def save(resource:)
+      def save(resource:, valid: true)
         af_object = resource_factory.from_resource(resource: resource)
 
         check_lock_tokens(af_object: af_object, resource: resource)
@@ -31,9 +31,8 @@ module Wings
         # the #save! api differs between ActiveFedora::Base and ActiveFedora::File objects,
         # if we get a falsey response, we expect we have a File that has failed to save due
         # to empty content
-        # we disable validation on the Active Fedora object
-        # because we've already done validation as a Valkyrie object
-        af_object.save!(validate: false) ||
+        # we disable validation on the Active Fedora object, only if validations have already been run and passed
+        af_object.save!(validate: !valid) ||
           raise(FailedSaveError.new("#{af_object.class}#save! returned non-true. It might be missing required content.", obj: af_object))
 
         resource_factory.to_resource(object: af_object)

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Actors::CollectionsMembershipActor, skip: !(Hyrax.config.collection_class < ActiveFedora::Base) do
+RSpec.describe Hyrax::Actors::CollectionsMembershipActor, skip: (!(Hyrax.config.collection_class < ActiveFedora::Base) || Hyrax.config.use_valkyrie?) do
   let(:user) { create(:user) }
   let(:ability) { ::Ability.new(user) }
   let(:curation_concern) { build(:work, user: user) }

--- a/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
+++ b/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
+RSpec.describe Hyrax::Actors::InterpretVisibilityActor, unless: Hyrax.config.use_valkyrie? do
   let(:user) { create(:user) }
   let(:ability) { ::Ability.new(user) }
   let(:curation_concern) { GenericWork.new }

--- a/spec/actors/hyrax/actors/lease_actor_spec.rb
+++ b/spec/actors/hyrax/actors/lease_actor_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Hyrax::Actors::LeaseActor do
 
   describe "#destroy" do
     let(:work) do
-      FactoryBot.valkyrie_create(:hyrax_resource, :under_lease)
+      FactoryBot.valkyrie_create(:hyrax_resource, :lease: lease)
     end
+    let(:lease) { FactoryBot.create(:hyrax_lease) }
 
     before do
       work.visibility = public_vis
@@ -33,12 +34,12 @@ RSpec.describe Hyrax::Actors::LeaseActor do
         FactoryBot.valkyrie_create(:hyrax_resource, lease: lease)
       end
 
-      let(:lease) { FactoryBot.build(:hyrax_lease) }
+      let(:lease) { FactoryBot.create(:hyrax_lease) }
 
       before do
         allow(Hyrax::TimeService)
           .to receive(:time_in_utc)
-          .and_return(work.lease.lease_expiration_date + 1)
+          .and_return(work.lease.lease_expiration_date.to_datetime + 1)
       end
 
       it "leaves the lease in place" do

--- a/spec/actors/hyrax/actors/lease_actor_spec.rb
+++ b/spec/actors/hyrax/actors/lease_actor_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::Actors::LeaseActor do
 
   describe "#destroy" do
     let(:work) do
-      FactoryBot.valkyrie_create(:hyrax_resource, :lease: lease)
+      FactoryBot.valkyrie_create(:hyrax_resource, lease: lease)
     end
     let(:lease) { FactoryBot.create(:hyrax_lease) }
 

--- a/spec/controllers/hyrax/generic_works_controller_json_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_json_spec.rb
@@ -56,8 +56,13 @@ RSpec.describe Hyrax::GenericWorksController do
     describe 'failed create', :clean_repo do
       before { post :create, params: { generic_work: {}, format: :json } }
       it "returns 422 and the errors" do
-        created_resource = assigns[:curation_concern]
-        expect(response).to respond_unprocessable_entity(errors: created_resource.errors.messages.as_json)
+        resource = assigns[:curation_concern].respond_to?(:errors) ? assigns[:curation_concern] : assigns[:form]
+
+        expect(response.code).to eq "422"
+
+        # TODO: adjust Hyrax::WorksControllerBehavior#form_err_msg to return the same type of message that Hyrax::WorksControllerBehavior#create does
+        # so that the below expectation applies
+        # expect(response).to respond_unprocessable_entity(errors: resource.errors.messages.as_json)
       end
     end
 

--- a/spec/controllers/hyrax/generic_works_controller_json_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_json_spec.rb
@@ -56,11 +56,10 @@ RSpec.describe Hyrax::GenericWorksController do
     describe 'failed create', :clean_repo do
       before { post :create, params: { generic_work: {}, format: :json } }
       it "returns 422 and the errors" do
-        resource = assigns[:curation_concern].respond_to?(:errors) ? assigns[:curation_concern] : assigns[:form]
-
         expect(response.code).to eq "422"
 
         # TODO: adjust Hyrax::WorksControllerBehavior#form_err_msg to return the same type of message that Hyrax::WorksControllerBehavior#create does
+        # resource = assigns[:curation_concern].respond_to?(:errors) ? assigns[:curation_concern] : assigns[:form]
         # so that the below expectation applies
         # expect(response).to respond_unprocessable_entity(errors: resource.errors.messages.as_json)
       end

--- a/spec/controllers/hyrax/generic_works_controller_json_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_json_spec.rb
@@ -55,13 +55,14 @@ RSpec.describe Hyrax::GenericWorksController do
     # The clean is here because this test depends on the repo not having an AdminSet/PermissionTemplate created yet
     describe 'failed create', :clean_repo do
       before { post :create, params: { generic_work: {}, format: :json } }
-      it "returns 422 and the errors" do
-        expect(response.code).to eq "422"
 
-        # TODO: adjust Hyrax::WorksControllerBehavior#form_err_msg to return the same type of message that Hyrax::WorksControllerBehavior#create does
-        # resource = assigns[:curation_concern].respond_to?(:errors) ? assigns[:curation_concern] : assigns[:form]
-        # so that the below expectation applies
-        # expect(response).to respond_unprocessable_entity(errors: resource.errors.messages.as_json)
+      it 'returns 422 and the errors' do
+        # NOTE: this passes in all four 2.7/valkyrie and 3.2/valkyrie pipelines, but does not pass locally in koppie
+        # because Hyrax::WorksControllerBehavior#form_err_msg doesn't return the same type of message that
+        # Hyrax::WorksControllerBehavior#create does
+        resource = assigns[:curation_concern].respond_to?(:errors) ? assigns[:curation_concern] : assigns[:form]
+        expect(response.code).to eq '422'
+        expect(response).to respond_unprocessable_entity(errors: resource.errors.messages.as_json)
       end
     end
 

--- a/spec/factories/hyrax_lease.rb
+++ b/spec/factories/hyrax_lease.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :hyrax_lease, class: "Hyrax::Lease" do
-    lease_expiration_date   { Time.zone.today + 10 }
+    lease_expiration_date   { (Time.zone.today + 10).to_s }
     visibility_after_lease  { 'authenticated' }
     visibility_during_lease { 'open' }
 
     to_create do |instance|
-      Valkyrie.config.metadata_adapter.persister.save(resource: instance)
+      saved_instance = Valkyrie.config.metadata_adapter.persister.save(resource: instance)
+      instance.id = saved_instance.id
+      saved_instance
     end
 
     trait :expired do

--- a/spec/factories/hyrax_lease.rb
+++ b/spec/factories/hyrax_lease.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     end
 
     trait :expired do
-      lease_expiration_date { (Time.zone.today - 1).to_datetime }
+      lease_expiration_date { (Time.zone.today - 2).to_datetime }
     end
   end
 end

--- a/spec/factories/hyrax_lease.rb
+++ b/spec/factories/hyrax_lease.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :hyrax_lease, class: "Hyrax::Lease" do
-    lease_expiration_date   { Time.zone.today + 10 }
+    lease_expiration_date   { (Time.zone.today + 10).to_datetime }
     visibility_after_lease  { 'authenticated' }
     visibility_during_lease { 'open' }
 
@@ -12,7 +12,7 @@ FactoryBot.define do
     end
 
     trait :expired do
-      lease_expiration_date { Time.zone.today - 1 }
+      lease_expiration_date { (Time.zone.today - 1).to_datetime }
     end
   end
 end

--- a/spec/factories/hyrax_lease.rb
+++ b/spec/factories/hyrax_lease.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :hyrax_lease, class: "Hyrax::Lease" do
-    lease_expiration_date   { (Time.zone.today + 10).to_s }
+    lease_expiration_date   { Time.zone.today + 10 }
     visibility_after_lease  { 'authenticated' }
     visibility_during_lease { 'open' }
 

--- a/spec/factories/hyrax_resource.rb
+++ b/spec/factories/hyrax_resource.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     end
 
     trait :under_lease do
-      association :lease, factory: :hyrax_lease
+      lease_id { FactoryBot.create(:hyrax_lease).id }
     end
   end
 end

--- a/spec/features/lease_spec.rb
+++ b/spec/features/lease_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe 'leases' do
     sign_in user
   end
   describe 'create a new leased object' do
-    let(:future_date) { 5.days.from_now }
-    let(:later_future_date) { 10.days.from_now }
+    let(:future_date) { Time.zone.today + 5 }
+    let(:later_future_date) { Time.zone.today + 10 }
 
     it 'can be created, displayed and updated', :clean_repo, :workflow do
       visit '/concern/generic_works/new'
@@ -19,18 +19,18 @@ RSpec.describe 'leases' do
       click_button 'Save'
 
       # chosen lease date is on the show page
-      expect(page).to have_content(future_date.to_date.to_formatted_s(:standard))
+      expect(page).to have_content(future_date.to_formatted_s(:standard))
 
       click_link 'Edit'
       click_link 'Lease Management Page'
 
       expect(page).to have_content('This Generic Work is under lease.')
-      expect(page).to have_xpath("//input[@name='generic_work[lease_expiration_date]' and @value='#{future_date.to_datetime.iso8601}']") # current lease date is pre-populated in edit field
+      expect(page).to have_xpath("//input[@name='generic_work[lease_expiration_date]' and @value='#{future_date}']") # current lease date is pre-populated in edit field
 
       fill_in 'until', with: later_future_date.to_s
 
       click_button 'Update Lease'
-      expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard)) # new lease date is displayed in message
+      expect(page).to have_content(later_future_date.to_formatted_s(:standard)) # new lease date is displayed in message
 
       click_link 'Edit'
       fill_in 'Title', with: 'Lease test CHANGED'

--- a/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::ValkyrieFileSetIndexer do
+RSpec.describe Hyrax::ValkyrieFileSetIndexer, if: Hyrax.config.use_valkyrie? do
   include Hyrax::FactoryHelpers
 
   let(:fileset_id) { 'fs1' }
@@ -266,6 +266,31 @@ RSpec.describe Hyrax::ValkyrieFileSetIndexer do
         allow(mock_file).to receive(:format_label).and_return(['Portable Network Graphics'])
       end
       it { is_expected.to eq ['Portable Network Graphics'] }
+    end
+  end
+
+  describe '#index_lease' do
+    before do
+      allow(file_set).to receive(:lease).and_return(lease)
+    end
+
+    context 'with a valid lease' do
+      let(:lease) { FactoryBot.create(:hyrax_lease) }
+
+      xit 'sets the lease expiration date and visibility settings' do
+        # wip
+
+        expect(subject['lease_expiration_date_dtsi']).to eq lease.lease_expiration_date
+        expect(subject['visibility_after_lease_ssim']).to eq lease.lease_expiration_date
+        expect(subject['visibility_during_lease_ssim']).to eq lease.lease_expiration_date
+      end
+    end
+
+    context 'with an expired lease' do
+      let(:lease) { FactoryBot.create(:hyrax_lease, :expired) }
+
+      xit 'sets the lease expiration date and visibility settings' do
+      end
     end
   end
 end

--- a/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
@@ -239,6 +239,32 @@ RSpec.describe Hyrax::ValkyrieFileSetIndexer, if: Hyrax.config.use_valkyrie? do
         expect(subject['original_file_id_ssi']).to eq "#{file_set.id}/files/#{file_set.original_file_id}"
       end
     end
+
+    context 'with a valid lease' do
+      let(:lease) { FactoryBot.create(:hyrax_lease) }
+
+      before { allow(file_set).to receive(:lease_id).and_return(lease.id) }
+
+      it 'sets the lease expiration date and visibility settings' do
+        expect(subject['lease_expiration_date_dtsi']).to eq lease.lease_expiration_date
+        expect(subject['visibility_after_lease_ssim']).to eq lease.visibility_after_lease
+        expect(subject['visibility_during_lease_ssim']).to eq lease.visibility_during_lease
+        expect(subject['lease_history_ssim']).to be nil
+      end
+    end
+
+    context 'with an expired lease' do
+      let(:lease) { FactoryBot.create(:hyrax_lease, :expired) }
+
+      before { allow(file_set).to receive(:lease_id).and_return(lease.id) }
+
+      it 'sets the lease expiration date and visibility settings' do
+        expect(subject['lease_expiration_date_dtsi']).to be nil
+        expect(subject['visibility_after_lease_ssim']).to be nil
+        expect(subject['visibility_during_lease_ssim']).to be nil
+        expect(subject['lease_history_ssim']).to eq lease.lease_history
+      end
+    end
   end
 
   describe '#file_format' do
@@ -266,31 +292,6 @@ RSpec.describe Hyrax::ValkyrieFileSetIndexer, if: Hyrax.config.use_valkyrie? do
         allow(mock_file).to receive(:format_label).and_return(['Portable Network Graphics'])
       end
       it { is_expected.to eq ['Portable Network Graphics'] }
-    end
-  end
-
-  describe '#index_lease' do
-    before do
-      allow(file_set).to receive(:lease).and_return(lease)
-    end
-
-    context 'with a valid lease' do
-      let(:lease) { FactoryBot.create(:hyrax_lease) }
-
-      xit 'sets the lease expiration date and visibility settings' do
-        # wip
-
-        expect(subject['lease_expiration_date_dtsi']).to eq lease.lease_expiration_date
-        expect(subject['visibility_after_lease_ssim']).to eq lease.lease_expiration_date
-        expect(subject['visibility_during_lease_ssim']).to eq lease.lease_expiration_date
-      end
-    end
-
-    context 'with an expired lease' do
-      let(:lease) { FactoryBot.create(:hyrax_lease, :expired) }
-
-      xit 'sets the lease expiration date and visibility settings' do
-      end
     end
   end
 end

--- a/spec/models/hyrax/resource_spec.rb
+++ b/spec/models/hyrax/resource_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe Hyrax::Resource do
     subject(:resource) { described_class.new(lease: lease) }
     let(:lease)        { FactoryBot.build(:hyrax_lease) }
 
-    it 'saves the lease' do
+    it 'saves the lease id' do
+      resource.lease = Hyrax.persister.save(resource: lease)
+
       expect(Hyrax.persister.save(resource: resource).lease)
         .to have_attributes(lease_expiration_date: lease.lease_expiration_date)
     end

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -292,7 +292,8 @@ RSpec.describe Hyrax::AdminSetCreateService do
         let(:admin_set) { FactoryBot.build(:invalid_hyrax_admin_set) } # Missing title
 
         it 'will not call the workflow_importer' do
-          expect { service.create! }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { service.create! }.to raise_error(RuntimeError)
+          expect(workflow_importer).not_to have_received(:call)
         end
       end
     end

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -291,9 +291,8 @@ RSpec.describe Hyrax::AdminSetCreateService do
       context "when the admin_set is invalid" do
         let(:admin_set) { FactoryBot.build(:invalid_hyrax_admin_set) } # Missing title
 
-        it 'will not call the workflow_importer' do
-          expect { service.create! }.to raise_error(RuntimeError)
-          expect(workflow_importer).not_to have_received(:call)
+        it 'will not find the sipity workflow' do
+          expect { service.create! }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -292,8 +292,7 @@ RSpec.describe Hyrax::AdminSetCreateService do
         let(:admin_set) { FactoryBot.build(:invalid_hyrax_admin_set) } # Missing title
 
         it 'will not call the workflow_importer' do
-          expect { service.create! }.to raise_error(RuntimeError)
-          expect(workflow_importer).not_to have_received(:call)
+          expect { service.create! }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end

--- a/spec/services/hyrax/lease_manager_spec.rb
+++ b/spec/services/hyrax/lease_manager_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Hyrax::LeaseManager do
         expect(manager.lease)
           .to have_attributes visibility_after_lease: 'authenticated',
                               visibility_during_lease: 'open',
-                              lease_expiration_date: an_instance_of(String),
+                              lease_expiration_date: an_instance_of(DateTime),
                               lease_history: be_empty
       end
     end

--- a/spec/services/hyrax/lease_manager_spec.rb
+++ b/spec/services/hyrax/lease_manager_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::LeaseManager do
 
   shared_context 'with expired lease' do
     let(:resource) { FactoryBot.build(:hyrax_resource, lease: lease) }
-    let(:lease)    { FactoryBot.build(:hyrax_lease, :expired) }
+    let(:lease)    { FactoryBot.create(:hyrax_lease, :expired) }
   end
 
   describe '#apply' do
@@ -90,7 +90,7 @@ RSpec.describe Hyrax::LeaseManager do
         expect(manager.lease)
           .to have_attributes visibility_after_lease: 'authenticated',
                               visibility_during_lease: 'open',
-                              lease_expiration_date: an_instance_of(Date),
+                              lease_expiration_date: an_instance_of(String),
                               lease_history: be_empty
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -149,6 +149,8 @@ RSpec.configure do |config|
     User.group_service = TestHydraGroupService.new
     # Set a geonames username; doesn't need to be real.
     Hyrax.config.geonames_username = 'hyrax-test'
+    # Initialize query_service class attribute by calling to avoid it sometimes being set to test_adapter
+    Hyrax::SolrQueryService.query_service
     # disable analytics except for specs which will have proper api mocks
   end
 

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -363,9 +363,7 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       let(:work) { FactoryBot.create(:leased_work) }
 
       it 'repopulates the lease' do
-        # the lease does get recreated on the converted item, but with a new id
-        # otherwise, it throws: "Attempting to recreate existing ldp_source"
-        expect(converter.convert).not_to have_attributes(lease_id: work.lease_id)
+        expect(converter.convert).to have_attributes(lease_id: work.lease_id)
       end
     end
 

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
         expect(work.errors.full_messages).to eq(converted_work.errors.full_messages)
       end
     end
-    context 'with an invalid FileSet object' do
+    context 'with an invalid FileSet object', unless: Hyrax.config.use_valkyrie? do
+      # valkyrie backed resources do not respond to `valid?`.
       it 'round trip converts to an FileSet object this is also invalid' do
         file_set = ::FileSet.new(lease_expiration_date: 1.day.ago)
         expect(file_set).not_to be_valid

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -33,10 +33,17 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
         expect(work.errors.full_messages).to eq(converted_work.errors.full_messages)
       end
     end
+
     context 'with an invalid FileSet object', unless: Hyrax.config.use_valkyrie? do
       # valkyrie backed resources do not respond to `valid?`.
+      let(:expired_lease) { Hydra::AccessControls::Lease.new(lease_expiration_date: (Time.zone.today - 2).to_datetime) }
+      let(:file_set) { ::FileSet.new }
+
+      before do
+        allow(file_set).to receive(:lease).and_return(expired_lease)
+      end
+
       it 'round trip converts to an FileSet object this is also invalid' do
-        file_set = ::FileSet.new(lease_expiration_date: 1.day.ago)
         expect(file_set).not_to be_valid
         converted_file_set = described_class.new(resource: file_set.valkyrie_resource).convert
         expect(converted_file_set).not_to be_valid

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -363,7 +363,9 @@ RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
       let(:work) { FactoryBot.create(:leased_work) }
 
       it 'repopulates the lease' do
-        expect(converter.convert).to have_attributes(lease_id: work.lease_id)
+        # the lease does get recreated on the converted item, but with a new id
+        # otherwise, it throws: "Attempting to recreate existing ldp_source"
+        expect(converter.convert).not_to have_attributes(lease_id: work.lease_id)
       end
     end
 


### PR DESCRIPTION
### Fixes
- #6126

### Summary
fix deactivating leases in koppie

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* create a work, or update a work, to have a lease in the future
* go to the "/leases" endpoint
* click the name of the work
* select "deactivate"
* be taken back to the work show page and notice the lease is removed

### Detailed Description
while working on #6098, braydon and I began updating some of the lease code to follow the pattern of the embargo code we were implementing. however, actually fixing the ability to deactivate leases was out of scope for #5844, so I created a ticket and the work was moved here.

#### some other things to note:
- the lease is no longer saved on the work. it us referenced using a `lease_id` attrubute
- adding a file to a work with a lease, adds a lease to the file
- removing the lease from the work does not remove the lease from the file set even if you tell it to. this is the same functionality with dassie on main though, so I did not fix it
  - on `main` however, we're able to go to "/leases" and see the file set. then click on it and deactivate it
  - in valkyrie "/leases" shows that there's a fileset with a lease on it...but the fileset doesn't have "title" metadata so we can't click into it to deactivate it. fixing fileset metadata felt out of scope so I didn't address it. (you could manually get there by going to "/leases/<fileset_id>/edit" though)

@samvera/hyrax-code-reviewers
