### PR TITLE
use locally defined conf to map mime_types derivative methods 

### DIFF
--- a/app/services/hyrax/file_set_derivatives_service.rb
+++ b/app/services/hyrax/file_set_derivatives_service.rb
@@ -31,11 +31,11 @@ module Hyrax
 
     def create_derivatives(filename)
       case mime_type
-      when *file_set.class.pdf_mime_types             then create_pdf_derivatives(filename)
-      when *file_set.class.office_document_mime_types then create_office_document_derivatives(filename)
-      when *file_set.class.audio_mime_types           then create_audio_derivatives(filename)
-      when *file_set.class.video_mime_types           then create_video_derivatives(filename)
-      when *file_set.class.image_mime_types           then create_image_derivatives(filename)
+      when *Hyrax.config.derivative_mime_type_mappings[:pdf]    then create_pdf_derivatives(filename)
+      when *Hyrax.config.derivative_mime_type_mappings[:office] then create_office_document_derivatives(filename)
+      when *Hyrax.config.derivative_mime_type_mappings[:audio]  then create_audio_derivatives(filename)
+      when *Hyrax.config.derivative_mime_type_mappings[:video]  then create_video_derivatives(filename)
+      when *Hyrax.config.derivative_mime_type_mappings[:image] then create_image_derivatives(filename)
       end
     end
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -182,6 +182,50 @@ module Hyrax
     # Override characterization runner
     attr_accessor :characterization_runner
 
+    attr_writer :derivative_mime_type_mappings
+    ##
+    # Maps mimetypes to create_*_derivatives methods
+    #
+    # @note these used to be set by +Hydra::Works::MimeTypes+ methods injected
+    #   into `FileSet`. for backwards compatibility, those are used as defaults
+    #   if present, but since `FileSet` is an application side model (and slated
+    #   to be removed) we shouldn't count on it providing these methods.
+    #
+    # @see Hyrax::VaDerivativeService
+    def derivative_mime_type_mappings # rubocop:disable Metrics/MethodLength
+      @derivative_mime_type_mappings ||=
+        { audio: ("FileSet".safe_constantize.try(:audio_mime_types) || ['audio/mp3',
+                                                                        'audio/mpeg',
+                                                                        'audio/wav',
+                                                                        'audio/x-wave',
+                                                                        'audio/x-wav',
+                                                                        'audio/ogg']),
+          image: ("FileSet".safe_constantize.try(:image_mime_types) || ['image/png',
+                                                                        'image/jpeg',
+                                                                        'image/jpg',
+                                                                        'image/jp2',
+                                                                        'image/bmp',
+                                                                        'image/gif',
+                                                                        'image/tiff']),
+          office: ("FileSet".safe_constantize.try(:office_mime_types) ||
+                   ['text/rtf',
+                    'application/msword',
+                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                    'application/vnd.oasis.opendocument.text',
+                    'application/vnd.ms-excel',
+                    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                    'application/vnd.ms-powerpoint',
+                    'application/vnd.openxmlformats-officedocument.presentationml.presentation']),
+          pdf: ("FileSet".safe_constantize.try(:pdf_mime_types) || ['application/pdf']),
+          video: ("FileSet".safe_constantize.try(:video_mime_types) || ['video/mpeg',
+                                                                        'video/mp4',
+                                                                        'video/webm',
+                                                                        'video/x-msvideo',
+                                                                        'video/avi',
+                                                                        'video/quicktime',
+                                                                        'application/mxf']) }
+    end
+
     attr_writer :derivative_services
     # The registered candidate derivative services.  In the array, the first `valid?` candidate will
     # handle the derivative generation.

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -9,6 +9,8 @@ module Hyrax
   # engine options. For convenient reference, options are grouped into the
   # following functional areas:
   #
+  # - Analytics
+  # - Files
   # - Groups
   # - Identifiers
   # - IIIF
@@ -148,6 +150,57 @@ module Hyrax
     attr_writer :analytic_start_date
     attr_reader :analytic_start_date
 
+    # @!endgroup
+    # @!group Files
+
+    ##
+    # @!attribute [rw] characterization_service
+    #   @return [#run] the service to use for charactaerization for Valkyrie
+    #     objects
+    #   @ see Hyrax::Characterization::ValkyrieCharacterizationService
+    attr_writer :characterization_service
+    def characterization_service
+      @characterization_service ||=
+        Hyrax::Characterization::ValkyrieCharacterizationService
+    end
+
+    ##
+    # Options to pass to the characterization service
+    # @!attribute [rw] characterization_options
+    #  @return [Hash] of options like {ch12n_tool: :fits_servlet}
+    attr_accessor :characterization_options
+
+    ##
+    # @!attribute [w] characterization_proxy
+    #   Which FileSet file to use for mime type resolution
+    #   @ see Hyrax::FileSetTypeService
+    attr_writer :characterization_proxy
+    def characterization_proxy
+      @characterization_proxy ||= :original_file
+    end
+
+    # Override characterization runner
+    attr_accessor :characterization_runner
+
+    attr_writer :derivative_services
+    # The registered candidate derivative services.  In the array, the first `valid?` candidate will
+    # handle the derivative generation.
+    #
+    # @return [Array] of objects that conform to Hyrax::DerivativeService interface.
+    # @see Hyrax::DerivativeService
+    def derivative_services
+      @derivative_services ||= [Hyrax::FileSetDerivativesService]
+    end
+
+    attr_writer :fixity_service
+    def fixity_service
+      @fixity_service ||= Hyrax::Fixity::ActiveFedoraFixityService
+    end
+
+    attr_writer :max_days_between_fixity_checks
+    def max_days_between_fixity_checks
+      @max_days_between_fixity_checks ||= 7
+    end
     # @!endgroup
     # @!group Groups
 
