### PR TITLE
skip ActiveFedora specs if `disable_wings` is on

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -259,6 +259,10 @@ RSpec.configure do |config|
 
   config.profile_examples = 10
 
+  config.before(:example, :active_fedora) do
+    skip("Don't test Wings") if Hyrax.config.disable_wings
+  end
+
   config.before(:example, :clean_repo) do
     clean_active_fedora_repository unless Hyrax.config.disable_wings
     Hyrax::RedisEventStore.instance.then(&:flushdb)
@@ -331,7 +335,9 @@ RSpec.configure do |config|
       .to receive(:metadata_adapter)
       .and_return(Valkyrie::MetadataAdapter.find(adapter_name))
 
-    if adapter_name != :wings_adapter
+    if adapter_name == :wings_adapter
+      skip("Don't test Wings when it is dasabled") if Hyrax.config.disable_wings
+    else
       allow(Hyrax.config).to receive(:disable_wings).and_return(true)
       hide_const("Wings") # disable_wings=true removes the Wings constant
     end

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'wings'
 require 'wings/active_fedora_converter'
 
-RSpec.describe Wings::ActiveFedoraConverter, :clean_repo do
+RSpec.describe Wings::ActiveFedoraConverter, :active_fedora, :clean_repo do
   subject(:converter) { described_class.new(resource: resource) }
   let(:attributes)    { { id: id } }
   let(:id)            { 'moomin_id' }

--- a/spec/wings/attribute_transformer_spec.rb
+++ b/spec/wings/attribute_transformer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'wings/attribute_transformer'
 
-RSpec.describe Wings::AttributeTransformer do
+RSpec.describe Wings::AttributeTransformer, :active_fedora do
   let(:id)   { 'moomin123' }
   let(:work) { GenericWork.new(id: id, **attributes) }
 

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/hydra/works/services/add_file_to_file_set'
 
-RSpec.describe Wings::Works::AddFileToFileSet, :clean_repo do
+RSpec.describe Wings::Works::AddFileToFileSet, :active_fedora, :clean_repo do
   let(:af_file_set)             { create(:file_set, id: 'fileset_id') }
   let!(:file_set)               { af_file_set.valkyrie_resource }
 

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/model_transformer'
 
-RSpec.describe Wings::ModelTransformer, :clean_repo do
+RSpec.describe Wings::ModelTransformer, :active_fedora, :clean_repo do
   subject(:factory) { described_class.new(pcdm_object: pcdm_object) }
   let(:pcdm_object) { work }
   let(:adapter)     { Valkyrie::MetadataAdapter.find(:memory) }

--- a/spec/wings/orm_converter_spec.rb
+++ b/spec/wings/orm_converter_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/orm_converter'
 
-RSpec.describe Wings::OrmConverter do
+RSpec.describe Wings::OrmConverter, :active_fedora do
   describe '.to_valkyrie_resource_class' do
     context 'when given a ActiveFedora class (eg. a constant that responds to #properties)' do
       context 'for the returned object (e.g. a class)' do

--- a/spec/wings/services/custom_queries/find_access_control_spec.rb
+++ b/spec/wings/services/custom_queries/find_access_control_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/services/custom_queries/find_access_control'
 
-RSpec.describe Wings::CustomQueries::FindAccessControl do
+RSpec.describe Wings::CustomQueries::FindAccessControl, :active_fedora do
   subject(:query_handler) { described_class.new(query_service: query_service) }
   let(:adapter)           { Valkyrie::MetadataAdapter.find(:wings_adapter) }
   let(:persister)         { adapter.persister }

--- a/spec/wings/services/custom_queries/find_collections_by_type_spec.rb
+++ b/spec/wings/services/custom_queries/find_collections_by_type_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/services/custom_queries/find_collections_by_type'
 
-RSpec.describe Wings::CustomQueries::FindCollectionsByType, :clean_repo do
+RSpec.describe Wings::CustomQueries::FindCollectionsByType, :active_fedora, :clean_repo do
   subject(:query_handler) { described_class.new(query_service: query_service) }
   let(:collection_type)   { FactoryBot.create(:collection_type) }
   let(:type_gid)          { collection_type.to_global_id }

