### PR TITLE
Make fileset representative_id and thumbnail_id readonly in form

### DIFF
--- a/app/forms/hyrax/forms/file_set_form.rb
+++ b/app/forms/hyrax/forms/file_set_form.rb
@@ -12,8 +12,8 @@ module Hyrax
       # be configurable.
       include Hyrax::FormFields(:file_set_metadata)
 
-      property :representative_id, type: Valkyrie::Types::String
-      property :thumbnail_id, type: Valkyrie::Types::String
+      property :representative_id, type: Valkyrie::Types::String, writeable: false
+      property :thumbnail_id, type: Valkyrie::Types::String, writeable: false
     end
   end
 end

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -104,14 +104,6 @@ module Hyrax
     end
 
     ##
-    # @return [Valkyrie::ID]
-    def representative_id=(_input)
-      # saving a file set using valkyrie would err because this method didn't exist.
-      Rails.logger.warn('This is not a valid method for file sets')
-      id
-    end
-
-    ##
     # @return [Boolean] true
     def pcdm_object?
       true


### PR DESCRIPTION
### Fixes

Fixes #6351

### Summary

These are not settable file set fields, reflect that in the form.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Able to edit file set and upload new file versions
*
*

### Changes proposed in this pull request:
* Set represetative_id and thumbnail_id to writeable: false in the form
* Remove compatibility method that patched this for representative_id previously
*

@samvera/hyrax-code-reviewers
