### PR TITLE
Versioning w/ Valkyrie

### DIFF
--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -62,3 +62,4 @@ gem 'riiif', '~> 2.1'
 gem 'rsolr', '>= 1.0', '< 3'
 gem 'sidekiq', '~> 6.0'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
+gem "valkyrie", github: "samvera/valkyrie", branch: "storage_versioning"

--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -62,4 +62,3 @@ gem 'riiif', '~> 2.1'
 gem 'rsolr', '>= 1.0', '< 3'
 gem 'sidekiq', '~> 6.0'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
-gem "valkyrie", github: "samvera/valkyrie", branch: "storage_versioning"

--- a/.koppie/Gemfile
+++ b/.koppie/Gemfile
@@ -26,7 +26,6 @@ gem 'turbolinks', '~> 5'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier', '>= 1.3.0'
-gem "valkyrie", github: "samvera/valkyrie", branch: "storage_versioning"
 
 group :development do
   gem 'better_errors' # add command line in browser when errors

--- a/.koppie/Gemfile
+++ b/.koppie/Gemfile
@@ -26,6 +26,7 @@ gem 'turbolinks', '~> 5'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier', '>= 1.3.0'
+gem "valkyrie", github: "samvera/valkyrie", branch: "storage_versioning"
 
 group :development do
   gem 'better_errors' # add command line in browser when errors

--- a/.koppie/config/initializers/1_valkyrie.rb
+++ b/.koppie/config/initializers/1_valkyrie.rb
@@ -47,8 +47,8 @@ Valkyrie.config.metadata_adapter = :nurax_pg_metadata_adapter
 #
 # Valkyrie.config.storage_adapter = :repository_s3
 Valkyrie::StorageAdapter.register(
-  Valkyrie::Storage::Disk.new(base_path: Rails.root.join("storage", "files"),
-                              file_mover: FileUtils.method(:cp)),
+  Valkyrie::Storage::VersionedDisk.new(base_path: Rails.root.join("storage", "files"),
+                                       file_mover: FileUtils.method(:cp)),
   :disk
 )
 Valkyrie.config.storage_adapter  = :disk

--- a/app/controllers/concerns/hyrax/valkyrie_downloads_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/valkyrie_downloads_controller_behavior.rb
@@ -17,7 +17,7 @@ module Hyrax
       file_metadata = find_file_metadata(file_set: file_set, use: use, mime_type: mime_type)
       return unless stale?(last_modified: file_metadata.updated_at, template: false)
 
-      file = Hyrax.storage_adapter.find_by(id: file_metadata.file_identifier)
+      file = Valkyrie::StorageAdapter.find_by(id: file_metadata.file_identifier)
       prepare_file_headers_valkyrie(metadata: file_metadata, file: file)
 
       # Warning - using the range header will load the range selection in to memory

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -41,6 +41,7 @@ module Hyrax
 
     layout :decide_layout
 
+
     # GET /concern/file_sets/:id
     def edit
       initialize_edit_form
@@ -115,12 +116,14 @@ module Hyrax
       when Hyrax::Resource
         change_set = Hyrax::Forms::ResourceForm.for(file_set)
 
-        change_set.validate(attributes) &&
+        result =
+          change_set.validate(attributes) &&
           transactions['change_set.update_file_set']
-            .with_step_args(
-              'file_set.save_acl' => { permissions_params: change_set.input_params["permissions"] }
-            )
-            .call(change_set).value_or { false }
+          .with_step_args(
+            'file_set.save_acl' => { permissions_params: change_set.input_params["permissions"] }
+          )
+          .call(change_set).value_or { false }
+        @file_set = result if result
       else
         file_attributes = form_class.model_attributes(attributes)
         actor.update_metadata(file_attributes)
@@ -281,11 +284,6 @@ module Hyrax
     end
 
     def wants_to_revert_valkyrie?
-      puts "REVERTING"
-      puts "FILE METADATA ID: #{file_metadata.id}"
-      puts "LATEST VERSION: #{Hyrax::VersioningService.new(resource: file_metadata).latest_version.version_id}"
-      puts "PARAMS: #{params[:revision]}"
-      puts params.key?(:revision) && params[:revision] != Hyrax::VersioningService.new(resource: file_metadata).latest_version.version_id.to_s
       params.key?(:revision) && params[:revision] != Hyrax::VersioningService.new(resource: file_metadata).latest_version.version_id.to_s
     end
 

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -130,7 +130,7 @@ module Hyrax
     def parent(file_set: curation_concern)
       @parent ||=
         case file_set
-        when Hyrax::Resource
+        when Hyrax::FileSet
           Hyrax.query_service.find_parents(resource: file_set).first
         else
           file_set.parent

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -144,7 +144,7 @@ module Hyrax
     end
 
     def attempt_update
-      return attempt_update_valkyrie if Hyrax.config.use_valkyrie?
+      return attempt_update_valkyrie if ::FileSet < Hyrax::Resource
       if wants_to_revert?
         actor.revert_content(params[:revision])
       elsif params.key?(:file_set)

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -129,8 +129,8 @@ module Hyrax
         .with_step_args(
           'file_set.save_acl' => { permissions_params: change_set.input_params["permissions"] }
         )
-          .call(change_set).value_or { false }
-        @file_set = result if result
+        .call(change_set).value_or { false }
+      @file_set = result if result
     end
 
     def parent(file_set: curation_concern)
@@ -161,9 +161,8 @@ module Hyrax
     end
 
     def attempt_update_valkyrie
-      if wants_to_revert_valkyrie?
-        revert_valkyrie
-      elsif params.key?(:file_set)
+      return revert_valkyrie if wants_to_revert_valkyrie?
+      if params.key?(:file_set)
         if params[:file_set].key?(:files)
           ValkyrieIngestJob.perform_later(uploaded_file_from_path)
         else

--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -370,6 +370,7 @@ module Hyrax
       can :manage, curation_concerns_models
       can :manage, Sipity::WorkflowResponsibility
       can :manage, :collection_types
+      can :manage, ::FileSet
     end
 
     ##
@@ -418,7 +419,7 @@ module Hyrax
     end
 
     def curation_concerns_models
-      [::FileSet, Hyrax.config.collection_class] + Hyrax.config.curation_concerns
+      [::FileSet, ::Hyrax::FileSet, Hyrax.config.collection_class] + Hyrax.config.curation_concerns
     end
 
     def can_review_submissions?

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -59,7 +59,7 @@ module Hyrax
       module_function :uri_for
     end
 
-    attribute :file_identifier, Valkyrie::Types::ID # id of the file stored by the storage adapter
+    attribute :file_identifier, ::Valkyrie::Types::ID # id of the file stored by the storage adapter
     attribute :alternate_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID) # id of the file, populated for queryability
     attribute :file_set_id, ::Valkyrie::Types::ID # id of parent file set resource
 

--- a/app/presenters/hyrax/version_list_presenter.rb
+++ b/app/presenters/hyrax/version_list_presenter.rb
@@ -38,9 +38,11 @@ module Hyrax
 
     def wrapped_list
       @wrapped_list ||=
-        @versioning_service.versions.map { |v| Hyrax::VersionPresenter.new(v) } # wrap each item in a presenter
-                           .sort { |a, b| b.version.created <=> a.version.created } # sort list of versions based on creation date
-                           .tap { |l| l.first.try(:current!) } # set the first version to the current version
+        begin
+          presenters = @versioning_service.versions.map { |v| Hyrax::VersionPresenter.new(v) } # wrap each item in a presenter
+          presenters.sort! { |a, b| b.version.created <=> a.version.created } if presenters.first&.version.respond_to?(:created) # sort list of versions based on creation date
+          presenters.tap { |l| l.first.try(:current!) } # set the first version to the current version
+        end
     end
   end
 end

--- a/app/presenters/hyrax/version_list_presenter.rb
+++ b/app/presenters/hyrax/version_list_presenter.rb
@@ -40,7 +40,11 @@ module Hyrax
       @wrapped_list ||=
         begin
           presenters = @versioning_service.versions.map { |v| Hyrax::VersionPresenter.new(v) } # wrap each item in a presenter
-          presenters.sort! { |a, b| b.version.created <=> a.version.created } if presenters.first&.version.respond_to?(:created) # sort list of versions based on creation date
+          if presenters.first&.version&.respond_to?(:created)
+            presenters.sort! { |a, b| b.version.created <=> a.version.created } if presenters.first&.version.respond_to?(:created) # sort list of versions based on creation date
+          else
+            presenters.reverse!
+          end
           presenters.tap { |l| l.first.try(:current!) } # set the first version to the current version
         end
     end

--- a/app/presenters/hyrax/version_presenter.rb
+++ b/app/presenters/hyrax/version_presenter.rb
@@ -19,14 +19,25 @@ module Hyrax
       version.try(:label) || version.version_id.to_s
     end
 
+    def uri
+      version.try(:uri) || version.version_id.to_s
+    end
+
     def created
-      @created ||= version.try(:created)&.in_time_zone&.to_formatted_s(:long_ordinal) || "Unknown"
+      @created ||= created_time&.in_time_zone&.to_formatted_s(:long_ordinal) || "Unknown"
+    end
+
+    def created_time
+      version.try(:created) || version_committer.try(:created_at)
+    end
+
+    def version_committer
+      Hyrax::VersionCommitter
+        .find_by(version_id: @version.try(:uri) || @version.try(:version_id))
     end
 
     def committer
-      Hyrax::VersionCommitter
-        .find_by(version_id: @version.try(:uri) || @version.try(:version_id))
-        &.committer_login
+      version_committer&.committer_login
     end
   end
 end

--- a/app/presenters/hyrax/version_presenter.rb
+++ b/app/presenters/hyrax/version_presenter.rb
@@ -15,13 +15,17 @@ module Hyrax
       @current = true
     end
 
+    def label
+      version.try(:label) || version.version_id.to_s
+    end
+
     def created
-      @created ||= version.created.in_time_zone.to_formatted_s(:long_ordinal)
+      @created ||= version.try(:created)&.in_time_zone&.to_formatted_s(:long_ordinal) || "Unknown"
     end
 
     def committer
       Hyrax::VersionCommitter
-        .find_by(version_id: @version.uri)
+        .find_by(version_id: @version.try(:uri) || @version.try(:version_id))
         &.committer_login
     end
   end

--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -34,7 +34,7 @@ class Hyrax::ValkyrieUpload
     @storage_adapter = storage_adapter
   end
 
-  def upload(filename:, file_set:, io:, use: Hyrax::FileMetadata::Use::ORIGINAL_FILE, user: nil, mime_type: nil)
+  def upload(filename:, file_set:, io:, use: Hyrax::FileMetadata::Use::ORIGINAL_FILE, user: nil, mime_type: nil) # rubocop:disable Metrics/AbcSize
     return version_upload(file_set: file_set, io: io, user: user) if use == Hyrax::FileMetadata::Use::ORIGINAL_FILE && file_set.original_file_id && storage_adapter.supports?(:versions)
     streamfile = storage_adapter.upload(file: io, original_filename: filename, resource: file_set)
     file_metadata = Hyrax::FileMetadata(streamfile)

--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -42,7 +42,7 @@ class Hyrax::ValkyrieUpload
     file_metadata.pcdm_use = [use]
     file_metadata.recorded_size = [io.size]
     file_metadata.mime_type = mime_type if mime_type
