### PR TITLE
disable generated Controller specs for AF models if `disable_wings`

### DIFF
--- a/spec/controllers/hyrax/generic_works_controller_json_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_json_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # This tests the Hyrax::WorksControllerBehavior module
 # which is included into .internal_test_app/app/controllers/hyrax/generic_works_controller.rb
-RSpec.describe Hyrax::GenericWorksController do
+RSpec.describe Hyrax::GenericWorksController, :active_fedora do
   routes { Rails.application.routes }
 
   let(:user) { create(:user) }

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -3,7 +3,7 @@
 # which is included into .internal_test_app/app/controllers/hyrax/generic_works_controller.rb
 require 'hyrax/specs/spy_listener'
 
-RSpec.describe Hyrax::GenericWorksController do
+RSpec.describe Hyrax::GenericWorksController, :active_fedora do
   routes { Rails.application.routes }
   let(:main_app) { Rails.application.routes.url_helpers }
   let(:hyrax) { Hyrax::Engine.routes.url_helpers }


### PR DESCRIPTION
these concrete controller specs are replaced by tests of the abstract behavior, tested against valkyrie models. disable them when we `disable_wings`

@samvera/hyrax-code-reviewers
