### PR TITLE
Display all descriptive metadata for collections on koppie.

### DIFF
--- a/.koppie/config/metadata/collection_resource.yaml
+++ b/.koppie/config/metadata/collection_resource.yaml
@@ -40,21 +40,29 @@ attributes:
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "rights_statement_tesim"
   abstract:
     type: string
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "abstract_tesim"
   access_right:
     type: string
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "access_right_tesim"
   alternative_title:
     type: string
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "alternative_title_tesim"
   based_near:
     type: string
     multiple: true
@@ -71,6 +79,8 @@ attributes:
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "contributor_tesim"
   date_created:
     type: date_time
     multiple: true
@@ -83,6 +93,8 @@ attributes:
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "identifier_tesim"
   import_url:
     type: string
   keyword:
@@ -98,20 +110,28 @@ attributes:
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "publisher_tesim"
   label:
     type: string
     form:
       primary: false
+    index_keys:
+      - "label_tesim"
   language:
     type: string
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "language_tesim"
   license:
     type: string
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "license_tesim"
   relative_path:
     type: string
   related_url:
@@ -134,11 +154,15 @@ attributes:
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "rights_notes_tesim"
   source:
     type: string
     multiple: true
     form:
       primary: false
+    index_keys:
+      - "source_tesim"
   subject:
     type: string
     multiple: true


### PR DESCRIPTION
### Fixes

Fixes #6208; refs [#5798](https://github.com/samvera/hyrax/issues/5798)

### Summary
Index all form fields for collection display on koppie.

### Screenshots
Before changes
<img width="1440" alt="Screen Shot - koppie collection display - before changed" src="https://github.com/samvera/hyrax/assets/2430784/f71efc3c-5b31-4957-8939-b5f900d37de6">

After change:
<img width="1439" alt="Screen Shot - koppie collection display - after changed" src="https://github.com/samvera/hyrax/assets/2430784/3c559809-5fac-49b5-b006-7e6aa1f34633">


@samvera/hyrax-code-reviewers
