### PR TITLE
skip more Wings specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -333,16 +333,16 @@ RSpec.configure do |config|
   config.prepend_before(:example, :valkyrie_adapter) do |example|
     adapter_name = example.metadata[:valkyrie_adapter]
 
-    allow(Hyrax)
-      .to receive(:metadata_adapter)
-      .and_return(Valkyrie::MetadataAdapter.find(adapter_name))
-
     if adapter_name == :wings_adapter
       skip("Don't test Wings when it is dasabled") if Hyrax.config.disable_wings
     else
       allow(Hyrax.config).to receive(:disable_wings).and_return(true)
       hide_const("Wings") # disable_wings=true removes the Wings constant
     end
+
+    allow(Hyrax)
+      .to receive(:metadata_adapter)
+      .and_return(Valkyrie::MetadataAdapter.find(adapter_name))
   end
 
   # Prepend this before block to ensure that it runs before other before blocks like clean_repo

--- a/spec/wings/valkyrie/metadata_adapter_spec.rb
+++ b/spec/wings/valkyrie/metadata_adapter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 require 'wings'
 
-RSpec.describe Wings::Valkyrie::MetadataAdapter do
+RSpec.describe Wings::Valkyrie::MetadataAdapter, :active_fedora do
   let(:adapter) { described_class.new }
 
   it_behaves_like "a Valkyrie::MetadataAdapter"


### PR DESCRIPTION
since the wings adapter isn't registered, we need to `skip` before we try to find it from `MetadataAdapter.find`.

@samvera/hyrax-code-reviewers