-    file_metadata.original_filename = filename || File.basename(io)
+    file_metadata.original_filename = File.basename(filename).to_s || File.basename(io)
 
     if use == Hyrax::FileMetadata::Use::ORIGINAL_FILE
       # Set file set label.

--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -42,6 +42,7 @@ class Hyrax::ValkyrieUpload
     file_metadata.pcdm_use = [use]
     file_metadata.recorded_size = [io.size]
     file_metadata.mime_type = mime_type if mime_type
+    file_metadata.original_filename = filename || File.basename(io)
 
     if use == Hyrax::FileMetadata::Use::ORIGINAL_FILE
       # Set file set label.
@@ -67,7 +68,7 @@ class Hyrax::ValkyrieUpload
 
   def version_upload(file_set:, io:, user:)
     file_metadata = Hyrax.query_service.custom_queries.find_file_metadata_by(id: file_set.original_file_id)
-    storage_adapter.upload_version(file: io, id: file_metadata.file_identifier)
+    Hyrax::VersioningService.create(file_metadata, user, io)
     ContentNewVersionEventJob.perform_later(file_set, user)
   end
 

--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -69,6 +69,7 @@ class Hyrax::ValkyrieUpload
   def version_upload(file_set:, io:, user:)
     file_metadata = Hyrax.query_service.custom_queries.find_file_metadata_by(id: file_set.original_file_id)
     Hyrax::VersioningService.create(file_metadata, user, io)
+    Hyrax.publisher.publish("file.uploaded", metadata: file_metadata)
     ContentNewVersionEventJob.perform_later(file_set, user)
   end
 

--- a/app/services/hyrax/versioning_service.rb
+++ b/app/services/hyrax/versioning_service.rb
@@ -88,9 +88,9 @@ module Hyrax
       # Make a version and record the version committer
       # @param [ActiveFedora::File | Hyrax::FileMetadata] content
       # @param [User, String] user
-      def create(content, user = nil)
+      def create(content, user = nil, file = nil)
         use_valkyrie = content.is_a? Hyrax::FileMetadata
-        perform_create(content, user, use_valkyrie)
+        perform_create(content, user, file, use_valkyrie)
       end
 
       # @param [ActiveFedora::File | Hyrax::FileMetadata] file
@@ -110,14 +110,14 @@ module Hyrax
         user_key = user_key.user_key if user_key.respond_to?(:user_key)
         version = latest_version_of(content)
         return if version.nil?
-        version_id = content.is_a?(Hyrax::FileMetadata) ? version.id.to_s : version.uri
+        version_id = content.is_a?(Hyrax::FileMetadata) ? version.version_id.to_s : version.uri
         Hyrax::VersionCommitter.create(version_id: version_id, committer_login: user_key)
       end
 
       private
 
-      def perform_create(content, user, use_valkyrie)
-        use_valkyrie ? perform_create_through_valkyrie(content, user) : perform_create_through_active_fedora(content, user)
+      def perform_create(content, user, file, use_valkyrie)
+        use_valkyrie ? perform_create_through_valkyrie(content, file, user) : perform_create_through_active_fedora(content, user)
       rescue NotImplementedError
         Hyrax.logger.warn "Declining to create a Version for #{content}; #{self} doesn't support versioning with use_valkyrie: #{use_valkyrie}"
       end
@@ -127,8 +127,14 @@ module Hyrax
         record_committer(content, user) if user
       end
 
-      def perform_create_through_valkyrie(content, user) # no-op
-        raise NotImplementedError
+      def perform_create_through_valkyrie(content, file, user)
+        raise NotImplementedError unless Hyrax.storage_adapter.supports?(:versions)
+        Hyrax.storage_adapter.upload_version(id: content.file_identifier, file: file)
+        record_committer(content, user) if user
+      end
+
+      def storage_adapter
+        Hyrax.storage_adapter
       end
     end
   end

--- a/app/services/hyrax/versioning_service.rb
+++ b/app/services/hyrax/versioning_service.rb
@@ -35,7 +35,9 @@ module Hyrax
       if !supports_multiple_versions?
         []
       elsif resource.is_a?(Hyrax::FileMetadata)
-        storage_adapter.find_versions(id: resource.file_identifier).to_a
+        # Reverse - Valkyrie puts these most recent first, we assume most recent
+        # last.
+        storage_adapter.find_versions(id: resource.file_identifier).to_a.reverse
       else
         return resource.versions if resource.versions.is_a?(Array)
         resource.versions.all.to_a
@@ -67,7 +69,7 @@ module Hyrax
     # If the resource is nil, this method returns an empty string.
     def versioned_file_id
       latest = latest_version
-      if latest
+      if latest && !resource.is_a?(Hyrax::FileMetadata)
         if latest.respond_to?(:id)
           latest.id
         else
@@ -76,7 +78,7 @@ module Hyrax
       elsif resource.nil?
         ""
       elsif resource.is_a?(Hyrax::FileMetadata)
-        resource.file_identifier
+        latest_version&.version_id || resource.file_identifier
       else
         resource.id
       end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -82,7 +82,7 @@ SUMMARY
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 5.10'
-  spec.add_dependency 'valkyrie', '~> 3.0.1'
+  spec.add_dependency 'valkyrie', '~> 3.1.0'
   spec.add_dependency 'view_component', '~> 2.74.1' # Pin until blacklight is updated with workaround for https://github.com/ViewComponent/view_component/issues/1565
   spec.add_dependency 'sprockets', '~> 3.7'
   spec.add_dependency 'sass-rails', '~> 6.0'

--- a/lib/hyrax/specs/shared_specs/valkyrie_storage_versions.rb
+++ b/lib/hyrax/specs/shared_specs/valkyrie_storage_versions.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.shared_examples 'a Valkyrie::StorageAdapter with versioning support' do
-  describe '#supports?' do
-    it 'supports versions' do
-      expect(storage_adapter.supports?(:versions)).to eq true
-    end
-  end
-end

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -53,6 +53,9 @@ module Hyrax
       require 'hyrax/transactions/steps/set_user_as_depositor'
       require 'hyrax/transactions/steps/update_work_members'
       require 'hyrax/transactions/steps/validate'
+      require 'hyrax/transactions/steps/delete_all_file_metadata'
+      require 'hyrax/transactions/steps/file_metadata_delete'
+      require 'hyrax/transactions/file_metadata_destroy'
 
       extend Dry::Container::Mixin
 
@@ -128,9 +131,23 @@ module Hyrax
         end
       end
 
+      namespace "file_metadata" do |ops| # Hyrax::FileMetadata
+        ops.register 'destroy' do
+          FileMetadataDestroy.new
+        end
+
+        ops.register 'delete' do
+          Steps::FileMetadataDelete.new
+        end
+      end
+
       namespace 'file_set' do |ops| # Hyrax::FileSet resource
         ops.register 'delete' do
           Steps::DeleteResource.new
+        end
+
+        ops.register 'delete_all_file_metadata' do
+          Steps::DeleteAllFileMetadata.new(property: :file_ids)
         end
 
         ops.register 'destroy' do

--- a/lib/hyrax/transactions/file_metadata_destroy.rb
+++ b/lib/hyrax/transactions/file_metadata_destroy.rb
@@ -7,10 +7,8 @@ module Hyrax
     # destroys a FileSet resource.
     #
     # @since 3.1.0
