### PR TITLE
Set geonames usernames using environment variable

### DIFF
--- a/.dassie/config/initializers/hyrax.rb
+++ b/.dassie/config/initializers/hyrax.rb
@@ -42,7 +42,7 @@ Hyrax.config do |config|
     config.browse_everything = nil
   end
 
-  # config.geonames_username = ''
+  config.geonames_username = ENV['GEONAMES_USERNAME'] || ''
 
   ##
   # Set the system-wide virus scanner

--- a/.koppie/config/initializers/hyrax.rb
+++ b/.koppie/config/initializers/hyrax.rb
@@ -106,7 +106,7 @@ Hyrax.config do |config|
 
   # Location autocomplete uses geonames to search for named regions
   # Username for connecting to geonames
-  # config.geonames_username = ''
+  config.geonames_username = ENV['GEONAMES_USERNAME'] || ''
 
   # Should the acceptance of the licence agreement be active (checkbox), or
   # implied when the save button is pressed? Set to true for active

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -95,7 +95,7 @@ Hyrax.config do |config|
 
   # Location autocomplete uses geonames to search for named regions
   # Username for connecting to geonames
-  # config.geonames_username = ''
+  config.geonames_username = ENV['GEONAMES_USERNAME'] || ''
 
   # Should the acceptance of the licence agreement be active (checkbox), or
   # implied when the save button is pressed? Set to true for active


### PR DESCRIPTION
### Fixes

Closes #5799 Closes #5799

### Summary

Make geonames username configurable with environment variable.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* To test locally,  set docker-compose GEONAMES_USERNAME environment variable to valid user name
* To test in QA, set  GEONAMES_USERNAME environment variable to valid user name

### Type of change (for release notes)

- `notes-minor` New Features that are backward compatible

@samvera/hyrax-code-reviewers
