### PR TITLE
test behavior after a published Fixity check failure on Valkyrie

### DIFF
--- a/app/services/hyrax/fixity_check_failure_service.rb
+++ b/app/services/hyrax/fixity_check_failure_service.rb
@@ -14,7 +14,7 @@ module Hyrax
     end
 
     def message
-      uri = file_set.original_file.uri.to_s
+      uri = checksum_audit_log.checked_uri
       file_title = file_set.title.first
       I18n.t('hyrax.notifications.fixity_check_failure.message', log_date: log_date, file_title: file_title, uri: uri)
     end

--- a/spec/services/hyrax/fixity_check_failure_service_spec.rb
+++ b/spec/services/hyrax/fixity_check_failure_service_spec.rb
@@ -1,31 +1,61 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::FixityCheckFailureService do
-  let!(:depositor) { create(:user) }
-  let!(:log_date) { '2015-07-15 03:06:59' }
+  subject(:service) { described_class.new(file_set, checksum_audit_log: checksum_audit_log) }
+  let(:depositor) { FactoryBot.create(:user) }
   let(:inbox) { depositor.mailbox.inbox }
-  let(:file) { Hydra::PCDM::File.new }
-  let(:version_uri) { "#{file.uri}/fcr:versions/version1" }
-  let(:file_set) do
-    create(:file_set, user: depositor, title: ["World Icon"]).tap { |fs| fs.original_file = file }
+
+  context "with Valkyrie models", valkyrie_adapter: :test_adapter, storage_adapter: :test_disk do
+    let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set, depositor: depositor.user_key, title: ['moomin_fs']) }
+    let(:file_uri) { file_metadata.file_identifier.id }
+
+    let(:file_metadata) do
+      FactoryBot.valkyrie_create(:hyrax_file_metadata, :with_file, file_set: file_set)
+    end
+
+    let(:checksum_audit_log) do
+      ChecksumAuditLog.new(file_set_id: file_set.id,
+                           file_id: file_metadata.id,
+                           checked_uri: file_uri,
+                           created_at: '2023-08-29 03:06:59',
+                           updated_at: '2023-08-29 03:06:59',
+                           passed: false)
+    end
+
+    describe "#call" do
+      it "sends failing mail" do
+        expect { service.call }.to change { inbox.count }.by 1
+
+        inbox.each { |msg| expect(msg.last_message.subject).to eq('Failing Fixity Check') }
+        inbox.each { |msg| expect(msg.last_message.body).to eq('The fixity check run at ' + checksum_audit_log.created_at.to_s + ' for moomin_fs' + ' (' + file_uri + ') failed.') }
+      end
+    end
   end
 
-  let(:checksum_audit_log) do
-    ChecksumAuditLog.new(file_set_id: file_set.id,
-                         file_id: file_set.original_file.id,
-                         checked_uri: version_uri,
-                         created_at: log_date,
-                         updated_at: log_date,
-                         passed: false)
-  end
+  context "for an ActiveFedora FileSet", :active_fedora do
+    let(:file) { Hydra::PCDM::File.new }
+    let(:log_date) { '2015-07-15 03:06:59' }
+    let(:version_uri) { "#{file.uri}/fcr:versions/version1" }
 
-  describe "#call" do
-    subject { described_class.new(file_set, checksum_audit_log: checksum_audit_log) }
+    let(:file_set) do
+      FactoryBot.create(:file_set, user: depositor, title: ["World Icon"]).tap { |fs| fs.original_file = file }
+    end
 
-    it "sends failing mail" do
-      subject.call
-      expect(inbox.count).to eq(1)
-      inbox.each { |msg| expect(msg.last_message.subject).to eq('Failing Fixity Check') }
-      inbox.each { |msg| expect(msg.last_message.body).to eq('The fixity check run at ' + checksum_audit_log.created_at.to_s + ' for ' + file_set.to_s + ' (' + file.uri + ') failed.') }
+    let(:checksum_audit_log) do
+      ChecksumAuditLog.new(file_set_id: file_set.id,
+                           file_id: file_set.original_file.id,
+                           checked_uri: version_uri,
+                           created_at: log_date,
+                           updated_at: log_date,
+                           passed: false)
+    end
+
+    describe "#call" do
+      it "sends failing mail" do
+        subject.call
+        expect(inbox.count).to eq(1)
+        inbox.each { |msg| expect(msg.last_message.subject).to eq('Failing Fixity Check') }
+        inbox.each { |msg| expect(msg.last_message.body).to eq('The fixity check run at ' + checksum_audit_log.created_at.to_s + ' for ' + file_set.to_s + ' (' + version_uri + ') failed.') }
+      end
     end
   end
 end

--- a/spec/services/hyrax/listeners/file_set_lifecycle_notification_listener_spec.rb
+++ b/spec/services/hyrax/listeners/file_set_lifecycle_notification_listener_spec.rb
@@ -4,61 +4,100 @@ RSpec.describe Hyrax::Listeners::FileSetLifecycleNotificationListener do
   subject(:listener) { described_class.new }
   let(:data)         { { result: :success } }
   let(:event)        { Dry::Events::Event.new(event_type, data) }
-  let(:file_set)     { create(:file_set, user: user) }
   let(:inbox)        { user.mailbox.inbox }
-  let(:user)         { create(:user) }
+  let(:user)         { FactoryBot.create(:user) }
 
-  describe '#on_file_set_audited' do
-    let(:event_type) { :on_file_set_audited }
+  context "with Valkyrie models", valkyrie_adapter: :test_adapter, storage_adapter: :test_disk do
+    let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set, depositor: user.user_key) }
 
