### PR TITLE
🐛 Fix for Collection Sort_by functionality

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -33,8 +33,6 @@ module Hyrax
     end
 
     def show
-      # Pass sort params to the search builder
-      params[:sort] ||= Hyrax::Collections::CollectionMemberSearchService::DEFAULT_SORT_FIELD
       @curation_concern = @collection # we must populate curation_concern
       presenter
       query_collection_members

--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -33,6 +33,8 @@ module Hyrax
     end
 
     def show
+      # Pass sort params to the search builder
+      params[:sort] ||= Hyrax::Collections::CollectionMemberSearchService::DEFAULT_SORT_FIELD
       @curation_concern = @collection # we must populate curation_concern
       presenter
       query_collection_members

--- a/app/search_builders/hyrax/collection_search_builder.rb
+++ b/app/search_builders/hyrax/collection_search_builder.rb
@@ -20,7 +20,7 @@ module Hyrax
 
     # @return [String] Solr field name indicating default sort order
     def sort_field
-      "title_si"
+      "title_ssi"
     end
 
     # This overrides the models in FilterByType

--- a/app/services/hyrax/collections/collection_member_search_service.rb
+++ b/app/services/hyrax/collections/collection_member_search_service.rb
@@ -46,8 +46,10 @@ module Hyrax
       #
       # @return [Blacklight::Solr::Response]
       def available_member_works
+        sort_field = user_params[:sort] || DEFAULT_SORT_FIELD
         response, _docs = search_results do |builder|
           builder.search_includes_models = :works
+          builder.merge(sort: sort_field)
           builder
         end
         response

--- a/app/services/hyrax/collections/collection_member_search_service.rb
+++ b/app/services/hyrax/collections/collection_member_search_service.rb
@@ -46,7 +46,7 @@ module Hyrax
       #
       # @return [Blacklight::Solr::Response]
       def available_member_works
-        sort_field = user_params[:sort] || DEFAULT_SORT_FIELD
+        sort_field = user_params[:sort]
         response, _docs = search_results do |builder|
           builder.search_includes_models = :works
           builder.merge(sort: sort_field)

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::CollectionSearchBuilder do
   let(:scope) { FakeSearchBuilderScope.new(current_user: user) }
 
   describe '#sort_field' do
-    its(:sort_field) { is_expected.to eq('title_si') }
+    its(:sort_field) { is_expected.to eq('title_ssi') }
   end
 
   describe '#models' do


### PR DESCRIPTION
Credit goes to Palni Palci for pointing out this bug + contributing the fix back.

### Summary

On the Collection show page, the sort_by dropdown button was not working. A user could select and option and a request would be made, but the sort params was not making it through to the search builder and therefore did not sort the items regardless of the selection.


## Accepted Criteria

- [ ] Works on the public view of the collection page are by default, sorted A-Z

## Testing Instructions

- [ ] Login in as an admin user
- [ ] Click on Collections. Find a collection with several works and click on it. Click to see the public view of it. 
- [ ] Change the selections of the sort_by drop down. The works' orders should change accordingly.

### Detailed Description

[DEMO](https://share.getcloudapp.com/RBuz7EQg)

### Changes proposed in this pull request:
* FIX TYPO? title_si => title_ssi. si 
  - title_si: The suffix _si suggests that this field should be treated as a "Short Integer" based on Solr's default dynamic field definitions.~
  - title_ssi: The suffix _ssi suggests that this field is a "String, stored, and indexed".
* Pass sort selection through the controller and onto the search builder to make it work.

@samvera/hyrax-code-reviewers
