### PR TITLE
disable WorkFormService specs in .koppie

### DIFF
--- a/app/controllers/hyrax/batch_uploads_controller.rb
+++ b/app/controllers/hyrax/batch_uploads_controller.rb
@@ -6,6 +6,10 @@ module Hyrax
 
     # Gives the class of the form.
     class BatchUploadFormService
+      def self.build(resource, current_ability, *extra)
+        form_class.new(resource, current_ability, *extra)
+      end
+
       def self.form_class(_ = nil)
         ::Hyrax::Forms::BatchUploadForm
       end

--- a/app/controllers/hyrax/batch_uploads_controller.rb
+++ b/app/controllers/hyrax/batch_uploads_controller.rb
@@ -5,7 +5,7 @@ module Hyrax
     include Hyrax::WorksControllerBehavior
 
     # Gives the class of the form.
-    class BatchUploadFormService < Hyrax::WorkFormService
+    class BatchUploadFormService
       def self.form_class(_ = nil)
         ::Hyrax::Forms::BatchUploadForm
       end

--- a/spec/services/hyrax/work_form_service_spec.rb
+++ b/spec/services/hyrax/work_form_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hyrax::WorkFormService do
+RSpec.describe Hyrax::WorkFormService, :active_fedora do
   subject(:form_service) { described_class }
   let(:work)             { GenericWork.new }
 


### PR DESCRIPTION
WorkFormService is replaced by `Hyrax::FormFactory` for valkyrie.

`BatchUploadFormService` inherited it (and is used with valkyrie), but doesn't actually use the behavior. drop the class relationship to avoid confusion. right before a major release is a great time to drop behavior like this :)


@samvera/hyrax-code-reviewers
