### PR TITLE
rework `:with_files` factory to work with ActiveFedora/Wings

### DIFF
--- a/spec/factories/hyrax_file_set.rb
+++ b/spec/factories/hyrax_file_set.rb
@@ -62,7 +62,14 @@ FactoryBot.define do
 
     trait :with_files do
       transient do
-        files { [valkyrie_create(:hyrax_file_metadata), valkyrie_create(:hyrax_file_metadata)] }
+        ios { [File.open('spec/fixtures/image.png'), File.open('spec/fixtures/Example.ogg')] }
+
+        after(:create) do |file_set, evaluator|
+          evaluator.ios.each do |file|
+            filename = File.basename(file.path).to_s
+            Hyrax::ValkyrieUpload.file(filename: filename, file_set: file_set, io: file)
+          end
+        end
       end
     end
 

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -324,7 +324,6 @@ RSpec.describe Hyrax::FileSetPresenter do
       context 'with a file' do
         let(:file_set) do
           FactoryBot.valkyrie_create(:hyrax_file_set,
-                                     :with_files,
                                      files: [file_metadata],
                                      original_file: file_metadata)
         end


### PR DESCRIPTION
Fedora builds FileMetadata nodes when files are uploaded, and creating them directly isn't allowed. `Hyrax::ValkyrieUpload` supports the specialized needs of the adapter, so use it to do this step for portability.

@samvera/hyrax-code-reviewers
