### PR TITLE
Bump dockerfile alpine and ruby versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
-ARG RUBY_VERSION=3.2.1
+ARG ALPINE_VERSION=3.18
+ARG RUBY_VERSION=3.2.2
 
-# Replace with official jemalloc package in alpine 3.17
-FROM ruby:$RUBY_VERSION-alpine3.16 as builder
-RUN apk add build-base curl
-RUN curl -sL https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 | tar -xj && \
-    cd jemalloc-5.3.0 && \
-    ./configure && \
-    make && \
-    make install
+FROM ruby:$RUBY_VERSION-alpine$ALPINE_VERSION as builder
+RUN apk add build-base curl jemalloc
 
-FROM ruby:$RUBY_VERSION-alpine3.16 as hyrax-base
+FROM ruby:$RUBY_VERSION-alpine$ALPINE_VERSION as hyrax-base
 
 ARG DATABASE_APK_PACKAGE="postgresql-dev"
 ARG EXTRA_APK_PACKAGES="git"
@@ -43,7 +38,7 @@ ENV PATH="/app/samvera:$PATH"
 ENV RAILS_ROOT="/app/samvera/hyrax-webapp"
 ENV RAILS_SERVE_STATIC_FILES="1"
 
-COPY --from=builder /usr/local/lib/libjemalloc.so.2 /usr/local/lib/
+COPY --from=builder /usr/lib/libjemalloc.so.2 /usr/local/lib/
 ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
 
 ENTRYPOINT ["hyrax-entrypoint.sh"]

--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -142,6 +142,10 @@ services:
     volumes:
       - solr_home:/var/solr/data:cached
       - .koppie/solr/conf:/opt/solr/server/configsets/hyraxconf
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 524288
     networks:
       - koppie
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,6 +147,10 @@ services:
     volumes:
       - solr_home:/var/solr/data:cached
       - .dassie/solr/conf:/opt/solr/server/configsets/hyraxconf
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 524288
     networks:
       - hyrax
 


### PR DESCRIPTION
### Summary

- Update Dockerfile to use Ruby 3.22, Alpine 3.18 

This also affords dropping the manual installation of jemalloc, as in
Alpine 3.18 the desired version is in the package repository.

https://pkgs.alpinelinux.org/package/v3.18/main/x86_64/jemalloc

- docker-compose: set solr ulimits 

This fixes a known issues on some devices where the solr container can
take minutes to start.

Already applied on nurax[1].

1. https://github.com/samvera-labs/nurax/blob/pg/docker-compose.yml#L113-L116

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Tested with `koppie` [docker-compose instructions](https://github.com/samvera/hyrax/blob/main/CONTAINERS.md#koppie-internal-test-app-with-valkyrie-connector-to-postgres)

### Type of change (for release notes)

`notes-container`

### Changes proposed in this pull request:
* Alpine version converted to `ARG` and updated to `3.18` as default in `Dockerfile`
* Ruby version default updated to `3.22` in `Dockerfile`
* `jemalloc` installed now using alpine package manager
* `ulimit` set on solr container in docker compose files

@samvera/hyrax-code-reviewers
