### PR TITLE
remove Hyrax::RoleManagement from `.koppie`

### DIFF
--- a/.koppie/Gemfile
+++ b/.koppie/Gemfile
@@ -12,7 +12,6 @@ gem 'coffee-rails', '~> 4.2'
 gem 'dalli'
 gem 'devise', '4.8.0'
 gem 'devise-guests', '0.8.1'
-gem 'hydra-role-management'
 gemspec name: 'hyrax', path: ENV.fetch('HYRAX_ENGINE_PATH', '..')
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'

--- a/.koppie/app/models/ability.rb
+++ b/.koppie/app/models/ability.rb
@@ -1,15 +1,11 @@
 class Ability
   include Hydra::Ability
-  
+
   include Hyrax::Ability
   self.ability_logic += [:everyone_can_create_curation_concerns]
 
   # Define any customized permissions here.
   def custom_permissions
-    if current_user.admin?
-      can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
-    end
-
     # Limits deleting objects to a the admin user
     #
     # if current_user.admin?

--- a/.koppie/app/models/user.rb
+++ b/.koppie/app/models/user.rb
@@ -1,8 +1,6 @@
 class User < ApplicationRecord
   # Connects this user object to Hydra behaviors.
   include Hydra::User
-  # Connects this user object to Role-management behaviors.
-  include Hydra::RoleManagement::UserRoles
 
   # Connects this user object to Hyrax behaviors.
   include Hyrax::User

--- a/.koppie/config/role_map.yml
+++ b/.koppie/config/role_map.yml
@@ -1,28 +1,6 @@
-# nurax-pg uses Hydra::RoleManagement for user and role definition.  The following
-# examples show how to perform common setup actions.
-#
-# @see https://github.com/samvera/hydra-role-management
-#
-# Create admin role
-#
-#   admin_role = Role.find_or_create_by(name: 'admin')
-#
-# Create a user
-#
-#   admin_user = User.find_or_create_by(email: 'user@example.com') do |user|
-#     user.password = 'change_me'
-#     user.password_confirmation = 'change_me'
-#     user.confirmed_at = DateTime.now
-#   end
-#   admin_user.roles << admin_role unless admin_user.roles.include?(admin_role)
-#   admin_user.save!(validate: false)
-#
-# You can create non-admin roles and assign users to those roles using a similar pattern.
-#
-# The following roles might be used for testing, so they remain here.  They will not
-# be available for use when logged in through the browser.
-#
 development:
+  admin:
+    - admin@example.com
   archivist:
     - archivist1@example.com
 
@@ -45,4 +23,4 @@ test:
 
 production:
   admin:
-    - systems@curationexperts.com
+    - admin@example.com

--- a/.koppie/config/routes.rb
+++ b/.koppie/config/routes.rb
@@ -5,14 +5,13 @@ Rails.application.routes.draw do
         mount BrowseEverything::Engine => '/browse'
 
   mount Blacklight::Engine => '/'
-  
+
   concern :searchable, Blacklight::Routes::Searchable.new
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable
   end
   devise_for :users
-  mount Hydra::RoleManagement::Engine => '/'
   mount Sidekiq::Web => '/sidekiq'
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'


### PR DESCRIPTION
including this makes the whole application very different from `.dassie`, in a way that complicates the test suite substantially.

@samvera/hyrax-code-reviewers
