### PR TITLE
Fix valkyrie resource json response

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -79,7 +79,7 @@ module Hyrax
         wants.html { presenter && parent_presenter }
         wants.json do
           # load @curation_concern manually because it's skipped for html
-          @curation_concern = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id])
+          @curation_concern = load_curation_concern
           curation_concern # This is here for authorization checks (we could add authorize! but let's use the same method for CanCanCan)
           render :show, status: :ok
         end
@@ -144,6 +144,14 @@ module Hyrax
     end
 
     private
+
+    def load_curation_concern
+      if Hyrax.config.disable_wings
+        Hyrax.query_service.find_by(id: params[:id])
+      else
+        Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[:id])
+      end
+    end
 
     def iiif_manifest_builder
       self.class.iiif_manifest_builder ||

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -84,9 +84,6 @@ module Hyrax
           render :show, status: :ok
         end
         additional_response_formats(wants)
-        wants.ttl { render body: presenter.export_as_ttl, mime_type: Mime[:ttl] }
-        wants.jsonld { render body: presenter.export_as_jsonld, mime_type: Mime[:jsonld] }
-        wants.nt { render body: presenter.export_as_nt, mime_type: Mime[:nt] }
       end
     end
     # rubocop:enable Metrics/AbcSize
@@ -434,10 +431,47 @@ module Hyrax
     end
 
     def additional_response_formats(format)
+      respond_to_endnote(format)
+      respond_to_ttl(format)
+      respond_to_jsonld(format)
+      respond_to_nt(format)
+    end
+
+    def respond_to_endnote(format)
       format.endnote do
         send_data(presenter.solr_document.export_as_endnote,
                   type: "application/x-endnote-refer",
                   filename: presenter.solr_document.endnote_filename)
+      end
+    end
+
+    def respond_to_ttl(format)
+      format.ttl do
+        if presenter.valkyrie_presenter?
+          render plain: "Error: Not Implemented", status: :not_implemented
+        else
+          render body: presenter.export_as_ttl, mime_type: Mime[:ttl]
+        end
+      end
+    end
+
+    def respond_to_jsonld(format)
+      format.jsonld do
+        if presenter.valkyrie_presenter?
+          render plain: "Error: Not Implemented", status: :not_implemented
+        else
+          render body: presenter.export_as_jsonld, mime_type: Mime[:jsonld]
+        end
+      end
+    end
+
+    def respond_to_nt(format)
+      format.nt do
+        if presenter.valkyrie_presenter?
+          render plain: "Error: Not Implemented", status: :not_implemented
+        else
+          render body: presenter.export_as_nt, mime_type: Mime[:nt]
+        end
       end
     end
 

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -8,10 +8,15 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
   let(:work)  { FactoryBot.valkyrie_create(:hyrax_work, alternate_ids: [id], title: title) }
   let(:id)    { '123' }
 
+  let(:work_route_path) do
+    "#{work.model_name.singular_route_key}_path"
+  end
+
   let(:main_app_routes) do
     ActionDispatch::Routing::RouteSet.new.tap do |r|
       r.draw do # draw minimal routes for this controller mixin
         mount Hyrax::Engine, at: '/'
+        namespaced_resources 'hyrax/test/simple_work', except: [:index]
         namespaced_resources 'hyrax/test/simple_work_legacy', except: [:index]
         devise_for :users
         resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog'
@@ -74,7 +79,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         get :create, params: { test_simple_work: { title: 'comet in moominland' } }
 
         expect(response)
-          .to redirect_to paths.hyrax_test_simple_work_legacy_path(id: assigns(:curation_concern).id, locale: :en)
+          .to redirect_to paths.send(work_route_path, id: assigns(:curation_concern).id, locale: :en)
       end
 
       it 'sets current user as depositor' do
@@ -221,9 +226,8 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
           get :create, params: params
 
           expect(flash[:notice]).to be_html_safe
-          expect(flash[:notice]).to eq "Your files are being processed by Hyrax in the background. " \
-                                       "The metadata and access controls you specified are being applied. " \
-                                       "You may need to refresh this page to see these updates."
+          expect(flash[:notice]).to eq I18n.t("hyrax.works.create.after_create_html",
+                                              application_name: I18n.t('hyrax.product_name', default: 'Hyrax'))
           expect(assigns(:curation_concern)).to have_file_set_members(be_persisted, be_persisted)
         end
 
@@ -449,7 +453,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
         expect(assigns[:form])
           .to have_attributes(depositor: user.user_key,
-                              admin_set_id: AdminSet::DEFAULT_ID)
+                              admin_set_id: Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s)
       end
 
       it 'renders form' do
@@ -540,7 +544,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
 
   describe '#update' do
     it 'redirects to new user login' do
-      patch :update, params: { id: id }
+      patch :update, params: { id: work.id }
 
       expect(response).to redirect_to paths.new_user_session_path(locale: :en)
     end
@@ -551,16 +555,16 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
       before { Hyrax::AdminSetCreateService.find_or_create_default_admin_set }
 
       it 'redirects to updated work' do
-        patch :update, params: { id: id, test_simple_work: { title: 'new title' } }
+        patch :update, params: { id: work.id, test_simple_work: { title: 'new title' } }
 
         expect(response)
