### PR TITLE
Review and Approval panel style fixes

### DIFF
--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -116,6 +116,11 @@ ul.tabular {
   background: #fff;
   border-color: #e0e0e0;
 
+  & > .btn {
+    padding: 0;
+    border: 0;
+  }
+
   .card-header {
     background-color: #e6ab5f;
     color: #ffffff;

--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -121,6 +121,16 @@ ul.tabular {
     border: 0;
   }
 
+  .btn-primary {
+    margin-bottom: 1rem;
+  }
+
+  .workflow-comments {
+    label {
+      font-weight: bold;
+    }
+  }
+
   .card-header {
     background-color: #e6ab5f;
     color: #ffffff;
@@ -137,4 +147,5 @@ ul.tabular {
 
 .workflow-actions {
   background-color: #f8f8f8;
+  padding: 1rem;
 }

--- a/app/views/hyrax/base/_workflow_actions.html.erb
+++ b/app/views/hyrax/base/_workflow_actions.html.erb
@@ -6,33 +6,35 @@
   </button>
   <%= form_tag main_app.hyrax_workflow_action_path(presenter), method: :put do %>
     <div id="workflow_controls_collapse" class="card-body collapse">
-      <div class="col-sm-3 workflow-actions">
-        <h3><%= t('.actions') %></h3>
+      <div class="row">
+        <div class="col-sm-3 workflow-actions">
+          <h3><%= t('.actions') %></h3>
 
-        <% presenter.workflow.actions.each do |key, label| %>
-          <div class="form-check">
-            <label class="form-check-label">
-              <%= radio_button_tag 'workflow_action[name]', key, key == 'comment_only', class: 'form-check-input' %>
-              <%= label %>
-            </label>
-          </div>
-        <% end %>
-      </div>
-      <div class="col-sm-9 workflow-comments">
-        <div class="form-group">
-          <label for="workflow_action_comment"><%= t('.review_comment') %>:</label>
-          <textarea class="form-control" name="workflow_action[comment]" id="workflow_action_comment"></textarea>
-        </div>
-
-        <input class="btn btn-primary" type="submit" value="Submit" />
-
-        <h4><%= t('.previous_comments') %></h4>
-        <dl>
-          <% presenter.workflow.comments.each do |comment| %>
-            <dt><%= comment.name_of_commentor %></dt>
-            <dd><%= comment.comment %></dd>
+          <% presenter.workflow.actions.each do |key, label| %>
+            <div class="form-check">
+              <label class="form-check-label">
+                <%= radio_button_tag 'workflow_action[name]', key, key == 'comment_only', class: 'form-check-input' %>
+                <%= label %>
+              </label>
+            </div>
           <% end %>
-        </dl>
+        </div>
+        <div class="col-sm-9 workflow-comments">
+          <div class="form-group">
+            <label for="workflow_action_comment"><%= t('.review_comment') %>:</label>
+            <textarea class="form-control" name="workflow_action[comment]" id="workflow_action_comment"></textarea>
+          </div>
+
+          <input class="btn btn-primary" type="submit" value="Submit" />
+
+          <h4><%= t('.previous_comments') %></h4>
+          <dl>
+            <% presenter.workflow.comments.each do |comment| %>
+              <dt><%= comment.name_of_commentor %></dt>
+              <dd><%= comment.comment %></dd>
+            <% end %>
+          </dl>
+        </div>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
### Summary

Between hyrax 3 and 4 the layout and styling of the Review and Approval changed significantly, which seems unintentional after reviewing the commit history for that file.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
In the hyrax dassie environment, create an admin set with the "One stop mediated deposit" workflow. Deposit a work into this admin set. On the resulting work page, expand the "Review and Approval" panel at the top of the page. Compare this between a hyrax 3 and 4/5 instance.

### Type of change (for release notes)
notes-bugfix

### Detailed Description

There were a number of style and layout changes, likely the result of the bootstrap upgrade. The issues include:
* The main button/header to expand the panel now has a large white padding around it
* Inside the panel, all the components are now arranged into a single column at any window width, whereas before the "Actions" section was on the left and the other parts were to the right (the bootstrap columns are still arranged this way)
* The "Actions" section no longer has padding at the top and bottom, so it looks cut off
* The label for the comments input is no longer bold
* There is very little spacing between the submit button and the "Previous comments" section

See the following screenshot for the hyrax-3 display:
<img width="1090" alt="hyrax3_review_approval" src="https://github.com/samvera/hyrax/assets/969810/0afa6fa1-1600-4e78-974b-bc22ff9bdfdd">
And the hyrax-5 display:
<img width="1155" alt="hyrax5_review_approval" src="https://github.com/samvera/hyrax/assets/969810/e72b44bd-5a80-4eea-bd16-d8259f8f98ab">


### Changes proposed in this pull request:
* Updates to css and added a row div

This PR should fix the listed issues, although it still looks a little different due to new defaults in bootstrap 5.
<img width="1101" alt="hyrax5_review_approval_fixed" src="https://github.com/samvera/hyrax/assets/969810/195efe48-a7ee-4d2d-a67b-0edec13f79eb">

@samvera/hyrax-code-reviewers
