### PR TITLE
Don't clear embargo dates while adding user to admin participants list.

### DIFF
--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -266,6 +266,8 @@ module Hyrax
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
       def permission_template_update_params
+        return attributes unless attributes.key?(:release_varies) || attributes.key?(:release_embargo)
+
         filtered_attributes = attributes.except(:release_varies, :release_embargo)
         # If 'varies' before date option selected, then set release_period='before' and save release_date as-is
         if attributes[:release_varies] == Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE

--- a/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
@@ -67,6 +67,24 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
         expect(response).to redirect_to(hyrax.edit_dashboard_collection_path(permission_template.source_id, locale: 'en', anchor: 'sharing'))
         expect(flash[:notice]).to eq(I18n.t('sharing', scope: 'hyrax.dashboard.collections.form.permission_update_notices'))
       end
+
+      context "with embargo date" do
+        let(:release_date) { '2023-09-30' }
+
+        before do
+          permission_template.update(release_date: release_date)
+        end
+
+        it "is successful with embargo date intact" do
+          expect(controller).to receive(:authorize!).with(:update, Hyrax::PermissionTemplate)
+          expect(form).to receive(:update).with(ActionController::Parameters.new(form_attributes).permit!).and_return(updated: true, content_tab: 'sharing')
+          put :update, params: input_params
+          expect(response).to redirect_to(hyrax.edit_dashboard_collection_path(permission_template.source_id, locale: 'en', anchor: 'sharing'))
+
+          updated = Hyrax::PermissionTemplate.find_by(id: permission_template.id)
+          expect(updated.release_date.strftime('%Y-%m-%d')).to eq(release_date)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Fixes

Fixes #5849; refs #5849

### Summary

Avoid clearing embargo dates in permission template while adding user to admin participants list.

@samvera/hyrax-code-reviewers
