### PR TITLE
disable Hyrax::FileSetVisibilityPropagator unless using ActiveFedora

### DIFF
--- a/spec/services/hyrax/file_set_visibility_propagator_spec.rb
+++ b/spec/services/hyrax/file_set_visibility_propagator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hyrax::FileSetVisibilityPropagator do
+RSpec.describe Hyrax::FileSetVisibilityPropagator, :active_fedora do
   subject(:propagator) { described_class.new(source: work) }
   let(:work)           { FactoryBot.create(:work_with_files) }
 


### PR DESCRIPTION
this class is only used for/only supports ActiveFedora models.

@samvera/hyrax-code-reviewers
