### PR TITLE
make `Hyrax::Identifier::Dispatcher` support Valkryie

### DIFF
--- a/app/services/hyrax/identifier/dispatcher.rb
+++ b/app/services/hyrax/identifier/dispatcher.rb
@@ -53,8 +53,16 @@ module Hyrax
       #
       # @see #assign_for
       def assign_for!(object:, attribute: :identifier)
-        assign_for(object: object, attribute: attribute).save!
-        object
+        result = assign_for(object: object, attribute: attribute)
+
+        case result
+        when Valkyrie::Resource
+          Hyrax.persister.save(resource: result)
+        else
+          result.save
+        end
+
+        result
       end
     end
   end

--- a/app/services/hyrax/identifier/dispatcher.rb
+++ b/app/services/hyrax/identifier/dispatcher.rb
@@ -60,9 +60,8 @@ module Hyrax
           Hyrax.persister.save(resource: result)
         else
           result.save
+          result
         end
-
-        result
       end
     end
   end

--- a/spec/services/hyrax/identifier/dispatcher_spec.rb
+++ b/spec/services/hyrax/identifier/dispatcher_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Hyrax::Identifier::Dispatcher do
   subject(:dispatcher) { described_class.new(registrar: fake_registrar.new) }
   let(:identifier)     { 'moomin/123/abc' }
-  let(:object)         { build(:generic_work) }
+  let(:object)         { FactoryBot.build(:monograph) }
 
   let(:fake_registrar) do
     Class.new do
@@ -16,10 +16,6 @@ RSpec.describe Hyrax::Identifier::Dispatcher do
   end
 
   shared_examples 'performs identifier assignment' do |method|
-    it 'returns the same object' do
-      expect(dispatcher.public_send(method, object: object)).to eql object
-    end
-
     it 'assigns to the identifier attribute by default' do
       dispatcher.public_send(method, object: object)
       expect(object.identifier).to contain_exactly(identifier)
@@ -59,10 +55,20 @@ RSpec.describe Hyrax::Identifier::Dispatcher do
     include_examples 'performs identifier assignment', :assign_for!
 
     it 'saves the object' do
-      expect { dispatcher.assign_for!(object: object) }
-        .to change { object.new_record? }
-        .from(true)
-        .to(false)
+      expect(dispatcher.assign_for!(object: object)).to be_persisted
+    end
+
+    context 'with an ActiveFedora model', :active_fedora do
+      let(:object) { FactoryBot.build(:work) }
+
+      include_examples 'performs identifier assignment', :assign_for!
+
+      it 'saves the object' do
+        expect { dispatcher.assign_for!(object: object) }
+          .to change { object.new_record? }
+          .from(true)
+          .to(false)
+      end
     end
   end
 end


### PR DESCRIPTION
adds support for valkyrie to `Hyrax::Identifier::Dispatcher`.

add legacy ActiveFedora tests and flag as `:active_fedora`

@samvera/hyrax-code-reviewers
