### PR TITLE
Clarify purpose of FileSetFileService 

### DIFF
--- a/app/indexers/hyrax/valkyrie_file_set_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_file_set_indexer.rb
@@ -25,8 +25,8 @@ module Hyrax
         index_lease(solr_doc)
         index_embargo(solr_doc)
 
-        # Add in metadata from the original file.
-        file_metadata = Hyrax::FileSetFileService.new(file_set: resource).primary_file
+        # Add in metadata from the primary file.
+        file_metadata = Hyrax.config.file_set_file_service.new(file_set: resource).primary_file
         return solr_doc unless file_metadata
 
         # Label is the actual file name. It's not editable by the user.

--- a/app/indexers/hyrax/valkyrie_file_set_indexer.rb
+++ b/app/indexers/hyrax/valkyrie_file_set_indexer.rb
@@ -26,7 +26,7 @@ module Hyrax
         index_embargo(solr_doc)
 
         # Add in metadata from the original file.
-        file_metadata = Hyrax::FileSetFileService.new(file_set: resource).original_file
+        file_metadata = Hyrax::FileSetFileService.new(file_set: resource).primary_file
         return solr_doc unless file_metadata
 
         # Label is the actual file name. It's not editable by the user.

--- a/app/presenters/hyrax/version_list_presenter.rb
+++ b/app/presenters/hyrax/version_list_presenter.rb
@@ -20,8 +20,13 @@ module Hyrax
     #   relevant file versions.
     #
     # @raise [ArgumentError] if we can't build an enumerable
-    def self.for(file_set:)
-      original_file = Hyrax::FileSetFileService.new(file_set: file_set).primary_file
+    def self.for(file_set:, file_service: Hyrax.config.file_set_file_service)
+      original_file = case file_set
+                      when ActiveFedora::Base
+                        file_set.original_file
+                      else
+                        file_service.new(file_set: file_set).primary_file
+                      end
 
       new(Hyrax::VersioningService.new(resource: original_file))
     rescue NoMethodError

--- a/app/presenters/hyrax/version_list_presenter.rb
+++ b/app/presenters/hyrax/version_list_presenter.rb
@@ -19,13 +19,10 @@ module Hyrax
     # @return [Hyrax::VersionListPresenter] an enumerable of presenters for the
     #   relevant file versions.
     #
-    # @raise [ArgumentError] if we can't build an enu
+    # @raise [ArgumentError] if we can't build an enumerable
     def self.for(file_set:)
-      original_file = if file_set.respond_to?(:original_file)
-                        file_set.original_file
-                      else
-                        Hyrax::FileSetFileService.new(file_set: file_set).original_file
-                      end
+      original_file = Hyrax::FileSetFileService.new(file_set: file_set).primary_file
+
       new(Hyrax::VersioningService.new(resource: original_file))
     rescue NoMethodError
       raise ArgumentError

--- a/app/services/hyrax/file_set_file_service.rb
+++ b/app/services/hyrax/file_set_file_service.rb
@@ -53,11 +53,11 @@ module Hyrax
         #
         # See NOTE above regarding use of :find_file_metadata_by.
         @primary_file ||= begin
-                             query_service.custom_queries.find_original_file(file_set: file_set)
-                           rescue Valkyrie::Persistence::ObjectNotFoundError
-                             fallback_id = file_set.file_ids.first
-                             query_service.custom_queries.find_file_metadata_by(id: fallback_id) if fallback_id
-                           end
+                            query_service.custom_queries.find_original_file(file_set: file_set)
+                          rescue Valkyrie::Persistence::ObjectNotFoundError
+                            fallback_id = file_set.file_ids.first
+                            query_service.custom_queries.find_file_metadata_by(id: fallback_id) if fallback_id
+                          end
       end
     end
     alias original_file primary_file

--- a/app/services/hyrax/file_set_file_service.rb
+++ b/app/services/hyrax/file_set_file_service.rb
@@ -2,8 +2,17 @@
 
 module Hyrax
   ##
-  # A service for accessing specific Hyrax::FileMetadata objects referenced by a
-  # Hyrax::FileSet.
+  # A service for accessing {Hyrax::FileMetadata} resources by their status
+  # within a {Hyrax::FileSet}. For example, this is the home for the abstraction
+  # of a "Primary" file for the FileSet, used for versioning and as the default
+  # source for the FileSet label, etc...
+  #
+  # If you're looking for {Hyrax::FileMetadata} by PCDM Use, use the custom
+  # queries (e.g. +Hyrax.custom_queries.find_original_file+).
+  #
+  # @note housing the "primary" file abstraction here allows us to begin
+  #   separating from the idea that the `pcdmuse:OriginalFile` is special
+  #   in Hyrax in a hard coded way.
   class FileSetFileService
     ##
     # @!attribute [r] file_set
