### PR TITLE
Default sort order of notifications page

### DIFF
--- a/app/views/hyrax/notifications/_notifications.html.erb
+++ b/app/views/hyrax/notifications/_notifications.html.erb
@@ -1,6 +1,6 @@
 <% if messages.present? %>
   <div class="table-responsive">
-    <table class="table table-striped datatable">
+    <table class="table table-striped datatable" data-order='[[0, "desc"]]'>
       <thead>
         <tr>
           <th><%= t('hyrax.mailbox.date') %></th>


### PR DESCRIPTION
### Fixes

None, committing back a local override

### Summary

Changes the default sort order on the notifications page to sorting in descending order by timestamp, so that newest notifications display first.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
Visit the notifications page by clicking the notification counter at the top of the page. Observe that without this PR the notifications display oldest notifications first. With this PR, the new notifications are displayed first.

### Type of change (for release notes)

notes-bugfix - default the notifications page to display newest entries first

### Detailed Description

This was a [local override](https://github.com/UNC-Libraries/hy-c/pull/92) in our repository that was requested so that users wouldn't have to page through all their old notifications to see recent activity. While updating overrides, I figured it would make sense to offer it back in case it was useful more broadly.

### Changes proposed in this pull request:
Sets a default sort for datatables in the html of the notifications table.

@samvera/hyrax-code-reviewers
