### PR TITLE
Fix Valkyrie base view specs

### DIFF
--- a/app/views/hyrax/base/show.json.jbuilder
+++ b/app/views/hyrax/base/show.json.jbuilder
@@ -2,5 +2,6 @@
 @curation_concern = ::Wings::ActiveFedoraConverter.convert(resource: @curation_concern) if
   @curation_concern.is_a?(Hyrax::Resource) && Object.const_defined?("Wings")
 
-json.extract! @curation_concern, *[:id] + @curation_concern.class.fields.reject { |f| [:has_model].include? f }
+json.extract! @curation_concern, *@curation_concern.class.fields.reject { |f| [:has_model].include? f }
+json.id @curation_concern.id.to_s
 json.version @curation_concern.try(:etag)

--- a/lib/hyrax/resource_name.rb
+++ b/lib/hyrax/resource_name.rb
@@ -15,5 +15,9 @@ module Hyrax
       @route_key          = legacy_model.model_name.route_key
       @singular_route_key = legacy_model.model_name.singular_route_key
     end
+
+    def human
+      super.titleize
+    end
   end
 end

--- a/spec/hyrax/resource_name_spec.rb
+++ b/spec/hyrax/resource_name_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe Hyrax::ResourceName do
     expect(name.singular_route_key).to start_with 'hyrax_'
   end
 
-  context 'when a legacy resource is registered with Wings' do
+  it 'has a titleized human name' do
+    expect(name.human).to eq name.human.titleize
+  end
+
+  context 'when a legacy resource is registered with Wings', :active_fedora do
     let(:work_class) { Hyrax::Test::BookResource }
 
     it 'uses the legacy route key' do
@@ -21,6 +25,10 @@ RSpec.describe Hyrax::ResourceName do
 
     it 'uses the legacy singular route key' do
       expect(name.singular_route_key).to eq 'test_book'
+    end
+
+    it 'has a titleized human name' do
+      expect(name.human).to eq name.human.titleize
     end
   end
 end

--- a/spec/views/hyrax/base/_currently_shared.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_currently_shared.html.erb_spec.rb
@@ -2,33 +2,35 @@
 RSpec.describe 'hyrax/base/_currently_shared.html.erb', type: :view do
   let(:user) { stub_model(User) }
 
-  let(:work) do
-    stub_model(GenericWork, id: '456')
-  end
-
-  let(:file_set) do
-    stub_model(FileSet, id: '123',
-                        depositor: 'bob',
-                        resource_type: ['Dataset'], in_works: [work])
-  end
-
-  let(:file_set_form) do
-    view.simple_form_for(file_set, url: '/update') do |fs_form|
-      return fs_form
-    end
-  end
-
   before do
     allow(controller).to receive(:current_user).and_return(user)
     allow(work).to receive(:depositor).and_return(user)
   end
 
-  it "draws the permissions form without error" do
-    render partial: 'hyrax/base/currently_shared', locals: { f: file_set_form }
+  context 'with ActiveFedora', :active_fedora do
+    let(:work) do
+      stub_model(GenericWork, id: '456')
+    end
 
-    # actual testing of who gets what permission access is done in
-    # the EditPermissionsService (is it?!)
-    expect(rendered).to have_content("Depositor")
+    let(:file_set) do
+      stub_model(FileSet, id: '123',
+                          depositor: 'bob',
+                          resource_type: ['Dataset'], in_works: [work])
+    end
+
+    let(:file_set_form) do
+      view.simple_form_for(file_set, url: '/update') do |fs_form|
+        return fs_form
+      end
+    end
+
+    it "draws the permissions form without error" do
+      render partial: 'hyrax/base/currently_shared', locals: { f: file_set_form }
+
+      # actual testing of who gets what permission access is done in
+      # the EditPermissionsService (is it?!)
+      expect(rendered).to have_content("Depositor")
+    end
   end
 
   context "with ResourceForm", valkyrie_adapter: :test_adapter do

--- a/spec/views/hyrax/base/_form_files.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_files.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/base/_form_files.html.erb', type: :view do
   let(:model) { stub_model(GenericWork) }
-  let(:form) { Hyrax::GenericWorkForm.new(model, double, controller) }
+  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(model) : Hyrax::GenericWorkForm.new(model, double, controller) }
   let(:f) { double(object: form) }
 
   before do

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
   end
   let(:ability) { double }
   let(:work) { GenericWork.new }
