### PR TITLE
Fix lease/embargo controller and specs in koppie

### DIFF
--- a/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/embargoes_controller_behavior.rb
@@ -31,7 +31,13 @@ module Hyrax
       filter_docs_with_edit_access!
       copy_visibility = []
       copy_visibility = params[:embargoes].values.map { |h| h[:copy_visibility] } if params[:embargoes]
-      resources = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: Hyrax.config.use_valkyrie?)
+
+      resources = if Hyrax.config.use_valkyrie?
+                    Hyrax.query_service.find_many_by_ids(ids: batch)
+                  else
+                    Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
+                  end
+
       resources.each do |resource|
         if Hyrax.config.use_valkyrie?
           EmbargoManager.new(resource: resource).release!

--- a/app/controllers/concerns/hyrax/leases_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/leases_controller_behavior.rb
@@ -29,7 +29,13 @@ module Hyrax
       filter_docs_with_edit_access!
       copy_visibility = []
       copy_visibility = params[:leases].values.map { |h| h[:copy_visibility] } if params[:leases]
-      resources = Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: Hyrax.config.use_valkyrie?)
+
+      resources = if Hyrax.config.use_valkyrie?
+                    Hyrax.query_service.find_many_by_ids(ids: batch)
+                  else
+                    Hyrax.custom_queries.find_many_by_alternate_ids(alternate_ids: batch, use_valkyrie: false)
+                  end
+
       resources.each do |resource|
         if Hyrax.config.use_valkyrie?
           LeaseManager.new(resource: resource).release!

--- a/spec/controllers/hyrax/embargoes_controller_spec.rb
+++ b/spec/controllers/hyrax/embargoes_controller_spec.rb
@@ -1,150 +1,279 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::EmbargoesController do
-  let(:user) { create(:user) }
-  let(:a_work) { create(:generic_work, user: user) }
-  let(:not_my_work) { create(:generic_work) }
-  before { sign_in user }
+  context 'with ActiveFedora', :active_fedora do
+    let(:user) { create(:user) }
+    let(:a_work) { create(:generic_work, user: user) }
+    let(:not_my_work) { create(:generic_work) }
+    before { sign_in user }
 
-  describe '#index' do
-    context 'when I am NOT a repository manager' do
-      it 'redirects' do
-        get :index
-        expect(response).to redirect_to root_path
+    describe '#index' do
+      context 'when I am NOT a repository manager' do
+        it 'redirects' do
+          get :index
+          expect(response).to redirect_to root_path
+        end
       end
-    end
-    context 'when I am a repository manager' do
-      let(:user) { create(:user, groups: ['admin']) }
+      context 'when I am a repository manager' do
+        let(:user) { create(:user, groups: ['admin']) }
 
-      it 'shows me the page' do
-        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
-        expect(controller).to receive(:add_breadcrumb).with('Manage Embargoes', embargoes_path)
-        get :index
-        expect(response).to be_successful
-        expect(response).to render_template('dashboard')
-      end
-    end
-  end
-
-  describe '#edit' do
-    context 'when I do not have edit permissions for the object' do
-      it 'redirects' do
-        get :edit, params: { id: not_my_work }
-        expect(response.status).to eq 302
-        expect(flash[:alert]).to eq 'You are not authorized to access this page.'
-      end
-    end
-    context 'when I have permission to edit the object' do
-      it 'shows me the page' do
-        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
-        expect(controller).to receive(:add_breadcrumb).with('Manage Embargoes', embargoes_path)
-        expect(controller).to receive(:add_breadcrumb).with('Update Embargo', '#')
-        get :edit, params: { id: a_work }
-        expect(response).to be_successful
-        expect(response).to render_template('dashboard')
-      end
-    end
-  end
-
-  describe '#destroy' do
-    context 'when I do not have edit permissions for the object' do
-      it 'denies access' do
-        get :destroy, params: { id: not_my_work }
-        expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
+        it 'shows me the page' do
+          expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Manage Embargoes', embargoes_path)
+          get :index
+          expect(response).to be_successful
+          expect(response).to render_template('dashboard')
+        end
       end
     end
 
