### PR TITLE
remove fallback behavior for dropped InitializeWorkflowActor

### DIFF
--- a/app/services/hyrax/listeners/workflow_listener.rb
+++ b/app/services/hyrax/listeners/workflow_listener.rb
@@ -7,17 +7,14 @@ module Hyrax
     # manages workflow accordingly.
     class WorkflowListener
       ##
-      # @note respects class attribute configuration at
-      #   {Hyrax::Actors::InitializeWorkflowActor.workflow_factory}, but falls
-      #   back on {Hyrax::Workflow::WorkflowFactory} to prepare for removal of
-      #   Actors
-      # @return [#create] default: {Hyrax::Workflow::WorkflowFactory}
-      def factory
-        if defined?(Hyrax::Actors::InitializeWorkflowActor)
-          Hyrax::Actors::InitializeWorkflowActor.workflow_factory
-        else
-          Hyrax::Workflow::WorkflowFactory
-        end
+      # @!attribute [rw] factory
+      #   @return [#create]
+      attr_accessor :factory
+
+      ##
+      # @param [#create] factory
+      def initialize(factory: Hyrax::Workflow::WorkflowFactory)
+        @factory = factory
       end
 
       ##


### PR DESCRIPTION
this behavior existed to ensure overrides of `InitializeWorkflowActor` continued to work in the Hyrax 4 series.

we don't want this dead reference anymore in Hyrax 5.

### Changes proposed in this pull request:
* remove references to removed code.

@samvera/hyrax-code-reviewers