-  let(:form) do
-    Hyrax::GenericWorkForm.new(work, ability, controller)
-  end
+  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
 
   let(:form_template) do
     %(

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
   let(:ability) { double }
   let(:user) { stub_model(User) }
   let(:form) do
-    Hyrax::GenericWorkForm.new(work, ability, controller)
+    Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(work).prepopulate! : Hyrax::GenericWorkForm.new(work, ability, controller)
   end
   let(:page) do
     view.simple_form_for form do |f|
@@ -116,7 +116,7 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
   context "when the work has been saved before" do
     before do
       # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
-      allow(work).to receive(:new_record?).and_return(false)
+      allow(work).to receive_messages(new_record?: false, new_record: false)
       assign(:form, form)
       allow(Hyrax.config).to receive(:active_deposit_agreement_acceptance)
         .and_return(true)
@@ -124,8 +124,12 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
 
     let(:work) { stub_model(GenericWork, id: '456', etag: '123456') }
 
-    it "renders the deposit agreement already checked and the version" do
+    it "renders the deposit agreement already checked" do
       expect(page).to have_selector("#agreement[checked]")
+    end
+
+    # Not applicable without wings; see Hyrax::Forms::ResourceForm::LockKeyPrepopulator
+    it 'renders the version', :active_fedora do
       expect(page).to have_selector("input#generic_work_version[value=\"123456\"]", visible: false)
     end
   end

--- a/spec/views/hyrax/base/_form_rendering.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_rendering.html.erb_spec.rb
@@ -2,9 +2,7 @@
 RSpec.describe 'hyrax/base/_form_rendering.html.erb', type: :view do
   let(:ability) { double }
   let(:work) { stub_model(GenericWork, new_record?: false) }
-  let(:form) do
-    Hyrax::GenericWorkForm.new(work, ability, controller)
-  end
+  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
 
   let(:page) do
     view.simple_form_for form do |f|

--- a/spec/views/hyrax/base/_form_share.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_share.erb_spec.rb
@@ -3,9 +3,7 @@ RSpec.describe 'hyrax/base/_form_share.html.erb', type: :view do
   let(:ability) { instance_double(Ability, admin?: false, user_groups: [], current_user: user) }
   let(:user) { stub_model(User) }
   let(:work) { GenericWork.new }
-  let(:form) do
-    Hyrax::GenericWorkForm.new(work, ability, controller)
-  end
+  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
   let(:form_template) do
     %(
       <%= simple_form_for [main_app, @form] do |f| %>

--- a/spec/views/hyrax/base/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/base/edit.html.erb_spec.rb
@@ -4,10 +4,7 @@ RSpec.describe 'hyrax/base/edit.html.erb', type: :view do
   let(:work) { stub_model(GenericWork, id: '456', title: ["A nice work"]) }
   let(:ability) { double }
   let(:controller_class) { Hyrax::GenericWorksController }
-
-  let(:form) do
-    Hyrax::GenericWorkForm.new(work, ability, controller)
-  end
+  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
 
   before do
     allow(view).to receive(:curation_concern).and_return(work)
@@ -19,7 +16,7 @@ RSpec.describe 'hyrax/base/edit.html.erb', type: :view do
   end
 
   it "sets a header and draws the form" do
-    expect(view).to receive(:provide).with(:page_title, 'A nice work // Generic Work [456] // Hyrax')
+    expect(view).to receive(:provide).with(:page_title, "A nice work // Generic Work [456] // #{I18n.t('hyrax.product_name')}")
     expect(view).to receive(:provide).with(:page_header).and_yield
     render
     expect(rendered).to eq "  <h1><span class=\"fa fa-edit\" aria-hidden=\"true\"></span>Edit Work</h1>\n\na form\n"
@@ -31,7 +28,7 @@ RSpec.describe 'hyrax/base/edit.html.erb', type: :view do
     let(:controller_class) { Hyrax::MonographsController }
 
     it "sets a header and draws the form" do
-      expect(view).to receive(:provide).with(:page_title, "comet in moominland // Simple work [#{work.id}] // Hyrax")
+      expect(view).to receive(:provide).with(:page_title, "comet in moominland // Simple Work [#{work.id}] // #{I18n.t('hyrax.product_name')}")
       expect(view).to receive(:provide).with(:page_header).and_yield
       render
       expect(rendered).to eq "  <h1><span class=\"fa fa-edit\" aria-hidden=\"true\"></span>Edit Work</h1>\n\na form\n"

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
   describe 'head tag page title' do
     it 'appears in head tags' do
       head_tag = Nokogiri::HTML(rendered).xpath("//head/title")
-      expect(head_tag.text).to eq("Work | My Title | ID: 999 | Hyrax")
+      expect(head_tag.text).to eq("Work | My Title | ID: 999 | #{I18n.t('hyrax.product_name')}")
     end
   end
 
@@ -193,7 +193,7 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
       expect(tag.attribute('content').value).to eq('@bot4lib')
 
       tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:site_name']")
-      expect(tag.attribute('content').value).to eq('Hyrax')
+      expect(tag.attribute('content').value).to eq(I18n.t('hyrax.product_name'))
 
       tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:type']")
       expect(tag.attribute('content').value).to eq('object')

--- a/spec/views/hyrax/base/show.json.jbuilder_spec.rb
+++ b/spec/views/hyrax/base/show.json.jbuilder_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'hyrax/base/show.json.jbuilder' do
 
   it "renders json of the curation_concern" do
     json = JSON.parse(rendered)
-    expect(json['id']).to eq curation_concern.id
+    expect(json['id']).to eq curation_concern.id.to_s
     expect(json['title']).to match_array curation_concern.title
     expected_fields = curation_concern.class.fields.reject { |f| [:has_model, :create_date].include? f }
     expected_fields << :date_created


### PR DESCRIPTION
### Fixes

Fixes #6307

### Summary
Fixes all failing koppie specs in spec/views/hyrax/base

### Changes proposed in this pull request:
* To match existing specs, resource model human names are now titleized
* The work id is explicitly converted to a string in case it was a Valkyrie::ID
*

@samvera/hyrax-code-reviewers
