### PR TITLE
port most FileSetPresenter specs to Valkyrie

### DIFF
--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -60,9 +60,42 @@ module Hyrax
     self.characterization_proxy = Hyrax.config.characterization_proxy
 
     attribute :file_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID) # id for FileMetadata resources
-    attribute :thumbnail_id, Valkyrie::Types::ID.optional # id for FileMetadata resource
-    attribute :original_file_id, Valkyrie::Types::ID.optional # id for FileMetadata resource
-    attribute :extracted_text_id, Valkyrie::Types::ID.optional # id for FileMetadata resource
+
+    # @return [Hyrax::FileMetadata, nil]
+    def original_file
+      Hyrax.custom_queries.find_original_file(file_set: self)
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      nil
+    end
+
+    # @return [Valkyrie::ID, nil]
+    def original_file_id
+      original_file&.id
+    end
+
+    # @return [Hyrax::FileMetadata, nil]
+    def thumbnail
+      Hyrax.custom_queries.find_thumbnail(file_set: self)
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      nil
+    end
+
+    # @return [Valkyrie::ID, nil]
+    def thumbnail_id
+      thumbnail&.id
+    end
+
+    # @return [Hyrax::FileMetadata, nil]
+    def extracted_text
+      Hyrax.custom_queries.find_extracted_text(file_set: self)
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      nil
+    end
+
+    # @return [Valkyrie::ID, nil]
+    def extracted_text_id
+      extracted_text&.id
+    end
 
     ##
     # @return [Valkyrie::ID]

--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -81,33 +81,7 @@ class Hyrax::ValkyrieUpload
   # @return [Hyrax::FileSet] updated file set
   def add_file_to_file_set(file_set:, file_metadata:, user:)
     file_set.file_ids << file_metadata.id
-    set_file_use_ids(file_set, file_metadata)
-
     Hyrax.persister.save(resource: file_set)
     Hyrax.publisher.publish('object.membership.updated', object: file_set, user: user)
-  end
-
-  private
-
-  # @api private
-  # @param [Hyrax::FileSet] file_set the file set to add to
-  # @param [Hyrax::FileMetadata] file_metadata the metadata object representing
-  #   the file to add
-  # @return [void]
-  def set_file_use_ids(file_set, file_metadata)
-    file_metadata.pcdm_use.each do |type|
-      case type
-      when Hyrax::FileMetadata::Use::ORIGINAL_FILE
-        file_set.original_file_id = file_metadata.id
-      when Hyrax::FileMetadata::Use::THUMBNAIL
-        file_set.thumbnail_id = file_metadata.id
-      when Hyrax::FileMetadata::Use::EXTRACTED_TEXT
-        file_set.extracted_text_id = file_metadata.id
-      when Hyrax::FileMetadata::Use::SERVICE_FILE
-        # do nothing
-      else
-        Hyrax.logger.warn "Unknown file use #{file_metadata.type} specified for #{file_metadata.file_identifier}"
-      end
-    end
   end
 end

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -249,7 +249,7 @@ RSpec.shared_examples 'a Hyrax::Work' do
   end
 end
 
-RSpec.shared_examples 'a Hyrax::FileSet' do
+RSpec.shared_examples 'a Hyrax::FileSet', valkyrie_adapter: :test_adapter do
   subject(:fileset)   { described_class.new }
   let(:adapter)       { Valkyrie::MetadataAdapter.find(:test_adapter) }
   let(:persister)     { adapter.persister }
@@ -275,12 +275,10 @@ RSpec.shared_examples 'a Hyrax::FileSet' do
     end
 
     context 'with files' do
-      let(:file_class) { Hyrax::FileMetadata }
-      let(:files) do
-        [file_class.new, file_class.new, file_class.new]
-          .map! { |f| persister.save(resource: f) }
-      end
-
+      let(:original_file) { FactoryBot.valkyrie_create :hyrax_file_metadata, :original_file }
+      let(:thumbnail) { FactoryBot.valkyrie_create :hyrax_file_metadata, :thumbnail }
+      let(:extracted_text) { FactoryBot.valkyrie_create :hyrax_file_metadata, :extracted_text }
+      let(:files) { [original_file, thumbnail, extracted_text] }
       let(:file_ids) { files.map(&:id) }
 
       before { fileset.file_ids = file_ids }
@@ -300,6 +298,21 @@ RSpec.shared_examples 'a Hyrax::FileSet' do
       it 'can not have the same file multiple times' do
         expect { fileset.file_ids << file_ids.first }
           .not_to change { query_service.custom_queries.find_files(file_set: fileset) }
