### PR TITLE
use Valkyrie to setup AdminSetService specs

### DIFF
--- a/spec/factories/administrative_sets.rb
+++ b/spec/factories/administrative_sets.rb
@@ -15,6 +15,13 @@ FactoryBot.define do
     end
 
     after(:create) do |admin_set, evaluator|
+      admin_set.permission_manager.edit_groups = evaluator.edit_groups
+      admin_set.permission_manager.edit_users  = evaluator.edit_users
+      admin_set.permission_manager.read_users  = evaluator.read_users
+      admin_set.permission_manager.read_groups  = evaluator.read_groups
+
+      admin_set.permission_manager.acl.save
+
       if evaluator.with_permission_template
         template = Hyrax::PermissionTemplate.find_or_create_by(source_id: admin_set.id.to_s)
         evaluator.access_grants.each do |grant|

--- a/spec/services/hyrax/admin_set_service_spec.rb
+++ b/spec/services/hyrax/admin_set_service_spec.rb
@@ -8,24 +8,23 @@ RSpec.describe Hyrax::AdminSetService do
            search_state_class: nil)
   end
   let(:service) { described_class.new(context) }
-  let(:user) { create(:user) }
+  let(:user) { FactoryBot.create(:user) }
 
   describe "#search_results", :clean_repo do
-    subject { service.search_results(access) }
-
-    let!(:as1) { create(:admin_set, read_groups: ['public'], title: ['foo']) }
-    let!(:as2) { create(:admin_set, read_groups: ['public'], title: ['bar']) }
-    let!(:as3) { create(:admin_set, edit_users: [user.user_key], title: ['baz']) }
+    let!(:as1) { FactoryBot.valkyrie_create(:hyrax_admin_set, read_groups: ['public']) }
+    let!(:as2) { FactoryBot.valkyrie_create(:hyrax_admin_set, read_groups: ['public']) }
+    let!(:as3) { FactoryBot.valkyrie_create(:hyrax_admin_set, edit_users: [user.user_key]) }
 
     before do
-      create(:collection, :public) # this should never be returned.
+      FactoryBot.valkyrie_create(:hyrax_collection, :public) # this should never be returned.
     end
 
     context "with read access" do
       let(:access) { :read }
 
       it "returns three admin sets" do
-        expect(subject.map(&:id)).to match_array [as1.id, as2.id, as3.id]
+        expect(service.search_results(access).map(&:id))
+          .to contain_exactly(as1.id, as2.id, as3.id)
       end
     end
 
@@ -33,7 +32,8 @@ RSpec.describe Hyrax::AdminSetService do
       let(:access) { :edit }
 
       it "returns one admin set" do
-        expect(subject.map(&:id)).to match_array [as3.id]
+        expect(service.search_results(access).map(&:id))
+          .to contain_exactly(as3.id)
       end
     end
   end


### PR DESCRIPTION
makes these tests pass under both `.dassie` and `.koppie`.

related to #6137 

@samvera/hyrax-code-reviewers
