### PR TITLE
drop explicit dry-struct dependency

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -48,7 +48,6 @@ SUMMARY
   spec.add_dependency 'dry-container', '~> 0.11'
   spec.add_dependency 'dry-events', '~> 1.0', '>= 1.0.1'
   spec.add_dependency 'dry-monads', '~> 1.6'
-  spec.add_dependency 'dry-struct', '~> 1.6'
   spec.add_dependency 'dry-validation', '~> 1.10'
   spec.add_dependency 'flipflop', '~> 2.3'
   # Pin more tightly because 0.x gems are potentially unstable


### PR DESCRIPTION
Hyrax doesn't directly depend on `Dry::Struct`, and only uses it through `valkryie` and other dependency gems. specifying a version here can only cause problems.

@samvera/hyrax-code-reviewers
