### PR TITLE
support legacy "Collection" and "AdminSet" in SolrDocumentBehavior

### DIFF
--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -53,19 +53,22 @@ module Hyrax
     ##
     # @return [Boolean]
     def collection?
-      hydra_model == Hyrax.config.collection_class
+      hydra_model == Hyrax.config.collection_class ||
+        ("Collection".safe_constantize == hydra_model)
     end
 
     ##
     # @return [Boolean]
     def file_set?
-      hydra_model == ::FileSet || hydra_model == Hyrax::FileSet
+      hydra_model == Hyrax::FileSet ||
+        ("::FileSet".safe_constantize == hydra_model)
     end
 
     ##
     # @return [Boolean]
     def admin_set?
-      hydra_model == Hyrax.config.admin_set_class
+      (hydra_model == Hyrax.config.admin_set_class) ||
+        ("AdminSet".safe_constantize == hydra_model)
     end
 
     ##

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -158,15 +158,27 @@ RSpec.describe ::SolrDocument, type: :model do
   end
 
   describe "#admin_set?" do
-    let(:attributes) { { 'has_model_ssim' => 'AdminSet' } }
+    let(:attributes) { { 'has_model_ssim' => Hyrax.config.admin_set_model } }
 
     it { is_expected.to be_admin_set }
+
+    context "with legacy indexed admin set" do
+      let(:attributes) { { 'has_model_ssim' => "AdminSet" } }
+
+      it { is_expected.to be_admin_set }
+    end
   end
 
   describe "#collection?" do
     let(:attributes) { { 'has_model_ssim' => Hyrax.config.collection_model } }
 
     it { is_expected.to be_collection }
+
+    context "with legacy indexed collection" do
+      let(:attributes) { { 'has_model_ssim' => "Collection" } }
+
+      it { is_expected.to be_collection }
+    end
   end
 
   describe "#work?" do


### PR DESCRIPTION
when models are indexed as "Collection" or "AdminSet" treat them as `#collection?` and `#admin_set?` regardless of configured model classes.

this should better support legacy index documents and an easier transition.

@samvera/hyrax-code-reviewers
