### PR TITLE
never try to clean ActiveFedora if Wings is disabled

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -119,6 +119,7 @@ end
 ActiveJob::Base.queue_adapter = :test
 
 def clean_active_fedora_repository
+  return if Hyrax.config.disable_wings
   ActiveFedora::Cleaner.clean!
   # The JS is executed in a different thread, so that other thread
   # may think the root path has already been created:


### PR DESCRIPTION
if `disable_wings` is on, the application should never be writing any Fedora data, and there's likely not even one present. make the fedora clean operation a no-op in this case.

@samvera/hyrax-code-reviewers
