### PR TITLE
Remove deprecated .create_default_admin_set method

### DIFF
--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -19,23 +19,6 @@ module Hyrax
 
     class << self
       # @api public
-      # Creates the default Hyrax::AdministrativeSet and corresponding data
-      # @param admin_set_id [String] The default admin set ID
-      # @param title [Array<String>] The title of the default admin set
-      # @return [TrueClass]
-      # @see Hyrax::AdministrativeSet
-      # @deprecated
-      # TODO: When this deprecated method is removed, update private method
-      #       .create_default_admin_set! to remove the parameters.
-      def create_default_admin_set(admin_set_id: DEFAULT_ID, title: DEFAULT_TITLE)
-        Deprecation.warn("'##{__method__}' will be removed in Hyrax 4.0.  " \
-                         "Instead, use 'Hyrax::AdminSetCreateService.find_or_create_default_admin_set'.")
-        create_default_admin_set!(admin_set_id: admin_set_id, title: title).present?
-      rescue RuntimeError => _err
-        false
-      end
-
-      # @api public
       # Finds the default AdministrativeSet if it exists; otherwise, creates it and corresponding data
       # @return [Hyrax::AdministrativeSet] The default admin set.
       # @see Hyrax::AdministrativeSet

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -6,27 +6,6 @@ RSpec.describe Hyrax::AdminSetCreateService do
   let(:persister) { Hyrax.persister }
   let(:query_service) { Hyrax.query_service }
 
-  describe '.create_default_admin_set', :clean_repo do
-    context "when new admin set persists" do
-      it "is a convenience method for .create_default_admin_set!" do
-        expect(described_class).to receive(:create_default_admin_set!).and_call_original
-        expect(described_class.create_default_admin_set).to eq true
-      end
-    end
-
-    context "when new admin set fails to persist" do
-      before do
-        allow(persister).to receive(:save).with(resource: instance_of(Hyrax::AdministrativeSet))
-                                          .and_raise(RuntimeError)
-      end
-
-      it "returns false" do
-        expect(described_class).to receive(:create_default_admin_set!).and_call_original
-        expect(described_class.create_default_admin_set).to eq false
-      end
-    end
-  end
-
   describe '.find_or_create_default_admin_set', :clean_repo do
     context "when default admin set doesn't exist yet" do
       it "is a convenience method for .create_default_admin_set!" do


### PR DESCRIPTION
### Changes proposed in this pull request:
* Remove deprecated .create_default_admin_set method

@samvera/hyrax-code-reviewers
