### PR TITLE
Add additional aria-labels to form elements

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -8,7 +8,7 @@
     </label>
 
     <div class="input-group col-sm-9">
-      <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+      <%= text_field_tag :q, current_search_parameters , 'aria-label': 'Search', class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
       <div class="input-group-append">
         <button type="submit" class="btn btn-primary" id="search-submit-header">

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -31,7 +31,7 @@
         </li>
         <li class="form-check">
           <label class="form-check-label">
-            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, class: 'form-check-input', data: { 'target': '#collapseEmbargo' } %>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, 'aria-label': 'Embargo', class: 'form-check-input', data: { 'target': '#collapseEmbargo' } %>
             <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) %>
             <br />
             <%= t('hyrax.visibility.embargo.note_html') %>
@@ -39,7 +39,7 @@
               <div class="form-inline">
                 <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
                 <%= t('hyrax.works.form.visibility_until') %>
-                <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date&.to_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.date_field :embargo_release_date, wrapper: :inline, 'aria-label': 'Embargo Release Date', value: f.object.embargo_release_date&.to_date || Date.tomorrow, class: 'datepicker form-control' %>
                 <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
               </div>
             </div>
@@ -47,7 +47,7 @@
         </li>
         <li class="form-check">
           <label class="form-check-label">
-            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, class: 'form-check-input', data: { 'target': '#collapseLease' } %>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, 'aria-label': 'Lease', class: 'form-check-input', data: { 'target': '#collapseLease' } %>
             <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE) %>
             <br />
             <%= t('hyrax.visibility.lease.note_html') %>
@@ -55,7 +55,7 @@
               <div class="form-inline">
                 <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
                 <%= t('hyrax.works.form.visibility_until') %>
-                <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date&.to_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.date_field :lease_expiration_date, wrapper: :inline, 'aria-label': 'Lease Expiration Date', value: f.object.lease_expiration_date&.to_date || Date.tomorrow, class: 'datepicker form-control' %>
                 <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
               </div>
             </div>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -2,7 +2,7 @@
   <div class="col-sm-6">
     <% if !workflow_restriction?(presenter) %>
       <% if presenter.show_deposit_for?(collections: @user_collections) %>
-        <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+        <input type="checkbox" aria-label="Batch Documents" style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
         <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
                       class: 'btn btn-secondary submits-batches submits-batches-add',
                       data: { toggle: "modal", target: "#collection-list-container" } %>

--- a/app/views/hyrax/my/_search_form.html.erb
+++ b/app/views/hyrax/my/_search_form.html.erb
@@ -7,7 +7,7 @@
     </label>
 
     <div class="input-group mb-sm-auto col-sm-9">
-      <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+      <%= text_field_tag :q, current_search_parameters , 'aria-label': 'Search', class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
       <div class="input-group-append">
         <button type="submit" class="btn btn-primary" id="search-submit-header">
           <%= t('hyrax.search.button.html') %>


### PR DESCRIPTION
### Fixes

Committing back local overrides

### Summary
Adds aria-labels to a few form components based on accessibility work in our local repository

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
Use the WAVE plugin to check for missing aria labels on the work create/editing page to see if the embargo/lease options have labels with this PR. Check the main search form, and the search form on the "my works" page.

### Type of change (for release notes)

notes-bugfix - Add additional missing aria-labels

### Detailed Description

Committing back a few aria-labels that we had added to our local repository after doing an accessibility survey.

### Changes proposed in this pull request:
* Adds missing aria-label attributes.

@samvera/hyrax-code-reviewers
