### PR TITLE
disable `work_form_spec` when AF is disabled

### DIFF
--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Forms::WorkForm do
+RSpec.describe Hyrax::Forms::WorkForm, :active_fedora do
   let(:work) { GenericWork.new }
   let(:form) { described_class.new(work, nil, controller) }
   let(:works) { [GenericWork.new, FileSet.new, GenericWork.new] }


### PR DESCRIPTION
the unit under test inherits `HydraEditor::Form`, which is only relevant for ActiveFedora. don't test it if we're not using AF models.

fixes #6308


@samvera/hyrax-code-reviewers
