### PR TITLE
Fixes the deletion of collections 500 (#6362).

### DIFF
--- a/app/controllers/hyrax/batch_edits_controller.rb
+++ b/app/controllers/hyrax/batch_edits_controller.rb
@@ -41,9 +41,9 @@ module Hyrax
       batch.each do |doc_id|
         resource = Hyrax.query_service.find_by(id: Valkyrie::ID.new(doc_id))
         transactions['collection_resource.destroy']
-          .with_step_args('collection_resource.delete' => { user: current_user })
-          .call(resource)
-          .value!
+          .with_step_args('collection_resource.delete' => { user: current_user },
+                          'collection_resource.remove_from_membership' => { user: current_user })
+          .call(resource).value!
       end
       flash[:notice] = "Batch delete complete"
       after_destroy_collection

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -245,7 +245,10 @@ module Hyrax
       end
 
       def valkyrie_destroy
-        if transactions['collection_resource.destroy'].call(@collection).success?
+        if transactions['collection_resource.destroy']
+             .with_step_args('collection_resource.delete' => { user: current_user },
+                             'collection_resource.remove_from_membership' => { user: current_user })
+             .call(@collection).success?
           after_destroy(params[:id])
         else
           after_destroy_error(params[:id])

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -246,9 +246,9 @@ module Hyrax
 
       def valkyrie_destroy
         if transactions['collection_resource.destroy']
-             .with_step_args('collection_resource.delete' => { user: current_user },
-                             'collection_resource.remove_from_membership' => { user: current_user })
-             .call(@collection).success?
+           .with_step_args('collection_resource.delete' => { user: current_user },
+                           'collection_resource.remove_from_membership' => { user: current_user })
+           .call(@collection).success?
           after_destroy(params[:id])
         else
           after_destroy_error(params[:id])

--- a/lib/hyrax/transactions/collection_destroy.rb
+++ b/lib/hyrax/transactions/collection_destroy.rb
@@ -10,6 +10,7 @@ module Hyrax
     class CollectionDestroy < Transaction
       # TODO: Add step that checks if collection is empty for collections of types that require it
       DEFAULT_STEPS = ['collection_resource.delete_acl',
+                       'collection_resource.remove_from_membership',
                        'collection_resource.delete'].freeze
 
       ##

--- a/lib/hyrax/transactions/collection_destroy.rb
+++ b/lib/hyrax/transactions/collection_destroy.rb
@@ -9,8 +9,8 @@ module Hyrax
     # @since 3.4.0
     class CollectionDestroy < Transaction
       # TODO: Add step that checks if collection is empty for collections of types that require it
-      DEFAULT_STEPS = ['collection_resource.delete',
-                       'collection_resource.delete_acl'].freeze
+      DEFAULT_STEPS = ['collection_resource.delete_acl',
+                       'collection_resource.delete'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -42,6 +42,7 @@ module Hyrax
       require 'hyrax/transactions/steps/ensure_admin_set'
       require 'hyrax/transactions/steps/set_collection_type_gid'
       require 'hyrax/transactions/steps/remove_file_set_from_work'
+      require 'hyrax/transactions/steps/remove_from_membership'
       require 'hyrax/transactions/steps/save'
       require 'hyrax/transactions/steps/save_access_control'
       require 'hyrax/transactions/steps/save_collection_banner'
@@ -208,6 +209,10 @@ module Hyrax
 
         ops.register 'delete_acl' do
           Steps::DeleteAccessControl.new
+        end
+
+        ops.register 'remove_from_membership' do
+          Steps::RemoveFromMembership.new
         end
 
         ops.register 'save_acl' do

--- a/lib/hyrax/transactions/steps/delete_resource.rb
+++ b/lib/hyrax/transactions/steps/delete_resource.rb
@@ -26,26 +26,37 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(resource, user: nil)
           return Failure(:resource_not_persisted) unless resource.persisted?
+          members = find_child_members(resource: resource)
 
           @persister.delete(resource: resource)
-          publish_changes(resource: resource, user: user)
+          publish_changes(resource: resource, user: user, members: members)
 
           Success(resource)
         end
 
         private
 
-        def publish_changes(resource:, user:)
+        def publish_changes(resource:, user:, members:)
           if resource.collection?
             @publisher.publish('collection.deleted',
                                collection: resource,
                                id: resource.id.id,
-                               user: user)
+                               user: user,
+                               members: members)
           else
             @publisher.publish('object.deleted',
                                object: resource,
                                id: resource.id.id,
-                               user: user)
+                               user: user,
+                               members: members)
+          end
+        end
+
+        def find_child_members(resource:)
+          if resource.collection?
+            Hyrax.custom_queries.find_members_of(collection: resource)
+          else
+            Hyrax.custom_queries.find_child_file_sets(resource: resource)
           end
         end
       end

