### PR TITLE
Collection and sidebar style fixes

### DIFF
--- a/app/assets/javascripts/hyrax/batch_select_all.js
+++ b/app/assets/javascripts/hyrax/batch_select_all.js
@@ -41,7 +41,7 @@
     var checked = $("#check_all")[0]['checked'];
 
     // check each individual box
-    $("input[type='checkbox'].batch_document_selector").each(function(index, value) {
+    $("input[type='checkbox'].batch_document_selector:not(.disabled)").each(function(index, value) {
        value['checked'] = checked;
     });
     toggleButtons();

--- a/app/assets/stylesheets/hyrax/_file-listing.scss
+++ b/app/assets/stylesheets/hyrax/_file-listing.scss
@@ -70,8 +70,6 @@ h4 .small {
 .batch-info {
 
   .sort-toggle {
-    height: 5.1em;
-
     button {
       margin-left: 10px;
     }

--- a/app/assets/stylesheets/hyrax/sidebar.scss
+++ b/app/assets/stylesheets/hyrax/sidebar.scss
@@ -56,6 +56,29 @@ $gutter-width: $grid-gutter-width/2;
     }
   }
 
+  &:not(.maximized) {
+    .sidebar-action-text,
+    a span + span,
+    h5 {
+      display: none;
+    }
+
+    .nav li {
+      text-align: center;
+      a {
+        padding-left: 0;
+        padding-right: 0;
+      }
+      .fa {
+        margin-right: 0;
+      }
+    }
+
+    .nav-item {
+      width: $drawer-small;
+    }
+  }
+
   .sidebar-toggle {
     cursor: pointer;
     background-color: $body-background-color;

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -7,7 +7,7 @@
   </td>
   <td>
     <div class="media">
-      <%= link_to [main_app, document], "class" => "media-left", "aria-hidden" => "true" do %>
+      <%= link_to [main_app, document], "class" => "media-left mr-3", "aria-hidden" => "true" do %>
         <%= document_presenter(document)&.thumbnail&.thumbnail_tag(
           { class: "d-none d-md-block file_listing_thumbnail", alt: "#{document.title_or_label} #{t('hyrax.homepage.admin_sets.thumbnail')}" },
           { suppress_link: true }

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -12,7 +12,7 @@
     <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
       data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>" />
     <% else %>
-    <input type="checkbox" class="disabled" disabled=true />
+    <input type="checkbox" class="disabled batch_document_selector" disabled=true />
     <% end %>
   </td>
   <td>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -7,7 +7,7 @@
   </td>
   <td>
     <div class="media">
-      <%= link_to [main_app, document], "class" => "media-left", "aria-hidden" => "true" do %>
+      <%= link_to [main_app, document], "class" => "media-left mr-3", "aria-hidden" => "true" do %>
         <%= document_presenter(document)&.thumbnail&.thumbnail_tag(
           { class: "d-none d-md-block file_listing_thumbnail", alt: document.title_or_label }, { suppress_link: true }
         ) %>

--- a/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/dashboard/collections/_sort_and_per_page.html.erb
@@ -11,8 +11,8 @@
   <% if show_sort_and_per_page? && collection_member_sort_fields.many? %>
     <div class="sort-toggle">
       <%= form_tag dashboard_collection_path(collection), method: :get, class: 'per_page' do %>
-         <div class="form-group row form-control-lg">
-           <fieldset class="col-sm-9">
+         <div class="form-group row">
+           <fieldset class="col-sm-7 col-lg-8">
              <legend class="sr-only"><%= t('hyrax.sort_label') %></legend>
              <%= label_tag(:sort, t(".sort_by")) %>
              <%= select_tag(:sort, options_from_collection_for_select(collection_member_sort_fields, 'first', lambda {|field| field.last.label}, h(params[:sort]))) %>
@@ -22,7 +22,7 @@
              <%= render Blacklight::HiddenSearchStateComponent.new(params: search_state.params_for_search.except(:per_page, :sort)) %>
              <button class="btn btn-info"><span class="fa fa-refresh"></span> <%= t('helpers.action.refresh') %></button>
            </fieldset>
-           <div class="col-sm-3">
+           <div class="col-sm-5 col-lg-4">
              <%= render 'hyrax/collections/view_type_group' %>
            </div>
          </div>


### PR DESCRIPTION
### Fixes

Display issues with collection pages and the dashboard sidebar in hyrax 4 and 5.

### Summary

A few minor style fixes for the collection pages (both in the dashboard and the public display), and the sidebar in the dashboard

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
View any collection with at least one work added to it. Do so in both the public and dashboard view.

### Type of change (for release notes)
notes-minor

### Detailed Description

On collection pages in hyrax 4-5, we got feedback about the following issues:

1. The thumbnail and the title of works were right next to each other with no spacing
2. The refresh button overlaps the works table on many screen sizes (and gets worse at smaller ones)
3. On the dashboard collection browse page, the checkbox for collections which cannot be selected for batch operations is out of place.

See this images for an example of the problems:
<img width="825" alt="collections_spacing_issue" src="https://github.com/samvera/hyrax/assets/969810/4a007dc6-c2f1-40a2-91ae-d01698e7aff6">

<img width="329" alt="collections_checkbox" src="https://github.com/samvera/hyrax/assets/969810/56a5672a-1e93-4896-a501-4457cd264930">

Additionally, when collapsing the sidebar menu using the "<" button, the text of the menu entries continue to be visible but what a white text color:
<img width="260" alt="sidebar_escape" src="https://github.com/samvera/hyrax/assets/969810/d625d872-fa92-429d-b00a-cfc26ed3b439">

### Changes proposed in this pull request:
This PR addresses the described issues with collection pages and the sidebar. The collection page spacing should look similar to the following (depending on the width of your window):
<img width="775" alt="collections_spacing_fixed" src="https://github.com/samvera/hyrax/assets/969810/f87b59bb-de33-4ce4-b6bf-c1b2ce40ba5e">


@samvera/hyrax-code-reviewers
