### PR TITLE
do not fall back to generic resourceform if there is a syntax error

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -123,20 +123,17 @@ module Hyrax
         def for(resource)
           klass = "#{resource.class.name}Form".safe_constantize
 
-          if klass
-            klass.new(resource)
+          return  klass.new(resource) if klass
+          case resource
+          when Hyrax::AdministrativeSet
+            Hyrax::Forms::AdministrativeSetForm.new(resource)
+          when Hyrax::FileSet
+            Hyrax::Forms::FileSetForm.new(resource)
+          when Hyrax::PcdmCollection
+            Hyrax::Forms::PcdmCollectionForm.new(resource)
           else
-            case resource
-            when Hyrax::AdministrativeSet
-              Hyrax::Forms::AdministrativeSetForm.new(resource)
-            when Hyrax::FileSet
-              Hyrax::Forms::FileSetForm.new(resource)
-            when Hyrax::PcdmCollection
-              Hyrax::Forms::PcdmCollectionForm.new(resource)
-            else
-              # NOTE: This will create a +Hyrax::Forms::PcdmObjectForm+.
-              Hyrax::Forms::ResourceForm(resource.class).new(resource)
-            end
+            # NOTE: This will create a +Hyrax::Forms::PcdmObjectForm+.
+            Hyrax::Forms::ResourceForm(resource.class).new(resource)
           end
         end
 

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -121,18 +121,22 @@ module Hyrax
         #   monograph  = Monograph.new
         #   change_set = Hyrax::Forms::ResourceForm.for(monograph)
         def for(resource)
-          "#{resource.class.name}Form".constantize.new(resource)
-        rescue NameError => _err
-          case resource
-          when Hyrax::AdministrativeSet
-            Hyrax::Forms::AdministrativeSetForm.new(resource)
-          when Hyrax::FileSet
-            Hyrax::Forms::FileSetForm.new(resource)
-          when Hyrax::PcdmCollection
-            Hyrax::Forms::PcdmCollectionForm.new(resource)
+          klass = "#{resource.class.name}Form".safe_constantize
+
+          if klass
+            klass.new(resource)
           else
-            # NOTE: This will create a +Hyrax::Forms::PcdmObjectForm+.
-            Hyrax::Forms::ResourceForm(resource.class).new(resource)
+            case resource
+            when Hyrax::AdministrativeSet
+              Hyrax::Forms::AdministrativeSetForm.new(resource)
+            when Hyrax::FileSet
+              Hyrax::Forms::FileSetForm.new(resource)
+            when Hyrax::PcdmCollection
+              Hyrax::Forms::PcdmCollectionForm.new(resource)
+            else
+              # NOTE: This will create a +Hyrax::Forms::PcdmObjectForm+.
+              Hyrax::Forms::ResourceForm(resource.class).new(resource)
+            end
           end
         end
 


### PR DESCRIPTION
### Summary

do not fall back to generic ResourceForm if there is a syntax error in your work type Form object. Before this commit, any method missing or other name error in GenericWorkForm would simply cause the app to use ResourceForm(GenericWork) instead. This hides the error from you while not giving you the features you'd expect. 


@samvera/hyrax-code-reviewers
