### PR TITLE
Add method to VersioningService to detect support

### DIFF
--- a/app/services/hyrax/versioning_service.rb
+++ b/app/services/hyrax/versioning_service.rb
@@ -32,14 +32,10 @@ module Hyrax
     # If the resource is nil, or if it is a Hyrax::FileMetadata and versioning
     # is not supported in the storage adapter, an empty array will be returned.
     def versions
-      if resource.nil?
+      if !supports_multiple_versions?
         []
       elsif resource.is_a?(Hyrax::FileMetadata)
-        if storage_adapter.try(:"supports?", :versions)
-          storage_adapter.find_versions(id: resource.file_identifier).to_a
-        else
-          []
-        end
+        storage_adapter.find_versions(id: resource.file_identifier).to_a
       else
         return resource.versions if resource.versions.is_a?(Array)
         resource.versions.all.to_a
@@ -51,6 +47,16 @@ module Hyrax
     # Hyrax::VersioningService.
     def latest_version
       versions.last
+    end
+
+    ##
+    # Returns whether support for multiple versions exists on this
+    # +Hyrax::VersioningService+.
+    #
+    # Versioning is unsupported on nil resources or on Valkyrie resources when
+    # the configured storage adapter does not advertise versioning support.
+    def supports_multiple_versions?
+      !(resource.nil? || resource.is_a?(Hyrax::FileMetadata) && !storage_adapter.try(:"supports?", :versions))
     end
 
     ##

--- a/spec/services/hyrax/versioning_service_spec.rb
+++ b/spec/services/hyrax/versioning_service_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Hyrax::VersioningService do
       Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :original_file, versioning: true)
     end
 
+    describe '#supports_multiple_versions?' do
+      subject do
+        described_class.new(resource: file.original_file).supports_multiple_versions?
+      end
+
+      it { is_expected.to be true }
+    end
+
     describe '#versions' do
       subject do
         described_class.new(resource: file.original_file).versions.map do |v|
@@ -87,6 +95,24 @@ RSpec.describe Hyrax::VersioningService do
       storage_adapter.upload(resource: file_set, file: file, original_filename: file.original_filename)
     end
     let(:file_metadata) { query_service.custom_queries.find_file_metadata_by(id: uploaded.id) }
+
+    describe '#supports_multiple_versions?' do
+      subject do
+        described_class.new(resource: file_metadata).supports_multiple_versions?
+      end
+
+      context 'when versions are unsupported' do
+        before do
+          allow(storage_adapter).to receive(:supports?).and_return(false)
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context 'when versions are supported' do
+        it { is_expected.to be true }
+      end
+    end
 
     describe '#versions' do
       subject { described_class.new(resource: file_metadata).versions.map(&:id) }


### PR DESCRIPTION
Right now `Hyrax::VersioningService` does some silent coersion of versioning information in the case that versioning is not supported by the storage adapter. But, it might be good to actively provide a different UI to users in some cases depending on whether multiple versions of a file can actually be stored.

This commit adds a `supports_multiple_versions?` method to `Hyrax::VersioningService` which returns `true` iff the `resource` is non‐nil and not a `FileMetadata` object, or if it is a `FileMetadata` object and the storage adapter supports versioning.

This check requires having both a resource and a storage adapter in‐hand. My guess is that this is reasonable, but if we need to detect versioning support more generally (without a specific resource), a different solution may be desirable (altho
`Hyrax.storage_adapter.try?(:"supports?", :versions)` works in this case.)

---

Related to #6211 in the sense of being a prerequisite for disabling this functionality in the UI in cases where it will definitely not work.