### PR TITLE
Fix db_migrate service failing to find db-migrate-seed.sh

### DIFF
--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -9,7 +9,7 @@ services:
         - EXTRA_APK_PACKAGES=git less chromium
         - APP_PATH=.koppie
     image: ghcr.io/samvera/koppie
-    command: sh -l -c 'bundle && yarn && bundle exec puma -v -b tcp://0.0.0.0:3000'
+    command: sh -c 'bundle && yarn && bundle exec puma -v -b tcp://0.0.0.0:3000'
     stdin_open: true
     tty: true
     user: root
@@ -46,7 +46,7 @@ services:
       args:
         - APP_PATH=.koppie
     image: ghcr.io/samvera/koppie-worker
-    command: sh -l -c 'bundle && bundle exec sidekiq'
+    command: sh -c 'bundle && bundle exec sidekiq'
     user: root
     env_file:
       - .koppie/.env
@@ -78,7 +78,7 @@ services:
     user: root
     env_file:
       - .koppie/.env
-    command: sh -l -c 'bundle && db-migrate-seed.sh'
+    command: sh -c 'bundle && db-migrate-seed.sh'
     depends_on:
       - postgres
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       args:
         - EXTRA_APK_PACKAGES=git less chromium
     image: ghcr.io/samvera/dassie
-    command: sh -l -c 'bundle && bundle exec puma -v -b tcp://0.0.0.0:3000'
+    command: sh -c 'bundle && bundle exec puma -v -b tcp://0.0.0.0:3000'
     stdin_open: true
     tty: true
     user: root
@@ -42,7 +42,7 @@ services:
       context: .
       target: hyrax-engine-dev-worker
     image: ghcr.io/samvera/dassie-worker
-    command: sh -l -c 'bundle && bundle exec sidekiq'
+    command: sh -c 'bundle && bundle exec sidekiq'
     user: root
     env_file:
       - .dassie/.env
@@ -73,7 +73,7 @@ services:
     user: root
     env_file:
       - .dassie/.env
-    command: sh -l -c 'bundle && db-migrate-seed.sh'
+    command: sh -c 'bundle && db-migrate-seed.sh'
     depends_on:
       - postgres
     volumes:


### PR DESCRIPTION
### Fixes

db_migrate service failing to find db-migrate-seed.sh

Not sure why a login shell was specified, but it is causing problems now. PATH does not contain /app/samvera inside a login shell.