-    it 'does not raise an error; is resilient to missing event payload data' do
-      expect { listener.on_file_set_audited(event) }.not_to raise_error
-    end
+    describe '#on_file_set_audited' do
+      let(:event_type) { :on_file_set_audited }
 
-    context 'on failure' do
-      let(:data)    { { result: :failure, file_set: file_set, audit_log: log } }
-      let(:file)    { Hydra::PCDM::File.new }
-      let(:version) { "#{file.uri}/fcr:versions/version1" }
-
-      let(:log) do
-        ChecksumAuditLog.new(file_set_id: file_set.id,
-                             file_id: file_set.original_file.id,
-                             checked_uri: version,
-                             created_at: '2019-11-04 03:06:59',
-                             updated_at: '2019-11-04 03:06:59',
-                             passed: false)
+      it 'does not raise an error; is resilient to missing event payload data' do
+        expect { listener.on_file_set_audited(event) }.not_to raise_error
       end
 
-      let(:file_set) do
-        create(:file_set, user: user, title: ['Bad Checksum']).tap { |fs| fs.original_file = file }
-      end
+      context 'on failure' do
+        let(:data) { { result: :failure, file_set: file_set, audit_log: log } }
+        let(:file_uri) { file_metadata.file_identifier.id }
 
-      it 'creates a failure message for the user' do
-        expect { listener.on_file_set_audited(event) }
-          .to change { inbox.last }
-          .to have_attributes subject: 'Failing Fixity Check'
+        let(:file_metadata) do
+          FactoryBot.valkyrie_create(:hyrax_file_metadata, :with_file, file_set: file_set)
+        end
+
+        let(:log) do
+          ChecksumAuditLog.new(file_set_id: file_set.id,
+                               file_id: file_metadata.id,
+                               checked_uri: file_uri,
+                               created_at: '2023-08-29 03:06:59',
+                               updated_at: '2023-08-29 03:06:59',
+                               passed: false)
+        end
+
+        it "sends a failure message for the depositor" do
+          expect { listener.on_file_set_audited(event) }
+            .to change { inbox.last }
+            .to have_attributes subject: 'Failing Fixity Check'
+        end
       end
     end
   end
 
-  describe '#on_file_set_url_imported' do
-    let(:event_type) { :on_file_set_url_imported }
+  context "with ActiveFedora models", :active_fedora do
+    let(:file_set) { FactoryBot.create(:file_set, user: user) }
 
-    it 'does not raise an error; is resilient to missing event payload data' do
-      expect { listener.on_file_set_url_imported(event) }.not_to raise_error
-    end
+    describe '#on_file_set_audited' do
+      let(:event_type) { :on_file_set_audited }
 
-    context 'on failure' do
-      let(:data) { { result: :failure, user: user, file_set: file_set } }
-
-      before do
-        allow(file_set.errors).to receive(:full_messages).and_return(['huge mistake'])
+      it 'does not raise an error; is resilient to missing event payload data' do
+        expect { listener.on_file_set_audited(event) }.not_to raise_error
       end
 
-      it 'creates a failure message for the user' do
-        expect { listener.on_file_set_url_imported(event) }
-          .to change { inbox.last }
-          .to have_attributes subject: 'File Import Error'
+      context 'on failure' do
+        let(:data)    { { result: :failure, file_set: file_set, audit_log: log } }
+        let(:file)    { Hydra::PCDM::File.new }
+        let(:version) { "#{file.uri}/fcr:versions/version1" }
+
+        let(:log) do
+          ChecksumAuditLog.new(file_set_id: file_set.id,
+                               file_id: file_set.original_file.id,
+                               checked_uri: version,
+                               created_at: '2019-11-04 03:06:59',
+                               updated_at: '2019-11-04 03:06:59',
+                               passed: false)
+        end
+
+        let(:file_set) do
+          create(:file_set, user: user, title: ['Bad Checksum']).tap { |fs| fs.original_file = file }
+        end
+
+        it 'creates a failure message for the user' do
+          expect { listener.on_file_set_audited(event) }
+            .to change { inbox.last }
+            .to have_attributes subject: 'Failing Fixity Check'
+        end
+      end
+    end
+
+    describe '#on_file_set_url_imported' do
+      let(:event_type) { :on_file_set_url_imported }
+
+      it 'does not raise an error; is resilient to missing event payload data' do
+        expect { listener.on_file_set_url_imported(event) }.not_to raise_error
+      end
+
+      context 'on failure' do
+        let(:data) { { result: :failure, user: user, file_set: file_set } }
+
+        before do
+          allow(file_set.errors).to receive(:full_messages).and_return(['huge mistake'])
+        end
+
+        it 'creates a failure message for the user' do
+          expect { listener.on_file_set_url_imported(event) }
+            .to change { inbox.last }
+            .to have_attributes subject: 'File Import Error'
+        end
       end
     end
   end


### PR DESCRIPTION
if a Valkyrie Fixity service (to be invented) fails, it should be able to
publish an event to be picked up by `FileSetLifecycleNotificationListener` and a
notification can be published.

this updates the tests for the fixity failure notification path to avoid testing
AF behavior when Wings is disabled, and to add support for Valkyrie to the code
path.

### Changes proposed in this pull request:
* fixes a bug in the Fixity failure notifications that always reported the `original_file` failed, even when another file's fixity was checked
* adds support for Valkyrie to fixity failure notification code paths

@samvera/hyrax-code-reviewers
