### PR TITLE
Don't force "Collection" model filter from the view 

### DIFF
--- a/app/controllers/hyrax/my/collections_controller.rb
+++ b/app/controllers/hyrax/my/collections_controller.rb
@@ -37,6 +37,8 @@ module Hyrax
         hyrax.my_collections_url(*args)
       end
 
+      # @api public
+      #
       # The url of the "more" link for additional facet values
       def search_facet_path(args = {})
         hyrax.my_dashboard_collections_facet_path(args[:id])

--- a/app/views/hyrax/admin/collection_types/index.html.erb
+++ b/app/views/hyrax/admin/collection_types/index.html.erb
@@ -40,7 +40,7 @@
                  <% unless collection_type.admin_set? || collection_type.user_collection? %>
                   <button class="btn btn-danger btn-sm delete-collection-type"
                           data-collection-type="<%= collection_type.to_json %>"
-                          data-collection-type-index="<%= hyrax.dashboard_collections_path({ 'f[collection_type_gid_ssim][]' => collection_type.to_global_id.to_s, 'f[has_model_ssim][]' => 'Collection' }) %>"
+                          data-collection-type-index="<%= hyrax.dashboard_collections_path({ 'f[collection_type_gid_ssim][]' => collection_type.to_global_id.to_s }) %>"
                           data-has-collections="<%= collection_type.collections.any? %>">
                     <%= t('helpers.action.delete') %>
                   </button>

--- a/spec/controllers/hyrax/my/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/my/collections_controller_spec.rb
@@ -1,37 +1,57 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::My::CollectionsController, type: :controller do
-  describe "logged in user" do
+RSpec.describe Hyrax::My::CollectionsController, :clean_repo, type: :controller do
+  context "with a logged in user" do
+    let(:user) { FactoryBot.create(:user) }
+
+    before { sign_in(user) }
+
     describe "#index" do
-      let(:user) { create(:user) }
-      let(:response) { instance_double(Blacklight::Solr::Response, response: { 'numFound' => 3 }) }
-      let(:doc_list) { [double(id: 123), double(id: 456)] }
-
-      before do
-        sign_in user
-      end
-
-      it "shows the search results and sets breadcrumbs" do
-        allow_any_instance_of(Hyrax::SearchService).to receive(:search_results).and_return([response, doc_list])
-
+      it "sets breadcrumbs" do
         expect(controller).to receive(:add_breadcrumb).with('Home', root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Collections', my_collections_path(locale: 'en'))
+        get :index, params: { per_page: 1 }
+      end
 
-        get :index, params: { per_page: 2 }
-        expect(assigns[:document_list].length).to eq 2
+      it "shows empty results with no collections" do
+        get :index, params: { per_page: 1 }
+
+        expect(assigns[:document_list]).to be_empty
+      end
+
+      context "with collections deposited by user" do
+        let!(:user_collections) do
+          [FactoryBot.valkyrie_create(:hyrax_collection, user: user),
+           FactoryBot.valkyrie_create(:hyrax_collection, user: user)]
+        end
+
+        let!(:other_collections) do
+          [FactoryBot.valkyrie_create(:hyrax_collection),
+           FactoryBot.valkyrie_create(:hyrax_collection)]
+        end
+
+        it "shows only user collections" do
+          get :index, params: { per_page: 10 }
+
+          expect(assigns[:document_list])
+            .to contain_exactly(have_attributes(id: user_collections.first.id),
+                                have_attributes(id: user_collections.last.id))
+        end
       end
     end
   end
 
   describe "#search_facet_path" do
-    subject { controller.send(:search_facet_path, id: 'keyword_sim') }
-
-    it { is_expected.to eq "/dashboard/my/collections/facet/keyword_sim?locale=en" }
+    it do
+      expect(controller.send(:search_facet_path, id: 'keyword_sim'))
+        .to eq "/dashboard/my/collections/facet/keyword_sim?locale=en"
+    end
   end
 
   describe "#search_builder_class" do
-    subject { controller.blacklight_config.search_builder_class }
-
-    it { is_expected.to eq Hyrax::My::CollectionsSearchBuilder }
+    it 'has a default search builder class'do
+      expect(controller.blacklight_config.search_builder_class)
+        .to eq Hyrax::My::CollectionsSearchBuilder
+    end
   end
 end

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     after(:create) do |collection, evaluator|
       if evaluator.members.present?
         evaluator.members.map do |member|
-          member.membner_of_collection_ids += [collection.id]
+          member.member_of_collection_ids += [collection.id]
           member = Hyrax.persister.save(resource: member)
           Hyrax.index_adapter.save(resource: member) if evaluator.with_index
         end

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -19,10 +19,14 @@ FactoryBot.define do
       access_grants { [] }
     end
 
+    after(:build) do |collection, evaluator|
+      collection.depositor ||= evaluator.user.user_key
+    end
+
     after(:create) do |collection, evaluator|
       if evaluator.members.present?
         evaluator.members.map do |member|
-          member.member_of_collection_ids += [collection.id]
+          member.membner_of_collection_ids += [collection.id]
           member = Hyrax.persister.save(resource: member)
           Hyrax.index_adapter.save(resource: member) if evaluator.with_index
         end


### PR DESCRIPTION
### Fixes

Fixes a Valkyrie-only bug where collections are filtered en-masse from the Collection listing because they are indexed from a model other than the AF `Collection`

refs #5522 

### Summary

the search builders for the target controller already search effectively for the
model class, and may have better strategies for doing so in the future. adding a
filter here prevents applications from using Collection models not named
"Collection".

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* test as in issue #5522 

### Changes proposed in this pull request:
* adds some controller tests (it turns out these are irrelevant to the change, but improve testing anyway)
* Fix bug: "Empty collections displayed when clicking "View collections of this type" after trying deleting non-empty collection type"

@samvera/hyrax-code-reviewers
