### PR TITLE
only use specialized `Wings::WorkSearchBuilder` if Wings is enabled

### DIFF
--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     include Hyrax::WorksControllerBehavior # rubocop:disable RSpec/DescribedClass
 
     self.curation_concern_type = Hyrax::Test::SimpleWork
-    self.search_builder_class  = Wings::WorkSearchBuilder(Hyrax::Test::SimpleWork)
+    self.search_builder_class  = Wings::WorkSearchBuilder(Hyrax::Test::SimpleWork) unless
+      Hyrax.config.disable_wings
     self.work_form_service     = Hyrax::FormFactory.new
   end
 


### PR DESCRIPTION
`WorksControllerBehavior` offers the option to use it with `curation_concern_type` that is a `Valkyrie::Resource`. in the event that one does this, and `Wings` is turned on, it's necessary to provide a custom search_builder_class to the controller to allow it to find resources indexed as their mapped `ActiveFedora` objects.

that is, Valkyrie objects saved by Wings are indexed by ActiveFedora using model names provided by AF.

none of this is needed if Valkyrie is handling the indexing, and the normal search builder can be used in that case. so don't try to setup this class for `.koppie` and in other cases where Wings is not in use.


@samvera/hyrax-code-reviewers
