### PR TITLE
Hide versioning UI when unsupported by adapter

### DIFF
--- a/app/presenters/hyrax/version_list_presenter.rb
+++ b/app/presenters/hyrax/version_list_presenter.rb
@@ -5,17 +5,19 @@ module Hyrax
   class VersionListPresenter
     include Enumerable
 
+    attr_reader :versioning_service
+
     ##
-    # @param version_list [Array<#created>]
-    def initialize(version_list)
-      @raw_list = version_list
+    # @param service [Hyrax::VersioningService]
+    def initialize(service)
+      @versioning_service = service
     end
 
     ##
     # @param [Object] an object representing the File Set
     #
-    # @return [Enumerable<Hyrax::VersionPresenter>] an enumerable of presenters
-    #   for the relevant file versions.
+    # @return [Hyrax::VersionListPresenter] an enumerable of presenters for the
+    #   relevant file versions.
     #
     # @raise [ArgumentError] if we can't build an enu
     def self.for(file_set:)
@@ -24,18 +26,19 @@ module Hyrax
                       else
                         Hyrax::FileSetFileService.new(file_set: file_set).original_file
                       end
-      new(Hyrax::VersioningService.new(resource: original_file).versions)
+      new(Hyrax::VersioningService.new(resource: original_file))
     rescue NoMethodError
       raise ArgumentError
     end
 
-    delegate :each, to: :wrapped_list
+    delegate :each, :empty?, to: :wrapped_list
+    delegate :supports_multiple_versions?, to: :versioning_service
 
     private
 
     def wrapped_list
       @wrapped_list ||=
-        @raw_list.map { |v| Hyrax::VersionPresenter.new(v) } # wrap each item in a presenter
+        @versioning_service.versions.map { |v| Hyrax::VersionPresenter.new(v) } # wrap each item in a presenter
                  .sort { |a, b| b.version.created <=> a.version.created } # sort list of versions based on creation date
                  .tap { |l| l.first.try(:current!) } # set the first version to the current version
     end

--- a/app/views/hyrax/file_sets/_versioning.html.erb
+++ b/app/views/hyrax/file_sets/_versioning.html.erb
@@ -1,6 +1,6 @@
 <div id="versioning_display" class="tab-pane">
   <h2><%= t('.header') %></h2>
-  <%= simple_form_for [main_app, curation_concern], html: { multipart: true, class: 'nav-safety' } do |f| %>
+  <% if @version_list.supports_multiple_versions? %><%= simple_form_for [main_app, curation_concern], html: { multipart: true, class: 'nav-safety' } do |f| %>
     <div id="fileuploadVersioning">
       <!-- Redirect browsers with JavaScript disabled to the origin page -->
       <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>"/></noscript>
@@ -45,10 +45,10 @@
         <%= t('.upload') %>
       <% end %>
 
-    </div> <!-- fileuploadVersioning -->
-  <% end %>
+    </div> <!-- /fileuploadVersioning -->
+  <% end %><% end %>
 
-  <%= form_for [main_app, curation_concern],
+  <% if !@version_list.empty? %><%= form_for [main_app, curation_concern],
                html: { class: 'edit_file_set_previous_version nav-safety' } do |f| %>
     <h3><%= t('.restore') %></h3>
     <% @version_list.each do |version| %>
@@ -68,7 +68,7 @@
                  type: 'submit' do %>
       <%= t('.save') %>
     <% end %>
-  <% end %>
+  <% end %><% end %>
 
   <%= render 'hyrax/uploads/js_templates_versioning' %>
 

--- a/spec/presenters/hyrax/version_list_presenter_spec.rb
+++ b/spec/presenters/hyrax/version_list_presenter_spec.rb
@@ -1,63 +1,77 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::VersionListPresenter do
-  let(:resource_version) do
-    ActiveFedora::VersionsGraph::ResourceVersion.new.tap do |v|
-      v.uri = 'http://example.com/version1'
-      v.label = 'version1'
-      v.created = '2014-12-09T02:03:18.296Z'
-    end
-  end
+  let(:file_set) { FactoryBot.create(:file_set) }
+  subject(:enum) { described_class.for(file_set: file_set) }
 
-  let(:resource_version2) do
-    ActiveFedora::VersionsGraph::ResourceVersion.new.tap do |v|
-      v.uri = 'http://example.com/version2'
-      v.label = 'version2'
-      v.created = '2014-12-19T02:03:18.296Z'
-    end
-  end
-
-  subject(:enum) { described_class.new([resource_version, resource_version2]) }
-
-  describe ".for" do
-    context "with an ActiveFedora::Base" do
-      it "gives an empty enumerable" do
-        file_set = FactoryBot.create(:file_set)
-
-        expect(described_class.for(file_set: file_set)).to be_none
-      end
-
-      it "enumerates over version presenters for original_file" do
-        file_set   = FactoryBot.create(:file_set)
-        binary     = StringIO.new("hey")
-        new_binary = StringIO.new("hey2")
-
-        Hydra::Works::AddFileToFileSet
-          .call(file_set, binary, :original_file, versioning: true)
-        Hydra::Works::AddFileToFileSet
-          .call(file_set, new_binary, :original_file, versioning: true)
-
-        expect(described_class.for(file_set: file_set).count).to eq 2
+  context "when the file set has no versions" do
+    describe ".for" do
+      it "returns an enumerable with no members" do
+        expect(enum.count).to eq 0
       end
     end
 
