### PR TITLE
refine Hyrax::EmbargoSearch behavior to find only enforced embargoes

### DIFF
--- a/app/actors/hyrax/actors/embargo_actor.rb
+++ b/app/actors/hyrax/actors/embargo_actor.rb
@@ -14,12 +14,9 @@ module Hyrax
       def destroy
         case work
         when Valkyrie::Resource
-          embargo_manager = Hyrax::EmbargoManager.new(resource: work)
-          return if embargo_manager.embargo.embargo_release_date.blank?
-
-          embargo_manager.deactivate!
-          work.embargo = Hyrax.persister.save(resource: embargo_manager.embargo)
-          Hyrax::AccessControlList(work).save
+          Hyrax::EmbargoManager.deactivate_embargo_for(resource: work) &&
+            Hyrax.persister.save(resource: work.embargo) &&
+            Hyrax::AccessControlList(work).save
         else
           work.embargo_visibility! # If the embargo has lapsed, update the current visibility.
           work.deactivate_embargo!

--- a/app/presenters/hyrax/embargo_presenter.rb
+++ b/app/presenters/hyrax/embargo_presenter.rb
@@ -23,5 +23,9 @@ module Hyrax
     def embargo_history
       solr_document['embargo_history_ssim']
     end
+
+    def enforced?
+      solr_document.embargo_enforced?
+    end
   end
 end

