### PR TITLE
disable CreateDerivativesJob tests when `disable_wings` is true

### DIFF
--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe CreateDerivativesJob do
+RSpec.describe CreateDerivativesJob, :active_fedora do
   around do |example|
     ffmpeg_enabled = Hyrax.config.enable_ffmpeg
     Hyrax.config.enable_ffmpeg = true


### PR DESCRIPTION
this is ActiveFedora-specific code, replaced by ValkyrieCreateDerivativesJob in Valkyrie code paths.

@samvera/hyrax-code-reviewers
