### PR TITLE
Valkyrie Fedora metadata/storage adapter compatibility

### DIFF
--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -18,7 +18,7 @@ module Hyrax
                        "with id #{file.id}. Initializing a new one")
 
     FileMetadata.new(file_identifier: file.id,
-                     original_filename: File.basename(file.io))
+                     original_filename: File.basename(file.disk_path))
   end
 
   class FileMetadata < Valkyrie::Resource

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -63,7 +63,7 @@ module Hyrax
   #   `it_behaves_like 'has_members'`.  Shared specs are defined in /lib/hyrax/specs/shared_specs/hydra_works.rb.
   # * Work to File Set: (0..m)  A work can have many file sets.
   # @example Add a file set to a work (code from Hyrax::WorkUploadsHandler#append_to_work)
-  #       work.member_ids << file_set.id
+  #       work.member_ids += [file_set.id]
   #       work.representative_id = file_set.id if work.respond_to?(:representative_id) && work.representative_id.blank?
   #       work.thumbnail_id = file_set.id if work.respond_to?(:thumbnail_id) && work.thumbnail_id.blank?
   #       Hyrax.persister.save(resource: work)

--- a/app/services/hyrax/collections/collection_member_service.rb
+++ b/app/services/hyrax/collections/collection_member_service.rb
@@ -106,7 +106,7 @@ module Hyrax
         def add_member(collection_id:, new_member:, user:)
           message = Hyrax::MultipleMembershipChecker.new(item: new_member).check(collection_ids: [collection_id], include_current_members: true)
           raise Hyrax::SingleMembershipError, message if message.present?
-          new_member.member_of_collection_ids << collection_id # only populate this direction
+          new_member.member_of_collection_ids += [collection_id] # only populate this direction
           new_member = Hyrax.persister.save(resource: new_member)
           publish_metadata_updated(new_member, user)
           new_member

--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -80,7 +80,7 @@ class Hyrax::ValkyrieUpload
   #
   # @return [Hyrax::FileSet] updated file set
   def add_file_to_file_set(file_set:, file_metadata:, user:)
-    file_set.file_ids << file_metadata.id
+    file_set.file_ids += [file_metadata.id]
     Hyrax.persister.save(resource: file_set)
     Hyrax.publisher.publish('object.membership.updated', object: file_set, user: user)
   end

--- a/app/services/hyrax/work_uploads_handler.rb
+++ b/app/services/hyrax/work_uploads_handler.rb
@@ -124,7 +124,7 @@ module Hyrax
     #
     # @todo figure out how to know less about Work's ideas about FileSet use here. Maybe post-Wings, work.
     def append_to_work(file_set)
-      work.member_ids << file_set.id
+      work.member_ids += [file_set.id]
       work.representative_id = file_set.id if work.respond_to?(:representative_id) && work.representative_id.blank?
       work.thumbnail_id = file_set.id if work.respond_to?(:thumbnail_id) && work.thumbnail_id.blank?
     end

--- a/app/validators/hyrax/collection_membership_validator.rb
+++ b/app/validators/hyrax/collection_membership_validator.rb
@@ -29,7 +29,7 @@ module Hyrax
         record.member_of_collections_attributes
               .each do |_k, h|
                 next if h["_destroy"] == "true"
-                collection_ids << Valkyrie::ID.new(h["id"])
+                collection_ids += [Valkyrie::ID.new(h["id"])]
               end
       end
 

--- a/config/initializers/file_length_patch.rb
+++ b/config/initializers/file_length_patch.rb
@@ -1,0 +1,4 @@
+# Valkyrie::Storage::Fedora expects io objects to have #length
+class ::File
+  alias_method :length, :size unless ::File.respond_to? :length
+end

--- a/config/initializers/file_length_patch.rb
+++ b/config/initializers/file_length_patch.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 # Valkyrie::Storage::Fedora expects io objects to have #length
 class ::File
-  alias_method :length, :size unless ::File.respond_to? :length
+  alias length size unless ::File.respond_to? :length
 end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -569,11 +569,13 @@ module Hyrax
     #
     # @return [#call] lambda/proc that generates a Faraday connection
     def fedora_connection_builder
-      @fedora_connection_builder ||= ->(url) { Faraday.new(url) do |f|
-        f.request :multipart
-        f.request :url_encoded
-        f.adapter Faraday.default_adapter
-      end }
+      @fedora_connection_builder ||= lambda { |url|
+        Faraday.new(url) do |f|
+          f.request :multipart
+          f.request :url_encoded
+          f.adapter Faraday.default_adapter
+        end
+      }
     end
     attr_writer :fedora_connection_builder
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -565,6 +565,18 @@ module Hyrax
       @derivatives_storage_adapter = Valkyrie::StorageAdapter.find(adapter.to_sym)
     end
 
+    # A HTTP connection to use for Valkyrie Fedora requests
+    #
+    # @return [#call] lambda/proc that generates a Faraday connection
+    def fedora_connection_builder
+      @fedora_connection_builder ||= ->(url) { Faraday.new(url) do |f|
+        f.request :multipart
+        f.request :url_encoded
+        f.adapter Faraday.default_adapter
+      end }
+    end
+    attr_writer :fedora_connection_builder
+
     ##
     # @return [#save, #save_all, #delete, #wipe!] an indexing adapter
     def index_adapter

--- a/lib/hyrax/transactions/steps/add_to_parent.rb
+++ b/lib/hyrax/transactions/steps/add_to_parent.rb
@@ -20,7 +20,7 @@ module Hyrax
           return Success(obj) if parent_id.blank?
 
           parent = Hyrax.query_service.find_by(id: parent_id)
-          parent.member_ids << obj.id
+          parent.member_ids += [obj.id]
           Hyrax.persister.save(resource: parent)
 
           user ||= ::User.find_by_user_key(obj.depositor)


### PR DESCRIPTION
### Summary

Various fixes needed to run Hyrax using valkyrie fedora adapters

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Reconfigure koppie to use `Valkyrie::Persistence::Fedora::MetadataAdapter` and `Valkyrie::Storage::Fedora` configured for a Fedora 6 instance
* koppie can create a monograph and display the IIIF viewer for it.
*

### Changes proposed in this pull request:
* Replace use of `<<` with `+= []`
* Patch ::File to have length alias for size
* Don't use io object directly for basename
* Add config for faraday connection for valkyrie fedora adapters

@samvera/hyrax-code-reviewers