-    context "with a bad argument" do
+    describe "#each" do
+      it "yields nothing" do
+        versions_descending = []
+        enum.each do |v|
+          versions_descending.push(v.label)
+        end
+        expect(versions_descending).to be_empty
+      end
+    end
+
+    describe "#empty?" do
+      it "is true" do
+        expect(enum).to be_empty
+      end
+    end
+  end
+
+  context "when the file set has versions" do
+    before do
+      binary     = StringIO.new("hey")
+      new_binary = StringIO.new("hey2")
+
+      Hydra::Works::AddFileToFileSet
+        .call(file_set, binary, :original_file, versioning: true)
+      Hydra::Works::AddFileToFileSet
+        .call(file_set, new_binary, :original_file, versioning: true)
+    end
+
+    describe ".for" do
+      it "returns an enumerable with members" do
+        expect(enum.count).to eq 2
+      end
+    end
+
+    describe "#each" do
+      it "yields version presenters in order" do
+        versions = Hyrax::VersioningService.new(resource: file_set.original_file).versions
+        versions_descending = []
+        enum.each do |v|
+          expect(v).to be_kind_of Hyrax::VersionPresenter
+          versions_descending.push(v.uri)
+        end
+        expect(versions_descending).to eq versions
+          .sort { |a, b| b.created <=> a.created }
+          .map(&:uri)
+      end
+    end
+
+    describe "#empty?" do
+      it "is false" do
+        expect(enum).not_to be_empty
+      end
+    end
+  end
+
+  context "when the file set is bad" do
+    let(:file_set) { nil }
+
+    describe ".for" do
       it "raises an error" do
-        expect { described_class.for(file_set: nil) }
-          .to raise_error ArgumentError
+        expect { enum }.to raise_error ArgumentError
       end
-    end
-  end
-
-  describe "#each" do
-    it "yields version_presenters" do
-      versions_descending = []
-
-      enum.each do |v|
-        expect(v).to be_kind_of Hyrax::VersionPresenter
-        versions_descending.push(v.label)
-      end
-
-      expect(versions_descending).to eq ['version2', 'version1']
     end
   end
 end

--- a/spec/views/hyrax/file_sets/_versioning.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_versioning.html.erb_spec.rb
@@ -1,19 +1,36 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/file_sets/_versioning.html.erb', type: :view do
   let(:file_set) { stub_model(FileSet) }
+  let(:versioning_service) { Hyrax::VersioningService.new(resource: nil) }
 
   before do
-    allow(file_set).to receive(:files).and_return([])
     allow(view).to receive(:curation_concern).and_return(file_set)
-    assign(:version_list, [])
-    render
+    assign(:version_list, Hyrax::VersionListPresenter.new(versioning_service))
   end
 
-  context "without additional users" do
+  context "when versioning is supported" do
+    before do
+      allow(versioning_service).to receive(:supports_multiple_versions?).and_return(true)
+      allow(versioning_service).to receive(:versions).and_return([])
+      render
+    end
+
     it "draws the new version form without error" do
       expect(rendered).to have_content t("hyrax.file_sets.versioning.choose_file")
       expect(rendered).to have_content t("hyrax.uploads.js_templates_versioning.options.messages.max_file_size")
       expect(rendered).to have_content "maxFileSize: #{Hyrax.config.uploader[:maxFileSize]}"
+      expect(rendered).to have_content t("hyrax.file_sets.versioning.upload")
+    end
+  end
+
+  context "when versioning is unsupported" do
+    before do
+      allow(versioning_service).to receive(:supports_multiple_versions?).and_return(false)
+      render
+    end
+
+    it "does not draw the new version form" do
+      expect(rendered).not_to have_content t("hyrax.file_sets.versioning.upload")
     end
   end
 end


### PR DESCRIPTION
- Modify `Hyrax::VersionListPresenter` to wrap a `Hyrax::VersioningService`, instead directly wrapping an array of version presenters. This enables querying whether multiple versions are supported directly on the version list presenter by delegating it to the wrapped service. I also think this is a bit simpler from a code perspective.

- Suppress the UI for manually creating a new version of a file when the storage adapter does not support multiple versions. Note: Currently dassie supports multiple versions, but koppie does not.

- Suppress the UI for restoring a previous versions when the version list is empty. The fallback behaviour for the version list (i·e when versioning is unsupported) is an empty list, so this is effectively the same as the previous check, but the semantics are slightly different.

The end result of these changes is that the “Versions” tab is entirely empty in koppie (currently, with no versioning supported). We may want to either hide the tab in its entirety or else put a message there stating that versioning is not supported.

---

Related to #6211 in the sense that it prevents the confusing behaviour of users *appearing* able to upload new versions when versions are not actually supported. Probably we also want some work to prevent logging of new versions that aren’t actually being created (step №8 in that issue), but this PR handles the user‐facing side of things.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* In an application with versioning enabled (e·g dassie), no change in behaviour is observable
* In an application with versioning disabled (e·g koppie), the versioning tab is empty and users cannot upload new versions