### PR TITLE
Redis current is depericated, replace in a similar manner to other gems

### DIFF
--- a/app/services/hyrax/lock_manager.rb
+++ b/app/services/hyrax/lock_manager.rb
@@ -47,11 +47,10 @@ module Hyrax
     # @api private
     #
     # @note support both a ConnectionPool and a raw Redis client for now.
-    #   we should drop support for `Redis.current` in 5.0.0.
     #   `#then` supports both options. for a ConnectionPool it will block
     #   until a connection is available.
     def pool
-      Hyrax.config.redis_connection || Redis.current
+      Hyrax.config.redis_connection || Redis.new
     end
   end
 end

--- a/lib/hyrax/redis_event_store.rb
+++ b/lib/hyrax/redis_event_store.rb
@@ -25,15 +25,14 @@ module Hyrax
       #
       # @return [Redis]
       def instance
-        connection = Hyrax.config.redis_connection || Redis.current
-
-        if connection.is_a? Redis::Namespace
-          connection.namespace = namespace
-          connection
-        elsif connection == Redis.current
-          Redis.current = Redis::Namespace.new(namespace, redis: connection)
+        if  Hyrax.config.redis_connection&.is_a?(Redis::Namespace)
+          c = Hyrax.config.redis_connection
+          c.namespace = namespace
+          c
+        elsif Hyrax.config.redis_connection
+          Hyrax.config.redis_connection
         else
-          connection
+          Redis::Namespace.new(namespace, redis: Redis.new)
         end
       end
 

--- a/spec/lib/hyrax/redis_event_store_spec.rb
+++ b/spec/lib/hyrax/redis_event_store_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyrax::RedisEventStore do
       it { is_expected.to eq(1) }
     end
     context "when the Redis command fails" do
-      before { allow(Redis).to receive(:current).and_raise(Redis::CommandError) }
+      before { allow(Hyrax.config).to receive(:redis_connection).and_raise(Redis::CommandError) }
       context "without a logger" do
         before { allow(Rails).to receive(:logger).and_return(false) }
         it { is_expected.to be_nil }
@@ -31,11 +31,11 @@ RSpec.describe Hyrax::RedisEventStore do
     subject { described_class.new("key").fetch("size") }
 
     context "when the Redis command fails" do
-      before { allow(Redis).to receive(:current).and_raise(Redis::CommandError) }
+      before { allow(Hyrax.config).to receive(:redis_connection).and_raise(Redis::CommandError) }
       it { is_expected.to eq([]) }
     end
     context "when the Redis is unavailable" do
-      before { allow(Redis).to receive(:current).and_raise(Redis::CannotConnectError) }
+      before { allow(Hyrax.config).to receive(:redis_connection).and_raise(Redis::CannotConnectError) }
       it { is_expected.to eq([]) }
     end
   end
@@ -44,11 +44,11 @@ RSpec.describe Hyrax::RedisEventStore do
     subject { described_class.new("key").push("some value") }
 
     context "when the Redis command fails" do
-      before { allow(Redis).to receive(:current).and_raise(Redis::CommandError) }
+      before { allow(Hyrax.config).to receive(:redis_connection).and_raise(Redis::CommandError) }
       it { is_expected.to be_nil }
     end
     context "when the Redis is unavailable" do
-      before { allow(Redis).to receive(:current).and_raise(Redis::CannotConnectError) }
+      before { allow(Hyrax.config).to receive(:redis_connection).and_raise(Redis::CannotConnectError) }
       it { is_expected.to be_nil }
     end
   end


### PR DESCRIPTION
### Fixes

Fixes #6056

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* I dont think this can be tested other than specs and nurax continuing to work at all

@samvera/hyrax-code-reviewers