-    class FileSetDestroy < Transaction
-      DEFAULT_STEPS = ['file_set.remove_from_work',
-                       'file_set.delete',
-                       'file_set.delete_all_file_metadata'].freeze
+    class FileMetadataDestroy < Transaction
+      DEFAULT_STEPS = ['file_metadata.delete'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/steps/delete_all_file_metadata.rb
+++ b/lib/hyrax/transactions/steps/delete_all_file_metadata.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Deletes a resource from the persister, returning a `Dry::Monads::Result`
+      # (`Success`|`Failure`).
+      #
+      # @see https://dry-rb.org/gems/dry-monads/1.0/result/
+      class DeleteAllFileMetadata
+        include Dry::Monads[:result]
+
+        ##
+        # @params [#save] persister
+        def initialize(property:, query_service: Hyrax.query_service, persister: Hyrax.persister, publisher: Hyrax.publisher)
+          @property = property
+          @persister = persister
+          @query_service = query_service
+          @publisher = publisher
+        end
+
+        ##
+        # @param [Valkyrie::Resource] resource
+        # @param [::User] the user resposible for the delete action
+        #
+        # @return [Dry::Monads::Result]
+        def call(resource)
+          return Failure(:resource_not_persisted) unless resource.persisted?
+
+          resource[@property].each do |file_id|
+            Hyrax::Transactions::Container['file_metadata.destroy'].call(@query_service.find_by(id: file_id))
+          end
+
+          Success(resource)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/delete_all_file_metadata.rb
+++ b/lib/hyrax/transactions/steps/delete_all_file_metadata.rb
@@ -30,7 +30,9 @@ module Hyrax
           return Failure(:resource_not_persisted) unless resource.persisted?
 
           resource[@property].each do |file_id|
-            Hyrax::Transactions::Container['file_metadata.destroy'].call(@query_service.find_by(id: file_id))
+            Hyrax::Transactions::Container['file_metadata.destroy'].call(@query_service.custom_queries.find_file_metadata_by(id: file_id))
+          rescue ::Ldp::Gone
+            nil
           end
 
           Success(resource)

--- a/lib/hyrax/transactions/steps/file_metadata_delete.rb
+++ b/lib/hyrax/transactions/steps/file_metadata_delete.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Deletes a resource from the persister, returning a `Dry::Monads::Result`
+      # (`Success`|`Failure`).
+      #
+      # @see https://dry-rb.org/gems/dry-monads/1.0/result/
+      class FileMetadataDelete
+        include Dry::Monads[:result]
+
+        ##
+        # @params [#save] persister
+        def initialize(persister: Hyrax.persister, storage_adapter: Hyrax.storage_adapter, publisher: Hyrax.publisher)
+          @persister = persister
+          @publisher = publisher
+          @storage_adapter = storage_adapter
+        end
+
+        ##
+        # @param [Valkyrie::Resource] resource
+        # @param [::User] the user resposible for the delete action
+        #
+        # @return [Dry::Monads::Result]
+        def call(resource)
+          return Failure(:resource_not_persisted) unless resource.persisted?
+
+          @persister.delete(resource: resource)
+          Valkyrie::StorageAdapter.delete(id: resource.file_identifier)
+
+          Success(resource)
+        end
+      end
+    end
+  end
+end

--- a/lib/wings/valkyrie/storage.rb
+++ b/lib/wings/valkyrie/storage.rb
@@ -32,7 +32,7 @@ module Wings
       end
 
       def upload(file:, original_filename:, resource:, content_type: DEFAULT_CTYPE, # rubocop:disable Metrics/ParameterLists
-                 resource_uri_transformer: default_resource_uri_transformer, use: Hydra::PCDM::Vocab::PCDMTerms.File,
+                 resource_uri_transformer: default_resource_uri_transformer, use: Hydra::PCDM::Vocab::PCDMTerms.File, # rubocop:disable Lint/UnusedMethodArgument
                  id_hint: 'original', **_extra_arguments)
         id = if resource.try(:file_set?)
                upload_with_works(resource: resource, file: file, use: use)

--- a/lib/wings/valkyrie/storage.rb
+++ b/lib/wings/valkyrie/storage.rb
@@ -19,14 +19,9 @@ module Wings
     # For use with Hyrax, this adapter defaults to Fedora 4.
     class Storage < ::Valkyrie::Storage::Fedora
       DEFAULT_CTYPE = 'application/octet-stream'
-      LINK_HEADER = "<http://www.w3.org/ns/ldp#NonRDFSource>; rel=\"type\""
       FILES_PATH = 'files'
-      VERSIONS_SLUG = '/fcr:versions'
-
-      attr_reader :sha1
 
       def initialize(connection: Ldp::Client.new(ActiveFedora.fedora.host), base_path: ActiveFedora.fedora.base_path, fedora_version: 4)
-        @sha1 = fedora_version == 5 ? "sha" : "sha1"
         super
       end
 
@@ -36,83 +31,18 @@ module Wings
         ::Valkyrie::ID.new(id.to_s.sub(/^.+\/\//, PROTOCOL))
       end
 
-      ##
-      # @param key [Symbol] the key for plugin behavior to check support for
-      #
-      # @return [Boolean] whether
-      def supports?(key)
-        key == :versions
-      end
-
       def upload(file:, original_filename:, resource:, content_type: DEFAULT_CTYPE, # rubocop:disable Metrics/ParameterLists
                  resource_uri_transformer: default_resource_uri_transformer, use: Hydra::PCDM::Vocab::PCDMTerms.File,
-                 id_hint: 'original', **extra_arguments)
+                 id_hint: 'original', **_extra_arguments)
         id = if resource.try(:file_set?)
                upload_with_works(resource: resource, file: file, use: use)
              else
-               put_file(file: file,
-                        original_filename: original_filename,
-                        resource: resource,
-                        content_type: content_type,
-                        resource_uri_transformer: resource_uri_transformer,
-                        id_hint: id_hint, **extra_arguments)
+               return super(file: file, original_filename: original_filename, resource: resource, content_type: content_type, resource_uri_transformer: resource_uri_transformer_factory(id_hint))
              end
-
         find_by(id: cast_to_valkyrie_id(id))
       end
 
-      ##
-      # @return [Enumerable<Version> ordered list of versions
-      def find_versions(id:)
-        response = connection.http.get(fedora_identifier(id: id) + VERSIONS_SLUG)
-        return [] if response.status == 404
-
-        reader = RDF::Reader.for(content_type: response.headers['content-type'])
-        version_graph = RDF::Graph.new << reader.new(response.body)
-        query = { predicate: RDF::Vocab::Fcrepo4.hasVersion }
-
-        version_graph.query(query).objects.map do |uri|
-          timestamp =
-            version_graph.query([uri, RDF::Vocab::Fcrepo4.created, :created])
-                         .first_object
-                         .object
-          Version.new(id: cast_to_valkyrie_id(uri.to_s), created: timestamp, adapter: self)
-        end.sort
-      end
-
-      ##
-      # abstractly, {Version} objects should have an {#id} and be orderable
-      # over {#<=>} (allowing e.g. `#sort` to define a consistent order---
-      # oldest to newest---for a collection of versions). the {#id} should be a
-      # globally unique identifier for the version.
-      #
-      # this implementation uses an orderable {#version_token}. in practice
-      # the token is the fcrepo created date for the version, as extracted from
-      # the versions graph.
-      Version = Struct.new("Version", :id, :created, :adapter, keyword_init: true) do
-        include Comparable
-
-        ##
-        # @return [#read]
-        def io
-          adapter.find_by(id: id)
-        end
-
-        def version_token
-          created
-        end
-
-        def <=>(other)
-          raise ArgumentError unless other.respond_to?(:version_token)
-          version_token <=> other.version_token
-        end
-      end
-
       private
-
-      def digest_for(file)
-        "#{sha1}=#{Digest::SHA1.file(file)}"
-      end
 
       def default_resource_uri_transformer
         lambda do |resource, hint|
@@ -121,24 +51,12 @@ module Wings
         end
       end
 
-      ##
-      # Create a file with HTTP put; no containers here.
-      # @return [String] the identifier of the created file
-      def put_file(file:, original_filename:, resource:, content_type:, # rubocop:disable Metrics/ParameterLists
-                   resource_uri_transformer:, id_hint:, **_extra_arguments)
-        identifier = resource_uri_transformer.call(resource, id_hint)
-
-        connection.http.put do |request|
-          request.url identifier
-          request.headers['Content-Type'] = content_type
-          request.headers['Content-Length'] = (file.try(:size) || file.try(:length)).to_s
-          request.headers['Content-Disposition'] = "attachment; filename=\"#{original_filename}\""
-          request.headers['digest'] = digest_for(file)
-          request.headers['link'] = LINK_HEADER
-          request.body = Faraday::UploadIO.new(file, content_type, original_filename)
+      # Transforms default_resource_uri_transformer to conform to Valkyrie's
+      # expected interface of passing a resource and base url.
+      def resource_uri_transformer_factory(hint)
+        lambda do |resource, _base_url|
+          default_resource_uri_transformer.call(resource, hint)
         end
-
-        identifier
       end
 
       def upload_with_works(resource:, file:, use:)

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -863,6 +863,9 @@ RSpec.describe Hyrax::FileSetsController do
       before do
         allow(controller.main_app).to receive(:polymorphic_path).and_call_original
         allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{public_work.id}?locale=en")
+        allow(controller)
+          .to receive(:additional_response_formats)
+          .with(ActionController::MimeResponds::Collector)
       end
 
       describe '#edit' do
@@ -906,6 +909,9 @@ RSpec.describe Hyrax::FileSetsController do
         end
         let(:inactive_file_set) { query_service.find_members(resource: inactive_work).first }
         before do
+          allow(controller)
+            .to receive(:additional_response_formats)
+            .with(ActionController::MimeResponds::Collector)
           allow(controller.main_app).to receive(:polymorphic_path).and_call_original
           allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{active_work.id}?locale=en")
         end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -3,247 +3,36 @@
 RSpec.describe Hyrax::FileSetsController do
   routes      { Rails.application.routes }
   let(:user)  { FactoryBot.create(:user) }
-  let(:actor) { controller.send(:actor) }
 
-  context "when signed in" do
-    before { sign_in user }
+  describe "active fedora", :active_fedora do
+    let(:actor) { controller.send(:actor) }
+    context "when signed in" do
+      before { sign_in user }
 
-    describe "#destroy" do
-      context "file_set with a parent" do
-        let(:file_set) { FactoryBot.create(:file_set, user: user) }
-        let(:work) { FactoryBot.create(:work, title: ['test title'], user: user) }
+      describe "#destroy" do
+        context "file_set with a parent" do
+          let(:file_set) { FactoryBot.create(:file_set, user: user) }
+          let(:work) { FactoryBot.create(:work, title: ['test title'], user: user) }
 
-        before do
-          work.ordered_members << file_set
-          work.save!
-        end
-
-        it "deletes the file" do
-          expect(ContentDeleteEventJob).to receive(:perform_later).with(file_set.id, user)
-
-          expect { delete :destroy, params: { id: file_set } }
-            .to change { FileSet.exists?(file_set.id) }
-            .from(true)
-            .to(false)
-
-          expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
-        end
-      end
-    end
-
-    describe "#edit" do
-      let(:parent) { FactoryBot.create(:work, :public, user: user) }
-
-      let(:file_set) do
-        FactoryBot.create(:file_set, user: user).tap do |file_set|
-          parent.ordered_members << file_set
-          parent.save!
-        end
-      end
-
-      before do
-        binary = StringIO.new("hey")
-        Hydra::Works::AddFileToFileSet.call(file_set, binary, :original_file, versioning: true)
-        request.env['HTTP_REFERER'] = 'http://test.host/foo'
-      end
-
-      it "sets the breadcrumbs and versions presenter" do
-        app_helpers    = Rails.application.routes.url_helpers
-        engine_helpers = Hyrax::Engine.routes.url_helpers
-
-        expect(controller)
-          .to receive(:add_breadcrumb)
-          .with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller)
-          .to receive(:add_breadcrumb)
-          .with(I18n.t('hyrax.dashboard.title'), engine_helpers.dashboard_path(locale: 'en'))
-        expect(controller)
-          .to receive(:add_breadcrumb)
-          .with(I18n.t('hyrax.dashboard.my.works'), engine_helpers.my_works_path(locale: 'en'))
-        expect(controller)
-          .to receive(:add_breadcrumb)
-          .with(I18n.t('hyrax.file_set.browse_view'), app_helpers.hyrax_file_set_path(file_set, locale: 'en'))
-
-        get :edit, params: { id: file_set }
-
-        expect(response).to be_successful
-        expect(assigns[:file_set]).to eq file_set
-        expect(assigns[:version_list]).to be_kind_of Hyrax::VersionListPresenter
-        expect(assigns[:parent]).to eq parent
-        expect(response).to render_template(:edit)
-        expect(response).to render_template('dashboard')
-      end
-    end
-
-    describe "#update" do
-      let(:parent) { FactoryBot.create(:work, :public, user: user) }
-
-      let(:file_set) do
-        FactoryBot.create(:file_set, user: user, title: ['test title']).tap do |file_set|
-          parent.ordered_members << file_set
-          parent.save!
-        end
-      end
-
-      context "when updating metadata" do
-        it "spawns a content update event job" do
-          expect do
-            post :update, params: {
-              id: file_set,
-              file_set: {
-                title: ['new_title'],
-                keyword: [''],
-                permissions_attributes: [{ type: 'person',
-                                           name: 'archivist1',
-                                           access: 'edit' }]
-              }
-            }
-          end.to have_enqueued_job(ContentUpdateEventJob).exactly(:once)
-
-          expect(response)
-            .to redirect_to main_app.hyrax_file_set_path(file_set, locale: 'en')
-          expect(assigns[:file_set].modified_date)
-            .not_to be file_set.modified_date
-        end
-      end
-
-      context "when updating the attached file direct upload" do
-        let(:actor) { double }
-
-        before do
-          allow(Hyrax::Actors::FileActor).to receive(:new).and_return(actor)
-        end
-
-        it "spawns a ContentNewVersionEventJob", perform_enqueued: [IngestJob] do
-          expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
-          expect(actor).to receive(:ingest_file).with(JobIoWrapper).and_return(true)
-          file = fixture_file_upload('/world.png', 'image/png')
-          post :update, params: { id: file_set, filedata: file, file_set: { keyword: [''], permissions_attributes: [{ type: 'person', name: 'archivist1', access: 'edit' }] } }
-          post :update, params: { id: file_set, file_set: { files: [file], keyword: [''], permissions_attributes: [{ type: 'person', name: 'archivist1', access: 'edit' }] } }
-        end
-      end
-
-      context "when updating the attached file already uploaded" do
-        let(:actor) { double(Hyrax::Actors::FileActor) }
-
-        before do
-          allow(Hyrax::Actors::FileActor).to receive(:new).and_return(actor)
-        end
-
-        it "spawns a ContentNewVersionEventJob", perform_enqueued: [IngestJob] do
-          expect(actor)
-            .to receive(:ingest_file)
-            .with(JobIoWrapper)
-            .and_return(true)
-          expect(ContentNewVersionEventJob)
-            .to receive(:perform_later)
-            .with(file_set, user)
-
-          file = fixture_file_upload('/world.png', 'image/png')
-          allow(Hyrax::UploadedFile)
-            .to receive(:find)
-            .with(["1"])
-            .and_return([file])
-
-          post :update, params: { id: file_set, files_files: ["1"] }
-
-          expect(assigns[:file_set].modified_date)
-            .not_to be file_set.modified_date
-          expect(assigns[:file_set].title)
-            .to contain_exactly(*file_set.title)
-        end
-      end
-
-      context "with two existing versions from different users", :perform_enqueued do
-        let(:file1)       { "world.png" }
-        let(:file2)       { "image.jpg" }
-        let(:second_user) { create(:user) }
-        let(:version1)    { "version1" }
-        let(:actor1)      { Hyrax::Actors::FileSetActor.new(file_set, user) }
-        let(:actor2)      { Hyrax::Actors::FileSetActor.new(file_set, second_user) }
-
-        before do
-          ActiveJob::Base.queue_adapter.filter = [IngestJob]
-          actor1.create_content(fixture_file_upload(file1))
-          actor2.create_content(fixture_file_upload(file2))
-        end
-
-        describe "restoring a previous version" do
-          context "as the first user" do
-            before do
-              sign_in user
-              post :update, params: { id: file_set, revision: version1 }
-            end
-
-            let(:restored_content) { file_set.reload.original_file }
-            let(:versions)         { restored_content.versions }
-            let(:latest_version)   { Hyrax::VersioningService.latest_version_of(restored_content) }
-
-            it "restores the first versions's content and metadata" do
-              # expect(restored_content.mime_type).to eq "image/png"
-              expect(restored_content).to be_a(Hydra::PCDM::File)
-              expect(restored_content.original_name).to eq file1
-              expect(versions.all.count).to eq 3
-              expect(versions.last.label).to eq latest_version.label
-              expect(Hyrax::VersionCommitter.where(version_id: versions.last.uri).pluck(:committer_login))
-                .to eq [user.user_key]
-            end
+          before do
+            work.ordered_members << file_set
+            work.save!
           end
 
-          context "as a user without edit access" do
-            before { sign_in second_user }
+          it "deletes the file" do
+            expect(ContentDeleteEventJob).to receive(:perform_later).with(file_set.id, user)
 
-            it "is unauthorized" do
-              post :update, params: { id: file_set, revision: version1 }
-              expect(response.code).to eq '401'
-              expect(response).to render_template 'unauthorized'
-              expect(response).to render_template('dashboard')
-            end
+            expect { delete :destroy, params: { id: file_set } }
+              .to change { FileSet.exists?(file_set.id) }
+              .from(true)
+              .to(false)
+
+            expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
           end
         end
       end
 
-      it "adds new groups and users" do
-        post :update, params: {
-          id: file_set,
-          file_set: { keyword: [''],
-                      permissions_attributes: [
-                        { type: 'person', name: 'user1', access: 'edit' },
-                        { type: 'group', name: 'group1', access: 'read' }
-                      ] }
-        }
-
-        expect(assigns[:file_set])
-          .to have_attributes(read_groups: contain_exactly("group1"),
-                              edit_users: include("user1", user.user_key))
-      end
-
-      it "updates existing groups and users" do
-        file_set.edit_groups = ['group3']
-        file_set.save
-
-        post :update, params: {
-          id: file_set,
-          file_set: { keyword: [''],
-                      permissions_attributes: [
-                        { id: file_set.permissions.last.id, type: 'group', name: 'group3', access: 'read' }
-                      ] }
-        }
-
-        expect(assigns[:file_set].read_groups).to contain_exactly("group3")
-      end
-
-      context 'update visibility' do
-        let(:update_params) { { visibility: 'open' } }
-
-        it 'can make file set public' do
-          patch :update, params: { id: file_set, file_set: update_params }
-
-          expect(assigns[:file_set].read_groups).to contain_exactly('public')
-        end
-      end
-
-      context "when there's an error saving" do
+      describe "#edit" do
         let(:parent) { FactoryBot.create(:work, :public, user: user) }
 
         let(:file_set) do
@@ -253,60 +42,336 @@ RSpec.describe Hyrax::FileSetsController do
           end
         end
 
-        before { allow(FileSet).to receive(:find).and_return(file_set) }
-
-        it "draws the edit page" do
-          expect(file_set).to receive(:valid?).and_return(false)
-          post :update, params: { id: file_set, file_set: { keyword: [''] } }
-          expect(response.code).to eq '422'
-          expect(response).to render_template('edit')
-          expect(response).to render_template('dashboard')
-          expect(assigns[:file_set]).to eq file_set
+        before do
+          binary = StringIO.new("hey")
+          Hydra::Works::AddFileToFileSet.call(file_set, binary, :original_file, versioning: true)
+          request.env['HTTP_REFERER'] = 'http://test.host/foo'
         end
-      end
-    end
 
-    describe "#edit" do
-      let(:file_set) { FactoryBot.create(:file_set, read_groups: ['public']) }
+        it "sets the breadcrumbs and versions presenter" do
+          app_helpers    = Rails.application.routes.url_helpers
+          engine_helpers = Hyrax::Engine.routes.url_helpers
 
-      let(:file) do
-        Hydra::Derivatives::IoDecorator
-          .new(File.open(fixture_path + '/world.png'),
-               'image/png', 'world.png')
-      end
+          expect(controller)
+            .to receive(:add_breadcrumb)
+            .with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+          expect(controller)
+            .to receive(:add_breadcrumb)
+            .with(I18n.t('hyrax.dashboard.title'), engine_helpers.dashboard_path(locale: 'en'))
+          expect(controller)
+            .to receive(:add_breadcrumb)
+            .with(I18n.t('hyrax.dashboard.my.works'), engine_helpers.my_works_path(locale: 'en'))
+          expect(controller)
+            .to receive(:add_breadcrumb)
+            .with(I18n.t('hyrax.file_set.browse_view'), app_helpers.hyrax_file_set_path(file_set, locale: 'en'))
 
-      before { Hydra::Works::UploadFileToFileSet.call(file_set, file) }
-
-      context "someone else's files" do
-        it "sets flash error" do
           get :edit, params: { id: file_set }
-          expect(response.code).to eq '401'
-          expect(response).to render_template('unauthorized')
+
+          expect(response).to be_successful
+          expect(assigns[:file_set]).to eq file_set
+          expect(assigns[:version_list]).to be_kind_of Hyrax::VersionListPresenter
+          expect(assigns[:parent]).to eq parent
+          expect(response).to render_template(:edit)
           expect(response).to render_template('dashboard')
         end
       end
-    end
 
-    describe "#show" do
-      let(:work) do
-        FactoryBot.create(:generic_work, :public,
-                          title: ['test title'],
-                          user: user)
+      describe "#update" do
+        let(:parent) { FactoryBot.create(:work, :public, user: user) }
+
+        let(:file_set) do
+          FactoryBot.create(:file_set, user: user, title: ['test title']).tap do |file_set|
+            parent.ordered_members << file_set
+            parent.save!
+          end
+        end
+
+        context "when updating metadata" do
+          it "spawns a content update event job" do
+            expect do
+              post :update, params: {
+                id: file_set,
+                file_set: {
+                  title: ['new_title'],
+                  keyword: [''],
+                  permissions_attributes: [{ type: 'person',
+                                             name: 'archivist1',
+                                             access: 'edit' }]
+                }
+              }
+            end.to have_enqueued_job(ContentUpdateEventJob).exactly(:once)
+
+            expect(response)
+              .to redirect_to main_app.hyrax_file_set_path(file_set, locale: 'en')
+            expect(assigns[:file_set].modified_date)
+              .not_to be file_set.modified_date
+          end
+        end
+
+        context "when updating the attached file direct upload" do
+          let(:actor) { double }
+
+          before do
+            allow(Hyrax::Actors::FileActor).to receive(:new).and_return(actor)
+          end
+
+          it "spawns a ContentNewVersionEventJob", perform_enqueued: [IngestJob] do
+            expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
+            expect(actor).to receive(:ingest_file).with(JobIoWrapper).and_return(true)
+            file = fixture_file_upload('/world.png', 'image/png')
+            post :update, params: { id: file_set, filedata: file, file_set: { keyword: [''], permissions_attributes: [{ type: 'person', name: 'archivist1', access: 'edit' }] } }
+            post :update, params: { id: file_set, file_set: { files: [file], keyword: [''], permissions_attributes: [{ type: 'person', name: 'archivist1', access: 'edit' }] } }
+          end
+        end
+
+        context "when updating the attached file already uploaded" do
+          let(:actor) { double(Hyrax::Actors::FileActor) }
+
+          before do
+            allow(Hyrax::Actors::FileActor).to receive(:new).and_return(actor)
+          end
+
+          it "spawns a ContentNewVersionEventJob", perform_enqueued: [IngestJob] do
+            expect(actor)
+              .to receive(:ingest_file)
+              .with(JobIoWrapper)
+              .and_return(true)
+            expect(ContentNewVersionEventJob)
+              .to receive(:perform_later)
+              .with(file_set, user)
+
+            file = fixture_file_upload('/world.png', 'image/png')
+            allow(Hyrax::UploadedFile)
+              .to receive(:find)
+              .with(["1"])
+              .and_return([file])
+
+            post :update, params: { id: file_set, files_files: ["1"] }
+
+            expect(assigns[:file_set].modified_date)
+              .not_to be file_set.modified_date
+            expect(assigns[:file_set].title)
+              .to contain_exactly(*file_set.title)
+          end
+        end
+
+        context "with two existing versions from different users", :perform_enqueued do
+          let(:file1)       { "world.png" }
+          let(:file2)       { "image.jpg" }
+          let(:second_user) { create(:user) }
+          let(:version1)    { "version1" }
+          let(:actor1)      { Hyrax::Actors::FileSetActor.new(file_set, user) }
+          let(:actor2)      { Hyrax::Actors::FileSetActor.new(file_set, second_user) }
+
+          before do
+            ActiveJob::Base.queue_adapter.filter = [IngestJob]
+            actor1.create_content(fixture_file_upload(file1))
+            actor2.create_content(fixture_file_upload(file2))
+          end
+
+          describe "restoring a previous version" do
+            context "as the first user" do
+              before do
+                sign_in user
+                post :update, params: { id: file_set, revision: version1 }
+              end
+
+              let(:restored_content) { file_set.reload.original_file }
+              let(:versions)         { restored_content.versions }
+              let(:latest_version)   { Hyrax::VersioningService.latest_version_of(restored_content) }
+
+              it "restores the first versions's content and metadata" do
+                # expect(restored_content.mime_type).to eq "image/png"
+                expect(restored_content).to be_a(Hydra::PCDM::File)
+                expect(restored_content.original_name).to eq file1
+                expect(versions.all.count).to eq 3
+                expect(versions.last.label).to eq latest_version.label
+                expect(Hyrax::VersionCommitter.where(version_id: versions.last.uri).pluck(:committer_login))
+                  .to eq [user.user_key]
+              end
+            end
+
+            context "as a user without edit access" do
+              before { sign_in second_user }
+
+              it "is unauthorized" do
+                post :update, params: { id: file_set, revision: version1 }
+                expect(response.code).to eq '401'
+                expect(response).to render_template 'unauthorized'
+                expect(response).to render_template('dashboard')
+              end
+            end
+          end
+        end
+
+        it "adds new groups and users" do
+          post :update, params: {
+            id: file_set,
+            file_set: { keyword: [''],
+                        permissions_attributes: [
+                          { type: 'person', name: 'user1', access: 'edit' },
+                          { type: 'group', name: 'group1', access: 'read' }
+                        ] }
+          }
+
+          expect(assigns[:file_set])
+            .to have_attributes(read_groups: contain_exactly("group1"),
+                                edit_users: include("user1", user.user_key))
+        end
+
+        it "updates existing groups and users" do
+          file_set.edit_groups = ['group3']
+          file_set.save
+
+          post :update, params: {
+            id: file_set,
+            file_set: { keyword: [''],
+                        permissions_attributes: [
+                          { id: file_set.permissions.last.id, type: 'group', name: 'group3', access: 'read' }
+                        ] }
+          }
+
+          expect(assigns[:file_set].read_groups).to contain_exactly("group3")
+        end
+
+        context 'update visibility' do
+          let(:update_params) { { visibility: 'open' } }
+
+          it 'can make file set public' do
+            patch :update, params: { id: file_set, file_set: update_params }
+
+            expect(assigns[:file_set].read_groups).to contain_exactly('public')
+          end
+        end
+
+        context "when there's an error saving" do
+          let(:parent) { FactoryBot.create(:work, :public, user: user) }
+
+          let(:file_set) do
+            FactoryBot.create(:file_set, user: user).tap do |file_set|
+              parent.ordered_members << file_set
+              parent.save!
+            end
+          end
+
+          before { allow(FileSet).to receive(:find).and_return(file_set) }
+
+          it "draws the edit page" do
+            expect(file_set).to receive(:valid?).and_return(false)
+            post :update, params: { id: file_set, file_set: { keyword: [''] } }
+            expect(response.code).to eq '422'
+            expect(response).to render_template('edit')
+            expect(response).to render_template('dashboard')
+            expect(assigns[:file_set]).to eq file_set
+          end
+        end
       end
 
-      let(:file_set) do
-        FactoryBot.create(:file_set, title: ['test file'], user: user).tap do |file_set|
+      describe "#edit" do
+        let(:file_set) { FactoryBot.create(:file_set, read_groups: ['public']) }
+
+        let(:file) do
+          Hydra::Derivatives::IoDecorator
+            .new(File.open(fixture_path + '/world.png'),
+                 'image/png', 'world.png')
+        end
+
+        before { Hydra::Works::UploadFileToFileSet.call(file_set, file) }
+
+        context "someone else's files" do
+          it "sets flash error" do
+            get :edit, params: { id: file_set }
+            expect(response.code).to eq '401'
+            expect(response).to render_template('unauthorized')
+            expect(response).to render_template('dashboard')
+          end
+        end
+      end
+
+      describe "#show" do
+        let(:work) do
+          FactoryBot.create(:generic_work, :public,
+                            title: ['test title'],
+                            user: user)
+        end
+
+        let(:file_set) do
+          FactoryBot.create(:file_set, title: ['test file'], user: user).tap do |file_set|
+            work.ordered_members << file_set
+            work.save!
+          end
+        end
+
+        before do
           work.ordered_members << file_set
           work.save!
         end
+
+        context "without a referer" do
+          let(:work) do
+            FactoryBot.create(:generic_work, :public,
+                              title: ['test title'],
+                              user: user)
+          end
+
+          before do
+            work.ordered_members << file_set
+            work.save!
+            file_set.save!
+          end
+
+          it "shows me the file and set breadcrumbs" do
+            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set, locale: 'en'))
+            get :show, params: { id: file_set }
+            expect(response).to be_successful
+            expect(flash).to be_empty
+            expect(assigns[:presenter]).to be_kind_of Hyrax::FileSetPresenter
+            expect(assigns[:presenter].id).to eq file_set.id
+            expect(assigns[:presenter].events).to be_kind_of Array
+            expect(assigns[:presenter].fixity_check_status).to eq 'Fixity checks have not yet been run on this object'
+          end
+        end
+
+        context "with a referer" do
+          before do
+            request.env['HTTP_REFERER'] = 'http://test.host/foo'
+            work.ordered_members << file_set
+            work.save!
+            file_set.save!
+          end
+
+          it "shows me the breadcrumbs" do
+            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set, locale: 'en'))
+            get :show, params: { id: file_set }
+            expect(response).to be_successful
+          end
+        end
       end
 
