### PR TITLE
Generate terms and build permitted params for valkyrie ResourceBatchEditForm dynamically.

### DIFF
--- a/app/forms/hyrax/forms/resource_batch_edit_form.rb
+++ b/app/forms/hyrax/forms/resource_batch_edit_form.rb
@@ -17,17 +17,15 @@ module Hyrax
         @names = []
         @batch_document_ids = batch_document_ids
         if @batch_document_ids.present?
-          super(model.class.new(initialize_combined_fields))
+          combined_fields = model_attributes(model, initialize_combined_fields)
+          super(model.class.new(combined_fields))
         else
           super(model)
         end
       end
 
       def terms
-        [:creator, :contributor, :description,
-         :keyword, :resource_type, :license, :publisher, :date_created,
-         :subject, :language, :identifier, :based_near,
-         :related_url]
+        primary_terms + secondary_terms
       end
 
       attr_reader :batch_document_ids
@@ -84,6 +82,16 @@ module Hyrax
           end
           names << work.to_s
         end
+      end
+
+      # Model attributes for ActiveFedora compatibility
+      def model_attributes(model, attrs)
+        return attrs unless model.is_a? ActiveFedora::Base
+
+        attrs.keys.each do |k|
+          attrs[k] = Array.wrap(attrs[k]).first unless model.class.properties[k.to_s]&.multiple?
+        end
+        attrs
       end
     end
   end

--- a/app/forms/hyrax/forms/resource_batch_edit_form.rb
+++ b/app/forms/hyrax/forms/resource_batch_edit_form.rb
@@ -7,6 +7,10 @@ module Hyrax
       self.required_fields = []
       self.model_class = Hyrax.primary_work_type
 
+      # Terms that need to exclude from batch edit
+      class_attribute :terms_excluded
+      self.terms_excluded = [:abstract, :label, :source]
+
       # Contains a list of titles of all the works in the batch
       attr_accessor :names
 
@@ -36,7 +40,7 @@ module Hyrax
         terms_secondary = definitions.select { |_, definition| definition[:display] && !definition[:primary] }
                                      .keys.map(&:to_sym)
 
-        terms_primary + terms_secondary
+        (terms_primary + terms_secondary) - terms_excluded
       end
 
       attr_reader :batch_document_ids

--- a/spec/forms/hyrax/forms/resource_batch_edit_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_batch_edit_form_spec.rb
@@ -43,18 +43,18 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
 
     it do
       is_expected.to include(:creator,
-                         :contributor,
-                         :description,
-                         :keyword,
-                         :resource_type,
-                         :license,
-                         :publisher,
-                         :date_created,
-                         :subject,
-                         :language,
-                         :identifier,
-                         :based_near,
-                         :related_url)
+        :contributor,
+        :description,
+        :keyword,
+        :resource_type,
+        :license,
+        :publisher,
+        :date_created,
+        :subject,
+        :language,
+        :identifier,
+        :based_near,
+        :related_url)
     end
   end
 
@@ -79,31 +79,31 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
     subject { described_class.build_permitted_params }
 
     it do
-      is_expected.to eq [{ creator: [] },
-                         { contributor: [] },
-                         { description: [] },
-                         { keyword: [] },
-                         { resource_type: [] },
-                         { license: [] },
-                         { publisher: [] },
-                         { date_created: [] },
-                         { subject: [] },
-                         { language: [] },
-                         { identifier: [] },
-                         { based_near: [] },
-                         { related_url: [] },
-                         { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
-                         :on_behalf_of,
-                         :version,
-                         :add_works_to_collection,
-                         :visibility_during_embargo,
-                         :embargo_release_date,
-                         :visibility_after_embargo,
-                         :visibility_during_lease,
-                         :lease_expiration_date,
-                         :visibility_after_lease,
-                         :visibility,
-                         { based_near_attributes: [:id, :_destroy] }]
+      is_expected.to include({ creator: [] },
+        { contributor: [] },
+        { description: [] },
+        { keyword: [] },
+        { resource_type: [] },
+        { license: [] },
+        { publisher: [] },
+        { date_created: [] },
+        { subject: [] },
+        { language: [] },
+        { identifier: [] },
+        { based_near: [] },
+        { related_url: [] },
+        { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
+        :on_behalf_of,
+        :version,
+        :add_works_to_collection,
+        :visibility_during_embargo,
+        :embargo_release_date,
+        :visibility_after_embargo,
+        :visibility_during_lease,
+        :lease_expiration_date,
+        :visibility_after_lease,
+        :visibility,
+        { based_near_attributes: [:id, :_destroy] })
     end
   end
 end


### PR DESCRIPTION
### Fixes

Fixes #5797 ; refs #5797

### Summary

Dynamically generate terms and build permitted params for valkyrie batch edit.

### For Reviewers

If there's work that needs to be done on this PR, it should get picked up by the Princeton team.

@samvera/hyrax-code-reviewers
