### PR TITLE
disable `AttachFilesToWorkJob` specs if `disable_wings`

### DIFF
--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe AttachFilesToWorkJob, perform_enqueued: [AttachFilesToWorkJob] do
+RSpec.describe AttachFilesToWorkJob, :active_fedora, perform_enqueued: [AttachFilesToWorkJob] do
   let(:file1) { File.open(fixture_path + '/world.png') }
   let(:file2) { File.open(fixture_path + '/image.jp2') }
   let(:uploaded_file1) { build(:uploaded_file, file: file1) }


### PR DESCRIPTION
AttachFilesToWorkJob is an Actor Stack/ActiveFedora system; even though it was once rewritten for valkyrie under Wings, it shouldn't be tested in valkyrie native apps.

@samvera/hyrax-code-reviewers