@@ -484,45 +537,6 @@ module Hyrax
     def microdata_default_type
       @microdata_default_type ||= 'http://schema.org/CreativeWork'
     end
-
-    attr_writer :fixity_service
-    def fixity_service
-      @fixity_service ||= Hyrax::Fixity::ActiveFedoraFixityService
-    end
-
-    attr_writer :max_days_between_fixity_checks
-    def max_days_between_fixity_checks
-      @max_days_between_fixity_checks ||= 7
-    end
-
-    # Override characterization runner
-    attr_accessor :characterization_runner
-
-    ##
-    # @!attribute [rw] characterization_service
-    #   @return [#run] the service to use for charactaerization for Valkyrie
-    #     objects
-    #   @ see Hyrax::Characterization::ValkyrieCharacterizationService
-    attr_writer :characterization_service
-    def characterization_service
-      @characterization_service ||=
-        Hyrax::Characterization::ValkyrieCharacterizationService
-    end
-
-    ##
-    # @!attribute [w] characterization_proxy
-    #   Which FileSet file to use for mime type resolution
-    #   @ see Hyrax::FileSetTypeService
-    attr_writer :characterization_proxy
-    def characterization_proxy
-      @characterization_proxy ||= :original_file
-    end
-
-    ##
-    # Options to pass to the characterization service
-    # @!attribute [rw] characterization_options
-    #  @return [Hash] of options like {ch12n_tool: :fits_servlet}
-    attr_accessor :characterization_options
 
     # Attributes for the lock manager which ensures a single process/thread is mutating a ore:Aggregation at once.
     # @!attribute [w] lock_retry_count
@@ -880,16 +894,6 @@ module Hyrax
     # @return [Array<Integer>]
     def range_for_number_of_results_to_display_per_page
       @range_for_number_of_results_to_display_per_page ||= [10, 20, 50, 100]
-    end
-
-    attr_writer :derivative_services
-    # The registered candidate derivative services.  In the array, the first `valid?` candidate will
-    # handle the derivative generation.
-    #
-    # @return [Array] of objects that conform to Hyrax::DerivativeService interface.
-    # @see Hyrax::DerivativeService
-    def derivative_services
-      @derivative_services ||= [Hyrax::FileSetDerivativesService]
     end
 
     attr_writer :visibility_map

--- a/spec/factories/hyrax_file_metadata.rb
+++ b/spec/factories/hyrax_file_metadata.rb
@@ -31,5 +31,9 @@ FactoryBot.define do
         visibility_setting { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
       end
     end
+
+    trait :image do
+      mime_type { 'image/png' }
+    end
   end
 end

--- a/spec/services/hyrax/file_set_derivatives_service_spec.rb
+++ b/spec/services/hyrax/file_set_derivatives_service_spec.rb
@@ -2,13 +2,21 @@
 require 'hyrax/specs/shared_specs'
 
 RSpec.describe Hyrax::FileSetDerivativesService do
-  let(:valid_file_set) do
-    FileSet.new.tap do |f|
-      allow(f).to receive(:mime_type).and_return(FileSet.image_mime_types.first)
+  context 'for active_fedora', :active_fedora do
+    let(:valid_file_set) do
+      FileSet.new.tap do |f|
+        allow(f).to receive(:mime_type).and_return('image/png')
+      end
     end
+
+    it_behaves_like "a Hyrax::DerivativeService"
   end
 
-  subject { described_class.new(file_set) }
+  context 'for a valkyrie resource', valkyrie_adapter: :test_adapter do
+    let(:valid_file_set) do
+      FactoryBot.valkyrie_create(:hyrax_file_metadata, :image)
+    end
 
-  it_behaves_like "a Hyrax::DerivativeService"
+    it_behaves_like "a Hyrax::DerivativeService"
+  end
 end


### PR DESCRIPTION
Adds `Hyrax.config.derivative_mime_type_mappings` to provide configuration
mapping mime_types to derivative handling behavior. This used to be triggered
based on `FileSet` class methods, but Hyrax has never had direct control over
`FileSet` (usually an ActiveFedora model).

new Valkyrie applications normally won't want to define a model class named
this. currently, they are forced to because `FileSet` is referenced in various
places (including here!) in the codebase. we probably don't want to ask them to
hang configuration off this, so provide a local configuration option and default
to the class defenitions for backward compatibility.

### Changes proposed in this pull request:
* Adds  `Hyrax.config.derivative_mime_type_mappings`, which can be overridden as an alternative to redefining `FileSet.image_mime_types` and similar methods.


@samvera/hyrax-code-reviewers
