### PR TITLE
Fix sirenia fcrepo volume location

### DIFF
--- a/docker-compose-sirenia.yml
+++ b/docker-compose-sirenia.yml
@@ -133,10 +133,13 @@ services:
   fcrepo:
     image: fcrepo/fcrepo:6.4.0
     environment:
-      - CATALINA_OPTS=-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+      - >-
+        CATALINA_OPTS=-Dfcrepo.home=/fcrepo-home -Djava.awt.headless=true -Dfile.encoding=UTF-8 
+        -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m 
+        -XX:MaxPermSize=256m -XX:+DisableExplicitGC -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
       - JAVA_OPTS=-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
     volumes:
-      - fcrepo:/var/lib/fcrepo
+      - fcrepo:/fcrepo-home
     ports:
       - 8081:8080
     networks:


### PR DESCRIPTION
Sirenia's fcrepo data location was not correct due to inaccurate documentation.

This sets the location manually and updates the volume mount to match. The "corrupt admin set" message seen when restarting sirenia should then be fixed.