### PR TITLE
Turns off AF testing in koppie testing for nested_collections_search_builder_spec.

### DIFF
--- a/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::Dashboard::NestedCollectionsSearchBuilder do
   let(:ability) { ::Ability.new(user) }
   let(:test_nest_direction) { :as_parent }
 
-  [false, true].each do |test_valkyrie|
+  (Hyrax.config.disable_wings ? [true] : [false, true]).each do |test_valkyrie|
     context "when test_valkyrie is #{test_valkyrie}" do
       let(:builder) do
         described_class.new(scope: scope, access: access, collection: collection, nest_direction: test_nest_direction)


### PR DESCRIPTION
### Fixes

Fixes `spec/search_builders/hyrax/dashboard/nested_collections_search_builder_spec.rb` failures in koppie spec.

### Summary

Turns off AF testing in koppie testing for nested_collections_search_builder_spec.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Detailed Description

Avoids ActiveFedora-specific testing when running test suite in Koppie by checking `Hyrax.config.disable_wings` and only using Valkyrie objects if true.

@samvera/hyrax-code-reviewers