@@ -23,7 +32,7 @@ module Hyrax
     end
 
     ##
-    # Return the Hyrax::FileMetadata which should be considered “original” for
+    # Return the Hyrax::FileMetadata which should be considered “primary” for
     # indexing and version‐tracking.
     #
     # If +file_set.original_file_id+ is defined, it will be used; otherwise,
@@ -32,7 +41,7 @@ module Hyrax
     # first file in its :file_ids.
     #
     # @return [Hyrax::FileMetadata]
-    def original_file
+    def primary_file
       if file_set.original_file_id
         # Always just use original_file_id if it is defined.
         #
@@ -43,7 +52,7 @@ module Hyrax
         # Cache the fallback to avoid needing to do this query twice.
         #
         # See NOTE above regarding use of :find_file_metadata_by.
-        @original_file ||= begin
+        @primary_file ||= begin
                              query_service.custom_queries.find_original_file(file_set: file_set)
                            rescue Valkyrie::Persistence::ObjectNotFoundError
                              fallback_id = file_set.file_ids.first
@@ -51,5 +60,7 @@ module Hyrax
                            end
       end
     end
+    alias original_file primary_file
+    deprecation_deprecate :original_file
   end
 end

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -248,6 +248,10 @@ Hyrax.config do |config|
   # Identify the form that will be used for File Sets
   # config.file_set_form = Hyrax::Forms::FileSetForm
 
+  # Service for resolving {FileMetadata} nodes by status, e.g. "primary", rather
+  # than use.
+  # config.file_set_file_service = Hyrax::FileSetFileService
+
   # Identify the form that will be used for Collections
   # config.pcdm_collection_form = Hyrax::Forms::PcdmCollectionForm
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -267,6 +267,14 @@ module Hyrax
       @derivative_services ||= [Hyrax::FileSetDerivativesService]
     end
 
+    ##
+    # @!attribute [rw] file_set_file_service
+    #   @return [Class] implementer of {Hyrax::FileSetFileService}
+    attr_writer :file_set_file_service
+    def file_set_file_service
+      @file_set_file_service ||= Hyrax::FileSetFileService
+    end
+
     attr_writer :fixity_service
     def fixity_service
       @fixity_service ||= Hyrax::Fixity::ActiveFedoraFixityService

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:feature_config_path) }
   it { is_expected.to respond_to(:file_set_form) }
   it { is_expected.to respond_to(:file_set_form=) }
+  it { is_expected.to respond_to(:file_set_file_service) }
+  it { is_expected.to respond_to(:file_set_file_service=) }
   it { is_expected.to respond_to(:identifier_registrars) }
   it { is_expected.to respond_to(:iiif_image_compliance_level_uri) }
   it { is_expected.to respond_to(:iiif_image_compliance_level_uri=) }

--- a/spec/services/hyrax/file_set_file_service_spec.rb
+++ b/spec/services/hyrax/file_set_file_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::FileSetFileService do
       it "finds the original_file" do
         expect(service.primary_file)
           .to have_attributes(file_set_id: file_set.id,
-                              pcdm_use: contain_exactly("http://pcdm.org/use#OriginalFile"))
+                              pcdm_use: include("http://pcdm.org/use#OriginalFile"))
       end
     end
 

--- a/spec/services/hyrax/file_set_file_service_spec.rb
+++ b/spec/services/hyrax/file_set_file_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::FileSetFileService do
+  subject(:service) { described_class.new(file_set: file_set) }
+  let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set) }
+
+  describe "#primary_file" do
+    it "is nil when there are no files" do
+      expect(service.primary_file).to be_nil
+    end
+
+    context "with an original file by use" do
+      let(:file_set) { FactoryBot.valkyrie_create(:hyrax_file_set, :with_files) }
+
+      it "finds the original_file" do
+        expect(service.primary_file)
+          .to have_attributes(file_set_id: file_set.id,
+                              pcdm_use: contain_exactly("http://pcdm.org/use#OriginalFile"))
+      end
+    end
+
+    context "when the FileSet has an #original_file_id" do
+      it "always resolves by original_file_id"
+    end
+
+    context "when there is no OriginalFile, but files exist" do
+      it "resolves the first file"
+    end
+  end
+end


### PR DESCRIPTION
this service seems at first glance like it's just layering complexity on the
`#find_original_file` custom query (i almost deprecated it for this reason). but
its actually hiding an abstraction: the idea that the `pcdmuse:OriginalFile` is
the "primary" file for a FileSet.

this abstraction is useful, if Hyrax uses it consistently, because downstream
applications may want to determine the "primary" file any number of other
ways. (treating the OriginalFile as primary isn't at all in line with the PCDM
Use vocabulary's description of it, anyway).

clarify this all a bit with documentation and a method rename refactor.

@samvera/hyrax-code-reviewers