+      end
+
+      it 'returns an original_file' do
+        expect(fileset.original_file).to eq original_file
+        expect(fileset.original_file_id).to eq original_file.id
+      end
+
+      it 'returns a thumbnail' do
+        expect(fileset.thumbnail).to eq thumbnail
+        expect(fileset.thumbnail_id).to eq thumbnail.id
+      end
+
+      it 'returns an extracted_text' do
+        expect(fileset.extracted_text).to eq extracted_text
+        expect(fileset.extracted_text_id).to eq extracted_text.id
       end
     end
   end

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -170,6 +170,7 @@ module Wings
 
     # for files, add attributes to metadata_node, plus some other work
     def add_file_attributes(af_object)
+      add_file_uri(af_object)
       converted_attrs = normal_attributes
       pcdm_use = converted_attrs.delete(:pcdm_use)
       af_object.metadata_node.attributes = converted_attrs
@@ -178,6 +179,11 @@ module Wings
       new_type = (resource.pcdm_use - af_object.metadata_node.type.to_a).first
       af_object.metadata_node.type = new_type if new_type
       af_object.mime_type = resource.mime_type
+    end
+
+    def add_file_uri(af_object)
+      file_uri = Hyrax.storage_adapter.fedora_identifier(id: resource.file_identifier)
+      af_object.uri = file_uri.to_s if af_object.uri.to_s.blank? && file_uri.to_s.present?
     end
 
     def perform_lease_conversion(af_object:, resource:)

--- a/spec/factories/hyrax_file_metadata.rb
+++ b/spec/factories/hyrax_file_metadata.rb
@@ -3,7 +3,7 @@
 ##
 # Use this factory for FileMetadata for Files in valkyrie.
 FactoryBot.define do
-  factory :hyrax_file_metadata, class: 'Hyrax::FileMetadata' do
+  factory :hyrax_file_metadata, class: 'Hyrax::FileMetadata', aliases: [:file_metadata] do
     transient do
       use { nil }
       visibility_setting { nil }
