### PR TITLE
refactor flaky `valkyrie_ingest_job` spec

### DIFF
--- a/spec/jobs/valkyrie_create_derivatives_job_spec.rb
+++ b/spec/jobs/valkyrie_create_derivatives_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe ValkyrieCreateDerivativesJob, index_adapter: :solr_index, valkyrie_adapter: :test_adapter, storage_adapter: :test_disk do
+  let(:file_metadata) { Hyrax::ValkyrieUpload.file(filename: "image.jpg", file_set: file_set, io: file) }
+  let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+  let(:fits_response) { IO.read('spec/fixtures/png_fits.xml') }
+  let(:file) { upload.uploader.file.to_file }
+  let(:solr) { Hyrax.index_adapter.connection }
+  let(:upload) { FactoryBot.create(:uploaded_file, file_set_uri: file_set.id, file: File.open('spec/fixtures/image.png')) }
+
+  before do
+    allow(Hydra::FileCharacterization).to receive(:characterize).and_return(fits_response)
+    file_metadata.file_set_id = file_set.id
+    Hyrax.persister.save(resource: file_metadata)
+  end
+
+  describe "#perform" do
+    it "indexes the thumbnail" do
+      ValkyrieCreateDerivativesJob.perform_now(file_set.id.to_s, file_metadata.id.to_s)
+
+      solr_doc = solr.get("select", params: { q: "id:#{file_set.id}" })["response"]["docs"].first
+      expect(solr_doc["thumbnail_path_ss"]).to include "?file=thumbnail"
+    end
+  end
+end

--- a/spec/jobs/valkyrie_ingest_job_spec.rb
+++ b/spec/jobs/valkyrie_ingest_job_spec.rb
@@ -33,23 +33,6 @@ RSpec.describe ValkyrieIngestJob do
         .to contain_exactly(reloaded_file_set.original_file_id)
     end
 
-    # Thumbnail assertion should be in ValkyrieCreateDerivativesJob spec, but I
-    # couldn't find a nice way to generate a FileSet with a real file attached
-    # programatically for a spec.
-    context "when in Valkyrie mode" do
-      it 'runs derivatives', index_adapter: :solr_index, perform_enqueued: true do
-        allow(ValkyrieCreateDerivativesJob).to receive(:perform_later).and_call_original
-        allow(Hyrax::ValkyrieUpload).to receive(:file).and_call_original
-
-        described_class.perform_now(upload)
-
-        expect(Hyrax::ValkyrieUpload).to have_received(:file)
-        expect(ValkyrieCreateDerivativesJob).to have_received(:perform_later)
-        solr_doc = Hyrax.index_adapter.connection.get("select", params: { q: "id:#{file_set.id}" })["response"]["docs"].first
-        expect(solr_doc["thumbnail_path_ss"]).not_to be_empty
-      end
-    end
-
     it 'makes original_file queryable by use' do
       described_class.perform_now(upload)
 


### PR DESCRIPTION
this test was being setup on the wrong unit (see removed comment), increasing the complexity. it was running multiple layers of background jobs and relied on a lot of configuration that wasn't very isolated.

the tested unit only needs to run against native valkyrie adapters (not Wings), so it can be run as a unit test against the appropriate test adapters.

chipping away at #6136 and beginning to get my head around #6137.

@samvera/hyrax-code-reviewers
