### PR TITLE
mark generic_work_abilities_spec ActiveFedora only

### DIFF
--- a/spec/abilities/generic_work_abilities_spec.rb
+++ b/spec/abilities/generic_work_abilities_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'cancan/matchers'
 
-RSpec.describe Hyrax::Ability do
+RSpec.describe Hyrax::Ability, :active_fedora do
   subject { Ability.new(current_user) }
 
   let(:generic_work) { create(:private_generic_work, user: creating_user) }


### PR DESCRIPTION
GenericWork tests are ActiveFedora specs, in general

@samvera/hyrax-code-reviewers
