### PR TITLE
Bump min rails version to 6.1 and align dassie/koppie gems

### DIFF
--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -9,11 +9,11 @@ end
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.0'
+gem 'rails', '~> 6.1'
 # Use postgresql as the database for Active Record
-gem 'pg', '>= 0.18', '< 2.0'
+gem 'pg', '~> 1.3'
 # Use Puma as the app server
-gem 'puma', '~> 4.3.8'
+gem 'puma'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 6.0'
 # Use Uglifier as compressor for JavaScript assets
@@ -32,11 +32,16 @@ gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem "debug", ">= 1.0.0"
+  gem 'pry-doc'
+  gem 'pry-rails'
+  gem 'pry-rescue'
 end
 
 group :development do
+  gem 'better_errors' # add command line in browser when errors
+  gem 'binding_of_caller' # deeper stack trace used by better errors
+
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
@@ -52,13 +57,9 @@ gemspec name: 'hyrax', path: ENV.fetch('HYRAX_ENGINE_PATH', '..')
 
 gem 'bootstrap', '~> 4.0'
 gem 'devise'
-gem 'devise-guests', '~> 0.6'
+gem 'devise-guests', '~> 0.8'
 gem 'jquery-rails'
-gem 'pry-byebug'
-gem 'pry-doc'
-gem 'pry-rails'
-gem 'pry-rescue'
 gem 'riiif', '~> 2.1'
 gem 'rsolr', '>= 1.0', '< 3'
-gem 'sidekiq', '~> 6.0'
+gem 'sidekiq', '~> 6.4'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'

--- a/.koppie/Gemfile
+++ b/.koppie/Gemfile
@@ -10,14 +10,14 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap', '~> 4.0'
 gem 'coffee-rails', '~> 4.2'
 gem 'dalli'
-gem 'devise', '4.8.0'
-gem 'devise-guests', '0.8.1'
+gem 'devise'
+gem 'devise-guests', '~> 0.8'
 gemspec name: 'hyrax', path: ENV.fetch('HYRAX_ENGINE_PATH', '..')
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'
 gem 'pg', '~> 1.3'
-gem 'puma', '~> 5.5.2'
-gem 'rails', '~> 6.0'
+gem 'puma'
+gem 'rails', '~> 6.1'
 gem 'riiif', '~> 2.1'
 gem 'rsolr', '>= 1.0', '< 3'
 gem 'sass-rails', '~> 6.0'
@@ -40,11 +40,8 @@ group :development do
 end
 
 group :development, :test do
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem "pry-byebug"
+  gem "debug", ">= 1.0.0"
   gem "pry-doc"
   gem "pry-rails"
   gem "pry-rescue"
-  gem 'rspec-rails'
-  gem 'solr_wrapper', '>= 0.3'
 end

--- a/.koppie/Rakefile
+++ b/.koppie/Rakefile
@@ -4,5 +4,3 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
-
-require 'solr_wrapper/rake_task' unless Rails.env.production?

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -30,7 +30,7 @@ SUMMARY
   # NOTE: rails does not follow sem-ver conventions, it's
   # minor version releases can include breaking changes; see
   # http://guides.rubyonrails.org/maintenance_policy.html
-  spec.add_dependency 'rails', '~> 6.0'
+  spec.add_dependency 'rails', '~> 6.1'
 
   spec.add_dependency 'active-fedora', '~> 14.0'
   spec.add_dependency 'almond-rails', '~> 0.1'
@@ -98,7 +98,7 @@ SUMMARY
   spec.add_development_dependency 'pg', '~> 1.2'
   spec.add_development_dependency 'rspec-activemodel-mocks', '~> 1.0'
   spec.add_development_dependency 'rspec-its', '~> 1.1'
-  spec.add_development_dependency 'rspec-rails', '~> 5.0'
+  spec.add_development_dependency 'rspec-rails', '~> 6.0'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency "selenium-webdriver", '~> 4.4'
   spec.add_development_dependency 'i18n-debug'


### PR DESCRIPTION
### Summary

Updates rails to 6.1 since 6.0 is end-of-life. Other gem discrepancies between dassie and koppie are resolved here. On my workstation their gem lock files are now identical.


@samvera/hyrax-code-reviewers
