### PR TITLE
chart: use fits chart 0.2.0

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 3.4.0
+version: 3.5.0
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo
@@ -34,6 +34,6 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: nginx.enabled
   - name: fits
-    version: 0.1.0
+    version: 0.2.0
     repository: https://samvera-labs.github.io/fits-charts
     condition: fits.enabled


### PR DESCRIPTION
This uses the new fits container image published by samvera which uses the fits-servlet docker configuration.

@samvera/hyrax-code-reviewers