-      before do
-        work.ordered_members << file_set
-        work.save!
-      end
+      context 'someone elses (public) files' do
+        let(:creator) do
+          FactoryBot.create(:user, email: 'archivist1@example.com')
+        end
 
-      context "without a referer" do
+        let(:parent) do
+          FactoryBot.create(:work, :public, user: creator, read_groups: ['public'])
+        end
+
+        let(:public_file_set) do
+          FactoryBot.create(:file_set, user: creator, read_groups: ['public']).tap do |file_set|
+            parent.ordered_members << file_set
+            parent.save!
+          end
+        end
+
         let(:work) do
           FactoryBot.create(:generic_work, :public,
                             title: ['test title'],
@@ -314,218 +379,685 @@ RSpec.describe Hyrax::FileSetsController do
         end
 
         before do
-          work.ordered_members << file_set
+          sign_in user
+          work.ordered_members << public_file_set
           work.save!
-          file_set.save!
+          public_file_set.save!
         end
 
-        it "shows me the file and set breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set, locale: 'en'))
-          get :show, params: { id: file_set }
-          expect(response).to be_successful
-          expect(flash).to be_empty
-          expect(assigns[:presenter]).to be_kind_of Hyrax::FileSetPresenter
-          expect(assigns[:presenter].id).to eq file_set.id
-          expect(assigns[:presenter].events).to be_kind_of Array
-          expect(assigns[:presenter].fixity_check_status).to eq 'Fixity checks have not yet been run on this object'
-        end
-      end
+        describe '#edit' do
+          it 'gives me the unauthorized page' do
+            get :edit, params: { id: public_file_set }
 
-      context "with a referer" do
-        before do
-          request.env['HTTP_REFERER'] = 'http://test.host/foo'
-          work.ordered_members << file_set
-          work.save!
-          file_set.save!
+            expect(response.code).to eq '401'
+            expect(response).to render_template(:unauthorized)
+            expect(response).to render_template('dashboard')
+          end
         end
 
-        it "shows me the breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set, locale: 'en'))
-          get :show, params: { id: file_set }
-          expect(response).to be_successful
+        describe '#show' do
+          it 'allows access to the file' do
+            get :show, params: { id: public_file_set }
+
+            expect(response).to be_successful
+          end
         end
       end
     end
 
-    context 'someone elses (public) files' do
-      let(:creator) do
-        FactoryBot.create(:user, email: 'archivist1@example.com')
-      end
-
-      let(:parent) do
-        FactoryBot.create(:work, :public, user: creator, read_groups: ['public'])
-      end
-
-      let(:public_file_set) do
-        FactoryBot.create(:file_set, user: creator, read_groups: ['public']).tap do |file_set|
-          parent.ordered_members << file_set
-          parent.save!
-        end
-      end
+    context 'when not signed in' do
+      let(:work) { FactoryBot.create(:work, :public, user: user) }
+      let(:private_file_set) { FactoryBot.create(:file_set) }
+      let(:public_file_set) { FactoryBot.create(:file_set, read_groups: ['public']) }
 
       let(:work) do
         FactoryBot.create(:generic_work, :public,
-               title: ['test title'],
-               user: user)
+                          title: ['test title'],
+                          user: user)
       end
 
       before do
