### PR TITLE
Add correct mime type to a/v derivatives saved via valkyrie

### DIFF
--- a/app/services/hyrax/file_set_derivatives_service.rb
+++ b/app/services/hyrax/file_set_derivatives_service.rb
@@ -5,7 +5,7 @@ module Hyrax
     attr_reader :file_set
     delegate :mime_type, to: :file_set
 
-    # @param file_set [Hyrax::FileSet] At least for this class, it must have #uri and #mime_type
+    # @param file_set [Hyrax::FileSet, Hyrax::FileMetadata] At least for this class, it must have #uri and #mime_type
     def initialize(file_set)
       @file_set = file_set
     end
@@ -91,15 +91,15 @@ module Hyrax
 
     def create_audio_derivatives(filename)
       Hydra::Derivatives::AudioDerivatives.create(filename,
-                                                  outputs: [{ label: 'mp3', format: 'mp3', url: derivative_url('mp3') },
-                                                            { label: 'ogg', format: 'ogg', url: derivative_url('ogg') }])
+                                                  outputs: [{ label: 'mp3', format: 'mp3', url: derivative_url('mp3'), mime_type: 'audio/mpeg' },
+                                                            { label: 'ogg', format: 'ogg', url: derivative_url('ogg'), mime_type: 'audio/ogg' }])
     end
 
     def create_video_derivatives(filename)
       Hydra::Derivatives::VideoDerivatives.create(filename,
-                                                  outputs: [{ label: :thumbnail, format: 'jpg', url: derivative_url('thumbnail') },
-                                                            { label: 'webm', format: 'webm', url: derivative_url('webm') },
-                                                            { label: 'mp4', format: 'mp4', url: derivative_url('mp4') }])
+                                                  outputs: [{ label: :thumbnail, format: 'jpg', url: derivative_url('thumbnail'), mime_type: 'image/jpeg' },
+                                                            { label: 'webm', format: 'webm', url: derivative_url('webm'), mime_type: 'video/webm' },
+                                                            { label: 'mp4', format: 'mp4', url: derivative_url('mp4'), mime_type: 'video/mp4' }])
     end
 
     def create_image_derivatives(filename)

--- a/app/services/hyrax/valkyrie_persist_derivatives.rb
+++ b/app/services/hyrax/valkyrie_persist_derivatives.rb
@@ -32,7 +32,7 @@ module Hyrax
 
       filename = filename(directives)
       Hyrax.logger.debug "Uploading derivative for FileSet #{file_set.id} as #{filename}"
-      uploader.upload(io: tmpfile, filename: filename, file_set: file_set, use: file_metadata(directives))
+      uploader.upload(io: tmpfile, filename: filename, file_set: file_set, use: file_metadata(directives), mime_type: directives[:mime_type])
     end
 
     # The filepath will look something like

--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -34,12 +34,13 @@ class Hyrax::ValkyrieUpload
     @storage_adapter = storage_adapter
   end
 
-  def upload(filename:, file_set:, io:, use: Hyrax::FileMetadata::Use::ORIGINAL_FILE, user: nil)
+  def upload(filename:, file_set:, io:, use: Hyrax::FileMetadata::Use::ORIGINAL_FILE, user: nil, mime_type: nil)
     streamfile = storage_adapter.upload(file: io, original_filename: filename, resource: file_set)
     file_metadata = Hyrax::FileMetadata(streamfile)
     file_metadata.file_set_id = file_set.id
     file_metadata.pcdm_use = [use]
     file_metadata.recorded_size = [io.size]
+    file_metadata.mime_type = mime_type if mime_type
 
     if use == Hyrax::FileMetadata::Use::ORIGINAL_FILE
       # Set file set label.

--- a/spec/factories/hyrax_file_metadata.rb
+++ b/spec/factories/hyrax_file_metadata.rb
@@ -36,6 +36,14 @@ FactoryBot.define do
       mime_type { 'image/png' }
     end
 
+    trait :audio_file do
+      mime_type { 'audio/x-wave' }
+    end
+
+    trait :video_file do
+      mime_type { 'video/mp4' }
+    end
+
     trait :with_file do
       transient do
         file { FactoryBot.create(:uploaded_file) }

--- a/spec/services/hyrax/valkyrie_persist_derivatives_spec.rb
+++ b/spec/services/hyrax/valkyrie_persist_derivatives_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe Hyrax::ValkyriePersistDerivatives, valkyrie_adapter: :test_adapte
         .to change { Hyrax.custom_queries.find_files(file_set: file_set) }
         .from(be_empty)
     end
+
+    context "when given a mime_type directive" do
+      let(:directives) do
+        { url: "file:///app/samvera/hyrax-webapp/derivatives/#{id}-webm.webm",
+          mime_type: 'video/webm' }
+      end
+
+      it 'adds the mime_type to the file metadata' do
+        described_class.call(stream, directives)
+        files = Hyrax.custom_queries.find_files(file_set: file_set)
+        expect(files.first.mime_type).to eq 'video/webm'
+      end
+    end
   end
 
   describe '.fileset_for_directives' do


### PR DESCRIPTION
By saving mime type passed to ValkyriePersistDerivatives

advances gh-6294