### PR TITLE
skip AF model specs when disable_wings is flagged

### DIFF
--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe AdminSet, type: :model do
+RSpec.describe AdminSet, :active_fedora, type: :model do
   let(:gf1) { create(:generic_work, user: user) }
   let(:gf2) { create(:generic_work, user: user) }
   let(:gf3) { create(:generic_work, user: user) }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe ::Collection, type: :model do
+RSpec.describe ::Collection, :active_fedora, type: :model do
   let(:collection) { build(:public_collection_lw) }
 
   it "has open visibility" do

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -2,7 +2,7 @@
 # This tests the FileSet model that is inserted into the host app by hyrax:models
 # It includes the Hyrax::FileSetBehavior module and nothing else
 # So this test covers both the FileSetBehavior module and the generated FileSet model
-RSpec.describe FileSet do
+RSpec.describe FileSet, :active_fedora do
   include Hyrax::FactoryHelpers
 
   let(:user) { create(:user) }

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe GenericWork do
+RSpec.describe GenericWork, :active_fedora do
   it 'has a title' do
     subject.title = ['foo']
     expect(subject.title).to eq ['foo']


### PR DESCRIPTION
If we've disabled Wings, that means there's no ActiveFedora in our codebase anymore (at least aspirationally), don't test models that won't exist!

@samvera/hyrax-code-reviewers
