### PR TITLE
Pass our ch12n config to the ch12n service and enable fits_servlet

### DIFF
--- a/.dassie/.env
+++ b/.dassie/.env
@@ -1,6 +1,7 @@
 ANALYTICS_START_DATE=2021-08-21
 BUNDLE_GEMFILE=Gemfile.dassie
 BUNDLE_PATH=/app/bundle
+CH12N_TOOL=fits_servlet
 CHROME_HEADLESS_MODE=false
 DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
 DATABASE_TEST_URL=postgresql://hyrax_user:hyrax_password@postgres/hyrax_test?pool=5

--- a/.koppie/.env
+++ b/.koppie/.env
@@ -1,5 +1,6 @@
 BUNDLE_GEMFILE=Gemfile.koppie
 BUNDLE_PATH=/app/bundle
+CH12N_TOOL=fits_servlet
 CHROME_HEADLESS_MODE=false
 DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
 DATABASE_TEST_URL=postgresql://hyrax_user:hyrax_password@postgres/hyrax_test?pool=5

--- a/app/services/hyrax/listeners/file_metadata_listener.rb
+++ b/app/services/hyrax/listeners/file_metadata_listener.rb
@@ -52,7 +52,7 @@ module Hyrax
 
         Hyrax.config
              .characterization_service
-             .run(metadata: event[:metadata], file: event[:metadata].file)
+             .run(metadata: event[:metadata], file: event[:metadata].file, **Hyrax.config.characterization_options)
       end
     end
   end


### PR DESCRIPTION
### Summary

Pass our ch12n config to the ch12n service and enable fits_servlet

refs #6160 

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Characterization is run using the fits_servlet service in koppie. 
* Observe the increased rate of file ingest.
*

@samvera/hyrax-code-reviewers
