### PR TITLE
Perform characterization on valkyrie resources in a job

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -51,7 +51,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
     # value. So later we'll ensure it's set to the new file's filename.
     reset_title = file_set.title.first == file_set.label
 
-    characterization_service.run(file_set.characterization_proxy, filepath)
+    characterization_service.run(file_set.characterization_proxy, filepath, **Hyrax.config.characterization_options)
     Hyrax.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
     file_set.characterization_proxy.alpha_channels = channels(filepath) if file_set.image? && Hyrax.config.iiif_image_server?
     file_set.characterization_proxy.save!

--- a/app/jobs/valkyrie_characterization_job.rb
+++ b/app/jobs/valkyrie_characterization_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class ValkyrieCharacterizationJob < Hyrax::ApplicationJob
+  queue_as Hyrax.config.ingest_queue_name
+  def perform(file_metadata_id)
+    file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: file_metadata_id)
+    Hyrax.config.characterization_service
+         .run(metadata: file_metadata, file: file_metadata.file, **Hyrax.config.characterization_options)
+  end
+end

--- a/app/services/hyrax/listeners/file_metadata_listener.rb
+++ b/app/services/hyrax/listeners/file_metadata_listener.rb
@@ -50,9 +50,7 @@ module Hyrax
         # Run characterization for original file only
         return unless event[:metadata]&.original_file?
 
-        Hyrax.config
-             .characterization_service
-             .run(metadata: event[:metadata], file: event[:metadata].file, **Hyrax.config.characterization_options)
+        ValkyrieCharacterizationJob.perform_later(event[:metadata].id.to_s)
       end
     end
   end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CharacterizeJob, :active_fedora, :clean_repo do
 
   before do
     allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
-    allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+    allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename, **Hyrax.config.characterization_options)
     allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
   end
 
@@ -36,7 +36,7 @@ RSpec.describe CharacterizeJob, :active_fedora, :clean_repo do
 
     it 'skips Hyrax::WorkingDirectory.copy_repository_resource_to_working_directory' do
       expect(Hyrax::WorkingDirectory).not_to receive(:copy_repository_resource_to_working_directory)
-      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename, **Hyrax.config.characterization_options)
       described_class.perform_now(file_set, file.id, filename)
     end
   end
@@ -46,14 +46,14 @@ RSpec.describe CharacterizeJob, :active_fedora, :clean_repo do
 
     it 'uses Hyrax::WorkingDirectory.copy_repository_resource_to_working_directory to pull the repo file' do
       expect(Hyrax::WorkingDirectory).to receive(:copy_repository_resource_to_working_directory)
-      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename, **Hyrax.config.characterization_options)
       described_class.perform_now(file_set, file.id, filename)
     end
   end
 
   context 'when the characterization proxy content is present' do
     it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
-      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename, **Hyrax.config.characterization_options)
       expect(file).to receive(:save!)
       expect(file_set).to receive(:update_index)
       expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
@@ -70,7 +70,7 @@ RSpec.describe CharacterizeJob, :active_fedora, :clean_repo do
 
   context 'FileSet with preexisting characterization metadata getting a new version' do
     before do
-      allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename, **Hyrax.config.characterization_options)
       allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
     end
 

--- a/spec/jobs/valkyrie_characterization_job_spec.rb
+++ b/spec/jobs/valkyrie_characterization_job_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe ValkyrieCharacterizationJob, valkyrie_adapter: :test_adapter do
+  context 'with a file' do
+    let(:file_metadata) { FactoryBot.valkyrie_create(:hyrax_file_metadata) }
+    let(:file) { double }
+
+    before do
+      allow(file_metadata).to receive(:file).and_return(file)
+      allow(Hyrax.custom_queries).to receive(:find_file_metadata_by).with(id: file_metadata.id).and_return(file_metadata)
+    end
+
+    it 'calls the characterization service' do
+      expect(Hyrax.config.characterization_service).to receive(:run).with(metadata: file_metadata, file: file, **Hyrax.config.characterization_options)
+      described_class.perform_now(file_metadata.id)
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Perform characterization on valkyrie resources in a job, pass ch12n options to CharacterizeJob

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Characterization for Valkyrie resources is done by a background job
* Characterization for Valkyrie resources uses the fits servlet
* Characterization for Active Fedora objects is done by the fits servlet

### Changes proposed in this pull request:
* Pass the characterization (ch12n) options through to the ch12n service
* Wrap calls to the ch12n service in a job
*

