### PR TITLE
Fix by_resource_type_spec.rb when using Valkyrie

### DIFF
--- a/spec/services/hyrax/statistics/works/by_resource_type_spec.rb
+++ b/spec/services/hyrax/statistics/works/by_resource_type_spec.rb
@@ -5,16 +5,17 @@ RSpec.describe Hyrax::Statistics::Works::ByResourceType do
 
   describe "#query", :clean_repo do
     before do
-      # Creating factories here led to failures found within
-      # https://travis-ci.org/samvera/hyrax/jobs/454752377
-      # One should be able to invoke create(:generic_work)...
-      # ...however, there are difficulties here which relate to the "terms"
-      # requestHandler
-      # @see https://github.com/samvera/hyrax/issues/3491
-      GenericWork.create(title: ['test'], resource_type: ['Conference Proceeding']).save!
-      GenericWork.create(title: ['test'], resource_type: ['Conference Proceeding']).save!
-      GenericWork.create(title: ['test'], resource_type: ['Image']).save!
-      GenericWork.create(title: ['test'], resource_type: ['Journal']).save!
+      if Hyrax.config.use_valkyrie?
+        FactoryBot.valkyrie_create(:monograph, title: ['test 1'], resource_type: ['Conference Proceeding'])
+        FactoryBot.valkyrie_create(:monograph, title: ['test 2'], resource_type: ['Conference Proceeding'])
+        FactoryBot.valkyrie_create(:monograph, title: ['test 3'], resource_type: ['Image'])
+        FactoryBot.valkyrie_create(:monograph, title: ['test 4'], resource_type: ['Journal'])
+      else
+        GenericWork.create(title: ['test 1'], resource_type: ['Conference Proceeding']).save!
+        GenericWork.create(title: ['test 2'], resource_type: ['Conference Proceeding']).save!
+        GenericWork.create(title: ['test 3'], resource_type: ['Image']).save!
+        GenericWork.create(title: ['test 4'], resource_type: ['Journal']).save!
+      end
     end
 
     subject { service.query }


### PR DESCRIPTION
### Fixes

Fixes #6310

### Summary

`by_resource_type_spec.rb` are currently failing when Valkyrie is used.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Run `by_resource_type_spec.rb` and verify that all tests pass
*
*

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Detailed Description

The current failure encountered when running the test suite:

```
undefined method `create' for GenericWork:Class
```

is due to the underlying assumption in the spec that ActiveFedora is used. When Valkyrie us used, the `create` method fails because `GenericWork` is a `Valkyrie::Resource` instance, not an `ActiveFedora::Base` instance. In this PR, I check if Valkyrie is used, and change the way works are created.

### Changes proposed in this pull request:
* Check if Valkyrie is used in `by_resource_type_spec.rb`
* Change the way works are created depending on the use of Valkyrie
*

@samvera/hyrax-code-reviewers
