### PR TITLE
Koppie: Short circuit specs loading of wings files

### DIFF
--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'wings/valkyrie/query_service'
 
 RSpec.describe Hyrax::Actors::FileActor, :active_fedora do

--- a/spec/actors/hyrax/actors/generic_work_actor_spec.rb
+++ b/spec/actors/hyrax/actors/generic_work_actor_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return unless defined? Hyrax::Actors::GenericWorkActor
+
 require 'redlock'
 require 'hyrax/specs/spy_listener'
 

--- a/spec/forms/hyrax/generic_work_form_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return unless defined? Hyrax::GenericWorkForm
+
 # TODO: this should be merged with work_form_spec.rb
 RSpec.describe Hyrax::GenericWorkForm do
   let(:work) { GenericWork.new }

--- a/spec/wings/active_fedora_converter_spec.rb
+++ b/spec/wings/active_fedora_converter_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'spec_helper'
 require 'wings'
 require 'wings/active_fedora_converter'

--- a/spec/wings/attribute_transformer_spec.rb
+++ b/spec/wings/attribute_transformer_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'wings/attribute_transformer'
 
 RSpec.describe Wings::AttributeTransformer, :active_fedora do

--- a/spec/wings/converter_value_mapper_spec.rb
+++ b/spec/wings/converter_value_mapper_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'spec_helper'
 require 'wings/converter_value_mapper'
 

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'wings_helper'
 require 'wings/hydra/works/services/add_file_to_file_set'
 

--- a/spec/wings/model_transformer_spec.rb
+++ b/spec/wings/model_transformer_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'wings_helper'
 require 'wings/model_transformer'
 

--- a/spec/wings/orm_converter_spec.rb
+++ b/spec/wings/orm_converter_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'wings_helper'
 require 'wings/orm_converter'
 

--- a/spec/wings/services/custom_queries/find_access_control_spec.rb
+++ b/spec/wings/services/custom_queries/find_access_control_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'wings_helper'
 require 'wings/services/custom_queries/find_access_control'
 

--- a/spec/wings/services/custom_queries/find_collections_by_type_spec.rb
+++ b/spec/wings/services/custom_queries/find_collections_by_type_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'wings_helper'
 require 'wings/services/custom_queries/find_collections_by_type'
 

--- a/spec/wings/services/custom_queries/find_file_metadata_spec.rb
+++ b/spec/wings/services/custom_queries/find_file_metadata_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'wings_helper'
 require 'wings/hydra/works/services/add_file_to_file_set'
 require 'wings/services/custom_queries/find_file_metadata'

--- a/spec/wings/services/custom_queries/find_ids_by_model_spec.rb
+++ b/spec/wings/services/custom_queries/find_ids_by_model_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'wings_helper'
 require 'wings/services/custom_queries/find_ids_by_model'
 

--- a/spec/wings/services/custom_queries/find_many_by_alternate_ids_spec.rb
+++ b/spec/wings/services/custom_queries/find_many_by_alternate_ids_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'wings_helper'
 require 'wings/services/custom_queries/find_many_by_alternate_ids'
 

--- a/spec/wings/transformer_value_mapper_spec.rb
+++ b/spec/wings/transformer_value_mapper_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'spec_helper'
 require 'wings/transformer_value_mapper'
 

--- a/spec/wings/valkyrie/metadata_adapter_spec.rb
+++ b/spec/wings/valkyrie/metadata_adapter_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 require 'wings'

--- a/spec/wings/valkyrie/persister_spec.rb
+++ b/spec/wings/valkyrie/persister_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'wings_helper'
 require 'valkyrie/specs/shared_specs'
 require 'wings'

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 require 'wings'

--- a/spec/wings/valkyrie/resource_factory_spec.rb
+++ b/spec/wings/valkyrie/resource_factory_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'spec_helper'
 require 'wings'
 

--- a/spec/wings/valkyrie/storage_spec.rb
+++ b/spec/wings/valkyrie/storage_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 

--- a/spec/wings_spec.rb
+++ b/spec/wings_spec.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+
 require 'spec_helper'
 require 'wings'
 


### PR DESCRIPTION
### Summary

Short circuit specs loading of wings files in koppie

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* The Wings module is not defined after running specs in koppie
* Specs for AF generated classes are not loaded
*

### Detailed Description

These specs manually load wings files causing the Wings module to become defined even when the sepc is filtered by use of the `:active_fedora` spec metadata.

This also skips specs for generated classes that are ActiveFedora specific. These are not present in koppie causing failing specs.

### Changes proposed in this pull request:
* Conditionally `return` to short circuit specs loading Wings or requiring classes not available in koppie
*
*

