### PR TITLE
update CollectionType GlobalID update task to use valkyrie

### DIFF
--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -28,9 +28,11 @@ module Hyrax
       validates :collection_type_gid, presence: true
 
       # Need to define here in order to override setter defined by ActiveTriples
-      def collection_type_gid=(new_collection_type_gid, force: false)
+      def collection_type_gid=(new_collection_type_gid)
         new_collection_type_gid = new_collection_type_gid&.to_s
-        raise "Can't modify collection type of this collection" if !force && persisted? && !collection_type_gid_was.nil? && collection_type_gid_was != new_collection_type_gid
+        raise "Can't modify collection type of this collection" if
+          !Thread.current[:force_collection_type_gid] && # Used by update_collection_type_global_ids rake task
+          persisted? && !collection_type_gid_was.nil? && collection_type_gid_was != new_collection_type_gid
         new_collection_type = Hyrax::CollectionType.find_by_gid!(new_collection_type_gid)
         super(new_collection_type_gid)
         @collection_type = new_collection_type

--- a/lib/tasks/collection_type_global_id.rake
+++ b/lib/tasks/collection_type_global_id.rake
@@ -7,12 +7,13 @@ namespace :hyrax do
 
       count = 0
 
-      Collection.all.each do |collection|
-        next if collection.collection_type_gid == collection.collection_type.to_global_id.to_s
+      Hyrax.query_service.find_all_of_model(model: Hyrax::PcdmCollection).each do |collection|
+        type = Hyrax::CollectionType.find_by_gid(collection.collection_type_gid)
+        next if collection.collection_type_gid == type.to_global_id.to_s
 
-        collection.public_send(:collection_type_gid=, collection.collection_type.to_global_id, force: true)
+        collection.public_send(:collection_type_gid=, type.to_global_id, force: true)
 
-        collection.save &&
+        Hyrax.persister.save(resource: collection) &&
           count += 1
       end
 

--- a/lib/tasks/collection_type_global_id.rake
+++ b/lib/tasks/collection_type_global_id.rake
@@ -11,10 +11,14 @@ namespace :hyrax do
         type = Hyrax::CollectionType.find_by_gid(collection.collection_type_gid)
         next if collection.collection_type_gid == type.to_global_id.to_s
 
-        collection.public_send(:collection_type_gid=, type.to_global_id, force: true)
+        # Awful hack to allow converted AF collections to force update collection_type_gid
+        Thread.current[:force_collection_type_gid] = true
+        collection.collection_type_gid = type.to_global_id
 
         Hyrax.persister.save(resource: collection) &&
           count += 1
+      ensure
+        Thread.current[:force_collection_type_gid] = false
       end
 
       puts "Updated #{count} collections."

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -109,18 +109,20 @@ RSpec.describe "Rake tasks" do
         let(:other_collection_type) { FactoryBot.create(:collection_type) }
 
         let(:collections_with_legacy_gids) do
-          [FactoryBot.create(:collection, collection_type_gid: "gid://internal/sometext/#{collection_type.id}"),
-           FactoryBot.create(:collection, collection_type_gid: "gid://internal/sometext/#{other_collection_type.id}")]
+          [FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: "gid://internal/sometext/#{collection_type.id}"),
+           FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: "gid://internal/sometext/#{other_collection_type.id}")]
         end
 
         before do
-          FactoryBot.create_list(:collection, 3, collection_type_gid: collection_type.to_global_id)
-          FactoryBot.create_list(:collection, 3, collection_type_gid: other_collection_type.to_global_id)
+          3.times do
+            FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id)
+            FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: other_collection_type.to_global_id)
+          end
         end
 
         it 'updates collections to use standard GlobalId URI' do
           expect { run_task 'hyrax:collections:update_collection_type_global_ids' }
-            .to change { collections_with_legacy_gids.map { |col| col.reload.collection_type_gid } }
+            .to change { collections_with_legacy_gids.map { |col| Hyrax.query_service.find_by(id: col.id).collection_type_gid } }
             .to eq [collection_type.to_global_id.to_s, other_collection_type.to_global_id.to_s]
         end
       end


### PR DESCRIPTION
i considered removing this task, but it was easy to rewrite and Hyrax still supports lookup for both GlobalID styles

@samvera/hyrax-code-reviewers
