### PR TITLE
don't test AF path in `FileSetAttachedEventJob` when `disable_wings`

### DIFF
--- a/spec/jobs/file_set_attached_event_job_spec.rb
+++ b/spec/jobs/file_set_attached_event_job_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FileSetAttachedEventJob do
     allow(Hyrax::TimeService).to receive(:time_in_utc).at_least(:once).and_return(mock_time)
   end
 
-  context 'with a FileSet' do
+  context 'with a FileSet', :active_fedora do
     let(:file_set) { curation_concern.file_sets.first }
     let(:curation_concern) { create(:work_with_one_file, title: ['MacBeth'], user: user) }
 


### PR DESCRIPTION
this job supports both Valkyrie and AF model and has tests for both. if we've removed AF from the environment, only test the Valkyrie path.

@samvera/hyrax-code-reviewers
