### PR TITLE
switch docker-compose browser engines to multiarch `seleniarm`

### DIFF
--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -90,7 +90,9 @@ services:
       - koppie
 
   chrome:
-    image: selenium/standalone-chrome:3.141
+    image: seleniarm/standalone-chromium:114.0
+    environment:
+      - START_XVFB=false
     logging:
       driver: none
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,15 +85,17 @@ services:
       - hyrax
 
   chrome:
-    image: selenium/standalone-chrome:3.141
+    image: seleniarm/standalone-chromium:114.0
+    environment:
+      - START_XVFB=false
     logging:
       driver: none
     volumes:
       - /dev/shm:/dev/shm
     shm_size: 2G
     ports:
-      - "4444:4444"
-      - "5959:5900"
+      - "4445:4444"
+      - "5960:5900"
     networks:
       - hyrax
 

--- a/lib/hyrax/specs/capybara.rb
+++ b/lib/hyrax/specs/capybara.rb
@@ -20,10 +20,15 @@ require 'webdrivers' unless ENV['IN_DOCKER'].present? || ENV['HUB_URL'].present?
 Capybara.save_path = ENV['CI'] ? "/tmp/test-results" : Rails.root.join('tmp', 'capybara')
 
 if ENV['IN_DOCKER'].present? || ENV['HUB_URL'].present?
-  args = %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400]
-  args.push('headless') if ActiveModel::Type::Boolean.new.cast(ENV['CHROME_HEADLESS_MODE'])
-
-  options = Selenium::WebDriver::Options.chrome("goog:chromeOptions" => { args: args })
+  options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.add_argument("--headless") if ENV["CHROME_HEADLESS_MODE"]
+    opts.add_argument("--disable-gpu") if Gem.win_platform?
+    # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
+    opts.add_argument("--disable-site-isolation-trials")
+    opts.add_argument("--window-size=1440,1440")
+    opts.add_argument("--enable-features=NetworkService,NetworkServiceInProcess")
+    opts.add_argument("--disable-features=VizDisplayCompositor")
+  end
 
   Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
     driver = Capybara::Selenium::Driver.new(app,


### PR DESCRIPTION
this should add support for ARM based environments (e.g. M1/M2 Macs) to run browser tests in `dassie` and `koppie`

@samvera/hyrax-code-reviewers