--- a/spec/wings/services/custom_queries/find_file_metadata_spec.rb
+++ b/spec/wings/services/custom_queries/find_file_metadata_spec.rb
@@ -3,7 +3,7 @@ require 'wings_helper'
 require 'wings/hydra/works/services/add_file_to_file_set'
 require 'wings/services/custom_queries/find_file_metadata'
 
-RSpec.describe Wings::CustomQueries::FindFileMetadata, :clean_repo do
+RSpec.describe Wings::CustomQueries::FindFileMetadata, :active_fedora, :clean_repo do
   subject(:query_handler) { described_class.new(query_service: query_service) }
   let(:query_service) { Hyrax.query_service }
   let(:af_file_id1) { 'file1' }

--- a/spec/wings/services/custom_queries/find_many_by_alternate_ids_spec.rb
+++ b/spec/wings/services/custom_queries/find_many_by_alternate_ids_spec.rb
@@ -2,7 +2,7 @@
 require 'wings_helper'
 require 'wings/services/custom_queries/find_many_by_alternate_ids'
 
-RSpec.describe Wings::CustomQueries::FindManyByAlternateIds do
+RSpec.describe Wings::CustomQueries::FindManyByAlternateIds, :active_fedora do
   let(:query_service) { Hyrax.query_service }
 
   let(:work1) { create(:public_work) }

--- a/spec/wings/transformer_value_mapper_spec.rb
+++ b/spec/wings/transformer_value_mapper_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'wings/transformer_value_mapper'
 
-RSpec.describe Wings::TransformerValueMapper do
+RSpec.describe Wings::TransformerValueMapper, :active_fedora do
   subject(:mapper) { described_class.for(value) }
   let(:value)      { 'a value' }
   let(:uri)        { RDF::URI('http://example.com/moomin') }

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -3,7 +3,7 @@ require 'wings_helper'
 require 'valkyrie/specs/shared_specs'
 require 'wings'
 
-RSpec.describe Wings::Valkyrie::Persister do
+RSpec.describe Wings::Valkyrie::Persister, :active_fedora do
   subject(:persister) { described_class.new(adapter: adapter) }
   let(:adapter) { Wings::Valkyrie::MetadataAdapter.new }
   let(:query_service) { adapter.query_service }

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 require 'wings'
 
-RSpec.describe Wings::Valkyrie::QueryService, :clean_repo do
+RSpec.describe Wings::Valkyrie::QueryService, :active_fedora, :clean_repo do
   before do
     module Hyrax::Test
       module QueryService

--- a/spec/wings/valkyrie/resource_factory_spec.rb
+++ b/spec/wings/valkyrie/resource_factory_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'wings'
 
-RSpec.describe Wings::Valkyrie::ResourceFactory do
+RSpec.describe Wings::Valkyrie::ResourceFactory, :active_fedora do
   subject(:factory) { described_class.new(adapter: adapter) }
   let(:adapter)     { Valkyrie::Persistence::Memory::MetadataAdapter.new }
   let(:work)        { GenericWork.new }

--- a/spec/wings/valkyrie/storage_spec.rb
+++ b/spec/wings/valkyrie/storage_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'hyrax/specs/shared_specs/valkyrie_storage_versions'
 require 'valkyrie/specs/shared_specs'
 
-RSpec.describe Wings::Valkyrie::Storage, :clean_repo do
+RSpec.describe Wings::Valkyrie::Storage, :active_fedora, :clean_repo do
   subject(:storage_adapter) { described_class.new }
   let(:file) { fixture_file_upload('/world.png', 'image/png') }
 


### PR DESCRIPTION
if we're flagging `disable_wings`, there's no FCRepo backend for this system. don't run any tests that are focused on ensuring FCRepo related or ActiveFedora related behavior.

Anything tested in this way should eventually be deprecated and removed.

@samvera/hyrax-code-reviewers
