### PR TITLE
mark Hyrax Callbacks tests as :active_fedora

### DIFF
--- a/spec/config/hyrax_events_spec.rb
+++ b/spec/config/hyrax_events_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: truep
+# frozen_string_literal: true
 RSpec.describe "hyrax_events using Hyrax callbacks", :active_fedora do
   let(:curation_concern) { create(:work) }
   let(:file_set) { create(:file_set) }

--- a/spec/config/hyrax_events_spec.rb
+++ b/spec/config/hyrax_events_spec.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
-RSpec.describe "hyrax_events using Hyrax callbacks" do
+# frozen_string_literal: truep
+RSpec.describe "hyrax_events using Hyrax callbacks", :active_fedora do
   let(:curation_concern) { create(:work) }
   let(:file_set) { create(:file_set) }
   let(:user) { create(:user) }


### PR DESCRIPTION
Hyrax::Callbacks is deprecated and only used by ActiveFedora apps

@samvera/hyrax-code-reviewers
