### PR TITLE
Make form classes configurable

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -16,14 +16,13 @@ module Hyrax
       @resource_forms ||= {}.compare_by_identity
       @resource_forms[model_class] ||=
         if model_class <= Hyrax::AdministrativeSet
-          Hyrax::Forms::AdministrativeSetForm
+          Hyrax.config.administrative_set_form
         elsif model_class <= Hyrax::FileSet
-          Hyrax::Forms::FileSetForm
+          Hyrax.config.file_set_form
         elsif model_class <= Hyrax::PcdmCollection
-          Hyrax::Forms::PcdmCollectionForm
+          Hyrax.config.pcdm_collection_form
         else
-          "Hyrax::Forms::PcdmObjectForm".constantize # autoload
-          Hyrax::Forms::PcdmObjectForm(model_class)
+          Hyrax.config.pcdm_object_form_builder.call(model_class)
         end
     end
 

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -242,6 +242,20 @@ Hyrax.config do |config|
   # config.admin_set_model = 'AdminSet'
   # config.admin_set_model = 'Hyrax::AdministrativeSet'
 
+  # Identify the form that will be used for Admin Sets
+  # config.administrative_set_form = Hyrax::Forms::AdministrativeSetForm
+
+  # Identify the form that will be used for File Sets
+  # config.file_set_form = Hyrax::Forms::FileSetForm
+
+  # Identify the form that will be used for Collections
+  # config.pcdm_collection_form = Hyrax::Forms::PcdmCollectionForm
+
+  # Provide a proc for form generation for Objects
+  # config.pcdm_object_form_builder = lambda do |model_class|
+  #   Hyrax::Forms::PcdmObjectForm(model_class)
+  # end
+
   # When your application is ready to use the valkyrie index instead of the one
   # maintained by active fedora, you will need to set this to true. You will
   # also need to update your Blacklight configuration.

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -890,6 +890,37 @@ module Hyrax
       @index_field_mapper ||= ActiveFedora.index_field_mapper
     end
 
+    attr_writer :administrative_set_form
+    ##
+    # @return [Class]
+    def administrative_set_form
+      @administrative_set_model ||= Hyrax::Forms::AdministrativeSetForm
+    end
+
+    attr_writer :file_set_form
+    ##
+    # @return [Class]
+    def file_set_form
+      @file_set_form ||= Hyrax::Forms::FileSetForm
+    end
+
+    attr_writer :pcdm_collection_form
+    ##
+    # @return [Class]
+    def pcdm_collection_form
+      @pcdm_collection_form ||= Hyrax::Forms::PcdmCollectionForm
+    end
+
+    attr_writer :pcdm_object_form_builder
+    ##
+    # @return [Proc]
+    def pcdm_object_form_builder
+      "Hyrax::Forms::PcdmObjectForm".constantize # autoload
+      @pcdm_object_form_builder = lambda do |model_class|
+        Hyrax::Forms::PcdmObjectForm(model_class)
+      end
+    end
+
     # Should a button with "Share my work" show on the front page to users who are not logged in?
     attr_writer :display_share_button_when_not_logged_in
     def display_share_button_when_not_logged_in?

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:admin_set_model=) }
   it { is_expected.to respond_to(:admin_set_predicate) }
   it { is_expected.to respond_to(:admin_set_predicate=) }
+  it { is_expected.to respond_to(:administrative_set_form) }
+  it { is_expected.to respond_to(:administrative_set_form=) }
   it { is_expected.to respond_to(:analytic_start_date) }
   it { is_expected.to respond_to(:analytics?) }
   it { is_expected.to respond_to(:analytics_provider) }
@@ -51,6 +53,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:enable_noids?) }
   it { is_expected.to respond_to(:extract_full_text?) }
   it { is_expected.to respond_to(:feature_config_path) }
+  it { is_expected.to respond_to(:file_set_form) }
+  it { is_expected.to respond_to(:file_set_form=) }
   it { is_expected.to respond_to(:identifier_registrars) }
   it { is_expected.to respond_to(:iiif_image_compliance_level_uri) }
   it { is_expected.to respond_to(:iiif_image_compliance_level_uri=) }
@@ -75,6 +79,10 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:max_days_between_fixity_checks=) }
   it { is_expected.to respond_to(:max_notifications_for_dashboard) }
   it { is_expected.to respond_to(:owner_permission_levels) }
+  it { is_expected.to respond_to(:pcdm_collection_form) }
+  it { is_expected.to respond_to(:pcdm_collection_form=) }
+  it { is_expected.to respond_to(:pcdm_object_form_builder) }
+  it { is_expected.to respond_to(:pcdm_object_form_builder=) }
   it { is_expected.to respond_to(:permission_levels) }
   it { is_expected.to respond_to(:permission_options) }
   it { is_expected.to respond_to(:persistent_hostpath) }


### PR DESCRIPTION
This commit allows applications to provide their own behaviours in subclasses of the default Hyrax form classes
(`Hyrax::Forms::AdministrativeSetForm`, `Hyrax::Forms::FileSetForm`, `Hyrax::Forms::PcdmCollectionForm`, `Hyrax::Forms::PcdmObjectForm`) and then tell Hyrax to use those subclasses instead via Hyrax configuration.

The situation of `Hyrax::Forms::PcdmCollectionForm` is a bit complicated, since these classes are generated dynamically on‐demand. So the configuration in this case is a Proc rather than a simple class.