### PR TITLE
Deprecate use of ActiveFedora and Wings

### DIFF
--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -15,6 +15,8 @@
 # However, these dependencies should be considered temprorary: this code will
 # be deprecated for removal in a future release.
 #
+# @deprecated Wings will be removed when ActiveFedora is no longer supported by Hyrax.
+#
 # @example casting an ActiveFedora model to Valkyrie
 #   work     = GenericWork.create(title: ['Comet in Moominland'])
 #   resource = work.valkyrie_resource
@@ -56,6 +58,9 @@
 # @see https://wiki.duraspace.org/display/samvera/Hyrax-Valkyrie+Development+Working+Group
 #      for further context regarding the approach
 module Wings
+  Deprecation.warn(self, "ActiveFedora and Wings will be removed from a future major release of Hyrax in favor " \
+    "of Valkyrie resource models. Please migrate your models from ActiveFedora::Base to Hyrax::Resource.")
+  
   ##
   # @api public
   #

--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -60,7 +60,7 @@
 module Wings
   Deprecation.warn(self, "ActiveFedora and Wings will be removed from a future major release of Hyrax in favor " \
     "of Valkyrie resource models. Please migrate your models from ActiveFedora::Base to Hyrax::Resource.")
-  
+
   ##
   # @api public
   #


### PR DESCRIPTION
Hyrax on Valkyrie is a stable feature in Hyrax 5. As planned, ActiveFedora and Wings will be removed in a future major version of Hyrax.

@samvera/hyrax-code-reviewers
