### PR TITLE
Fix user links menu running off right side of page

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -10,7 +10,7 @@
         <span><%= current_user.name %></span>
         <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
       </a>
-      <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+      <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
         <%= link_to "My Profile", hyrax.dashboard_profile_path(current_user), class: 'dropdown-item' %>
         <%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path, class: "dropdown-item" %>
         <div class="dropdown-divider"></div>


### PR DESCRIPTION
### Summary

In hyrax 4 or 5, when the user's username is very short (particularly when username's are not email addresses) the dropdown menu containing user links in the top right corner will run off the right side of the screen.

<img width="310" alt="Screen Shot 2023-10-23 at 3 34 54 PM" src="https://github.com/samvera/hyrax/assets/969810/e337101f-0644-4f88-ac6d-72dab148de72">


### Guidance for testing, such as acceptance criteria or new user interface behaviors:
Log in to nurax or dassie with a user with a very short name, such as "b@b.b", or admin if you are not using a scheme that requires email addresses as the username.

### Type of change (for release notes)

notes-bugfix

### Detailed Description

N/A

### Changes proposed in this pull request:
* Makes the menu right aligned so that options will not stick off the right side of the page

@samvera/hyrax-code-reviewers
