### PR TITLE
use TimeService in batch edits

### DIFF
--- a/app/controllers/hyrax/batch_edits_controller.rb
+++ b/app/controllers/hyrax/batch_edits_controller.rb
@@ -52,7 +52,7 @@ module Hyrax
     def update_document(obj)
       interpret_visiblity_params(obj)
       obj.attributes = work_params(admin_set_id: obj.admin_set_id).except(*visibility_params)
-      obj.date_modified = Time.current.ctime
+      obj.date_modified = TimeService.time_in_utc
 
       InheritPermissionsJob.perform_now(obj)
       VisibilityCopyJob.perform_now(obj)


### PR DESCRIPTION
Hyrax has a timeservice which we should use in place of `Time.current.ctime` to set `:date_modified`

@samvera/hyrax-code-reviewers
