### PR TITLE
Fix embargo expiry job spec

### DIFF
--- a/spec/factories/hyrax_file_set.rb
+++ b/spec/factories/hyrax_file_set.rb
@@ -48,6 +48,28 @@ FactoryBot.define do
       Hyrax.index_adapter.save(resource: file_set) if evaluator.with_index
     end
 
+    trait :under_embargo do
+      association :embargo, factory: :hyrax_embargo
+
+      after(:create) do |fs, _e|
+        Hyrax::EmbargoManager.new(resource: fs).apply
+        fs.permission_manager.acl.save
+      end
+    end
+
+    trait :with_expired_enforced_embargo do
+      after(:build) do |fs, _evaluator|
+        fs.embargo = FactoryBot.valkyrie_create(:hyrax_embargo, :expired)
+      end
+
+      after(:create) do |fs, _evaluator|
+        allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(10.days.ago)
+        Hyrax::EmbargoManager.new(resource: fs).apply
+        fs.permission_manager.acl.save
+        allow(Hyrax::TimeService).to receive(:time_in_utc).and_call_original
+      end
+    end
+
     trait :public do
       transient do
         visibility_setting { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -21,9 +21,8 @@ FactoryBot.define do
       after(:create) do |work, _evaluator|
         allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(10.days.ago)
         Hyrax::EmbargoManager.new(resource: work).apply
-        allow(Hyrax::TimeService).to receive(:time_in_utc).and_call_original
-
         work.permission_manager.acl.save
+        allow(Hyrax::TimeService).to receive(:time_in_utc).and_call_original
       end
     end
 

--- a/spec/jobs/embargo_expiry_job_spec.rb
+++ b/spec/jobs/embargo_expiry_job_spec.rb
@@ -2,19 +2,14 @@
 RSpec.describe EmbargoExpiryJob, :clean_repo do
   subject { described_class }
   let(:past_date) { 2.days.ago }
-  let(:embargoed_work) { create(:embargoed_work) }
+  let(:embargoed_work) { valkyrie_create(:hyrax_work, embargo: work_set_embargo) }
+  let(:work_set_embargo) { valkyrie_create(:hyrax_embargo, visibility_during_embargo: 'restricted') }
 
-  let!(:work_with_expired_embargo) do
-    build(:work, embargo_release_date: past_date.to_s, visibility_during_embargo: 'restricted', visibility_after_embargo: 'open').tap do |work|
-      work.save(validate: false)
-    end
-  end
+  let(:work_with_expired_embargo) { valkyrie_create(:hyrax_work, embargo: work_set_embargo_expired) }
+  let(:work_set_embargo_expired) { valkyrie_create(:hyrax_embargo, embargo_release_date: past_date, visibility_during_embargo: 'restricted') }
 
-  let!(:file_set_with_expired_embargo) do
-    build(:file_set, embargo_release_date: past_date.to_s, visibility_during_embargo: 'restricted', visibility_after_embargo: 'open').tap do |file_set|
-      file_set.save(validate: false)
-    end
-  end
+  let(:file_set_with_expired_embargo) { valkyrie_create(:hyrax_file_set, embargo: file_set_embargo) }
+  let(:file_set_embargo) { valkyrie_create(:hyrax_embargo, embargo_release_date: past_date, visibility_during_embargo: 'restricted') }
 
   describe '#records_with_expired_embargos' do
     it 'returns all records with expired embargos' do
@@ -29,19 +24,19 @@ RSpec.describe EmbargoExpiryJob, :clean_repo do
   describe '#perform' do
     it 'expires embargos on works with expired embargos' do
       described_class.new.perform
-      work_with_expired_embargo.reload
+      # work_with_expired_embargo.reload
       expect(work_with_expired_embargo.visibility).to eq('open')
     end
 
     it 'expires embargos on file sets with expired embargos' do
       described_class.new.perform
-      file_set_with_expired_embargo.reload
+      # file_set_with_expired_embargo.reload
       expect(file_set_with_expired_embargo.visibility).to eq('open')
     end
 
     it "Doesn't expire embargos that are still in effect" do
       described_class.new.perform
-      embargoed_work.reload
+      # embargoed_work.reload
       expect(embargoed_work.visibility).to eq('restricted')
     end
   end

--- a/spec/jobs/embargo_expiry_job_spec.rb
+++ b/spec/jobs/embargo_expiry_job_spec.rb
@@ -1,43 +1,87 @@
 # frozen_string_literal: true
 RSpec.describe EmbargoExpiryJob, :clean_repo do
   subject { described_class }
-  let(:past_date) { 2.days.ago }
-  let(:embargoed_work) { valkyrie_create(:hyrax_work, embargo: work_set_embargo) }
-  let(:work_set_embargo) { valkyrie_create(:hyrax_embargo, visibility_during_embargo: 'restricted') }
 
-  let(:work_with_expired_embargo) { valkyrie_create(:hyrax_work, embargo: work_set_embargo_expired) }
-  let(:work_set_embargo_expired) { valkyrie_create(:hyrax_embargo, embargo_release_date: past_date, visibility_during_embargo: 'restricted') }
+  context "with Valkyrie resources" do
+    let(:embargoed_work) { valkyrie_create(:hyrax_work, :under_embargo) }
+    let(:work_with_expired_embargo) { valkyrie_create(:hyrax_work, :with_expired_enforced_embargo) }
+    let(:file_set_with_expired_embargo) { valkyrie_create(:hyrax_file_set, :with_expired_enforced_embargo) }
 
-  let(:file_set_with_expired_embargo) { valkyrie_create(:hyrax_file_set, embargo: file_set_embargo) }
-  let(:file_set_embargo) { valkyrie_create(:hyrax_embargo, embargo_release_date: past_date, visibility_during_embargo: 'restricted') }
+    describe '#records_with_expired_embargos' do
+      it 'returns all records with expired embargos' do
+        records = [work_with_expired_embargo.id, file_set_with_expired_embargo.id]
+        expect(described_class.new.records_with_expired_embargos.map(&:id)).to eq(records)
+      end
+    end
 
-  describe '#records_with_expired_embargos' do
-    it 'returns all records with expired embargos' do
-      records = described_class.new.records_with_expired_embargos
+    describe '#perform' do
+      it 'expires embargos on works with expired embargos' do
+        expect(work_with_expired_embargo.visibility).to eq('authenticated')
+        described_class.new.perform
+        reloaded = Hyrax.query_service.find_by(id: work_with_expired_embargo.id)
+        expect(reloaded.visibility).to eq('open')
+      end
 
-      expect(records.map(&:id))
-        .to contain_exactly(work_with_expired_embargo.id,
-                            file_set_with_expired_embargo.id)
+      it 'expires embargos on file sets with expired embargos' do
+        expect(file_set_with_expired_embargo.visibility).to eq('authenticated')
+        described_class.new.perform
+        reloaded = Hyrax.query_service.find_by(id: file_set_with_expired_embargo.id)
+        expect(reloaded.visibility).to eq('open')
+      end
+
+      it "Doesn't expire embargos that are still in effect" do
+        expect(embargoed_work.visibility).to eq('authenticated')
+        described_class.new.perform
+        reloaded = Hyrax.query_service.find_by(id: embargoed_work.id)
+        expect(reloaded.visibility).to eq('authenticated')
+      end
     end
   end
 
-  describe '#perform' do
-    it 'expires embargos on works with expired embargos' do
-      described_class.new.perform
-      # work_with_expired_embargo.reload
-      expect(work_with_expired_embargo.visibility).to eq('open')
+  context 'with ActiveFedora objects', :active_fedora do
+    let(:past_date) { 2.days.ago }
+    let(:embargoed_work) { create(:embargoed_work) }
+
+    let!(:work_with_expired_embargo) do
+      build(:work, embargo_release_date: past_date.to_s, visibility_during_embargo: 'restricted', visibility_after_embargo: 'open').tap do |work|
+        work.save(validate: false)
+      end
     end
 
-    it 'expires embargos on file sets with expired embargos' do
-      described_class.new.perform
-      # file_set_with_expired_embargo.reload
-      expect(file_set_with_expired_embargo.visibility).to eq('open')
+    let!(:file_set_with_expired_embargo) do
+      build(:file_set, embargo_release_date: past_date.to_s, visibility_during_embargo: 'restricted', visibility_after_embargo: 'open').tap do |file_set|
+        file_set.save(validate: false)
+      end
     end
 
-    it "Doesn't expire embargos that are still in effect" do
-      described_class.new.perform
-      # embargoed_work.reload
-      expect(embargoed_work.visibility).to eq('restricted')
+    describe '#records_with_expired_embargos' do
+      it 'returns all records with expired embargos' do
+        records = described_class.new.records_with_expired_embargos
+
+        expect(records.map(&:id))
+          .to contain_exactly(work_with_expired_embargo.id,
+                              file_set_with_expired_embargo.id)
+      end
+    end
+
+    describe '#perform' do
+      it 'expires embargos on works with expired embargos' do
+        described_class.new.perform
+        work_with_expired_embargo.reload
+        expect(work_with_expired_embargo.visibility).to eq('open')
+      end
+
+      it 'expires embargos on file sets with expired embargos' do
+        described_class.new.perform
+        file_set_with_expired_embargo.reload
+        expect(file_set_with_expired_embargo.visibility).to eq('open')
+      end
+
+      it "Doesn't expire embargos that are still in effect" do
+        described_class.new.perform
+        embargoed_work.reload
+        expect(embargoed_work.visibility).to eq('restricted')
+      end
     end
   end
 end


### PR DESCRIPTION
Add valkyrie specs for EmbargoExpiryJob

Marks existing spec as AF only.

Duplicates existing EmbargoExpiryJob specs but with Valkyrie resources.

Spec setup is simplified by not specifying "restricted" visibility, instead expecting the factory
default "authenticated". Additional checks to confirm the initial visibility state are also added.

The embargo traits from the hyrax_work factory are copied to the hyrax_file_set factory.

Saving of the expired embargo ACL is moved to inside the time machine to 10 days ago. Without this
change the solr doc will not contain the embargo related fields, causing
`#records_with_expired_embargoes` to not find those resources.