### PR TITLE
don't test AF path in `InheritPermissionsJob` when `disable_wings`

### DIFF
--- a/spec/jobs/inherit_permissions_job_spec.rb
+++ b/spec/jobs/inherit_permissions_job_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 RSpec.describe InheritPermissionsJob do
   let(:user) { FactoryBot.create(:user) }
-  let(:work) { FactoryBot.create(:work_with_one_file, user: user) }
 
-  context "when using a legacy AF resource" do
+  context "when using a legacy AF resource", :active_fedora do
+    let(:work) { FactoryBot.create(:work_with_one_file, user: user) }
+
     before do
       work.permissions.build(name: name, type: type, access: access)
       work.save


### PR DESCRIPTION
this job supports both Valkyrie and AF model and has tests for both. if we've removed AF from the environment, only test the Valkyrie path.

@samvera/hyrax-code-reviewers
