### PR TITLE
Remove deprecated `available_child_collections` and `available_parent_collections`

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -123,21 +123,6 @@ module Hyrax
         collection_member_service.available_member_subcollections.documents
       end
 
-      ##
-      # @deprecated this implementation requires an extra db round trip, had a
-      #   buggy cacheing mechanism, and was largely duplicative of other code.
-      #   all versions of this code are replaced by
-      #   {CollectionsHelper#available_parent_collections_data}.
-      def available_parent_collections(scope:)
-        return @available_parents if @available_parents.present?
-
-        collection = model_class.find(id)
-        colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: scope, limit_to_id: nil)
-        @available_parents = colls.map do |col|
-          { "id" => col.id, "title_first" => col.title.first }
-        end.to_json
-      end
-
       private
 
       def all_files_with_access

--- a/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
+++ b/app/forms/hyrax/forms/dashboard/nest_collection_form.rb
@@ -44,40 +44,6 @@ module Hyrax
           persistence_service.persist_nested_collection_for(parent: parent, child: child, user: context.current_user)
         end
 
-        ##
-        # @deprecated this method is unused by hyrax, and is effectively a
-        #   delegation to `Hyrax::Collections::NestedCollectionQueryService`.
-        #   if you want to be sure to use nested indexing to generate this list,
-        #   use the query service directly.
-        #
-        # For the given parent, what are all of the available collections that
-        # can be added as sub-collection of the parent.
-        def available_child_collections
-          Deprecation.warn "#{self.class}#available_child_collections " \
-                           "is deprecated. the helper of the same name or " \
-                           "Hyrax::Collections::NestedCollectionQueryService " \
-                           "instead."
-
-          query_service.available_child_collections(parent: parent, scope: context)
-        end
-
-        ##
-        # @deprecated this method is unused by hyrax, and is effectively a
-        #   delegation to `Hyrax::Collections::NestedCollectionQueryService`.
-        #   if you want to be sure to use nested indexing to generate this list,
-        #   use the query service directly.
-        #
-        # For the given child, what are all of the available collections to
-        # which the child can be added as a sub-collection.
-        def available_parent_collections
-          Deprecation.warn "#{self.class}#available_parent_collections " \
-                           "is deprecated. the helper of the same name or " \
-                           "Hyrax::Collections::NestedCollectionQueryService " \
-                           "instead."
-
-          query_service.available_parent_collections(child: child, scope: context)
-        end
-
         # when creating a NEW collection, we need to do some basic validation before
         # rerouting to new_dashboard_collection_path to add the new collection as
         # a child. Since we don't yet have a child collection, the valid? option can't be used here.

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -172,23 +172,6 @@ module Hyrax
       create_work_presenter.first_model
     end
 
-    ##
-    # @deprecated this implementation requires an extra db round trip, had a
-    #   buggy cacheing mechanism, and was largely duplicative of other code.
-    #   all versions of this code are replaced by
-    #   {CollectionsHelper#available_parent_collections_data}.
-    def available_parent_collections(scope:)
-      Deprecation.warn("#{self.class}#available_parent_collections is " \
-                       "deprecated. Use available_parent_collections_data " \
-                       "helper instead.")
-      return @available_parents if @available_parents.present?
-      collection = Hyrax.config.collection_class.find(id)
-      colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: scope, limit_to_id: nil)
-      @available_parents = colls.map do |col|
-        { "id" => col.id, "title_first" => col.title.first }
-      end.to_json
-    end
-
     def subcollection_count=(total)
       @subcollection_count = total unless total.nil?
     end

--- a/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/dashboard/nest_collection_form_spec.rb
@@ -96,28 +96,6 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
       end
     end
 
-    describe '#available_child_collections' do
-      it 'delegates to the underlying query_service' do
-        expect(query_service)
-          .to receive(:available_child_collections)
-          .with(parent: parent, scope: context)
-          .and_return(:results)
-
-        expect(form.available_child_collections).to eq(:results)
-      end
-    end
-
-    describe '#available_parent_collections' do
-      it 'delegates to the underlying query_service' do
-        expect(query_service)
-          .to receive(:available_parent_collections)
-          .with(child: child, scope: context)
-          .and_return(:results)
-
-        expect(form.available_parent_collections).to eq(:results)
-      end
-    end
-
     describe '#validate_add' do
       context 'when not nestable' do
         let(:parent) { double(nestable?: false) }
@@ -252,28 +230,6 @@ RSpec.describe Hyrax::Forms::Dashboard::NestCollectionForm, type: :form do
 
           expect(form.save).to eq :persisted
         end
-      end
-    end
-
-    describe '#available_child_collections' do
-      it 'delegates to the underlying query_service' do
-        expect(query_service)
-          .to receive(:available_child_collections)
-          .with(parent: parent, scope: context)
-          .and_return(:results)
-
-        expect(form.available_child_collections).to eq(:results)
-      end
-    end
-
-    describe '#available_parent_collections' do
-      it 'delegates to the underlying query_service' do
-        expect(query_service)
-          .to receive(:available_parent_collections)
-          .with(child: child, scope: context)
-          .and_return(:results)
-
-        expect(form.available_parent_collections).to eq(:results)
       end
     end
 


### PR DESCRIPTION
### Changes proposed in this pull request:
* Remove previously deprecated methods
*
*

@samvera/hyrax-code-reviewers
