### PR TITLE
make valkyrie solr adapter take full url argument

### DIFF
--- a/lib/valkyrie/indexing/solr/indexing_adapter.rb
+++ b/lib/valkyrie/indexing/solr/indexing_adapter.rb
@@ -81,6 +81,8 @@ module Valkyrie
           # if any configuration is missing, derive it from Blacklight
           config = blacklight_based_config.with_indifferent_access.merge(config)
 
+          return config['url'] if config['url'].present?
+
           "http://#{config['host']}:#{config['port']}/solr/#{config['core']}"
         end
 


### PR DESCRIPTION
### Summary

Previously Valkyrie solr could only be set with host, port and core. This prevents Valkyrie from being able to work with authenticated Solr or really any Solr that doesn't follow the strict pattern. Long term, I feel like the Valkyrie config should go away and we should just support the same options as the blacklight.yml already supports. Specifying Solr twice seems unnecessary, but this at least provides a solution which is good enough for production.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Set a `config/valkyrie_index.yml` that looks like
```yaml
development:
  adapter: solr
  url: <%= ENV['SOLR_URL'] + 'hydra-development' || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
test: &test
  adapter: solr
  url: <%= ENV['SOLR_URL'] ? ENV['SOLR_URL'] + 'hydra-test' : "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>
production:
  adapter: solr
  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
``` 
* Set SOLR_URL and start the app
* It should be able to see Solr


@samvera/hyrax-code-reviewers
