### PR TITLE
ensure `work_requires_file?` is `true` in specs that depend on it

### DIFF
--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -117,6 +117,8 @@ RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
 
   context "when a file uploaded and then deleted" do
     before do
+      allow(Hyrax.config).to receive(:work_requires_files?).and_return(true)
+
       sign_in user
       click_link 'Works'
       find('#add-new-work-button').click
@@ -129,6 +131,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
       within('div#add-files') do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
       end
+
       expect(page).to have_css('ul li#required-files.complete', text: 'Add files')
       click_button 'Delete' # delete the file
       expect(page).to have_css('ul li#required-files.incomplete', text: 'Add files')


### PR DESCRIPTION
fixes a spec that dependend on `engine_cart` setup being a particular way.

@samvera/hyrax-code-reviewers
