### PR TITLE
never set `metadata/storage_adapter` to wings or AF if disable_wings

### DIFF
--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -98,12 +98,12 @@ end
 Valkyrie::MetadataAdapter.register(
   Wings::Valkyrie::MetadataAdapter.new, :wings_adapter
 )
-Valkyrie.config.metadata_adapter = :wings_adapter
+Valkyrie.config.metadata_adapter = :wings_adapter unless Hyrax.config.disable_wings
 
 Valkyrie::StorageAdapter.register(
   Wings::Valkyrie::Storage.new, :active_fedora
 )
-Valkyrie.config.storage_adapter = :active_fedora
+Valkyrie.config.storage_adapter = :active_fedora unless Hyrax.config.disable_wings
 
 # TODO: Custom query registration is not Wings specific.  These custom_queries need to be registered for other adapters too.
 #       A refactor is needed to add the default implementations to hyrax.rb and only handle the wings specific overrides here.

--- a/spec/wings_helper.rb
+++ b/spec/wings_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
-require 'wings'
+unless Hyrax.config.disable_wings
+  require 'wings'
 
-Dir[File.expand_path(File.join(File.dirname(__FILE__), 'wings', 'support', 'matchers', '**', '*.rb'))].each { |f| require f }
+  Dir[File.expand_path(File.join(File.dirname(__FILE__), 'wings', 'support', 'matchers', '**', '*.rb'))].each { |f| require f }
+end


### PR DESCRIPTION
some test on `.koppie` seem to fail on test order(?) issues, when they decide to use the Wings adapter for metadata persistence. it seems like something during the test suite run is setting the adapter to `:wings_adapter` and then not unsetting it. my best guess is that something is requiring `wings` or `wings/setup` (maybe via `wings/helper`) during the test run.

@samvera/hyrax-code-reviewers
