### PR TITLE
update bitnami chart dependencies 

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -30,8 +30,8 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: solr.enabled
   - name: nginx
-    version: 13.2.30
-    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+    version: 15.2.0
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: nginx.enabled
   - name: fits
     version: 0.1.0

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -10,8 +10,8 @@ dependencies:
     repository: oci://ghcr.io/samvera
     condition: fcrepo.enabled
   - name: memcached
-    version: 6.3.13
-    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+    version: 6.6.0
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: memcached.enabled
   - name: minio
     version: 12.1.14

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -22,8 +22,8 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: redis
-    version: 17.8.7
-    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+    version: 17.16.0
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
   - name: solr
     version: 7.2.1

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -26,8 +26,8 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
   - name: solr
-    version: 7.2.1
-    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+    version: 8.0.0
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: solr.enabled
   - name: nginx
     version: 13.2.30

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -18,8 +18,8 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: postgresql
-    version: 12.2.5
-    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+    version: 12.9.0
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: redis
     version: 17.8.7

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 3.2.0
+version: 3.3.0
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -14,8 +14,8 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: memcached.enabled
   - name: minio
-    version: 12.1.14
-    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+    version: 12.8.0
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: postgresql
     version: 12.2.5


### PR DESCRIPTION
Two charts had major version bumps: solr and nginx

replaces #6218, which failed CI because it was from a fork

@samvera/hyrax-code-reviewers
