### PR TITLE
Adds a permissive schema to the Fedora Valkyrie adapter (#6332).

### DIFF
--- a/.dassie/config/metadata/collection_resource.yaml
+++ b/.dassie/config/metadata/collection_resource.yaml
@@ -13,11 +13,14 @@ attributes:
     form:
       primary: true
       multiple: true
+    predicate: http://hyrax-example.com/target_audience
   department:
     type: string
     form:
       primary: true
+    predicate: http://hyrax-example.com/department
   course:
     type: string
     form:
       primary: false
+    predicate: http://hyrax-example.com/course

--- a/.dassie/config/metadata/monograph.yaml
+++ b/.dassie/config/metadata/monograph.yaml
@@ -23,6 +23,7 @@
 attributes:
   monograph_title:
     type: string
+    predicate: http://hyrax-example.com/monograph_title
   record_info:
     type: string
     form:
@@ -30,26 +31,33 @@ attributes:
       primary: true
     index_keys:
       - "record_info_tesim"
+    predicate: http://hyrax-example.com/record_info
   place_of_publication:
     type: string
     form:
       required: false
       primary: true
+    predicate: http://hyrax-example.com/place_of_publication
   genre:
     type: string
     form:
       primary: true
+    predicate: http://hyrax-example.com/genre
   series_title:
     type: string
     form:
       primary: false
+    predicate: http://hyrax-example.com/series_title
   target_audience:
     type: string
     form:
       multiple: true
+    predicate: http://hyrax-example.com/target_audience
   table_of_contents:
     type: string
     form:
       multiple: false
+    predicate: http://hyrax-example.com/table_of_contents
   date_of_issuance:
     type: string
+    predicate: http://hyrax-example.com/date_of_issuance

--- a/.dassie/config/metadata/sample_metadata.yaml
+++ b/.dassie/config/metadata/sample_metadata.yaml
@@ -1,3 +1,4 @@
 attributes:
   sample_attribute:
     type: string
+    predicate: http://hyrax-example.com/sample_attribute

--- a/.koppie/config/initializers/1_valkyrie.rb
+++ b/.koppie/config/initializers/1_valkyrie.rb
@@ -32,7 +32,8 @@ Valkyrie::MetadataAdapter.register(
   Valkyrie::Persistence::Fedora::MetadataAdapter.new(
     connection: ::Ldp::Client.new(Hyrax.config.fedora_connection_builder.call(
       ENV.fetch('FCREPO_URL') { "http://localhost:8080/fcrepo/rest" })),
-    base_path: Rails.env, #, schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: RDF::URI("http://example.com/title"))
+    base_path: Rails.env,
+    schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(Hyrax::SimpleSchemaLoader.new.permissive_schema_for_valkrie_adapter),
     fedora_version: 6
   ), :nurax_fedora_metadata_adapter
 )

--- a/.koppie/config/metadata/collection_resource.yaml
+++ b/.koppie/config/metadata/collection_resource.yaml
@@ -2,6 +2,8 @@
 # index key names, and form properties.
 #
 # Attributes must have a type but all other configuration options are optional.
+# Please note: If using Valkyrie's Fedora Metadata Adapter, predicates for attributes
+# must be placed here.
 #
 # attributes:
 #   attribute_name:
@@ -27,6 +29,7 @@ attributes:
       primary: true
     index_keys:
       - "description_tesim"
+    predicate: http://purl.org/dc/elements/1.1/description
   creator:
     type: string
     multiple: true
@@ -35,6 +38,7 @@ attributes:
       primary: false
     index_keys:
       - "creator_tesim"
+    predicate: http://purl.org/dc/elements/1.1/creator
   rights_statement:
     type: string
     multiple: true
@@ -42,6 +46,7 @@ attributes:
       primary: false
     index_keys:
       - "rights_statement_tesim"
+    predicate: http://www.europeana.eu/schemas/edm/rights
   abstract:
     type: string
     multiple: true
@@ -49,6 +54,7 @@ attributes:
       primary: false
     index_keys:
       - "abstract_tesim"
+    predicate: http://purl.org/dc/terms/abstract
   access_right:
     type: string
     multiple: true
@@ -56,6 +62,7 @@ attributes:
       primary: false
     index_keys:
       - "access_right_tesim"
+    predicate: http://purl.org/dc/terms/accessRights
   alternative_title:
     type: string
     multiple: true
@@ -63,6 +70,7 @@ attributes:
       primary: false
     index_keys:
       - "alternative_title_tesim"
+    predicate: http://purl.org/dc/terms/alternative
   based_near:
     type: string
     multiple: true
@@ -71,9 +79,11 @@ attributes:
     index_keys:
       - "based_near_sim"
       - "based_near_tesim"
+    predicate: http://xmlns.com/foaf/0.1/based_near
   bibliographic_citation:
     type: string
     multiple: true
+    predicate: http://purl.org/dc/terms/bibliographicCitation
   contributor:
     type: string
     multiple: true
@@ -81,6 +91,7 @@ attributes:
       primary: false
     index_keys:
       - "contributor_tesim"
+    predicate: http://purl.org/dc/elements/1.1/contributor
   date_created:
     type: date_time
     multiple: true
@@ -88,6 +99,7 @@ attributes:
       primary: false
     index_keys:
       - "date_created_tesim"
+    predicate: http://purl.org/dc/terms/created
   identifier:
     type: string
     multiple: true
@@ -95,8 +107,10 @@ attributes:
       primary: false
     index_keys:
       - "identifier_tesim"
+    predicate: http://purl.org/dc/terms/identifier
   import_url:
     type: string
+    predicate: http://scholarsphere.psu.edu/ns#importUrl
   keyword:
     type: string
     multiple: true
@@ -105,6 +119,7 @@ attributes:
       - "keyword_tesim"
     form:
       primary: false
+    predicate: http://schema.org/keywords
   publisher:
     type: string
     multiple: true
@@ -112,12 +127,14 @@ attributes:
       primary: false
     index_keys:
       - "publisher_tesim"
+    predicate: http://purl.org/dc/elements/1.1/publisher
   label:
     type: string
     form:
       primary: false
     index_keys:
       - "label_tesim"
+    predicate: info:fedora/fedora-system:def/model#downloadFilename
   language:
     type: string
     multiple: true
@@ -125,6 +142,7 @@ attributes:
       primary: false
     index_keys:
       - "language_tesim"
+    predicate: http://purl.org/dc/elements/1.1/language
   license:
     type: string
     multiple: true
@@ -132,8 +150,10 @@ attributes:
       primary: false
     index_keys:
       - "license_tesim"
+    predicate: http://purl.org/dc/terms/license
   relative_path:
     type: string
+    predicate: http://scholarsphere.psu.edu/ns#relativePath
   related_url:
     type: string
     multiple: true
@@ -141,6 +161,7 @@ attributes:
       primary: false
     index_keys:
       - "related_url_tesim"
+    predicate: http://www.w3.org/2000/01/rdf-schema#seeAlso
   resource_type:
     type: string
     multiple: true
@@ -149,6 +170,7 @@ attributes:
     index_keys:
       - "resource_type_sim"
       - "resource_type_tesim"
+    predicate: http://purl.org/dc/terms/type
   rights_notes:
     type: string
     multiple: true
@@ -156,6 +178,7 @@ attributes:
       primary: false
     index_keys:
       - "rights_notes_tesim"
+    predicate: http://purl.org/dc/elements/1.1/rights
   source:
     type: string
     multiple: true
@@ -163,6 +186,7 @@ attributes:
       primary: false
     index_keys:
       - "source_tesim"
+    predicate: http://purl.org/dc/terms/source
   subject:
     type: string
     multiple: true
@@ -171,3 +195,4 @@ attributes:
       - "subject_tesim"
     form:
       primary: false
+    predicate: http://purl.org/dc/elements/1.1/subject

--- a/.koppie/config/metadata/generic_work.yaml
+++ b/.koppie/config/metadata/generic_work.yaml
@@ -2,6 +2,8 @@
 # index key names, and form properties.
 #
 # Attributes must have a type but all other configuration options are optional.
+# Please note: If using Valkyrie's Fedora Metadata Adapter, predicates for attributes
+# must be placed here.
 #
 # attributes:
 #   attribute_name:

--- a/.koppie/config/metadata/monograph.yaml
+++ b/.koppie/config/metadata/monograph.yaml
@@ -2,6 +2,8 @@
 # index key names, and form properties.
 #
 # Attributes must have a type but all other configuration options are optional.
+# Please note: If using Valkyrie's Fedora Metadata Adapter, predicates for attributes
+# must be placed here.
 #
 # attributes:
 #   attribute_name:
@@ -23,6 +25,7 @@
 attributes:
   monograph_title:
     type: string
+    predicate: http://hyrax-example.com/monograph_title
   record_info:
     type: string
     form:
@@ -30,26 +33,33 @@ attributes:
       primary: true
     index_keys:
       - "record_info_tesim"
+    predicate: http://hyrax-example.com/record_info
   place_of_publication:
     type: string
     form:
       required: false
       primary: true
+    predicate: http://hyrax-example.com/place_of_publication
   genre:
     type: string
     form:
       primary: true
+    predicate: http://hyrax-example.com/genre
   series_title:
     type: string
     form:
       primary: false
+    predicate: http://hyrax-example.com/series_title
   target_audience:
     type: string
     form:
       multiple: true
+    predicate: http://hyrax-example.com/target_audience
   table_of_contents:
     type: string
     form:
       multiple: false
+    predicate: http://hyrax-example.com/table_of_contents
   date_of_issuance:
     type: string
+    predicate: http://hyrax-example.com/date_of_issuance

--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -43,6 +43,12 @@ module Hyrax
       end
     end
 
+    def permissive_schema_for_valkrie_adapter
+      metadata_files.each_with_object({}) do |schema_name, ret_hsh|
+        predicate_pairs(ret_hsh, schema_name)
+      end
+    end
+
     ##
     # @api private
     class AttributeDefinition
@@ -153,6 +159,18 @@ module Hyrax
 
     def config_search_paths
       [Rails.root, Hyrax::Engine.root]
+    end
+
+    def metadata_files
+      file_name_arr = []
+      config_search_paths.each { |root_path| file_name_arr += Dir.entries(root_path.to_s + "/config/metadata/") }
+      file_name_arr.reject { |fn| !fn.include?('.yaml') }.uniq.map { |y| y.gsub('.yaml', '') }
+    end
+
+    def predicate_pairs(ret_hsh, schema_name)
+      schema_config(schema_name)['attributes'].each do |name, config|
+        ret_hsh[name] = RDF::URI(config['predicate']) if ret_hsh[name].blank?
+      end
     end
   end
 end

--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -169,7 +169,7 @@ module Hyrax
 
     def predicate_pairs(ret_hsh, schema_name)
       schema_config(schema_name)['attributes'].each do |name, config|
-        ret_hsh[name] = RDF::URI(config['predicate']) if ret_hsh[name].blank?
+        ret_hsh[name.to_sym] = RDF::URI(config['predicate']) if ret_hsh[name].blank?
       end
     end
   end

--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -169,20 +169,20 @@ module Hyrax
 
     def predicate_pairs(ret_hsh, schema_name)
       schema_config(schema_name)['attributes'].each do |name, config|
+        predicate = RDF::URI(config['predicate'])
         if ret_hsh[name].blank?
-          ret_hsh[name.to_sym] = RDF::URI(config['predicate'])
-        else
-          multiple_predicate_message(name)
+          ret_hsh[name.to_sym] = predicate
+        elsif ret_hsh[name] != predicate
+          multiple_predicate_message(name, ret_hsh[name], predicate)
         end
       end
     end
 
-    def multiple_predicate_message(name)
-      message =  "The attribute of #{name} has been assigned multiple times " \
-                 "within the metadata YAMLs. Please be aware that once the " \
-                 "attribute's predicate value is first assigned, any other value " \
-                 "will be ignored."
-
+    def multiple_predicate_message(name, existing, incoming)
+      message =  "The attribute of #{name} has been assigned a predicate multiple times " \
+                 "within the metadata YAMLs. Please be aware that once the attribute's " \
+                 "predicate value is first assigned, any other value will be ignored. " \
+                 "The existing value is #{existing} preventing the use of #{incoming}"
       Hyrax.logger.warn(message)
     end
   end

--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -169,8 +169,21 @@ module Hyrax
 
     def predicate_pairs(ret_hsh, schema_name)
       schema_config(schema_name)['attributes'].each do |name, config|
-        ret_hsh[name.to_sym] = RDF::URI(config['predicate']) if ret_hsh[name].blank?
+        if ret_hsh[name].blank?
+          ret_hsh[name.to_sym] = RDF::URI(config['predicate'])
+        else
+          multiple_predicate_message(name)
+        end
       end
+    end
+
+    def multiple_predicate_message(name)
+      message =  "The attribute of #{name} has been assigned multiple times " \
+                 "within the metadata YAMLs. Please be aware that once the " \
+                 "attribute's predicate value is first assigned, any other value " \
+                 "will be ignored."
+
+      Hyrax.logger.warn(message)
     end
   end
 end

--- a/config/metadata/basic_metadata.yaml
+++ b/config/metadata/basic_metadata.yaml
@@ -7,6 +7,7 @@ attributes:
       primary: false
     index_keys:
       - "abstract_tesim"
+    predicate: http://purl.org/dc/terms/abstract
   access_right:
     type: string
     multiple: true
@@ -14,6 +15,7 @@ attributes:
       primary: false
     index_keys:
       - "access_right_tesim"
+    predicate: http://purl.org/dc/terms/accessRights
   alternative_title:
     type: string
     multiple: true
@@ -21,6 +23,7 @@ attributes:
       primary: false
     index_keys:
       - "alternative_title_tesim"
+    predicate: http://purl.org/dc/terms/alternative
   based_near:
     type: string
     multiple: true
@@ -29,9 +32,11 @@ attributes:
     index_keys:
       - "based_near_sim"
       - "based_near_tesim"
+    predicate: http://xmlns.com/foaf/0.1/based_near
   bibliographic_citation:
     type: string
     multiple: true
+    predicate: http://purl.org/dc/terms/bibliographicCitation
   contributor:
     type: string
     multiple: true
@@ -39,6 +44,7 @@ attributes:
       primary: false
     index_keys:
       - "contributor_tesim"
+    predicate: http://purl.org/dc/elements/1.1/contributor
   creator:
     type: string
     multiple: true
@@ -47,6 +53,7 @@ attributes:
       primary: true
     index_keys:
       - "creator_tesim"
+    predicate: http://purl.org/dc/elements/1.1/creator
   date_created:
     type: date_time
     multiple: true
@@ -54,6 +61,7 @@ attributes:
       primary: false
     index_keys:
       - "date_created_tesim"
+    predicate: http://purl.org/dc/terms/created
   description:
     type: string
     multiple: true
@@ -61,6 +69,7 @@ attributes:
       primary: false
     index_keys:
       - "description_tesim"
+    predicate: http://purl.org/dc/elements/1.1/description
   identifier:
     type: string
     multiple: true
@@ -68,8 +77,10 @@ attributes:
       primary: false
     index_keys:
       - "identifier_tesim"
+    predicate: http://purl.org/dc/terms/identifier
   import_url:
     type: string
+    predicate: http://scholarsphere.psu.edu/ns#importUrl
   keyword:
     type: string
     multiple: true
@@ -78,6 +89,7 @@ attributes:
       - "keyword_tesim"
     form:
       primary: false
+    predicate: http://schema.org/keywords
   publisher:
     type: string
     multiple: true
@@ -85,12 +97,14 @@ attributes:
       primary: false
     index_keys:
       - "publisher_tesim"
+    predicate: http://purl.org/dc/elements/1.1/publisher
   label:
     type: string
     form:
       primary: false
     index_keys:
       - "label_tesim"
+    predicate: info:fedora/fedora-system:def/model#downloadFilename
   language:
     type: string
     multiple: true
@@ -98,6 +112,7 @@ attributes:
       primary: false
     index_keys:
       - "language_tesim"
+    predicate: http://purl.org/dc/elements/1.1/language
   license:
     type: string
     multiple: true
@@ -105,8 +120,10 @@ attributes:
       primary: false
     index_keys:
       - "license_tesim"
+    predicate: http://purl.org/dc/terms/license
   relative_path:
     type: string
+    predicate: http://scholarsphere.psu.edu/ns#relativePath
   related_url:
     type: string
     multiple: true
@@ -114,6 +131,7 @@ attributes:
       primary: false
     index_keys:
       - "related_url_tesim"
+    predicate: http://www.w3.org/2000/01/rdf-schema#seeAlso
   resource_type:
     type: string
     multiple: true
@@ -122,6 +140,7 @@ attributes:
     index_keys:
       - "resource_type_sim"
       - "resource_type_tesim"
+    predicate: http://purl.org/dc/terms/type
   rights_notes:
     type: string
     multiple: true
@@ -129,6 +148,7 @@ attributes:
       primary: false
     index_keys:
       - "rights_notes_tesim"
+    predicate: http://purl.org/dc/elements/1.1/rights
   rights_statement:
     type: string
     multiple: true
@@ -136,6 +156,7 @@ attributes:
       primary: true
     index_keys:
       - "rights_statement_tesim"
+    predicate: http://www.europeana.eu/schemas/edm/rights
   source:
     type: string
     multiple: true
@@ -143,6 +164,7 @@ attributes:
       primary: false
     index_keys:
       - "source_tesim"
+    predicate: http://purl.org/dc/terms/source
   subject:
     type: string
     multiple: true
@@ -151,3 +173,4 @@ attributes:
       - "subject_tesim"
     form:
       primary: false
+    predicate: http://purl.org/dc/elements/1.1/subject

--- a/config/metadata/core_metadata.yaml
+++ b/config/metadata/core_metadata.yaml
@@ -9,9 +9,13 @@ attributes:
       required: true
       primary: true
       multiple: true
+    predicate: http://purl.org/dc/terms/title
   date_modified:
     type: date_time
+    predicate: http://purl.org/dc/terms/modified
   date_uploaded:
     type: date_time
+    predicate: http://purl.org/dc/terms/dateSubmitted
   depositor:
     type: string
+    predicate: http://id.loc.gov/vocabulary/relators/dpt

--- a/config/metadata/file_set_metadata.yaml
+++ b/config/metadata/file_set_metadata.yaml
@@ -12,17 +12,20 @@ attributes:
       primary: true
     index_keys:
       - "creator_tesim"
+    predicate: http://purl.org/dc/elements/1.1/creator
   license:
     type: string
     multiple: true
     form:
       required: false
       primary: true
+    predicate: http://purl.org/dc/terms/license
 
   # Other attributes:
   abstract:
     type: string
     multiple: true
+    predicate: http://purl.org/dc/terms/abstract
   # form:
   #   primary: false
   # missing: access_right
@@ -35,12 +38,14 @@ attributes:
     index_keys:
       - "based_near_sim"
       - "based_near_tesim"
+    predicate: http://xmlns.com/foaf/0.1/based_near
   # missing: bibliograpic_citation
   contributor:
     type: string
     multiple: true
     form:
       primary: false
+    predicate: http://purl.org/dc/elements/1.1/contributor
   # required: creator
   date_created:
     type: date_time
@@ -49,6 +54,7 @@ attributes:
       primary: false
     index_keys:
       - "date_created_tesim"
+    predicate: http://purl.org/dc/terms/created
   description:
     type: string
     multiple: true
@@ -56,11 +62,13 @@ attributes:
       primary: false
     index_keys:
       - "description_tesim"
+    predicate: http://purl.org/dc/elements/1.1/description
   identifier:
     type: string
     multiple: true
     form:
       primary: false
+    predicate: http://purl.org/dc/terms/identifier
   # missing: import_url
   keyword:
     type: string
@@ -70,9 +78,11 @@ attributes:
     index_keys:
       - "keyword_sim"
       - "keyword_tesim"
+    predicate: http://schema.org/keywords
   # missing: publisher
   label:
     type: string
+    predicate: info:fedora/fedora-system:def/model#downloadFilename
   # form:
   #   primary: false
   language:
@@ -80,12 +90,14 @@ attributes:
     multiple: true
     form:
       primary: false
+    predicate: http://purl.org/dc/elements/1.1/language
   # required: license
   publisher:
     type: string
     multiple: true
     form:
       primary: false
+    predicate: http://purl.org/dc/elements/1.1/publisher
   related_url:
     type: string
     multiple: true
@@ -93,8 +105,10 @@ attributes:
       primary: false
     index_keys:
       - "related_url_tesim"
+    predicate: http://www.w3.org/2000/01/rdf-schema#seeAlso
   relative_path:
     type: string
+    predicate: http://scholarsphere.psu.edu/ns#relativePath
   resource_type:
     type: string
     multiple: true
@@ -103,9 +117,11 @@ attributes:
     index_keys:
       - "resource_type_sim"
       - "resource_type_tesim"
+    predicate: http://purl.org/dc/terms/type
   rights_notes:
     type: string
     multiple: true
+    predicate: http://purl.org/dc/elements/1.1/rights
   # form:
   #   primary: false
   rights_statement:
@@ -115,9 +131,11 @@ attributes:
   #   primary: true
     index_keys:
       - "rights_statement_tesim"
+    predicate: http://www.europeana.eu/schemas/edm/rights
   source:
     type: string
     multiple: true
+    predicate: http://purl.org/dc/terms/source
   # form:
   #   primary: false
   subject:
@@ -128,3 +146,4 @@ attributes:
     index_keys:
       - "subject_sim"
       - "subject_tesim"
+    predicate: http://purl.org/dc/elements/1.1/subject

--- a/config/metadata/hyrax_internal_metadata.yaml
+++ b/config/metadata/hyrax_internal_metadata.yaml
@@ -1,0 +1,56 @@
+---
+attributes:
+  admin_set_id: 
+    predicate: http://purl.org/dc/terms/isPartOf
+  id:
+    predicate: http://purl.org/dc/terms/id
+  internal_resource:
+    predicate: info:fedora/fedora-system:def/model#hasModel
+  representative_id:
+    predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedMediaFragment
+  state:
+    predicate: http://fedora.info/definitions/1/0/access/ObjState#objState
+  thumbnail_id:
+    predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedImage
+  created_at: 
+    predicate: http://purl.org/dc/terms/created
+  byte_order:
+    predicate: http://sweet.jpl.nasa.gov/2.2/reprDataFormat.owl#byteOrder
+  color_space:
+    predicate: http://www.w3.org/2003/12/exif/ns#colorSpace
+  compression:
+    predicate: http://vocabulary.samvera.org/ns#compressionScheme
+  file_identifier:
+    predicate: http://vocabulary.samvera.org/ns#fileIdentifier
+  file_set_id:
+    predicate: http://vocabulary.samvera.org/ns#fileSetId
+  format_label:
+    predicate: http://www.loc.gov/premis/rdf/v1#hasFormatName
+  height: 
+    predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#height
+  mime_type:
+    predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMimeType
+  original_filename:
+    predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#filename
+  pcdm_use:
+    predicate: http://vocabulary.samvera.org/ns#pcdmUse
+  recorded_size:
+    predicate: http://www.loc.gov/premis/rdf/v1#hasSize
+  valid:
+    predicate: http://vocabulary.samvera.org/ns#valid
+  well_formed:
+    predicate: http://vocabulary.samvera.org/ns#wellFormed
+  width:
+    predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#width
+  access_to:
+    predicate: http://www.w3.org/ns/auth/acl#accessTo
+  permissions:
+    predicate: http://vocabulary.samvera.org/ns#permissions
+  updated_at:
+    predicate: http://vocabulary.samvera.org/ns#updatedAt
+  agent:
+    predicate: http://www.w3.org/ns/auth/acl#agent
+  mode:
+    predicate: http://www.w3.org/ns/auth/acl#mode
+  file_ids:
+    predicate: http://pcdm.org/models#hasFile

--- a/config/metadata/hyrax_internal_metadata.yaml
+++ b/config/metadata/hyrax_internal_metadata.yaml
@@ -1,56 +1,57 @@
 ---
+# This internal metadata config is used to define predicates for hyrax internals only
 attributes:
-  admin_set_id: 
+  access_to:
+    predicate: http://www.w3.org/ns/auth/acl#accessTo
+  admin_set_id:
     predicate: http://purl.org/dc/terms/isPartOf
-  id:
-    predicate: http://purl.org/dc/terms/id
-  internal_resource:
-    predicate: info:fedora/fedora-system:def/model#hasModel
-  representative_id:
-    predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedMediaFragment
-  state:
-    predicate: http://fedora.info/definitions/1/0/access/ObjState#objState
-  thumbnail_id:
-    predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedImage
-  created_at: 
-    predicate: http://purl.org/dc/terms/created
+  agent:
+    predicate: http://www.w3.org/ns/auth/acl#agent
   byte_order:
     predicate: http://sweet.jpl.nasa.gov/2.2/reprDataFormat.owl#byteOrder
   color_space:
     predicate: http://www.w3.org/2003/12/exif/ns#colorSpace
   compression:
     predicate: http://vocabulary.samvera.org/ns#compressionScheme
+  created_at:
+    predicate: http://purl.org/dc/terms/created
   file_identifier:
     predicate: http://vocabulary.samvera.org/ns#fileIdentifier
+  file_ids:
+    predicate: http://pcdm.org/models#hasFile
   file_set_id:
     predicate: http://vocabulary.samvera.org/ns#fileSetId
   format_label:
     predicate: http://www.loc.gov/premis/rdf/v1#hasFormatName
-  height: 
+  height:
     predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#height
+  id:
+    predicate: http://purl.org/dc/terms/id
+  internal_resource:
+    predicate: info:fedora/fedora-system:def/model#hasModel
   mime_type:
     predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMimeType
+  mode:
+    predicate: http://www.w3.org/ns/auth/acl#mode
   original_filename:
     predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#filename
   pcdm_use:
     predicate: http://vocabulary.samvera.org/ns#pcdmUse
+  permissions:
+    predicate: http://vocabulary.samvera.org/ns#permissions
   recorded_size:
     predicate: http://www.loc.gov/premis/rdf/v1#hasSize
+  representative_id:
+    predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedMediaFragment
+  state:
+    predicate: http://fedora.info/definitions/1/0/access/ObjState#objState
+  thumbnail_id:
+    predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedImage
+  updated_at:
+    predicate: http://vocabulary.samvera.org/ns#updatedAt
   valid:
     predicate: http://vocabulary.samvera.org/ns#valid
   well_formed:
     predicate: http://vocabulary.samvera.org/ns#wellFormed
   width:
     predicate: http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#width
-  access_to:
-    predicate: http://www.w3.org/ns/auth/acl#accessTo
-  permissions:
-    predicate: http://vocabulary.samvera.org/ns#permissions
-  updated_at:
-    predicate: http://vocabulary.samvera.org/ns#updatedAt
-  agent:
-    predicate: http://www.w3.org/ns/auth/acl#agent
-  mode:
-    predicate: http://www.w3.org/ns/auth/acl#mode
-  file_ids:
-    predicate: http://pcdm.org/models#hasFile

--- a/lib/generators/hyrax/collection_resource/templates/collection_metadata.yaml
+++ b/lib/generators/hyrax/collection_resource/templates/collection_metadata.yaml
@@ -2,6 +2,8 @@
 # index key names, and form properties.
 #
 # Attributes must have a type but all other configuration options are optional.
+# Please note: If using Valkyrie's Fedora Metadata Adapter, predicates for attributes
+# must be placed here.
 #
 # attributes:
 #   attribute_name:

--- a/lib/generators/hyrax/work_resource/templates/metadata.yaml
+++ b/lib/generators/hyrax/work_resource/templates/metadata.yaml
@@ -2,6 +2,8 @@
 # index key names, and form properties.
 #
 # Attributes must have a type but all other configuration options are optional.
+# Please note: If using Valkyrie's Fedora Metadata Adapter, predicates for attributes
+# must be placed here.
 #
 # attributes:
 #   attribute_name:

--- a/spec/services/hyrax/simple_schema_loader_spec.rb
+++ b/spec/services/hyrax/simple_schema_loader_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Hyrax::SimpleSchemaLoader do
       expect(permissive_schema.size).to eq(38)
       expect(permissive_schema.values.all? { |v| v.is_a? RDF::URI }).to be_truthy
       expect(permissive_schema.values.all? { |v| v.value.present? }).to be_truthy
-      expect(permissive_schema['sample_attribute'].value).to eq("http://hyrax-example.com/sample_attribute")
+      expect(permissive_schema[:sample_attribute].value).to eq("http://hyrax-example.com/sample_attribute")
     end
   end
 end

--- a/spec/services/hyrax/simple_schema_loader_spec.rb
+++ b/spec/services/hyrax/simple_schema_loader_spec.rb
@@ -37,4 +37,15 @@ RSpec.describe Hyrax::SimpleSchemaLoader do
         .to eq(title: { required: true, primary: true, multiple: true })
     end
   end
+
+  describe '#permissive_schema_for_valkrie_adapter' do
+    let(:permissive_schema) { schema_loader.permissive_schema_for_valkrie_adapter }
+
+    it 'provides the expected hash' do
+      expect(permissive_schema.size).to eq(38)
+      expect(permissive_schema.values.all? { |v| v.is_a? RDF::URI }).to be_truthy
+      expect(permissive_schema.values.all? { |v| v.value.present? }).to be_truthy
+      expect(permissive_schema['sample_attribute'].value).to eq("http://hyrax-example.com/sample_attribute")
+    end
+  end
 end

--- a/spec/services/hyrax/simple_schema_loader_spec.rb
+++ b/spec/services/hyrax/simple_schema_loader_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Hyrax::SimpleSchemaLoader do
     let(:permissive_schema) { schema_loader.permissive_schema_for_valkrie_adapter }
 
     it 'provides the expected hash' do
-      expect(permissive_schema.size).to eq(38)
+      expect(permissive_schema.size).to eq(65)
       expect(permissive_schema.values.all? { |v| v.is_a? RDF::URI }).to be_truthy
       expect(permissive_schema.values.all? { |v| v.value.present? }).to be_truthy
       expect(permissive_schema[:sample_attribute].value).to eq("http://hyrax-example.com/sample_attribute")


### PR DESCRIPTION
### Fixes

Fixes #6332 

### Summary

Processes predicates from metadata YAMLs for permissive schema.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Bring sirenia docker container online (`docker compose -f docker-compose-sirenia.yml up`)
* Create a Monograph object in the UI (`localhost:3002`).
* Open the Fedora UI and find the Monograph object (id will match the show page's path end).
* Click the object and ensure that the predicates to the left of the fields `creator`, `dateSubmitted`, `modified`, and `title` all contain the letters "dc".

### Type of change (for release notes)

`notes-valkyrie` Valkyrie Progress

### Detailed Description

Our Basic and Core Metadata terms didn't have their predicates carry over when we transitioned to Valkyrie from ActiveFedora. This code implements the assigning of predicates in the Metadata YAMLs and logic to build the permissive schema required to pass to the Fedora adapter.

### Changes proposed in this pull request:
* *.yaml: adds the legacy predicates to core and basic metadata attributes, as well as inserts fictitious predicates to those objects that are only used for examples. Helpful comments instructing users to only create attributes in these YAMLs have also been added.
* .koppie/config/initializers/1_valkyrie.rb: uses the new `Hyrax::SimpleSchemaLoader` method to populate a schema hash for the Fedora Valkyrie adapter.
* app/services/hyrax/simple_schema_loader.rb: creates a schema delivery method and two supporting private methods that assist with its construction.
* spec/services/hyrax/simple_schema_loader_spec.rb: tests the intended functionality of the schema method.

@samvera/hyrax-code-reviewers
