### PR TITLE
don't test legacy CharacterizeJob in `.koppie`

### DIFF
--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe CharacterizeJob, :clean_repo do
+RSpec.describe CharacterizeJob, :active_fedora, :clean_repo do
   let(:file_set_id) { 'abc12345' }
   let(:upload_root) { Pathname.new(ENV.fetch('HYRAX_UPLOAD_PATH', Rails.root.join('tmp', 'uploads'))) }
   let(:filename)    { upload_root.join('ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }


### PR DESCRIPTION
this job is only invoked from the ActorStack. Valkyrie ingest characterizes in the same background job that handles the ingest.

@samvera/hyrax-code-reviewers