@@ -30,6 +30,10 @@ FactoryBot.define do
       transient do
         visibility_setting { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
       end
+    end
+
+    trait :original_file do
+      use { Hyrax::FileMetadata::Use.uri_for(use: :original_file) }
     end
 
     trait :image do

--- a/spec/factories/hyrax_file_metadata.rb
+++ b/spec/factories/hyrax_file_metadata.rb
@@ -36,6 +36,14 @@ FactoryBot.define do
       use { Hyrax::FileMetadata::Use.uri_for(use: :original_file) }
     end
 
+    trait :thumbnail do
+      use { Hyrax::FileMetadata::Use.uri_for(use: :thumbnail_file) }
+    end
+
+    trait :extracted_text do
+      use { Hyrax::FileMetadata::Use.uri_for(use: :extracted_file) }
+    end
+
     trait :image do
       mime_type { 'image/png' }
     end

--- a/spec/factories/hyrax_file_set.rb
+++ b/spec/factories/hyrax_file_set.rb
@@ -24,9 +24,6 @@ FactoryBot.define do
           .assign_access_for(visibility: evaluator.visibility_setting)
       end
       file_set.file_ids = evaluator.files.map(&:id) if evaluator.files
-      file_set.original_file_id = evaluator.original_file.id if evaluator.original_file
-      file_set.extracted_text_id = evaluator.extracted_text.id if evaluator.extracted_text
-      file_set.thumbnail_id = evaluator.thumbnail.id if evaluator.thumbnail
 
       file_set.permission_manager.edit_groups = evaluator.edit_groups
       file_set.permission_manager.edit_users  = evaluator.edit_users

--- a/spec/factories/hyrax_file_set.rb
+++ b/spec/factories/hyrax_file_set.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
       file_set.permission_manager.edit_groups = evaluator.edit_groups
       file_set.permission_manager.edit_users  = evaluator.edit_users
       file_set.permission_manager.read_users  = evaluator.read_users
-      file_set.permission_manager.read_users  = evaluator.read_groups
+      file_set.permission_manager.read_groups = evaluator.read_groups
     end
 
     after(:create) do |file_set, evaluator|
@@ -44,7 +44,7 @@ FactoryBot.define do
       file_set.permission_manager.edit_groups = evaluator.edit_groups
       file_set.permission_manager.edit_users  = evaluator.edit_users
       file_set.permission_manager.read_users  = evaluator.read_users
-      file_set.permission_manager.read_users  = evaluator.read_groups
+      file_set.permission_manager.read_groups = evaluator.read_groups
 
       file_set.permission_manager.acl.save
 

--- a/spec/factories/uploaded_files.rb
+++ b/spec/factories/uploaded_files.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
   factory :uploaded_file, class: Hyrax::UploadedFile do
     user
     file { File.open('spec/fixtures/image.jp2') }
+
+    trait :audio do
+      file { File.open('spec/fixtures/sample_mpeg4.mp4') }
+    end
   end
 end

--- a/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/valkyrie_file_set_indexer_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe Hyrax::ValkyrieFileSetIndexer, if: Hyrax.config.use_valkyrie? do
       allow(Hyrax.custom_queries).to receive(:find_original_file).with(file_set: file_set).and_return(mock_file)
       allow(Hyrax.custom_queries).to receive(:find_file_metadata_by).with(id: file_set.original_file_id).and_return(mock_file)
       allow(Hyrax.custom_queries).to receive(:find_thumbnail).with(file_set: file_set).and_return(mock_thumbnail)
+      allow(Hyrax.custom_queries).to receive(:find_extracted_text).with(file_set: file_set).and_return(mock_text)
       allow(mock_file).to receive(:file_name).and_return(file_name)
     end
     subject { indexer.generate_solr_document }

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -29,15 +29,11 @@ RSpec.describe Hyrax::FileSetPresenter do
   end
 
   describe "#model_name" do
-    it do
-      name = subject.model_name
-      require 'pry'; binding.pry
-    end
     its(:model_name) { is_expected.to be_kind_of ActiveModel::Name }
   end
 
   describe "#to_partial_path" do
-    its(:to_partial_path) { is_expected.to eq 'file_sets/file_set' }
+    its(:to_partial_path) { is_expected.to eq 'hyrax/file_sets/file_set' }
   end
 
   describe "office_document?" do
@@ -450,7 +446,6 @@ RSpec.describe Hyrax::FileSetPresenter do
       let!(:parent) do
         FactoryBot.valkyrie_create(:hyrax_work, :public, state: active, member_ids: [file_set.id])
       end
-
 
       before do
         allow(ability).to receive(:can?).with(:read, anything) do |_read, solr_doc|

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -73,14 +73,30 @@ RSpec.describe Wings::ActiveFedoraConverter, :active_fedora, :clean_repo do
 
     context 'when given a FileMetadata node' do
       let(:resource) { Hyrax::FileMetadata.new(file_identifier: file.id) }
+      let(:io) { fixture_file_upload('/world.png', 'image/png') }
       let(:file) do
-        io = fixture_file_upload('/world.png', 'image/png')
         file_set = FactoryBot.valkyrie_create(:hyrax_file_set)
         storage_adapter.upload(file: io, resource: file_set, original_filename: 'test-world.png')
       end
 
       context 'when it describes an ActiveFedora File' do
-        it 'converts to a Hydra::Pcdm::File'
+        let(:storage_adapter) { Valkyrie::StorageAdapter.find(:active_fedora) }
+
+        it 'converts to a Hydra::Pcdm::File' do
+          expect(converter.convert).to be_a Hydra::PCDM::File
+        end
+
+        it 'refers to the correct file id' do
+          expect(converter.convert)
+            .to have_attributes(uri: storage_adapter.fedora_identifier(id: file.id))
+        end
+
+        it 'round trips' do
+          af = converter.convert
+          af.save
+          io.rewind
+          expect(Hydra::PCDM::File.find(af.id).content).to eq io.read
+        end
       end
 
       context 'when it describes a file for an arbitrary storage adapter' do

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -349,16 +349,11 @@ RSpec.describe Wings::ModelTransformer, :active_fedora, :clean_repo do
   end
 
   context 'build for file' do
-    let(:id)       { '123' }
-    let(:file_set) { FactoryBot.create(:file_set, id: id) }
-    let(:file) { file_set.build_original_file }
+    let(:file_set) { FactoryBot.create(:file_set, :image) }
+    let(:file) { file_set.original_file }
     let(:pcdm_object) { file_set }
 
     context 'with content' do
-      before do
-        file.content = 'foo'
-      end
-
       it 'sets file id in file set resource' do
         expect(subject.build.original_file_id).to eq file.id
       end


### PR DESCRIPTION
this passes most FileSetPresenter specs, but reveals a potential issue that i haven't yet been able to determine the correct behavior about.

it changes the presenter's #to_partial_path from `"file_sets/file_set"` to `"hyrax/file_sets/file_set`". the behavior in the original `::FileSet` is provided by `Hyrax::Naming`.

`PcdmCollection` uses a custom name class `Hyrax::CollectionName` to ensure ActiveModel naming behavior is compatible with `::Collection`, and it seems natural to assume `Hyrax::FileSet` should do similarly. BUT, why is this only coming up now? `.koppie` and `nurax-pg` are passing many automated and manual tests using the current `#model_name` implementation. Why?

maybe it's okay to just change the test and allow that the partial path change for Valkyrie native apps? what's going on here?

@samvera/hyrax-code-reviewers
