### PR TITLE
Sidebar entry focus color fix

### DIFF
--- a/app/assets/stylesheets/hyrax/sidebar.scss
+++ b/app/assets/stylesheets/hyrax/sidebar.scss
@@ -137,9 +137,14 @@ $gutter-width: $grid-gutter-width/2;
     li {
       white-space: nowrap;
 
-      > a:hover, > a:focus {
+      > a:focus {
+        color: $admin-sidebar-link-color;
+      }
+
+      > a:hover {
         text-decoration: none;
         background-color: $admin-sidebar-link-background-color;
+        color: $admin-sidebar-link-hover-color;
       }
     }
     


### PR DESCRIPTION
### Summary

When using tab to navigate through the sidebar in the dashboard, or after clicking a menu link, the entry will be highlighted white with white text. This applies to hyrax 4 and 5.

<img width="331" alt="Screen Shot 2023-10-23 at 4 07 51 PM" src="https://github.com/samvera/hyrax/assets/969810/89b121ee-5096-49a5-be75-6ef36031314b">


### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Log into nurax or dassie, go to the dashboard, then press tab until you have a menu item in the sidebar selected.

### Type of change (for release notes)

notes-bugfix

### Changes proposed in this pull request:
* Focused entries no longer get a highlight background color.

This matches the behavior in hyrax 3. I don't have a problem with giving it a different background color if others would like to add one, but it is at least legible this way. Alternatively we could highlight it the same way that we do when hovering.

<img width="267" alt="Screen Shot 2023-10-23 at 5 20 13 PM" src="https://github.com/samvera/hyrax/assets/969810/d8c8986d-a2a6-4f9e-808f-a4b0a386fa5b">


@samvera/hyrax-code-reviewers
