### PR TITLE
Upgrade Valkyrie to 3.1.1

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -82,7 +82,7 @@ SUMMARY
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 5.10'
-  spec.add_dependency 'valkyrie', '~> 3.1.0'
+  spec.add_dependency 'valkyrie', '~> 3.1.1'
   spec.add_dependency 'view_component', '~> 2.74.1' # Pin until blacklight is updated with workaround for https://github.com/ViewComponent/view_component/issues/1565
   spec.add_dependency 'sprockets', '~> 3.7'
   spec.add_dependency 'sass-rails', '~> 6.0'


### PR DESCRIPTION
### Fixes

Fixes #6337 

### Summary

Hyrax permissions are broken on Fedora 6 due to the attribute `:mode` of `Hyrax::Permission` not getting preserved properly through the older Valkyrie Fedora adapter. `:mode` is passed to the Valkyrie Fedora adapter as a `Symbol`, and versions of Valkyrie prior to `3.1.1` do not handle preserving `Symbol` values properly for Fedora.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:

* Running locally with Valkyrie/Fedora, log in to dashboard as admin user
* Create a new Generic Work
* Add required metadata and a file
* Select Public as Visibility and save
* Work will save and visibility will be set to Private

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

I submitted a [PR](https://github.com/samvera/valkyrie/pull/937) to Valkyrie to convert `Symbol` values to `String` when preserving them through the Fedora adapter. This ensure the `:mode` attribute of `Hyrax::Permission`, which is of type `Valkyrie::Types::Coercible::Symbol`, is preserved correctly on Fedora. The latest version of Valkyrie, 3.1.1, includes changes in that PR.

### Changes proposed in this pull request:
* Upgrade Valkyrie to 3.1.1

@samvera/hyrax-code-reviewers
