### PR TITLE
Enable access of form classes, not just instances

### DIFF
--- a/app/forms/hyrax/forms/pcdm_object_form.rb
+++ b/app/forms/hyrax/forms/pcdm_object_form.rb
@@ -3,6 +3,27 @@
 module Hyrax
   module Forms
     ##
+    # @api public
+    #
+    # @example defining a form class using HydraEditor-like configuration
+    #   class MonographForm < Hyrax::Forms::PcdmObjectForm(Monograph)
+    #     self.required_fields = [:title, :creator, :rights_statement]
+    #     # other WorkForm-like configuration here
+    #   end
+    def self.PcdmObjectForm(work_class)
+      Class.new(Hyrax::Forms::PcdmObjectForm) do
+        self.model_class = work_class
+
+        ##
+        # @return [String]
+        def self.inspect
+          return "Hyrax::Forms::PcdmObjectForm(#{model_class})" if name.blank?
+          super
+        end
+      end
+    end
+
+    ##
     # A form for PCDM objects: resources which have collection relationships and
     # generally resemble +Hyrax::Work+.
     class PcdmObjectForm < Hyrax::Forms::ResourceForm

--- a/lib/generators/hyrax/work_resource/templates/form.rb.erb
+++ b/lib/generators/hyrax/work_resource/templates/form.rb.erb
@@ -5,7 +5,7 @@
 #
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
-class <%= class_name %>Form < Hyrax::Forms::ResourceForm(<%= class_name %>)
+class <%= class_name %>Form < Hyrax::Forms::PcdmObjectForm(<%= class_name %>)
   include Hyrax::FormFields(:basic_metadata)
   include Hyrax::FormFields(:<%= file_name %>)
 


### PR DESCRIPTION
Previously, there was no easy way to access the form for a given model in the case where that model is not a PCDM object, as `Hyrax::Forms::ResourceForm()` only worked in that case. This commit moves the logic in `Hyrax::Forms::ResourceForm.for()` into `Hyrax::Forms::ResourceForm()` so that the logic doesn’t need to be duplicated in cases where just the class (and not a specific instance) is desired.

It also makes `Hyrax::Forms::PcdmObjectForm()` callable and updates the form generator to use that going forward. This simply makes the existing behaviour of `Hyrax::Forms::ResourceForm()` more explicit; it already produced a `Hyrax::Forms::PcdmObjectForm` subclass. I think this is a minor change (since the old behaviour still works fine) but idk.