### PR TITLE
Use updated fitsservlet image

### DIFF
--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -117,7 +117,7 @@ services:
       - koppie
 
   fits:
-    image: harvardlts/fitsservlet_container:1.5.0
+    image: ghcr.io/samvera/fitsservlet:1.6.0
     ports:
       - 8080
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
       - hyrax
 
   fits:
-    image: harvardlts/fitsservlet_container:1.5.0
+    image: ghcr.io/samvera/fitsservlet:1.6.0
     ports:
       - 8080
     networks:


### PR DESCRIPTION
### Fixes

refs #6160 

### Summary

Use updated fitsservlet with FITS 1.6.0 and more recent base image. Should be replaced with an official upstream image when available.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* dassie/koppie able to characterize files using the fitsservlet service

@samvera/hyrax-code-reviewers
