### PR TITLE
Fix instance variable used for admin set form

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -894,7 +894,7 @@ module Hyrax
     ##
     # @return [Class]
     def administrative_set_form
-      @administrative_set_model ||= Hyrax::Forms::AdministrativeSetForm
+      @administrative_set_form ||= Hyrax::Forms::AdministrativeSetForm
     end
 
     attr_writer :file_set_form


### PR DESCRIPTION
This doesn’t have any behavioural change, but the instance variable used for remembering the admin set form was mistakenly named `@administrative_set_model` (compare `@admin_set_model`) and not `@administrative_set_form`.