### PR TITLE
Save permission attributes for FileSet edit.

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -116,7 +116,11 @@ module Hyrax
         change_set = Hyrax::Forms::ResourceForm.for(file_set)
 
         change_set.validate(attributes) &&
-          transactions['change_set.apply'].call(change_set).value_or { false }
+          transactions['change_set.update_file_set']
+            .with_step_args(
+              'file_set.save_acl' => { permissions_params: change_set.input_params["permissions"] }
+            )
+            .call(change_set).value_or { false }
       else
         file_attributes = form_class.model_attributes(attributes)
         actor.update_metadata(file_attributes)

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -24,6 +24,7 @@ module Hyrax
       require 'hyrax/transactions/collection_destroy'
       require 'hyrax/transactions/collection_update'
       require 'hyrax/transactions/file_set_destroy'
+      require 'hyrax/transactions/file_set_update'
       require 'hyrax/transactions/work_create'
       require 'hyrax/transactions/work_destroy'
       require 'hyrax/transactions/work_update'
@@ -112,6 +113,10 @@ module Hyrax
           CollectionUpdate.new
         end
 
+        ops.register 'update_file_set' do
+          FileSetUpdate.new
+        end
+
         ops.register 'update_work' do
           WorkUpdate.new
         end
@@ -132,6 +137,10 @@ module Hyrax
 
         ops.register 'remove_from_work' do
           Steps::RemoveFileSetFromWork.new
+        end
+
+        ops.register 'save_acl' do
+          Steps::SaveAccessControl.new
         end
       end
 

--- a/lib/hyrax/transactions/file_set_update.rb
+++ b/lib/hyrax/transactions/file_set_update.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'hyrax/transactions/transaction'
+
+module Hyrax
+  module Transactions
+    ##
+    # Updates a {Hyrax::FileSet} from a ChangeSet
+    #
+    # @since 3.4.0
+    class FileSetUpdate < Transaction
+      DEFAULT_STEPS = ['change_set.apply',
+                       'file_set.save_acl'].freeze
+
+      ##
+      # @see Hyrax::Transactions::Transaction
+      def initialize(container: Container, steps: DEFAULT_STEPS)
+        super
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -233,6 +233,16 @@ RSpec.describe Hyrax::FileSetsController do
         expect(assigns[:file_set].read_groups).to contain_exactly("group3")
       end
 
+      context 'update visibility' do
+        let(:update_params) { { visibility: 'open' } }
+
+        it 'can make file set public' do
+          patch :update, params: { id: file_set, file_set: update_params }
+
+          expect(assigns[:file_set].read_groups).to contain_exactly('public')
+        end
+      end
+
       context "when there's an error saving" do
         let(:parent) { FactoryBot.create(:work, :public, user: user) }
 

--- a/spec/features/edit_file_spec.rb
+++ b/spec/features/edit_file_spec.rb
@@ -24,4 +24,22 @@ RSpec.describe "Editing a file:", type: :feature do
       expect(page).to have_content "Edit #{file_title}"
     end
   end
+
+  context 'when the user tries to update permissions' do
+    let(:file_set) { create(:file_set, user: user, title: [file_title], read_groups: ['public']) }
+
+    it 'successfully update visibility' do
+      visit edit_hyrax_file_set_path(file_set)
+      click_link 'Permissions'
+
+      expect(find('#file_set_visibility_open').checked?).to be(true)
+
+      find('#file_set_visibility_authenticated').click
+      within "#permission" do
+        click_button 'Save'
+      end
+
+      expect(page).to have_css('span.badge.badge-info', text: 'Institution')
+    end
+  end
 end

--- a/spec/hyrax/transactions/file_set_update_spec.rb
+++ b/spec/hyrax/transactions/file_set_update_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::FileSetUpdate do
+  subject(:tx)     { described_class.new }
+  let(:file_set)   { FactoryBot.valkyrie_create(:hyrax_file_set, title: 'image.jpg') }
+  let(:change_set) { Hyrax::Forms::AdministrativeSetForm.new(file_set) }
+  let(:user)       { FactoryBot.create(:user) }
+  let(:xmas)       { DateTime.parse('2022-12-25 11:30').iso8601 }
+
+  before { allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(xmas) }
+
+  describe '#call' do
+    it 'is a success' do
+      expect(tx.call(change_set)).to be_success
+    end
+
+    it 'sets attributes' do
+      change_set.title = 'new file title'
+
+      expect(tx.call(change_set).value!)
+        .to have_attributes(title: contain_exactly('new file title'))
+    end
+  end
+end


### PR DESCRIPTION
### Fixes

Fixes #6177 ; refs #6177

### Summary

Save permission attributes with file_set.update transaction during file update.


@samvera/hyrax-code-reviewers
