### PR TITLE
Fix IIIF manifests when the presenter model is a SolrDocument

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter.rb
@@ -93,8 +93,8 @@ module Hyrax
     ##
     # @return [Array<#to_s>]
     def member_ids
-      m = model.is_a?(::SolrDocument) ? model.hydra_model : model
-      m.class < Hyrax::Resource ? Array(model.member_ids) : Hyrax::SolrDocument::OrderedMembers.decorate(model).ordered_member_ids
+      m = model.is_a?(::SolrDocument) ? model.hydra_model : model.class
+      m < Hyrax::Resource ? Array(model.member_ids) : Hyrax::SolrDocument::OrderedMembers.decorate(model).ordered_member_ids
     end
 
     ##


### PR DESCRIPTION
### Summary

hydra_model is already a class, don't call `class` on it

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Manifests in koppie or Nurax PG include a sequence section with URLS for the IIIF endpoint.
* or
* The universal viewer displays the work's images.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Detailed Description

Fix IIIF manifests when the presenter model is a SolrDocument. `hydra_model` already returns a class. Calling `class` on it breaks the Hyrax::Resource subclass determination causing the wrong code path to be used resulting in a manifest without any images.

@samvera/hyrax-code-reviewers
