### PR TITLE
Fix work deletion

### DIFF
--- a/lib/hyrax/transactions/work_destroy.rb
+++ b/lib/hyrax/transactions/work_destroy.rb
@@ -8,8 +8,8 @@ module Hyrax
     #
     # @since 3.0.0
     class WorkDestroy < Transaction
-      DEFAULT_STEPS = ['work_resource.delete',
-                       'work_resource.delete_acl'].freeze
+      DEFAULT_STEPS = ['work_resource.delete_acl',
+                       'work_resource.delete'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction


### PR DESCRIPTION
### Fixes

Fixes #6333 

### Summary

In valkyrie/fedora, deleting a work results in an error. The underlying issue is the application attempting to re-access a work on Fedora after it was deleted.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:

1. Load sirenia (See #6331) 
2. Create a work
3. Delete the work
4. Verify work is deleted successfully without any errors

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

A work deletion executes two transactions:
- 'work_resource.delete'
- 'work_resource.delete_acl'

In the previous ordering of these transactions, a work resource is deleted in Fedora, and then access to the resource is re-attempted when the `work_resource.delete_acl` transaction is processing. Specifically, `work_resource.delete_acl` involves finding the ACL using `find_access_control_for(resource:)` in `app/services/hyrax/custom_queries/find_access_control.rb`, which attempts to load the resource (work) on Fedora through Valkyrie. When a resource is deleted on Fedora and then an access is attempted, Fedora returns the error: `Discovered tombstone resource at ...`.

### Changes proposed in this pull request:
* Reorder the transactions needed to delete a work by deleting the ACL first then the actual work on Fedora

@samvera/hyrax-code-reviewers
