### PR TITLE
add PermissionTemplate application to the `work_create` transaction 

### DIFF
--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -31,6 +31,7 @@ module Hyrax
       require 'hyrax/transactions/steps/add_to_collections'
       require 'hyrax/transactions/steps/add_to_parent'
       require 'hyrax/transactions/steps/apply_collection_type_permissions'
+      require 'hyrax/transactions/steps/apply_permission_template'
       require 'hyrax/transactions/steps/change_depositor'
       require 'hyrax/transactions/steps/check_for_empty_admin_set'
       require 'hyrax/transactions/steps/delete_access_control'
@@ -201,6 +202,10 @@ module Hyrax
 
         ops.register 'add_to_parent' do
           Steps::AddToParent.new
+        end
+
+        ops.register 'apply_permission_template' do
+          Steps::ApplyPermissionTemplate.new
         end
 
         ops.register 'change_depositor' do

--- a/lib/hyrax/transactions/steps/apply_permission_template.rb
+++ b/lib/hyrax/transactions/steps/apply_permission_template.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # A `dry-transcation` step that applies a permission template
+      # to a saved object.
+      #
+      # @note by design, this step should succeed even if for some reason a
+      #   permission template could not be applied. it's better to complete the
+      #   rest of the creation process with missing ACL grants than to crash and
+      #   miss other crucial steps.
+      #
+      # @since 4.1.0
+      class ApplyPermissionTemplate
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Hyrax::Work] object
+        #
+        # @return [Dry::Monads::Result]
+        def call(object)
+          template = Hyrax::PermissionTemplate.find_by(source_id: object&.admin_set_id)
+
+          if template.blank?
+            Hyrax.logger.info("At create time, #{object} doesn't have a " \
+                              "PermissionTemplate, which it should have via " \
+                              "AdministrativeSet #{object&.admin_set_id}). " \
+                              "Continuing to create this object anyway.")
+
+            return Success(object)
+          end
+
+          Hyrax::PermissionTemplateApplicator.apply(template).to(model: object) &&
+            Success(object)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/work_create.rb
+++ b/lib/hyrax/transactions/work_create.rb
@@ -12,6 +12,7 @@ module Hyrax
                        'change_set.ensure_admin_set',
                        'change_set.set_user_as_depositor',
                        'change_set.apply',
+                       'work_resource.apply_permission_template',
                        'work_resource.save_acl',
                        'work_resource.add_file_sets',
                        'work_resource.change_depositor',

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -155,7 +155,8 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         it "grants edit access to the manage users" do
           post :create, params: { test_simple_work: create_params }
 
-          expect(assigns[:curation_concern].edit_users).to include(admin_set_user)
+          expect(assigns[:curation_concern].edit_users.to_a)
+            .to include(admin_set_user.user_key)
         end
       end
 

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -134,6 +134,31 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         end
       end
 
+      context 'when setting an admin set' do
+        let(:admin_set_user) { FactoryBot.create(:user) }
+
+        let(:admin_set) do
+          FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: admin_set_user)
+        end
+
+        let(:create_params) do
+          { title: 'comet in moominland',
+            admin_set_id: admin_set.id }
+        end
+
+        it "sets the admin set" do
+          post :create, params: { test_simple_work: create_params }
+
+          expect(assigns[:curation_concern].admin_set_id).to eq admin_set.id
+        end
+
+        it "grants edit access to the manage users" do
+          post :create, params: { test_simple_work: create_params }
+
+          expect(assigns[:curation_concern].edit_users).to include(admin_set_user)
+        end
+      end
+
       context 'when adding a collection' do
         let(:collection) { FactoryBot.valkyrie_create(:pcdm_collection) }
 

--- a/spec/factories/administrative_sets.rb
+++ b/spec/factories/administrative_sets.rb
@@ -33,6 +33,15 @@ FactoryBot.define do
     end
   end
 
+  trait :with_permission_template do
+    with_permission_template { true }
+    access_grants do
+      [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
+         agent_id: user.user_key,
+         access: Hyrax::PermissionTemplateAccess::MANAGE }]
+    end
+  end
+
   factory :invalid_hyrax_admin_set, class: 'Hyrax::AdministrativeSet' do
     # Title is required.  Without title, the admin set is invalid.
   end

--- a/spec/hyrax/transactions/steps/apply_permission_template_spec.rb
+++ b/spec/hyrax/transactions/steps/apply_permission_template_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::ApplyPermissionTemplate, valkyrie_adapter: :test_adapter do
+  subject(:step) { described_class.new }
+
+  context 'when there is no admin set' do
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work) }
+
+    it 'gives success and does nothing' do
+      expect(step.call(work)).to be_success
+    end
+  end
+
+  context 'with default admin set' do
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :with_default_admin_set) }
+
+    it 'gives success' do
+      expect(step.call(work)).to be_success
+    end
+  end
+
+  context 'when admin set is missing permission template' do
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :with_admin_set) }
+
+    it 'gives success' do
+      expect(step.call(work)).to be_success
+    end
+  end
+
+  context 'when the admin set has a grants in a permission template' do
+    let(:admin_set_user) { FactoryBot.create(:user) }
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :with_admin_set, admin_set: admin_set) }
+
+    let(:admin_set) do
+      FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: admin_set_user)
+    end
+
+    it 'grants edit access to manager' do
+      expect(step.call(work).value!.edit_users.to_a)
+        .to include admin_set_user.user_key
+    end
+  end
+end


### PR DESCRIPTION
users in the PermissionTemplate for the adminset/workflow should get edit access to new objects added to the admin set. test that at the controller level.

to achieve this:

when we save a resource, we should run the `PermissionTemplateApplicator`against it, to apply the template matching the resource's `AdministrativeSet`.

in the legacy Actor Stack, this step happens before the object is first saved. in the Valkyrie model, we treat the ACL as a separate resource which can (and has to) be saved separately, so it's convenient to first save the object first, and then check for permission template application.

in the old model, we fail to save the work if a permission template doesn'texist for the admin set. here, if we're missing an admin set or it is missing a permission template, we simply decline to apply and always succeed (except in cases of unhandled exceptions).

this was initially implemented as part of transactions in 05b66b90aaf, but removed when shifting to Valkyrie because it wasn't tested anywhere. we couldn't figure out what the desired behavior was, so we left it out of the new implementation.

related to #5848.

### Changes proposed in this pull request:
* adds a failing test at the controller layer for the behavior desired in #5848 
* reinstates an implementation of a transaction step to apply a permission template, similar to the one developed for 05b66b90aaf

@samvera/hyrax-code-reviewers
