### PR TITLE
don't run AF Works::MigrationService specs if `disable_wings`

### DIFF
--- a/spec/services/hyrax/works/migration_service_spec.rb
+++ b/spec/services/hyrax/works/migration_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # rubocop:disable RSpec/InstanceVariable
-RSpec.describe Hyrax::Works::MigrationService, clean_repo: true do
+RSpec.describe Hyrax::Works::MigrationService, :active_fedora, clean_repo: true do
   let(:predicate_from) { ::RDF::Vocab::DC11.description }
   let(:predicate_to) { ::RDF::Vocab::SCHEMA.description }
   let(:predicate_from2) { ::RDF::Vocab::DC.rights }


### PR DESCRIPTION
this service is for FCRepo backends only

@samvera/hyrax-code-reviewers