-          .to redirect_to paths.hyrax_test_simple_work_legacy_path(id: id, locale: :en)
+          .to redirect_to paths.send(work_route_path, id: work.id, locale: :en)
       end
 
       it 'updates the work metadata' do
-        patch :update, params: { id: id, test_simple_work: { title: 'new title' } }
+        patch :update, params: { id: work.id, test_simple_work: { title: 'new title' } }
 
-        expect(Hyrax.query_service.find_by(id: id))
+        expect(Hyrax.query_service.find_by(id: work.id))
           .to have_attributes title: contain_exactly('new title')
       end
 
@@ -568,7 +572,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         let(:uploads) { FactoryBot.create_list(:uploaded_file, 2, user: user) }
 
         it 'attaches the files' do
-          params = { id: id, test_simple_work: { title: 'comet in moominland' },
+          params = { id: work.id, test_simple_work: { title: 'comet in moominland' },
                      uploaded_files: uploads.map(&:id) }
 
           get :update, params: params
@@ -576,7 +580,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         end
 
         it 'sets the file visibility' do
-          params = { id: id,
+          params = { id: work.id,
                      test_simple_work: { title: 'comet in moominland',
                                          file_set: [{ uploaded_file_id: uploads.first.id, visibility: 'open' },
                                                     { uploaded_file_id: uploads.second.id, visibility: 'open' }] },
@@ -591,13 +595,13 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         let(:update_params) { { title: 'new title', visibility: 'open' } }
 
         it 'can make work public' do
-          patch :update, params: { id: id, test_simple_work: update_params }
+          patch :update, params: { id: work.id, test_simple_work: update_params }
 
           expect(Hyrax::VisibilityReader.new(resource: assigns(:curation_concern)).read).to eq 'open'
         end
 
         it 'saves the visibility' do
-          patch :update, params: { id: id, test_simple_work: update_params }
+          patch :update, params: { id: work.id, test_simple_work: update_params }
 
           expect(Hyrax::AccessControlList(assigns[:curation_concern]).permissions)
             .to include(have_attributes(mode: :read, agent: 'group/public'))
@@ -608,7 +612,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         let(:update_params) { { title: 'comet in moominland', permissions_attributes: { "0" => { type: 'person', access: 'read', name: 'foo@bar.com' } } } }
 
         it 'saves the visibility' do
-          post :update, params: { id: id, test_simple_work: update_params }
+          post :update, params: { id: work.id, test_simple_work: update_params }
 
           expect(Hyrax::AccessControlList(assigns[:curation_concern]).permissions)
             .to include(have_attributes(mode: :read, agent: 'foo@bar.com'))
@@ -627,7 +631,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
           end
 
           it 'stays on the edit form and flashes an error message' do
-            patch :update, params: { id: id, test_simple_work: update_params }
+            patch :update, params: { id: work.id, test_simple_work: update_params }
 
             expect(flash[:error]).to eq error_msg
             expect(response).to render_template(:edit)
@@ -645,7 +649,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
           end
 
           it 'stays on the edit form and flashes an error message' do
-            patch :update, params: { id: id, test_simple_work: update_params }
+            patch :update, params: { id: work.id, test_simple_work: update_params }
 
             expect(flash[:error]).to eq error_msg
             expect(response).to render_template(:edit)

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -478,21 +478,21 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         expect(response.status).to eq 200
       end
 
-      it 'resolves ntriples' do
+      it 'resolves ntriples', :active_fedora do
         get :show, params: { id: work.id }, format: :nt
 
         expect(RDF::Reader.for(:ntriples).new(response.body).objects)
           .to include(RDF::Literal(title.first))
       end
 
-      it 'resolves turtle' do
+      it 'resolves turtle', :active_fedora do
         get :show, params: { id: work.id }, format: :ttl
 
         expect(RDF::Reader.for(:ttl).new(response.body).objects)
           .to include(RDF::Literal(title.first))
       end
 
-      it 'resolves jsonld' do
+      it 'resolves jsonld', :active_fedora do
         get :show, params: { id: work.id }, format: :jsonld
 
         expect(RDF::Reader.for(:jsonld).new(response.body).objects)

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -173,13 +173,16 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
       end
 
       context "ttl" do
-        let(:presenter) { double }
+        let(:presenter) do
+          double("Presenter Double",
+                 export_as_ttl: 'ttl graph',
+                 'editor?': true,
+                 to_model: stub_model(GenericWork),
+                 'valkyrie_presenter?': false)
+        end
 
         before do
           allow(controller).to receive(:presenter).and_return(presenter)
-          allow(presenter).to receive(:export_as_ttl).and_return("ttl graph")
-          allow(presenter).to receive(:editor?).and_return(true)
-          allow(presenter).to receive(:to_model).and_return(stub_model(GenericWork))
         end
 
         it 'renders a turtle file' do


### PR DESCRIPTION
### Fixes

Fixes #6366

### Summary

Fix valkyrie resource json response

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Adding `.json` to a work's show page url gives a json representation of the work
* Other responses that depend on building a graph (`.ttl` `.nt` `.jsonld`) return a 501 not implemented status for valkyrie resources
*

### Changes proposed in this pull request:
* For the json response, use the work id to find_by
* Don't attempt to respond to formats that depend on building a graph with active fedora
* Move response formats to individual methods
* Fix work_controller_behavior_spec for koppie

@samvera/hyrax-code-reviewers