-        sign_in user
+        work.ordered_members << private_file_set
         work.ordered_members << public_file_set
         work.save!
         public_file_set.save!
       end
 
       describe '#edit' do
-        it 'gives me the unauthorized page' do
+        it 'requires login' do
           get :edit, params: { id: public_file_set }
 
-          expect(response.code).to eq '401'
-          expect(response).to render_template(:unauthorized)
-          expect(response).to render_template('dashboard')
+          expect(response)
+            .to fail_redirect_and_flash(main_app.new_user_session_path,
+                                        'You need to sign in or sign up before continuing.')
         end
       end
 
       describe '#show' do
-        it 'allows access to the file' do
+        it 'denies access to private files' do
+          get :show, params: { id: private_file_set }
+
+          expect(response)
+            .to fail_redirect_and_flash(main_app.new_user_session_path(locale: 'en'),
+                                        'You are not authorized to access this page.')
+        end
+
+        it 'allows access to public files' do
+          expect(controller)
+            .to receive(:additional_response_formats)
+            .with(ActionController::MimeResponds::Collector)
+
           get :show, params: { id: public_file_set }
 
           expect(response).to be_successful
         end
       end
-    end
-  end
 
-  context 'when not signed in' do
-    let(:work) { FactoryBot.create(:work, :public, user: user) }
-    let(:private_file_set) { FactoryBot.create(:file_set) }
-    let(:public_file_set) { FactoryBot.create(:file_set, read_groups: ['public']) }
+      describe '#show' do
+        let(:parent_work_active) do
+          FactoryBot
+            .create(:work, :public, state: Vocab::FedoraResourceStatus.active)
+        end
 
-    let(:work) do
-      FactoryBot.create(:generic_work, :public,
-                        title: ['test title'],
-                        user: user)
-    end
+        let(:file_set_active) do
+          FactoryBot.create(:file_set, read_groups: ['public']).tap do |file_set|
+            parent_work_active.ordered_members << file_set
+            parent_work_active.save!
+          end
+        end
 
-    before do
-      work.ordered_members << private_file_set
-      work.ordered_members << public_file_set
-      work.save!
-      public_file_set.save!
-    end
+        let(:parent_work_inactive) do
+          FactoryBot
+            .create(:work, :public, state: Vocab::FedoraResourceStatus.inactive)
+        end
 
-    describe '#edit' do
-      it 'requires login' do
-        get :edit, params: { id: public_file_set }
+        let(:file_set_inactive) do
+          FactoryBot.create(:file_set, read_groups: ['public']).tap do |file_set|
+            parent_work_inactive.ordered_members << file_set
+            parent_work_inactive.save!
+          end
+        end
 
-        expect(response)
-          .to fail_redirect_and_flash(main_app.new_user_session_path,
-                                      'You need to sign in or sign up before continuing.')
-      end
-    end
+        it "shows active parent" do
+          expect(controller)
+            .to receive(:additional_response_formats)
+            .with(ActionController::MimeResponds::Collector)
 
-    describe '#show' do
-      it 'denies access to private files' do
-        get :show, params: { id: private_file_set }
+          get :show, params: { id: file_set_active }
 
-        expect(response)
-          .to fail_redirect_and_flash(main_app.new_user_session_path(locale: 'en'),
-                                      'You are not authorized to access this page.')
-      end
+          expect(response).to be_successful
+        end
 
-      it 'allows access to public files' do
-        expect(controller)
-          .to receive(:additional_response_formats)
-          .with(ActionController::MimeResponds::Collector)
+        it "shows not currently available for inactive parent" do
+          get :show, params: { id: file_set_inactive }
 
-        get :show, params: { id: public_file_set }
-
-        expect(response).to be_successful
-      end
-    end
-
-    describe '#show' do
-      let(:parent_work_active) do
-        FactoryBot
-          .create(:work, :public, state: Vocab::FedoraResourceStatus.active)
-      end
-
-      let(:file_set_active) do
-        FactoryBot.create(:file_set, read_groups: ['public']).tap do |file_set|
-          parent_work_active.ordered_members << file_set
-          parent_work_active.save!
+          expect(response).to render_template 'unavailable'
+          expect(flash[:notice])
+            .to eq 'The file is not currently available because its parent work ' \
+          'has not yet completed the approval process'
+          expect(response.status).to eq 401
         end
       end
