### PR TITLE
refactor Hyrax::LeaseHelper specs to work under koppie

### DIFF
--- a/spec/helpers/hyrax/lease_helper_spec.rb
+++ b/spec/helpers/hyrax/lease_helper_spec.rb
@@ -139,6 +139,8 @@ RSpec.describe Hyrax::LeaseHelper do
       context 'when the wrapped work is under embargo' do
         let(:model) { FactoryBot.build(:hyrax_work, :under_lease) }
 
+        before { Hyrax::LeaseManager.apply_lease_for!(resource: resource.model) }
+
         it 'returns true' do
           # This allow call is a tweak to preserve spec for pre #4845 patch
           allow(model).to receive(:persisted?).and_return(true)

--- a/spec/helpers/hyrax/lease_helper_spec.rb
+++ b/spec/helpers/hyrax/lease_helper_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Hyrax::LeaseHelper do
-  let(:resource) { build(:monograph) }
+  let(:resource) { FactoryBot.build(:monograph) }
 
   describe 'lease_enforced?' do
     # Including this stub to preserve the spec structure before the #4845 change
@@ -77,7 +77,7 @@ RSpec.describe Hyrax::LeaseHelper do
       end
     end
 
-    context 'with an ActiveFedora resource' do
+    context 'with an ActiveFedora resource', :active_fedora do
       let(:resource) { build(:work) }
 
       it 'returns false' do
@@ -106,7 +106,7 @@ RSpec.describe Hyrax::LeaseHelper do
       end
     end
 
-    context 'with a HydraEditor::Form' do
+    context 'with a HydraEditor::Form', :active_fedora do
       let(:resource) { Hyrax::GenericWorkForm.new(model, ability, form_controller) }
       let(:model) { build(:work) }
       let(:ability) { :FAKE_ABILITY }
@@ -129,17 +129,15 @@ RSpec.describe Hyrax::LeaseHelper do
 
     context 'with a Hyrax::Forms::FailedSubmissionFormWrapper' do
       let(:resource) { Hyrax::Forms::FailedSubmissionFormWrapper.new(form: form, input_params: {}, permitted_params: {}) }
-      let(:model) { build(:work) }
-      let(:form) { Hyrax::GenericWorkForm.new(model, ability, form_controller) }
-      let(:ability) { :FAKE_ABILITY }
-      let(:form_controller) { :FAKE_CONTROLLER }
+      let(:model) { FactoryBot.build(:hyrax_work) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(model) }
 
       it 'returns false' do
         expect(lease_enforced?(resource)).to be false
       end
 
       context 'when the wrapped work is under embargo' do
-        let(:model) { build(:leased_work) }
+        let(:model) { FactoryBot.build(:hyrax_work, :under_lease) }
 
         it 'returns true' do
           # This allow call is a tweak to preserve spec for pre #4845 patch
@@ -151,7 +149,7 @@ RSpec.describe Hyrax::LeaseHelper do
   end
 
   describe '#lease_history' do
-    context 'with an ActiveFedora resource' do
+    context 'with an ActiveFedora resource', :active_fedora do
       let(:resource) { FactoryBot.build(:work) }
 
       it 'is empty' do


### PR DESCRIPTION
some of these tests ensure interactions with AF models, these can be disabled.

others needed to be refactored to use Valkyrie for setup.