### PR TITLE
Fix formatter specs

### DIFF
--- a/spec/helpers/hyrax/citations_behaviors/formatters/apa_formatter_spec.rb
+++ b/spec/helpers/hyrax/citations_behaviors/formatters/apa_formatter_spec.rb
@@ -2,7 +2,14 @@
 RSpec.describe Hyrax::CitationsBehaviors::Formatters::ApaFormatter do
   subject(:formatter) { described_class.new(:no_context) }
 
-  let(:presenter) { Hyrax::WorkShowPresenter.new(SolrDocument.new(work.to_solr), :no_ability) }
+  let(:solr_document) do
+    if work.instance_of? ActiveFedora::Base
+      SolrDocument.new(work.to_solr)
+    else
+      SolrDocument.new(GenericWorkIndexer.new(resource: work).to_solr)
+    end
+  end
+  let(:presenter) { Hyrax::WorkShowPresenter.new(solr_document, :no_ability) }
   let(:work)      { build(:generic_work, title: ['Title'], creator: []) }
 
   it 'formats citations without creators' do

--- a/spec/helpers/hyrax/citations_behaviors/formatters/chicago_formatter_spec.rb
+++ b/spec/helpers/hyrax/citations_behaviors/formatters/chicago_formatter_spec.rb
@@ -2,7 +2,14 @@
 RSpec.describe Hyrax::CitationsBehaviors::Formatters::ChicagoFormatter do
   subject(:formatter) { described_class.new(:no_context) }
 
-  let(:presenter) { Hyrax::WorkShowPresenter.new(SolrDocument.new(work.to_solr), :no_ability) }
+  let(:solr_document) do
+    if work.instance_of? ActiveFedora::Base
+      SolrDocument.new(work.to_solr)
+    else
+      SolrDocument.new(GenericWorkIndexer.new(resource: work).to_solr)
+    end
+  end
+  let(:presenter) { Hyrax::WorkShowPresenter.new(solr_document, :no_ability) }
   let(:work)      { build(:generic_work, title: ['<ScrIPt>prompt("Confirm Password")</sCRIpt>']) }
 
   it 'sanitizes input' do


### PR DESCRIPTION
### Fixes

Fixes #6305 

### Summary

Fix failing specs due to use of wrong/outdated method to convert a Work resource into Solr.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Run tests for `spec/helpers/hyrax/citations_behaviors/formatters`
*
*

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

Choose from:
- `notes-valkyrie` Valkyrie Progress

### Detailed Description

Tests in `/Users/abeleml/Desktop/samvera/hyrax/spec/helpers/hyrax/citations_behaviors/formatters` are failing when Valkyrie is used. I added changes that ensure generic works, whether an instance of `Hyrax::Work` or `ActiveFedora::Base` can be converted to a `SolrDocument` instance correctly in those tests.

### Changes proposed in this pull request:
* Use `GenericWorkIndexer` to convert a work instance to a `SolrDocument` when a work is an instance of `Hyrax::Work`, which is a Valkyrie resource
*
*

@samvera/hyrax-code-reviewers