+    end
 
-      let(:parent_work_inactive) do
+    describe 'integration test for suppressed documents' do
+      let(:work) do
         FactoryBot
           .create(:work, :public, state: Vocab::FedoraResourceStatus.inactive)
       end
 
-      let(:file_set_inactive) do
+      let(:file_set) do
         FactoryBot.create(:file_set, read_groups: ['public']).tap do |file_set|
-          parent_work_inactive.ordered_members << file_set
-          parent_work_inactive.save!
+          work.ordered_members << file_set
+          work.save!
         end
       end
 
-      it "shows active parent" do
-        expect(controller)
-          .to receive(:additional_response_formats)
-          .with(ActionController::MimeResponds::Collector)
+      before do
+        work.ordered_members << file_set
+        work.save!
 
-        get :show, params: { id: file_set_active }
-
-        expect(response).to be_successful
+        FactoryBot.create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
       end
 
-      it "shows not currently available for inactive parent" do
-        get :show, params: { id: file_set_inactive }
+      it 'renders the unavailable message because it is in workflow' do
+        get :show, params: { id: file_set }
 
-        expect(response).to render_template 'unavailable'
-        expect(flash[:notice])
-          .to eq 'The file is not currently available because its parent work ' \
-                 'has not yet completed the approval process'
-        expect(response.status).to eq 401
+        expect(response.code).to eq '401'
+        expect(response).to render_template(:unavailable)
+        expect(assigns[:presenter]).to be_instance_of Hyrax::FileSetPresenter
+        expect(flash[:notice]).to eq 'The file is not currently available because its parent work has not yet completed the approval process'
       end
     end
   end
 
-  describe 'integration test for suppressed documents' do
-    let(:work) do
-      FactoryBot
-        .create(:work, :public, state: Vocab::FedoraResourceStatus.inactive)
-    end
+  describe "with valkyrie" do
+    context "when signed in" do
+      let(:user)  { FactoryBot.create(:admin) }
+      before { sign_in user }
+      let(:file) { fixture_file_upload('/world.png', 'image/png') }
+      let(:work) { FactoryBot.valkyrie_create(:hyrax_work, uploaded_files: [FactoryBot.create(:uploaded_file)], edit_users: [user]) }
+      let(:file_set) { query_service.find_members(resource: work).first }
+      let(:file_metadata) { query_service.custom_queries.find_file_metadata_by(id: file_set.file_ids.first) }
+      let(:uploaded) { storage_adapter.find_by(id: file_metadata.file_identifier) }
+      let(:query_service) { Hyrax.query_service }
+      let(:storage_adapter) { Hyrax.storage_adapter }
 
-    let(:file_set) do
-      FactoryBot.create(:file_set, read_groups: ['public']).tap do |file_set|
-        work.ordered_members << file_set
-        work.save!
+      before do
+        # We can't redirect to a TestWork, there's no controller.
+        allow(controller).to receive(:redirect_to)
+      end
+
+      describe "#destroy" do
+        context "file_set with a parent" do
+          it "deletes the file" do
+            expect(ContentDeleteEventJob).to receive(:perform_later).with(file_set.id, user)
+
+            expect { storage_adapter.find_by(id: file_metadata.file_identifier) }.not_to raise_error
+            delete :destroy, params: { id: file_set }
+
+            expect { query_service.find_by(id: file_set.id) }.to raise_error
+            expect { storage_adapter.find_by(id: file_metadata.file_identifier) }.to raise_error
+          end
+        end
+      end
+
+      describe "#edit" do
+        let(:parent) { FactoryBot.create(:work, :public, user: user) }
+
+        let(:file_set) do
+          FactoryBot.create(:file_set, user: user).tap do |file_set|
+            parent.ordered_members << file_set
+            parent.save!
+          end
+        end
+
+        before do
+          binary = StringIO.new("hey")
+          Hydra::Works::AddFileToFileSet.call(file_set, binary, :original_file, versioning: true)
+          request.env['HTTP_REFERER'] = 'http://test.host/foo'
+        end
+
+        it "sets the breadcrumbs and versions presenter" do
+          app_helpers    = Rails.application.routes.url_helpers
+          engine_helpers = Hyrax::Engine.routes.url_helpers
+
+          expect(controller)
+            .to receive(:add_breadcrumb)
+            .with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+          expect(controller)
+            .to receive(:add_breadcrumb)
+            .with(I18n.t('hyrax.dashboard.title'), engine_helpers.dashboard_path(locale: 'en'))
+          expect(controller)
+            .to receive(:add_breadcrumb)
+            .with(I18n.t('hyrax.dashboard.my.works'), engine_helpers.my_works_path(locale: 'en'))
+          expect(controller)
+            .to receive(:add_breadcrumb)
+            .with(I18n.t('hyrax.file_set.browse_view'), app_helpers.hyrax_file_set_path(file_set, locale: 'en'))
+
+          get :edit, params: { id: file_set }
+
+          expect(response).to be_successful
+          expect(assigns[:file_set]).to eq file_set
+          expect(assigns[:version_list]).to be_kind_of Hyrax::VersionListPresenter
+          expect(assigns[:parent]).to eq parent
+          expect(response).to render_template(:edit)
+          expect(response).to render_template('dashboard')
+        end
+      end
+
+      describe "#update" do
+        let(:parent) { FactoryBot.create(:work, :public, user: user) }
+
+        let(:file_set) do
+          FactoryBot.create(:file_set, user: user, title: ['test title']).tap do |file_set|
+            parent.ordered_members << file_set
+            parent.save!
+          end
+        end
+
+        context "when updating metadata" do
+          it "spawns a content update event job" do
+            expect do
+              post :update, params: {
+                id: file_set,
+                file_set: {
+                  title: ['new_title'],
+                  keyword: [''],
+                  permissions_attributes: [{ type: 'person',
+                                             name: 'archivist1',
+                                             access: 'edit' }]
+                }
+              }
+            end.to have_enqueued_job(ContentUpdateEventJob).exactly(:once)
+
+            expect(response)
+              .to redirect_to main_app.hyrax_file_set_path(file_set, locale: 'en')
+            expect(assigns[:file_set].modified_date)
+              .not_to be file_set.modified_date
+          end
+        end
+
+        context "when updating the attached file direct upload" do
+          let(:actor) { double }
+
+          before do
+            allow(Hyrax::Actors::FileActor).to receive(:new).and_return(actor)
+          end
+
+          it "spawns a ContentNewVersionEventJob", perform_enqueued: [IngestJob] do
+            expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set, user)
+            expect(actor).to receive(:ingest_file).with(JobIoWrapper).and_return(true)
+            file = fixture_file_upload('/world.png', 'image/png')
+            post :update, params: { id: file_set, filedata: file, file_set: { keyword: [''], permissions_attributes: [{ type: 'person', name: 'archivist1', access: 'edit' }] } }
+            post :update, params: { id: file_set, file_set: { files: [file], keyword: [''], permissions_attributes: [{ type: 'person', name: 'archivist1', access: 'edit' }] } }
+          end
+        end
+
+        context "when updating the attached file already uploaded" do
+          let(:actor) { double(Hyrax::Actors::FileActor) }
+
+          before do
+            allow(Hyrax::Actors::FileActor).to receive(:new).and_return(actor)
+          end
+
+          it "spawns a ContentNewVersionEventJob", perform_enqueued: [IngestJob] do
+            expect(actor)
+              .to receive(:ingest_file)
+              .with(JobIoWrapper)
+              .and_return(true)
+            expect(ContentNewVersionEventJob)
+              .to receive(:perform_later)
+              .with(file_set, user)
+
+            file = fixture_file_upload('/world.png', 'image/png')
+            allow(Hyrax::UploadedFile)
+              .to receive(:find)
+              .with(["1"])
+              .and_return([file])
+
+            post :update, params: { id: file_set, files_files: ["1"] }
+
+            expect(assigns[:file_set].modified_date)
+              .not_to be file_set.modified_date
+            expect(assigns[:file_set].title)
+              .to contain_exactly(*file_set.title)
+          end
+        end
+
+        context "with two existing versions from different users", :perform_enqueued do
+          let(:file1)       { "world.png" }
+          let(:file2)       { "image.jpg" }
+          let(:second_user) { create(:user) }
+          let(:version1)    { "version1" }
+          let(:actor1)      { Hyrax::Actors::FileSetActor.new(file_set, user) }
+          let(:actor2)      { Hyrax::Actors::FileSetActor.new(file_set, second_user) }
+
+          before do
+            ActiveJob::Base.queue_adapter.filter = [IngestJob]
+            actor1.create_content(fixture_file_upload(file1))
+            actor2.create_content(fixture_file_upload(file2))
+          end
+
+          describe "restoring a previous version" do
+            context "as the first user" do
+              before do
+                sign_in user
+                post :update, params: { id: file_set, revision: version1 }
+              end
+
+              let(:restored_content) { file_set.reload.original_file }
+              let(:versions)         { restored_content.versions }
+              let(:latest_version)   { Hyrax::VersioningService.latest_version_of(restored_content) }
+
+              it "restores the first versions's content and metadata" do
+                # expect(restored_content.mime_type).to eq "image/png"
+                expect(restored_content).to be_a(Hydra::PCDM::File)
+                expect(restored_content.original_name).to eq file1
+                expect(versions.all.count).to eq 3
+                expect(versions.last.label).to eq latest_version.label
+                expect(Hyrax::VersionCommitter.where(version_id: versions.last.uri).pluck(:committer_login))
+                  .to eq [user.user_key]
+              end
+            end
+
+            context "as a user without edit access" do
+              before { sign_in second_user }
+
+              it "is unauthorized" do
+                post :update, params: { id: file_set, revision: version1 }
+                expect(response.code).to eq '401'
+                expect(response).to render_template 'unauthorized'
+                expect(response).to render_template('dashboard')
+              end
+            end
+          end
+        end
+
+        it "adds new groups and users" do
+          post :update, params: {
+            id: file_set,
+            file_set: { keyword: [''],
+                        permissions_attributes: [
+                          { type: 'person', name: 'user1', access: 'edit' },
+                          { type: 'group', name: 'group1', access: 'read' }
+                        ] }
+          }
+
+          expect(assigns[:file_set])
+            .to have_attributes(read_groups: contain_exactly("group1"),
+                                edit_users: include("user1", user.user_key))
+        end
+
+        it "updates existing groups and users" do
+          file_set.edit_groups = ['group3']
+          file_set.save
+
+          post :update, params: {
+            id: file_set,
+            file_set: { keyword: [''],
+                        permissions_attributes: [
+                          { id: file_set.permissions.last.id, type: 'group', name: 'group3', access: 'read' }
+                        ] }
+          }
+
+          expect(assigns[:file_set].read_groups).to contain_exactly("group3")
+        end
+
+        context 'update visibility' do
+          let(:update_params) { { visibility: 'open' } }
+
+          it 'can make file set public' do
+            patch :update, params: { id: file_set, file_set: update_params }
+
+            expect(assigns[:file_set].read_groups).to contain_exactly('public')
+          end
+        end
+
+        context "when there's an error saving" do
+          let(:parent) { FactoryBot.create(:work, :public, user: user) }
+
+          let(:file_set) do
+            FactoryBot.create(:file_set, user: user).tap do |file_set|
+              parent.ordered_members << file_set
+              parent.save!
+            end
+          end
+
+          before { allow(FileSet).to receive(:find).and_return(file_set) }
+
+          it "draws the edit page" do
+            expect(file_set).to receive(:valid?).and_return(false)
+            post :update, params: { id: file_set, file_set: { keyword: [''] } }
+            expect(response.code).to eq '422'
+            expect(response).to render_template('edit')
+            expect(response).to render_template('dashboard')
+            expect(assigns[:file_set]).to eq file_set
+          end
+        end
+      end
+
+      describe "#edit" do
+        let(:file_set) { FactoryBot.create(:file_set, read_groups: ['public']) }
+
+        let(:file) do
+          Hydra::Derivatives::IoDecorator
+            .new(File.open(fixture_path + '/world.png'),
+                 'image/png', 'world.png')
+        end
+
+        before { Hydra::Works::UploadFileToFileSet.call(file_set, file) }
+
+        context "someone else's files" do
+          it "sets flash error" do
+            get :edit, params: { id: file_set }
+            expect(response.code).to eq '401'
+            expect(response).to render_template('unauthorized')
+            expect(response).to render_template('dashboard')
+          end
+        end
+      end
+
+      describe "#show" do
+        let(:work) do
+          FactoryBot.create(:generic_work, :public,
+                            title: ['test title'],
+                            user: user)
+        end
+
+        let(:file_set) do
+          FactoryBot.create(:file_set, title: ['test file'], user: user).tap do |file_set|
+            work.ordered_members << file_set
+            work.save!
+          end
+        end
+
+        before do
+          work.ordered_members << file_set
+          work.save!
+        end
+
+        context "without a referer" do
+          let(:work) do
+            FactoryBot.create(:generic_work, :public,
+                              title: ['test title'],
+                              user: user)
+          end
+
+          before do
+            work.ordered_members << file_set
+            work.save!
+            file_set.save!
+          end
+
+          it "shows me the file and set breadcrumbs" do
+            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set, locale: 'en'))
+            get :show, params: { id: file_set }
+            expect(response).to be_successful
+            expect(flash).to be_empty
+            expect(assigns[:presenter]).to be_kind_of Hyrax::FileSetPresenter
+            expect(assigns[:presenter].id).to eq file_set.id
+            expect(assigns[:presenter].events).to be_kind_of Array
+            expect(assigns[:presenter].fixity_check_status).to eq 'Fixity checks have not yet been run on this object'
+          end
+        end
+
+        context "with a referer" do
+          before do
+            request.env['HTTP_REFERER'] = 'http://test.host/foo'
+            work.ordered_members << file_set
+            work.save!
+            file_set.save!
+          end
+
+          it "shows me the breadcrumbs" do
+            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set, locale: 'en'))
+            get :show, params: { id: file_set }
+            expect(response).to be_successful
+          end
+        end
+      end
+
+      context 'someone elses (public) files' do
+        let(:creator) do
+          FactoryBot.create(:user, email: 'archivist1@example.com')
+        end
+
+        let(:parent) do
+          FactoryBot.create(:work, :public, user: creator, read_groups: ['public'])
+        end
+
+        let(:public_file_set) do
+          FactoryBot.create(:file_set, user: creator, read_groups: ['public']).tap do |file_set|
+            parent.ordered_members << file_set
+            parent.save!
+          end
+        end
+
+        let(:work) do
+          FactoryBot.create(:generic_work, :public,
+                            title: ['test title'],
+                            user: user)
+        end
+
+        before do
+          sign_in user
+          work.ordered_members << public_file_set
+          work.save!
+          public_file_set.save!
+        end
+
+        describe '#edit' do
+          it 'gives me the unauthorized page' do
+            get :edit, params: { id: public_file_set }
+
+            expect(response.code).to eq '401'
+            expect(response).to render_template(:unauthorized)
+            expect(response).to render_template('dashboard')
+          end
+        end
+
+        describe '#show' do
+          it 'allows access to the file' do
+            get :show, params: { id: public_file_set }
+
+            expect(response).to be_successful
+          end
+        end
       end
     end
 