--- a/lib/hyrax/transactions/steps/delete_resource.rb
+++ b/lib/hyrax/transactions/steps/delete_resource.rb
@@ -26,37 +26,26 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(resource, user: nil)
           return Failure(:resource_not_persisted) unless resource.persisted?
-          members = find_child_members(resource: resource)
 
           @persister.delete(resource: resource)
-          publish_changes(resource: resource, user: user, members: members)
+          publish_changes(resource: resource, user: user)
 
           Success(resource)
         end
 
         private
 
-        def publish_changes(resource:, user:, members:)
+        def publish_changes(resource:, user:)
           if resource.collection?
             @publisher.publish('collection.deleted',
                                collection: resource,
                                id: resource.id.id,
-                               user: user,
-                               members: members)
+                               user: user)
           else
             @publisher.publish('object.deleted',
                                object: resource,
                                id: resource.id.id,
-                               user: user,
-                               members: members)
-          end
-        end
-
-        def find_child_members(resource:)
-          if resource.collection?
-            Hyrax.custom_queries.find_members_of(collection: resource)
-          else
-            Hyrax.custom_queries.find_child_file_sets(resource: resource)
+                               user: user)
           end
         end
       end

--- a/lib/hyrax/transactions/steps/remove_from_membership.rb
+++ b/lib/hyrax/transactions/steps/remove_from_membership.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Removes a collection from its members, returning a `Dry::Monads::Result`
+      # (`Success`|`Failure`).
+      #
+      # @see https://dry-rb.org/gems/dry-monads/1.0/result/
+      class RemoveFromMembership
+        include Dry::Monads[:result]
+
+        ##
+        # @params [#save] persister
+        def initialize(query_service: Hyrax.custom_queries, persister: Hyrax.persister, publisher: Hyrax.publisher)
+          @persister = persister
+          @query_service = query_service
+          @publisher = publisher
+        end
+
+        ##
+        # @param [Valkyrie::Resource] resource
+        # @param [::User] the user resposible for the delete action
+        #
+        # @return [Dry::Monads::Result]
+        def call(collection, user: nil)
+          return Failure(:resource_not_persisted) unless collection.persisted?
+
+          @query_service.find_members_of(collection: collection).each do |member|
+            member.member_of_collection_ids -= [collection.id]
+            @persister.save(resource: member)
+            @publisher.publish('collection.membership.updated', collection: collection, user: user)
+          rescue StandardError
+            nil
+          end
+
+          Success(collection)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/remove_from_membership.rb
+++ b/lib/hyrax/transactions/steps/remove_from_membership.rb
@@ -27,6 +27,7 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(collection, user: nil)
           return Failure(:resource_not_persisted) unless collection.persisted?
+          return Failure(:user_not_present) if user.blank?
 
           @query_service.find_members_of(collection: collection).each do |member|
             member.member_of_collection_ids -= [collection.id]

--- a/spec/hyrax/transactions/collection_destroy_spec.rb
+++ b/spec/hyrax/transactions/collection_destroy_spec.rb
@@ -5,7 +5,7 @@ require 'hyrax/transactions'
 RSpec.describe Hyrax::Transactions::CollectionDestroy, valkyrie_adapter: :test_adapter do
   subject(:tx)   { described_class.new }
   let(:resource) { FactoryBot.valkyrie_create(:hyrax_collection) }
-  let(:user)         { FactoryBot.create(:user) }
+  let(:user)     { FactoryBot.create(:user) }
 
   describe '#call' do
     it 'is a success' do

