### PR TITLE
♻️ Adding indices to Hyrax::CounterMetrics

### DIFF
--- a/.dassie/db/migrate/20230808102105_add_indices_to_hyrax_counter_metrics.hyrax.rb
+++ b/.dassie/db/migrate/20230808102105_add_indices_to_hyrax_counter_metrics.hyrax.rb
@@ -1,0 +1,8 @@
+class AddIndicesToHyraxCounterMetrics < ActiveRecord::Migration[6.0]
+  def change
+    add_index :hyrax_counter_metrics, :worktype
+    add_index :hyrax_counter_metrics, :resource_type
+    add_index :hyrax_counter_metrics, :work_id
+    add_index :hyrax_counter_metrics, :date
+  end
+end

--- a/lib/generators/hyrax/templates/db/migrate/20230808102105_add_indices_to_hyrax_counter_metrics.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20230808102105_add_indices_to_hyrax_counter_metrics.rb.erb
@@ -1,0 +1,8 @@
+class AddIndicesToHyraxCounterMetrics < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_index :hyrax_counter_metrics, :worktype
+    add_index :hyrax_counter_metrics, :resource_type
+    add_index :hyrax_counter_metrics, :work_id
+    add_index :hyrax_counter_metrics, :date
+  end
+end


### PR DESCRIPTION
Without these indices, what could be a large database could result in significant performance degradations at query time.  Each of these fields is very likely to be part of a "WHERE" statement.

Ported from:

- https://github.com/samvera/hyrax/pull/6140

Related to:

- https://github.com/samvera/hyrax/pull/6130
- https://github.com/scientist-softserv/palni-palci/issues/616WIP