-    before do
-      work.ordered_members << file_set
-      work.save!
+    context 'when not signed in' do
+      let(:work) { FactoryBot.create(:work, :public, user: user) }
+      let(:private_file_set) { FactoryBot.create(:file_set) }
+      let(:public_file_set) { FactoryBot.create(:file_set, read_groups: ['public']) }
 
-      FactoryBot.create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+      let(:work) do
+        FactoryBot.create(:generic_work, :public,
+                          title: ['test title'],
+                          user: user)
+      end
+
+      before do
+        work.ordered_members << private_file_set
+        work.ordered_members << public_file_set
+        work.save!
+        public_file_set.save!
+      end
+
+      describe '#edit' do
+        it 'requires login' do
+          get :edit, params: { id: public_file_set }
+
+          expect(response)
+            .to fail_redirect_and_flash(main_app.new_user_session_path,
+                                        'You need to sign in or sign up before continuing.')
+        end
+      end
+
+      describe '#show' do
+        it 'denies access to private files' do
+          get :show, params: { id: private_file_set }
+
+          expect(response)
+            .to fail_redirect_and_flash(main_app.new_user_session_path(locale: 'en'),
+                                        'You are not authorized to access this page.')
+        end
+
+        it 'allows access to public files' do
+          expect(controller)
+            .to receive(:additional_response_formats)
+            .with(ActionController::MimeResponds::Collector)
+
+          get :show, params: { id: public_file_set }
+
+          expect(response).to be_successful
+        end
+      end
+
+      describe '#show' do
+        let(:parent_work_active) do
+          FactoryBot
+            .create(:work, :public, state: Vocab::FedoraResourceStatus.active)
+        end
+
+        let(:file_set_active) do
+          FactoryBot.create(:file_set, read_groups: ['public']).tap do |file_set|
+            parent_work_active.ordered_members << file_set
+            parent_work_active.save!
+          end
+        end
+
+        let(:parent_work_inactive) do
+          FactoryBot
+            .create(:work, :public, state: Vocab::FedoraResourceStatus.inactive)
+        end
+
+        let(:file_set_inactive) do
+          FactoryBot.create(:file_set, read_groups: ['public']).tap do |file_set|
+            parent_work_inactive.ordered_members << file_set
+            parent_work_inactive.save!
+          end
+        end
+
+        it "shows active parent" do
+          expect(controller)
+            .to receive(:additional_response_formats)
+            .with(ActionController::MimeResponds::Collector)
+
+          get :show, params: { id: file_set_active }
+
+          expect(response).to be_successful
+        end
+
+        it "shows not currently available for inactive parent" do
+          get :show, params: { id: file_set_inactive }
+
+          expect(response).to render_template 'unavailable'
+          expect(flash[:notice])
+            .to eq 'The file is not currently available because its parent work ' \
+          'has not yet completed the approval process'
+          expect(response.status).to eq 401
+        end
+      end
     end
 
-    it 'renders the unavailable message because it is in workflow' do
-      get :show, params: { id: file_set }
+    describe 'integration test for suppressed documents' do
+      let(:work) do
+        FactoryBot
+          .create(:work, :public, state: Vocab::FedoraResourceStatus.inactive)
+      end
 
-      expect(response.code).to eq '401'
-      expect(response).to render_template(:unavailable)
-      expect(assigns[:presenter]).to be_instance_of Hyrax::FileSetPresenter
-      expect(flash[:notice]).to eq 'The file is not currently available because its parent work has not yet completed the approval process'
+      let(:file_set) do
+        FactoryBot.create(:file_set, read_groups: ['public']).tap do |file_set|
+          work.ordered_members << file_set
+          work.save!
+        end
+      end
+
+      before do
+        work.ordered_members << file_set
+        work.save!
+
+        FactoryBot.create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+      end
+
+      it 'renders the unavailable message because it is in workflow' do
+        get :show, params: { id: file_set }
+
+        expect(response.code).to eq '401'
+        expect(response).to render_template(:unavailable)
+        expect(assigns[:presenter]).to be_instance_of Hyrax::FileSetPresenter
+        expect(flash[:notice]).to eq 'The file is not currently available because its parent work has not yet completed the approval process'
+      end
     end
   end
 end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -535,7 +535,7 @@ RSpec.describe Hyrax::FileSetsController do
     end
   end
 
-  describe "with valkyrie" do
+  describe "with valkyrie", if: ::FileSet < Hyrax::Resource do
     context "when signed in" do
       let(:user)  { FactoryBot.create(:user) }
       before { sign_in user }
@@ -548,6 +548,7 @@ RSpec.describe Hyrax::FileSetsController do
       let(:storage_adapter) { Hyrax.storage_adapter }
 
       before do
+        allow(Hyrax.config).to receive(:use_valkyrie?).and_return(true)
         # We can't redirect to a TestWork, there's no controller.
         allow(controller).to receive(:redirect_to)
       end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -860,6 +860,10 @@ RSpec.describe Hyrax::FileSetsController do
       let(:private_file_set) { query_service.find_members(resource: private_work).first }
       let(:uploaded) { storage_adapter.find_by(id: file_metadata.file_identifier) }
       let(:query_service) { Hyrax.query_service }
+      before do
+        allow(controller.main_app).to receive(:polymorphic_path).and_call_original
+        allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{public_work.id}?locale=en")
+      end
 
       describe '#edit' do
         it 'requires login' do
@@ -881,10 +885,6 @@ RSpec.describe Hyrax::FileSetsController do
         end
 
         it 'allows access to public files' do
-          expect(controller)
-            .to receive(:additional_response_formats)
-            .with(ActionController::MimeResponds::Collector)
-
           get :show, params: { id: public_file_set }
 
           expect(response).to be_successful

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -77,6 +77,8 @@ FactoryBot.define do
         perform_enqueued_jobs(only: ValkyrieIngestJob) do
           Hyrax::WorkUploadsHandler.new(work: Hyrax.query_service.find_by(id: work.id)).add(files: evaluator.uploaded_files).attach
         end
+        # I'm not sure why, but Wings required this reload.
+        work.member_ids = Hyrax.query_service.find_by(id: work.id).member_ids
       end
 
       Hyrax.index_adapter.save(resource: Hyrax.query_service.find_by(id: work.id)) if evaluator.with_index

--- a/spec/presenters/hyrax/version_list_presenter_spec.rb
+++ b/spec/presenters/hyrax/version_list_presenter_spec.rb
@@ -1,76 +1,142 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::VersionListPresenter do
-  let(:file_set) { FactoryBot.create(:file_set) }
-  subject(:enum) { described_class.for(file_set: file_set) }
-
-  context "when the file set has no versions" do
-    describe ".for" do
-      it "returns an enumerable with no members" do
-        expect(enum.count).to eq 0
-      end
-    end
-
-    describe "#each" do
-      it "yields nothing" do
-        versions_descending = []
-        enum.each do |v|
-          versions_descending.push(v.label)
+  context "for active fedora", :active_fedora do
+    let(:file_set) { FactoryBot.create(:file_set) }
+    subject(:enum) { described_class.for(file_set: file_set) }
+    context "when the file set has no versions" do
+      describe ".for" do
+        it "returns an enumerable with no members" do
+          expect(enum.count).to eq 0
         end
-        expect(versions_descending).to be_empty
+      end
+
+      describe "#each" do
+        it "yields nothing" do
+          versions_descending = []
+          enum.each do |v|
+            versions_descending.push(v.label)
+          end
+          expect(versions_descending).to be_empty
+        end
+      end
+
+      describe "#empty?" do
+        it "is true" do
+          expect(enum).to be_empty
+        end
       end
     end
 