--- a/spec/hyrax/transactions/collection_destroy_spec.rb
+++ b/spec/hyrax/transactions/collection_destroy_spec.rb
@@ -5,10 +5,16 @@ require 'hyrax/transactions'
 RSpec.describe Hyrax::Transactions::CollectionDestroy, valkyrie_adapter: :test_adapter do
   subject(:tx)   { described_class.new }
   let(:resource) { FactoryBot.valkyrie_create(:hyrax_collection) }
+  let(:user)         { FactoryBot.create(:user) }
 
   describe '#call' do
     it 'is a success' do
-      expect(tx.call(resource)).to be_success
+      expect(
+        tx
+          .with_step_args('collection_resource.delete' => { user: user },
+                          'collection_resource.remove_from_membership' => { user: user })
+          .call(resource)
+      ).to be_success
     end
   end
 end

--- a/spec/hyrax/transactions/steps/remove_from_membership_spec.rb
+++ b/spec/hyrax/transactions/steps/remove_from_membership_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+require 'hyrax/specs/spy_listener'
+
+RSpec.describe Hyrax::Transactions::Steps::RemoveFromMembership, valkyrie_adapter: :test_adapter do
+  subject(:step) { described_class.new }
+  let(:user)         { FactoryBot.create(:user) }
+  let(:collection)   { FactoryBot.valkyrie_create(:hyrax_collection) }
+  let(:work)         { FactoryBot.valkyrie_create(:monograph, member_of_collection_ids: [collection.id]) }
+  let(:spy_listener) { Hyrax::Specs::SpyListener.new }
+
+  describe '#call' do
+    before do
+      work
+      Hyrax.publisher.subscribe(spy_listener)
+    end
+    after { Hyrax.publisher.unsubscribe(spy_listener) }
+
+    it 'fails without a user' do
+      expect(step.call(collection)).to be_failure
+    end
+
+    it 'gives success' do
+      expect(step.call(collection, user: user)).to be_success
+    end
+
+    it 'removes collection references from member objects' do
+      expect { step.call(collection, user: user) }
+        .to change { Hyrax.custom_queries.find_members_of(collection: collection).size }
+        .from(1)
+        .to(0)
+    end
+
+    it 'publishes events' do
+      expect { step.call(collection, user: user) }
+        .to change { spy_listener.collection_membership_updated&.payload }
+        .to match(collection: collection, user: user)
+    end
+  end
+end

--- a/spec/services/hyrax/listeners/member_cleanup_listener_spec.rb
+++ b/spec/services/hyrax/listeners/member_cleanup_listener_spec.rb
@@ -42,14 +42,14 @@ RSpec.describe Hyrax::Listeners::MemberCleanupListener do
       work
     end
 
-    it 'removes collection references from member objects' do
+    xit 'removes collection references from member objects' do
       expect { listener.on_collection_deleted(event) }
         .to change { Hyrax.custom_queries.find_members_of(collection: event[:collection]).size }
         .from(1)
         .to(0)
     end
 
-    it 'publishes events' do
+    xit 'publishes events' do
       listener.on_collection_deleted(event)
       expect(spy_listener.collection_membership_updated&.payload)
         .to include(collection: collection, user: user)


### PR DESCRIPTION
### Fixes

Fixes #6362
### Summary

Fixes the deletion of collections 500 errors.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
Pre-req: create a collection or have manager access to a collection

* In valkyrie/fedora (sirenia), log in and navigate to Dashboard -> Collections
* Click on the title of a collection
* Click "Delete Collection"
* Click "OK"
* No errors should occur. Collection should be removed in all possible storage locations.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes
- `notes-valkyrie` Valkyrie Progress

### Detailed Description

The objects being queried are missing from their stores when we attempt to eliminate their children. This causes errors that redirects the user to the edit page of an object that no longer exists. This PR pulls the objects to remove first, deletes second.

### Changes proposed in this pull request:
* Retrieves the object child members before deleting the objects from their respective stores.
* Passes along a `members` variable that contains the intended FileSets or Works.
* Switches the order of deletion to ACL first, Work second.

@samvera/hyrax-code-reviewers
