### PR TITLE
deprecate `Statistics::QueryService`

### DIFF
--- a/app/services/hyrax/statistics/query_service.rb
+++ b/app/services/hyrax/statistics/query_service.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 module Hyrax
   module Statistics
+    ##
+    # @deprecated for removal in 6.0.0
     class QueryService
+      extend Deprecation
+      self.deprecation_horizon = 'hyrax version 6.0.0'
+      deprecation_deprecate :initialize
+
       # query to find works created during the time range
       # @param [DateTime] start_datetime starting date time for range query
       # @param [DateTime] end_datetime ending date time for range query

--- a/spec/services/hyrax/statistics/query_service_spec.rb
+++ b/spec/services/hyrax/statistics/query_service_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Statistics::QueryService, :clean_repo do
+RSpec.describe Hyrax::Statistics::QueryService, :clean_repo, :active_fedora do
   let(:service) { described_class.new }
 
   describe "#count" do


### PR DESCRIPTION
we now use a Statistics::ValkyrieQueryService by default everywhere, so this one should be deprecated for removal and not tested in valkyrie stacks.


@samvera/hyrax-code-reviewers
