### PR TITLE
reindexing a record will clear acls and permission groups

### DIFF
--- a/app/indexers/hyrax/permission_indexer.rb
+++ b/app/indexers/hyrax/permission_indexer.rb
@@ -13,7 +13,7 @@ module Hyrax
     def to_solr
       super.tap do |index_document|
         config      = Hydra.config.permissions
-        permissions = Hyrax::PermissionManager.new(resource: resource)
+        permissions = resource.permission_manager || Hyrax::PermissionManager.new(resource: resource)
 
         index_document[config.edit.group] = permissions.edit_groups.to_a
         index_document[config.edit.individual] = permissions.edit_users.to_a

--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -169,7 +169,6 @@ module Hyrax
       change_set.sync
       persister.save(resource: change_set.resource)
       Hyrax.publisher.publish('object.acl.updated', acl: self, result: :success)
-      @change_set = nil
 
       true
     end


### PR DESCRIPTION
### Summary

When writing specs I noticed my records would be correct in the index but then they would get updated and suddenly they would loose their read_groups / edit_groups / edit_users / read_users. Also if you save an ACL list and then index the record again at any point it will loose the visibility setting.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* create a record in the console
* index it
* view the visibility and permisisons
* save the acl
* view the visibility and permissions
* index it again
* view the visibility and permisisons

@samvera/hyrax-code-reviewers