--- a/app/services/hyrax/embargo_manager.rb
+++ b/app/services/hyrax/embargo_manager.rb
@@ -251,7 +251,7 @@ module Hyrax
       embargo_state = embargo.active? ? 'active' : 'expired'
       history_record = embargo_history_message(
         embargo_state,
-        Time.zone.today,
+        Hyrax::TimeService.time_in_utc,
         embargo.embargo_release_date,
         embargo.visibility_during_embargo,
         embargo.visibility_after_embargo

--- a/app/services/hyrax/embargo_service.rb
+++ b/app/services/hyrax/embargo_service.rb
@@ -1,24 +1,26 @@
 # frozen_string_literal: true
 module Hyrax
+  ##
+  # Methods for Querying Repository to find Embargoed Objects
   class EmbargoService < RestrictionService
     class << self
-      #
-      # Methods for Querying Repository to find Embargoed Objects
-      #
-
       # Returns all assets with embargo release date set to a date in the past
-      def assets_with_expired_embargoes
+      def assets_with_expired_enforced_embargoes
         builder = Hyrax::ExpiredEmbargoSearchBuilder.new(self)
         presenters(builder)
       end
+      alias assets_with_expired_embargoes assets_with_expired_enforced_embargoes
 
-      # Returns all assets with embargo release date set
-      #   (assumes that when lease visibility is applied to assets
-      #    whose leases have expired, the lease expiration date will be removed from its metadata)
-      def assets_under_embargo
+      ##
+      # Returns all assets with embargoes that are currently enforced,
+      # regardless of whether the embargoes are active or expired.
+      #
+      # @see Hyrax::EmbargoManager
+      def assets_with_enforced_embargoes
         builder = Hyrax::EmbargoSearchBuilder.new(self)
-        presenters(builder)
+        presenters(builder).select(&:enforced?)
       end
+      alias assets_under_embargo assets_with_enforced_embargoes
 
       # Returns all assets that have had embargoes deactivated in the past.
       def assets_with_deactivated_embargoes

--- a/lib/tasks/embargo_lease.rake
+++ b/lib/tasks/embargo_lease.rake
@@ -8,6 +8,7 @@ namespace :hyrax do
 
       Hyrax.query_service.find_many_by_ids(ids: ids).each do |resource|
         Hyrax::EmbargoManager.release_embargo_for(resource: resource) &&
+          Hyrax.persister.save(resource: resource.embargo) &&
           Hyrax::AccessControlList(resource).save
       end
     end

--- a/spec/factories/administrative_sets.rb
+++ b/spec/factories/administrative_sets.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
       admin_set.permission_manager.edit_groups = evaluator.edit_groups
       admin_set.permission_manager.edit_users  = evaluator.edit_users
       admin_set.permission_manager.read_users  = evaluator.read_users
-      admin_set.permission_manager.read_groups  = evaluator.read_groups
+      admin_set.permission_manager.read_groups = evaluator.read_groups
 
       admin_set.permission_manager.acl.save
 

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -8,6 +8,20 @@ FactoryBot.define do
       association :embargo, factory: :hyrax_embargo
     end
 
+    trait :with_expired_enforced_embargo do
+      after(:build) do |work, evaluator|
+        work.embargo = FactoryBot.valkyrie_create(:hyrax_embargo, :expired)
+      end
+
+      after(:create) do |work, _evaluator|
+        allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(10.days.ago)
+        Hyrax::EmbargoManager.new(resource: work).apply
+        allow(Hyrax::TimeService).to receive(:time_in_utc).and_call_original
+
+        work.permission_manager.acl.save
+      end
+    end
+
     trait :under_lease do
       association :lease, factory: :hyrax_lease
     end

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -6,6 +6,11 @@ FactoryBot.define do
   factory :hyrax_work, class: 'Hyrax::Test::SimpleWork' do
     trait :under_embargo do
       association :embargo, factory: :hyrax_embargo
+
+      after(:create) do |work, _e|
+        Hyrax::EmbargoManager.new(resource: work).apply
+        work.permission_manager.acl.save
+      end
     end
 
     trait :with_expired_enforced_embargo do

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     end
 
     trait :with_expired_enforced_embargo do
-      after(:build) do |work, evaluator|
+      after(:build) do |work, _evaluator|
         work.embargo = FactoryBot.valkyrie_create(:hyrax_embargo, :expired)
       end
 

--- a/spec/helpers/hyrax/embargo_helper_spec.rb
+++ b/spec/helpers/hyrax/embargo_helper_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Hyrax::EmbargoHelper do
   end
 
   describe '#embargo_history' do
-    context 'with an ActiveFedora resource' do
+    context 'with an ActiveFedora resource', :active_fedora do
       let(:resource) { FactoryBot.build(:work) }
 
       it 'is empty' do

--- a/spec/models/concerns/hyrax/solr_document_behavior_spec.rb
+++ b/spec/models/concerns/hyrax/solr_document_behavior_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Hyrax::SolrDocumentBehavior do
     # actually index the whole embargo structure.
     context 'when only an embargo date is indexed' do
       let(:solr_hash) do
-        { "embargo_release_date_dtsi" => "2023-08-30T00:00:00Z"}
+        { "embargo_release_date_dtsi" => "2023-08-30T00:00:00Z" }
       end
 
       it 'is "embargo"' do

--- a/spec/presenters/hyrax/embargo_presenter_spec.rb
+++ b/spec/presenters/hyrax/embargo_presenter_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::EmbargoPresenter do
+  subject(:presenter) { described_class.new(document) }
   let(:document) { SolrDocument.new(attributes) }
-  let(:presenter) { described_class.new(document) }
   let(:attributes) { {} }
 
-  describe "visibility" do
+  describe "#visibility" do
     subject { presenter.visibility }
 
     it { is_expected.to eq 'restricted' }
   end
 
-  describe "to_s" do
+  describe "#to_s" do
     let(:attributes) { { 'title_tesim' => ['Hey guys!'] } }
 
     subject { presenter.to_s }
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::EmbargoPresenter do
     it { is_expected.to eq 'Hey guys!' }
   end
 
-  describe "human_readable_type" do
+  describe "#human_readable_type" do
     let(:attributes) { { 'human_readable_type_tesim' => ['File'] } }
 
     subject { presenter.human_readable_type }
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::EmbargoPresenter do
     it { is_expected.to eq '15 Oct 2015' }
   end
 
-  describe "visibility_after_embargo" do
+  describe "#visibility_after_embargo" do
     let(:attributes) { { 'visibility_after_embargo_ssim' => ['restricted'] } }
 
     subject { presenter.visibility_after_embargo }
@@ -42,11 +42,22 @@ RSpec.describe Hyrax::EmbargoPresenter do
     it { is_expected.to eq 'restricted' }
   end
 
-  describe "embargo_history" do
+  describe "#embargo_history" do
     let(:attributes) { { 'embargo_history_ssim' => ['This is in the past'] } }
 
     subject { presenter.embargo_history }
 
     it { is_expected.to eq ['This is in the past'] }
+  end
+
+  describe "#enforced?" do
+    let(:attributes) do
+      { "embargo_release_date_dtsi" => "2023-08-30T00:00:00Z",
+        "visibility_during_embargo_ssim" => "restricted",
+        "visibility_after_embargo_ssim" => "open",
+        "visibility_ssi" => "restricted" }
+    end
+
+    it { is_expected.to be_enforced }
   end
 end

--- a/spec/services/hyrax/embargo_service_spec.rb
+++ b/spec/services/hyrax/embargo_service_spec.rb
@@ -1,38 +1,55 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::EmbargoService do
-  subject { described_class }
+RSpec.describe Hyrax::EmbargoService, :clean_repo do
+  subject(:service) { described_class }
 
   let(:future_date) { 2.days.from_now }
   let(:past_date) { 2.days.ago }
 
-  let!(:work_with_expired_embargo1) do
-    build(:work, embargo_release_date: past_date.to_s).tap do |work|
-      work.save(validate: false)
-    end
+  let!(:work_with_expired_enforced_embargo1) do
+    FactoryBot.valkyrie_create(:hyrax_work, :with_expired_enforced_embargo)
   end
 
-  let!(:work_with_expired_embargo2) do
-    build(:work, embargo_release_date: past_date.to_s).tap do |work|
-      work.save(validate: false)
-    end
+  let!(:work_with_expired_enforced_embargo2) do
+    FactoryBot.valkyrie_create(:hyrax_work, :with_expired_enforced_embargo)
   end
 
-  let!(:work_with_embargo_in_effect) { create(:work, embargo_release_date: future_date.to_s) }
+  let!(:work_with_released_embargo) do
+    FactoryBot.create(:embargoed_work, with_embargo_attributes: { embargo_date: past_date.to_s })
+  end
+
+  let!(:work_with_embargo_in_effect) do
+    FactoryBot.create(:embargoed_work, with_embargo_attributes: { embargo_date: future_date.to_s })
+  end
+
   let!(:work_without_embargo) { create(:generic_work) }
 
   describe '#assets_with_expired_embargoes' do
-    it 'returns an array of assets with expired embargoes' do
-      returned_pids = subject.assets_with_expired_embargoes.map(&:id)
-      expect(returned_pids).to include work_with_expired_embargo1.id, work_with_expired_embargo2.id
-      expect(returned_pids).not_to include work_with_embargo_in_effect.id, work_without_embargo.id
+    it 'returns an array of assets with expired embargoes that are still enforced' do
+      expect(service.assets_with_expired_embargoes)
+        .to contain_exactly(have_attributes(id: work_with_expired_enforced_embargo1.id),
+                            have_attributes(id: work_with_expired_enforced_embargo2.id))
     end
   end
 
-  describe '#assets_under_embargo' do
-    it 'returns all assets with embargo release date set' do
-      returned_pids = subject.assets_under_embargo.map(&:id)
-      expect(returned_pids).to include work_with_expired_embargo1.id, work_with_expired_embargo2.id, work_with_embargo_in_effect.id
-      expect(returned_pids).not_to include work_without_embargo.id
+  describe '#assets_with_enforced_embargoes' do
+    it 'returns all assets with enforced embargoes' do
+      expect(service.assets_under_embargo)
+        .to contain_exactly(have_attributes(id: work_with_embargo_in_effect.id),
+                            have_attributes(id: work_with_expired_enforced_embargo1.id),
+                            have_attributes(id: work_with_expired_enforced_embargo2.id))
+    end
+
+    context 'after the embargo is released' do
+      before do
+        Hyrax::EmbargoManager.release_embargo_for(resource: work_with_expired_enforced_embargo1)
+        work_with_expired_enforced_embargo1.permission_manager.acl.save
+      end
+
+      it 'does not include the work' do
+      expect(service.assets_under_embargo)
+        .to contain_exactly(have_attributes(id: work_with_embargo_in_effect.id),
+                            have_attributes(id: work_with_expired_enforced_embargo2.id))
+      end
     end
   end
 
@@ -49,12 +66,9 @@ RSpec.describe Hyrax::EmbargoService do
     end
 
     it 'returns all assets with embargo history set' do
-      returned_pids = subject.assets_with_deactivated_embargoes.map(&:id)
-      expect(returned_pids).to include id
-      expect(returned_pids).not_to include(work_without_embargo.id,
-                                           work_with_expired_embargo1.id,
-                                           work_with_expired_embargo2.id,
-                                           work_with_embargo_in_effect.id)
+      expect(service.assets_with_deactivated_embargoes)
+        .to contain_exactly(have_attributes(id: id),
+                            have_attributes(id: work_with_released_embargo.id))
     end
   end
 end

--- a/spec/services/hyrax/embargo_service_spec.rb
+++ b/spec/services/hyrax/embargo_service_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe Hyrax::EmbargoService, :clean_repo do
       end
 
       it 'does not include the work' do
-      expect(service.assets_under_embargo)
-        .to contain_exactly(have_attributes(id: work_with_embargo_in_effect.id),
-                            have_attributes(id: work_with_expired_enforced_embargo2.id))
+        expect(service.assets_under_embargo)
+          .to contain_exactly(have_attributes(id: work_with_embargo_in_effect.id),
+                              have_attributes(id: work_with_expired_enforced_embargo2.id))
       end
     end
   end

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Rake tasks" do
       expect { run_task 'hyrax:embargo:deactivate_expired' }
         .to change {
           Hyrax.query_service.find_many_by_ids(ids: expired.map(&:id))
-            .map { |work| work.embargo.embargo_history }
+               .map { |work| work.embargo.embargo_history }
         }
         .from(contain_exactly(be_empty, be_empty))
         .to(contain_exactly([start_with('An expired embargo was deactivated')],
@@ -32,7 +32,7 @@ RSpec.describe "Rake tasks" do
       expect { run_task 'hyrax:embargo:deactivate_expired' }
         .to change {
           Hyrax.query_service.find_many_by_ids(ids: expired.map(&:id))
-            .map { |work| work.permission_manager.read_groups.to_a }
+               .map { |work| work.permission_manager.read_groups.to_a }
         }
         .from([contain_exactly('registered'), contain_exactly('registered')])
         .to([include('public'), include('public')])
@@ -42,7 +42,7 @@ RSpec.describe "Rake tasks" do
       expect { run_task 'hyrax:embargo:deactivate_expired' }
         .to change {
           Hyrax.query_service.find_many_by_ids(ids: expired.map(&:id))
-            .map(&:visibility)
+               .map(&:visibility)
         }
         .from(['authenticated', 'authenticated'])
         .to(['open', 'open'])
@@ -52,7 +52,7 @@ RSpec.describe "Rake tasks" do
       expect { run_task 'hyrax:embargo:deactivate_expired' }
         .not_to change {
           Hyrax.query_service.find_many_by_ids(ids: active.map(&:id))
-            .map(&:visibility)
+               .map(&:visibility)
         }
         .from(['authenticated', 'authenticated'])
     end

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -2,6 +2,61 @@
 require 'rake'
 
 RSpec.describe "Rake tasks" do
+  describe "hyrax:embargo:deactivate_expired", :clean_repo do
+    let!(:active) do
+      [FactoryBot.valkyrie_create(:hyrax_work, :under_embargo),
+       FactoryBot.valkyrie_create(:hyrax_work, :under_embargo)]
+    end
+
+    let!(:expired) do
+      [FactoryBot.valkyrie_create(:hyrax_work, :with_expired_enforced_embargo),
+       FactoryBot.valkyrie_create(:hyrax_work, :with_expired_enforced_embargo)]
+    end
+
+    before do
+      load_rake_environment [File.expand_path("../../../lib/tasks/embargo_lease.rake", __FILE__)]
+    end
+
+    it "updates the persisted work ACLs for expired embargoes" do
+      expect { run_task 'hyrax:embargo:deactivate_expired' }
+        .to change {
+          Hyrax.query_service.find_many_by_ids(ids: expired.map(&:id))
+            .map { |work| work.permission_manager.read_groups.to_a }
+        }
+        .from([contain_exactly('registered'), contain_exactly('registered')])
+        .to([include('public'), include('public')])
+    end
+
+    it "updates the persisted work visibility for expired embargoes" do
+      expect { run_task 'hyrax:embargo:deactivate_expired' }
+        .to change {
+          Hyrax.query_service.find_many_by_ids(ids: expired.map(&:id))
+            .map(&:visibility)
+        }
+        .from(['authenticated', 'authenticated'])
+        .to(['open', 'open'])
+    end
+
+    it "does not update visibility for works with active embargoes" do
+      expect { run_task 'hyrax:embargo:deactivate_expired' }
+        .not_to change {
+          Hyrax.query_service.find_many_by_ids(ids: active.map(&:id))
+            .map(&:visibility)
+        }
+        .from(['authenticated', 'authenticated'])
+    end
+
+    it "removes the work from Hyrax::EmbargoHelper.assets_under_embargo" do
+      helper = Class.new { include Hyrax::EmbargoHelper }
+
+      # this helper is the source of truth for listing currently enforced embargoes for the UI
+      expect { run_task 'hyrax:embargo:deactivate_expired' }
+        .to change { helper.new.assets_under_embargo }
+        .from(contain_exactly(*(active + expired).map { |work| have_attributes(id: work.id) }))
+        .to(contain_exactly(*active.map { |work| have_attributes(id: work.id) }))
+    end
+  end
+
   describe "hyrax:user:list_emails" do
     let!(:user1) { create(:user) }
     let!(:user2) { create(:user) }

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe "Rake tasks" do
       load_rake_environment [File.expand_path("../../../lib/tasks/embargo_lease.rake", __FILE__)]
     end
 
+    it "adds embargo history for expired embargoes" do
+      expect { run_task 'hyrax:embargo:deactivate_expired' }
+        .to change {
+          Hyrax.query_service.find_many_by_ids(ids: expired.map(&:id))
+            .map { |work| work.embargo.embargo_history }
+        }
+        .from(contain_exactly(be_empty, be_empty))
+        .to(contain_exactly([start_with('An expired embargo was deactivated')],
+                            [start_with('An expired embargo was deactivated')]))
+    end
+
     it "updates the persisted work ACLs for expired embargoes" do
       expect { run_task 'hyrax:embargo:deactivate_expired' }
         .to change {


### PR DESCRIPTION
since sometime in 2014, `Hyrax::EmbargoSearch` has looked for ALL resources that have ANY embargo date when determining which objects are under embargo. the actual embargo object metadata is indexed (under both AF and Valkyrie), so there's no need to be this aggressive about it.

for the UI, find only the objects that are actually under a currently enforced embargo (according to the index). as a first pass at implementing this, we find all the objects that have indexed embargo dates, then drop any that aren't currently being enforced (where the indexed visibility differs from the embargo's prescribed visibility).

we could probably improve upon this, but this should suit as a first pass.

related to ##6235

### Changes proposed in this pull request:
* change how the Hyrax UI determines which objects are under embargo from the index to match `Hyrax::EmbargoManager` definitions
* ensures `EmbargoManager#release` sets `#embargo_history` correctly; after running this method, it's necessary to save both the Embargo and the AccessControl to persist the changes.

@samvera/hyrax-code-reviewers
