### PR TITLE
remove bin/rails from dockerfile copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ USER app
 RUN mkdir -p /app/samvera/hyrax-webapp
 WORKDIR /app/samvera/hyrax-webapp
 
-COPY --chown=1001:101 ./bin /app/samvera
+COPY --chown=1001:101 ./bin/*.sh /app/samvera/
 ENV PATH="/app/samvera:$PATH"
 ENV RAILS_ROOT="/app/samvera/hyrax-webapp"
 ENV RAILS_SERVE_STATIC_FILES="1"


### PR DESCRIPTION
 so that there is not a broken rails executable at /app/samvera/rails

### Fixes

the ability to call `rails c`, `rails s` etc from with in Docker

@samvera/hyrax-code-reviewers
