### PR TITLE
Add postgresql port helm chart helper template

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 3.3.1
+version: 3.4.0
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo
@@ -35,5 +35,5 @@ dependencies:
     condition: nginx.enabled
   - name: fits
     version: 0.1.0
-    repository:  https://samvera-labs.github.io/fits-charts
+    repository: https://samvera-labs.github.io/fits-charts
     condition: fits.enabled

--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -147,6 +147,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end }}
 {{- end -}}
 
+{{- define "hyrax.postgresql.port" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.containerPorts.postgresql | default 5432 }}
+{{- else }}
+{{- .Values.externalPostgresql.port | default 5432 }}
+{{- end }}
+{{- end -}}
+
 {{- define "hyrax.postgresql.url" -}}
 {{- printf "postgresql://%s:%s@%s/%s?pool=5" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) -}}
 {{- end -}}

--- a/chart/hyrax/templates/configmap-env.yaml
+++ b/chart/hyrax/templates/configmap-env.yaml
@@ -14,7 +14,7 @@ data:
   CH12N_TOOL: "fits"
   {{- end }}
   DB_HOST: {{ template "hyrax.postgresql.host" . }}
-  DB_PORT: {{ .Values.postgresql.containerPorts.postgresql | default 5432 | quote }}
+  DB_PORT: {{ include "hyrax.postgresql.port" . | quote }}
   DB_USERNAME: {{ template "hyrax.postgresql.database" . }}
   {{- if .Values.memcached.enabled }}
   MEMCACHED_HOST: {{ template "hyrax.memcached.fullname" . }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -119,6 +119,7 @@ externalPostgresql: {}
 #  username:
 #  password:
 #  database:
+#  port:
 
 embargoRelease:
   enabled: true


### PR DESCRIPTION
### Fixes

### Summary

Add an `externalPostgresl.port` value option and a `hyrax.postgresl.port` helper template. 

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Run locally using `--dry-run --debug` to confirm the default value with `postgresql.enabled` is `"5432"`
* Run with a `--values` file saved in `/tmp/comet-pg.yaml` as shown below to demonstrate setting an external port
*  via: `helm upgrade --dry-run --debug --install --values /tmp/comet-pg.yaml --atomic --namespace comet-review surfliner-comet-testing ./`

```yaml
postgresql:
  enabled: false
externalPostgresql:
  port: 5555
```

@samvera/hyrax-code-reviewers