-    describe "#empty?" do
-      it "is true" do
-        expect(enum).to be_empty
+    context "when the file set has versions" do
+      before do
+        binary     = StringIO.new("hey")
+        new_binary = StringIO.new("hey2")
+
+        Hydra::Works::AddFileToFileSet
+          .call(file_set, binary, :original_file, versioning: true)
+        Hydra::Works::AddFileToFileSet
+          .call(file_set, new_binary, :original_file, versioning: true)
+      end
+
+      describe ".for" do
+        it "returns an enumerable with members" do
+          expect(enum.count).to eq 2
+        end
+      end
+
+      describe "#each" do
+        it "yields version presenters in order" do
+          versions = Hyrax::VersioningService.new(resource: file_set.original_file).versions
+          versions_descending = []
+          enum.each do |v|
+            expect(v).to be_kind_of Hyrax::VersionPresenter
+            versions_descending.push(v.uri)
+          end
+          expect(versions_descending).to eq versions
+            .sort { |a, b| b.created <=> a.created }
+            .map(&:uri)
+        end
+      end
+
+      describe "#empty?" do
+        it "is false" do
+          expect(enum).not_to be_empty
+        end
+      end
+    end
+
+    context "when the file set is bad" do
+      let(:file_set) { nil }
+
+      describe ".for" do
+        it "raises an error" do
+          expect { enum }.to raise_error ArgumentError
+        end
       end
     end
   end
 
-  context "when the file set has versions" do
-    before do
-      binary     = StringIO.new("hey")
-      new_binary = StringIO.new("hey2")
-
-      Hydra::Works::AddFileToFileSet
-        .call(file_set, binary, :original_file, versioning: true)
-      Hydra::Works::AddFileToFileSet
-        .call(file_set, new_binary, :original_file, versioning: true)
-    end
-
-    describe ".for" do
-      it "returns an enumerable with members" do
-        expect(enum.count).to eq 2
-      end
-    end
-
-    describe "#each" do
-      it "yields version presenters in order" do
-        versions = Hyrax::VersioningService.new(resource: file_set.original_file).versions
-        versions_descending = []
-        enum.each do |v|
-          expect(v).to be_kind_of Hyrax::VersionPresenter
-          versions_descending.push(v.uri)
+  context "for valkyrie" do
+    let(:file) { fixture_file_upload('/world.png', 'image/png') }
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work, uploaded_files: [FactoryBot.create(:uploaded_file)]) }
+    let(:file_set) { query_service.find_members(resource: work).first }
+    let(:file_metadata) { query_service.custom_queries.find_file_metadata_by(id: file_set.file_ids.first) }
+    let(:uploaded) { storage_adapter.find_by(id: file_metadata.file_identifier) }
+    let(:query_service) { Hyrax.query_service }
+    let(:storage_adapter) { Hyrax.storage_adapter }
+    subject(:enum) { described_class.for(file_set: file_set) }
+    context "when the file set has no versions" do
+      let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+      describe ".for" do
+        it "returns an enumerable with no members" do
+          expect(enum.count).to eq 0
         end
-        expect(versions_descending).to eq versions
-          .sort { |a, b| b.created <=> a.created }
-          .map(&:uri)
+      end
+
+      describe "#each" do
+        it "yields nothing" do
+          versions_descending = []
+          enum.each do |v|
+            versions_descending.push(v.label)
+          end
+          expect(versions_descending).to be_empty
+        end
+      end
+
+      describe "#empty?" do
+        it "is true" do
+          expect(enum).to be_empty
+        end
       end
     end
 
-    describe "#empty?" do
-      it "is false" do
-        expect(enum).not_to be_empty
+    context "when the file set has versions" do
+      let(:another_file) { fixture_file_upload('/hyrax_generic_stub.txt') }
+      let(:new_version) { storage_adapter.upload_version(id: uploaded.id, file: another_file) }
+      before do
+        new_version
+      end
+
+      describe ".for" do
+        it "returns an enumerable with members" do
+          expect(enum.count).to eq 2
+        end
+      end
+
+      describe "#empty?" do
+        it "is false" do
+          expect(enum).not_to be_empty
+        end
       end
     end
-  end
 
-  context "when the file set is bad" do
-    let(:file_set) { nil }
+    context "when the file set is bad" do
+      let(:file_set) { nil }
 
-    describe ".for" do
-      it "raises an error" do
-        expect { enum }.to raise_error ArgumentError
+      describe ".for" do
+        it "raises an error" do
+          expect { enum }.to raise_error ArgumentError
+        end
       end
     end
   end

--- a/spec/presenters/hyrax/version_presenter_spec.rb
+++ b/spec/presenters/hyrax/version_presenter_spec.rb
@@ -1,58 +1,61 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::VersionPresenter do
-  let(:resource_version) do
-    ActiveFedora::VersionsGraph::ResourceVersion.new.tap do |v|
-      v.uri = 'http://example.com/version1'
-      v.label = 'version1'
-      v.created = '2014-12-09T02:03:18.296Z'
-    end
-  end
-
-  let(:presenter) { described_class.new(resource_version) }
-
-  describe "#label" do
-    subject { presenter.label }
-
-    it { is_expected.to eq 'version1' }
-  end
-
-  describe "#uri" do
-    subject { presenter.uri }
-
-    it { is_expected.to eq 'http://example.com/version1' }
-  end
-
-  describe "#created" do
-    around do |example|
-      # Stub out the local timezone to (+08:00)
-      tmp_zone = Time.zone
-      Time.zone = "America/Los_Angeles"
-      example.call
-      Time.zone = tmp_zone
+  # VERSIONING-TODO: Add Valkyrie specs here.
+  context "for ActiveFedora", :active_fedora do
+    let(:resource_version) do
+      ActiveFedora::VersionsGraph::ResourceVersion.new.tap do |v|
+        v.uri = 'http://example.com/version1'
+        v.label = 'version1'
+        v.created = '2014-12-09T02:03:18.296Z'
+      end
     end
 
-    subject { presenter.created }
+    let(:presenter) { described_class.new(resource_version) }
 
-    it { is_expected.to eq "December 8th, 2014 18:03" }
-  end
+    describe "#label" do
+      subject { presenter.label }
 
-  describe "#current?" do
-    subject { presenter.current? }
-
-    it { is_expected.to be false }
-
-    context "when current! is set" do
-      before { presenter.current! }
-      it { is_expected.to be true }
+      it { is_expected.to eq 'version1' }
     end
-  end
 
-  describe "#committer" do
-    before do
-      Hyrax::VersionCommitter.create(version_id: resource_version.uri, committer_login: 'jill')
+    describe "#uri" do
+      subject { presenter.uri }
+
+      it { is_expected.to eq 'http://example.com/version1' }
     end
-    subject { presenter.committer }
 
-    it { is_expected.to eq 'jill' }
+    describe "#created" do
+      around do |example|
+        # Stub out the local timezone to (+08:00)
+        tmp_zone = Time.zone
+        Time.zone = "America/Los_Angeles"
+        example.call
+        Time.zone = tmp_zone
+      end
+
+      subject { presenter.created }
+
+      it { is_expected.to eq "December 8th, 2014 18:03" }
+    end
+
+    describe "#current?" do
+      subject { presenter.current? }
+
+      it { is_expected.to be false }
+
+      context "when current! is set" do
+        before { presenter.current! }
+        it { is_expected.to be true }
+      end
+    end
+
+    describe "#committer" do
+      before do
+        Hyrax::VersionCommitter.create(version_id: resource_version.uri, committer_login: 'jill')
+      end
+      subject { presenter.committer }
+
+      it { is_expected.to eq 'jill' }
+    end
   end
 end

--- a/spec/presenters/hyrax/version_presenter_spec.rb
+++ b/spec/presenters/hyrax/version_presenter_spec.rb
@@ -58,4 +58,69 @@ RSpec.describe Hyrax::VersionPresenter do
       it { is_expected.to eq 'jill' }
     end
   end
+
+  context "for Valkyrie" do
+    let(:resource_version) do
+      Valkyrie::StorageAdapter::File.new(
+        id: "versiondisk://v-current-test",
+        version_id: "versiondisk://v-1-test.jpg",
+        io: File.open("spec/fixtures/4-20.png")
+      )
+    end
+
+    let(:presenter) { described_class.new(resource_version) }
+    let(:committer) { Hyrax::VersionCommitter.create(version_id: resource_version.version_id, committer_login: 'jill') }
+
+    before do
+      committer
+    end
+
+    describe "#label" do
+      subject { presenter.label }
+
+      it { is_expected.to eq 'versiondisk://v-1-test.jpg' }
+    end
+
+    describe "#uri" do
+      subject { presenter.uri }
+
+      it { is_expected.to eq 'versiondisk://v-1-test.jpg' }
+    end
+
+    describe "#created" do
+      around do |example|
+        # Stub out the local timezone to (+08:00)
+        tmp_zone = Time.zone
+        Time.zone = "America/Los_Angeles"
+        example.call
+        Time.zone = tmp_zone
+      end
+      before do
+      end
+
+      subject { presenter.created }
+
+      it { is_expected.to eq committer.try(:created_at)&.in_time_zone&.to_formatted_s(:long_ordinal) }
+    end
+
+    describe "#current?" do
+      subject { presenter.current? }
+
+      it { is_expected.to be false }
+
+      context "when current! is set" do
+        before { presenter.current! }
+        it { is_expected.to be true }
+      end
+    end
+
+    describe "#committer" do
+      before do
+        Hyrax::VersionCommitter.create(version_id: resource_version.version_id, committer_login: 'jill')
+      end
+      subject { presenter.committer }
+
+      it { is_expected.to eq 'jill' }
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,10 @@ Valkyrie::StorageAdapter.register(
   Valkyrie::Storage::Disk.new(base_path: Rails.root / 'tmp' / 'test_adapter_uploads'),
   :test_disk
 )
+Valkyrie::StorageAdapter.register(
+  Valkyrie::Storage::Disk.new(base_path: File.expand_path('../fixtures', __FILE__)),
+  :fixture_disk
+)
 
 # Require supporting ruby files from spec/support/ and subdirectories.  Note: engine, not Rails.root context.
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -135,6 +135,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before :suite do
+    FactoryBot::SyntaxRunner.include ActiveJob::TestHelper
     FactoryBot::SyntaxRunner.include RSpec::Mocks::ExampleMethods
     Hyrax::RedisEventStore.instance.then(&:flushdb)
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/wings/valkyrie/storage_spec.rb
+++ b/spec/wings/valkyrie/storage_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'spec_helper'
-require 'hyrax/specs/shared_specs/valkyrie_storage_versions'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Wings::Valkyrie::Storage, :active_fedora, :clean_repo do
@@ -8,7 +7,6 @@ RSpec.describe Wings::Valkyrie::Storage, :active_fedora, :clean_repo do
   let(:file) { fixture_file_upload('/world.png', 'image/png') }
 
   it_behaves_like "a Valkyrie::StorageAdapter"
-  # it_behaves_like "a Valkyrie::StorageAdapter with versioning support"
 
   context 'when accessing an existing AF file' do
     let(:content)  { StringIO.new("test content") }


### PR DESCRIPTION
Implements versioning in Hyrax for binary content using Valkyrie's released version support in 3.1.0.

In nurax-pg this will mean wiping everything and migrating to a VersionedDisk adapter.