### PR TITLE
skip `MembersPermissionJobBehavior` AF tests when `disable_wings`

### DIFF
--- a/spec/jobs/hyrax/grant_edit_to_members_job_spec.rb
+++ b/spec/jobs/hyrax/grant_edit_to_members_job_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Hyrax::GrantEditToMembersJob do
   let(:depositor) { create(:user) }
 
-  context "when using active fedora" do
+  context "when using active fedora", :active_fedora do
     let(:work) { create(:work) }
     let(:file_set_ids) { ['xyz123abc', 'abc789zyx'] }
 

--- a/spec/jobs/hyrax/grant_read_to_members_job_spec.rb
+++ b/spec/jobs/hyrax/grant_read_to_members_job_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Hyrax::GrantReadToMembersJob, perform_enqueued: [Hyrax::GrantReadToMembersJob] do
   let(:depositor) { FactoryBot.create(:user) }
 
-  context "when using active fedora" do
+  context "when using active fedora", :active_fedora do
     let(:work) { FactoryBot.create(:work_with_files) }
 
     it 'loops over FileSet IDs, spawning a job for each' do

--- a/spec/jobs/hyrax/revoke_edit_from_members_job_spec.rb
+++ b/spec/jobs/hyrax/revoke_edit_from_members_job_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::RevokeEditFromMembersJob do
+RSpec.describe Hyrax::RevokeEditFromMembersJob, :active_fedora do
   let(:depositor) { create(:user) }
 
   context "when using active fedora" do


### PR DESCRIPTION
these jobs inherit `MembersPermissionJobBehavior`, which supports both Valkyrie and AF model and has tests for both. if we've removed AF from the environment, only test the Valkyrie path.

@samvera/hyrax-code-reviewers
