### PR TITLE
Remove deprecated `reset_access_controls!`

### DIFF
--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -9,13 +9,6 @@ module Hyrax
       delegate :access_grants, :access_grants_attributes=, :release_date, :release_period, :visibility, to: :model
       delegate :available_workflows, :active_workflow, :source, :source_id, to: :model
 
-      ##
-      # @deprecated  use PermissionTemplate#reset_access_controls_for instead.
-      def reset_access_controls!
-        Deprecation.warn("reset_access_controls! is deprecated; use PermissionTemplate#reset_access_controls_for instead.")
-        source_model.reset_access_controls!
-      end
-
       # Stores which radio button under release "Varies" option is selected
       attr_accessor :release_varies
       # Selected release embargo timeframe (if any) under release "Varies" option

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
   it { is_expected.to delegate_method(:source_model).to(:model) }
   it { is_expected.to delegate_method(:source_id).to(:model) }
   it { is_expected.to delegate_method(:visibility).to(:model) }
-  it { is_expected.to delegate_method(:reset_access_controls!).to(:source_model) }
 
   it 'is expected to delegate method #active_workflow_id to #active_workflow#id' do
     workflow = double(:workflow, id: 1234, active: true)

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe ::Collection, :active_fedora, type: :model do
     end
   end
 
-  describe '#reset_access_controls!' do
+  describe 'permission_template reset_access_controls_for' do
     let!(:user) { build(:user) }
     let(:collection_type) { create(:collection_type) }
     let!(:collection) { FactoryBot.build(:collection_lw, user: user, collection_type: collection_type) }


### PR DESCRIPTION
### Changes proposed in this pull request:
* Remove deprecated `Hyrax::Forms::PermissionTemplateForm#reset_access_controls!`
* Relabel a spec that still referred to this method name

@samvera/hyrax-code-reviewers