-    context 'when I have permission to edit the object' do
-      context 'that has no files' do
-        it 'deactivates embargo and redirects' do
-          get :destroy, params: { id: a_work }
-          expect(response).to redirect_to edit_embargo_path(a_work)
+    describe '#edit' do
+      context 'when I do not have edit permissions for the object' do
+        it 'redirects' do
+          get :edit, params: { id: not_my_work }
+          expect(response.status).to eq 302
+          expect(flash[:alert]).to eq 'You are not authorized to access this page.'
+        end
+      end
+      context 'when I have permission to edit the object' do
+        it 'shows me the page' do
+          expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Manage Embargoes', embargoes_path)
+          expect(controller).to receive(:add_breadcrumb).with('Update Embargo', '#')
+          get :edit, params: { id: a_work }
+          expect(response).to be_successful
+          expect(response).to render_template('dashboard')
+        end
+      end
+    end
+
+    describe '#destroy' do
+      context 'when I do not have edit permissions for the object' do
+        it 'denies access' do
+          get :destroy, params: { id: not_my_work }
+          expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
         end
       end
 
-      context 'that has files' do
+      context 'when I have permission to edit the object' do
+        context 'that has no files' do
+          it 'deactivates embargo and redirects' do
+            get :destroy, params: { id: a_work }
+            expect(response).to redirect_to edit_embargo_path(a_work)
+          end
+        end
+
+        context 'that has files' do
+          before do
+            a_work.members << create(:file_set)
+            a_work.save!
+          end
+
+          it 'deactivates embargo and checks to see if we want to copy the visibility to files' do
+            get :destroy, params: { id: a_work }
+            expect(response).to redirect_to confirm_permission_path(a_work)
+          end
+        end
+      end
+    end
+
+    describe '#update' do
+      context 'when I have permission to edit the object' do
+        let(:file_set) { create(:file_set, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+        let(:release_date) { Time.zone.today + 2 }
+
         before do
-          a_work.members << create(:file_set)
-          a_work.save!
+          a_work.members << file_set
+          a_work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          a_work.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          a_work.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          a_work.embargo_release_date = release_date.to_s
+          a_work.embargo.save(validate: false)
+          a_work.save(validate: false)
         end
 
-        it 'deactivates embargo and checks to see if we want to copy the visibility to files' do
-          get :destroy, params: { id: a_work }
-          expect(response).to redirect_to confirm_permission_path(a_work)
+        context 'with an expired embargo' do
+          let(:release_date) { Time.zone.today - 2 }
+
+          it 'deactivates embargo, do not update the file set visibility, and redirect' do
+            patch :update, params: { batch_document_ids: [a_work.id], embargoes: {} }
+            expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            expect(response).to redirect_to embargoes_path
+            expect(flash[:notice]).to be_present
+          end
+        end
+
+        context 'with an expired embargo' do
+          let(:release_date) { Time.zone.today - 2 }
+
+          it 'deactivates embargo, update the visibility and redirect' do
+            patch :update, params: { batch_document_ids: [a_work.id], embargoes: { '0' => { copy_visibility: a_work.id } } }
+            expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            expect(response).to redirect_to embargoes_path
+            expect(flash[:notice]).to be_present
+          end
+        end
+
+        context 'with an expired embargo and filesets in batch_document_ids and in embargoes' do
+          let(:file_set2) { create(:file_set, id: 'fileset_2', visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+          let(:file_set3) { create(:file_set, id: 'fileset_3', visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+          let(:release_date) { Time.zone.today - 2 }
+          let(:batch) { [file_set2.id, a_work.id] }
+          before do
+            file_set2.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            file_set2.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            file_set2.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            file_set2.embargo_release_date = release_date.to_s
+            file_set2.embargo.save(validate: false)
+            file_set2.save(validate: false)
+            file_set3.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            file_set3.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            file_set3.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            file_set3.embargo_release_date = release_date.to_s
+            file_set3.embargo.save(validate: false)
+            file_set3.save(validate: false)
+          end
+
+          it 'deactivates embargo, updates the visibility and redirects' do
+            allow(controller).to receive(:filter_docs_with_edit_access!).and_return(true)
+            patch :update, params: { batch_document_ids: batch, embargoes: { '0' => { copy_visibility: file_set2.id }, '1' => { copy_visibility: a_work.id } } }
+            expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            expect(file_set2.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            expect(file_set3.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            expect(response).to redirect_to embargoes_path
+            expect(flash[:notice]).to be_present
+          end
         end
       end
     end
   end
 
-  describe '#update' do
-    context 'when I have permission to edit the object' do
-      let(:file_set) { create(:file_set, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
-      let(:release_date) { Time.zone.today + 2 }
+  context 'with Valkyrie' do
+    let(:user) { create(:user) }
+    let(:not_my_work) { valkyrie_create(:hyrax_work) }
+    let(:a_work) do
+      valkyrie_create(:hyrax_work,
+                      edit_users: [user], members: [a_file_set], embargo: an_embargo,
+                      visibility_setting: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
+    end
+    let(:a_file_set) { valkyrie_create(:hyrax_file_set, :public) }
+    let(:release_date) { Time.zone.today + 2 }
+    let(:an_embargo) { valkyrie_create(:hyrax_embargo, embargo_release_date: release_date) }
 
-      before do
-        a_work.members << file_set
-        a_work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-        a_work.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-        a_work.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-        a_work.embargo_release_date = release_date.to_s
-        a_work.embargo.save(validate: false)
-        a_work.save(validate: false)
+    before { sign_in user }
+
+    describe '#index' do
+      context 'when I am NOT a repository manager' do
+        it 'redirects' do
+          get :index
+          expect(response).to redirect_to root_path
+        end
       end
+      context 'when I am a repository manager' do
+        let(:user) { create(:admin) }
 
-      context 'with an expired embargo' do
-        let(:release_date) { Time.zone.today - 2 }
+        it 'shows me the page' do
+          expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Manage Embargoes', embargoes_path)
+          get :index
+          expect(response).to be_successful
+          expect(response).to render_template('dashboard')
+        end
+      end
+    end
 
-        it 'deactivates embargo, do not update the file set visibility, and redirect' do
-          patch :update, params: { batch_document_ids: [a_work.id], embargoes: {} }
-          expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-          expect(response).to redirect_to embargoes_path
-          expect(flash[:notice]).to be_present
+    describe '#edit' do
+      context 'when I do not have edit permissions for the object' do
+        it 'redirects' do
+          get :edit, params: { id: not_my_work }
+          expect(response.status).to eq 302
+          expect(flash[:alert]).to eq 'You are not authorized to access this page.'
+        end
+      end
+      context 'when I have permission to edit the object' do
+        it 'shows me the page' do
+          expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Manage Embargoes', embargoes_path)
+          expect(controller).to receive(:add_breadcrumb).with('Update Embargo', '#')
+          get :edit, params: { id: a_work }
+          expect(response).to be_successful
+          expect(response).to render_template('dashboard')
+        end
+      end
+    end
+
+    describe '#destroy' do
+      context 'when I do not have edit permissions for the object' do
+        it 'denies access' do
+          get :destroy, params: { id: not_my_work }
+          expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
         end
       end
 
-      context 'with an expired embargo' do
-        let(:release_date) { Time.zone.today - 2 }
+      context 'when I have permission to edit the object' do
+        context 'that has no files' do
+          let(:a_file_set) { nil }
 
-        it 'deactivates embargo, update the visibility and redirect' do
-          patch :update, params: { batch_document_ids: [a_work.id], embargoes: { '0' => { copy_visibility: a_work.id } } }
-          expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-          expect(response).to redirect_to embargoes_path
-          expect(flash[:notice]).to be_present
+          it 'deactivates embargo and redirects' do
+            get :destroy, params: { id: a_work }
+            expect(response).to redirect_to edit_embargo_path(a_work)
+          end
+        end
+
+        context 'that has files' do
+          it 'deactivates embargo and checks to see if we want to copy the visibility to files' do
+            get :destroy, params: { id: a_work }
+            expect(response).to redirect_to confirm_permission_path(a_work)
+          end
         end
       end
+    end
 
-      context 'with an expired embargo and filesets in batch_document_ids and in embargoes' do
-        let(:file_set2) { create(:file_set, id: 'fileset_2', visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
-        let(:file_set3) { create(:file_set, id: 'fileset_3', visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
-        let(:release_date) { Time.zone.today - 2 }
-        let(:batch) { [file_set2.id, a_work.id] }
-        before do
-          file_set2.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-          file_set2.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-          file_set2.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-          file_set2.embargo_release_date = release_date.to_s
-          file_set2.embargo.save(validate: false)
-          file_set2.save(validate: false)
-          file_set3.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-          file_set3.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-          file_set3.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-          file_set3.embargo_release_date = release_date.to_s
-          file_set3.embargo.save(validate: false)
-          file_set3.save(validate: false)
-        end
+    describe '#update' do
+      context 'when I have permission to edit the object' do
+        let(:a_file_set) { valkyrie_create(:hyrax_file_set, :authenticated) }
 
-        it 'deactivates embargo, updates the visibility and redirects' do
-          allow(controller).to receive(:filter_docs_with_edit_access!).and_return(true)
-          patch :update, params: { batch_document_ids: batch, embargoes: { '0' => { copy_visibility: file_set2.id }, '1' => { copy_visibility: a_work.id } } }
-          expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-          expect(file_set2.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-          expect(file_set3.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-          expect(response).to redirect_to embargoes_path
-          expect(flash[:notice]).to be_present
+        context 'with an expired embargo' do
+          let(:release_date) { Time.zone.today - 2 }
+
+          it 'deactivates embargo, do not update the file set visibility, and redirect' do
+            patch :update, params: { batch_document_ids: [a_work.id], embargoes: {} }
+            expect(Hyrax.query_service.find_by(id: a_work.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            expect(Hyrax.query_service.find_by(id: a_file_set.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            expect(response).to redirect_to embargoes_path
+            expect(flash[:notice]).to be_present
+          end
+
+          it 'deactivates embargo, update the visibility and redirect' do
+            patch :update, params: { batch_document_ids: [a_work.id], embargoes: { '0' => { copy_visibility: a_work.id } } }
+            expect(Hyrax.query_service.find_by(id: a_work.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            expect(Hyrax.query_service.find_by(id: a_file_set.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            expect(response).to redirect_to embargoes_path
+            expect(flash[:notice]).to be_present
+          end
+
+          context 'with filesets in batch_document_ids and in embargoes' do
+            let(:a_2nd_file_set) { valkyrie_create(:hyrax_file_set, :authenticated, embargo: valkyrie_create(:hyrax_embargo, embargo_release_date: release_date)) }
+            let(:a_3rd_file_set) { valkyrie_create(:hyrax_file_set, :authenticated, embargo: valkyrie_create(:hyrax_embargo, embargo_release_date: release_date)) }
+            let(:batch) { [a_2nd_file_set.id, a_work.id] }
+
+            it 'deactivates embargo, updates the visibility and redirects' do
+              allow(controller).to receive(:filter_docs_with_edit_access!).and_return(true)
+              patch :update, params: { batch_document_ids: batch, embargoes: { '0' => { copy_visibility: a_2nd_file_set.id }, '1' => { copy_visibility: a_work.id } } }
+              expect(Hyrax.query_service.find_by(id: a_work.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+              expect(Hyrax.query_service.find_by(id: a_file_set.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+              expect(Hyrax.query_service.find_by(id: a_2nd_file_set.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+              expect(Hyrax.query_service.find_by(id: a_3rd_file_set.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+              expect(response).to redirect_to embargoes_path
+              expect(flash[:notice]).to be_present
+            end
+          end
         end
       end
     end

--- a/spec/controllers/hyrax/leases_controller_spec.rb
+++ b/spec/controllers/hyrax/leases_controller_spec.rb
@@ -1,119 +1,229 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::LeasesController do
-  let(:user) { create(:user) }
-  let(:a_work) { create(:generic_work, user: user) }
-  let(:not_my_work) { create(:generic_work) }
+  context 'with ActiveFedora', :active_fedora do
+    let(:user) { create(:user) }
+    let(:a_work) { create(:generic_work, user: user) }
+    let(:not_my_work) { create(:generic_work) }
 
-  before { sign_in user }
+    before { sign_in user }
 
-  describe '#index' do
-    context 'when I am NOT a repository manager' do
-      it 'redirects' do
-        get :index
-        expect(response).to redirect_to root_path
+    describe '#index' do
+      context 'when I am NOT a repository manager' do
+        it 'redirects' do
+          get :index
+          expect(response).to redirect_to root_path
+        end
       end
-    end
-    context 'when I am a repository manager' do
-      let(:user) { create(:user, groups: ['admin']) }
+      context 'when I am a repository manager' do
+        let(:user) { create(:user, groups: ['admin']) }
 
-      it 'shows me the page' do
-        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
-        expect(controller).to receive(:add_breadcrumb).with('Manage Leases', leases_path)
+        it 'shows me the page' do
+          expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Manage Leases', leases_path)
 
-        get :index
-        expect(response).to be_successful
-        expect(response).to render_template('dashboard')
-      end
-    end
-  end
-
-  describe '#edit' do
-    context 'when I do not have edit permissions for the object' do
-      it 'redirects' do
-        get :edit, params: { id: not_my_work }
-        expect(response.status).to eq 302
-        expect(flash[:alert]).to eq 'You are not authorized to access this page.'
-      end
-    end
-    context 'when I have permission to edit the object' do
-      it 'shows me the page' do
-        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
-        expect(controller).to receive(:add_breadcrumb).with('Manage Leases', leases_path)
-        expect(controller).to receive(:add_breadcrumb).with('Update Lease', '#')
-
-        get :edit, params: { id: a_work }
-        expect(response).to be_successful
-        expect(response).to render_template('dashboard')
-      end
-    end
-  end
-
-  describe '#destroy' do
-    context 'when I do not have edit permissions for the object' do
-      it 'denies access' do
-        get :destroy, params: { id: not_my_work }
-        expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
+          get :index
+          expect(response).to be_successful
+          expect(response).to render_template('dashboard')
+        end
       end
     end
 
-    context 'when I have permission to edit the object' do
-      context 'that has no files' do
-        it 'deactivates the lease and redirects' do
-          get :destroy, params: { id: a_work }
-          expect(response).to redirect_to edit_lease_path(a_work)
+    describe '#edit' do
+      context 'when I do not have edit permissions for the object' do
+        it 'redirects' do
+          get :edit, params: { id: not_my_work }
+          expect(response.status).to eq 302
+          expect(flash[:alert]).to eq 'You are not authorized to access this page.'
+        end
+      end
+      context 'when I have permission to edit the object' do
+        it 'shows me the page' do
+          expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Manage Leases', leases_path)
+          expect(controller).to receive(:add_breadcrumb).with('Update Lease', '#')
+
+          get :edit, params: { id: a_work }
+          expect(response).to be_successful
+          expect(response).to render_template('dashboard')
+        end
+      end
+    end
+
+    describe '#destroy' do
+      context 'when I do not have edit permissions for the object' do
+        it 'denies access' do
+          get :destroy, params: { id: not_my_work }
+          expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
         end
       end
 
-      context 'with files' do
+      context 'when I have permission to edit the object' do
+        context 'that has no files' do
+          it 'deactivates the lease and redirects' do
+            get :destroy, params: { id: a_work }
+            expect(response).to redirect_to edit_lease_path(a_work)
+          end
+        end
+
+        context 'with files' do
+          before do
+            a_work.members << create(:file_set)
+            a_work.save!
+          end
+
+          it 'deactivates the lease and redirects' do
+            get :destroy, params: { id: a_work }
+            expect(response).to redirect_to confirm_permission_path(a_work)
+          end
+        end
+      end
+    end
+
+    describe '#update' do
+      context 'when I have permission to edit the object' do
+        let(:file_set) { create(:file_set, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+        let(:expiration_date) { Time.zone.today + 2 }
+
         before do
-          a_work.members << create(:file_set)
-          a_work.save!
+          a_work.members << file_set
+          a_work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          a_work.visibility_during_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          a_work.visibility_after_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          a_work.lease_expiration_date = expiration_date.to_s
+          a_work.lease.save(validate: false)
+          a_work.save(validate: false)
         end
 
-        it 'deactivates the lease and redirects' do
-          get :destroy, params: { id: a_work }
-          expect(response).to redirect_to confirm_permission_path(a_work)
+        context 'with an expired lease' do
+          let(:expiration_date) { Time.zone.today - 2 }
+
+          it 'deactivates lease, do not update the visibility, and redirect' do
+            patch :update, params: { batch_document_ids: [a_work.id], leases: {} }
+            expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            expect(response).to redirect_to leases_path
+          end
+        end
+
+        context 'with an expired lease' do
+          let(:expiration_date) { Time.zone.today - 2 }
+
+          it 'deactivates lease, update the visibility and redirect' do
+            patch :update, params: { batch_document_ids: [a_work.id], leases: { '0' => { copy_visibility: a_work.id } } }
+            expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            expect(response).to redirect_to leases_path
+          end
         end
       end
     end
   end
 
-  describe '#update' do
-    context 'when I have permission to edit the object' do
-      let(:file_set) { create(:file_set, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
-      let(:expiration_date) { Time.zone.today + 2 }
+  context 'with Valkyrie' do
+    let(:user) { create(:user) }
+    let(:not_my_work) { valkyrie_create(:hyrax_work) }
+    let(:a_work) do
+      valkyrie_create(:hyrax_work,
+                      edit_users: [user], members: [a_file_set], lease: a_lease,
+                      visibility_setting: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
+    end
+    let(:a_file_set) { valkyrie_create(:hyrax_file_set, :public) }
+    let(:expiration_date) { Time.zone.today + 2 }
+    let(:a_lease) { valkyrie_create(:hyrax_lease, lease_expiration_date: expiration_date) }
 
-      before do
-        a_work.members << file_set
-        a_work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-        a_work.visibility_during_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-        a_work.visibility_after_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-        a_work.lease_expiration_date = expiration_date.to_s
-        a_work.lease.save(validate: false)
-        a_work.save(validate: false)
+    before { sign_in user }
+
+    describe '#index' do
+      context 'when I am NOT a repository manager' do
+        it 'redirects' do
+          get :index
+          expect(response).to redirect_to root_path
+        end
       end
+      context 'when I am a repository manager' do
+        let(:user) { create(:admin) }
 
-      context 'with an expired lease' do
-        let(:expiration_date) { Time.zone.today - 2 }
+        it 'shows me the page' do
+          expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Manage Leases', leases_path)
 
-        it 'deactivates lease, do not update the visibility, and redirect' do
-          patch :update, params: { batch_document_ids: [a_work.id], leases: {} }
-          expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-          expect(response).to redirect_to leases_path
+          get :index
+          expect(response).to be_successful
+          expect(response).to render_template('dashboard')
+        end
+      end
+    end
+
+    describe '#edit' do
+      context 'when I do not have edit permissions for the object' do
+        it 'redirects' do
+          get :edit, params: { id: not_my_work }
+          expect(response.status).to eq 302
+          expect(flash[:alert]).to eq 'You are not authorized to access this page.'
+        end
+      end
+      context 'when I have permission to edit the object' do
+        it 'shows me the page' do
+          expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Manage Leases', leases_path)
+          expect(controller).to receive(:add_breadcrumb).with('Update Lease', '#')
+
+          get :edit, params: { id: a_work }
+          expect(response).to be_successful
+          expect(response).to render_template('dashboard')
+        end
+      end
+    end
+
+    describe '#destroy' do
+      context 'when I do not have edit permissions for the object' do
+        it 'denies access' do
+          get :destroy, params: { id: not_my_work }
+          expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
         end
       end
 
-      context 'with an expired lease' do
-        let(:expiration_date) { Time.zone.today - 2 }
+      context 'when I have permission to edit the object' do
+        context 'that has no files' do
+          let(:a_file_set) { nil }
 
-        it 'deactivates lease, update the visibility and redirect' do
-          patch :update, params: { batch_document_ids: [a_work.id], leases: { '0' => { copy_visibility: a_work.id } } }
-          expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-          expect(response).to redirect_to leases_path
+          it 'deactivates the lease and redirects' do
+            get :destroy, params: { id: a_work }
+            expect(response).to redirect_to edit_lease_path(a_work)
+          end
+        end
+
+        context 'with files' do
+          it 'deactivates the lease and redirects' do
+            get :destroy, params: { id: a_work }
+            expect(response).to redirect_to confirm_permission_path(a_work)
+          end
+        end
+      end
+    end
+
+    describe '#update' do
+      context 'when I have permission to edit the object' do
+        context 'with an expired lease' do
+          let(:expiration_date) { Time.zone.today - 2 }
+
+          it 'deactivates lease, do not update the visibility, and redirect' do
+            patch :update, params: { batch_document_ids: [a_work.id], leases: {} }
+            expect(Hyrax.query_service.find_by(id: a_work.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            expect(Hyrax.query_service.find_by(id: a_file_set.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            expect(response).to redirect_to leases_path
+          end
+
+          it 'deactivates lease, update the visibility and redirect' do
+            patch :update, params: { batch_document_ids: [a_work.id], leases: { '0' => { copy_visibility: a_work.id } } }
+            expect(Hyrax.query_service.find_by(id: a_work.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            expect(Hyrax.query_service.find_by(id: a_file_set.id).visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            expect(response).to redirect_to leases_path
+          end
         end
       end
     end

--- a/spec/factories/hyrax_file_set.rb
+++ b/spec/factories/hyrax_file_set.rb
@@ -54,6 +54,12 @@ FactoryBot.define do
       end
     end
 
+    trait :authenticated do
+      transient do
+        visibility_setting { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+      end
+    end
+
     trait :with_files do
       transient do
         files { [valkyrie_create(:hyrax_file_metadata), valkyrie_create(:hyrax_file_metadata)] }

--- a/spec/factories/hyrax_file_set.rb
+++ b/spec/factories/hyrax_file_set.rb
@@ -25,10 +25,10 @@ FactoryBot.define do
       end
       file_set.file_ids = evaluator.files.map(&:id) if evaluator.files
 
-      file_set.permission_manager.edit_groups = evaluator.edit_groups
-      file_set.permission_manager.edit_users  = evaluator.edit_users
-      file_set.permission_manager.read_users  = evaluator.read_users
-      file_set.permission_manager.read_groups = evaluator.read_groups
+      file_set.permission_manager.edit_groups = file_set.permission_manager.edit_groups.to_a + evaluator.edit_groups
+      file_set.permission_manager.edit_users  = file_set.permission_manager.edit_users.to_a + evaluator.edit_users
+      file_set.permission_manager.read_users  = file_set.permission_manager.read_users.to_a + evaluator.read_users
+      file_set.permission_manager.read_groups = file_set.permission_manager.read_groups.to_a + evaluator.read_groups
     end
 
     after(:create) do |file_set, evaluator|
@@ -38,10 +38,10 @@ FactoryBot.define do
         writer.permission_manager.acl.save
       end
 
-      file_set.permission_manager.edit_groups = evaluator.edit_groups
-      file_set.permission_manager.edit_users  = evaluator.edit_users
-      file_set.permission_manager.read_users  = evaluator.read_users
-      file_set.permission_manager.read_groups = evaluator.read_groups
+      file_set.permission_manager.edit_groups = file_set.permission_manager.edit_groups.to_a + evaluator.edit_groups
+      file_set.permission_manager.edit_users  = file_set.permission_manager.edit_users.to_a + evaluator.edit_users
+      file_set.permission_manager.read_users  = file_set.permission_manager.read_users.to_a + evaluator.read_users
+      file_set.permission_manager.read_groups = file_set.permission_manager.read_groups.to_a + evaluator.read_groups
 
       file_set.permission_manager.acl.save
 

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -35,6 +35,7 @@ FactoryBot.define do
       edit_users         { [] }
       edit_groups        { [] }
       read_users         { [] }
+      read_groups        { [] }
       members            { nil }
       visibility_setting { nil }
       with_index         { true }
@@ -48,9 +49,10 @@ FactoryBot.define do
           .assign_access_for(visibility: evaluator.visibility_setting)
       end
 
-      work.permission_manager.edit_groups = evaluator.edit_groups
-      work.permission_manager.edit_users  = evaluator.edit_users
-      work.permission_manager.read_users  = evaluator.read_users
+      work.permission_manager.edit_groups = work.permission_manager.edit_groups.to_a + evaluator.edit_groups
+      work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users
+      work.permission_manager.read_users  = work.permission_manager.read_users.to_a + evaluator.read_users
+      work.permission_manager.read_groups = work.permission_manager.read_groups.to_a + evaluator.read_groups
 
       work.member_ids = evaluator.members.map(&:id) if evaluator.members
     end
@@ -61,9 +63,10 @@ FactoryBot.define do
           .new(resource: work)
           .assign_access_for(visibility: evaluator.visibility_setting)
       end
-      work.permission_manager.edit_groups = evaluator.edit_groups
-      work.permission_manager.edit_users  = evaluator.edit_users
-      work.permission_manager.read_users  = evaluator.read_users
+      work.permission_manager.edit_groups = work.permission_manager.edit_groups.to_a + evaluator.edit_groups
+      work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users
+      work.permission_manager.read_users  = work.permission_manager.read_users.to_a + evaluator.read_users
+      work.permission_manager.read_groups = work.permission_manager.read_groups.to_a + evaluator.read_groups
 
       # these are both no-ops if an active embargo/lease isn't present
       Hyrax::EmbargoManager.new(resource: work).apply

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -54,7 +54,7 @@ FactoryBot.define do
       work.permission_manager.read_users  = work.permission_manager.read_users.to_a + evaluator.read_users
       work.permission_manager.read_groups = work.permission_manager.read_groups.to_a + evaluator.read_groups
 
-      work.member_ids = evaluator.members.map(&:id) if evaluator.members
+      work.member_ids = evaluator.members.compact.map(&:id) if evaluator.members
     end
 
     after(:create) do |work, evaluator|


### PR DESCRIPTION
### Fixes

Fixes #6290 

### Summary

Uses the non-custom query for embargoes and leases and make their specs work in koppie

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* See #6290 

### Changes proposed in this pull request:
* Uses the non-custom query for embargoes and leases 
* Mark AF specs in the embargo and lease controller specs
* Add Valkyrie specs in the embargo and lease controller specs
* Change hyrax work/file_set factory permissions to be additive to preserve visibility settings
* Compact nil members in hyrax work factory

@samvera/hyrax-code-reviewers
