### PR TITLE
Fixes the swapping of Thumbnail and Rep. Media per work (#6361).

### DIFF
--- a/app/assets/javascripts/hyrax/file_manager/member.es6
+++ b/app/assets/javascripts/hyrax/file_manager/member.es6
@@ -10,7 +10,7 @@ export class InputTracker {
     this.notifier = notifier
     this.element.data("initial-value", this.element.val())
     this.element.data("tracker", this)
-    this.element.trigger("change", this.value_changed)
+    this.element.on("change", this.value_changed)
   }
 
   reset() {

--- a/app/views/hyrax/base/_file_manager_resource_form.html.erb
+++ b/app/views/hyrax/base/_file_manager_resource_form.html.erb
@@ -1,5 +1,5 @@
 <div class="resource-form-container">
-  <%= simple_form_for [main_app, @form], remote: true, html: { id: 'resource-form', 'data-type': 'json' } do |f| %>
+  <%= simple_form_for [main_app, @form], remote: true, authenticity_token: true, html: { id: 'resource-form', 'data-type': 'json' } do |f| %>
     <%= f.input :thumbnail_id, as: :hidden, input_html: { data: {member_link: 'thumbnail_id'}} %>
     <%= f.input :representative_id, as: :hidden, input_html: { data: {member_link: 'representative_id'}} %>
   <% end %>


### PR DESCRIPTION
### Fixes

Fixes #6361

### Summary

Fixes the swapping of Thumbnail and Representative Media per work 

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Navigate to a Work that contains more than one file
* Click on the "File Manager" button
* Select radio buttons for Thumbnail and Representative Media on an image that is not currently selected
* Click on "Save" in the Toolbar
* Navigate back to the Works index page
* See that Thumbnail and Representative Media have changed
* Enter File Manager again and see that just chosen image is set as Thumbnail and Representative Media

### Type of change (for release notes)
- `notes-bugfix` Bug Fixes
- `notes-valkyrie` Valkyrie Progress

### Detailed Description

Previously, when attempting to change the image assigned to Thumbnail and Representative Media, the Save button wasn't being enabled by Javascript. Once that issue was fixed, clicking Save produced an error: `ActionController::InvalidAuthenticityToken`. This was caused by Rails needing an `authenticity_token` assigned to each form. That attribute was assigned in the associated form.

### Changes proposed in this pull request:
* app/assets/javascripts/hyrax/file_manager/member.es6: change the JS method to `on` instead of `trigger`.
* app/views/hyrax/base/_file_manager_resource_form.html.erb: includes the requirement of an `authenticity_token`.

@samvera/hyrax-code-reviewers
